### PR TITLE
Add implicit cache redirect

### DIFF
--- a/src/ApolloClient.ts
+++ b/src/ApolloClient.ts
@@ -27,6 +27,7 @@ import {
 
 import {
   CustomResolverMap,
+  CustomResolver,
 } from './data/readFromStore';
 
 import {
@@ -129,6 +130,9 @@ export default class ApolloClient {
    * @param dataIdFromObject A function that returns a object identifier given a particular result
    * object.
    *
+   * @param defaultIdLookup A function used to find objects in the cache by their key.
+   * Should return an object identifer given a particular result object and arguments.
+   *
    * @param queryTransformer A function that takes a {@link SelectionSet} and modifies it in place
    * in some way. The query transformer is then applied to the every GraphQL document before it is
    * sent to the server.
@@ -149,6 +153,7 @@ export default class ApolloClient {
     reduxRootSelector,
     initialState,
     dataIdFromObject,
+    defaultIdLookup,
     resultTransformer,
     resultComparator,
     ssrMode = false,
@@ -164,6 +169,7 @@ export default class ApolloClient {
     reduxRootSelector?: string | ApolloStateSelector,
     initialState?: any,
     dataIdFromObject?: IdGetter,
+    defaultIdLookup?: CustomResolver,
     resultTransformer?: ResultTransformer,
     resultComparator?: ResultComparator,
     ssrMode?: boolean,
@@ -220,6 +226,7 @@ export default class ApolloClient {
 
     this.reducerConfig = {
       dataIdFromObject,
+      defaultIdLookup,
       mutationBehaviorReducers,
       customResolvers,
     };

--- a/src/data/readFromStore.ts
+++ b/src/data/readFromStore.ts
@@ -11,6 +11,7 @@ import {
   NormalizedCache,
   isJsonValue,
   isIdValue,
+  toIdValue,
   IdValue,
 } from './storeUtils';
 
@@ -158,6 +159,10 @@ const readStoreResolver: Resolver = (
           return resolver(obj, args);
         }
       }
+    }
+
+    if (args && context.store[args.id]) {
+      return toIdValue(args.id);
     }
 
     if (! context.returnPartialData) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -43,6 +43,7 @@ import {
 
 import {
   CustomResolverMap,
+  CustomResolver,
 } from './data/readFromStore';
 
 import assign = require('lodash/assign');
@@ -178,6 +179,7 @@ export function createApolloStore({
 
 export type ApolloReducerConfig = {
   dataIdFromObject?: IdGetter;
+  defaultIdLookup?: CustomResolver;
   mutationBehaviorReducers?: MutationBehaviorReducerMap;
   customResolvers?: CustomResolverMap;
 }

--- a/test/readFromStore.ts
+++ b/test/readFromStore.ts
@@ -1,6 +1,6 @@
 import mockNetworkInterface from './mocks/mockNetworkInterface';
 import { assert } from 'chai';
-import ApolloClient, { toIdValue } from '../src';
+import ApolloClient from '../src';
 import assign = require('lodash/assign');
 import omit = require('lodash/omit');
 

--- a/test/readFromStore.ts
+++ b/test/readFromStore.ts
@@ -652,9 +652,13 @@ describe('reading from the store', () => {
     });
   });
 
-  it(`does cache lookups for id arguments`, () => {
+  it(`does cache lookups when defaultIdLookup is supplied`, () => {
     const dataIdFromObject = (obj: any) => {
       return obj.id;
+    };
+
+    const defaultIdLookup = (obj: any, args: any): string => {
+      return args.id;
     };
 
     const listQuery = gql`{ people { id name } }`;
@@ -682,6 +686,7 @@ describe('reading from the store', () => {
     const client = new ApolloClient({
       networkInterface,
       dataIdFromObject,
+      defaultIdLookup,
     });
 
     return client.query({ query: listQuery }).then(() => {

--- a/test/readFromStore.ts
+++ b/test/readFromStore.ts
@@ -1,10 +1,14 @@
+import mockNetworkInterface from './mocks/mockNetworkInterface';
 import { assert } from 'chai';
+import ApolloClient, { toIdValue } from '../src';
 import assign = require('lodash/assign');
 import omit = require('lodash/omit');
 
 import {
   readQueryFromStore,
 } from '../src/data/readFromStore';
+
+import { NetworkStatus } from '../src/queries/store';
 
 import {
   NormalizedCache,
@@ -645,6 +649,55 @@ describe('reading from the store', () => {
       stringField: result['stringField'],
       numberField: result['numberField'],
       computedField: 'This is a string!5bit',
+    });
+  });
+
+  it(`does cache lookups for id arguments`, () => {
+    const dataIdFromObject = (obj: any) => {
+      return obj.id;
+    };
+
+    const listQuery = gql`{ people { id name } }`;
+
+    const listData = {
+      people: [
+        {
+          id: '4',
+          name: 'Luke Skywalker',
+          __typename: 'Person',
+        },
+      ],
+    };
+
+    const netListQuery = gql`{ people { id name __typename } }`;
+
+    const itemQuery = gql`{ person(id: 4) { id name } }`;
+
+    // We don't expect the item query to go to the server at all
+    const networkInterface = mockNetworkInterface({
+      request: { query: netListQuery },
+      result: { data: listData },
+    });
+
+    const client = new ApolloClient({
+      networkInterface,
+      dataIdFromObject,
+    });
+
+    return client.query({ query: listQuery }).then(() => {
+      return client.query({ query: itemQuery });
+    }).then((itemResult) => {
+      assert.deepEqual(itemResult, {
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        data: {
+          person: {
+            __typename: 'Person',
+            id: '4',
+            name: 'Luke Skywalker',
+          },
+        },
+      });
     });
   });
 });


### PR DESCRIPTION
I wanted to open this issue as a PR because its sometimes easier to convey ideas that way.

This PR makes this issue https://github.com/apollostack/apollo-client/issues/332 automatic.

When typing [this message](https://apollographql.slack.com/archives/general/p1481622624001992) it felt a bit unnecessary since every field which would like to use local cache lookups will look exactly the same.

Based on my experience from working with apollo and relay, as well as the reactions from people in the chat, I'd say people assume that this functionality is present. Writing resolvers for your own cache is not expected behaviour.

This PR is not a good implementation, but it works and I figured I'd start here. I dont think everyone wants this, so it might be good to hide behind a flag. Also, not everyone uses the literal `id` as the id param.

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [X] Rebase your changes on master so that they can be merged easily
- [X] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change
- [ ] Add your name and email to the AUTHORS file (optional)
- [ ] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion

