### PR TITLE
Removed explicit typing for NodeJS.Timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 3 to 6 months), to signal the start of a more stable API.
 
 ### vNEXT
-- Removed explicit node typings so as to not impose node typings on projects that depend on apollo-client. [PR #1248](https://github.com/apollostack/apollo-client/pull/1248)
+- Removed dependency on Node.js typings. [PR #1248](https://github.com/apollostack/apollo-client/pull/1248)
 - ...
 
 ### 0.8.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 3 to 6 months), to signal the start of a more stable API.
 
 ### vNEXT
+- Removed explicit node typings so as to not impose node typings on projects that depend on apollo-client. [PR #1248](https://github.com/apollostack/apollo-client/pull/1248)
 - ...
 
 ### 0.8.1

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -115,7 +115,7 @@ import { WatchQueryOptions } from './watchQueryOptions';
 import { ObservableQuery } from './ObservableQuery';
 
 export class QueryManager {
-  public pollingTimers: {[queryId: string]: NodeJS.Timer | any}; //oddity in Typescript
+  public pollingTimers: {[queryId: string]: any}; // intended for NodeJS.Timer | any
   public scheduler: QueryScheduler;
   public store: ApolloStore;
 

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -115,7 +115,7 @@ import { WatchQueryOptions } from './watchQueryOptions';
 import { ObservableQuery } from './ObservableQuery';
 
 export class QueryManager {
-  public pollingTimers: {[queryId: string]: any}; // intended for NodeJS.Timer | any
+  public pollingTimers: {[queryId: string]: any};
   public scheduler: QueryScheduler;
   public store: ApolloStore;
 

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -40,7 +40,7 @@ export class QueryScheduler {
   public queryManager: QueryManager;
 
   // Map going from polling interval widths to polling timers.
-  private pollingTimers: { [interval: number]: NodeJS.Timer | any }; // oddity in Typescript
+  private pollingTimers: { [interval: number]: any }; // intended for NodeJS.Timer | any
 
   constructor({
     queryManager,

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -40,7 +40,7 @@ export class QueryScheduler {
   public queryManager: QueryManager;
 
   // Map going from polling interval widths to polling timers.
-  private pollingTimers: { [interval: number]: any }; // intended for NodeJS.Timer | any
+  private pollingTimers: { [interval: number]: any };
 
   constructor({
     queryManager,

--- a/src/transport/batching.ts
+++ b/src/transport/batching.ts
@@ -25,7 +25,7 @@ export class QueryBatcher {
   public queuedRequests: QueryFetchRequest[] = [];
 
   private pollInterval: Number;
-  private pollTimer: NodeJS.Timer | any; //oddity in Typescript
+  private pollTimer: any; // intended for NodeJS.Timer | any
 
   //This function is called to the queries in the queue to the server.
   private batchFetchFunction: (request: Request[]) => Promise<ExecutionResult[]>;

--- a/src/transport/batching.ts
+++ b/src/transport/batching.ts
@@ -25,7 +25,7 @@ export class QueryBatcher {
   public queuedRequests: QueryFetchRequest[] = [];
 
   private pollInterval: Number;
-  private pollTimer: any; // intended for NodeJS.Timer | any
+  private pollTimer: any;
 
   //This function is called to the queries in the queue to the server.
   private batchFetchFunction: (request: Request[]) => Promise<ExecutionResult[]>;


### PR DESCRIPTION
Removed explicit typing for NodeJS.Timer so as to not impose node typings on projects that depend on apollo-client

PR per Issue: https://github.com/apollographql/apollo-client/issues/1247
All tests passing, lint passing, compiles without error.
