### PR TITLE
return error and data

### DIFF
--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -134,7 +134,19 @@ export class ObservableQuery<T> extends Observable<ApolloQueryResult<T>> {
         graphQLErrors: queryStoreValue.graphQLErrors,
         networkError: queryStoreValue.networkError,
       });
-      return { data: {}, loading: false, networkStatus: queryStoreValue.networkStatus, error };
+
+      let returnData = data;
+      if (partial && !this.options.returnPartialData) {
+        returnData = {};
+      }
+
+      return {
+        data: returnData,
+        loading: false,
+        networkStatus: queryStoreValue.networkStatus,
+        error,
+        partial,
+      };
     }
 
     const queryLoading = !queryStoreValue || queryStoreValue.networkStatus === NetworkStatus.loading;

--- a/test/ObservableQuery.ts
+++ b/test/ObservableQuery.ts
@@ -641,6 +641,54 @@ describe('ObservableQuery', () => {
         });
     });
 
+    it('returns partial data from store when errors occurred', (done) => {
+      const queryManager = mockQueryManager({
+        request: { query, variables },
+        result: { data: dataOne },
+      }, {
+        request: { query: superQuery, variables },
+        result: { data: superDataOne, errors: [error] },
+      });
+
+      queryManager.query({ query, variables })
+        .then((result: any) => {
+          const observable = queryManager.watchQuery({
+            query: superQuery,
+            variables,
+            returnPartialData: true,
+          });
+          assert.deepEqual(observable.currentResult(), {
+            data: dataOne,
+            loading: true,
+            networkStatus: 1,
+            partial: true,
+          });
+          let handleCount = 0;
+          const subscription = observable.subscribe({
+              next: result => {
+                done(new Error('Should have received error'));
+              },
+              error: error => {
+                try {
+                  handleCount++;
+                  const subResult = observable.currentResult();
+
+                  assert.deepEqual(subResult, {
+                    data: superDataOne,
+                    loading: false,
+                    networkStatus: 7,
+                    partial: true,
+                    //error: 'Error: GraphQL error: is offline.'
+                  });
+                } catch (e) {
+                  subscription.unsubscribe();
+                  done(e);
+                }
+              },
+            });
+        });
+    });
+
     it('returns partial data from the store immediately', (done) => {
       const queryManager = mockQueryManager({
         request: { query, variables },


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

This change enables us to receive data and error if you have enabled the `returnPartialData` and given that the data returned wasn't fully satisfying the query.
if all data is there and you receive an error you will also still get the data.

I am not sure if it should be implemented in other api methods as well (only in `currentResult` atm). 
I tried adding a test but couldn't really get it to work so some help with the test would be nice.

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change
- [ ] Add your name and email to the AUTHORS file (optional)
- [ ] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion
