### PR TITLE
Expose QueryManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 3 to 6 months), to signal the start of a more stable API.
 
 ### vNEXT
-- ...
+- Add `QueryManager` as an index export [PR #1269](https://github.com/apollographql/apollo-client/pull/1269)
 
 
 ### 0.8.2

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,10 @@ import {
 } from './core/ObservableQuery';
 
 import {
+  QueryManager,
+} from './core/QueryManager';
+
+import {
   Subscription,
 } from './util/Observable';
 
@@ -100,6 +104,7 @@ export {
   WatchQueryOptions,
   MutationOptions,
   ObservableQuery,
+  QueryManager,
   MutationQueryReducersMap,
   Subscription,
   SubscriptionOptions,


### PR DESCRIPTION
It allows us to introduce `apollo-test-utils`

Why? `apollo-test-utils` uses `QueryManager` and since it's not available directly from `apollo-client` it needs to go deeper (`/core`) and deeper (`QueryManager.ts`) to get it.

Sooooo it will cause an error because some testing tools will use `QueryManager.js` file which has ES6 syntax (`import` and `export`).

By exporting `QueryManager` directly in `apollo-client` we will avoid that issue.

@helfer This way we can move on with `apollo-test-utils`