### PR TITLE
Add imperative read method to ApolloClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 3 to 6 months), to signal the start of a more stable API.
 
 ### vNEXT
-- Add imperitive `read` method to client for arbitrary data access from the store. [PR #1280](https://github.com/apollographql/apollo-client/pull/1280)
+- Add imperative `read` method to client for arbitrary data access from the store. [PR #1280](https://github.com/apollographql/apollo-client/pull/1280)
 
 ### 0.8.4
 - Fix afterware to support retrying requests [PR #1274](https://github.com/apollostack/apollo-client/pull/1274).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 3 to 6 months), to signal the start of a more stable API.
 
 ### vNEXT
-
+- Add imperitive `read` method to client for arbitrary data access from the store. [PR #1280](https://github.com/apollographql/apollo-client/pull/1280)
 
 ### 0.8.3
 - Fix bug that caused query reducers to always be called with initial variables. [PR #1270](https://github.com/apollostack/apollo-client/pull/1270).

--- a/src/ApolloClient.ts
+++ b/src/ApolloClient.ts
@@ -377,11 +377,13 @@ export default class ApolloClient {
     id,
     fragment,
     fragmentName,
+    variables,
     returnPartialData,
   }: {
     id: string,
     fragment: DocumentNode,
     fragmentName?: string,
+    variables?: Object,
     returnPartialData?: boolean,
   }): FragmentType {
     this.initStore();
@@ -430,6 +432,7 @@ export default class ApolloClient {
       rootId: id,
       store: reduxRootSelector(this.store.getState()).data,
       query,
+      variables,
       returnPartialData,
     });
   }

--- a/src/data/readFromStore.ts
+++ b/src/data/readFromStore.ts
@@ -56,6 +56,7 @@ export type ReadQueryOptions = {
   variables?: Object,
   returnPartialData?: boolean,
   previousResult?: any,
+  rootId?: string,
   config?: ApolloReducerConfig,
 };
 
@@ -247,6 +248,7 @@ export function diffQueryAgainstStore({
   variables,
   returnPartialData = true,
   previousResult,
+  rootId = 'ROOT_QUERY',
   config,
 }: ReadQueryOptions): DiffResult {
   // Throw the right validation error by trying to find a query in the document
@@ -264,7 +266,7 @@ export function diffQueryAgainstStore({
 
   const rootIdValue = {
     type: 'id',
-    id: 'ROOT_QUERY',
+    id: rootId,
     previousResult,
   };
 

--- a/test/ApolloClient.ts
+++ b/test/ApolloClient.ts
@@ -1,0 +1,179 @@
+import { assert } from 'chai';
+import gql from 'graphql-tag';
+import { Store } from '../src/store';
+import ApolloClient from '../src/ApolloClient';
+
+describe('ApolloClient', () => {
+  describe('read', () => {
+    it('will read some data from state', () => {
+      const client = new ApolloClient({
+        initialState: {
+          apollo: {
+            data: {
+              'ROOT_QUERY': {
+                a: 1,
+                b: 2,
+                c: 3,
+              },
+            },
+          },
+        },
+      });
+
+      assert.deepEqual(client.read({ selection: gql`{ a }` }), { a: 1 });
+      assert.deepEqual(client.read({ selection: gql`{ b c }` }), { b: 2, c: 3 });
+      assert.deepEqual(client.read({ selection: gql`{ a b c }` }), { a: 1, b: 2, c: 3 });
+    });
+
+    it('will read some deeply nested data from state', () => {
+      const client = new ApolloClient({
+        initialState: {
+          apollo: {
+            data: {
+              'ROOT_QUERY': {
+                a: 1,
+                b: 2,
+                c: 3,
+                d: {
+                  type: 'id',
+                  id: 'foo',
+                  generated: false,
+                },
+              },
+              'foo': {
+                e: 4,
+                f: 5,
+                g: 6,
+                h: {
+                  type: 'id',
+                  id: 'bar',
+                  generated: false,
+                },
+              },
+              'bar': {
+                i: 7,
+                j: 8,
+                k: 9,
+              },
+            },
+          },
+        },
+      });
+
+      assert.deepEqual(
+        client.read({ selection: gql`{ a d { e } }` }),
+        { a: 1, d: { e: 4 } },
+      );
+      assert.deepEqual(
+        client.read({ selection: gql`{ a d { e h { i } } }` }),
+        { a: 1, d: { e: 4, h: { i: 7 } } },
+      );
+      assert.deepEqual(
+        client.read({ selection: gql`{ a b c d { e f g h { i j k } } }` }),
+        { a: 1, b: 2, c: 3, d: { e: 4, f: 5, g: 6, h: { i: 7, j: 8, k: 9 } } },
+      );
+    });
+
+    it('will read some deeply nested data from state at any id', () => {
+      const client = new ApolloClient({
+        initialState: {
+          apollo: {
+            data: {
+              'ROOT_QUERY': {
+                a: 1,
+                b: 2,
+                c: 3,
+                d: {
+                  type: 'id',
+                  id: 'foo',
+                  generated: false,
+                },
+              },
+              'foo': {
+                e: 4,
+                f: 5,
+                g: 6,
+                h: {
+                  type: 'id',
+                  id: 'bar',
+                  generated: false,
+                },
+              },
+              'bar': {
+                i: 7,
+                j: 8,
+                k: 9,
+              },
+            },
+          },
+        },
+      });
+
+      assert.deepEqual(
+        client.read({ selection: gql`{ e h { i } }`, id: 'foo' }),
+        { e: 4, h: { i: 7 } },
+      );
+      assert.deepEqual(
+        client.read({ selection: gql`{ e f g h { i j k } }`, id: 'foo' }),
+        { e: 4, f: 5, g: 6, h: { i: 7, j: 8, k: 9 } },
+      );
+      assert.deepEqual(
+        client.read({ selection: gql`{ i }`, id: 'bar' }),
+        { i: 7 },
+      );
+      assert.deepEqual(
+        client.read({ selection: gql`{ i j k }`, id: 'bar' }),
+        { i: 7, j: 8, k: 9 },
+      );
+    });
+
+    it('will read some data from state with variables', () => {
+      const client = new ApolloClient({
+        initialState: {
+          apollo: {
+            data: {
+              'ROOT_QUERY': {
+                'field({"literal":true,"value":42})': 1,
+                'field({"literal":false,"value":42})': 2,
+              },
+            },
+          },
+        },
+      });
+
+      assert.deepEqual(client.read({
+        selection: gql`{
+          a: field(literal: true, value: 42)
+          b: field(literal: $literal, value: $value)
+        }`,
+        variables: {
+          literal: false,
+          value: 42,
+        },
+      }), { a: 1, b: 2 });
+    });
+
+    it('will read some parital data from state', () => {
+      const client = new ApolloClient({
+        initialState: {
+          apollo: {
+            data: {
+              'ROOT_QUERY': {
+                a: 1,
+                b: 2,
+                c: 3,
+              },
+            },
+          },
+        },
+      });
+
+      assert.deepEqual(client.read({ selection: gql`{ a }`, returnPartialData: true }), { a: 1 });
+      assert.deepEqual(client.read({ selection: gql`{ b c }`, returnPartialData: true }), { b: 2, c: 3 });
+      assert.deepEqual(client.read({ selection: gql`{ a b c }`, returnPartialData: true }), { a: 1, b: 2, c: 3 });
+      assert.deepEqual(client.read({ selection: gql`{ a d }`, returnPartialData: true }), { a: 1 });
+      assert.deepEqual(client.read({ selection: gql`{ b c d }`, returnPartialData: true }), { b: 2, c: 3 });
+      assert.deepEqual(client.read({ selection: gql`{ a b c d }`, returnPartialData: true }), { a: 1, b: 2, c: 3 });
+    });
+  });
+});

--- a/test/ApolloClient.ts
+++ b/test/ApolloClient.ts
@@ -4,7 +4,7 @@ import { Store } from '../src/store';
 import ApolloClient from '../src/ApolloClient';
 
 describe('ApolloClient', () => {
-  describe('read', () => {
+  describe('readQuery', () => {
     it('will read some data from state', () => {
       const client = new ApolloClient({
         initialState: {
@@ -20,9 +20,9 @@ describe('ApolloClient', () => {
         },
       });
 
-      assert.deepEqual(client.read({ selection: gql`{ a }` }), { a: 1 });
-      assert.deepEqual(client.read({ selection: gql`{ b c }` }), { b: 2, c: 3 });
-      assert.deepEqual(client.read({ selection: gql`{ a b c }` }), { a: 1, b: 2, c: 3 });
+      assert.deepEqual(client.readQuery({ query: gql`{ a }` }), { a: 1 });
+      assert.deepEqual(client.readQuery({ query: gql`{ b c }` }), { b: 2, c: 3 });
+      assert.deepEqual(client.readQuery({ query: gql`{ a b c }` }), { a: 1, b: 2, c: 3 });
     });
 
     it('will read some deeply nested data from state', () => {
@@ -61,69 +61,16 @@ describe('ApolloClient', () => {
       });
 
       assert.deepEqual(
-        client.read({ selection: gql`{ a d { e } }` }),
+        client.readQuery({ query: gql`{ a d { e } }` }),
         { a: 1, d: { e: 4 } },
       );
       assert.deepEqual(
-        client.read({ selection: gql`{ a d { e h { i } } }` }),
+        client.readQuery({ query: gql`{ a d { e h { i } } }` }),
         { a: 1, d: { e: 4, h: { i: 7 } } },
       );
       assert.deepEqual(
-        client.read({ selection: gql`{ a b c d { e f g h { i j k } } }` }),
+        client.readQuery({ query: gql`{ a b c d { e f g h { i j k } } }` }),
         { a: 1, b: 2, c: 3, d: { e: 4, f: 5, g: 6, h: { i: 7, j: 8, k: 9 } } },
-      );
-    });
-
-    it('will read some deeply nested data from state at any id', () => {
-      const client = new ApolloClient({
-        initialState: {
-          apollo: {
-            data: {
-              'ROOT_QUERY': {
-                a: 1,
-                b: 2,
-                c: 3,
-                d: {
-                  type: 'id',
-                  id: 'foo',
-                  generated: false,
-                },
-              },
-              'foo': {
-                e: 4,
-                f: 5,
-                g: 6,
-                h: {
-                  type: 'id',
-                  id: 'bar',
-                  generated: false,
-                },
-              },
-              'bar': {
-                i: 7,
-                j: 8,
-                k: 9,
-              },
-            },
-          },
-        },
-      });
-
-      assert.deepEqual(
-        client.read({ selection: gql`{ e h { i } }`, id: 'foo' }),
-        { e: 4, h: { i: 7 } },
-      );
-      assert.deepEqual(
-        client.read({ selection: gql`{ e f g h { i j k } }`, id: 'foo' }),
-        { e: 4, f: 5, g: 6, h: { i: 7, j: 8, k: 9 } },
-      );
-      assert.deepEqual(
-        client.read({ selection: gql`{ i }`, id: 'bar' }),
-        { i: 7 },
-      );
-      assert.deepEqual(
-        client.read({ selection: gql`{ i j k }`, id: 'bar' }),
-        { i: 7, j: 8, k: 9 },
       );
     });
 
@@ -141,8 +88,8 @@ describe('ApolloClient', () => {
         },
       });
 
-      assert.deepEqual(client.read({
-        selection: gql`{
+      assert.deepEqual(client.readQuery({
+        query: gql`query ($literal: Boolean, $value: Int) {
           a: field(literal: true, value: 42)
           b: field(literal: $literal, value: $value)
         }`,
@@ -168,12 +115,150 @@ describe('ApolloClient', () => {
         },
       });
 
-      assert.deepEqual(client.read({ selection: gql`{ a }`, returnPartialData: true }), { a: 1 });
-      assert.deepEqual(client.read({ selection: gql`{ b c }`, returnPartialData: true }), { b: 2, c: 3 });
-      assert.deepEqual(client.read({ selection: gql`{ a b c }`, returnPartialData: true }), { a: 1, b: 2, c: 3 });
-      assert.deepEqual(client.read({ selection: gql`{ a d }`, returnPartialData: true }), { a: 1 });
-      assert.deepEqual(client.read({ selection: gql`{ b c d }`, returnPartialData: true }), { b: 2, c: 3 });
-      assert.deepEqual(client.read({ selection: gql`{ a b c d }`, returnPartialData: true }), { a: 1, b: 2, c: 3 });
+      assert.deepEqual(client.readQuery({ query: gql`{ a }`, returnPartialData: true }), { a: 1 });
+      assert.deepEqual(client.readQuery({ query: gql`{ b c }`, returnPartialData: true }), { b: 2, c: 3 });
+      assert.deepEqual(client.readQuery({ query: gql`{ a b c }`, returnPartialData: true }), { a: 1, b: 2, c: 3 });
+      assert.deepEqual(client.readQuery({ query: gql`{ a d }`, returnPartialData: true }), { a: 1 });
+      assert.deepEqual(client.readQuery({ query: gql`{ b c d }`, returnPartialData: true }), { b: 2, c: 3 });
+      assert.deepEqual(client.readQuery({ query: gql`{ a b c d }`, returnPartialData: true }), { a: 1, b: 2, c: 3 });
+    });
+  });
+
+  describe('readFragment', () => {
+    it('will read some deeply nested data from state at any id', () => {
+      const client = new ApolloClient({
+        initialState: {
+          apollo: {
+            data: {
+              'ROOT_QUERY': {
+                __typename: 'Type1',
+                a: 1,
+                b: 2,
+                c: 3,
+                d: {
+                  type: 'id',
+                  id: 'foo',
+                  generated: false,
+                },
+              },
+              'foo': {
+                __typename: 'Type2',
+                e: 4,
+                f: 5,
+                g: 6,
+                h: {
+                  type: 'id',
+                  id: 'bar',
+                  generated: false,
+                },
+              },
+              'bar': {
+                __typename: 'Type3',
+                i: 7,
+                j: 8,
+                k: 9,
+              },
+            },
+          },
+        },
+      });
+
+      assert.deepEqual(
+        client.readFragment({ fragment: gql`fragment foo on Foo { e h { i } }`, id: 'foo' }),
+        { e: 4, h: { i: 7 } },
+      );
+      assert.deepEqual(
+        client.readFragment({ fragment: gql`fragment foo on Foo { e f g h { i j k } }`, id: 'foo' }),
+        { e: 4, f: 5, g: 6, h: { i: 7, j: 8, k: 9 } },
+      );
+      assert.deepEqual(
+        client.readFragment({ fragment: gql`fragment bar on Bar { i }`, id: 'bar' }),
+        { i: 7 },
+      );
+      assert.deepEqual(
+        client.readFragment({ fragment: gql`fragment bar on Bar { i j k }`, id: 'bar' }),
+        { i: 7, j: 8, k: 9 },
+      );
+      assert.deepEqual(
+        client.readFragment({
+          fragment: gql`fragment foo on Foo { e f g h { i j k } } fragment bar on Bar { i j k }`,
+          id: 'foo',
+          fragmentName: 'foo',
+        }),
+        { e: 4, f: 5, g: 6, h: { i: 7, j: 8, k: 9 } },
+      );
+      assert.deepEqual(
+        client.readFragment({
+          fragment: gql`fragment foo on Foo { e f g h { i j k } } fragment bar on Bar { i j k }`,
+          id: 'bar',
+          fragmentName: 'bar',
+        }),
+        { i: 7, j: 8, k: 9 },
+      );
+    });
+
+    it('will read some parital data from state', () => {
+      const client = new ApolloClient({
+        initialState: {
+          apollo: {
+            data: {
+              'x': {
+                __typename: 'Type1',
+                a: 1,
+                b: 2,
+                c: 3,
+              },
+            },
+          },
+        },
+      });
+
+      assert.deepEqual(
+        client.readFragment({ fragment: gql`fragment y on Y { a }`, returnPartialData: true, id: 'x' }),
+        { a: 1 },
+      );
+      assert.deepEqual(
+        client.readFragment({ fragment: gql`fragment y on Y { b c }`, returnPartialData: true, id: 'x' }),
+        { b: 2, c: 3 },
+      );
+      assert.deepEqual(
+        client.readFragment({ fragment: gql`fragment y on Y { a b c }`, returnPartialData: true, id: 'x' }),
+        { a: 1, b: 2, c: 3 },
+      );
+      assert.deepEqual(
+        client.readFragment({ fragment: gql`fragment y on Y { a d }`, returnPartialData: true, id: 'x' }),
+        { a: 1 },
+      );
+      assert.deepEqual(
+        client.readFragment({ fragment: gql`fragment y on Y { b c d }`, returnPartialData: true, id: 'x' }),
+        { b: 2, c: 3 },
+      );
+      assert.deepEqual(
+        client.readFragment({ fragment: gql`fragment y on Y { a b c d }`, returnPartialData: true, id: 'x' }),
+        { a: 1, b: 2, c: 3 },
+      );
+    });
+
+    it('will throw an error when there is no fragment', () => {
+      const client = new ApolloClient();
+
+      assert.throws(() => {
+        client.readFragment({ id: 'x', fragment: gql`query { a b c }` });
+      }, 'Found 0 fragments when exactly 1 was expected because `fragmentName` was not provided.');
+      assert.throws(() => {
+        client.readFragment({ id: 'x', fragment: gql`schema { query: Query }` });
+      }, 'Found 0 fragments when exactly 1 was expected because `fragmentName` was not provided.');
+    });
+
+    it('will throw an error when there is more than one fragment but no fragment name', () => {
+      const client = new ApolloClient();
+
+      assert.throws(() => {
+        client.readFragment({ id: 'x', fragment: gql`fragment a on A { a } fragment b on B { b }` });
+      }, 'Found 2 fragments when exactly 1 was expected because `fragmentName` was not provided.');
+      assert.throws(() => {
+        client.readFragment({ id: 'x', fragment: gql`fragment a on A { a } fragment b on B { b } fragment c on C { c }` });
+      }, 'Found 3 fragments when exactly 1 was expected because `fragmentName` was not provided.');
     });
   });
 });

--- a/test/ApolloClient.ts
+++ b/test/ApolloClient.ts
@@ -260,5 +260,35 @@ describe('ApolloClient', () => {
         client.readFragment({ id: 'x', fragment: gql`fragment a on A { a } fragment b on B { b } fragment c on C { c }` });
       }, 'Found 3 fragments when exactly 1 was expected because `fragmentName` was not provided.');
     });
+
+    it('will read some data from state with variables', () => {
+      const client = new ApolloClient({
+        initialState: {
+          apollo: {
+            data: {
+              'foo': {
+                __typename: 'Type1',
+                'field({"literal":true,"value":42})': 1,
+                'field({"literal":false,"value":42})': 2,
+              },
+            },
+          },
+        },
+      });
+
+      assert.deepEqual(client.readFragment({
+        id: 'foo',
+        fragment: gql`
+          fragment foo on Foo {
+            a: field(literal: true, value: 42)
+            b: field(literal: $literal, value: $value)
+          }
+        `,
+        variables: {
+          literal: false,
+          value: 42,
+        },
+      }), { a: 1, b: 2 });
+    });
   });
 });

--- a/test/readFromStore.ts
+++ b/test/readFromStore.ts
@@ -704,6 +704,17 @@ describe('reading from the store', () => {
       `,
     });
 
+    assert.deepEqual(queryResult1, {
+      stringField: 'This is a string too!',
+      numberField: 6,
+      nullField: null,
+      deepNestedObj: {
+        stringField: 'This is a deep string',
+        numberField: 7,
+        nullField: null,
+      },
+    });
+
     const queryResult2 = readQueryFromStore({
       store,
       rootId: 'abcdef',
@@ -714,17 +725,6 @@ describe('reading from the store', () => {
           nullField
         }
       `,
-    });
-
-    assert.deepEqual(queryResult1, {
-      stringField: 'This is a string too!',
-      numberField: 6,
-      nullField: null,
-      deepNestedObj: {
-        stringField: 'This is a deep string',
-        numberField: 7,
-        nullField: null,
-      },
     });
 
     assert.deepEqual(queryResult2, {

--- a/test/readFromStore.ts
+++ b/test/readFromStore.ts
@@ -648,7 +648,7 @@ describe('reading from the store', () => {
   });
 
   it('will read from an arbitrary root id', () => {
-    const result: any = {
+    const data: any = {
       id: 'abcd',
       stringField: 'This is a string!',
       numberField: 5,
@@ -669,7 +669,7 @@ describe('reading from the store', () => {
     };
 
     const store = {
-      'ROOT_QUERY': assign({}, assign({}, omit(result, 'nestedObj', 'deepNestedObj')), {
+      'ROOT_QUERY': assign({}, assign({}, omit(data, 'nestedObj', 'deepNestedObj')), {
         __typename: 'Query',
         nestedObj: {
           type: 'id',
@@ -677,14 +677,14 @@ describe('reading from the store', () => {
           generated: false,
         },
       }) as StoreObject,
-      abcde: assign({}, result.nestedObj, {
+      abcde: assign({}, data.nestedObj, {
         deepNestedObj: {
           type: 'id',
           id: 'abcdef',
           generated: false,
         },
       }) as StoreObject,
-      abcdef: result.deepNestedObj as StoreObject,
+      abcdef: data.deepNestedObj as StoreObject,
     } as NormalizedCache;
 
     const queryResult1 = readQueryFromStore({

--- a/test/readFromStore.ts
+++ b/test/readFromStore.ts
@@ -646,4 +646,91 @@ describe('reading from the store', () => {
       computedField: 'This is a string!5bit',
     });
   });
+
+  it('will read from an arbitrary root id', () => {
+    const result: any = {
+      id: 'abcd',
+      stringField: 'This is a string!',
+      numberField: 5,
+      nullField: null,
+      nestedObj: {
+        id: 'abcde',
+        stringField: 'This is a string too!',
+        numberField: 6,
+        nullField: null,
+      } as StoreObject,
+      deepNestedObj: {
+        stringField: 'This is a deep string',
+        numberField: 7,
+        nullField: null,
+      } as StoreObject,
+      nullObject: null,
+      __typename: 'Item',
+    };
+
+    const store = {
+      'ROOT_QUERY': assign({}, assign({}, omit(result, 'nestedObj', 'deepNestedObj')), {
+        __typename: 'Query',
+        nestedObj: {
+          type: 'id',
+          id: 'abcde',
+          generated: false,
+        },
+      }) as StoreObject,
+      abcde: assign({}, result.nestedObj, {
+        deepNestedObj: {
+          type: 'id',
+          id: 'abcdef',
+          generated: false,
+        },
+      }) as StoreObject,
+      abcdef: result.deepNestedObj as StoreObject,
+    } as NormalizedCache;
+
+    const queryResult1 = readQueryFromStore({
+      store,
+      rootId: 'abcde',
+      query: gql`
+        {
+          stringField
+          numberField
+          nullField
+          deepNestedObj {
+            stringField
+            numberField
+            nullField
+          }
+        }
+      `,
+    });
+
+    const queryResult2 = readQueryFromStore({
+      store,
+      rootId: 'abcdef',
+      query: gql`
+        {
+          stringField
+          numberField
+          nullField
+        }
+      `,
+    });
+
+    assert.deepEqual(queryResult1, {
+      stringField: 'This is a string too!',
+      numberField: 6,
+      nullField: null,
+      deepNestedObj: {
+        stringField: 'This is a deep string',
+        numberField: 7,
+        nullField: null,
+      },
+    });
+
+    assert.deepEqual(queryResult2, {
+      stringField: 'This is a deep string',
+      numberField: 7,
+      nullField: null,
+    });
+  });
 });

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -52,4 +52,4 @@ import './customResolvers';
 import './isEqual';
 import './cloneDeep';
 import './assign';
-import './environment'
+import './environment';

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -53,3 +53,4 @@ import './isEqual';
 import './cloneDeep';
 import './assign';
 import './environment';
+import './ApolloClient';


### PR DESCRIPTION
I told you it was pretty easy @helfer 😊

The major thing this adds is the ability to start at any id from `readQueryFromStore`. There are now tests for that functionality.

I did not add tests for the method on `ApolloClient`, yet, because it does not look like there is a test file for the `ApolloClient` class at the moment. I assume we will want one though when we add `write` as well.

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
- [ ] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion
