### PR TITLE
Do not swallow request attributes when using query batching.

### DIFF
--- a/src/transport/batching.ts
+++ b/src/transport/batching.ts
@@ -59,13 +59,9 @@ export class QueryBatcher {
       return undefined;
     }
 
-    const requests: Request[] = this.queuedRequests.map((queuedRequest) => {
-      return {
-        query: queuedRequest.request.query,
-        variables: queuedRequest.request.variables,
-        operationName: queuedRequest.request.operationName,
-      };
-    });
+    const requests: Request[] = this.queuedRequests.map(
+      (queuedRequest) => queuedRequest.request,
+    );
 
     const promises: (Promise<ExecutionResult> | undefined)[] = [];
     const resolvers: any[] = [];


### PR DESCRIPTION
I am currently trying to get batching working with persisted queries (https://github.com/apollographql/persistgraphql). Very recently, a PR has been merged which makes this much easier. However, the batching network interface from apollo-client currently swallows every request values except for "query", "operationName", and "variables".

The change in this PR simply pipes through any properties from the request objects in the batch.