### PR TITLE
Use `fetchMore` network status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 3 to 6 months), to signal the start of a more stable API.
 
 ### vNEXT
+- Add `fetchMore` network status to enable loading information for `fetchMore` queries. [PR #1305](https://github.com/apollographql/apollo-client/pull/1305)
 - ...
 
 ### 0.8.6

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,7 +27,7 @@ As stated before, the list below is not exhaustive. **Apollo Client is a communi
 ### UI integration ergonomics
 - [x] 'Immutable' results
 - [x] Deep-freezing of results in development mode
-- [ ] `fetchMore` network status
+- [x] `fetchMore` network status
 
 ### Performance
 - [x] Query deduplication

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -18,6 +18,7 @@ export type QueryResultAction = {
   document: DocumentNode;
   operationName: string;
   requestId: number;
+  fetchMoreForQueryId?: string;
   extraReducers?: ApolloReducer[];
 };
 
@@ -30,6 +31,7 @@ export interface QueryErrorAction {
   error: Error;
   queryId: string;
   requestId: number;
+  fetchMoreForQueryId?: string;
 }
 
 export function isQueryErrorAction(action: ApolloAction): action is QueryErrorAction {
@@ -48,6 +50,7 @@ export interface QueryInitAction {
   storePreviousVariables: boolean;
   isRefetch: boolean;
   isPoll: boolean;
+  fetchMoreForQueryId?: string;
   metadata: any;
 }
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -228,7 +228,7 @@ export class ObservableQuery<T> extends Observable<ApolloQueryResult<T>> {
           query: combinedOptions.query,
           forceFetch: true,
         } as WatchQueryOptions;
-        return this.queryManager.fetchQuery(qid, combinedOptions);
+        return this.queryManager.fetchQuery(qid, combinedOptions, FetchType.normal, this.queryId);
       })
       .then((fetchMoreResult) => {
         const reducer = fetchMoreOptions.updateQuery;

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -482,7 +482,16 @@ export class QueryManager {
     return resPromise;
   }
 
-  public fetchQuery<T>(queryId: string, options: WatchQueryOptions, fetchType?: FetchType): Promise<ApolloQueryResult<T>> {
+  public fetchQuery<T>(
+    queryId: string,
+    options: WatchQueryOptions,
+    fetchType?: FetchType,
+
+    // This allows us to track if this is a query spawned by a `fetchMore`
+    // call for another query. We need this data to compute the `fetchMore`
+    // network status for the query this is fetching for.
+    fetchMoreForQueryId?: string,
+  ): Promise<ApolloQueryResult<T>> {
     const {
       variables = {},
       forceFetch = false,
@@ -536,6 +545,7 @@ export class QueryManager {
       storePreviousVariables: shouldFetch,
       isPoll: fetchType === FetchType.poll,
       isRefetch: fetchType === FetchType.refetch,
+      fetchMoreForQueryId,
       metadata,
     });
 
@@ -559,6 +569,7 @@ export class QueryManager {
         queryId,
         document: queryDoc,
         options,
+        fetchMoreForQueryId,
       });
     }
 
@@ -900,11 +911,13 @@ export class QueryManager {
     queryId,
     document,
     options,
+    fetchMoreForQueryId,
   }: {
     requestId: number,
     queryId: string,
     document: DocumentNode,
     options: WatchQueryOptions,
+    fetchMoreForQueryId?: string,
   }): Promise<ExecutionResult> {
     const {
       variables,
@@ -933,6 +946,7 @@ export class QueryManager {
             result,
             queryId,
             requestId,
+            fetchMoreForQueryId,
             extraReducers,
           });
 
@@ -985,6 +999,7 @@ export class QueryManager {
               error,
               queryId,
               requestId,
+              fetchMoreForQueryId,
             });
 
             this.removeFetchQueryPromise(requestId);

--- a/src/queries/networkStatus.ts
+++ b/src/queries/networkStatus.ts
@@ -17,7 +17,7 @@ export enum NetworkStatus {
 
   /**
    * Indicates that `fetchMore` was called on this query and that the query created is currently in
-   * flight. As of commit `389d87a` this network status is not in use.
+   * flight.
    */
   fetchMore = 3,
 

--- a/test/fetchMore.ts
+++ b/test/fetchMore.ts
@@ -4,6 +4,7 @@ const { assert } = chai;
 import mockNetworkInterface from './mocks/mockNetworkInterface';
 import ApolloClient from '../src';
 import { ObservableQuery } from '../src/core/ObservableQuery';
+import { NetworkStatus } from '../src/queries/networkStatus';
 
 import { assign, cloneDeep } from 'lodash';
 
@@ -286,6 +287,120 @@ describe('fetchMore on an observable query', () => {
         assert.equal(comments[i - 1].text, `new comment ${i}`);
       }
       unsetup();
+    });
+  });
+
+  it('will set the network status to `fetchMore`', done => {
+    networkInterface = mockNetworkInterface(
+      { request: { query, variables }, result, delay: 5 },
+      { request: { query, variables: variablesMore }, result: resultMore, delay: 5 },
+    );
+
+    client = new ApolloClient({
+      networkInterface,
+      addTypename: true,
+    });
+
+    const observable = client.watchQuery({
+      query,
+      variables,
+      notifyOnNetworkStatusChange: true,
+    });
+
+    let count = 0;
+    observable.subscribe({
+      next: ({ data, networkStatus }) => {
+        switch (count++) {
+          case 0:
+            assert.equal(networkStatus, NetworkStatus.ready);
+            assert.equal((data as any).entry.comments.length, 10);
+            observable.fetchMore({
+              variables: { start: 10 },
+              updateQuery: (prev, options) => {
+                const state = cloneDeep(prev) as any;
+                state.entry.comments = [...state.entry.comments, ...(options.fetchMoreResult as any).data.entry.comments];
+                return state;
+              },
+            });
+            break;
+          case 1:
+            assert.equal(networkStatus, NetworkStatus.fetchMore);
+            assert.equal((data as any).entry.comments.length, 10);
+            break;
+          case 2:
+            assert.equal(networkStatus, NetworkStatus.ready);
+            assert.equal((data as any).entry.comments.length, 10);
+            break;
+          case 3:
+            assert.equal(networkStatus, NetworkStatus.ready);
+            assert.equal((data as any).entry.comments.length, 20);
+            done();
+            break;
+          default:
+            done(new Error('`next` called to many times'));
+        }
+      },
+      error: error => done(error),
+      complete: () => done(new Error('Should not have completed')),
+    });
+  });
+
+  it('will get an error from `fetchMore` if thrown', done => {
+    networkInterface = mockNetworkInterface(
+      { request: { query, variables }, result, delay: 5 },
+      { request: { query, variables: variablesMore }, error: new Error('Uh, oh!'), delay: 5 },
+    );
+
+    client = new ApolloClient({
+      networkInterface,
+      addTypename: true,
+    });
+
+    const observable = client.watchQuery({
+      query,
+      variables,
+      notifyOnNetworkStatusChange: true,
+    });
+
+    let count = 0;
+    observable.subscribe({
+      next: ({ data, networkStatus }) => {
+        switch (count++) {
+          case 0:
+            assert.equal(networkStatus, NetworkStatus.ready);
+            assert.equal((data as any).entry.comments.length, 10);
+            observable.fetchMore({
+              variables: { start: 10 },
+              updateQuery: (prev, options) => {
+                const state = cloneDeep(prev) as any;
+                state.entry.comments = [...state.entry.comments, ...(options.fetchMoreResult as any).data.entry.comments];
+                return state;
+              },
+            });
+            break;
+          case 1:
+            assert.equal(networkStatus, NetworkStatus.fetchMore);
+            assert.equal((data as any).entry.comments.length, 10);
+            break;
+          default:
+            done(new Error('`next` called when it wasn’t supposed to be.'));
+        }
+      },
+      error: error => {
+        try {
+          switch (count++) {
+            case 2:
+              assert.equal(error.message, 'Network error: Uh, oh!');
+              done();
+              break;
+            default:
+              done(new Error('`error` called when it wasn’t supposed to be.'));
+          }
+        } catch (error) {
+          done(error);
+        }
+      },
+      complete: () => done(new Error('`complete` called when it wasn’t supposed to be.')),
     });
   });
 });

--- a/test/fetchMore.ts
+++ b/test/fetchMore.ts
@@ -337,7 +337,7 @@ describe('fetchMore on an observable query', () => {
             done();
             break;
           default:
-            done(new Error('`next` called to many times'));
+            done(new Error('`next` called too many times'));
         }
       },
       error: error => done(error),


### PR DESCRIPTION
Closes https://github.com/apollographql/apollo-client/issues/851

This PR makes sure that the `fetchMore` network status is set appropriately in Redux when `fetchMore` is called from `ObservableQuery`. Because `fetchMore` spawns a new query with a different id the implementation of this network status is a little tricky. It feels like the best way to do it is adding the query id we may be fetching more for to our Redux actions which will change the network status on the correct query. Unfortunately, there is no easy, clean, way to do that.

This PR also cleans up error handling for `fetchMore` so if an error is thrown in a query spawned by `fetchMore` that error will be correctly propagated back to the parent query.

I contemplated keeping the information required to compute a `fetchMore` network status out of the store until I remembered that if I did that then there would be no way to notify observers that the computation changed 😣. So into Redux it must go!

This is an item on our roadmap to 1.0.

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change