### PR TITLE
Return stale data over error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 3 to 6 months), to signal the start of a more stable API.
 
 ### vNEXT
+- Prefer stale data over partial data in cases where a user would previously get an error. [PR #1306](https://github.com/apollographql/apollo-client/pull/1306)
 - ...
 
 ### 0.8.6

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,7 +22,7 @@ As stated before, the list below is not exhaustive. **Apollo Client is a communi
 ## Features planned for 1.0
 
 ### Client-side data store integration
-- [ ] Convenience methods for interacting directly with the store (ie. read from and write to any place in the store)
+- [x] Convenience methods for interacting directly with the store (ie. read from and write to any place in the store)
 
 ### UI integration ergonomics
 - [x] 'Immutable' results

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -18,6 +18,7 @@ export type ApolloQueryResult<T> = {
   data: T;
   loading: boolean;
   networkStatus: NetworkStatus;
+  stale: boolean;
 
   // This type is different from the GraphQLResult type because it doesn't include errors.
   // Those are thrown via the standard promise/observer catch mechanism.

--- a/test/ObservableQuery.ts
+++ b/test/ObservableQuery.ts
@@ -605,6 +605,7 @@ describe('ObservableQuery', () => {
             data: dataOne,
             loading: false,
             networkStatus: 7,
+            stale: false,
           });
           const observable = queryManager.watchQuery({
             query,
@@ -667,19 +668,21 @@ describe('ObservableQuery', () => {
           // we can use this to trigger the query
           subscribeAndCount(done, observable, (handleCount, subResult) => {
             const { data, loading, networkStatus } = observable.currentResult();
-            assert.deepEqual(subResult, { data, loading, networkStatus });
+            assert.deepEqual(subResult, { data, loading, networkStatus, stale: false });
 
             if (handleCount === 1) {
               assert.deepEqual(subResult, {
                 data: dataOne,
                 loading: true,
                 networkStatus: 1,
+                stale: false,
               });
             } else if (handleCount === 2) {
               assert.deepEqual(subResult, {
                 data: superDataOne,
                 loading: false,
                 networkStatus: 7,
+                stale: false,
               });
               done();
             }
@@ -712,13 +715,14 @@ describe('ObservableQuery', () => {
 
           subscribeAndCount(done, observable, (handleCount, subResult) => {
             const { data, loading, networkStatus } = observable.currentResult();
-            assert.deepEqual(subResult, { data, loading, networkStatus });
+            assert.deepEqual(subResult, { data, loading, networkStatus, stale: false });
 
             if (handleCount === 1) {
               assert.deepEqual(subResult, {
                 data: dataTwo,
                 loading: false,
                 networkStatus: 7,
+                stale: false,
               });
               done();
             }
@@ -765,13 +769,14 @@ describe('ObservableQuery', () => {
 
         subscribeAndCount(done, observable, (count, result) => {
           const { data, loading, networkStatus } = observable.currentResult();
-          assert.deepEqual(result, { data, loading, networkStatus });
+          assert.deepEqual(result, { data, loading, networkStatus, stale: false });
 
           if (count === 1) {
             assert.deepEqual(result, {
               data: dataOne,
               loading: false,
               networkStatus: 7,
+              stale: false,
             });
             queryManager.mutate({ mutation, optimisticResponse, updateQueries });
           } else if (count === 2) {

--- a/test/customResolvers.ts
+++ b/test/customResolvers.ts
@@ -49,6 +49,7 @@ describe('custom resolvers', () => {
       assert.deepEqual(itemResult, {
         loading: false,
         networkStatus: NetworkStatus.ready,
+        stale: false,
         data: {
           person: {
             __typename: 'Person',

--- a/test/subscribeToMore.ts
+++ b/test/subscribeToMore.ts
@@ -113,7 +113,7 @@ describe('subscribeToMore', () => {
       assert.equal(counter, 3);
       assert.deepEqual(
         latestResult,
-        { data: { entry: { value: 'Amanda Liu' } }, loading: false, networkStatus: 7 },
+        { data: { entry: { value: 'Amanda Liu' } }, loading: false, networkStatus: 7, stale: false },
       );
       done();
     }, 50);
@@ -163,7 +163,7 @@ describe('subscribeToMore', () => {
       assert.equal(counter, 2);
       assert.deepEqual(
         latestResult,
-        { data: { entry: { value: 'Amanda Liu' } }, loading: false, networkStatus: 7 },
+        { data: { entry: { value: 'Amanda Liu' } }, loading: false, networkStatus: 7, stale: false },
       );
       assert.equal(errorCount, 1);
       done();
@@ -214,7 +214,7 @@ describe('subscribeToMore', () => {
       assert.equal(counter, 2);
       assert.deepEqual(
         latestResult,
-        { data: { entry: { value: 'Amanda Liu' } }, loading: false, networkStatus: 7 },
+        { data: { entry: { value: 'Amanda Liu' } }, loading: false, networkStatus: 7, stale: false },
       );
       assert.equal(errorCount, 1);
       console.error = consoleErr;

--- a/test/util/subscribeAndCount.ts
+++ b/test/util/subscribeAndCount.ts
@@ -13,8 +13,13 @@ export default function(done: MochaDone, observable: ObservableQuery<any>,
         handleCount++;
         cb(handleCount, result);
       } catch (e) {
-        subscription.unsubscribe();
-        done(e);
+        // Wrap in a `setImmediate` so that we will unsubscribe on the next
+        // tick so that we can make sure that the `subscription` has a chance
+        // to be defined.
+        setImmediate(() => {
+          subscription.unsubscribe();
+          done(e);
+        });
       }
     },
     error: done,


### PR DESCRIPTION
This adds an initial naïve implementation that prefers stale data over partial data. When we are about to update our observers and we see that we can only get partial data from the store, instead of throwing an error (which was the old behavior) we instead return the data from the last result and set a `stale` flag to true.

Theoretically, a more detailed algorithm would only return stale data for individual objects instead of the entire result, but this should be more than enough to provide a better user experience than an error.

This is another item on our 1.0 roadmap.

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change