### PR TITLE
Adding updated typescript defs for refetchQueries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Expect active development and potentially significant breaking changes in the `0
 
 ### vNEXT
 - Prefer stale data over partial data in cases where a user would previously get an error. [PR #1306](https://github.com/apollographql/apollo-client/pull/1306)
+- Update TypeScript `MutationOptions` definition with the new object type available in `refetchQueries`. [PR #1315](https://github.com/apollographql/apollo-client/pull/1315)
 - ...
 
 ### 0.8.7

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -92,10 +92,15 @@ export interface SubscriptionOptions {
   variables?: { [key: string]: any };
 };
 
+export interface RefetchQueryOptions {
+  query: DocumentNode;
+  variables?: { [key: string]: any };
+};
+
 export interface MutationOptions {
   mutation: DocumentNode;
   variables?: Object;
   optimisticResponse?: Object;
   updateQueries?: MutationQueryReducersMap;
-  refetchQueries?: string[];
+  refetchQueries?: string[] | RefetchQueryOptions[];
 }

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -8,6 +8,10 @@ import {
   MutationQueryReducersMap,
 } from '../data/mutationResults';
 
+import {
+  PureQueryOptions,
+} from './types';
+
 /**
  * We can change these options to an ObservableQuery
  */
@@ -92,15 +96,10 @@ export interface SubscriptionOptions {
   variables?: { [key: string]: any };
 };
 
-export interface RefetchQueryOptions {
-  query: DocumentNode;
-  variables?: { [key: string]: any };
-};
-
 export interface MutationOptions {
   mutation: DocumentNode;
   variables?: Object;
   optimisticResponse?: Object;
   updateQueries?: MutationQueryReducersMap;
-  refetchQueries?: string[] | RefetchQueryOptions[];
+  refetchQueries?: string[] | PureQueryOptions[];
 }


### PR DESCRIPTION
The typescript def for refetchQueries only accepts strings. Adding the option for a the object syntax as well.
