### PR TITLE
Refactor to use unfetch instead of whatwg-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "graphql-tag": "^1.1.1",
     "redux": "^3.4.0",
     "symbol-observable": "^1.0.2",
-    "whatwg-fetch": "^2.0.0"
+    "unfetch": "^1.0.1"
   },
   "devDependencies": {
     "@types/benchmark": "^1.0.30",
@@ -89,7 +89,8 @@
     "typescript": "2.1.5",
     "uglify-js": "^2.6.2",
     "webpack": "^2.1.0-beta.28",
-    "webpack-bundle-analyzer": "^2.1.1"
+    "webpack-bundle-analyzer": "^2.1.1",
+    "whatwg-fetch": "^2.0.0"
   },
   "optionalDependencies": {
     "@types/async": "^2.0.31",

--- a/src/transport/batchedNetworkInterface.ts
+++ b/src/transport/batchedNetworkInterface.ts
@@ -2,7 +2,7 @@ import {
   ExecutionResult,
 } from 'graphql';
 
-import 'whatwg-fetch';
+import './fetchPolyfill';
 
 import {
   HTTPFetchNetworkInterface,

--- a/src/transport/fetchPolyfill.ts
+++ b/src/transport/fetchPolyfill.ts
@@ -1,0 +1,12 @@
+import fetch from 'unfetch';
+
+const context: any = (
+  typeof window !== 'undefined' ? window :
+  typeof global !== 'undefined' ? global :
+  typeof self !== 'undefined' ? self :
+  {}
+);
+
+if (typeof context.fetch === 'undefined') {
+  context.fetch = fetch;
+}

--- a/src/transport/networkInterface.ts
+++ b/src/transport/networkInterface.ts
@@ -1,4 +1,4 @@
-import 'whatwg-fetch';
+import './fetchPolyfill';
 
 import {
   ExecutionResult,

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -15,3 +15,9 @@ declare module 'graphql-tag/parser' {
 declare module 'graphql-tag/printer' {
   function print(ast: any): string;
 }
+
+declare module 'unfetch' {
+  // Uses the type of fetch from `@types/whatwg-fetch`.
+  const _fetch: typeof fetch
+  export default _fetch;
+}


### PR DESCRIPTION
This is something we may consider instead of removing `whatwg-fetch` given that [`unfetch`](https://www.npmjs.com/package/unfetch) is only 500 bytes.