### PR TITLE
Remove manual stack trace setting

### DIFF
--- a/src/errors/ApolloError.ts
+++ b/src/errors/ApolloError.ts
@@ -58,9 +58,6 @@ export class ApolloError extends Error {
     this.graphQLErrors = graphQLErrors || [];
     this.networkError = networkError || null;
 
-    // set up the stack trace
-    this.stack = new Error().stack;
-
     if (!errorMessage) {
       this.message = generateErrorMessage(this);
     } else {


### PR DESCRIPTION
Removes manual stack trace setting. This is the cause of our error stack traces only showing `Error:` and not displaying a message.

- [ ] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change