### PR TITLE
export addTypenameToDocument to root export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Expect active development and potentially significant breaking changes in the `0
 ### vNEXT
 - Clear pollInterval in `ObservableQuery#stopPolling` so that resubscriptions don't start polling again [PR #1328](https://github.com/apollographql/apollo-client/pull/1328)
 - Update dependencies (Typescript 2.2.1, node typings, etc.) [PR #1332][https://github.com/apollographql/apollo-client/pull/1332]
+- Add 'addTypenameToDocument' to root export for usage in custom network interfaces and testing
 - ...
 
 ### 0.9.0

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,10 @@ import {
 } from './queries/networkStatus';
 
 import {
+  addTypenameToDocument,
+} from './queries/queryTransform';
+
+import {
   ApolloError,
 } from './errors/ApolloError';
 
@@ -80,6 +84,7 @@ export {
   readQueryFromStore,
   writeQueryToStore,
   print as printAST,
+  addTypenameToDocument,
   createFragmentMap,
   NetworkStatus,
   ApolloError,


### PR DESCRIPTION
@helfer @stubailo I ran into an issue with testing where I needed the ability to addTypename.

Since adding typename to the document is the default in apollo client, applications typically have them added to their query before flight. When we want to mock the query using the mockNetworkinterface (https://github.com/apollographql/apollo-test-utils/blob/master/src/mocks/mockNetworkInterface.ts#L200 or https://github.com/apollographql/react-apollo/blob/master/src/test-utils.tsx#L227), we need to add the typename to the query from the test. This can be done on the test level, or possibly in the react-apollo or test-utils mockNetworkInterface.

Either way, we will need the exported addTypename.

TODO:

- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
- [x] Add your name and email to the AUTHORS file (optional)

