### PR TITLE
Bumping `graphql-tag`, ignoring deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Expect active development and potentially significant breaking changes in the `0
 ### vNEXT
 - Do not stringify error stack traces [PR #1347](https://github.com/apollographql/apollo-client/pull/1347)
 
+### 0.10.1
+- Address deprecation warnings coming from `graphql-tag` [graphql-tag#54](https://github.com/apollographql/graphql-tag/issues/54)
+
 ### 0.10.0
 - BREAKING: Run middleware and afterware only once per batched request [PR #1285](https://github.com/apollographql/apollo-client/pull/1285)
 - Add direct cache manipulation read and write methods to provide the user the power to interact with Apollo’s GraphQL data representation outside of mutations. [PR #1310](https://github.com/apollographql/apollo-client/pull/1310)

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "license": "MIT",
   "dependencies": {
     "graphql-anywhere": "^2.1.0",
-    "graphql-tag": "^1.1.1",
+    "graphql-tag": "^1.3.1",
     "redux": "^3.4.0",
     "symbol-observable": "^1.0.2",
     "whatwg-fetch": "^2.0.0"
@@ -62,8 +62,8 @@
     "@types/node": "^7.0.5",
     "@types/promises-a-plus": "0.0.27",
     "@types/sinon": "^1.16.29",
-    "browserify": "^14.0.0",
     "benchmark": "^2.1.3",
+    "browserify": "^14.0.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
     "colors": "^1.1.2",
@@ -93,7 +93,7 @@
   },
   "optionalDependencies": {
     "@types/async": "^2.0.31",
-    "@types/isomorphic-fetch": "0.0.33",
-    "@types/graphql": "^0.8.0"
+    "@types/graphql": "^0.8.0",
+    "@types/isomorphic-fetch": "0.0.33"
   }
 }

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -77,7 +77,7 @@ import {
   /* tslint:enable */
 } from 'graphql';
 
-import { print } from 'graphql-tag/printer';
+import { print } from 'graphql-tag/bundledPrinter';
 
 import {
   readQueryFromStore,

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import {
 
 import {
   print,
-} from 'graphql-tag/printer';
+} from 'graphql-tag/bundledPrinter';
 
 import {
   createApolloStore,

--- a/src/transport/Deduplicator.ts
+++ b/src/transport/Deduplicator.ts
@@ -5,7 +5,7 @@ import {
 
 import {
   print,
-} from 'graphql-tag/printer';
+} from 'graphql-tag/bundledPrinter';
 
 export class Deduplicator {
 

--- a/src/transport/networkInterface.ts
+++ b/src/transport/networkInterface.ts
@@ -5,7 +5,7 @@ import {
   DocumentNode,
 } from 'graphql';
 
-import { print } from 'graphql-tag/printer';
+import { print } from 'graphql-tag/bundledPrinter';
 
 import {
   MiddlewareInterface,

--- a/test/client.ts
+++ b/test/client.ts
@@ -29,7 +29,7 @@ import gql from 'graphql-tag';
 
 import {
   print,
-} from 'graphql-tag/printer';
+} from 'graphql-tag/bundledPrinter';
 
 import { NetworkStatus } from '../src/queries/networkStatus';
 

--- a/test/getFromAST.ts
+++ b/test/getFromAST.ts
@@ -14,7 +14,7 @@ import {
   OperationDefinitionNode,
 } from 'graphql';
 
-import { print } from 'graphql-tag/printer';
+import { print } from 'graphql-tag/bundledPrinter';
 import gql from 'graphql-tag';
 import { assert } from 'chai';
 

--- a/test/mocks/mockNetworkInterface.ts
+++ b/test/mocks/mockNetworkInterface.ts
@@ -12,7 +12,7 @@ import {
 
 import {
   print,
-} from 'graphql-tag/printer';
+} from 'graphql-tag/bundledPrinter';
 
 // Pass in multiple mocked responses, so that you can test flows that end up
 // making multiple queries to the server

--- a/test/networkInterface.ts
+++ b/test/networkInterface.ts
@@ -25,7 +25,7 @@ import {
 
 import gql from 'graphql-tag';
 
-import { print } from 'graphql-tag/printer';
+import { print } from 'graphql-tag/bundledPrinter';
 
 import { withWarning } from './util/wrap';
 

--- a/test/proxy.ts
+++ b/test/proxy.ts
@@ -1,7 +1,7 @@
 import { assert } from 'chai';
 import { createStore } from 'redux';
 import gql from 'graphql-tag';
-import { print } from 'graphql-tag/printer';
+import { print } from 'graphql-tag/bundledPrinter';
 import { createApolloStore } from '../src/store';
 import { ReduxDataProxy, TransactionDataProxy } from '../src/data/proxy';
 

--- a/test/queryTransform.ts
+++ b/test/queryTransform.ts
@@ -6,7 +6,7 @@ import {
   getQueryDefinition,
 } from '../src/queries/getFromAST';
 
-import { print } from 'graphql-tag/printer';
+import { print } from 'graphql-tag/bundledPrinter';
 import gql from 'graphql-tag';
 import { assert } from 'chai';
 

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -12,6 +12,6 @@ declare module 'graphql-tag/parser' {
   ): DocumentNode;
 }
 
-declare module 'graphql-tag/printer' {
+declare module 'graphql-tag/bundledPrinter' {
   function print(ast: any): string;
 }


### PR DESCRIPTION
`graphql-tag` has deprecated the export of the `printer` export (which we use for various AST-related tasks here in `apollo-client`). when `graphql-tag@v2` comes out, we can switch to using the printer / parser from the `graphql` package, but for now we know about the deprecation warning and can safely ignore it.

addresses [graphql-tag#54](https://github.com/apollographql/graphql-tag/issues/54)

TODO:

- [ ] ~Make sure all of the significant new logic is covered by tests~
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
- [x] Add your name and email to the AUTHORS file (optional)
- [ ] ~If this was a change that affects the external API, update the docs and post a link to the PR in the discussion~
