### PR TITLE
Add introspection query transform.

### DIFF
--- a/src/data/readFromStore.ts
+++ b/src/data/readFromStore.ts
@@ -13,6 +13,7 @@ import {
   isJsonValue,
   isIdValue,
   IdValue,
+  StoreValue,
 } from './storeUtils';
 
 import {
@@ -134,7 +135,6 @@ const fragmentMatcher: FragmentMatcher = (
   context: ReadStoreContext,
 ): boolean => {
   assertIdValue(idValue);
-
   const obj = context.store[idValue.id];
 
   if (! obj) {
@@ -162,13 +162,21 @@ match fragments.`);
     return true;
   }
 
-  // XXX here we reach an issue - we don't know if this fragment should match or not. It's either:
-  // 1. A fragment on a non-matching concrete type or interface or union
-  // 2. A fragment on a matching interface or union
-  // If it's 1, we don't want to return anything, if it's 2 we want to match. We can't tell the
-  // difference, so for now, we just do our best to resolve the fragment but turn on partial data
-  context.returnPartialData = true;
-  return true;
+  const typeKeyName = storeKeyNameFromFieldNameAndArgs('__type', {
+    name: typeCondition,
+  });
+
+  const typeObj = context.store[`$ROOT_QUERY.${typeKeyName}`];
+  const possibleTypes = ((typeObj && typeObj['possibleTypes'] || []) as Array<StoreValue>)
+    .filter(isIdValue)
+    .map((idValue: IdValue) => context.store[idValue.id] && context.store[idValue.id]['name']);
+
+  if (possibleTypes && possibleTypes.some((value) => value === obj.__typename)) {
+    context.returnPartialData = true;
+    return true;
+  }
+
+  return false;
 };
 
 const readStoreResolver: Resolver = (

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,7 @@ import {
 
 import {
   addTypenameToDocument,
+  addIntrospectionToDocument,
 } from './queries/queryTransform';
 
 import {
@@ -85,6 +86,7 @@ export {
   writeQueryToStore,
   print as printAST,
   addTypenameToDocument,
+  addIntrospectionToDocument,
   createFragmentMap,
   NetworkStatus,
   ApolloError,

--- a/src/queries/queryTransform.ts
+++ b/src/queries/queryTransform.ts
@@ -1,8 +1,10 @@
 import {
   DocumentNode,
   SelectionSetNode,
+  SelectionNode,
   DefinitionNode,
   OperationDefinitionNode,
+  NamedTypeNode,
   FieldNode,
   InlineFragmentNode,
 } from 'graphql';
@@ -53,6 +55,125 @@ export function addTypenameToDocument(doc: DocumentNode) {
   docClone.definitions.forEach((definition: DefinitionNode) => {
     const isRoot = definition.kind === 'OperationDefinition';
     addTypenameToSelectionSet((definition as OperationDefinitionNode).selectionSet, isRoot);
+  });
+
+  return docClone;
+}
+
+function createIntrospectionForFragment(fragmentName: string) {
+  const field: FieldNode = {
+    kind: 'Field',
+    name: {
+      kind: 'Name',
+      value: '__type',
+    },
+    alias: {
+      kind: 'Name',
+      value: `__${fragmentName}`,
+    },
+    arguments: [{
+      kind: 'Argument',
+      name: {
+        kind: 'Name',
+        value: 'name',
+      },
+      value: {
+        kind: 'StringValue',
+        value: fragmentName,
+      },
+    }],
+    selectionSet: {
+      kind: 'SelectionSet',
+      selections: [{
+        kind: 'Field',
+        name: {
+          kind: 'Name',
+          value: 'possibleTypes',
+        },
+        selectionSet: {
+          kind: 'SelectionSet',
+          selections: [{
+            kind: 'Field',
+            name: {
+              kind: 'Name',
+              value: 'name',
+            },
+          }],
+        },
+      }],
+    },
+  };
+
+  return field;
+}
+
+function fragmentIntrospectionExists(
+  selections: Array<SelectionNode>,
+  typeCondition: NamedTypeNode,
+) {
+  return selections.some((selection) => {
+    if (selection.kind === 'Field' && selection.name.value === '__type') {
+      if (selection.alias && selection.alias.value === `__${typeCondition.name.value}`) {
+        return true;
+      }
+    }
+
+    return false;
+  });
+}
+
+function addIntrospectionToSelectionSet(
+  rootSelections: Array<SelectionNode>,
+  currentSelectionSet: SelectionSetNode,
+) {
+  if (!currentSelectionSet.selections) {
+    return;
+  }
+
+  currentSelectionSet.selections.forEach((currentSelection) => {
+    if (currentSelection.kind === 'InlineFragment') {
+      const typeCondition = (currentSelection as InlineFragmentNode).typeCondition;
+
+      if (typeCondition && !fragmentIntrospectionExists(rootSelections, typeCondition)) {
+        // We haven't seen this type condition before. Add it to our list.
+        rootSelections.push(createIntrospectionForFragment(typeCondition.name.value));
+      }
+    }
+
+    if ((currentSelection.kind === 'InlineFragment' || currentSelection.kind === 'Field') && currentSelection.selectionSet) {
+      addIntrospectionToSelectionSet(rootSelections, currentSelection.selectionSet);
+    }
+  });
+}
+
+export function addIntrospectionToDocument(doc: DocumentNode) {
+  checkDocument(doc);
+  const docClone = cloneDeep(doc);
+
+  // Find the operation that we want to add the introspection fields to.
+  const operation = docClone.definitions.find(
+    (definition) => definition.kind === 'OperationDefinition' && definition.operation === 'query',
+  );
+
+  if (!operation) {
+    // Bail out early if we didn't find a query operation.
+    return docClone;
+  }
+
+  // Add the introspection fields to the root selection set of the query.
+  const rootSelections = (operation as OperationDefinitionNode).selectionSet.selections;
+  doc.definitions.forEach((definition: DefinitionNode) => {
+    if (definition.kind === 'FragmentDefinition') {
+      if (!fragmentIntrospectionExists(rootSelections, definition.typeCondition)) {
+        // We haven't seen this type condition before. Add it to our list.
+        const introspection = createIntrospectionForFragment(definition.typeCondition.name.value);
+        rootSelections.push(introspection);
+      }
+    }
+
+    if (definition.kind === 'FragmentDefinition' || definition.kind === 'OperationDefinition') {
+      addIntrospectionToSelectionSet(rootSelections, definition.selectionSet);
+    }
   });
 
   return docClone;


### PR DESCRIPTION
As discussed in https://github.com/apollographql/apollo-client/issues/1337 I am adding a query transform to retrieve type information about inline and spread fragments together with the query. Obviously this is not ideal but it solves the SSR issue for me. We need to further discuss how to properly solve this but since I had worked on this already I wanted to submit the PR anyways.