### PR TITLE
Fix a typo in the version number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Expect active development and potentially significant breaking changes in the `0
 
 ### vNEXT
 
-### 1.0.0-rc.1
+### 1.0.0-rc.2
 - throw error if deprecated options are being used [PR #1396](https://github.com/apollographql/apollo-client/pull/1396)
 
 ### 1.0.0-rc.1


### PR DESCRIPTION
then rc-2 has been introduced in  https://github.com/apollographql/apollo-client/commit/f8e48d937a33ca0271a55dda9a7a8b6d1d0cd0eb, the wrong version string has slipped into the changelog. 
Fixing that...
