### PR TITLE
Fix documentation for reduxRootSelector, reduxRootSelector must be a function

### DIFF
--- a/src/ApolloClient.ts
+++ b/src/ApolloClient.ts
@@ -118,8 +118,8 @@ export default class ApolloClient implements DataProxy {
    * @param networkInterface The {@link NetworkInterface} over which GraphQL documents will be sent
    * to a GraphQL spec-compliant server.
    *
-   * @param reduxRootSelector Either a "selector" function that receives state from the Redux store
-   * and returns the part of it that is managed by ApolloClient or a key that points to that state.
+   * @param reduxRootSelector A "selector" function that receives state from the Redux store
+   * and returns the part of it that is managed by ApolloClient.
    * This option should only be used if the store is created outside of the client.
    *
    * @param initialState The initial state assigned to the store.


### PR DESCRIPTION
Kept the type as `string | ApolloStateSelector` so that the tests can allow for backcompat / an upgrade path

<!--
  Thanks for filing a pull request on Apollo Client!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change
- [ ] Add your name and email to the AUTHORS file (optional)
- [ ] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion
