### PR TITLE
Remove duplicate SubscriptionOptions interface

### DIFF
--- a/src/ApolloClient.ts
+++ b/src/ApolloClient.ts
@@ -283,13 +283,7 @@ export default class ApolloClient implements DataProxy {
   public subscribe(options: SubscriptionOptions): Observable<any> {
     this.initStore();
 
-    const realOptions = {
-      ...options,
-      document: options.query,
-    };
-    delete realOptions.query;
-
-    return this.queryManager.startGraphQLSubscription(realOptions);
+    return this.queryManager.startGraphQLSubscription(options);
   }
 
   /**

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -258,7 +258,7 @@ export class ObservableQuery<T> extends Observable<ApolloQueryResult<T>> {
     options: SubscribeToMoreOptions,
   ): () => void {
     const observable = this.queryManager.startGraphQLSubscription({
-      document: options.document,
+      query: options.document,
       variables: options.variables,
     });
 

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -15,7 +15,6 @@ import {
   ApolloQueryResult,
   PureQueryOptions,
   FetchType,
-  SubscriptionOptions,
 } from './types';
 
 import {
@@ -112,7 +111,10 @@ import {
   ApolloError,
 } from '../errors/ApolloError';
 
-import { WatchQueryOptions } from './watchQueryOptions';
+import {
+  WatchQueryOptions,
+  SubscriptionOptions,
+} from './watchQueryOptions';
 
 import { ObservableQuery } from './ObservableQuery';
 
@@ -751,10 +753,10 @@ export class QueryManager {
     options: SubscriptionOptions,
   ): Observable<any> {
     const {
-      document,
+      query,
       variables,
     } = options;
-    let transformedDoc = document;
+    let transformedDoc = query;
     // Apply the query transformer if one has been provided.
     if (this.addTypename) {
       transformedDoc = addTypenameToDocument(transformedDoc);

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -2,11 +2,6 @@ import { DocumentNode } from 'graphql';
 import { QueryStoreValue } from '../queries/store';
 import { NetworkStatus } from '../queries/networkStatus';
 
-export interface SubscriptionOptions {
-  document: DocumentNode;
-  variables?: { [key: string]: any };
-};
-
 export type QueryListener = (queryStoreValue: QueryStoreValue) => void;
 
 export type PureQueryOptions = {

--- a/test/graphqlSubscriptions.ts
+++ b/test/graphqlSubscriptions.ts
@@ -29,7 +29,6 @@ describe('GraphQL Subscriptions', () => {
 
   let sub1: any;
   let options: any;
-  let realOptions: any;
   let watchQueryOptions: any;
   let sub2: any;
   let commentsQuery: any;
@@ -59,19 +58,6 @@ describe('GraphQL Subscriptions', () => {
 
     options = {
       query: gql`
-        subscription UserInfo($name: String) {
-          user(name: $name) {
-            name
-          }
-        }
-      `,
-      variables: {
-          name: 'Changping Chen',
-        },
-    };
-
-    realOptions = {
-      document: gql`
         subscription UserInfo($name: String) {
           user(name: $name) {
             name
@@ -193,7 +179,7 @@ describe('GraphQL Subscriptions', () => {
       addTypename: false,
     });
 
-    const obs = queryManager.startGraphQLSubscription(realOptions);
+    const obs = queryManager.startGraphQLSubscription(options);
 
     let counter = 0;
 
@@ -232,7 +218,7 @@ describe('GraphQL Subscriptions', () => {
       addTypename: false,
     });
 
-    const sub = queryManager.startGraphQLSubscription(realOptions).subscribe({
+    const sub = queryManager.startGraphQLSubscription(options).subscribe({
       next(result) {
         assert.deepEqual(result, results[numResults].result);
         numResults++;
@@ -292,7 +278,7 @@ describe('GraphQL Subscriptions', () => {
       next: () => null,
     });
 
-    const sub = queryManager.startGraphQLSubscription(realOptions).subscribe({
+    const sub = queryManager.startGraphQLSubscription(options).subscribe({
       next(result) {
         assert.deepEqual(result, results[numResults].result);
         numResults++;


### PR DESCRIPTION
This patch removes duplicate SubscriptionOptions interface definition from types and changes it from document to query.

TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change
- [ ] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion
