### PR TITLE
WIP: Add error logging for query mismatch

### DIFF
--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -865,6 +865,7 @@ export class QueryManager {
       const data = readQueryFromStore(readOptions);
       return maybeDeepFreeze({ data, partial: false });
     } catch (e) {
+      if (readOptions.store['ROOT_QUERY']) console.warn(e.message);
       return maybeDeepFreeze({ data: {}, partial: true });
     }
   }

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -865,7 +865,10 @@ export class QueryManager {
       const data = readQueryFromStore(readOptions);
       return maybeDeepFreeze({ data, partial: false });
     } catch (e) {
-      if (readOptions.store['ROOT_QUERY']) console.warn(e.message);
+      if (readOptions.store['ROOT_QUERY']) {
+        console.warn(e.message);
+      }
+
       return maybeDeepFreeze({ data: {}, partial: true });
     }
   }


### PR DESCRIPTION
When a server result and query are mismatched, Apollo silently catches the error (from readFromStore.ts:readStoreResolver) and returns an empty data object. This has been causing a lot of grief when running tests with mockNetworkInterface from apollo-test-utils.

Added a line to emit a warning when we get an error reading data from the store.