### PR TITLE
Export HTTPBatchedNetworkInterface from the package index.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Expect active development and potentially significant breaking changes in the `0
 
 ### vNEXT
 - Added `HTTPBatchedNetworkInterface` as an index export to make it easier
-to subclass externally, consistent with `HTTPFetchNetworkInterface`.
+to subclass externally, consistent with `HTTPFetchNetworkInterface`. [PR #1446](https://github.com/apollographql/apollo-client/pull/1446)
 
 ### 1.0.0-rc.4
 - Fix: Update TypeScript Middleware and Afterware interfaces to include a datatype for 'this' in apply function. [PR #1372](https://github.com/apollographql/apollo-client/pull/1372)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 3 to 6 months), to signal the start of a more stable API.
 
 ### vNEXT
-
+- Added `HTTPBatchedNetworkInterface` as an index export to make it easier
+to subclass externally, consistent with `HTTPFetchNetworkInterface`.
 
 ### 1.0.0-rc.4
 - Fix: Update TypeScript Middleware and Afterware interfaces to include a datatype for 'this' in apply function. [PR #1372](https://github.com/apollographql/apollo-client/pull/1372)

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import {
 
 import {
   createBatchingNetworkInterface,
+  HTTPBatchedNetworkInterface,
 } from './transport/batchedNetworkInterface';
 
 import {
@@ -75,8 +76,6 @@ import {
   toIdValue,
 } from './data/storeUtils';
 
-// We expose the print method from GraphQL so that people that implement
-// custom network interfaces can turn query ASTs into query strings as needed.
 export {
   createNetworkInterface,
   createBatchingNetworkInterface,
@@ -84,25 +83,25 @@ export {
   createApolloReducer,
   readQueryFromStore,
   writeQueryToStore,
-  print as printAST,
   addTypenameToDocument,
   createFragmentMap,
   NetworkStatus,
   ApolloError,
-
   getQueryDefinition,
   getFragmentDefinitions,
   FragmentMap,
-
   Request,
-
   ApolloQueryResult,
-
   toIdValue,
 
-  // internal type definitions for export
+  // Expose the print method from GraphQL so that people that implement
+  // custom network interfaces can turn query ASTs into query strings as needed.
+  print as printAST,
+
+  // Internal type definitions
   NetworkInterface,
   HTTPFetchNetworkInterface,
+  HTTPBatchedNetworkInterface,
   FetchPolicy,
   WatchQueryOptions,
   MutationOptions,


### PR DESCRIPTION
Added `HTTPBatchedNetworkInterface` as an index export to make it easier
to subclass externally, consistent with `HTTPFetchNetworkInterface`.

Also tidied some of the whitespace and comments nearby.