### PR TITLE
Revert "Do not swallow execute errors"

### DIFF
--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -753,7 +753,10 @@ export class QueryManager {
   public startQuery<T>(queryId: string, options: WatchQueryOptions, listener: QueryListener) {
     this.addQueryListener(queryId, listener);
 
-    this.fetchQuery<T>(queryId, options);
+    this.fetchQuery<T>(queryId, options)
+    // `fetchQuery` returns a Promise. In case of a failure it should be caucht or else the
+    // console will show an `Uncaught (in promise)` message. Ignore the error for now.
+    .catch((error: Error) => undefined);
 
     return queryId;
   }


### PR DESCRIPTION
Fixes #1449.

Obvious in retrospect. Note to self for next time: when in doubt, don't merge.

Reverts apollographql/apollo-client#1133

