### PR TITLE
Make updateQuery option of subscribeToMore optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Expect active development and potentially significant breaking changes in the `0
 ### vNEXT
 - Added `HTTPBatchedNetworkInterface` as an index export to make it easier
 to subclass externally, consistent with `HTTPFetchNetworkInterface`. [PR #1446](https://github.com/apollographql/apollo-client/pull/1446)
-
+- Make `updateQuery` option of `subscribeToMore` optional [PR #1455](https://github.com/apollographql/apollo-client/pull/1455)
 
 ### 1.0.0-rc.5
 - Fix: Revert PR that caused uncaught promise rejections [PR #1133](https://github.com/apollographql/apollo-client/pull/1133)

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -262,19 +262,20 @@ export class ObservableQuery<T> extends Observable<ApolloQueryResult<T>> {
       variables: options.variables,
     });
 
-    const reducer = options.updateQuery;
-
     const subscription = observable.subscribe({
       next: (data) => {
-        const mapFn = (previousResult: Object, { variables }: { variables: Object }) => {
-          return reducer(
-            previousResult, {
-              subscriptionData: { data },
-              variables,
-            },
-          );
-        };
-        this.updateQuery(mapFn);
+        if (options.updateQuery) {
+          const reducer = options.updateQuery;
+          const mapFn = (previousResult: Object, { variables }: { variables: Object }) => {
+            return reducer(
+              previousResult, {
+                subscriptionData: { data },
+                variables,
+              },
+            );
+          };
+          this.updateQuery(mapFn);
+        }
       },
       error: (err) => {
         if (options.onError) {

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -84,7 +84,7 @@ export interface FetchMoreQueryOptions {
 export type SubscribeToMoreOptions = {
   document: DocumentNode;
   variables?: { [key: string]: any };
-  updateQuery: (previousQueryResult: Object, options: {
+  updateQuery?: (previousQueryResult: Object, options: {
     subscriptionData: { data: any },
     variables: { [key: string]: any },
   }) => Object;


### PR DESCRIPTION
This patch fix #871 using the recommendations of #879

TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
- [ ] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion
