### PR TITLE
Remove the declaration of graphql-tag/bundledPrinter

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "license": "MIT",
   "dependencies": {
     "graphql-anywhere": "^3.0.1",
-    "graphql-tag": "^1.3.1",
+    "graphql-tag": "^1.3.2",
     "redux": "^3.4.0",
     "symbol-observable": "^1.0.2",
     "whatwg-fetch": "^2.0.0"

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,18 +1,1 @@
-/*
-
-  GRAPHQL
-
-*/
-declare module 'graphql/language/parser' {
-  import { Source, ParseOptions, DocumentNode } from 'graphql';
-  // XXX figure out how to directly export this method
-  function parse(
-      source: Source | string,
-      options?: ParseOptions
-  ): DocumentNode;
-}
-
-declare module 'graphql/language/printer' {
-  function print(ast: any): string;
-}
 

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -11,7 +11,3 @@ declare module 'graphql-tag/parser' {
       options?: ParseOptions
   ): DocumentNode;
 }
-
-declare module 'graphql-tag/bundledPrinter' {
-  function print(ast: any): string;
-}


### PR DESCRIPTION
thanks to apollographql/graphql-tag#63 `graphql-tag@^1.3.2` contains declaration of `print` function.