### PR TITLE
Revert notify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Expect active development and potentially significant breaking changes in the `0
 ### vNEXT
 - Fix: `cachePolicy: cache-and-network` queries now dispatch `APOLLO_QUERY_RESULT_CLIENT` [PR #1463](https://github.com/apollographql/apollo-client/pull/1463)
 - Fix: query deduplication no longer causes query errors to prevent subsequent successful execution of the same query  [PR #1481](https://github.com/apollographql/apollo-client/pull/1481)
+- Breaking: change default of notifyOnNetworkStatusChange back to false [PR #1482](https://github.com/apollographql/apollo-client/pull/1482)
 
 
 ### 1.0.0-rc.6

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -486,7 +486,7 @@ export class QueryManager {
     getQueryDefinition(options.query);
 
     if (typeof options.notifyOnNetworkStatusChange === 'undefined') {
-      options.notifyOnNetworkStatusChange = true;
+      options.notifyOnNetworkStatusChange = false;
     }
 
     let transformedOptions = { ...options } as WatchQueryOptions;
@@ -529,7 +529,7 @@ export class QueryManager {
     }
 
     if (typeof options.notifyOnNetworkStatusChange !== 'undefined' ) {
-      throw new Error('Cannot call "query" with "notifyOnNetworkStatusChange = true" ');
+      throw new Error('Cannot call "query" with "notifyOnNetworkStatusChange" option. Only "watchQuery" has that option.');
     }
     options.notifyOnNetworkStatusChange = false;
 


### PR DESCRIPTION
This sets `notifyOnNetworkStatusChange` back to `false` by default. It was an issue because many folks were surprised that their components were re-rendering more often.

We decided that it was better to revert this change now even though it's breaking, because we assume that very few people have made the switch yet and come to rely on this feature.