### PR TITLE
Add `refetch` option to `resetStore`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 3 to 6 months), to signal the start of a more stable API.
 
 ### vNEXT
+- Add `refetch` option to `resetStore`, this allows for calling resetStore without refetching watched queries
 - Fix: `cachePolicy: cache-and-network` queries now dispatch `APOLLO_QUERY_RESULT_CLIENT` [PR #1463](https://github.com/apollographql/apollo-client/pull/1463)
 - Fix: query deduplication no longer causes query errors to prevent subsequent successful execution of the same query  [PR #1481](https://github.com/apollographql/apollo-client/pull/1481)
 - Breaking: change default of notifyOnNetworkStatusChange back to false [PR #1482](https://github.com/apollographql/apollo-client/pull/1482)

--- a/src/ApolloClient.ts
+++ b/src/ApolloClient.ts
@@ -467,9 +467,14 @@ export default class ApolloClient implements DataProxy {
    * re-execute any queries then you should make sure to stop watching any
    * active queries.
    */
-  public resetStore() {
+  public resetStore(options: {
+    refetch?: boolean,
+  } = {}) {
+    const {
+      refetch = true,
+    } = options;
     if (this.queryManager) {
-      this.queryManager.resetStore();
+      this.queryManager.resetStore(options);
     }
   };
 

--- a/src/ApolloClient.ts
+++ b/src/ApolloClient.ts
@@ -474,7 +474,7 @@ export default class ApolloClient implements DataProxy {
       refetch = true,
     } = options;
     if (this.queryManager) {
-      this.queryManager.resetStore(options);
+      this.queryManager.resetStore({ refetch });
     }
   };
 

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -721,7 +721,12 @@ export class QueryManager {
     }
   }
 
-  public resetStore(): void {
+  public resetStore(options: {
+    refetch?: boolean,
+  } = {}): void {
+    const {
+      refetch = true,
+    } = options;
     // Before we have sent the reset action to the store,
     // we can no longer rely on the results returned by in-flight
     // requests since these may depend on values that previously existed
@@ -744,15 +749,17 @@ export class QueryManager {
     // watched. If there is an existing query in flight when the store is reset,
     // the promise for it will be rejected and its results will not be written to the
     // store.
-    Object.keys(this.observableQueries).forEach((queryId) => {
-      const storeQuery = this.reduxRootSelector(this.store.getState()).queries[queryId];
+    if (refetch) {
+      Object.keys(this.observableQueries).forEach((queryId) => {
+        const storeQuery = this.reduxRootSelector(this.store.getState()).queries[queryId];
 
-      const fetchPolicy = this.observableQueries[queryId].observableQuery.options.fetchPolicy;
+        const fetchPolicy = this.observableQueries[queryId].observableQuery.options.fetchPolicy;
 
-      if (fetchPolicy !== 'cache-only') {
-        this.observableQueries[queryId].observableQuery.refetch();
-      }
-    });
+        if (fetchPolicy !== 'cache-only') {
+          this.observableQueries[queryId].observableQuery.refetch();
+        }
+      });
+    }
   }
 
   public startQuery<T>(queryId: string, options: WatchQueryOptions, listener: QueryListener) {

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -2442,6 +2442,38 @@ describe('QueryManager', () => {
       queryManager.resetStore();
     });
 
+    it('should not call refetch on a mocked Observable if refetch option is set to false', (done) => {
+      const query = gql`
+        query {
+          author {
+            firstName
+            lastName
+          }
+        }`;
+      const queryManager = mockQueryManager();
+
+      let refetchCount = 0;
+      const mockObservableQuery: ObservableQuery<any> = {
+        refetch(variables: any): Promise<ExecutionResult> {
+          refetchCount ++;
+          done();
+          return null as never;
+        },
+        options: {
+          query: query,
+        },
+        scheduler: queryManager.scheduler,
+      } as any as ObservableQuery<any>;
+
+      const queryId = 'super-fake-id';
+      queryManager.addObservableQuery<any>(queryId, mockObservableQuery);
+      queryManager.resetStore({ refetch: false});
+      setTimeout(() => {
+        assert.equal(refetchCount, 0);
+        done();
+      }, 400);
+    });
+
     it('should not call refetch on a cache-only Observable if the store is reset', (done) => {
       const query = gql`
         query {


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
- [x] Add your name and email to the AUTHORS file (optional)
- [x] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion


As per title - add the option to call resetStore without having watched queries refetched