### PR TITLE
Consistent batching related names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 3 to 6 months), to signal the start of a more stable API.
 
 ### vNEXT
+- Breaking: `createBatchingNetworkInterface` renamed `createBatchNetworkInterface`, `HTTPBatchedNetworkInterface` renamed `HTTPBatchNetworkInterface`. [PR #1497](https://github.com/apollographql/apollo-client/pull/1497)
 
 ### 1.0.0-rc.7
 - Fix: `cachePolicy: cache-and-network` queries now dispatch `APOLLO_QUERY_RESULT_CLIENT` [PR #1463](https://github.com/apollographql/apollo-client/pull/1463)

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,9 +6,9 @@ import {
 } from './transport/networkInterface';
 
 import {
-  createBatchingNetworkInterface,
-  HTTPBatchedNetworkInterface,
-} from './transport/batchedNetworkInterface';
+  createBatchNetworkInterface,
+  HTTPBatchNetworkInterface,
+} from './transport/batchNetworkInterface';
 
 import {
   print,
@@ -83,7 +83,7 @@ import {
 
 export {
   createNetworkInterface,
-  createBatchingNetworkInterface,
+  createBatchNetworkInterface,
   createApolloStore,
   createApolloReducer,
   readQueryFromStore,
@@ -109,7 +109,7 @@ export {
   // Internal type definitions
   NetworkInterface,
   HTTPFetchNetworkInterface,
-  HTTPBatchedNetworkInterface,
+  HTTPBatchNetworkInterface,
   FetchPolicy,
   WatchQueryOptions,
   MutationOptions,

--- a/src/transport/afterware.ts
+++ b/src/transport/afterware.ts
@@ -1,5 +1,5 @@
 import { HTTPFetchNetworkInterface } from './networkInterface';
-import { HTTPBatchedNetworkInterface } from './batchedNetworkInterface';
+import { HTTPBatchNetworkInterface } from './batchNetworkInterface';
 
 export interface AfterwareResponse {
   response: Response;
@@ -16,5 +16,5 @@ export interface BatchAfterwareResponse {
 }
 
 export interface BatchAfterwareInterface {
-  applyBatchAfterware(this: HTTPBatchedNetworkInterface, response: BatchAfterwareResponse, next: Function): any;
+  applyBatchAfterware(this: HTTPBatchNetworkInterface, response: BatchAfterwareResponse, next: Function): any;
 }

--- a/src/transport/batchNetworkInterface.ts
+++ b/src/transport/batchNetworkInterface.ts
@@ -40,7 +40,7 @@ export interface BatchResponseAndOptions {
 // together requests over the HTTP transport. Note that this implementation will only work correctly
 // for GraphQL server implementations that support batching. If such a server is not available, you
 // should see `addQueryMerging` instead.
-export class HTTPBatchedNetworkInterface extends BaseNetworkInterface {
+export class HTTPBatchNetworkInterface extends BaseNetworkInterface {
 
   public _middlewares: BatchMiddlewareInterface[];
   public _afterwares: BatchAfterwareInterface[];
@@ -79,7 +79,7 @@ export class HTTPBatchedNetworkInterface extends BaseNetworkInterface {
 
     return new Promise((resolve, reject) => {
       middlewarePromise.then((batchRequestAndOptions: BatchRequestAndOptions) => {
-        return this.batchedFetchFromRemoteEndpoint(batchRequestAndOptions)
+        return this.batchFetchFromRemoteEndpoint(batchRequestAndOptions)
           .then(result => {
             const httpResponse = result as Response;
 
@@ -98,7 +98,7 @@ export class HTTPBatchedNetworkInterface extends BaseNetworkInterface {
           })
           .then(responses => {
             if (typeof responses.map !== 'function') {
-              throw new Error('BatchingNetworkInterface: server response is not an array');
+              throw new Error('BatchNetworkInterface: server response is not an array');
             }
 
             type ResponseAndOptions = {
@@ -191,7 +191,7 @@ export class HTTPBatchedNetworkInterface extends BaseNetworkInterface {
     return this;
   }
 
-  private batchedFetchFromRemoteEndpoint(
+  private batchFetchFromRemoteEndpoint(
     batchRequestAndOptions: BatchRequestAndOptions,
   ): Promise<Response> {
     const options: RequestInit = {};
@@ -218,15 +218,15 @@ export class HTTPBatchedNetworkInterface extends BaseNetworkInterface {
   };
 }
 
-export interface BatchingNetworkInterfaceOptions {
+export interface BatchNetworkInterfaceOptions {
   uri: string;
   batchInterval: number;
   opts?: RequestInit;
 }
 
-export function createBatchingNetworkInterface(options: BatchingNetworkInterfaceOptions): HTTPNetworkInterface {
+export function createBatchNetworkInterface(options: BatchNetworkInterfaceOptions): HTTPNetworkInterface {
   if (! options) {
     throw new Error('You must pass an options argument to createNetworkInterface.');
   }
-  return new HTTPBatchedNetworkInterface(options.uri, options.batchInterval, options.opts || {});
+  return new HTTPBatchNetworkInterface(options.uri, options.batchInterval, options.opts || {});
 }

--- a/src/transport/batching.ts
+++ b/src/transport/batching.ts
@@ -27,7 +27,7 @@ export class QueryBatcher {
   private pollInterval: Number;
   private pollTimer: any;
 
-  //This function is called to the queries in the queue to the server.
+  // This function is called to the queries in the queue to the server.
   private batchFetchFunction: (request: Request[]) => Promise<ExecutionResult[]>;
 
   constructor({
@@ -73,9 +73,9 @@ export class QueryBatcher {
     });
 
     this.queuedRequests = [];
-    const batchedPromise = this.batchFetchFunction(requests);
+    const batchPromise = this.batchFetchFunction(requests);
 
-    batchedPromise.then((results) => {
+    batchPromise.then((results) => {
       results.forEach((result, index) => {
         resolvers[index](result);
       });

--- a/src/transport/middleware.ts
+++ b/src/transport/middleware.ts
@@ -1,5 +1,5 @@
 import { Request, HTTPFetchNetworkInterface } from './networkInterface';
-import { HTTPBatchedNetworkInterface } from './batchedNetworkInterface';
+import { HTTPBatchNetworkInterface } from './batchNetworkInterface';
 
 
 export interface MiddlewareRequest {
@@ -17,5 +17,5 @@ export interface BatchMiddlewareRequest {
 }
 
 export interface BatchMiddlewareInterface {
-  applyBatchMiddleware(this: HTTPBatchedNetworkInterface, request: BatchMiddlewareRequest, next: Function): void;
+  applyBatchMiddleware(this: HTTPBatchNetworkInterface, request: BatchMiddlewareRequest, next: Function): void;
 }

--- a/src/transport/networkInterface.ts
+++ b/src/transport/networkInterface.ts
@@ -51,7 +51,7 @@ export interface NetworkInterface {
   query(request: Request): Promise<ExecutionResult>;
 }
 
-export interface BatchedNetworkInterface extends NetworkInterface {
+export interface BatchNetworkInterface extends NetworkInterface {
   batchQuery(requests: Request[]): Promise<ExecutionResult[]>;
 }
 
@@ -87,7 +87,7 @@ export function printRequest(request: Request): PrintedRequest {
   };
 }
 
-// Provide extension point for regular network interface and batched
+// Provide extension point for regular network interface and batch
 // network interface. Should not be used directly.
 export class BaseNetworkInterface implements NetworkInterface {
   public _middlewares: MiddlewareInterface[] | BatchMiddlewareInterface[];

--- a/test/batchNetworkInterface.ts
+++ b/test/batchNetworkInterface.ts
@@ -4,7 +4,7 @@ import { merge } from 'lodash';
 
 import * as sinon from 'sinon';
 
-import { HTTPBatchedNetworkInterface } from '../src/transport/batchedNetworkInterface';
+import { HTTPBatchNetworkInterface } from '../src/transport/batchNetworkInterface';
 
 import {
   createMockFetch,
@@ -27,9 +27,9 @@ import 'whatwg-fetch';
 
 declare var fetch: any;
 
-describe('HTTPBatchedNetworkInterface', () => {
+describe('HTTPBatchNetworkInterface', () => {
   // Helper method that tests a roundtrip given a particular set of requests to the
-  // batched network interface and the
+  // batch network interface and the
   const assertRoundtrip = ({
     requestResultPairs,
     fetchFunc,
@@ -47,10 +47,10 @@ describe('HTTPBatchedNetworkInterface', () => {
     opts?: RequestInit,
   }) => {
     const url = 'http://fake.com/graphql';
-    const batchedNetworkInterface = new HTTPBatchedNetworkInterface(url, 10, opts);
+    const batchNetworkInterface = new HTTPBatchNetworkInterface(url, 10, opts);
 
-    batchedNetworkInterface.use(middlewares);
-    batchedNetworkInterface.useAfter(afterwares);
+    batchNetworkInterface.use(middlewares);
+    batchNetworkInterface.useAfter(afterwares);
 
     const printedRequests: Array<any> = [];
     const resultList: Array<any> = [];
@@ -72,7 +72,7 @@ describe('HTTPBatchedNetworkInterface', () => {
       result: createMockedIResponse(resultList),
     });
 
-    return batchedNetworkInterface.batchQuery(requestResultPairs.map(({ request }) => request))
+    return batchNetworkInterface.batchQuery(requestResultPairs.map(({ request }) => request))
       .then((results) => {
         assert.deepEqual(results, resultList);
       });
@@ -113,11 +113,11 @@ describe('HTTPBatchedNetworkInterface', () => {
   it('should construct itself correctly', () => {
     const url = 'http://notreal.com/graphql';
     const opts = {};
-    const batchedNetworkInterface = new HTTPBatchedNetworkInterface(url, 10, opts);
-    assert(batchedNetworkInterface);
-    assert.equal(batchedNetworkInterface._uri, url);
-    assert.deepEqual(batchedNetworkInterface._opts, opts);
-    assert(batchedNetworkInterface.batchQuery);
+    const batchNetworkInterface = new HTTPBatchNetworkInterface(url, 10, opts);
+    assert(batchNetworkInterface);
+    assert.equal(batchNetworkInterface._uri, url);
+    assert.deepEqual(batchNetworkInterface._opts, opts);
+    assert(batchNetworkInterface.batchQuery);
   });
 
   it('should correctly return the result for a single request', () => {

--- a/test/batching.ts
+++ b/test/batching.ts
@@ -4,12 +4,12 @@ import { QueryBatcher,
 import { assert } from 'chai';
 import { Request } from '../src/transport/networkInterface';
 import {
-  mockBatchedNetworkInterface,
+  mockBatchNetworkInterface,
 } from './mocks/mockNetworkInterface';
 import gql from 'graphql-tag';
 import { ExecutionResult } from 'graphql';
 
-const networkInterface = mockBatchedNetworkInterface();
+const networkInterface = mockBatchNetworkInterface();
 
 describe('QueryBatcher', () => {
   it('should construct', () => {
@@ -69,7 +69,7 @@ describe('QueryBatcher', () => {
         'lastName': 'Smith',
       },
     };
-    const myNetworkInterface = mockBatchedNetworkInterface(
+    const myNetworkInterface = mockBatchNetworkInterface(
       {
         request: { query },
         result: { data },
@@ -105,7 +105,7 @@ describe('QueryBatcher', () => {
       const request2: Request = {
         query,
       };
-      const NI = mockBatchedNetworkInterface(
+      const NI = mockBatchNetworkInterface(
           {
             request: { query },
             result: {data },
@@ -134,7 +134,7 @@ describe('QueryBatcher', () => {
     });
 
     it('should return a promise when we enqueue a request and resolve it with a result', (done) => {
-      const NI = mockBatchedNetworkInterface(
+      const NI = mockBatchNetworkInterface(
           {
             request: { query },
             result: { data },
@@ -189,7 +189,7 @@ describe('QueryBatcher', () => {
       query: query,
     };
     const error = new Error('Network error');
-    const myNetworkInterface = mockBatchedNetworkInterface(
+    const myNetworkInterface = mockBatchNetworkInterface(
       {
         request: { query },
         error,

--- a/test/client.ts
+++ b/test/client.ts
@@ -59,8 +59,8 @@ import {
 } from '../src/transport/networkInterface';
 
 import {
-  createBatchingNetworkInterface,
-} from '../src/transport/batchedNetworkInterface';
+  createBatchNetworkInterface,
+} from '../src/transport/batchNetworkInterface';
 
 import mockNetworkInterface from './mocks/mockNetworkInterface';
 
@@ -1719,7 +1719,7 @@ describe('client', () => {
       },
       result: createMockedIResponse([firstResult, secondResult]),
     });
-    const networkInterface = createBatchingNetworkInterface({
+    const networkInterface = createBatchNetworkInterface({
       uri: 'http://not-a-real-url.com',
       batchInterval: 5,
       opts: {},
@@ -1780,7 +1780,7 @@ describe('client', () => {
       },
       result: createMockedIResponse(firstResult),
     });
-    const networkInterface = createBatchingNetworkInterface({
+    const networkInterface = createBatchNetworkInterface({
       uri: 'http://not-a-real-url.com',
       batchInterval: 5,
       opts: {},
@@ -1791,7 +1791,7 @@ describe('client', () => {
     ]).then((results) => {
       assert.equal(true, false, 'expected response to throw an error');
     }).catch( e => {
-      assert.equal(e.message, 'BatchingNetworkInterface: server response is not an array');
+      assert.equal(e.message, 'BatchNetworkInterface: server response is not an array');
       fetch = oldFetch;
       done();
     });
@@ -1860,7 +1860,7 @@ describe('client', () => {
       },
       result: createMockedIResponse([secondResult]),
     });
-    const networkInterface = createBatchingNetworkInterface({
+    const networkInterface = createBatchNetworkInterface({
       uri: 'http://not-a-real-url.com',
       batchInterval: 5,
       opts: {},

--- a/test/mocks/mockNetworkInterface.ts
+++ b/test/mocks/mockNetworkInterface.ts
@@ -1,6 +1,6 @@
 import {
   NetworkInterface,
-  BatchedNetworkInterface,
+  BatchNetworkInterface,
   Request,
   SubscriptionNetworkInterface,
 } from '../../src/transport/networkInterface';
@@ -28,10 +28,10 @@ export function mockSubscriptionNetworkInterface(
   return new MockSubscriptionNetworkInterface(mockedSubscriptions, mockedResponses);
 }
 
-export function mockBatchedNetworkInterface(
+export function mockBatchNetworkInterface(
     ...mockedResponses: MockedResponse[],
-): BatchedNetworkInterface {
-  return new MockBatchedNetworkInterface(mockedResponses);
+): BatchNetworkInterface {
+  return new MockBatchNetworkInterface(mockedResponses);
 }
 
 export interface ParsedRequest {
@@ -183,8 +183,8 @@ export class MockSubscriptionNetworkInterface extends MockNetworkInterface imple
   }
 }
 
-export class MockBatchedNetworkInterface
-extends MockNetworkInterface implements BatchedNetworkInterface {
+export class MockBatchNetworkInterface
+extends MockNetworkInterface implements BatchNetworkInterface {
 
   public batchQuery(requests: Request[]): Promise<ExecutionResult[]> {
     const resultPromises: Promise<ExecutionResult>[] = [];

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -46,7 +46,7 @@ import './fetchMore';
 import './errors';
 import './mockNetworkInterface';
 import './graphqlSubscriptions';
-import './batchedNetworkInterface';
+import './batchNetworkInterface';
 import './ObservableQuery';
 import './subscribeToMore';
 import './customResolvers';


### PR DESCRIPTION
External API changes:

- `createBatchingNetworkInterface` renamed `createBatchNetworkInterface`.
- `HTTPBatchedNetworkInterface` renamed `HTTPBatchNetworkInterface`.

Quite a few names have been updated internally.

Fixes https://github.com/apollographql/apollo-client/issues/1448.

<!--
  Thanks for filing a pull request on Apollo Client!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
- [x] Add your name and email to the AUTHORS file (optional)
- [ ] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion
