### PR TITLE
Make fetchMore throw an error if the updateQuery option is missing

### DIFF
--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -203,6 +203,9 @@ export class ObservableQuery<T> extends Observable<ApolloQueryResult<T>> {
   public fetchMore(
     fetchMoreOptions: FetchMoreQueryOptions & FetchMoreOptions,
   ): Promise<ApolloQueryResult<T>> {
+    if (!fetchMoreOptions.updateQuery) {
+      throw new Error('updateQuery option is required. This function defines how to update the query data with the new results.');
+    }
     return Promise.resolve()
       .then(() => {
         const qid = this.queryManager.generateQueryId();


### PR DESCRIPTION
Fixes #1032

I'm not sure if the error message is too verbose.