### PR TITLE
Fix currentResult / fragment matcher

### DIFF
--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -489,6 +489,7 @@ export class ObservableQuery<T> extends Observable<ApolloQueryResult<T>> {
       },
     };
 
+
     this.queryManager.startQuery<T>(
       this.queryId,
       this.options,

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -909,6 +909,7 @@ export class QueryManager {
       variables,
       config: this.reducerConfig,
       previousResult: lastResult ? lastResult.data : undefined,
+      fragmentMatcherFunction: this.fragmentMatcher.match,
     };
 
     try {

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -354,6 +354,129 @@ export class QueryManager {
     });
   }
 
+
+  public fetchQuery<T>(
+    queryId: string,
+    options: WatchQueryOptions,
+    fetchType?: FetchType,
+
+    // This allows us to track if this is a query spawned by a `fetchMore`
+    // call for another query. We need this data to compute the `fetchMore`
+    // network status for the query this is fetching for.
+    fetchMoreForQueryId?: string,
+  ): Promise<ApolloQueryResult<T>> {
+
+    const {
+      variables = {},
+      metadata = null,
+      fetchPolicy = 'cache-first', // cache-first is the default fetch policy.
+    } = options;
+
+    const {
+      queryDoc,
+    } = this.transformQueryDocument(options);
+
+    const queryString = print(queryDoc);
+
+    let storeResult: any;
+    let needToFetch: boolean = fetchPolicy === 'network-only';
+
+    // If this is not a force fetch, we want to diff the query against the
+    // store before we fetch it from the network interface.
+    // TODO we hit the cache even if the policy is network-first. This could be unnecessary if the network is up.
+    if ( (fetchType !== FetchType.refetch && fetchPolicy !== 'network-only')) {
+      const { isMissing, result } = diffQueryAgainstStore({
+        query: queryDoc,
+        store: this.reduxRootSelector(this.store.getState()).data,
+        variables,
+        returnPartialData: true,
+        fragmentMatcherFunction: this.fragmentMatcher.match,
+        config: this.reducerConfig,
+      });
+
+      // If we're in here, only fetch if we have missing fields
+      needToFetch = isMissing || fetchPolicy === 'cache-and-network';
+
+      storeResult = result;
+    }
+
+    const shouldFetch = needToFetch && fetchPolicy !== 'cache-only';
+
+    const requestId = this.generateRequestId();
+
+
+    // Initialize query in store with unique requestId
+    this.queryDocuments[queryId] = queryDoc;
+    this.store.dispatch({
+      type: 'APOLLO_QUERY_INIT',
+      queryString,
+      document: queryDoc,
+      variables,
+      fetchPolicy,
+      queryId,
+      requestId,
+      // we store the old variables in order to trigger "loading new variables"
+      // state if we know we will go to the server
+      storePreviousVariables: shouldFetch,
+      isPoll: fetchType === FetchType.poll,
+      isRefetch: fetchType === FetchType.refetch,
+      fetchMoreForQueryId,
+      metadata,
+    });
+
+    // If there is no part of the query we need to fetch from the server (or,
+    // cachePolicy is cache-only), we just write the store result as the final result.
+    const shouldDispatchClientResult = !shouldFetch || fetchPolicy === 'cache-and-network';
+    if (shouldDispatchClientResult) {
+      this.store.dispatch({
+        type: 'APOLLO_QUERY_RESULT_CLIENT',
+        result: { data: storeResult },
+        variables,
+        document: queryDoc,
+        complete: !shouldFetch,
+        queryId,
+        requestId,
+      });
+    }
+
+    if (shouldFetch) {
+      const networkResult = this.fetchRequest({
+        requestId,
+        queryId,
+        document: queryDoc,
+        options,
+        fetchMoreForQueryId,
+      }).catch( error => {
+        // This is for the benefit of `refetch` promises, which currently don't get their errors
+        // through the store like watchQuery observers do
+        if (isApolloError(error)) {
+          throw error;
+        } else {
+          this.store.dispatch({
+            type: 'APOLLO_QUERY_ERROR',
+            error,
+            queryId,
+            requestId,
+            fetchMoreForQueryId,
+          });
+
+          this.removeFetchQueryPromise(requestId);
+
+          throw new ApolloError({
+            networkError: error,
+          });
+        };
+      });
+
+      if (fetchPolicy !== 'cache-and-network') {
+        return networkResult;
+      }
+    }
+    // If we have no query to send to the server, we should return the result
+    // found within the store.
+    return Promise.resolve({ data: storeResult });
+  }
+
   // Returns a query listener that will update the given observer based on the
   // results (or lack thereof) for a particular query.
   public queryListenerForObserver<T>(
@@ -566,24 +689,6 @@ export class QueryManager {
     });
 
     return resPromise;
-  }
-
-  public fetchQuery<T>(
-    queryId: string,
-    options: WatchQueryOptions,
-    fetchType?: FetchType,
-    fetchMoreForQueryId?: string,
-  ): Promise<ApolloQueryResult<T>> {
-
-    // putting this in front of the real fetchQuery function lets us make sure
-    // that the fragment matcher is initialized before we try to read from the store
-    if (this.fragmentMatcher.canBypassInit(options.query)) {
-      return this.fetchQueryAfterInit(queryId, options, fetchType, fetchMoreForQueryId);
-    }
-
-    return this.fragmentMatcher.ensureReady(this).then( () => {
-      return this.fetchQueryAfterInit(queryId, options, fetchType, fetchMoreForQueryId);
-    });
   }
 
   public generateQueryId() {
@@ -840,110 +945,6 @@ export class QueryManager {
     };
   }
 
-  /** This function runs fetchQuery without initializing the fragment matcher.
-   * We always want to initialize the fragment matcher, so this function should not be accessible outside.
-   * The only place we call this function from is within fetchQuery after initializing the fragment matcher.
-   */
-  private fetchQueryAfterInit<T>(
-    queryId: string,
-    options: WatchQueryOptions,
-    fetchType?: FetchType,
-
-    // This allows us to track if this is a query spawned by a `fetchMore`
-    // call for another query. We need this data to compute the `fetchMore`
-    // network status for the query this is fetching for.
-    fetchMoreForQueryId?: string,
-  ): Promise<ApolloQueryResult<T>> {
-
-    const {
-      variables = {},
-      metadata = null,
-      fetchPolicy = 'cache-first', // cache-first is the default fetch policy.
-    } = options;
-
-    const {
-      queryDoc,
-    } = this.transformQueryDocument(options);
-
-    const queryString = print(queryDoc);
-
-    let storeResult: any;
-    let needToFetch: boolean = fetchPolicy === 'network-only';
-
-    // If this is not a force fetch, we want to diff the query against the
-    // store before we fetch it from the network interface.
-    // TODO we hit the cache even if the policy is network-first. This could be unnecessary if the network is up.
-    if ( (fetchType !== FetchType.refetch && fetchPolicy !== 'network-only')) {
-      const { isMissing, result } = diffQueryAgainstStore({
-        query: queryDoc,
-        store: this.reduxRootSelector(this.store.getState()).data,
-        variables,
-        returnPartialData: true,
-        fragmentMatcherFunction: this.fragmentMatcher.match,
-        config: this.reducerConfig,
-      });
-
-      // If we're in here, only fetch if we have missing fields
-      needToFetch = isMissing || fetchPolicy === 'cache-and-network';
-
-      storeResult = result;
-    }
-
-    const requestId = this.generateRequestId();
-    const shouldFetch = needToFetch && fetchPolicy !== 'cache-only';
-
-    // Initialize query in store with unique requestId
-    this.queryDocuments[queryId] = queryDoc;
-    this.store.dispatch({
-      type: 'APOLLO_QUERY_INIT',
-      queryString,
-      document: queryDoc,
-      variables,
-      fetchPolicy,
-      queryId,
-      requestId,
-      // we store the old variables in order to trigger "loading new variables"
-      // state if we know we will go to the server
-      storePreviousVariables: shouldFetch,
-      isPoll: fetchType === FetchType.poll,
-      isRefetch: fetchType === FetchType.refetch,
-      fetchMoreForQueryId,
-      metadata,
-    });
-
-    // If there is no part of the query we need to fetch from the server (or,
-    // cachePolicy is cache-only), we just write the store result as the final result.
-    const shouldDispatchClientResult = !shouldFetch || fetchPolicy === 'cache-and-network';
-    if (shouldDispatchClientResult) {
-      this.store.dispatch({
-        type: 'APOLLO_QUERY_RESULT_CLIENT',
-        result: { data: storeResult },
-        variables,
-        document: queryDoc,
-        complete: !shouldFetch,
-        queryId,
-        requestId,
-      });
-    }
-
-    if (shouldFetch) {
-      const networkResult = this.fetchRequest({
-        requestId,
-        queryId,
-        document: queryDoc,
-        options,
-        fetchMoreForQueryId,
-      });
-
-      if (fetchPolicy !== 'cache-and-network') {
-        return networkResult;
-      }
-    }
-    // If we have no query to send to the server, we should return the result
-    // found within the store.
-    return Promise.resolve({ data: storeResult });
-  }
-
   // XXX: I think we just store this on the observable query at creation time
   // TODO LATER: rename this function. Its main role is to apply the transform, nothing else!
   private getQueryParts<T>(observableQuery: ObservableQuery<T>) {
@@ -1079,25 +1080,7 @@ export class QueryManager {
           resolve({ data: resultFromStore, loading: false, networkStatus: NetworkStatus.ready, stale: false });
           return null;
         }).catch((error: Error) => {
-          // This is for the benefit of `refetch` promises, which currently don't get their errors
-          // through the store like watchQuery observers do
-          if (isApolloError(error)) {
-            reject(error);
-          } else {
-            this.store.dispatch({
-              type: 'APOLLO_QUERY_ERROR',
-              error,
-              queryId,
-              requestId,
-              fetchMoreForQueryId,
-            });
-
-            this.removeFetchQueryPromise(requestId);
-
-            reject(new ApolloError({
-              networkError: error,
-            }));
-          }
+          reject(error);
         });
     });
 

--- a/test/ObservableQuery.ts
+++ b/test/ObservableQuery.ts
@@ -630,17 +630,17 @@ describe('ObservableQuery', () => {
       `;
 
       const peopleData = [
-          { id: 1, name: 'John Smith', sex: "male", trouserSize: 6, __typename: 'Man' },
-          { id: 2, name: 'Sara Smith', sex: "female", skirtSize: 4, __typename: 'Woman' },
-          { id: 3, name: 'Budd Deey', sex: "male", trouserSize: 10, __typename: 'Man' },
+          { id: 1, name: 'John Smith', sex: 'male', trouserSize: 6, __typename: 'Man' },
+          { id: 2, name: 'Sara Smith', sex: 'female', skirtSize: 4, __typename: 'Woman' },
+          { id: 3, name: 'Budd Deey', sex: 'male', trouserSize: 10, __typename: 'Man' },
       ];
 
       const dataOneWithTypename = {
-        people: peopleData.slice(0,2),
+        people: peopleData.slice(0, 2),
       };
 
       const dataTwoWithTypename = {
-        people: peopleData.slice(0,3),
+        people: peopleData.slice(0, 3),
       };
 
 
@@ -667,18 +667,14 @@ describe('ObservableQuery', () => {
         }),
       });
 
-      console.log('gettin ready');
-
       const observable = client.watchQuery({ query: queryWithFragment, variables, notifyOnNetworkStatusChange: true });
 
       subscribeAndCount(done, observable, (count, result) => {
-        console.log('c', count);
         const { data, loading, networkStatus } = observable.currentResult();
         try {
           assert.deepEqual(result, { data, loading, networkStatus, stale: false });
-          console.log(networkStatus, 'good');
         } catch (e) {
-          done(e)
+          done(e);
         }
 
         if (count === 1) {

--- a/test/ObservableQuery.ts
+++ b/test/ObservableQuery.ts
@@ -28,6 +28,10 @@ import {
   NetworkInterface,
 } from '../src/transport/networkInterface';
 
+import {
+  IntrospectionFragmentMatcher,
+} from '../src/data/fragmentMatcher';
+
 import wrap from './util/wrap';
 import subscribeAndCount from './util/subscribeAndCount';
 
@@ -588,6 +592,108 @@ describe('ObservableQuery', () => {
   });
 
   describe('currentResult', () => {
+
+    it('returns the same value as observableQuery.next got', (done) => {
+
+      const queryWithFragment = gql`
+        fragment MaleInfo on Man {
+          trouserSize
+          __typename
+        }
+
+        fragment FemaleInfo on Woman {
+          skirtSize
+          __typename
+        }
+
+        fragment PersonInfo on Person {
+          id
+          name
+          sex
+          ... on Man {
+              ...MaleInfo
+              __typename
+          }
+          ... on Woman {
+              ...FemaleInfo
+              __typename
+          }
+          __typename
+        }
+
+        {
+          people {
+            ...PersonInfo
+            __typename
+          }
+        }
+      `;
+
+      const peopleData = [
+          { id: 1, name: 'John Smith', sex: "male", trouserSize: 6, __typename: 'Man' },
+          { id: 2, name: 'Sara Smith', sex: "female", skirtSize: 4, __typename: 'Woman' },
+          { id: 3, name: 'Budd Deey', sex: "male", trouserSize: 10, __typename: 'Man' },
+      ];
+
+      const dataOneWithTypename = {
+        people: peopleData.slice(0,2),
+      };
+
+      const dataTwoWithTypename = {
+        people: peopleData.slice(0,3),
+      };
+
+
+      const ni = mockNetworkInterface({
+        request: { query: queryWithFragment, variables },
+        result: { data: dataOneWithTypename },
+      }, {
+        request: { query: queryWithFragment, variables },
+        result: { data: dataTwoWithTypename },
+      });
+
+      const client = new ApolloClient({
+        networkInterface: ni,
+        fragmentMatcher: new IntrospectionFragmentMatcher({
+          introspectionQueryResultData: {
+            __schema: {
+              types: [{
+                kind: 'UNION',
+                name: 'Creature',
+                possibleTypes: [{ name: 'Person' }],
+              }],
+            },
+          },
+        }),
+      });
+
+      console.log('gettin ready');
+
+      const observable = client.watchQuery({ query: queryWithFragment, variables, notifyOnNetworkStatusChange: true });
+
+      subscribeAndCount(done, observable, (count, result) => {
+        console.log('c', count);
+        const { data, loading, networkStatus } = observable.currentResult();
+        try {
+          assert.deepEqual(result, { data, loading, networkStatus, stale: false });
+          console.log(networkStatus, 'good');
+        } catch (e) {
+          done(e)
+        }
+
+        if (count === 1) {
+          observable.refetch();
+        }
+        if (count === 3) {
+          setTimeout(done, 5);
+        }
+        if (count > 3) {
+          done(new Error('Observable.next called too many times'));
+        }
+      });
+    });
+
+
     it('returns the current query status immediately', (done) => {
       const observable: ObservableQuery<any> = mockWatchQuery({
         request: { query, variables },

--- a/test/client.ts
+++ b/test/client.ts
@@ -1023,7 +1023,7 @@ describe('client', () => {
           }],
         },
       },
-    })
+    });
 
     const client = new ApolloClient({
       networkInterface,

--- a/test/client.ts
+++ b/test/client.ts
@@ -964,8 +964,6 @@ describe('client', () => {
     const client = new ApolloClient({
       networkInterface,
       fragmentMatcher: {
-        ensureReady: () => Promise.resolve(),
-        canBypassInit: () => true,
         match: fancyFragmentMatcher,
       },
     });
@@ -1007,34 +1005,29 @@ describe('client', () => {
 
     const networkInterface = mockNetworkInterface(
       {
-        request: { query: fragmentMatcherIntrospectionQuery },
-        delay: 5, // we put a delay here to make really sure the client waits
-        result: {
-          data: {
-            __schema: {
-              types: [{
-                kind: 'INTERFACE',
-                name: 'Item',
-                possibleTypes: [{
-                  name: 'ColorItem',
-                }, {
-                  name: 'MonochromeItem',
-                }],
-              }],
-            },
-          },
-        },
-      },
-      {
         request: { query },
         result: { data: result },
       });
 
-    const fm = new IntrospectionFragmentMatcher();
+    const ifm = new IntrospectionFragmentMatcher({
+      introspectionQueryResultData: {
+        __schema: {
+          types: [{
+            kind: 'UNION',
+            name: 'Item',
+            possibleTypes: [{
+              name: 'ColorItem',
+            }, {
+              name: 'MonochromeItem',
+            }],
+          }],
+        },
+      },
+    })
 
     const client = new ApolloClient({
       networkInterface,
-      fragmentMatcher: fm,
+      fragmentMatcher: ifm,
     });
 
     return client.query({ query }).then((actualResult) => {

--- a/test/fragmentMatcher.ts
+++ b/test/fragmentMatcher.ts
@@ -20,7 +20,7 @@ describe('IntrospectionFragmentMatcher', () => {
     }
   }`;
 
-  it('will throw an error if match is called before init is done', () => {
+  it('will throw an error if match is called if it is not ready', () => {
     const ifm = new IntrospectionFragmentMatcher();
     assert.throws( () => (ifm.match as any)(), /called before/ );
   });
@@ -63,117 +63,5 @@ describe('IntrospectionFragmentMatcher', () => {
 
     assert.equal(ifm.match(idValue as any, 'Item', readStoreContext), true );
     assert.equal(ifm.match(idValue as any, 'NotAnItem', readStoreContext), false );
-  });
-
-  it('works if introspection query has to be fetched', () => {
-    const ifm = new IntrospectionFragmentMatcher();
-
-    const introspectionResultData = {
-      __schema: {
-        types: [{
-          kind: 'UNION',
-          name: 'Item',
-          possibleTypes: [{
-            name: 'ItemA',
-          }, {
-            name: 'ItemB',
-          }],
-        }],
-      },
-    };
-
-    const manager = mockQueryManager({
-          request: { query: introspectionQuery },
-          result: { data: introspectionResultData },
-        });
-
-    const store = {
-      'a': {
-        __typename: 'ItemB',
-      },
-    };
-
-    const idValue = {
-      type: 'id',
-      id: 'a',
-      generated: false,
-    };
-
-    const readStoreContext = {
-      store,
-      returnPartialData: false,
-      hasMissingField: false,
-      customResolvers: {},
-    };
-
-    return ifm.ensureReady(manager)
-    .then( () => {
-      assert.equal(ifm.match(idValue as any, 'Item', readStoreContext), true );
-      assert.equal(ifm.match(idValue as any, 'NotAnItem', readStoreContext), false );
-    });
-  });
-
-  it('does not need to fetch if introspection result is cached', () => {
-    const ifm = new IntrospectionFragmentMatcher();
-
-    const introspectionResultData = {
-      __schema: {
-        types: [{
-          kind: 'UNION',
-          name: 'Item',
-          possibleTypes: [{
-            name: 'ItemA',
-          }, {
-            name: 'ItemB',
-          }],
-        }],
-      },
-    };
-
-    const client = new ApolloClient({
-      fragmentMatcher: ifm,
-      networkInterface: { query: () => { throw new Error('Must not fetch from server!'); } },
-    });
-
-    client.writeQuery({ query: introspectionQuery, data: introspectionResultData });
-    client.writeQuery({ query: gql`{ a }`, data: { a: '1' } });
-
-    return client.query({ query: gql`{ a }` })
-    .then( res => {
-      return assert.deepEqual(res.data, { a: '1' });
-    });
-  });
-
-  it('will fetch introspection query only once even if called multiple times', () => {
-    const ifm = new IntrospectionFragmentMatcher();
-
-    const introspectionResultData = {
-      __schema: {
-        types: [{
-          kind: 'UNION',
-          name: 'Item',
-          possibleTypes: [{
-            name: 'ItemA',
-          }, {
-            name: 'ItemB',
-          }],
-        }],
-      },
-    };
-
-    const manager = mockQueryManager({
-          request: { query: introspectionQuery },
-          result: { data: introspectionResultData },
-        });
-
-
-    const p = ifm.ensureReady(manager)
-    .then( () => {
-      // test that it doesn't fetch again if it's already ready
-      assert.doesNotThrow(() => ifm.ensureReady(manager));
-    });
-    // test that calling it twice in the same tick doesn't cause problems
-    assert.doesNotThrow(() => ifm.ensureReady(manager));
-    return p;
   });
 });


### PR DESCRIPTION
This PR removes the auto-init functionality from the new fragment matcher (to make it synchronous) and fixes a small bug that caused currentResult to return empty data in some circumstances.