### PR TITLE
Revert "Added default query options"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### vNEXT
 
 
+### 1.1.1
+- Fix: Remove ability to set default fetchPolicy, which broke polling queries [PR #1630](https://github.com/apollographql/apollo-client/pull/1630)
+
 ### 1.1.0
 - Feature: support default values for query variables [PR #1492](https://github.com/apollographql/apollo-client/pull/1492)
 - Fix: Pass http json parsing error to network interface afterware [PR #1596](https://github.com/apollographql/apollo-client/pull/1596)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-client",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A simple yet functional GraphQL client.",
   "main": "./lib/apollo.umd.js",
   "module": "./lib/src/index.js",

--- a/src/ApolloClient.ts
+++ b/src/ApolloClient.ts
@@ -61,7 +61,6 @@ import {
   WatchQueryOptions,
   SubscriptionOptions,
   MutationOptions,
-  FetchPolicy,
 } from './core/watchQueryOptions';
 
 import {
@@ -133,7 +132,6 @@ export default class ApolloClient implements DataProxy {
   public fieldWithArgs: (fieldName: string, args?: Object) => string;
   public version: string;
   public queryDeduplication: boolean;
-  public defaultFetchPolicy: FetchPolicy;
 
   private devToolsHookCb: Function;
   private proxy: DataProxy | undefined;
@@ -166,8 +164,6 @@ export default class ApolloClient implements DataProxy {
    * with identical parameters (query, variables, operationName) is already in flight.
    *
    * @param fragmentMatcher A function to use for matching fragment conditions in GraphQL documents
-   *
-   * @param defaultFetchPolicy Set default fetch policy for all query
    */
 
   constructor(options: {
@@ -182,7 +178,6 @@ export default class ApolloClient implements DataProxy {
     connectToDevTools?: boolean,
     queryDeduplication?: boolean,
     fragmentMatcher?: FragmentMatcherInterface,
-    defaultFetchPolicy?: FetchPolicy,
   } = {}) {
     let {
       dataIdFromObject,
@@ -198,7 +193,6 @@ export default class ApolloClient implements DataProxy {
       connectToDevTools,
       fragmentMatcher,
       queryDeduplication = true,
-      defaultFetchPolicy = 'cache-first',
     } = options;
 
     if (typeof reduxRootSelector === 'function') {
@@ -221,7 +215,6 @@ export default class ApolloClient implements DataProxy {
     this.dataId = dataIdFromObject = dataIdFromObject || defaultDataIdFromObject;
     this.fieldWithArgs = storeKeyNameFromFieldNameAndArgs;
     this.queryDeduplication = queryDeduplication;
-    this.defaultFetchPolicy = defaultFetchPolicy;
 
     if (ssrForceFetchDelay) {
       setTimeout(() => this.disableNetworkFetches = false, ssrForceFetchDelay);
@@ -294,8 +287,6 @@ export default class ApolloClient implements DataProxy {
   public watchQuery<T>(options: WatchQueryOptions): ObservableQuery<T> {
     this.initStore();
 
-    options.fetchPolicy = options.fetchPolicy || this.defaultFetchPolicy;
-
     // XXX Overwriting options is probably not the best way to do this long term...
     if (this.disableNetworkFetches && options.fetchPolicy === 'network-only') {
       options = {
@@ -318,8 +309,6 @@ export default class ApolloClient implements DataProxy {
    */
   public query<T>(options: WatchQueryOptions): Promise<ApolloQueryResult<T>> {
     this.initStore();
-
-    options.fetchPolicy = options.fetchPolicy || this.defaultFetchPolicy;
 
     if (options.fetchPolicy === 'cache-and-network') {
       throw new Error('cache-and-network fetchPolicy can only be used with watchQuery');

--- a/test/client.ts
+++ b/test/client.ts
@@ -1394,49 +1394,6 @@ describe('client', () => {
     });
   });
 
-  it('uses default query options - fetch policy', () => {
-    const query = gql`
-      query number {
-        myNumber {
-          n
-        }
-      }
-    `;
-
-    const firstFetch = {
-      myNumber: {
-        n: 1,
-      },
-    };
-    const secondFetch = {
-      myNumber: {
-        n: 2,
-      },
-    };
-
-    let networkInterface = mockNetworkInterface({
-      request: { query },
-      result: { data: firstFetch },
-    }, {
-      request: { query },
-      result: { data: secondFetch },
-    });
-
-    const client = new ApolloClient({
-      networkInterface,
-      addTypename: false,
-      defaultFetchPolicy: 'network-only',
-    });
-
-    // Run a query first to initialize the store
-    return client.query({ query })
-      // then query for real
-      .then(() => client.query({ query }))
-      .then((result) => {
-        assert.deepEqual(result.data, { myNumber: { n: 2 } });
-      });
-  });
-
   describe('deprecated options', () => {
     const query = gql`
       query people {


### PR DESCRIPTION
Reverts apollographql/apollo-client#1597

This PR broke some expectations around what fetch policies are allowed in combination with pollInterval.