### PR TITLE
FragmentMatcher warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change log
 
 ### vNEXT
-
+- Feature: Print a warning when heuristically matching fragments on interface/union [PR #1635](https://github.com/apollographql/apollo-client/pull/1635)
 
 ### 1.1.1
 - Fix: Remove ability to set default fetchPolicy, which broke polling queries [PR #1630](https://github.com/apollographql/apollo-client/pull/1630)

--- a/src/data/writeToStore.ts
+++ b/src/data/writeToStore.ts
@@ -152,13 +152,15 @@ export function writeSelectionSetToStore({
       const resultFieldKey: string = resultKeyNameFromField(selection);
       const value: any = result[resultFieldKey];
 
-      if (value !== undefined) {
-        writeFieldToStore({
-          dataId,
-          value,
-          field: selection,
-          context,
-        });
+      if (included) {
+        if (typeof value !== 'undefined') {
+          writeFieldToStore({
+            dataId,
+            value,
+            field: selection,
+            context,
+          });
+        }
       }
     } else if (isInlineFragment(selection)) {
       if (included) {

--- a/src/util/warnOnce.ts
+++ b/src/util/warnOnce.ts
@@ -1,0 +1,15 @@
+
+const haveWarned = Object.create({});
+
+export function warnOnce(msg: string, type = 'warn') {
+  if (!haveWarned[msg]) {
+    haveWarned[msg] = true;
+    switch (type) {
+      case 'error':
+        console.error(msg);
+        break;
+      default:
+        console.warn(msg);
+    }
+  }
+}

--- a/test/ApolloClient.ts
+++ b/test/ApolloClient.ts
@@ -504,13 +504,14 @@ describe('ApolloClient', () => {
       });
 
       client.writeFragment({
-        data: { e: 4, h: { id: 'bar', i: 7 } },
+        data: { __typename: 'Foo', e: 4, h: { id: 'bar', i: 7 } },
         id: 'foo',
         fragment: gql`fragment fragmentFoo on Foo { e h { i } }`,
       });
 
       assert.deepEqual(client.store.getState().apollo.data, {
         'foo': {
+          __typename: 'Foo',
           e: 4,
           h: {
             type: 'id',
@@ -531,6 +532,7 @@ describe('ApolloClient', () => {
 
       assert.deepEqual(client.store.getState().apollo.data, {
         'foo': {
+          __typename: 'Foo',
           e: 4,
           f: 5,
           g: 6,
@@ -555,6 +557,7 @@ describe('ApolloClient', () => {
 
       assert.deepEqual(client.store.getState().apollo.data, {
         'foo': {
+          __typename: 'Foo',
           e: 4,
           f: 5,
           g: 6,
@@ -579,6 +582,7 @@ describe('ApolloClient', () => {
 
       assert.deepEqual(client.store.getState().apollo.data, {
         'foo': {
+          __typename: 'Foo',
           e: 4,
           f: 5,
           g: 6,
@@ -604,6 +608,7 @@ describe('ApolloClient', () => {
 
       assert.deepEqual(client.store.getState().apollo.data, {
         'foo': {
+          __typename: 'Foo',
           e: 4,
           f: 5,
           g: 6,
@@ -629,6 +634,7 @@ describe('ApolloClient', () => {
 
       assert.deepEqual(client.store.getState().apollo.data, {
         'foo': {
+          __typename: 'Foo',
           e: 4,
           f: 5,
           g: 6,

--- a/test/proxy.ts
+++ b/test/proxy.ts
@@ -203,7 +203,7 @@ describe('ReduxDataProxy', () => {
                 },
               },
               'foo': {
-                __typename: 'Type2',
+                __typename: 'Foo',
                 e: 4,
                 f: 5,
                 g: 6,
@@ -214,7 +214,7 @@ describe('ReduxDataProxy', () => {
                 },
               },
               'bar': {
-                __typename: 'Type3',
+                __typename: 'Bar',
                 i: 7,
                 j: 8,
                 k: 9,
@@ -264,7 +264,7 @@ describe('ReduxDataProxy', () => {
           apollo: {
             data: {
               'foo': {
-                __typename: 'Type1',
+                __typename: 'Foo',
                 'field({"literal":true,"value":42})': 1,
                 'field({"literal":false,"value":42})': 2,
               },
@@ -294,7 +294,7 @@ describe('ReduxDataProxy', () => {
         initialState: {
           apollo: {
             data: {
-              'bar': { __typename: 'Type1', a: 1, b: 2, c: 3 },
+              'bar': { __typename: 'Bar', a: 1, b: 2, c: 3 },
             },
           },
         },
@@ -303,7 +303,7 @@ describe('ReduxDataProxy', () => {
         initialState: {
           apollo: {
             data: {
-              'foo': { __typename: 'Type1', a: 1, b: 2, c: 3 },
+              'foo': { __typename: 'Foo', a: 1, b: 2, c: 3 },
             },
           },
         },

--- a/test/readFromStore.ts
+++ b/test/readFromStore.ts
@@ -6,6 +6,10 @@ import {
 } from '../src/data/readFromStore';
 
 import {
+  withError,
+} from './util/wrap';
+
+import {
   NormalizedCache,
   StoreObject,
   IdValue,
@@ -295,51 +299,55 @@ describe('reading from the store', () => {
     });
   });
 
-  it('runs a nested query with proper fragment fields in arrays', () => {
-    const store = {
-      'ROOT_QUERY': {
-        __typename: 'Query',
-        nestedObj: { type: 'id', id: 'abcde', generated: false },
-      } as StoreObject,
-      abcde: {
-        id: 'abcde',
-        innerArray: [{ type: 'id', generated: true, id: 'abcde.innerArray.0' } as any],
-      } as StoreObject,
-      'abcde.innerArray.0': {
-        id: 'abcdef',
-        someField: 3,
-      } as StoreObject,
-    } as NormalizedCache;
+  it('runs a nested query with proper fragment fields in arrays', (done) => {
+    withError(() => {
+      const store = {
+        'ROOT_QUERY': {
+          __typename: 'Query',
+          nestedObj: { type: 'id', id: 'abcde', generated: false },
+        } as StoreObject,
+        abcde: {
+          id: 'abcde',
+          innerArray: [{ type: 'id', generated: true, id: 'abcde.innerArray.0' } as any],
+        } as StoreObject,
+        'abcde.innerArray.0': {
+          id: 'abcdef',
+          someField: 3,
+        } as StoreObject,
+      } as NormalizedCache;
 
-    const queryResult = readQueryFromStore({
-      store,
-      query: gql`
-        {
-          ... on DummyQuery {
-            nestedObj {
-              innerArray { id otherField }
+      const queryResult = readQueryFromStore({
+        store,
+        query: gql`
+          {
+            ... on DummyQuery {
+              nestedObj {
+                innerArray { id otherField }
+              }
+            }
+            ... on Query {
+              nestedObj {
+                innerArray { id someField }
+              }
+            }
+            ... on DummyQuery2 {
+              nestedObj {
+                innerArray { id otherField2 }
+              }
             }
           }
-          ... on Query {
-            nestedObj {
-              innerArray { id someField }
-            }
-          }
-          ... on DummyQuery2 {
-            nestedObj {
-              innerArray { id otherField2 }
-            }
-          }
-        }
-      `,
-      fragmentMatcherFunction,
-    });
+        `,
+        fragmentMatcherFunction,
+      });
 
-    assert.deepEqual(queryResult, {
-      nestedObj: {
-        innerArray: [{id: 'abcdef', someField: 3}],
-      },
-    });
+      assert.deepEqual(queryResult, {
+        nestedObj: {
+          innerArray: [{id: 'abcdef', someField: 3}],
+        },
+      });
+      done();
+    }, /IntrospectionFragmentMatcher/);
+
   });
 
   it('runs a nested query with an array without IDs', () => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -25,6 +25,7 @@ console.warn = console.error = (...messages: string[]) => {
 
 process.on('unhandledRejection', () => {});
 
+import './warnOnce';
 import './fragmentMatcher';
 import './writeToStore';
 import './readFromStore';

--- a/test/util/wrap.ts
+++ b/test/util/wrap.ts
@@ -26,3 +26,19 @@ export function withWarning(func: Function, regex: RegExp) {
     console.warn = oldWarn;
   }
 }
+
+export function withError(func: Function, regex: RegExp) {
+  let message: string = null as never;
+  const oldError = console.error;
+
+  console.error = (m: string) => message = m;
+
+  try {
+    const result = func();
+    assert.match(message, regex);
+    return result;
+
+  } finally {
+    console.error = oldError;
+  }
+}

--- a/test/warnOnce.ts
+++ b/test/warnOnce.ts
@@ -1,0 +1,38 @@
+import { assert, expect } from 'chai';
+import { warnOnce } from '../src/util/warnOnce';
+
+let lastWarning: string | null;
+let numCalls = 0;
+let oldConsoleWarn: any;
+
+describe('warnOnce', () => {
+  beforeEach( () => {
+    numCalls = 0;
+    lastWarning = null;
+    oldConsoleWarn = console.warn;
+    console.warn = (msg: any) => { numCalls++; lastWarning = msg; };
+  });
+  afterEach( () => {
+    console.warn = oldConsoleWarn;
+  });
+  it('actually warns', () => {
+    warnOnce('hi');
+    assert(lastWarning === 'hi');
+    expect(numCalls).to.equal(1);
+  });
+
+  it('does not warn twice', () => {
+    warnOnce('ho');
+    warnOnce('ho');
+    expect(lastWarning).to.equal('ho');
+    expect(numCalls).to.equal(1);
+  });
+
+  it('warns two different things once', () => {
+    warnOnce('slow');
+    expect(lastWarning).to.equal('slow');
+    warnOnce('mo');
+    expect(lastWarning).to.equal('mo');
+    expect(numCalls).to.equal(2);
+  });
+});


### PR DESCRIPTION
Print a warning when the heuristic fragment matcher is used on an interface or union fragment condition.

TODO:
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
- [x] Add your name and email to the AUTHORS file (optional)
- [x] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion
