### PR TITLE
Recycler standby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ### vNEXT
+- Feature+Fix: Introduce "standby" fetchPolicy to mark queries that are not currently active, but should be available for refetchQueries and updateQueries [PR #1636](https://github.com/apollographql/apollo-client/pull/1636)
 - Feature: Print a warning when heuristically matching fragments on interface/union [PR #1635](https://github.com/apollographql/apollo-client/pull/1635)
 
 ### 1.1.1

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -337,6 +337,7 @@ export class ObservableQuery<T> extends Observable<ApolloQueryResult<T>> {
     // If fetchPolicy went from cache-only to something else, or from something else to network-only
     const tryFetch: boolean = (oldOptions.fetchPolicy !== 'network-only' && opts.fetchPolicy === 'network-only')
       || (oldOptions.fetchPolicy === 'cache-only' && opts.fetchPolicy !== 'cache-only')
+      || (oldOptions.fetchPolicy === 'standby' && opts.fetchPolicy !== 'standby')
       || false;
 
     return this.setVariables(this.options.variables, tryFetch);

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -807,7 +807,7 @@ export class QueryManager {
 
       const fetchPolicy = this.observableQueries[queryId].observableQuery.options.fetchPolicy;
 
-      if (fetchPolicy !== 'cache-only') {
+      if (fetchPolicy !== 'cache-only' && fetchPolicy !== 'standby') {
         this.observableQueries[queryId].observableQuery.refetch();
       }
     });

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -404,7 +404,7 @@ export class QueryManager {
       storeResult = result;
     }
 
-    const shouldFetch = needToFetch && fetchPolicy !== 'cache-only';
+    const shouldFetch = needToFetch && fetchPolicy !== 'cache-only' && fetchPolicy !== 'standby';
 
     const requestId = this.generateRequestId();
 

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -631,6 +631,9 @@ export class QueryManager {
       throw new Error('noFetch option is no longer supported since Apollo Client 1.0. Use fetchPolicy instead.');
     }
 
+    if (options.fetchPolicy === 'standby') {
+      throw new Error('client.watchQuery cannot be called with fetchPolicy set to "standby"');
+    }
 
     // get errors synchronously
     const queryDefinition = getQueryDefinition(options.query);

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -501,6 +501,11 @@ export class QueryManager {
 
       const fetchPolicy = storedQuery ? storedQuery.observableQuery.options.fetchPolicy : options.fetchPolicy;
 
+      if (fetchPolicy === 'standby') {
+        // don't watch the store for queries on standby
+        return;
+      }
+
       const shouldNotifyIfLoading = queryStoreValue.previousVariables ||
                                     fetchPolicy === 'cache-only' || fetchPolicy === 'cache-and-network';
 

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -22,9 +22,10 @@ import {
  * - cache-and-network: returns result from cache first (if it exists), then return network result once it's available
  * - cache-only: return result from cache if avaiable, fail otherwise.
  * - network-only: return result from network, fail if network call doesn't succeed.
+ * - standby: only for queries that aren't actively watched, but should be available for refetch and updateQueries.
  */
 
-export type FetchPolicy = 'cache-first' | 'cache-and-network' | 'network-only' | 'cache-only';
+export type FetchPolicy = 'cache-first' | 'cache-and-network' | 'network-only' | 'cache-only' | 'standby';
 
 /**
  * We can change these options to an ObservableQuery

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -2471,8 +2471,39 @@ describe('QueryManager', () => {
       setTimeout(() => {
         assert.equal(refetchCount, 0);
         done();
-      }, 400);
+      }, 50);
 
+    });
+
+    it('should not call refetch on a standby Observable if the store is reset', (done) => {
+      const query = gql`
+        query {
+          author {
+            firstName
+            lastName
+          }
+        }`;
+      const queryManager = createQueryManager({});
+      const options = assign({}) as WatchQueryOptions;
+      options.fetchPolicy = 'standby';
+      options.query = query;
+      let refetchCount = 0;
+      const mockObservableQuery: ObservableQuery<any> = {
+        refetch(variables: any): Promise<ExecutionResult> {
+          refetchCount ++;
+          return null as never;
+        },
+        options,
+        queryManager: queryManager,
+      } as any as ObservableQuery<any>;
+
+      const queryId = 'super-fake-id';
+      queryManager.addObservableQuery<any>(queryId, mockObservableQuery);
+      queryManager.resetStore();
+      setTimeout(() => {
+        assert.equal(refetchCount, 0);
+        done();
+      }, 50);
     });
 
     it('should throw an error on an inflight query() if the store is reset', (done) => {

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -2458,7 +2458,6 @@ describe('QueryManager', () => {
       const mockObservableQuery: ObservableQuery<any> = {
         refetch(variables: any): Promise<ExecutionResult> {
           refetchCount ++;
-          done();
           return null as never;
         },
         options,

--- a/test/client.ts
+++ b/test/client.ts
@@ -1646,7 +1646,16 @@ describe('client', () => {
         },
       });
     });
+  });
 
+  describe('standby fetchPolicy', () => {
+    it('cannot be applied during initial construction of a query', () => {
+      const client = new ApolloClient();
+      assert.throws(
+        () => client.watchQuery({ query: gql`{ abc }`, fetchPolicy: 'standby'}),
+        'client.watchQuery cannot be called with fetchPolicy set to "standby"',
+      );
+    });
   });
 
   describe('network-only fetchPolicy', () => {


### PR DESCRIPTION
This PR introduces a new fetch policy, which can be used by react-apollo and other integrations to keep a query in Apollo's store, but mark it as "standby". Standby queries will not watch the store, will not be refetched on store reset, but can be used in `updateQueries` and `refetchQueries` calls. This is mainly a response to issues like https://github.com/apollographql/react-apollo/issues/622 and https://github.com/apollographql/react-apollo/issues/531.

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
- [x] Add your name and email to the AUTHORS file (optional)
- [x] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion
