### PR TITLE
exported react-apollo types for easier local dev

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,8 @@ import {
 
 import {
   ObservableQuery,
+  FetchMoreOptions,
+  UpdateQueryOptions,
 } from './core/ObservableQuery';
 
 import {
@@ -34,6 +36,8 @@ import {
   MutationOptions,
   SubscriptionOptions,
   FetchPolicy,
+  FetchMoreQueryOptions,
+  SubscribeToMoreOptions,
 } from './core/watchQueryOptions';
 
 import {
@@ -121,6 +125,10 @@ export {
   SubscriptionOptions,
   ApolloStore,
   ApolloClient,
+  FetchMoreOptions,
+  UpdateQueryOptions,
+  FetchMoreQueryOptions,
+  SubscribeToMoreOptions,
 };
 
 export default ApolloClient;


### PR DESCRIPTION
@helfer there were a few types that react-apollo was importing from sub directories in AC. This made local linked dev + CI linking a pain / impossible.


TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change
