### PR TITLE
[WIP] Linked test ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
   - "6"
-  - "4"
 
 install:
   - npm install -g coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
   - npm link
     # XXX remove specific branch once https://github.com/apollographql/apollo-client/pull/1644 and https://github.com/apollographql/react-apollo/pull/679 are merged
   - git clone -b move-types https://github.com/apollographql/react-apollo
-  - cd react-apollo && npm link apollo-client && npm i && npm test
+  - cd react-apollo && npm link apollo-client && npm i && npm test && cd ../ && rm -rf react-apollo
     # end tests of react apollo
 
     # run coverage and file size checks

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,14 @@ install:
 
 script:
   - npm test
+
+    # run tests on current master of react-apollo
+  - npm link
+  - git clone https://github.com/apollographql/react-apollo
+  - cd react-apollo && npm link apollo-client && npm i && npm test
+    # end tests of react apollo
+
+    # run coverage and file size checks
   - npm run coverage
   - coveralls < ./coverage/lcov.info || true # ignore coveralls error
   - npm run filesize

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ script:
 
     # run tests on current master of react-apollo
   - npm link
-  - git clone https://github.com/apollographql/react-apollo
+    # XXX remove specific branch once https://github.com/apollographql/apollo-client/pull/1644 and https://github.com/apollographql/react-apollo/pull/679 are merged
+  - git clone -b move-types https://github.com/apollographql/react-apollo
   - cd react-apollo && npm link apollo-client && npm i && npm test
     # end tests of react apollo
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,8 @@ import {
 
 import {
   ObservableQuery,
+  FetchMoreOptions,
+  UpdateQueryOptions,
 } from './core/ObservableQuery';
 
 import {
@@ -34,6 +36,8 @@ import {
   MutationOptions,
   SubscriptionOptions,
   FetchPolicy,
+  FetchMoreQueryOptions,
+  SubscribeToMoreOptions,
 } from './core/watchQueryOptions';
 
 import {
@@ -121,6 +125,10 @@ export {
   SubscriptionOptions,
   ApolloStore,
   ApolloClient,
+  FetchMoreOptions,
+  UpdateQueryOptions,
+  FetchMoreQueryOptions,
+  SubscribeToMoreOptions,
 };
 
 export default ApolloClient;

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,7 +125,7 @@ export {
   SubscriptionOptions,
   ApolloStore,
   ApolloClient,
-  FetchMoreOptions,
+  // FetchMoreOptions,
   UpdateQueryOptions,
   FetchMoreQueryOptions,
   SubscribeToMoreOptions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,7 +125,7 @@ export {
   SubscriptionOptions,
   ApolloStore,
   ApolloClient,
-  // FetchMoreOptions,
+  FetchMoreOptions,
   UpdateQueryOptions,
   FetchMoreQueryOptions,
   SubscribeToMoreOptions,


### PR DESCRIPTION
This PR will run tests for react-apollo on every CI build of apollo-client. The goal here being that we want to ensure we don't break other libs when updating / changing AC. 

If this works, I'd love to add in apollo-angular (and any other popular libs needed).

This will make testing feedback take longer so we don't want to add *everything*

This points to https://github.com/apollographql/react-apollo/pull/679 but when that and #1644 are merged, we can point to master.

> This also removes node 4 from the testing matrix. Node 4 ships with npm 2 which doesn't like the mixed peer deps with react-apollo. Instead of updating npm, since node 4 is in no longer active (https://github.com/nodejs/LTS) lets just use node 6

@helfer those PR's don't need to be released necessarily, just merged to master