### PR TITLE
1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change log
 
 ### vNEXT
+
+### 1.1.2
 - Feature+Fix: Introduce "standby" fetchPolicy to mark queries that are not currently active, but should be available for refetchQueries and updateQueries [PR #1636](https://github.com/apollographql/apollo-client/pull/1636)
 - Feature: Print a warning when heuristically matching fragments on interface/union [PR #1635](https://github.com/apollographql/apollo-client/pull/1635)
 - Fix: Replace usage of Object.assign with util.assign to make it work in IE, make util.assign work with undefined and null sources as Object.assign does [PR #1643](https://github.com/apollographql/apollo-client/pull/1643)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-client",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A simple yet functional GraphQL client.",
   "main": "./lib/apollo.umd.js",
   "module": "./lib/src/index.js",


### PR DESCRIPTION
- "standby" fetchPolicy for queries that are being recycled.
- warning for heuristic fragment matching
- Fix: remove Object.assign by @borisnieuwenhuis

🏓 
