### PR TITLE
Add `createSchemaInterface` (WIP)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,11 @@ import {
 } from './transport/batchedNetworkInterface';
 
 import {
+  createSchemaInterface,
+  SchemaInterface,
+} from './transport/schemaInterface';
+
+import {
   print,
 } from 'graphql/language/printer';
 
@@ -89,6 +94,7 @@ import {
 export {
   createNetworkInterface,
   createBatchingNetworkInterface,
+  createSchemaInterface,
   createApolloStore,
   createApolloReducer,
   readQueryFromStore,
@@ -116,6 +122,7 @@ export {
   SubscriptionNetworkInterface,
   HTTPFetchNetworkInterface,
   HTTPBatchedNetworkInterface,
+  SchemaInterface,
   FetchPolicy,
   WatchQueryOptions,
   MutationOptions,

--- a/src/transport/schemaInterface.ts
+++ b/src/transport/schemaInterface.ts
@@ -1,0 +1,27 @@
+import {
+  graphql,
+  ExecutionResult,
+  GraphQLSchema,
+} from 'graphql';
+
+import {
+  NetworkInterface,
+  Request,
+} from './networkInterface';
+
+import { print } from 'graphql/language/printer';
+
+// Provides an interface to a local graphql schema
+export class SchemaInterface implements NetworkInterface {
+  constructor(private schema: GraphQLSchema, private contextValue?: any) {}
+
+  public query({ query, variables, operationName, rootValue = {} }: Request): Promise<ExecutionResult> {
+    return graphql(this.schema, print(query), rootValue, this.contextValue, variables, operationName);
+  }
+}
+
+// Creates an interface for a graphql schema
+export function createSchemaInterface( schema: GraphQLSchema, contextValue?: Object ): NetworkInterface {
+  return new SchemaInterface(schema, contextValue);
+}
+

--- a/test/schemaInterface.ts
+++ b/test/schemaInterface.ts
@@ -4,6 +4,7 @@ import {
   GraphQLString,
   GraphQLSchema,
   GraphQLObjectType,
+  ExecutionResult,
 } from 'graphql';
 
 import gql from 'graphql-tag';
@@ -29,13 +30,13 @@ describe('createSchemaInterface', () => {
           type: GraphQLString,
           resolve() {
             return RESOLVE_SYNC;
-          }
+          },
         },
         async: {
           type: GraphQLString,
           resolve() {
             return Promise.resolve(RESOLVE_ASYNC);
-          }
+          },
         },
         variables: {
           type: GraphQLString,
@@ -44,19 +45,19 @@ describe('createSchemaInterface', () => {
           },
           resolve(obj, { text }) {
             return `${RESOLVE_VARIABLE} ${text}`;
-          }
+          },
         },
         context: {
           type: GraphQLString,
           resolve(obj, args, { text }) {
             return `${RESOLVE_CONTEXT} ${text}`;
-          }
+          },
         },
         rootvalue: {
           type: GraphQLString,
           resolve(obj, args, context, { fieldName }) {
             return `${RESOLVE_ROOT_VALUE} ${fieldName}`;
-          }
+          },
         },
       },
     }),
@@ -67,17 +68,17 @@ describe('createSchemaInterface', () => {
   });
 
   it('should resolve sync schema', () => {
-    const query = gql`{ sync }`;
+    const query = gql`{ result: sync }`;
     return client.query({ query })
-      .then(({ data: { sync = '' } = {} }) => {
-        expect(sync).to.equal(RESOLVE_SYNC);
+      .then(({ data: { result = '' } = {} }: ExecutionResult) => {
+        expect(result).to.equal(RESOLVE_SYNC);
       });
   });
 
   it('should resolve async schema', () => {
     const query = gql`{ result: async }`;
     return client.query({ query })
-      .then(({ data: { result = '' } = {} }) => {
+      .then(({ data: { result = '' } = {} }: ExecutionResult) => {
         expect(result).to.equal(RESOLVE_ASYNC);
       });
   });
@@ -92,7 +93,7 @@ describe('createSchemaInterface', () => {
       value: 'foo',
     };
     return client.query({ query, variables })
-      .then(({ data: { result = '' } = {} }) => {
+      .then(({ data: { result = '' } = {} }: ExecutionResult) => {
         expect(result).to.equal(`${RESOLVE_VARIABLE} foo`);
       });
   });
@@ -100,7 +101,7 @@ describe('createSchemaInterface', () => {
   it('should make context available', () => {
     const query = gql`{ result: context }`;
     return client.query({ query })
-      .then(({ data: { result = '' } = {} }) => {
+      .then(({ data: { result = '' } = {} }: ExecutionResult) => {
         expect(result).to.equal(`${RESOLVE_CONTEXT} bar`);
       });
   });
@@ -108,7 +109,7 @@ describe('createSchemaInterface', () => {
   it('should make root value available', () => {
     const query = gql`{ result: rootvalue }`;
     return client.query({ query })
-      .then(({ data: { result = '' } = {} }) => {
+      .then(({ data: { result = '' } = {} }: ExecutionResult) => {
         expect(result).to.equal(`${RESOLVE_ROOT_VALUE} rootvalue`);
       });
   });

--- a/test/schemaInterface.ts
+++ b/test/schemaInterface.ts
@@ -1,0 +1,116 @@
+import { expect } from 'chai';
+import {
+  graphql,
+  GraphQLString,
+  GraphQLSchema,
+  GraphQLObjectType,
+} from 'graphql';
+
+import gql from 'graphql-tag';
+
+import ApolloClient from '../src';
+
+import {
+  createSchemaInterface,
+} from '../src/transport/schemaInterface';
+
+const RESOLVE_SYNC = 'sync resolve';
+const RESOLVE_ASYNC = 'async resolve';
+const RESOLVE_VARIABLE = 'resolve variable text:';
+const RESOLVE_CONTEXT = 'resolve context text:';
+const RESOLVE_ROOT_VALUE = 'resolve root value:';
+
+describe('createSchemaInterface', () => {
+  const schema = new GraphQLSchema({
+    query: new GraphQLObjectType({
+      name: 'Root',
+      fields: {
+        sync: {
+          type: GraphQLString,
+          resolve() {
+            return RESOLVE_SYNC;
+          }
+        },
+        async: {
+          type: GraphQLString,
+          resolve() {
+            return Promise.resolve(RESOLVE_ASYNC);
+          }
+        },
+        variables: {
+          type: GraphQLString,
+          args: {
+            text: { type: GraphQLString },
+          },
+          resolve(obj, { text }) {
+            return `${RESOLVE_VARIABLE} ${text}`;
+          }
+        },
+        context: {
+          type: GraphQLString,
+          resolve(obj, args, { text }) {
+            return `${RESOLVE_CONTEXT} ${text}`;
+          }
+        },
+        rootvalue: {
+          type: GraphQLString,
+          resolve(obj, args, context, { fieldName }) {
+            return `${RESOLVE_ROOT_VALUE} ${fieldName}`;
+          }
+        },
+      },
+    }),
+  });
+
+  const client = new ApolloClient({
+    networkInterface: createSchemaInterface(schema, { text: 'bar' }),
+  });
+
+  it('should resolve sync schema', () => {
+    const query = gql`{ sync }`;
+    return client.query({ query })
+      .then(({ data: { sync = '' } = {} }) => {
+        expect(sync).to.equal(RESOLVE_SYNC);
+      });
+  });
+
+  it('should resolve async schema', () => {
+    const query = gql`{ result: async }`;
+    return client.query({ query })
+      .then(({ data: { result = '' } = {} }) => {
+        expect(result).to.equal(RESOLVE_ASYNC);
+      });
+  });
+
+  it('should resolve using variables', () => {
+    const query = gql`
+      query result($value: String) {
+        result: variables(text: $value)
+      }
+    `;
+    const variables = {
+      value: 'foo',
+    };
+    return client.query({ query, variables })
+      .then(({ data: { result = '' } = {} }) => {
+        expect(result).to.equal(`${RESOLVE_VARIABLE} foo`);
+      });
+  });
+
+  it('should make context available', () => {
+    const query = gql`{ result: context }`;
+    return client.query({ query })
+      .then(({ data: { result = '' } = {} }) => {
+        expect(result).to.equal(`${RESOLVE_CONTEXT} bar`);
+      });
+  });
+
+  it('should make root value available', () => {
+    const query = gql`{ result: rootvalue }`;
+    return client.query({ query })
+      .then(({ data: { result = '' } = {} }) => {
+        expect(result).to.equal(`${RESOLVE_ROOT_VALUE} rootvalue`);
+      });
+  });
+
+});

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -56,4 +56,5 @@ import './cloneDeep';
 import './assign';
 import './environment';
 import './ApolloClient';
+import './schemaInterface';
 import './proxy';


### PR DESCRIPTION
Usage:
```js
const client = new ApolloClient({
  networkInterface: createSchemaInterface(schema, { foo: 'context' }),
});
```

Let me know if I need to add documentation / examples etc.

cc @helfer 

fixes: #1553