### PR TITLE
1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change log
 
 ### vNEXT
+
+### 1.2.0
 - Feature: Warn before writing to store if result shape does not match query [#1638](https://github.com/apollographql/apollo-client/pull/1638)
 - Fix: Replace more usage of Object.assign with util.assign to make it work in IE, previous fix was not complete [PR #1648](https://github.com/apollographql/apollo-client/pull/1648)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-client",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "A simple yet functional GraphQL client.",
   "main": "./lib/apollo.umd.js",
   "module": "./lib/src/index.js",


### PR DESCRIPTION
As of this release, Apollo Client will check results before writing them to the store and print a warning if there's a mismatch between query and result shape. 

Huge thanks to @cesarsolorzano who helped with this PR! ❤️  💪 