### PR TITLE
1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change log
 
 ### vNEXT
+
+### 1.2.2
 - Fix: Remove race condition in queryListenerFromObserver [PR #1670](https://github.com/apollographql/apollo-client/pull/1670)
 - Feature: Expose `dataIdFromObject` in addition to `dataId` [PR #1663](https://github.com/apollographql/apollo-client/pull/1663)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-client",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "A simple yet functional GraphQL client.",
   "main": "./lib/apollo.umd.js",
   "module": "./lib/src/index.js",


### PR DESCRIPTION
Thanks to @MichaelDeBoey for his PR to expose the `dataIdFromObject` function in Apollo Client so it can be used in `readFragment` and `writeFragment`!

Includes an attempt at fixing a long-standing bug in react-apollo & apollo-client.