### PR TITLE
Tests that use withError were silently failing

### DIFF
--- a/test/diffAgainstStore.ts
+++ b/test/diffAgainstStore.ts
@@ -90,8 +90,8 @@ describe('diffing queries against the store', () => {
     assert.deepEqual(store['1'], result.people_one);
   });
 
-  it('does not swallow errors other than field errors', (done) => {
-    withError( () => {
+  it('does not swallow errors other than field errors', () => {
+    return withError( () => {
       const firstQuery = gql`
         query {
           person {
@@ -117,7 +117,6 @@ describe('diffing queries against the store', () => {
           query: unionQuery,
         });
       }, /No fragment/);
-      done();
     }, /IntrospectionFragmentMatcher/);
   });
 

--- a/test/diffAgainstStore.ts
+++ b/test/diffAgainstStore.ts
@@ -91,33 +91,31 @@ describe('diffing queries against the store', () => {
   });
 
   it('does not swallow errors other than field errors', () => {
-    return withError( () => {
-      const firstQuery = gql`
-        query {
-          person {
-            powers
-          }
-        }`;
-      const firstResult = {
-        person: {
-          powers: 'the force',
-        },
-      };
-      const store = writeQueryToStore({
-        result: firstResult,
-        query: firstQuery,
+    const firstQuery = gql`
+      query {
+        person {
+          powers
+        }
+      }`;
+    const firstResult = {
+      person: {
+        powers: 'the force',
+      },
+    };
+    const store = writeQueryToStore({
+      result: firstResult,
+      query: firstQuery,
+    });
+    const unionQuery = gql`
+      query {
+        ...notARealFragment
+      }`;
+    return assert.throws(() => {
+      diffQueryAgainstStore({
+        store,
+        query: unionQuery,
       });
-      const unionQuery = gql`
-        query {
-          ...notARealFragment
-        }`;
-      assert.throws(() => {
-        diffQueryAgainstStore({
-          store,
-          query: unionQuery,
-        });
-      }, /No fragment/);
-    }, /IntrospectionFragmentMatcher/);
+    }, /No fragment/);
   });
 
   it('does not error on a correct query with union typed fragments', (done) => {

--- a/test/roundtrip.ts
+++ b/test/roundtrip.ts
@@ -256,7 +256,7 @@ describe('roundtrip', () => {
                 side: 'bright',
               },
             ],
-            });
+          });
         }, /Can\'t find field rank on object/);
     });
 

--- a/test/roundtrip.ts
+++ b/test/roundtrip.ts
@@ -234,8 +234,8 @@ describe('roundtrip', () => {
 
     // XXX this test is weird because it assumes the server returned an incorrect result
     // However, the user may have written this result with client.writeQuery.
-    it('should throw an error on two of the same inline fragment types', (done) => {
-      withError(() => {
+    it('should throw an error on two of the same inline fragment types', () => {
+      return withError(() => {
         assert.throws(() => {
           storeRoundtrip(gql`
             query {
@@ -259,8 +259,7 @@ describe('roundtrip', () => {
             ],
             });
         }, /Can\'t find field rank on object/);
-        done();
-       }, /IntrospectionFragmentMatcher/);
+      }, /IntrospectionFragmentMatcher/);
     });
 
     it('should resolve fields it can on interface with non matching inline fragments', (done) => {

--- a/test/roundtrip.ts
+++ b/test/roundtrip.ts
@@ -235,8 +235,7 @@ describe('roundtrip', () => {
     // XXX this test is weird because it assumes the server returned an incorrect result
     // However, the user may have written this result with client.writeQuery.
     it('should throw an error on two of the same inline fragment types', () => {
-      return withError(() => {
-        assert.throws(() => {
+        return assert.throws(() => {
           storeRoundtrip(gql`
             query {
               all_people {
@@ -259,7 +258,6 @@ describe('roundtrip', () => {
             ],
             });
         }, /Can\'t find field rank on object/);
-      }, /IntrospectionFragmentMatcher/);
     });
 
     it('should resolve fields it can on interface with non matching inline fragments', (done) => {


### PR DESCRIPTION
These tests now fail because they are not throwing the `console.error`