### PR TITLE
Exposed getMutationDefinition for devtools enhancement

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,7 @@ import {
 
 import {
   getQueryDefinition,
+  getMutationDefinition,
   getFragmentDefinitions,
   FragmentMap,
   createFragmentMap,
@@ -98,6 +99,7 @@ export {
   NetworkStatus,
   ApolloError,
   getQueryDefinition,
+  getMutationDefinition,
   getFragmentDefinitions,
   FragmentMap,
   Request,


### PR DESCRIPTION
Exposing getMutationDefinition on the client so mutations can be tracked via apollo-client-devtools.

- Discussion can be found here https://github.com/apollographql/apollo-client-devtools/issues/35
- PR for apollo-client-devtools can be found here https://github.com/apollographql/apollo-client-devtools/pull/36

I am not that familiar with this typescript, so not 100% if there is anything else I need to do. If there is please let me know and I will sort it out. I don't think any tests are required, but if you feel otherwise let me know. I haven't updated any docs as functions like getQueryDefinition is not documented.


