### PR TITLE
Optimistic response function

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -36,6 +36,7 @@ Olivier Ricordeau <olivier@ricordeau.org>
 Pavol Fulop <pavol.fulop@regex.sk>
 Pavol Fulop <pavolfulop@gmail.com>
 Rasmus Eneman <rasmus@eneman.eu>
+Robert Dickert <robert.dickert@gmail.com>
 Robin Ricard <ricard.robin@gmail.com>
 Sashko Stubailo <s.stubailo@gmail.com>
 Sashko Stubailo <sashko@stubailo.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### vNEXT
 
+- Feature: Pass a function to `optimisticResponse` and it will be called with the `variables` passed to the mutation.
+
 ### 1.2.2
 - Fix: Remove race condition in queryListenerFromObserver [PR #1670](https://github.com/apollographql/apollo-client/pull/1670)
 - Feature: Expose `dataIdFromObject` in addition to `dataId` [PR #1663](https://github.com/apollographql/apollo-client/pull/1663)

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -93,7 +93,7 @@ export interface MutationInitAction {
   variables: Object;
   operationName: string;
   mutationId: string;
-  optimisticResponse: Object | undefined;
+  optimisticResponse: Object | Function | undefined;
   extraReducers?: ApolloReducer[];
   updateQueries?: { [queryId: string]: MutationQueryReducer };
   update?: (proxy: DataProxy, mutationResult: Object) => void;

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -252,7 +252,7 @@ export class QueryManager {
   }: {
     mutation: DocumentNode,
     variables?: Object,
-    optimisticResponse?: Object,
+    optimisticResponse?: Object | Function,
     updateQueries?: MutationQueryReducersMap,
     refetchQueries?: string[] | PureQueryOptions[],
     update?: (proxy: DataProxy, mutationResult: Object) => void,

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -117,7 +117,7 @@ export interface MutationOptions {
    * the result of a mutation immediately, and update the UI later if any errors
    * appear.
    */
-  optimisticResponse?: Object;
+  optimisticResponse?: Object | Function;
 
   /**
    * A {@link MutationQueryReducersMap}, which is map from query names to

--- a/src/optimistic-data/store.ts
+++ b/src/optimistic-data/store.ts
@@ -54,9 +54,12 @@ export function optimistic(
   config: any,
 ): OptimisticStore {
   if (isMutationInitAction(action) && action.optimisticResponse) {
-    const optimisticResponse = typeof action.optimisticResponse === 'function'
-      ? action.optimisticResponse(action.variables)
-      : action.optimisticResponse;
+    let optimisticResponse;
+    if (typeof action.optimisticResponse === 'function') {
+      optimisticResponse = action.optimisticResponse(action.variables);
+    } else {
+      optimisticResponse = action.optimisticResponse;
+    }
     const fakeMutationResultAction: MutationResultAction = {
       type: 'APOLLO_MUTATION_RESULT',
       result: { data: optimisticResponse },

--- a/src/optimistic-data/store.ts
+++ b/src/optimistic-data/store.ts
@@ -54,9 +54,12 @@ export function optimistic(
   config: any,
 ): OptimisticStore {
   if (isMutationInitAction(action) && action.optimisticResponse) {
+    const optimisticResponse = typeof action.optimisticResponse === 'function'
+      ? action.optimisticResponse(action.variables)
+      : action.optimisticResponse;
     const fakeMutationResultAction: MutationResultAction = {
       type: 'APOLLO_MUTATION_RESULT',
-      result: { data: action.optimisticResponse },
+      result: { data: optimisticResponse },
       document: action.mutation,
       operationName: action.operationName,
       variables: action.variables,

--- a/test/optimistic.ts
+++ b/test/optimistic.ts
@@ -534,6 +534,8 @@ describe('optimistic mutation results', () => {
       }
     `;
 
+    const variables = { text: 'Optimistically generated from variables' };
+
     const mutationResult = {
       data: {
         __typename: 'Mutation',
@@ -559,7 +561,7 @@ describe('optimistic mutation results', () => {
     it('will use a passed variable in optimisticResponse', () => {
       let subscriptionHandle: Subscription;
       return setup({
-        request: { query: mutation },
+        request: { query: mutation, variables },
         result: mutationResult,
       })
       .then(() => {
@@ -574,7 +576,7 @@ describe('optimistic mutation results', () => {
       .then(() => {
         const promise = client.mutate({
           mutation,
-          variables: { text: 'Optimistically generated from variables' },
+          variables,
           optimisticResponse,
           update: (proxy, mResult: any) => {
             assert.equal(mResult.data.createTodo.id, '99');

--- a/test/optimistic.ts
+++ b/test/optimistic.ts
@@ -521,6 +521,96 @@ describe('optimistic mutation results', () => {
     });
   });
 
+  describe('passing a function to optimisticResponse', () => {
+    const mutation = gql`
+      mutation createTodo ($text: String) {
+        createTodo (text: $text) {
+          id
+          text
+          completed
+          __typename
+        }
+        __typename
+      }
+    `;
+
+    const mutationResult = {
+      data: {
+        __typename: 'Mutation',
+        createTodo: {
+          id: '99',
+          __typename: 'Todo',
+          text: 'This one was created with a mutation.',
+          completed: true,
+        },
+      },
+    };
+
+    const optimisticResponse = ({ text }: { text: string }) => ({
+      __typename: 'Mutation',
+      createTodo: {
+        __typename: 'Todo',
+        id: '99',
+        text,
+        completed: true,
+      },
+    });
+
+    it('will use a passed variable in optimisticResponse', () => {
+      let subscriptionHandle: Subscription;
+      return setup({
+        request: { query: mutation },
+        result: mutationResult,
+      })
+      .then(() => {
+        // we have to actually subscribe to the query to be able to update it
+        return new Promise( (resolve, reject) => {
+          const handle = client.watchQuery({ query });
+          subscriptionHandle = handle.subscribe({
+            next(res) { resolve(res); },
+          });
+        });
+      })
+      .then(() => {
+        const promise = client.mutate({
+          mutation,
+          variables: { text: 'Optimistically generated from variables' },
+          optimisticResponse,
+          update: (proxy, mResult: any) => {
+            assert.equal(mResult.data.createTodo.id, '99');
+
+            const id = 'TodoList5';
+            const fragment = gql`fragment todoList on TodoList { todos { id text completed __typename } }`;
+
+            const data: any = proxy.readFragment({ id, fragment });
+
+            proxy.writeFragment({
+              data: { ...data, todos: [mResult.data.createTodo, ...data.todos] },
+              id, fragment,
+            });
+          },
+        });
+
+        const dataInStore = client.queryManager.getDataWithOptimisticResults();
+        assert.equal((dataInStore['TodoList5'] as any).todos.length, 4);
+        assert.equal((dataInStore['Todo99'] as any).text, 'Optimistically generated from variables');
+
+        return promise;
+      })
+      .then(() => {
+        return client.query({ query });
+      })
+      .then((newResult: any) => {
+        subscriptionHandle.unsubscribe();
+        // There should be one more todo item than before
+        assert.equal(newResult.data.todoList.todos.length, 4);
+
+        // Since we used `prepend` it should be at the front
+        assert.equal(newResult.data.todoList.todos[0].text, 'This one was created with a mutation.');
+      });
+    });
+  });
+
   describe('optimistic updates using `updateQueries`', () => {
     const mutation = gql`
       mutation createTodo {


### PR DESCRIPTION
Allow the developer to pass a function instead of an object to `optimisticResponse`:

```js
    const optimisticResponse = ({ text }) => ({
      __typename: 'Mutation',
      createTodo: {
        __typename: 'Todo',
        id: '99',
        text,
        completed: true,
      },
    });
```

This will allow more flexibility in where/how the `optimisticResponse` is defined - it will no longer have to be colocated with the call to `mutate()` in order to get the data context for the response, allowing code reuse and more choices for ui framework integration.

I'm new to typescript, so let me know if I need to do something different with the type changes.

TODO:

discussed with @helfer prior to submission, and it's small - but it's been a while since we discussed it, and it affects the external API, so happy to discuss.

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)

- [X] Make sure all of the significant new logic is covered by tests
- [X] Rebase your changes on master so that they can be merged easily
- [X] Make sure all tests and linter rules pass
- [X] Update CHANGELOG.md with your change
- [X] Add your name and email to the AUTHORS file (optional)

If this looks good, I'll do this next:

- [ ] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion
- [ ] ~If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.~ - n/a
