### PR TITLE
HybridNetworkInterface

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -67,3 +67,4 @@ Andrew E. Rhyne <rhyneandrew@gmail.com>
 Miroslav Simulcik <simulcik.miro@gmail.com>
 Stephen Potter <me@stevepotter.me>
 Michaël De Boey <info@michaeldeboey.be>
+Gaurav Kulkarni <gaurav@gauravkulkarni.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ### vNEXT
+- Feature: `createHybridNetworkInterface` creates a network interface that will use either HTTPBatchedNetworkInterface or HTTPFetchNetworkInterface depending on whether request.disableBatch is set [PR #1732](https://github.com/apollographql/apollo-client/pull/1732)
 
 ### 1.2.2
 - Fix: Remove race condition in queryListenerFromObserver [PR #1670](https://github.com/apollographql/apollo-client/pull/1670)

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,11 @@ import {
 } from './transport/batchedNetworkInterface';
 
 import {
+  createHybridNetworkInterface,
+  HTTPHybridNetworkInterface,
+} from './transport/hybridNetworkInterface';
+
+import {
   print,
 } from 'graphql/language/printer';
 
@@ -90,6 +95,7 @@ import {
 export {
   createNetworkInterface,
   createBatchingNetworkInterface,
+  createHybridNetworkInterface,
   createApolloStore,
   createApolloReducer,
   readQueryFromStore,
@@ -118,6 +124,7 @@ export {
   SubscriptionNetworkInterface,
   HTTPFetchNetworkInterface,
   HTTPBatchedNetworkInterface,
+  HTTPHybridNetworkInterface,
   FetchPolicy,
   WatchQueryOptions,
   MutationOptions,

--- a/src/transport/hybridNetworkInterface.ts
+++ b/src/transport/hybridNetworkInterface.ts
@@ -1,0 +1,58 @@
+import { ExecutionResult } from 'graphql';
+
+import {
+  createNetworkInterface,
+  HTTPNetworkInterface,
+  NetworkInterfaceOptions,
+  BaseNetworkInterface,
+  Request,
+} from './networkInterface';
+
+import {
+  createBatchingNetworkInterface,
+  BatchingNetworkInterfaceOptions,
+} from './batchedNetworkInterface';
+
+import { MiddlewareInterface } from './middleware';
+
+import { AfterwareInterface } from './afterware';
+
+
+export class HTTPHybridNetworkInterface extends BaseNetworkInterface {
+  public networkInterface: HTTPNetworkInterface;
+  public batchedInterface: HTTPNetworkInterface;
+
+  constructor(options: BatchingNetworkInterfaceOptions) {
+    super(options.uri, options.opts);
+    this.networkInterface = createNetworkInterface(options);
+    this.batchedInterface = createBatchingNetworkInterface(options);
+  }
+
+  public query(request: Request): Promise<ExecutionResult> {
+    if (request.disableBatch) {
+      return this.networkInterface.query(request);
+    } else {
+      return this.batchedInterface.query(request);
+    }
+  }
+
+  public use(middlewares: MiddlewareInterface[]): HTTPNetworkInterface {
+    this.batchedInterface.use(middlewares);
+    this.networkInterface.use(middlewares);
+    return this;
+  }
+
+  public useAfter(afterwares: AfterwareInterface[]): HTTPNetworkInterface {
+    this.batchedInterface.useAfter(afterwares);
+    this.networkInterface.useAfter(afterwares);
+    return this;
+  }
+}
+
+export function createHybridNetworkInterface(options: BatchingNetworkInterfaceOptions): HTTPNetworkInterface {
+  if (! options) {
+    throw new Error('You must pass an options argument to createNetworkInterface.');
+  }
+  return new HTTPHybridNetworkInterface(options);
+}
+

--- a/test/hybridNetworkInterface.ts
+++ b/test/hybridNetworkInterface.ts
@@ -1,0 +1,106 @@
+import { assert } from 'chai';
+
+import gql from 'graphql-tag';
+
+import * as sinon from 'sinon';
+
+import {
+  createHybridNetworkInterface,
+  HTTPHybridNetworkInterface,
+} from '../src/transport/hybridNetworkInterface';
+
+describe('HTTPHybridNetworkInterface', () => {
+  // Some helper queries + results
+  const authorQuery = gql`
+    query {
+      author {
+        firstName
+        lastName
+      }
+    }`;
+
+  const uri = 'http://notreal.com/graphql';
+  const opts = {};
+
+  it('should construct itself correctly', () => {
+    const hybridNetworkInterface = createHybridNetworkInterface({ uri, batchInterval: 10, opts });
+    assert(hybridNetworkInterface);
+    assert.equal(hybridNetworkInterface._uri, uri);
+    assert.deepEqual(hybridNetworkInterface._opts, opts);
+    assert(hybridNetworkInterface.batchedInterface.batchQuery);
+    assert(hybridNetworkInterface.networkInterface);
+  });
+
+  it('should use the network interface when batch is disabled', () => {
+    const simpleRequest = {
+      query: authorQuery,
+      variables: {},
+      disableBatch: true,
+    };
+
+    const hybridNetworkInterface = createHybridNetworkInterface({ uri, batchInterval: 10, opts });
+    sinon.spy(hybridNetworkInterface.networkInterface, 'query');
+    sinon.spy(hybridNetworkInterface.batchedInterface, 'query');
+    hybridNetworkInterface.query(simpleRequest);
+    assert(hybridNetworkInterface.networkInterface.query.calledOnce);
+    assert.isFalse(hybridNetworkInterface.batchedInterface.query.calledOnce);
+  });
+
+  it('should use the batch interface by default', () => {
+    const simpleRequest = {
+      query: authorQuery,
+      variables: {},
+    };
+
+    const hybridNetworkInterface = createHybridNetworkInterface({ uri, batchInterval: 10, opts });
+    sinon.spy(hybridNetworkInterface.networkInterface, 'query');
+    sinon.spy(hybridNetworkInterface.batchedInterface, 'query');
+    hybridNetworkInterface.query(simpleRequest);
+    assert.isFalse(hybridNetworkInterface.networkInterface.query.calledOnce);
+    assert(hybridNetworkInterface.batchedInterface.query.calledOnce);
+  });
+
+  it('should take a middleware and assign it', () => {
+    const middleware = {
+      applyMiddleware(req: any, next: any) {
+        next();
+      },
+      applyBatchMiddleware(req: any, next: any) {
+        next();
+      },
+    };
+
+    const hybridNetworkInterface = createHybridNetworkInterface({ uri, batchInterval: 10, opts });
+    hybridNetworkInterface.use([middleware]);
+    assert.equal(hybridNetworkInterface.networkInterface._middlewares[0], middleware);
+    assert.equal(hybridNetworkInterface.batchedInterface._middlewares[0], middleware);
+  });
+
+  it('should chain middleware and afterware', () => {
+    const middleware = {
+      applyMiddleware(req: any, next: any) {
+        next();
+      },
+      applyBatchMiddleware(req: any, next: any) {
+        next();
+      },
+    };
+
+    const afterware = {
+      applyAfterware(req: any, next: any) {
+        next();
+      },
+      applyBatchAfterware(req: any, next: any) {
+        next();
+      },
+    };
+
+    const hybridNetworkInterface = createHybridNetworkInterface({ uri, batchInterval: 10, opts });
+    hybridNetworkInterface.use([middleware]).useAfter([afterware]);
+    assert.equal(hybridNetworkInterface.networkInterface._middlewares[0], middleware);
+    assert.equal(hybridNetworkInterface.batchedInterface._middlewares[0], middleware);
+    assert.equal(hybridNetworkInterface.networkInterface._afterwares[0], afterware);
+    assert.equal(hybridNetworkInterface.batchedInterface._afterwares[0], afterware);
+  });
+});
+

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -48,6 +48,7 @@ import './errors';
 import './mockNetworkInterface';
 import './graphqlSubscriptions';
 import './batchedNetworkInterface';
+import './hybridNetworkInterface';
 import './ObservableQuery';
 import './subscribeToMore';
 import './customResolvers';


### PR DESCRIPTION
First discussed here: https://apollographql.slack.com/archives/C11QBB84R/p1495471281173263
Issue filed here: https://github.com/apollographql/apollo-client/issues/1731

Core issue is that there are cases where a programmer would want to disable batching for a particular request to avoid the case where critical queries get automatically batched with slower ones. This creates a new NetworkInterface that's a hybrid which will route a request to the appropriate transport, defaulting to "Batched" but switching to HTTPFetchNetworkInterface if `disableBatch` is on the request.

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change
- [ ] Add your name and email to the AUTHORS file (optional)
- [ ] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion
- [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.
