### PR TITLE
Check if location source exists when rethrowing in `writeToStore`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ### vNEXT
+- Fix: Check if location source exists when rethrowing errors in `writeToStore`
 
 ### 1.2.2
 - Fix: Remove race condition in queryListenerFromObserver [PR #1670](https://github.com/apollographql/apollo-client/pull/1670)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change log
 
 ### vNEXT
-- Fix: Check if location source exists when rethrowing errors in `writeToStore`
+- Fix bug that caused errors in `writeToStore` to be rethrown as uncaught errors [PR #1673](https://github.com/apollographql/apollo-client/pull/1673)
 
 ### 1.2.2
 - Fix: Remove race condition in queryListenerFromObserver [PR #1670](https://github.com/apollographql/apollo-client/pull/1670)

--- a/src/data/writeToStore.ts
+++ b/src/data/writeToStore.ts
@@ -162,7 +162,7 @@ export function writeResultToStore({
     });
   } catch (e) {
     // XXX A bit hacky maybe ...
-    const e2 = new Error(`Error writing result to store for query ${document.loc && document.loc.source.body}`);
+    const e2 = new Error(`Error writing result to store for query ${document.loc && document.loc.source && document.loc.source.body}`);
     e2.message += '/n' + e.message;
     e2.stack = e.stack;
     throw e2;


### PR DESCRIPTION
When an error occurs in `writeToStore`, the error message is enhanced with the body of the location source. The source doesn't always exist, however, so we should check before trying to access its body. Here is an example of this happening:

<img width="755" alt="screen shot 2017-05-25 at 10 24 27" src="https://cloud.githubusercontent.com/assets/621323/26444513/abe6283c-4134-11e7-996a-877ee176a946.png">

<img width="808" alt="screen shot 2017-05-25 at 10 24 52" src="https://cloud.githubusercontent.com/assets/621323/26444527/b3863bae-4134-11e7-80e7-8b33934dadc6.png">


TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
