### PR TITLE
remove inital version of dep linking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,6 @@ install:
 script:
   - npm test
 
-    # run tests on current master of react-apollo
-  - npm link
-  - git clone https://github.com/apollographql/react-apollo
-  - cd react-apollo && npm link apollo-client && npm i && npm test && cd ../ && rm -rf react-apollo
-    # end tests of react apollo
-
     # run coverage and file size checks
   - npm run coverage
   - coveralls < ./coverage/lcov.info || true # ignore coveralls error


### PR DESCRIPTION
This method turned out to be more of a pain then a help. Working on a different way now but in the meantime, I'm going to pin the AC version on react-apollo so greenkeeper will work for us