### PR TITLE
IntrospectionResultData: fix broken typing

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,7 @@
 Authors
 
 Abhi Aiyer <abhiaiyer91@gmail.com>
+Avindra Goolcharan <aavindraa@gmail.com>
 Ben James <benhjames@sky.com>
 Brady Whitten <bwhitten518@gmail.com>
 Brett Jurgens <brett@brettjurgens.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ### vNEXT
+- Fix: broken edge case when setting up fragment matching with Typescript by fixing types on `IntrospectionResultData` [PR #1763](https://github.com/apollographql/apollo-client/pull/1763)
 
 ### v1.4.0
 - Feature: Add `operationName` to Redux actions where possible [PR #1676](https://github.com/apollographql/apollo-client/pull/1676)

--- a/src/data/fragmentMatcher.ts
+++ b/src/data/fragmentMatcher.ts
@@ -25,9 +25,9 @@ export type IntrospectionResultData = {
     types: [{
       kind: string,
       name: string,
-      possibleTypes: [{
+      possibleTypes: {
         name: string,
-      }],
+      }[],
     }],
   },
 };


### PR DESCRIPTION
The types:

`Original` : what is currently on `master`
`Fixed`: proposal in this PR

----

`data` represents a schema that will break due to invalid typing of `possibleTypes`.

`data2` will generate an error.

----

TL;DR;, I am trying to consume a GraphQL endpoint that is returning `[]` in `possibleTypes`, which `apollo-client` is refusing to accept.

```ts
 type Fixed = {
  __schema: {
    types: [{
      kind: string,
      name: string,
      possibleTypes: {
        name: string,
      }[],
    }],
  },
};

type Original = {
  __schema: {
    types: [{
      kind: string,
      name: string,
      possibleTypes: [{
        name: string,
      }],
    }],
  },
};

const data: Fixed = {
    __schema: {
        types: [
            {
                kind: 'someKind',
                name: 'someName',
                possibleTypes: []
            }
        ]
    }
};

const data2: Original = data; 
```