### PR TITLE
Specifically handle the connection directive when selecting store keys, fix #1779

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -41,6 +41,7 @@ Robert Dickert <robert.dickert@gmail.com>
 Robin Ricard <ricard.robin@gmail.com>
 Sashko Stubailo <s.stubailo@gmail.com>
 Sashko Stubailo <sashko@stubailo.com>
+Shadaj Laddad <shadaj@meteor.com>
 Simon Tucker <srtucker22@gmail.com>
 Slava Kim <imslavko@gmail.com>
 Slava Kim <slv@mit.edu>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### 1.5.0
 - `batchInterval` now has a default value of 10 ms [PR #1793](https://github.com/apollographql/apollo-client/pull/1793)
 - Added `batchMax` to allow you to limit the amount of queries in one batch. [PR #1659](https://github.com/apollographql/apollo-client/pull/1659)
+- the `@connection(key: ...)` directive can now be used to specify the key to use
+for the Apollo store and is removed by default when sending queries to the server [PR #1801](https://github.com/apollographql/apollo-client/pull/1801)
 
 ### 1.4.2
 - Improved error messages for writeToStore, readFragment and writeFragment [PR #1766](https://github.com/apollographql/apollo-client/pull/1766), [PR #1722](https://github.com/apollographql/apollo-client/pull/1722)

--- a/src/ApolloClient.ts
+++ b/src/ApolloClient.ts
@@ -65,7 +65,7 @@ import {
 } from './core/watchQueryOptions';
 
 import {
-  storeKeyNameFromFieldNameAndArgs,
+  getStoreKeyName,
 } from './data/storeUtils';
 
 import {
@@ -127,6 +127,7 @@ export default class ApolloClient implements DataProxy {
   public queryManager: QueryManager;
   public reducerConfig: ApolloReducerConfig;
   public addTypename: boolean;
+  public removeConnectionDirective: boolean;
   public disableNetworkFetches: boolean;
   /**
    * The dataIdFromObject function used by this client instance.
@@ -182,6 +183,7 @@ export default class ApolloClient implements DataProxy {
     ssrMode?: boolean,
     ssrForceFetchDelay?: number
     addTypename?: boolean,
+    removeConnectionDirective?: boolean,
     customResolvers?: CustomResolverMap,
     connectToDevTools?: boolean,
     queryDeduplication?: boolean,
@@ -197,6 +199,7 @@ export default class ApolloClient implements DataProxy {
       ssrMode = false,
       ssrForceFetchDelay = 0,
       addTypename = true,
+      removeConnectionDirective = true,
       customResolvers,
       connectToDevTools,
       fragmentMatcher,
@@ -219,10 +222,11 @@ export default class ApolloClient implements DataProxy {
     this.networkInterface = networkInterface ? networkInterface :
       createNetworkInterface({ uri: '/graphql' });
     this.addTypename = addTypename;
+    this.removeConnectionDirective = removeConnectionDirective;
     this.disableNetworkFetches = ssrMode || ssrForceFetchDelay > 0;
     this.dataId = dataIdFromObject = dataIdFromObject || defaultDataIdFromObject;
     this.dataIdFromObject = this.dataId;
-    this.fieldWithArgs = storeKeyNameFromFieldNameAndArgs;
+    this.fieldWithArgs = (fieldName, args) => getStoreKeyName(fieldName, undefined, args);
     this.queryDeduplication = queryDeduplication;
     this.ssrMode = ssrMode;
 
@@ -525,6 +529,7 @@ export default class ApolloClient implements DataProxy {
       reduxRootSelector: reduxRootSelector,
       store,
       addTypename: this.addTypename,
+      removeConnectionDirective: this.removeConnectionDirective,
       reducerConfig: this.reducerConfig,
       queryDeduplication: this.queryDeduplication,
       fragmentMatcher: this.fragmentMatcher,

--- a/src/ApolloClient.ts
+++ b/src/ApolloClient.ts
@@ -127,7 +127,6 @@ export default class ApolloClient implements DataProxy {
   public queryManager: QueryManager;
   public reducerConfig: ApolloReducerConfig;
   public addTypename: boolean;
-  public removeConnectionDirective: boolean;
   public disableNetworkFetches: boolean;
   /**
    * The dataIdFromObject function used by this client instance.
@@ -183,7 +182,6 @@ export default class ApolloClient implements DataProxy {
     ssrMode?: boolean,
     ssrForceFetchDelay?: number
     addTypename?: boolean,
-    removeConnectionDirective?: boolean,
     customResolvers?: CustomResolverMap,
     connectToDevTools?: boolean,
     queryDeduplication?: boolean,
@@ -199,7 +197,6 @@ export default class ApolloClient implements DataProxy {
       ssrMode = false,
       ssrForceFetchDelay = 0,
       addTypename = true,
-      removeConnectionDirective = true,
       customResolvers,
       connectToDevTools,
       fragmentMatcher,
@@ -222,11 +219,10 @@ export default class ApolloClient implements DataProxy {
     this.networkInterface = networkInterface ? networkInterface :
       createNetworkInterface({ uri: '/graphql' });
     this.addTypename = addTypename;
-    this.removeConnectionDirective = removeConnectionDirective;
     this.disableNetworkFetches = ssrMode || ssrForceFetchDelay > 0;
     this.dataId = dataIdFromObject = dataIdFromObject || defaultDataIdFromObject;
     this.dataIdFromObject = this.dataId;
-    this.fieldWithArgs = (fieldName, args) => getStoreKeyName(fieldName, undefined, args);
+    this.fieldWithArgs = getStoreKeyName;
     this.queryDeduplication = queryDeduplication;
     this.ssrMode = ssrMode;
 
@@ -529,7 +525,6 @@ export default class ApolloClient implements DataProxy {
       reduxRootSelector: reduxRootSelector,
       store,
       addTypename: this.addTypename,
-      removeConnectionDirective: this.removeConnectionDirective,
       reducerConfig: this.reducerConfig,
       queryDeduplication: this.queryDeduplication,
       fragmentMatcher: this.fragmentMatcher,

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -228,10 +228,15 @@ export class ObservableQuery<T> extends Observable<ApolloQueryResult<T>> {
     if (!fetchMoreOptions.updateQuery) {
       throw new Error('updateQuery option is required. This function defines how to update the query data with the new results.');
     }
+
+    let previous: any;
+
     return Promise.resolve()
       .then(() => {
         const qid = this.queryManager.generateQueryId();
         let combinedOptions: any = null;
+
+        previous = this.currentResult().data;
 
         if (fetchMoreOptions.query) {
           // fetch a new query
@@ -265,8 +270,9 @@ export class ObservableQuery<T> extends Observable<ApolloQueryResult<T>> {
           // TODO REFACTOR: reached max recursion depth (figuratively) when renaming queryVariables.
           // Continue renaming to variables further down when we have time.
           const queryVariables = variables;
+
           return reducer(
-            previousResult, {
+            previous, {
               fetchMoreResult: data as Object,
               queryVariables,
             });

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -228,9 +228,6 @@ export class ObservableQuery<T> extends Observable<ApolloQueryResult<T>> {
     if (!fetchMoreOptions.updateQuery) {
       throw new Error('updateQuery option is required. This function defines how to update the query data with the new results.');
     }
-
-    const previous = this.result();
-
     return Promise.resolve()
       .then(() => {
         const qid = this.queryManager.generateQueryId();
@@ -258,23 +255,18 @@ export class ObservableQuery<T> extends Observable<ApolloQueryResult<T>> {
           query: combinedOptions.query,
           fetchPolicy: 'network-only',
         } as WatchQueryOptions;
-
         return this.queryManager.fetchQuery(qid, combinedOptions, FetchType.normal, this.queryId);
-      }).then((fetchMoreResult) => {
-        return previous.then((prev) => {
-          return {prev, fetchMoreResult};
-        });
-      }).then(({prev, fetchMoreResult}) => {
+      })
+      .then((fetchMoreResult) => {
         const { data } = fetchMoreResult;
         const reducer = fetchMoreOptions.updateQuery;
-
         const mapFn = (previousResult: any, { variables }: {variables: any }) => {
+
           // TODO REFACTOR: reached max recursion depth (figuratively) when renaming queryVariables.
           // Continue renaming to variables further down when we have time.
           const queryVariables = variables;
-
           return reducer(
-            prev.data, {
+            previousResult, {
               fetchMoreResult: data as Object,
               queryVariables,
             });

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -46,6 +46,7 @@ import {
 
 import {
   addTypenameToDocument,
+  removeConnectionDirectiveFromDocument,
 } from '../queries/queryTransform';
 
 import {
@@ -135,6 +136,7 @@ export class QueryManager {
   public ssrMode: boolean;
 
   private addTypename: boolean;
+  private removeConnectionDirective: boolean;
   private deduplicator: Deduplicator;
   private reduxRootSelector: ApolloStateSelector;
   private reducerConfig: ApolloReducerConfig;
@@ -177,6 +179,7 @@ export class QueryManager {
     reducerConfig = { mutationBehaviorReducers: {} },
     fragmentMatcher,
     addTypename = true,
+    removeConnectionDirective = true,
     queryDeduplication = false,
     ssrMode = false,
   }: {
@@ -186,6 +189,7 @@ export class QueryManager {
     fragmentMatcher?: FragmentMatcherInterface,
     reducerConfig?: ApolloReducerConfig,
     addTypename?: boolean,
+    removeConnectionDirective?: boolean,
     queryDeduplication?: boolean,
     ssrMode?: boolean,
   }) {
@@ -200,6 +204,7 @@ export class QueryManager {
     this.queryListeners = {};
     this.queryDocuments = {};
     this.addTypename = addTypename;
+    this.removeConnectionDirective = removeConnectionDirective;
     this.queryDeduplication = queryDeduplication;
     this.ssrMode = ssrMode;
 
@@ -1017,6 +1022,10 @@ export class QueryManager {
     // Apply the query transformer if one has been provided
     if (this.addTypename) {
       queryDoc = addTypenameToDocument(queryDoc);
+    }
+
+    if (this.removeConnectionDirective) {
+      queryDoc = removeConnectionDirectiveFromDocument(queryDoc);
     }
 
     return {

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1096,24 +1096,28 @@ export class QueryManager {
           }
 
           return result;
-        }).then(() => {
-
+        }).then((result) => {
           let resultFromStore: any;
-          try {
-            // ensure result is combined with data already in store
-            // this will throw an error if there are missing fields in
-            // the results if returnPartialData is false.
-            resultFromStore = readQueryFromStore({
-              store: this.getApolloState().data,
-              variables,
-              query: document,
-              config: this.reducerConfig,
-              fragmentMatcherFunction: this.fragmentMatcher.match,
-            });
-            // ensure multiple errors don't get thrown
-            /* tslint:disable */
-          } catch (e) {}
-          /* tslint:enable */
+
+          if (fetchMoreForQueryId) {
+            resultFromStore = result.data;
+          } else {
+            try {
+              // ensure result is combined with data already in store
+              // this will throw an error if there are missing fields in
+              // the results if returnPartialData is false.
+              resultFromStore = readQueryFromStore({
+                store: this.getApolloState().data,
+                variables,
+                query: document,
+                config: this.reducerConfig,
+                fragmentMatcherFunction: this.fragmentMatcher.match,
+              });
+              // ensure multiple errors don't get thrown
+              /* tslint:disable */
+            } catch (e) {}
+            /* tslint:enable */
+          }
 
           const { reducerError } = this.getApolloState();
           if (reducerError && reducerError.queryId === queryId) {

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1100,6 +1100,8 @@ export class QueryManager {
           let resultFromStore: any;
 
           if (fetchMoreForQueryId) {
+            // XXX We don't write fetchMore results to the store because this would overwrite
+            // the original result in case an @connection directive is used.
             resultFromStore = result.data;
           } else {
             try {

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -46,7 +46,6 @@ import {
 
 import {
   addTypenameToDocument,
-  removeConnectionDirectiveFromDocument,
 } from '../queries/queryTransform';
 
 import {
@@ -136,7 +135,6 @@ export class QueryManager {
   public ssrMode: boolean;
 
   private addTypename: boolean;
-  private removeConnectionDirective: boolean;
   private deduplicator: Deduplicator;
   private reduxRootSelector: ApolloStateSelector;
   private reducerConfig: ApolloReducerConfig;
@@ -179,7 +177,6 @@ export class QueryManager {
     reducerConfig = { mutationBehaviorReducers: {} },
     fragmentMatcher,
     addTypename = true,
-    removeConnectionDirective = true,
     queryDeduplication = false,
     ssrMode = false,
   }: {
@@ -189,7 +186,6 @@ export class QueryManager {
     fragmentMatcher?: FragmentMatcherInterface,
     reducerConfig?: ApolloReducerConfig,
     addTypename?: boolean,
-    removeConnectionDirective?: boolean,
     queryDeduplication?: boolean,
     ssrMode?: boolean,
   }) {
@@ -204,7 +200,6 @@ export class QueryManager {
     this.queryListeners = {};
     this.queryDocuments = {};
     this.addTypename = addTypename;
-    this.removeConnectionDirective = removeConnectionDirective;
     this.queryDeduplication = queryDeduplication;
     this.ssrMode = ssrMode;
 
@@ -1022,10 +1017,6 @@ export class QueryManager {
     // Apply the query transformer if one has been provided
     if (this.addTypename) {
       queryDoc = addTypenameToDocument(queryDoc);
-    }
-
-    if (this.removeConnectionDirective) {
-      queryDoc = removeConnectionDirectiveFromDocument(queryDoc);
     }
 
     return {

--- a/src/data/readFromStore.ts
+++ b/src/data/readFromStore.ts
@@ -16,7 +16,7 @@ import {
 } from './storeUtils';
 
 import {
-  storeKeyNameFromFieldNameAndArgs,
+  getStoreKeyName,
 } from './storeUtils';
 
 import {
@@ -132,13 +132,13 @@ const readStoreResolver: Resolver = (
   idValue: IdValueWithPreviousResult,
   args: any,
   context: ReadStoreContext,
-  { resultKey }: ExecInfo,
+  { resultKey, directives }: ExecInfo,
 ) => {
   assertIdValue(idValue);
 
   const objId = idValue.id;
   const obj = context.store[objId];
-  const storeKeyName = storeKeyNameFromFieldNameAndArgs(fieldName, args);
+  const storeKeyName = getStoreKeyName(fieldName, directives, args);
   let fieldValue = (obj || {})[storeKeyName];
 
   if (typeof fieldValue === 'undefined') {

--- a/src/data/readFromStore.ts
+++ b/src/data/readFromStore.ts
@@ -138,7 +138,7 @@ const readStoreResolver: Resolver = (
 
   const objId = idValue.id;
   const obj = context.store[objId];
-  const storeKeyName = getStoreKeyName(fieldName, directives, args);
+  const storeKeyName = getStoreKeyName(fieldName, args, directives);
   let fieldValue = (obj || {})[storeKeyName];
 
   if (typeof fieldValue === 'undefined') {

--- a/src/data/store.ts
+++ b/src/data/store.ts
@@ -69,7 +69,8 @@ export function data(
     // Ignore results from old requests
     // XXX this means that if you have a refetch interval which is shorter than your roundtrip time,
     // your query will be in the loading state forever!
-    if (action.requestId < queries[action.queryId].lastRequestId) {
+    // do not write to the store if this is for fetchMore
+    if (action.requestId < queries[action.queryId].lastRequestId || action.fetchMoreForQueryId) {
       return previousState;
     }
 

--- a/src/data/storeUtils.ts
+++ b/src/data/storeUtils.ts
@@ -94,16 +94,16 @@ export function storeKeyNameFromField(field: FieldNode, variables?: Object): str
       argObj, name, value, variables));
   }
 
-  return getStoreKeyName(field.name.value, directivesObj, argObj);
+  return getStoreKeyName(field.name.value, argObj, directivesObj);
 }
 
 export type Directives = {
-    [fieldName: string]: {
+    [directiveName: string]: {
         [argName: string]: any;
     };
 };
 
-export function getStoreKeyName(fieldName: string, directives?: Directives, args?: Object): string {
+export function getStoreKeyName(fieldName: string, args?: Object, directives?: Directives): string {
   if (directives && directives['connection'] && directives['connection']['key']) {
     return directives['connection']['key'];
   }

--- a/src/transport/networkInterface.ts
+++ b/src/transport/networkInterface.ts
@@ -17,6 +17,10 @@ import {
   BatchAfterwareInterface,
 } from './afterware';
 
+import {
+  removeConnectionDirectiveFromDocument,
+} from '../queries/queryTransform';
+
 /**
  * This is an interface that describes an GraphQL document to be sent
  * to the server.
@@ -192,6 +196,12 @@ export class HTTPFetchNetworkInterface extends BaseNetworkInterface {
     return this.applyMiddlewares({
       request,
       options,
+    }).then((rao) => {
+      if (rao.request.query) {
+        rao.request.query = removeConnectionDirectiveFromDocument(rao.request.query);
+      }
+
+      return rao;
     }).then( (rao) => this.fetchFromRemoteEndpoint.call(this, rao))
       .then(response => this.applyAfterwares({
         response: response as Response,

--- a/test/client.ts
+++ b/test/client.ts
@@ -2555,7 +2555,7 @@ describe('client', () => {
     return withWarning(() => client.query({ query }), /Missing field description/);
   });
 
-  it('should run queries that include the connection directive', () => {
+  it('runs a query with the connection directive and writes it to the store key defined in the directive', () => {
     const query = gql`
       {
         books(skip: 0, limit: 2) @connection(key: "abc") {
@@ -2594,7 +2594,7 @@ describe('client', () => {
     });
   });
 
-  it('should run queries that include the connection directive even if there are no arguments', () => {
+  it('should not remove the connection directive at the store level', () => {
     const query = gql`
       {
         books(skip: 0, limit: 2) @connection {
@@ -2634,7 +2634,7 @@ describe('client', () => {
   });
 });
 
-it('should run queries that include the connection directive', () => {
+it('should run a query with the connection directive and write the result to the store key defined in the directive', () => {
     const query = gql`
       {
         books(skip: 0, limit: 2) @connection(key: "abc") {

--- a/test/readFromStore.ts
+++ b/test/readFromStore.ts
@@ -812,4 +812,43 @@ describe('reading from the store', () => {
       nullField: null,
     });
   });
+
+  it('properly handles the connection directive', () => {
+    const store: NormalizedCache = {
+      'ROOT_QUERY': {
+        'abc': [
+          {
+            'generated': true,
+            'id': 'ROOT_QUERY.abc.0',
+            'type': 'id',
+          },
+        ],
+      },
+      'ROOT_QUERY.abc.0': {
+        'name': 'efgh',
+      },
+    };
+
+    const queryResult = readQueryFromStore({
+      store,
+      query: gql`
+        {
+          books(skip: 0, limit: 2) @connection(key: "abc") {
+            name
+          }
+        }
+      `,
+    });
+
+    assert.deepEqual<{}>(
+      queryResult,
+      {
+        'books': [
+          {
+            'name': 'efgh',
+          },
+        ],
+      },
+    );
+  });
 });

--- a/test/util/wrap.ts
+++ b/test/util/wrap.ts
@@ -17,9 +17,10 @@ export function withWarning(func: Function, regex: RegExp) {
 
   console.warn = (m: string) => message = m;
 
-  return Promise.resolve(func()).then(() => {
+  return Promise.resolve(func()).then((val) => {
     assert.match(message, regex);
     console.warn = oldWarn;
+    return val;
   });
 }
 

--- a/test/writeToStore.ts
+++ b/test/writeToStore.ts
@@ -1311,4 +1311,62 @@ describe('writing to the store', () => {
       });
     }, /stringField(.|\n)*abcd/g);
   });
+
+  it('properly handles the connection directive', () => {
+    const store: NormalizedCache = {};
+
+    writeQueryToStore({
+      query: gql`
+        {
+          books(skip: 0, limit: 2) @connection(key: "abc") {
+            name
+          }
+        }
+      `,
+      result: {
+        books: [
+          {
+            name: 'abcd',
+          },
+        ],
+      },
+      store,
+    });
+
+    writeQueryToStore({
+      query: gql`
+        {
+          books(skip: 2, limit: 4) @connection(key: "abc") {
+            name
+          }
+        }
+      `,
+      result: {
+        books: [
+          {
+            name: 'efgh',
+          },
+        ],
+      },
+      store,
+    });
+
+    assert.deepEqual<NormalizedCache>(
+      store,
+      {
+        'ROOT_QUERY': {
+          'abc': [
+            {
+              'generated': true,
+              'id': 'ROOT_QUERY.abc.0',
+              'type': 'id',
+            },
+          ],
+        },
+        'ROOT_QUERY.abc.0': {
+          'name': 'efgh',
+        },
+      },
+    );
+  });
 });


### PR DESCRIPTION
This gives the client specific knowledge of the `@connection` directive so that the store key can be properly derived from the directive. This also updates the query transformer to remove the directive before sending requests to the server. This fixes #1779 

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
- [x] Add your name and email to the AUTHORS file (optional)
