### PR TITLE
1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### vNEXT
 
+### 1.5.0
 - `batchInterval` now has a default value of 10 ms [PR #1793](https://github.com/apollographql/apollo-client/pull/1793)
 - Added `batchMax` to allow you to limit the amount of queries in one batch. [PR #1659](https://github.com/apollographql/apollo-client/pull/1659)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-client",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "dependencies": {
     "@types/async": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-client",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "A simple yet functional GraphQL client.",
   "main": "./lib/apollo.umd.js",
   "module": "./lib/src/index.js",


### PR DESCRIPTION
Thanks to @ramyanaga, @happylinks and @kamilkisiela for their contributions in this version!

We've updated the batching network interface. `batchInterval` now has a default value (10ms) and there's a new option called `batchMaxQueries` which specifies an upper limit for the number of queries to batch together. If there are more than `batchMax` queries queued up, the batch gets sent immediately and a new batch is started, regardless of `batchInterval`.