### PR TITLE
Add Observable support in the Network Interface

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,6 +14,7 @@ David Glasser <glasser@meteor.com>
 Dominic Watson <intellix@gmail.com>
 Dhaivat Pandya <dhaivat@meteor.com>
 Dhaivat Pandya <dhaivatpandya@gmail.com>
+Evans Hauser <evanshauser@gmail.com>
 Doug Swain <pseudoramble@gmail.com>
 Google Inc.
 Ian Grayson <ian133@gmail.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@
 ### vNEXT
 
 ### 1.7.0
-- adapter that converts a network interface that returns an Observable into promised network interface
-[PR #1840](https://github.com/apollographql/apollo-client/pull/1840)
+- Add support for network interfaces that return observables [PR #1840](https://github.com/apollographql/apollo-client/pull/1840)
 
 ### 1.6.1
 - Pin @types/node to 8.0.2 to avoid breaking type update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### vNEXT
 
+### 1.7.0
+- adapter that converts a network interface that returns an Observable into promised network interface
+[PR #1840](https://github.com/apollographql/apollo-client/pull/1840)
+
 ### 1.6.1
 - Pin @types/node to 8.0.2 to avoid breaking type update
 

--- a/src/ApolloClient.ts
+++ b/src/ApolloClient.ts
@@ -216,7 +216,7 @@ export default class ApolloClient implements DataProxy {
       this.fragmentMatcher = fragmentMatcher;
     }
 
-    if ( networkInterface && typeof networkInterface.request === 'function') {
+    if ( networkInterface && typeof (<ObservableNetworkInterface>networkInterface).request === 'function') {
       this.networkInterface = {
         ...networkInterface,
         query: (request) => new Promise<ExecutionResult>((resolve, reject) => {

--- a/src/transport/networkInterface.ts
+++ b/src/transport/networkInterface.ts
@@ -21,6 +21,8 @@ import {
   removeConnectionDirectiveFromDocument,
 } from '../queries/queryTransform';
 
+import { Observable } from '../util/Observable';
+
 /**
  * This is an interface that describes an GraphQL document to be sent
  * to the server.
@@ -53,6 +55,11 @@ export interface PrintedRequest {
 export interface NetworkInterface {
   [others: string]: any;
   query(request: Request): Promise<ExecutionResult>;
+}
+
+export interface ObservableNetworkInterface {
+  [others: string]: any;
+  request(request: Request): Observable<ExecutionResult>;
 }
 
 export interface BatchedNetworkInterface extends NetworkInterface {

--- a/src/transport/networkInterface.ts
+++ b/src/transport/networkInterface.ts
@@ -58,7 +58,6 @@ export interface NetworkInterface {
 }
 
 export interface ObservableNetworkInterface {
-  [others: string]: any;
   request(request: Request): Observable<ExecutionResult>;
 }
 

--- a/test/client.ts
+++ b/test/client.ts
@@ -246,7 +246,6 @@ describe('client', () => {
   });
 
   it('should allow for a single query to take place', () => {
-
     const query = gql`
       query people {
         allPeople(first: 1) {
@@ -688,7 +687,6 @@ describe('client', () => {
   });
 
   it('should return GraphQL errors correctly for a single query with an observable enabled network interface', (done) => {
-
     const query = gql`
       query people {
         allPeople(first: 1) {
@@ -724,8 +722,6 @@ describe('client', () => {
   });
 
   it('should pass a network error correctly on a query with observable network interface', (done) => {
-
-
     const query = gql`
       query people {
         allPeople(first: 1) {

--- a/test/client.ts
+++ b/test/client.ts
@@ -64,6 +64,7 @@ import {
 } from '../src/transport/batchedNetworkInterface';
 
 import mockNetworkInterface from './mocks/mockNetworkInterface';
+import { mockObservableNetworkInterface } from './mocks/mockNetworkInterface';
 
 import {
   getFragmentDefinitions,
@@ -245,6 +246,7 @@ describe('client', () => {
   });
 
   it('should allow for a single query to take place', () => {
+
     const query = gql`
       query people {
         allPeople(first: 1) {
@@ -270,6 +272,49 @@ describe('client', () => {
     };
 
     return clientRoundtrip(query, data);
+  });
+
+  it('should allow a single query with an observable enabled network interface', (done) => {
+    const query = gql`
+      query people {
+        allPeople(first: 1) {
+          people {
+            name
+            __typename
+          }
+          __typename
+        }
+      }
+    `;
+
+    const data = {
+      allPeople: {
+        people: [
+          {
+            name: 'Luke Skywalker',
+            __typename: 'Person',
+          },
+        ],
+        __typename: 'People',
+      },
+    };
+
+    const variables = { first: 1 };
+
+    const networkInterface = mockObservableNetworkInterface({
+      request: { query, variables },
+      result: { data },
+    });
+
+    const client = new ApolloClient({
+      networkInterface,
+      addTypename: false,
+    });
+
+    const basic = client.query({ query, variables }).then((actualResult) => {
+      assert.deepEqual(actualResult.data, data);
+      done();
+    });
   });
 
   it('should allow for a single query with complex default variables to take place', () => {
@@ -639,6 +684,83 @@ describe('client', () => {
     return client.query({ query })
       .catch((error: ApolloError) => {
         assert.deepEqual(error.graphQLErrors, errors);
+      });
+  });
+
+  it('should return GraphQL errors correctly for a single query with an observable enabled network interface', (done) => {
+
+    const query = gql`
+      query people {
+        allPeople(first: 1) {
+          people {
+            name
+          }
+        }
+      }
+    `;
+
+    const errors: GraphQLError[] = [
+      {
+        name: 'test',
+        message: 'Syntax Error GraphQL request (8:9) Expected Name, found EOF',
+      },
+    ];
+
+    const networkInterface = mockObservableNetworkInterface({
+      request: { query },
+      result: { errors },
+    });
+
+    const client = new ApolloClient({
+      networkInterface,
+      addTypename: false,
+    });
+
+    client.query({ query })
+      .catch((error: ApolloError) => {
+        assert.deepEqual(error.graphQLErrors, errors);
+        done();
+      });
+  });
+
+  it('should pass a network error correctly on a query with observable network interface', (done) => {
+
+
+    const query = gql`
+      query people {
+        allPeople(first: 1) {
+          people {
+            name
+          }
+        }
+      }
+    `;
+
+    const data = {
+      person: {
+        firstName: 'John',
+        lastName: 'Smith',
+      },
+    };
+
+    const networkError = new Error('Some kind of network error.');
+
+    const networkInterface = mockObservableNetworkInterface({
+      request: { query },
+      result: { data },
+      error: networkError,
+    });
+
+    const client = new ApolloClient({
+      networkInterface,
+      addTypename: false,
+    });
+
+    client.query({ query })
+      .catch((error: ApolloError) => {
+        assert(error.networkError);
+        assert.deepEqual(error.networkError!.message, networkError.message);
+        done();
       });
   });
 


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

Adds adapter that converts an ObservableNetworkInterface, which returns an Observable, to a normal NetworkInterface. This provides the entry point for the new network layer, which returns Observables.

TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
- [x] Add your name and email to the AUTHORS file (optional)
