### PR TITLE
Updated package-lock.json to 1.7.0.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-client",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 1,
   "dependencies": {
     "@types/async": {


### PR DESCRIPTION
Just runned `npm install` and it changed the lock file. Sounds like this change was forgotten.