### PR TITLE
Remove the query store from Redux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ### vNEXT
+- Remove query tracking from the Redux store. Query status tracking is now handled outside of Redux in the QueryStore class. [PR #1859](https://github.com/apollographql/apollo-client/pull/1859)
 - Remove mutation tracking from the Redux store. Mutation status tracking is now handled outside of Redux in the MutationStore class. [PR #1846](https://github.com/apollographql/apollo-client/pull/1846)
 - Use generic types for store updating functions in mutations [PR #1882](https://github.com/apollographql/apollo-client/pull/1882)
 - Update to TypeScript 2.4.1 [PR #1892](https://github.com/apollographql/apollo-client/pull/1892)

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "benchmark": "npm run compile:benchmark && node --stack-size=20000 lib/benchmark/index.js",
     "benchmark:inspect": "npm run compile:benchmark && node --stack-size=20000 --inspect --debug-brk lib/benchmark/index.js",
     "posttest": "npm run lint",
-    "filesize": "npm run compile:browser && ./scripts/filesize.js --file=./dist/index.min.js --maxGzip=27",
+    "filesize": "npm run compile:browser && ./scripts/filesize.js --file=./dist/index.min.js --maxGzip=28",
     "flow-check": "flow check",
     "compile": "tsc",
     "compile:benchmark": "tsc -p tsconfig.test.json",

--- a/src/ApolloClient.ts
+++ b/src/ApolloClient.ts
@@ -446,7 +446,10 @@ export default class ApolloClient implements DataProxy {
         if (this.devToolsHookCb) {
           this.devToolsHookCb({
             action,
-            state: this.queryManager.getApolloState(),
+            state: {
+              queries: this.queryManager.queryStore.getStore(),
+              mutations: this.queryManager.mutationStore.getStore(),
+            },
             dataWithOptimisticResults: this.queryManager.getDataWithOptimisticResults(),
           });
         }
@@ -485,7 +488,10 @@ export default class ApolloClient implements DataProxy {
         if (this.devToolsHookCb) {
           this.devToolsHookCb({
             action,
-            state: this.queryManager.getApolloState(),
+            state: {
+              queries: this.queryManager.queryStore.getStore(),
+              mutations: this.queryManager.mutationStore.getStore(),
+            },
             dataWithOptimisticResults: this.queryManager.getDataWithOptimisticResults(),
           });
         }

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -148,7 +148,7 @@ export class ObservableQuery<T> extends Observable<ApolloQueryResult<T>> {
    */
   public currentResult(): ApolloCurrentResult<T> {
     const { data, partial } = this.queryManager.getCurrentQueryResult(this, true);
-    const queryStoreValue = this.queryManager.getApolloState().queries[this.queryId];
+    const queryStoreValue = this.queryManager.queryStore.get(this.queryId);
 
     if (queryStoreValue && (
       (queryStoreValue.graphQLErrors && queryStoreValue.graphQLErrors.length > 0) ||

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -20,6 +20,7 @@ import {
 } from './types';
 
 import {
+  QueryStore,
   QueryStoreValue,
 } from '../queries/store';
 
@@ -137,12 +138,15 @@ import {
 import { ObservableQuery } from './ObservableQuery';
 
 export class QueryManager {
+  public static EMIT_REDUX_ACTIONS = true;
+
   public pollingTimers: {[queryId: string]: any};
   public scheduler: QueryScheduler;
   public store: ApolloStore;
   public networkInterface: NetworkInterface;
   public ssrMode: boolean;
   public mutationStore: MutationStore = new MutationStore();
+  public queryStore: QueryStore = new QueryStore();
 
   private addTypename: boolean;
   private deduplicator: Deduplicator;
@@ -181,6 +185,8 @@ export class QueryManager {
   private queryIdsByName: { [queryName: string]: string[] };
 
   private lastRequestId: { [queryId: string]: number } = {};
+
+  private disableBroadcasting = false;
 
   constructor({
     networkInterface,
@@ -298,7 +304,7 @@ export class QueryManager {
         Object.keys(updateQueriesByName).forEach(queryName => (this.queryIdsByName[queryName] || []).forEach(queryId => {
           ret[queryId] = {
             reducer: updateQueriesByName[queryName],
-            query: this.getApolloState().queries[queryId],
+            query: this.queryStore.get(queryId),
           };
         }));
       }
@@ -446,23 +452,40 @@ export class QueryManager {
 
     // Initialize query in store with unique requestId
     this.queryDocuments[queryId] = queryDoc;
-    this.store.dispatch({
-      type: 'APOLLO_QUERY_INIT',
+
+    this.queryStore.initQuery({
+      queryId,
       queryString,
       document: queryDoc,
-      operationName: getOperationName(queryDoc),
-      variables,
-      fetchPolicy,
-      queryId,
-      requestId,
-      // we store the old variables in order to trigger "loading new variables"
-      // state if we know we will go to the server
       storePreviousVariables: shouldFetch,
+      variables,
       isPoll: fetchType === FetchType.poll,
       isRefetch: fetchType === FetchType.refetch,
-      fetchMoreForQueryId,
       metadata,
+      fetchMoreForQueryId,
     });
+
+    this.broadcastQueries();
+
+    if (QueryManager.EMIT_REDUX_ACTIONS) {
+      this.store.dispatch({
+        type: 'APOLLO_QUERY_INIT',
+        queryString,
+        document: queryDoc,
+        operationName: getOperationName(queryDoc),
+        variables,
+        fetchPolicy,
+        queryId,
+        requestId,
+        // we store the old variables in order to trigger "loading new variables"
+        // state if we know we will go to the server
+        storePreviousVariables: shouldFetch,
+        isPoll: fetchType === FetchType.poll,
+        isRefetch: fetchType === FetchType.refetch,
+        fetchMoreForQueryId,
+        metadata,
+      });
+    }
 
     this.lastRequestId[queryId] = requestId;
 
@@ -470,16 +493,21 @@ export class QueryManager {
     // fetchPolicy is cache-only), we just write the store result as the final result.
     const shouldDispatchClientResult = !shouldFetch || fetchPolicy === 'cache-and-network';
     if (shouldDispatchClientResult) {
-      this.store.dispatch({
-        type: 'APOLLO_QUERY_RESULT_CLIENT',
-        result: { data: storeResult },
-        variables,
-        document: queryDoc,
-        operationName: getOperationName(queryDoc),
-        complete: !shouldFetch,
-        queryId,
-        requestId,
-      });
+      this.queryStore.markQueryResultClient(queryId, !shouldFetch);
+      this.broadcastQueries();
+
+      if (QueryManager.EMIT_REDUX_ACTIONS) {
+        this.store.dispatch({
+          type: 'APOLLO_QUERY_RESULT_CLIENT',
+          result: { data: storeResult },
+          variables,
+          document: queryDoc,
+          operationName: getOperationName(queryDoc),
+          complete: !shouldFetch,
+          queryId,
+          requestId,
+        });
+      }
     }
 
     if (shouldFetch) {
@@ -496,13 +524,18 @@ export class QueryManager {
           throw error;
         } else {
           if (requestId >= (this.lastRequestId[queryId] || 1)) {
-            this.store.dispatch({
-              type: 'APOLLO_QUERY_ERROR',
-              error,
-              queryId,
-              requestId,
-              fetchMoreForQueryId,
-            });
+            if (QueryManager.EMIT_REDUX_ACTIONS) {
+              this.store.dispatch({
+                type: 'APOLLO_QUERY_ERROR',
+                error,
+                queryId,
+                requestId,
+                fetchMoreForQueryId,
+              });
+            }
+
+            this.queryStore.markQueryError(queryId, error, fetchMoreForQueryId);
+            this.broadcastQueries();
           }
 
           this.removeFetchQueryPromise(requestId);
@@ -540,7 +573,7 @@ export class QueryManager {
 
       // XXX This is to fix a strange race condition that was the root cause of react-apollo/#170
       // queryStoreValue was sometimes the old queryStoreValue and not what's currently in the store.
-      queryStoreValue = this.getApolloState().queries[queryId];
+      queryStoreValue = this.queryStore.get(queryId);
 
       const storedQuery = this.observableQueries[queryId];
 
@@ -766,10 +799,15 @@ export class QueryManager {
   }
 
   public stopQueryInStore(queryId: string) {
-    this.store.dispatch({
-      type: 'APOLLO_QUERY_STOP',
-      queryId,
-    });
+    this.queryStore.stopQuery(queryId);
+    this.broadcastQueries();
+
+    if (QueryManager.EMIT_REDUX_ACTIONS) {
+      this.store.dispatch({
+        type: 'APOLLO_QUERY_STOP',
+        queryId,
+      });
+    }
   }
 
   public getApolloState(): Store {
@@ -844,6 +882,8 @@ export class QueryManager {
       reject(new Error('Store reset while query was in flight.'));
     });
 
+    this.queryStore.reset(Object.keys(this.observableQueries));
+
     this.store.dispatch({
       type: 'APOLLO_STORE_RESET',
       observableQueryIds: Object.keys(this.observableQueries),
@@ -859,7 +899,7 @@ export class QueryManager {
     // store.
     const observableQueryPromises: Promise<ApolloQueryResult<any>>[] = [];
     Object.keys(this.observableQueries).forEach((queryId) => {
-      const storeQuery = this.reduxRootSelector(this.store.getState()).queries[queryId];
+      const storeQuery = this.queryStore.get(queryId);
 
       const fetchPolicy = this.observableQueries[queryId].observableQuery.options.fetchPolicy;
 
@@ -1111,6 +1151,8 @@ export class QueryManager {
 
           // default the lastRequestId to 1
           if (requestId >= (this.lastRequestId[queryId] || 1)) {
+            this.disableBroadcasting = true;
+
             // XXX handle multiple ApolloQueryResults
             this.store.dispatch({
               type: 'APOLLO_QUERY_RESULT',
@@ -1123,6 +1165,14 @@ export class QueryManager {
               fetchMoreForQueryId,
               extraReducers,
             });
+
+            this.disableBroadcasting = false;
+
+            const { reducerError } = this.getApolloState();
+            if (!reducerError || reducerError.queryId !== queryId) {
+              this.queryStore.markQueryResult(queryId, result, fetchMoreForQueryId);
+              this.broadcastQueries();
+            }
           }
 
           this.removeFetchQueryPromise(requestId);
@@ -1191,7 +1241,10 @@ export class QueryManager {
   }
 
   private broadcastQueries() {
-    const queries = this.getApolloState().queries;
+    if (this.disableBroadcasting) {
+      return;
+    }
+
     Object.keys(this.queryListeners).forEach((queryId: string) => {
       const listeners = this.queryListeners[queryId];
       // XXX due to an unknown race condition listeners can sometimes be undefined here.
@@ -1202,7 +1255,7 @@ export class QueryManager {
           // it's possible for the listener to be undefined if the query is being stopped
           // See here for more detail: https://github.com/apollostack/apollo-client/issues/231
           if (listener) {
-            const queryStoreValue = queries[queryId];
+            const queryStoreValue = this.queryStore.get(queryId);
             listener(queryStoreValue);
           }
         });

--- a/src/mutations/store.ts
+++ b/src/mutations/store.ts
@@ -1,6 +1,10 @@
 export class MutationStore {
   private store: {[mutationId: string]: MutationStoreValue} = {};
 
+  public getStore(): {[mutationId: string]: MutationStoreValue} {
+    return this.store;
+  }
+
   public get(mutationId: string): MutationStoreValue {
     return this.store[mutationId];
   }

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -55,10 +55,10 @@ export class QueryScheduler {
   }
 
   public checkInFlight(queryId: string) {
-    const queries = this.queryManager.getApolloState().queries;
+    const queries = this.queryManager.queryStore;
 
     // XXX we do this because some legacy tests use a fake queryId. We should rewrite those tests
-    return queries[queryId] && queries[queryId].networkStatus !== NetworkStatus.ready;
+    return queries.get(queryId) && queries.get(queryId).networkStatus !== NetworkStatus.ready;
   }
 
   public fetchQuery<T>(queryId: string, options: WatchQueryOptions, fetchType: FetchType) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -20,7 +20,6 @@ import {
 } from './data/storeUtils';
 
 import {
-  queries,
   QueryStore,
 } from './queries/store';
 
@@ -62,7 +61,6 @@ export interface ReducerError {
 
 export interface Store {
   data: NormalizedCache;
-  queries: QueryStore;
   optimistic: OptimisticStore;
   reducerError: ReducerError | null;
 }
@@ -110,8 +108,6 @@ export function createApolloReducer(config: ApolloReducerConfig): (state: Store,
   return function apolloReducer(state = {} as Store, action: ApolloAction) {
     try {
       const newState: Store = {
-        queries: queries(state.queries, action),
-
         data: data(state.data, action, config),
         optimistic: [] as any,
 
@@ -134,7 +130,6 @@ export function createApolloReducer(config: ApolloReducerConfig): (state: Store,
       );
 
       if (state.data === newState.data &&
-      state.queries === newState.queries &&
       state.optimistic === newState.optimistic &&
       state.reducerError === newState.reducerError) {
         return state;

--- a/test/QueryManager.ts
+++ b/test/QueryManager.ts
@@ -2442,7 +2442,6 @@ describe('QueryManager', () => {
       const currentState = queryManager.getApolloState();
       const expectedState: any = {
         data: {},
-        queries: {},
         optimistic: [],
         reducerError: null,
       };
@@ -2996,7 +2995,7 @@ describe('QueryManager', () => {
       (result) => {
         assert.deepEqual(result.data, data);
         assert.deepEqual(
-          queryManager.getApolloState().queries[observable.queryId].metadata,
+          queryManager.queryStore.get(observable.queryId).metadata,
           { foo: 'bar' },
         );
       },

--- a/test/client.ts
+++ b/test/client.ts
@@ -181,7 +181,6 @@ describe('client', () => {
       client.store.getState(),
       {
         apollo: {
-          queries: {},
           data: {},
           optimistic: [],
           reducerError: null,
@@ -575,18 +574,6 @@ describe('client', () => {
     };
 
     const finalState = { apollo: assign({}, initialState.apollo, {
-      queries: {
-        '1': {
-          queryString: print(query),
-          document: query,
-          variables: {},
-          networkStatus: NetworkStatus.ready,
-          networkError: null,
-          graphQLErrors: [],
-          previousVariables: null,
-          metadata: null,
-        },
-      },
       reducerError: null,
     }) };
 
@@ -1531,6 +1518,66 @@ describe('client', () => {
     // if deduplication didn't happen, result.data will equal data2.
     return Promise.all([q1, q2]).then(([result1, result2]) => {
       assert.deepEqual(result1.data, result2.data);
+    });
+  });
+
+  it('emits Redux actions when the flag is enabled', () => {
+    QueryManager.EMIT_REDUX_ACTIONS = true;
+
+    const query = gql`
+      query people {
+        allPeople(first: 1) {
+          people {
+            name
+            __typename
+          }
+          __typename
+        }
+      }
+    `;
+
+    const data = {
+      allPeople: {
+        people: [
+          {
+            name: 'Luke Skywalker',
+            __typename: 'Person',
+          },
+        ],
+        __typename: 'People',
+      },
+    };
+
+    const networkInterface = mockNetworkInterface({
+      request: { query: cloneDeep(query) },
+      result: { data },
+    });
+
+    const client = new ApolloClient({
+      networkInterface,
+    });
+
+    client.initStore();
+
+    const orig = client.store.dispatch;
+    let actionEmitted = false;
+
+    client.store.dispatch = (action) => {
+      if (action.type === 'APOLLO_QUERY_INIT') {
+        actionEmitted = true;
+      }
+
+      orig(action);
+    };
+
+    const queryPromise = client.query({ query }).then((result) => {
+      assert.deepEqual(result.data, data);
+    });
+
+    QueryManager.EMIT_REDUX_ACTIONS = false;
+
+    return queryPromise.then(() => {
+      assert(actionEmitted, 'An action was not emitted');
     });
   });
 

--- a/test/store.ts
+++ b/test/store.ts
@@ -21,7 +21,6 @@ describe('createApolloStore', () => {
     assert.deepEqual(
       store.getState()['apollo'],
       {
-        queries: {},
         data: {},
         optimistic: [],
         reducerError: null,
@@ -37,7 +36,6 @@ describe('createApolloStore', () => {
     assert.deepEqual(
       store.getState()['test'],
       {
-        queries: {},
         data: {},
         optimistic: [],
         reducerError: null,
@@ -61,7 +59,6 @@ describe('createApolloStore', () => {
 
     assert.deepEqual(store.getState(), {
       apollo: {
-        queries: {},
         data: initialState.apollo.data,
         optimistic: initialState.apollo.optimistic,
         reducerError: null,
@@ -115,7 +112,6 @@ describe('createApolloStore', () => {
     };
 
     const emptyState: Store = {
-      queries: { },
       data: { },
       optimistic: ([] as any[]),
       reducerError: null,
@@ -147,18 +143,6 @@ describe('createApolloStore', () => {
     };
 
     const emptyState: Store = {
-      queries: {
-        'test.0': {
-          'graphQLErrors': [],
-          'networkStatus': 1,
-          'networkError': null,
-          'previousVariables': null,
-          'queryString': '',
-          'document': queryDocument,
-          'variables': {},
-          'metadata': null,
-        },
-      },
       data: {},
       optimistic: ([] as any[]),
       reducerError: null,
@@ -232,7 +216,6 @@ describe('createApolloStore', () => {
     assert(/test!!!/.test(store.getState().apollo.reducerError.error));
 
     const resetState = {
-      queries: {},
       data: {},
       optimistic: [
         {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -10,7 +10,10 @@
 import 'es6-promise';
 import 'isomorphic-fetch';
 
+import { QueryManager } from '../src/core/QueryManager';
+
 process.env.NODE_ENV = 'test';
+QueryManager.EMIT_REDUX_ACTIONS = false;
 
 declare function require(name: string): any;
 require('source-map-support').install();


### PR DESCRIPTION
Depends on https://github.com/apollographql/apollo-client/pull/1846

This moves out the query store out from Redux into a separate class. Many now unused Redux actions are still dispatched for compatibility with applications that depend on those actions.

TODO:
- [x] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
