### PR TITLE
Instrument rollup to use window.Redux

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,9 +1,15 @@
+const globals = {
+  'redux': 'Redux'
+};
+
 export default {
   entry: 'lib/src/index.js',
   dest: 'lib/apollo.umd.js',
   format: 'umd',
   sourceMap: true,
   moduleName: 'apollo',
+  exports: 'named',
+  globals,
   onwarn
 };
 


### PR DESCRIPTION
Since there's the `window.Redux` [available](https://github.com/reactjs/redux#installation) we can take advantage of it.

`const globals = {}` - is a space to put packages that's objects are available in global scope.
`exports: 'named'` - just to stay close to what rollup's [documentation says](https://rollupjs.org/#big-list-of-options)