### PR TITLE
Replace usage of `Object` with `Record`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### vNEXT
 - added prettier to manage formatting of project [PR #1904](https://github.com/apollographql/apollo-client/pull/1904)
+- Replace use of `Object` with `Record<string, any>` in mutation types
 
 ### v.1.9.0-0
 - Remove query tracking from the Redux store. Query status tracking is now handled outside of Redux in the QueryStore class. [PR #1859](https://github.com/apollographql/apollo-client/pull/1859)

--- a/src/data/mutationResults.ts
+++ b/src/data/mutationResults.ts
@@ -4,23 +4,23 @@ import { ApolloExecutionResult } from '../core/types';
 
 // This is part of the public API, people write these functions in `updateQueries`.
 export type MutationQueryReducer<T> = (
-  previousResult: Object,
+  previousResult: Record<string, any>,
   options: {
     mutationResult: ApolloExecutionResult<T>;
     queryName: string | null;
-    queryVariables: Object;
+    queryVariables: Record<string, any>;
   },
-) => Object;
+) => Record<string, any>;
 
 export type MutationQueryReducersMap<T = { [key: string]: any }> = {
   [queryName: string]: MutationQueryReducer<T>;
 };
 
 export type OperationResultReducer = (
-  previousResult: Object,
+  previousResult: Record<string, any>,
   action: ApolloAction,
-  variables: Object,
-) => Object;
+  variables: Record<string, any>,
+) => Record<string, any>;
 
 export type OperationResultReducerMap = {
   [queryId: string]: OperationResultReducer;


### PR DESCRIPTION
Address #1818 

Using the `Object` type can be pretty restrictive, as you can't access properties on it. Using `Record` will let TS users access arbitrary properties on the objects.

[TS example showing usage of `Record` vs `Object`](https://www.typescriptlang.org/play/index.html#src=let%20x%3A%20Record%3Cstring%2C%20any%3E%0D%0A%0D%0Ax%20%3D%20%7B%20a%3A%201%20%7D%0D%0Ax.b%20%3D%204%0D%0A%0D%0Alet%20y%3A%20Object%0D%0Ay%20%3D%20%7B%20a%3A%201%20%7D%0D%0Ay.b%20%3D%204)

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.