### PR TITLE
Adds failing test for fetchMore utilizing a connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ### vNEXT
+- Fix issue with fetchMore not merging results correctly when the @connection directive is used [PR #1915](https://github.com/apollographql/apollo-client/pull/1915)
 - added prettier to manage formatting of project [PR #1904](https://github.com/apollographql/apollo-client/pull/1904)
 
 ### v.1.9.0-0

--- a/src/data/store.ts
+++ b/src/data/store.ts
@@ -38,6 +38,10 @@ export function data(
   const constAction = action;
 
   if (isQueryResultAction(action)) {
+    if (action.fetchMoreForQueryId) {
+      return previousState;
+    }
+
     // XXX handle partial result due to errors
     if (!graphQLResultHasError(action.result)) {
       // XXX use immutablejs instead of cloning


### PR DESCRIPTION
Per request #1873, related to #1906 

Can confirm issue described in #1906 by altering the assertion from
```javascript
        for (let i = 1; i <= 20; i++) {
          assert.equal(comments[i - 1].text, `comment ${i}`);
        }
```
to
```javascript
        for (let i = 1; i <= 10; i++) {
          assert.equal(comments[i - 1].text, `comment ${i + 10}`);
        }
        for (let i = 11; i <= 20; i++) {
          assert.equal(comments[i - 1].text, `comment ${i}`);
        }
```
