### PR TITLE
Fix flow signature for middleware

### DIFF
--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -39,7 +39,6 @@ export interface MiddlewareRequest {
 
 export interface MiddlewareInterface {
   applyMiddleware(
-    this: HTTPFetchNetworkInterface,
     request: MiddlewareRequest,
     next: Function,
   ): void,
@@ -52,7 +51,6 @@ export interface BatchMiddlewareRequest {
 
 export interface BatchMiddlewareInterface {
   applyBatchMiddleware(
-    this: HTTPBatchedNetworkInterface,
     request: BatchMiddlewareRequest,
     next: Function,
   ): void,
@@ -64,7 +62,6 @@ export interface AfterwareResponse {
 
 export interface AfterwareInterface {
   applyAfterware(
-    this: HTTPFetchNetworkInterface,
     response: AfterwareResponse,
     next: Function,
   ): any,
@@ -77,7 +74,6 @@ export interface BatchAfterwareResponse {
 
 export interface BatchAfterwareInterface {
   applyBatchAfterware(
-    this: HTTPBatchedNetworkInterface,
     response: BatchAfterwareResponse,
     next: Function,
   ): any,
@@ -98,12 +94,8 @@ export interface SubscriptionNetworkInterface {
   unsubscribe(id: Number): void,
 }
 
-export type NetworkMiddleware =
-  | MiddlewareInterface[]
-  | BatchMiddlewareInterface[];
-export type NetworkAfterware =
-  | AfterwareInterface[]
-  | BatchAfterwareInterface[];
+export type NetworkMiddleware = Array<MiddlewareInterface | BatchMiddlewareInterface>;
+export type NetworkAfterware = Array<AfterwareInterface | BatchAfterwareInterface>;
 
 declare export class HTTPNetworkInterface extends NetworkInterface {
   _uri: string,

--- a/test/flow.js
+++ b/test/flow.js
@@ -29,6 +29,30 @@ const client1 = new ApolloClient({
 });
 
 const networkInterface1 = createNetworkInterface("localhost:3000");
+
+networkInterface1.use([{
+  applyMiddleware(req, next) {
+    const token = localStorage.getItem('token') || ''
+    if (!req.options.headers) {
+        req.options.headers = { authorization: token }
+    } else if (req.options.headers instanceof Headers) {
+        req.options.headers.set('authorization', token)
+    } else {
+        req.options.headers.authorization = token;
+    }
+    next();
+  }
+}]);
+
+networkInterface1.useAfter([{
+  applyAfterware({ response }, next) {
+    if (response.status === 401) {
+      next();
+    }
+    next();
+  }
+}]);
+
 const client2 = new ApolloClient({ networkInterface: networkInterface1 });
 
 // $ExpectError


### PR DESCRIPTION
I don't believe "this" as an argument is a convention in flow, also flow seemed to be struggling with the union of interface[] types so I consolidated them into an array of the union of the interfaces. 

Added test cases modified from the copy/paste examples of middleware use from the docs.