### PR TITLE
Added apollo-link support for the network interface and deprecated ObservableNetworkInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ### vNEXT
+- Adds apollo-link network interface support [PR #1918](https://github.com/apollographql/apollo-client/pull/1918)
 - Fix issue with fetchMore not merging results correctly when the @connection directive is used [PR #1915](https://github.com/apollographql/apollo-client/pull/1915)
 - added prettier to manage formatting of project [PR #1904](https://github.com/apollographql/apollo-client/pull/1904)
 - Replace use of `Object` with `Record<string, any>` in mutation types

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
   "author": "Sashko Stubailo <sashko@stubailo.com>",
   "license": "MIT",
   "dependencies": {
+    "apollo-link": "^0.0.1",
     "graphql": "^0.10.0",
     "graphql-anywhere": "^3.0.1",
     "graphql-tag": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "bundlesize": [
     {
       "path": "./dist/index.min.js",
-      "threshold": "28 Kb"
+      "threshold": "30 Kb"
     }
   ],
   "jest": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "compile:benchmark": "tsc -p tsconfig.test.json",
     "compile:coverage": "tsc -p tsconfig.coverage.json",
     "compile:test": "tsc -p tsconfig.test.json",
-    "compile:browser": "rm -rf ./dist && mkdir ./dist && browserify ./lib/apollo.umd.js -o=./dist/index.js && npm run minify:browser",
+    "compile:browser": "rm -rf ./dist && mkdir ./dist && browserify ./lib/apollo.umd.js --i graphql-tag -o=./dist/index.js && npm run minify:browser",
     "minify:browser": "uglifyjs -c -m -o ./dist/index.min.js -- ./dist/index.js",
     "watch": "tsc -w",
     "watch:test": "tsc -p tsconfig.test.json -w",
@@ -54,7 +54,10 @@
     }
   },
   "lint-staged": {
-    "*.ts*": ["prettier --trailing-comma all --single-quote --write", "git add"]
+    "*.ts*": [
+      "prettier --trailing-comma all --single-quote --write",
+      "git add"
+    ]
   },
   "pre-commit": "lint-staged",
   "keywords": [
@@ -69,7 +72,7 @@
   "author": "Sashko Stubailo <sashko@stubailo.com>",
   "license": "MIT",
   "dependencies": {
-    "apollo-link": "^0.0.1",
+    "apollo-link": "^0.0.3",
     "graphql": "^0.10.0",
     "graphql-anywhere": "^3.0.1",
     "graphql-tag": "^2.0.0",

--- a/test/client.ts
+++ b/test/client.ts
@@ -68,7 +68,9 @@ import { withWarning } from './util/wrap';
 
 import observableToPromise from './util/observableToPromise';
 
-import { cloneDeep, assign } from 'lodash';
+import { cloneDeep, assign, isEqual } from 'lodash';
+
+import { ApolloLink, Observable } from 'apollo-link';
 
 declare var fetch: any;
 
@@ -267,7 +269,7 @@ describe('client', () => {
     return clientRoundtrip(query, { data });
   });
 
-  it('should allow a single query with an observable enabled network interface', done => {
+  it('should allow a single query with an apollo-link enabled network interface', done => {
     const query = gql`
       query people {
         allPeople(first: 1) {
@@ -294,10 +296,13 @@ describe('client', () => {
 
     const variables = { first: 1 };
 
-    const networkInterface = mockObservableNetworkInterface({
-      request: { query, variables },
-      result: { data },
-    });
+    const networkInterface = ApolloLink.from([
+      () => {
+        return Observable.of({
+          data,
+        });
+      },
+    ]);
 
     const client = new ApolloClient({
       networkInterface,
@@ -677,7 +682,7 @@ describe('client', () => {
     });
   });
 
-  it('should return GraphQL errors correctly for a single query with an observable enabled network interface', done => {
+  it('should return GraphQL errors correctly for a single query with an apollo-link enabled network interface', done => {
     const query = gql`
       query people {
         allPeople(first: 1) {
@@ -688,6 +693,16 @@ describe('client', () => {
       }
     `;
 
+    const data = {
+      allPeople: {
+        people: [
+          {
+            name: 'Luke Skywalker',
+          },
+        ],
+      },
+    };
+
     const errors: GraphQLError[] = [
       {
         name: 'test',
@@ -695,10 +710,13 @@ describe('client', () => {
       },
     ];
 
-    const networkInterface = mockObservableNetworkInterface({
-      request: { query },
-      result: { errors },
-    });
+    const networkInterface = ApolloLink.from([
+      () => {
+        return new Observable(observer => {
+          observer.next({ data, errors });
+        });
+      },
+    ]);
 
     const client = new ApolloClient({
       networkInterface,
@@ -711,7 +729,49 @@ describe('client', () => {
     });
   });
 
-  it('should pass a network error correctly on a query with observable network interface', done => {
+  it('should pass a network error correctly on a query using an observable network interface with a warning', done => {
+    withWarning(() => {
+      const query = gql`
+        query people {
+          allPeople(first: 1) {
+            people {
+              name
+            }
+          }
+        }
+      `;
+
+      const data = {
+        person: {
+          firstName: 'John',
+          lastName: 'Smith',
+        },
+      };
+
+      const networkError = new Error('Some kind of network error.');
+
+      const networkInterface = ApolloLink.from([
+        () => {
+          return new Observable(observer => {
+            throw networkError;
+          });
+        },
+      ]);
+
+      const client = new ApolloClient({
+        networkInterface,
+        addTypename: false,
+      });
+
+      client.query({ query }).catch((error: ApolloError) => {
+        assert(error.networkError);
+        assert.deepEqual(error.networkError!.message, networkError.message);
+        done();
+      });
+    }, /deprecated/);
+  });
+
+  it('should pass a network error correctly on a query with apollo-link network interface', done => {
     const query = gql`
       query people {
         allPeople(first: 1) {
@@ -731,11 +791,13 @@ describe('client', () => {
 
     const networkError = new Error('Some kind of network error.');
 
-    const networkInterface = mockObservableNetworkInterface({
-      request: { query },
-      result: { data },
-      error: networkError,
-    });
+    const networkInterface = ApolloLink.from([
+      () => {
+        return new Observable(observer => {
+          throw networkError;
+        });
+      },
+    ]);
 
     const client = new ApolloClient({
       networkInterface,
@@ -747,6 +809,43 @@ describe('client', () => {
       assert.deepEqual(error.networkError!.message, networkError.message);
       done();
     });
+  });
+
+  it('should warn when receiving multiple results from apollo-link network interface', () => {
+    const query = gql`
+      query people {
+        allPeople(first: 1) {
+          people {
+            name
+          }
+        }
+      }
+    `;
+
+    const data = {
+      allPeople: {
+        people: [
+          {
+            name: 'Luke Skywalker',
+          },
+        ],
+      },
+    };
+
+    const networkInterface = ApolloLink.from([
+      () => Observable.of({ data }, { data }),
+    ]);
+
+    const client = new ApolloClient({
+      networkInterface,
+      addTypename: false,
+    });
+
+    return withWarning(() => {
+      return client.query({ query }).then((result: ExecutionResult) => {
+        assert.deepEqual(result.data, data);
+      });
+    }, /multiple results/);
   });
 
   it('should surface errors in observer.next as uncaught', done => {


### PR DESCRIPTION
With the additional functionality, Apollo Client is able to use an `apollo-link` directly as the network interface. The `ObservableNetworkInterface` is no longer needed.

### Checklist:

- [ ] Make sure all of the significant new logic is covered by tests