### PR TITLE
Update lastResult with computed value of currentResult()

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -73,3 +73,4 @@ Stephen Potter <me@stevepotter.me>
 Michaël De Boey <info@michaeldeboey.be>
 Andreas Bergenwall <abergenw@gmail.com>
 Michiel Westerbeek <happylinks@gmail.com>
+James Reggio <james.reggio@gmail.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix issue with fetchMore not merging results correctly when the @connection directive is used [PR #1915](https://github.com/apollographql/apollo-client/pull/1915)
 - added prettier to manage formatting of project [PR #1904](https://github.com/apollographql/apollo-client/pull/1904)
 - Replace use of `Object` with `Record<string, any>` in mutation types
+- Fix loss of referential equality for results returned by `currentResults()` before an ObservableQuery is setup [PR #1927](https://github.com/apollographql/apollo-client/pull/1927)
 
 ### v.1.9.0-0
 - Remove query tracking from the Redux store. Query status tracking is now handled outside of Redux in the QueryStore class. [PR #1859](https://github.com/apollographql/apollo-client/pull/1859)

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -189,12 +189,18 @@ export class ObservableQuery<T> extends Observable<ApolloQueryResult<T>> {
       networkStatus = loading ? NetworkStatus.loading : NetworkStatus.ready;
     }
 
-    return {
+    const result = {
       data,
       loading: isNetworkRequestInFlight(networkStatus),
       networkStatus,
-      partial,
     };
+
+    if (!partial) {
+      const stale = false;
+      this.lastResult = { ...result, stale };
+    }
+
+    return { ...result, partial };
   }
 
   // Returns the last result that observer.next was called with. This is not the same as

--- a/test/ObservableQuery.ts
+++ b/test/ObservableQuery.ts
@@ -1105,7 +1105,7 @@ describe('ObservableQuery', () => {
             stale: false,
           });
 
-          if (handleCount === 1) {
+          if (handleCount === 2) {
             assert.deepEqual<ApolloQueryResult<any>>(subResult, {
               data: dataTwo,
               loading: false,


### PR DESCRIPTION
A pseudo-race condition exists for observable queries that return a result from `currentResult()` before `setUpQuery()` is invoked. The condition causes a referential equality checks to fail for results obtained before and after `setUpQuery()`, despite the results being truly equal.

This is problematic for `react-apollo` apps, since it can cause an unnecessary second render during initial component mounting, which is a perf-sensitive time for most apps (especially those built in React Native).

Here's the problem, in step-by-step detail:

1. A `graphql` query HOC from `react-apollo` begins mounting.
1. In `componentWillMount()`, it creates an `ObservableQuery` (but it doesn't subscribe).
1. In its initial `render()`, it calls `currentResult()` on the `ObservableQuery` instance, and reads a potentially complete result from the cache.
1. In `componentDidMount()`, it creates the first subscription to the `ObservableQuery`.
1. The `ObservableQuery` sees that it now has an observer, and calls `setUpQuery()`.
1. `setUpQuery()` invokes `startQuery()` on the query manager.
1. The query manager executes the query, which produces another immediate result from the cache.
1. The HOC's query observer receives this second result from the cache, and schedules a re-render.

This wouldn't be problematic if the two results from the cache were referentially equal, but they're not. They differ because `readQueryFromStore()` and `diffQueryAgainstStore()` utilize a `previousResult` argument to compare and eliminate creating new objects during the execution of `graphql-everywhere` against the local cache.

The query execution in Step 7 above does not receive an instance of the `previousResult` generated during Step 3, and as a result, returns a new instance of the result payload. (Further identical results are referentially equal, as expected, because the `previousResult` is preserved both locally within the closure generated by `queryListenerForObserver()`, as well as in a member variable on `ObservableQuery`.)

My original inclination was to alter `react-apollo` to avoid receiving cached data twice, but this is fraught with challenges pertaining to server rendering. Ultimately, the bug resides within `apollo-client`, **though I'm not convinced this is the right fix**.

There's obviously a lot of moving parts here, and a number of serious code smells, including:

* The `currentResult()` method in its entirety — it feels like it's attempt to simulate logic from the query manager synchronously, and it does so within the `ObservableQuery` module, which is far from the logic it's simulating.

* The use of captured state within the `queryListenerForObserver()` closure seems error-prone, especially given the callouts to race conditions within the method, and the use of the `this.observableQueries` reverse lookup mechanism — which is not guaranteed to resolve to an instance for a given `queryId`.

I've broken a test with my changes, and would sincerely appreciate some help getting this over the line. I'm definitely open to further discussing/clarifying the problem, if the above explanation is too challenging to follow.