### PR TITLE
Add documentation for ApolloClient.subscribe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ### vNEXT
+- Document ApolloClient.prototype.subscribe [PR #1932](https://github.com/apollographql/apollo-client/pull/1932)
 
 ### 1.9.0-1
 - Adds apollo-link network interface support [PR #1918](https://github.com/apollographql/apollo-client/pull/1918)

--- a/src/ApolloClient.ts
+++ b/src/ApolloClient.ts
@@ -397,6 +397,10 @@ export default class ApolloClient implements DataProxy {
     return this.queryManager.mutate<T>(options);
   }
 
+  /**
+   * This subscribes to a graphql subscription according to the options specified and returns an
+   * {@link Observable} which either emits received data or an error.
+   */
   public subscribe(options: SubscriptionOptions): Observable<any> {
     this.initStore();
 

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -99,7 +99,16 @@ export type SubscribeToMoreOptions = {
 };
 
 export interface SubscriptionOptions {
+  /**
+   * A GraphQL document, often created with `gql` from the `graphql-tag`
+   * package, that contains a single subscription inside of it.
+   */
   query: DocumentNode;
+
+  /**
+   * An object that maps from the name of a variable as used in the subscription
+   * GraphQL document to that variable's value.
+   */
   variables?: { [key: string]: any };
 }
 


### PR DESCRIPTION
This adds basic documentation on roughly the same level as query and mutate.
I want to add the subscribe method to the web docs and figured this as a pre-req