### PR TITLE
Fix NetworkMiddleware flow type

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,6 +17,7 @@ Dhaivat Pandya <dhaivatpandya@gmail.com>
 Evans Hauser <evanshauser@gmail.com>
 Doug Swain <pseudoramble@gmail.com>
 Google Inc.
+Hammad Jutt <jutt@ualberta.ca>
 Ian Grayson <ian133@gmail.com>
 Ian MacLeod <ian@nevir.net>
 James Baxley <james.baxley@newspring.cc>
@@ -55,7 +56,6 @@ amandajliu <ajliu72@gmail.com>
 davidwoody <davidjwoody@gmail.com>
 delianides <drew@delianides.com>
 greenkeeperio-bot <support@greenkeeper.io>
-hammadj <jutt@ualberta.ca>
 matt debergalis <matt@meteor.com>
 Vladimir Guguiev <wizardzloy@gmail.com>
 Edvin Eriksson <edvinerikson@gmail.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ### vNEXT
+- Fix NetworkMiddleware flow typings [PR #1937](https://github.com/apollographql/apollo-client/pull/1937)
 
 ### 1.9.0-1
 - Adds apollo-link network interface support [PR #1918](https://github.com/apollographql/apollo-client/pull/1918)

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -94,8 +94,8 @@ export interface SubscriptionNetworkInterface {
   unsubscribe(id: Number): void,
 }
 
-export type NetworkMiddleware = Array<MiddlewareInterface | BatchMiddlewareInterface>;
-export type NetworkAfterware = Array<AfterwareInterface | BatchAfterwareInterface>;
+export type NetworkMiddleware = Array<MiddlewareInterface> | Array<BatchMiddlewareInterface>;
+export type NetworkAfterware = Array<AfterwareInterface> | Array<BatchAfterwareInterface>;
 
 declare export class HTTPNetworkInterface extends NetworkInterface {
   _uri: string,

--- a/test/flow.js
+++ b/test/flow.js
@@ -11,7 +11,7 @@
 
 // @flow
 import ApolloClient, { createNetworkInterface, ApolloError } from "../src";
-import type { ApolloQueryResult } from "../src";
+import type { ApolloQueryResult, MiddlewareInterface, AfterwareInterface } from "../src";
 import type { DocumentNode } from "graphql";
 import gql from "graphql-tag";
 
@@ -30,28 +30,31 @@ const client1 = new ApolloClient({
 
 const networkInterface1 = createNetworkInterface("localhost:3000");
 
-networkInterface1.use([{
+const middleware: MiddlewareInterface[] = [{
   applyMiddleware(req, next) {
-    const token = localStorage.getItem('token') || ''
+    const token = localStorage.getItem('token') || '';
     if (!req.options.headers) {
-        req.options.headers = { authorization: token }
+      req.options.headers = { authorization: token }
     } else if (req.options.headers instanceof Headers) {
-        req.options.headers.set('authorization', token)
+      req.options.headers.set('authorization', token)
     } else {
-        req.options.headers.authorization = token;
+      req.options.headers.authorization = token;
     }
     next();
   }
-}]);
+}];
+networkInterface1.use(middleware);
 
-networkInterface1.useAfter([{
+const afterware: AfterwareInterface[] = [{
   applyAfterware({ response }, next) {
     if (response.status === 401) {
       next();
     }
     next();
   }
-}]);
+}];
+
+networkInterface1.useAfter(afterware);
 
 const client2 = new ApolloClient({ networkInterface: networkInterface1 });
 


### PR DESCRIPTION
When adding middleware and afterware to the network interface, it should only accept either `applyMiddleware` or `applyBatchMiddleware`, but not both. The way to types were defined, it would accept both types of middleware. This is the error that the test case I added would give:

```
test/flow.js:33
 33: const middleware: MiddlewareInterface[] = [{
                       ^^^^^^^^^^^^^^^^^^^ property `applyMiddleware` of MiddlewareInterface. Property not found in
 97: export type NetworkMiddleware = Array<MiddlewareInterface | BatchMiddlewareInterface>;
                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^ BatchMiddlewareInterface. See: src/index.js.flow:97

test/flow.js:48
 48: const afterware: AfterwareInterface[] = [{
                      ^^^^^^^^^^^^^^^^^^ property `applyAfterware` of AfterwareInterface. Property not found in
 98: export type NetworkAfterware = Array<AfterwareInterface | BatchAfterwareInterface>;
                                                               ^^^^^^^^^^^^^^^^^^^^^^^ BatchAfterwareInterface. See: src/index.js.flow:98
```