### PR TITLE
Move to apollo-link-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ### vNEXT
+- Move to `apollo-link-core` from `apollo-link` to reduce bundle size [PR #1955](https://github.com/apollographql/apollo-client/pull/1955)
 - Document ApolloClient.prototype.subscribe [PR #1932](https://github.com/apollographql/apollo-client/pull/1932)
 - Fix NetworkMiddleware flow typings [PR #1937](https://github.com/apollographql/apollo-client/pull/1937)
 

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   "author": "Sashko Stubailo <sashko@stubailo.com>",
   "license": "MIT",
   "dependencies": {
-    "apollo-link": "^0.2.0",
+    "apollo-link-core": "^0.2.0",
     "graphql": "^0.10.0",
     "graphql-anywhere": "^3.0.1",
     "graphql-tag": "^2.0.0",

--- a/test/client.ts
+++ b/test/client.ts
@@ -70,7 +70,7 @@ import observableToPromise from './util/observableToPromise';
 
 import { cloneDeep, assign, isEqual } from 'lodash';
 
-import { ApolloLink, Observable } from 'apollo-link';
+import { ApolloLink, Observable } from 'apollo-link-core';
 
 declare var fetch: any;
 


### PR DESCRIPTION
Replacing `apollo-link` with `apollo-link-core` to reduce bundle size

### Checklist:

- [x] Make sure all of the significant new logic is covered by tests