### PR TITLE
Trim @connection directives when using batch network interface

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,6 +3,7 @@ Authors
 Abhi Aiyer <abhiaiyer91@gmail.com>
 Avindra Goolcharan <aavindraa@gmail.com>
 Ben James <benhjames@sky.com>
+Ben Straub <ben@straub.cc>
 Brady Whitten <bwhitten518@gmail.com>
 Brett Jurgens <brett@brettjurgens.com>
 Bruce Williams <brwcodes@gmail.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### vNEXT
 - Document ApolloClient.prototype.subscribe [PR #1932](https://github.com/apollographql/apollo-client/pull/1932)
 - Fix NetworkMiddleware flow typings [PR #1937](https://github.com/apollographql/apollo-client/pull/1937)
+- Fix use of @connection directives when using batching [PR #1961](https://github.com/apollographql/apollo-client/pull/1961)
 
 ### 1.9.0-1
 - Adds apollo-link network interface support [PR #1918](https://github.com/apollographql/apollo-client/pull/1918)

--- a/src/transport/batchedNetworkInterface.ts
+++ b/src/transport/batchedNetworkInterface.ts
@@ -9,6 +9,7 @@ import {
   Request,
   printRequest,
 } from './networkInterface';
+import { removeConnectionDirectiveFromDocument } from '../queries/queryTransform';
 
 import { BatchAfterwareInterface } from './afterware';
 
@@ -84,6 +85,10 @@ export class HTTPBatchedNetworkInterface extends BaseNetworkInterface {
     return new Promise((resolve, reject) => {
       middlewarePromise
         .then((batchRequestAndOptions: BatchRequestAndOptions) => {
+          batchRequestAndOptions.requests.forEach(r => {
+            if (r.query)
+              r.query = removeConnectionDirectiveFromDocument(r.query);
+          });
           return this.batchedFetchFromRemoteEndpoint(batchRequestAndOptions)
             .then(result => {
               const httpResponse = result as Response;

--- a/test/batchedNetworkInterface.ts
+++ b/test/batchedNetworkInterface.ts
@@ -446,4 +446,10 @@ describe('HTTPBatchedNetworkInterface', () => {
         });
     });
   });
+
+  describe('transforming queries', () => {
+    it('should remove the @connection directive', () => {
+      // TODO:
+    });
+  });
 });


### PR DESCRIPTION
I discovered a problem when writing a prototype. If you write a query like this (reproducible [here](https://github.com/ben/react-apollo-error-template)):

```graphql
query abc {
  allTrainers @connection(key: "abc") { name }
}
```

…it works perfectly when using the standard `networkInterface`, since that one [strips out the `@connection` bits before transmitting the query](https://github.com/apollographql/apollo-client/blob/ae390a30cb330073645e886f9c1f20d2a509994e/src/transport/networkInterface.ts#L207-L215). However, when using `createBatchingNetworkInterface`, the `@connection` directive is not stripped, and is included with the request payload, which rightly confuses the server.

This adds a bit of code to bring the batch interface to parity with the standard one, at least for this particular feature.

### TODO

- [x] Fix the bug
- [x] Write tests
