### PR TITLE
Fix flow type issue with custom network interfaces

### DIFF
--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -24,7 +24,7 @@ export interface Request {
   operationName?: string | null,
 }
 
-declare export class NetworkInterface {
+export interface NetworkInterface {
   query(request: Request): Promise<ExecutionResult>,
 }
 
@@ -97,13 +97,14 @@ export interface SubscriptionNetworkInterface {
 export type NetworkMiddleware = Array<MiddlewareInterface> | Array<BatchMiddlewareInterface>;
 export type NetworkAfterware = Array<AfterwareInterface> | Array<BatchAfterwareInterface>;
 
-declare export class HTTPNetworkInterface extends NetworkInterface {
+declare export class HTTPNetworkInterface {
   _uri: string,
   _opts: RequestOptions,
   _middlewares: NetworkMiddleware,
   _afterwares: NetworkAfterware,
   use(middlewares: NetworkMiddleware): HTTPNetworkInterface,
   useAfter(afterwares: NetworkAfterware): HTTPNetworkInterface,
+  query(request: Request): Promise<ExecutionResult>
 }
 
 export interface BatchRequestAndOptions {
@@ -173,7 +174,7 @@ declare export function createNetworkInterface(
   secondArgOpts?: NetworkInterfaceOptions,
 ): HTTPNetworkInterface;
 
-declare export class BaseNetworkInterface extends NetworkInterface {
+declare export class BaseNetworkInterface {
   _middlewares: NetworkMiddleware,
   _afterwares: NetworkAfterware,
   _uri: string,

--- a/test/flow.js
+++ b/test/flow.js
@@ -11,7 +11,7 @@
 
 // @flow
 import ApolloClient, { createNetworkInterface, ApolloError } from "../src";
-import type { ApolloQueryResult, MiddlewareInterface, AfterwareInterface } from "../src";
+import type { ApolloQueryResult, MiddlewareInterface, AfterwareInterface, Request, HTTPNetworkInterface } from "../src";
 import type { DocumentNode } from "graphql";
 import gql from "graphql-tag";
 
@@ -24,9 +24,7 @@ const mutation: DocumentNode = gql`mutation { foo }`;
 const client = new ApolloClient("localhost:3000");
 
 // $ExpectError
-const client1 = new ApolloClient({
-  networkInterface: true,
-});
+const client1 = new ApolloClient({ networkInterface: true });
 
 const networkInterface1 = createNetworkInterface("localhost:3000");
 
@@ -68,6 +66,29 @@ const data = client.query({ query });
 
 // $ExpectError
 console.log(data.loading);
+
+class CustomNetworkInterface {
+  networkInterface: HTTPNetworkInterface;
+
+  constructor(networkInterface: HTTPNetworkInterface) {
+    this.networkInterface = networkInterface;
+  }
+
+  query(request: Request) {
+   return this.networkInterface.query(request);
+  }
+}
+
+const client3 = new ApolloClient({
+  networkInterface: new CustomNetworkInterface(networkInterface1)
+})
+
+class BadCustomNetworkInterface {}
+
+const client4 = new ApolloClient({
+  // $ExpectError
+  networkInterface: BadCustomNetworkInterface
+});
 
 // $ExpectError
 const status: Promise<ApolloError | boolean> = data.then(({ data, error }) => {


### PR DESCRIPTION
Since the type NetworkInterface was defined as a class, ApolloClient didn't allow for custom network interfaces to be passed. 

After a quick look in the codebase I discovered that NetworkInterface is also defined as an interface in Typescript.


### Checklist:
- [x] Make sure all of the significant new logic is covered by tests
