### PR TITLE
Allow data fetch after a NetworkError when polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Document ApolloClient.prototype.subscribe [PR #1932](https://github.com/apollographql/apollo-client/pull/1932)
 - Fix NetworkMiddleware flow typings [PR #1937](https://github.com/apollographql/apollo-client/pull/1937)
 - Fix use of @connection directives when using batching [PR #1961](https://github.com/apollographql/apollo-client/pull/1961)
+- Allow data fetch after a NetworkError when polling
 
 ### 1.9.0-1
 - Adds apollo-link network interface support [PR #1918](https://github.com/apollographql/apollo-client/pull/1918)

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -46,12 +46,13 @@ export class QueryScheduler {
   }
 
   public checkInFlight(queryId: string) {
-    const queries = this.queryManager.queryStore;
+    const querie = this.queryManager.queryStore.get(queryId);
 
     // XXX we do this because some legacy tests use a fake queryId. We should rewrite those tests
     return (
-      queries.get(queryId) &&
-      queries.get(queryId).networkStatus !== NetworkStatus.ready
+      querie &&
+      querie.networkStatus !== NetworkStatus.ready &&
+      querie.networkStatus !== NetworkStatus.error
     );
   }
 

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -46,13 +46,13 @@ export class QueryScheduler {
   }
 
   public checkInFlight(queryId: string) {
-    const querie = this.queryManager.queryStore.get(queryId);
+    const query = this.queryManager.queryStore.get(queryId);
 
     // XXX we do this because some legacy tests use a fake queryId. We should rewrite those tests
     return (
-      querie &&
-      querie.networkStatus !== NetworkStatus.ready &&
-      querie.networkStatus !== NetworkStatus.error
+      query &&
+      query.networkStatus !== NetworkStatus.ready &&
+      query.networkStatus !== NetworkStatus.error
     );
   }
 

--- a/test/scheduler.ts
+++ b/test/scheduler.ts
@@ -220,6 +220,9 @@ describe('QueryScheduler', () => {
 
       error(errorVal) {
         assert(errorVal);
+        const queryId = scheduler.intervalQueries[queryOptions.pollInterval][0];
+        assert.isFalse(scheduler.checkInFlight(queryId),
+            'Should be able to poll after an error')
         subscription.unsubscribe();
         done();
       },


### PR DESCRIPTION
Hi,
I had the case where I had some network errors while my query was set with polling options and until it was manually restarted, it didn't try to do anything.

This change allows to poll even if there is a network error.
