### PR TITLE
Align middleware flow types with redux middleware types.

### DIFF
--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -1123,9 +1123,7 @@ declare export class ApolloClient extends DataProxy {
   writeFragment(options: DataProxyWriteFragmentOptions): void,
   reducer(): (state: Store, action: ApolloAction) => Store,
   ___actionHookForDevTools(cb: Function): void,
-  middleware: () => (store: ApolloStore) => (next: any) => (
-    action: any,
-  ) => any,
+  middleware: <S, A>() => Middleware<S, A>,
   initStore(): void,
   resetStore(): void,
   getInitialState(): {

--- a/test/flow.js
+++ b/test/flow.js
@@ -11,7 +11,17 @@
 
 // @flow
 import ApolloClient, { createNetworkInterface, ApolloError } from "../src";
-import type { ApolloQueryResult, MiddlewareInterface, AfterwareInterface, Request, HTTPNetworkInterface } from "../src";
+import type {
+    ApolloQueryResult,
+    MiddlewareInterface,
+    AfterwareInterface,
+    Request,
+    HTTPNetworkInterface,
+    Store as ApolloState,
+    ApolloAction
+} from "../src";
+import {combineReducers, createStore, applyMiddleware} from 'redux';
+import type {Store as ReduxStore} from 'redux';
 import type { DocumentNode } from "graphql";
 import gql from "graphql-tag";
 
@@ -105,3 +115,20 @@ const result: ApolloQueryResult<mixed> = observable.result();
 
 // $ExpectError
 const current: Promise<ApolloQueryResult<mixed>> = observable.currentResult();
+
+const client5 = new ApolloClient({
+    networkInterface: networkInterface1
+});
+
+const reducer = combineReducers({
+    apollo: client5.reducer()
+});
+
+type State = {
+    apollo: ApolloState
+};
+
+const store: ReduxStore<State, ApolloAction> = createStore(
+    reducer,
+    applyMiddleware(client5.middleware())
+);


### PR DESCRIPTION
We're experiencing issues with mounting the apolloClient middleware in our own redux state tree. 

This is caused because the type signature of the middleware method is conflicting with the redux's own flow type definition. I figured it'd be better to reuse redux's Middleware type since apolloClient.middleware() seems to be designed specifically to plug the apolloClient into your own redux store.  

### Checklist:
- [x] Make sure all of the significant new logic is covered by tests