### PR TITLE
Fix mistake in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To use this client in a web browser or mobile app, you'll need a build system ca
 
 ## Usage
 
-If you know you want to use the core `apollo-client` package you can get started by constructing an instance of the core class [`ApolloClient`][] with a network interface created by network interface you may call the [`createNetworkInterface`][] function like so:
+If you know you want to use the core `apollo-client` package you can get started by constructing an instance of the core class [`ApolloClient`][] with a network interface created by the [`createNetworkInterface`][] function like so:
 
 ```js
 import ApolloClient, { createNetworkInterface } from 'apollo-client';


### PR DESCRIPTION
The mistake was introduced by https://github.com/apollographql/apollo-client/commit/5863eac1e7e20df6165f2b7a8b5e700909efa969 when consolidating the two examples for `new ApolloClient`.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.
