### PR TITLE
fixed two queries in flight bug for Apollo Link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### vNEXT
 
+-fixed `resolved` scoping issue for multiple queries in flight with Apollo Link [PR #2002](https://github.com/apollographql/apollo-client/pull/2002)
+
 ### 1.9.0
 - Move to `apollo-link-core` from `apollo-link` to reduce bundle size [PR #1955](https://github.com/apollographql/apollo-client/pull/1955)
 - Document ApolloClient.prototype.subscribe [PR #1932](https://github.com/apollographql/apollo-client/pull/1932)

--- a/src/ApolloClient.ts
+++ b/src/ApolloClient.ts
@@ -207,9 +207,9 @@ export default class ApolloClient implements DataProxy {
     const createQuery = (
       getResult: (request: Request) => Observable<ExecutionResult>,
     ) => {
-      let resolved = false;
       return (request: Request) =>
         new Promise<ExecutionResult>((resolve, reject) => {
+          let resolved = false;
           const subscription = getResult(request).subscribe({
             next: (data: ExecutionResult) => {
               if (!resolved) {


### PR DESCRIPTION
Apollo Client would warn if two queries were in flight at the same time, since `resolved` was not properly scoped.

### Checklist:

- [x] Make sure all of the significant new logic is covered by tests
