### PR TITLE
fix: flow: prevent RequestOptions null error

### DIFF
--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -117,12 +117,12 @@ export interface BatchResponseAndOptions {
   options: RequestOptions,
 }
 
-export interface BatchingNetworkInterfaceOptions {
+export type BatchingNetworkInterfaceOptions = {
   uri: string,
   batchInterval: number,
   // compatibility with NetworkInterfaceOptions
   opts?: ?RequestOptions,
-}
+};
 
 declare export function createBatchingNetworkInterface(
   options: BatchingNetworkInterfaceOptions,
@@ -159,13 +159,13 @@ export interface ResponseAndOptions {
   options: RequestOptions,
 }
 
-export interface NetworkInterfaceOptions {
+export type NetworkInterfaceOptions  = {
   // compatibility with BatchNetworkInrfaceOptions
   // also network interfaces throws an error in case you haven't provide an uri
   // in this case is right to fail typecheck too
   uri: string,
   opts?: ?RequestOptions,
-}
+};
 
 declare export function printRequest(request: Request): PrintedRequest;
 

--- a/test/flow.js
+++ b/test/flow.js
@@ -132,3 +132,12 @@ const store: ReduxStore<State, ApolloAction> = createStore(
     reducer,
     applyMiddleware(client5.middleware())
 );
+
+new ApolloClient({
+    networkInterface: createNetworkInterface({
+        uri: '/api/v1/graphql',
+        opts: {
+            credentials: 'same-origin',
+        }
+    }),
+});


### PR DESCRIPTION
Trying to do so:
```js
createNetworkInterface( {
        uri: '/api/v1/graphql',
        opts: {
            // Additional fetch options like `credentials` or `headers`
            credentials: 'same-origin',
        }
} )
```
will lead to flow error:
```sh
node_modules/apollo-client/apollo.umd.js.flow:124
    124:   opts?: ?RequestOptions,
                  ^^^^^^^^^^^^^^^ null. This type is incompatible with the expected param type of
                       v
     38:         opts: {
     39:             // Additional fetch options like `credentials` or `headers`
     40:             credentials: 'same-origin',
     41:         }
                 ^ object literal. See: config/project/index.js:38
```
because `NetworkInterfaceOptions` and `BatchingNetworkInterfaceOptions` were defined as interfaces not types.