### PR TITLE
Make fetch implementation configurable

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -75,3 +75,4 @@ Michaël De Boey <info@michaeldeboey.be>
 Andreas Bergenwall <abergenw@gmail.com>
 Michiel Westerbeek <happylinks@gmail.com>
 James Reggio <james.reggio@gmail.com>
+Christoph Tavan <dev@tavan.de>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ### vNEXT
+- Make `fetch` implementation configurable [PR #2008](https://github.com/apollographql/apollo-client/pull/2008)
 
 ### 1.9.0
 - Move to `apollo-link-core` from `apollo-link` to reduce bundle size [PR #1955](https://github.com/apollographql/apollo-client/pull/1955)

--- a/fetch-mock.typings.d.ts
+++ b/fetch-mock.typings.d.ts
@@ -281,6 +281,14 @@ declare namespace FetchMock {
               lot of array buffers, it can be useful to default to `false`
         */
       configure(opts: Object): void;
+      /**
+         * Configure the fetch implementation to be used
+         */
+      setImplementations(implementations: Object): void;
+      /**
+         * Return a sandbox
+         */
+      sandbox(): FetchMockStatic;
   }
 }
 

--- a/fetch-ponyfill.typings.d.ts
+++ b/fetch-ponyfill.typings.d.ts
@@ -1,0 +1,8 @@
+// Type definitions for fetch-ponyfill 4.1.0
+// Project: https://github.com/qubyte/fetch-ponyfill
+
+declare module 'fetch-ponyfill' {
+  function fetchPonyfill(options?: any): any;
+  namespace fetchPonyfill {}
+  export = fetchPonyfill;
+}

--- a/package.json
+++ b/package.json
@@ -73,12 +73,12 @@
   "license": "MIT",
   "dependencies": {
     "apollo-link-core": "^0.2.0",
+    "fetch-ponyfill": "^4.1.0",
     "graphql": "^0.10.0",
     "graphql-anywhere": "^3.0.1",
     "graphql-tag": "^2.0.0",
     "redux": "^3.4.0",
-    "symbol-observable": "^1.0.2",
-    "whatwg-fetch": "^2.0.0"
+    "symbol-observable": "^1.0.2"
   },
   "devDependencies": {
     "@types/benchmark": "1.0.30",
@@ -104,7 +104,6 @@
     "grunt": "1.0.1",
     "grunt-tslint": "5.0.1",
     "gzip-size": "3.0.0",
-    "isomorphic-fetch": "2.2.1",
     "istanbul": "0.4.5",
     "lint-staged": "4.0.2",
     "lodash": "4.17.4",

--- a/src/transport/batchedNetworkInterface.ts
+++ b/src/transport/batchedNetworkInterface.ts
@@ -1,7 +1,5 @@
 import { ExecutionResult } from 'graphql';
 
-import 'whatwg-fetch';
-
 import {
   BaseNetworkInterface,
   HTTPNetworkInterface,
@@ -43,13 +41,15 @@ export class HTTPBatchedNetworkInterface extends BaseNetworkInterface {
     batchInterval = 10,
     batchMax = 0,
     fetchOpts,
+    fetch = undefined,
   }: {
     uri: string;
     batchInterval?: number;
     batchMax?: number;
     fetchOpts: RequestInit;
+    fetch?: any;
   }) {
-    super(uri, fetchOpts);
+    super(uri, fetchOpts, fetch);
 
     if (typeof batchInterval !== 'number') {
       throw new Error(`batchInterval must be a number, got ${batchInterval}`);
@@ -236,7 +236,7 @@ export class HTTPBatchedNetworkInterface extends BaseNetworkInterface {
       return printRequest(request);
     });
 
-    return fetch(this._uri, {
+    return this._fetch(this._uri, {
       ...this._opts,
       body: JSON.stringify(printedRequests),
       method: 'POST',
@@ -255,6 +255,7 @@ export interface BatchingNetworkInterfaceOptions {
   batchInterval?: number;
   batchMax?: number;
   opts?: RequestInit;
+  fetch?: any;
 }
 
 export function createBatchingNetworkInterface(
@@ -270,5 +271,6 @@ export function createBatchingNetworkInterface(
     batchInterval: options.batchInterval,
     batchMax: options.batchMax,
     fetchOpts: options.opts || {},
+    fetch: options.fetch,
   });
 }

--- a/test/client.ts
+++ b/test/client.ts
@@ -1,7 +1,6 @@
 import * as chai from 'chai';
 const { assert } = chai;
 import * as sinon from 'sinon';
-import * as fetchMock from 'fetch-mock';
 
 import ApolloClient, { printAST } from '../src';
 
@@ -71,8 +70,6 @@ import observableToPromise from './util/observableToPromise';
 import { cloneDeep, assign, isEqual } from 'lodash';
 
 import { ApolloLink, Observable } from 'apollo-link-core';
-
-declare var fetch: any;
 
 // make it easy to assert with promises
 chai.use(chaiAsPromised);
@@ -2348,8 +2345,7 @@ describe('client', () => {
       },
     };
     const url = 'http://not-a-real-url.com';
-    const oldFetch = fetch;
-    fetch = createMockFetch({
+    const fetch = createMockFetch({
       url,
       opts: {
         body: JSON.stringify([
@@ -2372,6 +2368,7 @@ describe('client', () => {
       uri: 'http://not-a-real-url.com',
       batchInterval: 5,
       opts: {},
+      fetch,
     });
     Promise.all([
       networkInterface.query({ query: firstQuery }),
@@ -2382,7 +2379,6 @@ describe('client', () => {
           firstResult,
           secondResult,
         ]);
-        fetch = oldFetch;
         done();
       })
       .catch(e => {
@@ -2416,8 +2412,7 @@ describe('client', () => {
       }
     `;
     const url = 'http://not-a-real-url.com';
-    const oldFetch = fetch;
-    fetch = createMockFetch({
+    const fetch = createMockFetch({
       url,
       opts: {
         body: JSON.stringify([
@@ -2440,6 +2435,7 @@ describe('client', () => {
       uri: 'http://not-a-real-url.com',
       batchInterval: 5,
       opts: {},
+      fetch,
     });
     Promise.all([
       networkInterface.query({ query: firstQuery }),
@@ -2453,7 +2449,6 @@ describe('client', () => {
           e.message,
           'BatchingNetworkInterface: server response is not an array',
         );
-        fetch = oldFetch;
         done();
       });
   });
@@ -2491,8 +2486,7 @@ describe('client', () => {
       },
     };
     const url = 'http://not-a-real-url.com';
-    const oldFetch = fetch;
-    fetch = createMockFetch(
+    const fetch = createMockFetch(
       {
         url,
         opts: {
@@ -2530,6 +2524,7 @@ describe('client', () => {
       uri: 'http://not-a-real-url.com',
       batchInterval: 5,
       opts: {},
+      fetch,
     });
     Promise.all([
       networkInterface.query({ query: firstQuery }),
@@ -2545,7 +2540,6 @@ describe('client', () => {
           firstResult,
           secondResult,
         ]);
-        fetch = oldFetch;
         done();
       })
       .catch(e => {
@@ -2585,15 +2579,7 @@ describe('client', () => {
 
     const url = 'http://not-a-real-url.com';
 
-    const networkInterface = createBatchingNetworkInterface({
-      uri: url,
-      batchInterval: 5,
-      batchMax: 2,
-      opts: {},
-    });
-
-    const oldFetch = fetch;
-    fetch = createMockFetch(
+    const fetch = createMockFetch(
       {
         url,
         opts: {
@@ -2638,6 +2624,14 @@ describe('client', () => {
       },
     );
 
+    const networkInterface = createBatchingNetworkInterface({
+      uri: url,
+      batchInterval: 5,
+      batchMax: 2,
+      opts: {},
+      fetch,
+    });
+
     Promise.all([
       networkInterface.query({ query: authorQuery }),
       networkInterface.query({ query: personQuery }),
@@ -2661,7 +2655,6 @@ describe('client', () => {
           personResult,
           authorResult,
         ]);
-        fetch = oldFetch;
         done();
       })
       .catch(e => {
@@ -2701,14 +2694,7 @@ describe('client', () => {
 
     const url = 'http://not-a-real-url.com';
 
-    const networkInterface = createBatchingNetworkInterface({
-      uri: url,
-      batchInterval: 5,
-      opts: {},
-    });
-
-    const oldFetch = fetch;
-    fetch = createMockFetch({
+    const fetch = createMockFetch({
       url,
       opts: {
         body: JSON.stringify([
@@ -2731,6 +2717,13 @@ describe('client', () => {
         personResult,
         authorResult,
       ]),
+    });
+
+    const networkInterface = createBatchingNetworkInterface({
+      uri: url,
+      batchInterval: 5,
+      opts: {},
+      fetch,
     });
 
     Promise.all([
@@ -2756,7 +2749,6 @@ describe('client', () => {
           personResult,
           authorResult,
         ]);
-        fetch = oldFetch;
         done();
       })
       .catch(e => {

--- a/test/mocks/mockFetch.ts
+++ b/test/mocks/mockFetch.ts
@@ -1,5 +1,3 @@
-import 'whatwg-fetch';
-
 // This is an implementation of a mocked window.fetch implementation similar in
 // structure to the MockedNetworkInterface.
 

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -6,9 +6,8 @@
 /// <reference types="node" />
 /// <reference types="mocha" />
 
-// ensure support for fetch and promise
+// ensure support for promise
 import 'es6-promise';
-import 'isomorphic-fetch';
 
 import { QueryManager } from '../src/core/QueryManager';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
     "node_modules/typescript/lib/lib.es2015.d.ts",
     "node_modules/typescript/lib/lib.dom.d.ts",
     "typings.d.ts",
+    "fetch-ponyfill.typings.d.ts",
     "fetch-mock.typings.d.ts",
     "src/index.ts",
     "test/tests.ts",


### PR DESCRIPTION
Currently apollo-client relies on the globally available `fetch` api
which causes a number of problems. In the browser apollo-client uses a
polyfill which "pollutes" the global scope. This is something a library
should probably rather not do.

This change is based on previous discussion and work done in
apollographql/apollo-client#661 and apollographql/apollo-client#645.

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [x] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.

### Comments:

I believe that the current state where apollo-client inserts a fetch-polyfill and thus modifies the global scope is a behavior that a _library_ should not have. I would like to use `apollo-client` within another _library_ myself and I do not want to pollute the globale scope of they sites who will use my library.

The most straightforward change I can think of is allowing to optionally pass a `fetch` implementation as configuration option when creating the network interface.

This PR still has some rough edges. My main concerns are:

- [ ] Is `fetch` a good variable name for the config option?
- [ ] The fetch option is currently defined as type `any` which should of course be changed.
- [ ] The fetch-ponyfill type definitions could/should be improved, they are now just very generic.
- [ ] Documentation is missing.
- [ ] Changelog.

I'm curious about your feedback and I'll be happy fix the open points in case there's a chance to get this merged.

More references: #1134, #1155