### PR TITLE
Fixed the networkInterface config applying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - added prettier to manage formatting of project [PR #1904](https://github.com/apollographql/apollo-client/pull/1904)
 - Replace use of `Object` with `Record<string, any>` in mutation types
 - Fix loss of referential equality for results returned by `currentResults()` before an ObservableQuery is setup [PR #1927](https://github.com/apollographql/apollo-client/pull/1927)
+- Fix networkInterface applying in constructor [PR #2014](https://github.com/apollographql/apollo-client/pull/2014)
 
 ### 1.9.0-0
 - Remove query tracking from the Redux store. Query status tracking is now handled outside of Redux in the QueryStore class. [PR #1859](https://github.com/apollographql/apollo-client/pull/1859)

--- a/src/ApolloClient.ts
+++ b/src/ApolloClient.ts
@@ -6,6 +6,7 @@ import {
 } from './transport/networkInterface';
 
 import { execute, ApolloLink } from 'apollo-link-core';
+import { assign } from './util/assign';
 
 import {
   ExecutionResult,
@@ -242,12 +243,11 @@ export default class ApolloClient implements DataProxy {
         'function'
     ) {
       console.warn(`The Observable Network interface will be deprecated`);
-      this.networkInterface = {
-        ...networkInterface,
+      this.networkInterface = assign(networkInterface || {}, {
         query: createQuery(
           (networkInterface as ObservableNetworkInterface).request,
         ),
-      };
+      });
     } else {
       this.networkInterface = networkInterface
         ? <NetworkInterface>networkInterface


### PR DESCRIPTION
This is a hotfix for issue #2013 
The networkInterface config will be assigned with query config itself, without copying the config properties to a new object.