### PR TITLE
Use previous results for fields from custom resolvers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### vNEXT
 - Fix FetchMoreQueryOptions and IntrospectionResultData flow annotations [PR #2034](https://github.com/apollographql/apollo-client/pull/2034)
+- Fix referential equality bug for queries with custom resolvers [PR #2053](https://github.com/apollographql/apollo-client/pull/2053)
 
 ### 1.9.1
 - Add support for subscriptions with Apollo Link network stack [PR #1992](https://github.com/apollographql/apollo-client/pull/1992)

--- a/src/data/readFromStore.ts
+++ b/src/data/readFromStore.ts
@@ -140,24 +140,26 @@ const readStoreResolver: Resolver = (
         // Look for the field in the custom resolver map
         const resolver = type[fieldName];
         if (resolver) {
-          return resolver(obj, args);
+          fieldValue = resolver(obj, args);
         }
       }
     }
 
-    if (!context.returnPartialData) {
-      throw new Error(
-        `Can't find field ${storeKeyName} on object (${objId}) ${JSON.stringify(
-          obj,
-          null,
-          2,
-        )}.`,
-      );
+    if (typeof fieldValue === 'undefined') {
+      if (!context.returnPartialData) {
+        throw new Error(
+          `Can't find field ${storeKeyName} on object (${objId}) ${JSON.stringify(
+            obj,
+            null,
+            2,
+          )}.`,
+        );
+      }
+
+      context.hasMissingField = true;
+
+      return fieldValue;
     }
-
-    context.hasMissingField = true;
-
-    return fieldValue;
   }
 
   // if this is an object scalar, it must be a json blob and we have to unescape it


### PR DESCRIPTION
Hey look, another referential equality bug :trollface: 

These are really painful on React Native, where every unnecessary rerender is results in traffic over the bridge and thus a moment of unresponsive UI. It's clear that an effort to maintain referential equality was grafted onto the original code; I'm hoping it's more cohesively incorporated into the architecture of v2.

**Problem and fix description from the commit message:**

A logic error was causing the `readStoreResolver` from applying a `previousResult` to a top-level ID obtained via a custom resolver.

Effectively, this bug was causing the result of any query routed through a custom resolver to fail reference equality checks, even if the result is served completely from the cache and is completely unchanged.

This commit adds a regression test.