### PR TITLE
Gracefully handle errors during optimistic transactions

### DIFF
--- a/packages/apollo-client/src/data/store.ts
+++ b/packages/apollo-client/src/data/store.ts
@@ -98,9 +98,11 @@ export class DataStore {
         const orig = this.cache;
         this.cache = c;
 
-        changeFn();
-
-        this.cache = orig;
+        try {
+          changeFn();
+        } finally {
+          this.cache = orig;
+        }
       }, mutation.mutationId);
     }
   }


### PR DESCRIPTION
If someone throws during an `update`, `this.cache` never gets set back to the original guy - leaving the store forever stuck in a transaction

---

Probably could use some extra logging/tests too - but not sure what exact form that should take