### PR TITLE
Multiple results

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,13 +67,13 @@
   "pre-commit": "lint-staged",
   "dependencies": {},
   "devDependencies": {
-    "bundlesize": "0.13.2",
-    "danger": "1.1.0",
+    "bundlesize": "^0.14.1",
+    "danger": "^1.1.0",
     "lerna": "^2.0.0",
     "lint-staged": "^4.0.2",
     "pre-commit": "^1.2.2",
     "prettier": "^1.5.3",
-    "ts-jest": "20.0.7",
+    "ts-jest": "^20.0.7",
     "typescript": "^2.4.2"
   }
 }

--- a/packages/apollo-client/CHANGELOG.md
+++ b/packages/apollo-client/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ### vNEXT
+- Support multiple results from the network layer (links)
 - Remove internal Observable implemenation [BREAKING]. `next` is no longer called after `error` or `complete` is fired
 - Convert tests to use Jest
 - Replace core utils with apollo-utilities

--- a/packages/apollo-client/src/__mocks__/mockLinks.ts
+++ b/packages/apollo-client/src/__mocks__/mockLinks.ts
@@ -95,13 +95,11 @@ export class MockLink extends ApolloLink {
 }
 
 export class MockSubscriptionLink extends ApolloLink {
-  public mockedSubscription: MockedSubscription;
   // private observer: Observer<any>;
   private observer: any;
 
-  constructor(mockedSubscription: MockedSubscription) {
+  constructor() {
     super();
-    this.mockedSubscription = mockedSubscription;
   }
 
   public request() {

--- a/packages/apollo-client/src/__tests__/client.ts
+++ b/packages/apollo-client/src/__tests__/client.ts
@@ -568,7 +568,7 @@ describe('client', () => {
     });
   });
 
-  it('should warn when receiving multiple results from apollo-link network interface', () => {
+  it('should not warn when receiving multiple results from apollo-link network interface', () => {
     const query = gql`
       query people {
         allPeople(first: 1) {
@@ -597,11 +597,9 @@ describe('client', () => {
       addTypename: false,
     });
 
-    return withWarning(() => {
-      return client.query({ query }).then((result: ExecutionResult) => {
-        expect(result.data).toEqual(data);
-      });
-    }, /multiple results/);
+    return client.query({ query }).then((result: ExecutionResult) => {
+      expect(result.data).toEqual(data);
+    });
   });
 
   xit('should surface errors in observer.next as uncaught', done => {

--- a/packages/apollo-client/src/__tests__/mutationResults.ts
+++ b/packages/apollo-client/src/__tests__/mutationResults.ts
@@ -745,10 +745,12 @@ describe('mutation results', () => {
               case 0:
                 expect(variables).toEqual({ a: 1, b: 2 });
                 observer.next({ data: { result: 'hello' } });
+                observer.complete();
                 return;
               case 1:
                 expect(variables).toEqual({ a: 1, c: 3 });
                 observer.next({ data: { result: 'world' } });
+                observer.complete();
                 return;
               case 2:
                 expect(variables).toEqual({
@@ -757,10 +759,12 @@ describe('mutation results', () => {
                   c: 3,
                 });
                 observer.next({ data: { result: 'goodbye' } });
+                observer.complete();
                 return;
               case 3:
                 expect(variables).toEqual({});
                 observer.next({ data: { result: 'moon' } });
+                observer.complete();
                 return;
               default:
                 observer.error(new Error('Too many network calls.'));
@@ -825,6 +829,7 @@ describe('mutation results', () => {
                   b: 'water',
                 });
                 observer.next({ data: { result: 'hello' } });
+                observer.complete();
                 return;
               case 1:
                 expect(variables).toEqual({
@@ -833,6 +838,7 @@ describe('mutation results', () => {
                   c: 3,
                 });
                 observer.next({ data: { result: 'world' } });
+                observer.complete();
                 return;
               case 2:
                 expect(variables).toEqual({
@@ -841,6 +847,7 @@ describe('mutation results', () => {
                   c: 3,
                 });
                 observer.next({ data: { result: 'goodbye' } });
+                observer.complete();
                 return;
               default:
                 observer.error(new Error('Too many network calls.'));
@@ -902,6 +909,7 @@ describe('mutation results', () => {
                   c: null,
                 });
                 observer.next({ data: { result: 'hello' } });
+                observer.complete();
                 return;
               case 1:
                 expect(variables).toEqual({
@@ -910,6 +918,7 @@ describe('mutation results', () => {
                   c: 3,
                 });
                 observer.next({ data: { result: 'world' } });
+                observer.complete();
                 return;
               case 2:
                 expect(variables).toEqual({
@@ -918,6 +927,7 @@ describe('mutation results', () => {
                   c: null,
                 });
                 observer.next({ data: { result: 'moon' } });
+                observer.complete();
                 return;
               default:
                 observer.error(new Error('Too many network calls.'));

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -1,7 +1,6 @@
 import {
   execute,
   ApolloLink,
-  makePromise,
   Operation as Request,
   FetchResult,
 } from 'apollo-link-core';

--- a/packages/apollo-client/src/scheduler/__tests__/scheduler.ts
+++ b/packages/apollo-client/src/scheduler/__tests__/scheduler.ts
@@ -200,9 +200,9 @@ describe('QueryScheduler', () => {
       error,
     });
     const queryManager = new QueryManager({
-      store: new DataStore(new InMemoryCache()),
-
+      store: new DataStore(new InMemoryCache({}, { addTypename: false })),
       link,
+      addTypename: false,
     });
     const scheduler = new QueryScheduler({
       queryManager,

--- a/packages/apollo-client/src/scheduler/scheduler.ts
+++ b/packages/apollo-client/src/scheduler/scheduler.ts
@@ -48,7 +48,6 @@ export class QueryScheduler {
   public checkInFlight(queryId: string) {
     const query = this.queryManager.queryStore.get(queryId);
 
-    // XXX we do this because some legacy tests use a fake queryId. We should rewrite those tests
     return (
       query &&
       query.networkStatus !== NetworkStatus.ready &&


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->
This PR allows AC to accept multiple results from a network request (i.e. using Apollo link). It supports it in both mutations and queries, though currently there is not a top level API for `watchMutation`. 

@DxCx this is the work that was needed to support defer / live. The link for defer / live support will need to handle merging the updated results with what was in the store though. In another PR I'm going to add the store to the operation context so it can be used within links

### Checklist:
- [x] Make sure all of the significant new logic is covered by tests
