### PR TITLE
remove internal use of typename

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,13 +67,13 @@
   "pre-commit": "lint-staged",
   "dependencies": {},
   "devDependencies": {
-    "bundlesize": "^0.14.1",
-    "danger": "^1.1.0",
-    "lerna": "^2.0.0",
-    "lint-staged": "^4.0.2",
-    "pre-commit": "^1.2.2",
-    "prettier": "^1.5.3",
-    "ts-jest": "^20.0.7",
-    "typescript": "^2.4.2"
+    "bundlesize": "0.14.1",
+    "danger": "1.1.0",
+    "lerna": "2.0.0",
+    "lint-staged": "4.0.2",
+    "pre-commit": "1.2.2",
+    "prettier": "1.5.3",
+    "ts-jest": "20.0.7",
+    "typescript": "2.4.2"
   }
 }

--- a/packages/apollo-cache-core/src/cache.ts
+++ b/packages/apollo-cache-core/src/cache.ts
@@ -30,6 +30,8 @@ export type QueryWatch = {
 export abstract class Cache implements DataProxy {
   public abstract reset(): Promise<void>;
 
+  public abstract transformDocument(document: DocumentNode): DocumentNode;
+
   public abstract diffQuery(query: {
     query: DocumentNode;
     variables: any;

--- a/packages/apollo-client/CHANGELOG.md
+++ b/packages/apollo-client/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ### vNEXT
+- Remove internal typename usage in favor of cache transformers [BREAKING]
 - Introduce new ErrorPolicy to allow for errors from execution results to trigger observers
 - Support multiple results from the network layer (links)
 - Remove internal Observable implemenation [BREAKING]. `next` is no longer called after `error` or `complete` is fired

--- a/packages/apollo-client/src/ApolloClient.ts
+++ b/packages/apollo-client/src/ApolloClient.ts
@@ -38,7 +38,6 @@ export default class ApolloClient implements DataProxy {
   public link: ApolloLink;
   public store: DataStore;
   public queryManager: QueryManager;
-  public addTypename: boolean;
   public disableNetworkFetches: boolean;
   public version: string;
   public queryDeduplication: boolean;
@@ -61,8 +60,6 @@ export default class ApolloClient implements DataProxy {
    * @param ssrForceFetchDelay Determines the time interval before we force fetch queries for a
    * server side render.
    *
-   * @param addTypename Adds the __typename field to every level of a GraphQL document, required
-   * to support certain queries that contain fragments.
    *
    * @param queryDeduplication If set to false, a query will still be sent to the server even if a query
    * with identical parameters (query, variables, operationName) is already in flight.
@@ -75,7 +72,6 @@ export default class ApolloClient implements DataProxy {
     cache: Cache;
     ssrMode?: boolean;
     ssrForceFetchDelay?: number;
-    addTypename?: boolean;
     connectToDevTools?: boolean;
     queryDeduplication?: boolean;
   }) {
@@ -84,14 +80,12 @@ export default class ApolloClient implements DataProxy {
       cache,
       ssrMode = false,
       ssrForceFetchDelay = 0,
-      addTypename = true,
       connectToDevTools,
       queryDeduplication = true,
     } = options;
 
     this.link = link;
     this.store = new DataStore(cache);
-    this.addTypename = addTypename;
     this.disableNetworkFetches = ssrMode || ssrForceFetchDelay > 0;
     this.queryDeduplication = queryDeduplication;
     this.ssrMode = ssrMode;
@@ -300,7 +294,6 @@ export default class ApolloClient implements DataProxy {
 
     this.queryManager = new QueryManager({
       link: this.link,
-      addTypename: this.addTypename,
       store: this.store,
       queryDeduplication: this.queryDeduplication,
       ssrMode: this.ssrMode,

--- a/packages/apollo-client/src/__mocks__/mockQueryManager.ts
+++ b/packages/apollo-client/src/__mocks__/mockQueryManager.ts
@@ -11,6 +11,5 @@ export default (...mockedResponses: MockedResponse[]) => {
   return new QueryManager({
     link: mockSingleLink(...mockedResponses),
     store: new DataStore(new InMemoryCache({}, { addTypename: false })),
-    addTypename: false,
   });
 };

--- a/packages/apollo-client/src/__tests__/ApolloClient.ts
+++ b/packages/apollo-client/src/__tests__/ApolloClient.ts
@@ -1522,7 +1522,6 @@ describe('ApolloClient', () => {
             addTypename: false,
           },
         ),
-        addTypename: false,
       });
 
       client.writeQuery({
@@ -1872,7 +1871,6 @@ describe('ApolloClient', () => {
             addTypename: false,
           },
         ),
-        addTypename: false,
       });
 
       client.writeQuery({
@@ -1936,7 +1934,6 @@ describe('ApolloClient', () => {
             addTypename: false,
           },
         ),
-        addTypename: false,
       });
 
       client.writeQuery({
@@ -2000,7 +1997,6 @@ describe('ApolloClient', () => {
             addTypename: false,
           },
         ),
-        addTypename: false,
       });
 
       client.writeQuery({

--- a/packages/apollo-client/src/__tests__/client.ts
+++ b/packages/apollo-client/src/__tests__/client.ts
@@ -166,7 +166,6 @@ describe('client', () => {
     const client = new ApolloClient({
       link,
       cache: new InMemoryCache({}, { addTypename: false }),
-      addTypename: false,
     });
 
     client.query({ query, variables }).then(actualResult => {
@@ -213,7 +212,6 @@ describe('client', () => {
     const client = new ApolloClient({
       link,
       cache: new InMemoryCache({}, { addTypename: false }),
-      addTypename: false,
     });
 
     const basic = client.query({ query, variables }).then(actualResult => {
@@ -278,7 +276,6 @@ describe('client', () => {
     const client = new ApolloClient({
       link,
       cache: new InMemoryCache({}, { addTypename: false }),
-      addTypename: false,
     });
 
     const basic = client.query({ query, variables }).then(actualResult => {
@@ -405,7 +402,6 @@ describe('client', () => {
     const client = new ApolloClient({
       link,
       cache: new InMemoryCache(initialState.data, { addTypename: false }),
-      addTypename: false,
     });
 
     return client.query({ query }).then(result => {
@@ -442,7 +438,6 @@ describe('client', () => {
     const client = new ApolloClient({
       link,
       cache: new InMemoryCache({}, { addTypename: false }),
-      addTypename: false,
     });
 
     return client.query({ query }).catch((error: ApolloError) => {
@@ -489,7 +484,6 @@ describe('client', () => {
     const client = new ApolloClient({
       link,
       cache: new InMemoryCache({}, { addTypename: false }),
-      addTypename: false,
     });
 
     client.query({ query }).catch((error: ApolloError) => {
@@ -523,7 +517,6 @@ describe('client', () => {
       const client = new ApolloClient({
         link,
         cache: new InMemoryCache({}, { addTypename: false }),
-        addTypename: false,
       });
 
       client.query({ query }).catch((error: ApolloError) => {
@@ -558,7 +551,6 @@ describe('client', () => {
     const client = new ApolloClient({
       link,
       cache: new InMemoryCache({}, { addTypename: false }),
-      addTypename: false,
     });
 
     client.query({ query }).catch((error: ApolloError) => {
@@ -594,7 +586,6 @@ describe('client', () => {
     const client = new ApolloClient({
       link,
       cache: new InMemoryCache({}, { addTypename: false }),
-      addTypename: false,
     });
 
     return client.query({ query }).then((result: ExecutionResult) => {
@@ -648,7 +639,6 @@ describe('client', () => {
     const client = new ApolloClient({
       link,
       cache: new InMemoryCache({}, { addTypename: false }),
-      addTypename: false,
     });
 
     const handle = client.watchQuery({ query });
@@ -694,7 +684,6 @@ describe('client', () => {
     const client = new ApolloClient({
       link,
       cache: new InMemoryCache({}, { addTypename: false }),
-      addTypename: false,
     });
 
     const handle = client.watchQuery({ query });
@@ -737,7 +726,6 @@ describe('client', () => {
     const client = new ApolloClient({
       link,
       cache: new InMemoryCache({}, { addTypename: false }),
-      addTypename: false,
     });
 
     const handle = client.watchQuery({ query });
@@ -892,7 +880,6 @@ describe('client', () => {
     const client = new ApolloClient({
       link,
       cache: new InMemoryCache({}, { addTypename: false }),
-      addTypename: false,
     });
 
     return client.mutate({ mutation }).then(actualResult => {
@@ -930,7 +917,6 @@ describe('client', () => {
     const client = new ApolloClient({
       link,
       cache: new InMemoryCache({}, { addTypename: false }),
-      addTypename: false,
     });
 
     return client
@@ -975,7 +961,6 @@ describe('client', () => {
     const client = new ApolloClient({
       link,
       cache: new InMemoryCache({}, { addTypename: false }),
-      addTypename: false,
     });
 
     return client.query({ query }).then(actualResult => {
@@ -1012,7 +997,6 @@ describe('client', () => {
     const client = new ApolloClient({
       link,
       cache: new InMemoryCache({}, { addTypename: false }),
-      addTypename: false,
     });
 
     return client.query({ query }).then(actualResult => {
@@ -1294,7 +1278,6 @@ describe('client', () => {
     const client = new ApolloClient({
       link,
       cache: new InMemoryCache({}, { addTypename: false }),
-      addTypename: false,
     });
 
     return client.query({ query }).then(actualResult => {
@@ -1320,7 +1303,6 @@ describe('client', () => {
     const client = new ApolloClient({
       link,
       cache: new InMemoryCache({}, { addTypename: false }),
-      addTypename: false,
     });
 
     return client.mutate({ mutation }).then(actualResult => {
@@ -1363,7 +1345,7 @@ describe('client', () => {
     const client = new ApolloClient({
       link,
       cache: new InMemoryCache({}, { addTypename: false }),
-      addTypename: false,
+
       queryDeduplication: false,
     });
 
@@ -1412,7 +1394,6 @@ describe('client', () => {
     const client = new ApolloClient({
       link,
       cache: new InMemoryCache({}, { addTypename: false }),
-      addTypename: false,
     });
 
     const q1 = client.query({ query: queryDoc });
@@ -1487,11 +1468,10 @@ describe('client', () => {
         cache: new InMemoryCache(
           {},
           {
-            addTypename: false,
             dataIdFromObject: (obj: { id: any }) => obj.id,
+            addTypename: false,
           },
         ),
-        addTypename: false,
       });
 
       return client.query({ query }).then(result => {
@@ -1547,7 +1527,6 @@ describe('client', () => {
       const client = new ApolloClient({
         link,
         cache: new InMemoryCache({}, { addTypename: false }),
-        addTypename: false,
       });
 
       client.writeQuery({
@@ -1578,7 +1557,6 @@ describe('client', () => {
       const client = new ApolloClient({
         link,
         cache: new InMemoryCache({}, { addTypename: false }),
-        addTypename: false,
       });
 
       const obs = client.watchQuery({
@@ -1603,7 +1581,6 @@ describe('client', () => {
       const client = new ApolloClient({
         link,
         cache: new InMemoryCache({}, { addTypename: false }),
-        addTypename: false,
       });
 
       const obs = client.watchQuery({
@@ -1769,7 +1746,6 @@ describe('client', () => {
       const client = new ApolloClient({
         link,
         cache: new InMemoryCache({}, { addTypename: false }),
-        addTypename: false,
       });
 
       // Run a query first to initialize the store
@@ -1789,7 +1765,6 @@ describe('client', () => {
         link,
         ssrMode: true,
         cache: new InMemoryCache({}, { addTypename: false }),
-        addTypename: false,
       });
 
       const options: WatchQueryOptions = { query, fetchPolicy: 'network-only' };
@@ -1818,7 +1793,6 @@ describe('client', () => {
         link,
         ssrForceFetchDelay: 100,
         cache: new InMemoryCache({}, { addTypename: false }),
-        addTypename: false,
       });
 
       // Run a query first to initialize the store
@@ -1878,7 +1852,6 @@ describe('client', () => {
         error: networkError,
       }),
       cache: new InMemoryCache({}, { addTypename: false }),
-      addTypename: false,
     });
 
     client
@@ -1917,7 +1890,6 @@ describe('client', () => {
         result: { data, errors },
       }),
       cache: new InMemoryCache({}, { addTypename: false }),
-      addTypename: false,
     });
     client
       .mutate({ mutation })
@@ -1955,7 +1927,6 @@ describe('client', () => {
         result: { data, errors },
       }),
       cache: new InMemoryCache({}, { addTypename: false }),
-      addTypename: false,
     });
     client
       .mutate({ mutation, errorPolicy: 'all' })
@@ -1994,7 +1965,6 @@ describe('client', () => {
         result: { data, errors },
       }),
       cache: new InMemoryCache({}, { addTypename: false }),
-      addTypename: false,
     });
     client
       .mutate({ mutation, errorPolicy: 'ignore' })
@@ -2034,7 +2004,6 @@ describe('client', () => {
         result: { data, errors },
       }),
       cache: new InMemoryCache({}, { addTypename: false }),
-      addTypename: false,
     });
     const mutatePromise = client.mutate({
       mutation,
@@ -2105,7 +2074,6 @@ describe('client', () => {
       const client = new ApolloClient({
         link,
         cache: new InMemoryCache({}, { addTypename: false }),
-        addTypename: false,
       });
 
       const log: any[] = [];
@@ -2132,7 +2100,6 @@ describe('client', () => {
     const client = new ApolloClient({
       link,
       cache: new InMemoryCache({}, { addTypename: false }),
-      addTypename: false,
     });
 
     const handle = client.watchQuery({

--- a/packages/apollo-client/src/__tests__/fetchMore.ts
+++ b/packages/apollo-client/src/__tests__/fetchMore.ts
@@ -35,7 +35,6 @@ describe('updateQuery on a simple query', () => {
     const client = new ApolloClient({
       link,
       cache: new InMemoryCache(),
-      addTypename: true,
     });
 
     const obsHandle = client.watchQuery({
@@ -102,7 +101,6 @@ describe('updateQuery on a query with required and optional variables', () => {
     const client = new ApolloClient({
       link,
       cache: new InMemoryCache(),
-      addTypename: true,
     });
 
     const obsHandle = client.watchQuery({
@@ -218,7 +216,6 @@ describe('fetchMore on an observable query', () => {
     client = new ApolloClient({
       link,
       cache: new InMemoryCache(),
-      addTypename: true,
     });
 
     const obsHandle = client.watchQuery<any>({
@@ -323,7 +320,6 @@ describe('fetchMore on an observable query', () => {
     client = new ApolloClient({
       link,
       cache: new InMemoryCache(),
-      addTypename: true,
     });
 
     const observable = client.watchQuery({
@@ -386,7 +382,6 @@ describe('fetchMore on an observable query', () => {
     client = new ApolloClient({
       link,
       cache: new InMemoryCache(),
-      addTypename: true,
     });
 
     const observable = client.watchQuery({
@@ -508,7 +503,6 @@ describe('fetchMore on an observable query with connection', () => {
     client = new ApolloClient({
       link,
       cache: new InMemoryCache(),
-      addTypename: true,
     });
 
     const obsHandle = client.watchQuery<any>({
@@ -577,7 +571,6 @@ describe('fetchMore on an observable query with connection', () => {
     client = new ApolloClient({
       link,
       cache: new InMemoryCache(),
-      addTypename: true,
     });
 
     const observable = client.watchQuery({
@@ -640,7 +633,6 @@ describe('fetchMore on an observable query with connection', () => {
     client = new ApolloClient({
       link,
       cache: new InMemoryCache(),
-      addTypename: true,
     });
 
     const observable = client.watchQuery({

--- a/packages/apollo-client/src/__tests__/graphqlSubscriptions.ts
+++ b/packages/apollo-client/src/__tests__/graphqlSubscriptions.ts
@@ -81,7 +81,6 @@ describe('GraphQL Subscriptions', () => {
     const client = new ApolloClient({
       link,
       cache: new InMemoryCache({}, { addTypename: false }),
-      addTypename: false,
     });
 
     let count = 0;
@@ -108,7 +107,6 @@ describe('GraphQL Subscriptions', () => {
     const client = new ApolloClient({
       link,
       cache: new InMemoryCache({}, { addTypename: false }),
-      addTypename: false,
     });
 
     let count = 0;
@@ -134,7 +132,6 @@ describe('GraphQL Subscriptions', () => {
     const queryManager = new QueryManager({
       link,
       store: new DataStore(new InMemoryCache({}, { addTypename: false })),
-      addTypename: false,
     });
 
     const obs = queryManager.startGraphQLSubscription(options);
@@ -173,7 +170,6 @@ describe('GraphQL Subscriptions', () => {
     const queryManager = new QueryManager({
       link,
       store: new DataStore(new InMemoryCache({}, { addTypename: false })),
-      addTypename: false,
     });
 
     // tslint:disable-next-line

--- a/packages/apollo-client/src/__tests__/mutationResults.ts
+++ b/packages/apollo-client/src/__tests__/mutationResults.ts
@@ -131,7 +131,6 @@ describe('mutation results', () => {
 
     client = new ApolloClient({
       link,
-      addTypename: true,
       cache: new InMemoryCache(
         {},
         {
@@ -163,7 +162,6 @@ describe('mutation results', () => {
 
     client = new ApolloClient({
       link,
-      addTypename: true,
       cache: new InMemoryCache(
         {},
         {
@@ -689,7 +687,6 @@ describe('mutation results', () => {
     client = new ApolloClient({
       link,
       cache: new InMemoryCache({}, { addTypename: false }),
-      addTypename: false,
     });
 
     const watchedQuery = client.watchQuery({
@@ -736,7 +733,6 @@ describe('mutation results', () => {
     let count = 0;
 
     client = new ApolloClient({
-      addTypename: false,
       cache: new InMemoryCache({}, { addTypename: false }),
       link: ApolloLink.from([
         ({ variables }) =>
@@ -817,7 +813,6 @@ describe('mutation results', () => {
     let count = 0;
 
     client = new ApolloClient({
-      addTypename: false,
       cache: new InMemoryCache({}, { addTypename: false }),
       link: ApolloLink.from([
         ({ variables }) =>
@@ -896,7 +891,6 @@ describe('mutation results', () => {
     let count = 0;
 
     client = new ApolloClient({
-      addTypename: false,
       cache: new InMemoryCache({}, { addTypename: false }),
       link: ApolloLink.from([
         ({ variables }) =>

--- a/packages/apollo-client/src/__tests__/subscribeToMore.ts
+++ b/packages/apollo-client/src/__tests__/subscribeToMore.ts
@@ -87,7 +87,6 @@ describe('subscribeToMore', () => {
     const client = new ApolloClient({
       cache: new InMemoryCache({}, { addTypename: false }),
       link,
-      addTypename: false,
     });
 
     const obsHandle = client.watchQuery({ query });
@@ -138,7 +137,6 @@ describe('subscribeToMore', () => {
 
     const client = new ApolloClient({
       link,
-      addTypename: false,
       cache: new InMemoryCache({}, { addTypename: false }),
     });
 
@@ -198,7 +196,6 @@ describe('subscribeToMore', () => {
 
     const client = new ApolloClient({
       link,
-      addTypename: false,
       cache: new InMemoryCache({}, { addTypename: false }),
     });
 

--- a/packages/apollo-client/src/core/__tests__/ObservableQuery.ts
+++ b/packages/apollo-client/src/core/__tests__/ObservableQuery.ts
@@ -45,17 +45,10 @@ describe('ObservableQuery', () => {
     message: 'is offline.',
   };
 
-  const createQueryManager = ({
-    link,
-    addTypename = false,
-  }: {
-    link?: ApolloLink;
-    addTypename?: boolean;
-  }) => {
+  const createQueryManager = ({ link }: { link?: ApolloLink }) => {
     return new QueryManager({
       link: link || mockSingleLink(),
-      store: new DataStore(new InMemoryCache()),
-      addTypename,
+      store: new DataStore(new InMemoryCache({}, { addTypename: false })),
     });
   };
 

--- a/packages/apollo-client/src/core/__tests__/QueryManager.ts
+++ b/packages/apollo-client/src/core/__tests__/QueryManager.ts
@@ -45,17 +45,16 @@ describe('QueryManager', () => {
   // tests.
   const createQueryManager = ({
     link,
-    addTypename = false,
     config = {},
   }: {
     link?: ApolloLink;
-    addTypename?: boolean;
     config?: ApolloReducerConfig;
   }) => {
     return new QueryManager({
       link: link || mockSingleLink(),
-      store: new DataStore(new InMemoryCache({}, config)),
-      addTypename,
+      store: new DataStore(
+        new InMemoryCache({}, { addTypename: false, ...config }),
+      ),
     });
   };
 
@@ -1554,7 +1553,6 @@ describe('QueryManager', () => {
       const queryManager = new QueryManager({
         store: new DataStore(new InMemoryCache({}, { addTypename: false })),
         link,
-        addTypename: false,
       });
 
       const observable = queryManager.watchQuery<any>({
@@ -1612,7 +1610,6 @@ describe('QueryManager', () => {
       const queryManager = new QueryManager({
         store: new DataStore(new InMemoryCache({}, { addTypename: false })),
         link,
-        addTypename: false,
       });
 
       const observable = queryManager.watchQuery<any>({
@@ -1682,7 +1679,6 @@ describe('QueryManager', () => {
       const queryManager = new QueryManager({
         store: new DataStore(new InMemoryCache({}, { addTypename: false })),
         link,
-        addTypename: false,
       });
 
       const observable = queryManager.watchQuery<any>({
@@ -1753,7 +1749,6 @@ describe('QueryManager', () => {
       const queryManager = new QueryManager({
         store: new DataStore(new InMemoryCache({}, { addTypename: false })),
         link,
-        addTypename: false,
       });
 
       const observable = queryManager.watchQuery<any>({
@@ -1825,7 +1820,6 @@ describe('QueryManager', () => {
       const queryManager = new QueryManager({
         store: new DataStore(new InMemoryCache({}, { addTypename: false })),
         link,
-        addTypename: false,
       });
 
       const observable = queryManager.watchQuery<any>({
@@ -1953,7 +1947,6 @@ describe('QueryManager', () => {
           },
         ),
         store: new DataStore(new InMemoryCache({}, { addTypename: false })),
-        addTypename: false,
         ssrMode: true,
       });
 
@@ -2428,12 +2421,7 @@ describe('QueryManager', () => {
         }
       }
     `;
-    const unmodifiedQueryResult = {
-      author: {
-        firstName: 'John',
-        lastName: 'Smith',
-      },
-    };
+
     const transformedQueryResult = {
       author: {
         firstName: 'John',
@@ -2445,17 +2433,11 @@ describe('QueryManager', () => {
     //make sure that the query is transformed within the query
     //manager
     createQueryManager({
-      link: mockSingleLink(
-        {
-          request: { query },
-          result: { data: unmodifiedQueryResult },
-        },
-        {
-          request: { query: transformedQuery },
-          result: { data: transformedQueryResult },
-        },
-      ),
-      addTypename: true,
+      link: mockSingleLink({
+        request: { query: transformedQuery },
+        result: { data: transformedQueryResult },
+      }),
+      config: { addTypename: true },
     })
       .query({ query: query })
       .then(result => {
@@ -2482,12 +2464,7 @@ describe('QueryManager', () => {
         }
       }
     `;
-    const unmodifiedMutationResult = {
-      createAuthor: {
-        firstName: 'It works!',
-        lastName: 'It works!',
-      },
-    };
+
     const transformedMutationResult = {
       createAuthor: {
         firstName: 'It works!',
@@ -2497,17 +2474,11 @@ describe('QueryManager', () => {
     };
 
     createQueryManager({
-      link: mockSingleLink(
-        {
-          request: { query: mutation },
-          result: { data: unmodifiedMutationResult },
-        },
-        {
-          request: { query: transformedMutation },
-          result: { data: transformedMutationResult },
-        },
-      ),
-      addTypename: true,
+      link: mockSingleLink({
+        request: { query: transformedMutation },
+        result: { data: transformedMutationResult },
+      }),
+      config: { addTypename: true },
     })
       .mutate({ mutation: mutation })
       .then(result => {

--- a/packages/apollo-client/src/scheduler/__tests__/scheduler.ts
+++ b/packages/apollo-client/src/scheduler/__tests__/scheduler.ts
@@ -14,7 +14,6 @@ describe('QueryScheduler', () => {
     const queryManager = new QueryManager({
       link: mockSingleLink(),
       store: new DataStore(new InMemoryCache({}, { addTypename: false })),
-      addTypename: false,
     });
 
     const scheduler = new QueryScheduler({
@@ -66,7 +65,6 @@ describe('QueryScheduler', () => {
       store: new DataStore(new InMemoryCache({}, { addTypename: false })),
 
       link: link,
-      addTypename: false,
     });
     const scheduler = new QueryScheduler({
       queryManager,
@@ -110,7 +108,6 @@ describe('QueryScheduler', () => {
     const queryManager = new QueryManager({
       store: new DataStore(new InMemoryCache({}, { addTypename: false })),
       link: link,
-      addTypename: false,
     });
     const scheduler = new QueryScheduler({
       queryManager,
@@ -160,7 +157,6 @@ describe('QueryScheduler', () => {
       store: new DataStore(new InMemoryCache({}, { addTypename: false })),
 
       link,
-      addTypename: false,
     });
     const scheduler = new QueryScheduler({
       queryManager,
@@ -202,7 +198,6 @@ describe('QueryScheduler', () => {
     const queryManager = new QueryManager({
       store: new DataStore(new InMemoryCache({}, { addTypename: false })),
       link,
-      addTypename: false,
     });
     const scheduler = new QueryScheduler({
       queryManager,
@@ -361,7 +356,7 @@ describe('QueryScheduler', () => {
       pollInterval: interval,
     };
     const queryManager = new QueryManager({
-      store: new DataStore(new InMemoryCache()),
+      store: new DataStore(new InMemoryCache({}, { addTypename: false })),
       link: mockSingleLink(
         {
           request: { query: query1 },
@@ -372,7 +367,6 @@ describe('QueryScheduler', () => {
           result: { data: data2 },
         },
       ),
-      addTypename: false,
     });
     const scheduler = new QueryScheduler({
       queryManager,
@@ -422,7 +416,6 @@ describe('QueryScheduler', () => {
         request: { query },
         result: { data },
       }),
-      addTypename: false,
     });
     const scheduler = new QueryScheduler({
       queryManager,
@@ -479,7 +472,6 @@ describe('QueryScheduler', () => {
     const queryManager = new QueryManager({
       store: new DataStore(new InMemoryCache({}, { addTypename: false })),
       link: link,
-      addTypename: false,
     });
     const scheduler = new QueryScheduler({
       queryManager,


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->
This removes internal usage of `addTypename` within apollo-client in favor of the document being transformed by the cache.

cc @nevir 

### Checklist:
- [x] Make sure all of the significant new logic is covered by tests