### PR TITLE
Adds a defaultFetchPolicy

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -75,3 +75,4 @@ Michaël De Boey <info@michaeldeboey.be>
 Andreas Bergenwall <abergenw@gmail.com>
 Michiel Westerbeek <happylinks@gmail.com>
 James Reggio <james.reggio@gmail.com>
+Pete Corey <petecorey@gmail.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### vNEXT
 - Fix FetchMoreQueryOptions and IntrospectionResultData flow annotations [PR #2034](https://github.com/apollographql/apollo-client/pull/2034)
 - Fix referential equality bug for queries with custom resolvers [PR #2053](https://github.com/apollographql/apollo-client/pull/2053)
+- Add `defaultFetchPolicy` option to `ApolloClient` and `QueryManager` [PR #2099](https://github.com/apollographql/apollo-client/pull/2099)
 
 ### 1.9.1
 - Add support for subscriptions with Apollo Link network stack [PR #1992](https://github.com/apollographql/apollo-client/pull/1992)

--- a/src/ApolloClient.ts
+++ b/src/ApolloClient.ts
@@ -58,6 +58,7 @@ import { isProduction } from './util/environment';
 
 import {
   WatchQueryOptions,
+  FetchPolicy,
   SubscriptionOptions,
   MutationOptions,
 } from './core/watchQueryOptions';
@@ -120,6 +121,7 @@ export default class ApolloClient implements DataProxy {
   public reducerConfig: ApolloReducerConfig;
   public addTypename: boolean;
   public disableNetworkFetches: boolean;
+  public defaultFetchPolicy: FetchPolicy;
   /**
    * The dataIdFromObject function used by this client instance.
    */
@@ -183,6 +185,7 @@ export default class ApolloClient implements DataProxy {
       connectToDevTools?: boolean;
       queryDeduplication?: boolean;
       fragmentMatcher?: FragmentMatcherInterface;
+      defaultFetchPolicy?: FetchPolicy;
     } = {},
   ) {
     let { dataIdFromObject } = options;
@@ -197,6 +200,7 @@ export default class ApolloClient implements DataProxy {
       connectToDevTools,
       fragmentMatcher,
       queryDeduplication = true,
+      defaultFetchPolicy = 'cache-first',
     } = options;
 
     if (typeof reduxRootSelector === 'function') {
@@ -289,6 +293,7 @@ export default class ApolloClient implements DataProxy {
     this.fieldWithArgs = getStoreKeyName;
     this.queryDeduplication = queryDeduplication;
     this.ssrMode = ssrMode;
+    this.defaultFetchPolicy = defaultFetchPolicy;
 
     if (ssrForceFetchDelay) {
       setTimeout(
@@ -624,6 +629,7 @@ export default class ApolloClient implements DataProxy {
       queryDeduplication: this.queryDeduplication,
       fragmentMatcher: this.fragmentMatcher,
       ssrMode: this.ssrMode,
+      defaultFetchPolicy: this.defaultFetchPolicy,
     });
   }
 

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -95,7 +95,11 @@ import { tryFunctionOrLogError } from '../util/errorHandling';
 
 import { isApolloError, ApolloError } from '../errors/ApolloError';
 
-import { WatchQueryOptions, SubscriptionOptions } from './watchQueryOptions';
+import {
+  WatchQueryOptions,
+  FetchPolicy,
+  SubscriptionOptions,
+} from './watchQueryOptions';
 
 import { ObservableQuery } from './ObservableQuery';
 
@@ -109,6 +113,7 @@ export class QueryManager {
   public ssrMode: boolean;
   public mutationStore: MutationStore = new MutationStore();
   public queryStore: QueryStore = new QueryStore();
+  public defaultFetchPolicy: FetchPolicy;
 
   private addTypename: boolean;
   private deduplicator: Deduplicator;
@@ -163,6 +168,7 @@ export class QueryManager {
     addTypename = true,
     queryDeduplication = false,
     ssrMode = false,
+    defaultFetchPolicy = 'cache-first',
   }: {
     networkInterface: NetworkInterface;
     store: ApolloStore;
@@ -172,6 +178,7 @@ export class QueryManager {
     addTypename?: boolean;
     queryDeduplication?: boolean;
     ssrMode?: boolean;
+    defaultFetchPolicy?: FetchPolicy;
   }) {
     // XXX this might be the place to do introspection for inserting the `id` into the query? or
     // is that the network interface?
@@ -186,6 +193,7 @@ export class QueryManager {
     this.addTypename = addTypename;
     this.queryDeduplication = queryDeduplication;
     this.ssrMode = ssrMode;
+    this.defaultFetchPolicy = defaultFetchPolicy;
 
     // XXX This logic is duplicated in ApolloClient.ts for two reasons:
     // 1. we need it in ApolloClient.ts for readQuery and readFragment of the data proxy.
@@ -394,7 +402,7 @@ export class QueryManager {
     const {
       variables = {},
       metadata = null,
-      fetchPolicy = 'cache-first', // cache-first is the default fetch policy.
+      fetchPolicy = this.defaultFetchPolicy, // cache-first is the default fetch policy.
     } = options;
 
     const { queryDoc } = this.transformQueryDocument(options);

--- a/test/client.ts
+++ b/test/client.ts
@@ -315,86 +315,83 @@ describe('client', () => {
     });
   });
 
-  it(
-    'should allow multiple queries with an apollo-link enabled network interface',
-    done => {
-      const query = gql`
-        query people {
-          allPeople(first: 1) {
-            people {
-              name
-              __typename
-            }
+  it('should allow multiple queries with an apollo-link enabled network interface', done => {
+    const query = gql`
+      query people {
+        allPeople(first: 1) {
+          people {
+            name
             __typename
           }
+          __typename
         }
-      `;
+      }
+    `;
 
-      const query2 = gql`
-        query people {
-          people {
-            id
-          }
+    const query2 = gql`
+      query people {
+        people {
+          id
         }
-      `;
+      }
+    `;
 
-      const data = {
-        allPeople: {
-          people: [
-            {
-              name: 'Luke Skywalker',
-              __typename: 'Person',
-            },
-          ],
-          __typename: 'People',
-        },
-      };
+    const data = {
+      allPeople: {
+        people: [
+          {
+            name: 'Luke Skywalker',
+            __typename: 'Person',
+          },
+        ],
+        __typename: 'People',
+      },
+    };
 
-      const data2 = {
-        people: {
-          id: 'People',
-        },
-      };
+    const data2 = {
+      people: {
+        id: 'People',
+      },
+    };
 
-      const variables = { first: 1 };
+    const variables = { first: 1 };
 
-      const networkInterface = ApolloLink.from([
-        operation => {
-          if (operation.query === query) {
-            return Observable.of({
-              data,
-            });
-          } else {
-            return Observable.of({
-              data: data2,
-            });
-          }
-        },
-      ]);
-
-      const client = new ApolloClient({
-        networkInterface,
-        addTypename: false,
-      });
-
-      let done1 = false,
-        done2 = false;
-      client.query({ query, variables }).then(actualResult => {
-        assert.deepEqual(actualResult.data, data);
-        done1 = true;
-        if (done2) {
-          done();
+    const networkInterface = ApolloLink.from([
+      operation => {
+        if (operation.query === query) {
+          return Observable.of({
+            data,
+          });
+        } else {
+          return Observable.of({
+            data: data2,
+          });
         }
-      });
-      client.query({ query: query2, variables }).then(actualResult2 => {
-        assert.deepEqual(actualResult2.data, data2);
-        done2 = true;
-        if (done1) {
-          done();
-        }
-      });
-    },
-  );
+      },
+    ]);
+
+    const client = new ApolloClient({
+      networkInterface,
+      addTypename: false,
+    });
+
+    let done1 = false,
+      done2 = false;
+    client.query({ query, variables }).then(actualResult => {
+      assert.deepEqual(actualResult.data, data);
+      done1 = true;
+      if (done2) {
+        done();
+      }
+    });
+    client.query({ query: query2, variables }).then(actualResult2 => {
+      assert.deepEqual(actualResult2.data, data2);
+      done2 = true;
+      if (done1) {
+        done();
+      }
+    });
+  });
 
   it('should allow for a single query with complex default variables to take place', () => {
     const query = gql`
@@ -2249,6 +2246,25 @@ describe('client', () => {
         });
       clock.tick(0);
       return outerPromise;
+    });
+
+    it('uses defaultFetchPolicy', () => {
+      const client = new ApolloClient({
+        networkInterface,
+        addTypename: false,
+        defaultFetchPolicy: 'network-only',
+      });
+
+      // Run a query first to initialize the store
+      return (
+        client
+          .query({ query })
+          // then query for real
+          .then(() => client.query({ query }))
+          .then(result => {
+            assert.deepEqual<{}>(result.data, { myNumber: { n: 2 } });
+          })
+      );
     });
   });
 


### PR DESCRIPTION
ApolloClient and QueryManager now accept an optional `defaultFetchPolicy`, which defaults to `'cache-first'` to preserve old functionality.

This relates to issue #2061. This issue hasn't reached consensus yet, but I thought I'd throw up a PR for posterity.
