### PR TITLE
Support TypeScript types for DataProxy.writeFragment and DataProxy.wr…

### DIFF
--- a/src/ApolloClient.ts
+++ b/src/ApolloClient.ts
@@ -469,7 +469,7 @@ export default class ApolloClient implements DataProxy {
    * the store. This method will start at the root query. To start at a a
    * specific id returned by `dataIdFromObject` then use `writeFragment`.
    */
-  public writeQuery(options: DataProxyWriteQueryOptions): void {
+  public writeQuery<T>(options: DataProxyWriteQueryOptions<T>): void {
     return this.initProxy().writeQuery(options);
   }
 
@@ -484,7 +484,7 @@ export default class ApolloClient implements DataProxy {
    * in a document with multiple fragments then you must also specify a
    * `fragmentName`.
    */
-  public writeFragment(options: DataProxyWriteFragmentOptions): void {
+  public writeFragment<T>(options: DataProxyWriteFragmentOptions<T>): void {
     return this.initProxy().writeFragment(options);
   }
 

--- a/src/data/proxy.ts
+++ b/src/data/proxy.ts
@@ -56,11 +56,11 @@ export interface DataProxyReadFragmentOptions {
   variables?: Object;
 }
 
-export interface DataProxyWriteQueryOptions {
+export interface DataProxyWriteQueryOptions<QueryType = any> {
   /**
    * The data you will be writing to the store.
    */
-  data: any;
+  data: QueryType;
 
   /**
    * The GraphQL query shape to be used constructed using the `gql` template
@@ -75,11 +75,11 @@ export interface DataProxyWriteQueryOptions {
   variables?: Object;
 }
 
-export interface DataProxyWriteFragmentOptions {
+export interface DataProxyWriteFragmentOptions<FragmentType = any> {
   /**
    * The data you will be writing to the store.
    */
-  data: any;
+  data: FragmentType;
 
   /**
    * The root id to be used. This id should take the same form as the  value
@@ -132,14 +132,16 @@ export interface DataProxy {
   /**
    * Writes a GraphQL query to the root query id.
    */
-  writeQuery(options: DataProxyWriteQueryOptions): void;
+  writeQuery<QueryType>(options: DataProxyWriteQueryOptions<QueryType>): void;
 
   /**
    * Writes a GraphQL fragment to any arbitrary id. If there are more then
    * one fragments in the provided document then a `fragmentName` must be
    * provided to select the correct fragment.
    */
-  writeFragment(options: DataProxyWriteFragmentOptions): void;
+  writeFragment<FragmentType>(
+    options: DataProxyWriteFragmentOptions<FragmentType>,
+  ): void;
 }
 
 /**


### PR DESCRIPTION
…iteQuery data.

This change allows the type of data to be passed into `ApolloClient.writeFragment` and `ApolloClient.writeQuery`. This is useful to make user TypeScript code more concise by allowing data structure to be checked inline rather than having to be pulled out into a variable.

Old pattern:

```ts
const cacheData: types.Fragment = {
  title
};
client.writeFragment({
  id: nodeId,
  fragment: Fragment,
  data: cacheData
});
```

New pattern:

```ts
client.writeFragment<types.Fragment>({
  id: nodeId,
  fragment: Fragment,
  data: {
    title
  }
});
```


