### PR TITLE
Flow type fix: Convert MutationOptions to an object type.

### DIFF
--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -257,7 +257,7 @@ export interface SubscriptionOptions {
   },
 }
 
-export interface MutationOptions<T = { [key: string]: any}> {
+export type MutationOptions<T = { [key: string]: any}> = {
   mutation: DocumentNode,
   variables?: Object,
   optimisticResponse?: Object,

--- a/test/flow.js
+++ b/test/flow.js
@@ -18,7 +18,8 @@ import type {
     Request,
     HTTPNetworkInterface,
     Store as ApolloState,
-    ApolloAction
+    ApolloAction,
+    PureQueryOptions
 } from "../src";
 import {combineReducers, createStore, applyMiddleware} from 'redux';
 import type {Store as ReduxStore} from 'redux';
@@ -140,4 +141,14 @@ new ApolloClient({
             credentials: 'same-origin',
         }
     }),
+});
+
+client5.mutate({
+    mutation,
+    refetchQueries: ([{query}]: Array<PureQueryOptions>)
+});
+
+client.mutate({
+    mutation,
+    refetchQueries: (['{ foo }']: Array<string>)
 });


### PR DESCRIPTION
Fixes a flow issue with refetchQueries by converting MutationOptions from an interface to an object type.

We saw some issues with flow being unable to resolve the type of the refetchQueries property in a MutationOptions object.

In general flow seems to have some problems with Union types consisting out of Array types. E.g.: https://flow.org/try/#0FAYw9gdgzgLgBDAprAXHAggJ0wQwJ4A8smAlhAOYB8cAPhtvgRAK4C2ARoptQLxwDaARgC6AbiA

Most of the times these issues can be solved by providing additional type hints. However, it seems that because MutationOptions is defined as an interface, flow is unable to resolve the type, even when hints are provided. 

After a quick check I noticed that this is can be solved by converting MutationOptions to an object type. 

flow still isn't able to resolve the type of refetchQueries, but we can now solve it by adding type hints

Since MutationOptions seems to be a regular object I thought it was fine to align the type. 

In flow interfaces seem to be used mostly with classes instead of objects. (https://stackoverflow.com/questions/36904201/when-do-you-use-an-interface-over-a-type-alias-in-flow)

 
### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.
