### PR TITLE
Live support

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     {
       "name": "apollo-utilities",
       "path": "./packages/apollo-utilities/lib/bundle.min.js",
-      "threshold": "4.2 Kb"
+      "threshold": "4.3 Kb"
     },
     {
       "name": "graphql-anywhere",

--- a/packages/apollo-client/CHANGELOG.md
+++ b/packages/apollo-client/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ### vNEXT
+- Support @live queries via watchQuery
 - Refactor query tracking internally to QueryManager
 - Remove internal typename usage in favor of cache transformers [BREAKING]
 - Introduce new ErrorPolicy to allow for errors from execution results to trigger observers

--- a/packages/apollo-client/src/__mocks__/mockLinks.ts
+++ b/packages/apollo-client/src/__mocks__/mockLinks.ts
@@ -98,6 +98,7 @@ export class MockSubscriptionLink extends ApolloLink {
   // private observer: Observer<any>;
   private observer: any;
   public unsubscribers: any[] = [];
+  public setups: any[] = [];
 
   constructor() {
     super();
@@ -105,6 +106,7 @@ export class MockSubscriptionLink extends ApolloLink {
 
   public request() {
     return new Observable<FetchResult>(observer => {
+      this.setups.forEach(x => x());
       this.observer = observer;
       return {
         unsubscribe: () => {
@@ -121,6 +123,10 @@ export class MockSubscriptionLink extends ApolloLink {
       if (result.result && observer.next) observer.next(result.result);
       if (result.error && observer.error) observer.error(result.error);
     }, result.delay || 0);
+  }
+
+  public onSetup(listener): void {
+    this.setups = this.setups.concat([listener]);
   }
 
   public onUnsubscribe(listener): void {

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -17,6 +17,7 @@ import {
   getQueryDefinition,
   isProduction,
   maybeDeepFreeze,
+  hasDirectives,
 } from 'apollo-utilities';
 
 import { QueryScheduler } from '../scheduler/scheduler';
@@ -288,8 +289,11 @@ export class QueryManager {
       storeResult = result;
     }
 
-    const shouldFetch =
+    let shouldFetch =
       needToFetch && fetchPolicy !== 'cache-only' && fetchPolicy !== 'standby';
+
+    // we need to check to see if this is an operation that uses the @live directive
+    if (hasDirectives(['live'], query)) shouldFetch = true;
 
     const requestId = this.generateRequestId();
 

--- a/packages/apollo-client/src/core/__tests__/QueryManager/live.ts
+++ b/packages/apollo-client/src/core/__tests__/QueryManager/live.ts
@@ -1,0 +1,251 @@
+/*
+ * This test is used to verify the requirements for how react-apollo
+ * preserves observables using QueryRecycler. Eventually, QueryRecycler
+ * will be removed, but this test file should still be valid
+ */
+
+// externals
+import gql from 'graphql-tag';
+import { DocumentNode, ExecutionResult } from 'graphql';
+import { ApolloLink, Operation, Observable } from 'apollo-link-core';
+import InMemoryCache, { ApolloReducerConfig } from 'apollo-cache-inmemory';
+
+import { MockSubscriptionLink } from '../../../__mocks__/mockLinks';
+
+// core
+import { ApolloQueryResult } from '../../types';
+import { NetworkStatus } from '../../networkStatus';
+import { ObservableQuery } from '../../ObservableQuery';
+import { WatchQueryOptions } from '../../watchQueryOptions';
+import { QueryManager } from '../../QueryManager';
+import { DataStore } from '../../../data/store';
+
+describe('Live queries', () => {
+  it('handles mutliple results for live queries', done => {
+    const query = gql`
+      query LazyLoadLuke {
+        people_one(id: 1) {
+          name
+          friends @live {
+            name
+          }
+        }
+      }
+    `;
+
+    const initialData = {
+      people_one: {
+        name: 'Luke Skywalker',
+        friends: [{ name: 'Leia Skywalker' }],
+      },
+    };
+
+    const laterData = {
+      people_one: {
+        name: 'Luke Skywalker',
+        friends: [{ name: 'Leia Skywalker' }, { name: 'R2D2' }],
+      },
+    };
+    const link = new MockSubscriptionLink();
+    const queryManager = new QueryManager({
+      store: new DataStore(new InMemoryCache({}, { addTypename: false })),
+      link,
+    });
+
+    const observable = queryManager.watchQuery<any>({
+      query,
+      variables: {},
+    });
+
+    let count = 0;
+    observable.subscribe({
+      next: result => {
+        count++;
+        if (count === 1) {
+          expect(result.data).toEqual(initialData);
+          setTimeout(() => {
+            link.simulateResult({ result: { data: laterData } });
+          }, 10);
+        }
+        if (count === 2) {
+          expect(result.data).toEqual(laterData);
+          done();
+        }
+      },
+      error: e => {
+        console.error(e);
+      },
+    });
+
+    setTimeout(() => {
+      // fire off first result
+      link.simulateResult({ result: { data: initialData } });
+    }, 10);
+  });
+
+  // watchQuery => Observable => subscribe => data1 => unsubscribe =>
+  //    watchQuery => Observable => subscribe => data2
+  it('handles unsubscribing and resubscribing with live queries', done => {
+    const query = gql`
+      query LazyLoadLuke {
+        people_one(id: 1) {
+          name
+          friends @live {
+            name
+          }
+        }
+      }
+    `;
+
+    const initialData = {
+      people_one: {
+        name: 'Luke Skywalker',
+        friends: [{ name: 'Leia Skywalker' }],
+      },
+    };
+
+    const laterData = {
+      people_one: {
+        name: 'Luke Skywalker',
+        friends: [{ name: 'Leia Skywalker' }, { name: 'R2D2' }],
+      },
+    };
+
+    let count = 0;
+    const link = new MockSubscriptionLink();
+    const queryManager = new QueryManager({
+      store: new DataStore(new InMemoryCache({}, { addTypename: false })),
+      link,
+    });
+
+    const round2 = () => {
+      // watchQuery => Observable
+      const observable = queryManager.watchQuery<any>({
+        query,
+        variables: {},
+      });
+
+      // Observable => subscribe
+      const sub = observable.subscribe(result => {
+        count++;
+        if (count === 2) {
+          expect(result.data).toEqual(laterData);
+          done();
+        }
+      });
+
+      // subscribe => data2
+      link.simulateResult({ result: { data: laterData } });
+    };
+
+    // watchQuery => Observable
+    const observable = queryManager.watchQuery<any>({
+      query,
+      variables: {},
+    });
+
+    // Observable => subscribe
+    const sub = observable.subscribe(result => {
+      count++;
+      if (count === 1) {
+        expect(result.data).toEqual(initialData);
+
+        // data1 => unsubscribe
+        sub.unsubscribe();
+        round2();
+      }
+    });
+
+    setTimeout(() => {
+      // subscribe => data1
+      link.simulateResult({ result: { data: initialData } });
+    }, 10);
+  });
+  // watchQuery => Observable => subscribe => setupNetwork => data1 =>
+  //    unsubscribe => cleanup => watchQuery => Observable => subscribe =>
+  //      setupNetwork => data2 => cleanup
+  it('calls the correct cleanup for links with live queries', done => {
+    const query = gql`
+      query LazyLoadLuke {
+        people_one(id: 1) {
+          name
+          friends @live {
+            name
+          }
+        }
+      }
+    `;
+
+    const initialData = {
+      people_one: {
+        name: 'Luke Skywalker',
+        friends: [{ name: 'Leia Skywalker' }],
+      },
+    };
+
+    const laterData = {
+      people_one: {
+        name: 'Luke Skywalker',
+        friends: [{ name: 'Leia Skywalker' }, { name: 'R2D2' }],
+      },
+    };
+
+    let count = 0;
+    let cleanedupTimes = 0;
+    let createNetworkTimes = 0;
+    const link = new MockSubscriptionLink();
+    link.onSetup(() => createNetworkTimes++);
+    link.onUnsubscribe(() => cleanedupTimes++);
+
+    const queryManager = new QueryManager({
+      store: new DataStore(new InMemoryCache({}, { addTypename: false })),
+      link,
+    });
+
+    const round2 = () => {
+      // watchQuery => Observable
+      const observable = queryManager.watchQuery<any>({
+        query,
+        variables: {},
+      });
+
+      // Observable => subscribe
+      const sub = observable.subscribe(result => {
+        count++;
+        if (count === 2) {
+          expect(result.data).toEqual(laterData);
+          sub.unsubscribe();
+          expect(cleanedupTimes).toBe(2);
+          expect(createNetworkTimes).toBe(2);
+          done();
+        }
+      });
+
+      // subscribe => data2
+      link.simulateResult({ result: { data: laterData } });
+    };
+
+    // watchQuery => Observable
+    const observable = queryManager.watchQuery<any>({
+      query,
+      variables: {},
+    });
+
+    // Observable => subscribe
+    const sub = observable.subscribe(result => {
+      count++;
+      if (count === 1) {
+        expect(result.data).toEqual(initialData);
+
+        // data1 => unsubscribe
+        sub.unsubscribe();
+        round2();
+      }
+    });
+
+    setTimeout(() => {
+      // subscribe => data1
+      link.simulateResult({ result: { data: initialData } });
+    }, 10);
+  });
+});

--- a/packages/apollo-utilities/CHANGELOG.md
+++ b/packages/apollo-utilities/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Change log
 
 ### vNEXT
+- Added hasDirectives to recurse the AST and return a boolean for an array of directive names
 - Improved performance of common store actions by memoizing addTypename and removeConnectionDirective


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->
When using watchQuery with a `@live` directive somewhere in the selection set, we need to bypass the cache for making requests because it sets up a network subscription (and should even if the data is in the cache). So if there is a `@live` directive, we should always make the request.

The new utility could be helpful for things like cache specific directives (i.e. `@cache(ttl: 1000)`)

### Checklist:
- [x] Make sure all of the significant new logic is covered by tests