### PR TITLE
Treat dates properly in `isEqual`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ### vNEXT
+- Fix Date handling in isEqual [PR #2131](https://github.com/apollographql/apollo-client/pull/2131)
 
 ### 1.9.2
 - Fix FetchMoreQueryOptions and IntrospectionResultData flow annotations [PR #2034](https://github.com/apollographql/apollo-client/pull/2034)

--- a/src/util/isEqual.ts
+++ b/src/util/isEqual.ts
@@ -8,7 +8,7 @@ export function isEqual(a: any, b: any): boolean {
   }
   // Dates are equivalent if their difference is zero.
   if (a instanceof Date && b instanceof Date) {
-    return a.getTime() - b.getTime() === 0;
+    return a.getTime() === b.getTime();
   }
   // If a and b are both objects, we will compare their properties. This will compare arrays as
   // well.

--- a/src/util/isEqual.ts
+++ b/src/util/isEqual.ts
@@ -6,6 +6,10 @@ export function isEqual(a: any, b: any): boolean {
   if (a === b) {
     return true;
   }
+  // Dates are equivalent if their difference is zero.
+  if (a instanceof Date && b instanceof Date) {
+    return a - b === 0;
+  }
   // If a and b are both objects, we will compare their properties. This will compare arrays as
   // well.
   if (

--- a/src/util/isEqual.ts
+++ b/src/util/isEqual.ts
@@ -6,7 +6,7 @@ export function isEqual(a: any, b: any): boolean {
   if (a === b) {
     return true;
   }
-  // Dates are equivalent if their difference is zero.
+  // Dates are equivalent if their time values are equal.
   if (a instanceof Date && b instanceof Date) {
     return a.getTime() === b.getTime();
   }

--- a/src/util/isEqual.ts
+++ b/src/util/isEqual.ts
@@ -8,7 +8,7 @@ export function isEqual(a: any, b: any): boolean {
   }
   // Dates are equivalent if their difference is zero.
   if (a instanceof Date && b instanceof Date) {
-    return a - b === 0;
+    return a.getTime() - b.getTime() === 0;
   }
   // If a and b are both objects, we will compare their properties. This will compare arrays as
   // well.


### PR DESCRIPTION
Hey there.
I've stumbled upon a bug where my query wasn't updated and refetched when I was changing the variables object (calculated from props) that contained dates. I've tracked it down to the `isEqual` util function, which treated different dates as equal.
Should I add some tests to cover this case?