### PR TITLE
isEqual should not fail if objects don't have proto

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -71,6 +71,7 @@ Chris Handorf <chris.handorf@mac.com>
 Andrew E. Rhyne <rhyneandrew@gmail.com>
 Miroslav Simulcik <simulcik.miro@gmail.com>
 Stephen Potter <me@stevepotter.me>
+Sébastien Lorber <lorber.sebastien@gmail.com>
 Michaël De Boey <info@michaeldeboey.be>
 Andreas Bergenwall <abergenw@gmail.com>
 Michiel Westerbeek <happylinks@gmail.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### vNEXT
 
+- Fix errors when `isEqual` called with object having no prototype [PR #2138](https://github.com/apollographql/apollo-client/pull/2138)
+
 ### 1.9.2
 - Fix FetchMoreQueryOptions and IntrospectionResultData flow annotations [PR #2034](https://github.com/apollographql/apollo-client/pull/2034)
 - Fix referential equality bug for queries with custom resolvers [PR #2053](https://github.com/apollographql/apollo-client/pull/2053)

--- a/src/util/isEqual.ts
+++ b/src/util/isEqual.ts
@@ -17,8 +17,8 @@ export function isEqual(a: any, b: any): boolean {
     // Compare all of the keys in `a`. If one of the keys has a different value, or that key does
     // not exist in `b` return false immediately.
     for (const key in a) {
-      if (a.hasOwnProperty(key)) {
-        if (!b.hasOwnProperty(key)) {
+      if (Object.prototype.hasOwnProperty.call(a, key)) {
+        if (!Object.prototype.hasOwnProperty.call(b, key)) {
           return false;
         }
         if (!isEqual(a[key], b[key])) {
@@ -28,7 +28,7 @@ export function isEqual(a: any, b: any): boolean {
     }
     // Look through all the keys in `b`. If `b` has a key that `a` does not, return false.
     for (const key in b) {
-      if (!a.hasOwnProperty(key)) {
+      if (!Object.prototype.hasOwnProperty.call(a, key)) {
         return false;
       }
     }

--- a/test/isEqual.ts
+++ b/test/isEqual.ts
@@ -55,4 +55,17 @@ describe('isEqual', () => {
     assert(!isEqual({ x: { a: 1, b: 2, c: 3 } }, { x: { a: 1, b: 2 } }));
     assert(!isEqual({ x: { a: 1, b: 2 } }, { x: { a: 1, b: 2, c: 3 } }));
   });
+
+  it('should correctly compare deep objects without object prototype ', () => {
+    // Solves https://github.com/apollographql/apollo-client/issues/2132
+    const objNoProto = Object.create(null);
+    objNoProto.a = { b: 2, c: [3, 4] };
+    objNoProto.e = Object.create(null);
+    objNoProto.e.f = 5;
+    assert(isEqual(objNoProto, { a: { b: 2, c: [3, 4] }, e: { f: 5 } }));
+    assert(!isEqual(objNoProto, { a: { b: 2, c: [3, 4] }, e: { f: 6 } }));
+    assert(!isEqual(objNoProto, { a: { b: 2, c: [3, 4] }, e: null }));
+    assert(!isEqual(objNoProto, { a: { b: 2, c: [3] }, e: { f: 5 } }));
+    assert(!isEqual(objNoProto, null));
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/apollographql/apollo-client/issues/2132