### PR TITLE
fix typo

### DIFF
--- a/Upgrade.md
+++ b/Upgrade.md
@@ -141,6 +141,6 @@ const cache = new InMemoryCache({
 });
 
 const client = new ApolloClient({
-  cache: cache.restore(window.__APOLLO_STATE || {})
+  cache: cache.restore(window.__APOLLO_STATE__ || {})
 });
 ```


### PR DESCRIPTION
Just a typo fix for the Apollo state variable name.