### PR TITLE
Allow middleware to terminate the request chain early

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -34,6 +34,7 @@ Martijn Walraven <martijn@martijnwalraven.com>
 Matt Jeanes <matt@devshack.io>
 Maxime Quandalle <maxime@quandalle.com>
 Michiel ter Reehorst <michiel@jamiter.com>
+Mike Engel <mike@mike-engel.com>
 Mouad Debbar <mouad.debbar@gmail.com>
 Oleksandr Stubailo <sashko@Oleksandrs-MacBook-Pro.local>
 Olivier Ricordeau <olivier@ricordeau.org>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 - Fix errors when `isEqual` called with object having no prototype [PR #2138](https://github.com/apollographql/apollo-client/pull/2138)
 
+- Allow middleware to terminate the request early [PR #2176](https://github.com/apollographql/apollo-client/pull/2176)
+
 ### 1.9.2
 - Fix FetchMoreQueryOptions and IntrospectionResultData flow annotations [PR #2034](https://github.com/apollographql/apollo-client/pull/2034)
 - Fix referential equality bug for queries with custom resolvers [PR #2053](https://github.com/apollographql/apollo-client/pull/2053)

--- a/src/transport/networkInterface.ts
+++ b/src/transport/networkInterface.ts
@@ -134,8 +134,10 @@ export class HTTPFetchNetworkInterface extends BaseNetworkInterface {
     return new Promise((resolve, reject) => {
       const { request, options } = requestAndOptions;
       const queue = (funcs: MiddlewareInterface[], scope: any) => {
-        const next = () => {
-          if (funcs.length > 0) {
+        const next = (err?: Error | Object) => {
+          if (err) {
+            reject(err);
+          } else if (funcs.length > 0) {
             const f = funcs.shift();
             if (f) {
               f.applyMiddleware.apply(scope, [{ request, options }, next]);

--- a/test/networkInterface.ts
+++ b/test/networkInterface.ts
@@ -321,6 +321,24 @@ describe('network interface', () => {
       });
     });
 
+    it('should cause the parent request to fail', () => {
+      const testWare1 = TestErrorWare([]);
+
+      const swapi = createNetworkInterface({
+        uri: 'http://graphql-swapi.test/',
+      });
+      swapi.use([testWare1]);
+      const simpleRequest = {
+        query: simpleQueryWithVar,
+        variables: { personNum: 1 },
+        debugName: 'People query',
+      };
+
+      return swapi.query(simpleRequest).catch(data => {
+        return assert.equal(data.message, 'uh oh');
+      });
+    });
+
     it('handle multiple middlewares', () => {
       const testWare1 = TestWare([{ key: 'personNum', val: 1 }]);
       const testWare2 = TestWare([{ key: 'filmNum', val: 1 }]);
@@ -572,6 +590,14 @@ function TestWare(
       });
 
       next();
+    },
+  };
+}
+
+function TestErrorWare(options: Array<{ key: string; val: any }> = []) {
+  return {
+    applyMiddleware: (request: MiddlewareRequest, next: Function): void => {
+      next(new Error('uh oh'));
     },
   };
 }


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] ~If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)~
- [x] Make sure all of the significant new logic is covered by tests
- [x] ~If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.~

Hey Apollo team! Thanks for making apollo-client, it's awesome 🙂 

### Summary

My team is working on integrating apollo-client into our codebase and have several middleware functions that need to be on each request. We also have a need to have middleware failures terminate the request chain so that downstream subscribers can catch the error and act appropriately.

This follows the express API, where you can pass data to the `next` function to have it terminate the request chain and proceed to the error handler. In this case, rejecting the promise allows a downstream subscriber to use `catch` to handle the error.

### Risks

The biggest risk here is that some people don't sanitize the input into `next`. If they have it as a handler that passes data back, it would assume it's an error when it may not be. For example:

```
const myMiddleware = {
  applyMiddleware(req, next) {
    someAsyncAction().then(next)
  }
}
```

In that case, if `someAsyncAction` resolved with some data, it would be a false positive. If this is a worry, we can explicitly check to see if the incoming data is an instance of the `Error` object before terminating.

### Conclusion

I'm not sure if you're even taking new PRs for `1.x` given that `2.0` is in beta yet. I'm happy to answer any questions, however, make any changes, or provide more examples of why this is needed.

Thanks!