### PR TITLE
Set default errorPolicy to 'none' in QueryManager#mutate

### DIFF
--- a/packages/apollo-client/CHANGELOG.md
+++ b/packages/apollo-client/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ### vNEXT
+- Fix default ErrorPolicy in QueryManager#mutate [PR #2194](https://github.com/apollographql/apollo-client/pull/2194)
 - Fix Date handling in isEqual [PR #2131](https://github.com/apollographql/apollo-client/pull/2131)
 - Fix errors when `isEqual` called with object having no prototype [PR #2138](https://github.com/apollographql/apollo-client/pull/2138)
 - Support @live and @defer queries via watchQuery

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -127,7 +127,7 @@ export class QueryManager<TStore> {
     updateQueries: updateQueriesByName,
     refetchQueries = [],
     update: updateWithProxyFn,
-    errorPolicy = 'ignore',
+    errorPolicy = 'none',
   }: MutationOptions): Promise<FetchResult<T>> {
     if (!mutation) {
       throw new Error(


### PR DESCRIPTION
This PR fixes the default `errorPolicy` in `mutate`, that was set to `'ignore'` but should be `'none'` for backwards compatibility with 1.0. This was briefly discussed with @jbaxleyiii on Slack