### PR TITLE
Avoid undefined error when missing typename while writing a result to store

### DIFF
--- a/packages/apollo-cache-inmemory/CHANGELOG.md
+++ b/packages/apollo-cache-inmemory/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ### vNEXT
+- Fix error when missing __typename field in result [PR #2225](https://github.com/apollographql/apollo-client/pull/2225)
 - Refactored type usage
 - Prevented logging on defered queries
 - Refactored internal store from apollo-client into own package

--- a/packages/apollo-cache-inmemory/src/__tests__/writeToStore.ts
+++ b/packages/apollo-cache-inmemory/src/__tests__/writeToStore.ts
@@ -9,7 +9,11 @@ import {
 } from 'graphql';
 
 import gql from 'graphql-tag';
-import { storeKeyNameFromField, IdValue } from 'apollo-utilities';
+import {
+  storeKeyNameFromField,
+  IdValue,
+  addTypenameToDocument
+} from "apollo-utilities";
 
 import {
   writeQueryToStore,
@@ -1545,6 +1549,32 @@ describe('writing to the store', () => {
 
         expect(newStore['1']).toEqual(result.todos[0]);
       }, /Missing field price/);
+    });
+
+    it('should warn if a result is missing __typename when required (using an heuristic matcher)', () => {
+      const fragmentMatcherFunction = new HeuristicFragmentMatcher().match;
+
+      const result: any = {
+        todos: [
+          {
+            id: '1',
+            name: 'Todo 1',
+            description: 'Description 1'
+          }
+        ],
+      };
+
+      return withWarning(() => {
+        const newStore = writeResultToStore({
+          dataId: 'ROOT_QUERY',
+          result,
+          document: addTypenameToDocument(query),
+          dataIdFromObject: getIdField,
+          fragmentMatcherFunction
+        });
+
+        expect(newStore['1']).toEqual(result.todos[0]);
+      }, /Missing field __typename/);
     });
 
     it('should not warn if a field is null', () => {

--- a/packages/apollo-cache-inmemory/src/writeToStore.ts
+++ b/packages/apollo-cache-inmemory/src/writeToStore.ts
@@ -192,6 +192,7 @@ export function writeSelectionSetToStore({
         } else {
           // if this is a defered field we don't need to throw / wanr
           const isDefered =
+            selection.directives &&
             selection.directives.length &&
             selection.directives.some(
               directive => directive.name && directive.name.value === 'defer',


### PR DESCRIPTION
This PR fixes a small bug that happens when you attempt to write a result to the store without a `__typename`, when the query has been transformed with the `addTypenameToDocument` function that adds the `__typename` field.

This should warn saying that the `__typename` field is missing, but it was failing early in the process since it was attempting to access the `directives` property in the field, which doesn't exist in the `__typename` field added by the transform. And actually, the directives property is optional according to the spec so we should check for its existence.

The fix is just adding a check for that.