### PR TITLE
Added conditional refetchQueries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### vNEXT
 
+- Allow conditional refetchQueries [PR #2234](https://github.com/apollographql/apollo-client/pull/2234)
+
 ### 1.9.3
 - Fix Date handling in isEqual [PR #2131](https://github.com/apollographql/apollo-client/pull/2131)
 

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -352,7 +352,7 @@ export class QueryManager {
           }
 
           if (typeof refetchQueries === 'function') {
-            refetchQueries = refetchQueries(result);
+            refetchQueries = refetchQueries(result) || [];
           }
           if (typeof refetchQueries[0] === 'string') {
             (refetchQueries as string[]).forEach(name => {

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -241,7 +241,10 @@ export class QueryManager {
     variables?: Object;
     optimisticResponse?: Object | Function;
     updateQueries?: MutationQueryReducersMap<T>;
-    refetchQueries?: string[] | PureQueryOptions[];
+    refetchQueries?:
+      | string[]
+      | PureQueryOptions[]
+      | ((mutationResult: Object) => string[] | PureQueryOptions[]);
     update?: (proxy: DataProxy, mutationResult: Object) => void;
   }): Promise<ApolloExecutionResult<T>> {
     if (!mutation) {
@@ -348,6 +351,9 @@ export class QueryManager {
             return;
           }
 
+          if (typeof refetchQueries === 'function') {
+            refetchQueries = refetchQueries(result);
+          }
           if (typeof refetchQueries[0] === 'string') {
             (refetchQueries as string[]).forEach(name => {
               this.refetchQueryByName(name);


### PR DESCRIPTION
Implements: https://github.com/apollographql/react-apollo/issues/1168

Allows a user to refetchQueries conditionally by inspecting the result. i.e.:
```
mutate({
   variables: {id:2},
   refetchQueries: ({data:deleteResponse}) => deleteResponse.result.ok? [fetchUsers]:[]
})
```
