### PR TITLE
New http link

### DIFF
--- a/packages/apollo-cache-inmemory/src/inMemoryCache.ts
+++ b/packages/apollo-cache-inmemory/src/inMemoryCache.ts
@@ -48,7 +48,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCache> {
   }
 
   public restore(data: NormalizedCache): ApolloCache<NormalizedCache> {
-    this.data = data;
+    if (data) this.data = data;
     return this;
   }
 

--- a/packages/apollo-client-preset/package.json
+++ b/packages/apollo-client-preset/package.json
@@ -37,8 +37,8 @@
   "dependencies": {
     "apollo-cache-inmemory": "^0.2.0-beta.3",
     "apollo-client": "^2.0.0-beta.3",
-    "apollo-link": "0.6.1-beta.6",
-    "apollo-link-http": "0.6.1-beta.6",
+    "apollo-link": "0.7.0",
+    "apollo-link-http": "0.7.0",
     "graphql-tag": "^2.4.2"
   },
   "devDependencies": {

--- a/packages/apollo-client-preset/src/__tests__/smoke.ts
+++ b/packages/apollo-client-preset/src/__tests__/smoke.ts
@@ -1,5 +1,8 @@
 import ApolloClient, { gql, HttpLink, InMemoryCache } from '../';
 
+global.fetch = jest.fn(() =>
+  Promise.resolve({ json: () => Promise.resolve({}) }),
+);
 it('should have the required exports', () => {
   expect(ApolloClient).toBeDefined();
   expect(gql).toBeDefined();

--- a/packages/apollo-client-preset/src/index.ts
+++ b/packages/apollo-client-preset/src/index.ts
@@ -1,6 +1,6 @@
 export * from 'apollo-client';
 export * from 'apollo-link';
-import HttpLink from 'apollo-link-http';
+import { HttpLink } from 'apollo-link-http';
 export * from 'apollo-cache-inmemory';
 import InMemoryCache, { NormalizedCache } from 'apollo-cache-inmemory';
 

--- a/packages/apollo-client/CHANGELOG.md
+++ b/packages/apollo-client/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ### vNEXT
+- Update to latest stable link package
 - Fix error handling when recycling observables
 - Fix currentResult when errorPolicy is set to 'all'
 - Fix default ErrorPolicy in QueryManager#mutate [PR #2194](https://github.com/apollographql/apollo-client/pull/2194)

--- a/packages/apollo-client/package.json
+++ b/packages/apollo-client/package.json
@@ -50,8 +50,8 @@
   "license": "MIT",
   "dependencies": {
     "apollo-cache": "^0.2.0-beta.2",
-    "apollo-link": "0.6.1-beta.6",
-    "apollo-link-dedup": "0.4.1-beta.6",
+    "apollo-link": "0.7.0",
+    "apollo-link-dedup": "0.5.0",
     "apollo-utilities": "^0.2.0-beta.2",
     "graphql": "^0.11.0",
     "symbol-observable": "^1.0.2"


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->
This PR updates the underlying link in the `apollo-client-preset` and the `apollo-link` to the new version for the base client.

### Upgrading from `apollo-fetch` / `apollo-client` 
If you previously used either `apollo-fetch` or `apollo-client`, you will need to change the way `use` and `useAfter` are implemented in your app. They can both be implemented in a link like so:

#### Middleware

*Before*
```js
// before
import ApolloClient, { createNetworkInterface } from 'apollo-client';

const networkInterface = createNetworkInterface({ uri: '/graphql' });

networkInterface.use([{
  applyMiddleware(req, next) {
    if (!req.options.headers) {
      req.options.headers = {};  // Create the header object if needed.
    }
    req.options.headers['authorization'] = localStorage.getItem('token') ? localStorage.getItem('token') : null;
    next();
  }
}]);

```

*After*
```js
import { ApolloLink } from 'apollo-link';
import { createHttpLink } from 'apollo-link-http';

const httpLink = createHttpLink({ uri: '/graphql' });
const middlewareLink = new ApolloLink((operation, forward) => {
  operation.setContext({
    headers: {
      authorization: localStorage.getItem('token') || null
    }
  });
  return forward(operation)
})

// use with apollo-client
const link = middlewareLink.concat(httpLink);
```

#### Afterware (error)

*Before*
```js
import ApolloClient, { createNetworkInterface } from 'apollo-client';
import { logout } from './logout';

const networkInterface = createNetworkInterface({ uri: '/graphql' });

networkInterface.useAfter([{
  applyAfterware({ response }, next) {
    if (response.status === 401) {
      logout();
    }
    next();
  }
}]);
```
*After*

```js
import { ApolloLink } from 'apollo-link';
import { createHttpLink } from 'apollo-link-http';
import { onError } from 'apollo-link-error';

import { logout } from './logout';

const httpLink = createHttpLink({ uri: '/graphql' });
const errorLink = onError(({ networkError }) => {
  if (networkError.status === 401) {
    logout();
  }
})

// use with apollo-client
const link = errorLink.concat(httpLink);
```

#### Afterware (data manipulation)
*Before*
```js
import ApolloClient, { createNetworkInterface } from 'apollo-client';
import { logout } from './logout';

const networkInterface = createNetworkInterface({ uri: '/graphql' });

networkInterface.useAfter([{
  applyAfterware({ response }, next) {
    if (response.data.user.lastLoginDate) {
      response.data.user.lastLoginDate = new Date(response.data.user.lastLoginDate)
    }
    next();
  }
}]);
```

*After*
```js
import { ApolloLink } from 'apollo-link';
import { createHttpLink } from 'apollo-link-http';

const httpLink = createHttpLink({ uri: '/graphql' });
const addDatesLink = new ApolloLink((operation, forward) => {
  return forward(operation).map((response) => {
    if (response.data.user.lastLoginDate) {
      response.data.user.lastLoginDate = new Date(response.data.user.lastLoginDate)
    }
    return response;
  })
})

// use with apollo-client
const link = addDatesLink.concat(httpLink);

