### PR TITLE
Adds interface to allow for specification of IDs on Apollo Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change log
 
 ### vNEXT
-- Fix the ability to specify IDs in Apollo configuration to tell queries about updates when new information becomes available [PR #2274](https://github.com/apollographql/apollo-client/issues/2201#issuecomment-334992653)
+- Fix the ability to specify IDs in Apollo configuration to tell queries about updates when new information becomes available [PR #2274](https://github.com/apollographql/apollo-client/pull/2274)
 - Fix response not being included with errors that have response body [PR #2239](https://github.com/apollographql/apollo-client/pull/2239)
 
 ### 1.9.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ### vNEXT
+- Fix the ability to specify IDs in Apollo configuration to tell queries about updates when new information becomes available [PR #2274](https://github.com/apollographql/apollo-client/issues/2201#issuecomment-334992653)
 - Fix response not being included with errors that have response body [PR #2239](https://github.com/apollographql/apollo-client/pull/2239)
 
 ### 1.9.3

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -33,5 +33,10 @@ export enum FetchType {
   poll = 3,
 }
 
-export interface IdGetterObj extends Object { __typename?: string; id?: number; }
-export declare type IdGetter = (value: IdGetterObj) => string | null | undefined;
+export interface IdGetterObj extends Object {
+  __typename?: string;
+  id?: string;
+}
+export declare type IdGetter = (
+  value: IdGetterObj,
+) => string | null | undefined;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -33,4 +33,5 @@ export enum FetchType {
   poll = 3,
 }
 
-export type IdGetter = (value: Object) => string | null | undefined;
+export interface IdGetterObj extends Object { __typename?: string; id?: number; }
+export declare type IdGetter = (value: IdGetterObj) => string | null | undefined;


### PR DESCRIPTION
The issue came about when trying to specify IDs in Apollo configuration to tell queries about updates when new information becomes available for an Angular project, as per http://dev.apollodata.com/angular2/cache-updates.html

The original solution was proposed by @Nyaruiru:
https://github.com/apollographql/apollo-client/issues/2201#issuecomment-334992653
and was updated to pass tests.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.
