### PR TITLE
Expose ApolloClientOptions - Type of ApolloClient's constructor options

### DIFF
--- a/packages/apollo-client/CHANGELOG.md
+++ b/packages/apollo-client/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ### vNext
+- Define and expose `ApolloClientOptions`, Type of an object that represents ApolloClient's constructor argument.
 
 ### 2.0.0-rc.1
 - Fix bug where changed variables with different cache data didn't rerender properly

--- a/packages/apollo-client/src/ApolloClient.ts
+++ b/packages/apollo-client/src/ApolloClient.ts
@@ -28,6 +28,16 @@ export interface DefaultOptions {
 
 let hasSuggestedDevtools = false;
 
+export type ApolloClientOptions<TCacheShape> = {
+  link: ApolloLink;
+  cache: ApolloCache<TCacheShape>;
+  ssrMode?: boolean;
+  ssrForceFetchDelay?: number;
+  connectToDevTools?: boolean;
+  queryDeduplication?: boolean;
+  defaultOptions?: DefaultOptions;
+};
+
 /**
  * This is the primary Apollo Client class. It is used to send GraphQL documents (i.e. queries
  * and mutations) to a GraphQL spec-compliant server over a {@link NetworkInterface} instance,
@@ -69,15 +79,7 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
    * @param fragmentMatcher A function to use for matching fragment conditions in GraphQL documents
    */
 
-  constructor(options: {
-    link: ApolloLink;
-    cache: ApolloCache<TCacheShape>;
-    ssrMode?: boolean;
-    ssrForceFetchDelay?: number;
-    connectToDevTools?: boolean;
-    queryDeduplication?: boolean;
-    defaultOptions?: DefaultOptions;
-  }) {
+  constructor(options: ApolloClientOptions<TCacheShape>) {
     const {
       link,
       cache,

--- a/packages/apollo-client/src/index.ts
+++ b/packages/apollo-client/src/index.ts
@@ -19,7 +19,9 @@ export * from './core/types';
 
 export { ApolloError } from './errors/ApolloError';
 
-import ApolloClient from './ApolloClient';
+import ApolloClient, { ApolloClientOptions } from './ApolloClient';
+
+export { ApolloClientOptions };
 
 // export the client as both default and named
 export { ApolloClient };


### PR DESCRIPTION
It'd be helpful for UI integration libraries such as new angular-apollo, which will be released soon!