### PR TITLE
cache: `readQuery` returns now the query result

### DIFF
--- a/packages/apollo-cache-inmemory/CHANGELOG.md
+++ b/packages/apollo-cache-inmemory/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### vNEXT
 
-- `readQuery` returns now the query result instead of `Cache.DiffResult` [PR #2320](https://github.com/apollographql/apollo-client/pull/2320)
+- `readQuery` and `readFragment` return now the result instead of `Cache.DiffResult` [PR #2320](https://github.com/apollographql/apollo-client/pull/2320)
 
 ### 0.2.0-rc.1
 - move to named export to be consistent with rest of apollo ecosystem

--- a/packages/apollo-cache-inmemory/CHANGELOG.md
+++ b/packages/apollo-cache-inmemory/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### vNEXT
 
+- `readQuery` returns now the query result instead of `Cache.DiffResult` [PR #2320](https://github.com/apollographql/apollo-client/pull/2320)
+
 ### 0.2.0-rc.1
 - move to named export to be consistent with rest of apollo ecosystem
 

--- a/packages/apollo-cache-inmemory/src/inMemoryCache.ts
+++ b/packages/apollo-cache-inmemory/src/inMemoryCache.ts
@@ -103,7 +103,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCache> {
       previousResult: query.previousResult,
       fragmentMatcherFunction: this.config.fragmentMatcher.match,
       config: this.config,
-    });
+    }).result;
   }
 
   public watch(watch: Cache.WatchOptions): () => void {
@@ -192,7 +192,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCache> {
   public readFragment<FragmentType>(
     options: DataProxy.Fragment,
     optimistic: boolean = false,
-  ): Cache.DiffResult<FragmentType> | null {
+  ): FragmentType | null {
     return this.read({
       query: this.transformDocument(
         getFragmentQueryDocument(options.fragment, options.fragmentName),

--- a/packages/apollo-cache-inmemory/src/inMemoryCache.ts
+++ b/packages/apollo-cache-inmemory/src/inMemoryCache.ts
@@ -64,7 +64,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCache> {
     return this.data;
   }
 
-  public read<T>(query: Cache.ReadOptions): Cache.DiffResult<T> {
+  public read<T>(query: Cache.ReadOptions): T {
     if (query.rootId && typeof this.data[query.rootId] === 'undefined') {
       return null;
     }
@@ -181,7 +181,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCache> {
   public readQuery<QueryType>(
     options: DataProxy.Query,
     optimistic: boolean = false,
-  ): Cache.DiffResult<QueryType> {
+  ): QueryType {
     return this.read({
       query: options.query,
       variables: options.variables,

--- a/packages/apollo-cache-inmemory/src/inMemoryCache.ts
+++ b/packages/apollo-cache-inmemory/src/inMemoryCache.ts
@@ -103,7 +103,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCache> {
       previousResult: query.previousResult,
       fragmentMatcherFunction: this.config.fragmentMatcher.match,
       config: this.config,
-    }).result;
+    });
   }
 
   public watch(watch: Cache.WatchOptions): () => void {

--- a/packages/apollo-cache-inmemory/src/readFromStore.ts
+++ b/packages/apollo-cache-inmemory/src/readFromStore.ts
@@ -46,10 +46,10 @@ export const ID_KEY = typeof Symbol !== 'undefined' ? Symbol('id') : '@@id';
  */
 export function readQueryFromStore<QueryType>(
   options: ReadQueryOptions,
-): Cache.DiffResult<QueryType> {
+): QueryType {
   const optsPatch = { returnPartialData: false };
 
-  return diffQueryAgainstStore({
+  return diffQueryAgainstStore<QueryType>({
     ...options,
     ...optsPatch,
   }).result;

--- a/packages/apollo-cache/src/cache.ts
+++ b/packages/apollo-cache/src/cache.ts
@@ -69,7 +69,7 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
   public readFragment<FragmentType>(
     options: DataProxy.Fragment,
     optimistic: boolean = false,
-  ): Cache.DiffResult<FragmentType> | null {
+  ): FragmentType | null {
     return this.read({
       query: getFragmentQueryDocument(options.fragment, options.fragmentName),
       variables: options.variables,

--- a/packages/apollo-cache/src/cache.ts
+++ b/packages/apollo-cache/src/cache.ts
@@ -8,7 +8,7 @@ export type Transaction<T> = (c: ApolloCache<T>) => void;
 export abstract class ApolloCache<TSerialized> implements DataProxy {
   // required to implement
   // core API
-  public abstract read<T>(query: Cache.ReadOptions): Cache.DiffResult<T>;
+  public abstract read<T>(query: Cache.ReadOptions): T;
   public abstract write(write: Cache.WriteOptions): void;
   public abstract diff<T>(query: Cache.DiffOptions): Cache.DiffResult<T>;
   public abstract watch(watch: Cache.WatchOptions): () => void;
@@ -58,7 +58,7 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
   public readQuery<QueryType>(
     options: DataProxy.Query,
     optimistic: boolean = false,
-  ): Cache.DiffResult<QueryType> {
+  ): QueryType {
     return this.read({
       query: options.query,
       variables: options.variables,

--- a/packages/apollo-cache/src/types/DataProxy.ts
+++ b/packages/apollo-cache/src/types/DataProxy.ts
@@ -77,7 +77,7 @@ export interface DataProxy {
   readQuery<QueryType>(
     options: DataProxy.Query,
     optimistic?: boolean,
-  ): DataProxy.DiffResult<QueryType>;
+  ): QueryType;
 
   /**
    * Reads a GraphQL fragment from any arbitrary id. If there are more then

--- a/packages/apollo-cache/src/types/DataProxy.ts
+++ b/packages/apollo-cache/src/types/DataProxy.ts
@@ -87,7 +87,7 @@ export interface DataProxy {
   readFragment<FragmentType>(
     options: DataProxy.Fragment,
     optimistic?: boolean,
-  ): DataProxy.DiffResult<FragmentType> | null;
+  ): FragmentType | null;
 
   /**
    * Writes a GraphQL query to the root query id.

--- a/packages/apollo-client/src/ApolloClient.ts
+++ b/packages/apollo-client/src/ApolloClient.ts
@@ -1,6 +1,6 @@
 import { ApolloLink, FetchResult, GraphQLRequest, execute } from 'apollo-link';
 import { ExecutionResult } from 'graphql';
-import { Cache, ApolloCache, DataProxy } from 'apollo-cache';
+import { ApolloCache, DataProxy } from 'apollo-cache';
 import { isProduction } from 'apollo-utilities';
 
 import { QueryManager } from './core/QueryManager';
@@ -280,9 +280,7 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
    * in a document with multiple fragments then you must also specify a
    * `fragmentName`.
    */
-  public readFragment<T>(
-    options: DataProxy.Fragment,
-  ): Cache.DiffResult<T> | null {
+  public readFragment<T>(options: DataProxy.Fragment): T | null {
     return this.initProxy().readFragment<T>(options);
   }
 

--- a/packages/apollo-client/src/ApolloClient.ts
+++ b/packages/apollo-client/src/ApolloClient.ts
@@ -265,7 +265,7 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
    * the root query. To start at a specific id returned by `dataIdFromObject`
    * use `readFragment`.
    */
-  public readQuery<T>(options: DataProxy.Query): Cache.DiffResult<T> {
+  public readQuery<T>(options: DataProxy.Query): T {
     return this.initProxy().readQuery<T>(options);
   }
 


### PR DESCRIPTION
instead of `Cache.DiffResult`.

Fixes #2308 
