### PR TITLE
fix(client): throw error if constructor not initialized properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "license": "MIT",
   "scripts": {
     "bootstrap": "npm i && lerna bootstrap",
+    "postinstall": "lerna bootstrap",
     "postbootstrap": "npm run build",
     "build": "lerna run -- build",
     "test": "lerna run -- test",

--- a/packages/apollo-client/CHANGELOG.md
+++ b/packages/apollo-client/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### vNext
 - Define and expose `ApolloClientOptions`, Type of an object that represents ApolloClient's constructor argument.
 - Expose `ApolloCurrentResult`
+- Throw an error if cache or data are not supplied to the `ApolloClient` constructor
+- Add `graphql` as a dev dependency
 
 ### 2.0.0-rc.3
 - Only include `data` on subscriptionData when using `subscribeToMore`

--- a/packages/apollo-client/package.json
+++ b/packages/apollo-client/package.json
@@ -72,6 +72,7 @@
     "bundlesize": "0.15.3",
     "danger": "1.1.0",
     "flow-bin": "0.57.2",
+    "graphql": "^0.11.0",
     "graphql-tag": "2.4.2",
     "isomorphic-fetch": "2.2.1",
     "jest": "20.0.4",

--- a/packages/apollo-client/src/ApolloClient.ts
+++ b/packages/apollo-client/src/ApolloClient.ts
@@ -91,6 +91,15 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
       defaultOptions,
     } = options;
 
+    if (!link || !cache) {
+      throw new Error(`
+        In order to initialize Apollo Client, you must specify link & cache properties on the config object.
+        For more information, please visit:
+          http://dev.apollodata.com/react/initialization.html#creating-client
+        to help you get started.
+      `);
+    }
+
     this.link = link;
     this.cache = cache;
     this.store = new DataStore(cache);

--- a/packages/apollo-client/src/ApolloClient.ts
+++ b/packages/apollo-client/src/ApolloClient.ts
@@ -95,7 +95,7 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
       throw new Error(`
         In order to initialize Apollo Client, you must specify link & cache properties on the config object.
         For more information, please visit:
-          http://dev.apollodata.com/react/initialization.html#creating-client
+          https://apollographql.com/docs/react/setup
         to help you get started.
       `);
     }

--- a/packages/apollo-client/src/__tests__/ApolloClient.ts
+++ b/packages/apollo-client/src/__tests__/ApolloClient.ts
@@ -7,6 +7,30 @@ import { withWarning } from '../util/wrap';
 import ApolloClient from '../';
 
 describe('ApolloClient', () => {
+  describe('constructor', () => {
+    it('will throw an error if link is not passed in', () => {
+      expect(() => {
+        const client = new ApolloClient({ cache: new InMemoryCache() });
+      }).toThrowError(`
+        In order to initialize Apollo Client, you must specify link & cache properties on the config object.
+        For more information, please visit:
+          http://dev.apollodata.com/react/initialization.html#creating-client
+        to help you get started.
+      `);
+    });
+
+    it('will throw an error if cache is not passed in', () => {
+      expect(() => {
+        const client = new ApolloClient({ link: new ApolloLink.empty() });
+      }).toThrowError(`
+        In order to initialize Apollo Client, you must specify link & cache properties on the config object.
+        For more information, please visit:
+          http://dev.apollodata.com/react/initialization.html#creating-client
+        to help you get started.
+      `);
+    });
+  });
+
   describe('readQuery', () => {
     it('will read some data from the store', () => {
       const client = new ApolloClient({

--- a/packages/apollo-client/src/__tests__/ApolloClient.ts
+++ b/packages/apollo-client/src/__tests__/ApolloClient.ts
@@ -14,7 +14,7 @@ describe('ApolloClient', () => {
       }).toThrowError(`
         In order to initialize Apollo Client, you must specify link & cache properties on the config object.
         For more information, please visit:
-          http://dev.apollodata.com/react/initialization.html#creating-client
+          https://apollographql.com/docs/react/setup
         to help you get started.
       `);
     });
@@ -25,7 +25,7 @@ describe('ApolloClient', () => {
       }).toThrowError(`
         In order to initialize Apollo Client, you must specify link & cache properties on the config object.
         For more information, please visit:
-          http://dev.apollodata.com/react/initialization.html#creating-client
+          https://apollographql.com/docs/react/setup
         to help you get started.
       `);
     });


### PR DESCRIPTION
- throw an error if client is not initialized w/ link or cache
- added `graphql` as a dev dependency to `apollo-client`
- added postinstall script for lerna bootstrap

Closes #2319 