### PR TITLE
docs: fix syntax error

### DIFF
--- a/docs/source/basics/network-layer.md
+++ b/docs/source/basics/network-layer.md
@@ -60,7 +60,7 @@ const httpLink = new HttpLink({ uri: '/graphql' });
 
 const authMiddleware = new ApolloLink((operation, forward) => {
   // add the authorization to the headers
-  operation.setContext(({ headers = {} }) => ({
+  operation.setContext({
     headers: {
       authorization: localStorage.getItem('token') || null,
     } 


### PR DESCRIPTION
Old code didn't have enough closing parens, and also declared a function with parameters that weren't actually used.

