### PR TITLE
Use correct URL to React setup docs

### DIFF
--- a/packages/apollo-client/src/ApolloClient.ts
+++ b/packages/apollo-client/src/ApolloClient.ts
@@ -109,7 +109,7 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
         In order to initialize Apollo Client, you must specify link & cache properties on the config object.
         This is part of the required upgrade when migrating from Apollo Client 1.0 to Apollo Client 2.0.
         For more information, please visit:
-          https://apollographql.com/docs/react/setup
+          https://www.apollographql.com/docs/react/basics/setup.html
         to help you get started.
       `);
     }

--- a/packages/apollo-client/src/__tests__/__snapshots__/ApolloClient.ts.snap
+++ b/packages/apollo-client/src/__tests__/__snapshots__/ApolloClient.ts.snap
@@ -7,7 +7,7 @@ exports[
         In order to initialize Apollo Client, you must specify link & cache properties on the config object.
         This is part of the required upgrade when migrating from Apollo Client 1.0 to Apollo Client 2.0.
         For more information, please visit:
-          https://apollographql.com/docs/react/setup
+          https://www.apollographql.com/docs/react/basics/setup.html
         to help you get started.
       "
 `;
@@ -19,7 +19,7 @@ exports[
         In order to initialize Apollo Client, you must specify link & cache properties on the config object.
         This is part of the required upgrade when migrating from Apollo Client 1.0 to Apollo Client 2.0.
         For more information, please visit:
-          https://apollographql.com/docs/react/setup
+          https://www.apollographql.com/docs/react/basics/setup.html
         to help you get started.
       "
 `;


### PR DESCRIPTION
Whenever ApolloClient is supplied without the `cache` or `link` properties the console outputs a link to the React setup docs which isn't available. 

To clarify: this URL is dead https://www.apollographql.com/docs/react/setup
whether this isn't: https://www.apollographql.com/docs/react/basics/setup.html