### PR TITLE
fix(docs): `from` takes an array of links.

### DIFF
--- a/docs/source/basics/network-layer.md
+++ b/docs/source/basics/network-layer.md
@@ -111,7 +111,11 @@ const otherMiddleware = new ApolloLink((operation, forward) => {
 
 
 const client = new ApolloClient({
-  link: from(authMiddleware, otherMiddleware, httpLink),
+  link: from([
+    authMiddleware,
+    otherMiddleware,
+    httpLink
+  ]),
 });
 
 


### PR DESCRIPTION
The [multiple-middleware example](https://www.apollographql.com/docs/react/basics/network-layer.html#linkMiddleware) has an error in the code as `from()` only takes an array of links.