### PR TITLE
Fix for missing zen-observable dependencies

### DIFF
--- a/packages/apollo-client/AUTHORS
+++ b/packages/apollo-client/AUTHORS
@@ -76,3 +76,4 @@ Michaël De Boey <info@michaeldeboey.be>
 Andreas Bergenwall <abergenw@gmail.com>
 Michiel Westerbeek <happylinks@gmail.com>
 James Reggio <james.reggio@gmail.com>
+Kacper Wiszczuk <kacper.wiszczuk@gmail.com>

--- a/packages/apollo-client/package.json
+++ b/packages/apollo-client/package.json
@@ -54,7 +54,8 @@
     "apollo-link": "1.0.0",
     "apollo-link-dedup": "1.0.0",
     "apollo-utilities": "^1.0.0",
-    "symbol-observable": "^1.0.2"
+    "symbol-observable": "^1.0.2",
+    "zen-observable": "^0.6.0"
   },
   "peerDependencies": {
     "graphql": "^0.11.0"

--- a/packages/apollo-client/package.json
+++ b/packages/apollo-client/package.json
@@ -49,12 +49,12 @@
   "author": "Sashko Stubailo <sashko@stubailo.com>",
   "license": "MIT",
   "dependencies": {
+    "@types/zen-observable": "^0.5.3",
     "apollo-cache": "^1.0.0",
     "apollo-link": "1.0.0",
     "apollo-link-dedup": "1.0.0",
     "apollo-utilities": "^1.0.0",
-    "symbol-observable": "^1.0.2",
-    "zen-observable": "^0.6.0"
+    "symbol-observable": "^1.0.2"
   },
   "peerDependencies": {
     "graphql": "^0.11.0"
@@ -88,8 +88,7 @@
     "webpack-bundle-analyzer": "2.8.3"
   },
   "optionalDependencies": {
-    "@types/async": "2.0.45",
-    "@types/zen-observable": "0.5.3"
+    "@types/async": "2.0.45"
   },
   "jest": {
     "transform": {

--- a/packages/apollo-client/package.json
+++ b/packages/apollo-client/package.json
@@ -53,7 +53,8 @@
     "apollo-link": "1.0.0",
     "apollo-link-dedup": "1.0.0",
     "apollo-utilities": "^1.0.0",
-    "symbol-observable": "^1.0.2"
+    "symbol-observable": "^1.0.2",
+    "zen-observable": "^0.6.0"
   },
   "peerDependencies": {
     "graphql": "^0.11.0"
@@ -65,7 +66,6 @@
     "@types/jest": "21.1.2",
     "@types/lodash": "4.14.80",
     "@types/node": "8.0.46",
-    "@types/zen-observable": "0.5.3",
     "apollo-cache-inmemory": "^1.0.0",
     "benchmark": "2.1.4",
     "browserify": "14.5.0",
@@ -88,7 +88,8 @@
     "webpack-bundle-analyzer": "2.8.3"
   },
   "optionalDependencies": {
-    "@types/async": "2.0.45"
+    "@types/async": "2.0.45",
+    "@types/zen-observable": "0.5.3"
   },
   "jest": {
     "transform": {


### PR DESCRIPTION
- Moved @types/zen-observable dependency to optionalDependencies in apollo-client
- Added zen-observable as a dependency in apollo-client

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.
