### PR TITLE
add printer for better store warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,32 +24,32 @@
     {
       "name": "apollo-cache",
       "path": "./packages/apollo-cache/lib/bundle.min.js",
-      "threshold": "1 Kb"
+      "maxSize": "1 kB"
     },
     {
       "name": "apollo-cache-inmemory",
       "path": "./packages/apollo-cache-inmemory/lib/bundle.min.js",
-      "threshold": "5.7 Kb"
+      "maxSize": "8.2 kB"
     },
     {
       "name": "apollo-client",
       "path": "./packages/apollo-client/lib/bundle.min.js",
-      "threshold": "11.1 Kb"
+      "maxSize": "11.6 kB"
     },
     {
       "name": "apollo-client-preset",
       "path": "./packages/apollo-client-preset/lib/bundle.min.js",
-      "threshold": "30 Kb"
+      "maxSize": "30 kB"
     },
     {
       "name": "apollo-utilities",
       "path": "./packages/apollo-utilities/lib/bundle.min.js",
-      "threshold": "4.65 Kb"
+      "maxSize": "4.75 kB"
     },
     {
       "name": "graphql-anywhere",
       "path": "./packages/graphql-anywhere/lib/bundle.min.js",
-      "threshold": "1.7 Kb"
+      "maxSize": "1.7 kB"
     }
   ],
   "jest": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     {
       "name": "apollo-cache-inmemory",
       "path": "./packages/apollo-cache-inmemory/lib/bundle.min.js",
-      "maxSize": "8.2 kB"
+      "maxSize": "6.2 kB"
     },
     {
       "name": "apollo-client",

--- a/packages/apollo-cache-inmemory/CHANGELOG.md
+++ b/packages/apollo-cache-inmemory/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### vNEXT
 
+- improve errors for id mismatch when writing to the store
 - make it possible to swap the cache implementation. For example, you might want to use a `Map` to store the normalized objects, which can be faster than writing by keys to an `Object`. This also allows for custom use cases, such as emitting events on `.set()` or `.delete()` (think Observables), which was otherwise impossible without the use of Proxies, that are only available in some browsers. Unless you passed in the `store` to one of the `apollo-cache-inmemory` functions, such as: `writeQueryToStore` or `writeResultToStore`, no changes to your code are necessary. If you did access the cache's functions directly, all you need to do is add a `.toObject()` call on the cache — review the changes to the tests for [an example](https://github.com/apollographql/apollo-client/blob/cd563bcd1c2c15b973d0cdfd63332f5ee82da309/packages/apollo-cache-inmemory/src/__tests__/writeToStore.ts#L258). For reasoning behind this change and more information, see [Issue #2293](https://github.com/apollographql/apollo-client/issues/2293).
 - Don't broadcast query watchers during a transaction (for example, while mutation results are being processed) [Issue #2221](https://github.com/apollographql/apollo-client/issues/2221) [PR #2358](https://github.com/apollographql/apollo-client/pull/2358)
 - `readQuery` and `readFragment` return now the result instead of `Cache.DiffResult` [PR #2320](https://github.com/apollographql/apollo-client/pull/2320)

--- a/packages/apollo-cache-inmemory/package.json
+++ b/packages/apollo-cache-inmemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-cache-inmemory",
-  "version": "1.0.0",
+  "version": "1.1.0-beta.1",
   "description": "Core abstract of Caching layer for Apollo Client",
   "author": "James Baxley <james@meteor.com>",
   "contributors": [
@@ -38,6 +38,9 @@
     "apollo-cache": "^1.0.0",
     "apollo-utilities": "^1.0.0",
     "graphql-anywhere": "^4.0.0"
+  },
+  "peerDependencies": {
+    "graphql": "0.11.7"
   },
   "devDependencies": {
     "@types/graphql": "0.9.4",

--- a/packages/apollo-cache-inmemory/package.json
+++ b/packages/apollo-cache-inmemory/package.json
@@ -29,7 +29,7 @@
     "clean": "rimraf coverage/* && rimraf lib/*",
     "prepublishOnly": "npm run build",
     "build:browser":
-      "browserify ./lib/index.js --i apollo-cache-core --i apollo-utilities -o=./lib/bundle.js && npm run minify:browser",
+      "browserify ./lib/index.js --i apollo-cache-core --i apollo-utilities --i graphql -o=./lib/bundle.js && npm run minify:browser",
     "minify:browser":
       "uglifyjs -c -m -o ./lib/bundle.min.js -- ./lib/bundle.js",
     "filesize": "npm run build:browser"

--- a/packages/apollo-cache-inmemory/src/__tests__/__snapshots__/mapCache.ts.snap
+++ b/packages/apollo-cache-inmemory/src/__tests__/__snapshots__/mapCache.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[
+  `MapCache writing to the store throws when trying to write an object without id that was previously queried with id 1`
+] = `
+"Error writing result to store for query:
+ query Failure {
+  item {
+    stringField
+  }
+}
+
+Store error: the application attempted to write an object with no provided id but the store already contains an id of abcd for this object. The selectionSet that was trying to be written is:
+item {
+  stringField
+}"
+`;

--- a/packages/apollo-cache-inmemory/src/__tests__/__snapshots__/roundtrip.ts.snap
+++ b/packages/apollo-cache-inmemory/src/__tests__/__snapshots__/roundtrip.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[
+  `writing to the store throws when trying to write an object without id that was previously queried with id 1`
+] = `
+"Error writing result to store for query:
+ query Failure {
+  item {
+    stringField
+  }
+}
+
+Store error: the application attempted to write an object with no provided id but the store already contains an id of abcd for this object. The selectionSet that was trying to be written is:
+item {
+  stringField
+}"
+`;

--- a/packages/apollo-cache-inmemory/src/__tests__/__snapshots__/writeToStore.ts.snap
+++ b/packages/apollo-cache-inmemory/src/__tests__/__snapshots__/writeToStore.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[
+  `writing to the store throws when trying to write an object without id that was previously queried with id 1`
+] = `
+"Error writing result to store for query:
+ query Failure {
+  item {
+    stringField
+  }
+}
+
+Store error: the application attempted to write an object with no provided id but the store already contains an id of abcd for this object. The selectionSet that was trying to be written is:
+item {
+  stringField
+}"
+`;

--- a/packages/apollo-cache-inmemory/src/__tests__/writeToStore.ts
+++ b/packages/apollo-cache-inmemory/src/__tests__/writeToStore.ts
@@ -1655,7 +1655,7 @@ describe('writing to the store', () => {
           },
         },
         query: gql`
-          query {
+          query Failure {
             item {
               stringField
             }
@@ -1663,7 +1663,7 @@ describe('writing to the store', () => {
         `,
         dataIdFromObject: getIdField,
       });
-    }).toThrowError(/stringField(.|\n)*abcd/g);
+    }).toThrowErrorMatchingSnapshot();
 
     expect(() => {
       writeResultToStore({

--- a/packages/apollo-cache-inmemory/src/mapCache.ts
+++ b/packages/apollo-cache-inmemory/src/mapCache.ts
@@ -1,9 +1,5 @@
 import { NormalizedCache, NormalizedCacheObject, StoreObject } from './types';
 
-function getNormalizedDataId(dataId: string | number): string {
-  return typeof dataId === 'number' ? String(dataId) : dataId;
-}
-
 /**
  * A Map-based implementation of the NormalizedCache.
  * Note that you need a polyfill for Object.entries for this to work.
@@ -14,13 +10,13 @@ export class MapCache implements NormalizedCache {
     this.cache = new Map(Object.entries(data));
   }
   get(dataId: string): StoreObject {
-    return this.cache.get(getNormalizedDataId(dataId));
+    return this.cache.get(`${dataId}`);
   }
   set(dataId: string, value: StoreObject): void {
-    this.cache.set(getNormalizedDataId(dataId), value);
+    this.cache.set(`${dataId}`, value);
   }
   delete(dataId: string): void {
-    this.cache.delete(getNormalizedDataId(dataId));
+    this.cache.delete(`${dataId}`);
   }
   clear(): void {
     return this.cache.clear();

--- a/packages/apollo-cache-inmemory/src/writeToStore.ts
+++ b/packages/apollo-cache-inmemory/src/writeToStore.ts
@@ -6,6 +6,7 @@ import {
   OperationDefinitionNode,
   FragmentDefinitionNode,
 } from 'graphql';
+import { print } from 'graphql/language/printer';
 import { FragmentMatcher } from 'graphql-anywhere';
 
 import {
@@ -43,9 +44,7 @@ export class WriteError extends Error {
 export function enhanceErrorWithDocument(error: Error, document: DocumentNode) {
   // XXX A bit hacky maybe ...
   const enhancedError = new WriteError(
-    `Error writing result to store for query ${document.loc &&
-      document.loc.source &&
-      document.loc.source.body}`,
+    `Error writing result to store for query:\n ${print(document)}`,
   );
   enhancedError.message += '\n' + error.message;
   enhancedError.stack = error.stack;
@@ -428,7 +427,9 @@ function writeFieldToStore({
       ) {
         throw new Error(
           `Store error: the application attempted to write an object with no provided id` +
-            ` but the store already contains an id of ${escapedId.id} for this object.`,
+            ` but the store already contains an id of ${escapedId.id} for this object. The selectionSet` +
+            ` that was trying to be written is:\n` +
+            print(field),
         );
       }
 

--- a/packages/apollo-client/package.json
+++ b/packages/apollo-client/package.json
@@ -67,7 +67,7 @@
     "@types/jest": "21.1.2",
     "@types/lodash": "4.14.80",
     "@types/node": "8.0.46",
-    "apollo-cache-inmemory": "^1.0.0",
+    "apollo-cache-inmemory": "1.1.0-beta.1",
     "benchmark": "2.1.4",
     "browserify": "14.5.0",
     "bundlesize": "0.15.3",


### PR DESCRIPTION
A few things happening in this PR:

- fix bundlesize after hidden breaking change caused all builds to be green (need to follow up and reduce size of some packages again)
- adjust new Map Cache impl to force string coercion for ids
- add in printer for easier debugging of store problems.

**Note / call for ideas**
I don't like including the printer, however it is already in included in part of the required packages (apollo-link) so it won't actually increase overall bundle size of end applications. I really would like to do what the React team does and start to ship a dev and a production bundle. Anyone want to start in that direction?