### PR TITLE
Rename `wsClient` to `wsLink` for consistency

### DIFF
--- a/docs/source/features/subscriptions.md
+++ b/docs/source/features/subscriptions.md
@@ -70,7 +70,7 @@ Then, initialize a GraphQL subscriptions transport link:
 ```js
 import { WebSocketLink } from 'apollo-link-ws';
 
-const wsClient = new WebSocketLink({
+const wsLink = new WebSocketLink({
   uri: `ws://localhost:5000/`,
   options: {
     reconnect: true


### PR DESCRIPTION
Rename `wsClient` to `wsLink` for consistency