### PR TITLE
[Documentation change] Passing credentials in opts:{} is incorrect

### DIFF
--- a/docs/source/recipes/authentication.md
+++ b/docs/source/recipes/authentication.md
@@ -13,9 +13,7 @@ If your app is browser based and you are using cookies for login and session man
 ```js
 const link = createHttpLink({
   uri: '/graphql',
-  opts: {
-    credentials: 'same-origin',
-  },
+  credentials: 'same-origin'
 });
 
 const client = new ApolloClient({


### PR DESCRIPTION
Opened [this issue (#2443)](https://github.com/apollographql/apollo-client/issues/2443) a couple days ago, decided to look through the code today to see if I could fix it, turned out to be a simple docs error:


`credentials` should not be nested inside `opts`, this does not work. It needs to be on the top level of the object.
