### PR TITLE
prevent from accessing window if not defined

### DIFF
--- a/packages/apollo-client/CHANGELOG.md
+++ b/packages/apollo-client/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### vNEXT
 - Fixed mutation result error checking for empty array
+- Fix accessing undefined window when forcing connectToDevTools to true
 
 ### 2.0.1
 - remove errant console

--- a/packages/apollo-client/src/ApolloClient.ts
+++ b/packages/apollo-client/src/ApolloClient.ts
@@ -145,7 +145,7 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
     if (
       typeof connectToDevTools === 'undefined'
         ? defaultConnectToDevTools
-        : connectToDevTools
+        : connectToDevTools && typeof window !== 'undefined'
     ) {
       (window as any).__APOLLO_CLIENT__ = this;
     }


### PR DESCRIPTION
Hi,
When forcing the option `connectToDevTools` to true, apollo tries to attach `__APOLLO_CLIENT__` on window. Even if window is undefined ( Which will fail )