### PR TITLE
Correct gql imports (from graphql-tag)

### DIFF
--- a/docs/source/basics/mutations.md
+++ b/docs/source/basics/mutations.md
@@ -65,7 +65,8 @@ The simplest option is to directly pass options to the default `mutate` prop whe
 
 ```js
 import React, { Component } from 'react';
-import { gql, graphql } from 'react-apollo';
+import { graphql } from 'react-apollo';
+import gql from 'graphql-tag';
 
 class NewEntry extends Component {
   onClick() {
@@ -111,7 +112,8 @@ Here's that in context with a component, which can now be much simpler because i
 
 ```js
 import React, { Component } from 'react';
-import { gql, graphql } from 'react-apollo';
+import { graphql } from 'react-apollo';
+import gql from 'graphql-tag';
 
 const NewEntry = ({ submit }) => (
   <div onClick={() => submit('apollographql/apollo-client')}>


### PR DESCRIPTION
gql should always import from 'graphql-tag'.  See https://github.com/apollographql/apollo-client/issues/2432

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.
