### PR TITLE
[WIP] fix(errors): errors are now attached to data.error

### DIFF
--- a/packages/apollo-client/src/core/ObservableQuery.ts
+++ b/packages/apollo-client/src/core/ObservableQuery.ts
@@ -211,7 +211,7 @@ export class ObservableQuery<T> extends Observable<ApolloQueryResult<T>> {
       queryStoreValue.graphQLErrors &&
       this.options.errorPolicy === 'all'
     ) {
-      result.errors = queryStoreValue.graphQLErrors;
+      result.error = queryStoreValue.graphQLErrors;
     }
 
     if (!partial) {

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -629,6 +629,10 @@ export class QueryManager<TStore> {
       options.notifyOnNetworkStatusChange = false;
     }
 
+    if (typeof options.errorPolicy === 'undefined') {
+      options.errorPolicy = 'none';
+    }
+
     let transformedOptions = { ...options } as WatchQueryOptions;
 
     return new ObservableQuery<T>({


### PR DESCRIPTION
When this is finished, it should fix [this](https://github.com/apollographql/react-apollo/issues/1320) & all related issues in `react-apollo`.

One thing I want to discuss - do we want to change the property from errors to error on `currentResult` or just fix it [here](https://github.com/apollographql/react-apollo/blob/master/src/graphql.tsx#L540) when we destructure from it in `react-apollo`. I'm cool w/ either option, just let me know how you want to proceed so I can fix the tests. 😀 