### PR TITLE
Fixed incorrect yarn installation instructions on 'Precompilation with babel' docs

### DIFF
--- a/docs/source/recipes/babel.md
+++ b/docs/source/recipes/babel.md
@@ -20,7 +20,7 @@ Install the plugin in your dev dependencies:
 npm install --save-dev babel-plugin-graphql-tag
 
 # or with yarn
-yarn add --save-dev babel-plugin-graphql-tag
+yarn add --dev babel-plugin-graphql-tag
 ```
 
 Then add the plugin in your `.babelrc` configuration file:


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Summary

On following the installation instructions on this page of the wiki: https://www.apollographql.com/docs/react/recipes/babel.html

The yarn installation instructions fail with the following error:

```
yarn add --save-dev babel-plugin-graphql-tag
yarn add v1.0.2
error Missing list of packages to add to your project.
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
```

The solution is to use the `--dev` flag instead of `--save-dev`:

```
yarn add --dev babel-plugin-graphql-tag
```

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.
