### PR TITLE
Preserve original __typename in Relay pagination example

### DIFF
--- a/docs/source/recipes/pagination.md
+++ b/docs/source/recipes/pagination.md
@@ -212,6 +212,7 @@ const CommentsWithData = graphql(CommentsQuery, {
               // Put the new comments at the end of the list and update `pageInfo`
               // so we have the new `endCursor` and `hasNextPage` values
               comments: {
+                ...previousResult.comments,
                 edges: [...previousResult.comments.edges, ...newEdges],
                 pageInfo,
               },


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Summary

I noticed some warnings when running the Relay pagination example. There's a small mistake in the example code where we merge the old result with the new result. Because we overwrite the existing object we lose the original `__typename` property.

The solution I've chosen is to spread the original results in first. However, you could also manually include `__typename`.

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.
