### PR TITLE
Fix Relay pagination example

### DIFF
--- a/docs/source/recipes/pagination.md
+++ b/docs/source/recipes/pagination.md
@@ -208,14 +208,15 @@ const CommentsWithData = graphql(CommentsQuery, {
             const newEdges = fetchMoreResult.comments.edges;
             const pageInfo = fetchMoreResult.comments.pageInfo;
 
-            return {
+            return newEdges.length ? {
               // Put the new comments at the end of the list and update `pageInfo`
               // so we have the new `endCursor` and `hasNextPage` values
               comments: {
+                __typename: previousResult.comments.__typename,
                 edges: [...previousResult.comments.edges, ...newEdges],
                 pageInfo,
               },
-            };
+            } : previousResult;
           },
         });
       },


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

I have two suggestions here:
1. Preserve __typename.
2. Only update the result set if there are new edges returned.

I'm not sure how significant the first issue is, but it throws a console warning.  The second is a significant issue.  Consider the scenario where loadMoreEntries is called and the server returns an empty dataset:
```
{
  comments: {
    edges: [],
    pageInfo: {
      endCursor: null,
      hasNextPage:false,
    }
  }
}
```
This stores endCursor as null on the client, and any subsequent calls to loadMoreEntries will end up returning additional results from the beginning of the dataset.