### PR TITLE
Add apollo-link to independently installed packages

### DIFF
--- a/docs/source/basics/setup.md
+++ b/docs/source/basics/setup.md
@@ -13,7 +13,7 @@ To get started with Apollo and React, you will need to install a few packages fr
 npm install apollo-client-preset react-apollo graphql-tag graphql --save
 
 # installing each piece independently
-npm install apollo-client apollo-cache-inmemory apollo-link-http react-apollo graphql-tag graphql ---save
+npm install apollo-client apollo-cache-inmemory apollo-link-http apollo-link react-apollo graphql-tag graphql ---save
 ```
 
 > Note: You don't have to do anything special to get Apollo Client to work in React Native, just install and import it as usual.


### PR DESCRIPTION
It's a peer dependency of [apollo-link-http](https://github.com/apollographql/apollo-link/blob/master/packages/apollo-link-http/package.json#L43) and is included in the [preset](https://github.com/apollographql/apollo-client/blob/master/packages/apollo-client-preset/package.json#L40).
