### PR TITLE
Don't post comments from Codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,3 +8,4 @@ coverage:
         target: "83%"
     patch:
       enabled: false
+comment: false


### PR DESCRIPTION
There are quite a few comments posted on new PRs right now, and the code coverage information is already available via the GitHub PR status. I think it's mostly just noise.