### PR TITLE
fix writeFragment and readFragment issue

### DIFF
--- a/packages/apollo-cache-inmemory/src/writeToStore.ts
+++ b/packages/apollo-cache-inmemory/src/writeToStore.ts
@@ -427,7 +427,9 @@ function writeFieldToStore({
       ) {
         throw new Error(
           `Store error: the application attempted to write an object with no provided id` +
-            ` but the store already contains an id of ${escapedId.id} for this object. The selectionSet` +
+            ` but the store already contains an id of ${
+              escapedId.id
+            } for this object. The selectionSet` +
             ` that was trying to be written is:\n` +
             print(field),
         );

--- a/packages/apollo-client/CHANGELOG.md
+++ b/packages/apollo-client/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Include passed context in the context for mutations
 - Remove locked dep on apollo-link and apollo-link-dedup
 - Fix bug where setting options didn't adjust pollInterval correctly [PR#2573](https://github.com/apollographql/apollo-client/pull/2573)
+- Fix issue where write(Fragment|Query) didn't rerender store [PR#2574](https://github.com/apollographql/apollo-client/pull/2574)
+- Remove uneeded code causing equality failures [PR#2574](https://github.com/apollographql/apollo-client/pull/2574)
+- Potentially fix missing data when rerendering from cache bug in RA [PR#2574](https://github.com/apollographql/apollo-client/pull/2574)
 
 ### 2.0.2
 - Fixed mutation result error checking for empty array

--- a/packages/apollo-client/benchmark/index.ts
+++ b/packages/apollo-client/benchmark/index.ts
@@ -373,7 +373,9 @@ times(50, index => {
       })
       .then(() => {
         myBenchmark(
-          `read result with ${reservationCount} items associated with the result`,
+          `read result with ${
+            reservationCount
+          } items associated with the result`,
           done => {
             client
               .query({

--- a/packages/apollo-client/src/ApolloClient.ts
+++ b/packages/apollo-client/src/ApolloClient.ts
@@ -305,7 +305,9 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
    * specific id returned by `dataIdFromObject` then use `writeFragment`.
    */
   public writeQuery(options: DataProxy.WriteQueryOptions): void {
-    return this.initProxy().writeQuery(options);
+    const result = this.initProxy().writeQuery(options);
+    this.queryManager.broadcastQueries();
+    return result;
   }
 
   /**
@@ -320,7 +322,9 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
    * `fragmentName`.
    */
   public writeFragment(options: DataProxy.WriteFragmentOptions): void {
-    return this.initProxy().writeFragment(options);
+    const result = this.initProxy().writeFragment(options);
+    this.queryManager.broadcastQueries();
+    return result;
   }
 
   public __actionHookForDevTools(cb: () => any) {

--- a/packages/apollo-client/src/__tests__/client.ts
+++ b/packages/apollo-client/src/__tests__/client.ts
@@ -1553,7 +1553,7 @@ describe('client', () => {
           expect(result.loading).toBe(true);
         } else if (handleCount === 2) {
           expect(result.data).toEqual(networkFetch);
-          expect(!result.loading).toBe(true);
+          expect(result.loading).toBe(false);
           done();
         }
       });

--- a/packages/apollo-client/src/core/ObservableQuery.ts
+++ b/packages/apollo-client/src/core/ObservableQuery.ts
@@ -174,11 +174,7 @@ export class ObservableQuery<T> extends Observable<ApolloQueryResult<T>> {
       };
     }
 
-    const { data, partial } = this.queryManager.getCurrentQueryResult(
-      this,
-      false,
-      // isEqual(this.variables, this.lastVariables)
-    );
+    const { data, partial } = this.queryManager.getCurrentQueryResult(this);
 
     const queryLoading =
       !queryStoreValue ||
@@ -571,6 +567,7 @@ export class ObservableQuery<T> extends Observable<ApolloQueryResult<T>> {
       next: (result: ApolloQueryResult<T>) => {
         this.lastResult = result;
         this.observers.forEach(obs => obs.next && obs.next(result));
+        this.lastError = null;
       },
       error: (error: ApolloError) => {
         this.lastError = error;

--- a/packages/apollo-client/src/core/ObservableQuery.ts
+++ b/packages/apollo-client/src/core/ObservableQuery.ts
@@ -567,7 +567,6 @@ export class ObservableQuery<T> extends Observable<ApolloQueryResult<T>> {
       next: (result: ApolloQueryResult<T>) => {
         this.lastResult = result;
         this.observers.forEach(obs => obs.next && obs.next(result));
-        this.lastError = null;
       },
       error: (error: ApolloError) => {
         this.lastError = error;

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -445,14 +445,24 @@ export class QueryManager<TStore> {
 
       const lastError = observableQuery ? observableQuery.getLastError() : null;
 
-      const shouldNotifyIfLoading =
-        queryStoreValue.previousVariables ||
+      let shouldNotifyIfLoading =
+        (!newData && queryStoreValue.previousVariables != null) ||
         fetchPolicy === 'cache-only' ||
         fetchPolicy === 'cache-and-network';
 
-      const networkStatusChanged =
+      // if this caused by a cache broadcast but the query is still in flight
+      // don't notify the observer
+      // if (
+      //   isCacheBroadcast &&
+      //   isNetworkRequestInFlight(queryStoreValue.networkStatus)
+      // ) {
+      //   shouldNotifyIfLoading = false;
+      // }
+
+      const networkStatusChanged = Boolean(
         lastResult &&
-        queryStoreValue.networkStatus !== lastResult.networkStatus;
+          queryStoreValue.networkStatus !== lastResult.networkStatus,
+      );
 
       const errorStatusChanged =
         errorPolicy &&
@@ -711,23 +721,23 @@ export class QueryManager<TStore> {
   ) {
     const { cancel } = this.getQuery(queryId);
     if (cancel) cancel();
+    const previousResult = () => {
+      let previousResult = null;
+      const { observableQuery } = this.getQuery(queryId);
+      if (observableQuery) {
+        const lastResult = observableQuery.getLastResult();
+        if (lastResult) {
+          previousResult = lastResult.data;
+        }
+      }
 
+      return previousResult;
+    };
     return this.dataStore.getCache().watch({
       query: document as DocumentNode,
       variables: options.variables,
       optimistic: true,
-      previousResult: () => {
-        let previousResult = null;
-        const { observableQuery } = this.getQuery(queryId);
-        if (observableQuery) {
-          const lastResult = observableQuery.getLastResult();
-          if (lastResult) {
-            previousResult = lastResult.data;
-          }
-        }
-
-        return previousResult;
-      },
+      previousResult,
       callback: (newData: ApolloQueryResult<any>) => {
         this.setQuery(queryId, () => ({ invalidated: true, newData }));
       },
@@ -780,11 +790,11 @@ export class QueryManager<TStore> {
     const queryName = definition.name ? definition.name.value : null;
     this.setQuery(queryId, () => ({ observableQuery: null }));
     if (queryName) {
-      this.queryIdsByName[queryName] = this.queryIdsByName[
-        queryName
-      ].filter(val => {
-        return !(observableQuery.queryId === val);
-      });
+      this.queryIdsByName[queryName] = this.queryIdsByName[queryName].filter(
+        val => {
+          return !(observableQuery.queryId === val);
+        },
+      );
     }
   }
 
@@ -825,6 +835,7 @@ export class QueryManager<TStore> {
         observableQueryPromises.push(observableQuery.refetch());
       }
 
+      this.setQuery(queryId, () => ({ newData: null }));
       this.invalidate(true, queryId);
     });
 
@@ -929,31 +940,25 @@ export class QueryManager<TStore> {
     this.queries.delete(queryId);
   }
 
-  public getCurrentQueryResult<T>(
-    observableQuery: ObservableQuery<T>,
-    sameVariables: boolean = true,
-  ) {
+  public getCurrentQueryResult<T>(observableQuery: ObservableQuery<T>) {
     const { variables, query } = observableQuery.options;
     const lastResult = observableQuery.getLastResult();
-    if (lastResult && lastResult.data && sameVariables) {
-      return maybeDeepFreeze({ data: lastResult.data, partial: false });
+    const { newData } = this.getQuery(observableQuery.queryId);
+    // XXX test this
+    if (newData) {
+      return maybeDeepFreeze({ data: newData.result, partial: false });
     } else {
-      const { newData } = this.getQuery(observableQuery.queryId);
-      if (newData) {
-        return maybeDeepFreeze({ data: newData.data, partial: false });
-      } else {
-        try {
-          // the query is brand new, so we read from the store to see if anything is there
-          const diffResult = this.dataStore.getCache().read({
-            query,
-            variables,
-            optimistic: true,
-          });
+      try {
+        // the query is brand new, so we read from the store to see if anything is there
+        const data = this.dataStore.getCache().read({
+          query,
+          variables,
+          optimistic: true,
+        });
 
-          return maybeDeepFreeze({ data: diffResult, partial: false });
-        } catch (e) {
-          return maybeDeepFreeze({ data: {}, partial: true });
-        }
+        return maybeDeepFreeze({ data, partial: false });
+      } catch (e) {
+        return maybeDeepFreeze({ data: {}, partial: true });
       }
     }
   }

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -37,7 +37,7 @@ import { QueryListener, ApolloQueryResult, FetchType } from './types';
 export interface QueryInfo {
   listeners: QueryListener[];
   invalidated: boolean;
-  newData: ApolloQueryResult<any> | null;
+  newData: Cache.DiffResult<any> | null;
   document: DocumentNode | null;
   lastRequestId: number | null;
   // A map going from queryId to an observer for a query issued by watchQuery. We use
@@ -942,7 +942,6 @@ export class QueryManager<TStore> {
 
   public getCurrentQueryResult<T>(observableQuery: ObservableQuery<T>) {
     const { variables, query } = observableQuery.options;
-    const lastResult = observableQuery.getLastResult();
     const { newData } = this.getQuery(observableQuery.queryId);
     // XXX test this
     if (newData) {

--- a/packages/apollo-client/src/core/__tests__/ObservableQuery.ts
+++ b/packages/apollo-client/src/core/__tests__/ObservableQuery.ts
@@ -419,27 +419,30 @@ describe('ObservableQuery', () => {
       observable = queryManager.watchQuery({ query: testQuery });
 
       subscribeAndCount(done, observable, (handleCount, result) => {
-        if (handleCount === 1) {
-          expect(result.data).toEqual(data);
-          expect(timesFired).toBe(1);
+        try {
+          if (handleCount === 1) {
+            expect(result.data).toEqual(data);
+            expect(timesFired).toBe(1);
 
-          setTimeout(() => {
-            observable.setOptions({ fetchPolicy: 'cache-only' });
+            setTimeout(() => {
+              observable.setOptions({ fetchPolicy: 'cache-only' });
+              queryManager.resetStore();
+            }, 0);
+          } else if (handleCount === 2) {
+            expect(result.data).toEqual({});
+            expect(timesFired).toBe(1);
 
-            queryManager.resetStore();
-          }, 0);
-        } else if (handleCount === 2) {
-          expect(result.data).toEqual({});
-          expect(timesFired).toBe(1);
+            setTimeout(() => {
+              observable.setOptions({ fetchPolicy: 'cache-first' });
+            }, 0);
+          } else if (handleCount === 3) {
+            expect(result.data).toEqual(data);
+            expect(timesFired).toBe(2);
 
-          setTimeout(() => {
-            observable.setOptions({ fetchPolicy: 'cache-first' });
-          }, 0);
-        } else if (handleCount === 3) {
-          expect(result.data).toEqual(data);
-          expect(timesFired).toBe(2);
-
-          done();
+            done();
+          }
+        } catch (e) {
+          done.fail(e);
         }
       });
     });

--- a/packages/apollo-client/src/core/__tests__/QueryManager/index.ts
+++ b/packages/apollo-client/src/core/__tests__/QueryManager/index.ts
@@ -414,34 +414,31 @@ describe('QueryManager', () => {
 
   // XXX this looks like a bug in zen-observable but we should figure
   // out a solution for it
-  xit(
-    'handles an unsubscribe action that happens before data returns',
-    done => {
-      const subscription = assertWithObserver({
-        done,
-        query: gql`
-          query people {
-            allPeople(first: 1) {
-              people {
-                name
-              }
+  xit('handles an unsubscribe action that happens before data returns', done => {
+    const subscription = assertWithObserver({
+      done,
+      query: gql`
+        query people {
+          allPeople(first: 1) {
+            people {
+              name
             }
           }
-        `,
-        delay: 1000,
-        observer: {
-          next: () => {
-            done.fail(new Error('Should not deliver result'));
-          },
-          error: () => {
-            done.fail(new Error('Should not deliver result'));
-          },
+        }
+      `,
+      delay: 1000,
+      observer: {
+        next: () => {
+          done.fail(new Error('Should not deliver result'));
         },
-      });
+        error: () => {
+          done.fail(new Error('Should not deliver result'));
+        },
+      },
+    });
 
-      expect(subscription.unsubscribe).not.toThrow();
-    },
-  );
+    expect(subscription.unsubscribe).not.toThrow();
+  });
 
   it('supports interoperability with other Observable implementations like RxJS', done => {
     const expResult = {

--- a/packages/apollo-client/src/core/__tests__/QueryManager/multiple-results.ts
+++ b/packages/apollo-client/src/core/__tests__/QueryManager/multiple-results.ts
@@ -202,6 +202,7 @@ describe('mutiple results', () => {
         // errors should never be passed since they are ignored
         expect(result.errors).toBeUndefined();
         count++;
+
         if (count === 1) {
           expect(result.data).toEqual(initialData);
           // this should fire the `next` event without this error
@@ -214,9 +215,9 @@ describe('mutiple results', () => {
           expect(result.errors).toBeUndefined();
           // make sure the count doesn't go up by accident
           setTimeout(() => {
-            if (count === 3) throw new Error('error was not ignored');
+            if (count === 3) done.fail(new Error('error was not ignored'));
             done();
-          });
+          }, 10);
         }
       },
       error: e => {
@@ -269,30 +270,34 @@ describe('mutiple results', () => {
     let count = 0;
     observable.subscribe({
       next: result => {
-        // errors should never be passed since they are ignored
-        count++;
-        if (count === 1) {
-          expect(result.errors).toBeUndefined();
-          // this should fire the next event again
-          link.simulateResult({
-            result: { errors: [new Error('defer failed')] },
-          });
-        }
-        if (count === 2) {
-          expect(result.errors).toBeDefined();
-          link.simulateResult({ result: { data: laterData } });
-        }
-        if (count === 3) {
-          expect(result.errors).toBeUndefined();
-          // make sure the count doesn't go up by accident
-          setTimeout(() => {
-            if (count === 4) throw new Error('error was not ignored');
-            done();
-          });
+        try {
+          // errors should never be passed since they are ignored
+          count++;
+          if (count === 1) {
+            expect(result.errors).toBeUndefined();
+            // this should fire the next event again
+            link.simulateResult({
+              result: { errors: [new Error('defer failed')] },
+            });
+          }
+          if (count === 2) {
+            expect(result.errors).toBeDefined();
+            link.simulateResult({ result: { data: laterData } });
+          }
+          if (count === 3) {
+            expect(result.errors).toBeUndefined();
+            // make sure the count doesn't go up by accident
+            setTimeout(() => {
+              if (count === 4) done.fail(new Error('error was not ignored'));
+              done();
+            });
+          }
+        } catch (e) {
+          done.fail(e);
         }
       },
       error: e => {
-        console.error(e);
+        done.fail(e);
       },
     });
 

--- a/packages/apollo-client/src/scheduler/__tests__/scheduler.ts
+++ b/packages/apollo-client/src/scheduler/__tests__/scheduler.ts
@@ -187,19 +187,19 @@ describe('QueryScheduler', () => {
       }
     `;
     const data = [
-      {someAuthorAlias: {firstName: 'John', lastName: 'Smith'}},
-      {someAuthorAlias: {firstName: 'John', lastName: 'Doe'}},
+      { someAuthorAlias: { firstName: 'John', lastName: 'Smith' } },
+      { someAuthorAlias: { firstName: 'John', lastName: 'Doe' } },
       // When the test passes, this one doesn't get delivered.
-      {someAuthorAlias: {firstName: 'Jane', lastName: 'Doe'}},
+      { someAuthorAlias: { firstName: 'Jane', lastName: 'Doe' } },
     ];
     const queryOptions = {
       query: myQuery,
       pollInterval: 20,
     };
     const link = mockSingleLink(
-      {request: queryOptions, result: { data: data[0] } },
-      {request: queryOptions, result: { data: data[1] } },
-      {request: queryOptions, result: { data: data[2] } },
+      { request: queryOptions, result: { data: data[0] } },
+      { request: queryOptions, result: { data: data[1] } },
+      { request: queryOptions, result: { data: data[2] } },
     );
     const queryManager = new QueryManager({
       store: new DataStore(new InMemoryCache({ addTypename: false })),

--- a/packages/apollo-client/src/scheduler/scheduler.ts
+++ b/packages/apollo-client/src/scheduler/scheduler.ts
@@ -113,39 +113,41 @@ export class QueryScheduler<TCacheShape> {
     // 1. remove queries that have stopped polling
     // 2. call fetchQueries for queries that are polling and not in flight.
     // TODO: refactor this to make it cleaner
-    this.intervalQueries[interval] = this.intervalQueries[
-      interval
-    ].filter(queryId => {
-      // If queryOptions can't be found from registeredQueries or if it has a
-      // different interval, it means that this queryId is no longer registered
-      // and should be removed from the list of queries firing on this interval.
-      //
-      // We don't remove queries from intervalQueries immediately in
-      // stopPollingQuery so that we can keep the timer consistent when queries
-      // are removed and replaced, and to avoid quadratic behavior when stopping
-      // many queries.
-      if (!(this.registeredQueries.hasOwnProperty(queryId) &&
-            this.registeredQueries[queryId].pollInterval === interval)) {
-        return false;
-      }
+    this.intervalQueries[interval] = this.intervalQueries[interval].filter(
+      queryId => {
+        // If queryOptions can't be found from registeredQueries or if it has a
+        // different interval, it means that this queryId is no longer registered
+        // and should be removed from the list of queries firing on this interval.
+        //
+        // We don't remove queries from intervalQueries immediately in
+        // stopPollingQuery so that we can keep the timer consistent when queries
+        // are removed and replaced, and to avoid quadratic behavior when stopping
+        // many queries.
+        if (
+          !(
+            this.registeredQueries.hasOwnProperty(queryId) &&
+            this.registeredQueries[queryId].pollInterval === interval
+          )
+        ) {
+          return false;
+        }
 
-      // Don't fire this instance of the polling query is one of the instances is already in
-      // flight.
-      if (this.checkInFlight(queryId)) {
+        // Don't fire this instance of the polling query is one of the instances is already in
+        // flight.
+        if (this.checkInFlight(queryId)) {
+          return true;
+        }
+
+        const queryOptions = this.registeredQueries[queryId];
+        const pollingOptions = { ...queryOptions } as WatchQueryOptions;
+        pollingOptions.fetchPolicy = 'network-only';
+        // don't let unhandled rejections happen
+        this.fetchQuery<T>(queryId, pollingOptions, FetchType.poll).catch(
+          () => {},
+        );
         return true;
-      }
-
-      const queryOptions = this.registeredQueries[queryId];
-      const pollingOptions = { ...queryOptions } as WatchQueryOptions;
-      pollingOptions.fetchPolicy = 'network-only';
-      // don't let unhandled rejections happen
-      this.fetchQuery<T>(
-        queryId,
-        pollingOptions,
-        FetchType.poll,
-      ).catch(() => {});
-      return true;
-    });
+      },
+    );
 
     if (this.intervalQueries[interval].length === 0) {
       clearInterval(this.pollingTimers[interval]);
@@ -164,7 +166,9 @@ export class QueryScheduler<TCacheShape> {
 
     if (!interval) {
       throw new Error(
-        `A poll interval is required to start polling query with id '${queryId}'.`,
+        `A poll interval is required to start polling query with id '${
+          queryId
+        }'.`,
       );
     }
 

--- a/packages/apollo-utilities/src/directives.ts
+++ b/packages/apollo-utilities/src/directives.ts
@@ -69,7 +69,9 @@ export function shouldInclude(
       // means it has to be a variable value if this is a valid @skip or @include directive
       if (ifValue.kind !== 'Variable') {
         throw new Error(
-          `Argument for the @${directiveName} directive must be a variable or a bool ean value.`,
+          `Argument for the @${
+            directiveName
+          } directive must be a variable or a bool ean value.`,
         );
       } else {
         evaledValue = variables[(ifValue as VariableNode).name.value];

--- a/packages/apollo-utilities/src/fragments.ts
+++ b/packages/apollo-utilities/src/fragments.ts
@@ -37,9 +37,9 @@ export function getFragmentQueryDocument(
     // define our own operation definition later on.
     if (definition.kind === 'OperationDefinition') {
       throw new Error(
-        `Found a ${definition.operation} operation${definition.name
-          ? ` named '${definition.name.value}'`
-          : ''}. ` +
+        `Found a ${definition.operation} operation${
+          definition.name ? ` named '${definition.name.value}'` : ''
+        }. ` +
           'No operations are allowed when using a fragment as a query. Only fragments are allowed.',
       );
     }
@@ -55,7 +55,9 @@ export function getFragmentQueryDocument(
   if (typeof actualFragmentName === 'undefined') {
     if (fragments.length !== 1) {
       throw new Error(
-        `Found ${fragments.length} fragments. \`fragmentName\` must be provided when there is not exactly 1 fragment.`,
+        `Found ${
+          fragments.length
+        } fragments. \`fragmentName\` must be provided when there is not exactly 1 fragment.`,
       );
     }
     actualFragmentName = fragments[0].name.value;

--- a/packages/apollo-utilities/src/getFromAST.ts
+++ b/packages/apollo-utilities/src/getFromAST.ts
@@ -38,7 +38,9 @@ string in a "gql" tag? http://docs.apollostack.com/apollo-client/core.html#gql`)
     .map(definition => {
       if (definition.kind !== 'OperationDefinition') {
         throw new Error(
-          `Schema type definitions not allowed in queries. Found: "${definition.kind}"`,
+          `Schema type definitions not allowed in queries. Found: "${
+            definition.kind
+          }"`,
         );
       }
       return definition;

--- a/packages/apollo-utilities/src/index.js.flow
+++ b/packages/apollo-utilities/src/index.js.flow
@@ -20,14 +20,14 @@ import type {
 declare module 'apollo-utilities' {
   // storeUtils
   declare export interface IdValue {
-    type: 'id',
-    id: string,
-    generated: boolean,
+    type: 'id';
+    id: string;
+    generated: boolean;
   }
 
   declare export interface JsonValue {
-    type: 'json',
-    json: any,
+    type: 'json';
+    json: any;
   }
 
   declare export type ListValue = Array<?IdValue>;
@@ -145,7 +145,7 @@ declare module 'apollo-utilities' {
   ): OperationDefinitionNode | FragmentDefinitionNode;
 
   declare export interface FragmentMap {
-    [fragmentName: string]: FragmentDefinitionNode,
+    [fragmentName: string]: FragmentDefinitionNode;
   }
 
   declare export function createFragmentMap(

--- a/packages/apollo-utilities/src/storeUtils.ts
+++ b/packages/apollo-utilities/src/storeUtils.ts
@@ -117,8 +117,9 @@ export function valueToObjectRepresentation(
   } else if (isEnumValue(value)) {
     argObj[name.value] = (value as EnumValueNode).value;
   } else {
-    throw new Error(`The inline argument "${name.value}" of kind "${(value as any)
-      .kind}" is not supported.
+    throw new Error(`The inline argument "${name.value}" of kind "${
+      (value as any).kind
+    }" is not supported.
                     Use variables instead of inline arguments to overcome this limitation.`);
   }
 }
@@ -178,7 +179,7 @@ export function getStoreKeyName(
       (directives['connection']['filter'] as string[]).length > 0
     ) {
       const filterKeys = directives['connection']['filter']
-        ? directives['connection']['filter'] as string[]
+        ? (directives['connection']['filter'] as string[])
         : [];
       filterKeys.sort();
 


### PR DESCRIPTION
This PR does a few things:

- run newest version of prettier on code base (still need to fix dev tooling to do this for us)
- fix a bug with writeFragment / writeQuery
- remove the lastVariables code

I'm going to run this build against react-apollo locally prior to merging (done, calling this a green build!)

Fixes https://github.com/apollographql/apollo-client/issues/2570, https://github.com/apollographql/apollo-client/issues/2360, and https://github.com/apollographql/apollo-client/issues/2415