### PR TITLE
ensure ref equality when calling currentResult if possible

### DIFF
--- a/packages/apollo-client/CHANGELOG.md
+++ b/packages/apollo-client/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix issue where write(Fragment|Query) didn't rerender store [PR#2574](https://github.com/apollographql/apollo-client/pull/2574)
 - Remove uneeded code causing equality failures [PR#2574](https://github.com/apollographql/apollo-client/pull/2574)
 - Potentially fix missing data when rerendering from cache bug in RA [PR#2574](https://github.com/apollographql/apollo-client/pull/2574)
+- Preserve referential equality when calling currentResult if possible
 
 ### 2.0.2
 - Fixed mutation result error checking for empty array

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -942,6 +942,7 @@ export class QueryManager<TStore> {
 
   public getCurrentQueryResult<T>(observableQuery: ObservableQuery<T>) {
     const { variables, query } = observableQuery.options;
+    const lastResult = observableQuery.getLastResult();
     const { newData } = this.getQuery(observableQuery.queryId);
     // XXX test this
     if (newData) {
@@ -952,6 +953,7 @@ export class QueryManager<TStore> {
         const data = this.dataStore.getCache().read({
           query,
           variables,
+          previousResult: lastResult ? lastResult.data : undefined,
           optimistic: true,
         });
 

--- a/packages/apollo-client/src/core/__tests__/ObservableQuery.ts
+++ b/packages/apollo-client/src/core/__tests__/ObservableQuery.ts
@@ -322,6 +322,9 @@ describe('ObservableQuery', () => {
           observable.setOptions({ variables });
           const current = observable.currentResult();
           expect(current.data).toEqual(data);
+          const secondCurrent = observable.currentResult();
+          // ensure ref equality
+          expect(current.data).toBe(secondCurrent.data);
           done();
         }
       });


### PR DESCRIPTION
This PR fixes the bug introduced with the 2.0 version where `currentResult()` calls wouldn't return referentially equal results even if it could.

Fixes https://github.com/apollographql/apollo-client/issues/2453, and https://github.com/apollographql/apollo-client/issues/2489