### PR TITLE
Add Apollo cache to client on server-side example.

### DIFF
--- a/docs/source/recipes/server-side-rendering.md
+++ b/docs/source/recipes/server-side-rendering.md
@@ -73,6 +73,7 @@ import { ApolloClient } from 'apollo-client';
 import { createHttpLink } from 'apollo-link-http';
 import Express from 'express';
 import { StaticRouter } from 'react-router';
+import { InMemoryCache } from "apollo-cache-inmemory";
 
 import Layout from './routes/Layout';
 
@@ -92,6 +93,7 @@ app.use((req, res) => {
         cookie: req.header('Cookie'),
       },
     }),
+    cache: new InMemoryCache(),
   });
 
   const context = {};


### PR DESCRIPTION
This adds cache: InMemoryCache() to the SSR example. Without this, the server crashes on start:

```
Error:
        In order to initialize Apollo Client, you must specify link & cache properties on the config object.
        This is part of the required upgrade when migrating from Apollo Client 1.0 to Apollo Client 2.0.
        For more information, please visit:
          https://www.apollographql.com/docs/react/basics/setup.html
        to help you get started.
```

I'm not sure if this is the correct cache to use on the server (I've used Apollo for less than a day) so please correct me if I should be using something different here.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.
