### PR TITLE
Ensure that heuristics warnings are not logged in production

### DIFF
--- a/packages/apollo-cache-inmemory/src/writeToStore.ts
+++ b/packages/apollo-cache-inmemory/src/writeToStore.ts
@@ -257,7 +257,7 @@ export function writeSelectionSetToStore({
           fragment.typeCondition.name.value,
           fakeContext,
         );
-        if (fakeContext.returnPartialData) {
+        if (!isProduction() && fakeContext.returnPartialData) {
           console.error('WARNING: heuristic fragment matching going on!');
         }
       }

--- a/packages/apollo-client/AUTHORS
+++ b/packages/apollo-client/AUTHORS
@@ -80,3 +80,4 @@ James Reggio <james.reggio@gmail.com>
 Kacper Wiszczuk <kacper.wiszczuk@gmail.com>
 Soo Jae Hwang <misoguy1985@gmail.com>
 Luke Williams <luke.williams@2minute.com>
+Joshua Balfe <joshuabalfe@gmail.com>

--- a/packages/apollo-client/CHANGELOG.md
+++ b/packages/apollo-client/CHANGELOG.md
@@ -2,6 +2,7 @@
 # Change log
 
 ### vNEXT
+- Ensure that heuristics warnings do not fire in production
 
 ### 2.0.3
 - Revert returning `data` directly in subscriptions, now returns `data` and `errors`


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] ~~If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)~~
- [x] ~~Make sure all of the significant new logic is covered by tests~~
- [x] ~~If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.~~

### Overview

This PR ensures that heuristics warnings (`'WARNING: heuristic fragment matching going on!'`) don't get fired in production. 
