### PR TITLE
feat: expose a method to refetch all observed queries

### DIFF
--- a/packages/apollo-client/CHANGELOG.md
+++ b/packages/apollo-client/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### vNEXT
 - Ensure that heuristics warnings do not fire in production
+- Expose a method to refetch all observed queries without resetting the store [PR#2625](https://github.com/apollographql/apollo-client/pull/2625)
 
 ### 2.0.3
 - Revert returning `data` directly in subscriptions, now returns `data` and `errors`

--- a/packages/apollo-client/src/ApolloClient.ts
+++ b/packages/apollo-client/src/ApolloClient.ts
@@ -134,6 +134,7 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
     this.query = this.query.bind(this);
     this.mutate = this.mutate.bind(this);
     this.resetStore = this.resetStore.bind(this);
+    this.reFetchObservableQueries = this.reFetchObservableQueries.bind(this);
 
     // Attach the client instance to window to let us be found by chrome devtools, but only in
     // development mode
@@ -380,6 +381,25 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
   public resetStore(): Promise<ApolloQueryResult<any>[]> | Promise<null> {
     return this.queryManager
       ? this.queryManager.resetStore()
+      : Promise.resolve(null);
+  }
+
+  /**
+   * Refetches all of your active queries.
+   *
+   * `reFetchObservableQueries()` is useful if you want to bring the client back to proper state in case of a network outage
+   *
+   * It is important to remember that `reFetchObservableQueries()` *will* refetch any active
+   * queries. This means that any components that might be mounted will execute
+   * their queries again using your network interface. If you do not want to
+   * re-execute any queries then you should make sure to stop watching any
+   * active queries.
+   */
+  public reFetchObservableQueries():
+    | Promise<ApolloQueryResult<any>[]>
+    | Promise<null> {
+    return this.queryManager
+      ? this.queryManager.reFetchObservableQueries()
       : Promise.resolve(null);
   }
 

--- a/packages/apollo-client/src/__tests__/client.ts
+++ b/packages/apollo-client/src/__tests__/client.ts
@@ -2064,6 +2064,19 @@ describe('client', () => {
     client.resetStore();
   });
 
+  it('has a reFetchObservableQueries method which calls QueryManager', done => {
+    const client = new ApolloClient({
+      link: ApolloLink.empty(),
+      cache: new InMemoryCache(),
+    });
+    client.queryManager = {
+      reFetchObservableQueries: () => {
+        done();
+      },
+    } as QueryManager;
+    client.reFetchObservableQueries();
+  });
+
   it('should enable dev tools logging', () => {
     const query = gql`
       query people {

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -825,6 +825,10 @@ export class QueryManager<TStore> {
     // watched. If there is an existing query in flight when the store is reset,
     // the promise for it will be rejected and its results will not be written to the
     // store.
+    return dataStoreReset.then(() => this.reFetchObservableQueries());
+  }
+
+  public reFetchObservableQueries(): Promise<ApolloQueryResult<any>[]> {
     const observableQueryPromises: Promise<ApolloQueryResult<any>>[] = [];
     this.queries.forEach(({ observableQuery }, queryId) => {
       if (!observableQuery) return;
@@ -841,7 +845,7 @@ export class QueryManager<TStore> {
 
     this.broadcastQueries();
 
-    return dataStoreReset.then(() => Promise.all(observableQueryPromises));
+    return Promise.all(observableQueryPromises);
   }
 
   public startQuery<T>(


### PR DESCRIPTION
In a scenario where one updates state via a third party real time provider, one can run into situations where the real time provider is unable to do so. For instance with network outages. To be able to refetch all observed queries will make sure the state is in the correct state. Reset store cannot be used for this scenario, because it rejects any query that is mid-flight.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.
