### PR TITLE
Add example to server-side-rendering's local query section

### DIFF
--- a/docs/source/recipes/server-side-rendering.md
+++ b/docs/source/recipes/server-side-rendering.md
@@ -221,7 +221,41 @@ function Html({ content, state }) {
 
 <h3 id="local-queries">Avoiding the network for local queries</h3>
 
-If your GraphQL endpoint is on the same server that you're rendering from, you may want to avoid using the network when making your SSR queries. In particular, if localhost is firewalled on your production environment (eg. Heroku), making network requests for these queries will not work. One solution to this problem is to use an Apollo Link to fetch data using a local graphql schema instead of making a network request.
+If your GraphQL endpoint is on the same server that you're rendering from, you may want to avoid using the network when making your SSR queries. In particular, if localhost is firewalled on your production environment (eg. Heroku), making network requests for these queries will not work.
+
+One solution to this problem is to use an Apollo Link to fetch data using a local graphql schema instead of making a network request. To achieve this, when creating an Apollo Client on the server, you could create a different link instead of using `createHttpLink` that uses your schema and context to run the query immediately, without any additional network requests.
+
+```js
+import { ApolloLink, Observable, RequestHandler } from 'apollo-link';
+import { execute } from 'graphql';
+
+const context = {};
+
+const createServerLink = schema => new ApolloLink(operation => new Observable(observer => {
+  const { query, variables, operationName } = operation;
+  const context = {}; // Replace this with your server's GraphQL context
+
+  execute(schema, query, null, context, variables, operationName)
+    .then(res => {
+      observer.next(res);
+      observer.complete();
+    })
+    .catch(err => {
+      observer.error(err);
+    });
+
+  return () => {};
+}));
+
+// ...
+
+const client = new ApolloClient({
+  ssrMode: true,
+  // Instead of "createHttpLink" use your custom link factory here
+  link: createServerLink(schema),
+  cache: new InMemoryCache(),
+});
+```
 
 <h3 id="skip-for-ssr">Skipping queries for SSR</h3>
 

--- a/docs/source/recipes/server-side-rendering.md
+++ b/docs/source/recipes/server-side-rendering.md
@@ -229,8 +229,6 @@ One solution to this problem is to use an Apollo Link to fetch data using a loca
 import { ApolloLink, Observable, RequestHandler } from 'apollo-link';
 import { execute } from 'graphql';
 
-const context = {};
-
 const createServerLink = schema => new ApolloLink(operation => new Observable(observer => {
   const { query, variables, operationName } = operation;
   const context = {}; // Replace this with your server's GraphQL context


### PR DESCRIPTION
When reading through the "Server Side Rendering" docs of Apollo, I've noticed that the "Local Query" section doesn't actually provide an example on how to set up an Apollo Link that doesn't start additional network requests, so I've added a couple of lines of code there as an example.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.
