### PR TITLE
Correct variable scope to fix test failures

### DIFF
--- a/packages/apollo-cache-inmemory/src/__tests__/diffAgainstStore.ts
+++ b/packages/apollo-cache-inmemory/src/__tests__/diffAgainstStore.ts
@@ -7,9 +7,10 @@ import { HeuristicFragmentMatcher } from '../fragmentMatcher';
 
 const fragmentMatcherFunction = new HeuristicFragmentMatcher().match;
 
+let message: string = null as never;
+
 disableFragmentWarnings();
 export function withError(func: Function, regex: RegExp) {
-  let message: string = null as never;
   const oldError = console.error;
 
   console.error = (m: string) => (message = m);

--- a/packages/apollo-client/AUTHORS
+++ b/packages/apollo-client/AUTHORS
@@ -82,3 +82,4 @@ Soo Jae Hwang <misoguy1985@gmail.com>
 Luke Williams <luke.williams@2minute.com>
 Joshua Balfe <joshuabalfe@gmail.com>
 Mordechai Zuber <mez613@gmail.com>
+Ryan Wood <rwoody@gmail.com>


### PR DESCRIPTION
Looking into fixing a different issue, but I wanted to fix broken tests for `apollo-cache-inmemory` first.