### PR TITLE
fix(ObjectCache): removes not used cloning

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -56,7 +56,7 @@ const raiseIssueAboutPaths = (
   }
 };
 
-const authors = commits.map(x => x.author.login);
+const authors = commits.map(x => x.author!.login);
 const isBot = authors.some(x => ['greenkeeper', 'renovate'].indexOf(x) > -1);
 
 // Rules

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -56,7 +56,7 @@ const raiseIssueAboutPaths = (
   }
 };
 
-const authors = commits.map(x => x.author!.login);
+const authors = commits.map(x => x.author.login);
 const isBot = authors.some(x => ['greenkeeper', 'renovate'].indexOf(x) > -1);
 
 // Rules

--- a/packages/apollo-cache-inmemory/CHANGELOG.md
+++ b/packages/apollo-cache-inmemory/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Change log
 
 ### vNEXT
-
+- improves performance of in memory cache
 ### 1.1.2
 - Ensure that heuristics warnings do not fire in production [#2611](https://github.com/apollographql/apollo-client/pull/2611)
 
 ### 1.1.1
-- Change some access modifiers "private" to "protected" to allow code reuse by InMemoryCache subclasses. 
+- Change some access modifiers "private" to "protected" to allow code reuse by InMemoryCache subclasses.
 - improved rollup builds
 
 ### 1.1.0

--- a/packages/apollo-cache-inmemory/src/inMemoryCache.ts
+++ b/packages/apollo-cache-inmemory/src/inMemoryCache.ts
@@ -66,7 +66,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
   public extract(optimistic: boolean = false): NormalizedCacheObject {
     if (optimistic && this.optimistic.length > 0) {
       const patches = this.optimistic.map(opt => opt.data);
-      return Object.assign({ ...this.data.toObject() }, ...patches);
+      return Object.assign({}, this.data.toObject(), ...patches);
     }
 
     return this.data.toObject();

--- a/packages/apollo-cache-inmemory/src/inMemoryCache.ts
+++ b/packages/apollo-cache-inmemory/src/inMemoryCache.ts
@@ -18,7 +18,6 @@ import { writeResultToStore } from './writeToStore';
 import { readQueryFromStore, diffQueryAgainstStore } from './readFromStore';
 import { defaultNormalizedCacheFactory } from './objectCache';
 import { record } from './recordingCache';
-
 const defaultConfig: ApolloReducerConfig = {
   fragmentMatcher: new HeuristicFragmentMatcher(),
   dataIdFromObject: defaultDataIdFromObject,
@@ -67,7 +66,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
   public extract(optimistic: boolean = false): NormalizedCacheObject {
     if (optimistic && this.optimistic.length > 0) {
       const patches = this.optimistic.map(opt => opt.data);
-      return Object.assign(this.data.toObject(), ...patches);
+      return Object.assign({ ...this.data.toObject() }, ...patches);
     }
 
     return this.data.toObject();

--- a/packages/apollo-cache-inmemory/src/objectCache.ts
+++ b/packages/apollo-cache-inmemory/src/objectCache.ts
@@ -3,7 +3,7 @@ import { NormalizedCache, NormalizedCacheObject, StoreObject } from './types';
 export class ObjectCache implements NormalizedCache {
   constructor(private data: NormalizedCacheObject = {}) {}
   public toObject(): NormalizedCacheObject {
-    return { ...this.data };
+    return this.data;
   }
   public get(dataId: string): StoreObject {
     return this.data[dataId];


### PR DESCRIPTION
We had big performance issues with Apollo lately. 
It seems that the bottleneck always was the cache. While debugging, we recognized the massive cost of the `toObject()`  method in `ObjectCache.ts`. 
In the current version this method clones the whole cache every time a new GraphQL query is received. 
As we didn't find any use for a unique instance, this pull request removes the overhead. 
Following some performance examples:
**Current Version:**
![apollo-client-performance-old](https://user-images.githubusercontent.com/14233220/33650909-2c273b1c-da64-11e7-8ac6-a56b808c1176.png)
![apollo-client-performance-old-code](https://user-images.githubusercontent.com/14233220/33650910-2c426f68-da64-11e7-9081-1079bb6f71e8.png)
**Without Cloning:**
![apollo-client-performance-new](https://user-images.githubusercontent.com/14233220/33650931-40f3bd90-da64-11e7-9f44-d66fad61b2fe.png)
![apollo-client-performance-new-code](https://user-images.githubusercontent.com/14233220/33650930-40d39a88-da64-11e7-944e-056b27951775.png)

