### PR TITLE
Change data to protected

### DIFF
--- a/packages/apollo-cache-inmemory/CHANGELOG.md
+++ b/packages/apollo-cache-inmemory/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ### vNEXT
+- Change access modifier for data from "private" to "protected", to allow InMemoryCache subclasses to access it.
 
 ### 1.1.3
 - improves performance of in memory cache

--- a/packages/apollo-cache-inmemory/src/inMemoryCache.ts
+++ b/packages/apollo-cache-inmemory/src/inMemoryCache.ts
@@ -38,7 +38,7 @@ export function defaultDataIdFromObject(result: any): string | null {
 }
 
 export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
-  private data: NormalizedCache;
+  protected data: NormalizedCache;
   protected config: ApolloReducerConfig;
   protected optimistic: OptimisticStoreItem[] = [];
   private watches: Cache.WatchOptions[] = [];


### PR DESCRIPTION
This allows subclasses of `InMemoryCache` (for example https://github.com/rportugal/apollo-cache-redux/blob/master/src/reduxCache.ts) to directly access the data managed by the `InMemoryCache`.
The use case I'm trying to implement is a Null Cache, in which the data is always cleared up after a `read()` operation.
 
### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.
