### PR TITLE
Include optimistcResponse in the link context for mutations

### DIFF
--- a/packages/apollo-client/CHANGELOG.md
+++ b/packages/apollo-client/CHANGELOG.md
@@ -2,7 +2,7 @@
 # Change log
 
 ### vNEXT
-- include `optimisticResponse` in the context passed to apollo-link for mutations [PR#????]
+- include `optimisticResponse` in the context passed to apollo-link for mutations [PR#2704](https://github.com/apollographql/apollo-client/pull/2704)
 
 ### 2.1.1
 - fix eslint usage by fixing jsnext:main path

--- a/packages/apollo-client/CHANGELOG.md
+++ b/packages/apollo-client/CHANGELOG.md
@@ -2,6 +2,7 @@
 # Change log
 
 ### vNEXT
+- include `optimisticResponse` in the context passed to apollo-link for mutations [PR#????]
 
 ### 2.1.1
 - fix eslint usage by fixing jsnext:main path

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -1191,4 +1191,23 @@ export class QueryManager<TStore> {
       this.setQuery(fetchMoreForQueryId, () => ({ invalidated }));
     }
   }
+
+  private buildOperationForLink(
+    document: DocumentNode,
+    variables: any,
+    extraContext: any,
+  ) {
+    const cache = this.dataStore.getCache();
+    return {
+      query: cache.transformForLink
+        ? cache.transformForLink(document)
+        : document,
+      variables,
+      operationName: getOperationName(document) || undefined,
+      context: {
+        ...extraContext,
+        cache,
+      },
+    };
+  }
 }

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -139,14 +139,7 @@ export class QueryManager<TStore> {
         getDefaultValues(getMutationDefinition(mutation)),
         variables,
       ));
-
     const mutationString = print(mutation);
-    const request = {
-      query: mutation,
-      variables,
-      operationName: getOperationName(mutation) || undefined,
-      context,
-    } as GraphQLRequest;
 
     this.setQuery(mutationId, () => ({ document: mutation }));
 
@@ -186,17 +179,13 @@ export class QueryManager<TStore> {
     return new Promise((resolve, reject) => {
       let storeResult: FetchResult<T> | null;
       let error: ApolloError;
-      let newRequest = {
-        context: {},
-        ...request,
-        query: cache.transformForLink
-          ? cache.transformForLink(request.query)
-          : request.query,
-      };
 
-      (newRequest as any).context.cache = this.dataStore.getCache();
-
-      execute(this.link, newRequest).subscribe({
+      const operation = this.buildOperationForLink(
+        mutation,
+        variables,
+        context,
+      );
+      execute(this.link, operation).subscribe({
         next: (result: ExecutionResult) => {
           if (result.errors && errorPolicy === 'none') {
             error = new ApolloError({

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -877,12 +877,6 @@ export class QueryManager<TStore> {
       options.variables,
     );
 
-    const request: GraphQLRequest = {
-      query: transformedDoc,
-      variables,
-      operationName: getOperationName(transformedDoc) || undefined,
-    };
-
     let sub: Subscription;
     let observers: Observer<any>[] = [];
 
@@ -913,13 +907,10 @@ export class QueryManager<TStore> {
           },
         };
 
-        let newRequest = {
-          ...request,
-          query: cache.transformForLink
-            ? cache.transformForLink(request.query)
-            : request.query,
-        };
-        sub = execute(this.link, newRequest).subscribe(handler);
+        // TODO: Should subscriptions also accept a `context` option to pass
+        // through to links?
+        const operation = this.buildOperationForLink(transformedDoc, variables);
+        sub = execute(this.link, operation).subscribe(handler);
       }
 
       return () => {
@@ -1177,7 +1168,7 @@ export class QueryManager<TStore> {
   private buildOperationForLink(
     document: DocumentNode,
     variables: any,
-    extraContext: any,
+    extraContext?: any,
   ) {
     const cache = this.dataStore.getCache();
     return {

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -1,4 +1,4 @@
-import { execute, ApolloLink, GraphQLRequest, FetchResult } from 'apollo-link';
+import { execute, ApolloLink, FetchResult } from 'apollo-link';
 import { ExecutionResult, DocumentNode } from 'graphql';
 import { print } from 'graphql/language/printer';
 import { DedupLink as Deduplicator } from 'apollo-link-dedup';
@@ -180,11 +180,10 @@ export class QueryManager<TStore> {
       let storeResult: FetchResult<T> | null;
       let error: ApolloError;
 
-      const operation = this.buildOperationForLink(
-        mutation,
-        variables,
-        context,
-      );
+      const operation = this.buildOperationForLink(mutation, variables, {
+        ...context,
+        optimisticResponse,
+      });
       execute(this.link, operation).subscribe({
         next: (result: ExecutionResult) => {
           if (result.errors && errorPolicy === 'none') {


### PR DESCRIPTION
This passes optimistic responses through to links so that they can perform work based on it (for example: to retry mutations w/ optimistic responses)

Also, refactored `QueryManager`'s approach to building operation objects to pass to link to ensure that it's consistent (it's not completely consistent today - see the TODOs - but moves in that direction).
