### PR TITLE
Increase benchmark tolerance to better handle Travis performance variation

### DIFF
--- a/packages/apollo-client/benchmark/github-reporter.ts
+++ b/packages/apollo-client/benchmark/github-reporter.ts
@@ -58,10 +58,10 @@ export function collectAndReportBenchmarks() {
             pass = false;
           }
         } else {
-          if (res[element].mean - (res[element].moe * 2) > thresholds[element]) {
+          if (res[element].mean - (res[element].moe * 3) > thresholds[element]) {
             const perfDropMessage = `Performance drop detected for benchmark: "${
               element
-            }", ${res[element].mean} - ${res[element].moe * 2} > ${
+            }", ${res[element].mean} - ${res[element].moe * 3} > ${
               thresholds[element]
             }`;
             console.error(perfDropMessage);
@@ -73,7 +73,7 @@ export function collectAndReportBenchmarks() {
             console.log(
               `No performance drop detected for benchmark: "${element}", ${
                 res[element].mean
-              } - ${res[element].moe * 2} <= ${thresholds[element]}`,
+              } - ${res[element].moe * 3} <= ${thresholds[element]}`,
             );
           }
         }

--- a/packages/apollo-client/benchmark/github-reporter.ts
+++ b/packages/apollo-client/benchmark/github-reporter.ts
@@ -58,10 +58,10 @@ export function collectAndReportBenchmarks() {
             pass = false;
           }
         } else {
-          if (res[element].mean - res[element].moe > thresholds[element]) {
+          if (res[element].mean - (res[element].moe * 2) > thresholds[element]) {
             const perfDropMessage = `Performance drop detected for benchmark: "${
               element
-            }", ${res[element].mean} - ${res[element].moe} > ${
+            }", ${res[element].mean} - ${res[element].moe * 2} > ${
               thresholds[element]
             }`;
             console.error(perfDropMessage);
@@ -73,7 +73,7 @@ export function collectAndReportBenchmarks() {
             console.log(
               `No performance drop detected for benchmark: "${element}", ${
                 res[element].mean
-              } - ${res[element].moe} <= ${thresholds[element]}`,
+              } - ${res[element].moe * 2} <= ${thresholds[element]}`,
             );
           }
         }


### PR DESCRIPTION
Travis appears to have a lot of performance variation across builds, so this increases the tolerance when checking if the results are within the thresholds.