### PR TITLE
readQuery docs improvements

### DIFF
--- a/docs/source/basics/caching.md
+++ b/docs/source/basics/caching.md
@@ -82,7 +82,7 @@ Any code demonstration in the following sections will assume that we have alread
 
 <h3 id="readquery">readQuery</h3>
 
-The `readQuery` method is very similar to the [`query` method on `ApolloClient`][] except that `readQuery` will _never_ make a request to your GraphQL server. The `query` method, on the other hand, may send a request to your server if the appropriate data is not in your cache whereas `readQuery` will throw an error if the data is not in your cache. `readQuery` will _always_ read from the cache. You can use `readQuery` by giving it a GraphQL query like so:
+The `readQuery` method is very similar to the `query` method on `ApolloClient` except that `readQuery` will _never_ make a request to your GraphQL server. The `query` method, on the other hand, may send a request to your server if the appropriate data is not in your cache whereas `readQuery` will throw an error if the data is not in your cache. `readQuery` will _always_ read from the cache. You can use `readQuery` by giving it a GraphQL query like so:
 
 ```js
 const { todo } = client.readQuery({

--- a/docs/source/basics/mutations.md
+++ b/docs/source/basics/mutations.md
@@ -423,11 +423,11 @@ To read the data from the store that you are changing, make sure to use methods 
 
 For more information on updating your cache after a mutation with the `options.update` function make sure to read the [Apollo Client technical documentation on the subject](../features/caching.html#updating-the-cache-after-a-mutation).
 
-[`DataProxy`]: ../core/apollo-client-api.html#DataProxy
-[`writeQuery`]: ../core/apollo-client-api.html#DataProxy.writeQuery
-[`writeFragment`]: ../core/apollo-client-api.html#DataProxy.writeFragment
-[`readQuery`]: ../core/apollo-client-api.html#DataProxy.readQuery
-[`readFragment`]: ../core/apollo-client-api.html#DataProxy.readFragment
+[`DataProxy`]: caching.html#direct
+[`writeQuery`]: caching.html#writequery-and-writefragment
+[`writeFragment`]: caching.html#writequery-and-writefragment
+[`readQuery`]: caching.html#readquery
+[`readFragment`]: caching.html#readfragment
 
 **Example:**
 

--- a/packages/apollo-client/AUTHORS
+++ b/packages/apollo-client/AUTHORS
@@ -86,3 +86,4 @@ Lukas Jakob <lu.jakob@gmail.com>
 Divyendu Singh <mail@divyendusingh.com>
 Paddy Hamilton <paddy.sinclair.h@gmail.com>
 Robert Simon <shock.shock@gmail.com>
+Adam Tuttle <adamtuttlecodes@gmail.com>


### PR DESCRIPTION
Resolves #2760 

- fixes broken links from mutate's `options.update` to readQuery/etc
- fixes a formatting mistake in the readQuery docs