### PR TITLE
Minor fix to example code in "Mutations" docs

### DIFF
--- a/docs/source/basics/mutations.md
+++ b/docs/source/basics/mutations.md
@@ -277,7 +277,7 @@ client.mutate({
   variables: {
     text,
   },
-  update: (proxy, { data: { createTodo } }) => {
+  update: (proxy, { mutationResultData: { createTodo } }) => {
     // Read the data from our cache for this query.
     const data = proxy.readQuery({ query: TodoAppQuery });
 

--- a/docs/source/basics/mutations.md
+++ b/docs/source/basics/mutations.md
@@ -277,15 +277,15 @@ client.mutate({
   variables: {
     text,
   },
-  update: (proxy, { mutationResultData: { createTodo } }) => {
+  update: (proxy, { data: { createTodo } }) => {
     // Read the data from our cache for this query.
-    const data = proxy.readQuery({ query: TodoAppQuery });
+    const queryData = proxy.readQuery({ query: TodoAppQuery });
 
     // Add our todo from the mutation to the end.
-    data.todos.push(createTodo);
+    queryData.todos.push(createTodo);
 
     // Write our data back to the cache.
-    proxy.writeQuery({ query: TodoAppQuery, data });
+    proxy.writeQuery({ query: TodoAppQuery, queryData });
   },
 });
 ```


### PR DESCRIPTION
Function's param `data` can be confused with definition of `data` in `const` of function body.
Changed the name consistently to other examples in docs.

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.
