### PR TITLE
Add a Logger to the inmemory cache for write and read

### DIFF
--- a/packages/apollo-cache-inmemory/src/__tests__/cache.ts
+++ b/packages/apollo-cache-inmemory/src/__tests__/cache.ts
@@ -6,15 +6,13 @@ import { InMemoryCache, ApolloReducerConfig, NormalizedCache } from '..';
 disableFragmentWarnings();
 
 describe('Cache', () => {
-  function createCache(
-    {
-      initialState,
-      config,
-    }: {
-      initialState?: any;
-      config?: ApolloReducerConfig;
-    } = {},
-  ): ApolloCache<NormalizedCache> {
+  function createCache({
+    initialState,
+    config,
+  }: {
+    initialState?: any;
+    config?: ApolloReducerConfig;
+  } = {}): ApolloCache<NormalizedCache> {
     return new InMemoryCache(
       config || { addTypename: false },
       // XXX this is the old format. The tests need to be updated but since it is mapped down

--- a/packages/apollo-cache-inmemory/src/inMemoryCache.ts
+++ b/packages/apollo-cache-inmemory/src/inMemoryCache.ts
@@ -43,6 +43,8 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
   protected data: NormalizedCache;
   protected config: ApolloReducerConfig;
   protected optimistic: OptimisticStoreItem[] = [];
+  protected logger: Function;
+  private loggerEnabled: boolean;
   private watches: Cache.WatchOptions[] = [];
   private addTypename: boolean;
 

--- a/packages/apollo-cache-inmemory/src/types.ts
+++ b/packages/apollo-cache-inmemory/src/types.ts
@@ -69,6 +69,8 @@ export type ApolloReducerConfig = {
   addTypename?: boolean;
   cacheResolvers?: CacheResolverMap;
   storeFactory?: NormalizedCacheFactory;
+  logger?: Function;
+  loggerEnabled?: boolean;
 };
 
 export type ReadStoreContext = {

--- a/packages/apollo-cache/src/types/DataProxy.ts
+++ b/packages/apollo-cache/src/types/DataProxy.ts
@@ -1,4 +1,4 @@
-import { DocumentNode } from "graphql"; // eslint-disable-line import/no-extraneous-dependencies, import/no-unresolved
+import { DocumentNode } from 'graphql'; // eslint-disable-line import/no-extraneous-dependencies, import/no-unresolved
 
 export namespace DataProxy {
   export interface Query {
@@ -76,7 +76,7 @@ export interface DataProxy {
    */
   readQuery<QueryType>(
     options: DataProxy.Query,
-    optimistic?: boolean
+    optimistic?: boolean,
   ): QueryType | null;
 
   /**
@@ -86,7 +86,7 @@ export interface DataProxy {
    */
   readFragment<FragmentType>(
     options: DataProxy.Fragment,
-    optimistic?: boolean
+    optimistic?: boolean,
   ): FragmentType | null;
 
   /**

--- a/packages/apollo-client/benchmark/github-reporter.ts
+++ b/packages/apollo-client/benchmark/github-reporter.ts
@@ -4,7 +4,8 @@ import { thresholds } from './thresholds';
 
 export function collectAndReportBenchmarks() {
   const github = eval('new require("github")()') as GithubAPI;
-  const commitSHA = process.env.TRAVIS_PULL_REQUEST_SHA || process.env.TRAVIS_COMMIT || '';
+  const commitSHA =
+    process.env.TRAVIS_PULL_REQUEST_SHA || process.env.TRAVIS_COMMIT || '';
 
   github.authenticate({
     type: 'oauth',
@@ -58,12 +59,10 @@ export function collectAndReportBenchmarks() {
             pass = false;
           }
         } else {
-          if (res[element].mean - (res[element].moe * 3) > thresholds[element]) {
-            const perfDropMessage = `Performance drop detected for benchmark: "${
-              element
-            }", ${res[element].mean} - ${res[element].moe * 3} > ${
-              thresholds[element]
-            }`;
+          if (res[element].mean - res[element].moe * 3 > thresholds[element]) {
+            const perfDropMessage = `Performance drop detected for benchmark: "${element}", ${
+              res[element].mean
+            } - ${res[element].moe * 3} > ${thresholds[element]}`;
             console.error(perfDropMessage);
             if (message === '') {
               message = perfDropMessage;

--- a/packages/apollo-client/src/ApolloClient.ts
+++ b/packages/apollo-client/src/ApolloClient.ts
@@ -401,8 +401,8 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
     return this.queryManager
       ? this.queryManager.reFetchObservableQueries()
       : Promise.resolve(null);
-   }
-  
+  }
+
   /**
    * Exposes the cache's complete state, in a serializable format for later restoration.
    */
@@ -419,7 +419,6 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
    */
   public restore(serializedState: TCacheShape): ApolloCache<TCacheShape> {
     return this.initProxy().restore(serializedState);
-
   }
 
   /**

--- a/packages/apollo-client/src/__tests__/client.ts
+++ b/packages/apollo-client/src/__tests__/client.ts
@@ -71,9 +71,11 @@ describe('client', () => {
     });
 
     expect(() => {
-      client.query(gql`{
+      client.query(gql`
+        {
           a
-        }` as any);
+        }
+      ` as any);
     }).toThrowError(
       'query option is required. You must specify your GraphQL document in the query option.',
     );

--- a/packages/apollo-client/src/scheduler/scheduler.ts
+++ b/packages/apollo-client/src/scheduler/scheduler.ts
@@ -166,9 +166,7 @@ export class QueryScheduler<TCacheShape> {
 
     if (!interval) {
       throw new Error(
-        `A poll interval is required to start polling query with id '${
-          queryId
-        }'.`,
+        `A poll interval is required to start polling query with id '${queryId}'.`,
       );
     }
 

--- a/packages/apollo-utilities/src/directives.ts
+++ b/packages/apollo-utilities/src/directives.ts
@@ -69,9 +69,7 @@ export function shouldInclude(
       // means it has to be a variable value if this is a valid @skip or @include directive
       if (ifValue.kind !== 'Variable') {
         throw new Error(
-          `Argument for the @${
-            directiveName
-          } directive must be a variable or a bool ean value.`,
+          `Argument for the @${directiveName} directive must be a variable or a bool ean value.`,
         );
       } else {
         evaledValue = variables[(ifValue as VariableNode).name.value];


### PR DESCRIPTION
Really quick impl. of a basic logger. My use case only calls for writes/reads, and would probably implement my own logger as well.

adds 2 new options to the inMemoryCache

```js
{
  logger: console.log, // whatever log function you would like, default is console.log
  loggerEnabled: true, // enable the logger, boolean used for disabling it if you want in diff environments
}
```