### PR TITLE
logger

### DIFF
--- a/packages/apollo-cache-inmemory/src/inMemoryCache.ts
+++ b/packages/apollo-cache-inmemory/src/inMemoryCache.ts
@@ -23,6 +23,8 @@ const defaultConfig: ApolloReducerConfig = {
   dataIdFromObject: defaultDataIdFromObject,
   addTypename: true,
   storeFactory: defaultNormalizedCacheFactory,
+  logger: console.log,
+  loggerEnabled: true,
 };
 
 export function defaultDataIdFromObject(result: any): string | null {
@@ -41,6 +43,8 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
   protected data: NormalizedCache;
   protected config: ApolloReducerConfig;
   protected optimistic: OptimisticStoreItem[] = [];
+  protected logger: Function;
+  private loggerEnabled: boolean;
   private watches: Cache.WatchOptions[] = [];
   private addTypename: boolean;
 
@@ -56,6 +60,8 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
       this.config.cacheResolvers = (this.config as any).customResolvers;
     this.addTypename = this.config.addTypename ? true : false;
     this.data = this.config.storeFactory();
+    this.logger = this.config.logger;
+    this.loggerEnabled = this.config.loggerEnabled;
   }
 
   public restore(data: NormalizedCacheObject): this {
@@ -77,11 +83,17 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
       return null;
     }
 
-    return readQueryFromStore({
-      store: this.config.storeFactory(this.extract(query.optimistic)),
+    const paramsToLog = {
       query: this.transformDocument(query.query),
       variables: query.variables,
       rootId: query.rootId,
+    };
+
+    this.logger('APOLLO_CACHE READ', paramsToLog);
+
+    return readQueryFromStore({
+      store: this.config.storeFactory(this.extract(query.optimistic)),
+      ...paramsToLog,
       fragmentMatcherFunction: this.config.fragmentMatcher.match,
       previousResult: query.previousResult,
       config: this.config,
@@ -89,10 +101,16 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
   }
 
   public write(write: Cache.WriteOptions): void {
-    writeResultToStore({
+    const paramsToLog = {
       dataId: write.dataId,
       result: write.result,
       variables: write.variables,
+    };
+
+    this.logger('APOLLO_CACHE WRITE', paramsToLog);
+
+    writeResultToStore({
+      ...paramsToLog,
       document: this.transformDocument(write.query),
       store: this.data,
       dataIdFromObject: this.config.dataIdFromObject,
@@ -149,7 +167,6 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
 
   public performTransaction(transaction: Transaction<NormalizedCacheObject>) {
     // TODO: does this need to be different, or is this okay for an in-memory cache?
-
     let alreadySilenced = this.silenceBroadcast;
     this.silenceBroadcast = true;
 

--- a/packages/apollo-cache-inmemory/src/types.ts
+++ b/packages/apollo-cache-inmemory/src/types.ts
@@ -69,6 +69,8 @@ export type ApolloReducerConfig = {
   addTypename?: boolean;
   cacheResolvers?: CacheResolverMap;
   storeFactory?: NormalizedCacheFactory;
+  logger?: Function;
+  loggerEnabled?: boolean;
 };
 
 export type ReadStoreContext = {


### PR DESCRIPTION
Really quick impl. of a basic logger. My use case only calls for writes/reads, and would probably implement my own logger as well.

adds 2 new options to the inMemoryCache

```js
{
  logger: console.log, // whatever log function you would like, default is console.log
  loggerEnabled: true, // enable the logger, boolean used for disabling it if you want in diff environments
}
```