### PR TITLE
Export ErrorPolicy type from ApolloClient

### DIFF
--- a/packages/apollo-client/src/index.ts
+++ b/packages/apollo-client/src/index.ts
@@ -11,6 +11,7 @@ export {
   MutationOptions,
   SubscriptionOptions,
   FetchPolicy,
+  ErrorPolicy,
   FetchMoreQueryOptions,
   SubscribeToMoreOptions,
   MutationUpdaterFn,


### PR DESCRIPTION
### Description

This PR is related to [resolving react-apollo's issue](https://github.com/apollographql/react-apollo/issues/1486).

This issue can be easily resolved with few lines of code though, there is a glitch.

As you can see in [this import statement](https://github.com/apollographql/react-apollo/blob/177ccad8f3166c54b9df3eea17930ffdae302e46/src/types.ts#L1-L11), `apollo-client` exports every needed types for their dependencies. But `ErrorPolicy` type is missing.

I could import `ErrorPolicy` type using this statement.

```js
import { ErrorPolicy } from 'apollo-client/core/watchQueryOptions';
```

Since this syntax conflicts the styles of the import statement which already written, It will be better if `ErrorPolicy` type is exported in `index.ts`.