### PR TITLE
Add cache.writeData to base cache type & DataProxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     {
       "name": "apollo-cache",
       "path": "./packages/apollo-cache/lib/bundle.min.js",
-      "maxSize": "1 kB"
+      "maxSize": "1.2 kB"
     },
     {
       "name": "apollo-cache-inmemory",

--- a/packages/apollo-cache/src/__tests__/__snapshots__/utils.ts.snap
+++ b/packages/apollo-cache/src/__tests__/__snapshots__/utils.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`writing data with no query converts a JavaScript object to a query correctly arrays 1`] = `undefined`;
+
+exports[`writing data with no query converts a JavaScript object to a query correctly basic 1`] = `undefined`;
+
+exports[`writing data with no query converts a JavaScript object to a query correctly fragments 1`] = `undefined`;
+
+exports[`writing data with no query converts a JavaScript object to a query correctly nested 1`] = `undefined`;

--- a/packages/apollo-cache/src/__tests__/__snapshots__/utils.ts.snap
+++ b/packages/apollo-cache/src/__tests__/__snapshots__/utils.ts.snap
@@ -1,9 +1,63 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`writing data with no query converts a JavaScript object to a query correctly arrays 1`] = `undefined`;
+exports[
+  `writing data with no query converts a JavaScript object to a query correctly arrays 1`
+] = `
+"query GeneratedClientQuery {
+  number
+  bool
+  nested {
+    bool2
+    undef
+    nullField
+    str
+  }
+}
+"
+`;
 
-exports[`writing data with no query converts a JavaScript object to a query correctly basic 1`] = `undefined`;
+exports[
+  `writing data with no query converts a JavaScript object to a query correctly basic 1`
+] = `
+"query GeneratedClientQuery {
+  number
+  bool
+  bool2
+  undef
+  nullField
+  str
+}
+"
+`;
 
-exports[`writing data with no query converts a JavaScript object to a query correctly fragments 1`] = `undefined`;
+exports[
+  `writing data with no query converts a JavaScript object to a query correctly fragments 1`
+] = `
+"fragment GeneratedClientQuery on __FakeType {
+  number
+  bool
+  nested {
+    bool2
+    undef
+    nullField
+    str
+  }
+}
+"
+`;
 
-exports[`writing data with no query converts a JavaScript object to a query correctly nested 1`] = `undefined`;
+exports[
+  `writing data with no query converts a JavaScript object to a query correctly nested 1`
+] = `
+"query GeneratedClientQuery {
+  number
+  bool
+  nested {
+    bool2
+    undef
+    nullField
+    str
+  }
+}
+"
+`;

--- a/packages/apollo-cache/src/__tests__/utils.ts
+++ b/packages/apollo-cache/src/__tests__/utils.ts
@@ -1,4 +1,5 @@
-import { queryFromPojo, fragmentFromPojo} from '../utils'
+import { print } from 'graphql/language/printer';
+import { queryFromPojo, fragmentFromPojo } from '../utils';
 
 describe('writing data with no query', () => {
   describe('converts a JavaScript object to a query correctly', () => {
@@ -72,3 +73,4 @@ describe('writing data with no query', () => {
       ).toMatchSnapshot();
     });
   });
+});

--- a/packages/apollo-cache/src/__tests__/utils.ts
+++ b/packages/apollo-cache/src/__tests__/utils.ts
@@ -1,0 +1,74 @@
+import { queryFromPojo, fragmentFromPojo} from '../utils'
+
+describe('writing data with no query', () => {
+  describe('converts a JavaScript object to a query correctly', () => {
+    it('basic', () => {
+      expect(
+        print(
+          queryFromPojo({
+            number: 5,
+            bool: true,
+            bool2: false,
+            undef: undefined,
+            nullField: null,
+            str: 'string',
+          }),
+        ),
+      ).toMatchSnapshot();
+    });
+
+    it('nested', () => {
+      expect(
+        print(
+          queryFromPojo({
+            number: 5,
+            bool: true,
+            nested: {
+              bool2: false,
+              undef: undefined,
+              nullField: null,
+              str: 'string',
+            },
+          }),
+        ),
+      ).toMatchSnapshot();
+    });
+
+    it('arrays', () => {
+      expect(
+        print(
+          queryFromPojo({
+            number: [5],
+            bool: [[true]],
+            nested: [
+              {
+                bool2: false,
+                undef: undefined,
+                nullField: null,
+                str: 'string',
+              },
+            ],
+          }),
+        ),
+      ).toMatchSnapshot();
+    });
+
+    it('fragments', () => {
+      expect(
+        print(
+          fragmentFromPojo({
+            number: [5],
+            bool: [[true]],
+            nested: [
+              {
+                bool2: false,
+                undef: undefined,
+                nullField: null,
+                str: 'string',
+              },
+            ],
+          }),
+        ),
+      ).toMatchSnapshot();
+    });
+  });

--- a/packages/apollo-cache/src/types/Cache.ts
+++ b/packages/apollo-cache/src/types/Cache.ts
@@ -32,5 +32,6 @@ export namespace Cache {
   export import DiffResult = DataProxy.DiffResult;
   export import WriteQueryOptions = DataProxy.WriteQueryOptions;
   export import WriteFragmentOptions = DataProxy.WriteFragmentOptions;
+  export import WriteDataOptions = DataProxy.WriteDataOptions;
   export import Fragment = DataProxy.Fragment;
 }

--- a/packages/apollo-cache/src/types/DataProxy.ts
+++ b/packages/apollo-cache/src/types/DataProxy.ts
@@ -1,4 +1,4 @@
-import { DocumentNode } from "graphql"; // eslint-disable-line import/no-extraneous-dependencies, import/no-unresolved
+import { DocumentNode } from 'graphql'; // eslint-disable-line import/no-extraneous-dependencies, import/no-unresolved
 
 export namespace DataProxy {
   export interface Query {
@@ -58,6 +58,16 @@ export namespace DataProxy {
     data: any;
   }
 
+  export interface WriteDataOptions {
+    /**
+     * The data you will be writing to the store.
+     * It also takes an optional id property.
+     * The id is used to write a fragment to an existing object in the store.
+     */
+    data: any;
+    id?: string;
+  }
+
   export type DiffResult<T> = {
     result?: T;
     complete?: boolean;
@@ -76,7 +86,7 @@ export interface DataProxy {
    */
   readQuery<QueryType>(
     options: DataProxy.Query,
-    optimistic?: boolean
+    optimistic?: boolean,
   ): QueryType | null;
 
   /**
@@ -86,7 +96,7 @@ export interface DataProxy {
    */
   readFragment<FragmentType>(
     options: DataProxy.Fragment,
-    optimistic?: boolean
+    optimistic?: boolean,
   ): FragmentType | null;
 
   /**
@@ -100,4 +110,12 @@ export interface DataProxy {
    * provided to select the correct fragment.
    */
   writeFragment(options: DataProxy.WriteFragmentOptions): void;
+
+  /**
+   * Sugar for writeQuery & writeFragment.
+   * Writes data to the store without passing in a query.
+   * If you supply an id, the data will be written as a fragment to an existing object.
+   * Otherwise, the data is written to the root of the store.
+   */
+  writeData(options: DataProxy.WriteDataOptions): void;
 }

--- a/packages/apollo-cache/src/utils.ts
+++ b/packages/apollo-cache/src/utils.ts
@@ -1,0 +1,127 @@
+import {
+  DocumentNode,
+  OperationDefinitionNode,
+  SelectionSetNode,
+  FieldNode,
+  FragmentDefinitionNode,
+} from 'graphql';
+
+export function queryFromPojo(obj: any): DocumentNode {
+  const op: OperationDefinitionNode = {
+    kind: 'OperationDefinition',
+    operation: 'query',
+    name: {
+      kind: 'Name',
+      value: 'GeneratedClientQuery',
+    },
+    selectionSet: selectionSetFromObj(obj),
+  };
+
+  const out: DocumentNode = {
+    kind: 'Document',
+    definitions: [op],
+  };
+
+  return out;
+}
+
+export function fragmentFromPojo(obj: any, typename?: string): DocumentNode {
+  const frag: FragmentDefinitionNode = {
+    kind: 'FragmentDefinition',
+    typeCondition: {
+      kind: 'NamedType',
+      name: {
+        kind: 'Name',
+        value: typename || '__FakeType',
+      },
+    },
+    name: {
+      kind: 'Name',
+      value: 'GeneratedClientQuery',
+    },
+    selectionSet: selectionSetFromObj(obj),
+  };
+
+  const out: DocumentNode = {
+    kind: 'Document',
+    definitions: [frag],
+  };
+
+  return out;
+}
+
+function selectionSetFromObj(obj: any): SelectionSetNode {
+  if (
+    typeof obj === 'number' ||
+    typeof obj === 'boolean' ||
+    typeof obj === 'string' ||
+    typeof obj === 'undefined' ||
+    obj === null
+  ) {
+    // No selection set here
+    return null;
+  }
+
+  if (Array.isArray(obj)) {
+    // GraphQL queries don't include arrays
+    return selectionSetFromObj(obj[0]);
+  }
+
+  // Now we know it's an object
+  const selections: FieldNode[] = [];
+
+  Object.keys(obj).forEach(key => {
+    const field: FieldNode = {
+      kind: 'Field',
+      name: {
+        kind: 'Name',
+        value: key,
+      },
+    };
+
+    // Recurse
+    const nestedSelSet: SelectionSetNode = selectionSetFromObj(obj[key]);
+
+    if (nestedSelSet) {
+      field.selectionSet = nestedSelSet;
+    }
+
+    selections.push(field);
+  });
+
+  const selectionSet: SelectionSetNode = {
+    kind: 'SelectionSet',
+    selections,
+  };
+
+  return selectionSet;
+}
+
+export const justTypenameQuery: DocumentNode = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'query',
+      name: null,
+      variableDefinitions: null,
+      directives: [],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            alias: null,
+            name: {
+              kind: 'Name',
+              value: '__typename',
+            },
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          },
+        ],
+      },
+    },
+  ],
+};

--- a/packages/apollo-client/CHANGELOG.md
+++ b/packages/apollo-client/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### vNEXT
 - include `optimisticResponse` in the context passed to apollo-link for mutations [PR#2704](https://github.com/apollographql/apollo-client/pull/2704)
+- Add cache.writeData to base cache type & DataProxy [PR#2818](https://github.com/apollographql/apollo-client/pull/2818)
 
 ### 2.1.1
 - fix eslint usage by fixing jsnext:main path

--- a/packages/apollo-client/src/ApolloClient.ts
+++ b/packages/apollo-client/src/ApolloClient.ts
@@ -328,6 +328,22 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
     return result;
   }
 
+  /**
+   * Sugar for writeQuery & writeFragment
+   * This method will construct a query from the data object passed in.
+   * If no id is supplied, writeData will write the data to the root.
+   * If an id is supplied, writeData will write a fragment to the object
+   * specified by the id in the store.
+   *
+   * Since you aren't passing in a query to check the shape of the data,
+   * you must pass in an object that conforms to the shape of valid GraphQL data.
+   */
+  public writeData(options: DataProxy.WriteDataOptions): void {
+    const result = this.initProxy().writeData(options);
+    this.queryManager.broadcastQueries();
+    return result;
+  }
+
   public __actionHookForDevTools(cb: () => any) {
     this.devToolsHookCb = cb;
   }
@@ -401,8 +417,8 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
     return this.queryManager
       ? this.queryManager.reFetchObservableQueries()
       : Promise.resolve(null);
-   }
-  
+  }
+
   /**
    * Exposes the cache's complete state, in a serializable format for later restoration.
    */
@@ -419,7 +435,6 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
    */
   public restore(serializedState: TCacheShape): ApolloCache<TCacheShape> {
     return this.initProxy().restore(serializedState);
-
   }
 
   /**

--- a/packages/apollo-client/src/__tests__/ApolloClient.ts
+++ b/packages/apollo-client/src/__tests__/ApolloClient.ts
@@ -1303,6 +1303,170 @@ describe('ApolloClient', () => {
     });
   });
 
+  describe('writeData', () => {
+    it('lets you write to the cache by passing in data', () => {
+      const query = gql`
+        {
+          field
+        }
+      `;
+
+      const client = new ApolloClient({
+        cache: new InMemoryCache(),
+        link: ApolloLink.empty(),
+      });
+
+      client.writeData({ data: { field: 1 } });
+
+      return client.query({ query }).then(({ data }) => {
+        expect({ ...data }).toEqual({ field: 1 });
+      });
+    });
+
+    it('lets you write to an existing object in the cache using an ID', () => {
+      const query = gql`
+        {
+          obj {
+            field
+          }
+        }
+      `;
+
+      const client = new ApolloClient({
+        cache: new InMemoryCache(),
+        link: ApolloLink.empty(),
+      });
+
+      client.writeQuery({
+        query,
+        data: {
+          obj: { field: 1, id: 'uniqueId', __typename: 'Object' },
+        },
+      });
+
+      client.writeData({ id: 'Object:uniqueId', data: { field: 2 } });
+
+      return client.query({ query }).then(({ data }: any) => {
+        expect(data.obj.field).toEqual(2);
+      });
+    });
+
+    it(`doesn't overwrite __typename when writing to the cache with an id`, () => {
+      const query = gql`
+        {
+          obj {
+            field {
+              field2
+            }
+            id
+          }
+        }
+      `;
+
+      const client = new ApolloClient({
+        cache: new InMemoryCache(),
+        link: ApolloLink.empty(),
+      });
+
+      client.writeQuery({
+        query,
+        data: {
+          obj: {
+            field: { field2: 1, __typename: 'Field' },
+            id: 'uniqueId',
+            __typename: 'Object',
+          },
+        },
+      });
+
+      client.writeData({
+        id: 'Object:uniqueId',
+        data: { field: { field2: 2, __typename: 'Field' } },
+      });
+
+      return client
+        .query({ query })
+        .then(({ data }: any) => {
+          expect(data.obj.__typename).toEqual('Object');
+          expect(data.obj.field.__typename).toEqual('Field');
+        })
+        .catch(e => console.log(e));
+    });
+
+    it(`adds a __typename for an object without one when writing to the cache with an id`, () => {
+      const query = gql`
+        {
+          obj {
+            field {
+              field2
+            }
+            id
+          }
+        }
+      `;
+
+      // This would cause a warning to be printed because we don't have
+      // __typename on the obj field. But that's intentional because
+      // that's exactly the situation we're trying to test...
+
+      // Let's swap out console.warn to suppress this one message
+
+      const suppressString = '__typename';
+      const originalWarn = console.warn;
+      console.warn = (...args: any[]) => {
+        if (
+          args.find(element => {
+            if (typeof element === 'string') {
+              return element.indexOf(suppressString) !== -1;
+            }
+            return false;
+          }) != null
+        ) {
+          // Found a thing in the args we told it to exclude
+          return;
+        }
+        originalWarn.apply(console, args);
+      };
+
+      const client = new ApolloClient({
+        cache: new InMemoryCache(),
+        link: ApolloLink.empty(),
+      });
+
+      client.writeQuery({
+        query,
+        data: {
+          obj: {
+            field: {
+              field2: 1,
+              __typename: 'Field',
+            },
+            id: 'uniqueId',
+          },
+        },
+      });
+
+      client.writeData({
+        id: '$ROOT_QUERY.obj',
+        data: {
+          field: {
+            field2: 2,
+            __typename: 'Field',
+          },
+        },
+      });
+
+      return client
+        .query({ query })
+        .then(({ data }: any) => {
+          console.warn = originalWarn;
+          expect(data.obj.__typename).toEqual('__ClientData');
+          expect(data.obj.field.__typename).toEqual('Field');
+        })
+        .catch(e => console.log(e));
+    });
+  });
+
   describe('write then read', () => {
     it('will write data locally which will then be read back', () => {
       const client = new ApolloClient({


### PR DESCRIPTION
- Added writeData to base cache & DataProxy
- Created `utils` file with helper methods for `writeData`

Once this is merged, I can cut a release, update Apollo Client, and move over the tests for `writeData` from state link. It looks like all the tests for the DataProxy methods live there instead of in `apollo-cache`.
