### PR TITLE
Fix WrappedApp component syntax in Apollo 2 Migration README

### DIFF
--- a/docs/source/2.0-migration.md
+++ b/docs/source/2.0-migration.md
@@ -76,7 +76,7 @@ const client = new ApolloClient({
   networkInterface: createNetworkInterface({ uri: 'http://localhost:3000' }),
 });
 
-const WrappedApp = (
+const WrappedApp = () => (
   <ApolloProvider client={client}>
     <App />
   </ApolloProvider>
@@ -98,7 +98,7 @@ const client = new ApolloClient({
   cache: new InMemoryCache(),
 });
 
-const WrappedApp = (
+const WrappedApp = () => (
   <ApolloProvider client={client}>
     <App />
   </ApolloProvider>


### PR DESCRIPTION
I am not sure if this PR is correct but I was running into the following error and this is the React functional component syntax that I am aware of. Please let me know if I am missing something. 

```
Warning: React.createElement: type is invalid -- expected a string (for built-in components) or a class/function (for composite components) but got: object.
```

P.S. This is one of the most beautifully written migration guides that I have run into :)