### PR TITLE
Fix typo in error message

### DIFF
--- a/packages/apollo-client/CHANGELOG.md
+++ b/packages/apollo-client/CHANGELOG.md
@@ -2,6 +2,7 @@
 # Change log
 
 ### vNEXT
+- Fix typo in error message for invalid argument being passed to @skip or @include directives [PR#2865](https://github.com/apollographql/apollo-client/pull/2865)
 
 ### 2.2.0
 - include `optimisticResponse` in the context passed to apollo-link for mutations [PR#2704](https://github.com/apollographql/apollo-client/pull/2704)

--- a/packages/apollo-utilities/src/directives.ts
+++ b/packages/apollo-utilities/src/directives.ts
@@ -71,7 +71,7 @@ export function shouldInclude(
         throw new Error(
           `Argument for the @${
             directiveName
-          } directive must be a variable or a bool ean value.`,
+          } directive must be a variable or a boolean value.`,
         );
       } else {
         evaledValue = variables[(ifValue as VariableNode).name.value];


### PR DESCRIPTION
Fixes a minor typo in an error message. "bool ean" -> "boolean"