### PR TITLE
Fix typo in error message

### DIFF
--- a/packages/apollo-utilities/CHANGELOG.md
+++ b/packages/apollo-utilities/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 
 ### vNext
+- Fix typo in error message for invalid argument being passed to @skip or @include directives [PR#2867](https://github.com/apollographql/apollo-client/pull/2867)
 
 ### 1.0.5
 - package dependency updates

--- a/packages/apollo-utilities/src/directives.ts
+++ b/packages/apollo-utilities/src/directives.ts
@@ -71,7 +71,7 @@ export function shouldInclude(
         throw new Error(
           `Argument for the @${
             directiveName
-          } directive must be a variable or a bool ean value.`,
+          } directive must be a variable or a boolean value.`,
         );
       } else {
         evaledValue = variables[(ifValue as VariableNode).name.value];


### PR DESCRIPTION
Fixes a minor typo in an error message when an invalid parameter is used for the `@skip` or `@include` directives: "bool ean" -> "boolean"