### PR TITLE
Safer approach to adding Authentication header

### DIFF
--- a/docs/source/recipes/authentication.md
+++ b/docs/source/recipes/authentication.md
@@ -54,7 +54,7 @@ const authLink = setContext((_, { headers }) => {
   return {
     headers: {
       ...headers,
-      authorization: token ? `Bearer ${token}` : null,
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
     }
   }
 });

--- a/docs/source/recipes/authentication.md
+++ b/docs/source/recipes/authentication.md
@@ -54,7 +54,7 @@ const authLink = setContext((_, { headers }) => {
   return {
     headers: {
       ...headers,
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      authorization: token ? `Bearer ${token}` : "",
     }
   }
 });


### PR DESCRIPTION
In the authentication recipe, when a token does not exist, `authorization: null` is added to the request headers .  This assumes that the server will interpret "null" as unauthenticated and not throw an error.  The safer approach would be to include the Authorization header only when the token exists.