### PR TITLE
Add the usage of errorLink in ApolloClient.

### DIFF
--- a/docs/source/features/error-handling.md
+++ b/docs/source/features/error-handling.md
@@ -46,6 +46,22 @@ const link = onError(({ graphQLErrors, networkError }) => {
 
   if (networkError) console.log(`[Network error]: ${networkError}`);
 });
+
+const client = new ApolloClient({
+  link: errorLink.concat(new HttpLink({
+    uri: 'url/to/graphql',
+    // ... HttpLink options
+  })),
+  /* Or like this
+  link: ApolloLink.from([
+    errorLink,
+    new HttpLink({
+      // ...
+    }),
+    // ...
+  ]),
+  */
+})
 ```
 
 #### Options


### PR DESCRIPTION
 I would like to use more than two Links, I found that so many docs about Link only mention how to build but no how to use.
It should has some guide to description the usage of links, and no need to find another document to know the usage.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.
