### PR TITLE
Check for null mutation before making bookkeeping updates

### DIFF
--- a/packages/apollo-client/src/data/mutations.ts
+++ b/packages/apollo-client/src/data/mutations.ts
@@ -23,13 +23,25 @@ export class MutationStore {
   }
 
   public markMutationError(mutationId: string, error: Error) {
-    this.store[mutationId].loading = false;
-    this.store[mutationId].error = error;
+    const mutation = this.store[mutationId];
+
+    if (!mutation) {
+      return;
+    }
+
+    mutation.loading = false;
+    mutation.error = error;
   }
 
   public markMutationResult(mutationId: string) {
-    this.store[mutationId].loading = false;
-    this.store[mutationId].error = null;
+    const mutation = this.store[mutationId];
+
+    if (!mutation) {
+      return;
+    }
+
+    mutation.loading = false;
+    mutation.error = null;
   }
 
   public reset() {


### PR DESCRIPTION
`ApolloClient.resetStore()` will eventually invoke `MutationStore.reset()`.

If `ApolloClient.resetStore()` is invoked while a mutation is in flight (i.e., blocked on networking), when the mutation is complete, `markMutationError` or `markMutationComplete` will fail to find the mutation by its ID and will cause a null-pointer error.

This PR guards around the scenario. Simply returning in the event that the mutation ID lookup yields no results (as this PR does) should be safe because we've signaled no further interest in the result of the mutation at the time that we invoked `resetStore()`.