### PR TITLE
support no-cache requests

### DIFF
--- a/docs/source/basics/caching.md
+++ b/docs/source/basics/caching.md
@@ -226,6 +226,9 @@ client.writeQuery({
 
 Here are some common situations where you would need to access the cache directly. If you're manipulating the cache in an interesting way and would like your example to be featured, please send in a pull request!
 
+<h3 id="ignore">Bypassing the cache</h3>
+Sometimes it makes sense to not use the cache for a specfic operation. This can be done using either the `network-only` or `no-cache` fetchPolicy. The key difference between these two policies is that `network-only` still saves the response to the cache for later use, bypassing the reading and forcing a network request. The `no-cache` policy does not read, nor does it write to the cache with the response. This may be useful for sensitive data like passwords that you don't want to keep in the cache.
+
 <h3 id="server">Server side rendering</h3>
 
 First, you will need to initialize an `InMemoryCache` on the server and create an instance of `ApolloClient`. In the initial serialized HTML payload from the server, you should include a script tag that extracts the data from the cache. (The `.replace()` is necessary to prevent script injection attacks)

--- a/packages/apollo-client/CHANGELOG.md
+++ b/packages/apollo-client/CHANGELOG.md
@@ -2,6 +2,7 @@
 # Change log
 
 ### vNEXT
+- Add new fetchPolicy called 'no-cache' to bypass reading from or saving to the cache when making a query
 
 ### 2.2.1
 - Allow optional parameter to include queries in standby mode when refetching observed queries [PR#2804](https://github.com/apollographql/apollo-client/pull/2804)

--- a/packages/apollo-client/src/core/__tests__/fetchPolicies.ts
+++ b/packages/apollo-client/src/core/__tests__/fetchPolicies.ts
@@ -1,0 +1,324 @@
+import { cloneDeep, assign } from 'lodash';
+import { GraphQLError, ExecutionResult, DocumentNode } from 'graphql';
+import gql from 'graphql-tag';
+import { print } from 'graphql/language/printer';
+import { ApolloLink, Observable } from 'apollo-link';
+import {
+  InMemoryCache,
+  IntrospectionFragmentMatcher,
+  FragmentMatcherInterface,
+} from 'apollo-cache-inmemory';
+
+import { QueryManager } from '../QueryManager';
+import { WatchQueryOptions } from '../watchQueryOptions';
+
+import { ApolloError } from '../../errors/ApolloError';
+
+import ApolloClient, { printAST } from '../..';
+
+import subscribeAndCount from '../../util/subscribeAndCount';
+import { withWarning } from '../../util/wrap';
+
+import { mockSingleLink } from '../../__mocks__/mockLinks';
+
+const query = gql`
+  query {
+    author {
+      __typename
+      id
+      firstName
+      lastName
+    }
+  }
+`;
+
+const result = {
+  author: {
+    __typename: 'Author',
+    id: 1,
+    firstName: 'John',
+    lastName: 'Smith',
+  },
+};
+
+const mutation = gql`
+  mutation updateName($id: ID!, $firstName: String!) {
+    updateName(id: $id, firstName: $firstName) {
+      __typename
+      id
+      firstName
+    }
+  }
+`;
+
+const variables = {
+  id: 1,
+  firstName: 'James',
+};
+
+const mutationResult = {
+  updateName: {
+    id: 1,
+    __typename: 'Author',
+    firstName: 'James',
+  },
+};
+
+const merged = { author: { ...result.author, firstName: 'James' } };
+
+const createLink = () =>
+  mockSingleLink(
+    {
+      request: { query },
+      result: { data: result },
+    },
+    {
+      request: { query },
+      result: { data: result },
+    },
+  );
+
+const createFailureLink = () =>
+  mockSingleLink(
+    {
+      request: { query },
+      error: new Error('query failed'),
+    },
+    {
+      request: { query },
+      result: { data: result },
+    },
+  );
+
+const createMutationLink = () =>
+  // fetch the data
+  mockSingleLink(
+    {
+      request: { query },
+      result: { data: result },
+    },
+    // update the data
+    {
+      request: { query: mutation, variables },
+      result: { data: mutationResult },
+    },
+    // get the new results
+    {
+      request: { query },
+      result: { data: merged },
+    },
+  );
+
+describe('network-only', () => {
+  it('requests from the network even if already in cache', () => {
+    let called = 0;
+    const inspector = new ApolloLink((operation, forward) => {
+      called++;
+      return forward(operation).map(result => {
+        called++;
+        return result;
+      });
+    });
+
+    const client = new ApolloClient({
+      link: inspector.concat(createLink()),
+      cache: new InMemoryCache({ addTypename: false }),
+    });
+
+    return client.query({ query }).then(() =>
+      client
+        .query({ fetchPolicy: 'network-only', query })
+        .then(actualResult => {
+          expect(actualResult.data).toEqual(result);
+          expect(called).toBe(4);
+        }),
+    );
+  });
+  it('saves data to the cache on success', () => {
+    let called = 0;
+    const inspector = new ApolloLink((operation, forward) => {
+      called++;
+      return forward(operation).map(result => {
+        called++;
+        return result;
+      });
+    });
+
+    const client = new ApolloClient({
+      link: inspector.concat(createLink()),
+      cache: new InMemoryCache({ addTypename: false }),
+    });
+
+    return client.query({ query, fetchPolicy: 'network-only' }).then(() =>
+      client.query({ query }).then(actualResult => {
+        expect(actualResult.data).toEqual(result);
+        expect(called).toBe(2);
+      }),
+    );
+  });
+  it('does not save data to the cache on failure', () => {
+    let called = 0;
+    const inspector = new ApolloLink((operation, forward) => {
+      called++;
+      return forward(operation).map(result => {
+        called++;
+        return result;
+      });
+    });
+
+    const client = new ApolloClient({
+      link: inspector.concat(createFailureLink()),
+      cache: new InMemoryCache({ addTypename: false }),
+    });
+
+    let didFail = false;
+    return client
+      .query({ query, fetchPolicy: 'network-only' })
+      .catch(e => {
+        expect(e.message).toMatch('query failed');
+        didFail = true;
+      })
+      .then(() =>
+        client.query({ query }).then(actualResult => {
+          expect(actualResult.data).toEqual(result);
+          // the first error doesn't call .map on the inspector
+          expect(called).toBe(3);
+          expect(didFail).toBe(true);
+        }),
+      );
+  });
+
+  it('updates the cache on a mutation', () => {
+    let called = 0;
+    const inspector = new ApolloLink((operation, forward) => {
+      called++;
+      return forward(operation).map(result => {
+        called++;
+        return result;
+      });
+    });
+
+    const client = new ApolloClient({
+      link: inspector.concat(createMutationLink()),
+      cache: new InMemoryCache({ addTypename: false }),
+    });
+
+    return client
+      .query({ query })
+      .then(() =>
+        // XXX currently only no-cache is supported as a fetchPolicy
+        // this mainly serves to ensure the cache is updated correctly
+        client.mutate({ mutation, variables }),
+      )
+      .then(() => {
+        return client.query({ query }).then(actualResult => {
+          expect(actualResult.data).toEqual(merged);
+        });
+      });
+  });
+});
+describe('no-cache', () => {
+  it('requests from the network even if already in cache', () => {
+    let called = 0;
+    const inspector = new ApolloLink((operation, forward) => {
+      called++;
+      return forward(operation).map(result => {
+        called++;
+        return result;
+      });
+    });
+
+    const client = new ApolloClient({
+      link: inspector.concat(createLink()),
+      cache: new InMemoryCache({ addTypename: false }),
+    });
+
+    return client.query({ query }).then(() =>
+      client.query({ fetchPolicy: 'no-cache', query }).then(actualResult => {
+        expect(actualResult.data).toEqual(result);
+        expect(called).toBe(4);
+      }),
+    );
+  });
+  it('saves data to the cache on success', () => {
+    let called = 0;
+    const inspector = new ApolloLink((operation, forward) => {
+      called++;
+      return forward(operation).map(result => {
+        called++;
+        return result;
+      });
+    });
+
+    const client = new ApolloClient({
+      link: inspector.concat(createLink()),
+      cache: new InMemoryCache({ addTypename: false }),
+    });
+
+    return client.query({ query, fetchPolicy: 'no-cache' }).then(() =>
+      client.query({ query }).then(actualResult => {
+        expect(actualResult.data).toEqual(result);
+        // the second query couldn't read anything from the cache
+        expect(called).toBe(4);
+      }),
+    );
+  });
+
+  it('does not save data to the cache on failure', () => {
+    let called = 0;
+    const inspector = new ApolloLink((operation, forward) => {
+      called++;
+      return forward(operation).map(result => {
+        called++;
+        return result;
+      });
+    });
+
+    const client = new ApolloClient({
+      link: inspector.concat(createFailureLink()),
+      cache: new InMemoryCache({ addTypename: false }),
+    });
+
+    let didFail = false;
+    return client
+      .query({ query, fetchPolicy: 'no-cache' })
+      .catch(e => {
+        expect(e.message).toMatch('query failed');
+        didFail = true;
+      })
+      .then(() =>
+        client.query({ query }).then(actualResult => {
+          expect(actualResult.data).toEqual(result);
+          // the first error doesn't call .map on the inspector
+          expect(called).toBe(3);
+          expect(didFail).toBe(true);
+        }),
+      );
+  });
+  it('does not update the cache on a mutation', () => {
+    let called = 0;
+    const inspector = new ApolloLink((operation, forward) => {
+      called++;
+      return forward(operation).map(result => {
+        called++;
+        return result;
+      });
+    });
+
+    const client = new ApolloClient({
+      link: inspector.concat(createMutationLink()),
+      cache: new InMemoryCache({ addTypename: false }),
+    });
+
+    return client
+      .query({ query })
+      .then(() =>
+        client.mutate({ mutation, variables, fetchPolicy: 'no-cache' }),
+      )
+      .then(() => {
+        return client.query({ query }).then(actualResult => {
+          expect(actualResult.data).toEqual(result);
+        });
+      });
+  });
+});

--- a/packages/apollo-client/src/core/watchQueryOptions.ts
+++ b/packages/apollo-client/src/core/watchQueryOptions.ts
@@ -11,7 +11,8 @@ import { PureQueryOptions } from './types';
  * - cache-first (default): return result from cache. Only fetch from network if cached result is not available.
  * - cache-and-network: return result from cache first (if it exists), then return network result once it's available.
  * - cache-only: return result from cache if available, fail otherwise.
- * - network-only: return result from network, fail if network call doesn't succeed.
+ * - no-cache: return resutl from network, fail if network call doesn't succeed, don't save to cache
+ * - network-only: return result from network, fail if network call doesn't succeed, save to cache
  * - standby: only for queries that aren't actively watched, but should be available for refetch and updateQueries.
  */
 
@@ -20,6 +21,7 @@ export type FetchPolicy =
   | 'cache-and-network'
   | 'network-only'
   | 'cache-only'
+  | 'no-cache'
   | 'standby';
 
 /**
@@ -200,6 +202,11 @@ export interface MutationOptions<T = { [key: string]: any }>
    * Context to be passed to link execution chain
    */
   context?: any;
+
+  /**
+   * Specifies the {@link FetchPolicy} to be used for this query
+   */
+  fetchPolicy?: FetchPolicy;
 }
 
 // Add a level of indirection for `typedoc`.


### PR DESCRIPTION
This PR seeks to support a new `FetchPolicy` called `no-cache`. Unlike `network-only` (which has a somewhat confusing name I admit), this policy bypasses reads **AND** writes when interacting with the client. So it can be used to "turn off caching" when needed. This applies to mutations as well which now support using `FetchPolicy` but only for this use case (will throw otherwise)
