### PR TITLE
Remove extra dash in npm install --save statement (Docs only!)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Get started on the [home page](http://apollographql.com/client), which has great
 # installing the preset package
 npm install apollo-client-preset graphql-tag graphql --save
 # installing each piece independently
-npm install apollo-client apollo-cache-inmemory apollo-link-http graphql-tag graphql ---save
+npm install apollo-client apollo-cache-inmemory apollo-link-http graphql-tag graphql --save
 ```
 
 To use this client in a web browser or mobile app, you'll need a build system capable of loading NPM packages on the client. Some common choices include Browserify, Webpack, and Meteor 1.3+.


### PR DESCRIPTION
Simple update to README so there's only two dashes in "--save" for installation instructions