### PR TITLE
Add client, rest, and export to known directives in apollo-utilities

### DIFF
--- a/packages/apollo-utilities/CHANGELOG.md
+++ b/packages/apollo-utilities/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 
 ### vNext
+- Add client, rest, and export directives to list of known directives [PR#2949](https://github.com/apollographql/apollo-client/pull/2949)
 
 ### 1.1.1
 - Fix typo in error message for invalid argument being passed to @skip or @include directives [PR#2867](https://github.com/apollographql/apollo-client/pull/2867)

--- a/packages/apollo-utilities/src/storeUtils.ts
+++ b/packages/apollo-utilities/src/storeUtils.ts
@@ -164,7 +164,14 @@ export type Directives = {
   };
 };
 
-const KNOWN_DIRECTIVES: string[] = ['connection', 'include', 'skip'];
+const KNOWN_DIRECTIVES: string[] = [
+  'connection',
+  'include',
+  'skip',
+  'client',
+  'rest',
+  'export',
+];
 
 export function getStoreKeyName(
   fieldName: string,


### PR DESCRIPTION
This PR fixes an issue with `apollo-link-state` where adding the `@client` directive to the object key in #2710 broke `cache.writeData`:
https://github.com/apollographql/apollo-link-state/issues/187

This fix is temporary until we can think of a more robust solution for directional directives like `@client` and `@rest`. With directional directives, the cache doesn't care about the directive since it only impacts the execution, not the results. This is in contrast to translational directives like `@uppercase`, where the result is altered.
