### PR TITLE
Fix errors when reporting failed benchmarks to GitHub

### DIFF
--- a/packages/apollo-client/benchmark/github-reporter.ts
+++ b/packages/apollo-client/benchmark/github-reporter.ts
@@ -71,7 +71,7 @@ export function collectAndReportBenchmarks(uploadToGithub: Boolean) {
               }`;
               console.error(perfDropMessage);
               if (message === '') {
-                message = perfDropMessage;
+                message = `Performance drop detected for benchmark: "${element}"`;
                 pass = false;
               }
             } else {


### PR DESCRIPTION
This reduces the error message length, which was causing failed updates to the GitHub status.