### PR TITLE
BUGFIX: Add data to query result if errorPolicy is set to all

### DIFF
--- a/packages/apollo-client/AUTHORS
+++ b/packages/apollo-client/AUTHORS
@@ -90,3 +90,4 @@ Sondre Maere Overskaug <sondremo@gmail.com>
 Tim Griesser <tgriesser10@gmail.com>
 Adam Tuttle <adamtuttlecodes@gmail.com>
 Greg Bergé <berge.greg@gmail.com>
+Torsten Blindert <info@by-torsten.com>

--- a/packages/apollo-client/CHANGELOG.md
+++ b/packages/apollo-client/CHANGELOG.md
@@ -2,6 +2,7 @@
 # Change log
 
 ### vNEXT
+- Provide data when errorPolicy is set "all"
 
 ### 2.2.2
 - Fixed potential race condition in mutations

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -1063,7 +1063,7 @@ export class QueryManager<TStore> {
                   document,
                   variables,
                   fetchMoreForQueryId,
-                  errorPolicy === 'ignore',
+                  errorPolicy === 'ignore' || errorPolicy === 'all',
                 );
               } catch (e) {
                 reject(e);

--- a/packages/apollo-client/src/core/__tests__/ObservableQuery.ts
+++ b/packages/apollo-client/src/core/__tests__/ObservableQuery.ts
@@ -1388,7 +1388,7 @@ describe('ObservableQuery', () => {
     it('returns errors with data if errorPolicy is all', () => {
       const queryManager = mockQueryManager({
         request: { query, variables },
-        result: { errors: [error] },
+        result: { data: dataOne, errors: [error] },
       });
 
       const observable = queryManager.watchQuery({
@@ -1398,7 +1398,7 @@ describe('ObservableQuery', () => {
       });
 
       return observable.result().then(result => {
-        expect(result.data).toBeUndefined();
+        expect(result.data).toEqual(dataOne);
         expect(result.errors).toEqual([error]);
         const currentResult = observable.currentResult();
         expect(currentResult.loading).toBe(false);


### PR DESCRIPTION
This PR will add results.data to the query result if the errorPolicy is set to "all" as the documentation presumed.

Fixes issue #2703 