### PR TITLE
Fix setup anchor links

### DIFF
--- a/docs/source/basics/setup.md
+++ b/docs/source/basics/setup.md
@@ -40,7 +40,7 @@ const client = new ApolloClient({
 });
 ```
 
-The client takes a variety of [options](#constructor), but in particular, if you want to change the URL of the GraphQL server, you can customize your [`Apollo Link`](/docs/link):
+The client takes a variety of [options](#ApolloClient), but in particular, if you want to change the URL of the GraphQL server, you can customize your [`Apollo Link`](/docs/link):
 
 ```js
 import { ApolloClient } from 'apollo-client';

--- a/docs/source/basics/setup.md
+++ b/docs/source/basics/setup.md
@@ -25,7 +25,7 @@ To get started using Apollo with React, we need to create an `ApolloClient` and 
 
 <h3 id="creating-client">Creating a client</h3>
 
-To get started, create an [`ApolloClient`](#constructor) instance and point it at your GraphQL server:
+To get started, create an [`ApolloClient`](#ApolloClient) instance and point it at your GraphQL server:
 
 ```js
 import { ApolloClient } from 'apollo-client';


### PR DESCRIPTION
I didn't walk through the doc's git history to see when the `constructor` id was removed, but the `ApolloClient` id seemed like the place these links should point to.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.
