### PR TITLE
Use __typename when adding objects via writeQuery

### DIFF
--- a/docs/source/basics/caching.md
+++ b/docs/source/basics/caching.md
@@ -212,6 +212,7 @@ const myNewTodo = {
   id: '6',
   text: 'Start using Apollo Client.',
   completed: false,
+  __typename: 'Todo',
 };
 
 client.writeQuery({


### PR DESCRIPTION
When I tried to do this without `__typename`, I got a console warning when writing and an error when subsequently reading.