### PR TITLE
[WIP] `setVariables()` will notify subscribers when cache hit

### DIFF
--- a/packages/apollo-client/src/core/__tests__/ObservableQuery.ts
+++ b/packages/apollo-client/src/core/__tests__/ObservableQuery.ts
@@ -691,6 +691,10 @@ describe('ObservableQuery', () => {
         } else if (handleCount === 3) {
           expect(result.loading).toBe(false);
           expect(result.data).toEqual(dataTwo);
+          observable.setVariables(variables);
+        } else if (handleCount === 4) {
+          expect(result.loading).toBe(false);
+          expect(result.data).toEqual(dataOne);
           done();
         }
       });


### PR DESCRIPTION
This is a work in progress attempt to fix #2712. From my understanding when `setVariables()` is called and hit the cache, then the QueryManager will never `broadcastQueries();` with the cached result, hence the user's observers will never be notified of the result.

I tried to fix that by setting the cached result as a new result for the query and then broadcasting it. It does work for this particular case, as proven by the new unit tests. But it will also break a few other unit tests. I would need advice on how to go forward. Is my attempt the best way to do that ? should existing unit tests be adapted according to new behaviors ? or should the code be further modified to avoid breaking unit tests ?

I reached the limit of my understanding of this codebase and would really appreciate the help of somebody with a better overview of the entire project.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.
