### PR TITLE
Fix the code in docs for apollo engine with meteor

### DIFF
--- a/docs/source/recipes/meteor.md
+++ b/docs/source/recipes/meteor.md
@@ -349,10 +349,13 @@ createApolloServer(req => ({
   cacheControl: true,
 }), {
   configServer: (graphQLServer) => {
-    app.use(engine.expressMiddleware());
+    graphQLServer.use(engine.expressMiddleware());
     // Any other config server stuff
   },
 });
+
+// Start apollo engine
+engine.start();
 ```
 
 ## Importing `.graphql` files


### PR DESCRIPTION
starting apollo engine with `engine.start()`
and using the right variable name for using the middleware
