### PR TITLE
Add getCacheKey to context for cache resolver

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     {
       "name": "apollo-client",
       "path": "./packages/apollo-client/lib/bundle.min.js",
-      "maxSize": "11.7 kB"
+      "maxSize": "11.8 kB"
     },
     {
       "name": "apollo-client-preset",

--- a/packages/apollo-cache-inmemory/CHANGELOG.md
+++ b/packages/apollo-cache-inmemory/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ### vNEXT
+- Added `getCacheKey` function to cacheResolver context [#2998](https://github.com/apollographql/apollo-client/pull/2998)
 
 ### 1.1.8
 - dependency updates

--- a/packages/apollo-cache-inmemory/src/readFromStore.ts
+++ b/packages/apollo-cache-inmemory/src/readFromStore.ts
@@ -8,6 +8,7 @@ import {
   getQueryDefinition,
   isJsonValue,
   isIdValue,
+  toIdValue,
   getStoreKeyName,
 } from 'apollo-utilities';
 import { Cache } from 'apollo-cache';
@@ -83,7 +84,10 @@ const readStoreResolver: Resolver = (
         // Look for the field in the custom resolver map
         const resolver = type[fieldName];
         if (resolver) {
-          fieldValue = resolver(obj, args);
+          fieldValue = resolver(obj, args, {
+            getCacheKey: (obj: { __typename: string; id: string | number }) =>
+              toIdValue(context.dataIdFromObject(obj)),
+          });
         }
       }
     }
@@ -161,6 +165,7 @@ export function diffQueryAgainstStore<T>({
     // Global settings
     store,
     returnPartialData,
+    dataIdFromObject: config.dataIdFromObject,
     cacheResolvers: (config && config.cacheResolvers) || {},
     // Flag set during execution
     hasMissingField: false,

--- a/packages/apollo-cache-inmemory/src/readFromStore.ts
+++ b/packages/apollo-cache-inmemory/src/readFromStore.ts
@@ -165,7 +165,7 @@ export function diffQueryAgainstStore<T>({
     // Global settings
     store,
     returnPartialData,
-    dataIdFromObject: config.dataIdFromObject,
+    dataIdFromObject: (config && config.dataIdFromObject) || null,
     cacheResolvers: (config && config.cacheResolvers) || {},
     // Flag set during execution
     hasMissingField: false,

--- a/packages/apollo-cache-inmemory/src/types.ts
+++ b/packages/apollo-cache-inmemory/src/types.ts
@@ -76,6 +76,7 @@ export type ReadStoreContext = {
   returnPartialData: boolean;
   hasMissingField: boolean;
   cacheResolvers: CacheResolverMap;
+  dataIdFromObject?: IdGetter;
 };
 
 export interface FragmentMatcherInterface {
@@ -122,6 +123,7 @@ export type IntrospectionResultData = {
 export type CacheResolver = (
   rootValue: any,
   args: { [argName: string]: any },
+  context: any,
 ) => any;
 
 export type CacheResolverMap = {

--- a/packages/apollo-client/CHANGELOG.md
+++ b/packages/apollo-client/CHANGELOG.md
@@ -2,6 +2,7 @@
 # Change log
 
 ### vNEXT
+- Added `getCacheKey` function to the link context for use in state-link [PR#2998](https://github.com/apollographql/apollo-client/pull/2998)
 
 ### 2.2.3
 - dependency updates

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -13,7 +13,6 @@ import {
   isProduction,
   maybeDeepFreeze,
   hasDirectives,
-  toIdValue,
 } from 'apollo-utilities';
 
 import { QueryScheduler } from '../scheduler/scheduler';
@@ -1207,7 +1206,8 @@ export class QueryManager<TStore> {
         // getting an entry's cache key is useful for cacheResolvers & state-link
         getCacheKey: (obj: { __typename: string; id: string | number }) => {
           if ((cache as any).config) {
-            return toIdValue((cache as any).config.dataIdFromObject(obj));
+            // on the link, we just want the id string, not the full id value from toIdValue
+            return (cache as any).config.dataIdFromObject(obj);
           } else {
             throw new Error(
               'To use context.getCacheKey, you need to use a cache that has a configurable dataIdFromObject, like apollo-cache-inmemory.',

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -13,6 +13,7 @@ import {
   isProduction,
   maybeDeepFreeze,
   hasDirectives,
+  toIdValue,
 } from 'apollo-utilities';
 
 import { QueryScheduler } from '../scheduler/scheduler';
@@ -1193,6 +1194,7 @@ export class QueryManager<TStore> {
     extraContext?: any,
   ) {
     const cache = this.dataStore.getCache();
+
     return {
       query: cache.transformForLink
         ? cache.transformForLink(document)
@@ -1202,6 +1204,16 @@ export class QueryManager<TStore> {
       context: {
         ...extraContext,
         cache,
+        // getting an entry's cache key is useful for cacheResolvers & state-link
+        getCacheKey: (obj: { __typename: string; id: string | number }) => {
+          if ((cache as any).config) {
+            return toIdValue((cache as any).config.dataIdFromObject(obj));
+          } else {
+            throw new Error(
+              'To use context.getCacheKey, you need to use a cache that has a configurable dataIdFromObject, like apollo-cache-inmemory.',
+            );
+          }
+        },
       },
     };
   }

--- a/packages/apollo-client/src/core/__tests__/QueryManager/links.ts
+++ b/packages/apollo-client/src/core/__tests__/QueryManager/links.ts
@@ -348,13 +348,12 @@ describe('Link interactions', () => {
           cacheResolvers: {
             Query: {
               book: (_, { id }, context) => {
-                console.log(context);
                 expect(context.getCacheKey).toBeDefined();
                 const cacheKey = context.getCacheKey({
                   id,
                   __typename: 'Book',
                 });
-                expect(cacheKey).toEqual(`Book:${id}`);
+                expect(cacheKey.id).toEqual(`Book:${id}`);
                 return cacheKey;
               },
             },
@@ -368,7 +367,11 @@ describe('Link interactions', () => {
     return queryManager
       .query({ query: shouldHitCacheResolver })
       .then(({ data }) => {
-        expect({ ...data }).toEqual(bookData);
+        expect({
+          ...data,
+        }).toMatchObject({
+          book: { title: 'Woo', __typename: 'Book' },
+        });
       });
   });
 });

--- a/packages/apollo-client/src/core/__tests__/QueryManager/links.ts
+++ b/packages/apollo-client/src/core/__tests__/QueryManager/links.ts
@@ -338,6 +338,7 @@ describe('Link interactions', () => {
     const link = new ApolloLink((operation, forward) => {
       const { getCacheKey } = operation.getContext();
       expect(getCacheKey).toBeDefined();
+      expect(getCacheKey({ id: 1, __typename: 'Book' })).toEqual('Book:1');
       return Observable.of({ data: bookData });
     });
 

--- a/packages/apollo-client/src/core/__tests__/QueryManager/links.ts
+++ b/packages/apollo-client/src/core/__tests__/QueryManager/links.ts
@@ -347,9 +347,13 @@ describe('Link interactions', () => {
         new InMemoryCache({
           cacheResolvers: {
             Query: {
-              book: (_, { id }, { getCacheKey }) => {
-                expect(getCacheKey).toBeDefined();
-                const cacheKey = getCacheKey({ id, __typename: 'Book' });
+              book: (_, { id }, context) => {
+                console.log(context);
+                expect(context.getCacheKey).toBeDefined();
+                const cacheKey = context.getCacheKey({
+                  id,
+                  __typename: 'Book',
+                });
                 expect(cacheKey).toEqual(`Book:${id}`);
                 return cacheKey;
               },
@@ -361,8 +365,10 @@ describe('Link interactions', () => {
 
     await queryManager.query({ query });
 
-    return queryManager.query({ query }).then(({ data }) => {
-      expect({ ...data }).toEqual(bookData);
-    });
+    return queryManager
+      .query({ query: shouldHitCacheResolver })
+      .then(({ data }) => {
+        expect({ ...data }).toEqual(bookData);
+      });
   });
 });

--- a/packages/apollo-client/src/core/__tests__/QueryManager/links.ts
+++ b/packages/apollo-client/src/core/__tests__/QueryManager/links.ts
@@ -310,4 +310,59 @@ describe('Link interactions', () => {
     // fire off first result
     mockLink.simulateResult({ result: { data: initialData } });
   });
+  it('includes getCacheKey function on the context for cache resolvers', async () => {
+    const query = gql`
+      {
+        books {
+          id
+          title
+        }
+      }
+    `;
+
+    const shouldHitCacheResolver = gql`
+      {
+        book(id: 1) {
+          title
+        }
+      }
+    `;
+
+    const bookData = {
+      books: [
+        { id: 1, title: 'Woo', __typename: 'Book' },
+        { id: 2, title: 'Foo', __typename: 'Book' },
+      ],
+    };
+
+    const link = new ApolloLink((operation, forward) => {
+      const { getCacheKey } = operation.getContext();
+      expect(getCacheKey).toBeDefined();
+      return Observable.of({ data: bookData });
+    });
+
+    const queryManager = new QueryManager({
+      link,
+      store: new DataStore(
+        new InMemoryCache({
+          cacheResolvers: {
+            Query: {
+              book: (_, { id }, { getCacheKey }) => {
+                expect(getCacheKey).toBeDefined();
+                const cacheKey = getCacheKey({ id, __typename: 'Book' });
+                expect(cacheKey).toEqual(`Book:${id}`);
+                return cacheKey;
+              },
+            },
+          },
+        }),
+      ),
+    });
+
+    await queryManager.query({ query });
+
+    return queryManager.query({ query }).then(({ data }) => {
+      expect({ ...data }).toEqual(bookData);
+    });
+  });
 });


### PR DESCRIPTION
A `getCacheKey` function on the context would be super useful, not only for state-link when writing a fragment to the cache but also for cache resolvers.

Instead of:
```js
import { toIdValue } from 'apollo-utilities';
import { InMemoryCache } from 'apollo-cache-inmemory';

const cache = new InMemoryCache({
  cacheResolvers: {
    Query: {
      book: (_, args) => toIdValue(cache.config.dataIdFromObject({ __typename: 'Book', id: args.id })),
    },
  },
});
```

Now, you can do this:
```js
import { InMemoryCache } from 'apollo-cache-inmemory';

const cache = new InMemoryCache({
  cacheResolvers: {
    Query: {
      book: (_, args, { getCacheKey ) => getCacheKey({ __typename: 'Book', id: args.id }),
    },
  },
});
```
