### PR TITLE
Remove the fetchPolicy check when the request results arrive

### DIFF
--- a/packages/apollo-client/AUTHORS
+++ b/packages/apollo-client/AUTHORS
@@ -93,3 +93,4 @@ Adam Tuttle <adamtuttlecodes@gmail.com>
 Greg Bergé <berge.greg@gmail.com>
 Dotan Simha <dotansimha@gmail.com>
 Torsten Blindert <info@by-torsten.com>
+Pablo Lacerda de Miranda <pablolmiranda@gmail.com>

--- a/packages/apollo-client/CHANGELOG.md
+++ b/packages/apollo-client/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ### vNEXT
 - Added `getCacheKey` function to the link context for use in state-link [PR#2998](https://github.com/apollographql/apollo-client/pull/2998)
+- Removed the no-cache constrain around the dataStore update that avoid the listeners to receive
+the request result data [PR#3026](https://github.com/apollographql/apollo-client/pull/3026)
 
 ### 2.2.3
 - dependency updates

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -1039,7 +1039,7 @@ export class QueryManager<TStore> {
     options: WatchQueryOptions;
     fetchMoreForQueryId?: string;
   }): Promise<ExecutionResult> {
-    const { variables, context, errorPolicy = 'none', fetchPolicy } = options;
+    const { variables, context, errorPolicy = 'none' } = options;
     const operation = this.buildOperationForLink(document, variables, {
       ...context,
       // TODO: Should this be included for all entry points via
@@ -1056,19 +1056,17 @@ export class QueryManager<TStore> {
           // default the lastRequestId to 1
           const { lastRequestId } = this.getQuery(queryId);
           if (requestId >= (lastRequestId || 1)) {
-            if (fetchPolicy !== 'no-cache') {
-              try {
-                this.dataStore.markQueryResult(
-                  result,
-                  document,
-                  variables,
-                  fetchMoreForQueryId,
-                  errorPolicy === 'ignore' || errorPolicy === 'all',
-                );
-              } catch (e) {
-                reject(e);
-                return;
-              }
+            try {
+              this.dataStore.markQueryResult(
+                result,
+                document,
+                variables,
+                fetchMoreForQueryId,
+                errorPolicy === 'ignore' || errorPolicy === 'all',
+              );
+            } catch (e) {
+              reject(e);
+              return;
             }
 
             this.queryStore.markQueryResult(

--- a/packages/apollo-client/src/core/__tests__/fetchPolicies.ts
+++ b/packages/apollo-client/src/core/__tests__/fetchPolicies.ts
@@ -240,7 +240,8 @@ describe('no-cache', () => {
       }),
     );
   });
-  it('does not save the data to the cache on success', () => {
+
+  it('saves the data to the cache on success to broadcast the results data', () => {
     let called = 0;
     const inspector = new ApolloLink((operation, forward) => {
       called++;
@@ -259,7 +260,7 @@ describe('no-cache', () => {
       client.query({ query }).then(actualResult => {
         expect(actualResult.data).toEqual(result);
         // the second query couldn't read anything from the cache
-        expect(called).toBe(4);
+        expect(called).toBe(2);
       }),
     );
   });


### PR DESCRIPTION
The `no-cache` fetchPolicy doesn't update the listeners after the request results arrive.
Removing the constrain around the `this.dataStore.markQueryResult` solves the problem. 
After update the dataStore, the cache is not been used on further request, but allows all the listener to receive the correct data.

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [X] Make sure all of the significant new logic is covered by tests
- [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.
