### PR TITLE
Fix 2.0-migration.md formatting

### DIFF
--- a/docs/source/2.0-migration.md
+++ b/docs/source/2.0-migration.md
@@ -392,5 +392,6 @@ Ultimately we think the move off Redux will open the door for more powerful cach
 If you were using Redux for other purposes in your app with an older version of Apollo, you may have been relying on the fact that the `<ApolloProvider store=store>` component did double duty as a [`react-redux` `<Provider>`](https://github.com/reactjs/react-redux/blob/master/docs/api.md#provider-store). In react-apollo 2.0, `<ApolloProvider>` no longer has `<Provider>` semantics; you'll have to use `<Provider>` yourself.
 
 <h2 id="reducers" title="Query Reducers">Query Reducers</h2>
+
 Query reducers have been finally removed in the 2.0, instead we recommend using the more flexible [`update`](./basics/mutations.html#graphql-mutation-options-update) API instead of reducer.
 


### PR DESCRIPTION
This tiny PR simply adds a new line between the HTML markup and markdown markup to fix the broken link in the `update` section.

Before:
![image](https://user-images.githubusercontent.com/7641760/36316203-606b9c44-1342-11e8-9932-002af5d838b3.png)

After:
![image](https://user-images.githubusercontent.com/7641760/36316241-7862528e-1342-11e8-9918-24a68066c0cc.png)


