### PR TITLE
Update 2.0-migration.md onError documentation

### DIFF
--- a/docs/source/2.0-migration.md
+++ b/docs/source/2.0-migration.md
@@ -267,7 +267,7 @@ import { logout } from './logout';
 
 const httpLink = createHttpLink({ uri: '/graphql' });
 
-const errorLink = onError(({ networkError, graphQLErrors }) => {
+const errorLink = onError(({ networkError = {}, graphQLErrors }) => {
   if (networkError.statusCode === 401) {
     logout();
   }


### PR DESCRIPTION
In the documentation `onError` callback passes an object of `{networkError, graphQLErrors}` to the callback. The `networkError` parameter is  `undefined` if no network error happens, as seen in the code:

https://github.com/apollographql/apollo-link/blob/master/packages/apollo-link-error/src/index.ts#L31

Which matches how the library is used in its [own documentation](https://github.com/apollographql/apollo-link/tree/master/packages/apollo-link-error).

This PR changes the param to have a default value of `{}`, alternative approach would be checking for `if (networkError && networkError.statusCode === 401)`, both are fine with me :) 