### PR TITLE
Use the correct variable name for the query prop

### DIFF
--- a/docs/source/quick-start.md
+++ b/docs/source/quick-start.md
@@ -55,7 +55,7 @@ const GET_DOG = gql`
 `
 
 const App = () => (
-  <Query query={query}>
+  <Query query={GET_DOG}>
     {({ loading, error, data }) => {
       if (loading) return <div>Loading...</div>;
       if (error) return <div>Error :(</div>;


### PR DESCRIPTION
Hi, I was reading the [quick-start](https://www.apollographql.com/docs/react/quick-start.html) today and I noticed the example appears to use the wrong variable name for the query property.
