### PR TITLE
Sourcemaps for rollup bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,9 @@
     "lint-staged": "6.1.0",
     "pre-commit": "1.2.2",
     "prettier": "1.11.1",
+    "rollup-plugin-local-resolve": "^1.0.7",
+    "rollup-plugin-node-resolve": "^3.0.3",
+    "rollup-plugin-sourcemaps": "^0.4.2",
     "ts-jest": "20.0.14",
     "typescript": "2.5.2"
   }

--- a/packages/apollo-cache/rollup.config.js
+++ b/packages/apollo-cache/rollup.config.js
@@ -2,9 +2,6 @@ import resolve from 'rollup-plugin-node-resolve';
 
 import build from '../../rollup.config';
 
-export default Object.assign(
-  {
-    plugins: [resolve()],
-  },
-  build('apollo.cache.core'),
-);
+export default build('apollo.cache.core', {
+  plugins: [resolve()],
+});

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,5 @@
+import sourcemaps from 'rollup-plugin-sourcemaps';
+
 export const globals = {
   // Apollo
   'apollo-client': 'apollo.core',
@@ -8,23 +10,33 @@ export const globals = {
   'graphql-anywhere': 'graphqlAnywhere',
 };
 
-export default (name, override = {}) =>
-  Object.assign(
+export default (name, override = {}) => {
+  const config = Object.assign(
     {
       input: 'lib/index.js',
-      output: {
-        file: 'lib/bundle.umd.js',
-        format: 'umd',
-      },
-      name,
-      exports: 'named',
-      sourcemap: true,
-      external: Object.keys(globals),
+      //output: merged separately
       onwarn,
-      globals,
+      external: Object.keys(globals),
     },
     override,
   );
+
+  config.output = Object.assign(
+    {
+      file: 'lib/bundle.umd.js',
+      format: 'umd',
+      name,
+      exports: 'named',
+      sourcemap: true,
+      globals,
+    },
+    config.output,
+  );
+
+  config.plugins = config.plugins || [];
+  config.plugins.push(sourcemaps());
+  return config;
+};
 
 function onwarn(message) {
   const suppressed = ['UNRESOLVED_IMPORT', 'THIS_IS_UNDEFINED'];


### PR DESCRIPTION
The ts-jest package requires the `coverageMap` option to be enabled to get accurate coverage mapping back to the typescript files.

The rollup bundles' sourcemaps were pointing to the compiled javascript files, now they point a the ts files.