### PR TITLE
added another condition on lastError delivery, which is fetchPolicy n…

### DIFF
--- a/packages/apollo-client/CHANGELOG.md
+++ b/packages/apollo-client/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### vNEXT
 - Map coverage to original source
 - Added `getCacheKey` function to the link context for use in state-link [PR#2998](https://github.com/apollographql/apollo-client/pull/2998)
+- Added `this.options.fetchPolicy !== 'standby'` as additional checker if should send an observer.error [PR#3052](https://github.com/apollographql/apollo-client/pull/3052)
 
 ### 2.2.3
 - dependency updates

--- a/packages/apollo-client/src/core/ObservableQuery.ts
+++ b/packages/apollo-client/src/core/ObservableQuery.ts
@@ -530,7 +530,14 @@ export class ObservableQuery<T> extends Observable<ApolloQueryResult<T>> {
 
     // Deliver initial result
     if (observer.next && this.lastResult) observer.next(this.lastResult);
-    if (observer.error && this.lastError) observer.error(this.lastError);
+
+    // Deliver `lastError` if `fetchPolicy` is not `standby`
+    if (
+      observer.error &&
+      this.lastError &&
+      this.options.fetchPolicy !== 'standby'
+    )
+      observer.error(this.lastError);
 
     // setup the query if it hasn't been done before
     if (this.observers.length === 1) this.setUpQuery();


### PR DESCRIPTION
so while it is on standby and doing other process it wont send unnecessary lastError.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.
