### PR TITLE
[apollo-boost] pass operation prop to config.request

### DIFF
--- a/packages/apollo-boost/CHANGELOG.md
+++ b/packages/apollo-boost/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### vNext
 - Map coverage to original source
+- fix request parameter type
 
 ### 0.1.0
 - DEPRECATED: `apollo-client-preset`

--- a/packages/apollo-boost/CHANGELOG.md
+++ b/packages/apollo-boost/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### vNext
 - Map coverage to original source
-- fix request parameter type
+- fix request parameter type [#3056](https://github.com/apollographql/apollo-client/pull/3056)
 
 ### 0.1.0
 - DEPRECATED: `apollo-client-preset`

--- a/packages/apollo-boost/src/index.ts
+++ b/packages/apollo-boost/src/index.ts
@@ -50,13 +50,11 @@ export default class DefaultClient<TCache> extends ApolloClient<TCache> {
 
     const requestHandler =
       config && config.request
-        ? new ApolloLink((operation, forward) => {
-            const { ...request } = operation;
-
-            return new Observable(observer => {
+        ? new ApolloLink((operation, forward) =>
+            new Observable(observer => {
               let handle: any;
-              Promise.resolve(request)
-                .then(req => config.request(req))
+              Promise.resolve(operation)
+                .then(oper => config.request(oper))
                 .then(() => {
                   handle = forward(operation).subscribe({
                     next: observer.next.bind(observer),
@@ -69,8 +67,8 @@ export default class DefaultClient<TCache> extends ApolloClient<TCache> {
               return () => {
                 if (handle) handle.unsubscribe;
               };
-            });
-          })
+            })
+          )
         : false;
 
     const httpLink = new HttpLink({


### PR DESCRIPTION
As mentioned in #3044 setting up apollo-boost with a request parameter did not pass proper operation propery to the registered function. Therefore you cannot set authorization headers as described in the quick start.

This PR passes the proper operation to the registered callbacks and fixes #3044
No further changes were made.
