### PR TITLE
Pass non-optimistic query to subscribeToMore  #3062

### DIFF
--- a/packages/apollo-client/CHANGELOG.md
+++ b/packages/apollo-client/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Map coverage to original source
 - Added `getCacheKey` function to the link context for use in state-link [PR#2998](https://github.com/apollographql/apollo-client/pull/2998)
 - Fix Memory Leak in Query Manager [PR#3119](https://github.com/apollographql/apollo-client/pull/3119)
+- Pass non-optimistic query to `subscribeToMore` updateQuery
+[PR#3068](https://github.com/apollographql/apollo-client/pull/3068)
 
 ### 2.2.3
 - dependency updates

--- a/packages/apollo-client/src/__tests__/subscribeToMore.ts
+++ b/packages/apollo-client/src/__tests__/subscribeToMore.ts
@@ -76,6 +76,13 @@ describe('subscribeToMore', () => {
     },
   };
 
+  const result4 = {
+    data: {
+      entry: [{ value: 1 }, { value: 2 }],
+    },
+  };
+  const req4 = { request: { query }, result: result4 };
+
   it('triggers new result from subscription data', done => {
     let latestResult: any = null;
     const wSLink = mockObservableLink(sub1);
@@ -119,7 +126,7 @@ describe('subscribeToMore', () => {
         stale: false,
       });
       done();
-    }, 50);
+    }, 15);
 
     for (let i = 0; i < 2; i++) {
       wSLink.simulateResult(results[i]);
@@ -177,7 +184,7 @@ describe('subscribeToMore', () => {
       expect(counter).toBe(2);
       expect(errorCount).toBe(1);
       done();
-    }, 50);
+    }, 15);
 
     for (let i = 0; i < 2; i++) {
       wSLink.simulateResult(results2[i]);
@@ -238,11 +245,114 @@ describe('subscribeToMore', () => {
       expect(errorCount).toBe(1);
       console.error = consoleErr;
       done();
-    }, 50);
+    }, 15);
 
     for (let i = 0; i < 2; i++) {
       wSLink.simulateResult(results3[i]);
     }
+  });
+
+  it('should not corrupt the cache (#3062)', async done => {
+    let latestResult: any = null;
+    const wSLink = mockObservableLink(sub1);
+    const httpLink = mockSingleLink(req4);
+
+    const link = ApolloLink.split(isSub, wSLink, httpLink);
+    let counter = 0;
+
+    const client = new ApolloClient({
+      cache: new InMemoryCache({ addTypename: false }).restore({
+        'ROOT_QUERY.entry.0': {
+          value: 1,
+        },
+        'ROOT_QUERY.entry.1': {
+          value: 2,
+        },
+        ROOT_QUERY: {
+          entry: [
+            {
+              type: 'id',
+              id: 'ROOT_QUERY.entry.0',
+              generated: true,
+            },
+            {
+              type: 'id',
+              id: 'ROOT_QUERY.entry.1',
+              generated: true,
+            },
+          ],
+        },
+      }),
+      link,
+    });
+
+    const obsHandle = client.watchQuery({ query });
+
+    const sub = obsHandle.subscribe({
+      next(queryResult) {
+        latestResult = queryResult;
+        counter++;
+      },
+    });
+
+    let nextMutation = '';
+    obsHandle.subscribeToMore({
+      document: gql`
+        subscription createdEntry {
+          name
+        }
+      `,
+      updateQuery: (prev, { subscriptionData }) => {
+        expect(prev.entry).not.toContainEqual(nextMutation);
+        return {
+          entry: [...prev.entry, { value: subscriptionData.data.name }],
+        };
+      },
+    });
+
+    const wait = dur => new Promise(resolve => setTimeout(resolve, dur));
+
+    for (let i = 0; i < 2; i++) {
+      // init optimistic mutation
+      let data = client.cache.readQuery({ query }, false);
+      client.cache.recordOptimisticTransaction(proxy => {
+        nextMutation = { value: results[i].result.data.name };
+        proxy.writeQuery({
+          data: { entry: [...data.entry, nextMutation] },
+          query,
+        });
+      }, i);
+      // on slow networks, subscription can happen first
+      wSLink.simulateResult(results[i]);
+      await wait(results[i].delay + 1);
+      // complete mutation
+      client.cache.removeOptimistic(i);
+      // note: we don't complete mutation with performTransaction because a real example would detect duplicates
+    }
+    sub.unsubscribe();
+    expect(counter).toBe(3);
+    expect(latestResult).toEqual({
+      data: {
+        entry: [
+          {
+            value: 1,
+          },
+          {
+            value: 2,
+          },
+          {
+            value: 'Dahivat Pandya',
+          },
+          {
+            value: 'Amanda Liu',
+          },
+        ],
+      },
+      loading: false,
+      networkStatus: 7,
+      stale: false,
+    });
+    done();
   });
   // TODO add a test that checks that subscriptions are cancelled when obs is unsubscribed from.
 });

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -956,7 +956,10 @@ export class QueryManager<TStore> {
     this.queries.delete(queryId);
   }
 
-  public getCurrentQueryResult<T>(observableQuery: ObservableQuery<T>) {
+  public getCurrentQueryResult<T>(
+    observableQuery: ObservableQuery<T>,
+    optimistic: boolean = true,
+  ) {
     const { variables, query } = observableQuery.options;
     const lastResult = observableQuery.getLastResult();
     const { newData } = this.getQuery(observableQuery.queryId);
@@ -970,7 +973,7 @@ export class QueryManager<TStore> {
           query,
           variables,
           previousResult: lastResult ? lastResult.data : undefined,
-          optimistic: true,
+          optimistic,
         });
 
         return maybeDeepFreeze({ data, partial: false });
@@ -1000,7 +1003,7 @@ export class QueryManager<TStore> {
 
     const { variables, query } = observableQuery.options;
 
-    const { data } = this.getCurrentQueryResult(observableQuery);
+    const { data } = this.getCurrentQueryResult(observableQuery, false);
 
     return {
       previousResult: data,


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

Subscriptions will make optimistic queries in the cache become non-optimistic with `subscribeToMore`. See #3062  for unwanted effects

This PR addresses this issue

### Checklist:


- [X] Make sure all of the significant new logic is covered by tests

