### PR TITLE
Map coverage to original source

### DIFF
--- a/packages/apollo-boost/CHANGELOG.md
+++ b/packages/apollo-boost/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+### vNext
+- Map coverage to original source
+
 ### 0.1.0
 - DEPRECATED: `apollo-client-preset`
 - Changed to `apollo-boost` [#2965](https://github.com/apollographql/apollo-client/pull/2965)

--- a/packages/apollo-boost/package.json
+++ b/packages/apollo-boost/package.json
@@ -5,7 +5,8 @@
   "author": "Peggy Rayzis <peggy@apollographql.com>",
   "contributors": [
     "James Baxley <james@apollographql.com>",
-    "Sashko Stubailo <sashko@apollographql.com>"
+    "Sashko Stubailo <sashko@apollographql.com>",
+    "James Burgess <jamesmillerburgess@gmail.com>"
   ],
   "license": "MIT",
   "main": "./lib/index.js",
@@ -27,8 +28,10 @@
     "watch": "tsc -w -p .",
     "clean": "rimraf coverage/* && rimraf lib/*",
     "prepublishOnly": "npm run build",
-    "build:browser": "browserify ./lib/index.js --i apollo-utilities -o=./lib/bundle.js && npm run minify:browser",
-    "minify:browser": "uglifyjs -c -m -o ./lib/bundle.min.js -- ./lib/bundle.js",
+    "build:browser":
+      "browserify ./lib/index.js --i apollo-utilities -o=./lib/bundle.js && npm run minify:browser",
+    "minify:browser":
+      "uglifyjs -c -m -o ./lib/bundle.min.js -- ./lib/bundle.js",
     "filesize": "npm run build && npm run build:browser"
   },
   "dependencies": {
@@ -59,11 +62,7 @@
       ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     },
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js",
-      "json"
-    ]
+    "moduleFileExtensions": ["ts", "tsx", "js", "json"],
+    "mapCoverage": true
   }
 }

--- a/packages/apollo-cache-inmemory/CHANGELOG.md
+++ b/packages/apollo-cache-inmemory/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ### vNext
+- Map coverage to original source
 - Fixed bug with cacheRedirects not getting attached [#3016](https://github.com/apollographql/apollo-client/pull/3016)
 
 ### 1.1.9

--- a/packages/apollo-cache-inmemory/package.json
+++ b/packages/apollo-cache-inmemory/package.json
@@ -6,7 +6,8 @@
   "contributors": [
     "James Baxley <james@meteor.com>",
     "Jonas Helfer <jonas@helfer.email>",
-    "Sashko Stubailo <sashko@stubailo.com>"
+    "Sashko Stubailo <sashko@stubailo.com>",
+    "James Burgess <jamesmillerburgess@gmail.com>"
   ],
   "license": "MIT",
   "main": "./lib/bundle.umd.js",
@@ -32,8 +33,10 @@
     "watch": "tsc -w -p .",
     "clean": "rimraf coverage/* && rimraf lib/*",
     "prepublishOnly": "npm run build",
-    "build:browser": "browserify ./lib/bundle.umd.js --i apollo-cache --i apollo-utilities --i graphql -o=./lib/bundle.js && npm run minify:browser",
-    "minify:browser": "uglifyjs -c -m -o ./lib/bundle.min.js -- ./lib/bundle.js",
+    "build:browser":
+      "browserify ./lib/bundle.umd.js --i apollo-cache --i apollo-utilities --i graphql -o=./lib/bundle.js && npm run minify:browser",
+    "minify:browser":
+      "uglifyjs -c -m -o ./lib/bundle.min.js -- ./lib/bundle.js",
     "filesize": "npm run build:browser"
   },
   "dependencies": {
@@ -65,11 +68,7 @@
       ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     },
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js",
-      "json"
-    ]
+    "moduleFileExtensions": ["ts", "tsx", "js", "json"],
+    "mapCoverage": true
   }
 }

--- a/packages/apollo-cache/CHANGELOG.md
+++ b/packages/apollo-cache/CHANGELOG.md
@@ -1,5 +1,6 @@
 
 ### vNext
+- Map coverage to original source
 
 ### 1.1.3
 - dependency updates

--- a/packages/apollo-cache/package.json
+++ b/packages/apollo-cache/package.json
@@ -6,7 +6,8 @@
   "contributors": [
     "James Baxley <james@meteor.com>",
     "Jonas Helfer <jonas@helfer.email>",
-    "Sashko Stubailo <sashko@stubailo.com>"
+    "Sashko Stubailo <sashko@stubailo.com>",
+    "James Burgess <jamesmillerburgess@gmail.com>"
   ],
   "license": "MIT",
   "main": "./lib/bundle.umd.js",
@@ -24,7 +25,8 @@
   "scripts": {
     "coverage": "jest --coverage",
     "test": "jest",
-    "lint": "tslint --type-check -p tsconfig.json src/*.ts && tslint --type-check -p tsconfig.json tests/*.ts",
+    "lint":
+      "tslint --type-check -p tsconfig.json src/*.ts && tslint --type-check -p tsconfig.json tests/*.ts",
     "prebuild": "npm run clean",
     "build": "tsc -p .",
     "postbuild": "npm run bundle",
@@ -32,8 +34,10 @@
     "watch": "tsc -w -p .",
     "clean": "rimraf coverage/* && rimraf lib/*",
     "prepublishOnly": "npm run clean && npm run build",
-    "build:browser": "browserify ./lib/bundle.umd.js --i apollo-utilities -o=./lib/bundle.js && npm run minify:browser",
-    "minify:browser": "uglifyjs -c -m -o ./lib/bundle.min.js -- ./lib/bundle.js",
+    "build:browser":
+      "browserify ./lib/bundle.umd.js --i apollo-utilities -o=./lib/bundle.js && npm run minify:browser",
+    "minify:browser":
+      "uglifyjs -c -m -o ./lib/bundle.min.js -- ./lib/bundle.js",
     "filesize": "npm run build && npm run build:browser"
   },
   "dependencies": {
@@ -59,11 +63,7 @@
       ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     },
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js",
-      "json"
-    ]
+    "moduleFileExtensions": ["ts", "tsx", "js", "json"],
+    "mapCoverage": true
   }
 }

--- a/packages/apollo-client/AUTHORS
+++ b/packages/apollo-client/AUTHORS
@@ -93,3 +93,4 @@ Adam Tuttle <adamtuttlecodes@gmail.com>
 Greg Bergé <berge.greg@gmail.com>
 Dotan Simha <dotansimha@gmail.com>
 Torsten Blindert <info@by-torsten.com>
+James Burgess <jamesmillerburgess@gmail.com>

--- a/packages/apollo-client/CHANGELOG.md
+++ b/packages/apollo-client/CHANGELOG.md
@@ -2,6 +2,7 @@
 # Change log
 
 ### vNEXT
+- Map coverage to original source
 - Added `getCacheKey` function to the link context for use in state-link [PR#2998](https://github.com/apollographql/apollo-client/pull/2998)
 
 ### 2.2.3

--- a/packages/apollo-client/package.json
+++ b/packages/apollo-client/package.json
@@ -12,14 +12,18 @@
     "dev": "./scripts/dev.sh",
     "deploy": "./scripts/deploy.sh",
     "test": "jest",
-    "benchmark": "npm run build:benchmark && node benchmark_lib/benchmark/index.js",
-    "benchmark:inspect": "npm run build:benchmark && node --inspect --debug-brk benchmark_lib/benchmark/index.js",
+    "benchmark":
+      "npm run build:benchmark && node benchmark_lib/benchmark/index.js",
+    "benchmark:inspect":
+      "npm run build:benchmark && node --inspect --debug-brk benchmark_lib/benchmark/index.js",
     "filesize": "npm run build && npm run build:browser",
     "type-check": "flow check",
     "build": "tsc",
     "build:benchmark": "tsc -p tsconfig.benchmark.json",
-    "build:browser": "browserify ./lib/bundle.umd.js -o=./lib/bundle.js --i apollo-utilities --i apollo-cache --i apollo-link --i apollo-link-dedup && npm run minify:browser",
-    "minify:browser": "uglifyjs -c -m -o ./lib/bundle.min.js -- ./lib/bundle.js",
+    "build:browser":
+      "browserify ./lib/bundle.umd.js -o=./lib/bundle.js --i apollo-utilities --i apollo-cache --i apollo-link --i apollo-link-dedup && npm run minify:browser",
+    "minify:browser":
+      "uglifyjs -c -m -o ./lib/bundle.min.js -- ./lib/bundle.js",
     "watch": "tsc -w",
     "bundle": "rollup -c rollup.config.js",
     "postbuild": "npm run bundle",
@@ -43,6 +47,7 @@
     "react"
   ],
   "author": "Sashko Stubailo <sashko@stubailo.com>",
+  "contributors": ["James Burgess <jamesmillerburgess@gmail.com>"],
   "license": "MIT",
   "dependencies": {
     "@types/zen-observable": "^0.5.3",
@@ -93,14 +98,8 @@
       ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     },
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js",
-      "json"
-    ],
-    "setupFiles": [
-      "<rootDir>/scripts/tests.js"
-    ]
+    "moduleFileExtensions": ["ts", "tsx", "js", "json"],
+    "setupFiles": ["<rootDir>/scripts/tests.js"],
+    "mapCoverage": true
   }
 }

--- a/packages/apollo-client/package.json
+++ b/packages/apollo-client/package.json
@@ -47,7 +47,6 @@
     "react"
   ],
   "author": "Sashko Stubailo <sashko@stubailo.com>",
-  "contributors": ["James Burgess <jamesmillerburgess@gmail.com>"],
   "license": "MIT",
   "dependencies": {
     "@types/zen-observable": "^0.5.3",

--- a/packages/apollo-utilities/CHANGELOG.md
+++ b/packages/apollo-utilities/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 
 ### vNext
+- Map coverage to original source
 
 ### 1.1.3
 - dependency updates

--- a/packages/apollo-utilities/package.json
+++ b/packages/apollo-utilities/package.json
@@ -6,7 +6,8 @@
   "contributors": [
     "James Baxley <james@meteor.com>",
     "Jonas Helfer <jonas@helfer.email>",
-    "Sashko Stubailo <sashko@stubailo.com>"
+    "Sashko Stubailo <sashko@stubailo.com>",
+    "James Burgess <jamesmillerburgess@gmail.com>"
   ],
   "license": "MIT",
   "main": "./lib/bundle.umd.js",
@@ -32,8 +33,10 @@
     "watch": "tsc -w -p .",
     "clean": "rimraf lib/* && rimraf coverage/*",
     "prepublishOnly": "npm run clean && npm run build",
-    "build:browser": "browserify ./lib/bundle.umd.js -o=./lib/bundle.js && npm run minify:browser",
-    "minify:browser": "uglifyjs -c -m -o ./lib/bundle.min.js -- ./lib/bundle.js",
+    "build:browser":
+      "browserify ./lib/bundle.umd.js -o=./lib/bundle.js && npm run minify:browser",
+    "minify:browser":
+      "uglifyjs -c -m -o ./lib/bundle.min.js -- ./lib/bundle.js",
     "filesize": "npm run build && npm run build:browser"
   },
   "devDependencies": {
@@ -59,11 +62,7 @@
       ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     },
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js",
-      "json"
-    ]
+    "moduleFileExtensions": ["ts", "tsx", "js", "json"],
+    "mapCoverage": true
   }
 }

--- a/packages/graphql-anywhere/CHANGELOG.md
+++ b/packages/graphql-anywhere/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ## vNEXT
+- Map coverage to original source
 
 ### 4.1.4
 - dependency updates

--- a/packages/graphql-anywhere/package.json
+++ b/packages/graphql-anywhere/package.json
@@ -15,8 +15,10 @@
     "watch": "tsc -w",
     "prepublishOnly": "npm run build",
     "lint": "tslint --type-check -p tsconfig.json src/*.ts",
-    "build:browser": "browserify ./lib/bundle.umd.js -o=./lib/bundle.js --i apollo-utilities && npm run minify:browser",
-    "minify:browser": "uglifyjs -c -m -o ./lib/bundle.min.js -- ./lib/bundle.js",
+    "build:browser":
+      "browserify ./lib/bundle.umd.js -o=./lib/bundle.js --i apollo-utilities && npm run minify:browser",
+    "minify:browser":
+      "uglifyjs -c -m -o ./lib/bundle.min.js -- ./lib/bundle.js",
     "filesize": "npm run build:browser"
   },
   "repository": {
@@ -33,6 +35,7 @@
     "react"
   ],
   "author": "Sashko Stubailo <sashko@stubailo.com>",
+  "contributors": ["James Burgess <jamesmillerburgess@gmail.com>"],
   "license": "MIT",
   "dependencies": {
     "apollo-utilities": "^1.0.8"
@@ -62,11 +65,7 @@
       ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     },
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js",
-      "json"
-    ]
+    "moduleFileExtensions": ["ts", "tsx", "js", "json"],
+    "mapCoverage": true
   }
 }


### PR DESCRIPTION
I noticed that the coverage files generated from jest are not mapped correctly. There is an undocumented configuration option in jest, `mapCoverage`, that fixes TypeScript coverage maps. I've added it to each package's jest config.