### PR TITLE
Update subscribe.md

### DIFF
--- a/docs/source/features/subscriptions.md
+++ b/docs/source/features/subscriptions.md
@@ -211,7 +211,7 @@ and start the actual subscription by calling the `subscribeToNewComments` functi
 
 ```js
 export class CommentsPage extends Component {
-    componentWillMount() {
+    componentDidMount() {
         this.props.subscribeToNewComments({
             repoFullName: this.props.repoFullName,
         });


### PR DESCRIPTION
In `subscribeToNewComments` documentation, the suggestion usage is in the `componentWillMount` lifecycle.

According to the [react documentation](https://reactjs.org/docs/react-component.html#componentwillmount) about it, it's better to avoid using subscription, and rely on `componentDidMount` instead.

[Twitter reply](https://twitter.com/apollographql/status/968693661608415233) for reference.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.
