### PR TITLE
Fix Memory Leak in Query Manager

### DIFF
--- a/packages/apollo-client/AUTHORS
+++ b/packages/apollo-client/AUTHORS
@@ -94,3 +94,4 @@ Greg Bergé <berge.greg@gmail.com>
 Dotan Simha <dotansimha@gmail.com>
 Torsten Blindert <info@by-torsten.com>
 James Burgess <jamesmillerburgess@gmail.com>
+Kevin Maschtaler <kevin.maschtaler@gmail.com>

--- a/packages/apollo-client/CHANGELOG.md
+++ b/packages/apollo-client/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### vNEXT
 - Map coverage to original source
 - Added `getCacheKey` function to the link context for use in state-link [PR#2998](https://github.com/apollographql/apollo-client/pull/2998)
+- Fix Memory Leak in Query Manager [PR#3119](https://github.com/apollographql/apollo-client/pull/3119)
 
 ### 2.2.3
 - dependency updates

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -945,8 +945,8 @@ export class QueryManager<TStore> {
   }
 
   public stopQuery(queryId: string) {
-    this.removeQuery(queryId);
     this.stopQueryInStore(queryId);
+    this.removeQuery(queryId);
   }
 
   public removeQuery(queryId: string) {


### PR DESCRIPTION
## Description

When a query was stopped, it was removed from the Map but it was
then invalidated, creating a new unusable item that takes memory.

This commit just invalidate the query before removing it in order to
delete it for ever.

I have no idea if changing the order of these functions will have an impact for production usage, but it seems fixing the memory leak.

## Demonstration
I created a small gist to play with Apollo Client: https://gist.github.com/Kmaschta/9d4e6c5a68c9978177d42a068dfed2f6

To run it, just copy the files, install the dependencies and run it with node:

```bash
yarn install
node --inspect index.js

# You'll be able to trigger a GraphQL query with
curl http://localhost:3000/test
```

I used [siege](https://www.joedog.org/siege-home/) to simulate a high number of requests.

```bash
# Runs 25 workers over the target for 10s

timeout 10s siege http://localhost:3000/test
# Take First Snapshot
timeout 10s siege http://localhost:3000/test
# Take Second Snapshot
timeout 1m siege http://localhost:3000/test
# Take Last Snapshot
```

### Before

<details>
<summary>Console Output After 3 Requests</summary>

```txt
API available on on port 3000. Press Ctrl+C to stop it.
Queries Map {
  '1' => { listeners: [ [Function] ],
  invalidated: false,
  document: { kind: 'Document', definitions: [Array], loc: [Object] },
  newData: null,
  lastRequestId: 2,
  observableQuery: null,
  subscriptions: [],
  invalidate: false,
  cancel: [Function] } }
Queries Map {
  '1' => { listeners: [],
  invalidated: true,
  document: null,
  newData: null,
  lastRequestId: null,
  observableQuery: null,
  subscriptions: [] },
  '3' => { listeners: [ [Function] ],
  invalidated: false,
  document: { kind: 'Document', definitions: [Array], loc: [Object] },
  newData: null,
  lastRequestId: 4,
  observableQuery: null,
  subscriptions: [],
  invalidate: false,
  cancel: [Function] } }
Queries Map {
  '1' => { listeners: [],
  invalidated: true,
  document: null,
  newData: null,
  lastRequestId: null,
  observableQuery: null,
  subscriptions: [] },
  '3' => { listeners: [],
  invalidated: true,
  document: null,
  newData: null,
  lastRequestId: null,
  observableQuery: null,
  subscriptions: [] },
  '5' => { listeners: [ [Function] ],
  invalidated: false,
  document: { kind: 'Document', definitions: [Array], loc: [Object] },
  newData: null,
  lastRequestId: 6,
  observableQuery: null,
  subscriptions: [],
  invalidate: false,
  cancel: [Function] } }
```

</details>

We can see that the Query Manager's queries are invalidated but stacked.

**Heap Memory After Numerous Requests**

![image](https://user-images.githubusercontent.com/1819833/37019471-ac1e8d0c-2118-11e8-851c-adc76f08dcc3.png)

## After

<details>
<summary>Console Output After 3 Requests</summary>

```txt
API available on on port 3000. Press Ctrl+C to stop it.
Queries Map {
  '1' => { listeners: [ [Function] ],
  invalidated: false,
  document: { kind: 'Document', definitions: [Array], loc: [Object] },
  newData: null,
  lastRequestId: 2,
  observableQuery: null,
  subscriptions: [],
  invalidate: false,
  cancel: [Function] } }
Queries Map {
  '3' => { listeners: [ [Function] ],
  invalidated: false,
  document: { kind: 'Document', definitions: [Array], loc: [Object] },
  newData: null,
  lastRequestId: 4,
  observableQuery: null,
  subscriptions: [],
  invalidate: false,
  cancel: [Function] } }
Queries Map {
  '5' => { listeners: [ [Function] ],
  invalidated: false,
  document: { kind: 'Document', definitions: [Array], loc: [Object] },
  newData: null,
  lastRequestId: 6,
  observableQuery: null,
  subscriptions: [],
  invalidate: false,
  cancel: [Function] } }
```

</details>

Queries are no longuer stacked.

**Heap Memory After Numerous Requests**

![image](https://user-images.githubusercontent.com/1819833/37019683-823862fa-2119-11e8-9471-2cb89bd6fe88.png)
