### PR TITLE
Fix Memory leak in readFragment

### DIFF
--- a/packages/apollo-client/AUTHORS
+++ b/packages/apollo-client/AUTHORS
@@ -95,3 +95,4 @@ Dotan Simha <dotansimha@gmail.com>
 Torsten Blindert <info@by-torsten.com>
 James Burgess <jamesmillerburgess@gmail.com>
 Kevin Maschtaler <kevin.maschtaler@gmail.com>
+Ryan Sydnor <ryan.t.sydnor@gmail.com>

--- a/packages/apollo-utilities/CHANGELOG.md
+++ b/packages/apollo-utilities/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### vNext
 - Map coverage to original source
+- Fix memory leak in addTypenameToDocument due to readFragment [PR#3133](https://github.com/apollographql/apollo-client/pull/3133)
 
 ### 1.1.3
 - dependency updates

--- a/packages/apollo-utilities/src/transform.ts
+++ b/packages/apollo-utilities/src/transform.ts
@@ -168,7 +168,8 @@ export function removeDirectivesFromDocument(
 const added = new Map();
 export function addTypenameToDocument(doc: DocumentNode) {
   checkDocument(doc);
-  const cached = added.get(doc);
+  const docAsMapKey = JSON.stringify(doc);
+  const cached = added.get(docAsMapKey);
   if (cached) return cached;
 
   const docClone = cloneDeep(doc);
@@ -181,7 +182,7 @@ export function addTypenameToDocument(doc: DocumentNode) {
     );
   });
 
-  added.set(doc, docClone);
+  added.set(docAsMapKey, docClone);
   return docClone;
 }
 


### PR DESCRIPTION
### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] has-reproduction
- [ ] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->
/label memory-leak

A naive fix for https://github.com/apollographql/apollo-client/issues/3132. Happy to take another stab at it with some direction.