### PR TITLE
Fix subscribeToMore example

### DIFF
--- a/docs/source/features/subscriptions.md
+++ b/docs/source/features/subscriptions.md
@@ -182,7 +182,7 @@ const withData = graphql(COMMENT_QUERY, {
         return {
            ...props,
             subscribeToNewComments: params => {
-                return props.comments.subscribeToMore({
+                return props.data.subscribeToMore({
                     document: COMMENTS_SUBSCRIPTION,
                     variables: {
                         repoName: params.repoFullName,


### PR DESCRIPTION
The `subscribeToMore` method is available on the `data` key

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->