### PR TITLE
Add fragment colocation with ES import/exports to documentation

### DIFF
--- a/docs/source/features/fragments.md
+++ b/docs/source/features/fragments.md
@@ -140,6 +140,33 @@ FeedEntry.fragments = {
 };
 ```
 
+<h3 id="co-locating-fragments-with-es-modules">Co-locating Fragments With ES Modules</h3>
+When using ES Modules, you may want to take advantage of ES module exports to explicitly export your fragments instead of attaching
+it as a subfield of `ComponentClass.fragments`.
+
+For instance:
+
+```js
+export default class VoteButtons extends React.Component { ... }
+export const fragments = {
+  entry: gql`
+  fragment VoteButtons on Entry {
+    score
+    vote {
+      vote_value
+    }
+  }
+`,
+}
+```
+
+A benefit of doing this is that your module dependencies become more direct. Instead of loading a Component Class module just to get
+access to it's fragments, you can directly import its fragments.
+
+```
+import { fragments as VoteButtonsFragments } from './VoteButtons';
+```
+
 <h3 id="filtering-with-fragments">Filtering With Fragments</h3>
 
 We can also use the `graphql-anywhere` package to filter the exact fields from the `entry` before passing them to the subcomponent. So when we render a `VoteButtons`, we can simply do:


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

Add fragment co-location with ES Modules instead of a 'fragments' property existing on top of a Component class. This actually generally breaks Typescript/Flow implementations since extending static properties of `React.Component` _generally_ is not supported as far as I know.