### PR TITLE
Adding section for subscribe call in the Subscriptions docs

### DIFF
--- a/docs/source/features/subscriptions.md
+++ b/docs/source/features/subscriptions.md
@@ -114,6 +114,34 @@ const link = split(
 
 Now, queries and mutations will go over HTTP as normal, but subscriptions will be done over the websocket transport.
 
+<h2 id="subscribe">subscribe</h2>
+
+To accomodate for simple cases where you would like to react to subscription events, you can use the `subscribe` function.
+
+```js
+  componentDidMount() {
+    // call the "subscribe" method on Apollo Client
+    this.props.client.subscribe({
+      query: GRAPHQL_SUBSCRIPTION,
+    }).subscribe({
+      next: (data) => {
+        // ... do something with data
+      },
+      error(err) {
+        console.error('err', err);
+      },
+    });
+  }
+  
+  const GRAPHQL_SUBSCRIPTION = gql`
+    subscription {
+      ...
+    }
+  `;
+  
+  export const MyComponent = withApollo(MyComponent);
+```
+
 <h2 id="subscribe-to-more">subscribeToMore</h2>
 
 With GraphQL subscriptions your client will be alerted on push from the server and you should choose the pattern that fits your application the most:


### PR DESCRIPTION
> * Use it as a notification and run any logic you want when it fires, for example alerting the user or refetching data
> * Use the data sent along with the notification and merge it directly into the store (existing queries are automatically notified)

This section only describes the latter case, it's not very clear how to go about doing the former without extra googling, I think this change would be pretty helpful for people looking to implement a simple example that doesn't tie in with a query.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->