### PR TITLE
Add redirects for existing React Apollo 2.0 docs URLs.

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -55,3 +55,11 @@ sidebar_categories:
   API:
     - api/apollo-client
     - api/react-apollo
+
+redirects:
+  /docs/react/essentials/get-started.html#api:
+    docs/react/api/react-apollo.html
+  /docs/react/essentials/queries.html#api:
+    docs/react/api/react-apollo.html#graphql-query-options
+  /docs/react/basics/mutations.html#api:
+    docs/react/api/react-apollo.html#graphql-mutation-options

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -1,1 +1,26 @@
 / /docs/react/
+
+# React Apollo 2.0 - Basics
+# https://github.com/apollographql/apollo-client/pull/3097
+/docs/react/basics/setup.html /docs/react/essentials/get-started.html
+/docs/react/basics/queries.html /docs/react/essentials/queries.html
+/docs/react/basics/mutations.html /docs/react/essentials/mutations.html
+/docs/react/basics/network-layer.html /docs/react/advanced/network-layer.html
+/docs/react/basics/caching.html /docs/react/advanced/caching.html
+
+# React Apollo 2.0 - Features
+# https://github.com/apollographql/apollo-client/pull/3097
+/docs/react/features/caching.html /docs/react/advanced/caching.html
+/docs/react/features/cache-updates.html /docs/react/advanced/caching.html
+/docs/react/features/fragments.html /docs/react/advanced/fragments.html
+/docs/react/features/subscriptions.html /docs/react/advanced/subscriptions.html
+/docs/react/features/react-native.html /docs/react/recipes/react-native.html
+/docs/react/features/static-typing.html /docs/react/recipes/static-typing.html
+
+# React Apollo 2.0 - Recipes
+# https://github.com/apollographql/apollo-client/pull/3097
+/docs/react/recipes/query-splitting.html /docs/react/features/performance.html#query-splitting
+/docs/react/recipes/pagination.html /docs/react/features/pagination.html
+/docs/react/recipes/prefetching.html /docs/react/features/performance.html#prefetching
+/docs/react/recipes/server-side-rendering.html /docs/react/features/server-side-rendering.html
+/docs/react/recipes/fragment-matching.html /docs/react/advanced/fragments.html


### PR DESCRIPTION
Note: This PR targets #3097.  It will merge into that PR.

---

These redirects maintain the URLs in existence before the React Apollo 2.1 docs overhaul.

This includes both Netlify redirects for redirects that should be handled by the server (specifically, those that don't include anchor tags on the "from" side) and also a JavaScript-powered `redirects` directive in the `_config.yml` which utilizes a mechanism in the theme.