### PR TITLE
Code not matching description & small typo

### DIFF
--- a/docs/source/essentials/get-started.md
+++ b/docs/source/essentials/get-started.md
@@ -51,7 +51,7 @@ client
       }
     `
   })
-  .then(({ data }) => console.log({ data }));
+  .then(data => console.log({ data }));
 ```
 
 Open up your console and inspect the data object. You should see `rates` attached, along with some other properties like `loading` and `networkStatus`. While you don't need React or another front-end framework just to fetch data with Apollo Client, our view layer integrations make it easier to bind your queries to your UI and reactively update your components with data. Let's learn how to connect Apollo Client to React so we can start building query components with `react-apollo`.

--- a/docs/source/react-apollo-migration.md
+++ b/docs/source/react-apollo-migration.md
@@ -168,7 +168,7 @@ For more information on how to use the new Query component, read the [full guide
 Much like the Query component, the Mutation and Subscription component are ways to use Apollo directly within your react tree. They simplify integrating with Apollo, and keep your React app written in React! For more information on the Mutation component, [check out the usage guide](./essentials/mutations.html) or if you are wanting to learn about the Subscription component, [read how to here](./advanced/subscriptions.html).
 
 <h2 id="context">ApolloConsumer</h2>
-With upcoming versions of React (starting in React 16.3), there is a new version of context that makes is easier than ever to use components connected to state higher in the tree. While the 2.1 doesn't require React 16.3, we are making easier than ever to start writing in this style with the `<ApolloConsumer>` component. This is just like the `withApollo` higher order component, just in a normal React component! It takes no props and expects a child function which recieves the instance of Apollo Client in your tree. For example:
+With upcoming versions of React (starting in React 16.3), there is a new version of context that makes it easier than ever to use components connected to state higher in the tree. While the 2.1 doesn't require React 16.3, we are making easier than ever to start writing in this style with the `<ApolloConsumer>` component. This is just like the `withApollo` higher order component, just in a normal React component! It takes no props and expects a child function which recieves the instance of Apollo Client in your tree. For example:
 
 ```js
 const MyClient = () => (


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

If `data` is destructured it returns only `rates` array which is contrary to what is said in the description 😉 

Also there is a typo on `New in React Apollo 2.1` page at the bottom `ApolloConsumer`

# `is` -> `it`

`there is a new version of context that makes is easier` should be `there is a new version of context that makes it easier`