### PR TITLE
[docs] Update code and language in Get started: Create a client

### DIFF
--- a/docs/source/essentials/get-started.md
+++ b/docs/source/essentials/get-started.md
@@ -51,10 +51,10 @@ client
       }
     `
   })
-  .then(data => console.log({ data }));
+  .then(result => console.log(result));
 ```
 
-Open up your console and inspect the data object. You should see `rates` attached, along with some other properties like `loading` and `networkStatus`. While you don't need React or another front-end framework just to fetch data with Apollo Client, our view layer integrations make it easier to bind your queries to your UI and reactively update your components with data. Let's learn how to connect Apollo Client to React so we can start building query components with `react-apollo`.
+Open up your console and inspect the result object. You should see `data` property with `rates` attached, along with some other properties like `loading` and `networkStatus`. While you don't need React or another front-end framework just to fetch data with Apollo Client, our view layer integrations make it easier to bind your queries to your UI and reactively update your components with data. Let's learn how to connect Apollo Client to React so we can start building query components with `react-apollo`.
 
 <h2 id="creating-provider">Connect your client to React</h2>
 

--- a/docs/source/essentials/get-started.md
+++ b/docs/source/essentials/get-started.md
@@ -54,7 +54,7 @@ client
   .then(result => console.log(result));
 ```
 
-Open up your console and inspect the result object. You should see `data` property with `rates` attached, along with some other properties like `loading` and `networkStatus`. While you don't need React or another front-end framework just to fetch data with Apollo Client, our view layer integrations make it easier to bind your queries to your UI and reactively update your components with data. Let's learn how to connect Apollo Client to React so we can start building query components with `react-apollo`.
+Open up your console and inspect the result object. You should see a `data` property with `rates` attached, along with some other properties like `loading` and `networkStatus`. While you don't need React or another front-end framework just to fetch data with Apollo Client, our view layer integrations make it easier to bind your queries to your UI and reactively update your components with data. Let's learn how to connect Apollo Client to React so we can start building query components with `react-apollo`.
 
 <h2 id="creating-provider">Connect your client to React</h2>
 


### PR DESCRIPTION
Update code and language in the **Create a client** section (Get started) page.

Currently, the example and language is slightly in accurate.
<img width="817" alt="screen shot 2018-04-02 at 11 03 13 am" src="https://user-images.githubusercontent.com/3942264/38208334-9683ac0e-3665-11e8-9335-1bd80e133882.png">

The `data` argument passing to the resolve handler is actually the query result object with `{ data, loading, networkStatus, ... }`.
<img width="689" alt="screen shot 2018-04-02 at 10 48 48 am" src="https://user-images.githubusercontent.com/3942264/38208406-cab6a6fc-3665-11e8-9509-9bd49c9ecf72.png">

Proposed an update with the minor change in the language to avoid confusion.