### PR TITLE
Improve read performance for complicated queries by up to 50%

### DIFF
--- a/packages/apollo-cache-inmemory/CHANGELOG.md
+++ b/packages/apollo-cache-inmemory/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ### vNext
+- Various optimizations for cache read performance [#3300](https://github.com/apollographql/apollo-client/pull/3300)
 
 ### 1.1.12
 - Fix an edge case where fields that were unions of two types, one with an `id`,

--- a/packages/apollo-cache-inmemory/src/objectCache.ts
+++ b/packages/apollo-cache-inmemory/src/objectCache.ts
@@ -1,7 +1,7 @@
 import { NormalizedCache, NormalizedCacheObject, StoreObject } from './types';
 
 export class ObjectCache implements NormalizedCache {
-  constructor(private data: NormalizedCacheObject = {}) {}
+  constructor(private data: NormalizedCacheObject = Object.create(null)) {}
   public toObject(): NormalizedCacheObject {
     return this.data;
   }
@@ -15,10 +15,10 @@ export class ObjectCache implements NormalizedCache {
     this.data[dataId] = undefined;
   }
   public clear(): void {
-    this.data = {};
+    this.data = Object.create(null);
   }
   public replace(newData: NormalizedCacheObject): void {
-    this.data = newData || {};
+    this.data = newData || Object.create(null);
   }
 }
 

--- a/packages/apollo-cache-inmemory/src/readFromStore.ts
+++ b/packages/apollo-cache-inmemory/src/readFromStore.ts
@@ -10,7 +10,9 @@ import {
   isIdValue,
   toIdValue,
   getStoreKeyName,
+  StoreValue,
 } from 'apollo-utilities';
+
 import { Cache } from 'apollo-cache';
 
 import {
@@ -18,6 +20,7 @@ import {
   IdValueWithPreviousResult,
   ReadStoreContext,
   DiffQueryAgainstStoreOptions,
+  StoreObject,
 } from './types';
 
 /**
@@ -67,13 +70,20 @@ const readStoreResolver: Resolver = (
 
   const objId = idValue.id;
   const obj = context.store.get(objId);
-  const storeKeyName = getStoreKeyName(fieldName, args, directives);
-  let fieldValue = (obj || {})[storeKeyName];
 
-  if (typeof fieldValue === 'undefined') {
+  let storeKeyName = fieldName;
+  if (args || directives) {
+    storeKeyName = getStoreKeyName(storeKeyName, args, directives);
+  }
+
+  let fieldValue: StoreValue | string | void = void 0;
+
+  if (obj) {
+    fieldValue = obj[storeKeyName];
+
     if (
+      typeof fieldValue === 'undefined' &&
       context.cacheRedirects &&
-      obj &&
       (obj.__typename || objId === 'ROOT_QUERY')
     ) {
       const typename = obj.__typename || 'Query';
@@ -85,11 +95,12 @@ const readStoreResolver: Resolver = (
         const resolver = type[fieldName];
         if (resolver) {
           fieldValue = resolver(obj, args, {
-            getCacheKey: (obj: { __typename: string; id: string | number }) =>
-              toIdValue({
-                id: context.dataIdFromObject(obj),
-                typename: obj.__typename,
-              }),
+            getCacheKey(storeObj: StoreObject) {
+              return toIdValue({
+                id: context.dataIdFromObject(storeObj),
+                typename: storeObj.__typename,
+              });
+            },
           });
         }
       }

--- a/packages/apollo-cache-inmemory/src/readFromStore.ts
+++ b/packages/apollo-cache-inmemory/src/readFromStore.ts
@@ -300,14 +300,7 @@ function resultMapper(resultFields: any, idValue: IdValueWithPreviousResult) {
     }
   }
 
-  // Add the id to the result fields. It should be non-enumerable so users can’t see it without
-  // trying very hard.
-  Object.defineProperty(resultFields, ID_KEY, {
-    enumerable: false,
-    configurable: false,
-    writable: false,
-    value: idValue.id,
-  });
+  resultFields[ID_KEY] = idValue.id;
 
   return resultFields;
 }

--- a/packages/apollo-cache-inmemory/src/readFromStore.ts
+++ b/packages/apollo-cache-inmemory/src/readFromStore.ts
@@ -204,7 +204,7 @@ export function diffQueryAgainstStore<T>({
   );
 
   return {
-    result,
+    result: result as T,
     complete: !context.hasMissingField,
   };
 }

--- a/packages/apollo-cache-inmemory/src/readFromStore.ts
+++ b/packages/apollo-cache-inmemory/src/readFromStore.ts
@@ -73,6 +73,10 @@ const readStoreResolver: Resolver = (
 
   let storeKeyName = fieldName;
   if (args || directives) {
+    // We happen to know here that getStoreKeyName returns its first
+    // argument unmodified if there are no args or directives, so we can
+    // avoid calling the function at all in that case, as a small but
+    // important optimization to this frequently executed code.
     storeKeyName = getStoreKeyName(storeKeyName, args, directives);
   }
 

--- a/packages/apollo-client/AUTHORS
+++ b/packages/apollo-client/AUTHORS
@@ -4,6 +4,7 @@ Abhi Aiyer <abhiaiyer91@gmail.com>
 Avindra Goolcharan <aavindraa@gmail.com>
 Bazyli Brzóska <bazyli.brzoska@gmail.com>
 Ben James <benhjames@sky.com>
+Ben Newman <ben@apollographql.com>
 Ben Straub <ben@straub.cc>
 Brady Whitten <bwhitten518@gmail.com>
 Brett Jurgens <brett@brettjurgens.com>

--- a/packages/apollo-client/CHANGELOG.md
+++ b/packages/apollo-client/CHANGELOG.md
@@ -2,8 +2,8 @@
 # Change log
 
 ### vNEXT
-
 - fixed edge case bug of changing fetchPolicies right after resetStore with no variables present
+- Various optimizations for cache read performance [#3300](https://github.com/apollographql/apollo-client/pull/3300)
 
 ### 2.2.8
 - Added the graphQLResultHasError in QueryManager.ts to check not only if result.errors is null, but also empty.

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -343,7 +343,6 @@ export class QueryManager<TStore> {
 
     this.queryStore.initQuery({
       queryId,
-      queryString: print(query),
       document: query,
       storePreviousVariables: shouldFetch,
       variables,
@@ -512,7 +511,7 @@ export class QueryManager<TStore> {
               console.info(
                 'An unhandled error was thrown because no error handler is registered ' +
                   'for the query ' +
-                  queryStoreValue.queryString,
+                  print(queryStoreValue.document),
               );
             }
           }

--- a/packages/apollo-client/src/data/queries.ts
+++ b/packages/apollo-client/src/data/queries.ts
@@ -1,10 +1,10 @@
 import { DocumentNode, GraphQLError, ExecutionResult } from 'graphql';
+import { print } from 'graphql/language/printer';
 import { isEqual } from 'apollo-utilities';
 
 import { NetworkStatus } from '../core/networkStatus';
 
 export type QueryStoreValue = {
-  queryString: string;
   document: DocumentNode;
   variables: Object;
   previousVariables?: Object | null;
@@ -27,7 +27,6 @@ export class QueryStore {
 
   public initQuery(query: {
     queryId: string;
-    queryString: string;
     document: DocumentNode;
     storePreviousVariables: boolean;
     variables: Object;
@@ -38,7 +37,11 @@ export class QueryStore {
   }) {
     const previousQuery = this.store[query.queryId];
 
-    if (previousQuery && previousQuery.queryString !== query.queryString) {
+    if (
+      previousQuery &&
+      previousQuery.document !== query.document &&
+      print(previousQuery.document) !== print(query.document)
+    ) {
       // XXX we're throwing an error here to catch bugs where a query gets overwritten by a new one.
       // we should implement a separate action for refetching so that QUERY_INIT may never overwrite
       // an existing query (see also: https://github.com/apollostack/apollo-client/issues/732)
@@ -84,7 +87,6 @@ export class QueryStore {
     // the store. We probably want a refetch action instead, because I suspect that if you refetch
     // before the initial fetch is done, you'll get an error.
     this.store[query.queryId] = {
-      queryString: query.queryString,
       document: query.document,
       variables: query.variables,
       previousVariables,

--- a/packages/graphql-anywhere/CHANGELOG.md
+++ b/packages/graphql-anywhere/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ## vNEXT
+- Various optimizations for cache read performance [#3300](https://github.com/apollographql/apollo-client/pull/3300)
 
 ### 4.1.8
 - Map coverage to original source

--- a/packages/graphql-anywhere/src/graphql.ts
+++ b/packages/graphql-anywhere/src/graphql.ts
@@ -229,22 +229,12 @@ function executeSubSelectedArray(field, result, execContext) {
 }
 
 export function merge(dest, src) {
-  if (src === null || typeof src !== 'object') {
-    // These types just override whatever was in dest
-    return src;
-  }
-
-  // Merge sub-objects
-  Object.keys(dest).forEach(destKey => {
-    if (src.hasOwnProperty(destKey)) {
-      merge(dest[destKey], src[destKey]);
-    }
-  });
-
-  // Add props only on src
-  Object.keys(src).forEach(srcKey => {
-    if (!dest.hasOwnProperty(srcKey)) {
-      dest[srcKey] = src[srcKey];
+  Object.keys(src).forEach(key => {
+    const srcVal = src[key];
+    if (typeof dest[key] === 'undefined') {
+      dest[key] = srcVal;
+    } else if (srcVal && typeof srcVal === 'object') {
+      merge(dest[key], srcVal);
     }
   });
 }

--- a/packages/graphql-anywhere/src/graphql.ts
+++ b/packages/graphql-anywhere/src/graphql.ts
@@ -228,10 +228,12 @@ function executeSubSelectedArray(field, result, execContext) {
   });
 }
 
+const hasOwn = Object.prototype.hasOwnProperty;
+
 export function merge(dest, src) {
   Object.keys(src).forEach(key => {
     const srcVal = src[key];
-    if (typeof dest[key] === 'undefined') {
+    if (!hasOwn.call(dest, key)) {
       dest[key] = srcVal;
     } else if (srcVal && typeof srcVal === 'object') {
       merge(dest[key], srcVal);


### PR DESCRIPTION
Taken together, these small optimizations to frequently executed functions cut the time taken to read one large query from 4.5ms to 2.25ms. The specific benchmark is in a [private repository](https://github.com/apollographql/benchmarks), though perhaps we could make it public?

I have a lot more ideas about how to cache (and invalidate) partial query responses, which should improve repeated read performance significantly, but the changes in this PR will still be worthwhile for the first (cold cache) read.