### PR TITLE
Accommodate breaking changes in Renovate v12.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
-  "pinVersions": true,
+  "extends": [":pinOnlyDevDependencies"],
   "semanticCommits": true,
-  "depTypes": [{ "depType": "dependencies", "pinVersions": false }],
   "timezone": "America/Los_Angeles",
   "schedule": [
     "after 10pm and before 5am on every weekday"


### PR DESCRIPTION
Essentially, the scope and default settings for Renovate's `pinVersions` has changed in v12, which explains the incorrect version pinning suggestion for `peerDependencies` witnessed in https://github.com/apollographql/apollo-client/pull/3298.

For the full back-story, see the conversation in the following links.

Ref: https://github.com/renovateapp/renovate/releases/tag/12.0.0
Ref: https://github.com/apollographql/apollo-server/pull/954
Ref: https://github.com/apollographql/apollo-server/pull/955