### PR TITLE
Update issue triage doc to better align with repo triage flow

### DIFF
--- a/ISSUE_TRIAGE.md
+++ b/ISSUE_TRIAGE.md
@@ -43,27 +43,18 @@ The first step is in determining whether the issue is a bug, help question or fe
 4. Work with the requester and others in the community to build a clear specification for the feature and update the issue description accordingly.
 5. Finally, add the `confirmed` label and [classify](#classification) the issue.
 
-Core contributors may add the `pull-requests-encouraged` label to feature requests. This indicates the feature is aligned with the project roadmap and a high-quality pull request will almost certainly be merged.
+Core contributors may add the `help-wanted` label to feature requests. This indicates the feature is aligned with the project roadmap and a high-quality pull request will almost certainly be merged.
 
 <h2 id="classification">Classification</h2>
 
-Assign a classification (via GH labels) that enables the community to determine how to prioritize which issues to work on. The classification is based on *Severity x Impact* .
+Assign a classification (via GH labels) that enables the community to determine how to prioritize which issues to work on.
 
-### Severity
-_[Severity:has-workaround, Severity:production, Severity:blocks-development]_
+### Priority
 
-- If there is a workaround, apply the `Severity:has-workaround` label.
-- If the issue affects production apps, apply the `Severity:production` label.
-- If the issue blocks development, apply the `Severity:blocks-development` label.
-
-### Impact
-_[Impact:few, Impact:some, Impact:most]_
-
-This is a somewhat subjective label and is interpreted in conjunction with Github's upvotes. As a general guideline:
-
-- `Impact:few` issues would go unnoticed by almost all users, apart from those using a very niche feature, or a feature in an unusual way.
-- `Impact:some` issues would impact users using a feature that is commonly but not universally used.
-- `Impact:most` issues would impact more or less every user of Apollo.
+- `blocking`: Issue impacts production or dev due to perf, bug, build error, etc.
+- `high-priority`: Issue impacts more or less every user.
+- `medium-priority`: Issue impacts users using a feature that is commonly but not universally used.
+- `low-priority`: Issue would go unnoticed by almost all users, apart from those using a very niche feature, or a feature in an unusual way.
 
 ## Issues ready to claim
 


### PR DESCRIPTION
Hi all - I'm just dipping my toes into the Apollo repo's a bit from a triage point of view, and noticed that the issue triage doc in this repo doesn't really follow the triage process being used. The original doc was copied from the http://github.com/meteor/meteor repo, and was updated to mention Apollo. Looking over the current issues/PR's though, it's clear that a different process is being followed. 

As a starting point, this PR includes changes to the issue triage doc to replace Meteor's issue classification scheme with the one being used by this repo. To supplement these changes however, I would recommend cleaning up this repo's current label list a bit. There are labels in place that aren't being used, are duplicates, are ambiguous / confusing, etc. Since I can't really provide a PR for these types of changes, here's a quick label cleanup proposal (I'm not proposing any new labels - I'm just cleaning up the ones in place a bit).

### Proposed New Label List

**Issue Type Labels:**

- `bug`
- `discussion`
- `feature`
- `question`

**Issue Category Labels:**

- `docs`
- `memory-leak`
- `perf`
- `react-native`
- `tooling`
- `typescript`
- `usability`

**Priority Labels:**

- `blocking`
- `high-priority`
- `medium-priority`
- `low-priority`

**Triage Labels:**

- `confirmed`
- `can't-reproduce`
- `reproduction-needed`
- `has-reproduction`
- `help-wanted`
- `good-first-issue`
- `good-first-review`

**Bot Labels:**

- `no-recent-activity`

### Remove These Labels:

- `dependencies`: if it's a dependency issue that can't be fixed, then let people know in the issue comments, and close the issue; no need to label it.
- `duplicate`: if it's a duplicate, point people towards the previous duplicate issue, then close the issue; no need to label it.
- `idea`: This is pretty much the same as a `feature`; an idea is usually a loosely formed feature request. `idea` issues could be marked as `feature` instead, then could be expanded upon further as needed to flush out the details. Unless it's a bad idea, at which point the issue would just be closed.
- `in-progress`: Not really needed. If someone is working on the issue, they can let others know that in the comments. If someone internally is working on the issue, they can assign it to themselves. 
- `pull-requests-encouraged`: it appears as though the `help-wanted` label is being used for PR's encouraged, so no need for this one.
- `good first issue`: This should be switched over to the older `good-first-issue` with dashes, to line up with all other labels    
- `good first review`: Switch to `good-first-review` to line up with other labels
- `revisit`: This label is ambiguous; it's not clear what should be revisited (should the issue be revisited to be triaged? Should it be revisited to be worked on? Should it be revisited to be closed?) I think the general idea behind any open issue is that it should be routinely revisited.
- `waiting-response`: If anyone is waiting on a response, this can be conveyed in the issue comments. It isn't necessary to have a separate label for this.
- `refactor`: Refactoring code will be a natural outcome of working on a bug or feature request. I don't think this label needs to be tracked separately.

Thanks all - comments/criticisms welcome! 🙂 