### PR TITLE
Fix cache-and-network fetchPolicy complete check

### DIFF
--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -297,6 +297,7 @@ export class QueryManager<TStore> {
     const query = cache.transformDocument(options.query);
 
     let storeResult: any;
+    let storeComplete: boolean | undefined = false;
     let needToFetch: boolean =
       fetchPolicy === 'network-only' || fetchPolicy === 'no-cache';
 
@@ -317,6 +318,7 @@ export class QueryManager<TStore> {
 
       // If we're in here, only fetch if we have missing fields
       needToFetch = !complete || fetchPolicy === 'cache-and-network';
+      storeComplete = complete;
       storeResult = result;
     }
 
@@ -361,7 +363,9 @@ export class QueryManager<TStore> {
       !shouldFetch || fetchPolicy === 'cache-and-network';
 
     if (shouldDispatchClientResult) {
-      this.queryStore.markQueryResultClient(queryId, !shouldFetch);
+      const markComplete =
+        (fetchPolicy === 'cache-and-network' && storeComplete) || !shouldFetch;
+      this.queryStore.markQueryResultClient(queryId, markComplete);
 
       this.invalidate(true, queryId, fetchMoreForQueryId);
 


### PR DESCRIPTION
[Reference to issue](https://github.com/apollographql/apollo-client/issues/3177)

Fix problem with cache-and-network fetch policy. Even if data is presented in cache, it always fetch from remote store before will be showen.