### PR TITLE
Fix typo in documentation

### DIFF
--- a/packages/apollo-cache-inmemory/CHANGELOG.md
+++ b/packages/apollo-cache-inmemory/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ### vNext
+- Fix typo in documentation
 
 ### 1.1.12
 - Fix an edge case where fields that were unions of two types, one with an `id`,

--- a/packages/apollo-cache-inmemory/src/writeToStore.ts
+++ b/packages/apollo-cache-inmemory/src/writeToStore.ts
@@ -201,7 +201,7 @@ export function writeSelectionSetToStore({
             context,
           });
         } else {
-          // if this is a defered field we don't need to throw / wanr
+          // if this is a defered field we don't need to throw / warn
           const isDefered =
             selection.directives &&
             selection.directives.length &&

--- a/packages/apollo-client/AUTHORS
+++ b/packages/apollo-client/AUTHORS
@@ -8,6 +8,7 @@ Ben Straub <ben@straub.cc>
 Brady Whitten <bwhitten518@gmail.com>
 Brett Jurgens <brett@brettjurgens.com>
 Bruce Williams <brwcodes@gmail.com>
+Bryan Ricker <bryancricker@gmail.com>
 Caleb Meredith <calebmeredith8@gmail.com>
 Carl Wolsey <carl@wolsey.org>
 Clément Prévost <prevostclement@gmail.com>


### PR DESCRIPTION
Typo fix in writeToStore documentation.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->