### PR TITLE
Fix: add missing import in caching update docs

### DIFF
--- a/docs/source/advanced/caching.md
+++ b/docs/source/advanced/caching.md
@@ -303,6 +303,8 @@ mutate({
 Using `update` gives you full control over the cache, allowing you to make changes to your data model in response to a mutation in any way you like. `update` is the recommended way of updating the cache after a query. It is explained in full [here](../api/react-apollo.html#graphql-mutation-options-update).
 
 ```javascript
+import CommentAppQuery from '../queries/CommentAppQuery';
+
 const SUBMIT_COMMENT_MUTATION = gql`
   mutation submitComment($repoFullName: String!, $commentContent: String!) {
     submitComment(


### PR DESCRIPTION
Really minor change, just adding back an import line that exists in:
- https://github.com/apollographql/react-docs/blob/master/source/cache-updates.md#update
- and also in the angular docs of the site: https://www.apollographql.com/docs/angular/features/cache-updates.html#directAccess

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->