### PR TITLE
Override HttpLink hard-coded 'same-origin' with fetchOptions.credentials

### DIFF
--- a/packages/apollo-boost/src/index.ts
+++ b/packages/apollo-boost/src/index.ts
@@ -74,7 +74,7 @@ export default class DefaultClient<TCache> extends ApolloClient<TCache> {
     const httpLink = new HttpLink({
       uri: (config && config.uri) || '/graphql',
       fetchOptions: (config && config.fetchOptions) || {},
-      credentials: 'same-origin',
+      credentials: (config && config.fetchOptions && config.fetchOptions.credentials) || 'same-origin'
     });
 
     const link = ApolloLink.from([


### PR DESCRIPTION
Here's a quick fix for using ```apollo-boost``` with cors.