### PR TITLE
fix Subscription component prop name

### DIFF
--- a/docs/source/advanced/subscriptions.md
+++ b/docs/source/advanced/subscriptions.md
@@ -132,7 +132,7 @@ const COMMENTS_SUBSCRIPTION = gql`
 
 const DontReadTheComments = ({ repoFullName }) => (
   <Subscription
-    subscription={COMMENTS_SUBSCRIPTION}
+    query={COMMENTS_SUBSCRIPTION}
     variables={{ repoFullName }}
   >
     {({ data: { commentAdded }, loading }) => (


### PR DESCRIPTION
- [ ] feature
- [ ] blocking
- [x] docs

Coming from https://github.com/apollographql/subscriptions-transport-ws/issues/111

Or maybe `query` prop should actually be `subscription` and the actual API should be changed.