### PR TITLE
Fix watchQuery link to docs and ‘enhance’ link

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,11 @@ client.query({
 
 Now your client will be primed with some data in its cache. You can continue to make queries, or you can get your `client` instance to perform all sorts of advanced tasks on your GraphQL data. Such as [reactively watching queries with `watchQuery`][], [changing data on your server with `mutate`][], or [reading a fragment from your local cache with `readFragment`][].
 
-To learn more about all of the features available to you through the `apollo-client` package, be sure to read through the [**`apollo-client` API reference**][https://www.apollographql.com/docs/react/api/apollo-client.html].
+To learn more about all of the features available to you through the `apollo-client` package, be sure to read through the (**`apollo-client` API reference**)[https://www.apollographql.com/docs/react/api/apollo-client.html].
 
 [`ApolloClient`]: https://www.apollographql.com/docs/react/api/apollo-client.html
 [`apollo-boost`]: https://www.apollographql.com/docs/react/essentials/get-started.html#apollo-boost
-[reactively watching queries with `watchQuery`]: http://apollographql.com/docs/react/reference/index.html#ApolloClient\.watchQuery
+[reactively watching queries with `watchQuery`]: https://www.apollographql.com/docs/react/api/apollo-client.html#ApolloClient.watchQuery
 [changing data on your server with `mutate`]: https://www.apollographql.com/docs/react/essentials/mutations.html
 [reading a fragment from your local cache with `readFragment`]: https://www.apollographql.com/docs/react/advanced/caching.html#direct
 


### PR DESCRIPTION
The link to the watchQuery API docs is currently broken. Submitted a PR for this fix in `vue-apollo` earlier too: [PR](https://github.com/Akryum/vue-apollo/pull/269).
Also, replaced the squared brackets around the ‘apollo-client API reference’ text with parenthesis for better readability (IMHO).

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [X] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [X] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->