### PR TITLE
Remove danger AUTHOR request

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -116,7 +116,4 @@ if (!isBot) {
     );
   });
   raiseIssueAboutPaths(fail, onlyTestFiles, 'an `only` was left in the test');
-
-  // Politely ask for their name in the authors file
-  message('Please add your name and email to the AUTHORS file (optional)');
 }


### PR DESCRIPTION
We're currently reminding contributors to add their name to the `AUTHORS` file on every PR, whether they've added their name already or not. This creates a fair bit of PR noise. After some internal discussion, we've decided that maintaining the `AUTHORS` file isn't really needed anymore. Contributor details are already tracked using GitHub's contributors functionality, and the original intent of the `AUTHORS` file (to support people from companies that only allow contributions if their
name can be included in a specific contribution file) is no longer a priority. This commit removes the `AUTHORS` danger check. We'll keep the `AUTHORS` file in place for now. Thanks!
