### PR TITLE
fix(credentials): add requestCredentials as an option to the Apollo Boost config

### DIFF
--- a/packages/apollo-boost/src/__tests__/config.ts
+++ b/packages/apollo-boost/src/__tests__/config.ts
@@ -66,4 +66,15 @@ describe('config', () => {
 
     expect(client.cache.config.cacheRedirects).toEqual(cacheRedirects);
   });
+
+  it('allows you to pass in requestCredentials', () => {
+    const cacheRedirects = { Query: { foo: () => 'woo' } };
+
+    const client = new ApolloClient({
+      cacheRedirects,
+      requestCredentials: 'include',
+    });
+
+    expect(client.cache.config.cacheRedirects).toEqual(cacheRedirects);
+  });
 });

--- a/packages/apollo-boost/src/index.ts
+++ b/packages/apollo-boost/src/index.ts
@@ -17,6 +17,7 @@ export { gql, InMemoryCache, HttpLink };
 export interface PresetConfig {
   request?: (operation: Operation) => Promise<void>;
   uri?: string;
+  requestCredentials?: string;
   fetchOptions?: HttpLink.Options;
   clientState?: ClientStateConfig;
   onError?: ErrorLink.ErrorHandler;
@@ -50,31 +51,32 @@ export default class DefaultClient<TCache> extends ApolloClient<TCache> {
 
     const requestHandler =
       config && config.request
-        ? new ApolloLink((operation, forward) =>
-            new Observable(observer => {
-              let handle: any;
-              Promise.resolve(operation)
-                .then(oper => config.request(oper))
-                .then(() => {
-                  handle = forward(operation).subscribe({
-                    next: observer.next.bind(observer),
-                    error: observer.error.bind(observer),
-                    complete: observer.complete.bind(observer),
-                  });
-                })
-                .catch(observer.error.bind(observer));
+        ? new ApolloLink(
+            (operation, forward) =>
+              new Observable(observer => {
+                let handle: any;
+                Promise.resolve(operation)
+                  .then(oper => config.request(oper))
+                  .then(() => {
+                    handle = forward(operation).subscribe({
+                      next: observer.next.bind(observer),
+                      error: observer.error.bind(observer),
+                      complete: observer.complete.bind(observer),
+                    });
+                  })
+                  .catch(observer.error.bind(observer));
 
-              return () => {
-                if (handle) handle.unsubscribe;
-              };
-            })
+                return () => {
+                  if (handle) handle.unsubscribe;
+                };
+              }),
           )
         : false;
 
     const httpLink = new HttpLink({
       uri: (config && config.uri) || '/graphql',
       fetchOptions: (config && config.fetchOptions) || {},
-      credentials: 'same-origin',
+      credentials: (config && config.requestCredentials) || 'same-origin',
     });
 
     const link = ApolloLink.from([


### PR DESCRIPTION
Configurable Request credentials in apollo boost.

Re:
https://github.com/apollographql/apollo-client/issues/3407