### PR TITLE
Make ssrForceFetchDelay work with cache-and-network

### DIFF
--- a/packages/apollo-client/src/ApolloClient.ts
+++ b/packages/apollo-client/src/ApolloClient.ts
@@ -206,8 +206,10 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
     }
 
     // XXX Overwriting options is probably not the best way to do this long term...
-    if (this.disableNetworkFetches && options.fetchPolicy === 'network-only') {
-      options = { ...options, fetchPolicy: 'cache-first' } as WatchQueryOptions;
+    if (this.disableNetworkFetches) {
+      if (options.fetchPolicy === 'network-only' || options.fetchPolicy === 'cache-and-network') {
+        options = { ...options, fetchPolicy: 'cache-first' } as WatchQueryOptions;
+      }
     }
 
     return this.queryManager.watchQuery<T>(options);


### PR DESCRIPTION
Under SSR, we can use the `ssrForceFetchDelay` option to prevent the client-side from issuing duplicate network requests (for a short time after initialization).
https://github.com/apollographql/apollo-client/blob/dde2c9c00bddf6917239208bbe28f59b1a50c111/packages/apollo-client/src/ApolloClient.ts#L122

However, this option currently works only with `network-only`.
https://github.com/apollographql/apollo-client/blob/dde2c9c00bddf6917239208bbe28f59b1a50c111/packages/apollo-client/src/ApolloClient.ts#L239-L241

I think this option should also work with `cache-and-network`.