### PR TITLE
Changed `cache` to `client` to clarify code sample

### DIFF
--- a/docs/source/essentials/local-state.md
+++ b/docs/source/essentials/local-state.md
@@ -62,9 +62,9 @@ import Link from './Link';
 
 const FilterLink = ({ filter, children }) => (
   <ApolloConsumer>
-    {cache => (
+    {client => (
       <Link
-        onClick={() => cache.writeData({ data: { visibilityFilter: filter } })}
+        onClick={() => client.writeData({ data: { visibilityFilter: filter } })}
       >
         {children}
       </Link>
@@ -73,7 +73,7 @@ const FilterLink = ({ filter, children }) => (
 );
 ```
 
-The `ApolloConsumer` render prop function is called with a single value, the Apollo Client instance. You can think of the `ApolloConsumer` component as similar to the `Consumer` component from the [new React context API](https://github.com/reactjs/rfcs/blob/master/text/0002-new-version-of-context.md). From the client instance, you can directly call `cache.writeData` and pass in the data you'd like to write to the cache.
+The `ApolloConsumer` render prop function is called with a single value, the Apollo Client instance. You can think of the `ApolloConsumer` component as similar to the `Consumer` component from the [new React context API](https://github.com/reactjs/rfcs/blob/master/text/0002-new-version-of-context.md). From the client instance, you can directly call `client.writeData` and pass in the data you'd like to write to the cache.
 
 What if we want to immediately subscribe to the data we just wrote to the cache? Let's create an `active` property on the link that marks the link's filter as active if it's the same as the current `visibilityFilter` in the cache. To immediately subscribe to a client-side mutation, wrap it in a `Query` component instead of an `ApolloConsumer` component. The `Query` component also has the client instance exposed on its render prop function.
 


### PR DESCRIPTION
Small code sample change to clarify that the Apollo client instance is being used, instead of interacting with the cache directly. 

Fixes #3349.