### PR TITLE
Change `cacheResolvers` to `cacheRedirects` in `InMemoryCache` docs

### DIFF
--- a/docs/source/advanced/caching.md
+++ b/docs/source/advanced/caching.md
@@ -35,10 +35,10 @@ const client = new ApolloClient({
 
 The `InMemoryCache` constructor takes an optional config object with properties to customize your cache:
 
-- addTypename: A boolean to determine whether to add __typename to the document (default: `true`)
-- dataIdFromObject: A function that takes a data object and returns a unique identifier to be used when normalizing the data in the store. Learn more about how to customize `dataIdFromObject` in the [Normalization](#normalization) section.
-- fragmentMatcher: By default, the `InMemoryCache` uses a heuristic fragment matcher. If you are using fragments on unions and interfaces, you will need to use an `IntrospectionFragmentMatcher`. For more information, please read [our guide to setting up fragment matching for unions & interfaces](../recipes/fragment-matching.html).
-- cacheResolvers: A map of custom ways to resolve data from other parts of the cache.
+- `addTypename`: A boolean to determine whether to add __typename to the document (default: `true`)
+- `dataIdFromObject`: A function that takes a data object and returns a unique identifier to be used when normalizing the data in the store. Learn more about how to customize `dataIdFromObject` in the [Normalization](#normalization) section.
+- `fragmentMatcher`: By default, the `InMemoryCache` uses a heuristic fragment matcher. If you are using fragments on unions and interfaces, you will need to use an `IntrospectionFragmentMatcher`. For more information, please read [our guide to setting up fragment matching for unions & interfaces](../recipes/fragment-matching.html).
+- `cacheRedirects` (previously known as `cacheResolvers` or `customResolvers`): An map of functions to redirect a query to another entry in the cache before a request takes place. This is useful if you have a list of items and want to use the data from the list query on a detail page where you're querying an individual item. More on that [here](https://www.apollographql.com/docs/react/advanced/caching.html#cacheRedirect).
 
 <h3 id="normalization">Normalization</h3>
 


### PR DESCRIPTION
The `cacheResolvers` and `customResolvers` options where changed to `cachRedirects`.

Fixes #3365.
