### PR TITLE
Correct Dangerfile to account for commits which aren't tied to a GitHub user.

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -3,8 +3,9 @@ import { includes } from 'lodash';
 import * as fs from 'fs';
 
 // Setup
-const pr = danger.github.pr;
-const commits = danger.github.commits;
+const github = danger.github;
+const pr = github.pr;
+const commits = github.commits;
 const modified = danger.git.modified_files;
 const bodyAndTitle = (pr.body + pr.title).toLowerCase();
 console.log(commits.map(({ sha }) => sha));
@@ -24,8 +25,8 @@ const modifiedAppFiles = modified
 
 // Takes a list of file paths, and converts it into clickable links
 const linkableFiles = paths => {
-  const repoURL = danger.github.pr.head.repo.html_url;
-  const ref = danger.github.pr.head.ref;
+  const repoURL = pr.head.repo.html_url;
+  const ref = pr.head.ref;
   const links = paths.map(path => {
     return createLink(`${repoURL}/blob/${ref}/${path}`, path);
   });
@@ -92,7 +93,7 @@ if (!isBot) {
   // Warn when there is a big PR
   const bigPRThreshold = 500;
   if (
-    danger.github.pr.additions + danger.github.pr.deletions >
+    github.pr.additions + github.pr.deletions >
     bigPRThreshold
   ) {
     warn(':exclamation: Big PR');

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -58,8 +58,17 @@ const raiseIssueAboutPaths = (
   }
 };
 
-const authors = commits.map(x => x.author.login);
-const isBot = authors.some(x => ['greenkeeper', 'renovate'].indexOf(x) > -1);
+console.log("GitHub PR Username:", pr && pr.user && pr.user.login);
+
+const githubBotUsernames = [
+  'greenkeeper',
+  'renovate',
+];
+
+const isBot = pr
+  && pr.user
+  && pr.user.login
+  && githubBotUsernames.includes(pr.user.login);
 
 // Rules
 if (!isBot) {


### PR DESCRIPTION
From my commit message on 5d3889cf:

---

As demonstrated in the Danger test[0] on apollographql/apollo-client#3444, the `author` property is not always set.  While it could make sense to individually look at each individual commit's "login", Git commits are not always tied to GitHub users so it seems more relevant to look at the GitHub login of the user (or bot!) opening the PR, when making decisions about whether to apply bot-only policies.

[0]: https://circleci.com/gh/apollographql/apollo-client/8427