### PR TITLE
add envinfo to ISSUE_TEMPLATE

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -25,8 +25,12 @@ If possible, please create a reproduction using https://github.com/apollographql
 Instructions for how the issue can be reproduced by a maintainer or contributor. Be as specific as possible, and only mention what is necessary to reproduce the bug. If possible, try to isolate the exact circumstances in which the bug occurs and avoid speculation over what the cause might be.
 -->
 
-**Version**
-- apollo-client@<version number>
+**Versions**
+<!--
+Run the following command in your project directory and paste its results here:
+
+`npx envinfo@latest --raw '{"System":["OS"],"Binaries":["Node","npm","Yarn"],"Browsers":["Chrome","Edge","Firefox","Safari"],"npmPackages":"*apollo*","npmGlobalPackages":"*apollo*"}`
+-->
 
 <!--**Issue Labels**
 


### PR DESCRIPTION
This PR adds envinfo to your ISSUE_TEMPLATE to get better info about a developers development environment in the process of filing an issue. This approach has already worked well for react-native, create-react-app, jest, styled-components, expo and webpack. 

With one command, issue filers will get the following to paste into the issue: 

```
  System:
    OS: macOS High Sierra 10.13
  Binaries:
    Node: 8.11.0 - ~/.nvm/versions/node/v8.11.0/bin/node
    Yarn: 1.6.0 - ~/.yarn/bin/yarn
    npm: 5.6.0 - ~/Developer/ap2-client/node_modules/.bin/npm
  Browsers:
    Chrome: 66.0.3359.181
    Firefox: 59.0.2
    Safari: 11.0
  npmPackages:
    apollo-client: ^1.4.15 => 1.9.3 
    apollo-client-preset: ^1.0.8 => 1.0.8 
    apollo-link: ^1.2.2 => 1.2.2 
    apollo-link-context: ^1.0.8 => 1.0.8 
    apollo-link-error: ^1.0.9 => 1.0.9 
    apollo-link-http: ^1.0.9 => 1.5.4 
    apollo-upload-network-interface: ^1.0.4 => 1.0.4 
    react-apollo: ^2.1.4 => 2.1.4 
```

of course, envinfo can provide more or less info, depending on what you need, and once you decide what you want, an official preset can be pushed to envinfo to make the command more succinct, like this: `npx envinfo@latest --preset apollo`

/label issue template
