### PR TITLE
Change name of deprecated package babel-plugin-inline-import-graphql-ast

### DIFF
--- a/docs/source/recipes/babel.md
+++ b/docs/source/recipes/babel.md
@@ -9,7 +9,7 @@ To avoid this runtime overhead, you can precompile your queries created with `gr
 1. Using [babel-plugin-graphql-tag](#using-babel-plugin-graphql-tag)
 2. Using [graphql-tag.macro](#using-graphql-tagmacro)
 
-If you prefer to keep your GraphQL code in separate files (`.graphql` or `.gql`) you can use [babel-plugin-inline-import-graphql-ast](https://github.com/detrohutt/babel-plugin-inline-import-graphql-ast). This plugin still uses `graphql-tag` under the hood, but transparently. You simply `import` your operations/fragments as if each were an export from your GraphQL file. This carries the same precompilation benefits as the above approaches.
+If you prefer to keep your GraphQL code in separate files (`.graphql` or `.gql`) you can use [babel-plugin-import-graphql](https://github.com/detrohutt/babel-plugin-import-graphql). This plugin still uses `graphql-tag` under the hood, but transparently. You simply `import` your operations/fragments as if each were an export from your GraphQL file. This carries the same precompilation benefits as the above approaches.
 
 ## Using babel-plugin-graphql-tag
 
@@ -77,10 +77,10 @@ Install the plugin in your dev dependencies:
 
 ```
 # with npm
-npm install --save-dev babel-plugin-inline-import-graphql-ast
+npm install --save-dev babel-plugin-import-graphql
 
 # or with yarn
-yarn add --dev babel-plugin-inline-import-graphql-ast
+yarn add --dev babel-plugin-import-graphql
 ```
 
 Then add the plugin in your `.babelrc` configuration file:
@@ -114,7 +114,7 @@ export default graphql(myImportedQuery)(QueryingComponent);
 
 ## Fragments
 
-All of these approaches support the use of fragments. 
+All of these approaches support the use of fragments.
 
 For the first two approaches, you can have fragments defined in a different call to `gql` (either in the same file or in a different one). You can then include them into the main query using interpolation, like this:
 
@@ -143,4 +143,4 @@ const query = gql`
 `;
 ```
 
-With `babel-plugin-inline-import-graphql-ast`, you can just include your fragment in your GraphQL file along-side whatever uses it, or even import it from a separate file using the GraphQL `#import` syntax. See the [README](https://github.com/detrohutt/babel-plugin-inline-import-graphql-ast) for more information.
+With `babel-plugin-import-graphql`, you can just include your fragment in your GraphQL file along-side whatever uses it, or even import it from a separate file using the GraphQL `#import` syntax. See the [README](https://github.com/detrohutt/babel-plugin-import-graphql) for more information.

--- a/docs/source/recipes/webpack.md
+++ b/docs/source/recipes/webpack.md
@@ -55,7 +55,7 @@ export default graphql(currentUserQuery)(Profile)
 
 ## React native
 
-[React native](https://facebook.github.io/react-native/) can't use the Webpack loaders. To make the same transformation work in React native, use [babel-plugin-inline-import-graphql-ast](https://github.com/detrohutt/babel-plugin-inline-import-graphql-ast).
+[React native](https://facebook.github.io/react-native/) can't use the Webpack loaders. To make the same transformation work in React native, use [babel-plugin-import-graphql](https://github.com/detrohutt/babel-plugin-import-graphql).
 
 ## Create-React-App
 


### PR DESCRIPTION
Hi, I'm going to be doing an official release of my package soon and I hated the name so I changed it lol. I've updated all of the occurrences in the docs to the new name and fixed the links.

Note I'm leaving the original repo intact. So the links won't be broken without this PR, but I've deprecated the package on NPM. Users installing the old package will get a warning asking them to switch to `babel-plugin-import-graphql`.
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->