### PR TITLE
Remove `rxjs-compat` use

### DIFF
--- a/packages/apollo-client/package.json
+++ b/packages/apollo-client/package.json
@@ -79,7 +79,6 @@
     "lodash": "4.17.10",
     "rollup": "0.59.4",
     "rxjs": "6.2.0",
-    "rxjs-compat": "^6.2.0",
     "ts-jest": "20.0.14",
     "tslint": "5.10.0",
     "typescript": "2.8.3",

--- a/packages/apollo-client/src/core/__tests__/QueryManager/index.ts
+++ b/packages/apollo-client/src/core/__tests__/QueryManager/index.ts
@@ -1,5 +1,5 @@
 // externals
-import { from } from 'rxjs/observable/from';
+import { from } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { assign } from 'lodash';
 import gql from 'graphql-tag';


### PR DESCRIPTION
While merging in https://github.com/apollographql/apollo-client/pull/3500 we encountered `rxjs` `from` issues in some of the tests. I added `rxjs-compat` to work around these issues, but this shouldn't be needed. This commit aims to revert the `rxjs-compat` changes, to see if the CI gods will now be appeased.
