### PR TITLE
CHANGELOG updates for all packages

### DIFF
--- a/packages/apollo-boost/CHANGELOG.md
+++ b/packages/apollo-boost/CHANGELOG.md
@@ -1,42 +1,6 @@
-# Change log
+# CHANGELOG
 
-### vNext
+### 0.1.7
 
-## 1.1.4
-- Map coverage to original source
-- fix request parameter type [#3056](https://github.com/apollographql/apollo-client/pull/3056)
-
-### 0.1.0
-- DEPRECATED: `apollo-client-preset`
-- Changed to `apollo-boost` [#2965](https://github.com/apollographql/apollo-client/pull/2965)
-
-### 1.0.9 (last `apollo-client-preset` version)
-- Apollo Client 2.2.3
-
-### 1.0.8
-- Apollo Client 2.2.2
-
-### 1.0.7 (unpublished)
-- Apollo Client 2.2.1
-
-### 1.0.6
-- Apollo Client 2.2.0
-
-### 1.0.5
-- Apollo Client 2.1.1
-
-### 1.0.4
-- Apollo Client 2.1.0
-
-### 1.0.3
-- Apollo Client 2.0.3
-- improved rollup builds
-
-### 1.0.2
-- Apollo Client 2.0.2
-
-### 1.0.1
-- Apollo Client 2.0.1
-
-### 1.0.0
-- Apollo Client 2.0
+- No public facing functionality changes.
+- Various internal code cleanup, tooling and dependency changes.

--- a/packages/apollo-cache-inmemory/CHANGELOG.md
+++ b/packages/apollo-cache-inmemory/CHANGELOG.md
@@ -1,69 +1,118 @@
-# Change log
+# CHANGELOG
 
-### Next
+### 1.2.2
 
 - Fixed an issue that caused fragment only queries to sometimes fail.
   [Issue #3402](https://github.com/apollographql/apollo-client/issues/3402)
   [PR #3507](https://github.com/apollographql/apollo-client/pull/3507)  
-- Fixed cache invalidation for inlined mixed types in union fields within arrays.
+- Fixed cache invalidation for inlined mixed types in union fields within
+  arrays.
   [PR #3422](https://github.com/apollographql/apollo-client/pull/3422)
 
+### 1.2.1
+
+- Not documented
+
 ### 1.2.0
-- Various optimizations for cache read performance [#3300](https://github.com/apollographql/apollo-client/pull/3300)
+
+- Various optimizations for cache read performance
+  [PR #3300](https://github.com/apollographql/apollo-client/pull/3300)
 - Fix typo in documentation
 
 ### 1.1.12
-- Fix an edge case where fields that were unions of two types, one with an `id`,
-one without an `id`, would cause the cache to throw while saving the result [#3159](https://github.com/apollographql/apollo-client/pull/3159)
+
+- Fix an edge case where fields that were unions of two types, one with an
+  `id`, one without an `id`, would cause the cache to throw while saving the
+  result
+  [PR #3159](https://github.com/apollographql/apollo-client/pull/3159)
 - Map coverage to original source
-- Fixed bug with cacheRedirects not getting attached [#3016](https://github.com/apollographql/apollo-client/pull/3016)
+- Fixed bug with cacheRedirects not getting attached
+  [PR #3016](https://github.com/apollographql/apollo-client/pull/3016)
 
 ### 1.1.9
-- Added `getCacheKey` function to cacheResolver context [#2998](https://github.com/apollographql/apollo-client/pull/2998)
-- Changed `cacheResolvers` to `cacheRedirects`, added deprecation warning [#3001](https://github.com/apollographql/apollo-client/pull/3001)
+
+- Added `getCacheKey` function to cacheResolver context
+  [PR #2998](https://github.com/apollographql/apollo-client/pull/2998)
+- Changed `cacheResolvers` to `cacheRedirects`, added deprecation warning
+  [PR #3001](https://github.com/apollographql/apollo-client/pull/3001)
 
 ### 1.1.8
-- dependency updates
-- Fix IntrospectionResultData type definition [#2959](https://github.com/apollographql/apollo-client/issues/2959)
+
+- Dependency updates
+- Fix IntrospectionResultData type definition
+  [Issue #2959](https://github.com/apollographql/apollo-client/issues/2959)
 
 ### 1.1.7
-- update to latest apollo-utilities to support directives in cache
+
+- Update to latest apollo-utilities to support directives in cache
 
 ### 1.1.6 (unpublished)
-- update to latest apollo-utilities
+
+- Update to latest apollo-utilities
 
 ### 1.1.5
-- Update to latest apollo-cache base [#2818](https://github.com/apollographql/apollo-client/pull/2818)
+
+- Update to latest apollo-cache base
+  [PR #2818](https://github.com/apollographql/apollo-client/pull/2818)
 
 ### 1.1.4
-- Change access modifier for data from "private" to "protected", to allow InMemoryCache subclasses to access it.
+
+- Change access modifier for data from "private" to "protected", to allow
+  InMemoryCache subclasses to access it.
 
 ### 1.1.3
-- improves performance of in memory cache
+
+- Improves performance of in memory cache
 
 ### 1.1.2
-- Ensure that heuristics warnings do not fire in production [#2611](https://github.com/apollographql/apollo-client/pull/2611)
+
+- Ensure that heuristics warnings do not fire in production
+  [PR #2611](https://github.com/apollographql/apollo-client/pull/2611)
 
 ### 1.1.1
-- Change some access modifiers "private" to "protected" to allow code reuse by InMemoryCache subclasses.
-- improved rollup builds
+
+- Change some access modifiers "private" to "protected" to allow code reuse by
+  InMemoryCache subclasses.
+- Improved rollup builds
 
 ### 1.1.0
-- improve errors for id mismatch when writing to the store
-- make it possible to swap the cache implementation. For example, you might want to use a `Map` to store the normalized objects, which can be faster than writing by keys to an `Object`. This also allows for custom use cases, such as emitting events on `.set()` or `.delete()` (think Observables), which was otherwise impossible without the use of Proxies, that are only available in some browsers. Unless you passed in the `store` to one of the `apollo-cache-inmemory` functions, such as: `writeQueryToStore` or `writeResultToStore`, no changes to your code are necessary. If you did access the cache's functions directly, all you need to do is add a `.toObject()` call on the cache — review the changes to the tests for [an example](https://github.com/apollographql/apollo-client/blob/cd563bcd1c2c15b973d0cdfd63332f5ee82da309/packages/apollo-cache-inmemory/src/__tests__/writeToStore.ts#L258). For reasoning behind this change and more information, see [Issue #2293](https://github.com/apollographql/apollo-client/issues/2293).
+
+- Improve errors for id mismatch when writing to the store
+- Make it possible to swap the cache implementation. For example, you might
+  want to use a `Map` to store the normalized objects, which can be faster
+  than writing by keys to an `Object`. This also allows for custom use cases,
+  such as emitting events on `.set()` or `.delete()` (think Observables),
+  which was otherwise impossible without the use of Proxies, that are only
+  available in some browsers. Unless you passed in the `store` to one of the
+  `apollo-cache-inmemory` functions, such as: `writeQueryToStore` or
+  `writeResultToStore`, no changes to your code are necessary. If you did
+  access the cache's functions directly, all you need to do is add a
+  `.toObject()` call on the cache — review the changes to the tests for [an example](https://github.com/apollographql/apollo-client/blob/cd563bcd1c2c15b973d0cdfd63332f5ee82da309/packages/apollo-cache-inmemory/src/__tests__/writeToStore.ts#L258).
+  For reasoning behind this change and more information, see
+  [Issue #2293](https://github.com/apollographql/apollo-client/issues/2293).
 
 ### 1.0.0
-- Don't broadcast query watchers during a transaction (for example, while mutation results are being processed) [Issue #2221](https://github.com/apollographql/apollo-client/issues/2221) [PR #2358](https://github.com/apollographql/apollo-client/pull/2358)
-- `readQuery` and `readFragment` return now the result instead of `Cache.DiffResult` [PR #2320](https://github.com/apollographql/apollo-client/pull/2320)
+
+- Don't broadcast query watchers during a transaction (for example, while
+  mutation results are being processed)
+  [Issue #2221](https://github.com/apollographql/apollo-client/issues/2221)
+  [PR #2358](https://github.com/apollographql/apollo-client/pull/2358)
+- `readQuery` and `readFragment` return now the result instead of
+  `Cache.DiffResult`
+  [PR #2320](https://github.com/apollographql/apollo-client/pull/2320)
 
 ### 0.2.0-rc.1
-- move to named export to be consistent with rest of apollo ecosystem
+
+- Move to named export to be consistent with rest of apollo ecosystem
 
 ### 0.2.0-beta.6
-- rename customResolvers to cacheResolvers with backwards compat
+
+- Rename customResolvers to cacheResolvers with backwards compat
 
 ### 0.2.0-beta.5 and lower
-- Fix error when missing __typename field in result [PR #2225](https://github.com/apollographql/apollo-client/pull/2225)
+
+- Fix error when missing __typename field in result
+  [PR #2225](https://github.com/apollographql/apollo-client/pull/2225)
 - Refactored type usage
 - Prevented logging on defered queries
 - Refactored internal store from apollo-client into own package

--- a/packages/apollo-cache/CHANGELOG.md
+++ b/packages/apollo-cache/CHANGELOG.md
@@ -1,30 +1,52 @@
+# CHANGELOG
 
-### vNext
+### 1.1.9
 
-## 1.1.6
+- No public facing functionality changes.
+- Various internal code cleanup, tooling and dependency changes.
+
+### 1.1.8
+
+- Not documented
+
+### 1.1.7
+
+- Not documented
+
+### 1.1.6
+
 - Improve code coverage
 - Map coverage to original source
 
 ### 1.1.3
-- dependency updates
+
+- Dependency updates
 
 ### 1.1.2
-- dependency updates
+
+- Dependency updates
 
 ### 1.1.1
-- dependency updates
+
+- Dependency updates
 
 ### 1.1.0
-- Add cache.writeData to base cache type & DataProxy [PR#2818](https://github.com/apollographql/apollo-client/pull/2818)
+
+- Add cache.writeData to base cache type & DataProxy
+  [PR #2818](https://github.com/apollographql/apollo-client/pull/2818)
 
 ### 1.0.3
-- dependency updates
+
+- Dependency updates
 
 ### 1.0.2
-- package dependency updates
+
+- Package dependency updates
 
 ### 1.0.1
-- improved rollup builds
+
+- Improved rollup builds
 
 ### 1.0.0
-- initial solid cache API
+
+- Initial solid cache API

--- a/packages/apollo-client/CHANGELOG.md
+++ b/packages/apollo-client/CHANGELOG.md
@@ -1,7 +1,10 @@
-# Change log
+# CHANGELOG
 
-### vNext
+### 2.3.2
 
+- Fix SSR and `cache-and-network` fetch policy
+  [Issue #2119](https://github.com/apollographql/apollo-client/issues/2119)
+  [PR #3372](https://github.com/apollographql/apollo-client/pull/3372)
 - Fixed an issue where the `updateQuery` method passed to
   `ObservableQuery.fetchMore` was receiving the original query variables,
   instead of the new variables that it used to fetch more data.
@@ -21,10 +24,13 @@
   [PR #3367](https://github.com/apollographql/apollo-client/pull/3367)
   [PR #3469](https://github.com/apollographql/apollo-client/pull/3469)
 
+### 2.3.1
+
+- Not documented
+
 ### 2.3.0
 - fixed edge case bug of changing fetchPolicies right after resetStore with no variables present
 - Various optimizations for cache read performance [#3300](https://github.com/apollographql/apollo-client/pull/3300)
-- Fix SSR and `cache-and-network` fetch policy [#3372](https://github.com/apollographql/apollo-client/pull/3372)
 
 ### 2.2.8
 - Added the graphQLResultHasError in QueryManager.ts to check not only if result.errors is null, but also empty.

--- a/packages/apollo-utilities/CHANGELOG.md
+++ b/packages/apollo-utilities/CHANGELOG.md
@@ -1,51 +1,78 @@
-# Change log
+# CHANGELOG
 
-### vNext
+### 1.0.13
 
-- Make `maybeDeepFreeze` a little more defensive, by always using `Object.prototype.hasOwnProperty` (to avoid cases where the object being frozen doesn't have its own `hasOwnProperty`).
+- Make `maybeDeepFreeze` a little more defensive, by always using
+  `Object.prototype.hasOwnProperty` (to avoid cases where the object being
+  frozen doesn't have its own `hasOwnProperty`).
   [Issue #3426](https://github.com/apollographql/apollo-client/issues/3426)
   [PR #3418](https://github.com/apollographql/apollo-client/pull/3418)
-
 - Remove certain small internal caches to prevent memory leaks when using SSR.
   [PR #3444](https://github.com/apollographql/apollo-client/pull/3444)
 
+### 1.0.12
+
+- Not documented
+
 ### 1.0.11
-- `toIdValue` helper now takes an object with `id` and `typename` properties as the preferred interface [PR#3159](https://github.com/apollographql/apollo-client/pull/3159)
+
+- `toIdValue` helper now takes an object with `id` and `typename` properties
+  as the preferred interface
+  [PR #3159](https://github.com/apollographql/apollo-client/pull/3159)
 - Map coverage to original source
-- Don't `deepFreeze` in development/test environments if ES6 symbols are polyfilled [PR#3082](https://github.com/apollographql/apollo-client/pull/3082)
-- Added ability to include or ignore fragments in `getDirectivesFromDocument` [PR#3010](https://github.com/apollographql/apollo-client/pull/3010)
+- Don't `deepFreeze` in development/test environments if ES6 symbols are
+  polyfilled
+  [PR #3082](https://github.com/apollographql/apollo-client/pull/3082)
+- Added ability to include or ignore fragments in `getDirectivesFromDocument`
+  [PR #3010](https://github.com/apollographql/apollo-client/pull/3010)
 
 ### 1.0.9
-- dependency updates
+
+- Dependency updates
 - Added getDirectivesFromDocument utility function
-[PR#2974](https://github.com/apollographql/apollo-client/pull/2974)
+  [PR #2974](https://github.com/apollographql/apollo-client/pull/2974)
 
 ### 1.0.8
-- Add client, rest, and export directives to list of known directives [PR#2949](https://github.com/apollographql/apollo-client/pull/2949)
+
+- Add client, rest, and export directives to list of known directives
+  [PR #2949](https://github.com/apollographql/apollo-client/pull/2949)
 
 ### 1.0.7
-- Fix typo in error message for invalid argument being passed to @skip or @include directives [PR#2867](https://github.com/apollographql/apollo-client/pull/2867)
+
+- Fix typo in error message for invalid argument being passed to @skip or
+  @include directives
+  [PR #2867](https://github.com/apollographql/apollo-client/pull/2867)
 
 ### 1.0.6
-- update `getStoreKeyName` to support custom directives
+
+- Update `getStoreKeyName` to support custom directives
 
 ### 1.0.5
-- package dependency updates
+
+- Package dependency updates
 
 ### 1.0.4
-- package dependency updates
+
+- Package dependency updates
 
 ### 1.0.3
-- package dependency updates
+
+- Package dependency updates
 
 ### 1.0.2
-- improved rollup builds
+
+- Improved rollup builds
 
 ### 1.0.1
+
 - Added config to remove selection set of directive matches test
 
 ### 1.0.0
+
 - Added utilities from hermes cache
-- Added removeDirectivesFromDocument to allow cleaning of client only directives
-- Added hasDirectives to recurse the AST and return a boolean for an array of directive names
-- Improved performance of common store actions by memoizing addTypename and removeConnectionDirective
+- Added removeDirectivesFromDocument to allow cleaning of client only
+  directives
+- Added hasDirectives to recurse the AST and return a boolean for an array of
+  directive names
+- Improved performance of common store actions by memoizing addTypename and
+  removeConnectionDirective

--- a/packages/graphql-anywhere/CHANGELOG.md
+++ b/packages/graphql-anywhere/CHANGELOG.md
@@ -1,6 +1,6 @@
-# Change log
+# CHANGELOG
 
-### vNext
+### 4.1.11
 
 - Source files are now excluded when publishing to npm.
   [Issue #2806](https://github.com/apollographql/apollo-client/issues/2806)


### PR DESCRIPTION
`CHANGELOG` updates for each package (prepping for release). This also includes some random cleanup, to get the `CHANGELOG`'s into a more uniform format. This cleanup will be taken further in the future. 