### PR TITLE
chore(deps): update dependency `meteor-theme-hexo` to v1.0.13.

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
     "hexo-renderer-marked": "0.3.2",
     "hexo-server": "0.3.2",
     "hexo-typescript-api-box": "0.9.1",
-    "meteor-theme-hexo": "1.0.10",
+    "meteor-theme-hexo": "1.0.13",
     "typedoc": "0.9.0",
     "typescript": "2.8.3"
   },


### PR DESCRIPTION
Manually, without Renovate because we're outside normal Renovate hours for this repository.