### PR TITLE
Add optional generics to cache manipulation methods

### DIFF
--- a/packages/apollo-cache-inmemory/CHANGELOG.md
+++ b/packages/apollo-cache-inmemory/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+### vNext
+
+- Added optional generics to cache manipulation methods (typescript).
+  [PR #3541](https://github.com/apollographql/apollo-client/pull/3541)
+
 ### 1.2.2
 
 - Fixed an issue that caused fragment only queries to sometimes fail.

--- a/packages/apollo-cache-inmemory/src/inMemoryCache.ts
+++ b/packages/apollo-cache-inmemory/src/inMemoryCache.ts
@@ -208,8 +208,8 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     return document;
   }
 
-  public readQuery<QueryType>(
-    options: DataProxy.Query,
+  public readQuery<QueryType, TVariables = any>(
+    options: DataProxy.Query<TVariables>,
     optimistic: boolean = false,
   ): QueryType {
     return this.read({
@@ -219,8 +219,8 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     });
   }
 
-  public readFragment<FragmentType>(
-    options: DataProxy.Fragment,
+  public readFragment<FragmentType, TVariables = any>(
+    options: DataProxy.Fragment<TVariables>,
     optimistic: boolean = false,
   ): FragmentType | null {
     return this.read({
@@ -233,7 +233,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     });
   }
 
-  public writeQuery(options: DataProxy.WriteQueryOptions): void {
+  public writeQuery<TData = any, TVariables = any>(options: DataProxy.WriteQueryOptions<TData, TVariables>): void {
     this.write({
       dataId: 'ROOT_QUERY',
       result: options.data,
@@ -242,7 +242,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     });
   }
 
-  public writeFragment(options: DataProxy.WriteFragmentOptions): void {
+  public writeFragment<TData = any, TVariables = any>(options: DataProxy.WriteFragmentOptions<TData, TVariables>): void {
     this.write({
       dataId: options.id,
       result: options.data,

--- a/packages/apollo-cache/CHANGELOG.md
+++ b/packages/apollo-cache/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+### vNext
+
+- Added optional generics to cache manipulation methods (typescript).
+  [PR #3541](https://github.com/apollographql/apollo-client/pull/3541)
+
 ### 1.1.9
 
 - No public facing functionality changes.

--- a/packages/apollo-cache/src/types/Cache.ts
+++ b/packages/apollo-cache/src/types/Cache.ts
@@ -6,15 +6,15 @@ export namespace Cache {
     success: Boolean;
   }
 
-  export interface ReadOptions extends DataProxy.Query {
+  export interface ReadOptions<TVariables = any> extends DataProxy.Query<TVariables> {
     rootId?: string;
     previousResult?: any;
     optimistic: boolean;
   }
 
-  export interface WriteOptions extends DataProxy.Query {
+  export interface WriteOptions<TResult = any, TVariables = any> extends DataProxy.Query<TVariables> {
     dataId: string;
-    result: any;
+    result: TResult;
   }
 
   export interface DiffOptions extends ReadOptions {
@@ -25,7 +25,7 @@ export namespace Cache {
     callback: WatchCallback;
   }
 
-  export interface EvictOptions extends DataProxy.Query {
+  export interface EvictOptions<TVariables = any> extends DataProxy.Query<TVariables> {
     rootId?: string;
   }
 

--- a/packages/apollo-cache/src/types/DataProxy.ts
+++ b/packages/apollo-cache/src/types/DataProxy.ts
@@ -1,7 +1,7 @@
 import { DocumentNode } from 'graphql'; // eslint-disable-line import/no-extraneous-dependencies, import/no-unresolved
 
 export namespace DataProxy {
-  export interface Query {
+  export interface Query<TVariables> {
     /**
      * The GraphQL query shape to be used constructed using the `gql` template
      * string tag from `graphql-tag`. The query will be used to determine the
@@ -12,10 +12,10 @@ export namespace DataProxy {
     /**
      * Any variables that the GraphQL query may depend on.
      */
-    variables?: any;
+    variables?: TVariables;
   }
 
-  export interface Fragment {
+  export interface Fragment<TVariables> {
     /**
      * The root id to be used. This id should take the same form as the
      * value returned by your `dataIdFromObject` function. If a value with your
@@ -41,30 +41,30 @@ export namespace DataProxy {
     /**
      * Any variables that your GraphQL fragments depend on.
      */
-    variables?: any;
+    variables?: TVariables;
   }
 
-  export interface WriteQueryOptions extends Query {
+  export interface WriteQueryOptions<TData, TVariables> extends Query<TVariables> {
     /**
      * The data you will be writing to the store.
      */
-    data: any;
+    data: TData;
   }
 
-  export interface WriteFragmentOptions extends Fragment {
+  export interface WriteFragmentOptions<TData, TVariables> extends Fragment<TVariables> {
     /**
      * The data you will be writing to the store.
      */
-    data: any;
+    data: TData;
   }
 
-  export interface WriteDataOptions {
+  export interface WriteDataOptions<TData> {
     /**
      * The data you will be writing to the store.
      * It also takes an optional id property.
      * The id is used to write a fragment to an existing object in the store.
      */
-    data: any;
+    data: TData;
     id?: string;
   }
 
@@ -84,8 +84,8 @@ export interface DataProxy {
   /**
    * Reads a GraphQL query from the root query id.
    */
-  readQuery<QueryType>(
-    options: DataProxy.Query,
+  readQuery<QueryType, TVariables = any>(
+    options: DataProxy.Query<TVariables>,
     optimistic?: boolean,
   ): QueryType | null;
 
@@ -94,22 +94,22 @@ export interface DataProxy {
    * one fragments in the provided document then a `fragmentName` must be
    * provided to select the correct fragment.
    */
-  readFragment<FragmentType>(
-    options: DataProxy.Fragment,
+  readFragment<FragmentType, TVariables = any>(
+    options: DataProxy.Fragment<TVariables>,
     optimistic?: boolean,
   ): FragmentType | null;
 
   /**
    * Writes a GraphQL query to the root query id.
    */
-  writeQuery(options: DataProxy.WriteQueryOptions): void;
+  writeQuery<TData = any, TVariables = any>(options: DataProxy.WriteQueryOptions<TData, TVariables>): void;
 
   /**
    * Writes a GraphQL fragment to any arbitrary id. If there are more then
    * one fragments in the provided document then a `fragmentName` must be
    * provided to select the correct fragment.
    */
-  writeFragment(options: DataProxy.WriteFragmentOptions): void;
+  writeFragment<TData = any, TVariables = any>(options: DataProxy.WriteFragmentOptions<TData, TVariables>): void;
 
   /**
    * Sugar for writeQuery & writeFragment.
@@ -117,5 +117,5 @@ export interface DataProxy {
    * If you supply an id, the data will be written as a fragment to an existing object.
    * Otherwise, the data is written to the root of the store.
    */
-  writeData(options: DataProxy.WriteDataOptions): void;
+  writeData<TData = any>(options: DataProxy.WriteDataOptions<TData>): void;
 }

--- a/packages/apollo-client/CHANGELOG.md
+++ b/packages/apollo-client/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Typescript improvements. Made observable query parameterized on data and
   variables: `ObservableQuery<TData, TVariables>`
   [PR#3140](https://github.com/apollographql/apollo-client/pull/3140)
+- Added optional generics to cache manipulation methods (typescript).
+  [PR #3541](https://github.com/apollographql/apollo-client/pull/3541)
 
 ### 2.3.2
 

--- a/packages/apollo-client/src/ApolloClient.ts
+++ b/packages/apollo-client/src/ApolloClient.ts
@@ -283,7 +283,7 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
    * the root query. To start at a specific id returned by `dataIdFromObject`
    * use `readFragment`.
    */
-  public readQuery<T>(options: DataProxy.Query): T | null {
+  public readQuery<T, TVariables = any>(options: DataProxy.Query<TVariables>): T | null {
     return this.initProxy().readQuery<T>(options);
   }
 
@@ -298,7 +298,7 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
    * in a document with multiple fragments then you must also specify a
    * `fragmentName`.
    */
-  public readFragment<T>(options: DataProxy.Fragment): T | null {
+  public readFragment<T, TVariables = any>(options: DataProxy.Fragment<TVariables>): T | null {
     return this.initProxy().readFragment<T>(options);
   }
 
@@ -307,7 +307,7 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
    * the store. This method will start at the root query. To start at a a
    * specific id returned by `dataIdFromObject` then use `writeFragment`.
    */
-  public writeQuery(options: DataProxy.WriteQueryOptions): void {
+  public writeQuery<TData = any, TVariables = any>(options: DataProxy.WriteQueryOptions<TData, TVariables>): void {
     const result = this.initProxy().writeQuery(options);
     this.queryManager.broadcastQueries();
     return result;
@@ -324,7 +324,7 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
    * in a document with multiple fragments then you must also specify a
    * `fragmentName`.
    */
-  public writeFragment(options: DataProxy.WriteFragmentOptions): void {
+  public writeFragment<TData = any, TVariables = any>(options: DataProxy.WriteFragmentOptions<TData, TVariables>): void {
     const result = this.initProxy().writeFragment(options);
     this.queryManager.broadcastQueries();
     return result;
@@ -340,7 +340,7 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
    * Since you aren't passing in a query to check the shape of the data,
    * you must pass in an object that conforms to the shape of valid GraphQL data.
    */
-  public writeData(options: DataProxy.WriteDataOptions): void {
+  public writeData<TData = any>(options: DataProxy.WriteDataOptions<TData>): void {
     const result = this.initProxy().writeData(options);
     this.queryManager.broadcastQueries();
     return result;


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

This sort of falls outside of all of the checklist items above, so I checked them.

Currently, when using the read/write methods on the cache, it is very easy to make mistakes, by simply misspelling a variable for example.
This PR adds optional generic arguments to methods used to manipulate the cache.
I've made sure to add a default for all of the new generic arguments, so it should not break anything.