### PR TITLE
Remove @beta tag from apollo-boost install instruction

### DIFF
--- a/packages/apollo-boost/README.md
+++ b/packages/apollo-boost/README.md
@@ -5,10 +5,10 @@ Apollo Boost is a zero-config way to start using Apollo Client. It includes some
 
 ## Quick start
 
-First, install `apollo-boost`. If you don't have `graphql` & `react-apollo@beta` already in your project, please install those too.
+First, install `apollo-boost`. If you don't have `graphql` & `react-apollo` already in your project, please install those too.
 
 ```shell
-npm i apollo-boost graphql react-apollo@beta -S
+npm i apollo-boost graphql react-apollo -S
 ```
 
 Next, create your client. Once you create your client, hook it up to your app by passing it to the `ApolloProvider` exported from `react-apollo`.


### PR DESCRIPTION
This keeps these docs consistent with the [docs website](https://www.apollographql.com/docs/react/essentials/get-started.html#installation), which might help with people reading on npmjs.