### PR TITLE
Restore non-enumerability of resultFields[ID_KEY].

### DIFF
--- a/packages/apollo-cache-inmemory/CHANGELOG.md
+++ b/packages/apollo-cache-inmemory/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Added optional generics to cache manipulation methods (typescript).
   [PR #3541](https://github.com/apollographql/apollo-client/pull/3541)
 
+- Restore non-enumerability of `resultFields[ID_KEY]`.
+  [PR #3544](https://github.com/apollographql/apollo-client/pull/3544)
+
 ### 1.2.2
 
 - Fixed an issue that caused fragment only queries to sometimes fail.

--- a/packages/apollo-cache-inmemory/src/readFromStore.ts
+++ b/packages/apollo-cache-inmemory/src/readFromStore.ts
@@ -315,7 +315,12 @@ function resultMapper(resultFields: any, idValue: IdValueWithPreviousResult) {
     }
   }
 
-  resultFields[ID_KEY] = idValue.id;
+  Object.defineProperty(resultFields, ID_KEY, {
+    enumerable: false,
+    configurable: true,
+    writable: false,
+    value: idValue.id,
+  });
 
   return resultFields;
 }


### PR DESCRIPTION
The change to create a simple property rather than using `Object.defineProperty` was originally made in the interest of performance, but it seems to be causing problems for some users: https://github.com/apollographql/apollo-client/pull/3300#issuecomment-393252909