### PR TITLE
Avoid needless hasOwnProperty check in deepFreeze.

### DIFF
--- a/packages/apollo-utilities/CHANGELOG.md
+++ b/packages/apollo-utilities/CHANGELOG.md
@@ -9,6 +9,9 @@
   `{ prop2: 'value2', prop1: 'value1' }`.
   [PR #2869](https://github.com/apollographql/apollo-client/pull/2869)
 
+- Avoid needless `hasOwnProperty` check in `deepFreeze`.
+  [PR #3545](https://github.com/apollographql/apollo-client/pull/3545)
+
 ### 1.0.13
 
 - Make `maybeDeepFreeze` a little more defensive, by always using

--- a/packages/apollo-utilities/src/util/maybeDeepFreeze.ts
+++ b/packages/apollo-utilities/src/util/maybeDeepFreeze.ts
@@ -5,11 +5,8 @@ import { isDevelopment, isTest } from './environment';
 function deepFreeze(o: any) {
   Object.freeze(o);
 
-  const hasOwn = Object.prototype.hasOwnProperty;
-
   Object.getOwnPropertyNames(o).forEach(function(prop) {
     if (
-      hasOwn.call(o, prop) &&
       o[prop] !== null &&
       (typeof o[prop] === 'object' || typeof o[prop] === 'function') &&
       !Object.isFrozen(o[prop])


### PR DESCRIPTION
The "own" in `getOwnPropertyNames` ensures that all the names would pass the `hasOwnProperty` test.

Regarding [this comment](https://github.com/apollographql/apollo-client/pull/3300#issuecomment-390529032) by @jamesreggio, I would much rather patch `apollo-utilities` than revert the use of `Object.create(null)`, since empty prototype-free objects never accidentally appear to have properties inherited from `Object.prototype` (a correctness concern), and lookups of missing properties are faster since there's no prototype chain. Far from being deficient, `Object.create(null)` objects are what empty objects should always have been in JavaScript.