### PR TITLE
Highlight the switch to apollo-client

### DIFF
--- a/docs/source/recipes/authentication.md
+++ b/docs/source/recipes/authentication.md
@@ -65,6 +65,8 @@ const client = new ApolloClient({
 });
 ```
 
+Note that you'll need to switch to using ApolloClient from `apollo-client`, not `apollo-boost` if you haven't already done so, [as documented here](/docs/react/advanced/boost-migration.html).
+
 The server can use that header to authenticate the user and attach it to the GraphQL execution context, so resolvers can modify their behavior based on a user's role and permissions.
 
 <h2 id="login-logout">Reset store on logout</h2>

--- a/docs/source/recipes/authentication.md
+++ b/docs/source/recipes/authentication.md
@@ -8,7 +8,7 @@ Apollo Client uses the ultra flexible [Apollo Link](/docs/link) that includes se
 
 ## Cookie
 
-If your app is browser based and you are using cookies for login and session management with a backend, it's very easy to tell your network interface to send the cookie along with every request. You just need to pass the credentials option. e.g.  `credentials: 'same-origin'` as shown below, if your backend server is the same domain or else `credentials: 'include'` if your backend is a different domain. 
+If your app is browser based and you are using cookies for login and session management with a backend, it's very easy to tell your network interface to send the cookie along with every request. You just need to pass the credentials option. e.g.  `credentials: 'same-origin'` as shown below, if your backend server is the same domain or else `credentials: 'include'` if your backend is a different domain.
 
 ```js
 const link = createHttpLink({
@@ -24,7 +24,7 @@ const client = new ApolloClient({
 
 This option is simply passed through to the [`fetch` implementation](https://github.com/github/fetch) used by the HttpLink when sending the query.
 
-Note: the backend must also allow credentials from the requested origin. e.g. if using the popular 'cors' package from npm in node.js, the following settings would work in tandem with the above apollo client settings, 
+Note: the backend must also allow credentials from the requested origin. e.g. if using the popular 'cors' package from npm in node.js, the following settings would work in tandem with the above apollo client settings,
 ```js
 // enable cors
 var corsOptions = {
@@ -65,7 +65,7 @@ const client = new ApolloClient({
 });
 ```
 
-Note that you'll need to switch to using ApolloClient from `apollo-client`, not `apollo-boost` if you haven't already done so, [as documented here](/docs/react/advanced/boost-migration.html).
+Note that the above example is using `ApolloClient` from the `apollo-client` package. Headers can still be modified using `ApolloClient` from the `apollo-boost` package, but since `apollo-boost` doesn't allow the `HttpLink` instance it uses to be modified, headers have to be passed in as a config parameter. See the Apollo Boost [Configuration options](../essentials/get-started.html#configuration) section for more details.
 
 The server can use that header to authenticate the user and attach it to the GraphQL execution context, so resolvers can modify their behavior based on a user's role and permissions.
 


### PR DESCRIPTION
Users who have followed the getting started guide are likely still using Apollo Boost which doesn't support adding custom links. Switching to the proper ApolloClient is necessary to get the header authorization working (and cookie auth only works because the Apollo Boost defaults include `credentials: 'same-origin'` already.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->