### PR TITLE
Avoid null broadcastQueries in react

### DIFF
--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -1023,7 +1023,7 @@ export class QueryManager<TStore> {
   public broadcastQueries() {
     this.onBroadcast();
     this.queries.forEach((info, id) => {
-      if (!info.invalidated || !info.listeners) return;
+      if (!info.invalidated || !info.listeners.length || info.newData === null) return;
       info.listeners
         // it's possible for the listener to be undefined if the query is being stopped
         // See here for more detail: https://github.com/apollostack/apollo-client/issues/231


### PR DESCRIPTION
Hey all, I love the codebase, but we're trying to game down our Android performance right now, and we are seeing a little bit of render overhead when using `fetchMore` on a query because multiple renders are triggered, 2 with a value of null, and then a third with our expected newData.

I'm sure there's probably a lot of conditions I'm missing here, but I wanted to put down a basic PR to ask about how best to avoid triggering these re-renders and game it down to either just triggering the re-render when we've written our query result, or preventing causing the stuff above it to recalculate.

Thanks again for the excellent repo, and if you'd like anything from me, let me know and I'll see what I can put together this weekend.