### PR TITLE
Cache query documents transformed by InMemoryCache.

### DIFF
--- a/packages/apollo-cache-inmemory/CHANGELOG.md
+++ b/packages/apollo-cache-inmemory/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Restore non-enumerability of `resultFields[ID_KEY]`.
   [PR #3544](https://github.com/apollographql/apollo-client/pull/3544)
 
+- Cache query documents transformed by InMemoryCache.
+  [PR #3553](https://github.com/apollographql/apollo-client/pull/3553)
+
 ### 1.2.2
 
 - Fixed an issue that caused fragment only queries to sometimes fail.

--- a/packages/apollo-cache-inmemory/src/inMemoryCache.ts
+++ b/packages/apollo-cache-inmemory/src/inMemoryCache.ts
@@ -43,6 +43,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
   protected optimistic: OptimisticStoreItem[] = [];
   private watches: Cache.WatchOptions[] = [];
   private addTypename: boolean;
+  private typenameDocumentCache = new WeakMap<DocumentNode, DocumentNode>();
 
   // Set this while in a transaction to prevent broadcasts...
   // don't forget to turn it back on!
@@ -204,7 +205,16 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
   }
 
   public transformDocument(document: DocumentNode): DocumentNode {
-    if (this.addTypename) return addTypenameToDocument(document);
+    if (this.addTypename) {
+      let result = this.typenameDocumentCache.get(document);
+      if (!result) {
+        this.typenameDocumentCache.set(
+          document,
+          (result = addTypenameToDocument(document)),
+        );
+      }
+      return result;
+    }
     return document;
   }
 


### PR DESCRIPTION
After #3444 removed `Map`-based caching for `addTypenameToDocument` (in order to fix memory leaks), the `InMemoryCache#transformDocument` method now creates a completely new `DocumentNode` every time it's called (assuming `this.addTypename` is true, which it is by default).

This commit uses a `WeakMap` to cache calls to `addTypenameToDocument` in `InMemoryCache#transformDocument`, so that repeated cache reads will no longer create an unbounded number of new `DocumentNode` objects. The benefit of the `WeakMap` is that it does not prevent its keys (the original `DocumentNode` objects) from being garbage collected, which is another way of preventing memory leaks.  Note that `WeakMap` may have to be polyfilled in older browsers, but there are many options for that.

This optimization will be important for #3394, since the query document is involved in cache keys used to store cache partial query results.

cc @hwillson @jbaxleyiii @brunorzn