### PR TITLE
Allow pre-configured cache to be given as config option to Apollo Boost Client

### DIFF
--- a/packages/apollo-boost/CHANGELOG.md
+++ b/packages/apollo-boost/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### vNext
 
 - Allow `cache` to be given as a configuration option to `ApolloBoost`.
+  [Issue #3220](https://github.com/apollographql/apollo-client/issues/3220)
   [PR #3561](https://github.com/apollographql/apollo-client/pull/3561)
 - Allow `headers` and `credentials` to be passed in as configuration
   parameters to the `apollo-boost` `ApolloClient` constructor.

--- a/packages/apollo-boost/CHANGELOG.md
+++ b/packages/apollo-boost/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### vNext
 
+- Allow `cache` to be given as a configuration option to `ApolloBoost`.
+  [PR #3561](https://github.com/apollographql/apollo-client/pull/3561)
 - Allow `headers` and `credentials` to be passed in as configuration
   parameters to the `apollo-boost` `ApolloClient` constructor.
   [PR #3098](https://github.com/apollographql/apollo-client/pull/3098)

--- a/packages/apollo-boost/package.json
+++ b/packages/apollo-boost/package.json
@@ -34,6 +34,7 @@
     "filesize": "npm run build && npm run build:browser"
   },
   "dependencies": {
+    "apollo-cache": "^1.1.9",
     "apollo-cache-inmemory": "^1.2.2",
     "apollo-client": "^2.3.2",
     "apollo-link": "^1.0.6",
@@ -45,7 +46,6 @@
   "devDependencies": {
     "@types/graphql": "0.12.7",
     "@types/jest": "22.2.3",
-    "apollo-cache": "^1.1.9",
     "apollo-utilities": "^1.0.13",
     "browserify": "15.2.0",
     "fetch-mock": "6.4.3",

--- a/packages/apollo-boost/src/__tests__/config.ts
+++ b/packages/apollo-boost/src/__tests__/config.ts
@@ -1,4 +1,4 @@
-import ApolloClient, { gql } from '../';
+import ApolloClient, { gql, InMemoryCache } from '../';
 import { stripSymbols } from 'apollo-utilities';
 import { HttpLink } from 'apollo-link-http';
 import * as fetchMock from 'fetch-mock';
@@ -58,6 +58,28 @@ describe('config', () => {
         expect(stripSymbols(data)).toEqual({ foo: 'woo' });
         expect(requestCalled).toEqual(true);
       });
+  });
+
+  it('throws if passed cache and cacheRedirects', () => {
+    const cache = new InMemoryCache();
+    const cacheRedirects = { Query: { foo: () => 'woo' } };
+
+    expect(_ => {
+      const client = new ApolloClient({
+        cache,
+        cacheRedirects,
+      });
+    }).toThrow('Incompatible cache configuration');
+  });
+
+  it('allows you to pass in cache', () => {
+    const cache = new InMemoryCache();
+
+    const client = new ApolloClient({
+      cache,
+    });
+
+    expect(client.cache).toBe(cache);
   });
 
   it('allows you to pass in cacheRedirects', () => {

--- a/packages/apollo-boost/src/index.ts
+++ b/packages/apollo-boost/src/index.ts
@@ -28,72 +28,85 @@ export interface PresetConfig {
 }
 
 export default class DefaultClient<TCache> extends ApolloClient<TCache> {
-  constructor(config: PresetConfig) {
-    if (config && config.cache && config.cacheRedirects) {
+  constructor(config: PresetConfig = {}) {
+    const {
+      request,
+      uri,
+      credentials,
+      headers,
+      fetchOptions,
+      clientState,
+      cacheRedirects,
+      onError: errorCallback,
+    } = config;
+
+    let { cache } = config;
+
+    if (cache && cacheRedirects) {
       throw new Error(
-        'Incompatible cache configuration. If providing `cache` then configure' +
-          'the provided instance with `cacheRedirects` instead.',
+        'Incompatible cache configuration. If providing `cache` then ' +
+          'configure the provided instance with `cacheRedirects` instead.',
       );
     }
 
-    // First try to use a provided ApolloCache instance:
-    let cache = config && config.cache ? config.cache : null;
-
-    // If no cache instance, then create one using cacheRedirects if given:
-    if (cache === null) {
-      cache =
-        config && config.cacheRedirects
-          ? new InMemoryCache({ cacheRedirects: config.cacheRedirects })
-          : new InMemoryCache();
+    if (!cache) {
+      cache = cacheRedirects
+        ? new InMemoryCache({ cacheRedirects })
+        : new InMemoryCache();
     }
 
-    const stateLink =
-      config && config.clientState
-        ? withClientState({ ...config.clientState, cache })
-        : false;
+    const stateLink = clientState
+      ? withClientState({ ...clientState, cache })
+      : false;
 
-    const errorLink =
-      config && config.onError
-        ? onError(config.onError)
-        : onError(({ graphQLErrors, networkError }) => {
-            if (graphQLErrors)
-              graphQLErrors.map(({ message, locations, path }) =>
-                console.log(
-                  `[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`,
-                ),
-              );
-            if (networkError) console.log(`[Network error]: ${networkError}`);
-          });
+    const errorLink = errorCallback
+      ? onError(errorCallback)
+      : onError(({ graphQLErrors, networkError }) => {
+          if (graphQLErrors) {
+            graphQLErrors.map(({ message, locations, path }) =>
+              // tslint:disable-next-line
+              console.log(
+                `[GraphQL error]: Message: ${message}, Location: ` +
+                  `${locations}, Path: ${path}`,
+              ),
+            );
+          }
+          if (networkError) {
+            // tslint:disable-next-line
+            console.log(`[Network error]: ${networkError}`);
+          }
+        });
 
-    const requestHandler =
-      config && config.request
-        ? new ApolloLink(
-            (operation, forward) =>
-              new Observable(observer => {
-                let handle: any;
-                Promise.resolve(operation)
-                  .then(oper => config.request(oper))
-                  .then(() => {
-                    handle = forward(operation).subscribe({
-                      next: observer.next.bind(observer),
-                      error: observer.error.bind(observer),
-                      complete: observer.complete.bind(observer),
-                    });
-                  })
-                  .catch(observer.error.bind(observer));
+    const requestHandler = request
+      ? new ApolloLink(
+          (operation, forward) =>
+            new Observable(observer => {
+              let handle: any;
+              Promise.resolve(operation)
+                .then(oper => request(oper))
+                .then(() => {
+                  handle = forward(operation).subscribe({
+                    next: observer.next.bind(observer),
+                    error: observer.error.bind(observer),
+                    complete: observer.complete.bind(observer),
+                  });
+                })
+                .catch(observer.error.bind(observer));
 
-                return () => {
-                  if (handle) handle.unsubscribe;
-                };
-              }),
-          )
-        : false;
+              return () => {
+                if (handle) {
+                  handle.unsubscribe();
+                }
+              };
+            }),
+        )
+      : false;
 
     const httpLink = new HttpLink({
-      uri: (config && config.uri) || '/graphql',
-      fetchOptions: (config && config.fetchOptions) || {},
-      credentials: (config && config.credentials) || 'same-origin',
-      headers: (config && config.headers) || {},
+      uri: uri || '/graphql',
+      fetchOptions: fetchOptions || {},
+      credentials: credentials || 'same-origin',
+      headers: headers || {},
     });
 
     const link = ApolloLink.from([


### PR DESCRIPTION
### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)

This is related to https://github.com/apollographql/apollo-client/issues/3220

- [x] Make sure all of the significant new logic is covered by tests

New tests have been added

---

I've read through some discussions on this and I see that there are different opinions on the appropriateness of this kind of change and how it relates to your idea of the opinionated nature of ApolloBoost. Obviously, feel free to close the PR and disregard.

The challenge I'm running into, and which motivated this pull request, is that I have one small configuration change I need to make to the internal InMemoryCache configuration. That one small change is forcing me to drop ApolloBoost and instead configure everything manually.

It would be more user-friendly to be able to use ApolloBoost as is, but pass in specific dependency's when required while still retaining the rest of the defaults of ApolloBoost.

Anyhow, thanks for taking the time to read through this. I'll continue with my manual configuration for now. If this is a PR you're interested in moving forward with, let me know if there are any other changes you'd like to see implemented here. Otherwise, thanks for writing these great tools. 👋


<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->