### PR TITLE
Add missing `Apollo*Result` types to the API docs

### DIFF
--- a/docs/source/api/apollo-client.md
+++ b/docs/source/api/apollo-client.md
@@ -66,3 +66,5 @@ The `ApolloClient` class is the core API for Apollo, and the one you'll need to 
 {% tsapibox ApolloClientOptions %}
 {% tsapibox DefaultOptions %}
 {% tsapibox NetworkStatus %}
+{% tsapibox ApolloQueryResult %}
+{% tsapibox ApolloCurrentResult %}


### PR DESCRIPTION
Adding the following types:

- `ApolloQueryResult`
- `ApolloCurrentResult`

Fixes https://github.com/apollographql/apollo-client/issues/3412.