### PR TITLE
Fix typescript issue with `defaultOptions` in constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Export the `QueryOptions` interface, to make sure it can be used by other
   projects (like `apollo-angular`).
+- Fixed an issue caused by typescript changes to the constructor
+  `defaultOptions` param, that prevented `query` defaults from passing type
+  checks.
+  ([@hwillson](https://github.com/hwillson) in [#3585](https://github.com/apollographql/apollo-client/pull/3585))
 
 ### Apollo Boost (0.1.9)
 

--- a/packages/apollo-client/CHANGELOG.md
+++ b/packages/apollo-client/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 - Export the `QueryOptions` interface, to make sure it can be used by other
   projects (like `apollo-angular`).
+- Fixed an issue caused by typescript changes to the constructor
+  `defaultOptions` param, that prevented `query` defaults from passing type
+  checks.
+  [Issue #3583](https://github.com/apollographql/apollo-client/issues/3583)
+  [PR #]()
 
 ### 2.3.3
 

--- a/packages/apollo-client/CHANGELOG.md
+++ b/packages/apollo-client/CHANGELOG.md
@@ -8,7 +8,7 @@
   `defaultOptions` param, that prevented `query` defaults from passing type
   checks.
   [Issue #3583](https://github.com/apollographql/apollo-client/issues/3583)
-  [PR #]()
+  [PR #3585](https://github.com/apollographql/apollo-client/pull/3585)
 
 ### 2.3.3
 

--- a/packages/apollo-client/src/ApolloClient.ts
+++ b/packages/apollo-client/src/ApolloClient.ts
@@ -20,6 +20,7 @@ import { ObservableQuery } from './core/ObservableQuery';
 import { Observable } from './util/Observable';
 
 import {
+  QueryBaseOptions,
   QueryOptions,
   WatchQueryOptions,
   SubscriptionOptions,
@@ -34,7 +35,7 @@ import { version } from './version';
 
 export interface DefaultOptions {
   watchQuery?: ModifiableWatchQueryOptions;
-  query?: QueryOptions;
+  query?: QueryBaseOptions;
   mutate?: MutationBaseOptions;
 }
 
@@ -246,7 +247,7 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
     // XXX Overwriting options is probably not the best way to do this long
     // term...
     if (this.disableNetworkFetches && options.fetchPolicy === 'network-only') {
-      options = { ...options, fetchPolicy: 'cache-first' } as WatchQueryOptions;
+      options = { ...options, fetchPolicy: 'cache-first' } as QueryOptions;
     }
 
     return this.queryManager.query<T>(options);

--- a/packages/apollo-client/src/index.ts
+++ b/packages/apollo-client/src/index.ts
@@ -7,6 +7,7 @@ export {
   ApolloCurrentResult,
 } from './core/ObservableQuery';
 export {
+  QueryBaseOptions,
   QueryOptions,
   WatchQueryOptions,
   MutationOptions,


### PR DESCRIPTION
When the new `QueryBaseOptions` and `QueryOptions` interfaces were created in
https://github.com/apollographql/apollo-client/commit/eb89b23f667f0854443950ce9301945d8596d7a6, `ModifiableWatchQueryOptions` was replaced by `QueryOptions` when checking the `query` `defaultOptions` used in the Apollo Client constructor. Unfortunately, this introduced a small type check bug since the `query` property in `QueryOptions` is a mandatory property, whereas `ModifiableWatchQueryOptions` did not include this property. This commit replaces the use of `QueryOptions` with `QueryBaseOptions` when type checking `query` in `defaultOptions`, since `QueryBaseOptions` doesn't have a `query` property.

Fixes https://github.com/apollographql/apollo-client/issues/3583.
