### PR TITLE
Remove whitespaces from error msg.

### DIFF
--- a/packages/apollo-utilities/CHANGELOG.md
+++ b/packages/apollo-utilities/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+### vNext
+
+- Removed whitespaces from error message
+[ISSUE #3398](https://github.com/apollographql/apollo-client/issues/3398)
+
 ### 1.0.15
 
 - No changes

--- a/packages/apollo-utilities/CHANGELOG.md
+++ b/packages/apollo-utilities/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ### vNext
 
-- Removed whitespaces from error message
-[ISSUE #3398](https://github.com/apollographql/apollo-client/issues/3398)
+- Removed unnecessary whitespace from error message
+  [Issue #3398](https://github.com/apollographql/apollo-client/issues/3398)
+  [PR #3593](https://github.com/apollographql/apollo-client/pull/3593)
 
 ### 1.0.15
 

--- a/packages/apollo-utilities/src/storeUtils.ts
+++ b/packages/apollo-utilities/src/storeUtils.ts
@@ -128,11 +128,9 @@ export function valueToObjectRepresentation(
     argObj[name.value] = null;
   } else {
     throw new Error(
-      'The inline argument "' +
-        name.value +
-        '" of kind "' +
-        (value as any).kind +
-        '" is not supported. Use variables instead of inline arguments to overcome this limitation.',
+      `The inline argument "${name.value}" of kind "${(value as any).kind}"` +
+      'is not supported. Use variables instead of inline arguments to ' +
+      'overcome this limitation.'
     );
   }
 }

--- a/packages/apollo-utilities/src/storeUtils.ts
+++ b/packages/apollo-utilities/src/storeUtils.ts
@@ -127,10 +127,13 @@ export function valueToObjectRepresentation(
   } else if (isNullValue(value)) {
     argObj[name.value] = null;
   } else {
-    throw new Error(`The inline argument "${name.value}" of kind "${
-      (value as any).kind
-    }" is not supported.
-                    Use variables instead of inline arguments to overcome this limitation.`);
+    throw new Error(
+      'The inline argument "' +
+        name.value +
+        '" of kind "' +
+        (value as any).kind +
+        '" is not supported. Use variables instead of inline arguments to overcome this limitation.',
+    );
   }
 }
 


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

Fix for #3398 
Switched from string template to normal string concatenation in order to avoid white spaces in the console output after reformating with prettier.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->