### PR TITLE
Update MutationResult API docs to include `client`

### DIFF
--- a/docs/source/essentials/mutations.md
+++ b/docs/source/essentials/mutations.md
@@ -266,6 +266,8 @@ The render prop function that you pass to the `children` prop of `Mutation` is c
   <dd>Any errors returned from the mutation</dd>
   <dt>`called`: boolean</dt>
   <dd>A boolean indicating if the mutate function has been called</dd>
+  <dt>`client`: ApolloClient</dt>
+  <dd>Your `ApolloClient` instance. Useful for invoking cache methods outside the context of the update function, such as `client.writeData` and `client.readQuery`.</dd>
 </dl>
 
 <h2 id="next-steps">Next steps</h2>


### PR DESCRIPTION
Re-applies the effect of https://github.com/apollographql/apollo-client/pull/3370 now that the [original PR](https://github.com/apollographql/react-apollo/pull/1945) is merged.