### PR TITLE
Update @types/zen-observable version

### DIFF
--- a/packages/apollo-client/package.json
+++ b/packages/apollo-client/package.json
@@ -46,7 +46,7 @@
   "author": "Sashko Stubailo <sashko@stubailo.com>",
   "license": "MIT",
   "dependencies": {
-    "@types/zen-observable": "^0.5.3",
+    "@types/zen-observable": "^0.5.4",
     "apollo-cache": "^1.1.12",
     "apollo-link": "^1.0.0",
     "apollo-link-dedup": "^1.0.0",


### PR DESCRIPTION
Fix build error: can't update dependencies anymore (All declarations of 'observable' must have identical modifiers)

https://github.com/apollographql/apollo-angular/issues/658

