### PR TITLE
ObservableQuery.currentResult return value docs in comment

### DIFF
--- a/packages/apollo-client/src/core/ObservableQuery.ts
+++ b/packages/apollo-client/src/core/ObservableQuery.ts
@@ -153,7 +153,7 @@ export class ObservableQuery<
    * Return the result of the query from the local cache as well as some fetching status
    * `loading` and `networkStatus` allow to know if a request is in flight
    * `partial` lets you know if the result from the local cache is complete or partial
-   * @return {result: Object, loading: boolean, networkStatus: number, partial: boolean}
+   * @return {data: Object, error: ApolloError, loading: boolean, networkStatus: number, partial: boolean}
    */
   public currentResult(): ApolloCurrentResult<TData> {
     if (this.isTornDown) {


### PR DESCRIPTION
It should return 

`{data: Object, error: ApolloError, loading: boolean, networkStatus: number, partial: boolean}`

instead of

`{result: Object, loading: boolean, networkStatus: number, partial: boolean}`
