### PR TITLE
[docs] added related guides

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -52,6 +52,13 @@ sidebar_categories:
     - recipes/webpack
     - recipes/meteor
     - recipes/recompose
+  Related Guides:
+    - title: State Management
+      href: https://www.apollographql.com/docs/guides/state-mgmt.html
+    - title: Testing React Components
+      href: https://www.apollographql.com/docs/guides/testing-react-components.html
+    - title: Schema Design
+      href: https://www.apollographql.com/docs/guides/schema-design.html
   API:
     - api/apollo-client
     - api/react-apollo


### PR DESCRIPTION
I added a section on the sidebar with links to related guides.

I chose `State Management`, `Testing React Components`, and ` Schema Design` as I thought those were the most relevant guides to client developers.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->