### PR TITLE
Add missing `subscribe` entry to the Apollo Client API docs

### DIFF
--- a/docs/source/api/apollo-client.md
+++ b/docs/source/api/apollo-client.md
@@ -40,6 +40,7 @@ The `ApolloClient` class is the core API for Apollo, and the one you'll need to 
 {% tsapibox ApolloClient.watchQuery %}
 {% tsapibox ApolloClient.query %}
 {% tsapibox ApolloClient.mutate %}
+{% tsapibox ApolloClient.subscribe %}
 {% tsapibox ApolloClient.readQuery %}
 {% tsapibox ApolloClient.readFragment %}
 {% tsapibox ApolloClient.writeQuery %}


### PR DESCRIPTION
Continuation of https://github.com/apollographql/core-docs/pull/310. 