### PR TITLE
[apollo-boost] Support apollo-link-http's useGETForQueries option

### DIFF
--- a/packages/apollo-boost/CHANGELOG.md
+++ b/packages/apollo-boost/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### vNext
 
+- Support apollo-link-http's useGETForQueries option.
+  [PR #3669](https://github.com/apollographql/apollo-client/pull/3669)
 - Allow `fetch` to be given as a configuration option to ApolloBoost.  
   [Issue #3578](https://github.com/apollographql/apollo-client/issues/3578)  
   [PR #3590](https://github.com/apollographql/apollo-client/pull/3590)

--- a/packages/apollo-boost/package.json
+++ b/packages/apollo-boost/package.json
@@ -39,7 +39,7 @@
     "apollo-client": "^2.3.5",
     "apollo-link": "^1.0.6",
     "apollo-link-error": "^1.0.3",
-    "apollo-link-http": "^1.3.1",
+    "apollo-link-http": "^1.5.0",
     "apollo-link-state": "^0.4.0",
     "graphql-tag": "^2.4.2"
   },

--- a/packages/apollo-boost/src/__tests__/config.ts
+++ b/packages/apollo-boost/src/__tests__/config.ts
@@ -15,6 +15,12 @@ describe('config', () => {
     }
   `;
 
+  const mutation = gql`
+    mutation {
+      foo @client
+    }
+  `;
+
   const resolvers = {
     Query: {
       foo: () => 'woo',
@@ -188,6 +194,38 @@ describe('config', () => {
         'new-header1': 'value1',
         'new-header2': 'value2',
       });
+    });
+  });
+
+  describe('fetchOptions.useGETForQueries', () => {
+    beforeEach(() => {
+      fetchMock.restore();
+      fetchMock.get(/\/graphql\?query=.+/, makePromise(data));
+      fetchMock.post('/graphql', makePromise(data));
+    });
+
+    afterEach(() => {
+      fetchMock.restore();
+    });
+
+    it('allows you to use GET method for queries', () => {
+      const client = new ApolloClient({
+        fetchOptions: { useGETForQueries: true }
+      });
+
+      client.query({ query, errorPolicy: 'ignore' });
+      const [uri, options] = fetchMock.lastCall();
+      expect(options.method).toEqual('GET');
+    });
+
+    it('allows you to use POST method for mutations', () => {
+      const client = new ApolloClient({
+        fetchOptions: { useGETForQueries: true }
+      });
+
+      client.mutate({ mutation, errorPolicy: 'ignore' });
+      const [uri, options] = fetchMock.lastCall();
+      expect(options.method).toEqual('POST');
     });
   });
 });

--- a/packages/apollo-boost/src/index.ts
+++ b/packages/apollo-boost/src/index.ts
@@ -144,6 +144,7 @@ export default class DefaultClient<TCache> extends ApolloClient<TCache> {
       uri: uri || '/graphql',
       fetch,
       fetchOptions: fetchOptions || {},
+      useGETForQueries: (fetchOptions && fetchOptions.useGETForQueries),
       credentials: credentials || 'same-origin',
       headers: headers || {},
     });


### PR DESCRIPTION
Ref: https://github.com/apollographql/apollo-link/pull/510

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->