### PR TITLE
No data caching if errors in result

### DIFF
--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -1063,7 +1063,7 @@ export class QueryManager<TStore> {
           // default the lastRequestId to 1
           const { lastRequestId } = this.getQuery(queryId);
           if (requestId >= (lastRequestId || 1)) {
-            if (fetchPolicy !== 'no-cache') {
+            if (fetchPolicy !== 'no-cache' && !result.errors) {
               try {
                 this.dataStore.markQueryResult(
                   result,
@@ -1093,7 +1093,7 @@ export class QueryManager<TStore> {
             this.broadcastQueries();
           }
 
-          if (result.errors && errorPolicy === 'none') {
+          if (result.errors && errorPolicy === 'none' || result.errors) {
             reject(
               new ApolloError({
                 graphQLErrors: result.errors,

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -1093,7 +1093,7 @@ export class QueryManager<TStore> {
             this.broadcastQueries();
           }
 
-          if (result.errors && errorPolicy === 'none' || result.errors) {
+          if (result.errors && errorPolicy === 'none') {
             reject(
               new ApolloError({
                 graphQLErrors: result.errors,
@@ -1104,7 +1104,7 @@ export class QueryManager<TStore> {
             errorsFromStore = result.errors;
           }
 
-          if (fetchMoreForQueryId || fetchPolicy === 'no-cache') {
+          if (fetchMoreForQueryId || fetchPolicy === 'no-cache'  || result.errors) {
             // We don't write fetchMore results to the store because this would overwrite
             // the original result in case an @connection directive is used.
             resultFromStore = result.data;

--- a/packages/apollo-client/src/core/__tests__/ObservableQuery.ts
+++ b/packages/apollo-client/src/core/__tests__/ObservableQuery.ts
@@ -868,7 +868,7 @@ describe('ObservableQuery', () => {
       });
     });
 
-    it('does not invalidate the currentResult errors if the variables change', done => {
+    it('does invalidate the currentResult errors if the variables change', done => {
       const queryManager = mockQueryManager(
         {
           request: { query, variables },
@@ -891,7 +891,7 @@ describe('ObservableQuery', () => {
           expect(result.errors).toEqual([error]);
           expect(observable.currentResult().errors).toEqual([error]);
           observable.setVariables(differentVariables);
-          expect(observable.currentResult().errors).toEqual([error]);
+          expect(observable.currentResult().errors).toEqual([]);
         }
         // after loading is done and new results are returned
         if (handleCount === 3) {

--- a/packages/apollo-client/src/data/queries.ts
+++ b/packages/apollo-client/src/data/queries.ts
@@ -78,11 +78,6 @@ export class QueryStore {
       networkStatus = NetworkStatus.loading;
     }
 
-    let graphQLErrors: GraphQLError[] = [];
-    if (previousQuery && previousQuery.graphQLErrors) {
-      graphQLErrors = previousQuery.graphQLErrors;
-    }
-
     // XXX right now if QUERY_INIT is fired twice, like in a refetch situation, we just overwrite
     // the store. We probably want a refetch action instead, because I suspect that if you refetch
     // before the initial fetch is done, you'll get an error.
@@ -91,7 +86,7 @@ export class QueryStore {
       variables: query.variables,
       previousVariables,
       networkError: null,
-      graphQLErrors: graphQLErrors,
+      graphQLErrors: [],
       networkStatus,
       metadata: query.metadata,
     };


### PR DESCRIPTION
Related to [this issue](https://github.com/apollographql/apollo-client/issues/3662).

The presence of errors in the server response may be outside the controls of the client: for example it can change when different variables are passed to the query, if an external auth system is used, it can change over time... and so on.

With this in mind, inheriting error from the previous instance of a query is a wrong logic.

After this change the client doesn't save result's data in the datastore if it contains one or more errors. This causes a "physical" refetch of a query every time until no errors are given.