### PR TITLE
docs: Update blog URLs to reference blog.apollographql.com.

### DIFF
--- a/.github/ISSUE_REPLY_TEMPLATE.md
+++ b/.github/ISSUE_REPLY_TEMPLATE.md
@@ -6,12 +6,11 @@ To make things easier for you and for a maintiner or contributor to help out, he
 If this is your first time contributing to Apollo, one of our friendly bots will ask for you to sign the CLA. After that, take a look at the [contributor guide](https://github.com/apollographql/apollo-client/blob/master/CONTRIBUTING.md)!
 
 ### Creating a reproduction:
-- You can create a reproduction using [this template](https://codesandbox.io/s/7361K9q6w) on codesandbox, or try it locally using [the apollo error template](https://github.com/apollographql/react-apollo-error-template)
-- If you want to customize the schema to match the issue you are having, checkout [Apollo Launchpad](https://launchpad.graphql.com/new)
-- If your issue is related to react-native, try using [Expo](https://snack.expo.io/)
+- You can create a reproduction using [this template](https://codesandbox.io/s/7361K9q6w) on codesandbox, or try it locally using [the apollo error template](https://github.com/apollographql/react-apollo-error-template).
+- If you want to customize the schema to match the issue you are having, checkout [Apollo Launchpad](https://launchpad.graphql.com/new).
+- If your issue is related to react-native, try using [Expo](https://snack.expo.io/).
 
 ### Guides and Documentation
-The issue you are having (or the feature you are requesting) may already be fixed! To find the latest information about how to use Apollo, check out the [documentation](http://dev.apollodata.com/) and see the latest entry from [the blog](https://dev-blog.apollodata.com)
-
+The issue you are having (or the feature you are requesting) may already be fixed! To find the latest information about how to use Apollo, check out the [documentation](http://www.apollographql.com/docs/) and see the latest posts from [the Apollo GraphQL blog](https://blog.apollographql.com/).
 
 Thank you again for helping to improve Apollo Client!

--- a/docs/source/essentials/local-state.md
+++ b/docs/source/essentials/local-state.md
@@ -327,6 +327,6 @@ const Detail = ({ match: { params: { breed, id } } }) => (
 Managing your local data with Apollo Client can simplify your state management code since the Apollo cache is your single source of truth for all data in your application. If you'd like to learn more about `apollo-link-state`, check out:
 
 - [`apollo-link-state` docs](/docs/link/links/state.html): Dive deeper into the concepts we just learned, such as resolvers and mixed queries, by taking a look at the `apollo-link-state` docs.
-- [The future of state management](https://dev-blog.apollodata.com/the-future-of-state-management-dd410864cae2): Read about our vision for the future of state management with GraphQL in the `apollo-link-state` announcement post.
+- [The future of state management](https://blog.apollographql.com/the-future-of-state-management-dd410864cae2): Read about our vision for the future of state management with GraphQL in the `apollo-link-state` announcement post.
 - [Tutorial video by Sara Vieira](https://youtu.be/2RvRcnD8wHY): Check out this tutorial video by Sara Vieira if you'd like a step-by-step walkthrough on building an app with `apollo-link-state`.
 

--- a/docs/source/features/developer-tooling.md
+++ b/docs/source/features/developer-tooling.md
@@ -33,7 +33,7 @@ Make requests against either your app’s GraphQL server or the Apollo Client ca
 
 ![Store Inspector](../assets/devtools/apollo-client-devtools/apollo-devtools-store.png)
 
-View the state of your client-side cache as a tree and inspect every object inside. Visualize the [mental model](https://dev-blog.apollodata.com/the-concepts-of-graphql-bc68bd819be3) of the Apollo cache. Search for specific keys and values in the store and see the path to those keys highlighted.
+View the state of your client-side cache as a tree and inspect every object inside. Visualize the [mental model](https://blog.apollographql.com/the-concepts-of-graphql-bc68bd819be3) of the Apollo cache. Search for specific keys and values in the store and see the path to those keys highlighted.
 
 ![Watched Query Inspector](../assets/devtools/apollo-client-devtools/apollo-devtools-queries.png)
 

--- a/docs/source/recipes/meteor.md
+++ b/docs/source/recipes/meteor.md
@@ -118,7 +118,7 @@ In order to get the most out of it, you can attach a `dataloader` to every reque
 Here are some great resources to help you integrating query batching in your Meteor application:
 - About batched network interface:
   - [Apollo Client documentation](http://dev.apollodata.com/tools/graphql-tools/connectors.html#DataLoader-and-caching), the official documentation explaining how it works and how to set it up.
-  - [Query batching in Apollo](https://dev-blog.apollodata.com/query-batching-in-apollo-63acfd859862), an article from the Apollo blog with more in depth explanation.
+  - [Query batching in Apollo](https://blog.apollographql.com/query-batching-in-apollo-63acfd859862), an article from the Apollo blog with more in depth explanation.
 - About Dataloader:
   - Apollo's [Graphql server documentation](http://dev.apollodata.com/tools/graphql-tools/connectors.html#DataLoader-and-caching), get to know how to setup `dataloader` in your server-side implementation.
   - [Dataloader repository](https://github.com/facebook/dataloader), a detailed explanation of batching & caching processes, plus a bonus of a 30-minute source code walkthrough video.

--- a/docs/source/recipes/recompose.md
+++ b/docs/source/recipes/recompose.md
@@ -168,7 +168,7 @@ const enhancedComponent = compose(
 
 <h2 id="controlling-poll-interval">Controlling pollInterval</h2>
 
-This case is borrowed from [David Glasser's post on the Apollo blog](https://dev-blog.apollodata.com/dynamic-graphql-polling-with-react-and-apollo-client-fb36e390d250) about the Meteor's Galaxy UI migrations panel implementation. In the post, he says:
+This case is borrowed from [David Glasser's post on the Apollo blog](https://blog.apollographql.com/dynamic-graphql-polling-with-react-and-apollo-client-fb36e390d250) about the Meteor's Galaxy UI migrations panel implementation. In the post, he says:
 
 > We’re not usually running any migrations, so a nice, slow polling interval like 30 seconds seemed reasonable. But in the rare case where a migration is running, I wanted to be able to see much faster updates on its progress.
 

--- a/docs/source/recipes/simple-example.md
+++ b/docs/source/recipes/simple-example.md
@@ -225,7 +225,7 @@ Now you've seen all of the code you need to build a React Native app that loads 
 
 Let's get you building your own app from scratch! You have two tutorials to go through, and we recommend doing them in the following order:
 
-1. [Full-Stack GraphQL + React tutorial](https://dev-blog.apollodata.com/full-stack-react-graphql-tutorial-582ac8d24e3b#.cwvxzphyc) by [Jonas Helfer](https://twitter.com/helferjs).
+1. [Full-Stack GraphQL + React tutorial](https://blog.apollographql.com/full-stack-react-graphql-tutorial-582ac8d24e3b#.cwvxzphyc) by [Jonas Helfer](https://twitter.com/helferjs).
 2. [How to GraphQL](https://www.howtographql.com/react-apollo/0-introduction/) by the team and community around [Graphcool](https://www.graph.cool/), a hosted GraphQL backend platform.
 
 Have fun!

--- a/docs/source/why-apollo.md
+++ b/docs/source/why-apollo.md
@@ -122,20 +122,20 @@ Apollo Client is easy to get started with, but extensible for when you need to b
 
 This flexibility makes it simple to create your dream client by building extensions on top of Apollo. We're always really impressed by what our contributors have built on top of Apollo - check out some of their packages:
 - [Apollo Link community links](/docs/link/links/community.html): Pluggable links created by the community
-- [apollo-cache-persist](https://dev-blog.apollodata.com/announcing-apollo-cache-persist-cb05aec16325): Simple persistence for your Apollo cache ([@jamesreggio](https://github.com/jamesreggio))
+- [apollo-cache-persist](https://blog.apollographql.com/announcing-apollo-cache-persist-cb05aec16325): Simple persistence for your Apollo cache ([@jamesreggio](https://github.com/jamesreggio))
 - [apollo-storybook-decorator](https://github.com/abhiaiyer91/apollo-storybook-decorator): Wrap your React Storybook stories with Apollo Client ([@abhiaiyer91](https://github.com/abhiaiyer91))
-- [AppSync by AWS](https://dev-blog.apollodata.com/aws-appsync-powered-by-apollo-df61eb706183): Amazon's real-time GraphQL client uses Apollo Client under the hood
+- [AppSync by AWS](https://blog.apollographql.com/aws-appsync-powered-by-apollo-df61eb706183): Amazon's real-time GraphQL client uses Apollo Client under the hood
 
-When you choose Apollo to manage your data, you also gain the support of our amazing community. There are over 5000 developers on our [Apollo Slack](https://www.apollographql.com/#slack) channel for you to share ideas with. You can also read articles on best practices and our announcements on the [Apollo blog](https://dev-blog.apollodata.com/), updated weekly.
+When you choose Apollo to manage your data, you also gain the support of our amazing community. There are over 5000 developers on our [Apollo Slack](https://www.apollographql.com/#slack) channel for you to share ideas with. You can also read articles on best practices and our announcements on the [Apollo blog](https://blog.apollographql.com/), updated weekly.
 
 <h2 id="case-studies">Case studies</h2>
 
 Companies ranging from enterprises to startups trust Apollo Client to power their most critical web & native applications. If you'd like to learn more about how transitioning to GraphQL and Apollo simplified their engineers' workflows and improved their products, check out these case studies:
 
 - [The New York Times](https://open.nytimes.com/the-new-york-times-now-on-apollo-b9a78a5038c): Learn how The New York Times switched from Relay to Apollo & implemented features in their app such as SSR and persisted queries
-- [Express](https://dev-blog.apollodata.com/changing-the-architecture-of-express-com-23c950d43323): Easy-to-use pagination with Apollo helped improve the Express eCommerce team's key product pages
-- [Major League Soccer](https://dev-blog.apollodata.com/reducing-our-redux-code-with-react-apollo-5091b9de9c2a): MLS' switch from Redux to Apollo for state management enabled them to delete nearly all of their Redux code
-- [Expo](https://dev-blog.apollodata.com/using-graphql-apollo-at-expo-4c1f21f0f115): Developing their React Native app with Apollo allowed the Expo engineers to focus on improving their product instead of writing data fetching logic
+- [Express](https://blog.apollographql.com/changing-the-architecture-of-express-com-23c950d43323): Easy-to-use pagination with Apollo helped improve the Express eCommerce team's key product pages
+- [Major League Soccer](https://blog.apollographql.com/reducing-our-redux-code-with-react-apollo-5091b9de9c2a): MLS' switch from Redux to Apollo for state management enabled them to delete nearly all of their Redux code
+- [Expo](https://blog.apollographql.com/using-graphql-apollo-at-expo-4c1f21f0f115): Developing their React Native app with Apollo allowed the Expo engineers to focus on improving their product instead of writing data fetching logic
 - [KLM](https://youtu.be/T2njjXHdKqw): Learn how the KLM team scaled their Angular app with GraphQL and Apollo
 
 If your company is using Apollo Client in production, we'd love to feature a case study on our blog! Please get in touch via Slack so we can learn more about how you're using Apollo. Alternatively, if you already have a blog post or a conference talk that you'd like to feature here, please send in a PR.


### PR DESCRIPTION
This updates all blog URLs in the documentation to use blog.apollographql.com
as the domain, rather than dev-blog.apollodata.com.