### PR TITLE
Adjust `dataIdFromObject` logic to handle ID's with a value of 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@
 - Add `__typename` and `id` properties to `dataIdFromObject` parameter
   (typescript)  
   [@jfurler](https://github.com/jfurler) in [#3641](https://github.com/apollographql/apollo-client/pull/3641)
+- Fixed an issue caused by `dataIdFromObject` considering returned 0 values to
+  be falsy, instead of being a valid ID, which lead to the store not being
+  updated properly in some cases.  
+  [@hwillson](https://github.com/hwillson) in [#3711](https://github.com/apollographql/apollo-client/pull/3711)
 
 ## 2.3.5 (June 19, 2018)
 

--- a/packages/apollo-cache-inmemory/src/__tests__/writeToStore.ts
+++ b/packages/apollo-cache-inmemory/src/__tests__/writeToStore.ts
@@ -1207,6 +1207,48 @@ describe('writing to the store', () => {
     });
   });
 
+  it('should write to store if `dataIdFromObject` returns an ID of 0', () => {
+    const query = gql`
+      query {
+        author {
+          firstName
+          id
+          __typename
+        }
+      }
+    `;
+    const data = {
+      author: {
+        id: 0,
+        __typename: 'Author',
+        firstName: 'John',
+      },
+    };
+    const expStore = defaultNormalizedCacheFactory({
+      ROOT_QUERY: {
+        author: {
+          id: 0,
+          typename: 'Author',
+          type: 'id',
+          generated: false,
+        },
+      },
+      0: {
+        id: data.author.id,
+        __typename: data.author.__typename,
+        firstName: data.author.firstName,
+      },
+    });
+
+    expect(
+      writeQueryToStore({
+        result: data,
+        query,
+        dataIdFromObject: () => 0,
+      }).toObject(),
+    ).toEqual(expStore.toObject());
+  });
+
   describe('type escaping', () => {
     const dataIdFromObject = (object: any) => {
       if (object.__typename && object.id) {

--- a/packages/apollo-cache-inmemory/src/writeToStore.ts
+++ b/packages/apollo-cache-inmemory/src/writeToStore.ts
@@ -389,7 +389,7 @@ function writeFieldToStore({
         );
       }
 
-      if (semanticId) {
+      if (semanticId || (typeof semanticId === 'number' && semanticId === 0)) {
         valueDataId = semanticId;
         generated = false;
       }


### PR DESCRIPTION
If a custom `dataIdFromObject` function returns a numeric ID with the value 0, it's seen as being a falsy value. This then prevents the query result associated with the ID from being written to the store. These changes adjust the falsy check to accommodate 0 based custom ID's.

Fixes #2164.
