### PR TITLE
Add deprecation message to individual package changelogs

### DIFF
--- a/packages/apollo-boost/CHANGELOG.md
+++ b/packages/apollo-boost/CHANGELOG.md
@@ -1,9 +1,16 @@
 # CHANGELOG
 
+----
+
+**NOTE:** This changelog is no longer maintained. Changes are now tracked in
+the top level [`CHANGELOG.md`](https://github.com/apollographql/apollo-client/blob/master/CHANGELOG.md).
+
+----
+
 ### vNext
 
-- Allow `fetch` to be given as a configuration option to ApolloBoost.  
-  [Issue #3578](https://github.com/apollographql/apollo-client/issues/3578)  
+- Allow `fetch` to be given as a configuration option to ApolloBoost.
+  [Issue #3578](https://github.com/apollographql/apollo-client/issues/3578)
   [PR #3590](https://github.com/apollographql/apollo-client/pull/3590)
 
 ### 0.1.10

--- a/packages/apollo-cache-inmemory/CHANGELOG.md
+++ b/packages/apollo-cache-inmemory/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+----
+
+**NOTE:** This changelog is no longer maintained. Changes are now tracked in
+the top level [`CHANGELOG.md`](https://github.com/apollographql/apollo-client/blob/master/CHANGELOG.md).
+
+----
+
 ### 1.2.5
 
 - No changes.
@@ -21,7 +28,7 @@
 
 - Fixed an issue that caused fragment only queries to sometimes fail.
   [Issue #3402](https://github.com/apollographql/apollo-client/issues/3402)
-  [PR #3507](https://github.com/apollographql/apollo-client/pull/3507)  
+  [PR #3507](https://github.com/apollographql/apollo-client/pull/3507)
 - Fixed cache invalidation for inlined mixed types in union fields within
   arrays.
   [PR #3422](https://github.com/apollographql/apollo-client/pull/3422)

--- a/packages/apollo-cache/CHANGELOG.md
+++ b/packages/apollo-cache/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+----
+
+**NOTE:** This changelog is no longer maintained. Changes are now tracked in
+the top level [`CHANGELOG.md`](https://github.com/apollographql/apollo-client/blob/master/CHANGELOG.md).
+
+----
+
 ### 1.1.12
 
 - No changes.

--- a/packages/apollo-client/CHANGELOG.md
+++ b/packages/apollo-client/CHANGELOG.md
@@ -1,8 +1,15 @@
 # CHANGELOG
 
+----
+
+**NOTE:** This changelog is no longer maintained. Changes are now tracked in
+the top level [`CHANGELOG.md`](https://github.com/apollographql/apollo-client/blob/master/CHANGELOG.md).
+
+----
+
 ### vNext
 
-- Updated `graphql` `peerDependencies` to handle 14.x versions.  
+- Updated `graphql` `peerDependencies` to handle 14.x versions.
   [PR #3598](https://github.com/apollographql/apollo-client/pull/3598)
 
 ### 2.3.5
@@ -27,7 +34,7 @@
   [PR#3140](https://github.com/apollographql/apollo-client/pull/3140)
 - Added optional generics to cache manipulation methods (typescript).
   [PR #3541](https://github.com/apollographql/apollo-client/pull/3541)
-- Typescript improvements. Created a new `QueryOptions` interface that  
+- Typescript improvements. Created a new `QueryOptions` interface that
   is now used by `ApolloClient.query` options, instead of the previous
   `WatchQueryOptions` interface. This helps reduce confusion (especially
   in the docs) that made it look like `ApolloClient.query` accepted
@@ -49,7 +56,7 @@
   (Android), by instead setting the `prototype` of `this` manually.
   [Issue #3236](https://github.com/apollographql/apollo-client/issues/3236)
   [PR #3306](https://github.com/apollographql/apollo-client/pull/3306)
-- Added safeguards to make sure `QueryStore.initQuery` and   
+- Added safeguards to make sure `QueryStore.initQuery` and
   `QueryStore.markQueryResult` don't try to set the network status of a
   `fetchMoreForQueryId` query, if it does not exist in the store. This was
   happening when a query component was unmounted while a `fetchMore` was still

--- a/packages/apollo-utilities/CHANGELOG.md
+++ b/packages/apollo-utilities/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+----
+
+**NOTE:** This changelog is no longer maintained. Changes are now tracked in
+the top level [`CHANGELOG.md`](https://github.com/apollographql/apollo-client/blob/master/CHANGELOG.md).
+
+----
+
 ### 1.0.16
 
 - Removed unnecessary whitespace from error message

--- a/packages/graphql-anywhere/CHANGELOG.md
+++ b/packages/graphql-anywhere/CHANGELOG.md
@@ -1,8 +1,15 @@
 # CHANGELOG
 
+----
+
+**NOTE:** This changelog is no longer maintained. Changes are now tracked in
+the top level [`CHANGELOG.md`](https://github.com/apollographql/apollo-client/blob/master/CHANGELOG.md).
+
+----
+
 ### vNext
 
-- Add support for arrays to `filter`.       
+- Add support for arrays to `filter`.
   [PR #3591](https://github.com/apollographql/apollo-client/pull/3591)
 
 ### 4.1.14


### PR DESCRIPTION
We've centralized all package changes into one main top level [`CHANGELOG.md`](
https://github.com/apollographql/apollo-client/blob/master/CHANGELOG.md), to make it easier for people to see all package changes at once. This PR adds a small deprecation notice to all package `CHANGELOG.md`'s.