### PR TITLE
Adjust `graphql` peer dep to cover explicit minor ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
   semver 2), the current ^0.11.0 || ^14.0.0 graphql range doesn't cover
   0.12.* or 0.13.*. This fixes the `apollo-client@X has incorrect peer
   dependency "graphql@^0.11.0 || ^14.0.0"` errors that people might have
-  seen using `graphql` 0.12.x or 0.13.x.
+  seen using `graphql` 0.12.x or 0.13.x.  <br/>
   [@hwillson](https://github.com/hwillson) in [#3746](https://github.com/apollographql/apollo-client/pull/3746)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.3.8 (July 26, 2018)
 
-### Apollo Client (2.3.7)
+### Apollo Client (vNext)
 
 - Adjusted the `graphql` peer dependency to cover explicit minor ranges.
   Since the ^ operator only covers any minor version if the major version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 **Note:** This is a cumulative changelog that outlines all of the Apollo Client project child package changes that were bundled into a specific `apollo-client` release.
 
-## 2.3.8 (July 26, 2018)
+## vNext
 
 ### Apollo Client (vNext)
 
@@ -25,7 +25,7 @@
   caused by the typescript compiler getting confused at compile/publish time.
   `getQueryWithPreviousResult` return types are now excplicity identified,
   which helps Typescript avoid the local type reference. For more details,
-  see https://github.com/apollographql/apollo-client/issues/3729.
+  see https://github.com/apollographql/apollo-client/issues/3729.  <br/>
   [@hwillson](https://github.com/hwillson) in [#3731](https://github.com/apollographql/apollo-client/pull/3731)
 
 ### Apollo Boost (0.1.12)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 **Note:** This is a cumulative changelog that outlines all of the Apollo Client project child package changes that were bundled into a specific `apollo-client` release.
 
+## 2.3.8 (July 26, 2018)
+
+### Apollo Client (2.3.7)
+
+- Adjusted the `graphql` peer dependency to cover explicit minor ranges.
+  Since the ^ operator only covers any minor version if the major version
+  is not 0 (since a major version of 0 is technically considered development by
+  semver 2), the current ^0.11.0 || ^14.0.0 graphql range doesn't cover
+  0.12.* or 0.13.*. This fixes the `apollo-client@X has incorrect peer
+  dependency "graphql@^0.11.0 || ^14.0.0"` errors that people might have
+  seen using `graphql` 0.12.x or 0.13.x.
+  [@hwillson](https://github.com/hwillson) in [#3746](https://github.com/apollographql/apollo-client/pull/3746)
+
+
 ## 2.3.7 (July 24, 2018)
 
 ### Apollo Client (2.3.7)

--- a/packages/apollo-client/package.json
+++ b/packages/apollo-client/package.json
@@ -55,7 +55,7 @@
     "zen-observable": "^0.8.0"
   },
   "peerDependencies": {
-    "graphql": "^0.11.0 || ^14.0.0"
+    "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0"
   },
   "devDependencies": {
     "@types/benchmark": "1.0.31",


### PR DESCRIPTION
Since the ^ operator only covers any minor version if the major version is not 0 (since a major version of 0 is  technically considered development by semver 2), the current ^0.11.0 || ^14.0.0 graphql range doesn't cover 0.12.* or 0.13.*.

Fixes #3737.
