### PR TITLE
Update docs and issue template with FR repo details

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -5,7 +5,7 @@
 
   If you don't follow the template, your issue may end up being closed without anyone looking at it carefully, because it is not actionable for us without the information in this template.
 
-  If you're filing a feature request, you do not need to follow the template, but please mark the feature box at the bottom and include a specific example in which that feature would be useful.
+  **PLEASE NOTE:** Feature requests and non-bug related discussions no longer managed in this repo. Feature requests should be opened in https://github.com/apollographql/apollo-feature-requests.
 -->
 
 **Intended outcome:**
@@ -30,17 +30,4 @@ Instructions for how the issue can be reproduced by a maintainer or contributor.
 Run the following command in your project directory, and paste its (automatically copied to clipboard) results here:
 
 `npx envinfo@latest --preset apollo --clipboard`
--->
-
-<!--**Issue Labels**
-
-While not necessary, you can help organize our issues by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:
-
-- [ ] has-reproduction
-- [ ] feature
-- [ ] docs
-- [ ] blocking
-- [ ] good first issue
-
-To add a label not listed above, simply place `/label another-label-name` on a line by itself.
 -->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -5,7 +5,7 @@
 
   If you don't follow the template, your issue may end up being closed without anyone looking at it carefully, because it is not actionable for us without the information in this template.
 
-  **PLEASE NOTE:** Feature requests and non-bug related discussions no longer managed in this repo. Feature requests should be opened in https://github.com/apollographql/apollo-feature-requests.
+  **PLEASE NOTE:** Feature requests and non-bug related discussions are no longer managed in this repo. Feature requests should be opened in https://github.com/apollographql/apollo-feature-requests.
 -->
 
 **Intended outcome:**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,15 +22,3 @@
 
 - [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
 - [ ] Make sure all of the significant new logic is covered by tests
-- [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.
-
-<!--**Pull Request Labels**
-
-While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:
-
-- [ ] feature
-- [ ] blocking
-- [ ] docs
-
-To add a label not listed above, simply place `/label another-label-name` on a line by itself.
--->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Creating a good reproduction really helps contributors investigate and resolve y
 
 ### Improving the documentation
 
-Improving the documentation, examples, and other open source content can be the easiest way to contribute to the library. If you see a piece of content that can be better, open a PR with an improvement, no matter how small! If you would like to suggest a big change or major rewrite, we’d love to hear your ideas but please open an issue for discussion before writing the PR.
+Improving the documentation, examples, and other open source content can be the easiest way to contribute to the library. If you see a piece of content that can be better, open a PR with an improvement, no matter how small! If you would like to suggest a big change or major rewrite, we’d love to hear your ideas! Please open a feature request for discussion, over in the [Apollo Client Feature Request repo](https://github.com/apollographql/apollo-feature-requests), before writing the PR.
 
 ### Responding to issues
 
@@ -43,15 +43,9 @@ For a small bug fix change (less than 20 lines of code changed), feel free to op
 
 ### Suggesting features
 
-Most of the features in Apollo came from suggestions by you, the community! We welcome any ideas about how to make Apollo  better for your use case. Unless there is overwhelming demand for a feature, it might not get implemented immediately, but please include as much information as possible that will help people have a discussion about your proposal:
+Most of the features in Apollo Client came from suggestions by you, the community! We welcome any ideas about how to make Apollo  better for your use case. Head on over to the [Apollo Client Feature Request repo](https://github.com/apollographql/apollo-feature-requests), and open up a new feature request issue with your details.
 
-1. **Use case:** What are you trying to accomplish, in specific terms? Often, there might already be a good way to do what you need and a new feature is unnecessary, but it’s hard to know without information about the specific use case.
-2. **Could this be a plugin?** In many cases, a feature might be too niche to be included in the core of a library, and is better implemented as a companion package. If there isn’t a way to extend the library to do what you want, could we add additional plugin APIs? It’s important to make the case for why a feature should be part of the core functionality of the library.
-3. **Is there a workaround?** Is this a more convenient way to do something that is already possible, or is there some blocker that makes a workaround unfeasible?
-
-Feature requests will be labeled as such, and we encourage using GitHub issues as a place to discuss new features and possible implementation designs. Please refrain from submitting a pull request to implement a proposed feature until there is consensus that it should be included. This way, you can avoid putting in work that can’t be merged in.
-
-Once there is a consensus on the need for a new feature, proceed as listed below under “Big PRs”.
+**Note:** Feature Requests are no longer managed in this repo's issue tracker. Feature request based issues opened here will be closed.
 
 ## Big PRs
 
@@ -62,7 +56,7 @@ This includes:
 
 For significant changes to a repository, it’s important to settle on a design before starting on the implementation. This way, we can make sure that major improvements get the care and attention they deserve. Since big changes can be risky and might not always get merged, it’s good to reduce the amount of possible wasted effort by agreeing on an implementation design/plan first.
 
-1. **Open an issue.** Open an issue about your bug or feature, as described above.
+1. **Open an issue.** Open an issue about your bug in this repo, or about your feature request in the [Apollo Client Feature Request repo](https://github.com/apollographql/apollo-feature-requests).
 2. **Reach consensus.** Some contributors and community members should reach an agreement that this feature or bug is important, and that someone should work on implementing or fixing it.
 3. **Agree on intended behavior.** On the issue, reach an agreement about the desired behavior. In the case of a bug fix, it should be clear what it means for the bug to be fixed, and in the case of a feature, it should be clear what it will be like for developers to use the new feature.
 4. **Agree on implementation plan.** Write a plan for how this feature or bug fix should be implemented. What modules need to be added or rewritten? Should this be one pull request or multiple incremental improvements? Who is going to do each part?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,9 +43,9 @@ For a small bug fix change (less than 20 lines of code changed), feel free to op
 
 ### Suggesting features
 
-Most of the features in Apollo Client came from suggestions by you, the community! We welcome any ideas about how to make Apollo  better for your use case. Head on over to the [Apollo Client Feature Request repo](https://github.com/apollographql/apollo-feature-requests), and open up a new feature request issue with your details.
+Most of the features in Apollo Client came from suggestions by you, the community! We welcome any ideas about how to make Apollo  better for your use case. Head on over to the [Apollo Client Feature Request repo](https://github.com/apollographql/apollo-feature-requests), and open up a new feature request / discussion issue with your details.
 
-**Note:** Feature Requests are no longer managed in this repo's issue tracker. Feature request based issues opened here will be closed.
+**Note:** Feature requests and non-bug related discussions are no longer managed in this repo's issue tracker. Feature request and/or discussions opened here will be closed.
 
 ## Big PRs
 

--- a/ISSUE_TRIAGE.md
+++ b/ISSUE_TRIAGE.md
@@ -1,6 +1,6 @@
 # Issue Triage
 
-This document describes the process Apollo contributors use to organize issues. We use Github [issues](https://github.com/apollographql/apollo-client/issues) here to track bugs, and issues in the [Apollo Client Feature Request repo](https://github.com/apollographql/apollo-feature-requests) to track feature requests. Our goal is to maintain a list of issues that are relevant and well-defined (and [labeled](https://github.com/apollographql/apollo-client/labels)) such that a contributor can immediately begin working on the code for a fix or feature request. Contributors who want to dive in and write code aren't likely to prioritize working on issues that are ambiguous and have low impact.
+This document describes the process Apollo contributors use to organize issues. We use Github [issues](https://github.com/apollographql/apollo-client/issues) here to track bugs, and issues in the [Apollo Client Feature Request repo](https://github.com/apollographql/apollo-feature-requests) to track feature requests and discussions. Our goal is to maintain a list of issues that are relevant and well-defined (and [labeled](https://github.com/apollographql/apollo-client/labels)) such that a contributor can immediately begin working on the code for a fix or feature request. Contributors who want to dive in and write code aren't likely to prioritize working on issues that are ambiguous and have low impact.
 
 We would love to have more contributors who are willing to help out with triaging issues. You can begin by helping issue requesters create good reproductions and by confirming those reproductions on your own machine. It won't be long before the core maintainers notice your work and ask whether you'd like to be promoted to an issue maintainer.
 
@@ -35,7 +35,7 @@ The first step is in determining whether the issue is a bug, help question or fe
 
 ### Feature requests
 
-Apollo Client feature requests are managed in the [Apollo Client Feature Request repo](https://github.com/apollographql/apollo-feature-requests). Feature request triaging should happen there. Feature requests opened in this repository should be closed, with a message asking the original requestor to re-open the feature request in the FR repo.
+Apollo Client feature requests and discussions are managed in the [Apollo Client Feature Request repo](https://github.com/apollographql/apollo-feature-requests). Feature request triaging should happen there. Feature requests and/or discussions opened in this repository should be closed, with a message asking the original requestor to re-open the feature request / discussion in the FR repo.
 
 <h2 id="classification">Classification</h2>
 

--- a/ISSUE_TRIAGE.md
+++ b/ISSUE_TRIAGE.md
@@ -1,6 +1,6 @@
 # Issue Triage
 
-This document describes the process Apollo contributors use to organize issues. We use Github [issues](https://github.com/apollographql/apollo-client/issues) to track bugs and feature requests. Our goal is to maintain a list of issues that are relevant and well-defined (and [labeled](https://github.com/apollographql/apollo-client/labels)) such that a contributor can immediately begin working on the code for a fix or feature request. Contributors who want to dive in and write code aren't likely to prioritize working on issues that are ambiguous and have low impact.
+This document describes the process Apollo contributors use to organize issues. We use Github [issues](https://github.com/apollographql/apollo-client/issues) here to track bugs, and issues in the [Apollo Client Feature Request repo](https://github.com/apollographql/apollo-feature-requests) to track feature requests. Our goal is to maintain a list of issues that are relevant and well-defined (and [labeled](https://github.com/apollographql/apollo-client/labels)) such that a contributor can immediately begin working on the code for a fix or feature request. Contributors who want to dive in and write code aren't likely to prioritize working on issues that are ambiguous and have low impact.
 
 We would love to have more contributors who are willing to help out with triaging issues. You can begin by helping issue requesters create good reproductions and by confirming those reproductions on your own machine. It won't be long before the core maintainers notice your work and ask whether you'd like to be promoted to an issue maintainer.
 
@@ -31,19 +31,11 @@ The first step is in determining whether the issue is a bug, help question or fe
 
 ### Help questions
 
-[Stack Overflow](http://stackoverflow.com/questions/tagged/apollo) and our [Slack channel](http://dev.apollodata.com/#slack) are the place to ask for help on using the framework. Close issues that are help requests and politely refer the author to the above locations.
+[Stack Overflow](http://stackoverflow.com/questions/tagged/apollo) and our [Slack channel](https://www.apollographql.com/slack) are the place to ask for help on using the framework. Close issues that are help requests and politely refer the author to the above locations.
 
 ### Feature requests
 
-1. For reasons described [here](CONTRIBUTING.md#feature-requests), we would prefer features to be built as separate packages. If the feature can clearly be built as a package, explain this to the requester and close the issue.
-> - If the feature could be built as a package and serves a particular need, encourage the user to contribute it themselves.
->- If the underlying issue could be better solved by existing technology, encourage them to seek help in the [Slack channel](http://dev.apollodata.com/#slack) or on [Stack Overflow](http://stackoverflow.com/questions/tagged/apollo).
-2. If you haven't closed the issue, add the `feature` label.
-3. If it's not possible to build the feature as a package (as you identified in step 1), explore whether creating hooks in core would make it possible to do so. If it would, redefine the issue as a request to create those hooks.
-4. Work with the requester and others in the community to build a clear specification for the feature and update the issue description accordingly.
-5. Finally, add the `confirmed` label and [classify](#classification) the issue.
-
-Core contributors may add the `help-wanted` label to feature requests. This indicates the feature is aligned with the project roadmap and a high-quality pull request will almost certainly be merged.
+Apollo Client feature requests are managed in the [Apollo Client Feature Request repo](https://github.com/apollographql/apollo-feature-requests). Feature request triaging should happen there. Feature requests opened in this repository should be closed, with a message asking the original requestor to re-open the feature request in the FR repo.
 
 <h2 id="classification">Classification</h2>
 


### PR DESCRIPTION
Starting very shortly, all Apollo Client feature requests and discussions will be managed under the new https://github.com/apollographql/apollo-feature-requests repo. This PR kick starts the necessary documentation and issue template changes needed to point people in the right direction.