### PR TITLE
Jest config adjustment to address recent JSDom issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
   "jest": {
     "transform": {
       ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
-    }
+    },
+    "testURL": "http://localhost"
   },
   "lint-staged": {
     "*.ts*": [

--- a/packages/apollo-boost/package.json
+++ b/packages/apollo-boost/package.json
@@ -68,6 +68,7 @@
       "tsx",
       "js",
       "json"
-    ]
+    ],
+    "testURL": "http://localhost"
   }
 }

--- a/packages/apollo-cache-inmemory/package.json
+++ b/packages/apollo-cache-inmemory/package.json
@@ -73,6 +73,7 @@
       "tsx",
       "js",
       "json"
-    ]
+    ],
+    "testURL": "http://localhost"
   }
 }

--- a/packages/apollo-cache/package.json
+++ b/packages/apollo-cache/package.json
@@ -66,6 +66,7 @@
       "tsx",
       "js",
       "json"
-    ]
+    ],
+    "testURL": "http://localhost"
   }
 }

--- a/packages/apollo-client/package.json
+++ b/packages/apollo-client/package.json
@@ -102,6 +102,7 @@
     ],
     "setupFiles": [
       "<rootDir>/scripts/tests.js"
-    ]
+    ],
+    "testURL": "http://localhost"
   }
 }

--- a/packages/apollo-utilities/package.json
+++ b/packages/apollo-utilities/package.json
@@ -69,6 +69,7 @@
       "tsx",
       "js",
       "json"
-    ]
+    ],
+    "testURL": "http://localhost"
   }
 }

--- a/packages/graphql-anywhere/package.json
+++ b/packages/graphql-anywhere/package.json
@@ -71,6 +71,7 @@
       "tsx",
       "js",
       "json"
-    ]
+    ],
+    "testURL": "http://localhost"
   }
 }


### PR DESCRIPTION
A recent Renovate merged Jest update caused all tests to start to fail, due to JSDom security errors. This config adjustment was recommended in the Jest repo to address this issue.

Relates to:
https://github.com/facebook/jest/issues/6766#issuecomment-408344243
