### PR TITLE
Remove `tooling` label used by renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,6 @@
   "prCreation": "not-pending",
   "automerge": "minor",
   "labels": [
-    "tooling",
     "dependencies"
   ],
   "assignees": [


### PR DESCRIPTION
`tooling` is too generic as a label, and could be used for any kind of tooling. It doesn't add much when triaging issues, so let's get rid of it.