### PR TITLE
Add note about calling `refetchQueries` with an array of strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@
   [@hwillson](https://github.com/hwillson) in [#3762](https://github.com/apollographql/apollo-client/pull/3762)  <br/>
   [@chentsulin](https://github.com/chentsulin) in [#3688](https://github.com/apollographql/apollo-client/pull/3688)  <br/>
   [@chentsulin](https://github.com/chentsulin) in [#3687](https://github.com/apollographql/apollo-client/pull/3687)  <br/>
-  [@ardouglass](https://github.com/ardouglass) in [#3645](https://github.com/apollographql/apollo-client/pull/3645)
+  [@ardouglass](https://github.com/ardouglass) in [#3645](https://github.com/apollographql/apollo-client/pull/3645)  <br/>
+  [@hwillson](https://github.com/hwillson) in [#3764](https://github.com/apollographql/apollo-client/pull/3764)
 
 
 ## 2.3.7 (July 24, 2018)

--- a/docs/source/advanced/caching.md
+++ b/docs/source/advanced/caching.md
@@ -286,6 +286,8 @@ mutate({
 })
 ```
 
+Please note that if you call `refetchQueries` with an array of strings, then Apollo Client will look for any previously called queries that have the same names as the provided strings. It will then refetch those queries with their current variables.
+
 A very common way of using `refetchQueries` is to import queries defined for other components to make sure that those components will be updated:
 
 ```javascript


### PR DESCRIPTION
Mention that when `refetchQueries` is called with an array of strings, Apollo Client tries to find previously run queries with those names, and run them again (with the same variables).

Fixes #3617.
