### PR TITLE
Remove outdated README section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@
   [@chentsulin](https://github.com/chentsulin) in [#3688](https://github.com/apollographql/apollo-client/pull/3688)  <br/>
   [@chentsulin](https://github.com/chentsulin) in [#3687](https://github.com/apollographql/apollo-client/pull/3687)  <br/>
   [@ardouglass](https://github.com/ardouglass) in [#3645](https://github.com/apollographql/apollo-client/pull/3645)  <br/>
-  [@hwillson](https://github.com/hwillson) in [#3764](https://github.com/apollographql/apollo-client/pull/3764)
+  [@hwillson](https://github.com/hwillson) in [#3764](https://github.com/apollographql/apollo-client/pull/3764)  <br/>
+  [@hwillson](https://github.com/hwillson) in [#3767](https://github.com/apollographql/apollo-client/pull/3767)
 
 
 ## 2.3.7 (July 24, 2018)

--- a/packages/apollo-boost/README.md
+++ b/packages/apollo-boost/README.md
@@ -1,4 +1,5 @@
 # apollo-boost
+
 The fastest, easiest way to get started with Apollo Client!
 
 Apollo Boost is a zero-config way to start using Apollo Client. It includes some sensible defaults, such as our recommended `InMemoryCache` and `HttpLink`, which come configured for you with our recommended settings.
@@ -66,6 +67,7 @@ Time to celebrate! 🎉 You just made your first Query component. The Query comp
 ## What's in Apollo Boost
 
 Apollo Boost includes some packages that we think are essential to developing with Apollo Client. Here's what's in the box:
+
 - `apollo-client`: Where all the magic happens
 - `apollo-cache-inmemory`: Our recommended cache
 - `apollo-link-http`: An Apollo Link for remote data fetching
@@ -73,65 +75,4 @@ Apollo Boost includes some packages that we think are essential to developing wi
 - `apollo-link-state`: An Apollo Link for local state management
 - `graphql-tag`: Exports the `gql` function for your queries & mutations
 
-The awesome thing about Apollo Boost is that you don't have to set any of this up yourself! Just specify a few options if you'd like to use these features and we'll take care of the rest.
-
-### Apollo Boost options
-
-Here are the options you can pass to the `ApolloClient` exported from `apollo-boost`. None of them are required.
-- uri: A string representing your GraphQL server endpoint. Defaults to `/graphql`
-- fetchOptions: An object representing any options you would like to pass to fetch (credentials, headers, etc). These options are static, so they don't change on each request.
-- request?: (operation: Operation) => Promise<void>;
-  - This function is called on each request. It takes an operation and can return a promise. To dynamically set `fetchOptions`, you can add them to the context of the operation with `operation.setContext({ headers })`. Any options set here will take precedence over `fetchOptions`.
-  - Use this function for authentication
-- onError: (errorObj: { graphQLErrors: GraphQLError[], networkError: Error, response?: ExecutionResult, operation: Operation }) => void
-  - We include a default error handler to log out your errors for you. If you would like to handle your errors differently, specify this function
-- clientState: An object representing your configuration for `apollo-link-state`. This is useful if you would like to use the Apollo cache for local state management. Learn more in our [quick start](https://www.apollographql.com/docs/link/links/state.html#start).
-- cacheRedirects: An map of functions to redirect a query to another entry in the cache before a request takes place. This is useful if you have a list of items and want to use the data from the list query on a detail page where you're querying an individual item. More on that [here](https://www.apollographql.com/docs/react/advanced/caching.html#cacheRedirect).
-
-That's it! Here's an example of all those options in action:
-
-```js
-import ApolloClient from 'apollo-boost';
-
-const client = new ApolloClient({
-  uri: 'https://nx9zvp49q7.lp.gql.zone/graphql',
-  fetchOptions: {
-    credentials: 'include'
-  },
-  request: async (operation) => {
-    const token = await AsyncStorage.getItem('token');
-    operation.setContext({
-      headers: {
-        authorization: token
-      }
-    });
-  },
-  onError: ({ graphQLErrors, networkError }) => {
-    if (graphQLErrors) {
-      sendToLoggingService(graphQLErrors);
-    }
-    if (networkError) {
-      logoutUser();
-    }
-  },
-  clientState: {
-    defaults: {
-      isConnected: true
-    },
-    resolvers: {
-      Mutation: {
-        updateNetworkStatus: (_, { isConnected }, { cache }) => {
-          cache.writeData({ data: { isConnected }});
-          return null;
-        }
-      }
-    }
-  },
-  cacheRedirects: {
-    Query: {
-      movie: (_, { id }, { getCacheKey }) =>
-        getCacheKey({ __typename: 'Movie', id });
-    }
-  }
-});
-```
+The awesome thing about Apollo Boost is that you don't have to set any of this up yourself! Just specify a few options if you'd like to use these features and we'll take care of the rest. For a full list of available options, please refer to the Apollo Boost [configuration options](https://www.apollographql.com/docs/react/essentials/get-started.html#configuration) documentation.


### PR DESCRIPTION
The Apollo Boost README config options section, and provided config example, are outdated and have caused some confustion for people. Since we already have everything up to date in the official docs, this commit removes the duplicated (and invalid) section from the README, replacing it with a link to the docs.

Fixes #3210.
