### PR TITLE
Adjust `subscribe` to recognize the `no-cache` fetch policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
   [@PowerKiKi](https://github.com/PowerKiKi) in [#3692](https://github.com/apollographql/apollo-client/pull/3692)
 - Corrected `ApolloClient.queryManager` typing as it may be `undefined`.  <br/>
   [@danilobuerger](https://github.com/danilobuerger) in [#3661](https://github.com/apollographql/apollo-client/pull/3661)
+- Make sure using a `no-cache` fetch policy with subscriptions prevents data
+  from being cached.  <br/>
+  [@hwillson](https://github.com/hwillson) in [#3773](https://github.com/apollographql/apollo-client/pull/3773)
 - Documentation updates.  <br/>
   [@hwillson](https://github.com/hwillson) in [#3750](https://github.com/apollographql/apollo-client/pull/3750)  <br/>
   [@hwillson](https://github.com/hwillson) in [#3754](https://github.com/apollographql/apollo-client/pull/3754)  <br/>

--- a/packages/apollo-cache-inmemory/src/mapCache.ts
+++ b/packages/apollo-cache-inmemory/src/mapCache.ts
@@ -5,22 +5,28 @@ import { NormalizedCache, NormalizedCacheObject, StoreObject } from './types';
  * Note that you need a polyfill for Object.entries for this to work.
  */
 export class MapCache implements NormalizedCache {
-  cache: Map<string, StoreObject>;
+  private cache: Map<string, StoreObject>;
+
   constructor(data: NormalizedCacheObject = {}) {
     this.cache = new Map(Object.entries(data));
   }
-  get(dataId: string): StoreObject {
+
+  public get(dataId: string): StoreObject {
     return this.cache.get(`${dataId}`);
   }
-  set(dataId: string, value: StoreObject): void {
+
+  public set(dataId: string, value: StoreObject): void {
     this.cache.set(`${dataId}`, value);
   }
-  delete(dataId: string): void {
+
+  public delete(dataId: string): void {
     this.cache.delete(`${dataId}`);
   }
-  clear(): void {
+
+  public clear(): void {
     return this.cache.clear();
   }
+
   public toObject(): NormalizedCacheObject {
     const obj: NormalizedCacheObject = {};
     this.cache.forEach((dataId, key) => {
@@ -28,6 +34,7 @@ export class MapCache implements NormalizedCache {
     });
     return obj;
   }
+
   public replace(newData: NormalizedCacheObject): void {
     this.cache.clear();
     Object.entries(newData).forEach(([dataId, value]) =>

--- a/packages/apollo-cache-inmemory/src/recordingCache.ts
+++ b/packages/apollo-cache-inmemory/src/recordingCache.ts
@@ -1,9 +1,9 @@
 import { NormalizedCache, NormalizedCacheObject, StoreObject } from './types';
 
 export class RecordingCache implements NormalizedCache {
-  constructor(private readonly data: NormalizedCacheObject = {}) {}
-
   private recordedData: NormalizedCacheObject = {};
+
+  constructor(private readonly data: NormalizedCacheObject = {}) {}
 
   public record(
     transaction: (recordingCache: RecordingCache) => void,

--- a/packages/apollo-client/src/__tests__/graphqlSubscriptions.ts
+++ b/packages/apollo-client/src/__tests__/graphqlSubscriptions.ts
@@ -187,4 +187,26 @@ describe('GraphQL Subscriptions', () => {
       link.simulateResult(results[i]);
     }
   });
+
+  it('should not cache subscription data if a `no-cache` fetch policy is used', done => {
+    const link = mockObservableLink(sub1);
+    const cache = new InMemoryCache({ addTypename: false });
+    const client = new ApolloClient({
+      link,
+      cache,
+    });
+
+    expect(cache.extract()).toEqual({});
+
+    options.fetchPolicy = 'no-cache';
+    const sub = client.subscribe(options).subscribe({
+      next() {
+        expect(cache.extract()).toEqual({});
+        sub.unsubscribe();
+        done();
+      },
+    });
+
+    link.simulateResult(results[0]);
+  });
 });

--- a/packages/apollo-client/src/core/watchQueryOptions.ts
+++ b/packages/apollo-client/src/core/watchQueryOptions.ts
@@ -143,6 +143,11 @@ export interface SubscriptionOptions<TVariables = OperationVariables> {
    * GraphQL document to that variable's value.
    */
   variables?: TVariables;
+
+  /**
+   * Specifies the {@link FetchPolicy} to be used for this subscription.
+   */
+  fetchPolicy?: FetchPolicy;
 }
 
 export type RefetchQueryDescription = Array<string | PureQueryOptions>;

--- a/packages/apollo-client/src/util/subscribeAndCount.ts
+++ b/packages/apollo-client/src/util/subscribeAndCount.ts
@@ -3,7 +3,7 @@ import { ApolloQueryResult } from '../../src/core/types';
 import { Subscription } from '../../src/util/Observable';
 
 export default function subscribeAndCount(
-  done: (...args) => void,
+  done: jest.DoneCallback,
   observable: ObservableQuery<any>,
   cb: (handleCount: number, result: ApolloQueryResult<any>) => any,
 ): Subscription {

--- a/packages/apollo-client/src/util/wrap.ts
+++ b/packages/apollo-client/src/util/wrap.ts
@@ -1,6 +1,6 @@
 // I'm not sure why mocha doesn't provide something like this, you can't
 // always use promises
-export default (done: (...args) => void, cb: (...args: any[]) => any) => (
+export default (done: jest.DoneCallback, cb: (...args: any[]) => any) => (
   ...args: any[]
 ) => {
   try {

--- a/packages/apollo-client/tsconfig.json
+++ b/packages/apollo-client/tsconfig.json
@@ -10,9 +10,9 @@
     "strictNullChecks": true,
     "noUnusedParameters": true
   },
+  "include": ["src/**/*.ts"],
   "files": [
     "node_modules/typescript/lib/lib.es2015.d.ts",
-    "node_modules/typescript/lib/lib.dom.d.ts",
-    "src/index.ts"
+    "node_modules/typescript/lib/lib.dom.d.ts"
   ]
 }

--- a/packages/apollo-client/tsconfig.json
+++ b/packages/apollo-client/tsconfig.json
@@ -11,6 +11,10 @@
     "noUnusedParameters": true
   },
   "include": ["src/**/*.ts"],
+  "exclude": [
+    "**/__tests__/**/*",
+    "**/__mocks__/**/*"
+  ],
   "files": [
     "node_modules/typescript/lib/lib.es2015.d.ts",
     "node_modules/typescript/lib/lib.dom.d.ts"

--- a/packages/apollo-utilities/src/getFromAST.ts
+++ b/packages/apollo-utilities/src/getFromAST.ts
@@ -192,16 +192,18 @@ export function getDefaultValues(
   ) {
     const defaultValues = definition.variableDefinitions
       .filter(({ defaultValue }) => defaultValue)
-      .map(({ variable, defaultValue }): { [key: string]: JsonValue } => {
-        const defaultValueObj: { [key: string]: JsonValue } = {};
-        valueToObjectRepresentation(
-          defaultValueObj,
-          variable.name,
-          defaultValue as ValueNode,
-        );
+      .map(
+        ({ variable, defaultValue }): { [key: string]: JsonValue } => {
+          const defaultValueObj: { [key: string]: JsonValue } = {};
+          valueToObjectRepresentation(
+            defaultValueObj,
+            variable.name,
+            defaultValue as ValueNode,
+          );
 
-        return defaultValueObj;
-      });
+          return defaultValueObj;
+        },
+      );
 
     return assign({}, ...defaultValues);
   }

--- a/packages/graphql-anywhere/src/graphql-async.ts
+++ b/packages/graphql-anywhere/src/graphql-async.ts
@@ -42,7 +42,6 @@ import {
  * but below is an exported alternative that is async.
  * In the 5.0 version, this will be the only export again
  * and it will be async
- * 
  */
 export function graphql(
   resolver: Resolver,

--- a/packages/graphql-anywhere/src/graphql.ts
+++ b/packages/graphql-anywhere/src/graphql.ts
@@ -75,7 +75,6 @@ export type ExecOptions = {
  * but below is an exported alternative that is async.
  * In the 5.0 version, this will be the only export again
  * and it will be async
- * 
  */
 export function graphql(
   resolver: Resolver,


### PR DESCRIPTION
Currently `client.subscribe` calls are ignoring `no-cache` fetch policy settings. These changes make sure `no-cache` avoids writing subscription results to the cache.

Fixes #3709.
Fixes #3532.
