### PR TITLE
Doc change for `defaultOptions.watchQuery` when using React Apollo

### DIFF
--- a/docs/source/api/apollo-client.md
+++ b/docs/source/api/apollo-client.md
@@ -34,6 +34,8 @@ const defaultOptions = {
 
 These options will be merged with options supplied with each request.
 
+> **Note:** The React Apollo `<Query />` component uses Apollo Client's `watchQuery` functionality, so if you would like to set `defaultOptions` when using `<Query />`, be sure to set them under the `defaultOptions.watchQuery` property.
+
 The `ApolloClient` class is the core API for Apollo, and the one you'll need to  use no matter which integration you are using:
 
 {% tsapibox ApolloClient.constructor %}


### PR DESCRIPTION
Make sure that the docs clearly specify that when setting Apollo Client `defaultOptions` to be used with React Apollo `<Query />` components, `defaultOptions.watchQuery` should be used.

Reference: https://github.com/apollographql/apollo-client/issues/3452#issuecomment-410322219
