### PR TITLE
Replace deprecated `uglifyjs` with `uglify-js`

### DIFF
--- a/packages/apollo-boost/package.json
+++ b/packages/apollo-boost/package.json
@@ -56,7 +56,7 @@
     "ts-jest": "20.0.14",
     "tslint": "5.11.0",
     "typescript": "2.9.2",
-    "uglifyjs": "2.4.11"
+    "uglify-js": "^3.4.6"
   },
   "jest": {
     "transform": {

--- a/packages/apollo-cache-inmemory/package.json
+++ b/packages/apollo-cache-inmemory/package.json
@@ -61,7 +61,7 @@
     "ts-jest": "20.0.14",
     "tslint": "5.11.0",
     "typescript": "2.9.2",
-    "uglifyjs": "2.4.11"
+    "uglify-js": "^3.4.6"
   },
   "jest": {
     "transform": {

--- a/packages/apollo-cache/package.json
+++ b/packages/apollo-cache/package.json
@@ -54,7 +54,7 @@
     "ts-jest": "20.0.14",
     "tslint": "5.11.0",
     "typescript": "2.9.2",
-    "uglifyjs": "2.4.11"
+    "uglify-js": "^3.4.6"
   },
   "jest": {
     "transform": {

--- a/packages/apollo-utilities/package.json
+++ b/packages/apollo-utilities/package.json
@@ -57,7 +57,7 @@
     "ts-jest": "20.0.14",
     "tslint": "5.11.0",
     "typescript": "2.9.2",
-    "uglifyjs": "2.4.11"
+    "uglify-js": "^3.4.6"
   },
   "jest": {
     "transform": {


### PR DESCRIPTION
Fixes #3650.
Fixes #3651.
Fixes #3652.
Fixes #3653.
