### PR TITLE
Made link and cache optional

### DIFF
--- a/packages/apollo-client/src/ApolloClient.ts
+++ b/packages/apollo-client/src/ApolloClient.ts
@@ -42,8 +42,8 @@ export interface DefaultOptions {
 let hasSuggestedDevtools = false;
 
 export type ApolloClientOptions<TCacheShape> = {
-  link: ApolloLink;
-  cache: ApolloCache<TCacheShape>;
+  link?: ApolloLink;
+  cache?: ApolloCache<TCacheShape>;
   ssrMode?: boolean;
   ssrForceFetchDelay?: number;
   connectToDevTools?: boolean;


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests

`link` and `cache` should be optional properties of `defaultOptions`. We shouldn't have to specify these just to (for example) set `watchQuery.fetchPolicy`. In fact, the official example shows using `defaultOptions` without specifying `link` and `cache`:

https://www.apollographql.com/docs/react/api/apollo-client.html#apollo-client