### PR TITLE
added test to readQuery

### DIFF
--- a/packages/apollo-cache-inmemory/src/__tests__/cache.ts
+++ b/packages/apollo-cache-inmemory/src/__tests__/cache.ts
@@ -200,6 +200,7 @@ describe('Cache', () => {
         ),
       ).toEqual({ a: 1, b: 2 });
     });
+
     it('will read some data from the store with null variables', () => {
       const proxy = createCache({
         initialState: {
@@ -228,6 +229,40 @@ describe('Cache', () => {
           }),
         ),
       ).toEqual({ a: 1 });
+    });
+
+    it('should not mutate arguments passed in', () => {
+      const proxy = createCache({
+        initialState: {
+          apollo: {
+            data: {
+              ROOT_QUERY: {
+                'field({"literal":true,"value":42})': 1,
+                'field({"literal":false,"value":42})': 2,
+              },
+            },
+          },
+        },
+      });
+
+      const args = {
+        query: gql`
+          query($literal: Boolean, $value: Int) {
+            a: field(literal: true, value: 42)
+            b: field(literal: $literal, value: $value)
+          }
+        `,
+        variables: {
+          literal: false,
+          value: 42,
+        },
+      };
+
+      const preQueryCopy = { ...args };
+
+      expect(stripSymbols(proxy.readQuery(args))).toEqual({ a: 1, b: 2 });
+
+      expect(preQueryCopy).toEqual(args);
     });
   });
 


### PR DESCRIPTION
Adds a test to ensure that passed in arguments aren't mutated after a `readQuery` as requested per issue: https://github.com/apollographql/apollo-client/issues/2464