### PR TITLE
Docs updates for https://github.com/apollographql/react-apollo/pull/1966

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 **Note:** This is a cumulative changelog that outlines all of the Apollo Client project child package changes that were bundled into a specific `apollo-client` release.
 
+## vNext
+
+### Apollo Client (2.4.1)
+
+- Documentation updates.  <br/>
+  [@hwillson](https://github.com/hwillson) in [#](https://github.com/apollographql/apollo-client/pull/)
+
+
 ## 2.4.0 (August 17, 2018)
 
 ### Apollo Client (2.4.0)

--- a/docs/source/advanced/subscriptions.md
+++ b/docs/source/advanced/subscriptions.md
@@ -159,6 +159,8 @@ The Subscription component accepts the following props. Only `subscription` and 
   <dd>An object containing all of the variables your subscription needs to execute</dd>
   <dt>`shouldResubscribe`: boolean | (currentProps: Object, nextProps: Object) => boolean</dt>
   <dd>Determines if your subscription should be unsubscribed and subscribed again. By default, the component will only resubscribe if `variables` or `subscription` props change.</dd>
+  <dt>`onSubscriptionData`: (options: OnSubscriptionDataOptions<TData>) => any</dt>
+  <dd>Allows the registration of a callback function, that will be triggered each time the `Subscription` component receives data. The callback `options` object param consists of the current Apollo Client instance in `client`, and the received subscription data in `subscriptionData`.</dd>
 </dl>
 
 <h3 id="render-prop">Render prop function</h3>

--- a/docs/source/api/react-apollo.md
+++ b/docs/source/api/react-apollo.md
@@ -186,6 +186,8 @@ The Subscription component accepts the following props. Only `subscription` and 
   <dd>An object containing all of the variables your subscription needs to execute</dd>
   <dt>`shouldResubscribe`: boolean</dt>
   <dd>Determines if your subscription should be unsubscribed and subscribed again</dd>
+  <dt>`onSubscriptionData`: (options: OnSubscriptionDataOptions<TData>) => any</dt>
+  <dd>Allows the registration of a callback function, that will be triggered each time the `Subscription` component receives data. The callback `options` object param consists of the current Apollo Client instance in `client`, and the received subscription data in `subscriptionData`.</dd>
 </dl>
 
 <h3 id="subscription-render-prop">Render prop function</h3>


### PR DESCRIPTION
Doc updates for the new `<Subscription/>` `onSubscriptionData` callback option.

Reference: https://github.com/apollographql/react-apollo/pull/1966