### PR TITLE
Fix type for subscribeToMore

### DIFF
--- a/packages/apollo-client/package.json
+++ b/packages/apollo-client/package.json
@@ -13,7 +13,7 @@
     "coverage": "jest --coverage",
     "dev": "./scripts/dev.sh",
     "deploy": "./scripts/deploy.sh",
-    "test": "jest",
+    "test": "tsc -p tsconfig.test.json --noEmit && jest",
     "benchmark": "npm run build:benchmark && node benchmark_lib/benchmark/index.js",
     "benchmark:inspect": "npm run build:benchmark && node --inspect --debug-brk benchmark_lib/benchmark/index.js",
     "filesize": "npm run minify",

--- a/packages/apollo-client/src/__mocks__/mockLinks.ts
+++ b/packages/apollo-client/src/__mocks__/mockLinks.ts
@@ -20,10 +20,8 @@ export function mockSingleLink(
   return new MockLink(mockedResponses);
 }
 
-export function mockObservableLink(
-  mockedSubscription: MockedSubscription,
-): MockSubscriptionLink {
-  return new MockSubscriptionLink(mockedSubscription);
+export function mockObservableLink(): MockSubscriptionLink {
+  return new MockSubscriptionLink();
 }
 
 export interface MockedResponse {
@@ -118,6 +116,7 @@ export class MockSubscriptionLink extends ApolloLink {
         unsubscribe: () => {
           this.unsubscribers.forEach(x => x());
         },
+        closed: false
       };
     });
   }
@@ -131,11 +130,11 @@ export class MockSubscriptionLink extends ApolloLink {
     }, result.delay || 0);
   }
 
-  public onSetup(listener): void {
+  public onSetup(listener: any): void {
     this.setups = this.setups.concat([listener]);
   }
 
-  public onUnsubscribe(listener): void {
+  public onUnsubscribe(listener: any): void {
     this.unsubscribers = this.unsubscribers.concat([listener]);
   }
 }

--- a/packages/apollo-client/src/core/ObservableQuery.ts
+++ b/packages/apollo-client/src/core/ObservableQuery.ts
@@ -342,17 +342,17 @@ export class ObservableQuery<
   // XXX the subscription variables are separate from the query variables.
   // if you want to update subscription variables, right now you have to do that separately,
   // and you can only do it by stopping the subscription and then subscribing again with new variables.
-  public subscribeToMore(options: SubscribeToMoreOptions<TData, TVariables>) {
+  public subscribeToMore<TSubscriptionData = TData>(options: SubscribeToMoreOptions<TData, TVariables, TSubscriptionData>) {
     const subscription = this.queryManager
       .startGraphQLSubscription({
         query: options.document,
         variables: options.variables,
       })
       .subscribe({
-        next: (subscriptionData: { data: TData }) => {
+        next: (subscriptionData: { data: TSubscriptionData }) => {
           if (options.updateQuery) {
             this.updateQuery((previous, { variables }) =>
-              (options.updateQuery as UpdateQueryFn<TData, TVariables>)(
+              (options.updateQuery as UpdateQueryFn<TData, TVariables, TSubscriptionData>)(
                 previous,
                 {
                   subscriptionData,

--- a/packages/apollo-client/src/core/watchQueryOptions.ts
+++ b/packages/apollo-client/src/core/watchQueryOptions.ts
@@ -113,21 +113,22 @@ export interface FetchMoreQueryOptions<TVariables, K extends keyof TVariables> {
   variables?: Pick<TVariables, K>;
 }
 
-export type UpdateQueryFn<TData = any, TVariables = OperationVariables> = (
+export type UpdateQueryFn<TData = any, TVariables = OperationVariables, TSubscriptionData = TData> = (
   previousQueryResult: TData,
   options: {
-    subscriptionData: { data: TData };
+    subscriptionData: { data: TSubscriptionData };
     variables?: TVariables;
   },
 ) => TData;
 
 export type SubscribeToMoreOptions<
   TData = any,
-  TVariables = OperationVariables
+  TVariables = OperationVariables,
+  TSubscriptionData = TData
 > = {
   document: DocumentNode;
   variables?: TVariables;
-  updateQuery?: UpdateQueryFn<TData, TVariables>;
+  updateQuery?: UpdateQueryFn<TData, TVariables, TSubscriptionData>;
   onError?: (error: Error) => void;
 };
 

--- a/packages/apollo-client/tsconfig.test.json
+++ b/packages/apollo-client/tsconfig.test.json
@@ -1,6 +1,28 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "module": "commonjs"
-  }
+    "module": "commonjs",
+  },
+  "exclude": [
+    "src/__tests__/ApolloClient.ts",
+    "src/__tests__/client.ts",
+    "src/__tests__/fetchMore.ts",
+    "src/__tests__/graphqlSubscriptions.ts",
+    "src/__tests__/mutationResults.ts",
+    "src/__tests__/optimistic.ts",
+    "src/core/__tests__/ObservableQuery.ts",
+    "src/core/__tests__/QueryManager/index.ts",
+    "src/core/__tests__/QueryManager/links.ts",
+    "src/core/__tests__/QueryManager/live.ts",
+    "src/core/__tests__/QueryManager/multiple-results.ts",
+    "src/core/__tests__/QueryManager/recycler.ts",
+    "src/core/__tests__/fetchPolicies.ts",
+    "src/data/__tests__/queries.ts",
+    "src/errors/__tests__/ApolloError.ts",
+    "src/scheduler/__tests__/scheduler.ts",
+    "src/__mocks__/mockFetch.ts",
+    "src/__mocks__/mockLinks.ts",
+    "src/__mocks__/mockQueryManager.ts",
+    "src/__mocks__/mockWatchQuery.ts",
+  ]
 }


### PR DESCRIPTION
Currently, `subscribeToMore` can have only one type.
But Query and Subscription might be a different type.

Actually, our test already has such a case:

https://github.com/apollographql/apollo-client/blob/fd7622126dd314b7efb4e74a2944c986a3102378/packages/apollo-client/src/__tests__/subscribeToMore.ts#L306

I've noticed current our tests and mocks are broken in point of typing because ts-jest doesn't check type and tsc doesn't compile them.

https://github.com/apollographql/apollo-client/blob/fd7622126dd314b7efb4e74a2944c986a3102378/packages/apollo-client/tsconfig.json#L14-L15

I fixed `__tests__/subscribeToMore.ts` to pass compiling to test my change.
If you maintainers think it should be done by another PR, please feel free to ask me.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests

### Special Thanks

@joe-re Thank you for your help to fix this problem 🙏 