### PR TITLE
Allow `context` option in `refetchQueries`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
   The `CUSTOMER_MESSAGES_QUERY` above will be refetched using `context`.
   Normally queries are refetched using the original context they were first
   started with, but this provides a way to override the context, if needed.  <br/>
-  [@hwillson](https://github.com/hwillson) in [#](https://github.com/apollographql/apollo-client/pull/)
+  [@hwillson](https://github.com/hwillson) in [#3852](https://github.com/apollographql/apollo-client/pull/3852)
 
 - Documentation updates.  <br/>
   [@hwillson](https://github.com/hwillson) in [#3841](https://github.com/apollographql/apollo-client/pull/3841)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,41 @@
 
 ## vNext
 
-### Apollo Client (2.4.1)
+### Apollo Client (vNext)
+
+- `mutate`'s `refetchQueries` option now allows queries to include a custom
+  `context` option. This `context` will be used when refetching the query.
+  For example:
+
+  ```js
+  context = {
+    headers: {
+      token: 'some auth token',
+    },
+  };
+  client.mutate({
+    mutation: UPDATE_CUSTOMER_MUTATION,
+    variables: {
+      userId: user.id,
+      firstName,
+      ...
+    },
+    refetchQueries: [{
+      query: CUSTOMER_MESSAGES_QUERY,
+      variables: { userId: user.id },
+      context,
+    }],
+    context,
+  });
+  ```
+
+  The `CUSTOMER_MESSAGES_QUERY` above will be refetched using `context`.
+  Normally queries are refetched using the original context they were first
+  started with, but this provides a way to override the context, if needed.  <br/>
+  [@hwillson](https://github.com/hwillson) in [#](https://github.com/apollographql/apollo-client/pull/)
 
 - Documentation updates.  <br/>
-  [@hwillson](https://github.com/hwillson) in [#](https://github.com/apollographql/apollo-client/pull/)
+  [@hwillson](https://github.com/hwillson) in [#3841](https://github.com/apollographql/apollo-client/pull/3841)
 
 
 ## 2.4.0 (August 17, 2018)

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -234,13 +234,17 @@ export class QueryManager<TStore> {
             continue;
           }
 
-          refetchQueryPromises.push(
-            this.query({
-              query: refetchQuery.query,
-              variables: refetchQuery.variables,
-              fetchPolicy: 'network-only',
-            }),
-          );
+          const queryOptions: QueryOptions = {
+            query: refetchQuery.query,
+            variables: refetchQuery.variables,
+            fetchPolicy: 'network-only',
+          };
+
+          if (refetchQuery.context) {
+            queryOptions.context = refetchQuery.context;
+          }
+
+          refetchQueryPromises.push(this.query(queryOptions));
         }
 
         if (awaitRefetchQueries) {

--- a/packages/apollo-client/src/core/types.ts
+++ b/packages/apollo-client/src/core/types.ts
@@ -13,6 +13,7 @@ export type OperationVariables = { [key: string]: any };
 export type PureQueryOptions = {
   query: DocumentNode;
   variables?: { [key: string]: any };
+  context?: any;
 };
 
 export type ApolloQueryResult<T> = {


### PR DESCRIPTION
These changes adjust `mutate`'s `refetchQueries` option to allow queries to include a custom `context` option. This `context` will then be used when refetching the query, overriding any `context` that was previsouly set with the query, when it first ran.

These changes are a continuation of #3580. They do not include automatically setting the `context` of
refetched queries to say the `context` used for the parent mutation. A `context` has to be specified
with each refetched query, if needed. This was done to maintain backwards compatibilty (e.g. preventing issues that might arise by all of a sudden running refetched queries with a mutation `context`, that wasn't explicitly requested).
