### PR TITLE
Cache-and-network should return cache when offline

### DIFF
--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -420,6 +420,12 @@ export class QueryManager<TStore> {
           // Initial fetch with cache-and-network policy should return result from cache even
           // when following network request fails
           // It will be returned below from cache
+
+          this.queryStore.markQueryResultClient(queryId, true);
+          this.invalidate(true, queryId, fetchMoreForQueryId);
+          this.broadcastQueries();
+          this.removeFetchQueryPromise(requestId);
+
           return Promise.resolve<ExecutionResult>({ data: storeResult });
         } else {
           const { lastRequestId } = this.getQuery(queryId);

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -327,6 +327,7 @@ export class QueryManager<TStore> {
     const query = cache.transformDocument(options.query);
 
     let storeResult: any;
+    let storeResultComplete: boolean;
     let needToFetch: boolean =
       fetchPolicy === 'network-only' || fetchPolicy === 'no-cache';
 
@@ -348,6 +349,7 @@ export class QueryManager<TStore> {
       // If we're in here, only fetch if we have missing fields
       needToFetch = !complete || fetchPolicy === 'cache-and-network';
       storeResult = result;
+      storeResultComplete = !!complete;
     }
 
     let shouldFetch =
@@ -409,6 +411,16 @@ export class QueryManager<TStore> {
         // through the store like watchQuery observers do
         if (isApolloError(error)) {
           throw error;
+        } else if (
+          fetchType !== FetchType.refetch &&
+          fetchPolicy === 'cache-and-network' &&
+          storeResultComplete &&
+          storeResult
+        ) {
+          // Initial fetch with cache-and-network policy should return result from cache even
+          // when following network request fails
+          // It will be returned below from cache
+          return Promise.resolve(storeResult);
         } else {
           const { lastRequestId } = this.getQuery(queryId);
           if (requestId >= (lastRequestId || 1)) {

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -420,7 +420,7 @@ export class QueryManager<TStore> {
           // Initial fetch with cache-and-network policy should return result from cache even
           // when following network request fails
           // It will be returned below from cache
-          return Promise.resolve(storeResult);
+          return Promise.resolve<ExecutionResult>({ data: storeResult });
         } else {
           const { lastRequestId } = this.getQuery(queryId);
           if (requestId >= (lastRequestId || 1)) {


### PR DESCRIPTION
This PR addresses issue #3755

In short, when cache policy is `cache-and-network`, client is offline and cache contains query result, network request will still fire, return error, and cache result will be ignored.

I tested this PR in my app where I needed it for following scenario to be working:
  - Cache contains some data obtained via special query aka `download everything for offline use`. `cacheRedirects` are configured in a way that allows this query to cover all other necessary queries
  - App goes offline
  - Various queries should be displayed offline, but when online, they should be updated to latest results, I use `cache-and-network` for this

This PR is quite raw, as I'm not familiar with what side-effects my changes can produce. I can write basic test that confirms the intended behavior, but first I want someone with knowledge to review the code and suggest changes/more tests if necessary.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
