### PR TITLE
Update fragments.md

### DIFF
--- a/docs/source/advanced/fragments.md
+++ b/docs/source/advanced/fragments.md
@@ -212,7 +212,7 @@ fetch(`${YOUR_API_HOST}/graphql`, {
   headers: { 'Content-Type': 'application/json' },
   body: JSON.stringify({
     variables: {},
-    operationName: '',
+    operationName: null,
     query: `
       {
         __schema {


### PR DESCRIPTION
There is an issue where sometimes having "operationName" set to an empty string will result in an [Error: GraphQL error: No operation named ""] error (See https://github.com/apollographql/apollo-client/issues/1760). Replacing the empty string with null seems to fix this issue.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
