### PR TITLE
Add `clearStore` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - A new `clearStore` method has been added, that will remove all data from
   the store. Unlike `resetStore`, it will not refetch active queries after
   removing store data.
-  [@hwillson](https://github.com/hwillson) in [#](https://github.com/apollographql/apollo-client/pull/)
+  [@hwillson](https://github.com/hwillson) in [#3885](https://github.com/apollographql/apollo-client/pull/3885)
 
 ### Apollo Utilities (vNext)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Apollo Client no longer deep freezes query results.
   [@hwillson](https://github.com/hwillson) in [#3883](https://github.com/apollographql/apollo-client/pull/3883)
+- A new `clearStore` method has been added, that will remove all data from
+  the store. Unlike `resetStore`, it will not refetch active queries after
+  removing store data.
+  [@hwillson](https://github.com/hwillson) in [#](https://github.com/apollographql/apollo-client/pull/)
 
 ### Apollo Utilities (vNext)
 

--- a/docs/source/advanced/caching.md
+++ b/docs/source/advanced/caching.md
@@ -591,6 +591,9 @@ export class Foo extends Component {
 export default withApollo(Foo);
 ```
 
+If you want to clear the store but don't want to refetch active queries, use
+`client.clearStore()` instead of `client.resetStore()`.
+
 <h3 id="server">Server side rendering</h3>
 
 First, you will need to initialize an `InMemoryCache` on the server and create an instance of `ApolloClient`. In the initial serialized HTML payload from the server, you should include a script tag that extracts the data from the cache. (The `.replace()` is necessary to prevent script injection attacks)

--- a/docs/source/api/apollo-client.md
+++ b/docs/source/api/apollo-client.md
@@ -49,6 +49,7 @@ The `ApolloClient` class is the core API for Apollo, and the one you'll need to 
 {% tsapibox ApolloClient.writeFragment %}
 {% tsapibox ApolloClient.resetStore %}
 {% tsapibox ApolloClient.onResetStore %}
+{% tsapibox ApolloClient.clearStore %}
 
 <h2 id="ObservableQuery">ObservableQuery</h2>
 

--- a/docs/source/recipes/authentication.md
+++ b/docs/source/recipes/authentication.md
@@ -73,7 +73,7 @@ The server can use that header to authenticate the user and attach it to the Gra
 
 Since Apollo caches all of your query results, it's important to get rid of them when the login state changes.
 
-The easiest way to ensure that the UI and store state reflects the current user's permissions is to call `client.resetStore()` after your login or logout process has completed. This will cause the store to be cleared and all active queries to be refetched. Another option is to reload the page, which will have a similar effect.
+The easiest way to ensure that the UI and store state reflects the current user's permissions is to call `client.resetStore()` after your login or logout process has completed. This will cause the store to be cleared and all active queries to be refetched. If you just want the store to be cleared and don't want to refetch active queries, use `client.clearStore()` instead. Another option is to reload the page, which will have a similar effect.
 
 
 ```js

--- a/packages/apollo-client/src/ApolloClient.ts
+++ b/packages/apollo-client/src/ApolloClient.ts
@@ -447,6 +447,17 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
   }
 
   /**
+   * Remove all data from the store. Unlike `resetStore`, `clearStore` will
+   * not refetch any active queries.
+   */
+  public clearStore(): Promise<void | null> {
+    const { queryManager } = this;
+    return Promise.resolve().then(
+      () => (queryManager ? queryManager.clearStore() : Promise.resolve(null)),
+    );
+  }
+
+  /**
    * Allows callbacks to be registered that are executed with the store is reset.
    * onResetStore returns an unsubscribe function for removing your registered callbacks.
    */

--- a/packages/apollo-client/src/__tests__/ApolloClient.ts
+++ b/packages/apollo-client/src/__tests__/ApolloClient.ts
@@ -2192,4 +2192,31 @@ describe('ApolloClient', () => {
       );
     });
   });
+
+  describe('clearStore', () => {
+    it('should remove all data from the store', async () => {
+      const client = new ApolloClient({
+        link: ApolloLink.empty(),
+        cache: new InMemoryCache(),
+      });
+
+      client.writeQuery({
+        data: { a: 1 },
+        query: gql`
+          {
+            a
+          }
+        `,
+      });
+
+      expect(client.cache.data.data).toEqual({
+        ROOT_QUERY: {
+          a: 1,
+        },
+      });
+
+      await client.clearStore();
+      expect(client.cache.data.data).toEqual({});
+    });
+  });
 });


### PR DESCRIPTION
A new `clearStore` method has been added, that will remove all data from the store. Unlike `resetStore`, it will not refetch active queries after removing store data.

Fixes #2411.
Fixes #2774.
Fixes #3539.
Fixes #3813.
