### PR TITLE
Make graphql-anywhere filter function generic

### DIFF
--- a/packages/graphql-anywhere/src/utilities.ts
+++ b/packages/graphql-anywhere/src/utilities.ts
@@ -2,7 +2,10 @@ import { DocumentNode } from 'graphql';
 
 import { graphql } from './graphql';
 
-export function filter(doc: DocumentNode, data: any): any {
+export function filter<FD = any, D extends FD = any>(
+  doc: DocumentNode,
+  data: D,
+): FD {
   const resolver = (
     fieldName: string,
     root: any,


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

A common part of many GraphQL/TypeScript setups is automatically generating TypeScript typings for any queries/mutations/fragments in the source code. For example, at [Trialspark](https://www.trialspark.com/), we're using [graphql-code-generator](https://github.com/dotansimha/graphql-code-generator).

It would be great to more easily leverage the interfaces that tool is generating for our GraphQL fragments when using the `filter()` function from graphql-anywhere.

This PR makes `filter()` generic on two, **optional** type arguments. The first represents the filtered data that is returned; the second represents the larger superset of data that is passed. This way, we can pass the autogenerated typings for our fragments to the `filter()`s that use those fragments:

```typescript
import { MyFragment, MyBigQuery } from './generated-types';

const FRAGMENT = gql`
  fragment MyFragment on Thing {
    id
    foo
  }
`
const lotsOfData = { /* pretend there's a lot here */};
const data = filter<MyFragment, MyBigQuery>(FRAGMENT, lotsOfData);

data.foo // fine
data.bar // not fine
```