### PR TITLE
Example docs does not show the __typename is required

### DIFF
--- a/docs/source/features/pagination.md
+++ b/docs/source/features/pagination.md
@@ -117,7 +117,10 @@ const CommentsWithData = () => (
                 entry: {
                   // Put the new comments in the front of the list
                   comments: [...newComments, ...previousEntry.comments]
-                }
+                },
+                //note you must return the __typename (two underscores) in the updateQuery. It is attached on every graphQl request
+                //and can be accessed easily in your previous results or in any of your future results.
+                __typename: previousEntry.__typename
               };
             }
           })


### PR DESCRIPTION
I spent two hours trying to get the cursor based pagination to work and the only thing I was missing was the __typename, however, it wasn't in the example and struggled to find the answer elsewhere. Can you please add it to the example as it will likely help others.
