### PR TITLE
feat: support defaultOptions in apollo-boost

### DIFF
--- a/docs/source/essentials/get-started.md
+++ b/docs/source/essentials/get-started.md
@@ -164,7 +164,9 @@ Here are the options you can pass to the `ApolloClient` exported from `apollo-bo
   <dt>`headers`: Object</dt>
   <dd>Header key/value pairs to pass along with the request.</dd>
   <dt>`fetch`: GlobalFetch['fetch']</dt>
-  <dd>A [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) compatible API for making a request.</dd>  
+  <dd>A [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) compatible API for making a request.</dd>
+  <dt>`defaultOptions`: Object</dt>
+  <dd>Used to set the `apollo-client` defaultOptions.</dd>
   <dt>`cache`: ApolloCache</dt>
   <dd>A custom instance of `ApolloCache` to be used. The default value is `InMemoryCache` from `apollo-cache-inmemory`. This option is quite useful for using a custom cache with `apollo-cache-persist`.</dd>
 </dl>

--- a/packages/apollo-boost/src/index.ts
+++ b/packages/apollo-boost/src/index.ts
@@ -16,6 +16,7 @@ import ApolloClient from 'apollo-client';
 export { gql, InMemoryCache, HttpLink };
 
 export interface PresetConfig {
+  defaultOptions?: ApolloClient.DefaultOptions,
   request?: (operation: Operation) => Promise<void>;
   uri?: string;
   credentials?: string;
@@ -39,6 +40,7 @@ export interface PresetConfig {
 // For now, when updating the properties of the `PresetConfig` interface,
 // please also update this constant.
 const PRESET_CONFIG_KEYS = [
+  'defaultOptions',
   'request',
   'uri',
   'credentials',
@@ -68,6 +70,7 @@ export default class DefaultClient<TCache> extends ApolloClient<TCache> {
 
     const {
       request,
+      defaultOptions = {},
       uri,
       credentials,
       headers,
@@ -156,6 +159,6 @@ export default class DefaultClient<TCache> extends ApolloClient<TCache> {
     ].filter(x => !!x) as ApolloLink[]);
 
     // super hacky, we will fix the types eventually
-    super({ cache, link } as any);
+    super({ cache, defaultOptions, link } as any);
   }
 }

--- a/packages/apollo-boost/src/index.ts
+++ b/packages/apollo-boost/src/index.ts
@@ -11,12 +11,12 @@ import { onError, ErrorLink } from 'apollo-link-error';
 import { ApolloCache } from 'apollo-cache';
 import { InMemoryCache, CacheResolverMap } from 'apollo-cache-inmemory';
 import gql from 'graphql-tag';
-import ApolloClient from 'apollo-client';
+import ApolloClient, { ApolloClientDefaultOptions } from 'apollo-client';
 
 export { gql, InMemoryCache, HttpLink };
 
 export interface PresetConfig {
-  defaultOptions?: ApolloClient.DefaultOptions,
+  defaultOptions?: ApolloClientDefaultOptions,
   request?: (operation: Operation) => Promise<void>;
   uri?: string;
   credentials?: string;

--- a/packages/apollo-client/src/index.ts
+++ b/packages/apollo-client/src/index.ts
@@ -23,9 +23,12 @@ export * from './core/types';
 
 export { ApolloError } from './errors/ApolloError';
 
-import ApolloClient, { ApolloClientOptions } from './ApolloClient';
+import ApolloClient, {
+  ApolloClientOptions,
+  DefaultOptions as ApolloClientDefaultOptions,
+} from './ApolloClient';
 
-export { ApolloClientOptions };
+export { ApolloClientOptions, ApolloClientDefaultOptions };
 
 // export the client as both default and named
 export { ApolloClient };


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests --> NOTE: Boost does not seem to have tests so i'll check this
Issue i implemented the feature for: https://github.com/apollographql/apollo-client/issues/3900
