### PR TITLE
Fix incomplete data being passed as query result

### DIFF
--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -996,7 +996,7 @@ export class QueryManager<TStore> {
     const lastResult = observableQuery.getLastResult();
     const { newData } = this.getQuery(observableQuery.queryId);
     // XXX test this
-    if (newData) {
+    if (newData && newData.complete) {
       return { data: newData.result, partial: false };
     } else {
       try {


### PR DESCRIPTION
### Background
I discovered this issue when using `react-router-dom` `<Redirect />`s in my app. My situation was, I had a parent component—let's call it `<PersonPage />`:

```jsx
<PersonPage>
  {/* ... */}
</PersonPage>
```

And in that person page, I'm querying for a person:

```jsx
const personPageQuery = gql`
  query personForPersonPage {
    person(id: "abc") {
      id
      firstName
      lastName
    }
  }
`;

<PersonPage>
  <Query query={personPageQuery}>
    {() => (
      /* ... */
    )}
  </Query>
</PersonPage>
```

And inside the person page, I have a child page, `<PersonDetailsPage />`. And **`<PersonPage />` redirects to it on page load**:

```jsx
const personPageQuery = gql`
  query personForPersonPage {
    person(id: "abc") {
      id
      firstName
      lastName
    }
  }
`;

<PersonPage>
  <Query query={personPageQuery}>
    {() => (
      <Switch>
        <Redirect from="/" to="/details" exact />
        <Route path="/details" component={PersonDetailsPage} />
      </Switch>
    )}
  </Query>
</PersonPage>
```

And in the `<PersonDetailsPage />` I am also querying for **the same person as `<PersonPage />`** but requesting different data (with some overlap.):

```jsx
const personDetailsPageQuery = gql`
  query personForPersonPage {
    person(id: "abc") {
      id
      lastName
      age
    }
  }
`;

<PersonDetailsPage>
  <Query query={personDetailsPageQuery}>
    {() => (
      /* ... */
    )}
  </Query>
</PersonDetailsPage>
```

The `<PersonDetailsPage />` `<Query />` ends up calling its `children()` with incomplete/partial data:

```javascript
{
  __typename: 'Person',
  id: 'abc',
  lastName: 'Skywalker',
  // age is missing!
}
```

I believe the following is happening:

1. `<PersonPage />` renders, its `<Query />` is fired off
2. `<PersonPage />` redirects to `<PersonDetailsPage />`
3. `<PersonDetailsPage />` is rendered, its `<Query />` is fired
4. `<PersonPage />`'s `<Query />` finishes fetching data. **It triggers a `.forceUpdate()`.**
5. `<PersonDetailsPage />` is forced to rerender because of its parent's `.forceUpdate()`
6. As part of its `render()`, `<PersonDetailsPage />`'s `<Query />` calls `.currentResult()` on its `queryObservable`
7. This in turn calls `getCurrentQueryResult()` on the `QueryManager`
8. `getCurrentQueryResult()` returns **incomplete** data which it got when `<PersonPage />`'s query finished loading
9. The incomplete data is passed down to `<PersonDetailsPage />`'s `<Query />`'s `children()`
10. If something like an `Array` is missing from the incomplete data, this could cause a `TypeError`; usually something like `Cannot read property `map` of undefined`.

**I have managed to reproduce this with a failing test case in the `react-apollo` repo!**
https://github.com/trialspark/react-apollo/blob/9d382deb5f1824fe245730c49b62ef3cad62f416/test/client/Query.test.tsx#L1482-L1587

However, I believe the simplest fix is just to have `QueryManager.getCurrentQueryResult()` return:

```javascript
{ data: {}, partial: true }
```

in this situation.

Fixes apollographql/react-apollo#1701
Fixes #3947