### PR TITLE
Fix ReadQueryOptions type fields store & variables

### DIFF
--- a/packages/apollo-cache-inmemory/src/types.ts
+++ b/packages/apollo-cache-inmemory/src/types.ts
@@ -56,10 +56,10 @@ export type OptimisticStoreItem = {
 };
 
 export type ReadQueryOptions = {
-  store: NormalizedCache;
   query: DocumentNode;
+  store?: NormalizedCache;
   fragmentMatcherFunction?: FragmentMatcher;
-  variables?: Object;
+  variables?: object;
   previousResult?: any;
   rootId?: string;
   config?: ApolloReducerConfig;


### PR DESCRIPTION
1) Property `store` is not required. I'm using apollo-link-state and I don't have to explicitly declare store when declaring options for cache.readQuery. The documentation also reflects that [here](https://www.apollographql.com/docs/link/links/state.html#write-query).

2) Property `variables` should use TypeScript `object` non-primitive instead of `Object` as encouraged [here](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)