### PR TITLE
Update apollo-link dependency

### DIFF
--- a/packages/apollo-client/package.json
+++ b/packages/apollo-client/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@types/zen-observable": "^0.8.0",
     "apollo-cache": "file:../apollo-cache",
-    "apollo-link": "^1.0.0",
+    "apollo-link": "^1.1.0",
     "apollo-link-dedup": "^1.0.0",
     "apollo-utilities": "file:../apollo-utilities",
     "symbol-observable": "^1.0.2",


### PR DESCRIPTION
Yarn produces the following warning when using `graphql` version `^0.13.0`:
> "apollo-client > apollo-link@1.0.7" has incorrect peer dependency "graphql@^0.11.3 || ^0.12.3"

This PR removes the warning by upgrading the `apollo-link` dependency to the first version that includes `graphql` `0.13.0` in its `peerDependencies`.