### PR TITLE
Make window.navigator.userAgent check more defensive for React Native.

### DIFF
--- a/packages/apollo-client/src/ApolloClient.ts
+++ b/packages/apollo-client/src/ApolloClient.ts
@@ -171,6 +171,7 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
           // Only for Chrome
           if (
             window.navigator &&
+            window.navigator.userAgent &&
             window.navigator.userAgent.indexOf('Chrome') > -1
           ) {
             // tslint:disable-next-line


### PR DESCRIPTION
There is currently a bug involving `window.navigator` when running apollo-client with React Native (see issue here: https://github.com/apollographql/apollo-client/issues/3137).

This PR simply adds one more additional check before accessing `indexOf`.
