### PR TITLE
Add sideEffect entry for fixPolyfills in inmemory-cache

### DIFF
--- a/packages/apollo-cache-inmemory/package.json
+++ b/packages/apollo-cache-inmemory/package.json
@@ -15,7 +15,9 @@
   "module": "./lib/index.js",
   "jsnext:main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
-  "sideEffects": false,
+  "sideEffects": [
+    "./lib/fixPolyfills.js"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/apollographql/apollo-client.git"


### PR DESCRIPTION
This PR adds a `sideEffects` entry for a (seemingly new) file, `fixPolyfills`. This file does indeed have side effects. In the setup at Shopify, we have a part of the build that fails when files were unexpectedly tree shaken, and this file is currently tripping that check.