### PR TITLE
Fix apollo-cache-inmemory in IE11

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     {
       "name": "apollo-cache-inmemory",
       "path": "./packages/apollo-cache-inmemory/lib/bundle.min.js",
-      "maxSize": "6.75 kB"
+      "maxSize": "7 kB"
     },
     {
       "name": "apollo-client",

--- a/packages/apollo-cache-inmemory/src/fixPolyfills.ts
+++ b/packages/apollo-cache-inmemory/src/fixPolyfills.ts
@@ -1,6 +1,25 @@
-const frozen = {};
-const frozenTestMap = new Map();
+// Make sure Map.prototype.set returns the Map instance, per spec.
+// https://github.com/apollographql/apollo-client/issues/4024
+const testMap = new Map();
+if (testMap.set(1, 2) !== testMap) {
+  const { set } = testMap;
+  Map.prototype.set = function (...args) {
+    set.apply(this, args);
+    return this;
+  };
+}
 
+// Make sure Set.prototype.add returns the Set instance, per spec.
+const testSet = new Set();
+if (testSet.add(3) !== testSet) {
+  const { add } = testSet;
+  Set.prototype.add = function (...args) {
+    add.apply(this, args);
+    return this;
+  };
+}
+
+const frozen = {};
 if (typeof Object.freeze === 'function') {
   Object.freeze(frozen);
 }
@@ -12,13 +31,13 @@ try {
   // objects before they become non-extensible:
   // https://github.com/facebook/react-native/blob/98a6f19d7c/Libraries/vendor/core/Map.js#L44-L50
   // https://github.com/apollographql/react-apollo/issues/2442#issuecomment-426489517
-  frozenTestMap.set(frozen, frozen).delete(frozen);
+  testMap.set(frozen, frozen).delete(frozen);
 } catch {
   const wrap = (method: <T>(obj: T) => T): typeof method => {
     return method && (obj => {
       try {
         // If .set succeeds, also call .delete to avoid leaking memory.
-        frozenTestMap.set(obj, obj).delete(obj);
+        testMap.set(obj, obj).delete(obj);
       } finally {
         // If .set or .delete fails, the exception will be silently swallowed
         // by this return-from-finally statement:

--- a/packages/apollo-cache-inmemory/src/optimism.ts
+++ b/packages/apollo-cache-inmemory/src/optimism.ts
@@ -1,7 +1,7 @@
 declare function require(id: string): any;
 
 export type OptimisticWrapperFunction<
-  T = (...args: any[]) => any,
+  T = (...args: any[]) => any
 > = T & {
   // The .dirty(...) method of an optimistic function takes exactly the same
   // parameter types as the original function.
@@ -14,7 +14,9 @@ export type OptimisticWrapOptions = {
   makeCacheKey?(...args: any[]): any;
 };
 
-const { wrap }: {
+const {
+  wrap,
+}: {
   wrap<T>(
     originalFunction: T,
     options?: OptimisticWrapOptions,
@@ -40,7 +42,11 @@ export class CacheKeyNode<KeyType = object> {
   }
 
   getOrCreate(value: any): CacheKeyNode<KeyType> {
-    const map = this.children || (this.children = new Map);
-    return map.get(value) || map.set(value, new CacheKeyNode<KeyType>()).get(value);
+    const map = this.children || (this.children = new Map());
+    let node = map.get(value);
+    if (!node) {
+      map.set(value, node = new CacheKeyNode<KeyType>());
+    }
+    return node;
   }
 }


### PR DESCRIPTION
In IE11, `Map.prototype.set` is not spec-compliant and returns `undefined`. This commit removes the chained calls on `Map` to avoid the `TypeError`.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
