### PR TITLE
Various improvements around previousResult/newData change detection.

### DIFF
--- a/packages/apollo-cache-inmemory/src/inMemoryCache.ts
+++ b/packages/apollo-cache-inmemory/src/inMemoryCache.ts
@@ -339,20 +339,11 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
   // This method is wrapped in the constructor so that it will be called only
   // if the data that would be broadcast has changed.
   private maybeBroadcastWatch(c: Cache.WatchOptions) {
-    const previousResult = c.previousResult && c.previousResult();
-
-    const newData = this.diff({
+    c.callback(this.diff({
       query: c.query,
       variables: c.variables,
-      previousResult,
+      previousResult: c.previousResult && c.previousResult(),
       optimistic: c.optimistic,
-    });
-
-    if (previousResult &&
-        previousResult === newData.result) {
-      return;
-    }
-
-    c.callback(newData);
+    }));
   }
 }

--- a/packages/apollo-cache-inmemory/src/inMemoryCache.ts
+++ b/packages/apollo-cache-inmemory/src/inMemoryCache.ts
@@ -259,10 +259,12 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     if (this.addTypename) {
       let result = this.typenameDocumentCache.get(document);
       if (!result) {
-        this.typenameDocumentCache.set(
-          document,
-          (result = addTypenameToDocument(document)),
-        );
+        result = addTypenameToDocument(document);
+        this.typenameDocumentCache.set(document, result);
+        // If someone calls transformDocument and then mistakenly passes the
+        // result back into an API that also calls transformDocument, make sure
+        // we don't keep creating new query documents.
+        this.typenameDocumentCache.set(result, result);
       }
       return result;
     }

--- a/packages/apollo-client/src/core/ObservableQuery.ts
+++ b/packages/apollo-client/src/core/ObservableQuery.ts
@@ -1,4 +1,4 @@
-import { isEqual, tryFunctionOrLogError } from 'apollo-utilities';
+import { isEqual, tryFunctionOrLogError, cloneDeep } from 'apollo-utilities';
 import { GraphQLError } from 'graphql';
 import { NetworkStatus, isNetworkRequestInFlight } from './networkStatus';
 import { Observable, Observer, Subscription } from '../util/Observable';
@@ -201,7 +201,7 @@ export class ObservableQuery<
     }
 
     const result = {
-      data,
+      data: cloneDeep(data),
       loading: isNetworkRequestInFlight(networkStatus),
       networkStatus,
     } as ApolloQueryResult<TData>;
@@ -215,8 +215,7 @@ export class ObservableQuery<
     }
 
     if (!partial) {
-      const stale = false;
-      this.lastResult = { ...result, stale };
+      this.lastResult = { ...result, stale: false };
     }
 
     return { ...result, partial } as ApolloCurrentResult<TData>;
@@ -586,7 +585,7 @@ export class ObservableQuery<
 
     const observer: Observer<ApolloQueryResult<TData>> = {
       next: (result: ApolloQueryResult<TData>) => {
-        this.lastResult = result;
+        this.lastResult = cloneDeep(result);
         this.observers.forEach(obs => obs.next && obs.next(result));
       },
       error: (error: ApolloError) => {

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -54,16 +54,6 @@ export interface QueryInfo {
   cancel?: (() => void);
 }
 
-const defaultQueryInfo = {
-  listeners: [],
-  invalidated: false,
-  document: null,
-  newData: null,
-  lastRequestId: null,
-  observableQuery: null,
-  subscriptions: [],
-};
-
 export interface QueryPromise {
   resolve: (result: ApolloQueryResult<any>) => void;
   reject: (error: Error) => void;
@@ -1231,7 +1221,15 @@ export class QueryManager<TStore> {
   }
 
   private getQuery(queryId: string) {
-    return this.queries.get(queryId) || { ...defaultQueryInfo };
+    return this.queries.get(queryId) || {
+      listeners: [],
+      invalidated: false,
+      document: null,
+      newData: null,
+      lastRequestId: null,
+      observableQuery: null,
+      subscriptions: [],
+    };
   }
 
   private setQuery(queryId: string, updater: (prev: QueryInfo) => any) {

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -12,6 +12,7 @@ import {
   getQueryDefinition,
   isProduction,
   hasDirectives,
+  isEqual,
 } from 'apollo-utilities';
 
 import { QueryScheduler } from '../scheduler/scheduler';
@@ -609,10 +610,7 @@ export class QueryManager<TStore> {
               resultFromStore &&
               lastResult.networkStatus === resultFromStore.networkStatus &&
               lastResult.stale === resultFromStore.stale &&
-              // We can do a strict equality check here because we include a `previousResult`
-              // with `readQueryFromStore`. So if the results are the same they will be
-              // referentially equal.
-              lastResult.data === resultFromStore.data
+              isEqual(lastResult.data, resultFromStore.data)
             );
 
             if (isDifferentResult || previouslyHadError) {

--- a/packages/apollo-client/src/core/__tests__/ObservableQuery.ts
+++ b/packages/apollo-client/src/core/__tests__/ObservableQuery.ts
@@ -324,8 +324,7 @@ describe('ObservableQuery', () => {
           const current = observable.currentResult();
           expect(stripSymbols(current.data)).toEqual(data);
           const secondCurrent = observable.currentResult();
-          // ensure ref equality
-          expect(current.data).toBe(secondCurrent.data);
+          expect(current.data).toEqual(secondCurrent.data);
           done();
         }
       });

--- a/packages/apollo-utilities/package-lock.json
+++ b/packages/apollo-utilities/package-lock.json
@@ -8,11 +8,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
-    },
-    "fclone": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fclone/-/fclone-1.0.11.tgz",
-      "integrity": "sha1-EOhdo4v+p/xZk0HClu4ddyZu5kA="
     }
   }
 }

--- a/packages/apollo-utilities/package.json
+++ b/packages/apollo-utilities/package.json
@@ -39,8 +39,7 @@
     "filesize": "npm run minify"
   },
   "dependencies": {
-    "fast-json-stable-stringify": "^2.0.0",
-    "fclone": "^1.0.11"
+    "fast-json-stable-stringify": "^2.0.0"
   },
   "jest": {
     "transform": {

--- a/packages/apollo-utilities/src/util/cloneDeep.ts
+++ b/packages/apollo-utilities/src/util/cloneDeep.ts
@@ -1,8 +1,54 @@
-import fclone from 'fclone';
+const { toString } = Object.prototype;
 
 /**
  * Deeply clones a value to create a new instance.
  */
 export function cloneDeep<T>(value: T): T {
-  return fclone(value);
+  return cloneDeepHelper(value, new Map());
+}
+
+function cloneDeepHelper<T>(val: T, seen: Map<any, any>): T {
+  switch (toString.call(val)) {
+  case "[object Array]": {
+    if (seen.has(val)) return seen.get(val);
+    const copy: T & any[] = (val as any).slice(0);
+    seen.set(val, copy);
+    copy.forEach(function (child, i) {
+      copy[i] = cloneDeepHelper(child, seen);
+    });
+    return copy;
+  }
+
+  case "[object Date]":
+    return new Date(+val) as T & Date;
+
+  case "[object Object]": {
+    if (seen.has(val)) return seen.get(val);
+    // High fidelity polyfills of Object.create and Object.getPrototypeOf are
+    // possible in all JS environments, so we will assume they exist/work.
+    const copy = Object.create(Object.getPrototypeOf(val));
+    seen.set(val, copy);
+
+    if (typeof Object.getOwnPropertyDescriptor === "function") {
+      const handleKey = function (key: string | symbol) {
+        const desc = Object.getOwnPropertyDescriptor(val, key);
+        desc.value = cloneDeepHelper((val as any)[key], seen);
+        Object.defineProperty(copy, key, desc);
+      };
+      Object.getOwnPropertyNames(val).forEach(handleKey);
+      if (typeof Object.getOwnPropertySymbols === "function") {
+        Object.getOwnPropertySymbols(val).forEach(handleKey);
+      }
+    } else {
+      Object.keys(val).forEach(key => {
+        copy[key] = cloneDeepHelper((val as any)[key], seen);
+      });
+    }
+
+    return copy;
+  }
+
+  default:
+    return val;
+  }
 }


### PR DESCRIPTION
Fixes #3992, along with a few other miscellaneous improvements.

As #3992 (and specifically the [reproduction](https://codesandbox.io/s/q7rkm6y1ow) that @OurMajesty provided) demonstrates, now that the `InMemoryCache` may return the same object for multiple reads (when the data have not changed), the `previousResult` is often exactly (`===`) the same object as `newData.result`, which was causing the code removed by [this commit](https://github.com/apollographql/apollo-client/commit/d6a673fbc1444e115e90cc9e4c7fa3fc67bb7e56) to return early instead of broadcasting the watch.

This early return was unsafe, because the contents of the object may have changed since they were previously broadcast, so we actually do need to report those modifications, even though the object reference is the same.

In other words, `previousResult === newData.result` does not imply "nothing has changed," as I mistakenly assumed in this discussion: https://github.com/apollographql/apollo-client/pull/3394#issuecomment-420469871

In the longer term, I would like to eliminate the `previousResult` logic entirely, since it seems redundant now that we can precisely track changes to the store, but for now it's important for backwards compatibility. Specifically, `previousResult` still provides a way to prefer the previous object if it is structurally identical to the new object, though of course that preference is moot when `previousResult === newData.result`.

The `previousResult` object should never be used as a basis for skipping broadcasts. Only the application developer can decide whether `===` object identity means it's safe to skip rendering, likely in the context of a larger design which treats cache results as immutable data. The job of the
`InMemoryCache` is to make no unsound assumptions, and to broadcast results whenever they may have changed.