### PR TITLE
Throw when querying non-scalar objects without a selection set.

### DIFF
--- a/packages/apollo-cache-inmemory/src/readFromStore.ts
+++ b/packages/apollo-cache-inmemory/src/readFromStore.ts
@@ -401,18 +401,6 @@ export class StoreReader {
       info,
     );
 
-    // Handle all scalar types here
-    if (!field.selectionSet) {
-      return readStoreResult;
-    }
-
-    // From here down, the field has a selection set, which means it's trying to
-    // query a GraphQLObjectType
-    if (readStoreResult.result == null) {
-      // Basically any field in a GraphQL response can be null, or missing
-      return readStoreResult;
-    }
-
     function handleMissing<T>(res: ExecResult<T>): ExecResult<T> {
       let missing: ExecResultMissingField[] = null;
 
@@ -438,6 +426,19 @@ export class StoreReader {
         readStoreResult.result,
         execContext,
       ));
+    }
+
+    // Handle all scalar types here
+    if (!field.selectionSet) {
+      assertSelectionSetForIdValue(field, readStoreResult.result);
+      return readStoreResult;
+    }
+
+    // From here down, the field has a selection set, which means it's trying to
+    // query a GraphQLObjectType
+    if (readStoreResult.result == null) {
+      // Basically any field in a GraphQL response can be null, or missing
+      return readStoreResult;
     }
 
     // Returned value is an object, and the query has a sub-selection. Recurse.
@@ -476,14 +477,33 @@ export class StoreReader {
       }
 
       // This is an object, run the selection set on it
-      return handleMissing(this.executeSelectionSet({
-        selectionSet: field.selectionSet,
-        rootValue: item,
-        execContext,
-      }));
+      if (field.selectionSet) {
+        return handleMissing(this.executeSelectionSet({
+          selectionSet: field.selectionSet,
+          rootValue: item,
+          execContext,
+        }));
+      }
+
+      assertSelectionSetForIdValue(field, item);
+
+      return item;
     });
 
     return { result, missing };
+  }
+}
+
+function assertSelectionSetForIdValue(
+  field: FieldNode,
+  value: any,
+) {
+  if (!field.selectionSet && isIdValue(value)) {
+    throw new Error(
+      `Missing selection set for object of type ${
+        value.typename
+      } returned by query field ${field.name.value}`
+    );
   }
 }
 

--- a/packages/apollo-utilities/src/storeUtils.ts
+++ b/packages/apollo-utilities/src/storeUtils.ts
@@ -271,7 +271,9 @@ export function isInlineFragment(
 }
 
 export function isIdValue(idObject: StoreValue): idObject is IdValue {
-  return idObject && (idObject as IdValue | JsonValue).type === 'id';
+  return idObject &&
+    (idObject as IdValue | JsonValue).type === 'id' &&
+    typeof (idObject as IdValue).generated === 'boolean';
 }
 
 export type IdConfig = {


### PR DESCRIPTION
This would have helped diagnose the cause of #4025, which is that query fields with non-scalar types (or list-of-non-scalar types) must have a selection set.

In other words, given a schema like
```gql
type Query {
  selectedMessageList: [SelectedMessage]
}
```
a query like
```gql
query getSelectedMessageList {
  selectedMessageList @client
}
```
is invalid since it doesn't specify which fields of the `SelectedMessage` objects should be included in the list.

This PR prevents the cache from accidentally returning `IdValue` objects by throwing a helpful exception:
```
Missing selection set for object of type SelectedMessage returned from query field selectedMessageList
```