### PR TITLE
diffQueryAgainsStore set returnPartialData to false

### DIFF
--- a/packages/apollo-cache-inmemory/src/readFromStore.ts
+++ b/packages/apollo-cache-inmemory/src/readFromStore.ts
@@ -192,7 +192,7 @@ export class StoreReader {
     query,
     variables,
     previousResult,
-    returnPartialData = true,
+    returnPartialData = false,
     rootId = 'ROOT_QUERY',
     fragmentMatcherFunction,
     config,


### PR DESCRIPTION
Is there a reason why returnPartialData is true?
This was hiding an error and returning { data: undefined, networkState: 7, stale: true } for me.
I had forgotten to query for the id of an object and watchQuery could not find it in store.
With returnPartialData false i was able to get an error about missing property and finally find the problem.
With this true all i was getting from watchQuery was { data: undefined, networkState: 7, stale: true }.

Maybe related issues: #3030 , #2914
