### PR TITLE
Avoid copying non-enumerable and/or symbol keys in cloneDeep.

### DIFF
--- a/packages/apollo-utilities/src/util/cloneDeep.ts
+++ b/packages/apollo-utilities/src/util/cloneDeep.ts
@@ -19,37 +19,15 @@ function cloneDeepHelper<T>(val: T, seen: Map<any, any>): T {
     return copy;
   }
 
-  case "[object Date]":
-    return new Date(+val) as T & Date;
-
   case "[object Object]": {
     if (seen.has(val)) return seen.get(val);
     // High fidelity polyfills of Object.create and Object.getPrototypeOf are
     // possible in all JS environments, so we will assume they exist/work.
     const copy = Object.create(Object.getPrototypeOf(val));
     seen.set(val, copy);
-
-    if (typeof Object.getOwnPropertyDescriptor === "function") {
-      const handleKey = function (key: string | symbol) {
-        const desc = Object.getOwnPropertyDescriptor(val, key);
-        // If the property is backed by a getter function, this code turns it
-        // into a simple value property, though other descriptor properties like
-        // enumerable, writable, and configurable will be preserved.
-        desc.value = cloneDeepHelper((val as any)[key], seen);
-        delete desc.get;
-        delete desc.set;
-        Object.defineProperty(copy, key, desc);
-      };
-      Object.getOwnPropertyNames(val).forEach(handleKey);
-      if (typeof Object.getOwnPropertySymbols === "function") {
-        Object.getOwnPropertySymbols(val).forEach(handleKey);
-      }
-    } else {
-      Object.keys(val).forEach(key => {
-        copy[key] = cloneDeepHelper((val as any)[key], seen);
-      });
-    }
-
+    Object.keys(val).forEach(key => {
+      copy[key] = cloneDeepHelper((val as any)[key], seen);
+    });
     return copy;
   }
 


### PR DESCRIPTION
https://github.com/apollographql/apollo-client/pull/4039#issuecomment-432757104

The previous `fclone` implementation did not preserve non-enumerable or non-string keys either (see [here](https://github.com/soyuka/fclone/blob/797c64a1625a9123be93f8bb1e7374cab1419ff9/src/fclone.js#L52)), so this is not a breaking change.

The `Date` case was also a bit overzealous, since there are no actual use cases in this codebase that require `Date` objects to be duplicated, rather than simply passing them through.

If we're missing any cases that anyone cares about, we can easily expand the switch-case coverage in the future.