### PR TITLE
Implement ObservableQuery#isDifferentFromLastResult.

### DIFF
--- a/packages/apollo-client/src/core/ObservableQuery.ts
+++ b/packages/apollo-client/src/core/ObservableQuery.ts
@@ -247,6 +247,7 @@ export class ObservableQuery<
 
   public resetLastResults(): void {
     delete this.lastResult;
+    delete this.lastResultSnapshot;
     delete this.lastError;
     this.isTornDown = false;
   }

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -12,7 +12,6 @@ import {
   getQueryDefinition,
   isProduction,
   hasDirectives,
-  isEqual,
 } from 'apollo-utilities';
 
 import { QueryScheduler } from '../scheduler/scheduler';
@@ -605,15 +604,9 @@ export class QueryManager<TStore> {
           }
 
           if (observer.next) {
-            const isDifferentResult = !(
-              lastResult &&
-              resultFromStore &&
-              lastResult.networkStatus === resultFromStore.networkStatus &&
-              lastResult.stale === resultFromStore.stale &&
-              isEqual(lastResult.data, resultFromStore.data)
-            );
-
-            if (isDifferentResult || previouslyHadError) {
+            if (previouslyHadError ||
+                !observableQuery ||
+                observableQuery.isDifferentFromLastResult(resultFromStore)) {
               try {
                 observer.next(resultFromStore);
               } catch (e) {


### PR DESCRIPTION
This commit is a more conservative version of https://github.com/apollographql/apollo-client/pull/4032/commits/e66027c5341dc7aaf71ee7ffcba1305b9a553525.

We still need to make a deep clone of `observableQuery.lastResult` in order to determine if future results are different (see #3992), but we should be able to restrict the use of that snapshot to a single method, rather than replacing `observableQuery.lastResult` with the snapshot.

Should help with #4054 (cc @jsslai).

- [x] Diagnose and fix the failing tests.