### PR TITLE
Fix apollo-utilities isEqual bug due to missing hasOwnProperty check.

### DIFF
--- a/packages/apollo-utilities/src/util/__tests__/isEqual.ts
+++ b/packages/apollo-utilities/src/util/__tests__/isEqual.ts
@@ -83,4 +83,11 @@ describe('isEqual', () => {
     );
     expect(!isEqual(objNoProto, null)).toBe(true);
   });
+
+  it('should correctly handle modified prototypes', () => {
+    Array.prototype.foo = null;
+    expect(isEqual([1, 2, 3], [1, 2, 3])).toBe(true);
+    expect(!isEqual([1, 2, 3], [1, 2, 4])).toBe(true);
+    delete Array.prototype.foo;
+  });
 });

--- a/packages/apollo-utilities/src/util/isEqual.ts
+++ b/packages/apollo-utilities/src/util/isEqual.ts
@@ -32,7 +32,10 @@ export function isEqual(a: any, b: any): boolean {
     }
     // Look through all the keys in `b`. If `b` has a key that `a` does not, return false.
     for (const key in b) {
-      if (!Object.prototype.hasOwnProperty.call(a, key)) {
+      if (
+        Object.prototype.hasOwnProperty.call(b, key) &&
+        !Object.prototype.hasOwnProperty.call(a, key)
+      ) {
         return false;
       }
     }


### PR DESCRIPTION
Unfortunately some of our legacy pages still have libraries that modify prototypes of built-in objects. This was causing our cache (https://github.com/convoyinc/apollo-cache-hermes) to behave very strangely. After some debugging, I found that `isEqual` was broken due to a missing `hasOwnProperty` check, and thus always evaluated to false!
