### PR TITLE
Avoid modifying source objects when merging cache results.

### DIFF
--- a/packages/apollo-cache-inmemory/package-lock.json
+++ b/packages/apollo-cache-inmemory/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-cache-inmemory",
-  "version": "1.3.5",
+  "version": "1.3.9-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/apollo-cache-inmemory/package.json
+++ b/packages/apollo-cache-inmemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-cache-inmemory",
-  "version": "1.3.8",
+  "version": "1.3.9-beta.1",
   "description": "Core abstract of Caching layer for Apollo Client",
   "author": "James Baxley <james@meteor.com>",
   "contributors": [


### PR DESCRIPTION
As #4081 demonstrates, if there are key collisions during result merging, it's possible for source objects that were previously merged by reference into the `target` object (`finalResult.result`) to be modified destructively by later merges, which in some cases can lead to cycles in the results returned by the cache.

This version of the `merge` function uses a copy-on-first-write strategy to ensure we never modify `target` objects that might once have been `source` objects. The code could have been considerably simpler if I didn't try to track `pastCopies`, but performance and memory usage are very important for this code, which is why I went to the trouble of limiting the number of shallow copies made during a single `merge`.

- [x] Tests are absolutely necessary before merging this PR, since this behavior would be very easy to regress accidentally.