### PR TITLE
Refetch query when get any missing fields on cache

### DIFF
--- a/packages/apollo-cache-inmemory/src/__tests__/readFromStore.ts
+++ b/packages/apollo-cache-inmemory/src/__tests__/readFromStore.ts
@@ -582,6 +582,36 @@ describe('reading from the store', () => {
     }).toThrowError(/field missingField on object/);
   });
 
+  it('throws on a missing field and call refetch callback', done => {
+    const result = {
+      id: 'abcd',
+      stringField: 'This is a string!',
+      numberField: 5,
+      nullField: null,
+    } as StoreObject;
+
+    const store = defaultNormalizedCacheFactory({ ROOT_QUERY: result });
+
+    const refetch = () => {
+      done();
+    };
+
+    expect(() => {
+      reader.readQueryFromStore(
+        {
+          store,
+          query: gql`
+            {
+              stringField
+              missingField
+            }
+          `,
+        },
+        refetch,
+      );
+    }).toThrowError(/field missingField on object/);
+  });
+
   it('runs a nested query where the reference is null', () => {
     const result: any = {
       id: 'abcd',

--- a/packages/apollo-cache/src/cache.ts
+++ b/packages/apollo-cache/src/cache.ts
@@ -11,6 +11,7 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
   // core API
   public abstract read<T, TVariables = any>(
     query: Cache.ReadOptions<TVariables>,
+    refetch?: Function,
   ): T | null;
   public abstract write<TResult = any, TVariables = any>(
     write: Cache.WriteOptions<TResult, TVariables>,


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

Fix: https://github.com/apollographql/apollo-client/issues/3928

I implemented to refetch when get any missing fields on apollo-cache-inmemory.
I gave refetch logic as callback from apollo-client to apollo-cache-inmemory because refetch is client context. I feel this is needed more discussions..
How do you think?

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
