### PR TITLE
keep referential integrity of simple arrays read from the store

### DIFF
--- a/packages/apollo-cache-inmemory/src/__tests__/readFromStore.ts
+++ b/packages/apollo-cache-inmemory/src/__tests__/readFromStore.ts
@@ -656,6 +656,34 @@ describe('reading from the store', () => {
     });
   });
 
+  it('preserves referential integrity of simple array values', () => {
+    const simpleArray = ['one', 'two', 'three', ['four', 'five']];
+    const result: any = { simpleArray };
+
+    const store = defaultNormalizedCacheFactory({
+      ROOT_QUERY: assign({}, assign({}, omit(result, 'simpleArray')), {
+        simpleArray: {
+          type: 'json',
+          json: result.simpleArray,
+        } as JsonValue,
+      }) as StoreObject,
+    });
+
+    const queryResult = reader.readQueryFromStore({
+      store,
+      query: gql`
+        {
+          simpleArray
+        }
+      `,
+    });
+
+    const resultArray = (queryResult as any).simpleArray;
+
+    // simpleArray in the result should be the exact same object as the original
+    expect(resultArray).toBe(simpleArray); // must use 'toBe'
+  });
+
   it('runs an array of non-objects with null', () => {
     const result: any = {
       id: 'abcd',


### PR DESCRIPTION
This keeps the reference of simple arrays the same when reading from the store, unless necessary.

I ran into strange behaviour when working with `apollo-angular` and `watchQuery`, where a list field appears to update after a mutation, even though I'm not mutating or re-fetching that particular field. I tracked down the issue to `apollo-client`, and hence this PR.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->
