### PR TITLE
📝 update local state docs to work with apollo-cli codegen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Apollo Client (vNext)
 
+### Apollo Client (vNext)
+
+- Documtation updates.  <br/>
+  [@justinanastos](https://github.com/justinanastos) in [#4187](https://github.com/apollographql/apollo-client/pull/4187)
+
 ### Apollo Utilities (vNext)
 
 - Schema/AST tranformation utilities have been updated to work properly with

--- a/docs/source/essentials/local-state.md
+++ b/docs/source/essentials/local-state.md
@@ -239,7 +239,9 @@ You can optionally pass a client-side schema to the `typeDefs` config property. 
 Your schema should be written in [Schema Definition Language](/docs/graphql-tools/generate-schema.html#schema-language). Let's view our schema for our todo app:
 
 ```js
-const typeDefs = `
+import gql from 'graphql-tag';
+
+const typeDefs = gql`
   type Todo {
     id: Int!
     text: String!


### PR DESCRIPTION
[`apollo
client:codegen`](https://github.com/apollographql/apollo-tooling#apollo-clientcodegen-output) only looks inside `gql` tags. We need to use `gql` for the client-side schema so that the codegen validator will recognize the schema at all.

This will update the apollo-client docs so that they'll be compatible with codegen.