### PR TITLE
Modernize `apollo-utilities` graphql transformation functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,22 @@
 
 ## Apollo Client (vNext)
 
+### Apollo Client (vNext)
+
+- Apollo Client has been updated to use `graphql` 14.x as a dev dependency.  <br/>
+  [@hwillson](https://github.com/hwillson) in [#4233](https://github.com/apollographql/apollo-client/pull/4233)
+
+### Apollo Utilities (vNext)
+
+- Transformation utilities have been refactored to work with `graphql` 14.x.
+  GraphQL AST's are no longer being directly modified.  <br/>
+  [@hwillson](https://github.com/hwillson) in [#4233](https://github.com/apollographql/apollo-client/pull/4233)
+
 ## Apollo Client (2.4.8)
 
 ### Apollo Client (2.4.8)
 
-- Documtation and config updates.  <br/>
+- Documentation and config updates.  <br/>
   [@justinanastos](https://github.com/justinanastos) in [#4187](https://github.com/apollographql/apollo-client/pull/4187)  <br/>
   [@PowerKiKi](https://github.com/PowerKiKi) in [#3693](https://github.com/apollographql/apollo-client/pull/3693)  <br/>
   [@nandito](https://github.com/nandito) in [#3865](https://github.com/apollographql/apollo-client/pull/3865)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1409,9 +1409,9 @@
       "dev": true
     },
     "@types/graphql": {
-      "version": "0.12.7",
-      "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-0.12.7.tgz",
-      "integrity": "sha512-xuf/9ShwOOlxoV+J5ts4vAoPbL3nmcFU3z/Ad6jrsiB99hB/Wrs2fl3qJga5XJ1euAasMN/FsNPdHMV6+OV5vw==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-14.0.3.tgz",
+      "integrity": "sha512-TcFkpEjcQK7w8OcrQcd7iIBPjU0rdyi3ldj6d0iJ4PPSzbWqPBvXj9KSwO14hTOX2dm9RoiH7VuxksJLNYdXUQ==",
       "dev": true
     },
     "@types/isomorphic-fetch": {
@@ -6486,12 +6486,12 @@
       "dev": true
     },
     "graphql": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.13.2.tgz",
-      "integrity": "sha512-QZ5BL8ZO/B20VA8APauGBg3GyEgZ19eduvpLWoq5x7gMmWnHoy8rlQWPLmWgFvo1yNgjSEFMesmS4R6pPr7xog==",
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.0.2.tgz",
+      "integrity": "sha512-gUC4YYsaiSJT1h40krG3J+USGlwhzNTXSb4IOZljn9ag5Tj+RkoXrWp+Kh7WyE3t1NCfab5kzCuxBIvOMERMXw==",
       "dev": true,
       "requires": {
-        "iterall": "^1.2.1"
+        "iterall": "^1.2.2"
       }
     },
     "graphql-anywhere": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
   "devDependencies": {
     "@octokit/rest": "15.18.0",
     "@types/benchmark": "1.0.31",
-    "@types/graphql": "0.12.7",
+    "@types/graphql": "14.0.3",
     "@types/isomorphic-fetch": "0.0.34",
     "@types/jest": "23.3.10",
     "@types/lodash": "4.14.119",
@@ -105,7 +105,7 @@
     "danger": "4.4.10",
     "fetch-mock": "7.2.5",
     "flow-bin": "0.88.0",
-    "graphql": "0.13.2",
+    "graphql": "14.0.2",
     "graphql-tag": "2.10.0",
     "isomorphic-fetch": "2.2.1",
     "jest": "23.6.0",

--- a/packages/apollo-cache/src/utils.ts
+++ b/packages/apollo-cache/src/utils.ts
@@ -71,20 +71,16 @@ function selectionSetFromObj(obj: any): SelectionSetNode {
   const selections: FieldNode[] = [];
 
   Object.keys(obj).forEach(key => {
+    const nestedSelSet: SelectionSetNode = selectionSetFromObj(obj[key]);
+
     const field: FieldNode = {
       kind: 'Field',
       name: {
         kind: 'Name',
         value: key,
       },
+      selectionSet: nestedSelSet || undefined,
     };
-
-    // Recurse
-    const nestedSelSet: SelectionSetNode = selectionSetFromObj(obj[key]);
-
-    if (nestedSelSet) {
-      field.selectionSet = nestedSelSet;
-    }
 
     selections.push(field);
   });

--- a/packages/apollo-client/src/core/ObservableQuery.ts
+++ b/packages/apollo-client/src/core/ObservableQuery.ts
@@ -22,7 +22,7 @@ import { QueryStoreValue } from '../data/queries';
 
 export type ApolloCurrentResult<T> = {
   data: T | {};
-  errors?: GraphQLError[];
+  errors?: ReadonlyArray<GraphQLError>;
   loading: boolean;
   networkStatus: NetworkStatus;
   error?: ApolloError;
@@ -228,7 +228,8 @@ export class ObservableQuery<
   public isDifferentFromLastResult(newResult: ApolloQueryResult<TData>) {
     const { lastResultSnapshot: snapshot } = this;
     return !(
-      snapshot && newResult &&
+      snapshot &&
+      newResult &&
       snapshot.networkStatus === newResult.networkStatus &&
       snapshot.stale === newResult.stale &&
       isEqual(snapshot.data, newResult.data)
@@ -356,7 +357,9 @@ export class ObservableQuery<
   // XXX the subscription variables are separate from the query variables.
   // if you want to update subscription variables, right now you have to do that separately,
   // and you can only do it by stopping the subscription and then subscribing again with new variables.
-  public subscribeToMore<TSubscriptionData = TData>(options: SubscribeToMoreOptions<TData, TVariables, TSubscriptionData>) {
+  public subscribeToMore<TSubscriptionData = TData>(
+    options: SubscribeToMoreOptions<TData, TVariables, TSubscriptionData>,
+  ) {
     const subscription = this.queryManager
       .startGraphQLSubscription({
         query: options.document,
@@ -366,13 +369,14 @@ export class ObservableQuery<
         next: (subscriptionData: { data: TSubscriptionData }) => {
           if (options.updateQuery) {
             this.updateQuery((previous, { variables }) =>
-              (options.updateQuery as UpdateQueryFn<TData, TVariables, TSubscriptionData>)(
-                previous,
-                {
-                  subscriptionData,
-                  variables,
-                },
-              ),
+              (options.updateQuery as UpdateQueryFn<
+                TData,
+                TVariables,
+                TSubscriptionData
+              >)(previous, {
+                subscriptionData,
+                variables,
+              }),
             );
           }
         },

--- a/packages/apollo-client/src/core/types.ts
+++ b/packages/apollo-client/src/core/types.ts
@@ -18,7 +18,7 @@ export type PureQueryOptions = {
 
 export type ApolloQueryResult<T> = {
   data: T;
-  errors?: GraphQLError[];
+  errors?: ReadonlyArray<GraphQLError>;
   loading: boolean;
   networkStatus: NetworkStatus;
   stale: boolean;

--- a/packages/apollo-client/src/data/queries.ts
+++ b/packages/apollo-client/src/data/queries.ts
@@ -10,7 +10,7 @@ export type QueryStoreValue = {
   previousVariables?: Object | null;
   networkStatus: NetworkStatus;
   networkError?: Error | null;
-  graphQLErrors?: GraphQLError[];
+  graphQLErrors?: ReadonlyArray<GraphQLError>;
   metadata: any;
 };
 
@@ -78,7 +78,7 @@ export class QueryStore {
       networkStatus = NetworkStatus.loading;
     }
 
-    let graphQLErrors: GraphQLError[] = [];
+    let graphQLErrors: ReadonlyArray<GraphQLError> = [];
     if (previousQuery && previousQuery.graphQLErrors) {
       graphQLErrors = previousQuery.graphQLErrors;
     }

--- a/packages/apollo-client/src/errors/ApolloError.ts
+++ b/packages/apollo-client/src/errors/ApolloError.ts
@@ -31,7 +31,7 @@ const generateErrorMessage = (err: ApolloError) => {
 
 export class ApolloError extends Error {
   public message: string;
-  public graphQLErrors: GraphQLError[];
+  public graphQLErrors: ReadonlyArray<GraphQLError>;
   public networkError: Error | null;
 
   // An object that can be used to provide some additional information
@@ -48,7 +48,7 @@ export class ApolloError extends Error {
     errorMessage,
     extraInfo,
   }: {
-    graphQLErrors?: GraphQLError[];
+    graphQLErrors?: ReadonlyArray<GraphQLError>;
     networkError?: Error | null;
     errorMessage?: string;
     extraInfo?: any;

--- a/packages/apollo-utilities/src/__tests__/transform.ts
+++ b/packages/apollo-utilities/src/__tests__/transform.ts
@@ -534,7 +534,7 @@ describe('query transforms', () => {
     `;
     const expectedQueryStr = print(expectedQuery);
 
-    expect(expectedQueryStr).toBe(print(newQueryDoc));
+    expect(print(newQueryDoc)).toBe(expectedQueryStr);
   });
 
   it('should not add duplicates', () => {
@@ -565,7 +565,7 @@ describe('query transforms', () => {
     `;
     const expectedQueryStr = print(expectedQuery);
 
-    expect(expectedQueryStr).toBe(print(newQueryDoc));
+    expect(print(newQueryDoc)).toBe(expectedQueryStr);
   });
 
   it('should not screw up on a FragmentSpread within the query AST', () => {
@@ -1167,8 +1167,6 @@ describe('getDirectivesFromDocument', () => {
       const expected = gql`
         fragment client on ClientData {
           hi @client
-          bye @storage
-          bar
         }
 
         query Mixed {

--- a/packages/apollo-utilities/src/getFromAST.ts
+++ b/packages/apollo-utilities/src/getFromAST.ts
@@ -51,6 +51,8 @@ string in a "gql" tag? http://docs.apollostack.com/apollo-client/core.html#gql`)
       `Ambiguous GraphQL document: contains ${operations.length} operations`,
     );
   }
+
+  return doc;
 }
 
 export function getOperationDefinition(

--- a/packages/apollo-utilities/src/transform.ts
+++ b/packages/apollo-utilities/src/transform.ts
@@ -194,10 +194,8 @@ export function removeDirectivesFromDocument(
   return modifiedDoc;
 }
 
-export function addTypenameToDocument(doc: DocumentNode) {
-  checkDocument(doc);
-
-  const modifiedDoc = visit(doc, {
+export function addTypenameToDocument(doc: DocumentNode): DocumentNode {
+  return visit(checkDocument(doc), {
     SelectionSet: {
       enter(node, _key, parent) {
         // Don't add __typename to OperationDefinitions.
@@ -205,13 +203,13 @@ export function addTypenameToDocument(doc: DocumentNode) {
           parent &&
           (parent as OperationDefinitionNode).kind === 'OperationDefinition'
         ) {
-          return undefined;
+          return;
         }
 
         // No changes if no selections.
         const { selections } = node;
         if (!selections) {
-          return undefined;
+          return;
         }
 
         // If selections already have a __typename, or are part of an
@@ -224,7 +222,7 @@ export function addTypenameToDocument(doc: DocumentNode) {
           );
         });
         if (skip) {
-          return undefined;
+          return;
         }
 
         // Create and return a new SelectionSet with a __typename Field.
@@ -235,8 +233,6 @@ export function addTypenameToDocument(doc: DocumentNode) {
       },
     },
   });
-
-  return modifiedDoc;
 }
 
 const connectionRemoveConfig = {

--- a/packages/apollo-utilities/src/transform.ts
+++ b/packages/apollo-utilities/src/transform.ts
@@ -52,24 +52,14 @@ const TYPENAME_FIELD: FieldNode = {
   },
 };
 
-function isNotEmpty(
+function isEmpty(
   op: OperationDefinitionNode | FragmentDefinitionNode,
   fragments: FragmentMap,
-): Boolean {
-  // keep selections that are still valid
-  return (
-    op.selectionSet.selections.filter(
-      selectionSet =>
-        // anything that doesn't match the compound filter is okay
-        !// not an empty array
-        (
-          selectionSet &&
-          // look into fragments to verify they should stay
-          selectionSet.kind === 'FragmentSpread' &&
-          // see if the fragment in the map is valid (recursively)
-          !isNotEmpty(fragments[selectionSet.name.value], fragments)
-        ),
-    ).length > 0
+): boolean {
+  return op.selectionSet.selections.every(
+    selection =>
+      selection.kind === 'FragmentSpread' &&
+      isEmpty(fragments[selection.name.value], fragments),
   );
 }
 
@@ -347,9 +337,10 @@ export function getDirectivesFromDocument(
     },
   });
 
-  const operation = getOperationDefinitionOrDie(modifiedDoc);
-  const fragments = createFragmentMap(getFragmentDefinitions(modifiedDoc));
-  return isNotEmpty(operation, fragments) ? modifiedDoc : null;
+  return !isEmpty(
+    getOperationDefinitionOrDie(modifiedDoc),
+    createFragmentMap(getFragmentDefinitions(modifiedDoc)),
+  ) ? modifiedDoc : null;
 }
 
 function getArgumentMatcher(config: RemoveArgumentsConfig[]) {
@@ -451,9 +442,10 @@ export function removeArgumentsFromDocument(
     },
   });
 
-  const operation = getOperationDefinitionOrDie(modifiedDoc);
-  const fragments = createFragmentMap(getFragmentDefinitions(modifiedDoc));
-  return isNotEmpty(operation, fragments) ? modifiedDoc : null;
+  return !isEmpty(
+    getOperationDefinitionOrDie(modifiedDoc),
+    createFragmentMap(getFragmentDefinitions(modifiedDoc)),
+  ) ? modifiedDoc : null;
 }
 
 export function removeFragmentSpreadFromDocument(

--- a/packages/apollo-utilities/src/transform.ts
+++ b/packages/apollo-utilities/src/transform.ts
@@ -342,18 +342,15 @@ export function getDirectivesFromDocument(
 }
 
 function getArgumentMatcher(config: RemoveArgumentsConfig[]) {
-  return (argument: ArgumentNode): Boolean => {
-    return config.some((aConfig: RemoveArgumentsConfig) => {
-      if (
-        argument.value.kind !== 'Variable' ||
-        !(argument.value as VariableNode)
-      )
-        return false;
-      if (!argument.value.name) return false;
-      if (aConfig.name === argument.value.name.value) return true;
-      if (aConfig.test && aConfig.test(argument)) return true;
-      return false;
-    });
+  return function argumentMatcher(argument: ArgumentNode) {
+    return config.some(
+      (aConfig: RemoveArgumentsConfig) =>
+        argument.value &&
+        argument.value.kind === 'Variable' &&
+        argument.value.name &&
+        (aConfig.name === argument.value.name.value ||
+          (aConfig.test && aConfig.test(argument))),
+    );
   };
 }
 

--- a/packages/apollo-utilities/src/transform.ts
+++ b/packages/apollo-utilities/src/transform.ts
@@ -354,37 +354,6 @@ function getArgumentMatcher(config: RemoveArgumentsConfig[]) {
   };
 }
 
-function hasArgumentsInSelectionSet(
-  config: RemoveArgumentsConfig[],
-  selectionSet: SelectionSetNode,
-  nestedCheck: boolean = false,
-): boolean {
-  return filterSelectionSet(selectionSet, selection =>
-    hasArgumentsInSelection(config, selection, nestedCheck),
-  );
-}
-
-function hasArgumentsInSelection(
-  config: RemoveArgumentsConfig[],
-  selection: SelectionNode,
-  nestedCheck: boolean = false,
-): boolean {
-  // Selection is a FragmentSpread or InlineFragment, ignore (include it)...
-  if (selection.kind !== 'Field' || !(selection as FieldNode)) {
-    return true;
-  }
-
-  if (!selection.arguments) {
-    return false;
-  }
-
-  return (
-    selection.arguments.some(getArgumentMatcher(config)) ||
-    (nestedCheck &&
-      hasArgumentsInSelectionSet(config, selection.selectionSet, nestedCheck))
-  );
-}
-
 export function removeArgumentsFromDocument(
   config: RemoveArgumentsConfig[],
   doc: DocumentNode,

--- a/packages/apollo-utilities/src/transform.ts
+++ b/packages/apollo-utilities/src/transform.ts
@@ -152,13 +152,7 @@ export function removeDirectivesFromDocument(
     Directive: {
       enter(node) {
         // If a matching directive is found, remove it.
-        const directiveFound = directives.some(directive => {
-          if (directive.name && directive.name === node.name.value) return true;
-          if (directive.test && directive.test(node)) return true;
-          return false;
-        });
-        if (directiveFound) {
-          // Remove the directive.
+        if (getDirectiveMatcher(directives)(node)) {
           return null;
         }
       },

--- a/packages/apollo-utilities/src/transform.ts
+++ b/packages/apollo-utilities/src/transform.ts
@@ -259,8 +259,10 @@ const connectionRemoveConfig = {
 };
 
 export function removeConnectionDirectiveFromDocument(doc: DocumentNode) {
-  checkDocument(doc);
-  return removeDirectivesFromDocument([connectionRemoveConfig], doc);
+  return removeDirectivesFromDocument(
+    [connectionRemoveConfig],
+    checkDocument(doc),
+  );
 }
 
 function hasDirectivesInSelectionSet(

--- a/packages/apollo-utilities/src/transform.ts
+++ b/packages/apollo-utilities/src/transform.ts
@@ -265,8 +265,12 @@ function hasDirectivesInSelectionSet(
   selectionSet: SelectionSetNode,
   nestedCheck = true,
 ): boolean {
-  return filterSelectionSet(selectionSet, selection =>
-    hasDirectivesInSelection(directives, selection, nestedCheck),
+  return (
+    selectionSet &&
+    selectionSet.selections &&
+    selectionSet.selections.some(selection =>
+      hasDirectivesInSelection(directives, selection, nestedCheck),
+    )
   );
 }
 
@@ -444,15 +448,4 @@ function getAllFragmentSpreadsFromSelectionSet(
   });
 
   return allFragments;
-}
-
-function filterSelectionSet(
-  selectionSet: SelectionSetNode,
-  filter: (node: SelectionNode) => boolean,
-) {
-  if (!(selectionSet && selectionSet.selections)) {
-    return false;
-  }
-
-  return selectionSet.selections.filter(filter).length > 0;
 }

--- a/packages/apollo-utilities/src/transform.ts
+++ b/packages/apollo-utilities/src/transform.ts
@@ -10,8 +10,8 @@ import {
   FragmentSpreadNode,
   VariableDefinitionNode,
   VariableNode,
-  visit,
 } from 'graphql';
+import { visit } from 'graphql/language/visitor';
 
 import {
   checkDocument,

--- a/packages/apollo-utilities/src/transform.ts
+++ b/packages/apollo-utilities/src/transform.ts
@@ -282,12 +282,9 @@ function hasDirectivesInSelection(
   if (!selection.directives) {
     return false;
   }
-  const directiveMatcher = getDirectiveMatcher(directives);
-  const matchedDirectives = selection.directives.filter(directiveMatcher);
-  const hasMatches = matchedDirectives.length > 0;
 
   return (
-    hasMatches ||
+    selection.directives.some(getDirectiveMatcher(directives)) ||
     (nestedCheck &&
       hasDirectivesInSelectionSet(
         directives,

--- a/packages/apollo-utilities/src/transform.ts
+++ b/packages/apollo-utilities/src/transform.ts
@@ -191,7 +191,7 @@ export function removeDirectivesFromDocument(
   // aren't being used elsewhere.
   if (variablesToRemove) {
     variablesToRemove = variablesToRemove.filter(
-      variable => !variablesInUse.includes(variable.name),
+      variable => variablesInUse.indexOf(variable.name) === -1,
     );
     modifiedDoc = removeArgumentsFromDocument(variablesToRemove, modifiedDoc);
   }
@@ -201,7 +201,7 @@ export function removeDirectivesFromDocument(
   // document, as long as they aren't being used elsewhere.
   if (fragmentSpreadsToRemove) {
     fragmentSpreadsToRemove = fragmentSpreadsToRemove.filter(
-      fragSpread => !fragmentSpreadsInUse.includes(fragSpread.name),
+      fragSpread => fragmentSpreadsInUse.indexOf(fragSpread.name) === -1,
     );
     modifiedDoc = removeFragmentSpreadFromDocument(
       fragmentSpreadsToRemove,

--- a/packages/apollo-utilities/src/transform.ts
+++ b/packages/apollo-utilities/src/transform.ts
@@ -361,14 +361,12 @@ export function removeArgumentsFromDocument(
   return nullIfDocIsEmpty(visit(doc, {
     OperationDefinition: {
       enter(node) {
-        // Remove matching top level variables definitions.
-        const variableDefinitions = node.variableDefinitions.filter(
-          varDef =>
-            !config.some(arg => arg.name === varDef.variable.name.value),
-        );
         return {
           ...node,
-          variableDefinitions,
+          // Remove matching top level variables definitions.
+          variableDefinitions: node.variableDefinitions.filter(
+            varDef => !config.some(arg => arg.name === varDef.variable.name.value),
+          ),
         };
       },
     },

--- a/packages/apollo-utilities/src/transform.ts
+++ b/packages/apollo-utilities/src/transform.ts
@@ -66,13 +66,11 @@ function isEmpty(
 function getDirectiveMatcher(
   directives: (RemoveDirectiveConfig | GetDirectiveConfig)[],
 ) {
-  return function directiveMatcher(directive: DirectiveNode): boolean {
+  return function directiveMatcher(directive: DirectiveNode) {
     return directives.some(
-      (dir: RemoveDirectiveConfig | GetDirectiveConfig) => {
-        if (dir.name && dir.name === directive.name.value) return true;
-        if (dir.test && dir.test(directive)) return true;
-        return false;
-      },
+      dir =>
+        (dir.name && dir.name === directive.name.value) ||
+        (dir.test && dir.test(directive)),
     );
   };
 }

--- a/packages/apollo-utilities/src/transform.ts
+++ b/packages/apollo-utilities/src/transform.ts
@@ -446,32 +446,19 @@ export function removeArgumentsFromDocument(
 export function removeFragmentSpreadFromDocument(
   config: RemoveFragmentSpreadConfig[],
   doc: DocumentNode,
-): DocumentNode | null {
-  const modifiedDoc = visit(doc, {
-    FragmentSpread: {
-      enter(node) {
-        const fragSpreadFound = config.some(
-          fragSpread => fragSpread.name === node.name.value,
-        );
-        if (fragSpreadFound) {
-          return null;
-        }
-      },
-    },
+): DocumentNode {
+  function enter(
+    node: FragmentSpreadNode | FragmentDefinitionNode,
+  ): null | void {
+    if (config.some(def => def.name === node.name.value)) {
+      return null;
+    }
+  }
 
-    FragmentDefinition: {
-      enter(node) {
-        const fragDefFound = config.some(
-          fragDef => fragDef.name && fragDef.name === node.name.value,
-        );
-        if (fragDefFound) {
-          return null;
-        }
-      },
-    },
+  return visit(doc, {
+    FragmentSpread: { enter },
+    FragmentDefinition: { enter },
   });
-
-  return modifiedDoc;
 }
 
 function getAllFragmentSpreadsFromSelectionSet(

--- a/packages/apollo-utilities/src/transform.ts
+++ b/packages/apollo-utilities/src/transform.ts
@@ -464,33 +464,21 @@ export function removeFragmentSpreadFromDocument(
 function getAllFragmentSpreadsFromSelectionSet(
   selectionSet: SelectionSetNode,
 ): FragmentSpreadNode[] {
-  return selectionSet.selections
-    .map(getAllFragmentSpreadsFromSelection)
-    .reduce(
-      (allFragments, selectionFragments) => [
-        ...allFragments,
-        ...selectionFragments,
-      ],
-      [],
-    );
-}
+  const allFragments: FragmentSpreadNode[] = [];
 
-function getAllFragmentSpreadsFromSelection(
-  selection: SelectionNode,
-): FragmentSpreadNode[] {
-  if (
-    (selection.kind === 'Field' || selection.kind === 'InlineFragment') &&
-    selection.selectionSet
-  ) {
-    return getAllFragmentSpreadsFromSelectionSet(selection.selectionSet);
-  } else if (
-    selection.kind === 'FragmentSpread' &&
-    (selection as FragmentSpreadNode)
-  ) {
-    return [selection];
-  }
+  selectionSet.selections.forEach(selection => {
+    if ((selection.kind === 'Field' ||
+         selection.kind === 'InlineFragment') &&
+        selection.selectionSet) {
+      getAllFragmentSpreadsFromSelectionSet(
+        selection.selectionSet
+      ).forEach(frag => allFragments.push(frag));
+    } else if (selection.kind === 'FragmentSpread') {
+      allFragments.push(selection);
+    }
+  });
 
-  return [];
+  return allFragments;
 }
 
 function filterSelectionSet(

--- a/packages/apollo-utilities/src/transform.ts
+++ b/packages/apollo-utilities/src/transform.ts
@@ -377,10 +377,9 @@ function hasArgumentsInSelection(
   if (!selection.arguments) {
     return false;
   }
-  const matcher = getArgumentMatcher(config);
-  const matchedArguments = selection.arguments.filter(matcher);
+
   return (
-    matchedArguments.length > 0 ||
+    selection.arguments.some(getArgumentMatcher(config)) ||
     (nestedCheck &&
       hasArgumentsInSelectionSet(config, selection.selectionSet, nestedCheck))
   );

--- a/packages/apollo-utilities/src/transform.ts
+++ b/packages/apollo-utilities/src/transform.ts
@@ -114,13 +114,13 @@ export function removeDirectivesFromDocument(
           if (node.arguments) {
             // Store field argument variables so they can be removed
             // from the operation definition.
-            node.arguments
-              .filter(arg => arg.value.kind === 'Variable')
-              .forEach(arg => {
+            node.arguments.forEach(arg => {
+              if (arg.value.kind === 'Variable') {
                 variablesToRemove.push({
                   name: (arg.value as VariableNode).name.value,
                 });
-              });
+              }
+            });
           }
 
           if (node.selectionSet) {

--- a/packages/apollo-utilities/src/transform.ts
+++ b/packages/apollo-utilities/src/transform.ts
@@ -20,6 +20,7 @@ import {
   createFragmentMap,
   FragmentMap,
 } from './getFromAST';
+import { filterInPlace } from './util/filterInPlace';
 
 export type RemoveNodeConfig<N> = {
   name?: string;
@@ -171,22 +172,19 @@ export function removeDirectivesFromDocument(
   // If we've removed fields with arguments, make sure the associated
   // variables are also removed from the rest of the document, as long as they
   // aren't being used elsewhere.
-  if (modifiedDoc && variablesToRemove) {
-    variablesToRemove = variablesToRemove.filter(
-      variable => !variablesInUse[variable.name],
-    );
-
+  if (modifiedDoc &&
+      filterInPlace(variablesToRemove, v => !variablesInUse[v.name]).length) {
     modifiedDoc = removeArgumentsFromDocument(variablesToRemove, modifiedDoc);
   }
 
   // If we've removed selection sets with fragment spreads, make sure the
   // associated fragment definitions are also removed from the rest of the
   // document, as long as they aren't being used elsewhere.
-  if (modifiedDoc && fragmentSpreadsToRemove) {
-    fragmentSpreadsToRemove = fragmentSpreadsToRemove.filter(
-      fragSpread => !fragmentSpreadsInUse[fragSpread.name],
-    );
-
+  if (modifiedDoc &&
+      filterInPlace(
+        fragmentSpreadsToRemove,
+        fs => !fragmentSpreadsInUse[fs.name],
+      ).length) {
     modifiedDoc = removeFragmentSpreadFromDocument(
       fragmentSpreadsToRemove,
       modifiedDoc,

--- a/packages/apollo-utilities/src/util/filterInPlace.ts
+++ b/packages/apollo-utilities/src/util/filterInPlace.ts
@@ -1,0 +1,14 @@
+export function filterInPlace<T>(
+  array: T[],
+  test: (elem: T) => boolean,
+  context?: any,
+): T[] {
+  let target = 0;
+  array.forEach(function (elem, i) {
+    if (test.call(this, elem, i, array)) {
+      array[target++] = elem;
+    }
+  }, context);
+  array.length = target;
+  return array;
+}

--- a/packages/apollo-utilities/tsconfig.json
+++ b/packages/apollo-utilities/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "lib",
-    "lib": ["es6", "dom", "es7"]
+    "lib": ["es6", "dom"]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["src/**/__tests__/*.ts"]

--- a/packages/apollo-utilities/tsconfig.json
+++ b/packages/apollo-utilities/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "lib",
-    "lib": ["es6", "dom", "es2017.object"]
+    "lib": ["es6", "dom", "es7"]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["src/**/__tests__/*.ts"]


### PR DESCRIPTION
The graphql AST transformation capabilities provided by `apollo-utilities` are no longer in synch with `graphql` 14.x, as they rely on being able to directly modify a graphql based AST. `graphql` 14.x has made the internal document structure read only, so we'll need to update `apollo-utilities` to use a different approach (likely using [`graphql`'s visitor](https://graphql.org/graphql-js/language/#visitor) functionality). We've know about this for a while (Renovate keeps reminding us - e.g. https://github.com/apollographql/apollo-client/pull/3875), but we should definitely address this sooner than later.

As a start, this PR updates the `@types/graphql` and `graphql` dev deps to the latest 14.x based versions, which will break CI. This PR will serve as a placeholder until this is addressed. 