### PR TITLE
Fix incorrect documentation on error handling

### DIFF
--- a/docs/source/features/error-handling.md
+++ b/docs/source/features/error-handling.md
@@ -13,10 +13,10 @@ Any application, from simple to complex, can have its fair share of errors. It i
 
 <h2 id="policies" title="Error policies">Error policies</h2>
 
-Much like `fetchPolicy`, `errorPolicy` allows you to control how GraphQL Errors from the server are sent to your UI code. By default, the error policy treats any GraphQL Errors as network errors and ends the request chain. It doesn't save any data in the cache, and renders your UI with the `error` prop to be an ApolloError. By changing this policy per request, you can adjust how GraphQL Errors are managed in the cache and your UI. The possible options for `errorPolicy` are:
+Much like `fetchPolicy`, `errorPolicy` allows you to control how GraphQL Errors from the server are sent to your UI code. By default, the error policy treats any GraphQL Errors as network errors and ends the request chain. It doesn't save any data in the cache, and renders your UI with the `error` prop to be an ApolloError. By changing this policy per request, you can adjust how GraphQL Errors are managed. The possible options for `errorPolicy` are:
 - `none`: This is the default policy to match how Apollo Client 1.0 worked. Any GraphQL Errors are treated the same as network errors and any data is ignored from the response.
 - `ignore`: Ignore allows you to read any data that is returned alongside GraphQL Errors, but doesn't save the errors or report them to your UI.
-- `all`: Using the `all` policy is the best way to notify your users of potential issues while still showing as much data as possible from your server. It saves both data and errors into the Apollo Cache so your UI can use them.
+- `all`: Using the `all` policy is the best way to notify your users of potential issues while still showing as much data as possible from your server.
 
 You can set `errorPolicy` on each request like so:
 ```js
@@ -44,6 +44,8 @@ const ShowingSomeErrors = () => (
 );
 ```
 Any errors reported will come under an `error` prop along side the data returned from the cache or server.
+
+Note that errors are not stored in the cache. When using the `all` policy, queries with errors will be retrieved from the cache without the associated errors.
 
 
 <h2 id="network" title="Network errors">Network Errors</h2>


### PR DESCRIPTION
The documentation on `errorPolicy` was incorrect with respect to the way errors are cached. This updates the docs for parity with Apollo's current functionality.

Fixing this so that future developers do not spend too much time trying to figure out why error cacheing isn't working for them.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->