### PR TITLE
Replace LaunchPad sample servers with CodeSandBox servers

### DIFF
--- a/docs/source/essentials/mutations.md
+++ b/docs/source/essentials/mutations.md
@@ -9,7 +9,7 @@ This page assumes some familiarity with building GraphQL mutations. If you'd lik
 
 The following examples assume that you've already set up Apollo Client and have wrapped your React app in an `ApolloProvider` component. Read our [getting started](./get-started.html) guide if you need help with either of those steps. Let's dive in!
 
-> If you'd like to follow along with the examples, open up our [starter project](https://codesandbox.io/s/znl94y0vp) on CodeSandbox, and our sample GraphQL server on [Launchpad](https://launchpad.graphql.com/8v9r9kpn7q). You can view the completed version of the app [here](https://codesandbox.io/s/v3mn68xxvy).
+> If you'd like to follow along with the examples, open up our [starter project](https://codesandbox.io/s/znl94y0vp) on CodeSandbox, and our sample GraphQL server on [this CodeSandBox](https://codesandbox.io/s/plp0mopxq). You can view the completed version of the app [here](https://codesandbox.io/s/v3mn68xxvy).
 
 <h2 id="basic">The Mutation component</h2>
 

--- a/docs/source/essentials/queries.md
+++ b/docs/source/essentials/queries.md
@@ -9,7 +9,7 @@ This page assumes some familiarity with building GraphQL queries. If you'd like 
 
 The following examples assume that you've already set up Apollo Client and have wrapped your React app in an `ApolloProvider` component. Read our [getting started](./get-started.html) guide if you need help with either of those steps.
 
-> If you'd like to follow along with the examples, open up our [starter project](https://codesandbox.io/s/j2ly83749w) on CodeSandbox and our sample GraphQL server on [Launchpad](https://launchpad.graphql.com/nx9zvp49q7). You can view the completed version of the app [here](https://codesandbox.io/s/n3jykqpxwm).
+> If you'd like to follow along with the examples, open up our [starter project](https://codesandbox.io/s/j2ly83749w) on CodeSandbox and our sample GraphQL server on [this CodeSandbox](https://codesandbox.io/s/32ypr38l61). You can view the completed version of the app [here](https://codesandbox.io/s/n3jykqpxwm).
 
 <h2 id="basic">The Query component</h2>
 


### PR DESCRIPTION
The sample GraphQL Server for the queries.md and mutations.md are on LaunchPad, which has been deprecated. I've created a Sandbox following Peggy's lead in get-started.md. This will allow future documentation readers to follow along. 