### PR TITLE
Docs: import gql from apollo-boost instead of graphql-tag

### DIFF
--- a/docs/source/essentials/get-started.md
+++ b/docs/source/essentials/get-started.md
@@ -39,6 +39,7 @@ That's it! Now your client is ready to start fetching data. Before we hook up Ap
 
 ```js
 import { gql } from "apollo-boost";
+// or you can use `import gql from 'graphql-tag';` instead
 
 ...
 

--- a/docs/source/essentials/get-started.md
+++ b/docs/source/essentials/get-started.md
@@ -38,7 +38,7 @@ const client = new ApolloClient({
 That's it! Now your client is ready to start fetching data. Before we hook up Apollo Client to React, let's try sending a query with plain JavaScript first. In the same `index.js` file, try calling `client.query()`. Remember to first import the `gql` function for parsing your query string into a query document.
 
 ```js
-import gql from "graphql-tag";
+import { gql } from "apollo-boost";
 
 ...
 
@@ -90,7 +90,7 @@ Let's create an `ExchangeRates` component in `index.js` to see the `Query` compo
 
 ```jsx
 import { Query } from "react-apollo";
-import gql from "graphql-tag";
+import { gql } from "apollo-boost";
 
 const ExchangeRates = () => (
   <Query
@@ -164,7 +164,7 @@ Here are the options you can pass to the `ApolloClient` exported from `apollo-bo
   <dt>`headers`: Object</dt>
   <dd>Header key/value pairs to pass along with the request.</dd>
   <dt>`fetch`: GlobalFetch['fetch']</dt>
-  <dd>A [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) compatible API for making a request.</dd>  
+  <dd>A [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) compatible API for making a request.</dd>
   <dt>`cache`: ApolloCache</dt>
   <dd>A custom instance of `ApolloCache` to be used. The default value is `InMemoryCache` from `apollo-cache-inmemory`. This option is quite useful for using a custom cache with `apollo-cache-persist`.</dd>
 </dl>


### PR DESCRIPTION
On 'Get Started' page, I think we should `import { gql } from 'apollo-boost'` instead of `import gql from 'graphql-tag'` since at the beginning of this page we tell a reader to `npm install apollo-boost react-apollo graphql --save` (we don't install `graphql-tag`).