### PR TITLE
Remove `graphql-anywhere` and `apollo-boost` from bundlesize

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,19 +37,9 @@
       "maxSize": "10.25 kB"
     },
     {
-      "name": "apollo-boost",
-      "path": "./packages/apollo-boost/lib/bundle.min.js",
-      "maxSize": "35 kB"
-    },
-    {
       "name": "apollo-utilities",
       "path": "./packages/apollo-utilities/lib/bundle.min.js",
       "maxSize": "5 kB"
-    },
-    {
-      "name": "graphql-anywhere",
-      "path": "./packages/graphql-anywhere/lib/bundle.min.js",
-      "maxSize": "1.25 kB"
     }
   ],
   "jest": {


### PR DESCRIPTION
`graphql-anywhere` is no longer used by Apollo Client, and `apollo-boost` is going to be deprecated soon. This commit removes them from the `bundlesize` check, to get the total bundle size amount down to something that better reflects reality.
