### PR TITLE
fix(removeDirectivesFromDocument): Assert field directives type.

### DIFF
--- a/packages/apollo-utilities/src/__tests__/transform.ts
+++ b/packages/apollo-utilities/src/__tests__/transform.ts
@@ -504,6 +504,29 @@ describe('removeDirectivesFromDocument', () => {
 
     expect(doc).toBe(null);
   });
+
+  it('should not throw in combination with addTypenameToDocument', () => {
+    const query = gql`
+      query Simple {
+        ...fragmentSpread
+      }
+
+      fragment fragmentSpread on Thing {
+        ...inDirection
+      }
+
+      fragment inDirection on Thing {
+        field @storage
+      }
+    `;
+
+    expect(() => {
+      removeDirectivesFromDocument(
+        [{ name: 'storage', remove: true }],
+        addTypenameToDocument(query),
+      );
+    }).not.toThrow();
+  });
 });
 
 describe('query transforms', () => {

--- a/packages/apollo-utilities/src/transform.ts
+++ b/packages/apollo-utilities/src/transform.ts
@@ -119,6 +119,7 @@ export function removeDirectivesFromDocument(
 
         if (
           shouldRemoveField &&
+          node.directives &&
           node.directives.some(getDirectiveMatcher(directives))
         ) {
           if (node.arguments) {


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

After upgrade to `apollo-utilities@1.1.0` queries with `@client` directive start throwing errors because of injected `__typename` field.

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
