### PR TITLE
Update optimism to use its new TypeScript declarations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@
 
 ### Apollo Cache In-Memory (vNext)
 
+- The `optimism` npm package has been updated to a version (0.6.9) that
+  provides its own TypeScript declarations, which should fix problems like
+  [Issue #4327](https://github.com/apollographql/apollo-client/issues/4327). <br/>
+  [PR #4331](https://github.com/apollographql/apollo-client/pull/4331)
+
 - Error messages involving GraphQL queries now print the queries using
   `JSON.stringify` instead of the `print` function exported by the
   `graphql` package, to avoid pulling unnecessary printing logic into your
@@ -27,7 +32,7 @@
   results for non-identical queries (or sub-queries) with equivalent
   structure will no longer be cached together. This feature was a nice
   optimization in certain specific use cases, but it was not worth the
-  additional complexity or bundle size.
+  additional complexity or bundle size. <br/>
   [PR #4245](https://github.com/apollographql/apollo-client/pull/4245)
 
 - The `flattenSelections` helper function is no longer exported from

--- a/packages/apollo-cache-inmemory/package-lock.json
+++ b/packages/apollo-cache-inmemory/package-lock.json
@@ -33,9 +33,9 @@
       "integrity": "sha512-LWbJPZnidF8eczu7XmcnLBsumuyRBkpwIRPCZxlojouhBo5jEBO4toj6n7hMy6IxHU/c+MqDSWkvaTpPlMQcyA=="
     },
     "optimism": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.6.8.tgz",
-      "integrity": "sha512-bN5n1KCxSqwBDnmgDnzMtQTHdL+uea2HYFx1smvtE+w2AMl0Uy31g0aXnP/Nt85OINnMJPRpJyfRQLTCqn5Weg==",
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.6.9.tgz",
+      "integrity": "sha512-xoQm2lvXbCA9Kd7SCx6y713Y7sZ6fUc5R6VYpoL5M6svKJbTuvtNopexK8sO8K4s0EOUYHuPN2+yAEsNyRggkQ==",
       "requires": {
         "immutable-tuple": "^0.4.9"
       }

--- a/packages/apollo-cache-inmemory/package.json
+++ b/packages/apollo-cache-inmemory/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "apollo-cache": "file:../apollo-cache",
     "apollo-utilities": "file:../apollo-utilities",
-    "optimism": "^0.6.8"
+    "optimism": "^0.6.9"
   },
   "peerDependencies": {
     "graphql": "0.11.7 || ^0.12.0 || ^0.13.0 || ^14.0.0"

--- a/packages/apollo-cache-inmemory/src/cacheKeys.ts
+++ b/packages/apollo-cache-inmemory/src/cacheKeys.ts
@@ -1,19 +1,3 @@
-export type OptimisticWrapperFunction<
-  T = (...args: any[]) => any
-> = T & {
-  // The .dirty(...) method of an optimistic function takes exactly the same
-  // parameter types as the original function.
-  dirty: T;
-};
-
-export type OptimisticWrapOptions = {
-  max?: number;
-  disposable?: boolean;
-  makeCacheKey?(...args: any[]): any;
-};
-
-export { wrap } from 'optimism';
-
 export class CacheKeyNode<KeyType = object> {
   private children: Map<any, CacheKeyNode<KeyType>> | null = null;
   private key: KeyType | null = null;
@@ -34,7 +18,7 @@ export class CacheKeyNode<KeyType = object> {
     const map = this.children || (this.children = new Map());
     let node = map.get(value);
     if (!node) {
-      map.set(value, node = new CacheKeyNode<KeyType>());
+      map.set(value, (node = new CacheKeyNode<KeyType>()));
     }
     return node;
   }

--- a/packages/apollo-cache-inmemory/src/declarations.d.ts
+++ b/packages/apollo-cache-inmemory/src/declarations.d.ts
@@ -1,6 +1,0 @@
-declare module 'optimism' {
-  export function wrap<T>(
-    originalFunction: T,
-    options?: OptimisticWrapOptions,
-  ): OptimisticWrapperFunction<T>;
-}

--- a/packages/apollo-cache-inmemory/src/depTrackingCache.ts
+++ b/packages/apollo-cache-inmemory/src/depTrackingCache.ts
@@ -1,5 +1,5 @@
 import { NormalizedCache, NormalizedCacheObject, StoreObject } from './types';
-import { wrap, OptimisticWrapperFunction } from './optimism';
+import { wrap, OptimisticWrapperFunction } from 'optimism';
 
 const hasOwn = Object.prototype.hasOwnProperty;
 

--- a/packages/apollo-cache-inmemory/src/inMemoryCache.ts
+++ b/packages/apollo-cache-inmemory/src/inMemoryCache.ts
@@ -5,9 +5,9 @@ import { DocumentNode } from 'graphql';
 
 import { Cache, ApolloCache, Transaction } from 'apollo-cache';
 
-import {
-  addTypenameToDocument,
-} from 'apollo-utilities';
+import { addTypenameToDocument } from 'apollo-utilities';
+
+import { wrap } from 'optimism';
 
 import { HeuristicFragmentMatcher } from './fragmentMatcher';
 import {
@@ -18,9 +18,8 @@ import {
 
 import { StoreReader } from './readFromStore';
 import { StoreWriter } from './writeToStore';
-
 import { DepTrackingCache } from './depTrackingCache';
-import { wrap, CacheKeyNode } from './optimism';
+import { CacheKeyNode } from './cacheKeys';
 import { ObjectCache } from './objectCache';
 
 export interface InMemoryCacheConfig extends ApolloReducerConfig {

--- a/packages/apollo-cache-inmemory/src/readFromStore.ts
+++ b/packages/apollo-cache-inmemory/src/readFromStore.ts
@@ -39,9 +39,8 @@ import {
   SelectionSetNode,
 } from 'graphql';
 
-import { wrap, CacheKeyNode } from './optimism';
-export { OptimisticWrapperFunction } from './optimism';
-
+import { wrap } from 'optimism';
+import { CacheKeyNode } from './cacheKeys';
 import { DepTrackingCache } from './depTrackingCache';
 
 export type VariableMap = { [name: string]: any };


### PR DESCRIPTION
Since we've been struggling to declare correct types for the `optimism` npm package (for example: #4158, #4327), I finally decided to move the declarations into the `optimism` package itself: https://github.com/benjamn/optimism/commit/03b3f88424f718073513a22d2a3ab5dc13e15b90

Pretty easy! I wish I'd done this sooner.

Should fix #4327.