### PR TITLE
Revert breaking changes mistakenly released in patch update

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     {
       "name": "apollo-client",
       "path": "./packages/apollo-client/lib/bundle.min.js",
-      "maxSize": "9.15 kB"
+      "maxSize": "9.3 kB"
     },
     {
       "name": "apollo-utilities",

--- a/packages/apollo-boost/package-lock.json
+++ b/packages/apollo-boost/package-lock.json
@@ -236,6 +236,11 @@
       "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.1.tgz",
       "integrity": "sha512-jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg=="
     },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+    },
     "zen-observable": {
       "version": "0.8.11",
       "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.11.tgz",

--- a/packages/apollo-boost/package.json
+++ b/packages/apollo-boost/package.json
@@ -45,7 +45,8 @@
     "apollo-link-error": "^1.0.3",
     "apollo-link-http": "^1.3.1",
     "apollo-link-state": "^0.4.0",
-    "graphql-tag": "^2.4.2"
+    "graphql-tag": "^2.4.2",
+    "tslib": "^1.9.3"
   },
   "peerDependencies": {
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0"

--- a/packages/apollo-cache-inmemory/package-lock.json
+++ b/packages/apollo-cache-inmemory/package-lock.json
@@ -49,6 +49,11 @@
       "requires": {
         "immutable-tuple": "^0.4.9"
       }
+    },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     }
   }
 }

--- a/packages/apollo-cache-inmemory/package.json
+++ b/packages/apollo-cache-inmemory/package.json
@@ -44,7 +44,8 @@
   "dependencies": {
     "apollo-cache": "file:../apollo-cache",
     "apollo-utilities": "file:../apollo-utilities",
-    "optimism": "^0.6.9"
+    "optimism": "^0.6.9",
+    "tslib": "^1.9.3"
   },
   "peerDependencies": {
     "graphql": "0.11.7 || ^0.12.0 || ^0.13.0 || ^14.0.0"

--- a/packages/apollo-cache/package-lock.json
+++ b/packages/apollo-cache/package-lock.json
@@ -19,6 +19,11 @@
           "bundled": true
         }
       }
+    },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     }
   }
 }

--- a/packages/apollo-cache/package.json
+++ b/packages/apollo-cache/package.json
@@ -39,7 +39,8 @@
     "filesize": "npm run minify"
   },
   "dependencies": {
-    "apollo-utilities": "file:../apollo-utilities"
+    "apollo-utilities": "file:../apollo-utilities",
+    "tslib": "^1.9.3"
   },
   "jest": {
     "transform": {

--- a/packages/apollo-client/package-lock.json
+++ b/packages/apollo-client/package-lock.json
@@ -64,6 +64,11 @@
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
       "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+    },
     "zen-observable": {
       "version": "0.8.11",
       "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.11.tgz",

--- a/packages/apollo-client/package.json
+++ b/packages/apollo-client/package.json
@@ -53,6 +53,7 @@
     "apollo-link-dedup": "^1.0.0",
     "apollo-utilities": "file:../apollo-utilities",
     "symbol-observable": "^1.0.2",
+    "tslib": "^1.9.3",
     "zen-observable": "^0.8.0"
   },
   "peerDependencies": {

--- a/packages/apollo-client/src/ApolloClient.ts
+++ b/packages/apollo-client/src/ApolloClient.ts
@@ -63,7 +63,7 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
   public link: ApolloLink;
   public store: DataStore<TCacheShape>;
   public cache: ApolloCache<TCacheShape>;
-  private queryManager: QueryManager<TCacheShape> | undefined;
+  public queryManager: QueryManager<TCacheShape> | undefined;
   public disableNetworkFetches: boolean;
   public version: string;
   public queryDeduplication: boolean;
@@ -419,6 +419,38 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
   }
 
   /**
+   * This initializes the query manager that tracks queries and the cache
+   */
+  public initQueryManager(): QueryManager<TCacheShape> {
+    if (!this.queryManager) {
+      this.queryManager = new QueryManager({
+        link: this.link,
+        store: this.store,
+        queryDeduplication: this.queryDeduplication,
+        ssrMode: this.ssrMode,
+        clientAwareness: this.clientAwareness,
+        onBroadcast: () => {
+          if (this.devToolsHookCb) {
+            this.devToolsHookCb({
+              action: {},
+              state: {
+                queries: this.queryManager
+                  ? this.queryManager.queryStore.getStore()
+                  : {},
+                mutations: this.queryManager
+                  ? this.queryManager.mutationStore.getStore()
+                  : {},
+              },
+              dataWithOptimisticResults: this.cache.extract(true),
+            });
+          }
+        },
+      });
+    }
+    return this.queryManager;
+  }
+
+  /**
    * Resets your entire store by clearing out your cache and then re-executing
    * all of your active queries. This makes it so that you may guarantee that
    * there is no data left in your store from a time before you called this
@@ -523,38 +555,6 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
    */
   public restore(serializedState: TCacheShape): ApolloCache<TCacheShape> {
     return this.initProxy().restore(serializedState);
-  }
-
-  /**
-   * This initializes the query manager that tracks queries and the cache
-   */
-  private initQueryManager(): QueryManager<TCacheShape> {
-    if (!this.queryManager) {
-      this.queryManager = new QueryManager({
-        link: this.link,
-        store: this.store,
-        queryDeduplication: this.queryDeduplication,
-        ssrMode: this.ssrMode,
-        clientAwareness: this.clientAwareness,
-        onBroadcast: () => {
-          if (this.devToolsHookCb) {
-            this.devToolsHookCb({
-              action: {},
-              state: {
-                queries: this.queryManager
-                  ? this.queryManager.queryStore.getStore()
-                  : {},
-                mutations: this.queryManager
-                  ? this.queryManager.mutationStore.getStore()
-                  : {},
-              },
-              dataWithOptimisticResults: this.cache.extract(true),
-            });
-          }
-        },
-      });
-    }
-    return this.queryManager;
   }
 
   /**

--- a/packages/apollo-client/src/__mocks__/mockLinks.ts
+++ b/packages/apollo-client/src/__mocks__/mockLinks.ts
@@ -3,7 +3,6 @@ import {
   ApolloLink,
   FetchResult,
   Observable,
-  GraphQLRequest,
   // Observer,
 } from 'apollo-link';
 
@@ -26,7 +25,7 @@ export function mockObservableLink(): MockSubscriptionLink {
 }
 
 export interface MockedResponse {
-  request: GraphQLRequest;
+  request: Operation;
   result?: FetchResult;
   error?: Error;
   delay?: number;
@@ -146,7 +145,7 @@ export class MockSubscriptionLink extends ApolloLink {
   }
 }
 
-function requestToKey(request: GraphQLRequest): string {
+function requestToKey(request: Operation): string {
   const queryString = request.query && print(request.query);
 
   return JSON.stringify({

--- a/packages/apollo-client/src/__tests__/client.ts
+++ b/packages/apollo-client/src/__tests__/client.ts
@@ -28,11 +28,11 @@ describe('client', () => {
       cache: new InMemoryCache(),
     });
 
-    expect((client as any).queryManager).toBeUndefined();
+    expect(client.queryManager).toBeUndefined();
 
     // We only create the query manager on the first query
-    (client as any).initQueryManager();
-    expect((client as any).queryManager).toBeDefined();
+    client.initQueryManager();
+    expect(client.queryManager).toBeDefined();
     expect(client.cache).toBeDefined();
   });
 

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -13,6 +13,8 @@ import {
   hasDirectives,
 } from 'apollo-utilities';
 
+import { QueryScheduler } from '../scheduler/scheduler';
+
 import { isApolloError, ApolloError } from '../errors/ApolloError';
 
 import { Observer, Subscription, Observable } from '../util/Observable';
@@ -52,6 +54,7 @@ export interface QueryInfo {
 }
 
 export class QueryManager<TStore> {
+  public scheduler: QueryScheduler<TStore>;
   public link: ApolloLink;
   public mutationStore: MutationStore = new MutationStore();
   public queryStore: QueryStore = new QueryStore();
@@ -62,8 +65,6 @@ export class QueryManager<TStore> {
   private clientAwareness: Record<string, string> = {};
 
   private onBroadcast: () => void;
-
-  private ssrMode: boolean;
 
   // let's not start at zero to avoid pain with bad checks
   private idCounter = 1;
@@ -103,7 +104,7 @@ export class QueryManager<TStore> {
     this.dataStore = store;
     this.onBroadcast = onBroadcast;
     this.clientAwareness = clientAwareness;
-    this.ssrMode = ssrMode;
+    this.scheduler = new QueryScheduler({ queryManager: this, ssrMode });
   }
 
   public mutate<T>({
@@ -661,7 +662,7 @@ export class QueryManager<TStore> {
     let transformedOptions = { ...options } as WatchQueryOptions<TVariables>;
 
     return new ObservableQuery<T, TVariables>({
-      queryManager: this,
+      scheduler: this.scheduler,
       options: transformedOptions,
       shouldSubscribe: shouldSubscribe,
     });
@@ -1266,135 +1267,6 @@ export class QueryManager<TStore> {
         },
         clientAwareness: this.clientAwareness,
       },
-    };
-  }
-
-  public checkInFlight(queryId: string) {
-    const query = this.queryStore.get(queryId);
-
-    return (
-      query &&
-      query.networkStatus !== NetworkStatus.ready &&
-      query.networkStatus !== NetworkStatus.error
-    );
-  }
-
-  // Map from client ID to { interval, options }.
-  public pollingInfoByQueryId = new Map<string, {
-    interval: number;
-    lastPollTimeMs: number;
-    options: WatchQueryOptions;
-  }>();
-
-  private nextPoll: {
-    time: number;
-    timeout: NodeJS.Timeout;
-  } | null = null;
-
-  public startPollingQuery(
-    options: WatchQueryOptions,
-    queryId: string,
-    listener?: QueryListener,
-  ): string {
-    const { pollInterval } = options;
-
-    if (!pollInterval) {
-      throw new Error(
-        'Attempted to start a polling query without a polling interval.',
-      );
-    }
-
-    // Do not poll in SSR mode
-    if (!this.ssrMode) {
-      this.pollingInfoByQueryId.set(queryId, {
-        interval: pollInterval,
-        // Avoid polling until at least pollInterval milliseconds from now.
-        // The -10 is a fudge factor to help with tests that rely on simulated
-        // timeouts via jest.runTimersToTime.
-        lastPollTimeMs: Date.now() - 10,
-        options: {
-          ...options,
-          fetchPolicy: 'network-only',
-        },
-      });
-
-      if (listener) {
-        this.addQueryListener(queryId, listener);
-      }
-
-      this.schedulePoll(pollInterval);
-    }
-
-    return queryId;
-  }
-
-  public stopPollingQuery(queryId: string) {
-    // Since the master polling interval dynamically adjusts to the contents of
-    // this.pollingInfoByQueryId, stopping a query from polling is as easy as
-    // removing it from the map.
-    this.pollingInfoByQueryId.delete(queryId);
-  }
-
-  // Calling this method ensures a poll will happen within the specified time
-  // limit, canceling any pending polls that would not happen in time.
-  private schedulePoll(timeLimitMs: number) {
-    const now = Date.now();
-
-    if (this.nextPoll) {
-      if (timeLimitMs < this.nextPoll.time - now) {
-        // The next poll will happen too far in the future, so cancel it, and
-        // fall through to scheduling a new timeout.
-        clearTimeout(this.nextPoll.timeout);
-      } else {
-        // The next poll will happen within timeLimitMs, so all is well.
-        return;
-      }
-    }
-
-    this.nextPoll = {
-      // Estimated time when the timeout will fire.
-      time: now + timeLimitMs,
-
-      timeout: setTimeout(() => {
-        this.nextPoll = null;
-        let nextTimeLimitMs = Infinity;
-
-        this.pollingInfoByQueryId.forEach((info, queryId) => {
-          // Pick next timeout according to current minimum interval.
-          if (info.interval < nextTimeLimitMs) {
-            nextTimeLimitMs = info.interval;
-          }
-
-          if (!this.checkInFlight(queryId)) {
-            // If this query was last polled more than interval milliseconds
-            // ago, poll it now. Note that there may be a small delay between
-            // the desired polling time and the actual polling time (equal to
-            // at most the minimum polling interval across all queries), but
-            // that's the tradeoff to batching polling intervals.
-            if (Date.now() - info.lastPollTimeMs >= info.interval) {
-              const updateLastPollTime = () => {
-                info.lastPollTimeMs = Date.now();
-              };
-              this.fetchQuery(queryId, info.options, FetchType.poll).then(
-                // Set info.lastPollTimeMs after the fetch completes, whether
-                // or not it succeeded. Promise.prototype.finally would be nice
-                // here, but we don't have a polyfill for that at the moment,
-                // and this code has historically silenced errors, which is not
-                // the behavior of .finally(updateLastPollTime).
-                updateLastPollTime,
-                updateLastPollTime
-              );
-            }
-          }
-        });
-
-        // If there were no entries in this.pollingInfoByQueryId, then
-        // nextTimeLimitMs will still be Infinity, so this.schedulePoll will
-        // not be called, thus ending the master polling interval.
-        if (isFinite(nextTimeLimitMs)) {
-          this.schedulePoll(nextTimeLimitMs);
-        }
-      }, timeLimitMs),
     };
   }
 }

--- a/packages/apollo-client/src/scheduler/__tests__/scheduler.ts
+++ b/packages/apollo-client/src/scheduler/__tests__/scheduler.ts
@@ -2,35 +2,23 @@ import { InMemoryCache } from 'apollo-cache-inmemory';
 import gql from 'graphql-tag';
 import { stripSymbols } from 'apollo-utilities';
 
-import { QueryManager } from '../QueryManager';
+import { QueryScheduler } from '../scheduler';
+import { QueryManager } from '../../core/QueryManager';
 import { WatchQueryOptions } from '../../core/watchQueryOptions';
 import { mockSingleLink } from '../../__mocks__/mockLinks';
 import { NetworkStatus } from '../../core/networkStatus';
 
 import { DataStore } from '../../data/store';
-import { ObservableQuery } from '../../core/ObservableQuery';
-
-// Used only for unit testing.
-function registerPollingQuery<T>(
-  queryManager: QueryManager<any>,
-  queryOptions: WatchQueryOptions,
-): ObservableQuery<T> {
-  if (!queryOptions.pollInterval) {
-    throw new Error(
-      'Attempted to register a non-polling query with the scheduler.',
-    );
-  }
-  return new ObservableQuery<T>({
-    queryManager,
-    options: queryOptions,
-  });
-}
 
 describe('QueryScheduler', () => {
   it('should throw an error if we try to start polling a non-polling query', () => {
     const queryManager = new QueryManager({
       link: mockSingleLink(),
       store: new DataStore(new InMemoryCache({ addTypename: false })),
+    });
+
+    const scheduler = new QueryScheduler({
+      queryManager,
     });
 
     const query = gql`
@@ -45,7 +33,7 @@ describe('QueryScheduler', () => {
       query,
     };
     expect(() => {
-      queryManager.startPollingQuery(queryOptions, null as never);
+      scheduler.startPollingQuery(queryOptions, null as never);
     }).toThrow();
   });
 
@@ -79,13 +67,16 @@ describe('QueryScheduler', () => {
 
       link: link,
     });
+    const scheduler = new QueryScheduler({
+      queryManager,
+    });
     let timesFired = 0;
-    const queryId = queryManager.startPollingQuery(queryOptions, 'fake-id', () => {
+    const queryId = scheduler.startPollingQuery(queryOptions, 'fake-id', () => {
       timesFired += 1;
     });
     setTimeout(() => {
       expect(timesFired).toBeGreaterThanOrEqual(0);
-      queryManager.stopPollingQuery(queryId);
+      scheduler.stopPollingQuery(queryId);
       done();
     }, 120);
   });
@@ -119,14 +110,17 @@ describe('QueryScheduler', () => {
       store: new DataStore(new InMemoryCache({ addTypename: false })),
       link: link,
     });
+    const scheduler = new QueryScheduler({
+      queryManager,
+    });
     let timesFired = 0;
-    let queryId = queryManager.startPollingQuery(
+    let queryId = scheduler.startPollingQuery(
       queryOptions,
       'fake-id',
       queryStoreValue => {
         if (queryStoreValue.networkStatus !== NetworkStatus.poll) {
           timesFired += 1;
-          queryManager.stopPollingQuery(queryId);
+          scheduler.stopPollingQuery(queryId);
         }
       },
     );
@@ -165,8 +159,11 @@ describe('QueryScheduler', () => {
 
       link,
     });
+    const scheduler = new QueryScheduler({
+      queryManager,
+    });
     let timesFired = 0;
-    let observableQuery = registerPollingQuery(queryManager, queryOptions);
+    let observableQuery = scheduler.registerPollingQuery(queryOptions);
     let subscription = observableQuery.subscribe({
       next(result) {
         timesFired += 1;
@@ -209,8 +206,11 @@ describe('QueryScheduler', () => {
       store: new DataStore(new InMemoryCache({ addTypename: false })),
       link,
     });
+    const scheduler = new QueryScheduler({
+      queryManager,
+    });
     let timesFired = 0;
-    let observableQuery = registerPollingQuery(queryManager, queryOptions);
+    let observableQuery = scheduler.registerPollingQuery(queryOptions);
     let subscription = observableQuery.subscribe({
       next(result) {
         expect(stripSymbols(result.data)).toEqual(data[timesFired]);
@@ -255,7 +255,10 @@ describe('QueryScheduler', () => {
       store: new DataStore(new InMemoryCache({ addTypename: false })),
       link,
     });
-    let observableQuery = registerPollingQuery(queryManager, queryOptions);
+    const scheduler = new QueryScheduler({
+      queryManager,
+    });
+    let observableQuery = scheduler.registerPollingQuery(queryOptions);
     const subscription = observableQuery.subscribe({
       next() {
         done.fail(
@@ -265,9 +268,8 @@ describe('QueryScheduler', () => {
 
       error(errorVal) {
         expect(errorVal).toBeDefined();
-        queryManager.pollingInfoByQueryId.forEach((_: any, queryId: string) => {
-          expect(queryManager.checkInFlight(queryId)).toBe(false);
-        });
+        const queryId = scheduler.intervalQueries[queryOptions.pollInterval][0];
+        expect(scheduler.checkInFlight(queryId)).toBe(false);
         subscription.unsubscribe();
         done();
       },
@@ -296,7 +298,10 @@ describe('QueryScheduler', () => {
       store: new DataStore(new InMemoryCache()),
       link,
     });
-    const observer = registerPollingQuery(queryManager, queryOptions);
+    const scheduler = new QueryScheduler({
+      queryManager,
+    });
+    const observer = scheduler.registerPollingQuery(queryOptions);
     const subscription = observer.subscribe({});
     setTimeout(() => {
       subscription.unsubscribe();
@@ -321,20 +326,24 @@ describe('QueryScheduler', () => {
       request: queryOptions,
       result: { data },
     });
-    const queryManager = new QueryManager<any>({
+    const queryManager = new QueryManager({
       store: new DataStore(new InMemoryCache()),
       link,
     });
-    const queryId = 'fake-id';
-    queryManager.startPollingQuery(queryOptions, queryId);
-
-    let count = 0;
-    queryManager.pollingInfoByQueryId.forEach((info: { interval: number }, qid: string) => {
-      ++count;
-      expect(info.interval).toEqual(queryOptions.pollInterval);
-      expect(qid).toEqual(queryId);
+    const scheduler = new QueryScheduler({
+      queryManager,
     });
-    expect(count).toEqual(1);
+    const queryId = 'fake-id';
+    scheduler.addQueryOnInterval<any>(queryId, queryOptions);
+    expect(Object.keys(scheduler.intervalQueries).length).toEqual(1);
+    expect(Object.keys(scheduler.intervalQueries)[0]).toEqual(
+      queryOptions.pollInterval.toString(),
+    );
+    const queries = (<any>scheduler.intervalQueries)[
+      queryOptions.pollInterval.toString()
+    ];
+    expect(queries.length).toEqual(1);
+    expect(queries[0]).toEqual(queryId);
   });
 
   it('should add multiple queries to an interval correctly', () => {
@@ -382,26 +391,31 @@ describe('QueryScheduler', () => {
         },
       ),
     });
-    const observable1 = registerPollingQuery(queryManager, queryOptions1);
+    const scheduler = new QueryScheduler({
+      queryManager,
+    });
+    const observable1 = scheduler.registerPollingQuery(queryOptions1);
     observable1.subscribe({
       next() {
         //do nothing
       },
     });
 
-    const observable2 = registerPollingQuery(queryManager, queryOptions2);
+    const observable2 = scheduler.registerPollingQuery(queryOptions2);
     observable2.subscribe({
       next() {
         //do nothing
       },
     });
 
-    let count = 0;
-    queryManager.pollingInfoByQueryId.forEach((info: { interval: number }) => {
-      expect(info.interval).toEqual(interval);
-      ++count;
-    });
-    expect(count).toEqual(2);
+    const keys = Object.keys(scheduler.intervalQueries);
+    expect(keys.length).toEqual(1);
+    expect(keys[0]).toEqual(String(interval));
+
+    const queryIds = (<any>scheduler.intervalQueries)[keys[0]];
+    expect(queryIds.length).toEqual(2);
+    expect(scheduler.registeredQueries[queryIds[0]]).toEqual(queryOptions1);
+    expect(scheduler.registeredQueries[queryIds[1]]).toEqual(queryOptions2);
   });
 
   it('should remove queries from the interval list correctly', done => {
@@ -426,8 +440,11 @@ describe('QueryScheduler', () => {
         result: { data },
       }),
     });
+    const scheduler = new QueryScheduler({
+      queryManager,
+    });
     let timesFired = 0;
-    const observable = registerPollingQuery(queryManager, {
+    const observable = scheduler.registerPollingQuery({
       query,
       pollInterval: 10,
     });
@@ -436,7 +453,7 @@ describe('QueryScheduler', () => {
         timesFired += 1;
         expect(stripSymbols(result.data)).toEqual(data);
         subscription.unsubscribe();
-        expect(queryManager.pollingInfoByQueryId.size).toEqual(0);
+        expect(Object.keys(scheduler.registeredQueries).length).toEqual(0);
       },
     });
 
@@ -479,21 +496,25 @@ describe('QueryScheduler', () => {
       store: new DataStore(new InMemoryCache({ addTypename: false })),
       link: link,
     });
+    const scheduler = new QueryScheduler({
+      queryManager,
+    });
     let timesFired = 0;
-    let queryId = queryManager.startPollingQuery(queryOptions, 'fake-id', () => {
-      queryManager.stopPollingQuery(queryId);
+    let queryId = scheduler.startPollingQuery(queryOptions, 'fake-id', () => {
+      scheduler.stopPollingQuery(queryId);
     });
     setTimeout(() => {
-      let queryId2 = queryManager.startPollingQuery(
+      let queryId2 = scheduler.startPollingQuery(
         queryOptions,
         'fake-id2',
         () => {
           timesFired += 1;
         },
       );
+      expect(scheduler.intervalQueries[20].length).toEqual(1);
       setTimeout(() => {
         expect(timesFired).toBeGreaterThanOrEqual(1);
-        queryManager.stopPollingQuery(queryId2);
+        scheduler.stopPollingQuery(queryId2);
         done();
       }, 80);
     }, 200);

--- a/packages/apollo-client/src/scheduler/scheduler.ts
+++ b/packages/apollo-client/src/scheduler/scheduler.ts
@@ -1,0 +1,203 @@
+// The QueryScheduler is supposed to be a mechanism that schedules polling queries such that
+// they are clustered into the time slots of the QueryBatcher and are batched together. It
+// also makes sure that for a given polling query, if one instance of the query is inflight,
+// another instance will not be fired until the query returns or times out. We do this because
+// another query fires while one is already in flight, the data will stay in the "loading" state
+// even after the first query has returned.
+
+// At the moment, the QueryScheduler implements the one-polling-instance-at-a-time logic and
+// adds queries to the QueryBatcher queue.
+
+import { QueryManager } from '../core/QueryManager';
+
+import { FetchType, QueryListener } from '../core/types';
+
+import { ObservableQuery } from '../core/ObservableQuery';
+
+import { WatchQueryOptions } from '../core/watchQueryOptions';
+
+import { NetworkStatus } from '../core/networkStatus';
+
+export class QueryScheduler<TCacheShape> {
+  // Map going from queryIds to query options that are in flight.
+  public inFlightQueries: { [queryId: string]: WatchQueryOptions } = {};
+
+  // Map going from query ids to the query options associated with those queries. Contains all of
+  // the queries, both in flight and not in flight.
+  public registeredQueries: { [queryId: string]: WatchQueryOptions } = {};
+
+  // Map going from polling interval with to the query ids that fire on that interval.
+  // These query ids are associated with a set of options in the this.registeredQueries.
+  public intervalQueries: { [interval: number]: string[] } = {};
+
+  // We use this instance to actually fire queries (i.e. send them to the batching
+  // mechanism).
+  public queryManager: QueryManager<TCacheShape>;
+
+  // Map going from polling interval widths to polling timers.
+  private pollingTimers: { [interval: number]: any } = {};
+
+  private ssrMode: boolean = false;
+
+  constructor({
+    queryManager,
+    ssrMode,
+  }: {
+    queryManager: QueryManager<TCacheShape>;
+    ssrMode?: boolean;
+  }) {
+    this.queryManager = queryManager;
+    this.ssrMode = ssrMode || false;
+  }
+
+  public checkInFlight(queryId: string) {
+    const query = this.queryManager.queryStore.get(queryId);
+
+    return (
+      query &&
+      query.networkStatus !== NetworkStatus.ready &&
+      query.networkStatus !== NetworkStatus.error
+    );
+  }
+
+  public fetchQuery<T>(
+    queryId: string,
+    options: WatchQueryOptions,
+    fetchType: FetchType,
+  ) {
+    return new Promise((resolve, reject) => {
+      this.queryManager
+        .fetchQuery<T>(queryId, options, fetchType)
+        .then(result => {
+          resolve(result);
+        })
+        .catch(error => {
+          reject(error);
+        });
+    });
+  }
+
+  public startPollingQuery<T>(
+    options: WatchQueryOptions,
+    queryId: string,
+    listener?: QueryListener,
+  ): string {
+    if (!options.pollInterval) {
+      throw new Error(
+        'Attempted to start a polling query without a polling interval.',
+      );
+    }
+
+    // Do not poll in SSR mode
+    if (this.ssrMode) return queryId;
+
+    this.registeredQueries[queryId] = options;
+
+    if (listener) {
+      this.queryManager.addQueryListener(queryId, listener);
+    }
+    this.addQueryOnInterval<T>(queryId, options);
+
+    return queryId;
+  }
+
+  public stopPollingQuery(queryId: string) {
+    // Remove the query options from one of the registered queries.
+    // The polling function will then take care of not firing it anymore.
+    delete this.registeredQueries[queryId];
+  }
+
+  // Fires the all of the queries on a particular interval. Called on a setInterval.
+  public fetchQueriesOnInterval<T>(interval: number) {
+    // XXX this "filter" here is nasty, because it does two things at the same time.
+    // 1. remove queries that have stopped polling
+    // 2. call fetchQueries for queries that are polling and not in flight.
+    // TODO: refactor this to make it cleaner
+    this.intervalQueries[interval] = this.intervalQueries[interval].filter(
+      queryId => {
+        // If queryOptions can't be found from registeredQueries or if it has a
+        // different interval, it means that this queryId is no longer registered
+        // and should be removed from the list of queries firing on this interval.
+        //
+        // We don't remove queries from intervalQueries immediately in
+        // stopPollingQuery so that we can keep the timer consistent when queries
+        // are removed and replaced, and to avoid quadratic behavior when stopping
+        // many queries.
+        if (
+          !(
+            this.registeredQueries.hasOwnProperty(queryId) &&
+            this.registeredQueries[queryId].pollInterval === interval
+          )
+        ) {
+          return false;
+        }
+
+        // Don't fire this instance of the polling query is one of the instances is already in
+        // flight.
+        if (this.checkInFlight(queryId)) {
+          return true;
+        }
+
+        const queryOptions = this.registeredQueries[queryId];
+        const pollingOptions = { ...queryOptions } as WatchQueryOptions;
+        pollingOptions.fetchPolicy = 'network-only';
+        // don't let unhandled rejections happen
+        this.fetchQuery<T>(queryId, pollingOptions, FetchType.poll).catch(
+          () => {},
+        );
+        return true;
+      },
+    );
+
+    if (this.intervalQueries[interval].length === 0) {
+      clearInterval(this.pollingTimers[interval]);
+      delete this.intervalQueries[interval];
+    }
+  }
+
+  // Adds a query on a particular interval to this.intervalQueries and then fires
+  // that query with all the other queries executing on that interval. Note that the query id
+  // and query options must have been added to this.registeredQueries before this function is called.
+  public addQueryOnInterval<T>(
+    queryId: string,
+    queryOptions: WatchQueryOptions,
+  ) {
+    const interval = queryOptions.pollInterval;
+
+    if (!interval) {
+      throw new Error(
+        `A poll interval is required to start polling query with id '${queryId}'.`,
+      );
+    }
+
+    // If there are other queries on this interval, this query will just fire with those
+    // and we don't need to create a new timer.
+    if (
+      this.intervalQueries.hasOwnProperty(interval.toString()) &&
+      this.intervalQueries[interval].length > 0
+    ) {
+      this.intervalQueries[interval].push(queryId);
+    } else {
+      this.intervalQueries[interval] = [queryId];
+      // set up the timer for the function that will handle this interval
+      this.pollingTimers[interval] = setInterval(() => {
+        this.fetchQueriesOnInterval<T>(interval);
+      }, interval);
+    }
+  }
+
+  // Used only for unit testing.
+  public registerPollingQuery<T>(
+    queryOptions: WatchQueryOptions,
+  ): ObservableQuery<T> {
+    if (!queryOptions.pollInterval) {
+      throw new Error(
+        'Attempted to register a non-polling query with the scheduler.',
+      );
+    }
+    return new ObservableQuery<T>({
+      scheduler: this,
+      options: queryOptions,
+    });
+  }
+}

--- a/packages/apollo-client/tsconfig.test.json
+++ b/packages/apollo-client/tsconfig.test.json
@@ -19,5 +19,6 @@
     "src/core/__tests__/fetchPolicies.ts",
     "src/data/__tests__/queries.ts",
     "src/errors/__tests__/ApolloError.ts",
+    "src/scheduler/__tests__/scheduler.ts"
   ]
 }

--- a/packages/apollo-utilities/package-lock.json
+++ b/packages/apollo-utilities/package-lock.json
@@ -8,6 +8,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     }
   }
 }

--- a/packages/apollo-utilities/package.json
+++ b/packages/apollo-utilities/package.json
@@ -39,7 +39,8 @@
     "filesize": "npm run minify"
   },
   "dependencies": {
-    "fast-json-stable-stringify": "^2.0.0"
+    "fast-json-stable-stringify": "^2.0.0",
+    "tslib": "^1.9.3"
   },
   "jest": {
     "transform": {

--- a/packages/graphql-anywhere/package-lock.json
+++ b/packages/graphql-anywhere/package-lock.json
@@ -19,6 +19,11 @@
           "bundled": true
         }
       }
+    },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     }
   }
 }

--- a/packages/graphql-anywhere/package.json
+++ b/packages/graphql-anywhere/package.json
@@ -40,7 +40,8 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "apollo-utilities": "file:../apollo-utilities"
+    "apollo-utilities": "file:../apollo-utilities",
+    "tslib": "^1.9.3"
   },
   "jest": {
     "transform": {


### PR DESCRIPTION
In my rush to release https://github.com/apollographql/apollo-client/pull/4234, I removed some previously public members from the `QueryManager` and forgot to include an explicit dependency on the `tslib` package. This PR reverts the `QueryManager` changes for now, at least until https://github.com/apollographql/react-apollo/issues/2738 can be addressed, and fixes https://github.com/apollographql/apollo-client/issues/4332 by adding `tslib` to the dependencies of all client packages.

To prevent further breakage due to automatic patch updates, we will release new patch versions of the relevant packages after this PR is merged.

Once the underlying issues are fixed, we will un-revert the `QueryManager` changes and revisit how the package versions should be bumped.