### PR TITLE
fix(graphql-anywhere): fix allows rollup to build apollo-link-state

### DIFF
--- a/packages/graphql-anywhere/rollup.async.config.js
+++ b/packages/graphql-anywhere/rollup.async.config.js
@@ -4,6 +4,6 @@ export default build('graphqlAnywhereAsync', {
   input: 'lib/graphql-async.js',
   output: {
     file: 'lib/async.js',
-    format: 'umd',
+    format: 'es',
   },
 });


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

This PR allows rollup to build apps that use apollo-link-state, without having to resort to this workaround:

```js
  plugins: [
    commonjs({
      namedExports: {
        // Necessary to roll apollo-link-state up.
        // until graphql-anywhere 5.0
        'graphql-anywhere/lib/async': ['graphql']
      }
    })
  ]
```

Without this fix or the workaround:

```
(!) Missing exports
https://rollupjs.org/guide/en#error-name-is-not-exported-by-module-
node_modules/apollo-link-state/lib/index.js
graphql is not exported by node_modules/graphql-anywhere/lib/async.js
```
### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
