### PR TITLE
docs(local-state): Fix links to section headers

### DIFF
--- a/docs/source/essentials/local-state.md
+++ b/docs/source/essentials/local-state.md
@@ -30,11 +30,11 @@ const client = new ApolloClient({
 The three options you can pass to `clientState` are:
 
 <dl>
-  <dt>[`defaults`](#defaults.html): Object</dt>
+  <dt>[`defaults`](#defaults): Object</dt>
   <dd>The initial data you want to write to the Apollo cache when the client is initialized</dd>
-  <dt>[`resolvers`](#resolvers.html): Object</dt>
+  <dt>[`resolvers`](#resolvers): Object</dt>
   <dd>A map of functions that your GraphQL queries and mutations call in order to read and write to the cache</dd>
-  <dt>[`typeDefs`](#schema.html): string | Array<string></dt>
+  <dt>[`typeDefs`](#schema): string | Array<string></dt>
   <dd>A string representing your client-side schema written in [Schema Definition Language](/docs/graphql-tools/generate-schema.html#schema-language). This schema is not used for validation (yet!), but is used for introspection in Apollo DevTools</dd>
 </dl>
 


### PR DESCRIPTION
Hi! :wave: 

This PR just fixes some links to section headers in the `Local state management` part of the docs.

Cheers.