### PR TITLE
add reFetchObservableQueries to ApolloClient docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   [@quazzie](https://github.com/quazzie) in [#4041](https://github.com/apollographql/apollo-client/pull/4041)
 - Properly type `setQuery` and fix now typed callers.  <br/>
   [@danilobuerger](https://github.com/danilobuerger) in [#4369](https://github.com/apollographql/apollo-client/pull/4369)
-- Align with the React Apollo decision that result `data` should be 
+- Align with the React Apollo decision that result `data` should be
   `TData | undefined` instead of `TData | {}`.  <br/>
   [@danilobuerger](https://github.com/danilobuerger) in [#4356](https://github.com/apollographql/apollo-client/pull/4356)
 - Documentation updates.  <br/>
@@ -17,6 +17,7 @@
   [@jtassin](https://github.com/jtassin) in [#4287](https://github.com/apollographql/apollo-client/pull/4287)  <br />
   [@Gongreg](https://github.com/Gongreg) in [#4386](https://github.com/apollographql/apollo-client/pull/4386)  <br />
   [@davecardwell](https://github.com/davecardwell) in [#4399](https://github.com/apollographql/apollo-client/pull/4399)  <br />
+  [@michaelknoch](https://github.com/michaelknoch) in [#4384](https://github.com/apollographql/apollo-client/pull/4384)  <br />
 
 ## Apollo Client (2.4.12)
 

--- a/docs/source/api/apollo-client.md
+++ b/docs/source/api/apollo-client.md
@@ -54,6 +54,7 @@ The `ApolloClient` class is the core API for Apollo, and the one you'll need to 
 {% tsapibox ApolloClient.clearStore %}
 {% tsapibox ApolloClient.onClearStore %}
 {% tsapibox ApolloClient.stop %}
+{% tsapibox ApolloClient.reFetchObservableQueries %}
 
 <h2 id="ObservableQuery">ObservableQuery</h2>
 


### PR DESCRIPTION
I wondered why the ApolloClient.reFetchObservableQueries is not part of the documentation because its public api. Would love to see this merged.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
