### PR TITLE
Adding a section about react native debugger support for apollo dev tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   [@danilobuerger](https://github.com/danilobuerger) in [#4340](https://github.com/apollographql/apollo-client/pull/4340)  <br />
   [@justyn-clark](https://github.com/justyn-clark) in [#4383](https://github.com/apollographql/apollo-client/pull/4383)  <br />
   [@jtassin](https://github.com/jtassin) in [#4287](https://github.com/apollographql/apollo-client/pull/4287)  <br />
+  [@Gongreg](https://github.com/Gongreg) in [#4386](https://github.com/apollographql/apollo-client/pull/4386)  <br />
 
 ## Apollo Client (2.4.12)
 

--- a/docs/source/recipes/react-native.md
+++ b/docs/source/recipes/react-native.md
@@ -38,3 +38,14 @@ There are some Apollo examples written in React Native that you may wish to refe
 2. A [GitHub API Example](https://github.com/apollographql/GitHub-GraphQL-API-Example) built to work with GitHub's new GraphQL API.
 
 > If you've got an example to post here, please hit the "Edit on GitHub" button above and let us know!
+
+<h2 id="apollo-dev-tools">Apollo Dev Tools</h2>
+
+[React Native Debugger](https://github.com/jhen0409/react-native-debugger) supports Apollo Dev Tools. 
+
+Usage.
+
+1. Install React Native Debugger and open it as any application.
+2. Enable remote dev tools in your app. 
+3. (Optional) If you do not see Developer Tools panel or Apollo tab is missing in in them, toggle Developer Tools by right clicking anywhere and selecting "Toggle Developer Tools".
+

--- a/docs/source/recipes/react-native.md
+++ b/docs/source/recipes/react-native.md
@@ -41,11 +41,8 @@ There are some Apollo examples written in React Native that you may wish to refe
 
 <h2 id="apollo-dev-tools">Apollo Dev Tools</h2>
 
-[React Native Debugger](https://github.com/jhen0409/react-native-debugger) supports Apollo Dev Tools. 
+[React Native Debugger](https://github.com/jhen0409/react-native-debugger) supports the [Apollo Client Devtools](https://github.com/apollographql/apollo-client-devtools):
 
-Usage.
-
-1. Install React Native Debugger and open it as any application.
-2. Enable remote dev tools in your app. 
-3. (Optional) If you do not see Developer Tools panel or Apollo tab is missing in in them, toggle Developer Tools by right clicking anywhere and selecting "Toggle Developer Tools".
-
+1. Install React Native Debugger and open it.
+2. Enable "Debug JS Remotely" in your app.
+3. (Optional) If you do not see the Developer Tools panel or the Apollo tab is missing in them, toggle the Developer Tools by right clicking anywhere and selecting "Toggle Developer Tools".


### PR DESCRIPTION
Apollo dev tools were just merged into master of react native debugger.
https://github.com/jhen0409/react-native-debugger/pull/298

@peggyrayzis suggested to add a section about it in Apollo documentation.

The updated React Native Debugger is not released for download, but it will be done soon.