### PR TITLE
Fix: removeQuery not removing a fetch's reject fn, mistakenly triggering "store reset when query in flight" error when store resets

### DIFF
--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -961,6 +961,7 @@ export class QueryManager<TStore> {
   public removeQuery(queryId: string) {
     const { subscriptions } = this.getQuery(queryId);
     // teardown all links
+    this.fetchQueryRejectFns.delete(queryId);
     subscriptions.forEach(x => x.unsubscribe());
     this.queries.delete(queryId);
   }

--- a/packages/apollo-client/src/core/__tests__/QueryManager/index.ts
+++ b/packages/apollo-client/src/core/__tests__/QueryManager/index.ts
@@ -3229,6 +3229,42 @@ describe('QueryManager', () => {
       );
     });
 
+    it('should not error on a stopped query()', done => {
+      let queryManager: QueryManager<NormalizedCacheObject>;
+      const query = gql`
+        query {
+          author {
+            firstName
+            lastName
+          }
+        }
+      `;
+
+      const data = {
+        author: {
+          firstName: 'John',
+          lastName: 'Smith',
+        },
+      };
+
+      const link = new ApolloLink(
+        () =>
+          new Observable(observer => {
+            observer.next({ data });
+          }),
+      );
+
+      queryManager = createQueryManager({ link });
+
+      const queryId = '1';
+      queryManager
+        .fetchQuery(queryId, { query })
+        .catch(e => done.fail('Exception thrown for stopped query'));
+
+      queryManager.removeQuery(queryId);
+      queryManager.resetStore().then(() => done());
+    });
+
     it('should throw an error on an inflight fetch query if the store is reset', done => {
       const query = gql`
         query {


### PR DESCRIPTION
`removeQuery` was previously only calling `unsubscribe` on an operation's subscription, which doesn't trigger the `error` or `complete` handlers, thus the promise's `reject` function is not cleaned up (removed from `fetchQueryRejectFns`)

This PR changes `fetchQueryRejectFns` into a `Map`, and modifies `removeQuery` to delete an operation's associated reject fns from that map

Confirmed to have fixed the repo in https://github.com/apollographql/apollo-client/issues/3555 (cloned it and linked a local apollo-client to the project)

Should also fix https://github.com/apollographql/apollo-client/issues/3766 (although don't have a repro that exactly matches the submitted bug flow), possibly https://github.com/apollographql/apollo-client/issues/2919

Might not fix https://github.com/apollographql/apollo-client/issues/3792 (it sounds like another cleanup besides removing from `fetchQueryRejectFns` needs to happen)