### PR TITLE
Goodbye Slack, hello Spectrum

### DIFF
--- a/.github/ISSUE_TEMPLATE/question-discussion.md
+++ b/.github/ISSUE_TEMPLATE/question-discussion.md
@@ -1,10 +1,10 @@
 ---
 name: 🤗 Question / Discussion
-about: Questions / discussions are best posted in Apollo's Slack group or StackOverflow.
+about: Questions / discussions are best posted in Apollo's Spectrum community or StackOverflow.
 ---
 
 Need help or want to talk all things Apollo Client? Issues here are reserved for bugs, but one of the following resources should help:
 
-* Apollo's Slack: https://www.apollographql.com/slack
+* Apollo Spectrum community: https://spectrum.chat/apollo
 * StackOverflow (`apollo-client` tag): https://stackoverflow.com/questions/tagged/apollo-client
 * Apollo Feature Request repo: https://github.com/apollographql/apollo-feature-requests

--- a/COLLABORATORS.md
+++ b/COLLABORATORS.md
@@ -8,7 +8,7 @@ Thanks for helping make Apollo OSS better! Here are a few quick repo maintenance
 
 ## Issues
 
-- Issues are for bugs only. All other requests should be redirected accordingly, then closed. Feature requests have their own [repo](https://github.com/apollographql/apollo-feature-requests), and requests for help should go to [Slack](https://www.apollographql.com/slack) or [Stack Overflow](http://stackoverflow.com).
+- Issues are for bugs only. All other requests should be redirected accordingly, then closed. Feature requests have their own [repo](https://github.com/apollographql/apollo-feature-requests), and requests for help should go to [Spectrum](https://spectrum.chat/apollo) or [Stack Overflow](http://stackoverflow.com).
 - If a bug report is valid, add the `confirmed` label, and optionally decide if community help should be requested using the `help-wanted` label. If you’re planning on working on it, assign the issue to yourself.
 - If an issue isn’t easily reproducible, ask for a reproduction and add a `reproduction-needed` label.
 - If a reproduction has been asked for but hasn’t been received in 1 week, close the issue.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Excited about Apollo and want to make it better? We’re excited too!
 
 Apollo is a community of developers just like you, striving to create the best tools and libraries around GraphQL. We welcome anyone who wants to contribute or provide constructive feedback, no matter the age or level of experience. If you want to help but don't know where to start, let us know, and we'll find something for you.
 
-Oh, and if you haven't already, sign up for the [Apollo Slack](http://www.apollodata.com/#slack).
+Oh, and if you haven't already, join the [Apollo Spectrum community](https://spectrum.chat/apollo).
 
 Here are some ways to contribute to the project, from easiest to most difficult:
 
@@ -35,7 +35,7 @@ Improving the documentation, examples, and other open source content can be the 
 
 ### Responding to issues
 
-In addition to reporting issues, a great way to contribute to Apollo is to respond to other peoples' issues and try to identify the problem or help them work around it. If you’re interested in taking a more active role in this process, please go ahead and respond to issues. And don't forget to say "Hi" on Apollo Slack!
+In addition to reporting issues, a great way to contribute to Apollo is to respond to other peoples' issues and try to identify the problem or help them work around it. If you’re interested in taking a more active role in this process, please go ahead and respond to issues. And don't forget to say "Hi" in Apollo Spectrum!
 
 ### Small bug fixes
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Apollo Client](https://www.apollographql.com/client/) [![npm version](https://badge.fury.io/js/apollo-client.svg)](https://badge.fury.io/js/apollo-client) [![Get on Slack](https://img.shields.io/badge/slack-join-orange.svg)](http://www.apollostack.com/#slack) [![Open Source Helpers](https://www.codetriage.com/apollographql/apollo-client/badges/users.svg)](https://www.codetriage.com/apollographql/apollo-client)
+# [Apollo Client](https://www.apollographql.com/client/) [![npm version](https://badge.fury.io/js/apollo-client.svg)](https://badge.fury.io/js/apollo-client) [![Open Source Helpers](https://www.codetriage.com/apollographql/apollo-client/badges/users.svg)](https://www.codetriage.com/apollographql/apollo-client)
 
 Apollo Client is a fully-featured caching GraphQL client with integrations for React, Angular, and more. It allows you to easily build UI components that fetch data via GraphQL. To get the most value out of `apollo-client`, you should use it with one of its view layer integrations.
 

--- a/docs/source/why-apollo.md
+++ b/docs/source/why-apollo.md
@@ -126,7 +126,7 @@ This flexibility makes it simple to create your dream client by building extensi
 - [apollo-storybook-decorator](https://github.com/abhiaiyer91/apollo-storybook-decorator): Wrap your React Storybook stories with Apollo Client ([@abhiaiyer91](https://github.com/abhiaiyer91))
 - [AppSync by AWS](https://blog.apollographql.com/aws-appsync-powered-by-apollo-df61eb706183): Amazon's real-time GraphQL client uses Apollo Client under the hood
 
-When you choose Apollo to manage your data, you also gain the support of our amazing community. There are over 5000 developers on our [Apollo Slack](https://www.apollographql.com/#slack) channel for you to share ideas with. You can also read articles on best practices and our announcements on the [Apollo blog](https://blog.apollographql.com/), updated weekly.
+When you choose Apollo to manage your data, you also gain the support of our amazing community. There are thousands ov developers in our [Apollo Spectrum community](https://spectrum.chat/apollo) for you to share ideas with. You can also read articles on best practices and our announcements on the [Apollo blog](https://blog.apollographql.com/), updated weekly.
 
 <h2 id="case-studies">Case studies</h2>
 
@@ -138,4 +138,4 @@ Companies ranging from enterprises to startups trust Apollo Client to power thei
 - [Expo](https://blog.apollographql.com/using-graphql-apollo-at-expo-4c1f21f0f115): Developing their React Native app with Apollo allowed the Expo engineers to focus on improving their product instead of writing data fetching logic
 - [KLM](https://youtu.be/T2njjXHdKqw): Learn how the KLM team scaled their Angular app with GraphQL and Apollo
 
-If your company is using Apollo Client in production, we'd love to feature a case study on our blog! Please get in touch via Slack so we can learn more about how you're using Apollo. Alternatively, if you already have a blog post or a conference talk that you'd like to feature here, please send in a PR.
+If your company is using Apollo Client in production, we'd love to feature a case study on our blog! Please get in touch via Spectrum so we can learn more about how you're using Apollo. Alternatively, if you already have a blog post or a conference talk that you'd like to feature here, please send in a PR.

--- a/packages/apollo-client/ROADMAP.md
+++ b/packages/apollo-client/ROADMAP.md
@@ -13,16 +13,16 @@ Currently, there are three high-level priorities:
 2. **Live queries**
     * Unified Apollo Network Interface (initial draft [here](https://github.com/apollographql/apollo-network-interface))
     * Unified Transport (work in progress [here](https://github.com/apollographql/subscriptions-transport-ws/pull/108))
-    
+
 3. **First-class offline support**
     * Cache invalidation, deletion & memory management (design needed)
     * Persistent storage and state (overlaps with Apollo Store)
     * Automatic retries on connectivity issues (overlaps with Unified Network Interface)
-    
-    
-If you are interested in helping with any of the above, join the #contributing channel on the 
-[Apollo Slack](http://www.apollodata.com/#slack) and let us know you're interested in becoming a contributor!
- 
+
+
+If you are interested in helping with any of the above, join the #contributing channel in
+[Apollo Spectrum](https://spectrum.chat/apollo) and let us know you're interested in becoming a contributor!
+
 
 While the above goals are our feature focus, we are also always looking to improve developer ergonomics and performance.
 If you see something that could be improved, please do not hesitate to open an issue or make a PR!


### PR DESCRIPTION
Replace all mentions of the Apollo community Slack group with Apollo Spectrum.