### PR TITLE
Remove unused queryId after fetchMore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
 - Avoid updating (and later invalidating) cache watches when `fetchPolicy` is `'no-cache'`. <br/>
   [@bradleyayers](https://github.com/bradleyayers) in [PR #4573](https://github.com/apollographql/apollo-client/pull/4573), part of [issue #3452](https://github.com/apollographql/apollo-client/issues/3452)
 
+- Remove temporary `queryId` after `fetchMore` completes. <br/>
+  [@doomsower](https://github.com/doomsower) in [#4440](https://github.com/apollographql/apollo-client/pull/4440)
+
 ### Apollo Cache In-Memory
 
 - Support `new InMemoryCache({ freezeResults: true })` to help enforce immutability. <br/>

--- a/packages/apollo-client/src/core/ObservableQuery.ts
+++ b/packages/apollo-client/src/core/ObservableQuery.ts
@@ -343,10 +343,11 @@ export class ObservableQuery<
     );
 
     let combinedOptions: any;
+    let qid: string;
 
     return Promise.resolve()
       .then(() => {
-        const qid = this.queryManager.generateQueryId();
+        qid = this.queryManager.generateQueryId();
 
         if (fetchMoreOptions.query) {
           // fetch a new query
@@ -380,6 +381,7 @@ export class ObservableQuery<
             variables: combinedOptions.variables,
           }),
         );
+        this.queryManager.stopQuery(qid);
 
         return fetchMoreResult as ApolloQueryResult<TData>;
       });

--- a/packages/apollo-client/src/core/ObservableQuery.ts
+++ b/packages/apollo-client/src/core/ObservableQuery.ts
@@ -343,12 +343,10 @@ export class ObservableQuery<
     );
 
     let combinedOptions: any;
-    let qid: string;
+    const qid = this.queryManager.generateQueryId();
 
     return Promise.resolve()
       .then(() => {
-        qid = this.queryManager.generateQueryId();
-
         if (fetchMoreOptions.query) {
           // fetch a new query
           combinedOptions = fetchMoreOptions;
@@ -381,9 +379,14 @@ export class ObservableQuery<
             variables: combinedOptions.variables,
           }),
         );
+
         this.queryManager.stopQuery(qid);
 
         return fetchMoreResult as ApolloQueryResult<TData>;
+
+      }, error => {
+        this.queryManager.stopQuery(qid);
+        throw error;
       });
   }
 


### PR DESCRIPTION
This PR addresses issue #2286 (and #3901)

Every call of `fetchMore` on `ObservableQuery` causes another query to be created my queryManager. After this query gets executed, its result is merged into parent query's result. But child query is not disposed, it just sticks around in `queryManager.queries`/ `queryManager.queryStore` and does nothing. As far as I understand, this is a leak, and this query should be disposed. 

Please correct me if this is desired behavior, or if this change can produced any unexpected side-effects.
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
