### PR TITLE
Make sure `npm run watch` builds ESM/UMD bundles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4686,6 +4686,32 @@
         "es5-ext": "~0.10.14"
       }
     },
+    "event-stream": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+      "dev": true,
+      "requires": {
+        "duplexer": "~0.1.1",
+        "from": "~0",
+        "map-stream": "~0.1.0",
+        "pause-stream": "0.0.11",
+        "split": "0.3",
+        "stream-combiner": "~0.0.4",
+        "through": "~2.3.1"
+      },
+      "dependencies": {
+        "split": {
+          "version": "0.3.3",
+          "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+          "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+          "dev": true,
+          "requires": {
+            "through": "2"
+          }
+        }
+      }
+    },
     "events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
@@ -5465,6 +5491,12 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "dev": true
+    },
+    "from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
       "dev": true
     },
     "from2": {
@@ -9303,6 +9335,12 @@
       "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
       "dev": true
     },
+    "map-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+      "dev": true
+    },
     "map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -10653,6 +10691,15 @@
         "pify": "^3.0.0"
       }
     },
+    "pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+      "dev": true,
+      "requires": {
+        "through": "~2.3"
+      }
+    },
     "pbkdf2": {
       "version": "3.0.17",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
@@ -10956,6 +11003,15 @@
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
       "dev": true
+    },
+    "ps-tree": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
+      "integrity": "sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==",
+      "dev": true,
+      "requires": {
+        "event-stream": "=3.3.4"
+      }
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -13274,6 +13330,15 @@
         "readable-stream": "^2.0.2"
       }
     },
+    "stream-combiner": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+      "dev": true,
+      "requires": {
+        "duplexer": "~0.1.1"
+      }
+    },
     "stream-each": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
@@ -13925,6 +13990,53 @@
           "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
           "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
           "dev": true
+        }
+      }
+    },
+    "tsc-watch": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/tsc-watch/-/tsc-watch-2.1.2.tgz",
+      "integrity": "sha512-w80windZ4HAFpq2qtva/WsgfyYqS4CXTow+KjyO+AmYRFIDhzODUIK2BJW7M1Y8sL8NZUH0b4U1ET3436Q7Ctw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^5.1.0",
+        "node-cleanup": "^2.1.2",
+        "ps-tree": "^1.2.0",
+        "string-argv": "^0.1.1",
+        "strip-ansi": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "string-argv": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.1.1.tgz",
+          "integrity": "sha512-El1Va5ehZ0XTj3Ekw4WFidXvTmt9SrC0+eigdojgtJMVtPkF0qbBe9fyNSl9eQf+kUHnTSQxdQYzuHfZy8V+DQ==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "rollup-plugin-typescript2": "0.18.1",
     "rxjs": "6.4.0",
     "ts-jest": "23.1.4",
+    "tsc-watch": "^2.1.2",
     "tslib": "1.9.3",
     "tslint": "5.12.1",
     "typescript": "3.3.3",

--- a/packages/apollo-cache-inmemory/package.json
+++ b/packages/apollo-cache-inmemory/package.json
@@ -34,7 +34,7 @@
     "build": "tsc -b .",
     "postbuild": "npm run bundle",
     "bundle": "../../node_modules/rollup/bin/rollup -c rollup.config.js",
-    "watch": "tsc -w -p .",
+    "watch": "../../node_modules/tsc-watch/index.js --onSuccess \"npm run postbuild\"",
     "clean": "rm -rf coverage/* lib/*",
     "prepublishOnly": "npm run build"
   },

--- a/packages/apollo-cache/package.json
+++ b/packages/apollo-cache/package.json
@@ -31,7 +31,7 @@
     "build": "tsc -b .",
     "postbuild": "npm run bundle",
     "bundle": "../../node_modules/rollup/bin/rollup -c rollup.config.js",
-    "watch": "tsc -w -p .",
+    "watch": "../../node_modules/tsc-watch/index.js --onSuccess \"npm run postbuild\"",
     "clean": "rm -rf coverage/* lib/*",
     "prepublishOnly": "npm run clean && npm run build"
   },

--- a/packages/apollo-client/package.json
+++ b/packages/apollo-client/package.json
@@ -20,7 +20,7 @@
     "build": "tsc -b .",
     "postbuild": "npm run bundle",
     "build:benchmark": "tsc -p tsconfig.benchmark.json",
-    "watch": "tsc -w",
+    "watch": "../../node_modules/tsc-watch/index.js --onSuccess \"npm run postbuild\"",
     "bundle": "../../node_modules/rollup/bin/rollup -c rollup.config.js",
     "lint": "tslint -c \"../../config/tslint.json\" -p tsconfig.json src/*.ts",
     "testonly": "jest",

--- a/packages/apollo-utilities/package.json
+++ b/packages/apollo-utilities/package.json
@@ -31,7 +31,7 @@
     "build": "tsc -b .",
     "postbuild": "npm run bundle",
     "bundle": "../../node_modules/rollup/bin/rollup -c rollup.config.js",
-    "watch": "tsc -w -p .",
+    "watch": "../../node_modules/tsc-watch/index.js --onSuccess \"npm run postbuild\"",
     "clean": "rm -rf coverage/* lib/*",
     "prepublishOnly": "npm run clean && npm run build"
   },

--- a/packages/graphql-anywhere/package.json
+++ b/packages/graphql-anywhere/package.json
@@ -13,7 +13,7 @@
     "build": "tsc -b .",
     "postbuild": "npm run bundle",
     "bundle": "../../node_modules/rollup/bin/rollup -c rollup.config.js",
-    "watch": "tsc -w",
+    "watch": "../../node_modules/tsc-watch/index.js --onSuccess \"npm run postbuild\"",
     "prepublishOnly": "npm run build",
     "lint": "tslint -c \"../../config/tslint.json\" -p tsconfig.json src/*.ts",
     "clean": "rm -rf coverage/* lib/*"


### PR DESCRIPTION
Changes to make sure calling `npm run watch` in any of this repo's child packages ensures the final bundles are built after compilation has completed. For the full details on why this is needed, see: https://github.com/apollographql/react-apollo/pull/2765
