### PR TITLE
Prevent fragments from impacting @client fields

### DIFF
--- a/packages/apollo-client/src/__tests__/local-state/resolvers.ts
+++ b/packages/apollo-client/src/__tests__/local-state/resolvers.ts
@@ -361,6 +361,70 @@ describe('Basic resolver capabilities', () => {
         done();
       });
   });
+
+  it(
+    'should resolve @client fields using local resolvers and not have ' +
+    'their value overridden when a fragment is loaded',
+    () => {
+      const query = gql`
+        fragment LaunchDetails on Launch {
+          id
+          __typename
+        }
+
+        query Launch {
+          launch {
+            isInCart @client
+            ...LaunchDetails
+          }
+        }
+      `;
+
+      const link = new ApolloLink(() =>
+        Observable.of({
+          data: {
+            launch: {
+              id: 1,
+              __typename: 'Launch',
+            },
+          },
+        }),
+      );
+
+      const client = new ApolloClient({
+        cache: new InMemoryCache(),
+        link,
+        resolvers: {
+          Launch: {
+            isInCart() {
+              return true;
+            },
+          },
+        },
+      });
+
+      client.writeData({
+        data: {
+          launch: {
+            isInCart: false,
+            __typename: 'Launch',
+          },
+        },
+      });
+
+      return client.query({ query }).then(({ data }) => {
+        // `isInCart` resolver is fired, returning `true` (which is then
+        // stored in the cache).
+        expect(data.launch.isInCart).toBe(true);
+      }).then(() => {
+        client.query({ query }).then(({ data }) => {
+          // When the same query fires again, `isInCart` should be pulled from
+          // the cache and have a value of `true`.
+          expect(data.launch.isInCart).toBe(true);
+        });
+      });
+    }
+  );
 });
 
 describe('Writing cache data from resolvers', () => {

--- a/packages/apollo-client/src/core/LocalState.ts
+++ b/packages/apollo-client/src/core/LocalState.ts
@@ -346,7 +346,7 @@ export class LocalState<TCacheShape> {
       rootValue,
       execContext,
     ).then(result => ({
-      result,
+      result: mergeDeep(rootValue, result),
       exportedVariables: execContext.exportedVariables,
     }));
   }
@@ -357,7 +357,7 @@ export class LocalState<TCacheShape> {
     execContext: ExecContext,
   ) {
     const { fragmentMap, context, variables } = execContext;
-    const resultsToMerge: TData[] = [rootValue];
+    const resultsToMerge: TData[] = [];
 
     const execute = async (selection: SelectionNode): Promise<void> => {
       if (!shouldInclude(selection, variables)) {


### PR DESCRIPTION
In the `LocalState.resolveSelectionSet` method, we’re adding the `rootValue` to the `resultsToMerge` array multiple times. This is causing issues when a `@client` query, that also includes fragments,  is run. If the `@client` field is configured to use a local resolver, when the result is calculated and returned from the local resolver, the fragment results are then merged with the result, along with another copy of the `rootValue`. The second copy of the `rootValue` overrides the value received from the `@client` local resolver.

This PR moves the merging of the `rootValue` up a level, so it only happens once, and doesn’t override local resolver results.
