### PR TITLE
(WIP) Writing JSON data to apollo-cache

### DIFF
--- a/packages/apollo-cache-inmemory/src/writeToStore.ts
+++ b/packages/apollo-cache-inmemory/src/writeToStore.ts
@@ -288,6 +288,8 @@ export class StoreWriter {
         field.selectionSet,
         context,
       );
+    } else if (value.__typename === 'JSON') {
+      storeValue = value;
     } else {
       // It's an object
       let valueDataId = `${dataId}.${storeFieldName}`;


### PR DESCRIPTION
writeCache is somewhat incompatible with reading data from the server side. While I can receive values from the server of type JSON, I can't write to my local cache like that. This change detects __typename JSON and processes it (blindly).

This is likely the wrong solution. I saw that there were other open issues around this and I wanted to try to solve them.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
