### PR TITLE
Stop using cache results in local resolver root values

### DIFF
--- a/packages/apollo-client/src/__tests__/local-state/export.ts
+++ b/packages/apollo-client/src/__tests__/local-state/export.ts
@@ -433,8 +433,10 @@ describe('@client @export tests', () => {
         cache,
         link,
         resolvers: {
-          CurrentReviewer: {
-            id: () => currentReviewer.id,
+          Post: {
+            currentReviewer() {
+              return currentReviewer;
+            },
           },
         },
       });
@@ -442,9 +444,6 @@ describe('@client @export tests', () => {
       cache.writeData({
         data: {
           postRequiringReview: {
-            currentReviewer: {
-              __typename: 'CurrentReviewer',
-            },
             __typename: 'Post',
           },
         },

--- a/packages/apollo-client/src/core/LocalState.ts
+++ b/packages/apollo-client/src/core/LocalState.ts
@@ -143,24 +143,9 @@ export class LocalState<TCacheShape> {
     onlyRunForcedResolvers?: boolean;
   }): Promise<ExecutionResult<TData>> {
     if (document) {
-      const toMerge: TData[] = [];
-
-      const rootValueFromCache = this.buildRootValueFromCache(
-        document,
-        variables,
-      );
-
-      if (rootValueFromCache) {
-        toMerge.push(rootValueFromCache as TData);
-      }
-
-      if (remoteResult.data) {
-        toMerge.push(remoteResult.data);
-      }
-
       return this.resolveDocument(
         document,
-        mergeDeepArray(toMerge),
+        remoteResult.data,
         context,
         variables,
         this.fragmentMatcher,


### PR DESCRIPTION
In an effort to simulate `defaults` behaviour from `apollo-link-state`, we're leveraging cache results when running local resolvers. The idea being that if a local resolver isn't defined for a `@client` field, the local resolver handling code can then fallback on using any matching cache results, to resolve the field. While this works in theory, it has introduced a few problems, like the one reported in #4474.

Since local resolvers adhere to Apollo Client's query fetch policy, by default the cache is consulted first, when trying to resolve a `@client` field. This means we shouldn't need to attempt to resolve from the cache again, when processing local resolvers, in most cases. There are a few situations where we
might want to do this, but the requirements are theoretical at this point, and can be addressed in future changes if needed.

This PR removes the extra cache check, and adds a test to verify that the behaviour reported in #4474 is fixed.

Fixes #4474.
Supersedes #4483.