### PR TITLE
apollo-feature-requests#92 - Expose hook to updateQuery after running fetchQuery

### DIFF
--- a/packages/apollo-client/src/core/ObservableQuery.ts
+++ b/packages/apollo-client/src/core/ObservableQuery.ts
@@ -320,13 +320,17 @@ export class ObservableQuery<
       fetchPolicy: isNetworkFetchPolicy ? fetchPolicy : 'network-only',
     };
 
+    const {
+      previousResult: actualPreviousResult,
+    } = this.queryManager.getQueryWithPreviousResult(this.queryId);
+
     return this.queryManager
       .fetchQuery(this.queryId, combinedOptions, FetchType.refetch)
       .then((result: ApolloQueryResult<TData>) => {
         const { updateQuery } = this.options;
         if (typeof updateQuery === 'function') {
-          this.updateQuery((previousResult: any) =>
-            updateQuery(previousResult, {
+          this.updateQuery(() =>
+            updateQuery(actualPreviousResult, {
               nextQueryResult: result.data as TData,
               variables: this.variables,
             }),
@@ -532,6 +536,10 @@ export class ObservableQuery<
         return new Promise(resolve => resolve());
       }
 
+      const {
+        previousResult: actualPreviousResult,
+      } = this.queryManager.getQueryWithPreviousResult(this.queryId);
+
       // Use the same options as before, but with new variables
       return this.queryManager
         .fetchQuery(this.queryId, {
@@ -541,8 +549,8 @@ export class ObservableQuery<
         .then((result: ApolloQueryResult<TData>) => {
           const { updateQuery } = this.options;
           if (typeof updateQuery === 'function') {
-            this.updateQuery((previousResult: any) =>
-              updateQuery(previousResult, {
+            this.updateQuery(() =>
+              updateQuery(actualPreviousResult, {
                 nextQueryResult: result.data as TData,
                 variables: this.variables,
               }),

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -672,7 +672,7 @@ export class QueryManager<TStore> {
       options.notifyOnNetworkStatusChange = false;
     }
 
-    let transformedOptions = { ...options } as WatchQueryOptions<TVariables>;
+    let transformedOptions = { ...options } as WatchQueryOptions<T, TVariables>;
 
     return new ObservableQuery<T, TVariables>({
       scheduler: this.scheduler,

--- a/packages/apollo-client/src/core/watchQueryOptions.ts
+++ b/packages/apollo-client/src/core/watchQueryOptions.ts
@@ -62,7 +62,7 @@ export interface QueryBaseOptions<TVariables = OperationVariables> {
 /**
  * Query options.
  */
-export interface QueryOptions<TVariables = OperationVariables>
+export interface QueryOptions<TData = any, TVariables = OperationVariables>
   extends QueryBaseOptions<TVariables> {
   /**
    * A GraphQL document that consists of a single query to be sent down to the
@@ -71,6 +71,12 @@ export interface QueryOptions<TVariables = OperationVariables>
   // TODO REFACTOR: rename this to document. Didn't do it yet because it's in a
   // lot of tests.
   query: DocumentNode;
+
+  /**
+   * Function called after data is returned from resolvers and before result is
+   * written to store.
+   */
+  updateQuery?: AfterFetchUpdateQueryFn<TData, TVariables>;
 
   /**
    * Arbitrary metadata stored in the store with this query.  Designed for debugging,
@@ -101,11 +107,26 @@ export interface ModifiableWatchQueryOptions<TVariables = OperationVariables>
   notifyOnNetworkStatusChange?: boolean;
 }
 
+// XXX Better name?
+export type AfterFetchUpdateQueryFn<
+  TData = any,
+  TVariables = OperationVariables
+> = (
+  previousQueryResult: TData,
+  options: {
+    nextQueryResult?: TData;
+    variables?: TVariables;
+  },
+) => TData;
+
 /**
  * Watched query options.
  */
-export interface WatchQueryOptions<TVariables = OperationVariables>
-  extends QueryOptions<TVariables>,
+export interface WatchQueryOptions<
+  TData = any,
+  TVariables = OperationVariables
+>
+  extends QueryOptions<TData, TVariables>,
     ModifiableWatchQueryOptions<TVariables> {}
 
 export interface FetchMoreQueryOptions<TVariables, K extends keyof TVariables> {
@@ -113,7 +134,11 @@ export interface FetchMoreQueryOptions<TVariables, K extends keyof TVariables> {
   variables?: Pick<TVariables, K>;
 }
 
-export type UpdateQueryFn<TData = any, TVariables = OperationVariables, TSubscriptionData = TData> = (
+export type UpdateQueryFn<
+  TData = any,
+  TVariables = OperationVariables,
+  TSubscriptionData = TData
+> = (
   previousQueryResult: TData,
   options: {
     subscriptionData: { data: TSubscriptionData };


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:
1. If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)

Reference issue - https://github.com/apollographql/apollo-feature-requests/issues/92
CodeSandbox reproduction - https://codesandbox.io/s/yw5qrm5o8z

I haven't received much interest or discussion around the linked feature request so there is not yet any consensus to speak of. Is this a "small change" or should there be further discussion?

I'm very motivated to improve the capabilities of pagination to meet more use cases, but I'm not sure how to proceed without a discussion on the topic (per the CONTRIBUTING guidelines).

2. Make sure all of the significant new logic is covered by tests

I would rather wait until a discussion is had about the implementation.

TODO:
 - [ ] Sign CLA
 - [ ] Discuss implementation
 - [ ] Tests
 - [ ] Docs

----

My application is heavily focused on infinite scrolling lists. I have found that the current tools available for pagination are not able to meet the following use cases:

1. Refetching pages of a connected query and updating the existing query.
2. Removing items from a query after the items have been deleted/moved.

This feature would give the developer full control of what is written to the cache following a query that already has results written to the cache.