### PR TITLE
Enable local state only when client resolvers provided.

### DIFF
--- a/packages/apollo-client/src/__tests__/local-state/export.ts
+++ b/packages/apollo-client/src/__tests__/local-state/export.ts
@@ -19,6 +19,7 @@ describe('@client @export tests', () => {
       const client = new ApolloClient({
         cache,
         link: ApolloLink.empty(),
+        resolvers: {},
       });
       cache.writeData({ data: { field: 1 } });
 
@@ -47,6 +48,7 @@ describe('@client @export tests', () => {
       const client = new ApolloClient({
         cache,
         link: ApolloLink.empty(),
+        resolvers: {},
       });
 
       cache.writeData({
@@ -198,6 +200,7 @@ describe('@client @export tests', () => {
     const client = new ApolloClient({
       cache,
       link,
+      resolvers: {},
     });
 
     cache.writeData({
@@ -259,6 +262,7 @@ describe('@client @export tests', () => {
       const client = new ApolloClient({
         cache,
         link,
+        resolvers: {},
       });
 
       cache.writeData({
@@ -307,6 +311,7 @@ describe('@client @export tests', () => {
     const client = new ApolloClient({
       cache: new InMemoryCache(),
       link,
+      resolvers: {},
     });
 
     return client.query({ query }).then(({ data }: any) => {
@@ -360,6 +365,7 @@ describe('@client @export tests', () => {
       const client = new ApolloClient({
         cache,
         link,
+        resolvers: {},
       });
 
       cache.writeData({
@@ -548,6 +554,7 @@ describe('@client @export tests', () => {
       const client = new ApolloClient({
         cache,
         link,
+        resolvers: {},
       });
 
       cache.writeData({
@@ -599,6 +606,7 @@ describe('@client @export tests', () => {
       const client = new ApolloClient({
         cache,
         link,
+        resolvers: {},
       });
 
       cache.writeData({

--- a/packages/apollo-client/src/__tests__/local-state/general.ts
+++ b/packages/apollo-client/src/__tests__/local-state/general.ts
@@ -9,6 +9,7 @@ import {
   IntrospectionFragmentMatcher,
 } from 'apollo-cache-inmemory';
 import { ApolloLink, Observable, Operation } from 'apollo-link';
+import { hasDirectives } from 'apollo-utilities';
 
 describe('General functionality', () => {
   it('should not impact normal non-@client use', () => {
@@ -32,6 +33,38 @@ describe('General functionality', () => {
     return client.query({ query }).then(({ data }) => {
       expect({ ...data }).toMatchObject({ field: 1 });
     });
+  });
+
+  // TODO The functionality tested here should be removed (along with the test)
+  // once apollo-link-state is fully deprecated.
+  it('should strip @client fields only if no client resolvers specified', async () => {
+    const query = gql`
+      {
+        field @client
+      }
+    `;
+
+    const client = new ApolloClient({
+      cache: new InMemoryCache(),
+      link: new ApolloLink(operation => {
+        expect(hasDirectives(['client'], operation.query)).toBe(true);
+        return Observable.of({ data: { field: 'local' } });
+      }),
+    });
+
+    const { warn } = console;
+    const messages: string[] = [];
+    console.warn = (message: string) => messages.push(message);
+    try {
+      const result = await client.query({ query });
+      expect(result.data).toEqual({ field: 'local' });
+      expect(messages).toEqual([
+        'Found @client directives in query but no client resolvers were specified. ' +
+          'You can now pass apollo-link-state resolvers to the ApolloClient constructor.',
+      ]);
+    } finally {
+      console.warn = warn;
+    }
   });
 
   it('should not interfere with server introspection queries', () => {
@@ -232,6 +265,7 @@ describe('Cache manipulation', () => {
       const client = new ApolloClient({
         cache,
         link: ApolloLink.empty(),
+        resolvers: {},
       });
 
       cache.writeQuery({ query, data: { field: 'yo' } });
@@ -410,6 +444,7 @@ describe('Sample apps', () => {
     const client = new ApolloClient({
       link,
       cache: new InMemoryCache(),
+      resolvers: {},
     });
 
     const update = (
@@ -504,6 +539,7 @@ describe('Sample apps', () => {
     const client = new ApolloClient({
       link: ApolloLink.empty(),
       cache: new InMemoryCache(),
+      resolvers: {},
     });
 
     interface Todo {
@@ -749,6 +785,7 @@ describe('Combining client and server state/operations', () => {
     const client = new ApolloClient({
       cache,
       link,
+      resolvers: {},
     });
 
     cache.writeData({
@@ -786,6 +823,7 @@ describe('Combining client and server state/operations', () => {
     const client = new ApolloClient({
       cache,
       link,
+      resolvers: {},
     });
 
     cache.writeData({

--- a/packages/apollo-client/src/__tests__/local-state/general.ts
+++ b/packages/apollo-client/src/__tests__/local-state/general.ts
@@ -37,7 +37,7 @@ describe('General functionality', () => {
 
   // TODO The functionality tested here should be removed (along with the test)
   // once apollo-link-state is fully deprecated.
-  it('should strip @client fields only if no client resolvers specified', async () => {
+  it('should strip @client fields only if client resolvers specified', async () => {
     const query = gql`
       {
         field @client

--- a/packages/apollo-client/src/core/LocalState.ts
+++ b/packages/apollo-client/src/core/LocalState.ts
@@ -74,7 +74,7 @@ export type LocalStateOptions<TCacheShape> = {
 export class LocalState<TCacheShape> {
   private cache: ApolloCache<TCacheShape>;
   private client: ApolloClient<TCacheShape>;
-  private resolvers: Resolvers | Resolvers[] = {};
+  private resolvers?: Resolvers | Resolvers[];
   private fragmentMatcher: FragmentMatcher;
 
   constructor({
@@ -99,6 +99,7 @@ export class LocalState<TCacheShape> {
   }
 
   public addResolvers(resolvers: Resolvers | Resolvers[]) {
+    this.resolvers = this.resolvers || {};
     if (Array.isArray(resolvers)) {
       resolvers.forEach(resolverGroup => {
         this.resolvers = mergeDeep(this.resolvers, resolverGroup);
@@ -114,7 +115,7 @@ export class LocalState<TCacheShape> {
   }
 
   public getResolvers() {
-    return this.resolvers;
+    return this.resolvers || {};
   }
 
   // Run local client resolvers against the incoming query and remote data.
@@ -162,12 +163,21 @@ export class LocalState<TCacheShape> {
   // Client queries contain everything in the incoming document (if a @client
   // directive is found).
   public clientQuery(document: DocumentNode) {
-    return hasDirectives(['client'], document) ? document : null;
+    if (hasDirectives(['client'], document)) {
+      if (this.resolvers) {
+        return document;
+      }
+      invariant.warn(
+        'Found @client directives in query but no client resolvers were specified. ' +
+          'You can now pass apollo-link-state resolvers to the ApolloClient constructor.',
+      );
+    }
+    return null;
   }
 
   // Server queries are stripped of all @client based selection sets.
   public serverQuery(document: DocumentNode) {
-    return removeClientSetsFromDocument(document);
+    return this.resolvers ? removeClientSetsFromDocument(document) : document;
   }
 
   public prepareContext(context = {}) {
@@ -376,7 +386,8 @@ export class LocalState<TCacheShape> {
     ) {
       const resolverType =
         rootValue.__typename || execContext.defaultOperationType;
-      const resolverMap = (this.resolvers as any)[resolverType];
+      const resolverMap =
+        this.resolvers && (this.resolvers as any)[resolverType];
       if (resolverMap) {
         const resolve = resolverMap[aliasUsed ? fieldName : aliasedFieldName];
         if (resolve) {

--- a/packages/apollo-client/src/core/LocalState.ts
+++ b/packages/apollo-client/src/core/LocalState.ts
@@ -35,7 +35,6 @@ import ApolloClient from '../ApolloClient';
 import { Resolvers, OperationVariables } from './types';
 import { capitalizeFirstLetter } from '../util/capitalizeFirstLetter';
 
-
 export type Resolver = (
   fieldName: string,
   rootValue: any,
@@ -74,7 +73,7 @@ export type LocalStateOptions<TCacheShape> = {
 export class LocalState<TCacheShape> {
   private cache: ApolloCache<TCacheShape>;
   private client: ApolloClient<TCacheShape>;
-  private resolvers?: Resolvers | Resolvers[];
+  private resolvers?: Resolvers;
   private fragmentMatcher: FragmentMatcher;
 
   constructor({
@@ -386,8 +385,7 @@ export class LocalState<TCacheShape> {
     ) {
       const resolverType =
         rootValue.__typename || execContext.defaultOperationType;
-      const resolverMap =
-        this.resolvers && (this.resolvers as any)[resolverType];
+      const resolverMap = this.resolvers && this.resolvers[resolverType];
       if (resolverMap) {
         const resolve = resolverMap[aliasUsed ? fieldName : aliasedFieldName];
         if (resolve) {


### PR DESCRIPTION
If an application was previously using `apollo-link-state`, updating to `apollo-client@2.5.0` could cause problems because `@client` fields are now stripped by the integrated `LocalState` API, and thus will not be passed into the link chain.

This commit should ease the transition by enabling the `LocalState` functionality only if client `resolvers` were passed to the `ApolloClient` constructor, or the `LocalState#setResolvers` method has been called.

If no client resolvers have been specified, `@client` fields will remain in the query passed to the link chain, so `apollo-link-state` can still process them, though a warning will be logged in development.

If you want to use `@client` directives to read from or write to the cache without running resolver functions, you can pass an empty `resolvers: {}` map to enable the `LocalState` functionality (including the stripping of `@client` fields from queries). This behavior may become the default, making the `resolvers: {}` trick unnecessary, once `apollo-link-state` is fully deprecated.