### PR TITLE
Improve passing returnPartialData in @defer code

### DIFF
--- a/packages/apollo-cache-inmemory/src/inMemoryCache.ts
+++ b/packages/apollo-cache-inmemory/src/inMemoryCache.ts
@@ -183,6 +183,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
       rootId: options.rootId,
       fragmentMatcherFunction: this.config.fragmentMatcher.match,
       previousResult: options.previousResult,
+      returnPartialData: options.returnPartialData,
       config: this.config,
     });
   }

--- a/packages/apollo-cache-inmemory/src/readFromStore.ts
+++ b/packages/apollo-cache-inmemory/src/readFromStore.ts
@@ -167,7 +167,12 @@ export class StoreReader {
   public readQueryFromStore<QueryType>(
     options: ReadQueryOptions,
   ): QueryType {
-    const optsPatch = { returnPartialData: false };
+    const optsPatch = {};
+    // If `returnPartialData: true` wasn't _explicitly_ passed here,
+    // set it to false. (Otherwise `diffQueryAgainstStore`'s default of `true` would apply.)
+    if (!options.returnPartialData) {
+      optsPatch.returnPartialData = false;
+    }
 
     return this.diffQueryAgainstStore<QueryType>({
       ...options,


### PR DESCRIPTION
Hi! 

I had some time to dig into #4484 and I found a patch that made my app work OK. I noticed two issues relating to this bit of code (from #3686): 

https://github.com/apollographql/apollo-client/blob/d904386ec2f4d3a34899563862426e6278bdc22b/packages/apollo-client/src/data/store.ts#L89-L95

- `InMemoryCache.read` accepts a `returnPartialData` argument, but doesn't pass that value to the underlying call to `readQueryFromStore`. Instead, it's silently dropped. I updated it to pass that argument along. 
- `readQueryFromStore` replaced _any_ `returnPartialData` argument with `false`, even if `true` was specified. I updated it so that it _doesn't_ replace `true`, but it still replaces `undefined` with `false`. (If it didn't replace `undefined`, then `diffQueryAgainstStore` would use its own default of `true`, which is no good!)

Does this change look appropriate? I'll take a try at adding tests if it looks like I'm on the right track!

Also cc @clarencenpy who did the main PR for `@defer`, thanks for your work on that!