### PR TITLE
Avoid ../../src in relative module identifiers.

### DIFF
--- a/packages/apollo-client/src/__mocks__/mockQueryManager.ts
+++ b/packages/apollo-client/src/__mocks__/mockQueryManager.ts
@@ -1,8 +1,8 @@
-import { QueryManager } from '../../src/core/QueryManager';
+import { QueryManager } from '../core/QueryManager';
 
 import { mockSingleLink, MockedResponse } from './mockLinks';
 
-import { DataStore } from '../../src/data/store';
+import { DataStore } from '../data/store';
 import { InMemoryCache } from 'apollo-cache-inmemory';
 
 // Helper method for the tests that construct a query manager out of a

--- a/packages/apollo-client/src/__mocks__/mockWatchQuery.ts
+++ b/packages/apollo-client/src/__mocks__/mockWatchQuery.ts
@@ -2,7 +2,7 @@ import { MockedResponse } from './mockLinks';
 
 import mockQueryManager from './mockQueryManager';
 
-import { ObservableQuery } from '../../src/core/ObservableQuery'; // tslint:disable-line
+import { ObservableQuery } from '../core/ObservableQuery';
 
 export default (...mockedResponses: MockedResponse[]): ObservableQuery<any> => {
   const queryManager = mockQueryManager(...mockedResponses);

--- a/packages/apollo-client/src/util/observableToPromise.ts
+++ b/packages/apollo-client/src/util/observableToPromise.ts
@@ -1,6 +1,6 @@
-import { ObservableQuery } from '../../src/core/ObservableQuery';
-import { ApolloQueryResult } from '../../src/core/types';
-import { Subscription } from '../../src/util/Observable';
+import { ObservableQuery } from '../core/ObservableQuery';
+import { ApolloQueryResult } from '../core/types';
+import { Subscription } from '../util/Observable';
 
 /**
  *

--- a/packages/apollo-client/src/util/subscribeAndCount.ts
+++ b/packages/apollo-client/src/util/subscribeAndCount.ts
@@ -1,6 +1,6 @@
-import { ObservableQuery } from '../../src/core/ObservableQuery';
-import { ApolloQueryResult } from '../../src/core/types';
-import { Subscription } from '../../src/util/Observable';
+import { ObservableQuery } from '../core/ObservableQuery';
+import { ApolloQueryResult } from '../core/types';
+import { Subscription } from '../util/Observable';
 
 export default function subscribeAndCount(
   done: jest.DoneCallback,


### PR DESCRIPTION
Since the published code resides in `apollo-client/lib`, relative module identifiers should not assume the existence of the `apollo-client/src` directory.

In all likelihood, these `../../src` identifiers snuck in because of VS Code's auto-import functionality. In addition to auditing automatic imports more carefully in code reviews, perhaps we should add some sort of test that forbids `../../src` identifiers in generated code?

Then again, these particular imports are only importing types, so they do not correspond to any generated import code in `apollo-client/lib`, which is perhaps why they have gone unnoticed until now.