### PR TITLE
Support InMemoryCache({ freezeResults: true }) to help enforce immutability.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 **Note:** This is a cumulative changelog that outlines all of the Apollo Client project child package changes that were bundled into a specific `apollo-client` release.
 
+## Apollo Client vNEXT
+
+### Apollo Cache In-Memory
+
+- Support `new InMemoryCache({ freezeResults: true })` to help enforce immutability. <br/>
+  [@benjamn](https://github.com/benjamn) in [#4514](https://github.com/apollographql/apollo-client/pull/4514)
+
 ## Apollo Client 2.5.1
 
 ### apollo-client 2.5.1

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     {
       "name": "apollo-cache-inmemory",
       "path": "./packages/apollo-cache-inmemory/lib/bundle.cjs.min.js",
-      "maxSize": "4.9 kB"
+      "maxSize": "4.95 kB"
     },
     {
       "name": "apollo-client",

--- a/packages/apollo-cache-inmemory/src/__tests__/__snapshots__/cache.ts.snap
+++ b/packages/apollo-cache-inmemory/src/__tests__/__snapshots__/cache.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Cache writeFragment will write some deeply nested data into the store at any id (1/2) 1`] = `
+exports[`Cache writeFragment will write some deeply nested data into the store at any id (1/3) 1`] = `
 Object {
   "bar": Object {
     "i": 7,
@@ -17,7 +17,7 @@ Object {
 }
 `;
 
-exports[`Cache writeFragment will write some deeply nested data into the store at any id (1/2) 2`] = `
+exports[`Cache writeFragment will write some deeply nested data into the store at any id (1/3) 2`] = `
 Object {
   "bar": Object {
     "i": 7,
@@ -38,7 +38,7 @@ Object {
 }
 `;
 
-exports[`Cache writeFragment will write some deeply nested data into the store at any id (1/2) 3`] = `
+exports[`Cache writeFragment will write some deeply nested data into the store at any id (1/3) 3`] = `
 Object {
   "bar": Object {
     "i": 10,
@@ -59,129 +59,7 @@ Object {
 }
 `;
 
-exports[`Cache writeFragment will write some deeply nested data into the store at any id (1/2) 4`] = `
-Object {
-  "bar": Object {
-    "i": 10,
-    "j": 11,
-    "k": 12,
-  },
-  "foo": Object {
-    "e": 4,
-    "f": 5,
-    "g": 6,
-    "h": Object {
-      "generated": false,
-      "id": "bar",
-      "type": "id",
-      "typename": undefined,
-    },
-  },
-}
-`;
-
-exports[`Cache writeFragment will write some deeply nested data into the store at any id (1/2) 5`] = `
-Object {
-  "bar": Object {
-    "i": 7,
-    "j": 8,
-    "k": 9,
-  },
-  "foo": Object {
-    "e": 4,
-    "f": 5,
-    "g": 6,
-    "h": Object {
-      "generated": false,
-      "id": "bar",
-      "type": "id",
-      "typename": "Bar",
-    },
-  },
-}
-`;
-
-exports[`Cache writeFragment will write some deeply nested data into the store at any id (1/2) 6`] = `
-Object {
-  "bar": Object {
-    "i": 10,
-    "j": 11,
-    "k": 12,
-  },
-  "foo": Object {
-    "e": 4,
-    "f": 5,
-    "g": 6,
-    "h": Object {
-      "generated": false,
-      "id": "bar",
-      "type": "id",
-      "typename": "Bar",
-    },
-  },
-}
-`;
-
-exports[`Cache writeFragment will write some deeply nested data into the store at any id (2/2) 1`] = `
-Object {
-  "bar": Object {
-    "i": 7,
-  },
-  "foo": Object {
-    "e": 4,
-    "h": Object {
-      "generated": false,
-      "id": "bar",
-      "type": "id",
-      "typename": undefined,
-    },
-  },
-}
-`;
-
-exports[`Cache writeFragment will write some deeply nested data into the store at any id (2/2) 2`] = `
-Object {
-  "bar": Object {
-    "i": 7,
-    "j": 8,
-    "k": 9,
-  },
-  "foo": Object {
-    "e": 4,
-    "f": 5,
-    "g": 6,
-    "h": Object {
-      "generated": false,
-      "id": "bar",
-      "type": "id",
-      "typename": undefined,
-    },
-  },
-}
-`;
-
-exports[`Cache writeFragment will write some deeply nested data into the store at any id (2/2) 3`] = `
-Object {
-  "bar": Object {
-    "i": 10,
-    "j": 8,
-    "k": 9,
-  },
-  "foo": Object {
-    "e": 4,
-    "f": 5,
-    "g": 6,
-    "h": Object {
-      "generated": false,
-      "id": "bar",
-      "type": "id",
-      "typename": undefined,
-    },
-  },
-}
-`;
-
-exports[`Cache writeFragment will write some deeply nested data into the store at any id (2/2) 4`] = `
+exports[`Cache writeFragment will write some deeply nested data into the store at any id (1/3) 4`] = `
 Object {
   "bar": Object {
     "i": 10,
@@ -202,7 +80,7 @@ Object {
 }
 `;
 
-exports[`Cache writeFragment will write some deeply nested data into the store at any id (2/2) 5`] = `
+exports[`Cache writeFragment will write some deeply nested data into the store at any id (1/3) 5`] = `
 Object {
   "bar": Object {
     "i": 7,
@@ -223,7 +101,251 @@ Object {
 }
 `;
 
-exports[`Cache writeFragment will write some deeply nested data into the store at any id (2/2) 6`] = `
+exports[`Cache writeFragment will write some deeply nested data into the store at any id (1/3) 6`] = `
+Object {
+  "bar": Object {
+    "i": 10,
+    "j": 11,
+    "k": 12,
+  },
+  "foo": Object {
+    "e": 4,
+    "f": 5,
+    "g": 6,
+    "h": Object {
+      "generated": false,
+      "id": "bar",
+      "type": "id",
+      "typename": "Bar",
+    },
+  },
+}
+`;
+
+exports[`Cache writeFragment will write some deeply nested data into the store at any id (2/3) 1`] = `
+Object {
+  "bar": Object {
+    "i": 7,
+  },
+  "foo": Object {
+    "e": 4,
+    "h": Object {
+      "generated": false,
+      "id": "bar",
+      "type": "id",
+      "typename": undefined,
+    },
+  },
+}
+`;
+
+exports[`Cache writeFragment will write some deeply nested data into the store at any id (2/3) 2`] = `
+Object {
+  "bar": Object {
+    "i": 7,
+    "j": 8,
+    "k": 9,
+  },
+  "foo": Object {
+    "e": 4,
+    "f": 5,
+    "g": 6,
+    "h": Object {
+      "generated": false,
+      "id": "bar",
+      "type": "id",
+      "typename": undefined,
+    },
+  },
+}
+`;
+
+exports[`Cache writeFragment will write some deeply nested data into the store at any id (2/3) 3`] = `
+Object {
+  "bar": Object {
+    "i": 10,
+    "j": 8,
+    "k": 9,
+  },
+  "foo": Object {
+    "e": 4,
+    "f": 5,
+    "g": 6,
+    "h": Object {
+      "generated": false,
+      "id": "bar",
+      "type": "id",
+      "typename": undefined,
+    },
+  },
+}
+`;
+
+exports[`Cache writeFragment will write some deeply nested data into the store at any id (2/3) 4`] = `
+Object {
+  "bar": Object {
+    "i": 10,
+    "j": 11,
+    "k": 12,
+  },
+  "foo": Object {
+    "e": 4,
+    "f": 5,
+    "g": 6,
+    "h": Object {
+      "generated": false,
+      "id": "bar",
+      "type": "id",
+      "typename": undefined,
+    },
+  },
+}
+`;
+
+exports[`Cache writeFragment will write some deeply nested data into the store at any id (2/3) 5`] = `
+Object {
+  "bar": Object {
+    "i": 7,
+    "j": 8,
+    "k": 9,
+  },
+  "foo": Object {
+    "e": 4,
+    "f": 5,
+    "g": 6,
+    "h": Object {
+      "generated": false,
+      "id": "bar",
+      "type": "id",
+      "typename": "Bar",
+    },
+  },
+}
+`;
+
+exports[`Cache writeFragment will write some deeply nested data into the store at any id (2/3) 6`] = `
+Object {
+  "bar": Object {
+    "i": 10,
+    "j": 11,
+    "k": 12,
+  },
+  "foo": Object {
+    "e": 4,
+    "f": 5,
+    "g": 6,
+    "h": Object {
+      "generated": false,
+      "id": "bar",
+      "type": "id",
+      "typename": "Bar",
+    },
+  },
+}
+`;
+
+exports[`Cache writeFragment will write some deeply nested data into the store at any id (3/3) 1`] = `
+Object {
+  "bar": Object {
+    "i": 7,
+  },
+  "foo": Object {
+    "e": 4,
+    "h": Object {
+      "generated": false,
+      "id": "bar",
+      "type": "id",
+      "typename": undefined,
+    },
+  },
+}
+`;
+
+exports[`Cache writeFragment will write some deeply nested data into the store at any id (3/3) 2`] = `
+Object {
+  "bar": Object {
+    "i": 7,
+    "j": 8,
+    "k": 9,
+  },
+  "foo": Object {
+    "e": 4,
+    "f": 5,
+    "g": 6,
+    "h": Object {
+      "generated": false,
+      "id": "bar",
+      "type": "id",
+      "typename": undefined,
+    },
+  },
+}
+`;
+
+exports[`Cache writeFragment will write some deeply nested data into the store at any id (3/3) 3`] = `
+Object {
+  "bar": Object {
+    "i": 10,
+    "j": 8,
+    "k": 9,
+  },
+  "foo": Object {
+    "e": 4,
+    "f": 5,
+    "g": 6,
+    "h": Object {
+      "generated": false,
+      "id": "bar",
+      "type": "id",
+      "typename": undefined,
+    },
+  },
+}
+`;
+
+exports[`Cache writeFragment will write some deeply nested data into the store at any id (3/3) 4`] = `
+Object {
+  "bar": Object {
+    "i": 10,
+    "j": 11,
+    "k": 12,
+  },
+  "foo": Object {
+    "e": 4,
+    "f": 5,
+    "g": 6,
+    "h": Object {
+      "generated": false,
+      "id": "bar",
+      "type": "id",
+      "typename": undefined,
+    },
+  },
+}
+`;
+
+exports[`Cache writeFragment will write some deeply nested data into the store at any id (3/3) 5`] = `
+Object {
+  "bar": Object {
+    "i": 7,
+    "j": 8,
+    "k": 9,
+  },
+  "foo": Object {
+    "e": 4,
+    "f": 5,
+    "g": 6,
+    "h": Object {
+      "generated": false,
+      "id": "bar",
+      "type": "id",
+      "typename": "Bar",
+    },
+  },
+}
+`;
+
+exports[`Cache writeFragment will write some deeply nested data into the store at any id (3/3) 6`] = `
 Object {
   "bar": Object {
     "i": 10,

--- a/packages/apollo-cache-inmemory/src/__tests__/__snapshots__/mapCache.ts.snap
+++ b/packages/apollo-cache-inmemory/src/__tests__/__snapshots__/mapCache.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (1/2) 1`] = `
+exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (1/3) 1`] = `
 Object {
   "bar": Object {
     "i": 7,
@@ -17,7 +17,7 @@ Object {
 }
 `;
 
-exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (1/2) 2`] = `
+exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (1/3) 2`] = `
 Object {
   "bar": Object {
     "i": 7,
@@ -38,7 +38,7 @@ Object {
 }
 `;
 
-exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (1/2) 3`] = `
+exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (1/3) 3`] = `
 Object {
   "bar": Object {
     "i": 10,
@@ -59,129 +59,7 @@ Object {
 }
 `;
 
-exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (1/2) 4`] = `
-Object {
-  "bar": Object {
-    "i": 10,
-    "j": 11,
-    "k": 12,
-  },
-  "foo": Object {
-    "e": 4,
-    "f": 5,
-    "g": 6,
-    "h": Object {
-      "generated": false,
-      "id": "bar",
-      "type": "id",
-      "typename": undefined,
-    },
-  },
-}
-`;
-
-exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (1/2) 5`] = `
-Object {
-  "bar": Object {
-    "i": 7,
-    "j": 8,
-    "k": 9,
-  },
-  "foo": Object {
-    "e": 4,
-    "f": 5,
-    "g": 6,
-    "h": Object {
-      "generated": false,
-      "id": "bar",
-      "type": "id",
-      "typename": "Bar",
-    },
-  },
-}
-`;
-
-exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (1/2) 6`] = `
-Object {
-  "bar": Object {
-    "i": 10,
-    "j": 11,
-    "k": 12,
-  },
-  "foo": Object {
-    "e": 4,
-    "f": 5,
-    "g": 6,
-    "h": Object {
-      "generated": false,
-      "id": "bar",
-      "type": "id",
-      "typename": "Bar",
-    },
-  },
-}
-`;
-
-exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (2/2) 1`] = `
-Object {
-  "bar": Object {
-    "i": 7,
-  },
-  "foo": Object {
-    "e": 4,
-    "h": Object {
-      "generated": false,
-      "id": "bar",
-      "type": "id",
-      "typename": undefined,
-    },
-  },
-}
-`;
-
-exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (2/2) 2`] = `
-Object {
-  "bar": Object {
-    "i": 7,
-    "j": 8,
-    "k": 9,
-  },
-  "foo": Object {
-    "e": 4,
-    "f": 5,
-    "g": 6,
-    "h": Object {
-      "generated": false,
-      "id": "bar",
-      "type": "id",
-      "typename": undefined,
-    },
-  },
-}
-`;
-
-exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (2/2) 3`] = `
-Object {
-  "bar": Object {
-    "i": 10,
-    "j": 8,
-    "k": 9,
-  },
-  "foo": Object {
-    "e": 4,
-    "f": 5,
-    "g": 6,
-    "h": Object {
-      "generated": false,
-      "id": "bar",
-      "type": "id",
-      "typename": undefined,
-    },
-  },
-}
-`;
-
-exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (2/2) 4`] = `
+exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (1/3) 4`] = `
 Object {
   "bar": Object {
     "i": 10,
@@ -202,7 +80,7 @@ Object {
 }
 `;
 
-exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (2/2) 5`] = `
+exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (1/3) 5`] = `
 Object {
   "bar": Object {
     "i": 7,
@@ -223,7 +101,251 @@ Object {
 }
 `;
 
-exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (2/2) 6`] = `
+exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (1/3) 6`] = `
+Object {
+  "bar": Object {
+    "i": 10,
+    "j": 11,
+    "k": 12,
+  },
+  "foo": Object {
+    "e": 4,
+    "f": 5,
+    "g": 6,
+    "h": Object {
+      "generated": false,
+      "id": "bar",
+      "type": "id",
+      "typename": "Bar",
+    },
+  },
+}
+`;
+
+exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (2/3) 1`] = `
+Object {
+  "bar": Object {
+    "i": 7,
+  },
+  "foo": Object {
+    "e": 4,
+    "h": Object {
+      "generated": false,
+      "id": "bar",
+      "type": "id",
+      "typename": undefined,
+    },
+  },
+}
+`;
+
+exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (2/3) 2`] = `
+Object {
+  "bar": Object {
+    "i": 7,
+    "j": 8,
+    "k": 9,
+  },
+  "foo": Object {
+    "e": 4,
+    "f": 5,
+    "g": 6,
+    "h": Object {
+      "generated": false,
+      "id": "bar",
+      "type": "id",
+      "typename": undefined,
+    },
+  },
+}
+`;
+
+exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (2/3) 3`] = `
+Object {
+  "bar": Object {
+    "i": 10,
+    "j": 8,
+    "k": 9,
+  },
+  "foo": Object {
+    "e": 4,
+    "f": 5,
+    "g": 6,
+    "h": Object {
+      "generated": false,
+      "id": "bar",
+      "type": "id",
+      "typename": undefined,
+    },
+  },
+}
+`;
+
+exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (2/3) 4`] = `
+Object {
+  "bar": Object {
+    "i": 10,
+    "j": 11,
+    "k": 12,
+  },
+  "foo": Object {
+    "e": 4,
+    "f": 5,
+    "g": 6,
+    "h": Object {
+      "generated": false,
+      "id": "bar",
+      "type": "id",
+      "typename": undefined,
+    },
+  },
+}
+`;
+
+exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (2/3) 5`] = `
+Object {
+  "bar": Object {
+    "i": 7,
+    "j": 8,
+    "k": 9,
+  },
+  "foo": Object {
+    "e": 4,
+    "f": 5,
+    "g": 6,
+    "h": Object {
+      "generated": false,
+      "id": "bar",
+      "type": "id",
+      "typename": "Bar",
+    },
+  },
+}
+`;
+
+exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (2/3) 6`] = `
+Object {
+  "bar": Object {
+    "i": 10,
+    "j": 11,
+    "k": 12,
+  },
+  "foo": Object {
+    "e": 4,
+    "f": 5,
+    "g": 6,
+    "h": Object {
+      "generated": false,
+      "id": "bar",
+      "type": "id",
+      "typename": "Bar",
+    },
+  },
+}
+`;
+
+exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (3/3) 1`] = `
+Object {
+  "bar": Object {
+    "i": 7,
+  },
+  "foo": Object {
+    "e": 4,
+    "h": Object {
+      "generated": false,
+      "id": "bar",
+      "type": "id",
+      "typename": undefined,
+    },
+  },
+}
+`;
+
+exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (3/3) 2`] = `
+Object {
+  "bar": Object {
+    "i": 7,
+    "j": 8,
+    "k": 9,
+  },
+  "foo": Object {
+    "e": 4,
+    "f": 5,
+    "g": 6,
+    "h": Object {
+      "generated": false,
+      "id": "bar",
+      "type": "id",
+      "typename": undefined,
+    },
+  },
+}
+`;
+
+exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (3/3) 3`] = `
+Object {
+  "bar": Object {
+    "i": 10,
+    "j": 8,
+    "k": 9,
+  },
+  "foo": Object {
+    "e": 4,
+    "f": 5,
+    "g": 6,
+    "h": Object {
+      "generated": false,
+      "id": "bar",
+      "type": "id",
+      "typename": undefined,
+    },
+  },
+}
+`;
+
+exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (3/3) 4`] = `
+Object {
+  "bar": Object {
+    "i": 10,
+    "j": 11,
+    "k": 12,
+  },
+  "foo": Object {
+    "e": 4,
+    "f": 5,
+    "g": 6,
+    "h": Object {
+      "generated": false,
+      "id": "bar",
+      "type": "id",
+      "typename": undefined,
+    },
+  },
+}
+`;
+
+exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (3/3) 5`] = `
+Object {
+  "bar": Object {
+    "i": 7,
+    "j": 8,
+    "k": 9,
+  },
+  "foo": Object {
+    "e": 4,
+    "f": 5,
+    "g": 6,
+    "h": Object {
+      "generated": false,
+      "id": "bar",
+      "type": "id",
+      "typename": "Bar",
+    },
+  },
+}
+`;
+
+exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (3/3) 6`] = `
 Object {
   "bar": Object {
     "i": 10,

--- a/packages/apollo-cache-inmemory/src/__tests__/cache.ts
+++ b/packages/apollo-cache-inmemory/src/__tests__/cache.ts
@@ -25,6 +25,12 @@ describe('Cache', () => {
           resultCaching: false,
         }).restore(cloneDeep(data))
       ),
+      initialDataForCaches.map(
+        data => new InMemoryCache({
+          addTypename: false,
+          freezeResults: true,
+        }).restore(cloneDeep(data))
+      ),
     ];
 
     cachesList.forEach((caches, i) => {
@@ -47,6 +53,11 @@ describe('Cache', () => {
         addTypename: false,
         ...config,
         resultCaching: false,
+      }),
+      new InMemoryCache({
+        addTypename: false,
+        ...config,
+        freezeResults: true,
       }),
     ];
 

--- a/packages/apollo-cache-inmemory/src/inMemoryCache.ts
+++ b/packages/apollo-cache-inmemory/src/inMemoryCache.ts
@@ -26,6 +26,7 @@ import { ObjectCache } from './objectCache';
 
 export interface InMemoryCacheConfig extends ApolloReducerConfig {
   resultCaching?: boolean;
+  freezeResults?: boolean;
 }
 
 const defaultConfig: InMemoryCacheConfig = {
@@ -33,6 +34,7 @@ const defaultConfig: InMemoryCacheConfig = {
   dataIdFromObject: defaultDataIdFromObject,
   addTypename: true,
   resultCaching: true,
+  freezeResults: false,
 };
 
 export function defaultDataIdFromObject(result: any): string | null {
@@ -128,8 +130,11 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     // original this.data cache object.
     this.optimisticData = this.data;
 
-    this.storeReader = new StoreReader(this.cacheKeyRoot);
     this.storeWriter = new StoreWriter();
+    this.storeReader = new StoreReader({
+      cacheKeyRoot: this.cacheKeyRoot,
+      freezeResults: config.freezeResults,
+    });
 
     const cache = this;
     const { maybeBroadcastWatch } = cache;


### PR DESCRIPTION
Part of the plan I outlined in this comment: https://github.com/apollographql/apollo-client/issues/4464#issuecomment-467548798

If we could trust application code not to modify cache results, we wouldn't have to save deep snapshots of past results in order to implement `isDifferentFromLastResult` correctly (see #4069).

> Aside: why doesn't the cache just return defensive copies of all results? https://github.com/apollographql/apollo-client/issues/4031#issuecomment-435103281

While you might agree that immutability is a worthwhile aspiration, it can be hard to maintain that discipline across your entire application over time, especially in a team of multiple developers.

This commit implements a new `freezeResults` option for the `InMemoryCache` constructor, which (when true) causes all cache results to be frozen in development, so you can more easily detect accidental mutations.

> Note: mutating frozen objects only throws in strict mode, whereas it fails silently in non-strict code. ECMAScript module code automatically runs in strict mode, and most module transforms add "use strict" at the top of the generated code, so you're probably already using strict mode everywhere, though you might want to double-check.

The beauty of this implementation is that it does not need to repeatedly freeze entire results, because it can shallow-freeze the root of each subtree when that object is first created.

Thanks to result caching, those frozen objects can be shared between multiple different result trees without any additional freezing, and the entire result always ends up deeply frozen.

The freezing happens only in non-production environments, so there is no runtime cost to using `{ freezeResults: true }` in production. Please keep this in mind when benchmarking cache performance!