### PR TITLE
Properly set loading param with no-cache policy

### DIFF
--- a/packages/apollo-client/src/core/ObservableQuery.ts
+++ b/packages/apollo-client/src/core/ObservableQuery.ts
@@ -222,7 +222,7 @@ export class ObservableQuery<
     // See more: https://github.com/apollostack/apollo-client/issues/707
     // Basically: is there a query in flight right now (modolo the next tick)?
     const loading =
-      (this.options.fetchPolicy === 'network-only' && queryLoading) ||
+      ((this.options.fetchPolicy === 'network-only' || this.options.fetchPolicy === 'no-cache') && queryLoading) ||
       (partial && this.options.fetchPolicy !== 'cache-only');
 
     // if there is nothing in the query store, it means this query hasn't fired yet or it has been cleaned up. Therefore the


### PR DESCRIPTION
Small bug fix, looks like because the `partial` flag is not when the `fetchPolicy` is `no-cache`, and because `getCurrentResult` only handles that for the `fetchPolicy` `network-only` the `loading` flag is never properly set with `no-cache`

Discovered while tracking down another bug, see https://github.com/apollographql/react-apollo/issues/1314#issuecomment-468737387