### PR TITLE
Remove request for React Native example apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,18 @@
 
 ## Apollo Client vNEXT
 
+### Apollo Client 
+
+- Update the React Native docs to remove the request for external example 
+  apps that we can link to. We're no longer going to manage a list of 
+  external example apps.  <br />
+  [@hwillson](https://github.com/hwillson) in [#4531](https://github.com/apollographql/apollo-client/pull/4531)
+
 ### Apollo Cache In-Memory
 
 - Support `new InMemoryCache({ freezeResults: true })` to help enforce immutability. <br/>
   [@benjamn](https://github.com/benjamn) in [#4514](https://github.com/apollographql/apollo-client/pull/4514)
+
 
 ## Apollo Client 2.5.1
 

--- a/docs/source/recipes/react-native.md
+++ b/docs/source/recipes/react-native.md
@@ -37,8 +37,6 @@ There are some Apollo examples written in React Native that you may wish to refe
 1. The ["Hello World" example](https://github.com/apollographql/frontpage-react-native-app) used at dev.apollodata.com.
 2. A [GitHub API Example](https://github.com/apollographql/GitHub-GraphQL-API-Example) built to work with GitHub's new GraphQL API.
 
-> If you've got an example to post here, please hit the "Edit on GitHub" button above and let us know!
-
 <h2 id="apollo-dev-tools">Apollo Dev Tools</h2>
 
 [React Native Debugger](https://github.com/jhen0409/react-native-debugger) supports the [Apollo Client Devtools](https://github.com/apollographql/apollo-client-devtools):


### PR DESCRIPTION
We no longer want to maintain a list of external React Native example apps, so this PR removes the request from the docs. Maintaining a list of external links requires review/vet/approve/etc overhead, and is not something we can devote time to right now unfortunately.

Closes https://github.com/apollographql/apollo-client/pull/4428.