### PR TITLE
Use @condenast/bundlesize to avoid compiling iltorb.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,24 @@
         "regenerator-runtime": "^0.12.0"
       }
     },
+    "@condenast/bundlesize": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@condenast/bundlesize/-/bundlesize-0.18.1.tgz",
+      "integrity": "sha512-i/GG6p8j9BRrts4sG7ECLN5WrcJj+ubYEM+F6dR1BwbTHKo7Lt0sx6y/sZf1pg4jbHyGOHAe3jedkiVoj6e/qw==",
+      "dev": true,
+      "requires": {
+        "axios": "^0.17.0",
+        "brotli-size": "0.0.3",
+        "bytes": "^3.0.0",
+        "ci-env": "^1.4.0",
+        "commander": "^2.11.0",
+        "github-build": "^1.2.0",
+        "glob": "^7.1.2",
+        "gzip-size": "^4.0.0",
+        "prettycli": "^1.4.3",
+        "read-pkg-up": "^3.0.0"
+      }
+    },
     "@iamstarkov/listr-update-renderer": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@iamstarkov/listr-update-renderer/-/listr-update-renderer-0.4.1.tgz",
@@ -2790,13 +2808,13 @@
       "dev": true
     },
     "brotli-size": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/brotli-size/-/brotli-size-0.0.1.tgz",
-      "integrity": "sha1-jBruoBzSLzWbBIlRGFvVOf8Mgp8=",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/brotli-size/-/brotli-size-0.0.3.tgz",
+      "integrity": "sha512-bBIdd8uUGxKGldAVykxOqPegl+HlIm4FpXJamwWw5x77WCE8jO7AhXFE1YXOhOB28gS+2pTQete0FqRE6U5hQQ==",
       "dev": true,
       "requires": {
         "duplexer": "^0.1.1",
-        "iltorb": "^1.0.9"
+        "iltorb": "^2.0.5"
       }
     },
     "browser-process-hrtime": {
@@ -2970,24 +2988,6 @@
       "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
       "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
       "dev": true
-    },
-    "bundlesize": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/bundlesize/-/bundlesize-0.17.1.tgz",
-      "integrity": "sha512-p5I5Tpoug9aOVGg4kQETMJ8xquY66mX9XI19kXkkAFnmDhDXwSF+1jq1OjBGz7h27TAulM3k2wLEJPvickTt0A==",
-      "dev": true,
-      "requires": {
-        "axios": "^0.17.0",
-        "brotli-size": "0.0.1",
-        "bytes": "^3.0.0",
-        "ci-env": "^1.4.0",
-        "commander": "^2.11.0",
-        "github-build": "^1.2.0",
-        "glob": "^7.1.2",
-        "gzip-size": "^4.0.0",
-        "prettycli": "^1.4.3",
-        "read-pkg-up": "^3.0.0"
-      }
     },
     "byline": {
       "version": "5.0.0",
@@ -4261,9 +4261,9 @@
       }
     },
     "detect-libc": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-0.2.0.tgz",
-      "integrity": "sha1-R/31ZzSKF+wl/L8LnkRjSKdvn7U=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
       "dev": true
     },
     "detect-newline": {
@@ -4772,9 +4772,9 @@
       }
     },
     "expand-template": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.1.tgz",
-      "integrity": "sha512-cebqLtV8KOZfw0UI8TEFWxtczxxC1jvyUvx6H4fyp1K1FN7A4Q+uggVUlOsI1K8AGU0rwOGqP8nCapdrw8CYQg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
       "dev": true
     },
     "expand-tilde": {
@@ -6920,15 +6920,15 @@
       }
     },
     "iltorb": {
-      "version": "1.3.10",
-      "resolved": "https://registry.npmjs.org/iltorb/-/iltorb-1.3.10.tgz",
-      "integrity": "sha512-nyB4+ru1u8CQqQ6w7YjasboKN3NQTN8GH/V/eEssNRKhW6UbdxdWhB9fJ5EEdjJfezKY0qPrcwLyIcgjL8hHxA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/iltorb/-/iltorb-2.4.1.tgz",
+      "integrity": "sha512-huyAN7dSNe2b7VAl5AyvaeZ8XTcDTSF1b8JVYDggl+SBfHsORq3qMZeesZW7zoEy21s15SiERAITWT5cwxu1Uw==",
       "dev": true,
       "requires": {
-        "detect-libc": "^0.2.0",
-        "nan": "^2.6.2",
-        "node-gyp": "^3.6.2",
-        "prebuild-install": "^2.3.0"
+        "detect-libc": "^1.0.3",
+        "npmlog": "^4.1.2",
+        "prebuild-install": "^5.2.1",
+        "which-pm-runs": "^1.0.0"
       }
     },
     "immutable-tuple": {
@@ -9768,6 +9768,12 @@
         }
       }
     },
+    "napi-build-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.1.tgz",
+      "integrity": "sha512-boQj1WFgQH3v4clhu3mTNfP+vOBxorDlE8EKiMjUlLG3C4qAESnn9AxIOkFgTR2c9LtzNjPrjS60cT27ZKBhaA==",
+      "dev": true
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -10817,34 +10823,29 @@
       }
     },
     "prebuild-install": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.3.tgz",
-      "integrity": "sha512-/rI36cN2g7vDQnKWN8Uzupi++KjyqS9iS+/fpwG4Ea8d0Pip0PQ5bshUNzVwt+/D2MRfhVAplYMMvWLqWrCF/g==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.2.4.tgz",
+      "integrity": "sha512-CG3JnpTZXdmr92GW4zbcba4jkDha6uHraJ7hW4Fn8j0mExxwOKK20hqho8ZuBDCKYCHYIkFM1P2jhtG+KpP4fg==",
       "dev": true,
       "requires": {
         "detect-libc": "^1.0.3",
-        "expand-template": "^1.0.2",
+        "expand-template": "^2.0.3",
         "github-from-package": "0.0.0",
         "minimist": "^1.2.0",
         "mkdirp": "^0.5.1",
-        "node-abi": "^2.2.0",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^2.7.0",
         "noop-logger": "^0.1.1",
         "npmlog": "^4.0.1",
         "os-homedir": "^1.0.1",
         "pump": "^2.0.1",
-        "rc": "^1.1.6",
+        "rc": "^1.2.7",
         "simple-get": "^2.7.0",
         "tar-fs": "^1.13.0",
         "tunnel-agent": "^0.6.0",
         "which-pm-runs": "^1.0.0"
       },
       "dependencies": {
-        "detect-libc": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-          "dev": true
-        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "graphql-anywhere": "file:packages/graphql-anywhere"
   },
   "devDependencies": {
+    "@condenast/bundlesize": "0.18.1",
     "@octokit/rest": "16.16.3",
     "@types/benchmark": "1.0.31",
     "@types/graphql": "14.0.7",
@@ -70,7 +71,6 @@
     "@types/react": "16.8.6",
     "@types/react-dom": "16.8.2",
     "benchmark": "2.1.4",
-    "bundlesize": "0.17.1",
     "check-if-folder-contents-changed-in-git-commit-range": "1.0.0",
     "codecov": "3.2.0",
     "danger": "7.0.14",


### PR DESCRIPTION
Explanation: https://github.com/siddharthkp/bundlesize/pull/260#issuecomment-462760969

Also using `@condenast/bundlesize` for the `apollo-link` packages: https://github.com/apollographql/apollo-link/pull/965