### PR TITLE
Avoid costly cloneDeep snapshots when cache results are known to be immutable.

### DIFF
--- a/packages/apollo-boost/src/__tests__/config.ts
+++ b/packages/apollo-boost/src/__tests__/config.ts
@@ -145,8 +145,9 @@ describe('config', () => {
       version,
     });
 
-    expect(client.clientAwareness.name).toEqual(name);
-    expect(client.clientAwareness.version).toEqual(version);
+    const { clientAwareness } = client.queryManager as any;
+    expect(clientAwareness.name).toEqual(name);
+    expect(clientAwareness.version).toEqual(version);
   });
 
   const makePromise = res =>

--- a/packages/apollo-client/src/ApolloClient.ts
+++ b/packages/apollo-client/src/ApolloClient.ts
@@ -480,6 +480,10 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
    * This initializes the query manager that tracks queries and the cache
    */
   public initQueryManager(): QueryManager<TCacheShape> {
+    invariant.warn(
+      'Calling the initQueryManager method is no longer necessary, ' +
+        'and it will be removed from ApolloClient in version 3.0.',
+    );
     return this.queryManager;
   }
 

--- a/packages/apollo-client/src/ApolloClient.ts
+++ b/packages/apollo-client/src/ApolloClient.ts
@@ -55,6 +55,7 @@ export type ApolloClientOptions<TCacheShape> = {
   connectToDevTools?: boolean;
   queryDeduplication?: boolean;
   defaultOptions?: DefaultOptions;
+  assumeImmutableResults?: boolean;
   resolvers?: Resolvers | Resolvers[];
   typeDefs?: string | string[] | DocumentNode | DocumentNode[];
   fragmentMatcher?: FragmentMatcher;
@@ -103,6 +104,12 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
    *                       options supplied to `watchQuery`, `query`, or
    *                       `mutate`.
    *
+   * @param assumeImmutableResults When this option is true, the client will assume results
+   *                               read from the cache are never mutated by application code,
+   *                               which enables substantial performance optimizations. Passing
+   *                               `{ freezeResults: true }` to the `InMemoryCache` constructor
+   *                               can help enforce this immutability.
+   *
    * @param name A custom name that can be used to identify this client, when
    *             using Apollo client awareness features. E.g. "iOS".
    *
@@ -120,6 +127,7 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
       connectToDevTools,
       queryDeduplication = true,
       defaultOptions,
+      assumeImmutableResults = false,
       resolvers,
       typeDefs,
       fragmentMatcher,
@@ -244,6 +252,7 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
         version: clientAwarenessVersion!,
       },
       localState: this.localState,
+      assumeImmutableResults,
       onBroadcast: () => {
         if (this.devToolsHookCb) {
           this.devToolsHookCb({

--- a/packages/apollo-client/src/__tests__/client.ts
+++ b/packages/apollo-client/src/__tests__/client.ts
@@ -22,20 +22,6 @@ import { withWarning } from '../util/wrap';
 import { mockSingleLink } from '../__mocks__/mockLinks';
 
 describe('client', () => {
-  it('creates query manager lazily', () => {
-    const client = new ApolloClient({
-      link: ApolloLink.empty(),
-      cache: new InMemoryCache(),
-    });
-
-    expect(client.queryManager).toBeUndefined();
-
-    // We only create the query manager on the first query
-    client.initQueryManager();
-    expect(client.queryManager).toBeDefined();
-    expect(client.cache).toBeDefined();
-  });
-
   it('can be loaded via require', () => {
     /* tslint:disable */
     const ApolloClientRequire = require('../').default;
@@ -46,10 +32,6 @@ describe('client', () => {
       cache: new InMemoryCache(),
     });
 
-    expect(client.queryManager).toBeUndefined();
-
-    // We only create the query manager on the first query
-    client.initQueryManager();
     expect(client.queryManager).toBeDefined();
     expect(client.cache).toBeDefined();
   });

--- a/packages/apollo-client/src/core/ObservableQuery.ts
+++ b/packages/apollo-client/src/core/ObservableQuery.ts
@@ -250,7 +250,8 @@ export class ObservableQuery<
 
     if (!partial) {
       this.lastResult = { ...result, stale: false };
-      this.lastResultSnapshot = cloneDeep(this.lastResult);
+      this.lastResultSnapshot = this.queryManager.assumeImmutableResults
+        ? this.lastResult : cloneDeep(this.lastResult);
     }
 
     return { ...result, partial };
@@ -611,7 +612,8 @@ export class ObservableQuery<
     const observer: Observer<ApolloQueryResult<TData>> = {
       next: (result: ApolloQueryResult<TData>) => {
         this.lastResult = result;
-        this.lastResultSnapshot = cloneDeep(result);
+        this.lastResultSnapshot = this.queryManager.assumeImmutableResults
+          ? result : cloneDeep(result);
         this.observers.forEach(obs => obs.next && obs.next(result));
       },
       error: (error: ApolloError) => {

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -57,6 +57,7 @@ export class QueryManager<TStore> {
   public mutationStore: MutationStore = new MutationStore();
   public queryStore: QueryStore = new QueryStore();
   public dataStore: DataStore<TStore>;
+  public readonly assumeImmutableResults: boolean;
 
   private deduplicator: ApolloLink;
   private queryDeduplication: boolean;
@@ -94,6 +95,7 @@ export class QueryManager<TStore> {
     ssrMode = false,
     clientAwareness = {},
     localState,
+    assumeImmutableResults,
   }: {
     link: ApolloLink;
     queryDeduplication?: boolean;
@@ -102,6 +104,7 @@ export class QueryManager<TStore> {
     ssrMode?: boolean;
     clientAwareness?: Record<string, string>;
     localState?: LocalState<TStore>;
+    assumeImmutableResults?: boolean;
   }) {
     this.link = link;
     this.deduplicator = ApolloLink.from([new Deduplicator(), link]);
@@ -111,6 +114,7 @@ export class QueryManager<TStore> {
     this.clientAwareness = clientAwareness;
     this.localState = localState || new LocalState({ cache: store.getCache() });
     this.ssrMode = ssrMode;
+    this.assumeImmutableResults = !!assumeImmutableResults;
   }
 
   /**


### PR DESCRIPTION
The `cloneDeep` helper from `apollo-utilities` has begun showing up prominently in some performance profiles (#4464), because we were forced to start taking snapshots of previous results to guard against destructive modifications (#4069).

While we cannot mandate immutable data handling for all application code that interacts with Apollo Client, we can give developers the tools to eliminate the runtime cost of using `cloneDeep`, which is incurred to defend against destructive modifications of cache results. If we don't have to worry about destructive updates, we can skip calling `cloneDeep`. Some cooperation from the application developer is required to achieve this goal, and that's what this PR enables.

This new (highly recommended) strategy has two parts:

```ts
const client = new ApolloClient({
  link: ...,
  cache: new InMemoryCache({
    freezeResults: true, // new
  }),
  assumeImmutableResults: true, // new
});
```

1. Thanks to #4514, when you create an instance of `InMemoryCache`, you can instruct it to call `Object.freeze` (in development only) against all the result objects that it creates, which effectively prevents any destructive mutations of those objects. If you have been relying on mutability of cache results, you may need to update some of your code, but the `freezeResults` option should help you find the problematic spots, because modifications of frozen objects throw an exception (in [strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode)). Since the freezing happens only in development, this new functionality has zero runtime cost in production.

2. Once you know that your application code is no longer modifying cache results destructively, you can unlock significant performance improvements by passing `assumeImmutableResults: true` to the `ApolloClient` constructor. Once you have agreed not to modify cache results, the client can avoid using `cloneDeep` to take snapshots of previous results, and identical result (sub)trees will often be `===` to each other, so your UI rendering code can immediately detect when no changes have happened.

What do we mean by destructive modifications? For example, the following code destructively modifies a result object read from the cache:

```ts
const data = client.readQuery({ query });

const myNewTodo = {
  id: '6',
  text: 'Start using Apollo Client.',
  completed: false,
};

data.todos.push(myNewTodo);

client.writeQuery({ query, data });
```

While this works, Apollo Client has to do a lot of extra work to compensate for the possibility that nested result data might change at any time.

To rewrite this code in a non-destructive style, you should create a new `data.todos` list that includes the old todos plus `myNewTodo`:

```ts
const data = client.readQuery({ query });

const myNewTodo = {
  id: '6',
  text: 'Start using Apollo Client.',
  completed: false,
};

client.writeQuery({
  query,
  data: {
    todos: [...data.todos, myNewTodo],
  },
});
```

Both styles will work, but only the second style is compatible with the `{ assumeImmutableResults: true }` option. When you're using `new InMemoryCache({ freezeResults })`, the `data.todos.push(myNewTodo)` expression will throw an exception in development (in strict mode), because the `data.todos` object will be frozen.