### PR TITLE
Adjust wording of disabled local resolvers warning message

### DIFF
--- a/packages/apollo-client/src/__tests__/local-state/general.ts
+++ b/packages/apollo-client/src/__tests__/local-state/general.ts
@@ -59,8 +59,10 @@ describe('General functionality', () => {
       const result = await client.query({ query });
       expect(result.data).toEqual({ field: 'local' });
       expect(messages).toEqual([
-        'Found @client directives in query but no client resolvers were specified. ' +
-          'You can now pass apollo-link-state resolvers to the ApolloClient constructor.',
+        'Found @client directives in a query but no ApolloClient resolvers ' +
+        'were specified. This means ApolloClient local resolver handling ' +
+        'has been disabled, and @client directives will be passed through ' +
+        'to your link chain.',
       ]);
     } finally {
       console.warn = warn;

--- a/packages/apollo-client/src/core/LocalState.ts
+++ b/packages/apollo-client/src/core/LocalState.ts
@@ -167,8 +167,10 @@ export class LocalState<TCacheShape> {
         return document;
       }
       invariant.warn(
-        'Found @client directives in query but no client resolvers were specified. ' +
-          'You can now pass apollo-link-state resolvers to the ApolloClient constructor.',
+        'Found @client directives in a query but no ApolloClient resolvers ' +
+        'were specified. This means ApolloClient local resolver handling ' +
+        'has been disabled, and @client directives will be passed through ' +
+        'to your link chain.',
       );
     }
     return null;


### PR DESCRIPTION
The local resolvers are disabled warning message has been confusing people who want local resolvers disabled (so they want `@client` directives passed through the link chain), but aren't using `apollo-link-state` (they're using other custom links that leverage `@client`). This PR adjusts the warning message to remove the mention of `apollo-link-state`, and be explicit about `@client` directives being passed into the link chain.