### PR TITLE
Fix `QueryManager` for queries with `fetchPolicy="no-cache"`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
   ```
   which allows the client to avoid taking defensive snapshots of past results using `cloneDeep`, as explained by [@benjamn](https://github.com/benjamn) in [#4543](https://github.com/apollographql/apollo-client/pull/4543).
 
+- Avoid updating (and later invalidating) cache watches when `fetchPolicy` is `'no-cache'`. <br/>
+  [@bradleyayers](https://github.com/bradleyayers) in [PR #4573](https://github.com/apollographql/apollo-client/pull/4573), part of [issue #3452](https://github.com/apollographql/apollo-client/issues/3452)
+
 ### Apollo Cache In-Memory
 
 - Support `new InMemoryCache({ freezeResults: true })` to help enforce immutability. <br/>

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -437,7 +437,9 @@ export class QueryManager<TStore> {
     const requestId = this.generateRequestId();
 
     // set up a watcher to listen to cache updates
-    const cancel = this.updateQueryWatch(queryId, query, updatedOptions);
+    const cancel = fetchPolicy !== 'no-cache'
+      ? this.updateQueryWatch(queryId, query, updatedOptions)
+      : undefined;
 
     // Initialize query in store with unique requestId
     this.setQuery(queryId, () => ({


### PR DESCRIPTION
This PR fixes a bug with `fetchPolicy="no-cache"`, where data initially _appears_, and then subsequently _disappears_ (e.g. https://github.com/apollographql/apollo-client/issues/3452#issuecomment-438209541). I was able to reproduce the issue:

1. Use `InMemoryCache`.
2. Make a query with `fetchPolicy="no-cache"`. It will resolve correctly and the data will be available.
3. While that query is still being observed (via `ObservableQuery`), make a separate query using `cache-and-network` (I don't think the `fetchPolicy` is actually significant here).
4. When the new query updates the cache:

    1. `QueryManager#broadcastQueries()` is called.
    1. A cache watch's `callback` (which was incorrectly setup when the `no-cache` query was created) is executed and calls `this.setQuery(queryId, () => ({ invalidated: true, newData }));`
    1. Because the query isn't in the cache, `newData` is empty, but the query is updated anyway.
    1. The existing `ObservableQuery` for the `no-cache` query has the empty result emitted.

I'm not familiar enough with this codebase to know how to write a test for this, so it'd be great if someone else could jump in and help with that.

Relates to #3452.

Questions:

1. Why does `this.dataStore.getCache().watch({…})` trigger for the `no-cache` query when a different (unrelated) query updates the cache?

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
