### PR TITLE
Further reduce bundle size by improving QueryManager and ObservableQuery.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,12 +34,12 @@
     {
       "name": "apollo-client",
       "path": "./packages/apollo-client/lib/bundle.cjs.min.js",
-      "maxSize": "10.6 kB"
+      "maxSize": "10.5 kB"
     },
     {
       "name": "apollo-utilities",
       "path": "./packages/apollo-utilities/lib/bundle.cjs.min.js",
-      "maxSize": "4.2 kB"
+      "maxSize": "4.1 kB"
     }
   ],
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     {
       "name": "apollo-client",
       "path": "./packages/apollo-client/lib/bundle.cjs.min.js",
-      "maxSize": "10.5 kB"
+      "maxSize": "10 kB"
     },
     {
       "name": "apollo-utilities",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     {
       "name": "apollo-client",
       "path": "./packages/apollo-client/lib/bundle.cjs.min.js",
-      "maxSize": "10 kB"
+      "maxSize": "9.9 kB"
     },
     {
       "name": "apollo-utilities",

--- a/packages/apollo-cache-inmemory/package-lock.json
+++ b/packages/apollo-cache-inmemory/package-lock.json
@@ -5,37 +5,38 @@
   "requires": true,
   "dependencies": {
     "apollo-cache": {
-      "version": "file:../apollo-cache",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.2.1.tgz",
+      "integrity": "sha512-nzFmep/oKlbzUuDyz6fS6aYhRmfpcHWqNkkA9Bbxwk18RD6LXC4eZkuE0gXRX0IibVBHNjYVK+Szi0Yied4SpQ==",
       "requires": {
-        "apollo-utilities": "file:../apollo-utilities"
+        "apollo-utilities": "^1.2.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "apollo-utilities": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.2.1.tgz",
+      "integrity": "sha512-Zv8Udp9XTSFiN8oyXOjf6PMHepD4yxxReLsl6dPUy5Ths7jti3nmlBzZUOxuTWRwZn0MoclqL7RQ5UEJN8MAxg==",
+      "requires": {
+        "fast-json-stable-stringify": "^2.0.0",
+        "ts-invariant": "^0.2.1",
+        "tslib": "^1.9.3"
       },
       "dependencies": {
-        "apollo-utilities": {
-          "version": "file:../apollo-utilities",
-          "bundled": true,
+        "ts-invariant": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.2.1.tgz",
+          "integrity": "sha512-Z/JSxzVmhTo50I+LKagEISFJW3pvPCqsMWLamCTX8Kr3N5aMrnGOqcflbe5hLUzwjvgPfnLzQtHZv0yWQ+FIHg==",
           "requires": {
-            "fast-json-stable-stringify": "^2.0.0"
-          },
-          "dependencies": {
-            "fast-json-stable-stringify": {
-              "version": "2.0.0",
-              "bundled": true
-            }
+            "tslib": "^1.9.3"
           }
         }
       }
     },
-    "apollo-utilities": {
-      "version": "file:../apollo-utilities",
-      "requires": {
-        "fast-json-stable-stringify": "^2.0.0"
-      },
-      "dependencies": {
-        "fast-json-stable-stringify": {
-          "version": "2.0.0",
-          "bundled": true
-        }
-      }
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "immutable-tuple": {
       "version": "0.4.9",

--- a/packages/apollo-cache-inmemory/package.json
+++ b/packages/apollo-cache-inmemory/package.json
@@ -39,8 +39,8 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "apollo-cache": "file:../apollo-cache",
-    "apollo-utilities": "file:../apollo-utilities",
+    "apollo-cache": "^1.2.1",
+    "apollo-utilities": "^1.2.1",
     "optimism": "^0.6.9",
     "ts-invariant": "^0.3.2",
     "tslib": "^1.9.3"

--- a/packages/apollo-client/package-lock.json
+++ b/packages/apollo-client/package-lock.json
@@ -39,14 +39,6 @@
         "zen-observable-ts": "^0.8.13"
       }
     },
-    "apollo-link-dedup": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/apollo-link-dedup/-/apollo-link-dedup-1.0.13.tgz",
-      "integrity": "sha512-i4NuqT3DSFczFcC7NMUzmnYjKX7NggLY+rqYVf+kE9JjqKOQhT6wqhaWsVIABfIUGE/N0DTgYJBCMu/18aXmYA==",
-      "requires": {
-        "apollo-link": "^1.2.6"
-      }
-    },
     "apollo-utilities": {
       "version": "file:../apollo-utilities",
       "requires": {

--- a/packages/apollo-client/package-lock.json
+++ b/packages/apollo-client/package-lock.json
@@ -10,24 +10,12 @@
       "integrity": "sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg=="
     },
     "apollo-cache": {
-      "version": "file:../apollo-cache",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.2.1.tgz",
+      "integrity": "sha512-nzFmep/oKlbzUuDyz6fS6aYhRmfpcHWqNkkA9Bbxwk18RD6LXC4eZkuE0gXRX0IibVBHNjYVK+Szi0Yied4SpQ==",
       "requires": {
-        "apollo-utilities": "file:../apollo-utilities"
-      },
-      "dependencies": {
-        "apollo-utilities": {
-          "version": "file:../apollo-utilities",
-          "bundled": true,
-          "requires": {
-            "fast-json-stable-stringify": "^2.0.0"
-          },
-          "dependencies": {
-            "fast-json-stable-stringify": {
-              "version": "2.0.0",
-              "bundled": true
-            }
-          }
-        }
+        "apollo-utilities": "^1.2.1",
+        "tslib": "^1.9.3"
       }
     },
     "apollo-link": {
@@ -40,14 +28,27 @@
       }
     },
     "apollo-utilities": {
-      "version": "file:../apollo-utilities",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.2.1.tgz",
+      "integrity": "sha512-Zv8Udp9XTSFiN8oyXOjf6PMHepD4yxxReLsl6dPUy5Ths7jti3nmlBzZUOxuTWRwZn0MoclqL7RQ5UEJN8MAxg==",
       "requires": {
-        "fast-json-stable-stringify": "^2.0.0"
+        "fast-json-stable-stringify": "^2.0.0",
+        "ts-invariant": "^0.2.1",
+        "tslib": "^1.9.3"
       },
       "dependencies": {
         "fast-json-stable-stringify": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+          "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+        },
+        "ts-invariant": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.2.1.tgz",
+          "integrity": "sha512-Z/JSxzVmhTo50I+LKagEISFJW3pvPCqsMWLamCTX8Kr3N5aMrnGOqcflbe5hLUzwjvgPfnLzQtHZv0yWQ+FIHg==",
+          "requires": {
+            "tslib": "^1.9.3"
+          }
         }
       }
     },

--- a/packages/apollo-client/package.json
+++ b/packages/apollo-client/package.json
@@ -48,7 +48,6 @@
     "@types/zen-observable": "^0.8.0",
     "apollo-cache": "file:../apollo-cache",
     "apollo-link": "^1.0.0",
-    "apollo-link-dedup": "^1.0.0",
     "apollo-utilities": "file:../apollo-utilities",
     "symbol-observable": "^1.0.2",
     "ts-invariant": "^0.3.2",

--- a/packages/apollo-client/package.json
+++ b/packages/apollo-client/package.json
@@ -46,9 +46,9 @@
   "license": "MIT",
   "dependencies": {
     "@types/zen-observable": "^0.8.0",
-    "apollo-cache": "file:../apollo-cache",
+    "apollo-cache": "^1.2.1",
     "apollo-link": "^1.0.0",
-    "apollo-utilities": "file:../apollo-utilities",
+    "apollo-utilities": "^1.2.1",
     "symbol-observable": "^1.0.2",
     "ts-invariant": "^0.3.2",
     "tslib": "^1.9.3",

--- a/packages/apollo-client/src/ApolloClient.ts
+++ b/packages/apollo-client/src/ApolloClient.ts
@@ -377,7 +377,7 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
    */
   public subscribe<T = any, TVariables = OperationVariables>(
     options: SubscriptionOptions<TVariables>,
-  ): Observable<T> {
+  ): Observable<FetchResult<T>> {
     return this.queryManager.startGraphQLSubscription<T>(options);
   }
 

--- a/packages/apollo-client/src/ApolloClient.ts
+++ b/packages/apollo-client/src/ApolloClient.ts
@@ -505,17 +505,9 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
    */
   public resetStore(): Promise<ApolloQueryResult<any>[] | null> {
     return Promise.resolve()
-      .then(() => {
-        return this.queryManager
-          ? this.queryManager.clearStore()
-          : Promise.resolve(null);
-      })
+      .then(() => this.queryManager.clearStore())
       .then(() => Promise.all(this.resetStoreCallbacks.map(fn => fn())))
-      .then(() => {
-        return this.queryManager && this.queryManager.reFetchObservableQueries
-          ? this.queryManager.reFetchObservableQueries()
-          : Promise.resolve(null);
-      });
+      .then(() => this.reFetchObservableQueries());
   }
 
   /**
@@ -523,13 +515,9 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
    * not refetch any active queries.
    */
   public clearStore(): Promise<void | null> {
-    const { queryManager } = this;
     return Promise.resolve()
       .then(() => Promise.all(this.clearStoreCallbacks.map(fn => fn())))
-      .then(
-        () =>
-          queryManager ? queryManager.clearStore() : Promise.resolve(null),
-      );
+      .then(() => this.queryManager.clearStore());
   }
 
   /**
@@ -570,10 +558,8 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
    */
   public reFetchObservableQueries(
     includeStandby?: boolean,
-  ): Promise<ApolloQueryResult<any>[]> | Promise<null> {
-    return this.queryManager
-      ? this.queryManager.reFetchObservableQueries(includeStandby)
-      : Promise.resolve(null);
+  ): Promise<ApolloQueryResult<any>[]> {
+    return this.queryManager.reFetchObservableQueries(includeStandby);
   }
 
   /**

--- a/packages/apollo-client/src/__mocks__/mockLinks.ts
+++ b/packages/apollo-client/src/__mocks__/mockLinks.ts
@@ -7,7 +7,6 @@ import {
 } from 'apollo-link';
 
 import { print } from 'graphql/language/printer';
-import { multiplex } from '../util/observables';
 
 interface MockApolloLink extends ApolloLink {
   operation?: Operation;
@@ -113,7 +112,7 @@ export class MockSubscriptionLink extends ApolloLink {
   }
 
   public request() {
-    return multiplex(new Observable<FetchResult>(observer => {
+    return new Observable<FetchResult>(observer => {
       this.setups.forEach(x => x());
       this.observer = observer;
       return {
@@ -122,7 +121,7 @@ export class MockSubscriptionLink extends ApolloLink {
         },
         closed: false,
       };
-    }));
+    });
   }
 
   public simulateResult(result: MockedSubscriptionResult) {

--- a/packages/apollo-client/src/__mocks__/mockLinks.ts
+++ b/packages/apollo-client/src/__mocks__/mockLinks.ts
@@ -7,6 +7,7 @@ import {
 } from 'apollo-link';
 
 import { print } from 'graphql/language/printer';
+import { multiplex } from '../util/observables';
 
 interface MockApolloLink extends ApolloLink {
   operation?: Operation;
@@ -112,7 +113,7 @@ export class MockSubscriptionLink extends ApolloLink {
   }
 
   public request() {
-    return new Observable<FetchResult>(observer => {
+    return multiplex(new Observable<FetchResult>(observer => {
       this.setups.forEach(x => x());
       this.observer = observer;
       return {
@@ -121,7 +122,7 @@ export class MockSubscriptionLink extends ApolloLink {
         },
         closed: false,
       };
-    });
+    }));
   }
 
   public simulateResult(result: MockedSubscriptionResult) {

--- a/packages/apollo-client/src/__tests__/client.ts
+++ b/packages/apollo-client/src/__tests__/client.ts
@@ -2324,6 +2324,7 @@ describe('client', () => {
           new Observable(observer => {
             timesFired += 1;
             observer.next({ data });
+            observer.complete();
             return;
           }),
       ),

--- a/packages/apollo-client/src/__tests__/client.ts
+++ b/packages/apollo-client/src/__tests__/client.ts
@@ -2217,17 +2217,14 @@ describe('client', () => {
       });
   });
 
-  it('has a clearStore method which calls QueryManager', done => {
+  it('has a clearStore method which calls QueryManager', async () => {
     const client = new ApolloClient({
       link: ApolloLink.empty(),
       cache: new InMemoryCache(),
     });
-    client.queryManager = {
-      clearStore: () => {
-        done();
-      },
-    } as QueryManager;
-    client.clearStore();
+    const spy = jest.spyOn(client.queryManager, 'clearStore');
+    await client.clearStore();
+    expect(spy).toHaveBeenCalled();
   });
 
   it('has an onClearStore method which takes a callback to be called after clearStore', async () => {
@@ -2259,17 +2256,14 @@ describe('client', () => {
     expect(onClearStore).not.toHaveBeenCalled();
   });
 
-  it('has a resetStore method which calls QueryManager', done => {
+  it('has a resetStore method which calls QueryManager', async () => {
     const client = new ApolloClient({
       link: ApolloLink.empty(),
       cache: new InMemoryCache(),
     });
-    client.queryManager = {
-      clearStore: () => {
-        done();
-      },
-    } as QueryManager;
-    client.resetStore();
+    const spy = jest.spyOn(client.queryManager, 'clearStore');
+    await client.resetStore();
+    expect(spy).toHaveBeenCalled();
   });
 
   it('has an onResetStore method which takes a callback to be called after resetStore', async () => {
@@ -2429,17 +2423,14 @@ describe('client', () => {
     expect(next).toHaveBeenCalledTimes(2);
   });
 
-  it('has a reFetchObservableQueries method which calls QueryManager', done => {
+  it('has a reFetchObservableQueries method which calls QueryManager', async () => {
     const client = new ApolloClient({
       link: ApolloLink.empty(),
       cache: new InMemoryCache(),
     });
-    client.queryManager = {
-      reFetchObservableQueries: () => {
-        done();
-      },
-    } as QueryManager;
-    client.reFetchObservableQueries();
+    const spy = jest.spyOn(client.queryManager, 'reFetchObservableQueries');
+    await client.reFetchObservableQueries();
+    expect(spy).toHaveBeenCalled();
   });
 
   it('should enable dev tools logging', () => {

--- a/packages/apollo-client/src/__tests__/graphqlSubscriptions.ts
+++ b/packages/apollo-client/src/__tests__/graphqlSubscriptions.ts
@@ -259,23 +259,20 @@ describe('GraphQL Subscriptions', () => {
     return Promise.all(promises);
   });
 
-  it('should call complete handler when the subscription completes', done => {
+  it('should call complete handler when the subscription completes', () => {
     const link = mockObservableLink();
     const client = new ApolloClient({
       link,
       cache: new InMemoryCache({ addTypename: false }),
     });
-    const completeFn = jest.fn();
 
-    let count = 0;
-    const sub = client.subscribe(defaultOptions).subscribe({
-      complete() {
-        completeFn();
-      }
+    return new Promise(resolve => {
+      client.subscribe(defaultOptions).subscribe({
+        complete() {
+          resolve();
+        },
+      });
+      setTimeout(() => link.simulateComplete(), 100);
     });
-
-    link.simulateComplete();
-    expect(completeFn).toHaveBeenCalled();
-    done();
   });
 });

--- a/packages/apollo-client/src/__tests__/local-state/__snapshots__/general.ts.snap
+++ b/packages/apollo-client/src/__tests__/local-state/__snapshots__/general.ts.snap
@@ -2,4 +2,4 @@
 
 exports[`Combining client and server state/operations should correctly propagate an error from a client resolver 1`] = `"Network error: Illegal Query Operation Occurred"`;
 
-exports[`Combining client and server state/operations should correctly propagate an error from a client resolver 2`] = `"Illegal Mutation Operation Occurred"`;
+exports[`Combining client and server state/operations should correctly propagate an error from a client resolver 2`] = `"Network error: Illegal Mutation Operation Occurred"`;

--- a/packages/apollo-client/src/core/ObservableQuery.ts
+++ b/packages/apollo-client/src/core/ObservableQuery.ts
@@ -339,7 +339,8 @@ export class ObservableQuery<
       FetchMoreOptions<TData, TVariables>,
   ): Promise<ApolloQueryResult<TData>> {
     // early return if no update Query
-    invariant(fetchMoreOptions.updateQuery,
+    invariant(
+      fetchMoreOptions.updateQuery,
       'updateQuery option is required. This function defines how to update the query data with the new results.',
     );
 
@@ -417,7 +418,7 @@ export class ObservableQuery<
             options.onError(err);
             return;
           }
-          console.error('Unhandled GraphQL subscription error', err);
+          invariant.error('Unhandled GraphQL subscription error', err);
         },
       });
 
@@ -577,7 +578,7 @@ export class ObservableQuery<
       (observer as any)._subscription._observer.error = (
         error: ApolloError,
       ) => {
-        console.error('Unhandled error', error.message, error.stack);
+        invariant.error('Unhandled error', error.message, error.stack);
       };
     }
 

--- a/packages/apollo-client/src/core/ObservableQuery.ts
+++ b/packages/apollo-client/src/core/ObservableQuery.ts
@@ -1,4 +1,9 @@
-import { isEqual, tryFunctionOrLogError, cloneDeep } from 'apollo-utilities';
+import {
+  isEqual,
+  tryFunctionOrLogError,
+  cloneDeep,
+  getOperationDefinition,
+} from 'apollo-utilities';
 import { GraphQLError } from 'graphql';
 import { NetworkStatus, isNetworkRequestInFlight } from './networkStatus';
 import { Observable, Observer, Subscription } from '../util/Observable';
@@ -71,7 +76,8 @@ export class ObservableQuery<
   TVariables = OperationVariables
 > extends Observable<ApolloQueryResult<TData>> {
   public options: WatchQueryOptions<TVariables>;
-  public queryId: string;
+  public readonly queryId: string;
+  public readonly queryName?: string;
   /**
    *
    * The current value of the variables for this query. Can change.
@@ -109,6 +115,9 @@ export class ObservableQuery<
     this.variables = options.variables || ({} as TVariables);
     this.queryId = queryManager.generateQueryId();
     this.shouldSubscribe = shouldSubscribe;
+
+    const opDef = getOperationDefinition(options.query);
+    this.queryName = opDef && opDef.name && opDef.name.value;
 
     // related classes
     this.queryManager = queryManager;

--- a/packages/apollo-client/src/core/ObservableQuery.ts
+++ b/packages/apollo-client/src/core/ObservableQuery.ts
@@ -412,7 +412,7 @@ export class ObservableQuery<
   public setOptions(
     opts: ModifiableWatchQueryOptions,
   ): Promise<ApolloQueryResult<TData> | void> {
-    const { fetchPolicy: oldFechPolicy } = this.options;
+    const { fetchPolicy: oldFetchPolicy } = this.options;
     this.options = {
       ...this.options,
       ...opts,
@@ -430,9 +430,9 @@ export class ObservableQuery<
       this.options.variables as TVariables,
       // Try to fetch the query if fetchPolicy changed from either cache-only
       // or standby to something else, or changed to network-only.
-      oldFechPolicy !== fetchPolicy && (
-        oldFechPolicy === 'cache-only' ||
-        oldFechPolicy === 'standby' ||
+      oldFetchPolicy !== fetchPolicy && (
+        oldFetchPolicy === 'cache-only' ||
+        oldFetchPolicy === 'standby' ||
         fetchPolicy === 'network-only'
       ),
       opts.fetchResults,

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -35,7 +35,11 @@ import {
   OperationVariables,
 } from './types';
 import { LocalState } from './LocalState';
-import { afterAllUnsubscribed, asyncMap, multiplex, afterPromise } from '../util/observables';
+import {
+  afterAllUnsubscribed,
+  asyncMap,
+  afterPromise,
+} from '../util/observables';
 
 const { hasOwnProperty } = Object.prototype;
 
@@ -929,7 +933,7 @@ export class QueryManager<TStore> {
           : variables
         );
       }),
-      variables => multiplex(this.getObservableFromLink<T>(
+      variables => this.getObservableFromLink<T>(
         transformedDoc,
         {},
         variables,
@@ -951,7 +955,7 @@ export class QueryManager<TStore> {
         }
 
         return result;
-      })),
+      }),
     );
   }
 

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -287,7 +287,7 @@ export class QueryManager<TStore> {
             ApolloQueryResult<any>[] | ApolloQueryResult<{}>
           >[] = [];
 
-          for (const refetchQuery of refetchQueries) {
+          refetchQueries.forEach(refetchQuery => {
             if (typeof refetchQuery === 'string') {
               self.queries.forEach(({ observableQuery }) => {
                 if (
@@ -297,21 +297,20 @@ export class QueryManager<TStore> {
                   refetchQueryPromises.push(observableQuery.refetch());
                 }
               });
-              continue;
+            } else {
+              const queryOptions: QueryOptions = {
+                query: refetchQuery.query,
+                variables: refetchQuery.variables,
+                fetchPolicy: 'network-only',
+              };
+
+              if (refetchQuery.context) {
+                queryOptions.context = refetchQuery.context;
+              }
+
+              refetchQueryPromises.push(self.query(queryOptions));
             }
-
-            const queryOptions: QueryOptions = {
-              query: refetchQuery.query,
-              variables: refetchQuery.variables,
-              fetchPolicy: 'network-only',
-            };
-
-            if (refetchQuery.context) {
-              queryOptions.context = refetchQuery.context;
-            }
-
-            refetchQueryPromises.push(self.query(queryOptions));
-          }
+          });
 
           Promise.all(
             awaitRefetchQueries ? refetchQueryPromises : [],

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -12,7 +12,7 @@ import {
   hasClientExports,
 } from 'apollo-utilities';
 
-import { invariant } from 'ts-invariant';
+import { invariant, InvariantError } from 'ts-invariant';
 
 import { isApolloError, ApolloError } from '../errors/ApolloError';
 import { Observer, Subscription, Observable } from '../util/Observable';
@@ -125,7 +125,9 @@ export class QueryManager<TStore> {
     });
 
     this.fetchQueryRejectFns.forEach(reject => {
-      reject(new Error('QueryManager stopped while query was in flight'));
+      reject(
+        new InvariantError('QueryManager stopped while query was in flight'),
+      );
     });
   }
 
@@ -854,11 +856,9 @@ export class QueryManager<TStore> {
     // that we have issued so far and not yet resolved (in the case of
     // queries).
     this.fetchQueryRejectFns.forEach(reject => {
-      reject(
-        new Error(
-          'Store reset while query was in flight(not completed in link chain)',
-        ),
-      );
+      reject(new InvariantError(
+        'Store reset while query was in flight (not completed in link chain)',
+      ));
     });
 
     const resetIds: string[] = [];

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -773,9 +773,7 @@ export class QueryManager<TStore> {
   }
 
   public generateQueryId() {
-    const queryId = this.idCounter.toString();
-    this.idCounter++;
-    return queryId;
+    return String(this.idCounter++);
   }
 
   public stopQueryInStore(queryId: string) {

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -1329,11 +1329,8 @@ export class QueryManager<TStore> {
     variables: any,
     extraContext?: any,
   ) {
-    const cache = this.dataStore.getCache();
     return {
-      query: cache.transformForLink
-        ? cache.transformForLink(document)
-        : document,
+      query: this.dataStore.getCache().transformForLink(document),
       variables,
       operationName: getOperationName(document) || undefined,
       context: this.prepareContext(extraContext),

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -859,9 +859,7 @@ export class QueryManager<TStore> {
     this.mutationStore.reset();
 
     // begin removing data from the store
-    const reset = this.dataStore.reset();
-
-    return reset;
+    return this.dataStore.reset();
   }
 
   public resetStore(): Promise<ApolloQueryResult<any>[]> {

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -391,7 +391,7 @@ export class QueryManager<TStore> {
     // we need to check to see if this is an operation that uses the @live directive
     if (hasDirectives(['live'], query)) shouldFetch = true;
 
-    const requestId = this.generateRequestId();
+    const requestId = this.idCounter++;
 
     // set up a watcher to listen to cache updates
     const cancel = this.updateQueryWatch(queryId, query, options);
@@ -1281,12 +1281,6 @@ export class QueryManager<TStore> {
         subscriptions.add(subscription);
       });
     });
-  }
-
-  private generateRequestId() {
-    const requestId = this.idCounter;
-    this.idCounter++;
-    return requestId;
   }
 
   private getQuery(queryId: string) {

--- a/packages/apollo-client/src/data/store.ts
+++ b/packages/apollo-client/src/data/store.ts
@@ -169,17 +169,15 @@ export class DataStore<TSerialized> {
 
       this.cache.performTransaction(c => {
         cacheWrites.forEach(write => c.write(write));
-      });
 
-      // If the mutation has some writes associated with it then we need to
-      // apply those writes to the store by running this reducer again with a
-      // write action.
-      const update = mutation.update;
-      if (update) {
-        this.cache.performTransaction(c => {
+        // If the mutation has some writes associated with it then we need to
+        // apply those writes to the store by running this reducer again with a
+        // write action.
+        const { update } = mutation;
+        if (update) {
           tryFunctionOrLogError(() => update(c, mutation.result));
-        });
-      }
+        }
+      });
     }
   }
 

--- a/packages/apollo-client/src/util/observables.ts
+++ b/packages/apollo-client/src/util/observables.ts
@@ -1,0 +1,62 @@
+import { Observable, Observer } from './Observable';
+
+export function afterAllUnsubscribed<T>(
+  inner: Observable<T>,
+  cleanup: () => any,
+): Observable<T> {
+  const observers = new Set<Observer<T>>();
+  return new Observable<T>(observer => {
+    observers.add(observer);
+    const sub = inner.subscribe(observer);
+    return () => {
+      sub.unsubscribe();
+      if (observers.delete(observer) && !observers.size) {
+        cleanup();
+      }
+    };
+  });
+}
+
+// Like Observable.prototype.map, except that the mapping function can
+// optionally return a Promise (or be async).
+export function asyncMap<V, R>(
+  observable: Observable<V>,
+  mapFn: (value: V) => R | Promise<R>,
+): Observable<R> {
+  return new Observable<R>(observer => {
+    const { next, error, complete } = observer;
+    let activeNextCount = 0;
+    let completed = false;
+
+    const handler: Observer<V> = {
+      next(value) {
+        ++activeNextCount;
+        new Promise(resolve => {
+          resolve(mapFn(value));
+        }).then(
+          result => {
+            --activeNextCount;
+            next && next.call(observer, result);
+            completed && handler.complete!();
+          },
+          e => {
+            --activeNextCount;
+            error && error.call(observer, e);
+          },
+        );
+      },
+      error(e) {
+        error && error.call(observer, e);
+      },
+      complete() {
+        completed = true;
+        if (!activeNextCount) {
+          complete && complete.call(observer);
+        }
+      },
+    };
+
+    const sub = observable.subscribe(handler);
+    return () => sub.unsubscribe();
+  });
+}

--- a/packages/apollo-client/src/util/observables.ts
+++ b/packages/apollo-client/src/util/observables.ts
@@ -1,20 +1,5 @@
 import { Observable, Observer, Subscription } from './Observable';
 
-export function afterPromise<T, U>(
-  promise: Promise<T>,
-  makeObservable: (value: T) => Observable<U>,
-): Observable<U> {
-  const obsPromise = promise.then(makeObservable);
-  return new Observable<U>(observer => {
-    let sub: Subscription | null = null;
-    obsPromise.then(
-      observable => sub = observable.subscribe(observer),
-      error => observer.error && observer.error(error),
-    );
-    return () => sub && sub.unsubscribe();
-  });
-}
-
 // Returns a normal Observable that can have any number of subscribers,
 // while ensuring the original Observable gets subscribed to at most once.
 export function multiplex<T>(inner: Observable<T>): Observable<T> {

--- a/packages/apollo-client/src/util/observables.ts
+++ b/packages/apollo-client/src/util/observables.ts
@@ -1,22 +1,5 @@
 import { Observable, Observer, Subscription } from './Observable';
 
-export function afterAllUnsubscribed<T>(
-  inner: Observable<T>,
-  cleanup: () => any,
-): Observable<T> {
-  const observers = new Set<Observer<T>>();
-  return new Observable<T>(observer => {
-    observers.add(observer);
-    const sub = inner.subscribe(observer);
-    return () => {
-      sub.unsubscribe();
-      if (observers.delete(observer) && !observers.size) {
-        cleanup();
-      }
-    };
-  });
-}
-
 export function afterPromise<T, U>(
   promise: Promise<T>,
   makeObservable: (value: T) => Observable<U>,
@@ -51,11 +34,9 @@ export function multiplex<T>(inner: Observable<T>): Observable<T> {
       },
     });
     return () => {
-      if (observers.delete(observer) && !observers.size) {
-        if (sub) {
-          sub.unsubscribe();
-          sub = null;
-        }
+      if (observers.delete(observer) && !observers.size && sub) {
+        sub.unsubscribe();
+        sub = null;
       }
     };
   });

--- a/packages/apollo-utilities/src/transform.ts
+++ b/packages/apollo-utilities/src/transform.ts
@@ -23,6 +23,7 @@ import {
   getMainDefinition,
 } from './getFromAST';
 import { filterInPlace } from './util/filterInPlace';
+import { invariant } from 'ts-invariant';
 
 export type RemoveNodeConfig<N> = {
   name?: string;
@@ -254,7 +255,7 @@ const connectionRemoveConfig = {
         !directive.arguments ||
         !directive.arguments.some(arg => arg.name.value === 'key')
       ) {
-        console.warn(
+        invariant.warn(
           'Removing an @connection directive even though it does not have a key. ' +
             'You may want to use the key parameter to specify a store key.',
         );


### PR DESCRIPTION
As part of our ongoing effort to reduce bundle sizes (#4324), this PR makes a number of key improvements:
* Uses `invariant.{warn,error}` and `InvariantError` more consistently, to enable stripping long error strings in production via https://github.com/apollographql/invariant-packages.
* Eliminates the external dependency on https://www.npmjs.com/package/apollo-link-dedup in favor of a shorter internal implementation in the `getObservableFromLink` method.
* Uses the `getObservableFromLink` method to unify a substantial portion of query, mutation, and subscription logic.
* Introduces several reusable operators for working with `Observables`: `afterAllUnsubscribed`, `multiplex`, and `asyncMap`.
* Trims a large quantity of low-hanging bytes from `ObservableQuery.ts`.

The individual commits in this PR are worth reading by themselves, but the net effect is that some of the most complicated parts of `QueryManager` and `ObservableQuery` are much easier to reason about, and the `apollo-client` bundle size is finally less than 10KB—which doesn't even reflect the savings from no longer depending on `apollo-link-dedup`.