### PR TITLE
Perform all DocumentNode transforms once, and cache the results.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
   ```
   which allows the client to avoid taking defensive snapshots of past results using `cloneDeep`, as explained by [@benjamn](https://github.com/benjamn) in [#4543](https://github.com/apollographql/apollo-client/pull/4543).
 
+- Perform all `DocumentNode` transforms once, and cache the results. <br/>
+  [@benjamn](https://github.com/benjamn) in [#4601](https://github.com/apollographql/apollo-client/pull/4601)
+
 ### Apollo Cache In-Memory
 
 - Support `new InMemoryCache({ freezeResults: true })` to help enforce immutability. <br/>

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     {
       "name": "apollo-utilities",
       "path": "./packages/apollo-utilities/lib/bundle.cjs.min.js",
-      "maxSize": "4.1 kB"
+      "maxSize": "4.15 kB"
     }
   ],
   "lint-staged": {

--- a/packages/apollo-cache-inmemory/src/inMemoryCache.ts
+++ b/packages/apollo-cache-inmemory/src/inMemoryCache.ts
@@ -5,7 +5,7 @@ import { DocumentNode } from 'graphql';
 
 import { Cache, ApolloCache, Transaction } from 'apollo-cache';
 
-import { addTypenameToDocument } from 'apollo-utilities';
+import { addTypenameToDocument, canUseWeakMap } from 'apollo-utilities';
 
 import { wrap } from 'optimism';
 
@@ -89,7 +89,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
   private typenameDocumentCache = new Map<DocumentNode, DocumentNode>();
   private storeReader: StoreReader;
   private storeWriter: StoreWriter;
-  private cacheKeyRoot = new KeyTrie<object>(false);
+  private cacheKeyRoot = new KeyTrie<object>(canUseWeakMap);
 
   // Set this while in a transaction to prevent broadcasts...
   // don't forget to turn it back on!

--- a/packages/apollo-cache-inmemory/src/readFromStore.ts
+++ b/packages/apollo-cache-inmemory/src/readFromStore.ts
@@ -1,27 +1,28 @@
 import {
+  argumentsObjectFromField,
   assign,
-  getDefaultValues,
-  getQueryDefinition,
-  isEqual,
+  canUseWeakMap,
+  createFragmentMap,
   DirectiveInfo,
   FragmentMap,
-  IdValue,
-  StoreValue,
-  argumentsObjectFromField,
-  createFragmentMap,
+  getDefaultValues,
   getDirectiveInfoFromField,
   getFragmentDefinitions,
   getMainDefinition,
+  getQueryDefinition,
   getStoreKeyName,
+  IdValue,
+  isEqual,
   isField,
   isIdValue,
   isInlineFragment,
   isJsonValue,
+  maybeDeepFreeze,
+  mergeDeepArray,
   resultKeyNameFromField,
   shouldInclude,
+  StoreValue,
   toIdValue,
-  mergeDeepArray,
-  maybeDeepFreeze,
 } from 'apollo-utilities';
 
 import { Cache } from 'apollo-cache';
@@ -102,7 +103,7 @@ export class StoreReader {
   private freezeResults: boolean;
 
   constructor({
-    cacheKeyRoot = new KeyTrie<object>(false),
+    cacheKeyRoot = new KeyTrie<object>(canUseWeakMap),
     freezeResults = false,
   }: StoreReaderConfig = {}) {
     const {

--- a/packages/apollo-client/src/ApolloClient.ts
+++ b/packages/apollo-client/src/ApolloClient.ts
@@ -1,16 +1,11 @@
 import {
   ApolloLink,
-  Operation,
-  NextLink,
   FetchResult,
   GraphQLRequest,
   execute,
 } from 'apollo-link';
 import { ExecutionResult, DocumentNode } from 'graphql';
 import { ApolloCache, DataProxy } from 'apollo-cache';
-import {
-  removeConnectionDirectiveFromDocument,
-} from 'apollo-utilities';
 
 import { invariant, InvariantError } from 'ts-invariant';
 
@@ -151,22 +146,8 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
       );
     }
 
-    const supportedCache = new Map<DocumentNode, DocumentNode>();
-    const supportedDirectives = new ApolloLink(
-      (operation: Operation, forward: NextLink) => {
-        let result = supportedCache.get(operation.query);
-        if (!result) {
-          result = removeConnectionDirectiveFromDocument(operation.query);
-          supportedCache.set(operation.query, result);
-          supportedCache.set(result, result);
-        }
-        operation.query = result;
-        return forward(operation);
-      },
-    );
-
     // remove apollo-client supported directives
-    this.link = supportedDirectives.concat(link);
+    this.link = link;
     this.cache = cache;
     this.store = new DataStore(cache);
     this.disableNetworkFetches = ssrMode || ssrForceFetchDelay > 0;

--- a/packages/apollo-client/src/__tests__/local-state/resolvers.ts
+++ b/packages/apollo-client/src/__tests__/local-state/resolvers.ts
@@ -713,6 +713,7 @@ describe('Resolving field aliases', () => {
       const client = new ApolloClient({
         cache,
         link: ApolloLink.empty(),
+        resolvers: {},
       });
 
       cache.writeData({
@@ -814,6 +815,7 @@ describe('Force local resolvers', () => {
       const client = new ApolloClient({
         cache,
         link: ApolloLink.empty(),
+        resolvers: {},
       });
 
       cache.writeData({

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -2,14 +2,13 @@ import { execute, ApolloLink, FetchResult } from 'apollo-link';
 import { ExecutionResult, DocumentNode } from 'graphql';
 import { Cache } from 'apollo-cache';
 import {
-  assign,
   getDefaultValues,
   getOperationDefinition,
   getOperationName,
-  getQueryDefinition,
   hasDirectives,
   graphQLResultHasError,
   hasClientExports,
+  removeConnectionDirectiveFromDocument,
 } from 'apollo-utilities';
 
 import { invariant, InvariantError } from 'ts-invariant';
@@ -150,16 +149,13 @@ export class QueryManager<TStore> {
     );
 
     const mutationId = this.generateQueryId();
-    mutation = this.dataStore.getCache().transformDocument(mutation);
+    mutation = this.transform(mutation).document;
 
     this.setQuery(mutationId, () => ({ document: mutation }));
 
-    variables = {
-      ...getDefaultValues(getOperationDefinition(mutation)),
-      ...variables,
-    };
+    variables = this.getVariables(mutation, variables);
 
-    if (hasClientExports(mutation)) {
+    if (this.transform(mutation).hasClientExports) {
       variables = await this.localState.addExportedVariables(mutation, variables, context);
     }
 
@@ -347,14 +343,11 @@ export class QueryManager<TStore> {
       context = {},
     } = options;
 
-    const query = this.dataStore.getCache().transformDocument(options.query);
+    const query = this.transform(options.query).document;
 
-    let variables = {
-      ...getDefaultValues(getOperationDefinition(query)),
-      ...options.variables,
-    };
+    let variables = this.getVariables(query, options.variables);
 
-    if (hasClientExports(query)) {
+    if (this.transform(query).hasClientExports) {
       variables = await this.localState.addExportedVariables(query, variables, context);
     }
 
@@ -689,6 +682,63 @@ export class QueryManager<TStore> {
     };
   }
 
+  private transformCache = new WeakMap<DocumentNode, Readonly<{
+    document: Readonly<DocumentNode>;
+    hasClientExports: boolean;
+    clientQuery: Readonly<DocumentNode> | null;
+    serverQuery: Readonly<DocumentNode> | null;
+    defaultVars: Readonly<OperationVariables>;
+  }>>();
+
+  private transform(document: DocumentNode) {
+    const { transformCache } = this;
+
+    if (!transformCache.has(document)) {
+      const cache = this.dataStore.getCache();
+      const transformed = cache.transformDocument(document);
+      const forLink = removeConnectionDirectiveFromDocument(
+        cache.transformForLink(transformed));
+
+      const clientQuery = this.localState.clientQuery(transformed);
+      const serverQuery = this.localState.serverQuery(forLink);
+
+      const cacheEntry = {
+        document: transformed,
+        hasClientExports: hasClientExports(transformed),
+        clientQuery,
+        serverQuery,
+        defaultVars: getDefaultValues(
+          getOperationDefinition(transformed)
+        ) as OperationVariables,
+      };
+
+      const add = (doc: DocumentNode | null) => {
+        if (doc && !transformCache.has(doc)) {
+          transformCache.set(doc, cacheEntry);
+        }
+      }
+      // Add cacheEntry to the transformCache using several different keys,
+      // since any one of these documents could end up getting passed to the
+      // transform method again in the future.
+      add(document);
+      add(transformed);
+      add(clientQuery);
+      add(serverQuery);
+    }
+
+    return transformCache.get(document)!;
+  }
+
+  private getVariables(
+    document: DocumentNode,
+    variables?: OperationVariables,
+  ): OperationVariables {
+    return {
+      ...this.transform(document).defaultVars,
+      ...variables,
+    };
+  }
+
   // The shouldSubscribe option is a temporary fix that tells us whether watchQuery was called
   // directly (i.e. through ApolloClient) or through the query method within QueryManager.
   // Currently, the query method uses watchQuery in order to handle non-network errors correctly
@@ -705,18 +755,8 @@ export class QueryManager<TStore> {
       'client.watchQuery cannot be called with fetchPolicy set to "standby"',
     );
 
-    // get errors synchronously
-    const queryDefinition = getQueryDefinition(options.query);
-
     // assign variable default values if supplied
-    if (
-      queryDefinition.variableDefinitions &&
-      queryDefinition.variableDefinitions.length
-    ) {
-      const defaultValues = getDefaultValues(queryDefinition);
-
-      options.variables = assign({}, defaultValues, options.variables);
-    }
+    options.variables = this.getVariables(options.query, options.variables);
 
     if (typeof options.notifyOnNetworkStatusChange === 'undefined') {
       options.notifyOnNetworkStatusChange = false;
@@ -921,16 +961,12 @@ export class QueryManager<TStore> {
     fetchPolicy,
     variables,
   }: SubscriptionOptions): Observable<FetchResult<T>> {
-    let transformedDoc = this.dataStore.getCache().transformDocument(query);
-
-    variables = {
-      ...getDefaultValues(getOperationDefinition(transformedDoc)),
-      ...variables,
-    };
+    query = this.transform(query).document;
+    variables = this.getVariables(query, variables);
 
     const makeObservable = (variables: OperationVariables) =>
       this.getObservableFromLink<T>(
-        transformedDoc,
+        query,
         {},
         variables,
         false,
@@ -938,7 +974,7 @@ export class QueryManager<TStore> {
         if (!fetchPolicy || fetchPolicy !== 'no-cache') {
           this.dataStore.markSubscriptionResult(
             result,
-            transformedDoc,
+            query,
             variables,
           );
           this.broadcastQueries();
@@ -953,9 +989,9 @@ export class QueryManager<TStore> {
         return result;
       });
 
-    if (hasClientExports(transformedDoc)) {
+    if (this.transform(query).hasClientExports) {
       const observablePromise = this.localState.addExportedVariables(
-        transformedDoc,
+        query,
         variables,
       ).then(makeObservable);
 
@@ -1092,13 +1128,20 @@ export class QueryManager<TStore> {
   ): Observable<FetchResult<T>> {
     let observable: Observable<FetchResult<T>>;
 
-    const serverQuery = this.localState.serverQuery(query);
+    const { serverQuery } = this.transform(query);
     if (serverQuery) {
       const { inFlightLinkObservables, link } = this;
-      const operation = this.buildOperationForLink(serverQuery, variables, {
-        ...context,
-        forceFetch: !deduplication,
-      });
+
+      const operation = {
+        query: serverQuery,
+        variables,
+        operationName: getOperationName(serverQuery) || void 0,
+        context: this.prepareContext({
+          ...context,
+          forceFetch: !deduplication
+        }),
+      };
+
       context = operation.context;
 
       if (deduplication) {
@@ -1137,7 +1180,7 @@ export class QueryManager<TStore> {
       context = this.prepareContext(context);
     }
 
-    const clientQuery = this.localState.clientQuery(query);
+    const { clientQuery } = this.transform(query);
     if (clientQuery) {
       observable = asyncMap(observable, result => {
         return this.localState.runResolvers({
@@ -1304,19 +1347,6 @@ export class QueryManager<TStore> {
     if (fetchMoreForQueryId) {
       this.setQuery(fetchMoreForQueryId, () => ({ invalidated }));
     }
-  }
-
-  private buildOperationForLink(
-    document: DocumentNode,
-    variables: any,
-    extraContext?: any,
-  ) {
-    return {
-      query: this.dataStore.getCache().transformForLink(document),
-      variables,
-      operationName: getOperationName(document) || undefined,
-      context: this.prepareContext(extraContext),
-    };
   }
 
   private prepareContext(context = {}) {

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -9,6 +9,7 @@ import {
   graphQLResultHasError,
   hasClientExports,
   removeConnectionDirectiveFromDocument,
+  canUseWeakMap,
 } from 'apollo-utilities';
 
 import { invariant, InvariantError } from 'ts-invariant';
@@ -682,13 +683,16 @@ export class QueryManager<TStore> {
     };
   }
 
-  private transformCache = new WeakMap<DocumentNode, Readonly<{
-    document: Readonly<DocumentNode>;
-    hasClientExports: boolean;
-    clientQuery: Readonly<DocumentNode> | null;
-    serverQuery: Readonly<DocumentNode> | null;
-    defaultVars: Readonly<OperationVariables>;
-  }>>();
+  private transformCache = new (canUseWeakMap ? WeakMap : Map)<
+    DocumentNode,
+    Readonly<{
+      document: Readonly<DocumentNode>;
+      hasClientExports: boolean;
+      clientQuery: Readonly<DocumentNode> | null;
+      serverQuery: Readonly<DocumentNode> | null;
+      defaultVars: Readonly<OperationVariables>;
+    }>
+  >();
 
   private transform(document: DocumentNode) {
     const { transformCache } = this;

--- a/packages/apollo-utilities/src/index.ts
+++ b/packages/apollo-utilities/src/index.ts
@@ -4,6 +4,7 @@ export * from './getFromAST';
 export * from './transform';
 export * from './storeUtils';
 export * from './util/assign';
+export * from './util/canUse';
 export * from './util/cloneDeep';
 export * from './util/environment';
 export * from './util/errorHandling';

--- a/packages/apollo-utilities/src/util/canUse.ts
+++ b/packages/apollo-utilities/src/util/canUse.ts
@@ -1,0 +1,4 @@
+export const canUseWeakMap = typeof WeakMap === 'function' && !(
+  typeof navigator === 'object' &&
+  navigator.product === 'ReactNative'
+);


### PR DESCRIPTION
Much of this work was previously duplicated for every request, which was not only wasteful for obvious reasons, but also limited the benefits of caching based on `DocumentNode` references, since repeatedly transforming the same document changes its referential identity, making it hard to tell whether a given document has been encountered before.