### PR TITLE
Remove github CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @benjamn @hwillson


### PR DESCRIPTION
Github `CODEOWNERS` functionality sounds great in theory, but the extra noise generated by constantly being assigned for review on PR's is not necessary (we know PR's need to be looked at). We also can't expect community members to always submit `Draft` PR's when their changes are WIP, to help avoid code owner review assignment. Maybe we'll re-enable this in the future, but for now we're dropping it.