### PR TITLE
Accommodate `@client @export` variable changes in `ObservableQuery`

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     {
       "name": "apollo-client",
       "path": "./packages/apollo-client/lib/bundle.cjs.min.js",
-      "maxSize": "9.9 kB"
+      "maxSize": "9.95 kB"
     },
     {
       "name": "apollo-utilities",

--- a/packages/apollo-client/src/__tests__/fetchMore.ts
+++ b/packages/apollo-client/src/__tests__/fetchMore.ts
@@ -56,9 +56,8 @@ describe('updateQuery on a simple query', () => {
           res.entry.value = 2;
           return res;
         });
-
-        expect(latestResult.data.entry.value).toBe(2);
       })
+      .then(() => expect(latestResult.data.entry.value).toBe(2))
       .then(() => sub.unsubscribe());
   });
 });
@@ -123,9 +122,8 @@ describe('updateQuery on a query with required and optional variables', () => {
           res.entry.value = 2;
           return res;
         });
-
-        expect(latestResult.data.entry.value).toBe(2);
       })
+      .then(() => expect(latestResult.data.entry.value).toBe(2))
       .then(() => sub.unsubscribe());
   });
 });

--- a/packages/apollo-client/src/core/ObservableQuery.ts
+++ b/packages/apollo-client/src/core/ObservableQuery.ts
@@ -244,9 +244,7 @@ export class ObservableQuery<
 
     if (!partial) {
       this.lastResult = { ...result, stale: false };
-      this.lastResultSnapshot = this.queryManager.assumeImmutableResults
-        ? this.lastResult
-        : cloneDeep(this.lastResult);
+      this.updateLastResultSnapshot();
     }
 
     return { ...result, partial };
@@ -538,6 +536,12 @@ export class ObservableQuery<
     this.queryManager.startPollingQuery(this.options, this.queryId);
   }
 
+  private updateLastResultSnapshot() {
+    this.lastResultSnapshot = this.queryManager.assumeImmutableResults
+      ? this.lastResult
+      : cloneDeep(this.lastResult);
+  }
+
   private onSubscribe(observer: Observer<ApolloQueryResult<TData>>) {
     const first = !this.observers.size;
     this.observers.add(observer);
@@ -601,9 +605,7 @@ export class ObservableQuery<
         const lastResult = this.lastResult;
 
         this.lastResult = result;
-        this.lastResultSnapshot = this.queryManager.assumeImmutableResults
-          ? result
-          : cloneDeep(result);
+        this.updateLastResultSnapshot();
 
         // Before calling `next` on each observer, we need to first see if
         // the query is using `@client @export` directives, and update

--- a/packages/apollo-client/src/core/ObservableQuery.ts
+++ b/packages/apollo-client/src/core/ObservableQuery.ts
@@ -538,8 +538,8 @@ export class ObservableQuery<
     const previousResult = this.lastResult;
     this.lastResult = newResult;
     this.lastResultSnapshot = this.queryManager.assumeImmutableResults
-      ? this.lastResult
-      : cloneDeep(this.lastResult);
+      ? newResult
+      : cloneDeep(newResult);
     return previousResult;
   }
 

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -713,7 +713,7 @@ export class QueryManager<TStore> {
     }>
   >();
 
-  private transform(document: DocumentNode) {
+  public transform(document: DocumentNode) {
     const { transformCache } = this;
 
     if (!transformCache.has(document)) {


### PR DESCRIPTION
When using `client.watchQuery` to setup an `Observable` against a query that's using `@client @export` directives, cache changes could happen that lead to the value of the `@client @export` variable changing. When this happens, if the watched query is using a mixture of local and remote data, the watched query itself might become invalid, since the `@client @export` variable used to fetch the original data has now changed. 

To address this, this PR updates the `ObservableQuery` observers such that they first check to see if `@client @export` directives are being used, and update any associated variables. `ObservableQuery` will then perform a `refetch` using the new variables if needed, otherwise it will let the observers continue with their normal behaviour. 

It's important to note that these changes introduce Promises into `ObservableQuery` subscription handling, which can impact the timing of `ObservableQuery` subscriber object calls and/or callbacks. I haven't yet determined how much of an impact this could have in practice, but these changes did impact one existing test suite. I've modified the tests to accommodate these changes (as I believe that test did not represent a real usage scenario), but I think we'll need to consider the impact of these changes carefully before merging.

Fixes https://github.com/apollographql/apollo-client/issues/4530.
