### PR TITLE
Fix for 4417 apollo-cache-inmemory's fixPolyfills declares block-scoped variables that can cause duplicate types

### DIFF
--- a/packages/apollo-cache-inmemory/src/fixPolyfills.ts
+++ b/packages/apollo-cache-inmemory/src/fixPolyfills.ts
@@ -49,3 +49,5 @@ try {
   Object.seal = wrap(Object.seal);
   Object.preventExtensions = wrap(Object.preventExtensions);
 }
+
+export {}


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)

This is fix for issue https://github.com/apollographql/apollo-client/issues/4417
This solution is inspired from this thread https://stackoverflow.com/a/41975448/6836965

- [x] Make sure all of the significant new logic is covered by tests
