### PR TITLE
feat(apollo-client): Adds type vars to subscribeToMore for variables

### DIFF
--- a/packages/apollo-client/src/core/watchQueryOptions.ts
+++ b/packages/apollo-client/src/core/watchQueryOptions.ts
@@ -113,24 +113,24 @@ export interface FetchMoreQueryOptions<TVariables, K extends keyof TVariables> {
 
 export type UpdateQueryFn<
   TData = any,
-  TVariables = OperationVariables,
+  TSubscriptionVariables = OperationVariables,
   TSubscriptionData = TData
 > = (
   previousQueryResult: TData,
   options: {
     subscriptionData: { data: TSubscriptionData };
-    variables?: TVariables;
+    variables?: TSubscriptionVariables;
   },
 ) => TData;
 
 export type SubscribeToMoreOptions<
   TData = any,
-  TVariables = OperationVariables,
+  TSubscriptionVariables = OperationVariables,
   TSubscriptionData = TData
 > = {
   document: DocumentNode;
-  variables?: TVariables;
-  updateQuery?: UpdateQueryFn<TData, TVariables, TSubscriptionData>;
+  variables?: TSubscriptionVariables;
+  updateQuery?: UpdateQueryFn<TData, TSubscriptionVariables, TSubscriptionData>;
   onError?: (error: Error) => void;
 };
 


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests

Addresses #4246.

I was having some issues installing all needed dependencies, but this is just a type change and TSC doesn't show any errors for me.