### PR TITLE
Fix apollo-boost uri type

### DIFF
--- a/packages/apollo-boost/src/index.ts
+++ b/packages/apollo-boost/src/index.ts
@@ -4,7 +4,7 @@ export * from 'apollo-link';
 export * from 'apollo-cache-inmemory';
 
 import { Operation, ApolloLink, Observable } from 'apollo-link';
-import { HttpLink } from 'apollo-link-http';
+import { HttpLink, UriFunction } from 'apollo-link-http';
 import { onError, ErrorLink } from 'apollo-link-error';
 import { ApolloCache } from 'apollo-cache';
 import { InMemoryCache, CacheResolverMap } from 'apollo-cache-inmemory';
@@ -28,7 +28,7 @@ type ClientStateConfig = {
 
 export interface PresetConfig {
   request?: (operation: Operation) => Promise<void>;
-  uri?: string;
+  uri?: string | UriFunction;
   credentials?: string;
   headers?: any;
   fetch?: GlobalFetch['fetch'];


### PR DESCRIPTION
This fixes the apollo-boost `PresetConfig` type definition to accept `UriFunction` for the uri.

Here's the definition in apollo-http-link-common:
https://github.com/apollographql/apollo-link/blob/06701f3b6ea6bb4abbc1520821ccd585cbff07a1/packages/apollo-link-http-common/src/index.ts#L62

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
