### PR TITLE
Fix IntrospectionFragmentMatcher handling of fragment on root query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@
 - Support `new InMemoryCache({ freezeResults: true })` to help enforce immutability. <br/>
   [@benjamn](https://github.com/benjamn) in [#4514](https://github.com/apollographql/apollo-client/pull/4514)
 
+- Allow `IntrospectionFragmentMatcher` to match fragments against the root `Query`, as `HeuristicFragmentMatcher` does. <br/>
+  [@rynobax](https://github.com/rynobax) in [#4620](https://github.com/apollographql/apollo-client/pull/4620)
+
 ## Apollo Client 2.5.1
 
 ### apollo-client 2.5.1

--- a/packages/apollo-cache-inmemory/src/fragmentMatcher.ts
+++ b/packages/apollo-cache-inmemory/src/fragmentMatcher.ts
@@ -124,6 +124,10 @@ export class IntrospectionFragmentMatcher implements FragmentMatcherInterface {
 
     const obj = context.store.get(idValue.id);
 
+    if (!obj && idValue.id === 'ROOT_QUERY') {
+      return true;
+    }
+
     if (!obj) {
       return false;
     }

--- a/packages/apollo-cache-inmemory/src/fragmentMatcher.ts
+++ b/packages/apollo-cache-inmemory/src/fragmentMatcher.ts
@@ -42,12 +42,9 @@ export class HeuristicFragmentMatcher implements FragmentMatcherInterface {
   ): boolean | 'heuristic' {
     const obj = context.store.get(idValue.id);
 
-    if (!obj && idValue.id === 'ROOT_QUERY') {
-      return true;
-    }
-
     if (!obj) {
-      return false;
+      // https://github.com/apollographql/apollo-client/pull/3507
+      return idValue.id === 'ROOT_QUERY';
     }
 
     if (!obj.__typename) {
@@ -124,12 +121,9 @@ export class IntrospectionFragmentMatcher implements FragmentMatcherInterface {
 
     const obj = context.store.get(idValue.id);
 
-    if (!obj && idValue.id === 'ROOT_QUERY') {
-      return true;
-    }
-
     if (!obj) {
-      return false;
+      // https://github.com/apollographql/apollo-client/pull/4620
+      return idValue.id === 'ROOT_QUERY';
     }
 
     invariant(

--- a/packages/apollo-client/src/__tests__/client.ts
+++ b/packages/apollo-client/src/__tests__/client.ts
@@ -277,6 +277,78 @@ describe('client', () => {
   });
 
   it('should allow fragments on root query', () => {
+    const query = gql`
+      query {
+        ...QueryFragment
+      }
+
+      fragment QueryFragment on Query {
+        records {
+          id
+          name
+          __typename
+        }
+        __typename
+      }
+    `;
+
+    const data = {
+      records: [
+        { id: 1, name: 'One', __typename: 'Record' },
+        { id: 2, name: 'Two', __typename: 'Record' },
+      ],
+      __typename: 'Query',
+    };
+
+    return clientRoundtrip(query, { data }, null);
+  });
+
+  it('should allow fragments on root query with ifm', () => {
+    const query = gql`
+      query {
+        ...QueryFragment
+      }
+
+      fragment QueryFragment on Query {
+        records {
+          id
+          name
+          __typename
+        }
+        __typename
+      }
+    `;
+
+    const data = {
+      records: [
+        { id: 1, name: 'One', __typename: 'Record' },
+        { id: 2, name: 'Two', __typename: 'Record' },
+      ],
+      __typename: 'Query',
+    };
+
+    const ifm = new IntrospectionFragmentMatcher({
+      introspectionQueryResultData: {
+        __schema: {
+          types: [
+            {
+              kind: 'UNION',
+              name: 'Query',
+              possibleTypes: [
+                {
+                  name: 'Record',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+
+    return clientRoundtrip(query, { data }, null, ifm);
+  });
+
+  it('should merge fragments on root query', () => {
     // The fragment should be used after the selected fields for the query.
     // Otherwise, the results aren't merged.
     // see: https://github.com/apollographql/apollo-client/issues/1479


### PR DESCRIPTION
I came across a bug where IntrospectionFragmentMatcher will break when using a fragment on the root query ([example here](https://codesandbox.io/s/jz8jwjk933)).  #3402 suggested applying #3484's fix for the heuristic matcher to the fragment matcher.  It seems to have worked.