### PR TITLE
Add useGETForQueries option to apollo-boost client

### DIFF
--- a/packages/apollo-boost/src/index.ts
+++ b/packages/apollo-boost/src/index.ts
@@ -33,6 +33,7 @@ export interface PresetConfig {
   headers?: any;
   fetch?: GlobalFetch['fetch'];
   fetchOptions?: HttpLink.Options;
+  useGETForQueries?: boolean;
   clientState?: ClientStateConfig;
   onError?: ErrorLink.ErrorHandler;
   cacheRedirects?: CacheResolverMap;
@@ -61,6 +62,7 @@ const PRESET_CONFIG_KEYS = [
   'headers',
   'fetch',
   'fetchOptions',
+  'useGETForQueries',
   'clientState',
   'onError',
   'cacheRedirects',
@@ -94,6 +96,7 @@ export default class DefaultClient<TCache> extends ApolloClient<TCache> {
       headers,
       fetch,
       fetchOptions,
+      useGETForQueries,
       clientState,
       cacheRedirects,
       onError: errorCallback,
@@ -165,6 +168,7 @@ export default class DefaultClient<TCache> extends ApolloClient<TCache> {
       uri: uri || '/graphql',
       fetch,
       fetchOptions: fetchOptions || {},
+      useGETForQueries,
       credentials: credentials || 'same-origin',
       headers: headers || {},
     });


### PR DESCRIPTION
This PR just allows passing through the useGETForQueries option added by this PR:

https://github.com/apollographql/apollo-link/pull/510

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
