### PR TITLE
Feature/garbage collect cache

### DIFF
--- a/packages/apollo-cache-inmemory/src/inMemoryCache.ts
+++ b/packages/apollo-cache-inmemory/src/inMemoryCache.ts
@@ -230,10 +230,10 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
 
   public evict(evictee: Cache.EvictOptions): Cache.EvictionResult {
     let keys = this.diff({
-        query: evictee.query,
-        variables: evictee.variables,
-        optimistic: false,
-      }).involvedFields;
+      query: evictee.query,
+      variables: evictee.variables,
+      optimistic: false,
+    }).involvedFields;
     const unique = new Set(keys);
     //Don't delete the root
     unique.delete('ROOT_QUERY');
@@ -265,8 +265,8 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     const cacheObject = this.data.toObject();
     const cacheKeys = Object.keys(cacheObject);
 
-    for(let k of cacheKeys) {
-      if( !unique.has(k) ) {
+    for (let k of cacheKeys) {
+      if (!unique.has(k)) {
         this.data.delete(k);
       }
     }
@@ -380,13 +380,13 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     //See if the array is invalid
     //Note: Types don't permit nested arrays
     function checkArray(ary: any[]): boolean {
-      for(let v of ary) {
-        if( Array.isArray(v) ) {
-          if( checkArray(v) ) {
+      for (let v of ary) {
+        if (Array.isArray(v)) {
+          if (checkArray(v)) {
             return true;
           }
-        } else if( isIdValue(v) ) {
-          if( !cacheKeys.includes(v.id) ) {
+        } else if (isIdValue(v)) {
+          if (!cacheKeys.includes(v.id)) {
             return true;
           }
         } else {
@@ -400,28 +400,26 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
       const item = this.data.get(k);
       let newItem = null;
 
-      for(let field in item) {
+      for (let field in item) {
         const value = item[field];
 
-        if( Array.isArray(value) ) {
+        if (Array.isArray(value)) {
           const invalid = checkArray(value);
-          if( invalid ) {
-            if( !newItem ) newItem = {...item};
+          if (invalid) {
+            if (!newItem) newItem = { ...item };
             delete newItem[field];
-            console.log('deleted ' + field)
           }
-        } else if( isIdValue(value) ) {
-          if( !cacheKeys.includes(value.id) ) {
-            if( !newItem ) newItem = {...item};
+        } else if (isIdValue(value)) {
+          if (!cacheKeys.includes(value.id)) {
+            if (!newItem) newItem = { ...item };
             delete newItem[field];
-            console.log('deleted ' + field)
           }
         } else {
           //Nothing to do
         }
       }
 
-      if(newItem) {
+      if (newItem) {
         this.data.set(k, newItem);
       }
     });

--- a/packages/apollo-cache/src/types/DataProxy.ts
+++ b/packages/apollo-cache/src/types/DataProxy.ts
@@ -72,6 +72,7 @@ export namespace DataProxy {
 
   export type DiffResult<T> = {
     result?: T;
+    involvedFields?: string[];
     complete?: boolean;
   };
 }


### PR DESCRIPTION
This is an attempt at implementing a garbage collection capability to the inmemory cache.

A request for GC: #3965
Discussion about an eviction mechanism: https://github.com/apollographql/apollo-feature-requests/issues/4

This PR includes both a `gc()` method that removes entries not being watched as well as an attempt at `evict(...)`. I suspect evict will need more work as I haven't really tested it. I also suspect much critique could be made about code style. Though I did this effectively in a "spike" so I wanted to get what I can out here so others can guide making this a mergeable product.

Personally, I am most interested in the gc() method as it would resolve my immediate needs for relieving memory pressure. My initial experiments were very promising and I was able to run it in an interval timer without ill effect.