### PR TITLE
Remove --prefix-paths from development

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "start": "gatsby develop --prefix-paths",
+    "start": "gatsby develop",
     "types": "cd ../packages/apollo-client && typedoc --json ../../docs/docs.json --ignoreCompilerErrors ./src/index.ts"
   },
   "dependencies": {


### PR DESCRIPTION
This branch removes the `--prefix-paths` option from `gatsby develop` called by our NPM start script in the docs.