### PR TITLE
Call clearStore callbacks after clearing store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@
 - Remove temporary `queryId` after `fetchMore` completes. <br/>
   [@doomsower](https://github.com/doomsower) in [#4440](https://github.com/apollographql/apollo-client/pull/4440)
 
+- Call `clearStore` callbacks after clearing store. <br/>
+  [@ds8k](https://github.com/ds8k) in [#4695](https://github.com/apollographql/apollo-client/pull/4695)
+
 ### Apollo Cache In-Memory
 
 - Support `new InMemoryCache({ freezeResults: true })` to help enforce immutability. <br/>

--- a/packages/apollo-client/src/ApolloClient.ts
+++ b/packages/apollo-client/src/ApolloClient.ts
@@ -273,9 +273,7 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
    * to dispose of this `ApolloClient` instance.
    */
   public stop() {
-    if (this.queryManager) {
-      this.queryManager.stop();
-    }
+    this.queryManager.stop();
   }
 
   /**
@@ -505,29 +503,18 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
    */
   public resetStore(): Promise<ApolloQueryResult<any>[] | null> {
     return Promise.resolve()
-      .then(() => {
-        return this.queryManager
-          ? this.queryManager.clearStore()
-          : Promise.resolve(null);
-      })
+      .then(() => this.queryManager.clearStore())
       .then(() => Promise.all(this.resetStoreCallbacks.map(fn => fn())))
-      .then(() => {
-        return this.queryManager && this.queryManager.reFetchObservableQueries
-          ? this.queryManager.reFetchObservableQueries()
-          : Promise.resolve(null);
-      });
+      .then(() => this.queryManager.reFetchObservableQueries());
   }
 
   /**
    * Remove all data from the store. Unlike `resetStore`, `clearStore` will
    * not refetch any active queries.
    */
-  public clearStore(): Promise<any | null> {
-    const { queryManager } = this;
+  public clearStore(): Promise<any[]> {
     return Promise.resolve()
-      .then(() =>
-        queryManager ? queryManager.clearStore() : Promise.resolve(null),
-      )
+      .then(() => this.queryManager.clearStore())
       .then(() => Promise.all(this.clearStoreCallbacks.map(fn => fn())));
   }
 
@@ -570,9 +557,7 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
   public reFetchObservableQueries(
     includeStandby?: boolean,
   ): Promise<ApolloQueryResult<any>[]> | Promise<null> {
-    return this.queryManager
-      ? this.queryManager.reFetchObservableQueries(includeStandby)
-      : Promise.resolve(null);
+    return this.queryManager.reFetchObservableQueries(includeStandby);
   }
 
   /**

--- a/packages/apollo-client/src/ApolloClient.ts
+++ b/packages/apollo-client/src/ApolloClient.ts
@@ -522,14 +522,13 @@ export default class ApolloClient<TCacheShape> implements DataProxy {
    * Remove all data from the store. Unlike `resetStore`, `clearStore` will
    * not refetch any active queries.
    */
-  public clearStore(): Promise<void | null> {
+  public clearStore(): Promise<any | null> {
     const { queryManager } = this;
     return Promise.resolve()
-      .then(() => Promise.all(this.clearStoreCallbacks.map(fn => fn())))
-      .then(
-        () =>
-          queryManager ? queryManager.clearStore() : Promise.resolve(null),
-      );
+      .then(() =>
+        queryManager ? queryManager.clearStore() : Promise.resolve(null),
+      )
+      .then(() => Promise.all(this.clearStoreCallbacks.map(fn => fn())));
   }
 
   /**

--- a/packages/apollo-client/src/__tests__/client.ts
+++ b/packages/apollo-client/src/__tests__/client.ts
@@ -2296,6 +2296,7 @@ describe('client', () => {
       cache: new InMemoryCache(),
     });
     client.queryManager = {
+      reFetchObservableQueries() {},
       clearStore: () => {
         done();
       },


### PR DESCRIPTION
This makes `clearStore` work similarly to how `resetStore` works, which is to say the cache is first cleared and then callbacks are run. This resolves issue #4694