### PR TITLE
Support returnPartialData for watched queries again.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@
 - Accommodate `@client @export` variable changes in `ObservableQuery`. <br/>
   [@hwillson](https://github.com/hwillson) in [#4604](https://github.com/apollographql/apollo-client/pull/4604)
 
+- Support the `returnPartialData` option for watched queries again. <br/>
+  [@benjamn](https://github.com/benjamn) in [#4743](https://github.com/apollographql/apollo-client/pull/4743)
+
 ### Apollo Cache In-Memory
 
 - Support `new InMemoryCache({ freezeResults: true })` to help enforce immutability. <br/>

--- a/packages/apollo-client/src/core/LocalState.ts
+++ b/packages/apollo-client/src/core/LocalState.ts
@@ -250,10 +250,6 @@ export class LocalState<TCacheShape> {
     return forceResolvers;
   }
 
-  public shouldForceResolver(field: FieldNode) {
-    return this.shouldForceResolvers(field);
-  }
-
   // Query the cache and return matching data.
   private buildRootValueFromCache(
     document: DocumentNode,
@@ -384,7 +380,7 @@ export class LocalState<TCacheShape> {
     // `@client(always: true)`), then we'll skip running non-forced resolvers.
     if (
       !execContext.onlyRunForcedResolvers ||
-      this.shouldForceResolver(field)
+      this.shouldForceResolvers(field)
     ) {
       const resolverType =
         rootValue.__typename || execContext.defaultOperationType;

--- a/packages/apollo-client/src/core/LocalState.ts
+++ b/packages/apollo-client/src/core/LocalState.ts
@@ -262,6 +262,7 @@ export class LocalState<TCacheShape> {
     return this.cache.diff({
       query: buildQueryFromSelectionSet(document),
       variables,
+      returnPartialData: true,
       optimistic: false,
     }).result;
   }

--- a/packages/apollo-client/src/core/__tests__/ObservableQuery.ts
+++ b/packages/apollo-client/src/core/__tests__/ObservableQuery.ts
@@ -698,14 +698,14 @@ describe('ObservableQuery', () => {
         },
       );
 
-      subscribeAndCount(done, observable, (handleCount, result) => {
+      subscribeAndCount(done, observable, async (handleCount, result) => {
         if (handleCount === 1) {
           expect(stripSymbols(result.data)).toEqual(dataOne);
           expect(stripSymbols(observable.getCurrentResult().data)).toEqual(
             dataOne,
           );
-          observable.setVariables(differentVariables);
-          expect(observable.getCurrentResult().data).toEqual(undefined);
+          await observable.setVariables(differentVariables);
+          expect(observable.getCurrentResult().data).toEqual({});
           expect(observable.getCurrentResult().loading).toBe(true);
         }
         // after loading is false and data has returned
@@ -772,7 +772,7 @@ describe('ObservableQuery', () => {
             dataOne,
           );
           await observable.setVariables(differentVariables);
-          expect(observable.getCurrentResult().data).toEqual(undefined);
+          expect(observable.getCurrentResult().data).toEqual({});
           expect(observable.getCurrentResult().loading).toBe(true);
         }
         // after loading is false and data has returned
@@ -1354,6 +1354,7 @@ describe('ObservableQuery', () => {
         networkStatus: 1,
         partial: true,
       });
+
       setTimeout(
         wrap(done, () => {
           expect(observable.getCurrentResult()).toEqual({

--- a/packages/apollo-client/src/core/watchQueryOptions.ts
+++ b/packages/apollo-client/src/core/watchQueryOptions.ts
@@ -97,6 +97,12 @@ export interface ModifiableWatchQueryOptions<TVariables = OperationVariables>
    * Whether or not updates to the network status should trigger next on the observer of this query
    */
   notifyOnNetworkStatusChange?: boolean;
+
+  /**
+   * Allow returning incomplete data from the cache when a larger query cannot
+   * be fully satisfied by the cache, instead of returning nothing.
+   */
+  returnPartialData?: boolean;
 }
 
 /**

--- a/packages/apollo-client/src/data/mutations.ts
+++ b/packages/apollo-client/src/data/mutations.ts
@@ -26,24 +26,18 @@ export class MutationStore {
 
   public markMutationError(mutationId: string, error: Error) {
     const mutation = this.store[mutationId];
-
-    if (!mutation) {
-      return;
+    if (mutation) {
+      mutation.loading = false;
+      mutation.error = error;
     }
-
-    mutation.loading = false;
-    mutation.error = error;
   }
 
   public markMutationResult(mutationId: string) {
     const mutation = this.store[mutationId];
-
-    if (!mutation) {
-      return;
+    if (mutation) {
+      mutation.loading = false;
+      mutation.error = null;
     }
-
-    mutation.loading = false;
-    mutation.error = null;
   }
 
   public reset() {


### PR DESCRIPTION
PR #1370 inexplicably removed support for a useful feature: the ability to opt into receiving partial results from the cache for queries that are not fully satisfied by the cache, by passing the `returnPartialData: true` option to `client.watchQuery`.

This feature is especially important in conjunction with React (or any other view framework Apollo integrations that use `client.watchQuery`), since it can prevent rerendering `undefined` data just before fetching a larger query over the network.

A lot has changed since PR #1370 was merged in March 2017. The author and reviewer of that PR no longer work for Apollo, and I would like to believe that our current development culture would prevent us from ripping out such a useful feature without providing a meaningful replacement.