### PR TITLE
Preserve networkStatus for incomplete cache-and-network queries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@
 - Support the `returnPartialData` option for watched queries again. <br/>
   [@benjamn](https://github.com/benjamn) in [#4743](https://github.com/apollographql/apollo-client/pull/4743)
 
+- Preserve `networkStatus` for incomplete `cache-and-network` queries. <br/>
+  [@benjamn](https://github.com/benjamn) in [#4765](https://github.com/apollographql/apollo-client/pull/4765)
+
 ### Apollo Cache In-Memory
 
 - Support `new InMemoryCache({ freezeResults: true })` to help enforce immutability. <br/>

--- a/packages/apollo-client/src/core/__tests__/fetchPolicies.ts
+++ b/packages/apollo-client/src/core/__tests__/fetchPolicies.ts
@@ -21,6 +21,7 @@ import subscribeAndCount from '../../util/subscribeAndCount';
 import { withWarning } from '../../util/wrap';
 
 import { mockSingleLink } from '../../__mocks__/mockLinks';
+import { NetworkStatus } from '../networkStatus';
 
 const query = gql`
   query {
@@ -343,5 +344,113 @@ describe('no-cache', () => {
           expect(stripSymbols(actualResult.data)).toEqual(result);
         });
       });
+  });
+});
+
+describe('cache-and-network', function() {
+  it('gives appropriate networkStatus for refetched queries', done => {
+    const client = new ApolloClient({
+      link: ApolloLink.empty(),
+      cache: new InMemoryCache(),
+      resolvers: {
+        Query: {
+          hero(_data, args) {
+            return {
+              __typename: 'Hero',
+              ...args,
+              name: 'Luke Skywalker',
+            };
+          },
+        },
+      },
+    });
+
+    const observable = client.watchQuery({
+      query: gql`
+        query FetchLuke($id: String) {
+          hero(id: $id) @client {
+            id
+            name
+          }
+        }
+      `,
+      fetchPolicy: 'cache-and-network',
+      variables: { id: '1' },
+      notifyOnNetworkStatusChange: true,
+    });
+
+    function dataWithId(id: number | string) {
+      return {
+        hero: {
+          __typename: 'Hero',
+          id: String(id),
+          name: 'Luke Skywalker',
+        },
+      };
+    }
+
+    subscribeAndCount(done, observable, (count, result) => {
+      if (count === 1) {
+        expect(result).toEqual({
+          data: void 0,
+          loading: true,
+          networkStatus: NetworkStatus.loading,
+          stale: true,
+        });
+      } else if (count === 2) {
+        expect(result).toEqual({
+          data: dataWithId(1),
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          stale: false,
+        });
+        return observable.setVariables({ id: '2' });
+      } else if (count === 3) {
+        expect(result).toEqual({
+          data: dataWithId(1),
+          loading: true,
+          networkStatus: NetworkStatus.setVariables,
+          stale: false,
+        });
+      } else if (count === 4) {
+        expect(result).toEqual({
+          data: dataWithId(2),
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          stale: false,
+        });
+        return observable.refetch();
+      } else if (count === 5) {
+        expect(result).toEqual({
+          data: dataWithId(2),
+          loading: true,
+          networkStatus: NetworkStatus.refetch,
+          stale: false,
+        });
+      } else if (count === 6) {
+        expect(result).toEqual({
+          data: dataWithId(2),
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          stale: false,
+        });
+        return observable.refetch({ id: '3' });
+      } else if (count === 7) {
+        expect(result).toEqual({
+          data: dataWithId(2),
+          loading: true,
+          networkStatus: NetworkStatus.setVariables,
+          stale: false,
+        });
+      } else if (count === 8) {
+        expect(result).toEqual({
+          data: dataWithId(3),
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          stale: false,
+        });
+        done();
+      }
+    });
   });
 });

--- a/packages/apollo-client/src/data/queries.ts
+++ b/packages/apollo-client/src/data/queries.ts
@@ -151,13 +151,14 @@ export class QueryStore {
   }
 
   public markQueryResultClient(queryId: string, complete: boolean) {
-    if (!this.store || !this.store[queryId]) return;
-
-    this.store[queryId].networkError = null;
-    this.store[queryId].previousVariables = null;
-    this.store[queryId].networkStatus = complete
-      ? NetworkStatus.ready
-      : NetworkStatus.loading;
+    const storeValue = this.store && this.store[queryId];
+    if (storeValue) {
+      this.store[queryId].networkError = null;
+      this.store[queryId].previousVariables = null;
+      if (complete) {
+        this.store[queryId].networkStatus = NetworkStatus.ready;
+      }
+    }
   }
 
   public stopQuery(queryId: string) {

--- a/packages/apollo-client/src/data/queries.ts
+++ b/packages/apollo-client/src/data/queries.ts
@@ -153,10 +153,10 @@ export class QueryStore {
   public markQueryResultClient(queryId: string, complete: boolean) {
     const storeValue = this.store && this.store[queryId];
     if (storeValue) {
-      this.store[queryId].networkError = null;
-      this.store[queryId].previousVariables = null;
+      storeValue.networkError = null;
+      storeValue.previousVariables = null;
       if (complete) {
-        this.store[queryId].networkStatus = NetworkStatus.ready;
+        storeValue.networkStatus = NetworkStatus.ready;
       }
     }
   }


### PR DESCRIPTION
Blindly setting `networkStatus` to `NetworkStatus.loading` after the client part of a `cache-and-network` query was destroying useful information about the status of the request. Instead, we should set `networkStatus` to `NetworkStatus.ready` only when the request is complete, and leave `networkStatus` untouched otherwise.

Should fix #3660, #4693, and https://github.com/apollographql/react-apollo/issues/1217.