### PR TITLE
Update PresetConfig types in Apollo-Boost

### DIFF
--- a/packages/apollo-boost/src/index.ts
+++ b/packages/apollo-boost/src/index.ts
@@ -27,7 +27,7 @@ type ClientStateConfig = {
 };
 
 export interface PresetConfig {
-  request?: (operation: Operation) => Promise<void>;
+  request?: (operation: Operation) => Promise<void> | void;
   uri?: string | UriFunction;
   credentials?: string;
   headers?: any;


### PR DESCRIPTION
The `request` property for the `PresetConfig` interface can be of type `(operation: Operation) => void`, so I've updated the type to the following:
```
(operation: Operation) => Promise<void> | void;
```

I found this out because I was initializing a new `ApolloClient` as follows:

```ts
new ApolloClient<CacheType>({
    uri: ...,
    request: operation => {
        operation.setContext(...);
    },
    resolvers: ...,
    cache: ...,
})
```

Which works, but the typing complains about the `request` property not being of the type `(operation: Operation) => Promise<void>`, so I had to instead return a Promise that immediately resolves as follows:

```ts
new ApolloClient<CacheType>({
    uri: ...,
    request: operation => {
        operation.setContext(...);
		return Promise.resolve();
    },
    resolvers: ...,
    cache: ...,
})
```

### Checklist:

- [ ] ~If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)~
- [ ] ~Make sure all of the significant new logic is covered by tests~
