### PR TITLE
(feat) - ensure the local schema is backwards compatible

### DIFF
--- a/packages/apollo-cache-inmemory/src/writeToStore.ts
+++ b/packages/apollo-cache-inmemory/src/writeToStore.ts
@@ -200,6 +200,7 @@ export class StoreWriter {
             );
           }
 
+          // Should not throw for children of clients either...
           if (!isDefered && !isClient && context.fragmentMatcherFunction) {
             // XXX We'd like to throw an error, but for backwards compatibility's sake
             // we just print a warning for the time being.

--- a/packages/apollo-client/src/__tests__/local-state/general.ts
+++ b/packages/apollo-client/src/__tests__/local-state/general.ts
@@ -60,9 +60,9 @@ describe('General functionality', () => {
       expect(result.data).toEqual({ field: 'local' });
       expect(messages).toEqual([
         'Found @client directives in a query but no ApolloClient resolvers ' +
-        'were specified. This means ApolloClient local resolver handling ' +
-        'has been disabled, and @client directives will be passed through ' +
-        'to your link chain.',
+          'were specified. This means ApolloClient local resolver handling ' +
+          'has been disabled, and @client directives will be passed through ' +
+          'to your link chain.',
       ]);
     } finally {
       console.warn = warn;
@@ -789,13 +789,15 @@ describe('Combining client and server state/operations', () => {
             cool: true,
             __typename: 'Apollo',
           }),
-        }
+        },
       },
     });
 
     client.watchQuery({ query }).subscribe({
       next: ({ data }) => {
-        expect({ ...data }).toMatchObject({ apollo: { cool: true, __typename: 'Apollo' } });
+        expect({ ...data }).toMatchObject({
+          apollo: { cool: true, __typename: 'Apollo' },
+        });
         done();
       },
     });
@@ -919,21 +921,23 @@ describe('Combining client and server state/operations', () => {
     `;
 
     let watchCount = 0;
-    const link = new ApolloLink((operation: Operation): Observable<{}> => {
-      if (operation.operationName === 'SampleQuery') {
+    const link = new ApolloLink(
+      (operation: Operation): Observable<{}> => {
+        if (operation.operationName === 'SampleQuery') {
+          return Observable.of({
+            data: { user: { __typename: 'User', firstName: 'John' } },
+          });
+        }
+        if (operation.operationName === 'SampleMutation') {
+          return Observable.of({
+            data: { updateUser: { __typename: 'User', firstName: 'Harry' } },
+          });
+        }
         return Observable.of({
-          data: { user: { __typename: 'User', firstName: 'John' } },
+          errors: [new Error(`Unknown operation ${operation.operationName}`)],
         });
-      }
-      if (operation.operationName === 'SampleMutation') {
-        return Observable.of({
-          data: { updateUser: { __typename: 'User', firstName: 'Harry' } },
-        });
-      }
-      return Observable.of({
-        errors: [new Error(`Unknown operation ${operation.operationName}`)],
-      })
-    });
+      },
+    );
 
     const cache = new InMemoryCache();
     const client = new ApolloClient({

--- a/packages/apollo-client/src/__tests__/local-state/general.ts
+++ b/packages/apollo-client/src/__tests__/local-state/general.ts
@@ -770,6 +770,37 @@ describe('Combining client and server state/operations', () => {
     done();
   });
 
+  it('should handle a simple query with nullish fields', done => {
+    const query = gql`
+      query {
+        apollo @client {
+          cool
+          bug
+        }
+      }
+    `;
+    const cache = new InMemoryCache();
+
+    const client = new ApolloClient({
+      cache,
+      resolvers: {
+        Query: {
+          apollo: () => ({
+            cool: true,
+            __typename: 'Apollo',
+          }),
+        }
+      },
+    });
+
+    client.watchQuery({ query }).subscribe({
+      next: ({ data }) => {
+        expect({ ...data }).toMatchObject({ apollo: { cool: true, __typename: 'Apollo' } });
+        done();
+      },
+    });
+  });
+
   it('should handle a simple query with both server and client fields', done => {
     const query = gql`
       query GetCount {

--- a/packages/apollo-client/src/core/LocalState.ts
+++ b/packages/apollo-client/src/core/LocalState.ts
@@ -374,7 +374,7 @@ export class LocalState<TCacheShape> {
     const fieldName = field.name.value;
     const aliasedFieldName = resultKeyNameFromField(field);
     const aliasUsed = fieldName !== aliasedFieldName;
-    const defaultResult = rootValue[aliasedFieldName] || rootValue[fieldName];
+    const defaultResult = rootValue && (rootValue[aliasedFieldName] || rootValue[fieldName]);
     let resultPromise = Promise.resolve(defaultResult);
 
     // Usually all local resolvers are run when passing through here, but

--- a/packages/apollo-client/src/core/LocalState.ts
+++ b/packages/apollo-client/src/core/LocalState.ts
@@ -168,9 +168,9 @@ export class LocalState<TCacheShape> {
       }
       invariant.warn(
         'Found @client directives in a query but no ApolloClient resolvers ' +
-        'were specified. This means ApolloClient local resolver handling ' +
-        'has been disabled, and @client directives will be passed through ' +
-        'to your link chain.',
+          'were specified. This means ApolloClient local resolver handling ' +
+          'has been disabled, and @client directives will be passed through ' +
+          'to your link chain.',
       );
     }
     return null;
@@ -192,7 +192,8 @@ export class LocalState<TCacheShape> {
         if ((cache as any).config) {
           return (cache as any).config.dataIdFromObject(obj);
         } else {
-          invariant(false,
+          invariant(
+            false,
             'To use context.getCacheKey, you need to use a cache that has ' +
               'a configurable dataIdFromObject, like apollo-cache-inmemory.',
           );
@@ -374,7 +375,8 @@ export class LocalState<TCacheShape> {
     const fieldName = field.name.value;
     const aliasedFieldName = resultKeyNameFromField(field);
     const aliasUsed = fieldName !== aliasedFieldName;
-    const defaultResult = rootValue && (rootValue[aliasedFieldName] || rootValue[fieldName]);
+    const defaultResult =
+      rootValue && (rootValue[aliasedFieldName] || rootValue[fieldName]);
     let resultPromise = Promise.resolve(defaultResult);
 
     // Usually all local resolvers are run when passing through here, but
@@ -391,12 +393,14 @@ export class LocalState<TCacheShape> {
       if (resolverMap) {
         const resolve = resolverMap[aliasUsed ? fieldName : aliasedFieldName];
         if (resolve) {
-          resultPromise = Promise.resolve(resolve(
-            rootValue,
-            argumentsObjectFromField(field, variables),
-            execContext.context,
-            { field },
-          ));
+          resultPromise = Promise.resolve(
+            resolve(
+              rootValue,
+              argumentsObjectFromField(field, variables),
+              execContext.context,
+              { field },
+            ),
+          );
         }
       }
     }
@@ -461,7 +465,11 @@ export class LocalState<TCacheShape> {
 
         // This is an object, run the selection set on it.
         if (field.selectionSet) {
-          return this.resolveSelectionSet(field.selectionSet, item, execContext);
+          return this.resolveSelectionSet(
+            field.selectionSet,
+            item,
+            execContext,
+          );
         }
       }),
     );

--- a/packages/apollo-client/src/core/types.ts
+++ b/packages/apollo-client/src/core/types.ts
@@ -8,6 +8,7 @@ export type QueryListener = (
   queryStoreValue: QueryStoreValue,
   newData?: any,
   forceResolvers?: boolean,
+  isClient?: boolean
 ) => void;
 
 export type OperationVariables = { [key: string]: any };

--- a/packages/apollo-client/src/core/types.ts
+++ b/packages/apollo-client/src/core/types.ts
@@ -8,7 +8,7 @@ export type QueryListener = (
   queryStoreValue: QueryStoreValue,
   newData?: any,
   forceResolvers?: boolean,
-  isClient?: boolean
+  isClient?: boolean,
 ) => void;
 
 export type OperationVariables = { [key: string]: any };


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests

I noticed the new schema isn't backwards compatible in the case that it can't handle partial fetches, I've made a POC solution for this to hear your thoughts before continuing on this since this will require some more changes.