### PR TITLE
Export WatchQueryFetchPolicy

### DIFF
--- a/packages/apollo-client/src/index.ts
+++ b/packages/apollo-client/src/index.ts
@@ -12,6 +12,7 @@ export {
   MutationOptions,
   SubscriptionOptions,
   FetchPolicy,
+  WatchQueryFetchPolicy,
   ErrorPolicy,
   FetchMoreQueryOptions,
   SubscribeToMoreOptions,


### PR DESCRIPTION
React Apollo (and potentially other projects) will want access to `WatchQueryFetchPolicy`.
