### PR TITLE
Fix unsafe `update` example

### DIFF
--- a/docs/source/features/optimistic-ui.md
+++ b/docs/source/features/optimistic-ui.md
@@ -93,10 +93,11 @@ const CommentsPageWithMutations = ({ currentUser }) => (
             update: (proxy, { data: { submitComment } }) => {
               // Read the data from our cache for this query.
               const data = proxy.readQuery({ query: CommentAppQuery });
-              // Add our comment from the mutation to the end.
-              data.comments.push(submitComment);
-              // Write our data back to the cache.
-              proxy.writeQuery({ query: CommentAppQuery, data });
+              // Write our data back to the cache with the new comment in it
+              proxy.writeQuery({ query: CommentAppQuery, data: {
+                ...data,
+                comments: data.comments.concat([submitComment])
+              }});
             }
           })
         }

--- a/docs/source/features/optimistic-ui.md
+++ b/docs/source/features/optimistic-ui.md
@@ -96,7 +96,7 @@ const CommentsPageWithMutations = ({ currentUser }) => (
               // Write our data back to the cache with the new comment in it
               proxy.writeQuery({ query: CommentAppQuery, data: {
                 ...data,
-                comments: data.comments.concat([submitComment])
+                comments: [...data.comments, submitComment]
               }});
             }
           })


### PR DESCRIPTION
It's not generally safe to mutate the result of `readQuery` directly as in some circumstances the object you are mutating is shared with an object in the cache, so you can get some weird bugs from doing this.
