### PR TITLE
Preserve cache-and-network fetchPolicy when refetching.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@
 - Preserve `networkStatus` for incomplete `cache-and-network` queries. <br/>
   [@benjamn](https://github.com/benjamn) in [#4765](https://github.com/apollographql/apollo-client/pull/4765)
 
+- Preserve `cache-and-network` `fetchPolicy` when refetching. <br/>
+  [@benjamn](https://github.com/benjamn) in [#4840](https://github.com/apollographql/apollo-client/pull/4840)
+
 ### Apollo Cache In-Memory
 
 - Support `new InMemoryCache({ freezeResults: true })` to help enforce immutability. <br/>

--- a/packages/apollo-client/src/core/ObservableQuery.ts
+++ b/packages/apollo-client/src/core/ObservableQuery.ts
@@ -296,8 +296,9 @@ export class ObservableQuery<
       ));
     }
 
-    // Override fetchPolicy for this call only
-    // only network-only and no-cache are safe to use
+    // Unless the provided fetchPolicy always consults the network
+    // (no-cache, network-only, or cache-and-network), override it with
+    // network-only to force the refetch for this fetchQuery call.
     if (fetchPolicy !== 'no-cache' &&
         fetchPolicy !== 'cache-and-network') {
       fetchPolicy = 'network-only';

--- a/packages/apollo-client/src/core/ObservableQuery.ts
+++ b/packages/apollo-client/src/core/ObservableQuery.ts
@@ -298,7 +298,8 @@ export class ObservableQuery<
 
     // Override fetchPolicy for this call only
     // only network-only and no-cache are safe to use
-    if (fetchPolicy !== 'no-cache') {
+    if (fetchPolicy !== 'no-cache' &&
+        fetchPolicy !== 'cache-and-network') {
       fetchPolicy = 'network-only';
     }
 


### PR DESCRIPTION
Should help with the problem reported by @supercranky in [this comment](https://github.com/apollographql/apollo-client/issues/4636#issuecomment-483218323).

The apparent reasoning for preserving the `no-cache` and `network-only` fetch policies is that refetching requires a "network" fetch policy, but I believe `cache-and-network` should also count as a "network" fetch policy, since it always attempts to fetch from the network in addition to fetching from the cache. Even if that network request fails, it may be useful (e.g. for offline usage) to return partial data from the cache, which is currently not possible when refetching, given the `refetch` method's behavior of overriding non-network/cache-friendly `fetchPolicy`s.