### PR TITLE
Add cache-and-network to FetchPolicy options

### DIFF
--- a/packages/apollo-client/src/core/watchQueryOptions.ts
+++ b/packages/apollo-client/src/core/watchQueryOptions.ts
@@ -17,9 +17,10 @@ import { PureQueryOptions, OperationVariables } from './types';
  */
 export type FetchPolicy =
   | 'cache-first'
-  | 'network-only'
+  | 'cache-and-network'
   | 'cache-only'
   | 'no-cache'
+  | 'network-only'
   | 'standby';
 
 export type WatchQueryFetchPolicy = FetchPolicy | 'cache-and-network';


### PR DESCRIPTION
`cache-and-network` is a valid choice for fetchPolicy, and while it is documented, it is not part of the QueryOptions interface.
![Screen Shot 2019-05-22 at 1 31 48 PM](https://user-images.githubusercontent.com/514026/58195900-0d816300-7c97-11e9-8e41-074dce8bcfae.png)
![Screen Shot 2019-05-22 at 1 38 44 PM](https://user-images.githubusercontent.com/514026/58195902-0d816300-7c97-11e9-8ce5-5f140be884de.png)


