### PR TITLE
Fix unescaped < in React Apollo 2.1 migration guide

### DIFF
--- a/docs/source/react-apollo-migration.md
+++ b/docs/source/react-apollo-migration.md
@@ -168,7 +168,7 @@ For more information on how to use the new Query component, read the [full guide
 Much like the Query component, the Mutation and Subscription component are ways to use Apollo directly within your React tree. They simplify integrating with Apollo, and keep your React app written in React! For more information on the Mutation component, [check out the usage guide](./essentials/mutations.html) or if you are wanting to learn about the Subscription component, [read how to here](./advanced/subscriptions.html).
 
 <h2 id="context">ApolloConsumer</h2>
-With upcoming versions of React (starting in React 16.3), there is a new version of context that makes it easier than ever to use components connected to state higher in the tree. While the 2.1 doesn't require React 16.3, we are making it easier than ever to start writing in this style with the `<ApolloConsumer>` component. This is just like the `withApollo` higher order component, just in a normal React component! It takes no props and expects a child function which receives the instance of Apollo Client in your tree. For example:
+With upcoming versions of React (starting in React 16.3), there is a new version of context that makes it easier than ever to use components connected to state higher in the tree. While the 2.1 doesn't require React 16.3, we are making it easier than ever to start writing in this style with the `&lt;ApolloConsumer>` component. This is just like the `withApollo` higher order component, just in a normal React component! It takes no props and expects a child function which receives the instance of Apollo Client in your tree. For example:
 
 ```js
 const MyClient = () => (


### PR DESCRIPTION
The font also looks smaller at https://www.apollographql.com/docs/react/react-apollo-migration#context than in the preceding paragraph. Not sure why that is.