### PR TITLE
fix: should always reference the normalized `this.config` rather than raw `config`

### DIFF
--- a/packages/apollo-cache-inmemory/src/inMemoryCache.ts
+++ b/packages/apollo-cache-inmemory/src/inMemoryCache.ts
@@ -133,7 +133,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     this.storeWriter = new StoreWriter();
     this.storeReader = new StoreReader({
       cacheKeyRoot: this.cacheKeyRoot,
-      freezeResults: config.freezeResults,
+      freezeResults: this.config.freezeResults,
     });
 
     const cache = this;


### PR DESCRIPTION
The `config` argument can be `null` if a project does not have `strictNullChecks` enabled, thus triggering a `Cannot read property 'freezeResults' of null` error.

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
