### PR TITLE
feat: allow to cache to read id objects from cache

### DIFF
--- a/packages/apollo-cache-inmemory/src/__tests__/cache.ts
+++ b/packages/apollo-cache-inmemory/src/__tests__/cache.ts
@@ -1156,4 +1156,20 @@ describe('Cache', () => {
       expect(numBroadcasts).toEqual(1);
     });
   });
+
+  itWithInitialData(
+    'will read some data from the store without quuery',
+    [
+      {
+        a: 1,
+        b: 2,
+        c: 3,
+      },
+    ],
+    proxy => {
+      expect(
+        proxy.read({ rootId: 'a', query: undefined, optimistic: false }),
+      ).toEqual(1);
+    },
+  );
 });

--- a/packages/apollo-cache-inmemory/src/inMemoryCache.ts
+++ b/packages/apollo-cache-inmemory/src/inMemoryCache.ts
@@ -178,9 +178,14 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
   }
 
   public read<T>(options: Cache.ReadOptions): T | null {
-    if (typeof options.rootId === 'string' &&
-        typeof this.data.get(options.rootId) === 'undefined') {
-      return null;
+    if (typeof options.rootId === 'string') {
+      const data = this.data.get(options.rootId);
+      if (typeof data === 'undefined') {
+        return null;
+      }
+      if (!options.query) {
+        return data as any;
+      }
     }
 
     return this.storeReader.readQueryFromStore({


### PR DESCRIPTION
Implementation for #4877

I could implement that by:

1. Creating a separate method to read by specifying `rootId`

2. Reusing existing interface to return data

Implemented the second approach - this requires to use any as interface expects to return actual query results.
