### PR TITLE
Expose data for InMemoryCache

### DIFF
--- a/packages/apollo-cache-inmemory/src/inMemoryCache.ts
+++ b/packages/apollo-cache-inmemory/src/inMemoryCache.ts
@@ -80,16 +80,16 @@ export class OptimisticCacheLayer extends ObjectCache {
 }
 
 export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
-  private data: NormalizedCache;
-  private optimisticData: NormalizedCache;
+  protected data: NormalizedCache;
+  protected optimisticData: NormalizedCache;
 
-  protected config: InMemoryCacheConfig;
-  private watches = new Set<Cache.WatchOptions>();
+  private config: InMemoryCacheConfig;
+  protected watches = new Set<Cache.WatchOptions>();
   private addTypename: boolean;
-  private typenameDocumentCache = new Map<DocumentNode, DocumentNode>();
-  private storeReader: StoreReader;
-  private storeWriter: StoreWriter;
-  private cacheKeyRoot = new KeyTrie<object>(canUseWeakMap);
+  protected typenameDocumentCache = new Map<DocumentNode, DocumentNode>();
+  protected storeReader: StoreReader;
+  protected storeWriter: StoreWriter;
+  protected cacheKeyRoot = new KeyTrie<object>(canUseWeakMap);
 
   // Set this while in a transaction to prevent broadcasts...
   // don't forget to turn it back on!


### PR DESCRIPTION
## Motivation

The community is currently working on cache invalidation and deletion which is a quite a challenging issue. 

From my point of view existing cache can be extended to provide additional capabilities without using forked InMemoryCache etc. This will help to build extra cache invalidation methods. Test them in production based applications and contribute back to InMemoryCache when they are battle proven, while still using the latest and greatest version from Apollo team. 

To that InMemoryCache needs to expose certain fields to all classes that will extend it. This PR is just a suggestion. 

## What this PR does

It exposes `data` and `optimisticData` fields as protected so it will be possible to 
implement methods like `evict` etc. and experiment with InMemoryCache while still using sizable parts of the implementation.
For example:

```typescript 
class MyCustomCache extends InMemoryCache {
  public evict(query: Cache.EvictOptions): Cache.EvictionResult {
    if(this.data.get(query.rootId)){
      this.data.delete(query.rootId);
      this.broadcastWatches();
      return { success: true };
    }
    return { success:false };
  }
}
```