### PR TITLE
Implement missing evict method for InMemoryCache

### DIFF
--- a/packages/apollo-cache-inmemory/src/inMemoryCache.ts
+++ b/packages/apollo-cache-inmemory/src/inMemoryCache.ts
@@ -229,7 +229,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
   }
 
   public evict(query: Cache.EvictOptions): Cache.EvictionResult {
-    if(this.data.get(query.rootId)){
+    if(query.rootId && this.data.get(query.rootId)){
       this.data.delete(query.rootId);
       this.broadcastWatches();
       return { success: true };

--- a/packages/apollo-cache-inmemory/src/inMemoryCache.ts
+++ b/packages/apollo-cache-inmemory/src/inMemoryCache.ts
@@ -229,7 +229,12 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
   }
 
   public evict(query: Cache.EvictOptions): Cache.EvictionResult {
-    throw new InvariantError(`eviction is not implemented on InMemory Cache`);
+    if(this.data.get(query.rootId)){
+      this.data.delete(query.rootId);
+      this.broadcastWatches();
+      return { success: true };
+    }
+    return { success:false };
   }
 
   public reset(): Promise<void> {

--- a/packages/apollo-cache-inmemory/src/inMemoryCache.ts
+++ b/packages/apollo-cache-inmemory/src/inMemoryCache.ts
@@ -9,7 +9,7 @@ import { addTypenameToDocument, canUseWeakMap } from 'apollo-utilities';
 
 import { wrap } from 'optimism';
 
-import { invariant, InvariantError } from 'ts-invariant';
+import { invariant } from 'ts-invariant';
 
 import { HeuristicFragmentMatcher } from './fragmentMatcher';
 import {


### PR DESCRIPTION
## Motivation

To provide the ability to evict data from the cache by specifying rootId

## Example

```javascript
export const updateCache = (entityName) => {
  return (cache) => {
	removeObjectFromActiveQueries(cache)
	//------
    cache.evict({rootId: 'something:1', query: undefined})
    //------
  };
};

// Usage
client.mutate({
    mutation: schema.deleteTopic,
    variables: { id },
    update: updateCache('User'),
});
```


This method does not provide full cache consistency and it will be always used with the cache updates that should remove the object from active queries. For example when performing delete mutation on the server we can remove item from all the underlying queries but this data will stay as root key. Many developers often used a workaround to return the only id of the data and write that to the store. The motivation here is to provide rootLevel only eviction mechanism

## Notes

This change is essential for the community to build an extra link that will be able to invalidate some particular items from the cache at a certain period. 
Without a simple evict method there are no means now to perform deletion on the data. 

See this feature request for more context.
https://github.com/apollographql/apollo-feature-requests/issues/4