### PR TITLE
Reimplement isEqual without pulling in massive lodash.isequal.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 **Note:** This is a cumulative changelog that outlines all of the Apollo Client project child package changes that were bundled into a specific `apollo-client` release.
 
+## Apollo Client (2.6.2)
+
+### Apollo Utilities 1.3.2
+
+- Reimplement `isEqual` without pulling in massive `lodash.isequal`. <br/>
+  [@benjamn](https://github.com/benjamn) in [#4924](https://github.com/apollographql/apollo-client/pull/4924)
+
 ## Apollo Client (2.6.1)
 
 - In all Apollo Client packages, the compilation of `lib/bundle.esm.js` to `lib/bundle.cjs.js` and `lib/bundle.umd.js` now uses Babel instead of Rollup, since Babel correctly compiles some [edge cases](https://github.com/apollographql/apollo-client/issues/4843#issuecomment-495717720) that neither Rollup nor TypeScript compile correctly. <br/>

--- a/package-lock.json
+++ b/package-lock.json
@@ -3868,6 +3868,14 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@wry/equality": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.0.tgz",
+      "integrity": "sha512-TMUNoTUv1cT2u80R3yLXCDRa9kr2gfa09SbKMypqpqBd7++8GVi1tfMWwRXhWmPJXsuPGBsmvSZu2k+IS2x6XQ==",
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -4455,8 +4463,8 @@
     "apollo-utilities": {
       "version": "file:packages/apollo-utilities",
       "requires": {
+        "@wry/equality": "^0.1.0",
         "fast-json-stable-stringify": "^2.0.0",
-        "lodash.isequal": "^4.5.0",
         "ts-invariant": "^0.4.0",
         "tslib": "^1.9.3"
       },
@@ -15342,11 +15350,6 @@
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=",
       "dev": true
-    },
-    "lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
     "lodash.isinteger": {
       "version": "4.0.4",

--- a/packages/apollo-utilities/package-lock.json
+++ b/packages/apollo-utilities/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@wry/equality": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.0.tgz",
-      "integrity": "sha512-TMUNoTUv1cT2u80R3yLXCDRa9kr2gfa09SbKMypqpqBd7++8GVi1tfMWwRXhWmPJXsuPGBsmvSZu2k+IS2x6XQ==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.2.tgz",
+      "integrity": "sha512-t5xGmz9dKzMcE+2BxRmABY+Zuy1oNZDyoHTVgQmJ5Q3MTQ23Lnah2TPht+0Lwm0M19Mxh5kaD3b0Nij2PK0S2Q==",
       "requires": {
         "tslib": "^1.9.3"
       }

--- a/packages/apollo-utilities/package-lock.json
+++ b/packages/apollo-utilities/package-lock.json
@@ -1,31 +1,21 @@
 {
   "name": "apollo-utilities",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@types/lodash": {
-      "version": "4.14.133",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.133.tgz",
-      "integrity": "sha512-/3JqnvPnY58GLzG3Y7fpphOhATV1DDZ/Ak3DQufjlRK5E4u+s0CfClfNFtAGBabw+jDGtRFbOZe+Z02ZMWCBNQ=="
-    },
-    "@types/lodash.isequal": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/@types/lodash.isequal/-/lodash.isequal-4.5.5.tgz",
-      "integrity": "sha512-4IKbinG7MGP131wRfceK6W4E/Qt3qssEFLF30LnJbjYiSfHGGRU/Io8YxXrZX109ir+iDETC8hw8QsDijukUVg==",
+    "@wry/equality": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.0.tgz",
+      "integrity": "sha512-TMUNoTUv1cT2u80R3yLXCDRa9kr2gfa09SbKMypqpqBd7++8GVi1tfMWwRXhWmPJXsuPGBsmvSZu2k+IS2x6XQ==",
       "requires": {
-        "@types/lodash": "*"
+        "tslib": "^1.9.3"
       }
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
-    },
-    "lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
     "ts-invariant": {
       "version": "0.4.0",

--- a/packages/apollo-utilities/package.json
+++ b/packages/apollo-utilities/package.json
@@ -39,12 +39,9 @@
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0"
   },
   "dependencies": {
+    "@wry/equality": "^0.1.0",
     "fast-json-stable-stringify": "^2.0.0",
-    "lodash.isequal": "^4.5.0",
     "ts-invariant": "^0.4.0",
     "tslib": "^1.9.3"
-  },
-  "devDependencies": {
-    "@types/lodash.isequal": "^4.5.5"
   }
 }

--- a/packages/apollo-utilities/package.json
+++ b/packages/apollo-utilities/package.json
@@ -39,7 +39,7 @@
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0"
   },
   "dependencies": {
-    "@wry/equality": "^0.1.0",
+    "@wry/equality": "^0.1.2",
     "fast-json-stable-stringify": "^2.0.0",
     "ts-invariant": "^0.4.0",
     "tslib": "^1.9.3"

--- a/packages/apollo-utilities/rollup.config.js
+++ b/packages/apollo-utilities/rollup.config.js
@@ -4,5 +4,6 @@ export default rollup({
   name: 'apollo-utilities',
   extraGlobals: {
     'fast-json-stable-stringify': 'stringify',
+    '@wry/equality': 'wryEquality',
   },
 });

--- a/packages/apollo-utilities/src/util/isEqual.ts
+++ b/packages/apollo-utilities/src/util/isEqual.ts
@@ -1,8 +1,1 @@
-import isEqualLodash from 'lodash.isequal';
-
-/**
- * Performs a deep equality check on two JavaScript values.
- */
-export function isEqual(a: any, b: any): boolean {
-  return isEqualLodash(a, b);
-}
+export { equal as isEqual } from '@wry/equality';


### PR DESCRIPTION
Follow-up to #4915. I have kept the tests from that PR, just not the `lodash`-based implementation of `isEqual`.

The `lodash.isequal` package has a ton of extra features we don't need, and [weighs in](https://bundlephobia.com/result?p=lodash.isequal) at a whopping 10KB minified (3.8KB after gzip). Very little of that machinery is really necessary to fix #4824.

I extracted this functionality into a separate npm package called [`@wry/equality`](https://www.npmjs.com/package/@wry/equality), so we have the flexibility to depend on the same logic in other packages without importing `apollo-utilities`.

[Here](https://github.com/benjamn/wryware/blob/master/packages/equality/src/equality.ts)'s the new implementation.