### PR TITLE
Pass context from subscriptions through to links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,9 @@
 - Migrated React Apollo HOC and Components functionality into Apollo Client, making it accessible from `@apollo/client/react/components` and `@apollo/client/react/hoc` entry points.  <br/>
   [@hwillson](https://github.com/hwillson) in [#6558](https://github.com/apollographql/apollo-client/pull/6558)
 
+- Support passing a `context` object through the link execution chain when using subscriptions.  <br/>
+  [@sgtpepper43](https://github.com/sgtpepper43) in [#4925](https://github.com/apollographql/apollo-client/pull/4925)
+
 ### Bug Fixes
 
 - `useMutation` adjustments to help avoid an infinite loop / too many renders issue, caused by unintentionally modifying the `useState` based mutation result directly.  <br/>

--- a/src/__tests__/graphqlSubscriptions.ts
+++ b/src/__tests__/graphqlSubscriptions.ts
@@ -29,6 +29,9 @@ describe('GraphQL Subscriptions', () => {
       variables: {
         name: 'Changping Chen',
       },
+      context: {
+        someVar: 'Some value'
+      }
     };
 
     defaultOptions = {
@@ -241,5 +244,24 @@ describe('GraphQL Subscriptions', () => {
       });
       setTimeout(() => link.simulateComplete(), 100);
     });
+  });
+
+  it('should pass a context object through the link execution chain', done => {
+    const link = mockObservableLink();
+    const client = new ApolloClient({
+      cache: new InMemoryCache(),
+      link,
+    });
+
+    client.subscribe(options).subscribe({
+      next() {
+        expect(link.operation.getContext().someVar).toEqual(
+          options.context.someVar
+        );
+        done();
+      },
+    });
+
+    link.simulateResult(results[0]);
   });
 });

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -372,6 +372,7 @@ once, rather than every time you call fetchMore.`);
       .startGraphQLSubscription({
         query: options.document,
         variables: options.variables,
+        context: options.context,
       })
       .subscribe({
         next: (subscriptionData: { data: TSubscriptionData }) => {

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -597,6 +597,7 @@ export class QueryManager<TStore> {
     query,
     fetchPolicy,
     variables,
+    context = {},
   }: SubscriptionOptions): Observable<FetchResult<T>> {
     query = this.transform(query).document;
     variables = this.getVariables(query, variables);
@@ -604,7 +605,7 @@ export class QueryManager<TStore> {
     const makeObservable = (variables: OperationVariables) =>
       this.getObservableFromLink<T>(
         query,
-        {},
+        context,
         variables,
         false,
       ).map(result => {
@@ -636,6 +637,7 @@ export class QueryManager<TStore> {
       const observablePromise = this.localState.addExportedVariables(
         query,
         variables,
+        context,
       ).then(makeObservable);
 
       return new Observable<FetchResult<T>>(observer => {

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -140,6 +140,7 @@ export type SubscribeToMoreOptions<
   variables?: TSubscriptionVariables;
   updateQuery?: UpdateQueryFn<TData, TSubscriptionVariables, TSubscriptionData>;
   onError?: (error: Error) => void;
+  context?: Record<string, any>;
 };
 
 export interface SubscriptionOptions<TVariables = OperationVariables> {
@@ -159,6 +160,11 @@ export interface SubscriptionOptions<TVariables = OperationVariables> {
    * Specifies the {@link FetchPolicy} to be used for this subscription.
    */
   fetchPolicy?: FetchPolicy;
+
+  /**
+   * Context object to be passed through the link execution chain.
+   */
+  context?: Record<string, any>;
 }
 
 export type RefetchQueryDescription = Array<string | PureQueryOptions>;

--- a/src/utilities/testing/mocking/mockSubscriptionLink.ts
+++ b/src/utilities/testing/mocking/mockSubscriptionLink.ts
@@ -15,6 +15,7 @@ export interface MockedSubscriptionResult {
 export class MockSubscriptionLink extends ApolloLink {
   public unsubscribers: any[] = [];
   public setups: any[] = [];
+  public operation: Operation;
 
   private observer: any;
 
@@ -22,7 +23,8 @@ export class MockSubscriptionLink extends ApolloLink {
     super();
   }
 
-  public request(_req: any) {
+  public request(operation: Operation) {
+    this.operation = operation;
     return new Observable<FetchResult>(observer => {
       this.setups.forEach(x => x());
       this.observer = observer;


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

Resolves apollographql/apollo-feature-requests#93

Allow a context to be supplied when creating subscriptions, and pass that context through to the links.

There are a bunch of other changes in here that I'm pretty sure was made by the linter or prettier or whatever you've got going. Some pre-commit hook that automatically ran. I'll mark those changes and I can get rid of them if you want.

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests

