### PR TITLE
docs: fix indent spacing issues in cache sample

### DIFF
--- a/docs/source/essentials/local-state.md
+++ b/docs/source/essentials/local-state.md
@@ -234,10 +234,10 @@ const client = new ApolloClient({
 
 const data = {
   todos: [],
-    visibilityFilter: 'SHOW_ALL',
-    networkStatus: {
-      __typename: 'NetworkStatus',
-      isConnected: false,
+  visibilityFilter: 'SHOW_ALL',
+  networkStatus: {
+    __typename: 'NetworkStatus',
+    isConnected: false,
   },
 };
 


### PR DESCRIPTION
There's an indent spacing issues in the docs where there are extra indentations on the `visibilityFilter`, `networkStatus` properties of the `data` object.