### PR TITLE
Escape lt/gt signs in v2.4 docs

### DIFF
--- a/docs/source/api/react-apollo.md
+++ b/docs/source/api/react-apollo.md
@@ -80,7 +80,7 @@ The Query component accepts the following props. Only `query` and `children` are
   <dd>A callback executed once your query successfully completes.</dd>
   <dt>`onError`: (error: ApolloError) => void</dt>
   <dd>A callback executed in the event of an error.</dd>
-  <dt>`context`: Record<string, any></dt>
+  <dt>`context`: Record&lt;string, any&gt;</dt>
   <dd>Shared context between your Query component and your network interface (Apollo Link). Useful for setting headers from props or sending information to the `request` function of Apollo Boost.</dd>
   <dt>`partialRefetch`: boolean</dt>
   <dd>If `true`, perform a query `refetch` if the query result is marked as being partial, and the returned data is reset to an empty Object by the Apollo Client `QueryManager` (due to a cache miss). The default value is `false` for backwards-compatibility's sake, but should be changed to true for most use-cases.</dd>
@@ -103,9 +103,9 @@ The render prop function that you pass to the `children` prop of `Query` is call
   <dd>An object containing the variables the query was called with</dd>
   <dt>`networkStatus`: NetworkStatus</dt>
   <dd>A number from 1-8 corresponding to the detailed state of your network request. Includes information about refetching and polling status. Used in conjunction with the `notifyOnNetworkStatusChange` prop.</dd>
-  <dt>`refetch`: (variables?: TVariables) => Promise<ApolloQueryResult></dt>
+  <dt>`refetch`: (variables?: TVariables) => Promise&lt;ApolloQueryResult&gt;</dt>
   <dd>A function that allows you to refetch the query and optionally pass in new variables</dd>
-  <dt>`fetchMore`: ({ query?: DocumentNode, variables?: TVariables, updateQuery: Function}) => Promise<ApolloQueryResult></dt>
+  <dt>`fetchMore`: ({ query?: DocumentNode, variables?: TVariables, updateQuery: Function}) => Promise&lt;ApolloQueryResult&gt;</dt>
   <dd>A function that enables [pagination](/v2.4/features/pagination/) for your query</dd>
   <dt>`startPolling`: (interval: number) => void</dt>
   <dd>This function sets up an interval in ms and fetches the query each time the specified interval passes.</dd>
@@ -144,7 +144,7 @@ The Mutation component accepts the following props. Only `mutation` and `childre
   <dd>A callback executed once your mutation successfully completes</dd>
   <dt>`onError`: (error: ApolloError) => void</dt>
   <dd>A callback executed in the event of an error</dd>
-  <dt>`context`: Record<string, any></dt>
+  <dt>`context`: Record&lt;string, any&gt;</dt>
   <dd>Shared context between your Mutation component and your network interface (Apollo Link). Useful for setting headers from props or sending information to the `request` function of Apollo Boost.</dd>
   <dt>`client`: ApolloClient</dt>
   <dd>An `ApolloClient` instance. By default `Query` uses the client passed down via context, but a different client can be passed in.</dd>

--- a/docs/source/essentials/get-started.md
+++ b/docs/source/essentials/get-started.md
@@ -156,7 +156,7 @@ Here are the options you can pass to the `ApolloClient` exported from `apollo-bo
   <dd>This function is called on each request. It takes a GraphQL operation and can return a promise. To dynamically set `fetchOptions`, you can add them to the context of the operation with `operation.setContext({ headers })`. Any options set here will take precedence over `fetchOptions`. Useful for authentication.</dd>
   <dt>`onError`: (errorObj: { graphQLErrors: GraphQLError[], networkError: Error, response?: ExecutionResult, operation: Operation }) => void</dt>
   <dd>We include a default error handler to log out your errors to the console. If you would like to handle your errors differently, specify this function.</dd>
-  <dt>`clientState`: { resolvers?: Object, defaults?: Object, typeDefs?: string | Array<string> }</dt>
+  <dt>`clientState`: { resolvers?: Object, defaults?: Object, typeDefs?: string | Array&lt;string&gt; }</dt>
   <dd>An object representing your configuration for `apollo-link-state`. This is useful if you would like to use the Apollo cache for local state management. Learn more in our [quick start](https://www.apollographql.com/docs/link/links/state/#start).</dd>
   <dt>`cacheRedirects`: Object</dt>
   <dd>A map of functions to redirect a query to another entry in the cache before a request takes place. This is useful if you have a list of items and want to use the data from the list query on a detail page where you're querying an individual item. More on that [here](/v2.4/features/performance/#cache-redirects).</dd>

--- a/docs/source/essentials/local-state.md
+++ b/docs/source/essentials/local-state.md
@@ -34,7 +34,7 @@ The three options you can pass to `clientState` are:
   <dd>The initial data you want to write to the Apollo cache when the client is initialized</dd>
   <dt>[`resolvers`](#resolvers): Object</dt>
   <dd>A map of functions that your GraphQL queries and mutations call in order to read and write to the cache</dd>
-  <dt>[`typeDefs`](#schema): string | Array<string></dt>
+  <dt>[`typeDefs`](#schema): string | Array&lt;string&gt;</dt>
   <dd>A string representing your client-side schema written in [Schema Definition Language](https://www.apollographql.com/docs/graphql-tools/generate-schema.html#schema-language). This schema is not used for validation (yet!), but is used for introspection in Apollo DevTools</dd>
 </dl>
 

--- a/docs/source/essentials/mutations.md
+++ b/docs/source/essentials/mutations.md
@@ -248,7 +248,7 @@ The Mutation component accepts the following props. Only `mutation` and `childre
   <dd>A callback executed once your mutation successfully completes</dd>
   <dt>`onError`: (error: ApolloError) => void</dt>
   <dd>A callback executed in the event of an error</dd>
-  <dt>`context`: Record<string, any></dt>
+  <dt>`context`: Record&lt;string, any&gt;</dt>
   <dd>Shared context between your Mutation component and your network interface (Apollo Link). Useful for setting headers from props or sending information to the `request` function of Apollo Boost.</dd>
 </dl>
 

--- a/docs/source/essentials/queries.md
+++ b/docs/source/essentials/queries.md
@@ -267,7 +267,7 @@ The Query component accepts the following props. Only `query` and `children` are
   <dd>A callback executed once your query successfully completes.</dd>
   <dt>`onError`: (error: ApolloError) => void</dt>
   <dd>A callback executed in the event of an error.</dd>
-  <dt>`context`: Record<string, any></dt>
+  <dt>`context`: Record&lt;string, any&gt;</dt>
   <dd>Shared context between your Query component and your network interface (Apollo Link). Useful for setting headers from props or sending information to the `request` function of Apollo Boost.</dd>
   <dt>`partialRefetch`: boolean</dt>
   <dd>If `true`, perform a query `refetch` if the query result is marked as being partial, and the returned data is reset to an empty Object by the Apollo Client `QueryManager` (due to a cache miss). The default value is `false` for backwards-compatibility's sake, but should be changed to true for most use-cases.</dd>
@@ -288,9 +288,9 @@ The render prop function that you pass to the `children` prop of `Query` is call
   <dd>An object containing the variables the query was called with</dd>
   <dt>`networkStatus`: NetworkStatus</dt>
   <dd>A number from 1-8 corresponding to the detailed state of your network request. Includes information about refetching and polling status. Used in conjunction with the `notifyOnNetworkStatusChange` prop.</dd>
-  <dt>`refetch`: (variables?: TVariables) => Promise<ApolloQueryResult></dt>
+  <dt>`refetch`: (variables?: TVariables) => Promise&lt;ApolloQueryResult&gt;</dt>
   <dd>A function that allows you to refetch the query and optionally pass in new variables</dd>
-  <dt>`fetchMore`: ({ query?: DocumentNode, variables?: TVariables, updateQuery: Function}) => Promise<ApolloQueryResult></dt>
+  <dt>`fetchMore`: ({ query?: DocumentNode, variables?: TVariables, updateQuery: Function}) => Promise&lt;ApolloQueryResult&gt;</dt>
   <dd>A function that enables [pagination](/v2.4/features/pagination/) for your query</dd>
   <dt>`startPolling`: (interval: number) => void</dt>
   <dd>This function sets up an interval in ms and fetches the query each time the specified interval passes.</dd>


### PR DESCRIPTION
This branch changes `<` and `>` signs into `&lt;` and `&gt;`in the v2.4 docs. This is so that our markdown parser doesn't get type definitions confused with html tags, e.g. `<string>` or `<ApolloQueryResult>`