### PR TITLE
Add `returnPartialData` to the API docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Apollo Client (vNext)
 
 - Documentation updates.  <br/>
-  [@michael-watson](https://github.com/michael-watson) in [#4940](https://github.com/apollographql/apollo-client/pull/4940)
+  [@michael-watson](https://github.com/michael-watson) in [#4940](https://github.com/apollographql/apollo-client/pull/4940)  <br/>
+  [@hwillson](https://github.com/hwillson) in [#4969](https://github.com/apollographql/apollo-client/pull/4969)
 
 
 ## Apollo Client (2.6.2)

--- a/docs/source/api/react-apollo.md
+++ b/docs/source/api/react-apollo.md
@@ -87,6 +87,8 @@ The Query component accepts the following props. Only `query` and `children` are
   <dd>If `true`, perform a query `refetch` if the query result is marked as being partial, and the returned data is reset to an empty Object by the Apollo Client `QueryManager` (due to a cache miss). The default value is `false` for backwards-compatibility's sake, but should be changed to true for most use-cases.</dd>
   <dt>`client`: ApolloClient</dt>
   <dd>An `ApolloClient` instance. By default `Query` uses the client passed down via context, but a different client can be passed in.</dd>
+  <dt>`returnPartialData`: boolean</dt>
+  <dd>Opt into receiving partial results from the cache for queries that are not fully satisfied by the cache. `false` by default.</dd>
 </dl>
 
 ### Render prop function

--- a/docs/source/essentials/queries.md
+++ b/docs/source/essentials/queries.md
@@ -271,6 +271,8 @@ The Query component accepts the following props. Only `query` and `children` are
   <dd>Shared context between your Query component and your network interface (Apollo Link). Useful for setting headers from props or sending information to the <code>request</code> function of Apollo Boost.</dd>
   <dt><code>partialRefetch</code>: boolean</dt>
   <dd>If <code>true</code>, perform a query <code>refetch</code> if the query result is marked as being partial, and the returned data is reset to an empty Object by the Apollo Client <code>QueryManager</code> (due to a cache miss). The default value is <code>false</code> for backwards-compatibility's sake, but should be changed to true for most use-cases.</dd>
+  <dt><code>returnPartialData</code>: boolean</dt>
+  <dd>Opt into receiving partial results from the cache for queries that are not fully satisfied by the cache. <code>false</code> by default.</dd>
 </dl>
 
 ### Render prop function


### PR DESCRIPTION
This PR adds a quick mention of the missing `returnPartialData` feature we re-enabled in Apollo Client 2.6.