### PR TITLE
Fix VSCode settings.json typescript.tsdk option.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,5 @@
     "coverage": true,
     "npm": true
   },
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "../node_modules/typescript/lib"
 }

--- a/packages/apollo-cache-inmemory/src/__tests__/writeToStore.ts
+++ b/packages/apollo-cache-inmemory/src/__tests__/writeToStore.ts
@@ -1329,7 +1329,7 @@ describe('writing to the store', () => {
         ROOT_QUERY: {
           author: {
             type: 'id',
-            id: dataIdFromObject(data.author),
+            id: dataIdFromObject(data.author)!,
             generated: false,
             typename: 'Author',
           },
@@ -1374,7 +1374,7 @@ describe('writing to the store', () => {
         ROOT_QUERY: {
           author: {
             type: 'id',
-            id: dataIdFromObject(data.author),
+            id: dataIdFromObject(data.author)!,
             generated: false,
             typename: 'Author',
           },

--- a/packages/apollo-cache-inmemory/src/fragmentMatcher.ts
+++ b/packages/apollo-cache-inmemory/src/fragmentMatcher.ts
@@ -153,7 +153,11 @@ export class IntrospectionFragmentMatcher implements FragmentMatcherInterface {
     }
 
     const implementingTypes = this.possibleTypesMap[typeCondition];
-    if (implementingTypes && implementingTypes.indexOf(__typename) > -1) {
+    if (
+      __typename &&
+      implementingTypes &&
+      implementingTypes.indexOf(__typename) > -1
+    ) {
       return true;
     }
 

--- a/packages/apollo-cache-inmemory/src/inMemoryCache.ts
+++ b/packages/apollo-cache-inmemory/src/inMemoryCache.ts
@@ -114,7 +114,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
       this.config.cacheRedirects = (this.config as any).cacheResolvers;
     }
 
-    this.addTypename = this.config.addTypename;
+    this.addTypename = !!this.config.addTypename;
 
     // Passing { resultCaching: false } in the InMemoryCache constructor options
     // will completely disable dependency tracking, which will improve memory
@@ -183,18 +183,24 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
       return null;
     }
 
+    const { fragmentMatcher } = this.config;
+    const fragmentMatcherFunction = fragmentMatcher && fragmentMatcher.match;
+
     return this.storeReader.readQueryFromStore({
       store: options.optimistic ? this.optimisticData : this.data,
       query: this.transformDocument(options.query),
       variables: options.variables,
       rootId: options.rootId,
-      fragmentMatcherFunction: this.config.fragmentMatcher.match,
+      fragmentMatcherFunction,
       previousResult: options.previousResult,
       config: this.config,
-    });
+    }) || null;
   }
 
   public write(write: Cache.WriteOptions): void {
+    const { fragmentMatcher } = this.config;
+    const fragmentMatcherFunction = fragmentMatcher && fragmentMatcher.match;
+
     this.storeWriter.writeResultToStore({
       dataId: write.dataId,
       result: write.result,
@@ -202,20 +208,23 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
       document: this.transformDocument(write.query),
       store: this.data,
       dataIdFromObject: this.config.dataIdFromObject,
-      fragmentMatcherFunction: this.config.fragmentMatcher.match,
+      fragmentMatcherFunction,
     });
 
     this.broadcastWatches();
   }
 
   public diff<T>(query: Cache.DiffOptions): Cache.DiffResult<T> {
+    const { fragmentMatcher } = this.config;
+    const fragmentMatcherFunction = fragmentMatcher && fragmentMatcher.match;
+
     return this.storeReader.diffQueryAgainstStore({
       store: query.optimistic ? this.optimisticData : this.data,
       query: this.transformDocument(query.query),
       variables: query.variables,
       returnPartialData: query.returnPartialData,
       previousResult: query.previousResult,
-      fragmentMatcherFunction: this.config.fragmentMatcher.match,
+      fragmentMatcherFunction,
       config: this.config,
     });
   }
@@ -260,7 +269,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
 
       // Reapply the layers whose optimistic IDs do not match the removed ID.
       while (toReapply.length > 0) {
-        const layer = toReapply.pop();
+        const layer = toReapply.pop()!;
         this.performTransaction(layer.transaction, layer.optimisticId);
       }
 

--- a/packages/apollo-cache-inmemory/src/mapCache.ts
+++ b/packages/apollo-cache-inmemory/src/mapCache.ts
@@ -5,14 +5,14 @@ import { NormalizedCache, NormalizedCacheObject, StoreObject } from './types';
  * Note that you need a polyfill for Object.entries for this to work.
  */
 export class MapCache implements NormalizedCache {
-  private cache: Map<string, StoreObject>;
+  private cache: Map<string, StoreObject | undefined>;
 
   constructor(data: NormalizedCacheObject = {}) {
     this.cache = new Map(Object.entries(data));
   }
 
   public get(dataId: string): StoreObject {
-    return this.cache.get(`${dataId}`);
+    return this.cache.get(`${dataId}`)!;
   }
 
   public set(dataId: string, value: StoreObject): void {

--- a/packages/apollo-cache-inmemory/src/objectCache.ts
+++ b/packages/apollo-cache-inmemory/src/objectCache.ts
@@ -6,8 +6,9 @@ export class ObjectCache implements NormalizedCache {
   public toObject() {
     return this.data;
   }
+
   public get(dataId: string) {
-    return this.data[dataId];
+    return this.data[dataId]!;
   }
 
   public set(dataId: string, value: StoreObject) {

--- a/packages/apollo-cache-inmemory/src/types.ts
+++ b/packages/apollo-cache-inmemory/src/types.ts
@@ -37,7 +37,7 @@ export interface NormalizedCache {
  * a flattened representation of query result trees.
  */
 export interface NormalizedCacheObject {
-  [dataId: string]: StoreObject;
+  [dataId: string]: StoreObject | undefined;
 }
 
 export interface StoreObject {

--- a/packages/apollo-cache-inmemory/src/writeToStore.ts
+++ b/packages/apollo-cache-inmemory/src/writeToStore.ts
@@ -124,7 +124,7 @@ export class StoreWriter {
     fragmentMatcherFunction?: FragmentMatcher;
   }): NormalizedCache {
     // XXX TODO REFACTOR: this is a temporary workaround until query normalization is made to work with documents.
-    const operationDefinition = getOperationDefinition(document);
+    const operationDefinition = getOperationDefinition(document)!;
 
     try {
       return this.writeSelectionSetToStore({


### PR DESCRIPTION
Because of this incorrect path, VSCode was not picking up the correct `tsc` version and thus ignoring `tsconfig.json` in some of our packages, namely `apollo-cache-inmemory`.