### PR TITLE
Add performance instrumentation to Apollo client

### DIFF
--- a/packages/apollo-client/src/core/ObservableQuery.ts
+++ b/packages/apollo-client/src/core/ObservableQuery.ts
@@ -63,10 +63,10 @@ export interface UpdateQueryOptions<TVariables> {
 export const hasError = (
   storeValue: QueryStoreValue,
   policy: ErrorPolicy = 'none',
-) => storeValue && (
-  storeValue.networkError ||
-  (policy === 'none' && isNonEmptyArray(storeValue.graphQLErrors))
-);
+) =>
+  storeValue &&
+  (storeValue.networkError ||
+    (policy === 'none' && isNonEmptyArray(storeValue.graphQLErrors)));
 
 export class ObservableQuery<
   TData = any,
@@ -171,7 +171,7 @@ export class ObservableQuery<
     if (this.isTornDown) {
       const { lastResult } = this;
       return {
-        data: !this.lastError && lastResult && lastResult.data || void 0,
+        data: (!this.lastError && lastResult && lastResult.data) || void 0,
         error: this.lastError,
         loading: false,
         networkStatus: NetworkStatus.error,
@@ -185,8 +185,7 @@ export class ObservableQuery<
     const { fetchPolicy } = this.options;
 
     const isNetworkFetchPolicy =
-      fetchPolicy === 'network-only' ||
-      fetchPolicy === 'no-cache';
+      fetchPolicy === 'network-only' || fetchPolicy === 'no-cache';
 
     if (queryStoreValue) {
       const { networkStatus } = queryStoreValue;
@@ -225,7 +224,6 @@ export class ObservableQuery<
       if (queryStoreValue.graphQLErrors && this.options.errorPolicy === 'all') {
         result.errors = queryStoreValue.graphQLErrors;
       }
-
     } else {
       // We need to be careful about the loading state we show to the user, to try
       // and be vaguely in line with what the user would have seen from .subscribe()
@@ -233,8 +231,8 @@ export class ObservableQuery<
       // will not end up hitting the server.
       // See more: https://github.com/apollostack/apollo-client/issues/707
       // Basically: is there a query in flight right now (modolo the next tick)?
-      const loading = isNetworkFetchPolicy ||
-        (partial && fetchPolicy !== 'cache-only');
+      const loading =
+        isNetworkFetchPolicy || (partial && fetchPolicy !== 'cache-only');
 
       result = {
         data,
@@ -299,16 +297,17 @@ export class ObservableQuery<
     let { fetchPolicy } = this.options;
     // early return if trying to read from cache during refetch
     if (fetchPolicy === 'cache-only') {
-      return Promise.reject(new InvariantError(
-        'cache-only fetchPolicy option should not be used together with query refetch.',
-      ));
+      return Promise.reject(
+        new InvariantError(
+          'cache-only fetchPolicy option should not be used together with query refetch.',
+        ),
+      );
     }
 
     // Unless the provided fetchPolicy always consults the network
     // (no-cache, network-only, or cache-and-network), override it with
     // network-only to force the refetch for this fetchQuery call.
-    if (fetchPolicy !== 'no-cache' &&
-        fetchPolicy !== 'cache-and-network') {
+    if (fetchPolicy !== 'no-cache' && fetchPolicy !== 'cache-and-network') {
       fetchPolicy = 'network-only';
     }
 
@@ -346,26 +345,23 @@ export class ObservableQuery<
     );
 
     const combinedOptions = {
-      ...(fetchMoreOptions.query ? fetchMoreOptions : {
-        ...this.options,
-        ...fetchMoreOptions,
-        variables: {
-          ...this.variables,
-          ...fetchMoreOptions.variables,
-        },
-      }),
+      ...(fetchMoreOptions.query
+        ? fetchMoreOptions
+        : {
+            ...this.options,
+            ...fetchMoreOptions,
+            variables: {
+              ...this.variables,
+              ...fetchMoreOptions.variables,
+            },
+          }),
       fetchPolicy: 'network-only',
     } as WatchQueryOptions;
 
     const qid = this.queryManager.generateQueryId();
 
     return this.queryManager
-      .fetchQuery(
-        qid,
-        combinedOptions,
-        FetchType.normal,
-        this.queryId,
-      )
+      .fetchQuery(qid, combinedOptions, FetchType.normal, this.queryId)
       .then(
         fetchMoreResult => {
           this.updateQuery((previousResult: any) =>
@@ -456,11 +452,10 @@ export class ObservableQuery<
       this.options.variables as TVariables,
       // Try to fetch the query if fetchPolicy changed from either cache-only
       // or standby to something else, or changed to network-only.
-      oldFetchPolicy !== fetchPolicy && (
-        oldFetchPolicy === 'cache-only' ||
-        oldFetchPolicy === 'standby' ||
-        fetchPolicy === 'network-only'
-      ),
+      oldFetchPolicy !== fetchPolicy &&
+        (oldFetchPolicy === 'cache-only' ||
+          oldFetchPolicy === 'standby' ||
+          fetchPolicy === 'network-only'),
       opts.fetchResults,
     );
   }
@@ -519,10 +514,9 @@ export class ObservableQuery<
     }
 
     // Use the same options as before, but with new variables
-    return this.queryManager.fetchQuery(
-      this.queryId,
-      this.options,
-    ) as Promise<ApolloQueryResult<TData>>;
+    return this.queryManager.fetchQuery(this.queryId, this.options) as Promise<
+      ApolloQueryResult<TData>
+    >;
   }
 
   public updateQuery<TVars = TVariables>(
@@ -536,9 +530,7 @@ export class ObservableQuery<
       previousResult,
       variables,
       document,
-    } = queryManager.getQueryWithPreviousResult<TData, TVars>(
-      this.queryId,
-    );
+    } = queryManager.getQueryWithPreviousResult<TData, TVars>(this.queryId);
 
     const newResult = tryFunctionOrLogError(() =>
       mapFn(previousResult, { variables }),
@@ -616,47 +608,49 @@ export class ObservableQuery<
     }
 
     const onError = (error: ApolloError) => {
-      iterateObserversSafely(this.observers, 'error', this.lastError = error);
+      iterateObserversSafely(this.observers, 'error', (this.lastError = error));
     };
 
-    queryManager.observeQuery<TData>(queryId, this.options, {
-      next: (result: ApolloQueryResult<TData>) => {
-        if (this.lastError || this.isDifferentFromLastResult(result)) {
-          const previousResult = this.updateLastResult(result);
-          const { query, variables, fetchPolicy } = this.options;
+    queryManager
+      .observeQuery<TData>(queryId, this.options, {
+        next: (result: ApolloQueryResult<TData>) => {
+          if (this.lastError || this.isDifferentFromLastResult(result)) {
+            const previousResult = this.updateLastResult(result);
+            const { query, variables, fetchPolicy } = this.options;
 
-          // Before calling `next` on each observer, we need to first see if
-          // the query is using `@client @export` directives, and update
-          // any variables that might have changed. If `@export` variables have
-          // changed, and the query is calling against both local and remote
-          // data, a refetch is needed to pull in new data, using the
-          // updated `@export` variables.
-          if (queryManager.transform(query).hasClientExports) {
-            queryManager.getLocalState().addExportedVariables(
-              query,
-              variables,
-            ).then((variables: TVariables) => {
-              const previousVariables = this.variables;
-              this.variables = this.options.variables = variables;
-              if (
-                !result.loading &&
-                previousResult &&
-                fetchPolicy !== 'cache-only' &&
-                queryManager.transform(query).serverQuery &&
-                !isEqual(previousVariables, variables)
-              ) {
-                this.refetch();
-              } else {
-                iterateObserversSafely(this.observers, 'next', result);
-              }
-            });
-          } else {
-            iterateObserversSafely(this.observers, 'next', result);
+            // Before calling `next` on each observer, we need to first see if
+            // the query is using `@client @export` directives, and update
+            // any variables that might have changed. If `@export` variables have
+            // changed, and the query is calling against both local and remote
+            // data, a refetch is needed to pull in new data, using the
+            // updated `@export` variables.
+            if (queryManager.transform(query).hasClientExports) {
+              queryManager
+                .getLocalState()
+                .addExportedVariables(query, variables)
+                .then((variables: TVariables) => {
+                  const previousVariables = this.variables;
+                  this.variables = this.options.variables = variables;
+                  if (
+                    !result.loading &&
+                    previousResult &&
+                    fetchPolicy !== 'cache-only' &&
+                    queryManager.transform(query).serverQuery &&
+                    !isEqual(previousVariables, variables)
+                  ) {
+                    this.refetch();
+                  } else {
+                    iterateObserversSafely(this.observers, 'next', result);
+                  }
+                });
+            } else {
+              iterateObserversSafely(this.observers, 'next', result);
+            }
           }
-        }
-      },
-      error: onError,
-    }).catch(onError);
+        },
+        error: onError,
+      })
+      .catch(onError);
   }
 
   private tearDownQuery() {

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -148,7 +148,7 @@ export class QueryManager<TStore> {
 
     invariant(
       !fetchPolicy || fetchPolicy === 'no-cache',
-      "fetchPolicy for mutations currently only supports the 'no-cache' policy"
+      "fetchPolicy for mutations currently only supports the 'no-cache' policy",
     );
 
     const mutationId = this.generateQueryId();
@@ -159,7 +159,11 @@ export class QueryManager<TStore> {
     variables = this.getVariables(mutation, variables);
 
     if (this.transform(mutation).hasClientExports) {
-      variables = await this.localState.addExportedVariables(mutation, variables, context);
+      variables = await this.localState.addExportedVariables(
+        mutation,
+        variables,
+        context,
+      );
     }
 
     // Create a map of update queries by id to the query instead of by name.
@@ -188,11 +192,7 @@ export class QueryManager<TStore> {
       return ret;
     };
 
-    this.mutationStore.initMutation(
-      mutationId,
-      mutation,
-      variables,
-    );
+    this.mutationStore.initMutation(mutationId, mutation, variables);
 
     this.dataStore.markMutationInit({
       mutationId,
@@ -211,125 +211,127 @@ export class QueryManager<TStore> {
       let storeResult: FetchResult<T> | null;
       let error: ApolloError;
 
-      self.getObservableFromLink(
-        mutation,
-        {
-          ...context,
-          optimisticResponse,
-        },
-        variables,
-        false,
-      ).subscribe({
-        next(result: ExecutionResult) {
-          if (graphQLResultHasError(result) && errorPolicy === 'none') {
-            error = new ApolloError({
-              graphQLErrors: result.errors,
-            });
-            return;
-          }
-
-          self.mutationStore.markMutationResult(mutationId);
-
-          if (fetchPolicy !== 'no-cache') {
-            self.dataStore.markMutationResult({
-              mutationId,
-              result,
-              document: mutation,
-              variables,
-              updateQueries: generateUpdateQueriesInfo(),
-              update: updateWithProxyFn,
-            });
-          }
-
-          storeResult = result as FetchResult<T>;
-        },
-
-        error(err: Error) {
-          self.mutationStore.markMutationError(mutationId, err);
-          self.dataStore.markMutationComplete({
-            mutationId,
+      self
+        .getObservableFromLink(
+          mutation,
+          {
+            ...context,
             optimisticResponse,
-          });
-          self.broadcastQueries();
-          self.setQuery(mutationId, () => ({ document: null }));
-          reject(
-            new ApolloError({
-              networkError: err,
-            }),
-          );
-        },
-
-        complete() {
-          if (error) {
-            self.mutationStore.markMutationError(mutationId, error);
-          }
-
-          self.dataStore.markMutationComplete({
-            mutationId,
-            optimisticResponse,
-          });
-
-          self.broadcastQueries();
-
-          if (error) {
-            reject(error);
-            return;
-          }
-
-          // allow for conditional refetches
-          // XXX do we want to make this the only API one day?
-          if (typeof refetchQueries === 'function') {
-            refetchQueries = refetchQueries(storeResult as ExecutionResult);
-          }
-
-          const refetchQueryPromises: Promise<
-            ApolloQueryResult<any>[] | ApolloQueryResult<{}>
-          >[] = [];
-
-          if (isNonEmptyArray(refetchQueries)) {
-            refetchQueries.forEach(refetchQuery => {
-              if (typeof refetchQuery === 'string') {
-                self.queries.forEach(({ observableQuery }) => {
-                  if (
-                    observableQuery &&
-                    observableQuery.queryName === refetchQuery
-                  ) {
-                    refetchQueryPromises.push(observableQuery.refetch());
-                  }
-                });
-              } else {
-                const queryOptions: QueryOptions = {
-                  query: refetchQuery.query,
-                  variables: refetchQuery.variables,
-                  fetchPolicy: 'network-only',
-                };
-
-                if (refetchQuery.context) {
-                  queryOptions.context = refetchQuery.context;
-                }
-
-                refetchQueryPromises.push(self.query(queryOptions));
-              }
-            });
-          }
-
-          Promise.all(
-            awaitRefetchQueries ? refetchQueryPromises : [],
-          ).then(() => {
-            self.setQuery(mutationId, () => ({ document: null }));
-
-            if (
-              errorPolicy === 'ignore' &&
-              storeResult &&
-              graphQLResultHasError(storeResult)
-            ) {
-              delete storeResult.errors;
+          },
+          variables,
+          false,
+        )
+        .subscribe({
+          next(result: ExecutionResult) {
+            if (graphQLResultHasError(result) && errorPolicy === 'none') {
+              error = new ApolloError({
+                graphQLErrors: result.errors,
+              });
+              return;
             }
 
-            resolve(storeResult!);
-          });
-        },
-      });
+            self.mutationStore.markMutationResult(mutationId);
+
+            if (fetchPolicy !== 'no-cache') {
+              self.dataStore.markMutationResult({
+                mutationId,
+                result,
+                document: mutation,
+                variables,
+                updateQueries: generateUpdateQueriesInfo(),
+                update: updateWithProxyFn,
+              });
+            }
+
+            storeResult = result as FetchResult<T>;
+          },
+
+          error(err: Error) {
+            self.mutationStore.markMutationError(mutationId, err);
+            self.dataStore.markMutationComplete({
+              mutationId,
+              optimisticResponse,
+            });
+            self.broadcastQueries();
+            self.setQuery(mutationId, () => ({ document: null }));
+            reject(
+              new ApolloError({
+                networkError: err,
+              }),
+            );
+          },
+
+          complete() {
+            if (error) {
+              self.mutationStore.markMutationError(mutationId, error);
+            }
+
+            self.dataStore.markMutationComplete({
+              mutationId,
+              optimisticResponse,
+            });
+
+            self.broadcastQueries();
+
+            if (error) {
+              reject(error);
+              return;
+            }
+
+            // allow for conditional refetches
+            // XXX do we want to make this the only API one day?
+            if (typeof refetchQueries === 'function') {
+              refetchQueries = refetchQueries(storeResult as ExecutionResult);
+            }
+
+            const refetchQueryPromises: Promise<
+              ApolloQueryResult<any>[] | ApolloQueryResult<{}>
+            >[] = [];
+
+            if (isNonEmptyArray(refetchQueries)) {
+              refetchQueries.forEach(refetchQuery => {
+                if (typeof refetchQuery === 'string') {
+                  self.queries.forEach(({ observableQuery }) => {
+                    if (
+                      observableQuery &&
+                      observableQuery.queryName === refetchQuery
+                    ) {
+                      refetchQueryPromises.push(observableQuery.refetch());
+                    }
+                  });
+                } else {
+                  const queryOptions: QueryOptions = {
+                    query: refetchQuery.query,
+                    variables: refetchQuery.variables,
+                    fetchPolicy: 'network-only',
+                  };
+
+                  if (refetchQuery.context) {
+                    queryOptions.context = refetchQuery.context;
+                  }
+
+                  refetchQueryPromises.push(self.query(queryOptions));
+                }
+              });
+            }
+
+            Promise.all(awaitRefetchQueries ? refetchQueryPromises : []).then(
+              () => {
+                self.setQuery(mutationId, () => ({ document: null }));
+
+                if (
+                  errorPolicy === 'ignore' &&
+                  storeResult &&
+                  graphQLResultHasError(storeResult)
+                ) {
+                  delete storeResult.errors;
+                }
+
+                resolve(storeResult!);
+              },
+            );
+          },
+        });
     });
   }
 
@@ -353,7 +355,11 @@ export class QueryManager<TStore> {
     let variables = this.getVariables(query, options.variables);
 
     if (this.transform(query).hasClientExports) {
-      variables = await this.localState.addExportedVariables(query, variables, context);
+      variables = await this.localState.addExportedVariables(
+        query,
+        variables,
+        context,
+      );
     }
 
     options = { ...options, variables };
@@ -387,9 +393,10 @@ export class QueryManager<TStore> {
     const requestId = this.idCounter++;
 
     // set up a watcher to listen to cache updates
-    const cancel = fetchPolicy !== 'no-cache'
-      ? this.updateQueryWatch(queryId, query, options)
-      : undefined;
+    const cancel =
+      fetchPolicy !== 'no-cache'
+        ? this.updateQueryWatch(queryId, query, options)
+        : undefined;
 
     // Initialize query in store with unique requestId
     this.setQuery(queryId, () => ({
@@ -455,22 +462,19 @@ export class QueryManager<TStore> {
     this.invalidate(fetchMoreForQueryId);
 
     if (this.transform(query).hasForcedResolvers) {
-      return this.localState.runResolvers({
-        document: query,
-        remoteResult: { data: storeResult },
-        context,
-        variables,
-        onlyRunForcedResolvers: true,
-      }).then((result: FetchResult<T>) => {
-        this.markQueryResult(
-          queryId,
-          result,
-          options,
-          fetchMoreForQueryId,
-        );
-        this.broadcastQueries();
-        return result;
-      });
+      return this.localState
+        .runResolvers({
+          document: query,
+          remoteResult: { data: storeResult },
+          context,
+          variables,
+          onlyRunForcedResolvers: true,
+        })
+        .then((result: FetchResult<T>) => {
+          this.markQueryResult(queryId, result, options, fetchMoreForQueryId);
+          this.broadcastQueries();
+          return result;
+        });
     }
 
     this.broadcastQueries();
@@ -483,11 +487,7 @@ export class QueryManager<TStore> {
   private markQueryResult(
     queryId: string,
     result: ExecutionResult,
-    {
-      fetchPolicy,
-      variables,
-      errorPolicy,
-    }: WatchQueryOptions,
+    { fetchPolicy, variables, errorPolicy }: WatchQueryOptions,
     fetchMoreForQueryId?: string,
   ) {
     if (fetchPolicy === 'no-cache') {
@@ -548,8 +548,7 @@ export class QueryManager<TStore> {
       const lastResult = observableQuery && observableQuery.getLastResult();
 
       const networkStatusChanged = !!(
-        lastResult &&
-        lastResult.networkStatus !== queryStoreValue.networkStatus
+        lastResult && lastResult.networkStatus !== queryStoreValue.networkStatus
       );
 
       const shouldNotifyIfLoading =
@@ -565,18 +564,24 @@ export class QueryManager<TStore> {
 
       const hasGraphQLErrors = isNonEmptyArray(queryStoreValue.graphQLErrors);
 
-      const errorPolicy: ErrorPolicy = observableQuery
-        && observableQuery.options.errorPolicy
-        || options.errorPolicy
-        || 'none';
+      const errorPolicy: ErrorPolicy =
+        (observableQuery && observableQuery.options.errorPolicy) ||
+        options.errorPolicy ||
+        'none';
 
       // If we have either a GraphQL error or a network error, we create
       // an error and tell the observer about it.
-      if (errorPolicy === 'none' && hasGraphQLErrors || queryStoreValue.networkError) {
-        return invoke('error', new ApolloError({
-          graphQLErrors: queryStoreValue.graphQLErrors,
-          networkError: queryStoreValue.networkError,
-        }));
+      if (
+        (errorPolicy === 'none' && hasGraphQLErrors) ||
+        queryStoreValue.networkError
+      ) {
+        return invoke(
+          'error',
+          new ApolloError({
+            graphQLErrors: queryStoreValue.graphQLErrors,
+            networkError: queryStoreValue.networkError,
+          }),
+        );
       }
 
       try {
@@ -610,8 +615,7 @@ export class QueryManager<TStore> {
             const diffResult = this.dataStore.getCache().diff({
               query: document as DocumentNode,
               variables:
-                queryStoreValue.previousVariables ||
-                queryStoreValue.variables,
+                queryStoreValue.previousVariables || queryStoreValue.variables,
               returnPartialData: true,
               optimistic: true,
             });
@@ -624,10 +628,9 @@ export class QueryManager<TStore> {
         // If there is some data missing and the user has told us that they
         // do not tolerate partial data then we want to return the previous
         // result and mark it as stale.
-        const stale = isMissing && !(
-          options.returnPartialData ||
-          fetchPolicy === 'cache-only'
-        );
+        const stale =
+          isMissing &&
+          !(options.returnPartialData || fetchPolicy === 'cache-only');
 
         const resultFromStore: ApolloQueryResult<T> = {
           data: stale ? lastResult && lastResult.data : data,
@@ -642,7 +645,6 @@ export class QueryManager<TStore> {
         }
 
         invoke('next', resultFromStore);
-
       } catch (networkError) {
         invoke('error', new ApolloError({ networkError }));
       }
@@ -668,7 +670,8 @@ export class QueryManager<TStore> {
       const cache = this.dataStore.getCache();
       const transformed = cache.transformDocument(document);
       const forLink = removeConnectionDirectiveFromDocument(
-        cache.transformForLink(transformed));
+        cache.transformForLink(transformed),
+      );
 
       const clientQuery = this.localState.clientQuery(transformed);
       const serverQuery = this.localState.serverQuery(forLink);
@@ -682,7 +685,7 @@ export class QueryManager<TStore> {
         clientQuery,
         serverQuery,
         defaultVars: getDefaultValues(
-          getOperationDefinition(transformed)
+          getOperationDefinition(transformed),
         ) as OperationVariables,
       };
 
@@ -690,7 +693,7 @@ export class QueryManager<TStore> {
         if (doc && !transformCache.has(doc)) {
           transformCache.set(doc, cacheEntry);
         }
-      }
+      };
       // Add cacheEntry to the transformCache using several different keys,
       // since any one of these documents could end up getting passed to the
       // transform method again in the future.
@@ -859,9 +862,11 @@ export class QueryManager<TStore> {
     // that we have issued so far and not yet resolved (in the case of
     // queries).
     this.fetchQueryRejectFns.forEach(reject => {
-      reject(new InvariantError(
-        'Store reset while query was in flight (not completed in link chain)',
-      ));
+      reject(
+        new InvariantError(
+          'Store reset while query was in flight (not completed in link chain)',
+        ),
+      );
     });
 
     const resetIds: string[] = [];
@@ -932,7 +937,7 @@ export class QueryManager<TStore> {
     options: WatchQueryOptions,
     listener: QueryListener,
   ) {
-    invariant.warn("The QueryManager.startQuery method has been deprecated");
+    invariant.warn('The QueryManager.startQuery method has been deprecated');
 
     this.addQueryListener(queryId, listener);
 
@@ -953,18 +958,9 @@ export class QueryManager<TStore> {
     variables = this.getVariables(query, variables);
 
     const makeObservable = (variables: OperationVariables) =>
-      this.getObservableFromLink<T>(
-        query,
-        {},
-        variables,
-        false,
-      ).map(result => {
+      this.getObservableFromLink<T>(query, {}, variables, false).map(result => {
         if (!fetchPolicy || fetchPolicy !== 'no-cache') {
-          this.dataStore.markSubscriptionResult(
-            result,
-            query,
-            variables,
-          );
+          this.dataStore.markSubscriptionResult(result, query, variables);
           this.broadcastQueries();
         }
 
@@ -978,15 +974,14 @@ export class QueryManager<TStore> {
       });
 
     if (this.transform(query).hasClientExports) {
-      const observablePromise = this.localState.addExportedVariables(
-        query,
-        variables,
-      ).then(makeObservable);
+      const observablePromise = this.localState
+        .addExportedVariables(query, variables)
+        .then(makeObservable);
 
       return new Observable<FetchResult<T>>(observer => {
         let sub: Subscription | null = null;
         observablePromise.then(
-          observable => sub = observable.subscribe(observer),
+          observable => (sub = observable.subscribe(observer)),
           observer.error,
         );
         return () => sub && sub.unsubscribe();
@@ -1025,7 +1020,12 @@ export class QueryManager<TStore> {
     data: T | undefined;
     partial: boolean;
   } {
-    const { variables, query, fetchPolicy, returnPartialData } = observableQuery.options;
+    const {
+      variables,
+      query,
+      fetchPolicy,
+      returnPartialData,
+    } = observableQuery.options;
     const lastResult = observableQuery.getLastResult();
     const { newData } = this.getQuery(observableQuery.queryId);
 
@@ -1046,7 +1046,7 @@ export class QueryManager<TStore> {
     });
 
     return {
-      data: (complete || returnPartialData) ? result : void 0,
+      data: complete || returnPartialData ? result : void 0,
       partial: !complete,
     };
   }
@@ -1065,7 +1065,7 @@ export class QueryManager<TStore> {
       );
       invariant(
         foundObserveableQuery,
-        `ObservableQuery with this id doesn't exist: ${queryIdOrObservable}`
+        `ObservableQuery with this id doesn't exist: ${queryIdOrObservable}`,
       );
       observableQuery = foundObserveableQuery!;
     } else {
@@ -1122,14 +1122,15 @@ export class QueryManager<TStore> {
         operationName: getOperationName(serverQuery) || void 0,
         context: this.prepareContext({
           ...context,
-          forceFetch: !deduplication
+          forceFetch: !deduplication,
         }),
       };
 
       context = operation.context;
 
       if (deduplication) {
-        const byVariables = inFlightLinkObservables.get(serverQuery) || new Map();
+        const byVariables =
+          inFlightLinkObservables.get(serverQuery) || new Map();
         inFlightLinkObservables.set(serverQuery, byVariables);
 
         const varJson = JSON.stringify(variables);
@@ -1138,9 +1139,9 @@ export class QueryManager<TStore> {
         if (!observable) {
           byVariables.set(
             varJson,
-            observable = multiplex(
-              execute(link, operation) as Observable<FetchResult<T>>
-            )
+            (observable = multiplex(execute(link, operation) as Observable<
+              FetchResult<T>
+            >)),
           );
 
           const cleanup = () => {
@@ -1155,9 +1156,10 @@ export class QueryManager<TStore> {
             complete: cleanup,
           });
         }
-
       } else {
-        observable = multiplex(execute(link, operation) as Observable<FetchResult<T>>);
+        observable = multiplex(execute(link, operation) as Observable<
+          FetchResult<T>
+        >);
       }
     } else {
       observable = Observable.of({ data: {} } as FetchResult<T>);
@@ -1216,71 +1218,70 @@ export class QueryManager<TStore> {
         });
       };
 
-      const subscription = observable.map((result: ExecutionResult) => {
-        if (requestId >= this.getQuery(queryId).lastRequestId) {
-          this.markQueryResult(
-            queryId,
-            result,
-            options,
-            fetchMoreForQueryId,
-          );
+      const subscription = observable
+        .map((result: ExecutionResult) => {
+          if (requestId >= this.getQuery(queryId).lastRequestId) {
+            this.markQueryResult(queryId, result, options, fetchMoreForQueryId);
 
-          this.queryStore.markQueryResult(
-            queryId,
-            result,
-            fetchMoreForQueryId,
-          );
+            this.queryStore.markQueryResult(
+              queryId,
+              result,
+              fetchMoreForQueryId,
+            );
 
-          this.invalidate(queryId);
-          this.invalidate(fetchMoreForQueryId);
+            this.invalidate(queryId);
+            this.invalidate(fetchMoreForQueryId);
 
-          this.broadcastQueries();
-        }
-
-        if (errorPolicy === 'none' && isNonEmptyArray(result.errors)) {
-          return reject(new ApolloError({
-            graphQLErrors: result.errors,
-          }));
-        }
-
-        if (errorPolicy === 'all') {
-          errorsFromStore = result.errors;
-        }
-
-        if (fetchMoreForQueryId || fetchPolicy === 'no-cache') {
-          // We don't write fetchMore results to the store because this would overwrite
-          // the original result in case an @connection directive is used.
-          resultFromStore = result.data;
-        } else {
-          // ensure result is combined with data already in store
-          const { result, complete } = this.dataStore.getCache().diff<T>({
-            variables,
-            query: document,
-            optimistic: false,
-            returnPartialData: true,
-          });
-
-          if (complete || options.returnPartialData) {
-            resultFromStore = result;
+            this.broadcastQueries();
           }
-        }
-      }).subscribe({
-        error(error: ApolloError) {
-          cleanup();
-          reject(error);
-        },
 
-        complete() {
-          cleanup();
-          resolve({
-            data: resultFromStore,
-            errors: errorsFromStore,
-            loading: false,
-            networkStatus: NetworkStatus.ready,
-            stale: false,
-          });
-        },
-      });
+          if (errorPolicy === 'none' && isNonEmptyArray(result.errors)) {
+            return reject(
+              new ApolloError({
+                graphQLErrors: result.errors,
+              }),
+            );
+          }
+
+          if (errorPolicy === 'all') {
+            errorsFromStore = result.errors;
+          }
+
+          if (fetchMoreForQueryId || fetchPolicy === 'no-cache') {
+            // We don't write fetchMore results to the store because this would overwrite
+            // the original result in case an @connection directive is used.
+            resultFromStore = result.data;
+          } else {
+            // ensure result is combined with data already in store
+            const { result, complete } = this.dataStore.getCache().diff<T>({
+              variables,
+              query: document,
+              optimistic: false,
+              returnPartialData: true,
+            });
+
+            if (complete || options.returnPartialData) {
+              resultFromStore = result;
+            }
+          }
+        })
+        .subscribe({
+          error(error: ApolloError) {
+            cleanup();
+            reject(error);
+          },
+
+          complete() {
+            cleanup();
+            resolve({
+              data: resultFromStore,
+              errors: errorsFromStore,
+              loading: false,
+              networkStatus: NetworkStatus.ready,
+              stale: false,
+            });
+          },
+        });
 
       this.setQuery(queryId, ({ subscriptions }) => {
         subscriptions.add(subscription);
@@ -1311,10 +1312,7 @@ export class QueryManager<TStore> {
     this.queries.set(queryId, newInfo);
   }
 
-  private invalidate(
-    queryId: string | undefined,
-    invalidated = true,
-  ) {
+  private invalidate(queryId: string | undefined, invalidated = true) {
     if (queryId) {
       this.setQuery(queryId, () => ({ invalidated }));
     }
@@ -1339,11 +1337,14 @@ export class QueryManager<TStore> {
   }
 
   // Map from client ID to { interval, options }.
-  private pollingInfoByQueryId = new Map<string, {
-    interval: number;
-    timeout: NodeJS.Timeout;
-    options: WatchQueryOptions;
-  }>();
+  private pollingInfoByQueryId = new Map<
+    string,
+    {
+      interval: number;
+      timeout: NodeJS.Timeout;
+      options: WatchQueryOptions;
+    }
+  >();
 
   public startPollingQuery(
     options: WatchQueryOptions,

--- a/packages/apollo-client/src/core/performance.ts
+++ b/packages/apollo-client/src/core/performance.ts
@@ -1,0 +1,169 @@
+// Inspired by https://github.com/facebook/react/blob/e0472709c81f53b333feafb5442319d6d25dda4b/packages/react-reconciler/src/ReactDebugFiberPerf.js
+import { invariant } from 'ts-invariant';
+
+type MarkType = string;
+type MeasureType = string;
+
+type OperationIdentifier = { operationId?: string };
+type QueryIdentifier = { queryId?: string };
+type MutationIdentifier = { mutationId?: string };
+
+type Identifier = OperationIdentifier | QueryIdentifier | MutationIdentifier;
+
+type MarkOptions = Identifier & {
+  name: MarkType;
+};
+
+type MeasureOptions = Identifier & {
+  name: MeasureType;
+  startName: MarkType;
+  endName: MarkType;
+};
+
+const pendingPerformanceEntries = new Map<string, PerformanceEntry[]>();
+
+const isProd = false; // Always prod for now
+// TODO some performance methods are not widely supported, needs more feature detection
+const supportsUserTiming =
+  typeof performance !== 'undefined' &&
+  typeof performance.mark === 'function' &&
+  typeof performance.clearMarks === 'function' &&
+  typeof performance.measure === 'function' &&
+  typeof performance.clearMeasures === 'function';
+
+const shouldLogPerformance = supportsUserTiming && !isProd;
+
+const getId = (options: Identifier) => {
+  return 'operationId' in options
+    ? options.operationId
+    : 'queryId' in options
+    ? options.queryId
+    : 'mutationId' in options
+    ? options.mutationId
+    : undefined;
+};
+
+const apolloEmoji = 'Ⓐ'; // ish
+const formattedLabel = ({ name, ...options }: MarkOptions | MeasureOptions) => {
+  return `${apolloEmoji} ${name} ` + `(${getId(options)})`;
+};
+
+const startFor = (name: string) => `${name} start`;
+const endFor = (name: string) => `${name} end`;
+
+function mark(options: MarkOptions) {
+  performance.mark(formattedLabel(options));
+}
+
+function measure({
+  name,
+  startName,
+  endName,
+  ...identifier
+}: MeasureOptions): PerformanceEntry[] {
+  const startMarkLabel = formattedLabel({
+    name: startName,
+    ...identifier,
+  });
+  const endMarkLabel = formattedLabel({
+    name: endName,
+    ...identifier,
+  });
+
+  const measureLabel = formattedLabel({
+    name,
+    ...identifier,
+  });
+
+  const startEntries = performance.getEntriesByName(startMarkLabel);
+  const endEntries = performance.getEntriesByName(endMarkLabel);
+
+  invariant(
+    startEntries.length > 0,
+    `No start entries found when trying to measure ${measureLabel}`,
+  );
+  invariant(
+    startEntries.length < 2,
+    `Multiple start entries found when trying to measure ${measureLabel}`,
+  );
+  invariant(
+    endEntries.length > 0,
+    `No end entries found when trying to measure ${measureLabel}`,
+  );
+  invariant(
+    endEntries.length < 2,
+    `Multiple end entries found when trying to measure ${measureLabel}`,
+  );
+  invariant(
+    performance.getEntriesByName(measureLabel).length === 0,
+    `Preexisting entries for measure ${measureLabel} when trying to measure`,
+  );
+
+  performance.measure(measureLabel, startMarkLabel, endMarkLabel);
+  const measureEntries = performance.getEntriesByName(measureLabel);
+
+  // Cleanup
+  // See https://github.com/airbnb/react-with-styles/pull/214
+  performance.clearMarks(startMarkLabel);
+  performance.clearMarks(endMarkLabel);
+  performance.clearMeasures(measureLabel);
+
+  // Should be only one but returned as an array
+  return measureEntries;
+}
+
+export function isPerformanceSupported() {
+  return supportsUserTiming;
+}
+
+/**
+ * Start measuring an operation/a step.
+ * Returns a `done` callback than can be called without arguments instead of perfEnd(options) to end the measure.
+ */
+export function perfStart({ name, ...identifier }: MarkOptions) {
+  if (!shouldLogPerformance) return () => {};
+
+  const operationId = getId(identifier);
+
+  if (!operationId) return () => {};
+
+  mark({
+    name: startFor(name),
+    ...identifier,
+  });
+
+  return () => perfEnd({ name, ...identifier });
+}
+
+/**
+ * End the measure for an operation/a step
+ */
+export function perfEnd({ name, ...identifier }: MarkOptions): void {
+  if (shouldLogPerformance) return;
+
+  const operationId = getId(identifier);
+  if (!operationId) return;
+
+  mark({
+    name: endFor(name),
+    ...identifier,
+  });
+
+  const performanceEntries = measure({
+    name,
+    startName: startFor(name),
+    endName: endFor(name),
+    ...identifier,
+  });
+
+  if (!pendingPerformanceEntries.has(operationId))
+    pendingPerformanceEntries.set(operationId, []);
+
+  pendingPerformanceEntries.get(operationId)!.push(...performanceEntries);
+}
+
+export function extractPerfEntriesFor(operationId: string): PerformanceEntry[] {
+  const performanceEntries = pendingPerformanceEntries.get(operationId) || [];
+  pendingPerformanceEntries.delete(operationId);
+  return performanceEntries;
+}

--- a/packages/apollo-client/src/core/types.ts
+++ b/packages/apollo-client/src/core/types.ts
@@ -24,6 +24,7 @@ export type ApolloQueryResult<T> = {
   loading: boolean;
   networkStatus: NetworkStatus;
   stale: boolean;
+  performanceEntries?: PerformanceEntry[];
 };
 
 export enum FetchType {


### PR DESCRIPTION
- Created a performance entry library. Currently only works in the
  browser but should be easily adaptable if and when Node starts
  supporting the `performance` API (see `perf_hooks`)
- Added a `performanceEntries` property on the ApolloResult to give the
  caller the entries corresponding to the current query
- Instrumented ApolloClient to create start and end performance entries
  for critical parts of the query lifecycle
- Added `queryId` to methods called by `QueryManager` to make it
  possible to track the owner of a given step

An alternative design is to expose lifecycle hooks to the caller and let
them add the performance instrumentation. This would potentially be more
flexible (and make it easier to adapt to environments without
`performance`) at the cost of added complexity and boilerplate.

This work is part of an effort to optimize preflight and postflight
steps taken during the `query`/`watchQuery` process (in particular query
transformations before we initiate the query and deserialization + cache
diffing on the way back). Adding this instrumentation makes it easier to
measure progress programmatically (through benchmarks and production
observability).

Here's what it looks like in Chrome (two requests with the second updating the first, using fetch-mock hence the gap but lack of network activity):

![image](https://user-images.githubusercontent.com/653269/61915142-12150280-aef8-11e9-8f62-635f8f664143.png)

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
