### PR TITLE
Fix subscribeToMore to recognize fetch policy

### DIFF
--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -354,6 +354,7 @@ export class ObservableQuery<
     const subscription = this.queryManager
       .startGraphQLSubscription({
         query: options.document,
+        fetchPolicy: options.fetchPolicy,
         variables: options.variables,
       })
       .subscribe({

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -149,6 +149,7 @@ export type SubscribeToMoreOptions<
 > = {
   document: DocumentNode;
   variables?: TSubscriptionVariables;
+  fetchPolicy?: FetchPolicy;
   updateQuery?: UpdateQueryFn<TData, TSubscriptionVariables, TSubscriptionData>;
   onError?: (error: Error) => void;
 };


### PR DESCRIPTION
The `subscribeToMore` was missing the `fetchPolicy` option. I dunno if it's a bug or a feature... I think it's a missing piece of #3773.

Let me know in case there's need to add new tests. I guess it should also be documented before merging.

Thanks! 🚀 