### PR TITLE
fix: fetchMore should accept `context`

### DIFF
--- a/packages/apollo-client/src/core/watchQueryOptions.ts
+++ b/packages/apollo-client/src/core/watchQueryOptions.ts
@@ -121,6 +121,7 @@ export interface WatchQueryOptions<TVariables = OperationVariables>
 export interface FetchMoreQueryOptions<TVariables, K extends keyof TVariables> {
   query?: DocumentNode;
   variables?: Pick<TVariables, K>;
+  context?: any;
 }
 
 export type UpdateQueryFn<


### PR DESCRIPTION
Without this typescript complains that `fetchMore` doesn't accept a `context` property, but it actually does.

