### PR TITLE
Remove freezeResults option, assuming always true.

### DIFF
--- a/packages/apollo-cache-inmemory/src/__tests__/__snapshots__/cache.ts.snap
+++ b/packages/apollo-cache-inmemory/src/__tests__/__snapshots__/cache.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Cache writeFragment will write some deeply nested data into the store at any id (1/3) 1`] = `
+exports[`Cache writeFragment will write some deeply nested data into the store at any id (1/2) 1`] = `
 Object {
   "bar": Object {
     "i": 7,
@@ -14,7 +14,7 @@ Object {
 }
 `;
 
-exports[`Cache writeFragment will write some deeply nested data into the store at any id (1/3) 2`] = `
+exports[`Cache writeFragment will write some deeply nested data into the store at any id (1/2) 2`] = `
 Object {
   "bar": Object {
     "i": 7,
@@ -32,7 +32,7 @@ Object {
 }
 `;
 
-exports[`Cache writeFragment will write some deeply nested data into the store at any id (1/3) 3`] = `
+exports[`Cache writeFragment will write some deeply nested data into the store at any id (1/2) 3`] = `
 Object {
   "bar": Object {
     "i": 10,
@@ -50,43 +50,7 @@ Object {
 }
 `;
 
-exports[`Cache writeFragment will write some deeply nested data into the store at any id (1/3) 4`] = `
-Object {
-  "bar": Object {
-    "i": 10,
-    "j": 11,
-    "k": 12,
-  },
-  "foo": Object {
-    "e": 4,
-    "f": 5,
-    "g": 6,
-    "h": Object {
-      "__ref": "bar",
-    },
-  },
-}
-`;
-
-exports[`Cache writeFragment will write some deeply nested data into the store at any id (1/3) 5`] = `
-Object {
-  "bar": Object {
-    "i": 7,
-    "j": 8,
-    "k": 9,
-  },
-  "foo": Object {
-    "e": 4,
-    "f": 5,
-    "g": 6,
-    "h": Object {
-      "__ref": "bar",
-    },
-  },
-}
-`;
-
-exports[`Cache writeFragment will write some deeply nested data into the store at any id (1/3) 6`] = `
+exports[`Cache writeFragment will write some deeply nested data into the store at any id (1/2) 4`] = `
 Object {
   "bar": Object {
     "i": 10,
@@ -104,21 +68,7 @@ Object {
 }
 `;
 
-exports[`Cache writeFragment will write some deeply nested data into the store at any id (2/3) 1`] = `
-Object {
-  "bar": Object {
-    "i": 7,
-  },
-  "foo": Object {
-    "e": 4,
-    "h": Object {
-      "__ref": "bar",
-    },
-  },
-}
-`;
-
-exports[`Cache writeFragment will write some deeply nested data into the store at any id (2/3) 2`] = `
+exports[`Cache writeFragment will write some deeply nested data into the store at any id (1/2) 5`] = `
 Object {
   "bar": Object {
     "i": 7,
@@ -136,25 +86,7 @@ Object {
 }
 `;
 
-exports[`Cache writeFragment will write some deeply nested data into the store at any id (2/3) 3`] = `
-Object {
-  "bar": Object {
-    "i": 10,
-    "j": 8,
-    "k": 9,
-  },
-  "foo": Object {
-    "e": 4,
-    "f": 5,
-    "g": 6,
-    "h": Object {
-      "__ref": "bar",
-    },
-  },
-}
-`;
-
-exports[`Cache writeFragment will write some deeply nested data into the store at any id (2/3) 4`] = `
+exports[`Cache writeFragment will write some deeply nested data into the store at any id (1/2) 6`] = `
 Object {
   "bar": Object {
     "i": 10,
@@ -172,7 +104,21 @@ Object {
 }
 `;
 
-exports[`Cache writeFragment will write some deeply nested data into the store at any id (2/3) 5`] = `
+exports[`Cache writeFragment will write some deeply nested data into the store at any id (2/2) 1`] = `
+Object {
+  "bar": Object {
+    "i": 7,
+  },
+  "foo": Object {
+    "e": 4,
+    "h": Object {
+      "__ref": "bar",
+    },
+  },
+}
+`;
+
+exports[`Cache writeFragment will write some deeply nested data into the store at any id (2/2) 2`] = `
 Object {
   "bar": Object {
     "i": 7,
@@ -190,7 +136,25 @@ Object {
 }
 `;
 
-exports[`Cache writeFragment will write some deeply nested data into the store at any id (2/3) 6`] = `
+exports[`Cache writeFragment will write some deeply nested data into the store at any id (2/2) 3`] = `
+Object {
+  "bar": Object {
+    "i": 10,
+    "j": 8,
+    "k": 9,
+  },
+  "foo": Object {
+    "e": 4,
+    "f": 5,
+    "g": 6,
+    "h": Object {
+      "__ref": "bar",
+    },
+  },
+}
+`;
+
+exports[`Cache writeFragment will write some deeply nested data into the store at any id (2/2) 4`] = `
 Object {
   "bar": Object {
     "i": 10,
@@ -208,21 +172,7 @@ Object {
 }
 `;
 
-exports[`Cache writeFragment will write some deeply nested data into the store at any id (3/3) 1`] = `
-Object {
-  "bar": Object {
-    "i": 7,
-  },
-  "foo": Object {
-    "e": 4,
-    "h": Object {
-      "__ref": "bar",
-    },
-  },
-}
-`;
-
-exports[`Cache writeFragment will write some deeply nested data into the store at any id (3/3) 2`] = `
+exports[`Cache writeFragment will write some deeply nested data into the store at any id (2/2) 5`] = `
 Object {
   "bar": Object {
     "i": 7,
@@ -240,61 +190,7 @@ Object {
 }
 `;
 
-exports[`Cache writeFragment will write some deeply nested data into the store at any id (3/3) 3`] = `
-Object {
-  "bar": Object {
-    "i": 10,
-    "j": 8,
-    "k": 9,
-  },
-  "foo": Object {
-    "e": 4,
-    "f": 5,
-    "g": 6,
-    "h": Object {
-      "__ref": "bar",
-    },
-  },
-}
-`;
-
-exports[`Cache writeFragment will write some deeply nested data into the store at any id (3/3) 4`] = `
-Object {
-  "bar": Object {
-    "i": 10,
-    "j": 11,
-    "k": 12,
-  },
-  "foo": Object {
-    "e": 4,
-    "f": 5,
-    "g": 6,
-    "h": Object {
-      "__ref": "bar",
-    },
-  },
-}
-`;
-
-exports[`Cache writeFragment will write some deeply nested data into the store at any id (3/3) 5`] = `
-Object {
-  "bar": Object {
-    "i": 7,
-    "j": 8,
-    "k": 9,
-  },
-  "foo": Object {
-    "e": 4,
-    "f": 5,
-    "g": 6,
-    "h": Object {
-      "__ref": "bar",
-    },
-  },
-}
-`;
-
-exports[`Cache writeFragment will write some deeply nested data into the store at any id (3/3) 6`] = `
+exports[`Cache writeFragment will write some deeply nested data into the store at any id (2/2) 6`] = `
 Object {
   "bar": Object {
     "i": 10,

--- a/packages/apollo-cache-inmemory/src/__tests__/cache.ts
+++ b/packages/apollo-cache-inmemory/src/__tests__/cache.ts
@@ -24,12 +24,6 @@ describe('Cache', () => {
           resultCaching: false,
         }).restore(cloneDeep(data)),
       ),
-      initialDataForCaches.map(data =>
-        new InMemoryCache({
-          addTypename: false,
-          freezeResults: true,
-        }).restore(cloneDeep(data)),
-      ),
     ];
 
     cachesList.forEach((caches, i) => {
@@ -54,11 +48,6 @@ describe('Cache', () => {
         addTypename: false,
         ...config,
         resultCaching: false,
-      }),
-      new InMemoryCache({
-        addTypename: false,
-        ...config,
-        freezeResults: true,
       }),
     ];
 

--- a/packages/apollo-cache-inmemory/src/__tests__/roundtrip.ts
+++ b/packages/apollo-cache-inmemory/src/__tests__/roundtrip.ts
@@ -22,7 +22,6 @@ function assertDeeplyFrozen(value: any, stack: any[] = []) {
 
 function storeRoundtrip(query: DocumentNode, result: any, variables = {}) {
   const reader = new StoreReader();
-  const immutableReader = new StoreReader({ freezeResults: true });
   const writer = new StoreWriter();
 
   const store = writer.writeQueryToStore({
@@ -45,9 +44,9 @@ function storeRoundtrip(query: DocumentNode, result: any, variables = {}) {
   expect(store).toBeInstanceOf(EntityCache);
   expect(reader.readQueryFromStore(readOptions)).toBe(reconstructedResult);
 
-  const immutableResult = immutableReader.readQueryFromStore(readOptions);
+  const immutableResult = reader.readQueryFromStore(readOptions);
   expect(immutableResult).toEqual(reconstructedResult);
-  expect(immutableReader.readQueryFromStore(readOptions)).toBe(immutableResult);
+  expect(reader.readQueryFromStore(readOptions)).toBe(immutableResult);
   if (process.env.NODE_ENV !== 'production') {
     try {
       // Note: this illegal assignment will only throw in strict mode, but that's
@@ -234,8 +233,8 @@ describe('roundtrip', () => {
       },
     );
 
-    // Just because we read from the store using { freezeResults: true }, the
-    // original data should not be frozen.
+    // Reading immutable results from the store does not mean the original
+    // data should get frozen.
     expect(Object.isExtensible(updateClub)).toBe(true);
     expect(Object.isFrozen(updateClub)).toBe(false);
   });

--- a/packages/apollo-cache-inmemory/src/inMemoryCache.ts
+++ b/packages/apollo-cache-inmemory/src/inMemoryCache.ts
@@ -20,14 +20,12 @@ import { KeyTrie } from 'optimism';
 
 export interface InMemoryCacheConfig extends ApolloReducerConfig {
   resultCaching?: boolean;
-  freezeResults?: boolean;
 }
 
 const defaultConfig: InMemoryCacheConfig = {
   dataIdFromObject: defaultDataIdFromObject,
   addTypename: true,
   resultCaching: true,
-  freezeResults: false,
 };
 
 export function defaultDataIdFromObject(result: any): string | null {
@@ -92,7 +90,6 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
 
     this.storeReader = new StoreReader({
       cacheKeyRoot: this.cacheKeyRoot,
-      freezeResults: config.freezeResults,
       possibleTypes: this.possibleTypes,
     });
 

--- a/packages/apollo-cache-inmemory/src/readFromStore.ts
+++ b/packages/apollo-cache-inmemory/src/readFromStore.ts
@@ -98,17 +98,14 @@ type ExecSubSelectedArrayOptions = {
 type PossibleTypes = import('./inMemoryCache').InMemoryCache['possibleTypes'];
 export interface StoreReaderConfig {
   cacheKeyRoot?: KeyTrie<object>;
-  freezeResults?: boolean;
   possibleTypes?: PossibleTypes;
 }
 
 export class StoreReader {
-  private freezeResults: boolean;
   private possibleTypes?: PossibleTypes;
 
   constructor({
     cacheKeyRoot = new KeyTrie<object>(canUseWeakMap),
-    freezeResults = false,
     possibleTypes,
   }: StoreReaderConfig = {}) {
     const {
@@ -117,7 +114,6 @@ export class StoreReader {
       executeSubSelectedArray,
     } = this;
 
-    this.freezeResults = freezeResults;
     this.possibleTypes = possibleTypes;
 
     this.executeStoreQuery = wrap((options: ExecStoreQueryOptions) => {
@@ -391,7 +387,7 @@ export class StoreReader {
     // defensive shallow copies than necessary.
     finalResult.result = mergeDeepArray(objectsToMerge);
 
-    if (this.freezeResults && process.env.NODE_ENV !== 'production') {
+    if (process.env.NODE_ENV !== 'production') {
       Object.freeze(finalResult.result);
     }
 
@@ -437,9 +433,7 @@ export class StoreReader {
     if (!field.selectionSet) {
       if (process.env.NODE_ENV !== 'production') {
         assertSelectionSetForIdValue(contextValue.store, field, readStoreResult.result);
-        if (this.freezeResults) {
-          maybeDeepFreeze(readStoreResult);
-        }
+        maybeDeepFreeze(readStoreResult);
       }
       return readStoreResult;
     }
@@ -525,7 +519,7 @@ export class StoreReader {
       return item;
     });
 
-    if (this.freezeResults && process.env.NODE_ENV !== 'production') {
+    if (process.env.NODE_ENV !== 'production') {
       Object.freeze(array);
     }
 

--- a/packages/apollo-cache-inmemory/src/writeToStore.ts
+++ b/packages/apollo-cache-inmemory/src/writeToStore.ts
@@ -15,6 +15,7 @@ import {
   StoreValue,
   DeepMerger,
   getTypenameFromResult,
+  cloneDeep,
 } from 'apollo-utilities';
 
 import { invariant, InvariantError } from 'ts-invariant';
@@ -233,7 +234,10 @@ export class StoreWriter {
     context: WriteContext,
   ): StoreValue {
     if (!field.selectionSet || value === null) {
-      return value;
+      // In development, we need to clone scalar values so that they can be
+      // safely frozen with maybeDeepFreeze in readFromStore.ts. In production,
+      // it's cheaper to store the scalar values directly in the cache.
+      return process.env.NODE_ENV === 'production' ? value : cloneDeep(value);
     }
 
     if (Array.isArray(value)) {

--- a/packages/apollo-client/src/__tests__/ApolloClient.ts
+++ b/packages/apollo-client/src/__tests__/ApolloClient.ts
@@ -1329,8 +1329,6 @@ describe('ApolloClient', () => {
                   data,
                 );
                 const friends = result.data.people.friends;
-                friends[0].type = 'okayest';
-                friends[1].type = 'okayest';
 
                 // this should re call next
                 client.writeFragment({
@@ -1344,7 +1342,10 @@ describe('ApolloClient', () => {
                     }
                   `,
                   data: {
-                    friends,
+                    friends: [
+                      { ...friends[0], type: 'okayest' },
+                      { ...friends[1], type: 'okayest' },
+                    ],
                     __typename: 'Person',
                   },
                 });


### PR DESCRIPTION
This option was first added in Apollo Client 2.6, as a way to help enforce immutability of cache results: https://github.com/apollographql/apollo-client/pull/4514

As promised in [the Apollo Client 2.6 blog post](https://blog.apollographql.com/whats-new-in-apollo-client-2-6-b3acf28ecad1), all cache results will be frozen/immutable in the next major version (3.0):

> In Apollo Client 3.0, we intend to make both `freezeResults` and `assumeImmutableResults` `true` by default, in addition to using the TypeScript `Readonly<T>` type to discourage destructive modifications. In other words, if you embrace immutability now, you won’t have to do anything when it becomes mandatory.

I have not yet removed the `assumeImmutableResults` option from the `ApolloClient` constructor, since cache implementations other than `apollo-cache-inmemory` might not return immutable results.