### PR TITLE
Assume addTypename:true, but hide implicit __typename result fields.

### DIFF
--- a/packages/apollo-cache-inmemory/src/__tests__/__snapshots__/cache.ts.snap
+++ b/packages/apollo-cache-inmemory/src/__tests__/__snapshots__/cache.ts.snap
@@ -6,6 +6,7 @@ Object {
     "i": 7,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "h": Object {
       "__ref": "bar",
@@ -22,6 +23,7 @@ Object {
     "k": 9,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -35,11 +37,13 @@ Object {
 exports[`Cache writeFragment will write some deeply nested data into the store at any id (1/3) 3`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 10,
     "j": 8,
     "k": 9,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -53,11 +57,13 @@ Object {
 exports[`Cache writeFragment will write some deeply nested data into the store at any id (1/3) 4`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 10,
     "j": 11,
     "k": 12,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -71,11 +77,13 @@ Object {
 exports[`Cache writeFragment will write some deeply nested data into the store at any id (1/3) 5`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 7,
     "j": 8,
     "k": 9,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -89,11 +97,13 @@ Object {
 exports[`Cache writeFragment will write some deeply nested data into the store at any id (1/3) 6`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 10,
     "j": 11,
     "k": 12,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -110,6 +120,7 @@ Object {
     "i": 7,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "h": Object {
       "__ref": "bar",
@@ -126,6 +137,7 @@ Object {
     "k": 9,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -139,11 +151,13 @@ Object {
 exports[`Cache writeFragment will write some deeply nested data into the store at any id (2/3) 3`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 10,
     "j": 8,
     "k": 9,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -157,11 +171,13 @@ Object {
 exports[`Cache writeFragment will write some deeply nested data into the store at any id (2/3) 4`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 10,
     "j": 11,
     "k": 12,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -175,11 +191,13 @@ Object {
 exports[`Cache writeFragment will write some deeply nested data into the store at any id (2/3) 5`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 7,
     "j": 8,
     "k": 9,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -193,11 +211,13 @@ Object {
 exports[`Cache writeFragment will write some deeply nested data into the store at any id (2/3) 6`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 10,
     "j": 11,
     "k": 12,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -214,6 +234,7 @@ Object {
     "i": 7,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "h": Object {
       "__ref": "bar",
@@ -230,6 +251,7 @@ Object {
     "k": 9,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -243,11 +265,13 @@ Object {
 exports[`Cache writeFragment will write some deeply nested data into the store at any id (3/3) 3`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 10,
     "j": 8,
     "k": 9,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -261,11 +285,13 @@ Object {
 exports[`Cache writeFragment will write some deeply nested data into the store at any id (3/3) 4`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 10,
     "j": 11,
     "k": 12,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -279,11 +305,13 @@ Object {
 exports[`Cache writeFragment will write some deeply nested data into the store at any id (3/3) 5`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 7,
     "j": 8,
     "k": 9,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -297,11 +325,13 @@ Object {
 exports[`Cache writeFragment will write some deeply nested data into the store at any id (3/3) 6`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 10,
     "j": 11,
     "k": 12,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,

--- a/packages/apollo-cache-inmemory/src/__tests__/__snapshots__/mapCache.ts.snap
+++ b/packages/apollo-cache-inmemory/src/__tests__/__snapshots__/mapCache.ts.snap
@@ -6,6 +6,7 @@ Object {
     "i": 7,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "h": Object {
       "__ref": "bar",
@@ -22,6 +23,7 @@ Object {
     "k": 9,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -35,11 +37,13 @@ Object {
 exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (1/3) 3`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 10,
     "j": 8,
     "k": 9,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -53,11 +57,13 @@ Object {
 exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (1/3) 4`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 10,
     "j": 11,
     "k": 12,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -71,11 +77,13 @@ Object {
 exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (1/3) 5`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 7,
     "j": 8,
     "k": 9,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -89,11 +97,13 @@ Object {
 exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (1/3) 6`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 10,
     "j": 11,
     "k": 12,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -110,6 +120,7 @@ Object {
     "i": 7,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "h": Object {
       "__ref": "bar",
@@ -126,6 +137,7 @@ Object {
     "k": 9,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -139,11 +151,13 @@ Object {
 exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (2/3) 3`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 10,
     "j": 8,
     "k": 9,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -157,11 +171,13 @@ Object {
 exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (2/3) 4`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 10,
     "j": 11,
     "k": 12,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -175,11 +191,13 @@ Object {
 exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (2/3) 5`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 7,
     "j": 8,
     "k": 9,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -193,11 +211,13 @@ Object {
 exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (2/3) 6`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 10,
     "j": 11,
     "k": 12,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -214,6 +234,7 @@ Object {
     "i": 7,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "h": Object {
       "__ref": "bar",
@@ -230,6 +251,7 @@ Object {
     "k": 9,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -243,11 +265,13 @@ Object {
 exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (3/3) 3`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 10,
     "j": 8,
     "k": 9,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -261,11 +285,13 @@ Object {
 exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (3/3) 4`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 10,
     "j": 11,
     "k": 12,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -279,11 +305,13 @@ Object {
 exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (3/3) 5`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 7,
     "j": 8,
     "k": 9,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -297,11 +325,13 @@ Object {
 exports[`MapCache Cache writeFragment will write some deeply nested data into the store at any id (3/3) 6`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 10,
     "j": 11,
     "k": 12,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,

--- a/packages/apollo-cache-inmemory/src/__tests__/cache.ts
+++ b/packages/apollo-cache-inmemory/src/__tests__/cache.ts
@@ -2,6 +2,7 @@ import gql, { disableFragmentWarnings } from 'graphql-tag';
 import { stripSymbols, cloneDeep } from 'apollo-utilities';
 
 import { InMemoryCache, InMemoryCacheConfig } from '..';
+import { cloneWithoutTypename } from './testUtils';
 import { makeReference } from '../helpers';
 
 disableFragmentWarnings();
@@ -14,19 +15,15 @@ describe('Cache', () => {
   ) {
     const cachesList: InMemoryCache[][] = [
       initialDataForCaches.map(data =>
-        new InMemoryCache({
-          addTypename: false,
-        }).restore(cloneDeep(data)),
+        new InMemoryCache().restore(cloneDeep(data)),
       ),
       initialDataForCaches.map(data =>
         new InMemoryCache({
-          addTypename: false,
           resultCaching: false,
         }).restore(cloneDeep(data)),
       ),
       initialDataForCaches.map(data =>
         new InMemoryCache({
-          addTypename: false,
           freezeResults: true,
         }).restore(cloneDeep(data)),
       ),
@@ -46,17 +43,14 @@ describe('Cache', () => {
   ) {
     const caches = [
       new InMemoryCache({
-        addTypename: false,
         ...config,
         resultCaching: true,
       }),
       new InMemoryCache({
-        addTypename: false,
         ...config,
         resultCaching: false,
       }),
       new InMemoryCache({
-        addTypename: false,
         ...config,
         freezeResults: true,
       }),
@@ -907,7 +901,6 @@ describe('Cache', () => {
       'will write some deeply nested data into the store at any id',
       {
         dataIdFromObject: (o: any) => o.id,
-        addTypename: false,
       },
       proxy => {
         proxy.writeFragment({
@@ -1028,9 +1021,7 @@ describe('Cache', () => {
 
     itWithCacheConfig(
       'writes data that can be read back',
-      {
-        addTypename: true,
-      },
+      {},
       proxy => {
         const readWriteFragment = gql`
           fragment aFragment on query {
@@ -1053,15 +1044,13 @@ describe('Cache', () => {
           fragment: readWriteFragment,
           id: 'query',
         });
-        expect(stripSymbols(result)).toEqual(data);
+        expect(stripSymbols(result)).toEqual(cloneWithoutTypename(data));
       },
     );
 
     itWithCacheConfig(
       'will write some data to the store with variables',
-      {
-        addTypename: true,
-      },
+      {},
       proxy => {
         proxy.writeFragment({
           data: {

--- a/packages/apollo-cache-inmemory/src/__tests__/fragmentMatcher.ts
+++ b/packages/apollo-cache-inmemory/src/__tests__/fragmentMatcher.ts
@@ -29,6 +29,7 @@ describe('fragment matching', () => {
     `;
 
     const data = {
+      __typename: 'Query',
       animals: [
         {
           __typename: 'Cat',
@@ -73,6 +74,7 @@ describe('fragment matching', () => {
     `;
 
     const data = {
+      __typename: 'Query',
       bestFriend: {
         __typename: 'Dog',
         id: 2,
@@ -109,6 +111,7 @@ describe('fragment matching', () => {
     `;
 
     const data = {
+      __typename: 'Query',
       testResults: [
         {
           __typename: 'TestResult',
@@ -160,6 +163,7 @@ describe('fragment matching', () => {
     `;
 
     const data = {
+      __typename: 'Query',
       animals: [
         {
           __typename: 'Sphynx',
@@ -204,6 +208,7 @@ describe('fragment matching', () => {
     `;
 
     const data = {
+      __typename: 'Query',
       people: [
         {
           __typename: 'Person',

--- a/packages/apollo-cache-inmemory/src/__tests__/fragmentMatcher.ts
+++ b/packages/apollo-cache-inmemory/src/__tests__/fragmentMatcher.ts
@@ -1,14 +1,11 @@
-import { InMemoryCache } from '../inMemoryCache';
 import gql from 'graphql-tag';
+import { InMemoryCache } from '../inMemoryCache';
+import { cloneWithoutTypename } from './testUtils';
 
 describe('fragment matching', () => {
   it('can match exact types with or without possibleTypes', () => {
-    const cacheWithoutPossibleTypes = new InMemoryCache({
-      addTypename: true,
-    });
-
+    const cacheWithoutPossibleTypes = new InMemoryCache();
     const cacheWithPossibleTypes = new InMemoryCache({
-      addTypename: true,
       possibleTypes: {
         Animal: ['Cat', 'Dog'],
       },
@@ -47,15 +44,18 @@ describe('fragment matching', () => {
     };
 
     cacheWithoutPossibleTypes.writeQuery({ query, data });
-    expect(cacheWithoutPossibleTypes.readQuery({ query })).toEqual(data);
+    expect(cacheWithoutPossibleTypes.readQuery({ query })).toEqual(
+      cloneWithoutTypename(data),
+    );
 
     cacheWithPossibleTypes.writeQuery({ query, data });
-    expect(cacheWithPossibleTypes.readQuery({ query })).toEqual(data);
+    expect(cacheWithPossibleTypes.readQuery({ query })).toEqual(
+      cloneWithoutTypename(data),
+    );
   });
 
   it('can match interface subtypes', () => {
     const cache = new InMemoryCache({
-      addTypename: true,
       possibleTypes: {
         Animal: ['Cat', 'Dog'],
       },
@@ -83,12 +83,11 @@ describe('fragment matching', () => {
     };
 
     cache.writeQuery({ query, data });
-    expect(cache.readQuery({ query })).toEqual(data);
+    expect(cache.readQuery({ query })).toEqual(cloneWithoutTypename(data));
   });
 
   it('can match union member types', () => {
     const cache = new InMemoryCache({
-      addTypename: true,
       possibleTypes: {
         Status: ['PASSING', 'FAILING', 'SKIPPED'],
       },
@@ -134,12 +133,11 @@ describe('fragment matching', () => {
     };
 
     cache.writeQuery({ query, data });
-    expect(cache.readQuery({ query })).toEqual(data);
+    expect(cache.readQuery({ query })).toEqual(cloneWithoutTypename(data));
   });
 
   it('can match indirect subtypes while avoiding cycles', () => {
     const cache = new InMemoryCache({
-      addTypename: true,
       possibleTypes: {
         Animal: ['Animal', 'Bug', 'Mammal'],
         Bug: ['Ant', 'Spider', 'RolyPoly'],
@@ -183,13 +181,11 @@ describe('fragment matching', () => {
     };
 
     cache.writeQuery({ query, data });
-    expect(cache.readQuery({ query })).toEqual(data);
+    expect(cache.readQuery({ query })).toEqual(cloneWithoutTypename(data));
   });
 
   it('can match against the root Query', () => {
-    const cache = new InMemoryCache({
-      addTypename: true,
-    });
+    const cache = new InMemoryCache();
 
     const query = gql`
       query AllPeople {
@@ -224,6 +220,6 @@ describe('fragment matching', () => {
     };
 
     cache.writeQuery({ query, data });
-    expect(cache.readQuery({ query })).toEqual(data);
+    expect(cache.readQuery({ query })).toEqual(cloneWithoutTypename(data));
   });
 });

--- a/packages/apollo-cache-inmemory/src/__tests__/testUtils.ts
+++ b/packages/apollo-cache-inmemory/src/__tests__/testUtils.ts
@@ -1,0 +1,20 @@
+export function cloneWithoutTypename<D>(data: D): D {
+  return JSON.parse(JSON.stringify(data), function(key, value) {
+    return key === '__typename' ? void 0 : value;
+  });
+}
+
+describe('cloneWithoutTypename', () => {
+  it('needs at least one test to be defined', () => {
+    expect(
+      cloneWithoutTypename({
+        a: 1,
+        __typename: 'SomeType',
+        b: true,
+      }),
+    ).toEqual({
+      a: 1,
+      b: true,
+    });
+  });
+});

--- a/packages/apollo-cache-inmemory/src/inMemoryCache.ts
+++ b/packages/apollo-cache-inmemory/src/inMemoryCache.ts
@@ -27,7 +27,6 @@ export interface InMemoryCacheConfig extends ApolloReducerConfig {
 
 const defaultConfig: InMemoryCacheConfig = {
   dataIdFromObject: defaultDataIdFromObject,
-  addTypename: true,
   resultCaching: true,
   freezeResults: false,
 };
@@ -80,7 +79,6 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
 
   protected config: InMemoryCacheConfig;
   private watches = new Set<Cache.WatchOptions>();
-  private addTypename: boolean;
   private possibleTypes?: {
     [supertype: string]: {
       [subtype: string]: true;
@@ -98,7 +96,6 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
   constructor(config: InMemoryCacheConfig = {}) {
     super();
     this.config = { ...defaultConfig, ...config };
-    this.addTypename = !!this.config.addTypename;
 
     if (this.config.possibleTypes) {
       this.addPossibleTypes(this.config.possibleTypes);
@@ -299,19 +296,16 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
   }
 
   public transformDocument(document: DocumentNode): DocumentNode {
-    if (this.addTypename) {
-      let result = this.typenameDocumentCache.get(document);
-      if (!result) {
-        result = addTypenameToDocument(document);
-        this.typenameDocumentCache.set(document, result);
-        // If someone calls transformDocument and then mistakenly passes the
-        // result back into an API that also calls transformDocument, make sure
-        // we don't keep creating new query documents.
-        this.typenameDocumentCache.set(result, result);
-      }
-      return result;
+    let result = this.typenameDocumentCache.get(document);
+    if (!result) {
+      result = addTypenameToDocument(document);
+      this.typenameDocumentCache.set(document, result);
+      // If someone calls transformDocument and then mistakenly passes the
+      // result back into an API that also calls transformDocument, make sure
+      // we don't keep creating new query documents.
+      this.typenameDocumentCache.set(result, result);
     }
-    return document;
+    return result;
   }
 
   public addPossibleTypes(possibleTypes: PossibleTypesMap) {

--- a/packages/apollo-cache-inmemory/src/readFromStore.ts
+++ b/packages/apollo-cache-inmemory/src/readFromStore.ts
@@ -19,6 +19,7 @@ import {
   resultKeyNameFromField,
   shouldInclude,
   StoreValue,
+  addTypenameToDocument,
 } from 'apollo-utilities';
 
 import { Cache } from 'apollo-cache';
@@ -339,6 +340,13 @@ export class StoreReader {
     }
 
     selectionSet.selections.forEach(selection => {
+      // If this selection was added by the addTypenameToDocument function, it
+      // may be useful for maintaining accurate __typename information in the
+      // cache, but we do not need to include it in the query result.
+      if (addTypenameToDocument.didAdd(selection)) {
+        return;
+      }
+
       if (!shouldInclude(selection, variables)) {
         // Skip this entirely
         return;

--- a/packages/apollo-cache-inmemory/src/types.ts
+++ b/packages/apollo-cache-inmemory/src/types.ts
@@ -65,7 +65,6 @@ export type DiffQueryAgainstStoreOptions = ReadQueryOptions & {
 
 export type ApolloReducerConfig = {
   dataIdFromObject?: IdGetter;
-  addTypename?: boolean;
   cacheRedirects?: CacheResolverMap;
   possibleTypes?: PossibleTypesMap;
 };

--- a/packages/apollo-utilities/src/__tests__/transform.ts
+++ b/packages/apollo-utilities/src/__tests__/transform.ts
@@ -554,6 +554,7 @@ describe('query transforms', () => {
           }
           __typename
         }
+        __typename
       }
     `;
     const expectedQueryStr = print(expectedQuery);
@@ -564,6 +565,7 @@ describe('query transforms', () => {
   it('should not add duplicates', () => {
     let testQuery = gql`
       query {
+        __typename
         author {
           name {
             firstName
@@ -577,6 +579,7 @@ describe('query transforms', () => {
 
     const expectedQuery = gql`
       query {
+        __typename
         author {
           name {
             firstName
@@ -611,6 +614,7 @@ describe('query transforms', () => {
           }
           __typename
         }
+        __typename
       }
     `);
     const modifiedQuery = addTypenameToDocument(testQuery);
@@ -644,6 +648,7 @@ describe('query transforms', () => {
           }
           __typename
         }
+        __typename
       }
 
       fragment friendFields on User {
@@ -673,6 +678,7 @@ describe('query transforms', () => {
           lastName
           __typename
         }
+        __typename
       }
     `);
 
@@ -696,6 +702,7 @@ describe('query transforms', () => {
           lastName
           __typename
         }
+        __typename
       }
     `;
 
@@ -768,6 +775,7 @@ describe('query transforms', () => {
           }
           __typename
         }
+        __typename
       }
     `);
     const modifiedQuery = addTypenameToDocument(testQuery);

--- a/packages/apollo-utilities/src/transform.ts
+++ b/packages/apollo-utilities/src/transform.ts
@@ -49,14 +49,6 @@ export type RemoveVariableDefinitionConfig = RemoveNodeConfig<
   VariableDefinitionNode
 >;
 
-const TYPENAME_FIELD: FieldNode = {
-  kind: 'Field',
-  name: {
-    kind: 'Name',
-    value: '__typename',
-  },
-};
-
 function isEmpty(
   op: OperationDefinitionNode | FragmentDefinitionNode,
   fragments: FragmentMap,
@@ -207,6 +199,14 @@ export function removeDirectivesFromDocument(
   return modifiedDoc;
 }
 
+const TYPENAME_FIELD = Object.freeze({
+  kind: 'Field',
+  name: Object.freeze({
+    kind: 'Name',
+    value: '__typename',
+  }),
+} as FieldNode);
+
 export function addTypenameToDocument(doc: DocumentNode): DocumentNode {
   return visit(checkDocument(doc), {
     SelectionSet: {
@@ -249,6 +249,12 @@ export function addTypenameToDocument(doc: DocumentNode): DocumentNode {
       },
     },
   });
+}
+
+export namespace addTypenameToDocument {
+  export function didAdd(field: SelectionNode): field is FieldNode {
+    return field === TYPENAME_FIELD;
+  }
 }
 
 const connectionRemoveConfig = {

--- a/packages/apollo-utilities/src/transform.ts
+++ b/packages/apollo-utilities/src/transform.ts
@@ -211,14 +211,6 @@ export function addTypenameToDocument(doc: DocumentNode): DocumentNode {
   return visit(checkDocument(doc), {
     SelectionSet: {
       enter(node, _key, parent) {
-        // Don't add __typename to OperationDefinitions.
-        if (
-          parent &&
-          (parent as OperationDefinitionNode).kind === 'OperationDefinition'
-        ) {
-          return;
-        }
-
         // No changes if no selections.
         const { selections } = node;
         if (!selections) {


### PR DESCRIPTION
As @jbaxleyiii pointed out in [this comment](https://github.com/apollographql/apollo-client/pull/5146#discussion_r311808462), the root query and mutation types do not necessarily have to be called "Query" or "Mutation", and the only way to find their real names is to ask for their `__typename` fields. In other words, when adding `__typename` fields to a query, we should make sure the root operation has a `__typename` field, just like any other selection set. Hence the first commit in this PR: 4377e0280e14b5ef7b44a473972f8263088cdd85.

Until now, the `InMemoryCache` has allowed application developers to decide if the cache should add `__typename` to the queries it processes. While this might seem like a reasonable configuration option, the truth is that the cache always needs `__typename` information, and the only legitimate reason to pass `addTypename: false` is when you (the application developer) don't want to receive `__typename` fields in your query results when you didn't ask for them.

It turns out we can satisfy the latter goal by simply excluding any implicitly-injected `__typename` fields from cache results. With that objection out of the way, it becomes much less disruptive to force `addTypename: true` as the default behavior, which allows the cache to rely on the presence of type information without visibly polluting cache results returned to the application.