### PR TITLE
Fix useQuery import in first code section

### DIFF
--- a/docs/source/recipes/testing.mdx
+++ b/docs/source/recipes/testing.mdx
@@ -25,7 +25,7 @@ Consider the component below, which makes a basic query, and displays its result
 ```jsx
 import React from 'react';
 import gql from 'graphql-tag';
-import { Query } from '@apollo/react-components';
+import { useQuery } from '@apollo/react-components';
 
 // Make sure the query is also exported -- not just the component
 export const GET_DOG_QUERY = gql`


### PR DESCRIPTION
In first code section, used wrong import `Query` instead of `useQuery`

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
