### PR TITLE
Use `forEach` instead of `map` for error logging

### DIFF
--- a/packages/apollo-boost/src/index.ts
+++ b/packages/apollo-boost/src/index.ts
@@ -122,7 +122,7 @@ export default class DefaultClient<TCache> extends ApolloClient<TCache> {
       ? onError(errorCallback)
       : onError(({ graphQLErrors, networkError }) => {
           if (graphQLErrors) {
-            graphQLErrors.map(({ message, locations, path }) =>
+            graphQLErrors.forEach(({ message, locations, path }) =>
               // tslint:disable-next-line
               invariant.warn(
                 `[GraphQL error]: Message: ${message}, Location: ` +


### PR DESCRIPTION
I think the more proper way would be using `forEach` here, as `map` is needlessly returning an array of undefined elements.