### PR TITLE
Set the default doc selector to version 3

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -8,8 +8,9 @@ module.exports = {
         subtitle: 'Apollo Client',
         description: 'A guide to using the Apollo GraphQL Client with React',
         githubRepo: 'apollographql/apollo-client',
-        defaultVersion: 2.6,
+        defaultVersion: 3.0,
         versions: {
+          2.6: 'version-2.6',
           2.5: 'version-2.5',
           2.4: 'version-2.4',
         },


### PR DESCRIPTION
In preparation for Apollo Client 3 documentation work, this PR sets the default document selector version to 3, and wires the `version-2.6` branch in as the 2.6 option.