### PR TITLE
Upgrade the docs theme and supply check-links options properly

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -13,10 +13,12 @@ module.exports = {
           2.5: 'version-2.5',
           2.4: 'version-2.4',
         },
-        checkLinksExceptions: [
-          '/api/apollo-client/',
-          '/v2.4/api/apollo-client/',
-        ],
+        checkLinksOptions: {
+          exceptions: [
+            '/api/apollo-client/',
+            '/v2.4/api/apollo-client/',
+          ]
+        },
         typescriptApiBox: {
           data: require('./docs.json'),
           filepathPrefix: 'packages/apollo-client/src/',

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -6819,9 +6819,9 @@
       }
     },
     "gatsby-remark-copy-linked-files": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/gatsby-remark-copy-linked-files/-/gatsby-remark-copy-linked-files-2.1.5.tgz",
-      "integrity": "sha512-QiMFA/SZruX5h2l0uml0pGydQr4+twzXw5LLpKIWSwIDZoiXqc1rY60etiwkuJ81AlZqWOABiwYtWdYlowmimw==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-copy-linked-files/-/gatsby-remark-copy-linked-files-2.1.6.tgz",
+      "integrity": "sha512-VBLIyMKhHqW0lttl5Tjngd6UwD3aluMTiG6wT4noGKY2A3/NednUIr1VI+WZWrKFMBMir1vcstlxe4nwMgm7vA==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "cheerio": "^1.0.0-rc.2",
@@ -6896,6 +6896,24 @@
         "@babel/runtime": "^7.0.0",
         "parse-numeric-range": "^0.0.2",
         "unist-util-visit": "^1.3.0"
+      },
+      "dependencies": {
+        "unist-util-visit": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+          "requires": {
+            "unist-util-visit-parents": "^2.0.0"
+          }
+        }
+      }
+    },
+    "gatsby-remark-prismjs-title": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-prismjs-title/-/gatsby-remark-prismjs-title-1.0.0.tgz",
+      "integrity": "sha512-VKAw7LGAbzyDlztUfhOri+jDTjLyOPCJCNgkdt2+61+SP8M9wYzzma8NvVyzHP7J9hx0jcYq8F50XQH5dE42ow==",
+      "requires": {
+        "unist-util-visit": "~1.4.0"
       },
       "dependencies": {
         "unist-util-visit": {
@@ -7091,9 +7109,9 @@
       }
     },
     "gatsby-theme-apollo-docs": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/gatsby-theme-apollo-docs/-/gatsby-theme-apollo-docs-1.2.4.tgz",
-      "integrity": "sha512-Qrk7gj0ZeLL1nn5Eh4vvGpLjZnjrA5b8fat2Rl7H776MizGBWGZkh7jZz30ntzOzpHm987Z2iWthw0hUbNl+bg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/gatsby-theme-apollo-docs/-/gatsby-theme-apollo-docs-1.3.1.tgz",
+      "integrity": "sha512-JbyQEwgVh4mXrMNcMHDm5Y/oxl2t/7+TP2zoz5sBSCYbqBgp0tprhNm78Mk8vsYTalEorPHnzxAGFT8tRlnc0A==",
       "requires": {
         "@mdx-js/mdx": "^1.1.0",
         "@mdx-js/react": "^1.0.27",
@@ -7104,6 +7122,7 @@
         "gatsby-remark-check-links": "^1.2.0",
         "gatsby-remark-copy-linked-files": "^2.0.12",
         "gatsby-remark-prismjs": "^3.2.8",
+        "gatsby-remark-prismjs-title": "^1.0.0",
         "gatsby-remark-typescript": "0.0.9",
         "gatsby-source-filesystem": "^2.0.29",
         "gatsby-source-git": "^1.0.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "gatsby": "2.13.57",
-    "gatsby-theme-apollo-docs": "1.2.4"
+    "gatsby-theme-apollo-docs": "^1.3.1"
   },
   "devDependencies": {
     "typedoc": "0.15.0",


### PR DESCRIPTION
This branch supplies the old `checkLinksExceptions` in the new way:

```js
checkLinksOptions: {
  exceptions: [...]
}
```