### PR TITLE
Don't check for the @live directive if shouldFetch is already true

### DIFF
--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -380,9 +380,11 @@ export class QueryManager<TStore> {
 
     let shouldFetch =
       needToFetch && fetchPolicy !== 'cache-only' && fetchPolicy !== 'standby';
-
-    // we need to check to see if this is an operation that uses the @live directive
-    if (hasDirectives(['live'], query)) shouldFetch = true;
+    
+    if (!shouldFetch) {      
+      // we need to check to see if this is an operation that uses the @live directive
+      if (hasDirectives(['live'], query)) shouldFetch = true;
+    }
 
     const requestId = this.idCounter++;
 


### PR DESCRIPTION
hasDirective needs to traverse the query and seems wasteful/slow if we can avoid it.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] ~If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)~ A perf/bug fix.
- [x] ~Make sure all of the significant new logic is covered by tests~ No changes to the runtime logic.
