### PR TITLE
Fix table in docs broken by unescaped pipes

### DIFF
--- a/docs/source/essentials/local-state.mdx
+++ b/docs/source/essentials/local-state.mdx
@@ -1433,8 +1433,8 @@ client.setResolvers({ ... });
 ```
 | Method | Description |
 | - | - |
-| `addResolvers(resolvers: Resolvers | Resolvers[])` | A map of resolver functions that your GraphQL queries and mutations call in order to read and write to the cache. Resolver functions added through `addResolvers` are added to the internal resolver function map, meaning any existing resolvers (that aren't overwritten) are preserved. |
-| `setResolvers(resolvers: Resolvers | Resolvers[])` | A map of resolver functions that your GraphQL queries and mutations call in order to read and write to the cache. Resolver functions added through `setResolvers` overwrite all existing resolvers (a pre-existing resolver map is wiped out, before the new resolvers are added). |
+| addResolvers(resolvers: Resolvers \| Resolvers[]) | A map of resolver functions that your GraphQL queries and mutations call in order to read and write to the cache. Resolver functions added through `addResolvers` are added to the internal resolver function map, meaning any existing resolvers (that aren't overwritten) are preserved. |
+| setResolvers(resolvers: Resolvers \| Resolvers[]) | A map of resolver functions that your GraphQL queries and mutations call in order to read and write to the cache. Resolver functions added through `setResolvers` overwrite all existing resolvers (a pre-existing resolver map is wiped out, before the new resolvers are added). |
 | `getResolvers` | Get the currently defined resolver map. |
 | `setLocalStateFragmentMatcher(fragmentMatcher: FragmentMatcher)` | Set a custom `FragmentMatcher` to be used when resolving local state queries involving [fragments on unions or interfaces](/advanced/fragments/#fragments-on-unions-and-interfaces). |
 


### PR DESCRIPTION
Serves to replace #5261, because a pipe inside a code element apparently can't be escaped cleanly 😢The simplest fix seems to be just not rendering a couple of method names in monospace.