### PR TITLE
[DOCS] - Add errorPolicy to hooks example

### DIFF
--- a/docs/source/features/error-handling.mdx
+++ b/docs/source/features/error-handling.mdx
@@ -35,7 +35,7 @@ const MY_QUERY = gql`
 `;
 
 function ShowingSomeErrors() {
-  const { loading, error, data } = useQuery(MY_QUERY);
+  const { loading, error, data } = useQuery(MY_QUERY, { errorPolicy: "all" });
 
   if (loading) return <span>loading...</span>
   return (

--- a/docs/source/features/error-handling.mdx
+++ b/docs/source/features/error-handling.mdx
@@ -35,7 +35,10 @@ const MY_QUERY = gql`
 `;
 
 function ShowingSomeErrors() {
-  const { loading, error, data } = useQuery(MY_QUERY, { errorPolicy: "all" });
+  const { loading, error, data } = useQuery(
+    MY_QUERY,
+    { errorPolicy: "all"}
+  );
 
   if (loading) return <span>loading...</span>
   return (


### PR DESCRIPTION
Super simple fix. Just added basically one line as the hooks example did not actually include an errorPolicy.

Issue: #5272
