### PR TITLE
fix: enable multiple same-key optimistic layers

### DIFF
--- a/packages/apollo-cache-inmemory/src/__tests__/recordingCache.ts
+++ b/packages/apollo-cache-inmemory/src/__tests__/recordingCache.ts
@@ -25,23 +25,23 @@ describe('OptimisticCacheLayer', () => {
     });
 
     it('should passthrough values if not defined in recording', () => {
-      expect(cache.get('Human')).toBe(data.Human);
-      expect(cache.get('Animal')).toBe(data.Animal);
+      expect(cache.get('Human')).toEqual(data.Human);
+      expect(cache.get('Animal')).toEqual(data.Animal);
     });
 
     it('should return values defined during recording', () => {
       cache.set('Human', dataToRecord.Human);
-      expect(cache.get('Human')).toBe(dataToRecord.Human);
-      expect(underlyingCache.get('Human')).toBe(data.Human);
+      expect(cache.get('Human')).toEqual(dataToRecord.Human);
+      expect(underlyingCache.get('Human')).toEqual(data.Human);
     });
 
     it('should return undefined for values deleted during recording', () => {
-      expect(cache.get('Animal')).toBe(data.Animal);
+      expect(cache.get('Animal')).toEqual(data.Animal);
       // delete should be registered in the recording:
       cache.delete('Animal');
       expect(cache.get('Animal')).toBeUndefined();
       expect(cache.toObject()).toHaveProperty('Animal');
-      expect(underlyingCache.get('Animal')).toBe(data.Animal);
+      expect(underlyingCache.get('Animal')).toEqual(data.Animal);
     });
   });
 

--- a/packages/apollo-cache-inmemory/src/types.ts
+++ b/packages/apollo-cache-inmemory/src/types.ts
@@ -37,13 +37,15 @@ export interface NormalizedCache {
  * a flattened representation of query result trees.
  */
 export interface NormalizedCacheObject {
-  [dataId: string]: StoreObject | undefined;
+  [dataId: string]: StoreObject;
 }
 
-export interface StoreObject {
-  __typename?: string;
-  [storeFieldKey: string]: StoreValue;
-}
+export declare type StoreObject =
+  | {
+      __typename?: string;
+      [storeFieldKey: string]: StoreValue;
+    }
+  | undefined;
 
 export type OptimisticStoreItem = {
   id: string;


### PR DESCRIPTION
## The problem

When using mutations with optimistic updates, and a static `ApolloClient.query` call at the same time, the latter returns incorrect (`stale` results), despite having the query data available. A repro case would be:

1. `MutationA` is triggered, with an optimistic update. The optimistic update writes something under `data.foo.bar` as the result of that mutation.
2. `QueryB` is triggered, using `ApolloClient.query`. This query tries fetching data from `data.foo.qux`.
3. QueryB is returned with `stale`: `true` and `data`: `null`, once the network query has been successfully executed, and _data is in the cache_.

By the time `QueryB` finished, it wrote data to the cache. Queries always write to the `data` layer instead of the `optimisticData` layer, since their data is the source-of-truth, and thus, it's not volatile data. Immediately after, the engine will re-read from the cache to return the data back, **and that's where the issue is** (how data is read back).

When reading back, it will read from the optimistic layer added by `MutationA` first, since that one sits on top. That optimistic layer created `data.foo.bar`, meaning `data.foo` _exists_ (as `data.foo.bar`), but `data.foo.qux` **does not** (under the object created by `MutationA`'s optimistic update!).

This trips the `executeSelectionSet` which tries digging down under the wrong object, leading to a wrong missing field detection, and to the stale result being returned. That is all explained by `executeSelectionSet` picking the wrong object because how [`OptimisticCacheLayer#get` is implemented](https://github.com/apollographql/apollo-client/blob/b73b380655d8118f91596e15e11361781a834a5e/packages/apollo-cache-inmemory/src/inMemoryCache.ts#L75-L80). If the key exists in it, it does not really care whether _further down keys exist_, it simply returns the available value.

---

## Solutions

There are mainly two solutions: the naive, but not-100% accurate, and the complex, but 100% accurate:

* **Naive**: **that's what I implemented**. When reading from the cache, *if* the current layer contains an object, then *merge* this object with the parent layer. Otherwise, return the value as is, as it's crunching the one in the parent layer. This is not 100% accurate because it returns a _new object_ made of the composition of another two: the one in the current layer, and the one in the previous.

* **Complex**: implement back-tracking on `selectionSet`. Every time we fail reading [in `executeSelectionSet`](https://github.com/apollographql/apollo-client/blob/ed66999bac40226abfeada8d6c83b454636bb4b0/packages/apollo-cache-inmemory/src/readFromStore.ts#L355-L357), we bail and go to the parent cache. This would imply moving [this line](https://github.com/apollographql/apollo-client/blob/ed66999bac40226abfeada8d6c83b454636bb4b0/packages/apollo-cache-inmemory/src/readFromStore.ts#L333) further down, as well as enabling cache layers to explicitly return things from their parent. This would however ensure that the object returned exactly contains the key that you are willing to access, although the increased complexity might not be worth.

---

### Checklist:

- ~[ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)~
- [X] Make sure all of the significant new logic is covered by tests