### PR TITLE
Implement InMemoryCache garbage collection and eviction.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,15 @@
 
 ## Improvements
 
+- `InMemoryCache` now supports tracing garbage collection and eviction. <br/>
+  [@benjamn](https://github.com/benjamn) in [#5310](https://github.com/apollographql/apollo-client/pull/5310)
+
 - Fully removed `prettier`. The Apollo Client team has decided to no longer automatically enforce code formatting across the codebase. In most cases existing code styles should be followed as much as possible, but this is not a hard and fast rule.  <br/>
   [@hwillson](https://github.com/hwillson) in [#5227](https://github.com/apollographql/apollo-client/pull/5227)
+
 - Update the `fetchMore` type signature to accept `context`.  <br/>
   [@koenpunt](https://github.com/koenpunt) in [#5147](https://github.com/apollographql/apollo-client/pull/5147)
+
 - Fix type for `Resolver` and use it in the definition of `Resolvers`. <br />
   [@peoplenarthax](https://github.com/peoplenarthax) in [#4943](https://github.com/apollographql/apollo-client/pull/4943)
 
@@ -15,9 +20,9 @@
 
 - Removed `graphql-anywhere` since it's no longer used by Apollo Client.  <br/>
   [@hwillson](https://github.com/hwillson) in [#5159](https://github.com/apollographql/apollo-client/pull/5159)
+
 - Removed `apollo-boost` since Apollo Client 3.0 provides a boost like getting started experience out of the box.  <br/>
   [@hwillson](https://github.com/hwillson) in [#5217](https://github.com/apollographql/apollo-client/pull/5217)
-
 
 ## Apollo Client (2.6.4)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Improvements
 
-- `InMemoryCache` now supports tracing garbage collection and eviction. <br/>
+- `InMemoryCache` now supports tracing garbage collection and eviction. Note that the signature of the `evict` method has been simplified in a potentially backwards-incompatible way. <br/>
   [@benjamn](https://github.com/benjamn) in [#5310](https://github.com/apollographql/apollo-client/pull/5310)
 
 - Fully removed `prettier`. The Apollo Client team has decided to no longer automatically enforce code formatting across the codebase. In most cases existing code styles should be followed as much as possible, but this is not a hard and fast rule.  <br/>

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     {
       "name": "apollo-client",
       "path": "./lib/apollo-client.cjs.min.js",
-      "maxSize": "16.55 kB"
+      "maxSize": "16.9 kB"
     }
   ],
   "dependencies": {

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -17,9 +17,7 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
   ): void;
   public abstract diff<T>(query: Cache.DiffOptions): Cache.DiffResult<T>;
   public abstract watch(watch: Cache.WatchOptions): () => void;
-  public abstract evict<TVariables = any>(
-    query: Cache.EvictOptions<TVariables>,
-  ): Cache.EvictionResult;
+  public abstract evict(dataId: string): boolean;
   public abstract reset(): Promise<void>;
 
   // intializer / offline / ssr API

--- a/src/cache/core/types/Cache.ts
+++ b/src/cache/core/types/Cache.ts
@@ -2,9 +2,6 @@ import { DataProxy } from './DataProxy';
 
 export namespace Cache {
   export type WatchCallback = (newData: any) => void;
-  export interface EvictionResult {
-    success: Boolean;
-  }
 
   export interface ReadOptions<TVariables = any>
     extends DataProxy.Query<TVariables> {
@@ -25,11 +22,6 @@ export namespace Cache {
 
   export interface WatchOptions extends ReadOptions {
     callback: WatchCallback;
-  }
-
-  export interface EvictOptions<TVariables = any>
-    extends DataProxy.Query<TVariables> {
-    rootId?: string;
   }
 
   export import DiffResult = DataProxy.DiffResult;

--- a/src/cache/inmemory/__tests__/entityCache.ts
+++ b/src/cache/inmemory/__tests__/entityCache.ts
@@ -588,12 +588,7 @@ describe('EntityCache', () => {
       },
     });
 
-    expect(cache.evict({
-      rootId: "Author:J.K. Rowling",
-      query,
-    })).toEqual({
-      success: false,
-    });
+    expect(cache.evict("Author:J.K. Rowling")).toBe(false);
 
     const bookAuthorFragment = gql`
       fragment BookAuthor on Book {
@@ -661,12 +656,7 @@ describe('EntityCache', () => {
 
     expect(cache.gc()).toEqual([]);
 
-    expect(cache.evict({
-      rootId: 'Author:Robert Galbraith',
-      query,
-    })).toEqual({
-      success: true,
-    });
+    expect(cache.evict("Author:Robert Galbraith")).toBe(true);
 
     expect(cache.gc()).toEqual([]);
 
@@ -718,12 +708,7 @@ describe('EntityCache', () => {
 
     // If you're ever tempted to do this, you probably want to use cache.clear()
     // instead, but evicting the ROOT_QUERY should work at least.
-    expect(cache.evict({
-      rootId: "ROOT_QUERY",
-      query,
-    })).toEqual({
-      success: true,
-    });
+    expect(cache.evict("ROOT_QUERY")).toBe(true);
 
     expect(cache.extract(true)).toEqual({
       "Book:031648637X": {

--- a/src/cache/inmemory/__tests__/entityCache.ts
+++ b/src/cache/inmemory/__tests__/entityCache.ts
@@ -1,0 +1,396 @@
+import gql from 'graphql-tag';
+import { EntityCache, supportsResultCaching } from '../entityCache';
+import { InMemoryCache } from '../inMemoryCache';
+
+describe('EntityCache', () => {
+  it('should support result caching if so configured', () => {
+    const cacheWithResultCaching = new EntityCache.Root({
+      resultCaching: true,
+    });
+
+    const cacheWithoutResultCaching = new EntityCache.Root({
+      resultCaching: false,
+    });
+
+    expect(supportsResultCaching({ some: "arbitrary object " })).toBe(false);
+    expect(supportsResultCaching(cacheWithResultCaching)).toBe(true);
+    expect(supportsResultCaching(cacheWithoutResultCaching)).toBe(false);
+
+    const layerWithCaching = cacheWithResultCaching.addLayer("with caching", () => {});
+    expect(supportsResultCaching(layerWithCaching)).toBe(true);
+    const anotherLayer = layerWithCaching.addLayer("another layer", () => {});
+    expect(supportsResultCaching(anotherLayer)).toBe(true);
+    expect(
+      anotherLayer
+        .removeLayer("with caching")
+        .removeLayer("another layer")
+    ).toBe(cacheWithResultCaching);
+    expect(supportsResultCaching(cacheWithResultCaching)).toBe(true);
+
+    const layerWithoutCaching = cacheWithoutResultCaching.addLayer("with caching", () => {});
+    expect(supportsResultCaching(layerWithoutCaching)).toBe(false);
+    expect(layerWithoutCaching.removeLayer("with caching")).toBe(cacheWithoutResultCaching);
+    expect(supportsResultCaching(cacheWithoutResultCaching)).toBe(false);
+  });
+
+  it('should reclaim no-longer-reachable, unretained entities', () => {
+    const cache = new InMemoryCache({
+      resultCaching: true,
+      dataIdFromObject(value: any) {
+        switch (value && value.__typename) {
+          case 'Book':
+            return 'Book:' + value.isbn;
+          case 'Author':
+            return 'Author:' + value.name;
+        }
+      },
+    });
+
+    const query = gql`
+      query {
+        book {
+          title
+          author {
+            name
+          }
+        }
+      }
+    `;
+
+    cache.writeQuery({
+      query,
+      data: {
+        book: {
+          __typename: 'Book',
+          isbn: '9781451673319',
+          title: 'Fahrenheit 451',
+          author: {
+            __typename: 'Author',
+            name: 'Ray Bradbury',
+          }
+        },
+      },
+    });
+
+    expect(cache.extract()).toEqual({
+      ROOT_QUERY: {
+        'book': {
+          __ref: "Book:9781451673319",
+        },
+      },
+      "Book:9781451673319": {
+        __typename: "Book",
+        title: "Fahrenheit 451",
+        author: {
+          __ref: 'Author:Ray Bradbury',
+        }
+      },
+      "Author:Ray Bradbury": {
+        __typename: "Author",
+        name: "Ray Bradbury",
+      },
+    });
+
+    cache.writeQuery({
+      query,
+      data: {
+        book: {
+          __typename: 'Book',
+          isbn: '0312429215',
+          title: '2666',
+          author: {
+            __typename: 'Author',
+            name: 'Roberto Bolaño',
+          },
+        },
+      },
+    });
+
+    const snapshot = cache.extract();
+
+    expect(snapshot).toEqual({
+      ROOT_QUERY: {
+        'book': {
+          __ref: "Book:0312429215",
+        },
+      },
+      "Book:9781451673319": {
+        __typename: "Book",
+        title: "Fahrenheit 451",
+        author: {
+          __ref: 'Author:Ray Bradbury',
+        }
+      },
+      "Author:Ray Bradbury": {
+        __typename: "Author",
+        name: "Ray Bradbury",
+      },
+      "Book:0312429215": {
+        __typename: "Book",
+        author: {
+          __ref: "Author:Roberto Bolaño",
+        },
+        title: "2666",
+      },
+      "Author:Roberto Bolaño": {
+        __typename: "Author",
+        name: "Roberto Bolaño",
+      },
+    });
+
+    expect(cache.gc().sort()).toEqual([
+      'Author:Ray Bradbury',
+      'Book:9781451673319',
+    ]);
+
+    expect(cache.extract()).toEqual({
+      ROOT_QUERY: {
+        'book': {
+          __ref: "Book:0312429215",
+        },
+      },
+      "Book:0312429215": {
+        __typename: "Book",
+        author: {
+          __ref: "Author:Roberto Bolaño",
+        },
+        title: "2666",
+      },
+      "Author:Roberto Bolaño": {
+        __typename: "Author",
+        name: "Roberto Bolaño",
+      },
+    });
+
+    // Nothing left to garbage collect.
+    expect(cache.gc()).toEqual([]);
+
+    // Go back to the pre-GC snapshot.
+    cache.restore(snapshot);
+    expect(cache.extract()).toEqual(snapshot);
+
+    // Reading a specific fragment causes it to be retained during garbage collection.
+    const authorNameFragment = gql`
+      fragment AuthorName on Author {
+        name
+      }
+    `;
+    const ray = cache.readFragment({
+      id: 'Author:Ray Bradbury',
+      fragment: authorNameFragment,
+    });
+
+    expect(ray).toEqual({
+      __typename: 'Author',
+      name: 'Ray Bradbury',
+    });
+
+    expect(cache.gc()).toEqual([
+      // Only Fahrenheit 451 (the book) is reclaimed this time.
+      'Book:9781451673319',
+    ]);
+
+    expect(cache.extract()).toEqual({
+      ROOT_QUERY: {
+        'book': {
+          __ref: "Book:0312429215",
+        },
+      },
+      "Author:Ray Bradbury": {
+        __typename: "Author",
+        name: "Ray Bradbury",
+      },
+      "Book:0312429215": {
+        __typename: "Book",
+        author: {
+          __ref: "Author:Roberto Bolaño",
+        },
+        title: "2666",
+      },
+      "Author:Roberto Bolaño": {
+        __typename: "Author",
+        name: "Roberto Bolaño",
+      },
+    });
+
+    // Nothing left to garbage collect.
+    expect(cache.gc()).toEqual([]);
+  });
+
+  it('should respect optimistic updates, when active', () => {
+    const cache = new InMemoryCache({
+      resultCaching: true,
+      dataIdFromObject(value: any) {
+        switch (value && value.__typename) {
+          case 'Book':
+            return 'Book:' + value.isbn;
+          case 'Author':
+            return 'Author:' + value.name;
+        }
+      },
+    });
+
+    const query = gql`
+      query {
+        book {
+          title
+          author {
+            name
+          }
+        }
+      }
+    `;
+
+    cache.writeQuery({
+      query,
+      data: {
+        book: {
+          __typename: 'Book',
+          isbn: '9781451673319',
+          title: 'Fahrenheit 451',
+          author: {
+            __typename: 'Author',
+            name: 'Ray Bradbury',
+          }
+        },
+      },
+    });
+
+    expect(cache.gc()).toEqual([]);
+
+    // Orphan the F451 / Ray Bradbury data, but avoid collecting garbage yet.
+    cache.writeQuery({
+      query,
+      data: {
+        book: {
+          __typename: 'Book',
+          isbn: '1980719802',
+          title: '1984',
+          author: {
+            __typename: 'Author',
+            name: 'George Orwell',
+          },
+        }
+      }
+    });
+
+    cache.recordOptimisticTransaction(proxy => {
+      proxy.writeFragment({
+        id: 'Author:Ray Bradbury',
+        fragment: gql`
+          fragment AuthorBooks on Author {
+            books {
+              title
+            }
+          }
+        `,
+        data: {
+          books: [
+            {
+              __typename: 'Book',
+              isbn: '9781451673319',
+            },
+          ],
+        },
+      });
+    }, "ray books");
+
+    expect(cache.extract(true)).toEqual({
+      ROOT_QUERY: {
+        book: {
+          __ref: "Book:1980719802",
+        },
+      },
+      "Author:Ray Bradbury": {
+        __typename: "Author",
+        name: "Ray Bradbury",
+        books: [
+          {
+            __ref: "Book:9781451673319",
+          },
+        ],
+      },
+      "Book:9781451673319": {
+        __typename: "Book",
+        title: "Fahrenheit 451",
+        author: {
+          __ref: "Author:Ray Bradbury",
+        },
+      },
+      "Author:George Orwell": {
+        __typename: "Author",
+        name: "George Orwell",
+      },
+      "Book:1980719802": {
+        __typename: "Book",
+        title: "1984",
+        author: {
+          __ref: "Author:George Orwell",
+        },
+      },
+    });
+
+    // Nothing can be reclaimed while the optimistic update is retaining
+    // Fahrenheit 451.
+    expect(cache.gc()).toEqual([]);
+
+    cache.removeOptimistic("ray books");
+
+    expect(cache.extract(true)).toEqual({
+      ROOT_QUERY: {
+        book: {
+          __ref: "Book:1980719802",
+        },
+      },
+      "Author:Ray Bradbury": {
+        __typename: "Author",
+        name: "Ray Bradbury",
+        // Note that the optimistic books field has disappeared, as expected.
+      },
+      "Book:9781451673319": {
+        __typename: "Book",
+        title: "Fahrenheit 451",
+        author: {
+          __ref: "Author:Ray Bradbury",
+        },
+      },
+      "Author:George Orwell": {
+        __typename: "Author",
+        name: "George Orwell",
+      },
+      "Book:1980719802": {
+        __typename: "Book",
+        title: "1984",
+        author: {
+          __ref: "Author:George Orwell",
+        },
+      },
+    });
+
+    expect(cache.gc().sort()).toEqual([
+      "Author:Ray Bradbury",
+      "Book:9781451673319",
+    ]);
+
+    expect(cache.extract(true)).toEqual({
+      ROOT_QUERY: {
+        book: {
+          __ref: "Book:1980719802",
+        },
+      },
+      "Author:George Orwell": {
+        __typename: "Author",
+        name: "George Orwell",
+      },
+      "Book:1980719802": {
+        __typename: "Book",
+        title: "1984",
+        author: {
+          __ref: "Author:George Orwell",
+        },
+      },
+    });
+
+    expect(cache.gc()).toEqual([]);
+  });
+});

--- a/src/cache/inmemory/__tests__/entityCache.ts
+++ b/src/cache/inmemory/__tests__/entityCache.ts
@@ -189,6 +189,8 @@ describe('EntityCache', () => {
       fragment: authorNameFragment,
     });
 
+    expect(cache.retain('Author:Ray Bradbury')).toBe(1);
+
     expect(ray).toEqual({
       __typename: 'Author',
       name: 'Ray Bradbury',
@@ -222,7 +224,14 @@ describe('EntityCache', () => {
       },
     });
 
-    // Nothing left to garbage collect.
+    expect(cache.gc()).toEqual([]);
+
+    expect(cache.release('Author:Ray Bradbury')).toBe(0);
+
+    expect(cache.gc()).toEqual([
+      'Author:Ray Bradbury',
+    ]);
+
     expect(cache.gc()).toEqual([]);
   });
 
@@ -724,8 +733,7 @@ describe('EntityCache', () => {
       },
     });
 
-    // The book has been retained a couple of times since we've written it
-    // directly, but J.K. has never been directly written.
+    expect(cache.retain("Book:031648637X")).toBe(2);
     expect(cache.release("Book:031648637X")).toBe(1);
     expect(cache.release("Book:031648637X")).toBe(0);
 

--- a/src/cache/inmemory/__tests__/writeToStore.ts
+++ b/src/cache/inmemory/__tests__/writeToStore.ts
@@ -5,6 +5,7 @@ import {
   DefinitionNode,
   OperationDefinitionNode,
   ASTNode,
+  DocumentNode,
 } from 'graphql';
 import gql from 'graphql-tag';
 
@@ -1079,19 +1080,18 @@ describe('writing to the store', () => {
     mutation.definitions.map((def: OperationDefinitionNode) => {
       if (isOperationDefinition(def)) {
         expect(
-          writer
-            .writeSelectionSetToStore({
-              dataId: '5',
-              selectionSet: def.selectionSet,
-              result: cloneDeep(result),
-              context: {
-                store: defaultNormalizedCacheFactory(),
-                processedData: {},
-                variables,
-                dataIdFromObject: () => '5',
-              },
-            })
-            .toObject(),
+          writer.writeQueryToStore({
+            query: {
+              kind: 'Document',
+              definitions: [def],
+            } as DocumentNode,
+            dataId: '5',
+            result,
+            variables,
+            dataIdFromObject() {
+              return '5';
+            },
+          }).toObject(),
         ).toEqual({
           '5': {
             id: 'id',

--- a/src/cache/inmemory/entityCache.ts
+++ b/src/cache/inmemory/entityCache.ts
@@ -117,7 +117,7 @@ export abstract class EntityCache implements NormalizedCache {
         // Because we are iterating over an ECMAScript Set, the IDs we add here
         // will be visited in later iterations of the forEach loop only if they
         // were not previously contained by the Set.
-        Object.keys(this.findChildIds(id)).forEach(ids.add, ids);
+        Object.keys(this.findChildRefIds(id)).forEach(ids.add, ids);
         // By removing IDs from the snapshot object here, we protect them from
         // getting removed from the root cache layer below.
         delete snapshot[id];
@@ -137,19 +137,22 @@ export abstract class EntityCache implements NormalizedCache {
     [dataId: string]: Record<string, true>;
   } = Object.create(null);
 
-  public findChildIds(dataId: string): Record<string, true> {
+  public findChildRefIds(dataId: string): Record<string, true> {
     if (!hasOwn.call(this.refs, dataId)) {
       const found = this.refs[dataId] = Object.create(null);
-      // Use the little-known replacer function API of JSON.stringify to find
-      // { __ref } objects quickly and without a lot of traversal code.
-      JSON.stringify(this.data[dataId], (_key, value) => {
-        if (isReference(value)) {
-          found[value.__ref] = true;
-        } else if (value && typeof value === "object") {
-          // Returning the value allows the traversal to continue, which is
-          // necessary only when the value could contain other values that might
-          // be reference objects.
-          return value;
+      const workSet = new Set([this.data[dataId]]);
+      // Within the cache, only arrays and objects can contain child entity
+      // references, so we can prune the traversal using this predicate:
+      const canTraverse = (obj: any) => obj !== null && typeof obj === 'object';
+      workSet.forEach(obj => {
+        if (isReference(obj)) {
+          found[obj.__ref] = true;
+        } else if (canTraverse(obj)) {
+          Object.values(obj)
+            // No need to add primitive values to the workSet, since they cannot
+            // contain reference objects.
+            .filter(canTraverse)
+            .forEach(workSet.add, workSet);
         }
       });
     }
@@ -271,11 +274,11 @@ class Layer extends EntityCache {
     return ids;
   }
 
-  public findChildIds(dataId: string): Record<string, true> {
-    const fromParent = this.parent.findChildIds(dataId);
+  public findChildRefIds(dataId: string): Record<string, true> {
+    const fromParent = this.parent.findChildRefIds(dataId);
     return hasOwn.call(this.data, dataId) ? {
       ...fromParent,
-      ...super.findChildIds(dataId),
+      ...super.findChildRefIds(dataId),
     } : fromParent;
   }
 }

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -199,15 +199,15 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     return (optimistic ? this.optimisticData : this.data).release(rootId);
   }
 
-  public evict(query: Cache.EvictOptions): Cache.EvictionResult {
-    if (this.optimisticData.has(query.rootId)) {
+  public evict(dataId: string): boolean {
+    if (this.optimisticData.has(dataId)) {
       // Note that this deletion does not trigger a garbage collection, which
       // is convenient in cases where you want to evict multiple entities before
       // performing a single garbage collection.
-      this.optimisticData.delete(query.rootId);
-      return { success: !this.optimisticData.has(query.rootId) };
+      this.optimisticData.delete(dataId);
+      return !this.optimisticData.has(dataId);
     }
-    return { success: false };
+    return false;
   }
 
   public reset(): Promise<void> {

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -175,6 +175,11 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     };
   }
 
+  // Request garbage collection of unreachable normalized entities.
+  public gc() {
+    return this.optimisticData.gc();
+  }
+
   public evict(query: Cache.EvictOptions): Cache.EvictionResult {
     throw new InvariantError(`eviction is not implemented on InMemory Cache`);
   }

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -180,6 +180,26 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     return this.optimisticData.gc();
   }
 
+  // Call this method to ensure the given root ID remains in the cache after
+  // garbage collection, along with its transitive child entities. Note that
+  // the cache automatically retains all directly written entities. By default,
+  // the retainment persists after optimistic updates are removed. Pass true
+  // for the optimistic argument if you would prefer for the retainment to be
+  // discarded when the top-most optimistic layer is removed. Returns the
+  // resulting (non-negative) retainment count.
+  public retain(rootId: string, optimistic?: boolean): number {
+    return (optimistic ? this.optimisticData : this.data).retain(rootId);
+  }
+
+  // Call this method to undo the effect of the retain method, above. Once the
+  // retainment count falls to zero, the given ID will no longer be preserved
+  // during garbage collection, though it may still be preserved by other safe
+  // entities that refer to it. Returns the resulting (non-negative) retainment
+  // count, in case that's useful.
+  public release(rootId: string, optimistic?: boolean): number {
+    return (optimistic ? this.optimisticData : this.data).release(rootId);
+  }
+
   public evict(query: Cache.EvictOptions): Cache.EvictionResult {
     throw new InvariantError(`eviction is not implemented on InMemory Cache`);
   }

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -223,6 +223,11 @@ export class StoreReader {
       cacheRedirects: (config && config.cacheRedirects) || {},
     };
 
+    // Any IDs read explicitly from the cache (including ROOT_QUERY, most
+    // frequently) will be retained as reachable root IDs on behalf of their
+    // owner DocumentNode objects, until/unless evicted for all owners.
+    store.retain(rootId, query);
+
     const execResult = this.executeStoreQuery({
       query,
       objectOrReference: rootId === 'ROOT_QUERY'

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -224,9 +224,8 @@ export class StoreReader {
     };
 
     // Any IDs read explicitly from the cache (including ROOT_QUERY, most
-    // frequently) will be retained as reachable root IDs on behalf of their
-    // owner DocumentNode objects, until/unless evicted for all owners.
-    store.retain(rootId, query);
+    // frequently) will be retained as reachable root IDs, until released.
+    store.retain(rootId);
 
     const execResult = this.executeStoreQuery({
       query,

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -223,10 +223,6 @@ export class StoreReader {
       cacheRedirects: (config && config.cacheRedirects) || {},
     };
 
-    // Any IDs read explicitly from the cache (including ROOT_QUERY, most
-    // frequently) will be retained as reachable root IDs, until released.
-    store.retain(rootId);
-
     const execResult = this.executeStoreQuery({
       query,
       objectOrReference: rootId === 'ROOT_QUERY'

--- a/src/cache/inmemory/types.ts
+++ b/src/cache/inmemory/types.ts
@@ -30,6 +30,14 @@ export interface NormalizedCache {
    * replace the state of the store
    */
   replace(newData: NormalizedCacheObject): void;
+
+  /**
+   * Retain or release a given root ID on behalf of a specific "owner" object.
+   * During garbage collection, retained root IDs with one or more owners are
+   * considered immediately reachable. A single owner object counts only once.
+   */
+  retain(rootId: string, owner: object): void;
+  release(rootId: string, owner: object): void;
 }
 
 /**

--- a/src/cache/inmemory/types.ts
+++ b/src/cache/inmemory/types.ts
@@ -32,12 +32,15 @@ export interface NormalizedCache {
   replace(newData: NormalizedCacheObject): void;
 
   /**
-   * Retain or release a given root ID on behalf of a specific "owner" object.
-   * During garbage collection, retained root IDs with one or more owners are
-   * considered immediately reachable. A single owner object counts only once.
+   * Retain (or release) a given root ID to protect (or expose) it and its
+   * transitive child entities from (or to) garbage collection. The current
+   * retainment count is returned by both methods. Note that releasing a root
+   * ID does not cause that entity to be garbage collected, but merely removes
+   * it from the set of root IDs that will be considered during the next
+   * mark-and-sweep collection.
    */
-  retain(rootId: string, owner: object): void;
-  release(rootId: string, owner: object): void;
+  retain(rootId: string): number;
+  release(rootId: string): number;
 }
 
 /**

--- a/src/cache/inmemory/types.ts
+++ b/src/cache/inmemory/types.ts
@@ -16,6 +16,7 @@ export declare type IdGetter = (
  * StoreObjects from the cache
  */
 export interface NormalizedCache {
+  has(dataId: string): boolean;
   get(dataId: string): StoreObject;
   set(dataId: string, value: StoreObject): void;
   delete(dataId: string): void;

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -93,7 +93,7 @@ export class StoreWriter {
     });
   }
 
-  public writeSelectionSetToStore({
+  private writeSelectionSetToStore({
     result,
     dataId,
     selectionSet,

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -76,6 +76,12 @@ export class StoreWriter {
     dataIdFromObject?: IdGetter;
   }): NormalizedCache {
     const operationDefinition = getOperationDefinition(query)!;
+
+    // Any IDs written explicitly to the cache (including ROOT_QUERY, most
+    // frequently) will be retained as reachable root IDs on behalf of their
+    // owner DocumentNode objects, until/unless evicted for all owners.
+    store.retain(dataId, query);
+
     return this.writeSelectionSetToStore({
       result,
       dataId,

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -80,7 +80,7 @@ export class StoreWriter {
     // Any IDs written explicitly to the cache (including ROOT_QUERY, most
     // frequently) will be retained as reachable root IDs on behalf of their
     // owner DocumentNode objects, until/unless evicted for all owners.
-    store.retain(dataId, query);
+    store.retain(dataId);
 
     return this.writeSelectionSetToStore({
       result,


### PR DESCRIPTION
This PR adds a handful of powerful new methods to the official `InMemoryCache` class:

* The `cache.gc()` method removes any _unreachable_ objects from the normalized cache, using a [tracing garbage collection](https://en.wikipedia.org/wiki/Tracing_garbage_collection) strategy (as opposed to reference counting). Reachability is determined starting from a set of root entity IDs, which includes any IDs that have been directly written to or read from the cache—including the synthetic `ROOT_QUERY` ID, which is the default ID used when no specific ID is provided. From this root set of reachable IDs, garbage collection traces all child references (computed lazily and cached aggressively) until the entire reachable reference graph has been visited. Any remaining unvisited IDs are then removed from the cache, and the `cache.gc()` function returns a list of those removed ID strings.

> As of this writing, the `cache.gc()` method is never called automatically, but must be invoked by the application developer. Although garbage collection becomes more and more efficient over time, the first garbage collection takes time proportional to the number of entities in your cache, so you might want to run it during an idle period after page load.

* The `cache.retain(id)` method can be called to treat specific entities as immediately reachable "root" entities, which protects them (and all their transitive child references) from garbage collection. Note that this method is called automatically for the IDs written/read using `writeFragment` and `readFragment`. Our hope is that this method will not be needed very often, though it can be essential when you don't want certain data to be removed.

* The `cache.release(id)` method undoes the effect of `cache.retain(id)`, allowing the given ID to be garbage collected once it becomes otherwise unreachable. Note that `cache.release(id)` must be called at least as many times as `cache.retain(id)` was called for a given `id`. Both methods return the new retainment count. This retainment count is not a "reference count" in the usual sense, since most entities will never need to be retained or released, and we are not using a reference counting garbage collection strategy. In particular, `cache.release(id)` does not automatically trigger garbage collection when the retainment count falls back to zero.

* The `cache.evict(id)` method forcibly removes the given `rootId` from the cache, but does not immediately trigger garbage collection, since you might want to evict multiple IDs before triggering a single garbage collection. With that said, removing an entity from the cache can have significant consequences for the reachability of other entities, so eviction should usually be followed by garbage collection.

Closes #3965, #4681, #4917, #4916

Part of https://github.com/apollographql/apollo-feature-requests/issues/4