### PR TITLE
Stop returning unwanted __typename fields in cache results.

### DIFF
--- a/src/__tests__/__snapshots__/ApolloClient.ts.snap
+++ b/src/__tests__/__snapshots__/ApolloClient.ts.snap
@@ -37,6 +37,7 @@ Object {
     "h": 9,
   },
   "bar:foobar": Object {
+    "__typename": "bar",
     "e": 5,
     "f": 6,
     "id": "foobar",

--- a/src/__tests__/mutationResults.ts
+++ b/src/__tests__/mutationResults.ts
@@ -1113,6 +1113,7 @@ describe('mutation results', () => {
               proxy.writeFragment({
                 data: {
                   ...data,
+                  __typename: 'TodoList',
                   todos: [mResult.data.createTodo, ...data.todos],
                 },
                 id,
@@ -1204,6 +1205,7 @@ describe('mutation results', () => {
               proxy.writeFragment({
                 data: {
                   ...data,
+                  __typename: 'TodoList',
                   todos: [mResult.data.createTodo, ...data.todos],
                 },
                 id,

--- a/src/cache/inmemory/__tests__/__snapshots__/cache.ts.snap
+++ b/src/cache/inmemory/__tests__/__snapshots__/cache.ts.snap
@@ -6,6 +6,7 @@ Object {
     "i": 7,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "h": Object {
       "__ref": "bar",
@@ -22,6 +23,7 @@ Object {
     "k": 9,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -35,11 +37,13 @@ Object {
 exports[`Cache writeFragment will write some deeply nested data into the store at any id (1/2) 3`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 10,
     "j": 8,
     "k": 9,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -53,11 +57,13 @@ Object {
 exports[`Cache writeFragment will write some deeply nested data into the store at any id (1/2) 4`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 10,
     "j": 11,
     "k": 12,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -71,11 +77,13 @@ Object {
 exports[`Cache writeFragment will write some deeply nested data into the store at any id (1/2) 5`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 7,
     "j": 8,
     "k": 9,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -89,11 +97,13 @@ Object {
 exports[`Cache writeFragment will write some deeply nested data into the store at any id (1/2) 6`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 10,
     "j": 11,
     "k": 12,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -110,6 +120,7 @@ Object {
     "i": 7,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "h": Object {
       "__ref": "bar",
@@ -126,6 +137,7 @@ Object {
     "k": 9,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -139,11 +151,13 @@ Object {
 exports[`Cache writeFragment will write some deeply nested data into the store at any id (2/2) 3`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 10,
     "j": 8,
     "k": 9,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -157,11 +171,13 @@ Object {
 exports[`Cache writeFragment will write some deeply nested data into the store at any id (2/2) 4`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 10,
     "j": 11,
     "k": 12,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -175,11 +191,13 @@ Object {
 exports[`Cache writeFragment will write some deeply nested data into the store at any id (2/2) 5`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 7,
     "j": 8,
     "k": 9,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -193,11 +211,13 @@ Object {
 exports[`Cache writeFragment will write some deeply nested data into the store at any id (2/2) 6`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 10,
     "j": 11,
     "k": 12,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,

--- a/src/cache/inmemory/__tests__/cache.ts
+++ b/src/cache/inmemory/__tests__/cache.ts
@@ -3,6 +3,7 @@ import gql, { disableFragmentWarnings } from 'graphql-tag';
 import { stripSymbols, cloneDeep } from '../../../utilities';
 import { InMemoryCache, InMemoryCacheConfig } from '..';
 import { makeReference } from '../helpers';
+import { cloneWithoutTypename } from '../../../util/testUtils';
 
 disableFragmentWarnings();
 
@@ -1042,7 +1043,7 @@ describe('Cache', () => {
           fragment: readWriteFragment,
           id: 'query',
         });
-        expect(stripSymbols(result)).toEqual(data);
+        expect(stripSymbols(result)).toEqual(cloneWithoutTypename(data));
       },
     );
 

--- a/src/cache/inmemory/__tests__/fragmentMatcher.ts
+++ b/src/cache/inmemory/__tests__/fragmentMatcher.ts
@@ -1,6 +1,7 @@
 import gql from 'graphql-tag';
 
 import { InMemoryCache } from '../inMemoryCache';
+import { cloneWithoutTypename } from '../../../util/testUtils';
 
 describe('fragment matching', () => {
   it('can match exact types with or without possibleTypes', () => {
@@ -46,11 +47,13 @@ describe('fragment matching', () => {
       ],
     };
 
+    const dataWithoutTypename = cloneWithoutTypename(data);
+
     cacheWithoutPossibleTypes.writeQuery({ query, data });
-    expect(cacheWithoutPossibleTypes.readQuery({ query })).toEqual(data);
+    expect(cacheWithoutPossibleTypes.readQuery({ query })).toEqual(dataWithoutTypename);
 
     cacheWithPossibleTypes.writeQuery({ query, data });
-    expect(cacheWithPossibleTypes.readQuery({ query })).toEqual(data);
+    expect(cacheWithPossibleTypes.readQuery({ query })).toEqual(dataWithoutTypename);
   });
 
   it('can match interface subtypes', () => {
@@ -82,7 +85,7 @@ describe('fragment matching', () => {
     };
 
     cache.writeQuery({ query, data });
-    expect(cache.readQuery({ query })).toEqual(data);
+    expect(cache.readQuery({ query })).toEqual(cloneWithoutTypename(data));
   });
 
   it('can match union member types', () => {
@@ -132,7 +135,7 @@ describe('fragment matching', () => {
     };
 
     cache.writeQuery({ query, data });
-    expect(cache.readQuery({ query })).toEqual(data);
+    expect(cache.readQuery({ query })).toEqual(cloneWithoutTypename(data));
   });
 
   it('can match indirect subtypes while avoiding cycles', () => {
@@ -180,7 +183,7 @@ describe('fragment matching', () => {
     };
 
     cache.writeQuery({ query, data });
-    expect(cache.readQuery({ query })).toEqual(data);
+    expect(cache.readQuery({ query })).toEqual(cloneWithoutTypename(data));
   });
 
   it('can match against the root Query', () => {
@@ -220,6 +223,6 @@ describe('fragment matching', () => {
     };
 
     cache.writeQuery({ query, data });
-    expect(cache.readQuery({ query })).toEqual(data);
+    expect(cache.readQuery({ query })).toEqual(cloneWithoutTypename(data));
   });
 });

--- a/src/cache/inmemory/__tests__/optimistic.ts
+++ b/src/cache/inmemory/__tests__/optimistic.ts
@@ -53,10 +53,8 @@ describe('optimistic cache layers', () => {
     const result1984 = readOptimistic(cache);
     expect(result1984).toEqual({
       book: {
-        __typename: 'Book',
         title: '1984',
         author: {
-          __typename: 'Author',
           name: 'George Orwell',
         },
       },
@@ -87,10 +85,8 @@ describe('optimistic cache layers', () => {
       result2666InTransaction = readOptimistic(cache);
       expect(result2666InTransaction).toEqual({
         book: {
-          __typename: 'Book',
           title: '2666',
           author: {
-            __typename: 'Author',
             name: 'Roberto Bolaño',
           },
         },
@@ -120,10 +116,8 @@ describe('optimistic cache layers', () => {
 
       expect((resultCatch22 = readOptimistic(cache))).toEqual({
         book: {
-          __typename: 'Book',
           title: 'Catch-22',
           author: {
-            __typename: 'Author',
             name: 'Joseph Heller',
           },
         },
@@ -160,10 +154,8 @@ describe('optimistic cache layers', () => {
     const resultF451 = readRealistic(cache);
     expect(resultF451).toEqual({
       book: {
-        __typename: 'Book',
         title: 'Fahrenheit 451',
         author: {
-          __typename: 'Author',
           name: 'Ray Bradbury',
         },
       },
@@ -278,12 +270,10 @@ describe('optimistic cache layers', () => {
     expect(result).toEqual({
       books: [
         {
-          __typename: 'Book',
           title: 'Eager',
           subtitle: 'The Surprising, Secret Life of Beavers and Why They Matter',
         },
         {
-          __typename: 'Book',
           title: 'Spineless',
           subtitle: 'The Science of Jellyfish and the Art of Growing a Backbone',
         },
@@ -345,11 +335,12 @@ describe('optimistic cache layers', () => {
       }, optimistic);
     }
 
-    function withoutISBN(data: any) {
+    function withoutTypenameOrISBN(data: any) {
       return JSON.parse(JSON.stringify(
         data,
         (key, value) => {
           if (key === 'isbn') return;
+          if (key === '__typename') return;
           return value;
         },
       ));
@@ -358,8 +349,8 @@ describe('optimistic cache layers', () => {
     const resultWithTwoAuthors = readWithAuthors();
     expect(resultWithTwoAuthors).toEqual({
       books: [
-        withoutISBN(eagerBookData),
-        withoutISBN(spinelessBookData),
+        withoutTypenameOrISBN(eagerBookData),
+        withoutTypenameOrISBN(spinelessBookData),
       ],
     });
 
@@ -391,9 +382,9 @@ describe('optimistic cache layers', () => {
 
     expect(resultWithBuzz).toEqual({
       books: [
-        withoutISBN(eagerBookData),
-        withoutISBN(spinelessBookData),
-        withoutISBN(buzzBookData),
+        withoutTypenameOrISBN(eagerBookData),
+        withoutTypenameOrISBN(spinelessBookData),
+        withoutTypenameOrISBN(buzzBookData),
       ],
     });
     expect(resultWithBuzz.books[0]).toEqual(resultWithTwoAuthors.books[0]);

--- a/src/cache/inmemory/__tests__/writeToStore.ts
+++ b/src/cache/inmemory/__tests__/writeToStore.ts
@@ -1746,7 +1746,11 @@ describe('writing to the store', () => {
       ROOT_QUERY: {
         animals: [
           {
-            species: { name: 'cat' },
+            __typename: 'Animal',
+            species: {
+              __typename: 'Cat',
+              name: 'cat',
+            },
           },
         ],
       },
@@ -1772,7 +1776,11 @@ describe('writing to the store', () => {
       ROOT_QUERY: {
         animals: [
           {
-            species: { name: 'dog' },
+            __typename: 'Animal',
+            species: {
+              __typename: 'Dog',
+              name: 'dog',
+            },
           },
         ],
       },
@@ -1821,7 +1829,11 @@ describe('writing to the store', () => {
       ROOT_QUERY: {
         animals: [
           {
-            species: { name: 'cat' },
+            __typename: 'Animal',
+            species: {
+              __typename: 'Cat',
+              name: 'cat',
+            },
           },
         ],
       },
@@ -1848,11 +1860,13 @@ describe('writing to the store', () => {
     expect(store.toObject()).toEqual({
       'Dog__dog-species': {
         id: 'dog-species',
+        __typename: 'Dog',
         name: 'dog',
       },
       ROOT_QUERY: {
         animals: [
           {
+            __typename: 'Animal',
             species: makeReference('Dog__dog-species'),
           },
         ],

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -135,7 +135,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
 
     return this.storeReader.readQueryFromStore({
       store: options.optimistic ? this.optimisticData : this.data,
-      query: this.transformDocument(options.query),
+      query: options.query,
       variables: options.variables,
       rootId: options.rootId,
       previousResult: options.previousResult,
@@ -156,13 +156,13 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     this.broadcastWatches();
   }
 
-  public diff<T>(query: Cache.DiffOptions): Cache.DiffResult<T> {
+  public diff<T>(options: Cache.DiffOptions): Cache.DiffResult<T> {
     return this.storeReader.diffQueryAgainstStore({
-      store: query.optimistic ? this.optimisticData : this.data,
-      query: this.transformDocument(query.query),
-      variables: query.variables,
-      returnPartialData: query.returnPartialData,
-      previousResult: query.previousResult,
+      store: options.optimistic ? this.optimisticData : this.data,
+      query: options.query,
+      variables: options.variables,
+      returnPartialData: options.returnPartialData,
+      previousResult: options.previousResult,
       config: this.config,
     });
   }

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -143,13 +143,13 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     }) || null;
   }
 
-  public write(write: Cache.WriteOptions): void {
+  public write(options: Cache.WriteOptions): void {
     this.storeWriter.writeQueryToStore({
       store: this.data,
-      query: this.transformDocument(write.query),
-      result: write.result,
-      dataId: write.dataId,
-      variables: write.variables,
+      query: options.query,
+      result: options.result,
+      dataId: options.dataId,
+      variables: options.variables,
       dataIdFromObject: this.config.dataIdFromObject,
     });
 

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -117,8 +117,9 @@ export class StoreWriter {
   private processSelectionSet({
     result,
     selectionSet,
-    typename,
     context,
+    typename = getTypenameFromResult(
+      result, selectionSet, context.fragmentMap),
   }: {
     result: any;
     selectionSet: SelectionSetNode;
@@ -170,12 +171,6 @@ export class StoreWriter {
           );
         }
       } else {
-        // If the typename of the object we're processing was not provided,
-        // compute it lazily.
-        typename =
-          typename ||
-          getTypenameFromResult(result, selectionSet, context.fragmentMap);
-
         // This is not a field, so it must be a fragment, either inline or named
         const fragment = getFragmentFromSelection(
           selection,
@@ -201,6 +196,13 @@ export class StoreWriter {
         }
       }
     });
+
+    if (
+      typeof typename === 'string' &&
+      newFields.__typename === void 0
+    ) {
+      newFields.__typename = typename;
+    }
 
     return newFields;
   }

--- a/src/util/testUtils.ts
+++ b/src/util/testUtils.ts
@@ -3,18 +3,3 @@ export function cloneWithoutTypename<D>(data: D): D {
     return key === '__typename' ? void 0 : value;
   });
 }
-
-describe('cloneWithoutTypename', () => {
-  it('needs at least one test to be defined', () => {
-    expect(
-      cloneWithoutTypename({
-        a: 1,
-        __typename: 'SomeType',
-        b: true,
-      }),
-    ).toEqual({
-      a: 1,
-      b: true,
-    });
-  });
-});

--- a/src/util/testUtils.ts
+++ b/src/util/testUtils.ts
@@ -1,0 +1,20 @@
+export function cloneWithoutTypename<D>(data: D): D {
+  return JSON.parse(JSON.stringify(data), function(key, value) {
+    return key === '__typename' ? void 0 : value;
+  });
+}
+
+describe('cloneWithoutTypename', () => {
+  it('needs at least one test to be defined', () => {
+    expect(
+      cloneWithoutTypename({
+        a: 1,
+        __typename: 'SomeType',
+        b: true,
+      }),
+    ).toEqual({
+      a: 1,
+      b: true,
+    });
+  });
+});

--- a/src/utilities/storeUtils.ts
+++ b/src/utilities/storeUtils.ts
@@ -284,6 +284,9 @@ export function getTypenameFromResult(
       }
     }
   }
+  if (typeof result.__typename === 'string') {
+    return result.__typename;
+  }
 }
 
 export function isField(selection: SelectionNode): selection is FieldNode {


### PR DESCRIPTION
This change was extracted from #5154, per [@jbaxleyiii's approval](https://github.com/apollographql/apollo-client/pull/5154#issuecomment-521456323).

If you read from the cache using a query that does not have explicit `__typename` fields, the cache should not return data containing the `__typename` field. Unfortunately, we have a bunch of tests that currently enforce the accidental presence of `__typename`, so this relatively simple change required updating a lot of test code.