### PR TITLE
Stop calling addTypenameToDocument before InMemoryCache reads/writes.

### DIFF
--- a/src/__tests__/__snapshots__/ApolloClient.ts.snap
+++ b/src/__tests__/__snapshots__/ApolloClient.ts.snap
@@ -37,6 +37,7 @@ Object {
     "h": 9,
   },
   "bar:foobar": Object {
+    "__typename": "bar",
     "e": 5,
     "f": 6,
     "id": "foobar",

--- a/src/cache/inmemory/__tests__/__snapshots__/cache.ts.snap
+++ b/src/cache/inmemory/__tests__/__snapshots__/cache.ts.snap
@@ -6,6 +6,7 @@ Object {
     "i": 7,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "h": Object {
       "__ref": "bar",
@@ -22,6 +23,7 @@ Object {
     "k": 9,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -35,11 +37,13 @@ Object {
 exports[`Cache writeFragment will write some deeply nested data into the store at any id (1/2) 3`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 10,
     "j": 8,
     "k": 9,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -53,11 +57,13 @@ Object {
 exports[`Cache writeFragment will write some deeply nested data into the store at any id (1/2) 4`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 10,
     "j": 11,
     "k": 12,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -71,11 +77,13 @@ Object {
 exports[`Cache writeFragment will write some deeply nested data into the store at any id (1/2) 5`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 7,
     "j": 8,
     "k": 9,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -89,11 +97,13 @@ Object {
 exports[`Cache writeFragment will write some deeply nested data into the store at any id (1/2) 6`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 10,
     "j": 11,
     "k": 12,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -110,6 +120,7 @@ Object {
     "i": 7,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "h": Object {
       "__ref": "bar",
@@ -126,6 +137,7 @@ Object {
     "k": 9,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -139,11 +151,13 @@ Object {
 exports[`Cache writeFragment will write some deeply nested data into the store at any id (2/2) 3`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 10,
     "j": 8,
     "k": 9,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -157,11 +171,13 @@ Object {
 exports[`Cache writeFragment will write some deeply nested data into the store at any id (2/2) 4`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 10,
     "j": 11,
     "k": 12,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -175,11 +191,13 @@ Object {
 exports[`Cache writeFragment will write some deeply nested data into the store at any id (2/2) 5`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 7,
     "j": 8,
     "k": 9,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,
@@ -193,11 +211,13 @@ Object {
 exports[`Cache writeFragment will write some deeply nested data into the store at any id (2/2) 6`] = `
 Object {
   "bar": Object {
+    "__typename": "Bar",
     "i": 10,
     "j": 11,
     "k": 12,
   },
   "foo": Object {
+    "__typename": "Foo",
     "e": 4,
     "f": 5,
     "g": 6,

--- a/src/cache/inmemory/__tests__/diffAgainstStore.ts
+++ b/src/cache/inmemory/__tests__/diffAgainstStore.ts
@@ -418,6 +418,7 @@ describe('diffing queries against the store', () => {
 
     expect(simpleDiff.result).toEqual({
       people_one: {
+        __typename: 'Person',
         name: 'Luke Skywalker',
       },
     });
@@ -429,6 +430,7 @@ describe('diffing queries against the store', () => {
 
     expect(inlineDiff.result).toEqual({
       people_one: {
+        __typename: 'Person',
         name: 'Luke Skywalker',
       },
     });
@@ -440,6 +442,7 @@ describe('diffing queries against the store', () => {
 
     expect(namedDiff.result).toEqual({
       people_one: {
+        __typename: 'Person',
         name: 'Luke Skywalker',
       },
     });
@@ -1085,24 +1088,30 @@ describe('diffing queries against the store', () => {
 
         expect(result).toEqual({
           user: {
+            __typename: 'User',
             id: 1,
             name: 'Ben',
             company: {
+              __typename: 'Company',
               id: 1,
               name: 'Apollo',
               users: [
                 {
+                  __typename: 'User',
                   id: 1,
                   name: 'Ben',
                   company: {
+                    __typename: 'Company',
                     id: 1,
                     name: 'Apollo',
                   },
                 },
                 {
+                  __typename: 'User',
                   id: 2,
                   name: 'James',
                   company: {
+                    __typename: 'Company',
                     id: 1,
                     name: 'Apollo',
                   },

--- a/src/cache/inmemory/__tests__/readFromStore.ts
+++ b/src/cache/inmemory/__tests__/readFromStore.ts
@@ -62,6 +62,7 @@ describe('reading from the store', () => {
       });
 
       expect(stripSymbols(queryResult)).toEqual({
+        __typename: 'Query',
         nestedObj: {
           innerArray: [{ id: 'abcdef', someField: 3 }],
         },
@@ -356,6 +357,7 @@ describe('reading from the store', () => {
 
     // The result of the query shouldn't contain __data_id fields
     expect(stripSymbols(queryResult)).toEqual({
+      __typename: 'Query',
       stringField: 'This is a string!',
       numberField: 5,
       nullField: null,
@@ -837,23 +839,27 @@ describe('reading from the store', () => {
       }),
     ).toEqual({
       author: {
+        __typename: 'Author',
         name: 'Toni Morrison',
         books: [
           {
             title: 'The Bluest Eye',
             publisher: {
+              __typename: 'Publisher',
               name: 'Holt, Rinehart and Winston',
             },
           },
           {
             title: 'Song of Solomon',
             publisher: {
+              __typename: 'Publisher',
               name: 'Alfred A. Knopf, Inc.',
             },
           },
           {
             title: 'Beloved',
             publisher: {
+              __typename: 'Publisher',
               name: 'Alfred A. Knopf, Inc.',
             },
           },

--- a/src/cache/inmemory/__tests__/writeToStore.ts
+++ b/src/cache/inmemory/__tests__/writeToStore.ts
@@ -1746,7 +1746,11 @@ describe('writing to the store', () => {
       ROOT_QUERY: {
         animals: [
           {
-            species: { name: 'cat' },
+            __typename: 'Animal',
+            species: {
+              __typename: 'Cat',
+              name: 'cat',
+            },
           },
         ],
       },
@@ -1772,7 +1776,11 @@ describe('writing to the store', () => {
       ROOT_QUERY: {
         animals: [
           {
-            species: { name: 'dog' },
+            __typename: 'Animal',
+            species: {
+              __typename: 'Dog',
+              name: 'dog',
+            },
           },
         ],
       },
@@ -1821,7 +1829,11 @@ describe('writing to the store', () => {
       ROOT_QUERY: {
         animals: [
           {
-            species: { name: 'cat' },
+            __typename: 'Animal',
+            species: {
+              __typename: 'Cat',
+              name: 'cat',
+            },
           },
         ],
       },
@@ -1848,11 +1860,13 @@ describe('writing to the store', () => {
     expect(store.toObject()).toEqual({
       'Dog__dog-species': {
         id: 'dog-species',
+        __typename: 'Dog',
         name: 'dog',
       },
       ROOT_QUERY: {
         animals: [
           {
+            __typename: 'Animal',
             species: makeReference('Dog__dog-species'),
           },
         ],

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -87,6 +87,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     });
 
     this.storeReader = new StoreReader({
+      addTypename: this.addTypename,
       cacheKeyRoot: this.cacheKeyRoot,
       possibleTypes: this.possibleTypes,
     });
@@ -134,7 +135,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
 
     return this.storeReader.readQueryFromStore({
       store: options.optimistic ? this.optimisticData : this.data,
-      query: this.transformDocument(options.query),
+      query: options.query,
       variables: options.variables,
       rootId: options.rootId,
       previousResult: options.previousResult,
@@ -142,26 +143,26 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     }) || null;
   }
 
-  public write(write: Cache.WriteOptions): void {
+  public write(options: Cache.WriteOptions): void {
     this.storeWriter.writeQueryToStore({
       store: this.data,
-      query: this.transformDocument(write.query),
-      result: write.result,
-      dataId: write.dataId,
-      variables: write.variables,
+      query: options.query,
+      result: options.result,
+      dataId: options.dataId,
+      variables: options.variables,
       dataIdFromObject: this.config.dataIdFromObject,
     });
 
     this.broadcastWatches();
   }
 
-  public diff<T>(query: Cache.DiffOptions): Cache.DiffResult<T> {
+  public diff<T>(options: Cache.DiffOptions): Cache.DiffResult<T> {
     return this.storeReader.diffQueryAgainstStore({
-      store: query.optimistic ? this.optimisticData : this.data,
-      query: this.transformDocument(query.query),
-      variables: query.variables,
-      returnPartialData: query.returnPartialData,
-      previousResult: query.previousResult,
+      store: options.optimistic ? this.optimisticData : this.data,
+      query: options.query,
+      variables: options.variables,
+      returnPartialData: options.returnPartialData,
+      previousResult: options.previousResult,
       config: this.config,
     });
   }

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -123,8 +123,9 @@ export class StoreWriter {
   private processSelectionSet({
     result,
     selectionSet,
-    typename,
     context,
+    typename = getTypenameFromResult(
+      result, selectionSet, context.fragmentMap),
   }: {
     result: any;
     selectionSet: SelectionSetNode;
@@ -176,12 +177,6 @@ export class StoreWriter {
           );
         }
       } else {
-        // If the typename of the object we're processing was not provided,
-        // compute it lazily.
-        typename =
-          typename ||
-          getTypenameFromResult(result, selectionSet, context.fragmentMap);
-
         // This is not a field, so it must be a fragment, either inline or named
         const fragment = getFragmentFromSelection(
           selection,
@@ -207,6 +202,13 @@ export class StoreWriter {
         }
       }
     });
+
+    if (
+      typeof typename === 'string' &&
+      newFields.__typename === void 0
+    ) {
+      newFields.__typename = typename;
+    }
 
     return newFields;
   }

--- a/src/utilities/storeUtils.ts
+++ b/src/utilities/storeUtils.ts
@@ -284,6 +284,9 @@ export function getTypenameFromResult(
       }
     }
   }
+  if (typeof result.__typename === 'string') {
+    return result.__typename;
+  }
 }
 
 export function isField(selection: SelectionNode): selection is FieldNode {


### PR DESCRIPTION
Adding `__typename` fields to the query by calling `addTypenameToDocument` used to be necessary for writing results to the cache, but now (thanks to this PR) `__typename` fields in result objects are automatically written to the cache, so no transformation is necessary.

ApolloClient still calls `cache.transformDocument` to get a query with `__typename` fields to send to the server, and the cache still relies on results from the server coming back with `__typename` fields, but the cache no longer needs the query to be transformed to include `__typename`.

Compared to PR #5311, this commit should not be a breaking change. PR #5311 ultimately failed because hiding `__typename` fields threatened to disrupt `readFragment` => transform => `writeFragment` workflows, because `writeFragment` needs `__typename` information to work properly, so `readFragment` must return that information.