### PR TITLE
Update optimism to use lighter-weight dependency API in EntityCache.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1152,8 +1152,7 @@
     "@types/node": {
       "version": "12.7.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.4.tgz",
-      "integrity": "sha512-W0+n1Y+gK/8G2P/piTkBBN38Qc5Q1ZSO6B5H3QmPCUewaiXOo2GCAWZ4ElZCcNhjJuBSUSLGFUJnmlCn5+nxOQ==",
-      "dev": true
+      "integrity": "sha512-W0+n1Y+gK/8G2P/piTkBBN38Qc5Q1ZSO6B5H3QmPCUewaiXOo2GCAWZ4ElZCcNhjJuBSUSLGFUJnmlCn5+nxOQ=="
     },
     "@types/prop-types": {
       "version": "15.7.2",
@@ -1222,13 +1221,6 @@
       "requires": {
         "@types/node": ">=6",
         "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "12.7.4",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.4.tgz",
-          "integrity": "sha512-W0+n1Y+gK/8G2P/piTkBBN38Qc5Q1ZSO6B5H3QmPCUewaiXOo2GCAWZ4ElZCcNhjJuBSUSLGFUJnmlCn5+nxOQ=="
-        }
       }
     },
     "@wry/equality": {
@@ -6533,9 +6525,9 @@
       }
     },
     "optimism": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.10.2.tgz",
-      "integrity": "sha512-zPfBIxFFWMmQboM9+Z4MSJqc1PXp82v1PFq/GfQaufI69mHKlup7ykGNnfuGIGssXJQkmhSodQ/k9EWwjd8O8A==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.11.1.tgz",
+      "integrity": "sha512-EVUZtx/BKcmZbqE8u7Ai+83FiUS2sLD4ZsmBlS1Pgf+1d5pfLXtX4lA9219OG6cUd77AYxgK9+TBV1myD0QCbQ==",
       "requires": {
         "@wry/context": "^0.4.0"
       }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@wry/equality": "^0.1.9",
     "apollo-link": "^1.2.13",
     "fast-json-stable-stringify": "^2.0.0",
-    "optimism": "^0.10.2",
+    "optimism": "^0.11.1",
     "symbol-observable": "^1.2.0",
     "ts-invariant": "^0.4.4",
     "tslib": "^1.10.0",


### PR DESCRIPTION
Ever since #3394, we have used the http://npmjs.org/package/optimism to speed up repeated cache reads, by recording dependencies on specific cache IDs while computing functions like [`StoreReader#executeSelectionSet`](https://github.com/apollographql/apollo-client/blob/2de5d3b180536ea477d539d1886798405b889dcb/src/cache/inmemory/readFromStore.ts#L140-L142), and later invalidating those cached results if/when the underlying data changed in the cache.

While this system has proven to be logically correct and net-beneficial for many use cases, it wasn't as fast as it could be, because we handled the underlying ID-specific dependencies as if they were cached functions that could be recomputed, and paid the price of allowing them to have child dependencies of their own, even though they never did.

By taking advantage of the new `dep` API introduced by https://github.com/benjamn/optimism/pull/50, we can record and dirty these leaf dependencies much more cheaply, which should reduce the overhead associated with leaving `resultCaching` enabled in the `InMemoryCache`.

This performance diet is especially appealing because leaf dependencies (cache IDs) outnumber cache reads in most applications, and ID values can change in the `EntityCache` many times in between cache reads, so speeding up all those `get`/`set` operations is worthwhile.