### PR TITLE
docs: include FetchPolicy and ErrorPolicy on ApolloClient API reference

### DIFF
--- a/docs/source/api/apollo-client.mdx
+++ b/docs/source/api/apollo-client.mdx
@@ -125,3 +125,5 @@ different value for the same option in individual function calls.
 <TypescriptApiBox name="NetworkStatus" />
 <TypescriptApiBox name="ApolloQueryResult" />
 <TypescriptApiBox name="ApolloCurrentQueryResult" />
+<TypescriptApiBox name="FetchPolicy" />
+<TypescriptApiBox name="ErrorPolicy" />


### PR DESCRIPTION
[ApolloClient class API reference](https://www.apollographql.com/docs/react/api/apollo-client/) section mentions FetchPolicy and ErrorPolicy with links, although once you click on them it doesn't go anywhere, as there are no definitions for those two types on the sections.

i.e search for: `Specifies the FetchPolicy to be used for this query` and try clicking in `FetchPolicy`. 