### PR TITLE
feat(apollo-utilities): transform inline fragments

### DIFF
--- a/packages/apollo-utilities/src/__tests__/transform.ts
+++ b/packages/apollo-utilities/src/__tests__/transform.ts
@@ -192,6 +192,39 @@ describe('removeDirectivesFromDocument', () => {
     expect(print(doc)).toBe(print(expected));
   });
 
+  it('should remove inline fragments using a directive', () => {
+    const query = gql`
+      query Simple {
+        networkField
+        field {
+          ... on TypeA {
+            typeAThing
+          }
+          ... on TypeB @client {
+            typeBThing @client
+          }
+        }
+      }
+    `;
+
+    const expected = gql`
+      query Simple {
+        networkField
+        field {
+          ... on TypeA {
+            typeAThing
+          }
+        }
+      }
+    `;
+
+    const doc = removeDirectivesFromDocument(
+      [{ name: 'client', remove: true }],
+      query,
+    );
+    expect(print(doc)).toBe(print(expected));
+  });
+
   it('should not remove fragment spreads and definitions used without the removed directive', () => {
     const query = gql`
       query Simple {

--- a/packages/apollo-utilities/src/transform.ts
+++ b/packages/apollo-utilities/src/transform.ts
@@ -169,6 +169,24 @@ export function removeDirectivesFromDocument(
         },
       },
 
+      InlineFragment: {
+        enter(node) {
+          if (directives && node.directives) {
+            const shouldRemoveField = directives.some(
+              directive => directive.remove,
+            );
+
+            if (
+              shouldRemoveField &&
+              node.directives &&
+              node.directives.some(getDirectiveMatcher(directives))
+            ) {
+              return null;
+            }
+          }
+        },
+      },
+
       Directive: {
         enter(node) {
           // If a matching directive is found, remove it.


### PR DESCRIPTION
Consider the following schema on the server:

```graphql
interface Character {
  appearsIn: [Episode]!
}

type Human implements Character {
  appearsIn: [Episode]!
  height: Int
}
```

Then the following addition on the client:

```graphql
type Droid implements Character {
  appearsIn: [Episode]!
  primaryFunction: String
}
```

With the following query:

```graphql
query HeroForEpisode($ep: Episode!) {
  hero(episode: $ep) {
    ... on Human {
      height
    }
    ... on Droid @client {
      primaryFunction
    }
  }
}
```

The server will complain that the fragment spread has no type overlap
with parent, as the server does not have knowledge of the `Droid` type.

This commit strips out inline fragments which use a client directive,
allowing them to be resolved via local state.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
