### PR TITLE
some people take docs literally :)

### DIFF
--- a/docs/source/data/fragments.md
+++ b/docs/source/data/fragments.md
@@ -37,6 +37,8 @@ To do so, we can simply share a fragment describing the fields we need for a com
 ```js
 import gql from 'graphql-tag';
 
+let CommentsPage = {};
+
 CommentsPage.fragments = {
   comment: gql`
     fragment CommentsPageComment on Comment {
@@ -50,6 +52,8 @@ CommentsPage.fragments = {
     }
   `,
 };
+
+export CommentsPage;
 ```
 
 We put the fragment on `CommentsPage.fragments.comment` by convention, and use the familiar `gql` helper to create it.


### PR DESCRIPTION
I just saw https://spectrum.chat/apollo/general/can-someone-clear-something-up-with-the-documentation~4825f624-ccb6-470e-b281-5be024ffb26e and i agree that docs should be clear enough even when creating the object and export is something people just should understand, this makes it more clear, maybe :)