### PR TITLE
Adjust rollup to build an initial ESM bundle

### DIFF
--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -5,8 +5,6 @@ import fs from 'fs';
 
 import packageJson from '../package.json';
 
-const distDir = './dist';
-
 const globals = {
   'tslib': 'tslib',
   'ts-invariant': 'invariant',
@@ -29,12 +27,15 @@ function external(id) {
   return hasOwn.call(globals, id);
 }
 
+const distDir = './dist';
+const esmFile = packageJson.main.replace('.cjs', '.esm')
+
 function prepareESM() {
   return {
     input: packageJson.module,
     external,
     output: {
-      dir: distDir,
+      file: esmFile,
       format: 'esm',
       sourcemap: true,
     },
@@ -55,7 +56,7 @@ function prepareESM() {
 
 function prepareCJS() {
   return {
-    input: packageJson.module,
+    input: esmFile,
     external,
     output: {
       file: packageJson.main,


### PR DESCRIPTION
Since we aren't using the ESM bundle anywhere (we're referencing the CJS bundle as the `main` `package.json` entry point, and pointing to the expanded ESM code via the `module` entry point), we were hopeful we could get away from building an unnecessary ESM bundle. Instead of building an ESM bundle, we have an initial Rollup job that feeds the Typescript compiled ES5 source through the `invariantPlugin`, to help replace error messages with numeric codes. This happens in place, and unfortunately ends up duplicating and storing code back in `dist/index.js`, that later ends up causing issues when Rollup attempts to tree-shake / eliminate dead code (code stored in the `index.js` isn't properly removed when it should be).

To prevent the above issue from happening, this PR switches back to building an ESM bundle first (which includes running the `invariantPlugin`). The CJS bundle is then generated from the ESM bundle, leaving the original expanded `dist` code as is.