### PR TITLE
Remove the `ApolloClient` default export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@
   - `QueryManager#startQuery`
   - `ObservableQuery#currentResult`
 
+- `ApolloClient` is now only available as a named export. The default
+  `ApolloClient` export has been removed.
+
 ## Apollo Client (2.6.4)
 
 ### Apollo Client (2.6.4)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/client",
-  "version": "3.0.0-alpha.6",
+  "version": "3.0.0-alpha.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3093,7 +3093,7 @@
         },
         "debug": {
           "version": "4.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "optional": true,
@@ -3290,14 +3290,14 @@
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.3.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
           "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
           "dev": true,
           "optional": true,
@@ -3309,7 +3309,7 @@
         },
         "node-pre-gyp": {
           "version": "0.12.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
           "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
           "dev": true,
           "optional": true,
@@ -3339,14 +3339,14 @@
         },
         "npm-bundled": {
           "version": "1.0.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
           "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
           "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
           "dev": true,
           "optional": true,
@@ -3502,7 +3502,7 @@
         },
         "semver": {
           "version": "5.7.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
           "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true,
           "optional": true

--- a/src/ApolloClient.ts
+++ b/src/ApolloClient.ts
@@ -61,7 +61,7 @@ export type ApolloClientOptions<TCacheShape> = {
  * receive results from the server and cache the results in a store. It also delivers updates
  * to GraphQL queries through {@link Observable} instances.
  */
-export default class ApolloClient<TCacheShape> implements DataProxy {
+export class ApolloClient<TCacheShape> implements DataProxy {
   public link: ApolloLink;
   public store: DataStore<TCacheShape>;
   public cache: ApolloCache<TCacheShape>;

--- a/src/__tests__/ApolloClient.ts
+++ b/src/__tests__/ApolloClient.ts
@@ -6,7 +6,7 @@ import { HttpLink } from '../link/http';
 import { InMemoryCache, makeReference } from '../cache/inmemory';
 import { stripSymbols } from '../utilities';
 import { withWarning } from '../util/wrap';
-import ApolloClient from '../';
+import { ApolloClient } from '../';
 import { DefaultOptions } from '../ApolloClient';
 import { FetchPolicy, QueryOptions } from '../core/watchQueryOptions';
 

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -8,7 +8,7 @@ import { InMemoryCache, PossibleTypesMap } from '../cache/inmemory';
 import { stripSymbols } from '../utilities';
 import { WatchQueryOptions, FetchPolicy } from '../core/watchQueryOptions';
 import { ApolloError } from '../errors/ApolloError';
-import ApolloClient from '..';
+import { ApolloClient } from '..';
 import subscribeAndCount from '../util/subscribeAndCount';
 import { withWarning } from '../util/wrap';
 import { mockSingleLink } from '../__mocks__/mockLinks';
@@ -16,7 +16,7 @@ import { mockSingleLink } from '../__mocks__/mockLinks';
 describe('client', () => {
   it('can be loaded via require', () => {
     /* tslint:disable */
-    const ApolloClientRequire = require('../').default;
+    const ApolloClientRequire = require('../').ApolloClient;
     /* tslint:enable */
 
     const client = new ApolloClientRequire({

--- a/src/__tests__/fetchMore.ts
+++ b/src/__tests__/fetchMore.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 
 import { mockSingleLink } from '../__mocks__/mockLinks';
 import { InMemoryCache } from '../cache/inmemory';
-import ApolloClient, { NetworkStatus, ObservableQuery } from '../';
+import { ApolloClient, NetworkStatus, ObservableQuery } from '../';
 
 describe('updateQuery on a simple query', () => {
   const query = gql`

--- a/src/__tests__/graphqlSubscriptions.ts
+++ b/src/__tests__/graphqlSubscriptions.ts
@@ -2,7 +2,7 @@ import gql from 'graphql-tag';
 
 import { mockObservableLink, MockedSubscription } from '../__mocks__/mockLinks';
 import { InMemoryCache } from '../cache/inmemory';
-import ApolloClient from '../';
+import { ApolloClient } from '../';
 import { QueryManager } from '../core/QueryManager';
 import { DataStore } from '../data/store';
 

--- a/src/__tests__/local-state/export.ts
+++ b/src/__tests__/local-state/export.ts
@@ -3,7 +3,7 @@ import { print } from 'graphql/language/printer';
 
 import { Observable } from '../../util/Observable';
 import { ApolloLink } from '../../link/core';
-import ApolloClient from '../..';
+import { ApolloClient } from '../..';
 import { InMemoryCache } from '../../cache/inmemory';
 
 describe('@client @export tests', () => {

--- a/src/__tests__/local-state/general.ts
+++ b/src/__tests__/local-state/general.ts
@@ -4,7 +4,7 @@ import { introspectionQuery } from 'graphql/utilities';
 
 import { Observable } from '../../util/Observable';
 import { ApolloLink, Operation } from '../../link/core';
-import ApolloClient from '../..';
+import { ApolloClient } from '../..';
 import { ApolloCache } from '../../cache/core';
 import { InMemoryCache } from '../../cache/inmemory';
 import { hasDirectives } from '../../utilities';

--- a/src/__tests__/local-state/resolvers.ts
+++ b/src/__tests__/local-state/resolvers.ts
@@ -4,7 +4,7 @@ import { assign } from 'lodash';
 
 import { Observable } from '../../util/Observable';
 import { ApolloLink } from '../../link/core';
-import ApolloClient from '../..';
+import { ApolloClient } from '../..';
 import mockQueryManager from '../../__mocks__/mockQueryManager';
 import { Observer } from '../../util/Observable';
 import wrap from '../../util/wrap';

--- a/src/__tests__/local-state/subscriptions.ts
+++ b/src/__tests__/local-state/subscriptions.ts
@@ -2,7 +2,7 @@ import gql from 'graphql-tag';
 
 import { Observable } from '../../util/Observable';
 import { ApolloLink } from '../../link/core';
-import ApolloClient from '../..';
+import { ApolloClient } from '../..';
 import { InMemoryCache } from '../../cache/inmemory';
 
 describe('Basic functionality', () => {

--- a/src/__tests__/mutationResults.ts
+++ b/src/__tests__/mutationResults.ts
@@ -4,7 +4,7 @@ import gql from 'graphql-tag';
 import { Observable } from '../util/Observable';
 import { ApolloLink } from '../link/core';
 import { mockSingleLink } from '../__mocks__/mockLinks';
-import ApolloClient from '..';
+import { ApolloClient } from '..';
 import { InMemoryCache } from '../cache/inmemory';
 import { Subscription } from '../util/Observable';
 import { withWarning } from '../util/wrap';

--- a/src/__tests__/optimistic.ts
+++ b/src/__tests__/optimistic.ts
@@ -6,7 +6,7 @@ import gql from 'graphql-tag';
 import { mockSingleLink } from '../__mocks__/mockLinks';
 import { MutationQueryReducersMap } from '../core/types';
 import { Subscription } from '../util/Observable';
-import ApolloClient from '../';
+import { ApolloClient } from '../';
 import { addTypenameToDocument, stripSymbols } from '../utilities';
 import { InMemoryCache, makeReference } from '../cache/inmemory';
 

--- a/src/__tests__/subscribeToMore.ts
+++ b/src/__tests__/subscribeToMore.ts
@@ -3,7 +3,7 @@ import { DocumentNode, OperationDefinitionNode } from 'graphql';
 
 import { ApolloLink, Operation } from '../link/core';
 import { mockSingleLink, mockObservableLink } from '../__mocks__/mockLinks';
-import ApolloClient from '../';
+import { ApolloClient } from '../';
 import { InMemoryCache } from '../cache/inmemory';
 import { stripSymbols } from '../utilities';
 

--- a/src/core/LocalState.ts
+++ b/src/core/LocalState.ts
@@ -29,7 +29,7 @@ import {
   isField,
   isInlineFragment,
 } from '../utilities';
-import ApolloClient from '../ApolloClient';
+import { ApolloClient } from '../ApolloClient';
 import { Resolvers, OperationVariables } from './types';
 import { capitalizeFirstLetter } from '../util/capitalizeFirstLetter';
 

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -12,7 +12,7 @@ import { ObservableQuery } from '../ObservableQuery';
 import { NetworkStatus } from '../networkStatus';
 import { QueryManager } from '../QueryManager';
 import { DataStore } from '../../data/store';
-import ApolloClient from '../../';
+import { ApolloClient } from '../../';
 
 import wrap from '../../util/wrap';
 import subscribeAndCount from '../../util/subscribeAndCount';

--- a/src/core/__tests__/fetchPolicies.ts
+++ b/src/core/__tests__/fetchPolicies.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 import { ApolloLink } from '../../link/core';
 import { InMemoryCache } from '../../cache/inmemory';
 import { stripSymbols } from '../../utilities';
-import ApolloClient from '../..';
+import { ApolloClient } from '../..';
 import subscribeAndCount from '../../util/subscribeAndCount';
 import { mockSingleLink } from '../../__mocks__/mockLinks';
 import { NetworkStatus } from '../networkStatus';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,10 @@
 export {
+  ApolloClient,
+  ApolloClientOptions,
+  DefaultOptions
+} from './ApolloClient';
+
+export {
   ObservableQuery,
   FetchMoreOptions,
   UpdateQueryOptions,
@@ -29,16 +35,6 @@ export {
 } from './core/LocalState';
 
 export { isApolloError, ApolloError } from './errors/ApolloError';
-
-import ApolloClient, {
-  ApolloClientOptions,
-  DefaultOptions,
-} from './ApolloClient';
-export { ApolloClientOptions, DefaultOptions };
-
-// Export the client as both default and named.
-export { ApolloClient };
-export default ApolloClient;
 
 export * from './cache/core';
 export * from './cache/inmemory';

--- a/src/react/context/ApolloConsumer.tsx
+++ b/src/react/context/ApolloConsumer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { invariant } from 'ts-invariant';
 
-import ApolloClient from '../../ApolloClient';
+import { ApolloClient } from '../../ApolloClient';
 import { getApolloContext } from './ApolloContext';
 
 export interface ApolloConsumerProps {

--- a/src/react/context/ApolloContext.ts
+++ b/src/react/context/ApolloContext.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import ApolloClient from '../../ApolloClient';
+import { ApolloClient } from '../../ApolloClient';
 
 export interface ApolloContextValue {
   client?: ApolloClient<object>;

--- a/src/react/context/ApolloProvider.tsx
+++ b/src/react/context/ApolloProvider.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { invariant } from 'ts-invariant';
 
-import ApolloClient from '../../ApolloClient';
+import { ApolloClient } from '../../ApolloClient';
 import { getApolloContext } from './ApolloContext';
 
 export interface ApolloProviderProps<TCache> {

--- a/src/react/context/__tests__/ApolloConsumer.test.tsx
+++ b/src/react/context/__tests__/ApolloConsumer.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, cleanup } from '@testing-library/react';
 
 import { ApolloLink } from '../../../link/core';
-import ApolloClient from '../../../ApolloClient';
+import { ApolloClient } from '../../../ApolloClient';
 import { InMemoryCache as Cache } from '../../../cache/inmemory/inMemoryCache';
 import { ApolloProvider } from '../ApolloProvider';
 import { ApolloConsumer } from '../ApolloConsumer';

--- a/src/react/context/__tests__/ApolloProvider.test.tsx
+++ b/src/react/context/__tests__/ApolloProvider.test.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 import { render, cleanup } from '@testing-library/react';
 
 import { ApolloLink } from '../../../link/core';
-import ApolloClient from '../../../ApolloClient';
+import { ApolloClient } from '../../../ApolloClient';
 import { InMemoryCache as Cache } from '../../../cache/inmemory/inMemoryCache';
 import { ApolloProvider } from '../ApolloProvider';
 import { getApolloContext } from '../ApolloContext';

--- a/src/react/data/OperationData.ts
+++ b/src/react/data/OperationData.ts
@@ -2,7 +2,7 @@ import { DocumentNode } from 'graphql';
 import { equal as isEqual } from '@wry/equality';
 import { invariant } from 'ts-invariant';
 
-import ApolloClient from '../../ApolloClient';
+import { ApolloClient } from '../../ApolloClient';
 import { DocumentType, parser, operationName } from '../parser/parser';
 import { ApolloContextValue } from '../context/ApolloContext';
 import { CommonOptions } from '../types/types';

--- a/src/react/hooks/__tests__/useApolloClient.test.tsx
+++ b/src/react/hooks/__tests__/useApolloClient.test.tsx
@@ -5,7 +5,7 @@ import { InvariantError } from 'ts-invariant';
 import { ApolloLink } from '../../../link/core';
 import { ApolloProvider } from '../../context/ApolloProvider';
 import { resetApolloContext } from '../../context/ApolloContext';
-import ApolloClient from '../../../ApolloClient';
+import { ApolloClient } from '../../../ApolloClient';
 import { InMemoryCache } from '../../../cache/inmemory/inMemoryCache';
 import { useApolloClient } from '../useApolloClient';
 

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -4,7 +4,7 @@ import gql from 'graphql-tag';
 import { render, wait } from '@testing-library/react';
 
 import { MockedProvider } from '../../testing';
-import ApolloClient from '../../../ApolloClient';
+import { ApolloClient } from '../../../ApolloClient';
 import { InMemoryCache } from '../../../cache/inmemory/inMemoryCache';
 import { ApolloProvider } from '../../context/ApolloProvider';
 import { useLazyQuery } from '../useLazyQuery';

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -4,7 +4,7 @@ import gql from 'graphql-tag';
 import { render, cleanup, wait } from '@testing-library/react';
 
 import { MockedProvider, mockSingleLink } from '../../testing';
-import ApolloClient from '../../../ApolloClient';
+import { ApolloClient } from '../../../ApolloClient';
 import { InMemoryCache } from '../../../cache/inmemory/inMemoryCache';
 import { ApolloProvider } from '../../context/ApolloProvider';
 import { useMutation } from '../useMutation';

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -6,7 +6,7 @@ import { render, cleanup, wait } from '@testing-library/react';
 import { Observable } from '../../../util/Observable';
 import { ApolloLink } from '../../../link/core';
 import { MockedProvider, MockLink } from '../../testing';
-import ApolloClient from '../../../ApolloClient';
+import { ApolloClient } from '../../../ApolloClient';
 import { InMemoryCache } from '../../../cache/inmemory/inMemoryCache';
 import { ApolloProvider } from '../../context/ApolloProvider';
 import { useQuery } from '../useQuery';

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -3,7 +3,7 @@ import { render, cleanup, wait } from '@testing-library/react';
 import gql from 'graphql-tag';
 
 import { MockSubscriptionLink } from '../../testing';
-import ApolloClient from '../../../ApolloClient';
+import { ApolloClient } from '../../../ApolloClient';
 import { InMemoryCache as Cache } from '../../../cache/inmemory/inMemoryCache';
 import { ApolloProvider } from '../../context/ApolloProvider';
 import { useSubscription } from '../useSubscription';

--- a/src/react/hooks/useApolloClient.ts
+++ b/src/react/hooks/useApolloClient.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import { invariant } from 'ts-invariant';
 
-import ApolloClient from '../../ApolloClient';
+import { ApolloClient } from '../../ApolloClient';
 import { getApolloContext } from '../context/ApolloContext';
 
 export function useApolloClient(): ApolloClient<object> {

--- a/src/react/testing/mocks/MockedProvider.tsx
+++ b/src/react/testing/mocks/MockedProvider.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import ApolloClient from '../../../ApolloClient';
+import { ApolloClient } from '../../../ApolloClient';
 import { InMemoryCache as Cache } from '../../../cache/inmemory/inMemoryCache';
 import { ApolloProvider } from '../../context/ApolloProvider';
 import { MockLink } from './mockLink';

--- a/src/react/testing/mocks/types.ts
+++ b/src/react/testing/mocks/types.ts
@@ -1,5 +1,5 @@
 import { ApolloLink, GraphQLRequest, FetchResult } from '../../../link/core';
-import ApolloClient, { DefaultOptions } from '../../../ApolloClient';
+import { ApolloClient, DefaultOptions } from '../../../ApolloClient';
 import { Resolvers } from '../../../core/types';
 import { ApolloCache } from '../../../cache/core/cache';
 

--- a/src/react/testing/utils/createClient.ts
+++ b/src/react/testing/utils/createClient.ts
@@ -1,6 +1,6 @@
 import { DocumentNode } from 'graphql';
 
-import ApolloClient from '../../../ApolloClient';
+import { ApolloClient } from '../../../ApolloClient';
 import { InMemoryCache } from '../../../cache/inmemory/inMemoryCache';
 import { NormalizedCacheObject } from '../../../cache/inmemory/types';
 import { mockSingleLink } from '../mocks/mockLink';

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -3,7 +3,7 @@ import { DocumentNode } from 'graphql';
 
 import { Observable } from '../../util/Observable';
 import { FetchResult } from '../../link/core';
-import ApolloClient from '../../ApolloClient';
+import { ApolloClient } from '../../ApolloClient';
 import {
   ApolloQueryResult,
   PureQueryOptions,


### PR DESCRIPTION
AC 2 exports `ApolloClient` as both the default and a named export. Since people will likely be using more exports from the `@apollo/client` package in AC 3 (e.g. integrated React hooks, Apollo Link's, etc.), let's kill the default export and only support the named export moving forward.