### PR TITLE
Add ssr support to apollo-boost

### DIFF
--- a/packages/apollo-boost/src/index.ts
+++ b/packages/apollo-boost/src/index.ts
@@ -40,6 +40,8 @@ export interface PresetConfig {
   name?: string;
   version?: string;
   resolvers?: Resolvers | Resolvers[];
+  ssrForceFetchDelay?: number;
+  ssrMode?: boolean;
   typeDefs?: string | string[] | DocumentNode | DocumentNode[];
   fragmentMatcher?: LocalStateFragmentMatcher;
 }
@@ -68,6 +70,8 @@ const PRESET_CONFIG_KEYS = [
   'name',
   'version',
   'resolvers',
+  'ssrForceFetchDelay',
+  'ssrMode',
   'typeDefs',
   'fragmentMatcher',
 ];
@@ -99,6 +103,8 @@ export default class DefaultClient<TCache> extends ApolloClient<TCache> {
       onError: errorCallback,
       name,
       version,
+      ssrForceFetchDelay,
+      ssrMode,
       resolvers,
       typeDefs,
       fragmentMatcher,
@@ -193,6 +199,8 @@ export default class DefaultClient<TCache> extends ApolloClient<TCache> {
       link,
       name,
       version,
+      ssrForceFetchDelay,
+      ssrMode,
       resolvers: activeResolvers,
       typeDefs: activeTypeDefs,
       fragmentMatcher: activeFragmentMatcher,


### PR DESCRIPTION
Currently apollo-boost is missing a few config params that prevents ssr rendering to work as expected, since it's a small change with zero impact I've took the liberty to do it myself.

I've Added `ssrMode` and `ssrForceFetchDelay` to DefaultClient's PresetConfig, and passed it down on initialization to internal ApolloClient.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->
