### PR TITLE
Promise-ify all tests, and pass a Promise reject function to mocking utilities.

### DIFF
--- a/src/__mocks__/mockQueryManager.ts
+++ b/src/__mocks__/mockQueryManager.ts
@@ -4,9 +4,12 @@ import { InMemoryCache } from '../cache/inmemory/inMemoryCache';
 
 // Helper method for the tests that construct a query manager out of a
 // a list of mocked responses for a mocked network interface.
-export default (...mockedResponses: MockedResponse[]) => {
+export default (
+  reject: (reason: any) => any,
+  ...mockedResponses: MockedResponse[]
+) => {
   return new QueryManager({
-    link: mockSingleLink(...mockedResponses),
+    link: mockSingleLink(reject, ...mockedResponses),
     cache: new InMemoryCache({ addTypename: false }),
   });
 };

--- a/src/__mocks__/mockWatchQuery.ts
+++ b/src/__mocks__/mockWatchQuery.ts
@@ -4,8 +4,11 @@ import mockQueryManager from './mockQueryManager';
 
 import { ObservableQuery } from '../core/ObservableQuery';
 
-export default (...mockedResponses: MockedResponse[]): ObservableQuery<any> => {
-  const queryManager = mockQueryManager(...mockedResponses);
+export default (
+  reject: (reason: any) => any,
+  ...mockedResponses: MockedResponse[]
+): ObservableQuery<any> => {
+  const queryManager = mockQueryManager(reject, ...mockedResponses);
   const firstRequest = mockedResponses[0].request;
   return queryManager.watchQuery({
     query: firstRequest.query!,

--- a/src/__tests__/__snapshots__/client.ts.snap
+++ b/src/__tests__/__snapshots__/client.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`@connect should run a query with the connection directive and filter arguments and write the result to the correct store key 1`] = `
+exports[`@connection should run a query with the connection directive and filter arguments and write the result to the correct store key 1`] = `
 Object {
   "ROOT_QUERY": Object {
     "abc({\\"order\\":\\"popularity\\"})": Array [
@@ -13,7 +13,7 @@ Object {
 }
 `;
 
-exports[`@connect should run a query with the connection directive and write the result to the store key defined in the directive 1`] = `
+exports[`@connection should run a query with the connection directive and write the result to the store key defined in the directive 1`] = `
 Object {
   "ROOT_QUERY": Object {
     "abc": Array [

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -12,6 +12,7 @@ import { ApolloError } from '../errors/ApolloError';
 import { ApolloClient } from '..';
 import subscribeAndCount from './utils/subscribeAndCount';
 import { withWarning } from './utils/wrap';
+import { itAsync } from './utils/itAsync';
 import { mockSingleLink } from '../__mocks__/mockLinks';
 
 describe('client', () => {
@@ -78,7 +79,7 @@ describe('client', () => {
     );
   });
 
-  it('should allow for a single query to take place', () => new Promise((resolve, reject) => {
+  itAsync('should allow for a single query to take place', (resolve, reject) => {
     const query = gql`
       query people {
         allPeople(first: 1) {
@@ -104,9 +105,9 @@ describe('client', () => {
     };
 
     return clientRoundtrip(resolve, reject, query, { data });
-  }));
+  });
 
-  it('should allow a single query with an apollo-link enabled network interface', () => new Promise((resolve, reject) => {
+  itAsync('should allow a single query with an apollo-link enabled network interface', (resolve, reject) => {
     const query = gql`
       query people {
         allPeople(first: 1) {
@@ -144,9 +145,9 @@ describe('client', () => {
       expect(stripSymbols(actualResult.data)).toEqual(data);
       resolve();
     });
-  }));
+  });
 
-  it('should allow for a single query with complex default variables to take place', () => new Promise((resolve, reject) => {
+  itAsync('should allow for a single query with complex default variables to take place', (resolve, reject) => {
     const query = gql`
       query stuff(
         $test: Input = { key1: ["value", "value2"], key2: { key3: 4 } }
@@ -198,9 +199,9 @@ describe('client', () => {
       basic,
       withDefault,
     ]).then(resolve, reject);
-  }));
+  });
 
-  it('should allow for a single query with default values that get overridden with variables', () => new Promise((resolve, reject) => {
+  itAsync('should allow for a single query with default values that get overridden with variables', (resolve, reject) => {
     const query = gql`
       query people($first: Int = 1) {
         allPeople(first: $first) {
@@ -275,9 +276,9 @@ describe('client', () => {
       withDefault,
       withOverride,
     ]).then(resolve, reject);
-  }));
+  });
 
-  it('should allow fragments on root query', () => new Promise((resolve, reject) => {
+  itAsync('should allow fragments on root query', (resolve, reject) => {
     const query = gql`
       query {
         ...QueryFragment
@@ -302,9 +303,9 @@ describe('client', () => {
     };
 
     return clientRoundtrip(resolve, reject, query, { data }, null);
-  }));
+  });
 
-  it('should allow fragments on root query with ifm', () => new Promise((resolve, reject) => {
+  itAsync('should allow fragments on root query with ifm', (resolve, reject) => {
     const query = gql`
       query {
         ...QueryFragment
@@ -331,9 +332,9 @@ describe('client', () => {
     return clientRoundtrip(resolve, reject, query, { data }, null, {
       Query: ['Record'],
     });
-  }));
+  });
 
-  it('should merge fragments on root query', () => new Promise((resolve, reject) => {
+  itAsync('should merge fragments on root query', (resolve, reject) => {
     // The fragment should be used after the selected fields for the query.
     // Otherwise, the results aren't merged.
     // see: https://github.com/apollographql/apollo-client/issues/1479
@@ -366,9 +367,9 @@ describe('client', () => {
     return clientRoundtrip(resolve, reject, query, { data }, null, {
       Query: ['Record'],
     });
-  }));
+  });
 
-  it('store can be rehydrated from the server', () => new Promise((resolve, reject) => {
+  itAsync('store can be rehydrated from the server', (resolve, reject) => {
     const query = gql`
       query people {
         allPeople(first: 1) {
@@ -424,9 +425,9 @@ describe('client', () => {
         (client.cache as InMemoryCache).extract(),
       );
     }).then(resolve, reject);
-  }));
+  });
 
-  it('store can be rehydrated from the server using the shadow method', () => new Promise((resolve, reject) => {
+  itAsync('store can be rehydrated from the server using the shadow method', (resolve, reject) => {
     const query = gql`
       query people {
         allPeople(first: 1) {
@@ -480,9 +481,9 @@ describe('client', () => {
       expect(stripSymbols(result.data)).toEqual(data);
       expect(finalState.data).toEqual(client.extract());
     }).then(resolve, reject);
-  }));
+  });
 
-  it('stores shadow of restore returns the same result as accessing the method directly on the cache', () => new Promise((resolve, reject) => {
+  itAsync('stores shadow of restore returns the same result as accessing the method directly on the cache', (resolve, reject) => {
     const query = gql`
       query people {
         allPeople(first: 1) {
@@ -545,9 +546,9 @@ describe('client', () => {
     );
 
     resolve();
-  }));
+  });
 
-  it('should return errors correctly for a single query', () => new Promise((resolve, reject) => {
+  itAsync('should return errors correctly for a single query', (resolve, reject) => {
     const query = gql`
       query people {
         allPeople(first: 1) {
@@ -578,9 +579,9 @@ describe('client', () => {
     return client.query({ query }).catch((error: ApolloError) => {
       expect(error.graphQLErrors).toEqual(errors);
     }).then(resolve, reject);
-  }));
+  });
 
-  it('should return GraphQL errors correctly for a single query with an apollo-link enabled network interface', () => new Promise((resolve, reject) => {
+  itAsync('should return GraphQL errors correctly for a single query with an apollo-link enabled network interface', (resolve, reject) => {
     const query = gql`
       query people {
         allPeople(first: 1) {
@@ -625,9 +626,9 @@ describe('client', () => {
       expect(error.graphQLErrors).toEqual(errors);
       resolve();
     });
-  }));
+  });
 
-  xit('should pass a network error correctly on a query using an observable network interface with a warning', () => new Promise((resolve, reject) => {
+  itAsync.skip('should pass a network error correctly on a query using an observable network interface with a warning', (resolve, reject) => {
     withWarning(() => {
       const query = gql`
         query people {
@@ -660,9 +661,9 @@ describe('client', () => {
         resolve();
       });
     }, /deprecated/);
-  }));
+  });
 
-  it('should pass a network error correctly on a query with apollo-link network interface', () => new Promise((resolve, reject) => {
+  itAsync('should pass a network error correctly on a query with apollo-link network interface', (resolve, reject) => {
     const query = gql`
       query people {
         allPeople(first: 1) {
@@ -693,7 +694,7 @@ describe('client', () => {
       expect(error.networkError!.message).toEqual(networkError.message);
       resolve();
     });
-  }));
+  });
 
   it('should not warn when receiving multiple results from apollo-link network interface', () => {
     const query = gql`
@@ -728,7 +729,7 @@ describe('client', () => {
     });
   });
 
-  xit('should surface errors in observer.next as uncaught', () => new Promise((resolve, reject) => {
+  itAsync.skip('should surface errors in observer.next as uncaught', (resolve, reject) => {
     const expectedError = new Error('this error should not reach the store');
     const listeners = process.listeners('uncaughtException');
     const oldHandler = listeners[listeners.length - 1];
@@ -783,9 +784,9 @@ describe('client', () => {
         throw expectedError;
       },
     });
-  }));
+  });
 
-  xit('should surfaces errors in observer.error as uncaught', () => new Promise((resolve, reject) => {
+  itAsync.skip('should surfaces errors in observer.error as uncaught', (resolve, reject) => {
     const expectedError = new Error('this error should not reach the store');
     const listeners = process.listeners('uncaughtException');
     const oldHandler = listeners[listeners.length - 1];
@@ -830,9 +831,9 @@ describe('client', () => {
         throw expectedError;
       },
     });
-  }));
+  });
 
-  it('should allow for subscribing to a request', () => new Promise((resolve, reject) => {
+  itAsync('should allow for subscribing to a request', (resolve, reject) => {
     const query = gql`
       query people {
         allPeople(first: 1) {
@@ -871,9 +872,9 @@ describe('client', () => {
         resolve();
       },
     });
-  }));
+  });
 
-  it('should be able to transform queries', () => new Promise((resolve, reject) => {
+  itAsync('should be able to transform queries', (resolve, reject) => {
     const query = gql`
       query {
         author {
@@ -926,9 +927,9 @@ describe('client', () => {
     return client.query({ query }).then(actualResult => {
       expect(stripSymbols(actualResult.data)).toEqual(transformedResult);
     }).then(resolve, reject);
-  }));
+  });
 
-  it('should be able to transform queries on network-only fetches', () => new Promise((resolve, reject) => {
+  itAsync('should be able to transform queries on network-only fetches', (resolve, reject) => {
     const query = gql`
       query {
         author {
@@ -982,9 +983,9 @@ describe('client', () => {
         expect(stripSymbols(actualResult.data)).toEqual(transformedResult);
       })
       .then(resolve, reject);
-  }));
+  });
 
-  it('should handle named fragments on mutations', () => new Promise((resolve, reject) => {
+  itAsync('should handle named fragments on mutations', (resolve, reject) => {
     const mutation = gql`
       mutation {
         starAuthor(id: 12) {
@@ -1021,9 +1022,9 @@ describe('client', () => {
     return client.mutate({ mutation }).then(actualResult => {
       expect(stripSymbols(actualResult.data)).toEqual(result);
     }).then(resolve, reject);
-  }));
+  });
 
-  it('should be able to handle named fragments on network-only queries', () => new Promise((resolve, reject) => {
+  itAsync('should be able to handle named fragments on network-only queries', (resolve, reject) => {
     const query = gql`
       fragment authorDetails on Author {
         firstName
@@ -1061,9 +1062,9 @@ describe('client', () => {
         expect(stripSymbols(actualResult.data)).toEqual(result);
       })
       .then(resolve, reject);
-  }));
+  });
 
-  it('should be able to handle named fragments with multiple fragments', () => new Promise((resolve, reject) => {
+  itAsync('should be able to handle named fragments with multiple fragments', (resolve, reject) => {
     const query = gql`
       query {
         author {
@@ -1103,9 +1104,9 @@ describe('client', () => {
     return client.query({ query }).then(actualResult => {
       expect(stripSymbols(actualResult.data)).toEqual(result);
     }).then(resolve, reject);
-  }));
+  });
 
-  it('should be able to handle named fragments', () => new Promise((resolve, reject) => {
+  itAsync('should be able to handle named fragments', (resolve, reject) => {
     const query = gql`
       query {
         author {
@@ -1139,9 +1140,9 @@ describe('client', () => {
     return client.query({ query }).then(actualResult => {
       expect(stripSymbols(actualResult.data)).toEqual(result);
     }).then(resolve, reject);
-  }));
+  });
 
-  it('should be able to handle inlined fragments on an Interface type', () => new Promise((resolve, reject) => {
+  itAsync('should be able to handle inlined fragments on an Interface type', (resolve, reject) => {
     const query = gql`
       query items {
         items {
@@ -1188,9 +1189,9 @@ describe('client', () => {
     return client.query({ query }).then((actualResult: any) => {
       expect(stripSymbols(actualResult.data)).toEqual(result);
     }).then(resolve, reject);
-  }));
+  });
 
-  it('should be able to handle inlined fragments on an Interface type with introspection fragment matcher', () => new Promise((resolve, reject) => {
+  itAsync('should be able to handle inlined fragments on an Interface type with introspection fragment matcher', (resolve, reject) => {
     const query = gql`
       query items {
         items {
@@ -1239,9 +1240,9 @@ describe('client', () => {
     return client.query({ query }).then(actualResult => {
       expect(stripSymbols(actualResult.data)).toEqual(result);
     }).then(resolve, reject);
-  }));
+  });
 
-  it('should call updateQueries and update after mutation on query with inlined fragments on an Interface type', () => new Promise((resolve, reject) => {
+  itAsync('should call updateQueries and update after mutation on query with inlined fragments on an Interface type', (resolve, reject) => {
     const query = gql`
       query items {
         items {
@@ -1334,7 +1335,7 @@ describe('client', () => {
         reject(err);
       },
     });
-  }));
+  });
 
   it('should send operationName along with the query to the server', () => {
     const query = gql`
@@ -1386,7 +1387,7 @@ describe('client', () => {
     });
   });
 
-  it('does not deduplicate queries if option is set to false', () => new Promise((resolve, reject) => {
+  itAsync('does not deduplicate queries if option is set to false', (resolve, reject) => {
     const queryDoc = gql`
       query {
         author {
@@ -1434,9 +1435,9 @@ describe('client', () => {
       expect(stripSymbols(result1.data)).toEqual(data);
       expect(stripSymbols(result2.data)).toEqual(data2);
     }).then(resolve, reject);
-  }));
+  });
 
-  it('deduplicates queries by default', () => new Promise((resolve, reject) => {
+  itAsync('deduplicates queries by default', (resolve, reject) => {
     const queryDoc = gql`
       query {
         author {
@@ -1481,9 +1482,9 @@ describe('client', () => {
     return Promise.all([q1, q2]).then(([result1, result2]) => {
       expect(result1.data).toEqual(result2.data);
     }).then(resolve, reject);
-  }));
+  });
 
-  it('unsubscribes from deduplicated observables only once', () => new Promise((resolve, reject) => {
+  itAsync('unsubscribes from deduplicated observables only once', (resolve, reject) => {
     const document: DocumentNode = gql`
       query test1($x: String) {
         test(x: $x)
@@ -1526,7 +1527,7 @@ describe('client', () => {
     expect(unsubscribed).toBe(false);
 
     sub2.unsubscribe();
-  }));
+  });
 
   describe('deprecated options', () => {
     const query = gql`
@@ -1579,7 +1580,7 @@ describe('client', () => {
       },
     };
 
-    it('for internal store', () => new Promise((resolve, reject) => {
+    itAsync('for internal store', (resolve, reject) => {
       const link = mockSingleLink(reject, {
         request: { query },
         result: { data },
@@ -1601,7 +1602,7 @@ describe('client', () => {
           name: 'Luke Skywalker',
         });
       }).then(resolve, reject);
-    }));
+    });
   });
 
   describe('cache-and-network fetchPolicy', () => {
@@ -1668,7 +1669,7 @@ describe('client', () => {
       checkCacheAndNetworkError(() => client.query({ query }));
     });
 
-    it('fetches from cache first, then network', () => new Promise((resolve, reject) => {
+    itAsync('fetches from cache first, then network', (resolve, reject) => {
       const link = mockSingleLink(reject, {
         request: { query },
         result: { data: networkFetch },
@@ -1694,9 +1695,9 @@ describe('client', () => {
           resolve();
         }
       });
-    }));
+    });
 
-    it('does not fail if cache entry is not present', () => new Promise((resolve, reject) => {
+    itAsync('does not fail if cache entry is not present', (resolve, reject) => {
       const link = mockSingleLink(reject, {
         request: { query },
         result: { data: networkFetch },
@@ -1721,9 +1722,9 @@ describe('client', () => {
           resolve();
         }
       });
-    }));
+    });
 
-    it('fails if network request fails', () => new Promise((resolve, reject) => {
+    itAsync('fails if network request fails', (resolve, reject) => {
       const link = mockSingleLink(error => { throw error }); // no queries = no replies.
       const client = new ApolloClient({
         link,
@@ -1748,9 +1749,9 @@ describe('client', () => {
           setTimeout(resolve, 100);
         },
       });
-    }));
+    });
 
-    it('fetches from cache first, then network and does not have an unhandled error', () => new Promise((resolve, reject) => {
+    itAsync('fetches from cache first, then network and does not have an unhandled error', (resolve, reject) => {
       const link = mockSingleLink(reject, {
         request: { query },
         result: { errors: [{ message: 'network failure' }] },
@@ -1787,7 +1788,7 @@ describe('client', () => {
           }, 0);
         },
       });
-    }));
+    });
   });
 
   describe('standby queries', () => {
@@ -1813,7 +1814,7 @@ describe('client', () => {
       );
     });
 
-    it('are not watching the store or notifying on updates', () => new Promise((resolve, reject) => {
+    itAsync('are not watching the store or notifying on updates', (resolve, reject) => {
       const query = gql`
         {
           test
@@ -1852,9 +1853,9 @@ describe('client', () => {
           );
         }
       });
-    }));
+    });
 
-    it('return the current result when coming out of standby', () => new Promise((resolve, reject) => {
+    itAsync('return the current result when coming out of standby', (resolve, reject) => {
       const query = gql`
         {
           test
@@ -1890,7 +1891,7 @@ describe('client', () => {
           resolve();
         }
       });
-    }));
+    });
   });
 
   describe('network-only fetchPolicy', () => {
@@ -1927,7 +1928,7 @@ describe('client', () => {
       );
     }
 
-    it('forces the query to rerun', () => new Promise((resolve, reject) => {
+    itAsync('forces the query to rerun', (resolve, reject) => {
       const client = new ApolloClient({
         link: makeLink(reject),
         cache: new InMemoryCache({ addTypename: false }),
@@ -1942,9 +1943,9 @@ describe('client', () => {
           expect(stripSymbols(result.data)).toEqual({ myNumber: { n: 2 } });
         })
         .then(resolve, reject);
-    }));
+    });
 
-    it('can be disabled with ssrMode', () => new Promise((resolve, reject) => {
+    itAsync('can be disabled with ssrMode', (resolve, reject) => {
       const client = new ApolloClient({
         link: makeLink(reject),
         ssrMode: true,
@@ -1967,9 +1968,9 @@ describe('client', () => {
           });
         })
         .then(resolve, reject);
-    }));
+    });
 
-    it('can temporarily be disabled with ssrForceFetchDelay', () => new Promise((resolve, reject) => {
+    itAsync('can temporarily be disabled with ssrForceFetchDelay', (resolve, reject) => {
       const client = new ApolloClient({
         link: makeLink(reject),
         ssrForceFetchDelay: 100,
@@ -1992,10 +1993,10 @@ describe('client', () => {
           expect(stripSymbols(result.data)).toEqual({ myNumber: { n: 2 } });
         })
         .then(resolve, reject);
-    }));
+    });
   });
 
-  it('should pass a network error correctly on a mutation', () => new Promise((resolve, reject) => {
+  itAsync('should pass a network error correctly on a mutation', (resolve, reject) => {
     const mutation = gql`
       mutation {
         person {
@@ -2030,9 +2031,9 @@ describe('client', () => {
         expect(error.networkError!.message).toBe(networkError.message);
         resolve();
       });
-  }));
+  });
 
-  it('should pass a GraphQL error correctly on a mutation', () => new Promise((resolve, reject) => {
+  itAsync('should pass a GraphQL error correctly on a mutation', (resolve, reject) => {
     const mutation = gql`
       mutation {
         newPerson {
@@ -2068,8 +2069,8 @@ describe('client', () => {
         expect(error.graphQLErrors[0].message).toBe(errors[0].message);
         resolve();
       });
-  }));
-  it('should allow errors to be returned from a mutation', () => new Promise((resolve, reject) => {
+  });
+  itAsync('should allow errors to be returned from a mutation', (resolve, reject) => {
     const mutation = gql`
       mutation {
         newPerson {
@@ -2106,8 +2107,9 @@ describe('client', () => {
       .catch((error: ApolloError) => {
         throw error;
       });
-  }));
-  it('should strip errors on a mutation if ignored', () => new Promise((resolve, reject) => {
+  });
+
+  itAsync('should strip errors on a mutation if ignored', (resolve, reject) => {
     const mutation = gql`
       mutation {
         newPerson {
@@ -2142,9 +2144,9 @@ describe('client', () => {
       .catch((error: ApolloError) => {
         throw error;
       });
-  }));
+  });
 
-  it('should rollback optimistic after mutation got a GraphQL error', () => new Promise((resolve, reject) => {
+  itAsync('should rollback optimistic after mutation got a GraphQL error', (resolve, reject) => {
     const mutation = gql`
       mutation {
         newPerson {
@@ -2196,7 +2198,7 @@ describe('client', () => {
         expect(optimisticData).toBe(data);
         resolve();
       });
-  }));
+  });
 
   it('has a clearStore method which calls QueryManager', async () => {
     const client = new ApolloClient({
@@ -2458,7 +2460,7 @@ describe('client', () => {
     // });
   });
 
-  it('should propagate errors from network interface to observers', () => new Promise((resolve, reject) => {
+  itAsync('should propagate errors from network interface to observers', (resolve, reject) => {
     const link = ApolloLink.from([
       () =>
         new Observable(x => {
@@ -2488,9 +2490,9 @@ describe('client', () => {
         resolve();
       },
     });
-  }));
+  });
 
-  it('should be able to refetch after there was a network error', () => new Promise((resolve, reject) => {
+  itAsync('should be able to refetch after there was a network error', (resolve, reject) => {
     const query: DocumentNode = gql`
       query somethingelse {
         allPeople(first: 1) {
@@ -2605,9 +2607,9 @@ describe('client', () => {
     };
 
     subscription = observable.subscribe(observerOptions);
-  }));
+  });
 
-  it('should throw a GraphQL error', () => new Promise((resolve, reject) => {
+  itAsync('should throw a GraphQL error', (resolve, reject) => {
     const query = gql`
       query {
         posts {
@@ -2636,9 +2638,9 @@ describe('client', () => {
         'GraphQL error: Cannot query field "foo" on type "Post".',
       );
     }).then(resolve, reject);
-  }));
+  });
 
-  it('should warn if server returns wrong data', () => new Promise((resolve, reject) => {
+  itAsync('should warn if server returns wrong data', (resolve, reject) => {
     const query = gql`
       query {
         todos {
@@ -2677,9 +2679,9 @@ describe('client', () => {
       () => client.query({ query }),
       /Missing field description/,
     ).then(resolve, reject);
-  }));
+  });
 
-  it('runs a query with the connection directive and writes it to the store key defined in the directive', () => new Promise((resolve, reject) => {
+  itAsync('runs a query with the connection directive and writes it to the store key defined in the directive', (resolve, reject) => {
     const query = gql`
       {
         books(skip: 0, limit: 2) @connection(key: "abc") {
@@ -2719,9 +2721,9 @@ describe('client', () => {
     return client.query({ query }).then(actualResult => {
       expect(stripSymbols(actualResult.data)).toEqual(result);
     }).then(resolve, reject);
-  }));
+  });
 
-  it('should remove the connection directive before the link is sent', () => new Promise((resolve, reject) => {
+  itAsync('should remove the connection directive before the link is sent', (resolve, reject) => {
     const query = gql`
       {
         books(skip: 0, limit: 2) @connection(key: "books") {
@@ -2761,11 +2763,11 @@ describe('client', () => {
     return client.query({ query }).then(actualResult => {
       expect(stripSymbols(actualResult.data)).toEqual(result);
     }).then(resolve, reject);
-  }));
+  });
 });
 
 describe('@connection', () => {
-  it('should run a query with the connection directive and write the result to the store key defined in the directive', () => new Promise((resolve, reject) => {
+  itAsync('should run a query with the connection directive and write the result to the store key defined in the directive', (resolve, reject) => {
     const query = gql`
       {
         books(skip: 0, limit: 2) @connection(key: "abc") {
@@ -2806,9 +2808,9 @@ describe('@connection', () => {
       expect(stripSymbols(actualResult.data)).toEqual(result);
       expect((client.cache as InMemoryCache).extract()).toMatchSnapshot();
     }).then(resolve, reject);
-  }));
+  });
 
-  it('should run a query with the connection directive and filter arguments and write the result to the correct store key', () => new Promise((resolve, reject) => {
+  itAsync('should run a query with the connection directive and filter arguments and write the result to the correct store key', (resolve, reject) => {
     const query = gql`
       query books($order: string) {
         books(skip: 0, limit: 2, order: $order)
@@ -2851,7 +2853,7 @@ describe('@connection', () => {
       expect(stripSymbols(actualResult.data)).toEqual(result);
       expect((client.cache as InMemoryCache).extract()).toMatchSnapshot();
     }).then(resolve, reject);
-  }));
+  });
 
   describe('default settings', () => {
     const query = gql`
@@ -2873,7 +2875,7 @@ describe('@connection', () => {
       },
     };
 
-    it('allows setting default options for watchQuery', () => new Promise((resolve, reject) => {
+    itAsync('allows setting default options for watchQuery', (resolve, reject) => {
       const link = mockSingleLink(reject, {
         request: { query },
         result: { data: networkFetch },
@@ -2904,9 +2906,9 @@ describe('@connection', () => {
           resolve();
         }
       });
-    }));
+    });
 
-    it('allows setting default options for query', () => new Promise((resolve, reject) => {
+    itAsync('allows setting default options for query', (resolve, reject) => {
       const errors = [{ message: 'failure', name: 'failure' }];
       const link = mockSingleLink(reject, {
         request: { query },
@@ -2923,9 +2925,9 @@ describe('@connection', () => {
       return client.query({ query }).then(result => {
         expect(result.errors).toEqual(errors);
       }).then(resolve, reject);
-    }));
+    });
 
-    it('allows setting default options for mutation', () => new Promise((resolve, reject) => {
+    itAsync('allows setting default options for mutation', (resolve, reject) => {
       const mutation = gql`
         mutation upVote($id: ID!) {
           upvote(id: $id) {
@@ -2954,7 +2956,7 @@ describe('@connection', () => {
       return client.mutate({ mutation }).then(result => {
         expect(result.data).toEqual(data);
       }).then(resolve, reject);
-    }));
+    });
   });
 });
 

--- a/src/__tests__/fetchMore.ts
+++ b/src/__tests__/fetchMore.ts
@@ -4,6 +4,7 @@ import gql from 'graphql-tag';
 import { mockSingleLink } from '../__mocks__/mockLinks';
 import { InMemoryCache } from '../cache/inmemory/inMemoryCache';
 import { ApolloClient, NetworkStatus, ObservableQuery } from '../';
+import { itAsync } from './utils/itAsync';
 
 describe('updateQuery on a simple query', () => {
   const query = gql`
@@ -25,7 +26,7 @@ describe('updateQuery on a simple query', () => {
     },
   };
 
-  it('triggers new result from updateQuery', () => new Promise((resolve, reject) => {
+  itAsync('triggers new result from updateQuery', (resolve, reject) => {
     let latestResult: any = null;
     const link = mockSingleLink(reject, {
       request: { query },
@@ -60,7 +61,7 @@ describe('updateQuery on a simple query', () => {
       .then(() => expect(latestResult.data.entry.value).toBe(2))
       .then(() => sub.unsubscribe())
       .then(resolve, reject);
-  }));
+  });
 });
 
 describe('updateQuery on a query with required and optional variables', () => {
@@ -88,7 +89,7 @@ describe('updateQuery on a query with required and optional variables', () => {
     },
   };
 
-  it('triggers new result from updateQuery', () => new Promise((resolve, reject) => {
+  itAsync('triggers new result from updateQuery', (resolve, reject) => {
     let latestResult: any = null;
     const link = mockSingleLink(reject, {
       request: {
@@ -127,7 +128,7 @@ describe('updateQuery on a query with required and optional variables', () => {
       .then(() => expect(latestResult.data.entry.value).toBe(2))
       .then(() => sub.unsubscribe())
       .then(resolve, reject);
-  }));
+  });
 });
 
 describe('fetchMore on an observable query', () => {
@@ -241,7 +242,7 @@ describe('fetchMore on an observable query', () => {
     sub = null;
   }
 
-  it('triggers new result with new variables', () => new Promise((resolve, reject) => {
+  itAsync('triggers new result withAsync new variables', (resolve, reject) => {
     latestResult = null;
     return setup(reject, {
       request: {
@@ -278,9 +279,9 @@ describe('fetchMore on an observable query', () => {
         unsetup();
       })
       .then(resolve, reject);
-  }));
+  });
 
-  it('basic fetchMore results merging', () => new Promise((resolve, reject) => {
+  itAsync('basic fetchMore results merging', (resolve, reject) => {
     latestResult = null;
     return setup(reject, {
       request: {
@@ -313,9 +314,9 @@ describe('fetchMore on an observable query', () => {
         unsetup();
       })
       .then(resolve, reject);
-  }));
+  });
 
-  it('fetching more with a different query', () => new Promise((resolve, reject) => {
+  itAsync('fetching more with a different query', (resolve, reject) => {
     latestResult = null;
     return setup(reject, {
       request: {
@@ -350,9 +351,9 @@ describe('fetchMore on an observable query', () => {
         unsetup();
       })
       .then(resolve, reject);
-  }));
+  });
 
-  it('will set the `network` status to `fetchMore`', () => new Promise((resolve, reject) => {
+  itAsync('will set the `network` status to `fetchMore`', (resolve, reject) => {
     link = mockSingleLink(
       reject,
       { request: { query, variables }, result, delay: 5 },
@@ -413,9 +414,9 @@ describe('fetchMore on an observable query', () => {
       error: error => reject(error),
       complete: () => reject(new Error('Should not have completed')),
     });
-  }));
+  });
 
-  it('will not get an error from `fetchMore` if thrown', () => new Promise((resolve, reject) => {
+  itAsync('will not get an error from `fetchMore` if thrown', (resolve, reject) => {
     const fetchMoreError = new Error('Uh, oh!');
     link = mockSingleLink(
       reject,
@@ -481,9 +482,9 @@ describe('fetchMore on an observable query', () => {
         );
       },
     });
-  }));
+  });
 
-  it('will not leak fetchMore query', () => new Promise((resolve, reject) => {
+  itAsync('will not leak fetchMore query', (resolve, reject) => {
     latestResult = null;
     var beforeQueryCount;
     return setup(reject, {
@@ -517,7 +518,7 @@ describe('fetchMore on an observable query', () => {
         unsetup();
       })
       .then(resolve, reject);
-  }));
+  });
 });
 
 describe('fetchMore on an observable query with connection', () => {
@@ -620,7 +621,7 @@ describe('fetchMore on an observable query with connection', () => {
     sub = null;
   }
 
-  it('fetchMore with connection results merging', () => new Promise((resolve, reject) => {
+  itAsync('fetchMore with connection results merging', (resolve, reject) => {
     latestResult = null;
     return setup(reject, {
       request: {
@@ -653,9 +654,9 @@ describe('fetchMore on an observable query with connection', () => {
         unsetup();
       })
       .then(resolve, reject);
-  }));
+  });
 
-  it('will set the network status to `fetchMore`', () => new Promise((resolve, reject) => {
+  itAsync('will set the network status to `fetchMore`', (resolve, reject) => {
     link = mockSingleLink(
       reject,
       { request: { query: transformedQuery, variables }, result, delay: 5 },
@@ -716,9 +717,9 @@ describe('fetchMore on an observable query with connection', () => {
       error: error => reject(error),
       complete: () => reject(new Error('Should not have completed')),
     });
-  }));
+  });
 
-  it('will not get an error from `fetchMore` if thrown', () => new Promise((resolve, reject) => {
+  itAsync('will not get an error from `fetchMore` if thrown', (resolve, reject) => {
     const fetchMoreError = new Error('Uh, oh!');
     link = mockSingleLink(
       reject,
@@ -783,5 +784,5 @@ describe('fetchMore on an observable query with connection', () => {
         );
       },
     });
-  }));
+  });
 });

--- a/src/__tests__/fetchMore.ts
+++ b/src/__tests__/fetchMore.ts
@@ -25,9 +25,9 @@ describe('updateQuery on a simple query', () => {
     },
   };
 
-  it('triggers new result from updateQuery', () => {
+  it('triggers new result from updateQuery', () => new Promise((resolve, reject) => {
     let latestResult: any = null;
-    const link = mockSingleLink({
+    const link = mockSingleLink(reject, {
       request: { query },
       result,
     });
@@ -58,8 +58,9 @@ describe('updateQuery on a simple query', () => {
         });
       })
       .then(() => expect(latestResult.data.entry.value).toBe(2))
-      .then(() => sub.unsubscribe());
-  });
+      .then(() => sub.unsubscribe())
+      .then(resolve, reject);
+  }));
 });
 
 describe('updateQuery on a query with required and optional variables', () => {
@@ -87,9 +88,9 @@ describe('updateQuery on a query with required and optional variables', () => {
     },
   };
 
-  it('triggers new result from updateQuery', () => {
+  it('triggers new result from updateQuery', () => new Promise((resolve, reject) => {
     let latestResult: any = null;
-    const link = mockSingleLink({
+    const link = mockSingleLink(reject, {
       request: {
         query,
         variables,
@@ -124,8 +125,9 @@ describe('updateQuery on a query with required and optional variables', () => {
         });
       })
       .then(() => expect(latestResult.data.entry.value).toBe(2))
-      .then(() => sub.unsubscribe());
-  });
+      .then(() => sub.unsubscribe())
+      .then(resolve, reject);
+  }));
 });
 
 describe('fetchMore on an observable query', () => {
@@ -199,8 +201,12 @@ describe('fetchMore on an observable query', () => {
   let link: any;
   let sub: any;
 
-  function setup(...mockedResponses: any[]) {
+  function setup(
+    reject: (reason: any) => any,
+    ...mockedResponses: any[]
+  ) {
     link = mockSingleLink(
+      reject,
       {
         request: {
           query,
@@ -235,9 +241,9 @@ describe('fetchMore on an observable query', () => {
     sub = null;
   }
 
-  it('triggers new result with new variables', () => {
+  it('triggers new result with new variables', () => new Promise((resolve, reject) => {
     latestResult = null;
-    return setup({
+    return setup(reject, {
       request: {
         query,
         variables: variablesMore,
@@ -270,12 +276,13 @@ describe('fetchMore on an observable query', () => {
           expect(comments[i - 1].text).toEqual(`comment ${i}`);
         }
         unsetup();
-      });
-  });
+      })
+      .then(resolve, reject);
+  }));
 
-  it('basic fetchMore results merging', () => {
+  it('basic fetchMore results merging', () => new Promise((resolve, reject) => {
     latestResult = null;
-    return setup({
+    return setup(reject, {
       request: {
         query,
         variables: variablesMore,
@@ -304,12 +311,13 @@ describe('fetchMore on an observable query', () => {
           expect(comments[i - 1].text).toEqual(`comment ${i}`);
         }
         unsetup();
-      });
-  });
+      })
+      .then(resolve, reject);
+  }));
 
-  it('fetching more with a different query', () => {
+  it('fetching more with a different query', () => new Promise((resolve, reject) => {
     latestResult = null;
-    return setup({
+    return setup(reject, {
       request: {
         query: query2,
         variables: variables2,
@@ -340,11 +348,13 @@ describe('fetchMore on an observable query', () => {
           expect(comments[i - 1].text).toEqual(`new comment ${i}`);
         }
         unsetup();
-      });
-  });
+      })
+      .then(resolve, reject);
+  }));
 
-  it('will set the `network` status to `fetchMore`', done => {
+  it('will set the `network` status to `fetchMore`', () => new Promise((resolve, reject) => {
     link = mockSingleLink(
+      reject,
       { request: { query, variables }, result, delay: 5 },
       {
         request: { query, variables: variablesMore },
@@ -394,20 +404,21 @@ describe('fetchMore on an observable query', () => {
           case 3:
             expect(networkStatus).toBe(NetworkStatus.ready);
             expect((data as any).entry.comments.length).toBe(20);
-            done();
+            resolve();
             break;
           default:
-            done.fail(new Error('`next` called too many times'));
+            reject(new Error('`next` called too many times'));
         }
       },
-      error: error => done.fail(error),
-      complete: () => done.fail(new Error('Should not have completed')),
+      error: error => reject(error),
+      complete: () => reject(new Error('Should not have completed')),
     });
-  });
+  }));
 
-  it('will not get an error from `fetchMore` if thrown', done => {
+  it('will not get an error from `fetchMore` if thrown', () => new Promise((resolve, reject) => {
     const fetchMoreError = new Error('Uh, oh!');
     link = mockSingleLink(
+      reject,
       { request: { query, variables }, result, delay: 5 },
       {
         request: { query, variables: variablesMore },
@@ -457,25 +468,25 @@ describe('fetchMore on an observable query', () => {
           default:
             expect(networkStatus).toBe(NetworkStatus.ready);
             expect((data as any).entry.comments.length).toBe(10);
-            done();
+            resolve();
             break;
         }
       },
       error: () => {
-        done.fail(new Error('`error` called when it wasn’t supposed to be.'));
+        reject(new Error('`error` called when it wasn’t supposed to be.'));
       },
       complete: () => {
-        done.fail(
+        reject(
           new Error('`complete` called when it wasn’t supposed to be.'),
         );
       },
     });
-  });
+  }));
 
-  it('will not leak fetchMore query', () => {
+  it('will not leak fetchMore query', () => new Promise((resolve, reject) => {
     latestResult = null;
     var beforeQueryCount;
-    return setup({
+    return setup(reject, {
       request: {
         query,
         variables: variablesMore,
@@ -504,8 +515,9 @@ describe('fetchMore on an observable query', () => {
         ).length;
         expect(afterQueryCount).toBe(beforeQueryCount);
         unsetup();
-      });
-  });
+      })
+      .then(resolve, reject);
+  }));
 });
 
 describe('fetchMore on an observable query with connection', () => {
@@ -568,8 +580,12 @@ describe('fetchMore on an observable query with connection', () => {
   let link: any;
   let sub: any;
 
-  function setup(...mockedResponses: any[]) {
+  function setup(
+    reject: (reason: any) => any,
+    ...mockedResponses: any[]
+  ) {
     link = mockSingleLink(
+      reject,
       {
         request: {
           query: transformedQuery,
@@ -604,9 +620,9 @@ describe('fetchMore on an observable query with connection', () => {
     sub = null;
   }
 
-  it('fetchMore with connection results merging', () => {
+  it('fetchMore with connection results merging', () => new Promise((resolve, reject) => {
     latestResult = null;
-    return setup({
+    return setup(reject, {
       request: {
         query: transformedQuery,
         variables: variablesMore,
@@ -635,11 +651,13 @@ describe('fetchMore on an observable query with connection', () => {
           expect(comments[i - 1].text).toBe(`comment ${i}`);
         }
         unsetup();
-      });
-  });
+      })
+      .then(resolve, reject);
+  }));
 
-  it('will set the network status to `fetchMore`', done => {
+  it('will set the network status to `fetchMore`', () => new Promise((resolve, reject) => {
     link = mockSingleLink(
+      reject,
       { request: { query: transformedQuery, variables }, result, delay: 5 },
       {
         request: { query: transformedQuery, variables: variablesMore },
@@ -689,20 +707,21 @@ describe('fetchMore on an observable query with connection', () => {
           case 3:
             expect(networkStatus).toBe(NetworkStatus.ready);
             expect((data as any).entry.comments.length).toBe(20);
-            done();
+            resolve();
             break;
           default:
-            done.fail(new Error('`next` called too many times'));
+            reject(new Error('`next` called too many times'));
         }
       },
-      error: error => done.fail(error),
-      complete: () => done.fail(new Error('Should not have completed')),
+      error: error => reject(error),
+      complete: () => reject(new Error('Should not have completed')),
     });
-  });
+  }));
 
-  it('will not get an error from `fetchMore` if thrown', done => {
+  it('will not get an error from `fetchMore` if thrown', () => new Promise((resolve, reject) => {
     const fetchMoreError = new Error('Uh, oh!');
     link = mockSingleLink(
+      reject,
       { request: { query: transformedQuery, variables }, result, delay: 5 },
       {
         request: { query: transformedQuery, variables: variablesMore },
@@ -752,17 +771,17 @@ describe('fetchMore on an observable query with connection', () => {
           default:
             expect(networkStatus).toBe(NetworkStatus.ready);
             expect((data as any).entry.comments.length).toBe(10);
-            done();
+            resolve();
         }
       },
       error: () => {
-        done.fail(new Error('`error` called when it wasn’t supposed to be.'));
+        reject(new Error('`error` called when it wasn’t supposed to be.'));
       },
       complete: () => {
-        done.fail(
+        reject(
           new Error('`complete` called when it wasn’t supposed to be.'),
         );
       },
     });
-  });
+  }));
 });

--- a/src/__tests__/local-state/general.ts
+++ b/src/__tests__/local-state/general.ts
@@ -9,6 +9,7 @@ import { ApolloClient } from '../..';
 import { ApolloCache } from '../../cache/core/cache';
 import { InMemoryCache } from '../../cache/inmemory/inMemoryCache';
 import { hasDirectives } from '../../utilities/graphql/directives';
+import { itAsync } from '../utils/itAsync';
 
 describe('General functionality', () => {
   it('should not impact normal non-@client use', () => {
@@ -303,10 +304,10 @@ describe('Cache manipulation', () => {
       });
   });
 
-  it(
+  itAsync(
     'should be able to write to the cache with a local mutation and have ' +
       'things rerender automatically',
-    () => new Promise((resolve, reject) => {
+    (resolve, reject) => {
       const query = gql`
         {
           field @client
@@ -352,7 +353,7 @@ describe('Cache manipulation', () => {
           }
         },
       });
-    }),
+    },
   );
 
   it('should support writing to the cache with a local mutation using variables', () => {
@@ -405,7 +406,7 @@ describe('Cache manipulation', () => {
       });
   });
 
-  it("should read @client fields from cache on refetch (#4741)", () => new Promise((resolve, reject) => {
+  itAsync("should read @client fields from cache on refetch (#4741)", (resolve, reject) => {
     const query = gql`
       query FetchInitialData {
         serverData {
@@ -473,11 +474,11 @@ describe('Cache manipulation', () => {
         }
       },
     });
-  }));
+  });
 });
 
 describe('Sample apps', () => {
-  it('should support a simple counter app using local state', () => new Promise((resolve, reject) => {
+  itAsync('should support a simple counter app using local state', (resolve, reject) => {
     const query = gql`
       query GetCount {
         count @client
@@ -579,9 +580,9 @@ describe('Sample apps', () => {
       error: e => reject(e),
       complete: reject,
     });
-  }));
+  });
 
-  it('should support a simple todo app using local state', () => new Promise((resolve, reject) => {
+  itAsync('should support a simple todo app using local state', (resolve, reject) => {
     const query = gql`
       query GetTasks {
         todos @client {
@@ -662,11 +663,11 @@ describe('Sample apps', () => {
         }
       },
     });
-  }));
+  });
 });
 
 describe('Combining client and server state/operations', () => {
-  it('should merge remote and local state', () => new Promise((resolve, reject) => {
+  itAsync('should merge remote and local state', (resolve, reject) => {
     const query = gql`
       query list {
         list(name: "my list") {
@@ -761,9 +762,9 @@ describe('Combining client and server state/operations', () => {
     setTimeout(() => {
       client.mutate({ mutation, variables });
     }, 10);
-  }));
+  });
 
-  it('should correctly propagate an error from a client resolver', () => new Promise(async (resolve, reject) => {
+  itAsync('should correctly propagate an error from a client resolver', async (resolve, reject) => {
     const data = {
       list: {
         __typename: 'List',
@@ -827,9 +828,9 @@ describe('Combining client and server state/operations', () => {
     }
 
     resolve();
-  }));
+  });
 
-  it('should handle a simple query with both server and client fields', () => new Promise((resolve, reject) => {
+  itAsync('should handle a simple query with both server and client fields', (resolve, reject) => {
     const query = gql`
       query GetCount {
         count @client
@@ -861,9 +862,9 @@ describe('Combining client and server state/operations', () => {
         resolve();
       },
     });
-  }));
+  });
 
-  it('should support nested quering of both server and client fields', () => new Promise((resolve, reject) => {
+  itAsync('should support nested quering of both server and client fields', (resolve, reject) => {
     const query = gql`
       query GetUser {
         user {
@@ -911,9 +912,9 @@ describe('Combining client and server state/operations', () => {
         resolve();
       },
     });
-  }));
+  });
 
-  it('should combine both server and client mutations', () => new Promise((resolve, reject) => {
+  itAsync('should combine both server and client mutations', (resolve, reject) => {
     const query = gql`
       query SampleQuery {
         count @client
@@ -1015,5 +1016,5 @@ describe('Combining client and server state/operations', () => {
         }
       },
     });
-  }));
+  });
 });

--- a/src/__tests__/local-state/general.ts
+++ b/src/__tests__/local-state/general.ts
@@ -306,7 +306,7 @@ describe('Cache manipulation', () => {
   it(
     'should be able to write to the cache with a local mutation and have ' +
       'things rerender automatically',
-    done => {
+    () => new Promise((resolve, reject) => {
       const query = gql`
         {
           field @client
@@ -348,11 +348,11 @@ describe('Cache manipulation', () => {
 
           if (count === 2) {
             expect({ ...data }).toMatchObject({ field: 1 });
-            done();
+            resolve();
           }
         },
       });
-    },
+    }),
   );
 
   it('should support writing to the cache with a local mutation using variables', () => {
@@ -405,7 +405,7 @@ describe('Cache manipulation', () => {
       });
   });
 
-  it("should read @client fields from cache on refetch (#4741)", function (done) {
+  it("should read @client fields from cache on refetch (#4741)", () => new Promise((resolve, reject) => {
     const query = gql`
       query FetchInitialData {
         serverData {
@@ -469,15 +469,15 @@ describe('Cache manipulation', () => {
             ],
           });
         } else {
-          done();
+          resolve();
         }
       },
     });
-  });
+  }));
 });
 
 describe('Sample apps', () => {
-  it('should support a simple counter app using local state', done => {
+  it('should support a simple counter app using local state', () => new Promise((resolve, reject) => {
     const query = gql`
       query GetCount {
         count @client
@@ -554,7 +554,7 @@ describe('Sample apps', () => {
           try {
             expect({ ...data }).toMatchObject({ count: 0, lastCount: 1 });
           } catch (e) {
-            done.fail(e);
+            reject(e);
           }
           client.mutate({ mutation: increment, variables: { amount: 2 } });
         }
@@ -563,7 +563,7 @@ describe('Sample apps', () => {
           try {
             expect({ ...data }).toMatchObject({ count: 2, lastCount: 1 });
           } catch (e) {
-            done.fail(e);
+            reject(e);
           }
           client.mutate({ mutation: decrement, variables: { amount: 1 } });
         }
@@ -571,17 +571,17 @@ describe('Sample apps', () => {
           try {
             expect({ ...data }).toMatchObject({ count: 1, lastCount: 1 });
           } catch (e) {
-            done.fail(e);
+            reject(e);
           }
-          done();
+          resolve();
         }
       },
-      error: e => done.fail(e),
-      complete: done.fail,
+      error: e => reject(e),
+      complete: reject,
     });
-  });
+  }));
 
-  it('should support a simple todo app using local state', done => {
+  it('should support a simple todo app using local state', () => new Promise((resolve, reject) => {
     const query = gql`
       query GetTasks {
         todos @client {
@@ -658,15 +658,15 @@ describe('Sample apps', () => {
               __typename: 'Todo',
             },
           ]);
-          done();
+          resolve();
         }
       },
     });
-  });
+  }));
 });
 
 describe('Combining client and server state/operations', () => {
-  it('should merge remote and local state', done => {
+  it('should merge remote and local state', () => new Promise((resolve, reject) => {
     const query = gql`
       query list {
         list(name: "my list") {
@@ -745,11 +745,11 @@ describe('Combining client and server state/operations', () => {
         if (count === 1) {
           expect((response.data as any).list.items[0].isSelected).toBe(true);
           expect((response.data as any).list.items[1].isSelected).toBe(false);
-          done();
+          resolve();
         }
         count++;
       },
-      error: done.fail,
+      error: reject,
     });
     const variables = { id: 1 };
     const mutation = gql`
@@ -761,9 +761,9 @@ describe('Combining client and server state/operations', () => {
     setTimeout(() => {
       client.mutate({ mutation, variables });
     }, 10);
-  });
+  }));
 
-  it('should correctly propagate an error from a client resolver', async done => {
+  it('should correctly propagate an error from a client resolver', () => new Promise(async (resolve, reject) => {
     const data = {
       list: {
         __typename: 'List',
@@ -808,7 +808,7 @@ describe('Combining client and server state/operations', () => {
 
     try {
       await client.query({ query, variables });
-      done.fail('Should have thrown!');
+      reject('Should have thrown!');
     } catch (e) {
       // Test Passed!
       expect(() => {
@@ -818,7 +818,7 @@ describe('Combining client and server state/operations', () => {
 
     try {
       await client.mutate({ mutation, variables });
-      done.fail('Should have thrown!');
+      reject('Should have thrown!');
     } catch (e) {
       // Test Passed!
       expect(() => {
@@ -826,10 +826,10 @@ describe('Combining client and server state/operations', () => {
       }).toThrowErrorMatchingSnapshot();
     }
 
-    done();
-  });
+    resolve();
+  }));
 
-  it('should handle a simple query with both server and client fields', done => {
+  it('should handle a simple query with both server and client fields', () => new Promise((resolve, reject) => {
     const query = gql`
       query GetCount {
         count @client
@@ -858,12 +858,12 @@ describe('Combining client and server state/operations', () => {
     client.watchQuery({ query }).subscribe({
       next: ({ data }) => {
         expect({ ...data }).toMatchObject({ count: 0, lastCount: 1 });
-        done();
+        resolve();
       },
     });
-  });
+  }));
 
-  it('should support nested quering of both server and client fields', done => {
+  it('should support nested quering of both server and client fields', () => new Promise((resolve, reject) => {
     const query = gql`
       query GetUser {
         user {
@@ -906,14 +906,14 @@ describe('Combining client and server state/operations', () => {
             __typename: 'User',
           });
         } catch (e) {
-          done.fail(e);
+          reject(e);
         }
-        done();
+        resolve();
       },
     });
-  });
+  }));
 
-  it('should combine both server and client mutations', done => {
+  it('should combine both server and client mutations', () => new Promise((resolve, reject) => {
     const query = gql`
       query SampleQuery {
         count @client
@@ -1011,9 +1011,9 @@ describe('Combining client and server state/operations', () => {
             __typename: 'User',
             firstName: 'Harry',
           });
-          done();
+          resolve();
         }
       },
     });
-  });
+  }));
 });

--- a/src/__tests__/local-state/resolvers.ts
+++ b/src/__tests__/local-state/resolvers.ts
@@ -15,7 +15,7 @@ import { InMemoryCache } from '../../cache/inmemory/inMemoryCache';
 // Helper method that sets up a mockQueryManager and then passes on the
 // results to an observer.
 const assertWithObserver = ({
-  done,
+  reject,
   resolvers,
   query,
   serverQuery,
@@ -26,7 +26,7 @@ const assertWithObserver = ({
   delay,
   observer,
 }: {
-  done: jest.DoneCallback;
+  reject: (reason: any) => any;
   resolvers?: Resolvers;
   query: DocumentNode;
   serverQuery?: DocumentNode;
@@ -37,7 +37,7 @@ const assertWithObserver = ({
   delay?: number;
   observer: Observer<ApolloQueryResult<any>>;
 }) => {
-  const queryManager = mockQueryManager({
+  const queryManager = mockQueryManager(reject, {
     request: { query: serverQuery || query, variables },
     result: serverResult,
     error,
@@ -53,13 +53,13 @@ const assertWithObserver = ({
     queryOptions,
   ) as WatchQueryOptions;
   return queryManager.watchQuery<any>(finalOptions).subscribe({
-    next: wrap(done, observer.next!),
+    next: wrap(reject, observer.next!),
     error: observer.error,
   });
 };
 
 describe('Basic resolver capabilities', () => {
-  it('should run resolvers for @client queries', done => {
+  it('should run resolvers for @client queries', () => new Promise((resolve, reject) => {
     const query = gql`
       query Test {
         foo @client {
@@ -75,7 +75,7 @@ describe('Basic resolver capabilities', () => {
     };
 
     assertWithObserver({
-      done,
+      reject,
       resolvers,
       query,
       observer: {
@@ -83,15 +83,15 @@ describe('Basic resolver capabilities', () => {
           try {
             expect(data).toEqual({ foo: { bar: true } });
           } catch (error) {
-            done.fail(error);
+            reject(error);
           }
-          done();
+          resolve();
         },
       },
     });
-  });
+  }));
 
-  it('should handle queries with a mix of @client and server fields', done => {
+  it('should handle queries with a mix of @client and server fields', () => new Promise((resolve, reject) => {
     const query = gql`
       query Mixed {
         foo @client {
@@ -118,7 +118,7 @@ describe('Basic resolver capabilities', () => {
     };
 
     assertWithObserver({
-      done,
+      reject,
       resolvers,
       query,
       serverQuery,
@@ -128,15 +128,15 @@ describe('Basic resolver capabilities', () => {
           try {
             expect(data).toEqual({ foo: { bar: true }, bar: { baz: true } });
           } catch (error) {
-            done.fail(error);
+            reject(error);
           }
-          done();
+          resolve();
         },
       },
     });
-  });
+  }));
 
-  it('should handle a mix of @client fields with fragments and server fields', done => {
+  it('should handle a mix of @client fields with fragments and server fields', () => new Promise((resolve, reject) => {
     const query = gql`
       fragment client on ClientData {
         bar
@@ -168,7 +168,7 @@ describe('Basic resolver capabilities', () => {
     };
 
     assertWithObserver({
-      done,
+      reject,
       resolvers,
       query,
       serverQuery,
@@ -181,15 +181,15 @@ describe('Basic resolver capabilities', () => {
               bar: { baz: true },
             });
           } catch (error) {
-            done.fail(error);
+            reject(error);
           }
-          done();
+          resolve();
         },
       },
     });
-  });
+  }));
 
-  it('should have access to query variables when running @client resolvers', done => {
+  it('should have access to query variables when running @client resolvers', () => new Promise((resolve, reject) => {
     const query = gql`
       query WithVariables($id: ID!) {
         foo @client {
@@ -208,7 +208,7 @@ describe('Basic resolver capabilities', () => {
     };
 
     assertWithObserver({
-      done,
+      reject,
       resolvers,
       query,
       variables: { id: 1 },
@@ -217,15 +217,15 @@ describe('Basic resolver capabilities', () => {
           try {
             expect(data).toEqual({ foo: { bar: 1 } });
           } catch (error) {
-            done.fail(error);
+            reject(error);
           }
-          done();
+          resolve();
         },
       },
     });
-  });
+  }));
 
-  it('should pass context to @client resolvers', done => {
+  it('should pass context to @client resolvers', () => new Promise((resolve, reject) => {
     const query = gql`
       query WithContext {
         foo @client {
@@ -244,7 +244,7 @@ describe('Basic resolver capabilities', () => {
     };
 
     assertWithObserver({
-      done,
+      reject,
       resolvers,
       query,
       queryOptions: { context: { id: 1 } },
@@ -253,18 +253,18 @@ describe('Basic resolver capabilities', () => {
           try {
             expect(data).toEqual({ foo: { bar: 1 } });
           } catch (error) {
-            done.fail(error);
+            reject(error);
           }
-          done();
+          resolve();
         },
       },
     });
-  });
+  }));
 
   it(
     'should combine local @client resolver results with server results, for ' +
       'the same field',
-    done => {
+    () => new Promise((resolve, reject) => {
       const query = gql`
         query author {
           author {
@@ -295,7 +295,7 @@ describe('Basic resolver capabilities', () => {
       };
 
       assertWithObserver({
-        done,
+        reject,
         resolvers,
         query,
         serverQuery,
@@ -324,16 +324,16 @@ describe('Basic resolver capabilities', () => {
                 },
               });
             } catch (error) {
-              done.fail(error);
+              reject(error);
             }
-            done();
+            resolve();
           },
         },
       });
-    },
+    }),
   );
 
-  it('should handle resolvers that work with booleans properly', done => {
+  it('should handle resolvers that work with booleans properly', () => new Promise((resolve, reject) => {
     const query = gql`
       query CartDetails {
         isInCart @client
@@ -358,9 +358,9 @@ describe('Basic resolver capabilities', () => {
         expect({ ...data }).toMatchObject({
           isInCart: false,
         });
-        done();
+        resolve();
       });
-  });
+  }));
 
   it('should handle nested asynchronous @client resolvers (issue #4841)', () => {
     const query = gql`
@@ -702,7 +702,7 @@ describe('Writing cache data from resolvers', () => {
 });
 
 describe('Resolving field aliases', () => {
-  it('should run resolvers for missing client queries with aliased field', done => {
+  it('should run resolvers for missing client queries with aliased field', () => new Promise((resolve, reject) => {
     // expect.assertions(1);
     const query = gql`
       query Aliased {
@@ -738,17 +738,17 @@ describe('Resolving field aliases', () => {
           baz: { foo: true, __typename: 'Baz' },
         });
       } catch (e) {
-        done.fail(e);
+        reject(e);
         return;
       }
-      done();
-    }, done.fail);
-  });
+      resolve();
+    }, reject);
+  }));
 
   it(
     'should run resolvers for client queries when aliases are in use on ' +
       'the @client-tagged node',
-    done => {
+    () => new Promise((resolve, reject) => {
       const aliasedQuery = gql`
         query Test {
           fie: foo @client {
@@ -764,7 +764,7 @@ describe('Resolving field aliases', () => {
           Query: {
             foo: () => ({ bar: true, __typename: 'Foo' }),
             fie: () => {
-              done.fail(
+              reject(
                 "Called the resolver using the alias' name, instead of " +
                   'the correct resolver name.',
               );
@@ -775,12 +775,12 @@ describe('Resolving field aliases', () => {
 
       client.query({ query: aliasedQuery }).then(({ data }) => {
         expect(data).toEqual({ fie: { bar: true, __typename: 'Foo' } });
-        done();
-      }, done.fail);
-    },
+        resolve();
+      }, reject);
+    }),
   );
 
-  it('should respect aliases for *nested fields* on the @client-tagged node', done => {
+  it('should respect aliases for *nested fields* on the @client-tagged node', () => new Promise((resolve, reject) => {
     const aliasedQuery = gql`
       query Test {
         fie: foo @client {
@@ -803,7 +803,7 @@ describe('Resolving field aliases', () => {
         Query: {
           foo: () => ({ bar: true, __typename: 'Foo' }),
           fie: () => {
-            done.fail(
+            reject(
               "Called the resolver using the alias' name, instead of " +
                 'the correct resolver name.',
             );
@@ -817,9 +817,9 @@ describe('Resolving field aliases', () => {
         fie: { fum: true, __typename: 'Foo' },
         baz: { foo: true, __typename: 'Baz' },
       });
-      done();
-    }, done.fail);
-  });
+      resolve();
+    }, reject);
+  }));
 
   it(
     'should pull initialized values for aliased fields tagged with @client ' +
@@ -1062,7 +1062,7 @@ describe('Force local resolvers', () => {
   it(
     'should force the running of local resolvers marked with ' +
     '`@client(always: true)` when using `ApolloClient.watchQuery`',
-    (done) => {
+    () => new Promise((resolve, reject) => {
       const query = gql`
         query IsUserLoggedIn {
           isUserLoggedIn @client(always: true)
@@ -1101,14 +1101,14 @@ describe('Force local resolvers', () => {
                   // Result is loaded from the cache since the resolver
                   // isn't being forced.
                   expect(callCount).toBe(2);
-                  done();
+                  resolve();
                 }
               });
             }
           });
         }
       });
-    },
+    }),
   );
 
   it('should allow client-only virtual resolvers (#4731)', function() {
@@ -1156,7 +1156,7 @@ describe('Force local resolvers', () => {
 });
 
 describe('Async resolvers', () => {
-  it('should support async @client resolvers', async (done) => {
+  it('should support async @client resolvers', () => new Promise(async (resolve, reject) => {
     const query = gql`
       query Member {
         isLoggedIn @client
@@ -1176,12 +1176,12 @@ describe('Async resolvers', () => {
 
     const { data: { isLoggedIn } } = await client.query({ query });
     expect(isLoggedIn).toBe(true);
-    return done();
-  });
+    return resolve();
+  }));
 
   it(
     'should support async @client resolvers mixed with remotely resolved data',
-    async (done) => {
+    () => new Promise(async (resolve, reject) => {
       const query = gql`
         query Member {
           member {
@@ -1228,8 +1228,8 @@ describe('Async resolvers', () => {
       expect(member.name).toBe(testMember.name);
       expect(member.isLoggedIn).toBe(testMember.isLoggedIn);
       expect(member.sessionCount).toBe(testMember.sessionCount);
-      return done();
-    }
+      return resolve();
+    }),
   );
 });
 

--- a/src/__tests__/local-state/resolvers.ts
+++ b/src/__tests__/local-state/resolvers.ts
@@ -7,6 +7,7 @@ import { ApolloLink } from '../../link/core/ApolloLink';
 import { ApolloClient } from '../..';
 import mockQueryManager from '../../__mocks__/mockQueryManager';
 import wrap from '../../__tests__/utils/wrap';
+import { itAsync } from '../utils/itAsync';
 import { ApolloQueryResult, Resolvers } from '../../core/types';
 import { WatchQueryOptions } from '../../core/watchQueryOptions';
 import { LocalState } from '../../core/LocalState';
@@ -59,7 +60,7 @@ const assertWithObserver = ({
 };
 
 describe('Basic resolver capabilities', () => {
-  it('should run resolvers for @client queries', () => new Promise((resolve, reject) => {
+  itAsync('should run resolvers for @client queries', (resolve, reject) => {
     const query = gql`
       query Test {
         foo @client {
@@ -89,9 +90,9 @@ describe('Basic resolver capabilities', () => {
         },
       },
     });
-  }));
+  });
 
-  it('should handle queries with a mix of @client and server fields', () => new Promise((resolve, reject) => {
+  itAsync('should handle queries with a mix of @client and server fields', (resolve, reject) => {
     const query = gql`
       query Mixed {
         foo @client {
@@ -134,9 +135,9 @@ describe('Basic resolver capabilities', () => {
         },
       },
     });
-  }));
+  });
 
-  it('should handle a mix of @client fields with fragments and server fields', () => new Promise((resolve, reject) => {
+  itAsync('should handle a mix of @client fields with fragments and server fields', (resolve, reject) => {
     const query = gql`
       fragment client on ClientData {
         bar
@@ -187,9 +188,9 @@ describe('Basic resolver capabilities', () => {
         },
       },
     });
-  }));
+  });
 
-  it('should have access to query variables when running @client resolvers', () => new Promise((resolve, reject) => {
+  itAsync('should have access to query variables when running @client resolvers', (resolve, reject) => {
     const query = gql`
       query WithVariables($id: ID!) {
         foo @client {
@@ -223,9 +224,9 @@ describe('Basic resolver capabilities', () => {
         },
       },
     });
-  }));
+  });
 
-  it('should pass context to @client resolvers', () => new Promise((resolve, reject) => {
+  itAsync('should pass context to @client resolvers', (resolve, reject) => {
     const query = gql`
       query WithContext {
         foo @client {
@@ -259,12 +260,12 @@ describe('Basic resolver capabilities', () => {
         },
       },
     });
-  }));
+  });
 
-  it(
+  itAsync(
     'should combine local @client resolver results with server results, for ' +
       'the same field',
-    () => new Promise((resolve, reject) => {
+    (resolve, reject) => {
       const query = gql`
         query author {
           author {
@@ -330,10 +331,10 @@ describe('Basic resolver capabilities', () => {
           },
         },
       });
-    }),
+    },
   );
 
-  it('should handle resolvers that work with booleans properly', () => new Promise((resolve, reject) => {
+  itAsync('should handle resolvers that work with booleans properly', (resolve, reject) => {
     const query = gql`
       query CartDetails {
         isInCart @client
@@ -360,7 +361,7 @@ describe('Basic resolver capabilities', () => {
         });
         resolve();
       });
-  }));
+  });
 
   it('should handle nested asynchronous @client resolvers (issue #4841)', () => {
     const query = gql`
@@ -702,7 +703,7 @@ describe('Writing cache data from resolvers', () => {
 });
 
 describe('Resolving field aliases', () => {
-  it('should run resolvers for missing client queries with aliased field', () => new Promise((resolve, reject) => {
+  itAsync('should run resolvers for missing client queries with aliased field', (resolve, reject) => {
     // expect.assertions(1);
     const query = gql`
       query Aliased {
@@ -743,12 +744,12 @@ describe('Resolving field aliases', () => {
       }
       resolve();
     }, reject);
-  }));
+  });
 
-  it(
+  itAsync(
     'should run resolvers for client queries when aliases are in use on ' +
       'the @client-tagged node',
-    () => new Promise((resolve, reject) => {
+    (resolve, reject) => {
       const aliasedQuery = gql`
         query Test {
           fie: foo @client {
@@ -777,10 +778,10 @@ describe('Resolving field aliases', () => {
         expect(data).toEqual({ fie: { bar: true, __typename: 'Foo' } });
         resolve();
       }, reject);
-    }),
+    },
   );
 
-  it('should respect aliases for *nested fields* on the @client-tagged node', () => new Promise((resolve, reject) => {
+  itAsync('should respect aliases for *nested fields* on the @client-tagged node', (resolve, reject) => {
     const aliasedQuery = gql`
       query Test {
         fie: foo @client {
@@ -819,7 +820,7 @@ describe('Resolving field aliases', () => {
       });
       resolve();
     }, reject);
-  }));
+  });
 
   it(
     'should pull initialized values for aliased fields tagged with @client ' +
@@ -1059,10 +1060,10 @@ describe('Force local resolvers', () => {
     },
   );
 
-  it(
+  itAsync(
     'should force the running of local resolvers marked with ' +
     '`@client(always: true)` when using `ApolloClient.watchQuery`',
-    () => new Promise((resolve, reject) => {
+    (resolve, reject) => {
       const query = gql`
         query IsUserLoggedIn {
           isUserLoggedIn @client(always: true)
@@ -1108,7 +1109,7 @@ describe('Force local resolvers', () => {
           });
         }
       });
-    }),
+    },
   );
 
   it('should allow client-only virtual resolvers (#4731)', function() {
@@ -1156,7 +1157,7 @@ describe('Force local resolvers', () => {
 });
 
 describe('Async resolvers', () => {
-  it('should support async @client resolvers', () => new Promise(async (resolve, reject) => {
+  itAsync('should support async @client resolvers', async (resolve, reject) => {
     const query = gql`
       query Member {
         isLoggedIn @client
@@ -1177,11 +1178,11 @@ describe('Async resolvers', () => {
     const { data: { isLoggedIn } } = await client.query({ query });
     expect(isLoggedIn).toBe(true);
     return resolve();
-  }));
+  });
 
-  it(
+  itAsync(
     'should support async @client resolvers mixed with remotely resolved data',
-    () => new Promise(async (resolve, reject) => {
+    async (resolve, reject) => {
       const query = gql`
         query Member {
           member {
@@ -1229,7 +1230,7 @@ describe('Async resolvers', () => {
       expect(member.isLoggedIn).toBe(testMember.isLoggedIn);
       expect(member.sessionCount).toBe(testMember.sessionCount);
       return resolve();
-    }),
+    },
   );
 });
 

--- a/src/__tests__/mutationResults.ts
+++ b/src/__tests__/mutationResults.ts
@@ -7,6 +7,7 @@ import { mockSingleLink } from '../__mocks__/mockLinks';
 import { ApolloClient } from '..';
 import { InMemoryCache } from '../cache/inmemory/inMemoryCache';
 import { withWarning } from './utils/wrap';
+import { itAsync } from './utils/itAsync';
 
 describe('mutation results', () => {
   const query = gql`
@@ -195,13 +196,13 @@ describe('mutation results', () => {
     return obsHandle.result();
   }
 
-  it('correctly primes cache for tests', () => new Promise((resolve, reject) => {
+  itAsync('correctly primes cache for tests', (resolve, reject) => {
     return setup(reject).then(
       () => client.query({ query })
     ).then(resolve, reject);
-  }));
+  });
 
-  it('correctly integrates field changes by default', () => new Promise((resolve, reject) => {
+  itAsync('correctly integrates field changes by default', (resolve, reject) => {
     const mutation = gql`
       mutation setCompleted {
         setCompleted(todoId: "3") {
@@ -238,9 +239,9 @@ describe('mutation results', () => {
         expect(newResult.data.todoList.todos[0].completed).toBe(true);
       })
       .then(resolve, reject);
-  }));
+  });
 
-  it('correctly integrates field changes by default with variables', () => new Promise((resolve, reject) => {
+  itAsync('correctly integrates field changes by default with variables', (resolve, reject) => {
     const query = gql`
       query getMini($id: ID!) {
         mini(id: $id) {
@@ -327,9 +328,9 @@ describe('mutation results', () => {
       },
       error: reject,
     });
-  }));
+  });
 
-  it("should warn when the result fields don't match the query fields", () => new Promise((resolve, reject) => {
+  itAsync("should warn when the result fields don't match the query fields", (resolve, reject) => {
     let handle: any;
     let subscriptionHandle: Subscription;
     let counter = 0;
@@ -421,7 +422,7 @@ describe('mutation results', () => {
         .then(() => subscriptionHandle.unsubscribe())
         .then(resolve, reject);
     }, /Missing field description/);
-  }));
+  });
 
   describe('updateQueries', () => {
     const mutation = gql`
@@ -449,7 +450,7 @@ describe('mutation results', () => {
       },
     };
 
-    it('analogous of ARRAY_INSERT', () => new Promise((resolve, reject) => {
+    itAsync('analogous of ARRAY_INSERT', (resolve, reject) => {
       let subscriptionHandle: Subscription;
       return setup(reject, {
         request: { query: mutation },
@@ -499,9 +500,9 @@ describe('mutation results', () => {
           );
         })
         .then(resolve, reject);
-    }));
+    });
 
-    it('does not fail if optional query variables are not supplied', () => new Promise((resolve, reject) => {
+    itAsync('does not fail if optional query variables are not supplied', (resolve, reject) => {
       let subscriptionHandle: Subscription;
       const mutationWithVars = gql`
         mutation createTodo($requiredVar: String!, $optionalVar: String) {
@@ -575,9 +576,9 @@ describe('mutation results', () => {
           );
         })
         .then(resolve, reject);
-    }));
+    });
 
-    it('does not fail if the query did not complete correctly', () => new Promise((resolve, reject) => {
+    itAsync('does not fail if the query did not complete correctly', (resolve, reject) => {
       const obsHandle = setupObsHandle(reject, {
         request: { query: mutation },
         result: mutationResult,
@@ -603,9 +604,9 @@ describe('mutation results', () => {
           },
         },
       }).then(resolve, reject);
-    }));
+    });
 
-    it('does not fail if the query did not finish loading', () => new Promise((resolve, reject) => {
+    itAsync('does not fail if the query did not finish loading', (resolve, reject) => {
       const obsHandle = setupDelayObsHandle(reject, 15, {
         request: { query: mutation },
         result: mutationResult,
@@ -629,9 +630,9 @@ describe('mutation results', () => {
           },
         },
       }).then(resolve, reject);
-    }));
+    });
 
-    it('does not make next queries fail if a mutation fails', () => new Promise((resolve, reject) => {
+    itAsync('does not make next queries fail if a mutation fails', (resolve, reject) => {
       const obsHandle = setupObsHandle(
         error => { throw error },
         {
@@ -684,9 +685,9 @@ describe('mutation results', () => {
             .then(resolve, reject);
         },
       });
-    }));
+    });
 
-    it('error handling in reducer functions', () => new Promise((resolve, reject) => {
+    itAsync('error handling in reducer functions', (resolve, reject) => {
       const oldError = console.error;
       const errors: any[] = [];
       console.error = (msg: string) => {
@@ -726,10 +727,10 @@ describe('mutation results', () => {
           console.error = oldError;
         })
         .then(resolve, reject);
-    }));
+    });
   });
 
-  it('does not fail if one of the previous queries did not complete correctly', () => new Promise((resolve, reject) => {
+  itAsync('does not fail if one of the previous queries did not complete correctly', (resolve, reject) => {
     const variableQuery = gql`
       query Echo($message: String) {
         echo(message: $message)
@@ -831,9 +832,9 @@ describe('mutation results', () => {
     });
 
     watchedQuery.refetch(variables2);
-  }));
+  });
 
-  it('allows mutations with optional arguments', () => new Promise((resolve, reject) => {
+  itAsync('allows mutations with optional arguments', (resolve, reject) => {
     let count = 0;
 
     client = new ApolloClient({
@@ -909,9 +910,9 @@ describe('mutation results', () => {
         resolve();
       })
       .catch(reject);
-  }));
+  });
 
-  it('allows mutations with default values', () => new Promise((resolve, reject) => {
+  itAsync('allows mutations with default values', (resolve, reject) => {
     let count = 0;
 
     client = new ApolloClient({
@@ -985,9 +986,9 @@ describe('mutation results', () => {
         resolve();
       })
       .catch(reject);
-  }));
+  });
 
-  it('will pass null to the network interface when provided', () => new Promise((resolve, reject) => {
+  itAsync('will pass null to the network interface when provided', (resolve, reject) => {
     let count = 0;
 
     client = new ApolloClient({
@@ -1062,7 +1063,7 @@ describe('mutation results', () => {
         resolve();
       })
       .catch(reject);
-  }));
+  });
 
   describe('store transaction updater', () => {
     const mutation = gql`
@@ -1090,7 +1091,7 @@ describe('mutation results', () => {
       },
     };
 
-    it('analogous of ARRAY_INSERT', () => new Promise((resolve, reject) => {
+    itAsync('analogous of ARRAY_INSERT', (resolve, reject) => {
       let subscriptionHandle: Subscription;
       return setup(reject, {
         request: { query: mutation },
@@ -1156,9 +1157,9 @@ describe('mutation results', () => {
           );
         })
         .then(resolve, reject);
-    }));
+    });
 
-    it('does not fail if optional query variables are not supplied', () => new Promise((resolve, reject) => {
+    itAsync('does not fail if optional query variables are not supplied', (resolve, reject) => {
       let subscriptionHandle: Subscription;
       const mutationWithVars = gql`
         mutation createTodo($requiredVar: String!, $optionalVar: String) {
@@ -1248,9 +1249,9 @@ describe('mutation results', () => {
           );
         })
         .then(resolve, reject);
-    }));
+    });
 
-    it('does not make next queries fail if a mutation fails', () => new Promise((resolve, reject) => {
+    itAsync('does not make next queries fail if a mutation fails', (resolve, reject) => {
       const obsHandle = setupObsHandle(
         error => { throw error },
         {
@@ -1341,9 +1342,9 @@ describe('mutation results', () => {
             .then(resolve, reject);
         },
       });
-    }));
+    });
 
-    it('error handling in reducer functions', () => new Promise((resolve, reject) => {
+    itAsync('error handling in reducer functions', (resolve, reject) => {
       const oldError = console.error;
       const errors: any[] = [];
       console.error = (msg: string) => {
@@ -1381,6 +1382,6 @@ describe('mutation results', () => {
           console.error = oldError;
         })
         .then(resolve, reject);
-    }));
+    });
   });
 });

--- a/src/__tests__/mutationResults.ts
+++ b/src/__tests__/mutationResults.ts
@@ -119,8 +119,12 @@ describe('mutation results', () => {
   let client: ApolloClient<any>;
   let link: any;
 
-  function setupObsHandle(...mockedResponses: any[]) {
+  function setupObsHandle(
+    reject: (reason: any) => any,
+    ...mockedResponses: any[]
+  ) {
     link = mockSingleLink(
+      reject,
       {
         request: { query: queryWithTypename } as any,
         result,
@@ -148,8 +152,13 @@ describe('mutation results', () => {
     });
   }
 
-  function setupDelayObsHandle(delay: number, ...mockedResponses: any[]) {
+  function setupDelayObsHandle(
+    reject: (reason: any) => any,
+    delay: number,
+    ...mockedResponses: any[]
+  ) {
     link = mockSingleLink(
+      reject,
       {
         request: { query: queryWithTypename } as any,
         result,
@@ -178,20 +187,21 @@ describe('mutation results', () => {
     });
   }
 
-  function setup(...mockedResponses: any[]) {
-    const obsHandle = setupObsHandle(...mockedResponses);
+  function setup(
+    reject: (reason: any) => any,
+    ...mockedResponses: any[]
+  ) {
+    const obsHandle = setupObsHandle(reject, ...mockedResponses);
     return obsHandle.result();
   }
 
-  it('correctly primes cache for tests', () => {
-    return setup().then(() =>
-      client.query({
-        query,
-      }),
-    );
-  });
+  it('correctly primes cache for tests', () => new Promise((resolve, reject) => {
+    return setup(reject).then(
+      () => client.query({ query })
+    ).then(resolve, reject);
+  }));
 
-  it('correctly integrates field changes by default', () => {
+  it('correctly integrates field changes by default', () => new Promise((resolve, reject) => {
     const mutation = gql`
       mutation setCompleted {
         setCompleted(todoId: "3") {
@@ -214,7 +224,7 @@ describe('mutation results', () => {
       },
     };
 
-    return setup({
+    return setup(reject, {
       request: { query: mutation },
       result: mutationResult,
     })
@@ -226,9 +236,11 @@ describe('mutation results', () => {
       })
       .then((newResult: any) => {
         expect(newResult.data.todoList.todos[0].completed).toBe(true);
-      });
-  });
-  it('correctly integrates field changes by default with variables', done => {
+      })
+      .then(resolve, reject);
+  }));
+
+  it('correctly integrates field changes by default with variables', () => new Promise((resolve, reject) => {
     const query = gql`
       query getMini($id: ID!) {
         mini(id: $id) {
@@ -249,6 +261,7 @@ describe('mutation results', () => {
     `;
 
     const link = mockSingleLink(
+      reject,
       {
         request: {
           query,
@@ -301,22 +314,22 @@ describe('mutation results', () => {
 
           setTimeout(() => {
             if (count === 0)
-              done.fail(
+              reject(
                 new Error('mutate did not re-call observable with next value'),
               );
           }, 250);
         }
         if (count === 1) {
           expect(result.data.mini.cover).toBe('image2');
-          done();
+          resolve();
         }
         count++;
       },
-      error: done.fail,
+      error: reject,
     });
-  });
+  }));
 
-  it("should warn when the result fields don't match the query fields", () => {
+  it("should warn when the result fields don't match the query fields", () => new Promise((resolve, reject) => {
     let handle: any;
     let subscriptionHandle: Subscription;
     let counter = 0;
@@ -368,6 +381,7 @@ describe('mutation results', () => {
 
     return withWarning(() => {
       return setup(
+        reject,
         {
           request: { query: queryTodos },
           result: queryTodosResult,
@@ -404,9 +418,10 @@ describe('mutation results', () => {
             },
           });
         })
-        .then(() => subscriptionHandle.unsubscribe());
+        .then(() => subscriptionHandle.unsubscribe())
+        .then(resolve, reject);
     }, /Missing field description/);
-  });
+  }));
 
   describe('updateQueries', () => {
     const mutation = gql`
@@ -434,9 +449,9 @@ describe('mutation results', () => {
       },
     };
 
-    it('analogous of ARRAY_INSERT', () => {
+    it('analogous of ARRAY_INSERT', () => new Promise((resolve, reject) => {
       let subscriptionHandle: Subscription;
-      return setup({
+      return setup(reject, {
         request: { query: mutation },
         result: mutationResult,
       })
@@ -482,10 +497,11 @@ describe('mutation results', () => {
           expect(newResult.data.todoList.todos[0].text).toBe(
             'This one was created with a mutation.',
           );
-        });
-    });
+        })
+        .then(resolve, reject);
+    }));
 
-    it('does not fail if optional query variables are not supplied', () => {
+    it('does not fail if optional query variables are not supplied', () => new Promise((resolve, reject) => {
       let subscriptionHandle: Subscription;
       const mutationWithVars = gql`
         mutation createTodo($requiredVar: String!, $optionalVar: String) {
@@ -504,7 +520,7 @@ describe('mutation results', () => {
         requiredVar: 'x',
         // optionalVar: 'y',
       };
-      return setup({
+      return setup(reject, {
         request: {
           query: mutationWithVars,
           variables,
@@ -557,11 +573,12 @@ describe('mutation results', () => {
           expect(newResult.data.todoList.todos[0].text).toBe(
             'This one was created with a mutation.',
           );
-        });
-    });
+        })
+        .then(resolve, reject);
+    }));
 
-    it('does not fail if the query did not complete correctly', () => {
-      const obsHandle = setupObsHandle({
+    it('does not fail if the query did not complete correctly', () => new Promise((resolve, reject) => {
+      const obsHandle = setupObsHandle(reject, {
         request: { query: mutation },
         result: mutationResult,
       });
@@ -585,11 +602,11 @@ describe('mutation results', () => {
             return state;
           },
         },
-      });
-    });
+      }).then(resolve, reject);
+    }));
 
-    it('does not fail if the query did not finish loading', () => {
-      const obsHandle = setupDelayObsHandle(15, {
+    it('does not fail if the query did not finish loading', () => new Promise((resolve, reject) => {
+      const obsHandle = setupDelayObsHandle(reject, 15, {
         request: { query: mutation },
         result: mutationResult,
       });
@@ -611,11 +628,12 @@ describe('mutation results', () => {
             return state;
           },
         },
-      });
-    });
+      }).then(resolve, reject);
+    }));
 
-    it('does not make next queries fail if a mutation fails', done => {
+    it('does not make next queries fail if a mutation fails', () => new Promise((resolve, reject) => {
       const obsHandle = setupObsHandle(
+        error => { throw error },
         {
           request: { query: mutation },
           result: { errors: [new Error('mock error')] },
@@ -645,7 +663,7 @@ describe('mutation results', () => {
               },
             })
             .then(
-              () => done.fail(new Error('Mutation should have failed')),
+              () => reject(new Error('Mutation should have failed')),
               () =>
                 client.mutate({
                   mutation,
@@ -660,15 +678,15 @@ describe('mutation results', () => {
                 }),
             )
             .then(
-              () => done.fail(new Error('Mutation should have failed')),
+              () => reject(new Error('Mutation should have failed')),
               () => obsHandle.refetch(),
             )
-            .then(() => done(), done.fail);
+            .then(resolve, reject);
         },
       });
-    });
+    }));
 
-    it('error handling in reducer functions', () => {
+    it('error handling in reducer functions', () => new Promise((resolve, reject) => {
       const oldError = console.error;
       const errors: any[] = [];
       console.error = (msg: string) => {
@@ -676,7 +694,7 @@ describe('mutation results', () => {
       };
 
       let subscriptionHandle: Subscription;
-      return setup({
+      return setup(reject, {
         request: { query: mutation },
         result: mutationResult,
       })
@@ -706,11 +724,12 @@ describe('mutation results', () => {
           expect(errors).toHaveLength(1);
           expect(errors[0].message).toBe(`Hello... It's me.`);
           console.error = oldError;
-        });
-    });
+        })
+        .then(resolve, reject);
+    }));
   });
 
-  it('does not fail if one of the previous queries did not complete correctly', done => {
+  it('does not fail if one of the previous queries did not complete correctly', () => new Promise((resolve, reject) => {
     const variableQuery = gql`
       query Echo($message: String) {
         echo(message: $message)
@@ -754,6 +773,7 @@ describe('mutation results', () => {
     };
 
     link = mockSingleLink(
+      reject,
       {
         request: { query: variableQuery, variables: variables1 } as any,
         result: result1,
@@ -780,7 +800,7 @@ describe('mutation results', () => {
 
     const firstSubs = watchedQuery.subscribe({
       next: () => null,
-      error: done.fail,
+      error: reject,
     });
 
     // Cancel the query right away!
@@ -802,7 +822,7 @@ describe('mutation results', () => {
           });
         } else if (yieldCount === 2) {
           expect(data.echo).toBe('0');
-          done();
+          resolve();
         }
       },
       error: () => {
@@ -811,9 +831,9 @@ describe('mutation results', () => {
     });
 
     watchedQuery.refetch(variables2);
-  });
+  }));
 
-  it('allows mutations with optional arguments', done => {
+  it('allows mutations with optional arguments', () => new Promise((resolve, reject) => {
     let count = 0;
 
     client = new ApolloClient({
@@ -886,12 +906,12 @@ describe('mutation results', () => {
             'result({})': 'moon',
           },
         });
-        done();
+        resolve();
       })
-      .catch(done.fail);
-  });
+      .catch(reject);
+  }));
 
-  it('allows mutations with default values', done => {
+  it('allows mutations with default values', () => new Promise((resolve, reject) => {
     let count = 0;
 
     client = new ApolloClient({
@@ -962,12 +982,12 @@ describe('mutation results', () => {
             'result({"a":1,"b":"cheese","c":3})': 'goodbye',
           },
         });
-        done();
+        resolve();
       })
-      .catch(done.fail);
-  });
+      .catch(reject);
+  }));
 
-  it('will pass null to the network interface when provided', done => {
+  it('will pass null to the network interface when provided', () => new Promise((resolve, reject) => {
     let count = 0;
 
     client = new ApolloClient({
@@ -1039,10 +1059,10 @@ describe('mutation results', () => {
             'result({"a":null,"b":null,"c":null})': 'moon',
           },
         });
-        done();
+        resolve();
       })
-      .catch(done.fail);
-  });
+      .catch(reject);
+  }));
 
   describe('store transaction updater', () => {
     const mutation = gql`
@@ -1070,9 +1090,9 @@ describe('mutation results', () => {
       },
     };
 
-    it('analogous of ARRAY_INSERT', () => {
+    it('analogous of ARRAY_INSERT', () => new Promise((resolve, reject) => {
       let subscriptionHandle: Subscription;
-      return setup({
+      return setup(reject, {
         request: { query: mutation },
         result: mutationResult,
       })
@@ -1134,10 +1154,11 @@ describe('mutation results', () => {
           expect(newResult.data.todoList.todos[0].text).toBe(
             'This one was created with a mutation.',
           );
-        });
-    });
+        })
+        .then(resolve, reject);
+    }));
 
-    it('does not fail if optional query variables are not supplied', () => {
+    it('does not fail if optional query variables are not supplied', () => new Promise((resolve, reject) => {
       let subscriptionHandle: Subscription;
       const mutationWithVars = gql`
         mutation createTodo($requiredVar: String!, $optionalVar: String) {
@@ -1156,7 +1177,7 @@ describe('mutation results', () => {
         requiredVar: 'x',
         // optionalVar: 'y',
       };
-      return setup({
+      return setup(reject, {
         request: {
           query: mutationWithVars,
           variables,
@@ -1225,11 +1246,13 @@ describe('mutation results', () => {
           expect(newResult.data.todoList.todos[0].text).toBe(
             'This one was created with a mutation.',
           );
-        });
-    });
+        })
+        .then(resolve, reject);
+    }));
 
-    it('does not make next queries fail if a mutation fails', done => {
+    it('does not make next queries fail if a mutation fails', () => new Promise((resolve, reject) => {
       const obsHandle = setupObsHandle(
+        error => { throw error },
         {
           request: { query: mutation },
           result: { errors: [new Error('mock error')] },
@@ -1276,7 +1299,7 @@ describe('mutation results', () => {
               },
             })
             .then(
-              () => done.fail(new Error('Mutation should have failed')),
+              () => reject(new Error('Mutation should have failed')),
               () =>
                 client.mutate({
                   mutation,
@@ -1312,14 +1335,15 @@ describe('mutation results', () => {
                 }),
             )
             .then(
-              () => done.fail(new Error('Mutation should have failed')),
+              () => reject(new Error('Mutation should have failed')),
               () => obsHandle.refetch(),
             )
-            .then(() => done(), done.fail);
+            .then(resolve, reject);
         },
       });
-    });
-    it('error handling in reducer functions', () => {
+    }));
+
+    it('error handling in reducer functions', () => new Promise((resolve, reject) => {
       const oldError = console.error;
       const errors: any[] = [];
       console.error = (msg: string) => {
@@ -1327,7 +1351,7 @@ describe('mutation results', () => {
       };
 
       let subscriptionHandle: Subscription;
-      return setup({
+      return setup(reject, {
         request: { query: mutation },
         result: mutationResult,
       })
@@ -1355,7 +1379,8 @@ describe('mutation results', () => {
           expect(errors).toHaveLength(1);
           expect(errors[0].message).toBe(`Hello... It's me.`);
           console.error = oldError;
-        });
-    });
+        })
+        .then(resolve, reject);
+    }));
   });
 });

--- a/src/__tests__/optimistic.ts
+++ b/src/__tests__/optimistic.ts
@@ -99,8 +99,12 @@ describe('optimistic mutation results', () => {
   let client: ApolloClient;
   let link: any;
 
-  function setup(...mockedResponses: any[]) {
+  function setup(
+    reject: (reason: any) => any,
+    ...mockedResponses: any[]
+  ) {
     link = mockSingleLink(
+      reject,
       {
         request: { query },
         result,
@@ -188,9 +192,9 @@ describe('optimistic mutation results', () => {
         },
       };
 
-      it('handles a single error for a single mutation', async () => {
+      it('handles a single error for a single mutation', () => new Promise(async (resolve, reject) => {
         expect.assertions(6);
-        await setup({
+        await setup(reject, {
           request: { query: mutation },
           error: new Error('forbidden (test error)'),
         });
@@ -215,12 +219,15 @@ describe('optimistic mutation results', () => {
           expect((dataInStore['TodoList5'] as any).todos.length).toBe(3);
           expect(stripSymbols(dataInStore)).not.toHaveProperty('Todo99');
         }
-      });
 
-      it('handles errors produced by one mutation in a series', async () => {
+        resolve();
+      }));
+
+      it('handles errors produced by one mutation in a series', () => new Promise(async (resolve, reject) => {
         expect.assertions(10);
         let subscriptionHandle: Subscription;
         await setup(
+          reject,
           {
             request: { query: mutation },
             error: new Error('forbidden (test error)'),
@@ -282,9 +289,11 @@ describe('optimistic mutation results', () => {
         expect((dataInStore['TodoList5'] as any).todos).not.toContainEqual(
           makeReference('Todo99'),
         );
-      });
 
-      it('can run 2 mutations concurrently and handles all intermediate states well', async () => {
+        resolve();
+      }));
+
+      it('can run 2 mutations concurrently and handles all intermediate states well', () => new Promise(async (resolve, reject) => {
         expect.assertions(34);
         function checkBothMutationsAreApplied(
           expectedText1: any,
@@ -306,6 +315,7 @@ describe('optimistic mutation results', () => {
         }
         let subscriptionHandle: Subscription;
         await setup(
+          reject,
           {
             request: { query: mutation },
             result: mutationResult,
@@ -379,7 +389,9 @@ describe('optimistic mutation results', () => {
           'This one was created with a mutation.',
           'Second mutation.',
         );
-      });
+
+        resolve();
+      }));
     });
 
     describe('with `update`', () => {
@@ -414,10 +426,10 @@ describe('optimistic mutation results', () => {
         });
       };
 
-      it('handles a single error for a single mutation', async () => {
+      it('handles a single error for a single mutation', () => new Promise(async (resolve, reject) => {
         expect.assertions(6);
         try {
-          await setup({
+          await setup(reject, {
             request: { query: mutation },
             error: new Error('forbidden (test error)'),
           });
@@ -443,12 +455,15 @@ describe('optimistic mutation results', () => {
           expect((dataInStore['TodoList5'] as any).todos.length).toBe(3);
           expect(stripSymbols(dataInStore)).not.toHaveProperty('Todo99');
         }
-      });
 
-      it('handles errors produced by one mutation in a series', async () => {
+        resolve();
+      }));
+
+      it('handles errors produced by one mutation in a series', () => new Promise(async (resolve, reject) => {
         expect.assertions(10);
         let subscriptionHandle: Subscription;
         await setup(
+          reject,
           {
             request: { query: mutation },
             error: new Error('forbidden (test error)'),
@@ -510,9 +525,11 @@ describe('optimistic mutation results', () => {
         expect((dataInStore['TodoList5'] as any).todos).not.toContainEqual(
           makeReference('Todo99'),
         );
-      });
 
-      it('can run 2 mutations concurrently and handles all intermediate states well', async () => {
+        resolve();
+      }));
+
+      it('can run 2 mutations concurrently and handles all intermediate states well', () => new Promise(async (resolve, reject) => {
         expect.assertions(34);
         function checkBothMutationsAreApplied(
           expectedText1: any,
@@ -533,6 +550,7 @@ describe('optimistic mutation results', () => {
         }
         let subscriptionHandle: Subscription;
         await setup(
+          reject,
           {
             request: { query: mutation },
             result: mutationResult,
@@ -607,7 +625,9 @@ describe('optimistic mutation results', () => {
           'This one was created with a mutation.',
           'Second mutation.',
         );
-      });
+
+        resolve();
+      }));
     });
   });
 
@@ -681,8 +701,8 @@ describe('optimistic mutation results', () => {
       'should read the optimistic response of a mutation when making an ' +
         'ApolloClient.readQuery() call, if the `optimistic` param is set to ' +
         'true',
-      () => {
-        return setup({
+      () => new Promise((resolve, reject) => {
+        return setup(reject, {
           request: { query: todoListMutation },
           result: todoListMutationResult,
         }).then(() => {
@@ -696,16 +716,16 @@ describe('optimistic mutation results', () => {
               );
             },
           });
-        });
-      },
+        }).then(resolve, reject);
+      }),
     );
 
     it(
       'should not read the optimistic response of a mutation when making ' +
         'an ApolloClient.readQuery() call, if the `optimistic` param is set ' +
         'to false',
-      () => {
-        return setup({
+      () => new Promise((resolve, reject) => {
+        return setup(reject, {
           request: { query: todoListMutation },
           result: todoListMutationResult,
         }).then(() => {
@@ -718,8 +738,8 @@ describe('optimistic mutation results', () => {
               expect(data.todoList.todos[0].text).toEqual(incomingText);
             },
           });
-        });
-      },
+        }).then(resolve, reject);
+      })
     );
 
     const todoListFragment = gql`
@@ -737,8 +757,8 @@ describe('optimistic mutation results', () => {
       'should read the optimistic response of a mutation when making an ' +
         'ApolloClient.readFragment() call, if the `optimistic` param is set ' +
         'to true',
-      () => {
-        return setup({
+      () => new Promise((resolve, reject) => {
+        return setup(reject, {
           request: { query: todoListMutation },
           result: todoListMutationResult,
         }).then(() => {
@@ -758,16 +778,16 @@ describe('optimistic mutation results', () => {
               );
             },
           });
-        });
-      },
+        }).then(resolve, reject);
+      })
     );
 
     it(
       'should not read the optimistic response of a mutation when making ' +
         'an ApolloClient.readFragment() call, if the `optimistic` param is ' +
         'set to false',
-      () => {
-        return setup({
+      () => new Promise((resolve, reject) => {
+        return setup(reject, {
           request: { query: todoListMutation },
           result: todoListMutationResult,
         }).then(() => {
@@ -786,8 +806,8 @@ describe('optimistic mutation results', () => {
               expect(data.todos[0].text).toEqual(incomingText);
             },
           });
-        });
-      },
+        }).then(resolve, reject);
+      })
     );
   });
 
@@ -828,10 +848,10 @@ describe('optimistic mutation results', () => {
       },
     });
 
-    it('will use a passed variable in optimisticResponse', async () => {
+    it('will use a passed variable in optimisticResponse', () => new Promise(async (resolve, reject) => {
       expect.assertions(6);
       let subscriptionHandle: Subscription;
-      await setup({
+      await setup(reject, {
         request: { query: mutation, variables },
         result: mutationResult,
       });
@@ -896,7 +916,9 @@ describe('optimistic mutation results', () => {
       expect(newResult.data.todoList.todos[0].text).toEqual(
         'This one was created with a mutation.',
       );
-    });
+
+      resolve();
+    }));
   });
 
   describe('optimistic updates using `updateQueries`', () => {
@@ -964,10 +986,10 @@ describe('optimistic mutation results', () => {
       },
     };
 
-    it('will insert a single item to the beginning', async () => {
+    it('will insert a single item to the beginning', () => new Promise(async (resolve, reject) => {
       expect.assertions(7);
       let subscriptionHandle: Subscription;
-      await setup({
+      await setup(reject, {
         request: { query: mutation },
         result: mutationResult,
       });
@@ -1021,12 +1043,15 @@ describe('optimistic mutation results', () => {
       expect(newResult.data.todoList.todos[0].text).toEqual(
         'This one was created with a mutation.',
       );
-    });
 
-    it('two array insert like mutations', async () => {
+      resolve();
+    }));
+
+    it('two array insert like mutations', () => new Promise(async (resolve, reject) => {
       expect.assertions(9);
       let subscriptionHandle: Subscription;
       await setup(
+        reject,
         {
           request: { query: mutation },
           result: mutationResult,
@@ -1111,12 +1136,15 @@ describe('optimistic mutation results', () => {
       expect(newResult.data.todoList.todos[1].text).toEqual(
         'This one was created with a mutation.',
       );
-    });
 
-    it('two mutations, one fails', async () => {
+      resolve();
+    }));
+
+    it('two mutations, one fails', () => new Promise(async (resolve, reject) => {
       expect.assertions(10);
       let subscriptionHandle: Subscription;
       await setup(
+        reject,
         {
           request: { query: mutation },
           error: new Error('forbidden (test error)'),
@@ -1198,11 +1226,14 @@ describe('optimistic mutation results', () => {
       expect((dataInStore['TodoList5'] as any).todos).not.toContainEqual(
         makeReference('Todo99'),
       );
-    });
 
-    it('will handle dependent updates', async () => {
+      resolve();
+    }));
+
+    it('will handle dependent updates', () => new Promise(async (resolve, reject) => {
       expect.assertions(1);
       link = mockSingleLink(
+        reject,
         {
           request: { query },
           result,
@@ -1312,7 +1343,9 @@ describe('optimistic mutation results', () => {
           ...defaultTodos,
         ],
       ]);
-    });
+
+      resolve();
+    }));
   });
 
   describe('optimistic updates using `update`', () => {
@@ -1370,10 +1403,10 @@ describe('optimistic mutation results', () => {
       },
     };
 
-    it('will insert a single item to the beginning', async () => {
+    it('will insert a single item to the beginning', () => new Promise(async (resolve, reject) => {
       expect.assertions(6);
       let subscriptionHandle: Subscription;
-      await setup({
+      await setup(reject, {
         request: { query: mutation },
         delay: 300,
         result: mutationResult,
@@ -1437,12 +1470,15 @@ describe('optimistic mutation results', () => {
           'This one was created with a mutation.',
         );
       });
-    });
 
-    it('two array insert like mutations', async () => {
+      resolve();
+    }));
+
+    it('two array insert like mutations', () => new Promise(async (resolve, reject) => {
       expect.assertions(9);
       let subscriptionHandle: Subscription;
       await setup(
+        reject,
         {
           request: { query: mutation },
           result: mutationResult,
@@ -1545,12 +1581,15 @@ describe('optimistic mutation results', () => {
       expect(newResult.data.todoList.todos[1].text).toBe(
         'This one was created with a mutation.',
       );
-    });
 
-    it('two mutations, one fails', async () => {
+      resolve();
+    }));
+
+    it('two mutations, one fails', () => new Promise(async (resolve, reject) => {
       expect.assertions(10);
       let subscriptionHandle: Subscription;
       await setup(
+        reject,
         {
           request: { query: mutation },
           error: new Error('forbidden (test error)'),
@@ -1652,11 +1691,14 @@ describe('optimistic mutation results', () => {
       expect((dataInStore['TodoList5'] as any).todos).not.toContainEqual(
         makeReference('Todo99'),
       );
-    });
 
-    it('will handle dependent updates', async () => {
+      resolve();
+    }));
+
+    it('will handle dependent updates', () => new Promise(async (resolve, reject) => {
       expect.assertions(1);
       link = mockSingleLink(
+        reject,
         {
           request: { query },
           result,
@@ -1781,7 +1823,9 @@ describe('optimistic mutation results', () => {
           ...defaultTodos,
         ],
       ]);
-    });
+
+      resolve();
+    }));
   });
 });
 
@@ -1841,8 +1885,12 @@ describe('optimistic mutation - githunt comments', () => {
   let client: ApolloClient;
   let link: any;
 
-  function setup(...mockedResponses: any[]) {
+  function setup(
+    reject: (reason: any) => any,
+    ...mockedResponses: any[]
+  ) {
     link = mockSingleLink(
+      reject,
       {
         request: {
           query: addTypenameToDocument(query),
@@ -1934,7 +1982,7 @@ describe('optimistic mutation - githunt comments', () => {
     },
   };
 
-  it('can post a new comment', async () => {
+  it('can post a new comment', () => new Promise(async (resolve, reject) => {
     expect.assertions(1);
     const mutationVariables = {
       repoFullName: 'org/repo',
@@ -1942,7 +1990,7 @@ describe('optimistic mutation - githunt comments', () => {
     };
 
     let subscriptionHandle: Subscription;
-    await setup({
+    await setup(reject, {
       request: {
         query: addTypenameToDocument(mutation),
         variables: mutationVariables,
@@ -1971,5 +2019,7 @@ describe('optimistic mutation - githunt comments', () => {
 
     subscriptionHandle.unsubscribe();
     expect(newResult.data.entry.comments.length).toBe(2);
-  });
+
+    resolve();
+  }));
 });

--- a/src/__tests__/optimistic.ts
+++ b/src/__tests__/optimistic.ts
@@ -10,6 +10,7 @@ import { ApolloClient } from '../';
 import { addTypenameToDocument } from '../utilities/graphql/transform';
 import { makeReference } from '../utilities/graphql/storeUtils';
 import { stripSymbols } from './utils/stripSymbols';
+import { itAsync } from './utils/itAsync';
 import { InMemoryCache } from '../cache/inmemory/inMemoryCache';
 
 describe('optimistic mutation results', () => {
@@ -192,7 +193,7 @@ describe('optimistic mutation results', () => {
         },
       };
 
-      it('handles a single error for a single mutation', () => new Promise(async (resolve, reject) => {
+      itAsync('handles a single error for a single mutation', async (resolve, reject) => {
         expect.assertions(6);
         await setup(reject, {
           request: { query: mutation },
@@ -221,9 +222,9 @@ describe('optimistic mutation results', () => {
         }
 
         resolve();
-      }));
+      });
 
-      it('handles errors produced by one mutation in a series', () => new Promise(async (resolve, reject) => {
+      itAsync('handles errors produced by one mutation in a series', async (resolve, reject) => {
         expect.assertions(10);
         let subscriptionHandle: Subscription;
         await setup(
@@ -291,9 +292,9 @@ describe('optimistic mutation results', () => {
         );
 
         resolve();
-      }));
+      });
 
-      it('can run 2 mutations concurrently and handles all intermediate states well', () => new Promise(async (resolve, reject) => {
+      itAsync('can run 2 mutations concurrently and handles all intermediate states well', async (resolve, reject) => {
         expect.assertions(34);
         function checkBothMutationsAreApplied(
           expectedText1: any,
@@ -391,7 +392,7 @@ describe('optimistic mutation results', () => {
         );
 
         resolve();
-      }));
+      });
     });
 
     describe('with `update`', () => {
@@ -426,7 +427,7 @@ describe('optimistic mutation results', () => {
         });
       };
 
-      it('handles a single error for a single mutation', () => new Promise(async (resolve, reject) => {
+      itAsync('handles a single error for a single mutation', async (resolve, reject) => {
         expect.assertions(6);
         try {
           await setup(reject, {
@@ -457,9 +458,9 @@ describe('optimistic mutation results', () => {
         }
 
         resolve();
-      }));
+      });
 
-      it('handles errors produced by one mutation in a series', () => new Promise(async (resolve, reject) => {
+      itAsync('handles errors produced by one mutation in a series', async (resolve, reject) => {
         expect.assertions(10);
         let subscriptionHandle: Subscription;
         await setup(
@@ -527,9 +528,9 @@ describe('optimistic mutation results', () => {
         );
 
         resolve();
-      }));
+      });
 
-      it('can run 2 mutations concurrently and handles all intermediate states well', () => new Promise(async (resolve, reject) => {
+      itAsync('can run 2 mutations concurrently and handles all intermediate states well', async (resolve, reject) => {
         expect.assertions(34);
         function checkBothMutationsAreApplied(
           expectedText1: any,
@@ -627,7 +628,7 @@ describe('optimistic mutation results', () => {
         );
 
         resolve();
-      }));
+      });
     });
   });
 
@@ -697,11 +698,11 @@ describe('optimistic mutation results', () => {
       }
     `;
 
-    it(
+    itAsync(
       'should read the optimistic response of a mutation when making an ' +
         'ApolloClient.readQuery() call, if the `optimistic` param is set to ' +
         'true',
-      () => new Promise((resolve, reject) => {
+      (resolve, reject) => {
         return setup(reject, {
           request: { query: todoListMutation },
           result: todoListMutationResult,
@@ -717,14 +718,14 @@ describe('optimistic mutation results', () => {
             },
           });
         }).then(resolve, reject);
-      }),
+      },
     );
 
-    it(
+    itAsync(
       'should not read the optimistic response of a mutation when making ' +
         'an ApolloClient.readQuery() call, if the `optimistic` param is set ' +
         'to false',
-      () => new Promise((resolve, reject) => {
+      (resolve, reject) => {
         return setup(reject, {
           request: { query: todoListMutation },
           result: todoListMutationResult,
@@ -739,7 +740,7 @@ describe('optimistic mutation results', () => {
             },
           });
         }).then(resolve, reject);
-      })
+      },
     );
 
     const todoListFragment = gql`
@@ -753,11 +754,11 @@ describe('optimistic mutation results', () => {
       }
     `;
 
-    it(
+    itAsync(
       'should read the optimistic response of a mutation when making an ' +
         'ApolloClient.readFragment() call, if the `optimistic` param is set ' +
         'to true',
-      () => new Promise((resolve, reject) => {
+      (resolve, reject) => {
         return setup(reject, {
           request: { query: todoListMutation },
           result: todoListMutationResult,
@@ -779,14 +780,14 @@ describe('optimistic mutation results', () => {
             },
           });
         }).then(resolve, reject);
-      })
+      },
     );
 
-    it(
+    itAsync(
       'should not read the optimistic response of a mutation when making ' +
         'an ApolloClient.readFragment() call, if the `optimistic` param is ' +
         'set to false',
-      () => new Promise((resolve, reject) => {
+      (resolve, reject) => {
         return setup(reject, {
           request: { query: todoListMutation },
           result: todoListMutationResult,
@@ -807,7 +808,7 @@ describe('optimistic mutation results', () => {
             },
           });
         }).then(resolve, reject);
-      })
+      },
     );
   });
 
@@ -848,7 +849,7 @@ describe('optimistic mutation results', () => {
       },
     });
 
-    it('will use a passed variable in optimisticResponse', () => new Promise(async (resolve, reject) => {
+    itAsync('will use a passed variable in optimisticResponse', async (resolve, reject) => {
       expect.assertions(6);
       let subscriptionHandle: Subscription;
       await setup(reject, {
@@ -918,7 +919,7 @@ describe('optimistic mutation results', () => {
       );
 
       resolve();
-    }));
+    });
   });
 
   describe('optimistic updates using `updateQueries`', () => {
@@ -986,7 +987,7 @@ describe('optimistic mutation results', () => {
       },
     };
 
-    it('will insert a single item to the beginning', () => new Promise(async (resolve, reject) => {
+    itAsync('will insert a single itemAsync to the beginning', async (resolve, reject) => {
       expect.assertions(7);
       let subscriptionHandle: Subscription;
       await setup(reject, {
@@ -1045,9 +1046,9 @@ describe('optimistic mutation results', () => {
       );
 
       resolve();
-    }));
+    });
 
-    it('two array insert like mutations', () => new Promise(async (resolve, reject) => {
+    itAsync('two array insert like mutations', async (resolve, reject) => {
       expect.assertions(9);
       let subscriptionHandle: Subscription;
       await setup(
@@ -1138,9 +1139,9 @@ describe('optimistic mutation results', () => {
       );
 
       resolve();
-    }));
+    });
 
-    it('two mutations, one fails', () => new Promise(async (resolve, reject) => {
+    itAsync('two mutations, one fails', async (resolve, reject) => {
       expect.assertions(10);
       let subscriptionHandle: Subscription;
       await setup(
@@ -1228,9 +1229,9 @@ describe('optimistic mutation results', () => {
       );
 
       resolve();
-    }));
+    });
 
-    it('will handle dependent updates', () => new Promise(async (resolve, reject) => {
+    itAsync('will handle dependent updates', async (resolve, reject) => {
       expect.assertions(1);
       link = mockSingleLink(
         reject,
@@ -1345,7 +1346,7 @@ describe('optimistic mutation results', () => {
       ]);
 
       resolve();
-    }));
+    });
   });
 
   describe('optimistic updates using `update`', () => {
@@ -1403,7 +1404,7 @@ describe('optimistic mutation results', () => {
       },
     };
 
-    it('will insert a single item to the beginning', () => new Promise(async (resolve, reject) => {
+    itAsync('will insert a single itemAsync to the beginning', async (resolve, reject) => {
       expect.assertions(6);
       let subscriptionHandle: Subscription;
       await setup(reject, {
@@ -1472,9 +1473,9 @@ describe('optimistic mutation results', () => {
       });
 
       resolve();
-    }));
+    });
 
-    it('two array insert like mutations', () => new Promise(async (resolve, reject) => {
+    itAsync('two array insert like mutations', async (resolve, reject) => {
       expect.assertions(9);
       let subscriptionHandle: Subscription;
       await setup(
@@ -1583,9 +1584,9 @@ describe('optimistic mutation results', () => {
       );
 
       resolve();
-    }));
+    });
 
-    it('two mutations, one fails', () => new Promise(async (resolve, reject) => {
+    itAsync('two mutations, one fails', async (resolve, reject) => {
       expect.assertions(10);
       let subscriptionHandle: Subscription;
       await setup(
@@ -1693,9 +1694,9 @@ describe('optimistic mutation results', () => {
       );
 
       resolve();
-    }));
+    });
 
-    it('will handle dependent updates', () => new Promise(async (resolve, reject) => {
+    itAsync('will handle dependent updates', async (resolve, reject) => {
       expect.assertions(1);
       link = mockSingleLink(
         reject,
@@ -1825,7 +1826,7 @@ describe('optimistic mutation results', () => {
       ]);
 
       resolve();
-    }));
+    });
   });
 });
 
@@ -1982,7 +1983,7 @@ describe('optimistic mutation - githunt comments', () => {
     },
   };
 
-  it('can post a new comment', () => new Promise(async (resolve, reject) => {
+  itAsync('can post a new comment', async (resolve, reject) => {
     expect.assertions(1);
     const mutationVariables = {
       repoFullName: 'org/repo',
@@ -2021,5 +2022,5 @@ describe('optimistic mutation - githunt comments', () => {
     expect(newResult.data.entry.comments.length).toBe(2);
 
     resolve();
-  }));
+  });
 });

--- a/src/__tests__/subscribeToMore.ts
+++ b/src/__tests__/subscribeToMore.ts
@@ -7,6 +7,7 @@ import { mockSingleLink, mockObservableLink } from '../__mocks__/mockLinks';
 import { ApolloClient } from '../';
 import { InMemoryCache } from '../cache/inmemory/inMemoryCache';
 import { stripSymbols } from './utils/stripSymbols';
+import { itAsync } from './utils/itAsync';
 
 const isSub = (operation: Operation) =>
   (operation.query as DocumentNode).definitions
@@ -57,7 +58,7 @@ describe('subscribeToMore', () => {
     name: string;
   }
 
-  it('triggers new result from subscription data', () => new Promise((resolve, reject) => {
+  itAsync('triggers new result from subscription data', (resolve, reject) => {
     let latestResult: any = null;
     const wSLink = mockObservableLink();
     const httpLink = mockSingleLink(reject, req1);
@@ -107,9 +108,9 @@ describe('subscribeToMore', () => {
     for (let i = 0; i < 2; i++) {
       wSLink.simulateResult(results[i]);
     }
-  }));
+  });
 
-  it('calls error callback on error', () => new Promise((resolve, reject) => {
+  itAsync('calls error callback on error', (resolve, reject) => {
     let latestResult: any = null;
     const wSLink = mockObservableLink();
     const httpLink = mockSingleLink(reject, req1);
@@ -165,9 +166,9 @@ describe('subscribeToMore', () => {
     for (let i = 0; i < 2; i++) {
       wSLink.simulateResult(results2[i]);
     }
-  }));
+  });
 
-  it('prints unhandled subscription errors to the console', () => new Promise((resolve, reject) => {
+  itAsync('prints unhandled subscription errors to the console', (resolve, reject) => {
     let latestResult: any = null;
 
     const wSLink = mockObservableLink();
@@ -226,9 +227,9 @@ describe('subscribeToMore', () => {
     for (let i = 0; i < 2; i++) {
       wSLink.simulateResult(results3[i]);
     }
-  }));
+  });
 
-  it('should not corrupt the cache (#3062)', () => new Promise(async (resolve, reject) => {
+  itAsync('should not corrupt the cache (#3062)', async (resolve, reject) => {
     let latestResult: any = null;
     const wSLink = mockObservableLink();
     const httpLink = mockSingleLink(reject, req4);
@@ -324,10 +325,10 @@ describe('subscribeToMore', () => {
       stale: false,
     });
     resolve();
-  }));
+  });
   // TODO add a test that checks that subscriptions are cancelled when obs is unsubscribed from.
 
-  it('allows specification of custom types for variables and payload (#4246)', () => new Promise((resolve, reject) => {
+  itAsync('allows specification of custom types for variables and payload (#4246)', (resolve, reject) => {
     interface TypedOperation extends Operation {
       variables: {
         someNumber: number;
@@ -397,5 +398,5 @@ describe('subscribeToMore', () => {
     for (let i = 0; i < 2; i++) {
       wSLink.simulateResult(results[i]);
     }
-  }));
+  });
 });

--- a/src/__tests__/subscribeToMore.ts
+++ b/src/__tests__/subscribeToMore.ts
@@ -57,10 +57,10 @@ describe('subscribeToMore', () => {
     name: string;
   }
 
-  it('triggers new result from subscription data', done => {
+  it('triggers new result from subscription data', () => new Promise((resolve, reject) => {
     let latestResult: any = null;
     const wSLink = mockObservableLink();
-    const httpLink = mockSingleLink(req1);
+    const httpLink = mockSingleLink(reject, req1);
 
     const link = ApolloLink.split(isSub, wSLink, httpLink);
     let counter = 0;
@@ -101,18 +101,18 @@ describe('subscribeToMore', () => {
         networkStatus: 7,
         stale: false,
       });
-      done();
+      resolve();
     }, 15);
 
     for (let i = 0; i < 2; i++) {
       wSLink.simulateResult(results[i]);
     }
-  });
+  }));
 
-  it('calls error callback on error', done => {
+  it('calls error callback on error', () => new Promise((resolve, reject) => {
     let latestResult: any = null;
     const wSLink = mockObservableLink();
-    const httpLink = mockSingleLink(req1);
+    const httpLink = mockSingleLink(reject, req1);
 
     const link = ApolloLink.split(isSub, wSLink, httpLink);
 
@@ -159,19 +159,19 @@ describe('subscribeToMore', () => {
       });
       expect(counter).toBe(2);
       expect(errorCount).toBe(1);
-      done();
+      resolve();
     }, 15);
 
     for (let i = 0; i < 2; i++) {
       wSLink.simulateResult(results2[i]);
     }
-  });
+  }));
 
-  it('prints unhandled subscription errors to the console', done => {
+  it('prints unhandled subscription errors to the console', () => new Promise((resolve, reject) => {
     let latestResult: any = null;
 
     const wSLink = mockObservableLink();
-    const httpLink = mockSingleLink(req1);
+    const httpLink = mockSingleLink(reject, req1);
 
     const link = ApolloLink.split(isSub, wSLink, httpLink);
 
@@ -220,18 +220,18 @@ describe('subscribeToMore', () => {
       expect(counter).toBe(1);
       expect(errorCount).toBe(1);
       console.error = consoleErr;
-      done();
+      resolve();
     }, 15);
 
     for (let i = 0; i < 2; i++) {
       wSLink.simulateResult(results3[i]);
     }
-  });
+  }));
 
-  it('should not corrupt the cache (#3062)', async done => {
+  it('should not corrupt the cache (#3062)', () => new Promise(async (resolve, reject) => {
     let latestResult: any = null;
     const wSLink = mockObservableLink();
-    const httpLink = mockSingleLink(req4);
+    const httpLink = mockSingleLink(reject, req4);
 
     const link = ApolloLink.split(isSub, wSLink, httpLink);
     let counter = 0;
@@ -323,11 +323,11 @@ describe('subscribeToMore', () => {
       networkStatus: 7,
       stale: false,
     });
-    done();
-  });
+    resolve();
+  }));
   // TODO add a test that checks that subscriptions are cancelled when obs is unsubscribed from.
 
-  it('allows specification of custom types for variables and payload (#4246)', done => {
+  it('allows specification of custom types for variables and payload (#4246)', () => new Promise((resolve, reject) => {
     interface TypedOperation extends Operation {
       variables: {
         someNumber: number;
@@ -343,7 +343,7 @@ describe('subscribeToMore', () => {
 
     let latestResult: any = null;
     const wSLink = mockObservableLink();
-    const httpLink = mockSingleLink(typedReq);
+    const httpLink = mockSingleLink(reject, typedReq);
 
     const link = ApolloLink.split(isSub, wSLink, httpLink);
     let counter = 0;
@@ -391,11 +391,11 @@ describe('subscribeToMore', () => {
         networkStatus: 7,
         stale: false,
       });
-      done();
+      resolve();
     }, 15);
 
     for (let i = 0; i < 2; i++) {
       wSLink.simulateResult(results[i]);
     }
-  });
+  }));
 });

--- a/src/__tests__/utils/itAsync.ts
+++ b/src/__tests__/utils/itAsync.ts
@@ -1,0 +1,27 @@
+function wrap<TResult>(
+  original: (...args: any[]) => TResult,
+) {
+  return (
+    message: string,
+    callback: (
+      resolve: (result?: any) => void,
+      reject: (reason?: any) => void,
+    ) => any,
+    timeout?: number,
+  ) => original(message, function () {
+    return new Promise(
+      (resolve, reject) => callback.call(this, resolve, reject),
+    );
+  }, timeout);
+}
+
+const wrappedIt = wrap(it);
+export function itAsync(...args: Parameters<typeof wrappedIt>) {
+  return wrappedIt.apply(this, args);
+}
+
+export namespace itAsync {
+  export const only = wrap(it.only);
+  export const skip = wrap(it.skip);
+  export const todo = wrap(it.todo);
+}

--- a/src/__tests__/utils/subscribeAndCount.ts
+++ b/src/__tests__/utils/subscribeAndCount.ts
@@ -4,7 +4,7 @@ import { Subscription } from '../../utilities/observables/Observable';
 import { asyncMap } from '../../utilities/observables/observables';
 
 export default function subscribeAndCount(
-  done: jest.DoneCallback,
+  reject: (reason: any) => any,
   observable: ObservableQuery<any>,
   cb: (handleCount: number, result: ApolloQueryResult<any>) => any,
 ): Subscription {
@@ -20,12 +20,12 @@ export default function subscribeAndCount(
         // to be defined.
         setImmediate(() => {
           subscription.unsubscribe();
-          done.fail(e);
+          reject(e);
         });
       }
     },
   ).subscribe({
-    error: done.fail,
+    error: reject,
   });
   return subscription;
 }

--- a/src/__tests__/utils/wrap.ts
+++ b/src/__tests__/utils/wrap.ts
@@ -1,12 +1,13 @@
 // I'm not sure why mocha doesn't provide something like this, you can't
 // always use promises
-export default (done: jest.DoneCallback, cb: (...args: any[]) => any) => (
-  ...args: any[]
-) => {
+export default <TArgs extends any[], TResult>(
+  reject: (reason: any) => any,
+  cb: (...args: TArgs) => TResult,
+) => (...args: TArgs) => {
   try {
     return cb(...args);
   } catch (e) {
-    done.fail(e);
+    reject(e);
   }
 };
 

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -16,6 +16,7 @@ import { ApolloClient } from '../../';
 import wrap from '../../__tests__/utils/wrap';
 import subscribeAndCount from '../../__tests__/utils/subscribeAndCount';
 import { stripSymbols } from '../../__tests__/utils/stripSymbols';
+import { itAsync } from '../../__tests__/utils/itAsync';
 import { ApolloError } from '../../errors/ApolloError';
 
 describe('ObservableQuery', () => {
@@ -57,7 +58,7 @@ describe('ObservableQuery', () => {
 
   describe('setOptions', () => {
     describe('to change pollInterval', () => {
-      it('starts polling if goes from 0 -> something', () => new Promise((resolve, reject) => {
+      itAsync('starts polling if goes from 0 -> something', (resolve, reject) => {
         const manager = mockQueryManager(
           reject,
           {
@@ -90,9 +91,9 @@ describe('ObservableQuery', () => {
             resolve();
           }
         });
-      }));
+      });
 
-      it('stops polling if goes from something -> 0', () => new Promise((resolve, reject) => {
+      itAsync('stops polling if goes from something -> 0', (resolve, reject) => {
         const manager = mockQueryManager(
           reject,
           {
@@ -124,9 +125,9 @@ describe('ObservableQuery', () => {
             reject(new Error('Should not get more than one result'));
           }
         });
-      }));
+      });
 
-      it('can change from x>0 to y>0', () => new Promise((resolve, reject) => {
+      itAsync('can change from x>0 to y>0', (resolve, reject) => {
         const manager = mockQueryManager(
           reject,
           {
@@ -160,10 +161,10 @@ describe('ObservableQuery', () => {
             resolve();
           }
         });
-      }));
+      });
     });
 
-    it('does not break refetch', () => new Promise((resolve, reject) => {
+    itAsync('does not break refetch', (resolve, reject) => {
       // This query and variables are copied from react-apollo
       const queryWithVars = gql`
         query people($first: Int) {
@@ -211,9 +212,9 @@ describe('ObservableQuery', () => {
           resolve();
         }
       });
-    }));
+    });
 
-    it('rerenders when refetch is called', () => new Promise((resolve, reject) => {
+    itAsync('rerenders when refetch is called', (resolve, reject) => {
       // This query and variables are copied from react-apollo
       const query = gql`
         query people($first: Int) {
@@ -257,9 +258,9 @@ describe('ObservableQuery', () => {
           resolve();
         }
       });
-    }));
+    });
 
-    it('rerenders with new variables then shows correct data for previous variables', () => new Promise((resolve, reject) => {
+    itAsync('rerenders with new variables then shows correct data for previous variables', (resolve, reject) => {
       // This query and variables are copied from react-apollo
       const query = gql`
         query people($first: Int) {
@@ -313,11 +314,11 @@ describe('ObservableQuery', () => {
           resolve();
         }
       });
-    }));
+    });
 
     // TODO: Something isn't quite right with this test. It's failing but not
     // for the right reasons.
-    it.skip('if query is refetched, and an error is returned, no other observer callbacks will be called', () => new Promise((resolve, reject) => {
+    itAsync.skip('if query is refetched, and an error is returned, no other observer callbacks will be called', (resolve, reject) => {
       const observable: ObservableQuery<any> = mockWatchQuery(
         reject,
         {
@@ -352,9 +353,9 @@ describe('ObservableQuery', () => {
           setTimeout(resolve, 25);
         },
       });
-    }));
+    });
 
-    it('does a network request if fetchPolicy becomes networkOnly', () => new Promise((resolve, reject) => {
+    itAsync('does a network request if fetchPolicy becomes networkOnly', (resolve, reject) => {
       const observable: ObservableQuery<any> = mockWatchQuery(
         reject,
         {
@@ -376,9 +377,9 @@ describe('ObservableQuery', () => {
           resolve();
         }
       });
-    }));
+    });
 
-    it('does a network request if fetchPolicy is cache-only then store is reset then fetchPolicy becomes not cache-only', () => new Promise((resolve, reject) => {
+    itAsync('does a network request if fetchPolicy is cache-only then store is reset then fetchPolicy becomes not cache-only', (resolve, reject) => {
       let queryManager: QueryManager;
       let observable: ObservableQuery<any>;
       const testQuery = gql`
@@ -432,9 +433,9 @@ describe('ObservableQuery', () => {
           reject(e);
         }
       });
-    }));
+    });
 
-    it('does a network request if fetchPolicy changes from cache-only', () => new Promise((resolve, reject) => {
+    itAsync('does a network request if fetchPolicy changes from cache-only', (resolve, reject) => {
       let queryManager: QueryManager;
       let observable: ObservableQuery<any>;
       const testQuery = gql`
@@ -481,9 +482,9 @@ describe('ObservableQuery', () => {
           resolve();
         }
       });
-    }));
+    });
 
-    it('can set queries to standby and will not fetch when doing so', () => new Promise((resolve, reject) => {
+    itAsync('can set queries to standby and will not fetch when doing so', (resolve, reject) => {
       let queryManager: QueryManager;
       let observable: ObservableQuery<any>;
       const testQuery = gql`
@@ -531,9 +532,9 @@ describe('ObservableQuery', () => {
           throw new Error('Handle should not be triggered on standby query');
         }
       });
-    }));
+    });
 
-    it('will not fetch when setting a cache-only query to standby', () => new Promise((resolve, reject) => {
+    itAsync('will not fetch when setting a cache-only query to standby', (resolve, reject) => {
       let queryManager: QueryManager;
       let observable: ObservableQuery<any>;
       const testQuery = gql`
@@ -584,9 +585,9 @@ describe('ObservableQuery', () => {
           }
         });
       });
-    }));
+    });
 
-    it('returns a promise which eventually returns data', () => new Promise((resolve, reject) => {
+    itAsync('returns a promise which eventually returns data', (resolve, reject) => {
       const observable: ObservableQuery<any> = mockWatchQuery(
         reject,
         {
@@ -611,9 +612,9 @@ describe('ObservableQuery', () => {
             resolve();
           });
       });
-    }));
+    });
 
-    it('can bypass looking up results if passed to options', () => new Promise((resolve, reject) => {
+    itAsync('can bypass looking up results if passed to options', (resolve, reject) => {
       const observable: ObservableQuery<any> = mockWatchQuery(
         reject,
         {
@@ -640,11 +641,11 @@ describe('ObservableQuery', () => {
           throw new Error('Handle should not be called twice');
         }
       });
-    }));
+    });
   });
 
   describe('setVariables', () => {
-    it('reruns query if the variables change', () => new Promise((resolve, reject) => {
+    itAsync('reruns query if the variables change', (resolve, reject) => {
       const observable: ObservableQuery<any> = mockWatchQuery(
         reject,
         {
@@ -670,9 +671,9 @@ describe('ObservableQuery', () => {
           resolve();
         }
       });
-    }));
+    });
 
-    it('does invalidate the currentResult data if the variables change', () => new Promise((resolve, reject) => {
+    itAsync('does invalidate the currentResult data if the variables change', (resolve, reject) => {
       const observable: ObservableQuery<any> = mockWatchQuery(
         reject,
         {
@@ -706,9 +707,9 @@ describe('ObservableQuery', () => {
           resolve();
         }
       });
-    }));
+    });
 
-    it('does invalidate the currentResult data if the variables change', () => new Promise((resolve, reject) => {
+    itAsync('does invalidate the currentResult data if the variables change', (resolve, reject) => {
       // Standard data for all these tests
       const query = gql`
         query UsersQuery($page: Int) {
@@ -775,9 +776,9 @@ describe('ObservableQuery', () => {
           resolve();
         }
       });
-    }));
+    });
 
-    it('does not invalidate the currentResult errors if the variables change', () => new Promise((resolve, reject) => {
+    itAsync('does not invalidate the currentResult errors if the variables change', (resolve, reject) => {
       const queryManager = mockQueryManager(
         reject,
         {
@@ -813,17 +814,17 @@ describe('ObservableQuery', () => {
           resolve();
         }
       });
-    }));
+    });
 
-    it('does not perform a query when unsubscribed if variables change', () => new Promise((resolve, reject) => {
+    itAsync('does not perform a query when unsubscribed if variables change', (resolve, reject) => {
       // Note: no responses, will throw if a query is made
       const queryManager = mockQueryManager(reject);
       const observable = queryManager.watchQuery({ query, variables });
       return observable.setVariables(differentVariables)
         .then(resolve, reject);
-    }));
+    });
 
-    it('sets networkStatus to `setVariables` when fetching', () => new Promise((resolve, reject) => {
+    itAsync('sets networkStatus to `setVariables` when fetching', (resolve, reject) => {
       const mockedResponses = [
         {
           request: { query, variables },
@@ -859,9 +860,9 @@ describe('ObservableQuery', () => {
           resolve();
         }
       });
-    }));
+    });
 
-    it('sets networkStatus to `setVariables` when calling refetch with new variables', () => new Promise((resolve, reject) => {
+    itAsync('sets networkStatus to `setVariables` when calling refetch with new variables', (resolve, reject) => {
       const mockedResponses = [
         {
           request: { query, variables },
@@ -897,9 +898,9 @@ describe('ObservableQuery', () => {
           resolve();
         }
       });
-    }));
+    });
 
-    it('reruns observer callback if the variables change but data does not', () => new Promise((resolve, reject) => {
+    itAsync('reruns observer callback if the variables change but data does not', (resolve, reject) => {
       const observable: ObservableQuery<any> = mockWatchQuery(
         reject,
         {
@@ -924,9 +925,9 @@ describe('ObservableQuery', () => {
           resolve();
         }
       });
-    }));
+    });
 
-    it('does not rerun observer callback if the variables change but new data is in store', () => new Promise((resolve, reject) => {
+    itAsync('does not rerun observer callback if the variables change but new data is in store', (resolve, reject) => {
       const manager = mockQueryManager(
         reject,
         {
@@ -959,9 +960,9 @@ describe('ObservableQuery', () => {
           }
         });
       });
-    }));
+    });
 
-    it('does not rerun query if variables do not change', () => new Promise((resolve, reject) => {
+    itAsync('does not rerun query if variables do not change', (resolve, reject) => {
       const observable: ObservableQuery<any> = mockWatchQuery(
         reject,
         {
@@ -987,9 +988,9 @@ describe('ObservableQuery', () => {
           throw new Error('Observable callback should not fire twice');
         }
       });
-    }));
+    });
 
-    it('does not rerun query if set to not refetch', () => new Promise((resolve, reject) => {
+    itAsync('does not rerun query if set to not refetch', (resolve, reject) => {
       const observable: ObservableQuery<any> = mockWatchQuery(
         reject,
         {
@@ -1015,9 +1016,9 @@ describe('ObservableQuery', () => {
           throw new Error('Observable callback should not fire twice');
         }
       });
-    }));
+    });
 
-    it('handles variables changing while a query is in-flight', () => new Promise((resolve, reject) => {
+    itAsync('handles variables changing while a query is in-flight', (resolve, reject) => {
       // The expected behavior is that the original variables are forgotten
       // and the query stays in loading state until the result for the new variables
       // has returned.
@@ -1045,11 +1046,11 @@ describe('ObservableQuery', () => {
           resolve();
         }
       });
-    }));
+    });
   });
 
   describe('refetch', () => {
-    it('calls fetchRequest with fetchPolicy `network-only` when using a non-networked fetch policy', () => new Promise((resolve, reject) => {
+    itAsync('calls fetchRequest with fetchPolicy `network-only` when using a non-networked fetch policy', (resolve, reject) => {
       const mockedResponses = [
         {
           request: { query, variables },
@@ -1084,11 +1085,11 @@ describe('ObservableQuery', () => {
           resolve();
         }
       });
-    }));
+    });
 
-    it(
+    itAsync(
       'calls fetchRequest with fetchPolicy `no-cache` when using `no-cache` fetch policy',
-      () => new Promise((resolve, reject) => {
+      (resolve, reject) => {
         const mockedResponses = [
           {
             request: { query, variables },
@@ -1123,10 +1124,10 @@ describe('ObservableQuery', () => {
             resolve();
           }
         });
-      }),
+      }
     );
 
-    it('calls ObservableQuery.next even after hitting cache', () => new Promise((resolve, reject) => {
+    itAsync('calls ObservableQuery.next even after hitting cache', (resolve, reject) => {
       // This query and variables are copied from react-apollo
       const queryWithVars = gql`
         query people($first: Int) {
@@ -1195,9 +1196,9 @@ describe('ObservableQuery', () => {
           resolve();
         }
       });
-    }));
+    });
 
-    it('cache-and-network refetch should run @client(always: true) resolvers when network request fails', () => new Promise((resolve, reject) => {
+    itAsync('cache-and-network refetch should run @client(always: true) resolvers when network request fails', (resolve, reject) => {
       const query = gql`
         query MixedQuery {
           counter @client(always: true)
@@ -1320,11 +1321,11 @@ describe('ObservableQuery', () => {
           }
         },
       });
-    }));
+    });
   });
 
   describe('currentResult', () => {
-    it('returns the same value as observableQuery.next got', () => new Promise((resolve, reject) => {
+    itAsync('returns the same value as observableQuery.next got', (resolve, reject) => {
       const queryWithFragment = gql`
         fragment CatInfo on Cat {
           isTabby
@@ -1441,9 +1442,9 @@ describe('ObservableQuery', () => {
           reject(new Error('Observable.next called too many times'));
         }
       });
-    }));
+    });
 
-    it('returns the current query status immediately', () => new Promise((resolve, reject) => {
+    itAsync('returns the current query status immediately', (resolve, reject) => {
       const observable: ObservableQuery<any> = mockWatchQuery(reject, {
         request: { query, variables },
         result: { data: dataOne },
@@ -1478,9 +1479,9 @@ describe('ObservableQuery', () => {
         }),
         0,
       );
-    }));
+    });
 
-    it('returns results from the store immediately', () => new Promise((resolve, reject) => {
+    itAsync('returns results from the store immediately', (resolve, reject) => {
       const queryManager = mockQueryManager(reject, {
         request: { query, variables },
         result: { data: dataOne },
@@ -1504,9 +1505,9 @@ describe('ObservableQuery', () => {
           partial: false,
         });
       }).then(resolve, reject);
-    }));
+    });
 
-    it('returns errors from the store immediately', () => new Promise((resolve, reject) => {
+    itAsync('returns errors from the store immediately', (resolve, reject) => {
       const queryManager = mockQueryManager(reject, {
         request: { query, variables },
         result: { errors: [error] },
@@ -1527,9 +1528,9 @@ describe('ObservableQuery', () => {
           resolve();
         },
       });
-    }));
+    });
 
-    it('returns referentially equal errors', () => new Promise((resolve, reject) => {
+    itAsync('returns referentially equal errors', (resolve, reject) => {
       const queryManager = mockQueryManager(reject, {
         request: { query, variables },
         result: { errors: [error] },
@@ -1549,9 +1550,9 @@ describe('ObservableQuery', () => {
         const currentResult2 = observable.getCurrentResult();
         expect(currentResult.error === currentResult2.error).toBe(true);
       }).then(resolve, reject);
-    }));
+    });
 
-    it('returns errors with data if errorPolicy is all', () => new Promise((resolve, reject) => {
+    itAsync('returns errors with data if errorPolicy is all', (resolve, reject) => {
       const queryManager = mockQueryManager(reject, {
         request: { query, variables },
         result: { data: dataOne, errors: [error] },
@@ -1571,9 +1572,9 @@ describe('ObservableQuery', () => {
         expect(currentResult.errors).toEqual([error]);
         expect(currentResult.error).toBeUndefined();
       }).then(resolve, reject);
-    }));
+    });
 
-    it('ignores errors with data if errorPolicy is ignore', () => new Promise((resolve, reject) => {
+    itAsync('ignores errors with data if errorPolicy is ignore', (resolve, reject) => {
       const queryManager = mockQueryManager(reject, {
         request: { query, variables },
         result: { errors: [error], data: dataOne },
@@ -1593,9 +1594,9 @@ describe('ObservableQuery', () => {
         expect(currentResult.errors).toBeUndefined();
         expect(currentResult.error).toBeUndefined();
       }).then(resolve, reject);
-    }));
+    });
 
-    it('returns partial data from the store immediately', () => new Promise((resolve, reject) => {
+    itAsync('returns partial data from the store immediately', (resolve, reject) => {
       const superQuery = gql`
         query superQuery($id: ID!) {
           people_one(id: $id) {
@@ -1667,9 +1668,9 @@ describe('ObservableQuery', () => {
           }
         });
       });
-    }));
+    });
 
-    it('returns loading even if full data is available when using network-only fetchPolicy', () => new Promise((resolve, reject) => {
+    itAsync('returns loading even if full data is available when using network-only fetchPolicy', (resolve, reject) => {
       const queryManager = mockQueryManager(
         reject,
         {
@@ -1719,9 +1720,9 @@ describe('ObservableQuery', () => {
           }
         });
       });
-    }));
+    });
 
-    it('returns loading on no-cache fetchPolicy queries when calling getCurrentResult', () => new Promise((resolve, reject) => {
+    itAsync('returns loading on no-cache fetchPolicy queries when calling getCurrentResult', (resolve, reject) => {
       const queryManager = mockQueryManager(
         reject,
         {
@@ -1771,7 +1772,7 @@ describe('ObservableQuery', () => {
           }
         });
       });
-    }));
+    });
 
     describe('mutations', () => {
       const mutation = gql`
@@ -1796,7 +1797,7 @@ describe('ObservableQuery', () => {
         },
       };
 
-      it('returns optimistic mutation results from the store', () => new Promise((resolve, reject) => {
+      itAsync('returns optimistic mutation results from the store', (resolve, reject) => {
         const queryManager = mockQueryManager(
           reject,
           {
@@ -1848,12 +1849,12 @@ describe('ObservableQuery', () => {
             resolve();
           }
         });
-      }));
+      });
     });
   });
 
   describe('assumeImmutableResults', () => {
-    it('should prevent costly (but safe) cloneDeep calls', async () => new Promise(async (resolve, reject) => {
+    itAsync('should prevent costly (but safe) cloneDeep calls', async (resolve, reject) => {
       const queryOptions = {
         query: gql`
           query {
@@ -1947,11 +1948,11 @@ describe('ObservableQuery', () => {
       await checkThrows(false);
 
       resolve();
-    }));
+    });
   });
 
   describe('stopPolling', () => {
-    it('does not restart polling after stopping and resubscribing', () => new Promise((resolve, reject) => {
+    itAsync('does not restart polling after stopping and resubscribing', (resolve, reject) => {
       const observable = mockWatchQuery(
         reject,
         {
@@ -1989,11 +1990,11 @@ describe('ObservableQuery', () => {
           reject(new Error('should not start polling, already stopped'));
         }
       });
-    }));
+    });
   });
 
   describe('resetQueryStoreErrors', () => {
-    it("should remove any GraphQLError's stored in the query store", () => new Promise((resolve, reject) => {
+    itAsync("should remove any GraphQLError's stored in the query store", (resolve, reject) => {
       const graphQLError = new GraphQLError('oh no!');
 
       const observable: ObservableQuery<any> = mockWatchQuery(reject, {
@@ -2013,9 +2014,9 @@ describe('ObservableQuery', () => {
           resolve();
         }
       });
-    }));
+    });
 
-    it("should remove network error's stored in the query store", () => new Promise((resolve, reject) => {
+    itAsync("should remove network error's stored in the query store", (resolve, reject) => {
       const networkError = new Error('oh no!');
 
       const observable: ObservableQuery<any> = mockWatchQuery(reject, {
@@ -2033,6 +2034,6 @@ describe('ObservableQuery', () => {
           resolve();
         }
       });
-    }));
+    });
   });
 });

--- a/src/core/__tests__/QueryManager/index.ts
+++ b/src/core/__tests__/QueryManager/index.ts
@@ -36,6 +36,7 @@ import observableToPromise, {
   observableToPromiseAndSubscription,
 } from '../../../__tests__/utils/observableToPromise';
 import { stripSymbols } from '../../../__tests__/utils/stripSymbols';
+import { itAsync } from '../../../__tests__/utils/itAsync';
 
 describe('QueryManager', () => {
   // Standard "get id from object" method.
@@ -186,7 +187,7 @@ describe('QueryManager', () => {
     return mockQueryManager(reject, ...args);
   };
 
-  it('handles GraphQL errors', () => new Promise((resolve, reject) => {
+  itAsync('handles GraphQL errors', (resolve, reject) => {
     assertWithObserver({
       reject,
       query: gql`
@@ -220,9 +221,9 @@ describe('QueryManager', () => {
         },
       },
     });
-  }));
+  });
 
-  it('handles GraphQL errors as data', () => new Promise((resolve, reject) => {
+  itAsync('handles GraphQL errors as data', (resolve, reject) => {
     assertWithObserver({
       reject,
       query: gql`
@@ -260,9 +261,9 @@ describe('QueryManager', () => {
         },
       },
     });
-  }));
+  });
 
-  it('handles GraphQL errors with data returned', () => new Promise((resolve, reject) => {
+  itAsync('handles GraphQL errors with data returned', (resolve, reject) => {
     assertWithObserver({
       reject,
       query: gql`
@@ -302,9 +303,9 @@ describe('QueryManager', () => {
         },
       },
     });
-  }));
+  });
 
-  it('empty error array (handle non-spec-compliant server) #156', () => new Promise((resolve, reject) => {
+  itAsync('empty error array (handle non-spec-compliant server) #156', (resolve, reject) => {
     assertWithObserver({
       reject,
       query: gql`
@@ -334,11 +335,11 @@ describe('QueryManager', () => {
         },
       },
     });
-  }));
+  });
 
   // Easy to get into this state if you write an incorrect `formatError`
   // function with graphql-server or express-graphql
-  it('error array with nulls (handle non-spec-compliant server) #1185', () => new Promise((resolve, reject) => {
+  itAsync('error array with nulls (handle non-spec-compliant server) #1185', (resolve, reject) => {
     assertWithObserver({
       reject,
       query: gql`
@@ -364,9 +365,9 @@ describe('QueryManager', () => {
         },
       },
     });
-  }));
+  });
 
-  it('handles network errors', () => new Promise((resolve, reject) => {
+  itAsync('handles network errors', (resolve, reject) => {
     assertWithObserver({
       reject,
       query: gql`
@@ -391,9 +392,9 @@ describe('QueryManager', () => {
         },
       },
     });
-  }));
+  });
 
-  it('uses console.error to log unhandled errors', () => new Promise((resolve, reject) => {
+  itAsync('uses console.error to log unhandled errors', (resolve, reject) => {
     const oldError = console.error;
     let printed: any;
     console.error = (...args: any[]) => {
@@ -424,11 +425,11 @@ describe('QueryManager', () => {
       console.error = oldError;
       resolve();
     }, 10);
-  }));
+  });
 
   // XXX this looks like a bug in zen-observable but we should figure
   // out a solution for it
-  xit('handles an unsubscribe action that happens before data returns', () => new Promise((resolve, reject) => {
+  itAsync.skip('handles an unsubscribe action that happens before data returns', (resolve, reject) => {
     const subscription = assertWithObserver({
       reject,
       query: gql`
@@ -452,9 +453,9 @@ describe('QueryManager', () => {
     });
 
     expect(subscription.unsubscribe).not.toThrow();
-  }));
+  });
 
-  it('supports interoperability with other Observable implementations like RxJS', () => new Promise((resolve, reject) => {
+  itAsync('supports interoperability with other Observable implementations like RxJS', (resolve, reject) => {
     const expResult = {
       data: {
         allPeople: {
@@ -494,9 +495,9 @@ describe('QueryManager', () => {
         resolve();
       }),
     });
-  }));
+  });
 
-  it('allows you to subscribe twice to one query', () => new Promise((resolve, reject) => {
+  itAsync('allows you to subscribe twice to one query', (resolve, reject) => {
     const request = {
       query: gql`
         query fetchLuke($id: String) {
@@ -596,9 +597,9 @@ describe('QueryManager', () => {
         },
       });
     });
-  }));
+  });
 
-  it('resolves all queries when one finishes after another', () => new Promise((resolve, reject) => {
+  itAsync('resolves all queries when one finishes after another', (resolve, reject) => {
     const request = {
       query: gql`
         query fetchLuke($id: String) {
@@ -693,9 +694,9 @@ describe('QueryManager', () => {
       expect(stripSymbols(result.data)).toEqual(data3);
       finishCount++;
     });
-  }));
+  });
 
-  it('allows you to refetch queries', () => new Promise((resolve, reject) => {
+  itAsync('allows you to refetch queries', (resolve, reject) => {
     const request = {
       query: gql`
         query fetchLuke($id: String) {
@@ -737,9 +738,9 @@ describe('QueryManager', () => {
       },
       result => expect(stripSymbols(result.data)).toEqual(data2),
     ).then(resolve, reject);
-  }));
+  });
 
-  it('will return referentially equivalent data if nothing changed in a refetch', () => new Promise((resolve, reject) => {
+  itAsync('will return referentially equivalent data if nothing changed in a refetch', (resolve, reject) => {
     const request = {
       query: gql`
         {
@@ -823,9 +824,9 @@ describe('QueryManager', () => {
       },
       error: reject,
     });
-  }));
+  });
 
-  it('will return referentially equivalent data in getCurrentResult if nothing changed', () => new Promise((resolve, reject) => {
+  itAsync('will return referentially equivalent data in getCurrentResult if nothing changed', (resolve, reject) => {
     const request = {
       query: gql`
         {
@@ -871,9 +872,9 @@ describe('QueryManager', () => {
       },
       error: reject,
     });
-  }));
+  });
 
-  it('sets networkStatus to `refetch` when refetching', () => new Promise((resolve, reject) => {
+  itAsync('sets networkStatus to `refetch` when refetching', (resolve, reject) => {
     const request = {
       query: gql`
         query fetchLuke($id: String) {
@@ -919,9 +920,9 @@ describe('QueryManager', () => {
         expect(stripSymbols(result.data)).toEqual(data2);
       },
     ).then(resolve, reject);
-  }));
+  });
 
-  it('allows you to refetch queries with promises', () => new Promise(async (resolve, reject) => {
+  itAsync('allows you to refetch queries with promises', async (resolve, reject) => {
     const request = {
       query: gql`
         {
@@ -957,9 +958,9 @@ describe('QueryManager', () => {
       .refetch()
       .then(result => expect(stripSymbols(result.data)).toEqual(data2))
       .then(resolve, reject);
-  }));
+  });
 
-  it('allows you to refetch queries with new variables', () => new Promise((resolve, reject) => {
+  itAsync('allows you to refetch queries with new variables', (resolve, reject) => {
     const query = gql`
       {
         people_one(id: 1) {
@@ -1050,9 +1051,9 @@ describe('QueryManager', () => {
         expect(stripSymbols(result.data)).toEqual(data4);
       },
     ).then(resolve, reject);
-  }));
+  });
 
-  it('only modifies varaibles when refetching', () => new Promise((resolve, reject) => {
+  itAsync('only modifies varaibles when refetching', (resolve, reject) => {
     const query = gql`
       {
         people_one(id: 1) {
@@ -1104,9 +1105,9 @@ describe('QueryManager', () => {
         expect(updatedOptions).toEqual(originalOptions);
       },
     ).then(resolve, reject);
-  }));
+  });
 
-  it('continues to poll after refetch', () => new Promise((resolve, reject) => {
+  itAsync('continues to poll after refetch', (resolve, reject) => {
     const query = gql`
       {
         people_one(id: 1) {
@@ -1167,9 +1168,9 @@ describe('QueryManager', () => {
         observable.stopPolling();
       },
     ).then(resolve, reject);
-  }));
+  });
 
-  it('sets networkStatus to `poll` if a polling query is in flight', () => new Promise((resolve, reject) => {
+  itAsync('sets networkStatus to `poll` if a polling query is in flight', (resolve, reject) => {
     const query = gql`
       {
         people_one(id: 1) {
@@ -1232,9 +1233,9 @@ describe('QueryManager', () => {
         }
       },
     });
-  }));
+  });
 
-  it('supports returnPartialData #193', () => new Promise((resolve, reject) => {
+  itAsync('supports returnPartialData #193', (resolve, reject) => {
     const primeQuery = gql`
       query primeQuery {
         people_one(id: 1) {
@@ -1304,9 +1305,9 @@ describe('QueryManager', () => {
         });
       })
       .then(resolve, reject);
-  }));
+  });
 
-  it('can handle null values in arrays (#1551)', () => new Promise((resolve, reject) => {
+  itAsync('can handle null values in arrays (#1551)', (resolve, reject) => {
     const query = gql`
       {
         list {
@@ -1328,9 +1329,9 @@ describe('QueryManager', () => {
         resolve();
       },
     });
-  }));
+  });
 
-  it('should error if we pass fetchPolicy = cache-only on a polling query', () => new Promise((resolve, reject) => {
+  itAsync('should error if we pass fetchPolicy = cache-only on a polling query', (resolve, reject) => {
     assertWithObserver({
       reject,
       observer: {
@@ -1350,9 +1351,9 @@ describe('QueryManager', () => {
       `,
       queryOptions: { pollInterval: 200, fetchPolicy: 'cache-only' },
     });
-  }));
+  });
 
-  it('should error if we pass fetchPolicy = cache-first on a polling query', () => new Promise((resolve, reject) => {
+  itAsync('should error if we pass fetchPolicy = cache-first on a polling query', (resolve, reject) => {
     assertWithObserver({
       reject,
       observer: {
@@ -1374,9 +1375,9 @@ describe('QueryManager', () => {
       `,
       queryOptions: { pollInterval: 200, fetchPolicy: 'cache-first' },
     });
-  }));
+  });
 
-  it('supports cache-only fetchPolicy fetching only cached data', () => new Promise((resolve, reject) => {
+  itAsync('supports cache-only fetchPolicy fetching only cached data', (resolve, reject) => {
     const primeQuery = gql`
       query primeQuery {
         luke: people_one(id: 1) {
@@ -1424,9 +1425,9 @@ describe('QueryManager', () => {
         });
       })
       .then(resolve, reject);
-  }));
+  });
 
-  it('runs a mutation', () => new Promise((resolve, reject) => {
+  itAsync('runs a mutation', (resolve, reject) => {
     return assertMutationRoundtrip({
       resolve,
       reject,
@@ -1437,9 +1438,9 @@ describe('QueryManager', () => {
       `,
       data: { makeListPrivate: true },
     });
-  }));
+  });
 
-  it('runs a mutation even when errors is empty array #2912', () => new Promise((resolve, reject) => {
+  itAsync('runs a mutation even when errors is empty array #2912', (resolve, reject) => {
     const errors = [];
     return assertMutationRoundtrip({
       resolve,
@@ -1452,9 +1453,9 @@ describe('QueryManager', () => {
       errors,
       data: { makeListPrivate: true },
     });
-  }));
+  });
 
-  it('runs a mutation with default errorPolicy equal to "none"', () => new Promise((resolve, reject) => {
+  itAsync('runs a mutation with default errorPolicy equal to "none"', (resolve, reject) => {
     const errors = [new GraphQLError('foo')];
 
     return mockMutation({
@@ -1475,9 +1476,9 @@ describe('QueryManager', () => {
         expect(error.graphQLErrors).toEqual(errors);
       },
     ).then(resolve, reject);
-  }));
+  });
 
-  it('runs a mutation with variables', () => new Promise((resolve, reject) => {
+  itAsync('runs a mutation with variables', (resolve, reject) => {
     return assertMutationRoundtrip({
       resolve,
       reject,
@@ -1489,11 +1490,11 @@ describe('QueryManager', () => {
       variables: { listId: '1' },
       data: { makeListPrivate: true },
     });
-  }));
+  });
 
   const getIdField = ({ id }: { id: string }) => id;
 
-  it('runs a mutation with object parameters and puts the result in the store', () => new Promise((resolve, reject) => {
+  itAsync('runs a mutation with object parameters and puts the result in the store', (resolve, reject) => {
     const data = {
       makeListPrivate: {
         id: '5',
@@ -1523,9 +1524,9 @@ describe('QueryManager', () => {
         isPrivate: true,
       });
     }).then(resolve, reject);
-  }));
+  });
 
-  it('runs a mutation and puts the result in the store', () => new Promise((resolve, reject) => {
+  itAsync('runs a mutation and puts the result in the store', (resolve, reject) => {
     const data = {
       makeListPrivate: {
         id: '5',
@@ -1556,9 +1557,9 @@ describe('QueryManager', () => {
         isPrivate: true,
       });
     }).then(resolve, reject);
-  }));
+  });
 
-  it('runs a mutation and puts the result in the store with root key', () => new Promise((resolve, reject) => {
+  itAsync('runs a mutation and puts the result in the store with root key', (resolve, reject) => {
     const mutation = gql`
       mutation makeListPrivate {
         makeListPrivate(id: "5") {
@@ -1598,9 +1599,9 @@ describe('QueryManager', () => {
           isPrivate: true,
         });
       }).then(resolve, reject);
-  }));
+  });
 
-  it(`doesn't return data while query is loading`, () => new Promise((resolve, reject) => {
+  itAsync(`doesn't return data while query is loading`, (resolve, reject) => {
     const query1 = gql`
       {
         people_one(id: 1) {
@@ -1653,9 +1654,9 @@ describe('QueryManager', () => {
         expect(stripSymbols(result.data)).toEqual(data2),
       ),
     ]).then(resolve, reject);
-  }));
+  });
 
-  it(`updates result of previous query if the result of a new query overlaps`, () => new Promise((resolve, reject) => {
+  itAsync(`updates result of previous query if the result of a new query overlaps`, (resolve, reject) => {
     const query1 = gql`
       {
         people_one(id: 1) {
@@ -1717,9 +1718,9 @@ describe('QueryManager', () => {
           },
         }),
     ).then(resolve, reject);
-  }));
+  });
 
-  it('warns if you forget the template literal tag', () => new Promise(async (resolve, reject) => {
+  itAsync('warns if you forget the template literal tag', async (resolve, reject) => {
     const queryManager = mockQueryManager(reject);
     expect(() => {
       queryManager.query<any>({
@@ -1743,9 +1744,9 @@ describe('QueryManager', () => {
     }).toThrowError(/wrap the query string in a "gql" tag/);
 
     resolve();
-  }));
+  });
 
-  it('should transform queries correctly when given a QueryTransformer', () => new Promise((resolve, reject) => {
+  itAsync('should transform queries correctly when given a QueryTransformer', (resolve, reject) => {
     const query = gql`
       query {
         author {
@@ -1786,9 +1787,9 @@ describe('QueryManager', () => {
         expect(stripSymbols(result.data)).toEqual(transformedQueryResult);
       })
       .then(resolve, reject);
-  }));
+  });
 
-  it('should transform mutations correctly', () => new Promise((resolve, reject) => {
+  itAsync('should transform mutations correctly', (resolve, reject) => {
     const mutation = gql`
       mutation {
         createAuthor(firstName: "John", lastName: "Smith") {
@@ -1827,9 +1828,9 @@ describe('QueryManager', () => {
         expect(stripSymbols(result.data)).toEqual(transformedMutationResult);
         resolve();
       });
-  }));
+  });
 
-  it('should reject a query promise given a network error', () => new Promise((resolve, reject) => {
+  itAsync('should reject a query promise given a network error', (resolve, reject) => {
     const query = gql`
       query {
         author {
@@ -1856,9 +1857,9 @@ describe('QueryManager', () => {
         resolve();
       })
       .then(resolve, reject);
-  }));
+  });
 
-  it('should reject a query promise given a GraphQL error', () => new Promise((resolve, reject) => {
+  itAsync('should reject a query promise given a GraphQL error', (resolve, reject) => {
     const query = gql`
       query {
         author {
@@ -1884,9 +1885,9 @@ describe('QueryManager', () => {
           expect(!apolloError.networkError).toBeTruthy();
         },
       ).then(resolve, reject);
-  }));
+  });
 
-  it('should not empty the store when a non-polling query fails due to a network error', () => new Promise((resolve, reject) => {
+  itAsync('should not empty the store when a non-polling query fails due to a network error', (resolve, reject) => {
     const query = gql`
       query {
         author {
@@ -1935,9 +1936,9 @@ describe('QueryManager', () => {
       .catch(() => {
         reject(new Error('Threw an error on the first query.'));
       });
-  }));
+  });
 
-  it('should be able to unsubscribe from a polling query subscription', () => new Promise((resolve, reject) => {
+  itAsync('should be able to unsubscribe from a polling query subscription', (resolve, reject) => {
     const query = gql`
       query {
         author {
@@ -1970,9 +1971,9 @@ describe('QueryManager', () => {
     );
 
     return promise.then(resolve, reject);
-  }));
+  });
 
-  it('should not empty the store when a polling query fails due to a network error', () => new Promise((resolve, reject) => {
+  itAsync('should not empty the store when a polling query fails due to a network error', (resolve, reject) => {
     const query = gql`
       query {
         author {
@@ -2022,9 +2023,9 @@ describe('QueryManager', () => {
         ).toEqual(data.author);
       },
     ).then(resolve, reject);
-  }));
+  });
 
-  it('should not fire next on an observer if there is no change in the result', () => new Promise((resolve, reject) => {
+  itAsync('should not fire next on an observer if there is no change in the result', (resolve, reject) => {
     const query = gql`
       query {
         author {
@@ -2063,9 +2064,9 @@ describe('QueryManager', () => {
         expect(stripSymbols(result.data)).toEqual(data);
       }),
     ]).then(resolve, reject);
-  }));
+  });
 
-  it('should store metadata with watched queries', () => new Promise((resolve, reject) => {
+  itAsync('should store metadata with watched queries', (resolve, reject) => {
     const query = gql`
       query {
         author {
@@ -2098,9 +2099,9 @@ describe('QueryManager', () => {
         foo: 'bar',
       });
     }).then(resolve, reject);
-  }));
+  });
 
-  it('should return stale data when we orphan a real-id node in the store with a real-id node', () => new Promise((resolve, reject) => {
+  itAsync('should return stale data when we orphan a real-id node in the store with a real-id node', (resolve, reject) => {
     const query1 = gql`
       query {
         author {
@@ -2203,9 +2204,9 @@ describe('QueryManager', () => {
         },
       ),
     ]).then(resolve, reject);
-  }));
+  });
 
-  it('should return partial data when configured when we orphan a real-id node in the store with a real-id node', () => new Promise((resolve, reject) => {
+  itAsync('should return partial data when configured when we orphan a real-id node in the store with a real-id node', (resolve, reject) => {
     const query1 = gql`
       query {
         author {
@@ -2318,9 +2319,9 @@ describe('QueryManager', () => {
         },
       ),
     ]).then(resolve, reject);
-  }));
+  });
 
-  it('should error if we replace a real id node in the store with a generated id node', () => new Promise((resolve, reject) => {
+  itAsync('should error if we replace a real id node in the store with a generated id node', (resolve, reject) => {
     const queryWithId = gql`
       query {
         author {
@@ -2385,9 +2386,9 @@ describe('QueryManager', () => {
         wait: 60,
       }),
     ]).then(resolve, reject);
-  }));
+  });
 
-  it('should not error when merging a generated id store node  with a real id node', () => new Promise((resolve, reject) => {
+  itAsync('should not error when merging a generated id store node  with a real id node', (resolve, reject) => {
     const queryWithoutId = gql`
       query {
         author {
@@ -2473,9 +2474,9 @@ describe('QueryManager', () => {
         expect(stripSymbols(result.data)).toEqual(dataWithId),
       ),
     ]).then(resolve, reject);
-  }));
+  });
 
-  it('exposes errors on a refetch as a rejection', () => new Promise(async (resolve, reject) => {
+  itAsync('exposes errors on a refetch as a rejection', async (resolve, reject) => {
     const request = {
       query: gql`
         {
@@ -2532,9 +2533,9 @@ describe('QueryManager', () => {
         checkError(error);
       })
       .then(resolve, reject);
-  }));
+  });
 
-  it('does not return incomplete data when two queries for the same item are executed', () => new Promise((resolve, reject) => {
+  itAsync('does not return incomplete data when two queries for the same item are executed', (resolve, reject) => {
     const queryA = gql`
       query queryA {
         person(id: "abc") {
@@ -2614,10 +2615,10 @@ describe('QueryManager', () => {
         });
       }),
     ]).then(resolve, reject);
-  }));
+  });
 
   describe('polling queries', () => {
-    it('allows you to poll queries', () => new Promise((resolve, reject) => {
+    itAsync('allows you to poll queries', (resolve, reject) => {
       const query = gql`
         query fetchLuke($id: String) {
           people_one(id: $id) {
@@ -2665,9 +2666,9 @@ describe('QueryManager', () => {
         result => expect(stripSymbols(result.data)).toEqual(data1),
         result => expect(stripSymbols(result.data)).toEqual(data2),
       ).then(resolve, reject);
-    }));
+    });
 
-    it('does not poll during SSR', () => new Promise((resolve, reject) => {
+    itAsync('does not poll during SSR', (resolve, reject) => {
       const query = gql`
         query fetchLuke($id: String) {
           people_one(id: $id) {
@@ -2737,9 +2738,9 @@ describe('QueryManager', () => {
           }
         },
       });
-    }));
+    });
 
-    it('should let you handle multiple polled queries and unsubscribe from one of them', () => new Promise((resolve, reject) => {
+    itAsync('should let you handle multiple polled queries and unsubscribe from one of them', (resolve, reject) => {
       const query1 = gql`
         query {
           author {
@@ -2854,9 +2855,9 @@ describe('QueryManager', () => {
 
         resolve();
       }, 400);
-    }));
+    });
 
-    it('allows you to unsubscribe from polled queries', () => new Promise((resolve, reject) => {
+    itAsync('allows you to unsubscribe from polled queries', (resolve, reject) => {
       const query = gql`
         query fetchLuke($id: String) {
           people_one(id: $id) {
@@ -2914,9 +2915,9 @@ describe('QueryManager', () => {
       );
 
       return promise.then(resolve, reject);
-    }));
+    });
 
-    it('allows you to unsubscribe from polled query errors', () => new Promise((resolve, reject) => {
+    itAsync('allows you to unsubscribe from polled query errors', (resolve, reject) => {
       const query = gql`
         query fetchLuke($id: String) {
           people_one(id: $id) {
@@ -2989,9 +2990,9 @@ describe('QueryManager', () => {
           resolve();
         }, 4);
       });
-    }));
+    });
 
-    it('exposes a way to start a polling query', () => new Promise((resolve, reject) => {
+    itAsync('exposes a way to start a polling query', (resolve, reject) => {
       const query = gql`
         query fetchLuke($id: String) {
           people_one(id: $id) {
@@ -3040,9 +3041,9 @@ describe('QueryManager', () => {
         result => expect(stripSymbols(result.data)).toEqual(data1),
         result => expect(stripSymbols(result.data)).toEqual(data2),
       ).then(resolve, reject);
-    }));
+    });
 
-    it('exposes a way to stop a polling query', () => new Promise((resolve, reject) => {
+    itAsync('exposes a way to stop a polling query', (resolve, reject) => {
       const query = gql`
         query fetchLeia($id: String) {
           people_one(id: $id) {
@@ -3088,9 +3089,9 @@ describe('QueryManager', () => {
         expect(stripSymbols(result.data)).toEqual(data1);
         observable.stopPolling();
       }).then(resolve, reject);
-    }));
+    });
 
-    it('stopped polling queries still get updates', () => new Promise((resolve, reject) => {
+    itAsync('stopped polling queries still get updates', (resolve, reject) => {
       const query = gql`
         query fetchLeia($id: String) {
           people_one(id: $id) {
@@ -3150,10 +3151,10 @@ describe('QueryManager', () => {
           timeout = (error: Error) => reject(error);
         }),
       ]).then(resolve, reject);
-    }));
+    });
   });
   describe('store resets', () => {
-    it('returns a promise resolving when all queries have been refetched', () => new Promise((resolve, reject) => {
+    itAsync('returns a promise resolving when all queries have been refetched', (resolve, reject) => {
       const query = gql`
         query {
           author {
@@ -3246,9 +3247,9 @@ describe('QueryManager', () => {
           expect(stripSymbols(result2.data)).toEqual(data2Changed);
         });
       }).then(resolve, reject);
-    }));
+    });
 
-    it('should change the store state to an empty state', () => new Promise((resolve, reject) => {
+    itAsync('should change the store state to an empty state', (resolve, reject) => {
       const queryManager = createQueryManager({
         link: mockSingleLink(reject),
       });
@@ -3262,7 +3263,7 @@ describe('QueryManager', () => {
       expect(queryManager.mutationStore.getStore()).toEqual({});
 
       resolve();
-    }));
+    });
 
     xit('should only refetch once when we store reset', () => {
       let queryManager: QueryManager<NormalizedCacheObject>;
@@ -3322,7 +3323,7 @@ describe('QueryManager', () => {
       );
     });
 
-    it('should not refetch torn-down queries', () => new Promise((resolve, reject) => {
+    itAsync('should not refetch torn-down queries', (resolve, reject) => {
       let queryManager: QueryManager<NormalizedCacheObject>;
       let observable: ObservableQuery<any>;
       const query = gql`
@@ -3368,7 +3369,7 @@ describe('QueryManager', () => {
           resolve();
         }, 50);
       });
-    }));
+    });
 
     it('should not error on queries that are already in the store', () => {
       let queryManager: QueryManager<NormalizedCacheObject>;
@@ -3434,7 +3435,7 @@ describe('QueryManager', () => {
       );
     });
 
-    it('should not error on a stopped query()', () => new Promise((resolve, reject) => {
+    itAsync('should not error on a stopped query()', (resolve, reject) => {
       let queryManager: QueryManager<NormalizedCacheObject>;
       const query = gql`
         query {
@@ -3468,9 +3469,9 @@ describe('QueryManager', () => {
 
       queryManager.removeQuery(queryId);
       queryManager.resetStore().then(resolve, reject);
-    }));
+    });
 
-    it('should throw an error on an inflight fetch query if the store is reset', () => new Promise((resolve, reject) => {
+    itAsync('should throw an error on an inflight fetch query if the store is reset', (resolve, reject) => {
       const query = gql`
         query {
           author {
@@ -3502,9 +3503,9 @@ describe('QueryManager', () => {
       // Need to delay the reset at least until the fetchRequest method
       // has had a chance to enter this request into fetchQueryRejectFns.
       setTimeout(() => queryManager.resetStore(), 100);
-    }));
+    });
 
-    it('should call refetch on a mocked Observable if the store is reset', () => new Promise((resolve, reject) => {
+    itAsync('should call refetch on a mocked Observable if the store is reset', (resolve, reject) => {
       const query = gql`
         query {
           author {
@@ -3530,9 +3531,9 @@ describe('QueryManager', () => {
       const queryId = 'super-fake-id';
       queryManager.addObservableQuery<any>(queryId, mockObservableQuery);
       queryManager.resetStore();
-    }));
+    });
 
-    it('should not call refetch on a cache-only Observable if the store is reset', () => new Promise((resolve, reject) => {
+    itAsync('should not call refetch on a cache-only Observable if the store is reset', (resolve, reject) => {
       const query = gql`
         query {
           author {
@@ -3566,9 +3567,9 @@ describe('QueryManager', () => {
         expect(refetchCount).toEqual(0);
         resolve();
       }, 50);
-    }));
+    });
 
-    it('should not call refetch on a standby Observable if the store is reset', () => new Promise((resolve, reject) => {
+    itAsync('should not call refetch on a standby Observable if the store is reset', (resolve, reject) => {
       const query = gql`
         query {
           author {
@@ -3602,9 +3603,9 @@ describe('QueryManager', () => {
         expect(refetchCount).toEqual(0);
         resolve();
       }, 50);
-    }));
+    });
 
-    it('should throw an error on an inflight query() if the store is reset', () => new Promise((resolve, reject) => {
+    itAsync('should throw an error on an inflight query() if the store is reset', (resolve, reject) => {
       let queryManager: QueryManager<NormalizedCacheObject>;
       const query = gql`
         query {
@@ -3640,10 +3641,10 @@ describe('QueryManager', () => {
         .catch(() => {
           resolve();
         });
-    }));
+    });
   });
   describe('refetching observed queries', () => {
-    it('returns a promise resolving when all queries have been refetched', () => new Promise((resolve, reject) => {
+    itAsync('returns a promise resolving when all queries have been refetched', (resolve, reject) => {
       const query = gql`
         query {
           author {
@@ -3736,9 +3737,9 @@ describe('QueryManager', () => {
           expect(stripSymbols(result2.data)).toEqual(data2Changed);
         });
       }).then(resolve, reject);
-    }));
+    });
 
-    it('should only refetch once when we refetch observable queries', () => new Promise((resolve, reject) => {
+    itAsync('should only refetch once when we refetch observable queries', (resolve, reject) => {
       let queryManager: QueryManager<NormalizedCacheObject>;
       const query = gql`
         query {
@@ -3797,9 +3798,9 @@ describe('QueryManager', () => {
       ).catch(e => {
         reject(e);
       });
-    }));
+    });
 
-    it('should not refetch torn-down queries', () => new Promise((resolve, reject) => {
+    itAsync('should not refetch torn-down queries', (resolve, reject) => {
       let queryManager: QueryManager<NormalizedCacheObject>;
       let observable: ObservableQuery<any>;
       const query = gql`
@@ -3845,7 +3846,7 @@ describe('QueryManager', () => {
           resolve();
         }, 50);
       });
-    }));
+    });
 
     it('should not error on queries that are already in the store', () => {
       let queryManager: QueryManager<NormalizedCacheObject>;
@@ -3897,7 +3898,7 @@ describe('QueryManager', () => {
       );
     });
 
-    it('should NOT throw an error on an inflight fetch query if the observable queries are refetched', () => new Promise((resolve, reject) => {
+    itAsync('should NOT throw an error on an inflight fetch query if the observable queries are refetched', (resolve, reject) => {
       const query = gql`
         query {
           author {
@@ -3924,9 +3925,9 @@ describe('QueryManager', () => {
           reject(new Error('Should not return an error'));
         });
       queryManager.reFetchObservableQueries();
-    }));
+    });
 
-    it('should call refetch on a mocked Observable if the observed queries are refetched', () => new Promise((resolve, reject) => {
+    itAsync('should call refetch on a mocked Observable if the observed queries are refetched', (resolve, reject) => {
       const query = gql`
         query {
           author {
@@ -3952,9 +3953,9 @@ describe('QueryManager', () => {
       const queryId = 'super-fake-id';
       queryManager.addObservableQuery<any>(queryId, mockObservableQuery);
       queryManager.reFetchObservableQueries();
-    }));
+    });
 
-    it('should not call refetch on a cache-only Observable if the observed queries are refetched', () => new Promise((resolve, reject) => {
+    itAsync('should not call refetch on a cache-only Observable if the observed queries are refetched', (resolve, reject) => {
       const query = gql`
         query {
           author {
@@ -3988,9 +3989,9 @@ describe('QueryManager', () => {
         expect(refetchCount).toEqual(0);
         resolve();
       }, 50);
-    }));
+    });
 
-    it('should not call refetch on a standby Observable if the observed queries are refetched', () => new Promise((resolve, reject) => {
+    itAsync('should not call refetch on a standby Observable if the observed queries are refetched', (resolve, reject) => {
       const query = gql`
         query {
           author {
@@ -4024,9 +4025,9 @@ describe('QueryManager', () => {
         expect(refetchCount).toEqual(0);
         resolve();
       }, 50);
-    }));
+    });
 
-    it('should refetch on a standby Observable if the observed queries are refetched and the includeStandby parameter is set to true', () => new Promise((resolve, reject) => {
+    itAsync('should refetch on a standby Observable if the observed queries are refetched and the includeStandby parameter is set to true', (resolve, reject) => {
       const query = gql`
         query {
           author {
@@ -4061,9 +4062,9 @@ describe('QueryManager', () => {
         expect(refetchCount).toEqual(1);
         resolve();
       }, 50);
-    }));
+    });
 
-    it('should NOT throw an error on an inflight query() if the observed queries are refetched', () => new Promise((resolve, reject) => {
+    itAsync('should NOT throw an error on an inflight query() if the observed queries are refetched', (resolve, reject) => {
       let queryManager: QueryManager<NormalizedCacheObject>;
       const query = gql`
         query {
@@ -4103,11 +4104,11 @@ describe('QueryManager', () => {
             ),
           );
         });
-    }));
+    });
   });
 
   describe('loading state', () => {
-    it('should be passed as false if we are not watching a query', () => new Promise((resolve, reject) => {
+    itAsync('should be passed as false if we are not watching a query', (resolve, reject) => {
       const query = gql`
         query {
           fortuneCookie
@@ -4126,9 +4127,9 @@ describe('QueryManager', () => {
           expect(stripSymbols(result.data)).toEqual(data);
         })
         .then(resolve, reject);
-    }));
+    });
 
-    it('should be passed to the observer as true if we are returning partial data', () => new Promise((resolve, reject) => {
+    itAsync('should be passed to the observer as true if we are returning partial data', (resolve, reject) => {
       const fortuneCookie =
         'You must stick to your goal but rethink your approach';
       const primeQuery = gql`
@@ -4183,9 +4184,9 @@ describe('QueryManager', () => {
           );
         })
         .then(resolve, reject);
-    }));
+    });
 
-    it('should be passed to the observer as false if we are returning all the data', () => new Promise((resolve, reject) => {
+    itAsync('should be passed to the observer as false if we are returning all the data', (resolve, reject) => {
       assertWithObserver({
         reject,
         query: gql`
@@ -4211,9 +4212,9 @@ describe('QueryManager', () => {
           },
         },
       });
-    }));
+    });
 
-    it('will update on `resetStore`', () => new Promise((resolve, reject) => {
+    itAsync('will update on `resetStore`', (resolve, reject) => {
       const testQuery = gql`
         query {
           author {
@@ -4273,9 +4274,9 @@ describe('QueryManager', () => {
           },
           error: error => reject(error),
         });
-    }));
+    });
 
-    it('will be true when partial data may be returned', () => new Promise((resolve, reject) => {
+    itAsync('will be true when partial data may be returned', (resolve, reject) => {
       const query1 = gql`{
         a { x1 y1 z1 }
       }`;
@@ -4331,7 +4332,7 @@ describe('QueryManager', () => {
               error: reject,
             });
         }).then(resolve, reject);
-    }));
+    });
   });
 
   describe('refetchQueries', () => {
@@ -4350,7 +4351,7 @@ describe('QueryManager', () => {
       };
     });
 
-    it('should refetch the right query when a result is successfully returned', () => new Promise((resolve, reject) => {
+    itAsync('should refetch the right query when a result is successfully returned', (resolve, reject) => {
       const mutation = gql`
         mutation changeAuthorName {
           changeAuthorName(newName: "Jack Smith") {
@@ -4419,9 +4420,9 @@ describe('QueryManager', () => {
           expect(stripSymbols(result.data)).toEqual(secondReqData);
         },
       ).then(resolve, reject);
-    }));
+    });
 
-    it('should not warn and continue when an unknown query name is asked to refetch', () => new Promise((resolve, reject) => {
+    itAsync('should not warn and continue when an unknown query name is asked to refetch', (resolve, reject) => {
       const mutation = gql`
         mutation changeAuthorName {
           changeAuthorName(newName: "Jack Smith") {
@@ -4489,9 +4490,9 @@ describe('QueryManager', () => {
           expect(timesWarned).toBe(0);
         },
       ).then(resolve, reject);
-    }));
+    });
 
-    it('should ignore without warning a query name that is asked to refetch with no active subscriptions', () => new Promise((resolve, reject) => {
+    itAsync('should ignore without warning a query name that is asked to refetch with no active subscriptions', (resolve, reject) => {
       const mutation = gql`
         mutation changeAuthorName {
           changeAuthorName(newName: "Jack Smith") {
@@ -4555,9 +4556,9 @@ describe('QueryManager', () => {
         })
         .then(() => expect(timesWarned).toBe(0))
         .then(resolve, reject);
-    }));
+    });
 
-    it('also works with a query document and variables', () => new Promise((resolve, reject) => {
+    itAsync('also works with a query document and variables', (resolve, reject) => {
       const mutation = gql`
         mutation changeAuthorName($id: ID!) {
           changeAuthorName(newName: "Jack Smith", id: $id) {
@@ -4640,9 +4641,9 @@ describe('QueryManager', () => {
           count++;
         },
       });
-    }));
+    });
 
-    it('also works with a conditional function that returns false', () => new Promise((resolve, reject) => {
+    itAsync('also works with a conditional function that returns false', (resolve, reject) => {
       const mutation = gql`
         mutation changeAuthorName {
           changeAuthorName(newName: "Jack Smith") {
@@ -4702,9 +4703,9 @@ describe('QueryManager', () => {
         expect(stripSymbols(result.data)).toEqual(data);
         queryManager.mutate({ mutation, refetchQueries: conditional });
       }).then(resolve, reject);
-    }));
+    });
 
-    it('also works with a conditional function that returns an array of refetches', () => new Promise((resolve, reject) => {
+    itAsync('also works with a conditional function that returns an array of refetches', (resolve, reject) => {
       const mutation = gql`
         mutation changeAuthorName {
           changeAuthorName(newName: "Jack Smith") {
@@ -4768,9 +4769,9 @@ describe('QueryManager', () => {
         },
         result => expect(stripSymbols(result.data)).toEqual(secondReqData),
       ).then(resolve, reject);
-    }));
+    });
 
-    it('should refetch using the original query context (if any)', () => new Promise((resolve, reject) => {
+    itAsync('should refetch using the original query context (if any)', (resolve, reject) => {
       const mutation = gql`
         mutation changeAuthorName {
           changeAuthorName(newName: "Jack Smith") {
@@ -4848,9 +4849,9 @@ describe('QueryManager', () => {
           expect(context.headers.someHeader).toEqual(headers.someHeader);
         },
       ).then(resolve, reject);
-    }));
+    });
 
-    it('should refetch using the specified context, if provided', () => new Promise((resolve, reject) => {
+    itAsync('should refetch using the specified context, if provided', (resolve, reject) => {
       const mutation = gql`
         mutation changeAuthorName {
           changeAuthorName(newName: "Jack Smith") {
@@ -4934,7 +4935,7 @@ describe('QueryManager', () => {
           expect(context.headers.someHeader).toEqual(headers.someHeader);
         },
       ).then(resolve, reject);
-    }));
+    });
 
     afterEach(() => {
       console.warn = oldWarn;
@@ -5056,7 +5057,7 @@ describe('QueryManager', () => {
   });
 
   describe('store watchers', () => {
-    it('does not fill up the store on resolved queries', () => new Promise((resolve, reject) => {
+    itAsync('does not fill up the store on resolved queries', (resolve, reject) => {
       const query1 = gql`
         query One {
           one
@@ -5112,13 +5113,13 @@ describe('QueryManager', () => {
           expect(cache.watches.size).toBe(0);
         })
         .then(resolve, reject);
-    }));
+    });
   });
 
   describe('`no-cache` handling', () => {
-    it(
+    itAsync(
       'should return a query result (if one exists) when a `no-cache` fetch policy is used',
-      () => new Promise((resolve, reject) => {
+      (resolve, reject) => {
         const query = gql`
           query {
             author {
@@ -5152,12 +5153,12 @@ describe('QueryManager', () => {
           expect(currentResult.data).toEqual(data);
           resolve();
         });
-      })
+      },
     );
   });
 
   describe('client awareness', () => {
-    it('should pass client awareness settings into the link chain via context', () => new Promise((resolve, reject) => {
+    itAsync('should pass client awareness settings into the link chain via context', (resolve, reject) => {
       const query = gql`
         query {
           author {
@@ -5200,6 +5201,6 @@ describe('QueryManager', () => {
         expect(context.clientAwareness).toEqual(clientAwareness);
         resolve();
       });
-    }));
+    });
   });
 });

--- a/src/core/__tests__/fetchPolicies.ts
+++ b/src/core/__tests__/fetchPolicies.ts
@@ -3,6 +3,7 @@ import gql from 'graphql-tag';
 import { ApolloLink } from '../../link/core/ApolloLink';
 import { InMemoryCache } from '../../cache/inmemory/inMemoryCache';
 import { stripSymbols } from '../../__tests__/utils/stripSymbols';
+import { itAsync } from '../../__tests__/utils/itAsync';
 import { ApolloClient } from '../..';
 import subscribeAndCount from '../../__tests__/utils/subscribeAndCount';
 import { mockSingleLink } from '../../__mocks__/mockLinks';
@@ -100,7 +101,7 @@ const createMutationLink = (reject: (reason: any) => any) =>
   );
 
 describe('network-only', () => {
-  it('requests from the network even if already in cache', () => new Promise((resolve, reject) => {
+  itAsync('requests from the network even if already in cache', (resolve, reject) => {
     let called = 0;
     const inspector = new ApolloLink((operation, forward) => {
       called++;
@@ -123,9 +124,9 @@ describe('network-only', () => {
           expect(called).toBe(4);
         }),
     ).then(resolve, reject);
-  }));
+  });
 
-  it('saves data to the cache on success', () => new Promise((resolve, reject) => {
+  itAsync('saves data to the cache on success', (resolve, reject) => {
     let called = 0;
     const inspector = new ApolloLink((operation, forward) => {
       called++;
@@ -146,9 +147,9 @@ describe('network-only', () => {
         expect(called).toBe(2);
       }),
     ).then(resolve, reject);
-  }));
+  });
 
-  it('does not save data to the cache on failure', () => new Promise((resolve, reject) => {
+  itAsync('does not save data to the cache on failure', (resolve, reject) => {
     let called = 0;
     const inspector = new ApolloLink((operation, forward) => {
       called++;
@@ -177,9 +178,9 @@ describe('network-only', () => {
         expect(didFail).toBe(true);
       }))
       .then(resolve, reject);
-  }));
+  });
 
-  it('updates the cache on a mutation', () => new Promise((resolve, reject) => {
+  itAsync('updates the cache on a mutation', (resolve, reject) => {
     let called = 0;
     const inspector = new ApolloLink((operation, forward) => {
       called++;
@@ -207,11 +208,11 @@ describe('network-only', () => {
         });
       })
       .then(resolve, reject);
-  }));
+  });
 });
 
 describe('no-cache', () => {
-  it('requests from the network when not in cache', () => new Promise((resolve, reject) => {
+  itAsync('requests from the network when not in cache', (resolve, reject) => {
     let called = 0;
     const inspector = new ApolloLink((operation, forward) => {
       called++;
@@ -233,9 +234,9 @@ describe('no-cache', () => {
         expect(called).toBe(2);
       })
       .then(resolve, reject);
-  }));
+  });
 
-  it('requests from the network even if already in cache', () => new Promise((resolve, reject) => {
+  itAsync('requests from the network even if already in cache', (resolve, reject) => {
     let called = 0;
     const inspector = new ApolloLink((operation, forward) => {
       called++;
@@ -256,9 +257,9 @@ describe('no-cache', () => {
         expect(called).toBe(4);
       }),
     ).then(resolve, reject);
-  }));
+  });
 
-  it('does not save the data to the cache on success', () => new Promise((resolve, reject) => {
+  itAsync('does not save the data to the cache on success', (resolve, reject) => {
     let called = 0;
     const inspector = new ApolloLink((operation, forward) => {
       called++;
@@ -280,9 +281,9 @@ describe('no-cache', () => {
         expect(called).toBe(4);
       }),
     ).then(resolve, reject);
-  }));
+  });
 
-  it('does not save data to the cache on failure', () => new Promise((resolve, reject) => {
+  itAsync('does not save data to the cache on failure', (resolve, reject) => {
     let called = 0;
     const inspector = new ApolloLink((operation, forward) => {
       called++;
@@ -311,9 +312,9 @@ describe('no-cache', () => {
         expect(didFail).toBe(true);
       }))
       .then(resolve, reject);
-  }));
+  });
 
-  it('does not update the cache on a mutation', () => new Promise((resolve, reject) => {
+  itAsync('does not update the cache on a mutation', (resolve, reject) => {
     let called = 0;
     const inspector = new ApolloLink((operation, forward) => {
       called++;
@@ -339,11 +340,11 @@ describe('no-cache', () => {
         });
       })
       .then(resolve, reject);
-  }));
+  });
 });
 
 describe('cache-and-network', function() {
-  it('gives appropriate networkStatus for refetched queries', done => {
+  itAsync('gives appropriate networkStatus for refetched queries', (resolve, reject) => {
     const client = new ApolloClient({
       link: ApolloLink.empty(),
       cache: new InMemoryCache(),
@@ -384,7 +385,7 @@ describe('cache-and-network', function() {
       };
     }
 
-    subscribeAndCount(done, observable, (count, result) => {
+    subscribeAndCount(reject, observable, (count, result) => {
       if (count === 1) {
         expect(result).toEqual({
           data: void 0,
@@ -444,7 +445,7 @@ describe('cache-and-network', function() {
           networkStatus: NetworkStatus.ready,
           stale: false,
         });
-        done();
+        resolve();
       }
     });
   });

--- a/src/core/__tests__/scheduler.ts
+++ b/src/core/__tests__/scheduler.ts
@@ -2,6 +2,7 @@ import gql from 'graphql-tag';
 
 import { InMemoryCache } from '../../cache/inmemory/inMemoryCache';
 import { stripSymbols } from '../../__tests__/utils/stripSymbols';
+import { itAsync } from '../../__tests__/utils/itAsync';
 
 import { QueryManager } from '../QueryManager';
 import { WatchQueryOptions } from '../../core/watchQueryOptions';
@@ -36,7 +37,7 @@ function eachPollingQuery(
 }
 
 describe('QueryScheduler', () => {
-  it('should throw an error if we try to start polling a non-polling query', () => new Promise((resolve, reject) => {
+  itAsync('should throw an error if we try to start polling a non-polling query', (resolve, reject) => {
     const queryManager = new QueryManager({
       link: mockSingleLink(reject),
       cache: new InMemoryCache({ addTypename: false }),
@@ -56,9 +57,9 @@ describe('QueryScheduler', () => {
     }).toThrow();
 
     resolve();
-  }));
+  });
 
-  it('should correctly start polling queries', () => new Promise((resolve, reject) => {
+  itAsync('should correctly start polling queries', (resolve, reject) => {
     const query = gql`
       query {
         author {
@@ -96,9 +97,9 @@ describe('QueryScheduler', () => {
       queryManager.stop();
       resolve();
     }, 120);
-  }));
+  });
 
-  it('should correctly stop polling queries', () => new Promise((resolve, reject) => {
+  itAsync('should correctly stop polling queries', (resolve, reject) => {
     const query = gql`
       query {
         someAlias: author {
@@ -144,9 +145,9 @@ describe('QueryScheduler', () => {
       queryManager.stop();
       resolve();
     }, 170);
-  }));
+  });
 
-  it('should register a query and return an observable that can be unsubscribed', () => new Promise((resolve, reject) => {
+  itAsync('should register a query and return an observable that can be unsubscribed', (resolve, reject) => {
     const myQuery = gql`
       query {
         someAuthorAlias: author {
@@ -188,9 +189,9 @@ describe('QueryScheduler', () => {
       queryManager.stop();
       resolve();
     }, 100);
-  }));
+  });
 
-  it('should register a query and return an observable that can adjust interval', () => new Promise((resolve, reject) => {
+  itAsync('should register a query and return an observable that can adjust interval', (resolve, reject) => {
     const myQuery = gql`
       query {
         someAuthorAlias: author {
@@ -242,9 +243,9 @@ describe('QueryScheduler', () => {
       queryManager.stop();
       resolve();
     }, 100);
-  }));
+  });
 
-  it('should handle network errors on polling queries correctly', () => new Promise((resolve, reject) => {
+  itAsync('should handle network errors on polling queries correctly', (resolve, reject) => {
     const query = gql`
       query {
         author {
@@ -285,9 +286,9 @@ describe('QueryScheduler', () => {
         resolve();
       },
     });
-  }));
+  });
 
-  it('should not fire another query if one with the same id is in flight', () => new Promise((resolve, reject) => {
+  itAsync('should not fire another query if one with the same id is in flight', (resolve, reject) => {
     const query = gql`
       query B {
         fortuneCookie
@@ -316,9 +317,9 @@ describe('QueryScheduler', () => {
       queryManager.stop();
       resolve();
     }, 100);
-  }));
+  });
 
-  it('should add a query to an interval correctly', () => new Promise((resolve, reject) => {
+  itAsync('should add a query to an interval correctly', (resolve, reject) => {
     const query = gql`
       query {
         fortuneCookie
@@ -352,9 +353,9 @@ describe('QueryScheduler', () => {
     queryManager.stop();
 
     resolve();
-  }));
+  });
 
-  it('should add multiple queries to an interval correctly', () => new Promise((resolve, reject) => {
+  itAsync('should add multiple queries to an interval correctly', (resolve, reject) => {
     const query1 = gql`
       query {
         fortuneCookie
@@ -423,9 +424,9 @@ describe('QueryScheduler', () => {
     queryManager.stop();
 
     resolve();
-  }));
+  });
 
-  it('should remove queries from the interval list correctly', () => new Promise((resolve, reject) => {
+  itAsync('should remove queries from the interval list correctly', (resolve, reject) => {
     const query = gql`
       query {
         author {
@@ -469,9 +470,9 @@ describe('QueryScheduler', () => {
       queryManager.stop();
       resolve();
     }, 100);
-  }));
+  });
 
-  it('should correctly start new polling query after removing old one', () => new Promise((resolve, reject) => {
+  itAsync('should correctly start new polling query after removing old one', (resolve, reject) => {
     const query = gql`
       query {
         someAlias: author {
@@ -523,5 +524,5 @@ describe('QueryScheduler', () => {
         resolve();
       }, 80);
     }, 200);
-  }));
+  });
 });

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -4,6 +4,7 @@ import gql from 'graphql-tag';
 import { render, cleanup, wait } from '@testing-library/react';
 
 import { MockedProvider, mockSingleLink } from '../../testing';
+import { itAsync } from '../../../__tests__/utils/itAsync';
 import { ApolloClient } from '../../../ApolloClient';
 import { InMemoryCache } from '../../../cache/inmemory/inMemoryCache';
 import { ApolloProvider } from '../../context/ApolloProvider';
@@ -268,7 +269,7 @@ describe('useMutation Hook', () => {
   });
 
   describe('Optimistic response', () => {
-    it('should support optimistic response handling', async () => new Promise((resolve, reject) => {
+    itAsync('should support optimistic response handling', async (resolve, reject) => {
       const optimisticResponse = {
         __typename: 'Mutation',
         createTodo: {
@@ -342,6 +343,6 @@ describe('useMutation Hook', () => {
       return wait(() => {
         expect(renderCount).toBe(3);
       }).then(resolve, reject);
-    }));
+    });
   });
 });

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -268,7 +268,7 @@ describe('useMutation Hook', () => {
   });
 
   describe('Optimistic response', () => {
-    it('should support optimistic response handling', async () => {
+    it('should support optimistic response handling', async () => new Promise((resolve, reject) => {
       const optimisticResponse = {
         __typename: 'Mutation',
         createTodo: {
@@ -293,7 +293,7 @@ describe('useMutation Hook', () => {
         }
       ];
 
-      const link = mockSingleLink(...mocks);
+      const link = mockSingleLink(reject, ...mocks);
       const cache = new InMemoryCache();
       const client = new ApolloClient({
         cache,
@@ -341,7 +341,7 @@ describe('useMutation Hook', () => {
 
       return wait(() => {
         expect(renderCount).toBe(3);
-      });
-    });
+      }).then(resolve, reject);
+    }));
   });
 });

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -214,8 +214,8 @@ describe('useQuery Hook', () => {
       });
     });
 
-    it('should stop polling when the component is unmounted', async () => {
-      const mockLink = new MockLink(CAR_MOCKS);
+    it('should stop polling when the component is unmounted', async () => new Promise((resolve, reject) => {
+      const mockLink = new MockLink(error => { throw error }, CAR_MOCKS);
       const linkRequestSpy = jest.spyOn(mockLink, 'request');
       let renderCount = 0;
       const QueryComponent = ({ unmount }: { unmount: () => void }) => {
@@ -255,8 +255,8 @@ describe('useQuery Hook', () => {
 
       return wait(() => {
         expect(linkRequestSpy).toHaveBeenCalledTimes(2);
-      })
-    });
+      }).then(resolve, reject);
+    }));
 
     it(
       'should not throw an error if `stopPolling` is called manually after ' +

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -6,6 +6,7 @@ import { render, cleanup, wait } from '@testing-library/react';
 import { Observable } from '../../../utilities/observables/Observable';
 import { ApolloLink } from '../../../link/core/ApolloLink';
 import { MockedProvider, MockLink } from '../../testing';
+import { itAsync } from '../../../__tests__/utils/itAsync';
 import { ApolloClient } from '../../../ApolloClient';
 import { InMemoryCache } from '../../../cache/inmemory/inMemoryCache';
 import { ApolloProvider } from '../../context/ApolloProvider';
@@ -214,7 +215,7 @@ describe('useQuery Hook', () => {
       });
     });
 
-    it('should stop polling when the component is unmounted', async () => new Promise((resolve, reject) => {
+    itAsync('should stop polling when the component is unmounted', async (resolve, reject) => {
       const mockLink = new MockLink(error => { throw error }, CAR_MOCKS);
       const linkRequestSpy = jest.spyOn(mockLink, 'request');
       let renderCount = 0;
@@ -256,7 +257,7 @@ describe('useQuery Hook', () => {
       return wait(() => {
         expect(linkRequestSpy).toHaveBeenCalledTimes(2);
       }).then(resolve, reject);
-    }));
+    });
 
     it(
       'should not throw an error if `stopPolling` is called manually after ' +

--- a/src/react/testing/mocks/MockedProvider.tsx
+++ b/src/react/testing/mocks/MockedProvider.tsx
@@ -28,7 +28,7 @@ export class MockedProvider extends React.Component<
     const client = new ApolloClient({
       cache: cache || new Cache({ addTypename }),
       defaultOptions,
-      link: link || new MockLink(mocks || [], addTypename),
+      link: link || new MockLink(() => {}, mocks || [], addTypename),
       resolvers
     });
 

--- a/src/react/testing/utils/createClient.ts
+++ b/src/react/testing/utils/createClient.ts
@@ -11,7 +11,7 @@ export function createClient<TData>(
   variables = {},
 ): ApolloClient<NormalizedCacheObject> {
   return new ApolloClient({
-    link: mockSingleLink({
+    link: mockSingleLink(error => { throw error }, {
       request: { query, variables },
       result: { data },
     }),


### PR DESCRIPTION
Because Jest has no ability to trace uncaught exceptions back to the test responsible for throwing them, the Apollo Client test suite has been plagued for a long time by "No more mocked responses for the query" errors, often causing unrelated tests to fail.

I have finally tracked the source of these errors down to the implementation of `MockLink`, which was using `throw` to raise exceptions, potentially outside the bounds of the test for which the `MockLink` was originally created.

This gigantic commit does two things:
* Make all `done`/`done.fail`-style tests use `Promise` `resolve` and `reject` functions instead (the bulk of the changes). This is important because we don't want stray `done.fail` calls causing tests that have already passed to fail, and `resolve`/`reject` are conveniently idempotent.
* Make the mocking utilities (`MockLink`, `mockSingleLink`, etc.) require a `Promise` `reject` function, so that they can safely report errors back to the true original test that created the `Promise`.

A better testing framework would maintain an execution context for each test that allowed exceptions to be attributed to the correct test without explicitly passing around `reject` functions, but doing that right probably requires some ECMAScript language support (or at least a transpiler to simulate it). This is an exciting future possibility, but not something we can tackle here.