### PR TITLE
Avoid modifying actual cache while recording optimistic transactions.

### DIFF
--- a/src/__tests__/optimistic.ts
+++ b/src/__tests__/optimistic.ts
@@ -711,7 +711,7 @@ describe('optimistic mutation results', () => {
             mutation: todoListMutation,
             optimisticResponse: todoListOptimisticResponse,
             update: (proxy, mResult: any) => {
-              const data = client.readQuery({ query: todoListQuery }, true);
+              const data = proxy.readQuery({ query: todoListQuery }, true);
               expect(data.todoList.todos[0].text).toEqual(
                 todoListOptimisticResponse.createTodo.todos[0].text,
               );
@@ -735,7 +735,7 @@ describe('optimistic mutation results', () => {
             optimisticResponse: todoListOptimisticResponse,
             update: (proxy, mResult: any) => {
               const incomingText = mResult.data.createTodo.todos[0].text;
-              const data = client.readQuery({ query: todoListQuery }, false);
+              const data = proxy.readQuery({ query: todoListQuery }, false);
               expect(data.todoList.todos[0].text).toEqual(incomingText);
             },
           });
@@ -767,7 +767,7 @@ describe('optimistic mutation results', () => {
             mutation: todoListMutation,
             optimisticResponse: todoListOptimisticResponse,
             update: (proxy, mResult: any) => {
-              const data: any = client.readFragment(
+              const data: any = proxy.readFragment(
                 {
                   id: 'TodoList5',
                   fragment: todoListFragment,
@@ -797,7 +797,7 @@ describe('optimistic mutation results', () => {
             optimisticResponse: todoListOptimisticResponse,
             update: (proxy, mResult: any) => {
               const incomingText = mResult.data.createTodo.todos[0].text;
-              const data: any = client.readFragment(
+              const data: any = proxy.readFragment(
                 {
                   id: 'TodoList5',
                   fragment: todoListFragment,

--- a/src/cache/inmemory/__tests__/optimistic.ts
+++ b/src/cache/inmemory/__tests__/optimistic.ts
@@ -84,7 +84,7 @@ describe('optimistic cache layers', () => {
         },
       });
 
-      result2666InTransaction = readOptimistic(cache);
+      result2666InTransaction = readOptimistic(proxy);
       expect(result2666InTransaction).toEqual({
         book: {
           __typename: 'Book',
@@ -118,7 +118,7 @@ describe('optimistic cache layers', () => {
         },
       });
 
-      expect((resultCatch22 = readOptimistic(cache))).toEqual({
+      expect((resultCatch22 = readOptimistic(proxy))).toEqual({
         book: {
           __typename: 'Book',
           title: 'Catch-22',


### PR DESCRIPTION
This is potentially an observable breaking change for code that accesses the real (as opposed to optimistic) cache during optimistic updates, rather than using the provided `proxy` object.

Previously, the real `InMemoryCache` would also have its `cache.data` and `cache.optimisticData` properties temporarily updated to point to the new optimistic layer, so it would behave like the `proxy` cache for the duration of the transaction. Now, only the `proxy` object is updated, and the real cache is left untouched.

If this change causes any problems, the most likely solution is to make sure optimistic update functions only access the provided `proxy` object, if they are expecting to read or write optimistic data. See the tests that were updated in this commit for examples of this correction.

However, if the goal is to access non-optimistic data, using the real cache should now work more predictably than before, since the real cache is no longer modified during the transaction.

As a side benefit, we no longer need the `try`-`finally` block in `performTransaction`, because the `proxy` object can simply be forgotten once the transaction is done, so we no longer have to worry about resetting any temporarily modified properties of the real cache.