### PR TITLE
Provide toReference helper function in FieldFunctionOptions.

### DIFF
--- a/src/cache/inmemory/__tests__/diffAgainstStore.ts
+++ b/src/cache/inmemory/__tests__/diffAgainstStore.ts
@@ -1,6 +1,6 @@
 import gql, { disableFragmentWarnings } from 'graphql-tag';
 
-import { Reference, makeReference } from '../../../utilities/graphql/storeUtils';
+import { Reference, makeReference, isReference } from '../../../utilities/graphql/storeUtils';
 import { defaultNormalizedCacheFactory } from '../entityCache';
 import { StoreReader } from '../readFromStore';
 import { StoreWriter } from '../writeToStore';
@@ -959,12 +959,15 @@ describe('diffing queries against the store', () => {
         typePolicies: {
           Query: {
             fields: {
-              person(_, { args, parentObject: rootQuery }) {
+              person(_, { args, parentObject: rootQuery, toReference }) {
                 expect(typeof args.id).toBe('number');
-                const id = this.identify({ __typename: 'Person', id: args.id });
-                expect(id).toBe(`Person:${JSON.stringify({ id: args.id })}`);
+                const ref = toReference({ __typename: 'Person', id: args.id });
+                expect(isReference(ref)).toBe(true);
+                expect(ref).toEqual({
+                  __ref: `Person:${JSON.stringify({ id: args.id })}`,
+                });
                 const found = (rootQuery.people as Reference[]).find(
-                  person => person.__ref === id);
+                  person => person.__ref === ref.__ref);
                 expect(found).toBeTruthy();
                 return found;
               },

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -2,6 +2,7 @@ import gql from "graphql-tag";
 import { InMemoryCache } from "../inMemoryCache";
 import { StoreValue } from "../../../utilities";
 import { FieldPolicy } from "../policies";
+import { isReference } from "../../../utilities/graphql/storeUtils";
 
 describe("type policies", function () {
   const bookQuery = gql`
@@ -535,19 +536,24 @@ describe("type policies", function () {
               todos: {
                 keyArgs: [],
 
-                read(existing: any[], { args }) {
-                  return existing.slice(
+                read(existing: any[], { args, toReference }) {
+                  expect(typeof toReference).toBe("function");
+                  const slice = existing.slice(
                     args.offset,
                     args.offset + args.limit,
                   );
+                  slice.forEach(ref => expect(isReference(ref)).toBe(true));
+                  return slice;
                 },
 
-                merge(existing: any[], incoming: any[], { args }) {
+                merge(existing: any[], incoming: any[], { args, toReference }) {
+                  expect(typeof toReference).toBe("function");
                   const copy = existing ? existing.slice(0) : [];
                   const limit = args.offset + args.limit;
                   for (let i = args.offset; i < limit; ++i) {
                     copy[i] = incoming[i - args.offset];
                   }
+                  copy.forEach(todo => expect(isReference(todo)).toBe(true));
                   return copy;
                 }
               },

--- a/src/cache/inmemory/__tests__/writeToStore.ts
+++ b/src/cache/inmemory/__tests__/writeToStore.ts
@@ -1248,7 +1248,7 @@ describe('writing to the store', () => {
       const expStore = defaultNormalizedCacheFactory({
         ROOT_QUERY: {
           __typename: 'Query',
-          author: makeReference(policies.identify(data.author)),
+          author: policies.toReference(data.author),
         },
         [policies.identify(data.author)!]: {
           firstName: data.author.firstName,
@@ -1288,7 +1288,7 @@ describe('writing to the store', () => {
       const expStore = defaultNormalizedCacheFactory({
         ROOT_QUERY: {
           __typename: 'Query',
-          author: makeReference(policies.identify(data.author)),
+          author: policies.toReference(data.author),
         },
         [policies.identify(data.author)!]: {
           __typename: data.author.__typename,

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -20,6 +20,7 @@ import {
   storeKeyNameFromField,
   StoreValue,
   argumentsObjectFromField,
+  makeReference,
 } from '../../utilities/graphql/storeUtils';
 
 import { canUseWeakMap } from '../../utilities/common/canUse';
@@ -88,6 +89,7 @@ interface FieldFunctionOptions {
   parentObject: Readonly<StoreObject>;
   field: FieldNode;
   variables?: Record<string, any>;
+  toReference: Policies["toReference"];
 }
 
 interface FieldReadFunction<TExisting, TResult = TExisting> {
@@ -190,6 +192,17 @@ export class Policies {
     if (config.typePolicies) {
       this.addTypePolicies(config.typePolicies);
     }
+  }
+
+  // Bound function that returns a Reference using this.identify.
+  // Provided to read/merge functions as part of their options.
+  public toReference = (
+    object: StoreObject,
+    selectionSet?: SelectionSetNode,
+    fragmentMap?: FragmentMap,
+  ) => {
+    const id = this.identify(object, selectionSet, fragmentMap);
+    return id && makeReference(id);
   }
 
   public identify(
@@ -383,6 +396,7 @@ export class Policies {
         parentObject,
         field,
         variables,
+        toReference: this.toReference,
       });
     }
     return existing;
@@ -405,6 +419,7 @@ export class Policies {
         parentObject,
         field,
         variables,
+        toReference: this.toReference,
       });
     }
   }

--- a/src/core/__tests__/QueryManager/links.ts
+++ b/src/core/__tests__/QueryManager/links.ts
@@ -330,11 +330,11 @@ describe('Link interactions', () => {
         typePolicies: {
           Query: {
             fields: {
-              book(_, { parentObject: rootQuery, args }) {
-                const id = this.identify({ __typename: "Book", id: args.id });
-                expect(id).toEqual(`Book:${args.id}`);
+              book(_, { parentObject: rootQuery, args, toReference }) {
+                const ref = toReference({ __typename: "Book", id: args.id });
+                expect(ref).toEqual({ __ref: `Book:${args.id}` });
                 const found = (rootQuery.books as Reference[]).find(
-                  book => book.__ref === id);
+                  book => book.__ref === ref.__ref);
                 expect(found).toBeTruthy();
                 return found;
               },


### PR DESCRIPTION
It was already possible to pass an object with `__typename` and any key fields (like `id`) to the `this.identify` method in field `read` and `merge` functions, but `this.identify` only returns a string ID, whereas it's often more useful to wrap that ID with in a `{ __ref: <id> }` object.

Hence `toReference`. I considered the name `lookup` as well, but I decided it wasn't completely obvious what `lookup` would do, based on the name.

Also, `this.identify` might be inaccessible if the `read` or `merge` function is implemented using an arrow function rather than a shorthand method or normal function expression, whereas the `toReference` function is always bound to the `Policies` object.