### PR TITLE
Correct docs typo use `dataIdFromObject` not `dataObjectFromId`

### DIFF
--- a/docs/source/data/local-state.mdx
+++ b/docs/source/data/local-state.mdx
@@ -1047,7 +1047,7 @@ const client = new ApolloClient({
 
 `cache.writeData` also allows you to pass in an optional `id` property to write a fragment to an existing object in the cache. This is useful if you want to add some client-side fields to an existing object in the cache.
 
-The `id` should correspond to the object's cache key. If you're using the `InMemoryCache` and not overriding the `dataObjectFromId` config property, your cache key should be `__typename:id`.
+The `id` should correspond to the object's cache key. If you're using the `InMemoryCache` and not overriding the `dataIdFromObject` config property, your cache key should be `__typename:id`.
 
 ```js
 import { ApolloClient } from 'apollo-client';
@@ -1151,7 +1151,7 @@ const client = new ApolloClient({
 });
 ```
 
-In order to toggle our todo, we need the todo and its status from the cache, which is why we call `cache.readFragment` and pass in a fragment to retrieve it. The `id` we're passing into `cache.readFragment` refers to its cache key. If you're using the `InMemoryCache` and not overriding the `dataObjectFromId` config property, your cache key should be `__typename:id`.
+In order to toggle our todo, we need the todo and its status from the cache, which is why we call `cache.readFragment` and pass in a fragment to retrieve it. The `id` we're passing into `cache.readFragment` refers to its cache key. If you're using the `InMemoryCache` and not overriding the `dataIdFromObject` config property, your cache key should be `__typename:id`.
 
 To write the data to the cache, you can use either `cache.writeFragment` or `cache.writeData`. The only difference between the two is that `cache.writeFragment` requires that you pass in a fragment to validate that the shape of the data you're writing to the cache node is the same as the shape of the data required by the fragment. Under the hood, `cache.writeData` automatically constructs a fragment from the `data` object and `id` you pass in and calls `cache.writeFragment`.
 


### PR DESCRIPTION
This is just a small thing I noticed while reading the docs about getting the id from an object. I was a bit confused, because I tried searching the docs for dataObjectFromId, and of course didn't find anything else. ;)