### PR TITLE
Remove reference to GlobalFetch

### DIFF
--- a/packages/apollo-boost/src/index.ts
+++ b/packages/apollo-boost/src/index.ts
@@ -31,7 +31,7 @@ export interface PresetConfig {
   uri?: string | UriFunction;
   credentials?: string;
   headers?: any;
-  fetch?: GlobalFetch['fetch'];
+  fetch?: WindowOrWorkerGlobalScope['fetch'];
   fetchOptions?: HttpLink.Options;
   clientState?: ClientStateConfig;
   onError?: ErrorLink.ErrorHandler;


### PR DESCRIPTION
Per this resolved [issue](https://github.com/apollographql/apollo-link/issues/1094), apollo-boost should also remove reference to `GlobalFetch`.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->