### PR TITLE
Use CommonJS to deduplicate React context copies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/client",
-  "version": "3.0.0-alpha.8",
+  "version": "3.0.0-beta.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/client",
-  "version": "3.0.0-beta.4",
+  "version": "3.0.0-beta.5",
   "description": "A fully-featured caching GraphQL client.",
   "private": true,
   "keywords": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,11 +48,6 @@ export * from './cache/inmemory/types';
 
 export { ApolloProvider } from './react/context/ApolloProvider';
 export { ApolloConsumer } from './react/context/ApolloConsumer';
-export {
-  getApolloContext,
-  resetApolloContext,
-  ApolloContextValue
-} from './react/context/ApolloContext';
 export { useQuery } from './react/hooks/useQuery';
 export { useLazyQuery } from './react/hooks/useLazyQuery';
 export { useMutation } from './react/hooks/useMutation';

--- a/src/react/context/ApolloConsumer.tsx
+++ b/src/react/context/ApolloConsumer.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { invariant } from 'ts-invariant';
 
 import { ApolloClient } from '../../ApolloClient';
-import { getApolloContext } from './ApolloContext';
+
+const { getApolloContext } = require('./ApolloContext');
 
 export interface ApolloConsumerProps {
   children: (client: ApolloClient<object>) => React.ReactChild | null;

--- a/src/react/context/ApolloContext.ts
+++ b/src/react/context/ApolloContext.ts
@@ -1,21 +1,33 @@
-import React from 'react';
+const React = require('react');
 
-import { ApolloClient } from '../../ApolloClient';
+// IMPORTANT NOTE:
+//
+// This file is intentionally using CommonJS. It's very important to
+// create a React context for use with Apollo Client's React integration in
+// one place only. Otherwise we can end up with a situation like:
+//
+// 1. `MockedProvider` in the `testing` bundle creates its own context.
+// 2. An `ApolloClient` instance is stored in that context.
+// 3. If the application under test is being bundled by something like webpack,
+//    it can create its own separate context (since it's following the ESM
+//    source).
+// 4. This leads to the Apollo Client instance not being found in the
+//    separate application context.
+//
+// By using CJS to refer to this file across the entire codebase,
+// we ensure that we're only ever pointing to one copy of the source. We're
+// not pointing to a copy that has been converted to CJS when bundling
+// `apollo-client.cjs.js` or the `testing` bundle.
 
-export interface ApolloContextValue {
-  client?: ApolloClient<object>;
-  renderPromises?: Record<any, any>;
-}
+let apolloContext: any;
 
-let apolloContext: React.Context<ApolloContextValue>;
-
-export function getApolloContext() {
+exports.getApolloContext = function getApolloContext() {
   if (!apolloContext) {
-    apolloContext = React.createContext<ApolloContextValue>({});
+    apolloContext = React.createContext({});
   }
   return apolloContext;
 }
 
-export function resetApolloContext() {
-  apolloContext = React.createContext<ApolloContextValue>({});
+exports.resetApolloContext = function resetApolloContext() {
+  apolloContext = React.createContext({});
 }

--- a/src/react/context/ApolloProvider.tsx
+++ b/src/react/context/ApolloProvider.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { invariant } from 'ts-invariant';
 
 import { ApolloClient } from '../../ApolloClient';
-import { getApolloContext } from './ApolloContext';
+
+const { getApolloContext } = require('./ApolloContext');
 
 export interface ApolloProviderProps<TCache> {
   client: ApolloClient<TCache>;
@@ -16,7 +17,7 @@ export const ApolloProvider: React.FC<ApolloProviderProps<any>> = ({
   const ApolloContext = getApolloContext();
   return (
     <ApolloContext.Consumer>
-      {(context = {}) => {
+      {(context: any = {}) => {
         if (client && context.client !== client) {
           context = Object.assign({}, context, { client });
         }

--- a/src/react/context/__tests__/ApolloConsumer.test.tsx
+++ b/src/react/context/__tests__/ApolloConsumer.test.tsx
@@ -6,7 +6,8 @@ import { ApolloClient } from '../../../ApolloClient';
 import { InMemoryCache as Cache } from '../../../cache/inmemory/inMemoryCache';
 import { ApolloProvider } from '../ApolloProvider';
 import { ApolloConsumer } from '../ApolloConsumer';
-import { getApolloContext } from '../ApolloContext';
+
+const { getApolloContext } = require('../ApolloContext');
 
 const client = new ApolloClient({
   cache: new Cache(),

--- a/src/react/context/__tests__/ApolloProvider.test.tsx
+++ b/src/react/context/__tests__/ApolloProvider.test.tsx
@@ -5,7 +5,8 @@ import { ApolloLink } from '../../../link/core/ApolloLink';
 import { ApolloClient } from '../../../ApolloClient';
 import { InMemoryCache as Cache } from '../../../cache/inmemory/inMemoryCache';
 import { ApolloProvider } from '../ApolloProvider';
-import { getApolloContext } from '../ApolloContext';
+
+const { getApolloContext } = require('../ApolloContext');
 
 describe('<ApolloProvider /> Component', () => {
   afterEach(cleanup);

--- a/src/react/data/MutationData.ts
+++ b/src/react/data/MutationData.ts
@@ -1,6 +1,5 @@
 import { equal as isEqual } from '@wry/equality';
 
-import { ApolloContextValue } from '../context/ApolloContext';
 import { DocumentType } from '../parser/parser';
 import { ApolloError } from '../../errors/ApolloError';
 import {
@@ -29,7 +28,7 @@ export class MutationData<
     setResult
   }: {
     options: MutationOptions<TData, TVariables>;
-    context: ApolloContextValue;
+    context: any;
     result: MutationResult<TData>;
     setResult: (result: MutationResult<TData>) => any;
   }) {

--- a/src/react/data/OperationData.ts
+++ b/src/react/data/OperationData.ts
@@ -4,7 +4,6 @@ import { invariant } from 'ts-invariant';
 
 import { ApolloClient } from '../../ApolloClient';
 import { DocumentType, parser, operationName } from '../parser/parser';
-import { ApolloContextValue } from '../context/ApolloContext';
 import { CommonOptions } from '../types/types';
 
 export abstract class OperationData<TOptions = any> {
@@ -12,12 +11,12 @@ export abstract class OperationData<TOptions = any> {
   public previousOptions: CommonOptions<TOptions> = {} as CommonOptions<
     TOptions
   >;
-  public context: ApolloContextValue = {};
+  public context: any = {};
   public client: ApolloClient<object> | undefined;
 
   private options: CommonOptions<TOptions> = {} as CommonOptions<TOptions>;
 
-  constructor(options?: CommonOptions<TOptions>, context?: ApolloContextValue) {
+  constructor(options?: CommonOptions<TOptions>, context?: any) {
     this.options = options || ({} as CommonOptions<TOptions>);
     this.context = context || {};
   }

--- a/src/react/data/QueryData.ts
+++ b/src/react/data/QueryData.ts
@@ -11,7 +11,6 @@ import {
   FetchMoreOptions,
   UpdateQueryOptions
 } from '../../core/ObservableQuery';
-import { ApolloContextValue } from '../context/ApolloContext';
 import { DocumentType } from '../parser/parser';
 import {
   QueryResult,
@@ -38,7 +37,7 @@ export class QueryData<TData, TVariables> extends OperationData {
     forceUpdate
   }: {
     options: QueryOptions<TData, TVariables>;
-    context: ApolloContextValue;
+    context: any;
     forceUpdate: any;
   }) {
     super(options, context);

--- a/src/react/data/SubscriptionData.ts
+++ b/src/react/data/SubscriptionData.ts
@@ -1,6 +1,5 @@
 import { equal as isEqual } from '@wry/equality';
 
-import { ApolloContextValue } from '../context/ApolloContext';
 import { OperationData } from './OperationData';
 import {
   SubscriptionCurrentObservable,
@@ -21,7 +20,7 @@ export class SubscriptionData<
     setResult
   }: {
     options: SubscriptionOptions<TData, TVariables>;
-    context: ApolloContextValue;
+    context: any;
     setResult: any;
   }) {
     super(options, context);

--- a/src/react/hooks/__tests__/useApolloClient.test.tsx
+++ b/src/react/hooks/__tests__/useApolloClient.test.tsx
@@ -4,10 +4,11 @@ import { InvariantError } from 'ts-invariant';
 
 import { ApolloLink } from '../../../link/core/ApolloLink';
 import { ApolloProvider } from '../../context/ApolloProvider';
-import { resetApolloContext } from '../../context/ApolloContext';
 import { ApolloClient } from '../../../ApolloClient';
 import { InMemoryCache } from '../../../cache/inmemory/inMemoryCache';
 import { useApolloClient } from '../useApolloClient';
+
+const { resetApolloContext } = require('../../context/ApolloContext');
 
 describe('useApolloClient Hook', () => {
   afterEach(() => {

--- a/src/react/hooks/useApolloClient.ts
+++ b/src/react/hooks/useApolloClient.ts
@@ -2,7 +2,8 @@ import React from 'react';
 import { invariant } from 'ts-invariant';
 
 import { ApolloClient } from '../../ApolloClient';
-import { getApolloContext } from '../context/ApolloContext';
+
+const { getApolloContext } = require('../context/ApolloContext');
 
 export function useApolloClient(): ApolloClient<object> {
   const { client } = React.useContext(getApolloContext());

--- a/src/react/hooks/useMutation.ts
+++ b/src/react/hooks/useMutation.ts
@@ -1,10 +1,11 @@
 import { useContext, useState, useRef, useEffect } from 'react';
 import { DocumentNode } from 'graphql';
 
-import { getApolloContext } from '../context/ApolloContext';
 import { MutationHookOptions, MutationTuple } from '../types/types';
 import { MutationData } from '../data/MutationData';
 import { OperationVariables } from '../../core/types';
+
+const { getApolloContext } = require('../context/ApolloContext');
 
 export function useMutation<TData = any, TVariables = OperationVariables>(
   mutation: DocumentNode,

--- a/src/react/hooks/useSubscription.ts
+++ b/src/react/hooks/useSubscription.ts
@@ -1,10 +1,11 @@
 import { useContext, useState, useRef, useEffect } from 'react';
 import { DocumentNode } from 'graphql';
 
-import { getApolloContext } from '../context/ApolloContext';
 import { SubscriptionHookOptions } from '../types/types';
 import { SubscriptionData } from '../data/SubscriptionData';
 import { OperationVariables } from '../../core/types';
+
+const { getApolloContext } = require('../context/ApolloContext');
 
 export function useSubscription<TData = any, TVariables = OperationVariables>(
   subscription: DocumentNode,

--- a/src/react/hooks/utils/useBaseQuery.ts
+++ b/src/react/hooks/utils/useBaseQuery.ts
@@ -1,7 +1,6 @@
 import { useContext, useEffect, useReducer, useRef } from 'react';
 import { DocumentNode } from 'graphql';
 
-import { getApolloContext } from '../../context/ApolloContext';
 import {
   QueryHookOptions,
   QueryOptions,
@@ -11,6 +10,8 @@ import {
 import { QueryData } from '../../data/QueryData';
 import { useDeepMemo } from './useDeepMemo';
 import { OperationVariables } from '../../../core/types';
+
+const { getApolloContext } = require('../../context/ApolloContext');
 
 export function useBaseQuery<TData = any, TVariables = OperationVariables>(
   query: DocumentNode,


### PR DESCRIPTION
I was hopeful the changes made in https://github.com/apollographql/apollo-client/commit/e53d1e3f37924432261aa0954fdf39170b0e29e4 would have fixed the issues we were seeing with multiple React contexts being created (usually one for testing utilities like `MockedProvider`, another for the application under test). While those changes do work in most cases, the approach of always pulling the `ApolloProvider` from the `apollo-client.cjs.js` bundle confuses some tools/webpack configs, like Storybook.

This PR replaces the previous approach by ensuring the `ApolloContext` code is only ever referenced using CommonJS. By using CJS to refer to this file across the entire codebase, we ensure that we're only ever pointing to one copy of the source. We're not pointing to a copy that has been converted to CJS when bundling `apollo-client.cjs.js` or the `testing` bundle, then using a different copy that was bundled from the ESM source. 

This approach seems to resolve the multiple context issue across all boundaries. The `ApolloContext` file is very simple, so we're not losing much by using CJS (we're no longer exporting `ApolloContext` from Apollo Client, and tree-shaking/DCE can still remove the code that refers to `ApolloContext`).