### PR TITLE
Avoid reading from cache in ObservableQuery#getCurrentResult.

### DIFF
--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1,4 +1,3 @@
-import { GraphQLError } from 'graphql';
 import { invariant, InvariantError } from 'ts-invariant';
 
 import { isEqual } from '../utilities/common/isEqual';
@@ -19,13 +18,8 @@ import {
 import { QueryStoreValue } from '../data/queries';
 import { isNonEmptyArray } from '../utilities/common/arrays';
 
-export type ApolloCurrentQueryResult<T> = {
-  data: T | undefined;
-  errors?: ReadonlyArray<GraphQLError>;
-  loading: boolean;
-  networkStatus: NetworkStatus;
+export type ApolloCurrentQueryResult<T> = ApolloQueryResult<T> & {
   error?: ApolloError;
-  stale?: boolean;
 };
 
 export interface FetchMoreOptions<
@@ -154,6 +148,7 @@ export class ObservableQuery<
       error: this.lastError,
       loading: isNetworkRequestInFlight(networkStatus),
       networkStatus,
+      stale: lastResult ? lastResult.stale : false,
     };
 
     if (this.isTornDown) {
@@ -198,7 +193,7 @@ export class ObservableQuery<
       }
     }
 
-    this.updateLastResult({ ...result, stale: false });
+    this.updateLastResult(result);
 
     return result;
   }

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -25,7 +25,6 @@ export type ApolloCurrentQueryResult<T> = {
   loading: boolean;
   networkStatus: NetworkStatus;
   error?: ApolloError;
-  partial?: boolean;
   stale?: boolean;
 };
 
@@ -155,7 +154,6 @@ export class ObservableQuery<
       error: this.lastError,
       loading: isNetworkRequestInFlight(networkStatus),
       networkStatus,
-      partial: false,
     };
 
     if (this.isTornDown) {

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -137,46 +137,44 @@ export class ObservableQuery<
     });
   }
 
-  /**
-   * Return the result of the query from the local cache as well as some fetching status
-   * `loading` and `networkStatus` allow to know if a request is in flight
-   * `partial` lets you know if the result from the local cache is complete or partial
-   * @return {data: Object, error: ApolloError, loading: boolean, networkStatus: number, partial: boolean}
-   */
   public getCurrentResult(): ApolloCurrentQueryResult<TData> {
-    if (this.isTornDown) {
-      const { lastResult } = this;
-      return {
-        data: !this.lastError && lastResult && lastResult.data || void 0,
-        error: this.lastError,
-        loading: false,
-        networkStatus: NetworkStatus.error,
-      };
-    }
-
-    const { data, partial } = this.queryManager.getCurrentQueryResult(this);
-    const queryStoreValue = this.queryManager.queryStore.get(this.queryId);
-    let result: ApolloQueryResult<TData>;
-
+    const { lastResult, lastError } = this;
     const { fetchPolicy } = this.options;
-
     const isNetworkFetchPolicy =
       fetchPolicy === 'network-only' ||
       fetchPolicy === 'no-cache';
 
+    const networkStatus =
+      lastError ? NetworkStatus.error :
+      lastResult ? lastResult.networkStatus :
+      isNetworkFetchPolicy ? NetworkStatus.loading :
+      NetworkStatus.ready;
+
+    const result: ApolloCurrentQueryResult<TData> = {
+      data: !lastError && lastResult && lastResult.data || void 0,
+      error: this.lastError,
+      loading: isNetworkRequestInFlight(networkStatus),
+      networkStatus,
+      partial: false,
+    };
+
+    if (this.isTornDown) {
+      return result;
+    }
+
+    const queryStoreValue = this.queryManager.queryStore.get(this.queryId);
     if (queryStoreValue) {
       const { networkStatus } = queryStoreValue;
 
       if (hasError(queryStoreValue, this.options.errorPolicy)) {
-        return {
+        return Object.assign(result, {
           data: void 0,
-          loading: false,
           networkStatus,
           error: new ApolloError({
             graphQLErrors: queryStoreValue.graphQLErrors,
             networkError: queryStoreValue.networkError,
           }),
-        };
+        });
       }
 
       // Variables might have been added dynamically at query time, when
@@ -192,38 +190,19 @@ export class ObservableQuery<
         this.variables = this.options.variables;
       }
 
-      result = {
-        data,
+      Object.assign(result, {
         loading: isNetworkRequestInFlight(networkStatus),
         networkStatus,
-      } as ApolloQueryResult<TData>;
+      });
 
       if (queryStoreValue.graphQLErrors && this.options.errorPolicy === 'all') {
         result.errors = queryStoreValue.graphQLErrors;
       }
-
-    } else {
-      // We need to be careful about the loading state we show to the user, to try
-      // and be vaguely in line with what the user would have seen from .subscribe()
-      // but to still provide useful information synchronously when the query
-      // will not end up hitting the server.
-      // See more: https://github.com/apollostack/apollo-client/issues/707
-      // Basically: is there a query in flight right now (modolo the next tick)?
-      const loading = isNetworkFetchPolicy ||
-        (partial && fetchPolicy !== 'cache-only');
-
-      result = {
-        data,
-        loading,
-        networkStatus: loading ? NetworkStatus.loading : NetworkStatus.ready,
-      } as ApolloQueryResult<TData>;
     }
 
-    if (!partial) {
-      this.updateLastResult({ ...result, stale: false });
-    }
+    this.updateLastResult({ ...result, stale: false });
 
-    return { ...result, partial };
+    return result;
   }
 
   // Compares newResult to the snapshot we took of this.lastResult when it was

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -545,6 +545,9 @@ export class ObservableQuery<
     this.lastResultSnapshot = this.queryManager.assumeImmutableResults
       ? newResult
       : cloneDeep(newResult);
+    if (!isNonEmptyArray(newResult.errors)) {
+      delete this.lastError;
+    }
     return previousResult;
   }
 

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -765,11 +765,24 @@ export class QueryManager<TStore> {
 
     let transformedOptions = { ...options } as WatchQueryOptions<TVariables>;
 
-    return new ObservableQuery<T, TVariables>({
+    const observable = new ObservableQuery<T, TVariables>({
       queryManager: this,
       options: transformedOptions,
       shouldSubscribe: shouldSubscribe,
     });
+
+    this.queryStore.initQuery({
+      queryId: observable.queryId,
+      document: this.transform(options.query).document,
+      variables: options.variables,
+      storePreviousVariables: false,
+      isPoll: typeof options.pollInterval === 'number',
+      isRefetch: false,
+      metadata: options.metadata,
+      fetchMoreForQueryId: void 0,
+    });
+
+    return observable;
   }
 
   public query<T>(options: QueryOptions): Promise<ApolloQueryResult<T>> {

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -431,9 +431,9 @@ export class QueryManager<TStore> {
       fetchMoreForQueryId,
     });
 
-    this.broadcastQueries();
-
     if (shouldFetch) {
+      this.broadcastQueries();
+
       const networkResult = this.fetchRequest<T>({
         requestId,
         queryId,

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1047,7 +1047,7 @@ export class QueryManager<TStore> {
     this.queries.delete(queryId);
   }
 
-  public getCurrentQueryResult<T>(
+  private getCurrentQueryResult<T>(
     observableQuery: ObservableQuery<T>,
     optimistic: boolean = true,
   ): {

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -472,11 +472,11 @@ describe('ObservableQuery', () => {
       });
 
       subscribeAndCount(reject, observable, async (handleCount, result) => {
-        if (handleCount === 2) {
+        if (handleCount === 1) {
           expect(stripSymbols(result.data)).toEqual({});
           expect(timesFired).toBe(0);
           await observable.setOptions({ fetchPolicy: 'cache-first' });
-        } else if (handleCount === 3) {
+        } else if (handleCount === 2) {
           expect(stripSymbols(result.data)).toEqual(data);
           expect(timesFired).toBe(1);
           resolve();

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -1449,7 +1449,6 @@ describe('ObservableQuery', () => {
           data: dataOne,
           loading: false,
           networkStatus: 7,
-          partial: false,
         });
         resolve();
       });
@@ -1458,7 +1457,6 @@ describe('ObservableQuery', () => {
         loading: true,
         data: undefined,
         networkStatus: 1,
-        partial: false,
       });
 
       setTimeout(
@@ -1467,7 +1465,6 @@ describe('ObservableQuery', () => {
             loading: true,
             data: undefined,
             networkStatus: 1,
-            partial: false,
           });
         }),
         0,
@@ -1603,7 +1600,6 @@ describe('ObservableQuery', () => {
           data: void 0,
           loading: true,
           networkStatus: 1,
-          partial: false,
         });
 
         // we can use this to trigger the query
@@ -1669,7 +1665,6 @@ describe('ObservableQuery', () => {
           data: undefined,
           loading: true,
           networkStatus: 1,
-          partial: false,
         });
 
         subscribeAndCount(reject, observable, (handleCount, subResult) => {
@@ -1732,7 +1727,6 @@ describe('ObservableQuery', () => {
           data: undefined,
           loading: true,
           networkStatus: 1,
-          partial: false,
         });
 
         subscribeAndCount(reject, observable, (handleCount, subResult) => {
@@ -1747,7 +1741,6 @@ describe('ObservableQuery', () => {
               data,
               loading,
               networkStatus,
-              partial: false,
               stale: false,
             });
           } else if (handleCount === 2) {

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -1449,6 +1449,7 @@ describe('ObservableQuery', () => {
           data: dataOne,
           loading: false,
           networkStatus: 7,
+          stale: false,
         });
         resolve();
       });
@@ -1457,6 +1458,7 @@ describe('ObservableQuery', () => {
         loading: true,
         data: undefined,
         networkStatus: 1,
+        stale: false,
       });
 
       setTimeout(
@@ -1465,6 +1467,7 @@ describe('ObservableQuery', () => {
             loading: true,
             data: undefined,
             networkStatus: 1,
+            stale: false,
           });
         }),
         0,
@@ -1600,6 +1603,7 @@ describe('ObservableQuery', () => {
           data: void 0,
           loading: true,
           networkStatus: 1,
+          stale: false,
         });
 
         // we can use this to trigger the query
@@ -1665,6 +1669,7 @@ describe('ObservableQuery', () => {
           data: undefined,
           loading: true,
           networkStatus: 1,
+          stale: false,
         });
 
         subscribeAndCount(reject, observable, (handleCount, subResult) => {
@@ -1727,6 +1732,7 @@ describe('ObservableQuery', () => {
           data: undefined,
           loading: true,
           networkStatus: 1,
+          stale: false,
         });
 
         subscribeAndCount(reject, observable, (handleCount, subResult) => {

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -1496,8 +1496,8 @@ describe('ObservableQuery', () => {
         });
         expect(stripSymbols(observable.getCurrentResult())).toEqual({
           data: dataOne,
-          loading: false,
-          networkStatus: 7,
+          loading: true,
+          networkStatus: NetworkStatus.loading,
           partial: false,
         });
       }).then(resolve, reject);

--- a/src/react/data/QueryData.ts
+++ b/src/react/data/QueryData.ts
@@ -85,11 +85,17 @@ export class QueryData<TData, TVariables> extends OperationData {
     return currentResult.loading ? obs.result() : false;
   }
 
-  public afterExecute({ lazy = false }: { lazy?: boolean } = {}) {
+  public afterExecute({
+    queryResult,
+    lazy = false,
+  }: {
+    queryResult: QueryResult<TData, TVariables>;
+    lazy?: boolean;
+  }) {
     this.isMounted = true;
 
     if (!lazy || this.runLazy) {
-      this.handleErrorOrCompleted();
+      this.handleErrorOrCompleted(queryResult);
 
       // When the component is done rendering stored query errors, we'll
       // remove those errors from the `ObservableQuery` query store, so they
@@ -396,18 +402,18 @@ export class QueryData<TData, TVariables> extends OperationData {
     }
 
     result.client = this.client;
+    // Store options as this.previousOptions.
+    this.setOptions(options, true);
     this.previousData.loading =
-      (this.previousData.result && this.previousData.result.loading) || false;
-    this.previousData.result = result;
-    return result;
+      this.previousData.result && this.previousData.result.loading || false;
+    return this.previousData.result = result;
   }
 
-  private handleErrorOrCompleted() {
-    const obsQuery = this.currentObservable.query;
-    if (!obsQuery) return;
-
-    const { data, loading, error } = obsQuery.getCurrentResult();
-
+  private handleErrorOrCompleted({
+    data,
+    loading,
+    error,
+  }: QueryResult<TData, TVariables>) {
     if (!loading) {
       const { query, variables, onCompleted, onError } = this.getOptions();
 

--- a/src/react/data/QueryData.ts
+++ b/src/react/data/QueryData.ts
@@ -340,7 +340,7 @@ export class QueryData<TData, TVariables> extends OperationData {
     } else {
       // Fetch the current result (if any) from the store.
       const currentResult = this.currentObservable.query!.getCurrentResult();
-      const { loading, partial, networkStatus, errors } = currentResult;
+      const { loading, networkStatus, errors } = currentResult;
       let { error, data } = currentResult;
 
       // Until a set naming convention for networkError and graphQLErrors is
@@ -378,7 +378,6 @@ export class QueryData<TData, TVariables> extends OperationData {
         if (
           partialRefetch &&
           !data &&
-          partial &&
           fetchPolicy !== 'cache-only'
         ) {
           // When a `Query` component is mounted, and a mutation is executed

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -382,42 +382,39 @@ describe('useQuery Hook', () => {
         cache: new InMemoryCache()
       });
 
-      const onErrorMock = jest.fn();
+      let onError;
+      const onErrorPromise = new Promise(resolve => onError = resolve);
 
       let renderCount = 0;
       const Component = () => {
         const { loading, error, refetch, data, networkStatus } = useQuery(
           query,
           {
-            onError: onErrorMock,
+            onError,
             notifyOnNetworkStatusChange: true
           }
         );
 
-        switch (renderCount) {
-          case 0:
+        switch (++renderCount) {
+          case 1:
             expect(loading).toBeTruthy();
             break;
-          case 1:
+          case 2:
             expect(loading).toBeFalsy();
             expect(error).toBeDefined();
             expect(error!.message).toEqual('Network error: Oh no!');
-            setTimeout(() => {
-              expect(onErrorMock.mock.calls.length).toBe(1);
-              refetch();
-            });
-            break;
-          case 2:
-            expect(loading).toBeTruthy();
+            onErrorPromise.then(() => refetch());
             break;
           case 3:
+            expect(loading).toBeTruthy();
+            break;
+          case 4:
             expect(loading).toBeFalsy();
             expect(data).toEqual(resultData);
             break;
           default: // Do nothing
         }
 
-        renderCount += 1;
         return null;
       };
 

--- a/src/react/hooks/utils/useBaseQuery.ts
+++ b/src/react/hooks/utils/useBaseQuery.ts
@@ -57,7 +57,7 @@ export function useBaseQuery<TData = any, TVariables = OperationVariables>(
     ? (result as QueryTuple<TData, TVariables>)[1]
     : (result as QueryResult<TData, TVariables>);
 
-  useEffect(() => queryData.afterExecute({ lazy }), [
+  useEffect(() => queryData.afterExecute({ queryResult, lazy }), [
     queryResult.loading,
     queryResult.networkStatus,
     queryResult.error,


### PR DESCRIPTION
As an exploration of potential improvements after Apollo Client 3.0, I recently attempted to make `InMemoryCache` reads asynchronous, so that custom field `read` functions could return a promise, or perhaps an async iterator, which would ultimately allow us to remove our current local state implementation, which would be a significant bundle size savings.

The bad news: I had to update a lot of tests (no surprise there) in ways that felt too drastic for the Apollo Client 3.x release line, so I think we should postpone the idea of async cache reads until at least Apollo Client 4.0. Oh well!

The silver lining: I made a series of changes to prepare for async cache reads that make lots of sense right now. Hence, the contents of this PR.

The most important change is `Stop reading from cache in ObservableQuery#getCurrentResult.` (https://github.com/apollographql/apollo-client/commit/01376a3ad09e1a806d7517cad44502b4355456af), which makes the `getCurrentResult` function return whatever result it most recently received, without falling back to reading from the cache. This change was originally intended to enable async cache reads while keeping `getCurrentResult` synchronous (which is essential for React rendering, even with Suspense), but I believe this change will also prevent a whole class of inconsistencies due to reading from the cache at arbitrary times, rather than trusting Apollo Client to deliver results from the cache at appropriate times.