### PR TITLE
Wire up the `@apollo/client/cache` entry point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@
 - `@apollo/client/core` can be used to import the Apollo Client core, which includes everything the main `@apollo/client` package does, except for all React related functionality.  <br/>
   [@kamilkisiela](https://github.com/kamilkisiela) in [#5541](https://github.com/apollographql/apollo-client/pull/5541)
 
+- `@apollo/client/cache` can be used to import the Apollo Client cache without importing other parts of the Apollo Client codebase. <br/>
+  [@hwillson](https://github.com/hwillson) in [#5577](https://github.com/apollographql/apollo-client/pull/5577)
+
 ### Breaking Changes
 
 - Removed `graphql-anywhere` since it's no longer used by Apollo Client.  <br/>

--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -82,27 +82,6 @@ function prepareCJS(input, output) {
           'graphql-tag': ['gql'],
         },
       }),
-      // When generating the `dist/core/core.cjs.js` entry point (in
-      // `config/prepareDist.js`), we filter and re-export the exports we
-      // need from the main Apollo Client CJS bundle (to exclude React related
-      // code). This means that consumers of `core.cjs.js` attempt to load the
-      // full AC CJS bundle first (before filtering exports), which then means
-      // the React require in the AC CJS bundle is attempted and not found
-      // (since people using `core.cjs.js` want to use Apollo Client without
-      // React). To address this, we make React an optional require in the CJS
-      // bundle.
-      (() => {
-        const cjsBundle = output.replace(`${distDir}/`, '');
-        return {
-          generateBundle(_option, bundle) {
-            bundle[cjsBundle].code =
-              bundle[cjsBundle].code.replace(
-                "var React = require('react');",
-                "try { var React = require('react'); } catch (error) {}"
-              );
-          }
-        }
-      })()
     ],
   };
 }

--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -82,6 +82,27 @@ function prepareCJS(input, output) {
           'graphql-tag': ['gql'],
         },
       }),
+      // When generating the `dist/core/core.cjs.js` entry point (in
+      // `config/prepareDist.js`), we filter and re-export the exports we
+      // need from the main Apollo Client CJS bundle (to exclude React related
+      // code). This means that consumers of `core.cjs.js` attempt to load the
+      // full AC CJS bundle first (before filtering exports), which then means
+      // the React require in the AC CJS bundle is attempted and not found
+      // (since people using `core.cjs.js` want to use Apollo Client without
+      // React). To address this, we make React an optional require in the CJS
+      // bundle.
+      (() => {
+        const cjsBundle = output.replace(`${distDir}/`, '');
+        return {
+          generateBundle(_option, bundle) {
+            bundle[cjsBundle].code =
+              bundle[cjsBundle].code.replace(
+                "var React = require('react');",
+                "try { var React = require('react'); } catch (error) {}"
+              );
+          }
+        }
+      })()
     ],
   };
 }

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -1,0 +1,10 @@
+export { Transaction, ApolloCache } from './core/cache';
+export { Cache } from './core/types/Cache';
+export { DataProxy } from './core/types/DataProxy';
+
+export {
+  InMemoryCache,
+  InMemoryCacheConfig,
+} from './inmemory/inMemoryCache';
+export { defaultDataIdFromObject } from './inmemory/policies';
+export * from './inmemory/types';

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -34,15 +34,7 @@ export { isApolloError, ApolloError } from '../errors/ApolloError';
 
 /* Cache */
 
-export { Transaction, ApolloCache } from '../cache/core/cache';
-export { Cache } from '../cache/core/types/Cache';
-export { DataProxy } from '../cache/core/types/DataProxy';
-export {
-  InMemoryCache,
-  InMemoryCacheConfig,
-} from '../cache/inmemory/inMemoryCache';
-export { defaultDataIdFromObject } from '../cache/inmemory/policies';
-export * from '../cache/inmemory/types';
+export * from '../cache';
 
 /* Link */
 

--- a/src/react/context/ApolloConsumer.tsx
+++ b/src/react/context/ApolloConsumer.tsx
@@ -1,14 +1,15 @@
-import React from 'react';
 import { invariant } from 'ts-invariant';
 
 import { ApolloClient } from '../../ApolloClient';
 import { getApolloContext } from './ApolloContext';
+import { requireReactLazily } from '../react';
 
 export interface ApolloConsumerProps {
   children: (client: ApolloClient<object>) => React.ReactChild | null;
 }
 
 export const ApolloConsumer: React.FC<ApolloConsumerProps> = props => {
+  const React = requireReactLazily();
   const ApolloContext = getApolloContext();
   return (
     <ApolloContext.Consumer>

--- a/src/react/context/ApolloContext.ts
+++ b/src/react/context/ApolloContext.ts
@@ -1,6 +1,5 @@
-import React from 'react';
-
 import { ApolloClient } from '../../ApolloClient';
+import { requireReactLazily } from '../react';
 
 export interface ApolloContextValue {
   client?: ApolloClient<object>;
@@ -17,6 +16,7 @@ export interface ApolloContextValue {
 const contextSymbol = Symbol.for('__APOLLO_CONTEXT__');
 
 export function resetApolloContext() {
+  const React = requireReactLazily();
   Object.defineProperty(React, contextSymbol, {
     value: React.createContext<ApolloContextValue>({}),
     enumerable: false,
@@ -26,6 +26,7 @@ export function resetApolloContext() {
 }
 
 export function getApolloContext() {
+  const React = requireReactLazily();
   if (!(React as any)[contextSymbol]) {
     resetApolloContext();
   }

--- a/src/react/context/ApolloProvider.tsx
+++ b/src/react/context/ApolloProvider.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
 import { invariant } from 'ts-invariant';
 
 import { ApolloClient } from '../../ApolloClient';
 import { getApolloContext } from './ApolloContext';
+import { requireReactLazily } from '../react';
 
 export interface ApolloProviderProps<TCache> {
   client: ApolloClient<TCache>;
@@ -13,6 +13,7 @@ export const ApolloProvider: React.FC<ApolloProviderProps<any>> = ({
   client,
   children
 }) => {
+  const React = requireReactLazily();
   const ApolloContext = getApolloContext();
   return (
     <ApolloContext.Consumer>

--- a/src/react/context/__tests__/ApolloConsumer.test.tsx
+++ b/src/react/context/__tests__/ApolloConsumer.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, cleanup } from '@testing-library/react';
 
 import { ApolloLink } from '../../../link/core/ApolloLink';
@@ -7,6 +6,9 @@ import { InMemoryCache as Cache } from '../../../cache/inmemory/inMemoryCache';
 import { ApolloProvider } from '../ApolloProvider';
 import { ApolloConsumer } from '../ApolloConsumer';
 import { getApolloContext } from '../ApolloContext';
+import { requireReactLazily } from '../../react';
+
+const React = requireReactLazily();
 
 const client = new ApolloClient({
   cache: new Cache(),

--- a/src/react/context/__tests__/ApolloProvider.test.tsx
+++ b/src/react/context/__tests__/ApolloProvider.test.tsx
@@ -1,4 +1,3 @@
-import React, { useContext } from 'react';
 import { render, cleanup } from '@testing-library/react';
 
 import { ApolloLink } from '../../../link/core/ApolloLink';
@@ -6,6 +5,10 @@ import { ApolloClient } from '../../../ApolloClient';
 import { InMemoryCache as Cache } from '../../../cache/inmemory/inMemoryCache';
 import { ApolloProvider } from '../ApolloProvider';
 import { getApolloContext } from '../ApolloContext';
+import { requireReactLazily } from '../../react';
+
+const React = requireReactLazily();
+const { useContext } = React;
 
 describe('<ApolloProvider /> Component', () => {
   afterEach(cleanup);

--- a/src/react/hooks/__tests__/useApolloClient.test.tsx
+++ b/src/react/hooks/__tests__/useApolloClient.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, cleanup } from '@testing-library/react';
 import { InvariantError } from 'ts-invariant';
 
@@ -8,6 +7,9 @@ import { ApolloClient } from '../../../ApolloClient';
 import { InMemoryCache } from '../../../cache/inmemory/inMemoryCache';
 import { useApolloClient } from '../useApolloClient';
 import { resetApolloContext } from '../../context/ApolloContext';
+import { requireReactLazily } from '../../react';
+
+const React = requireReactLazily();
 
 describe('useApolloClient Hook', () => {
   afterEach(() => {

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
 import { render, wait } from '@testing-library/react';
@@ -8,6 +7,9 @@ import { ApolloClient } from '../../../ApolloClient';
 import { InMemoryCache } from '../../../cache/inmemory/inMemoryCache';
 import { ApolloProvider } from '../../context/ApolloProvider';
 import { useLazyQuery } from '../useLazyQuery';
+import { requireReactLazily } from '../../react';
+
+const React = requireReactLazily();
 
 describe('useLazyQuery Hook', () => {
   const CAR_QUERY: DocumentNode = gql`

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -1,4 +1,3 @@
-import React, { useEffect } from 'react';
 import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
 import { render, cleanup, wait } from '@testing-library/react';
@@ -9,6 +8,10 @@ import { ApolloClient } from '../../../ApolloClient';
 import { InMemoryCache } from '../../../cache/inmemory/inMemoryCache';
 import { ApolloProvider } from '../../context/ApolloProvider';
 import { useMutation } from '../useMutation';
+import { requireReactLazily } from '../../react';
+
+const React = requireReactLazily();
+const { useEffect } = React;
 
 describe('useMutation Hook', () => {
   interface Todo {

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -1,4 +1,3 @@
-import React, { useState, useReducer } from 'react';
 import { DocumentNode, GraphQLError } from 'graphql';
 import gql from 'graphql-tag';
 import { render, cleanup, wait } from '@testing-library/react';
@@ -12,6 +11,10 @@ import { ApolloClient } from '../../../ApolloClient';
 import { InMemoryCache } from '../../../cache/inmemory/inMemoryCache';
 import { ApolloProvider } from '../../context/ApolloProvider';
 import { useQuery } from '../useQuery';
+import { requireReactLazily } from '../../react';
+
+const React = requireReactLazily();
+const { useState, useReducer } = React;
 
 describe('useQuery Hook', () => {
   const CAR_QUERY: DocumentNode = gql`

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, cleanup, wait } from '@testing-library/react';
 import gql from 'graphql-tag';
 
@@ -7,6 +6,9 @@ import { ApolloClient } from '../../../ApolloClient';
 import { InMemoryCache as Cache } from '../../../cache/inmemory/inMemoryCache';
 import { ApolloProvider } from '../../context/ApolloProvider';
 import { useSubscription } from '../useSubscription';
+import { requireReactLazily } from '../../react';
+
+const React = requireReactLazily();
 
 describe('useSubscription Hook', () => {
   afterEach(cleanup);

--- a/src/react/hooks/useApolloClient.ts
+++ b/src/react/hooks/useApolloClient.ts
@@ -1,10 +1,11 @@
-import React from 'react';
 import { invariant } from 'ts-invariant';
 
 import { ApolloClient } from '../../ApolloClient';
 import { getApolloContext } from '../context/ApolloContext';
+import { requireReactLazily } from '../react';
 
 export function useApolloClient(): ApolloClient<object> {
+  const React = requireReactLazily();
   const { client } = React.useContext(getApolloContext());
   invariant(
     client,

--- a/src/react/hooks/useMutation.ts
+++ b/src/react/hooks/useMutation.ts
@@ -1,15 +1,16 @@
-import { useContext, useState, useRef, useEffect } from 'react';
 import { DocumentNode } from 'graphql';
 
 import { MutationHookOptions, MutationTuple } from '../types/types';
 import { MutationData } from '../data/MutationData';
 import { OperationVariables } from '../../core/types';
 import { getApolloContext } from '../context/ApolloContext';
+import { requireReactLazily } from '../react';
 
 export function useMutation<TData = any, TVariables = OperationVariables>(
   mutation: DocumentNode,
   options?: MutationHookOptions<TData, TVariables>
 ): MutationTuple<TData, TVariables> {
+  const { useContext, useState, useRef, useEffect } = requireReactLazily();
   const context = useContext(getApolloContext());
   const [result, setResult] = useState({ called: false, loading: false });
   const updatedOptions = options ? { ...options, mutation } : { mutation };

--- a/src/react/hooks/useSubscription.ts
+++ b/src/react/hooks/useSubscription.ts
@@ -1,15 +1,17 @@
-import { useContext, useState, useRef, useEffect } from 'react';
 import { DocumentNode } from 'graphql';
 
 import { SubscriptionHookOptions } from '../types/types';
 import { SubscriptionData } from '../data/SubscriptionData';
 import { OperationVariables } from '../../core/types';
 import { getApolloContext } from '../context/ApolloContext';
+import { requireReactLazily } from '../react';
 
 export function useSubscription<TData = any, TVariables = OperationVariables>(
   subscription: DocumentNode,
   options?: SubscriptionHookOptions<TData, TVariables>
 ) {
+  const React = requireReactLazily();
+  const { useContext, useState, useRef, useEffect } = React;
   const context = useContext(getApolloContext());
   const updatedOptions = options
     ? { ...options, subscription }

--- a/src/react/hooks/utils/useBaseQuery.ts
+++ b/src/react/hooks/utils/useBaseQuery.ts
@@ -1,4 +1,3 @@
-import { useContext, useEffect, useReducer, useRef } from 'react';
 import { DocumentNode } from 'graphql';
 
 import {
@@ -11,12 +10,15 @@ import { QueryData } from '../../data/QueryData';
 import { useDeepMemo } from './useDeepMemo';
 import { OperationVariables } from '../../../core/types';
 import { getApolloContext } from '../../context/ApolloContext';
+import { requireReactLazily } from '../../react';
 
 export function useBaseQuery<TData = any, TVariables = OperationVariables>(
   query: DocumentNode,
   options?: QueryHookOptions<TData, TVariables>,
   lazy = false
 ) {
+  const React = requireReactLazily();
+  const { useContext, useEffect, useReducer, useRef } = React;
   const context = useContext(getApolloContext());
   const [tick, forceUpdate] = useReducer(x => x + 1, 0);
   const updatedOptions = options ? { ...options, query } : { query };

--- a/src/react/hooks/utils/useDeepMemo.ts
+++ b/src/react/hooks/utils/useDeepMemo.ts
@@ -1,5 +1,6 @@
-import { useRef } from 'react';
 import { equal as isEqual } from '@wry/equality';
+
+import { requireReactLazily } from '../../react';
 
 /**
  * Memoize a result using deep equality. This hook has two advantages over
@@ -12,6 +13,8 @@ export function useDeepMemo<TKey, TValue>(
   memoFn: () => TValue,
   key: TKey
 ): TValue {
+  const React = requireReactLazily();
+  const { useRef } = React;
   const ref = useRef<{ key: TKey; value: TValue }>();
 
   if (!ref.current || !isEqual(key, ref.current.key)) {

--- a/src/react/react.ts
+++ b/src/react/react.ts
@@ -1,0 +1,9 @@
+let React: typeof import('react');
+
+// Apollo Client can be used without React, which means we want to make sure
+// `react` is only imported/required if actually needed. To help with this
+// the `react` module is lazy loaded using `requireReactLazily` when used by
+// Apollo Client's React integration layer.
+export function requireReactLazily(): typeof import('react') {
+  return React || (React = require('react'));
+}


### PR DESCRIPTION
Similar to the changes made in #5541, this commit adds a direct entry point for the Apollo Client cache code. Importing from `@apollo/client/cache` gives access to the cache code directly, without pulling in other parts of the Apollo Client codebase.