### PR TITLE
Never merge fields in cache unless objects have same identity.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@
 
 - The `QueryOptions`, `MutationOptions`, and `SubscriptionOptions` React Apollo interfaces have been renamed to `QueryDataOptions`, `MutationDataOptions`, and `SubscriptionDataOptions` (to avoid conflicting with similarly named and exported Apollo Client interfaces).
 
+- `InMemoryCache` will no longer merge the fields of written objects unless the objects are known to have the same identity, and the values of fields with the same name will not be recursively merged unless a custom `merge` function is defined by a field policy for that field, within a type policy associated with the `__typename` of the parent object. <br/>
+  [@benjamn](https://github.com/benjamn) in [#5603](https://github.com/apollographql/apollo-client/pull/5603)
+
 ## Apollo Client (2.6.4)
 
 ### Apollo Client (2.6.4)

--- a/src/__tests__/__snapshots__/ApolloClient.ts.snap
+++ b/src/__tests__/__snapshots__/ApolloClient.ts.snap
@@ -344,7 +344,6 @@ Object {
     "a": 1,
     "d": Object {
       "__typename": "D",
-      "e": 4,
       "h": Object {
         "__typename": "H",
         "i": 7,

--- a/src/__tests__/local-state/export.ts
+++ b/src/__tests__/local-state/export.ts
@@ -2,6 +2,7 @@ import gql from 'graphql-tag';
 import { print } from 'graphql/language/printer';
 
 import { Observable } from '../../utilities/observables/Observable';
+import { itAsync } from '../../utilities/testing/itAsync';
 import { ApolloLink } from '../../link/core/ApolloLink';
 import { ApolloClient } from '../..';
 import { InMemoryCache } from '../../cache/inmemory/inMemoryCache';
@@ -325,10 +326,10 @@ describe('@client @export tests', () => {
     });
   });
 
-  it(
+  itAsync(
     'should support setting an @client @export variable, loaded from the ' +
       'cache, on a virtual field that is combined into a remote query.',
-    done => {
+    (resolve, reject) => {
       const query = gql`
         query postRequiringReview($reviewerId: Int!) {
           postRequiringReview {
@@ -361,7 +362,7 @@ describe('@client @export tests', () => {
             reviewerDetails,
           },
         });
-      });
+      }).setOnError(reject);
 
       const cache = new InMemoryCache();
       const client = new ApolloClient({
@@ -375,6 +376,7 @@ describe('@client @export tests', () => {
           postRequiringReview: {
             loggedInReviewerId,
             __typename: 'Post',
+            id: 10,
           },
         },
       });
@@ -388,8 +390,7 @@ describe('@client @export tests', () => {
           },
           reviewerDetails,
         });
-        done();
-      });
+      }).then(resolve, reject);
     },
   );
 

--- a/src/cache/inmemory/__tests__/cache.ts
+++ b/src/cache/inmemory/__tests__/cache.ts
@@ -701,8 +701,9 @@ describe('Cache', () => {
           ROOT_QUERY: {
             __typename: "Query",
             a: 1,
+            // The new value for d overwrites the old value, since there
+            // is no custom merge function defined for Query.d.
             d: {
-              e: 4,
               h: {
                 i: 7,
               },

--- a/src/cache/inmemory/__tests__/writeToStore.ts
+++ b/src/cache/inmemory/__tests__/writeToStore.ts
@@ -1307,7 +1307,7 @@ describe('writing to the store', () => {
     });
   });
 
-  it('should merge objects when overwriting a generated id with a real id', () => {
+  it('should not merge unidentified data when replacing with ID reference', () => {
     const dataWithoutId = {
       author: {
         firstName: 'John',
@@ -1342,7 +1342,7 @@ describe('writing to the store', () => {
         }
       }
     `;
-    const expStoreWithoutId = defaultNormalizedCacheFactory({
+    const expectedStoreWithoutId = defaultNormalizedCacheFactory({
       ROOT_QUERY: {
         __typename: 'Query',
         author: {
@@ -1352,10 +1352,9 @@ describe('writing to the store', () => {
         },
       },
     });
-    const expStoreWithId = defaultNormalizedCacheFactory({
+    const expectedStoreWithId = defaultNormalizedCacheFactory({
       Author__129: {
         firstName: 'John',
-        lastName: 'Smith',
         id: '129',
         __typename: 'Author',
       },
@@ -1364,17 +1363,19 @@ describe('writing to the store', () => {
         author: makeReference('Author__129'),
       },
     });
+
     const storeWithoutId = writer.writeQueryToStore({
       result: dataWithoutId,
       query: queryWithoutId,
     });
-    expect(storeWithoutId.toObject()).toEqual(expStoreWithoutId.toObject());
+    expect(storeWithoutId.toObject()).toEqual(expectedStoreWithoutId.toObject());
+
     const storeWithId = writer.writeQueryToStore({
       result: dataWithId,
       query: queryWithId,
       store: storeWithoutId,
     });
-    expect(storeWithId.toObject()).toEqual(expStoreWithId.toObject());
+    expect(storeWithId.toObject()).toEqual(expectedStoreWithId.toObject());
   });
 
   it('should allow a union of objects of a different type, when overwriting a generated id with a real id', () => {


### PR DESCRIPTION
These changes realize the consequences of the following extremely important principles:

1. In order to accumulate GraphQL data over time, the `InMemoryCache` must be able to merge the fields of different response objects together, as those objects are written to the cache.

2. However, **merging the fields of two objects is allowable only when those objects are known to have the same identity.**

   If we cannot determine the identities of both objects (using `__typename` and `id`, or `keyFields`), or their identities are different, we should never merge their fields together, because doing so risks combining unrelated fields into the same logical entity object, resulting in an object that could never have been returned by the GraphQL server.

3. Even if two objects have the same identity, which allows us to merge their top-level fields, we should not assume we can recursively merge the values of fields that have the same name, unless those values are also identifiable objects with matching identities. Otherwise, we must replace the existing value with the incoming value, without attempting to combine them.

   **Exception A:** if the existing value and the incoming value are deeply equal to each other, then we can safely reuse the existing value to avoid needlessly altering references in the cache.

   **Exception B:** The application developer can provide custom field `merge` functions, e.g. for paginating array-valued fields. Since this level of customization was not possible in Apollo Client 2.x, some amount of automatic merging was necessary, but we can do the right thing now that the developer has more control.

I am happy that I did not have to update very many tests as a result of these changes, but the principles above are so important that I absolutely would have corrected as many tests as necessary to accommodate these changes. 🍳:feelsgood: ✨ 