### PR TITLE
Add InMemoryCache import to introductory example code

### DIFF
--- a/docs/source/get-started.mdx
+++ b/docs/source/get-started.mdx
@@ -28,9 +28,10 @@ Great, now that you have all the dependencies you need, let's create your Apollo
 In our `index.js` file, let's import `ApolloClient` from `@apollo/client` and add the endpoint for our GraphQL server to the `uri` property of the client config object.
 
 ```js
-import { ApolloClient, HttpLink } from '@apollo/client';
+import { ApolloClient, HttpLink, InMemoryCache } from '@apollo/client';
 
 const client = new ApolloClient({
+  cache: new InMemoryCache(),
   link: new HttpLink({
     uri: 'https://48p1r2roz4.sse.codesandbox.io',
   })


### PR DESCRIPTION
Without a cache specified in the client config, the client will error. Basically, this part of the docs doesn't work.

Tested with 3.0.0-beta4.

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
