### PR TITLE
Finer-grained InMemoryCache result caching.

### DIFF
--- a/src/cache/inmemory/__tests__/diffAgainstStore.ts
+++ b/src/cache/inmemory/__tests__/diffAgainstStore.ts
@@ -959,14 +959,14 @@ describe('diffing queries against the store', () => {
         typePolicies: {
           Query: {
             fields: {
-              person(_, { args, parentObject: rootQuery, toReference }) {
+              person(_, { args, toReference, getFieldValue }) {
                 expect(typeof args.id).toBe('number');
                 const ref = toReference({ __typename: 'Person', id: args.id });
                 expect(isReference(ref)).toBe(true);
                 expect(ref).toEqual({
                   __ref: `Person:${JSON.stringify({ id: args.id })}`,
                 });
-                const found = (rootQuery.people as Reference[]).find(
+                const found = (getFieldValue("people") as Reference[]).find(
                   person => person.__ref === ref.__ref);
                 expect(found).toBeTruthy();
                 return found;

--- a/src/cache/inmemory/__tests__/optimistic.ts
+++ b/src/cache/inmemory/__tests__/optimistic.ts
@@ -313,9 +313,9 @@ describe('optimistic cache layers', () => {
     // because the original query did not ask for author information.
     const resultWithSpinlessAuthor = read();
     expect(resultWithSpinlessAuthor).toEqual(result);
-    expect(resultWithSpinlessAuthor).not.toBe(result);
+    expect(resultWithSpinlessAuthor).toBe(result);
     expect(resultWithSpinlessAuthor.books[0]).toBe(result.books[0]);
-    expect(resultWithSpinlessAuthor.books[1]).not.toBe(result.books[1]);
+    expect(resultWithSpinlessAuthor.books[1]).toBe(result.books[1]);
 
     cache.recordOptimisticTransaction(proxy => {
       proxy.writeFragment({
@@ -436,7 +436,7 @@ describe('optimistic cache layers', () => {
     expect(resultAfterRemovingBuzzLayer).not.toBe(resultWithBuzz);
     resultWithTwoAuthors.books.forEach((book, i) => {
       expect(book).toEqual(resultAfterRemovingBuzzLayer.books[i]);
-      expect(book).not.toBe(resultAfterRemovingBuzzLayer.books[i]);
+      expect(book).toBe(resultAfterRemovingBuzzLayer.books[i]);
     });
 
     const nonOptimisticResult = readWithAuthors(false);

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -398,8 +398,10 @@ describe("type policies", function () {
           Person: {
             keyFields: ["firstName", "lastName"],
             fields: {
-              fullName(_, { parentObject: person }) {
-                return `${person.firstName} ${person.lastName}`;
+              fullName(_, { getFieldValue }) {
+                const firstName = getFieldValue("firstName");
+                const lastName = getFieldValue("lastName");
+                return `${firstName} ${lastName}`;
               },
             },
           },

--- a/src/cache/inmemory/__tests__/recordingCache.ts
+++ b/src/cache/inmemory/__tests__/recordingCache.ts
@@ -29,8 +29,8 @@ describe('OptimisticCacheLayer', () => {
     });
 
     it('should return values defined during recording', () => {
-      cache.set('Human', dataToRecord.Human);
-      expect(cache.get('Human')).toBe(dataToRecord.Human);
+      cache.merge('Human', dataToRecord.Human);
+      expect(cache.get('Human')).toEqual(dataToRecord.Human);
       expect(underlyingCache.get('Human')).toBe(data.Human);
     });
 
@@ -60,7 +60,7 @@ describe('OptimisticCacheLayer', () => {
 
     beforeEach(() => {
       cache = makeLayer(underlyingCache);
-      cache.set('Human', dataToRecord.Human);
+      cache.merge('Human', dataToRecord.Human);
       cache.delete('Animal');
       recording = cache.toObject();
     });

--- a/src/cache/inmemory/helpers.ts
+++ b/src/cache/inmemory/helpers.ts
@@ -3,9 +3,9 @@ import { Reference, isReference } from '../../utilities/graphql/storeUtils';
 
 export function getTypenameFromStoreObject(
   store: NormalizedCache,
-  storeObject: StoreObject | Reference,
+  objectOrReference: StoreObject | Reference,
 ): string | undefined {
-  return isReference(storeObject)
-    ? getTypenameFromStoreObject(store, store.get(storeObject.__ref))
-    : storeObject && storeObject.__typename;
+  return isReference(objectOrReference)
+    ? store.getFieldValue(objectOrReference.__ref, "__typename") as string
+    : objectOrReference && objectOrReference.__typename;
 }

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -126,7 +126,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
 
   public read<T>(options: Cache.ReadOptions): T | null {
     if (typeof options.rootId === 'string' &&
-        typeof this.data.get(options.rootId) === 'undefined') {
+        !this.data.has(options.rootId)) {
       return null;
     }
 

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -6,7 +6,7 @@ import {
   SelectionSetNode,
 } from 'graphql';
 import { wrap, KeyTrie } from 'optimism';
-import { InvariantError } from 'ts-invariant';
+import { invariant } from 'ts-invariant';
 
 import {
   isField,
@@ -193,8 +193,8 @@ export class StoreReader {
 
     if (hasMissingFields && ! returnPartialData) {
       execResult.missing!.forEach(info => {
-        if (info.tolerable) return;
-        throw new InvariantError(
+        invariant(
+          info.tolerable,
           `Can't find field ${info.fieldName} on object ${JSON.stringify(
             info.object,
             null,
@@ -320,11 +320,10 @@ export class StoreReader {
           fragment = selection;
         } else {
           // This is a named fragment
-          fragment = fragmentMap[selection.name.value];
-
-          if (!fragment) {
-            throw new InvariantError(`No fragment named ${selection.name.value}`);
-          }
+          invariant(
+            fragment = fragmentMap[selection.name.value],
+            `No fragment named ${selection.name.value}`,
+          );
         }
 
         const match = policies.fragmentMatches(fragment, typename);
@@ -425,13 +424,12 @@ function assertSelectionSetForIdValue(
     const workSet = new Set([fieldValue]);
     workSet.forEach(value => {
       if (value && typeof value === "object") {
-        if (isReference(value)) {
-          throw new InvariantError(
-            `Missing selection set for object of type ${
-              getTypenameFromStoreObject(store, value)
-            } returned for query field ${field.name.value}`,
-          )
-        }
+        invariant(
+          !isReference(value),
+          `Missing selection set for object of type ${
+            getTypenameFromStoreObject(store, value)
+          } returned for query field ${field.name.value}`,
+        );
         Object.values(value).forEach(workSet.add, workSet);
       }
     });

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -15,6 +15,7 @@ import {
   Reference,
   isReference,
   makeReference,
+  StoreValue,
 } from '../../utilities/graphql/storeUtils';
 import { canUseWeakMap } from '../../utilities/common/canUse';
 import { createFragmentMap, FragmentMap } from '../../utilities/graphql/fragments';
@@ -237,8 +238,12 @@ export class StoreReader {
       typename = object && object.__typename;
     }
 
+    function getFieldValue(fieldName: string): StoreValue {
+      return object && object[fieldName];
+    }
+
     if (this.config.addTypename) {
-      const typenameFromStore = object && object.__typename;
+      const typenameFromStore = getFieldValue("__typename");
       if (typeof typenameFromStore === "string" &&
           Object.values(
             policies.rootTypenamesById
@@ -265,8 +270,12 @@ export class StoreReader {
       if (!shouldInclude(selection, variables)) return;
 
       if (isField(selection)) {
-        let fieldValue = object &&
-          policies.readFieldFromStoreObject(object, selection, typename, variables);
+        let fieldValue = policies.readFieldFromStoreObject(
+          selection,
+          getFieldValue,
+          typename,
+          variables,
+        );
 
         if (fieldValue === void 0) {
           getMissing().push({

--- a/src/cache/inmemory/types.ts
+++ b/src/cache/inmemory/types.ts
@@ -20,7 +20,8 @@ export declare type IdGetter = (
 export interface NormalizedCache {
   has(dataId: string): boolean;
   get(dataId: string): StoreObject;
-  set(dataId: string, value: StoreObject): void;
+  getFieldValue(dataId: string, fieldName: string): StoreValue;
+  merge(dataId: string, incoming: StoreObject): void;
   delete(dataId: string): void;
   clear(): void;
 

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -371,7 +371,7 @@ function walkWithMergeOverrides(
       walkWithMergeOverrides(existingValue, incomingValue, child);
     }
     if (merge) {
-      incomingObject[name] = merge(existingValue, incomingValue, existingObject);
+      incomingObject[name] = merge(existingValue, incomingValue);
     }
   });
 }

--- a/src/core/__tests__/QueryManager/links.ts
+++ b/src/core/__tests__/QueryManager/links.ts
@@ -330,10 +330,10 @@ describe('Link interactions', () => {
         typePolicies: {
           Query: {
             fields: {
-              book(_, { parentObject: rootQuery, args, toReference }) {
+              book(_, { args, toReference, getFieldValue }) {
                 const ref = toReference({ __typename: "Book", id: args.id });
                 expect(ref).toEqual({ __ref: `Book:${args.id}` });
-                const found = (rootQuery.books as Reference[]).find(
+                const found = (getFieldValue("books") as Reference[]).find(
                   book => book.__ref === ref.__ref);
                 expect(found).toBeTruthy();
                 return found;


### PR DESCRIPTION
I encourage reading all the commit messages included here, but the final commit is the capstone:

### Use ID+field dependencies for result caching, rather than just ID

Until now, the `InMemoryCache` result caching system (introduced by #3394) registered dependencies on specific entity objects by ID, which meant changes to any of the fields of an entity in the cache would invalidate every query result that previously involved that entity, even if not all of those queries actually used any of the fields that changed.

While this system was logically correct, it resulted in unnecessary recomputation of cached query results. Perhaps most dramatically, any changes to the fields of the `ROOT_QUERY` object would necessitate the recomputation of every query that involved any root query fields, because those queries depended on the `ROOT_QUERY` ID rather than the specific fields they consumed.

With this commit, the `StoreReader` reads from the `EntityCache` using the new method `getFieldValue(dataId: string, fieldName: string): StoreValue`, which registers dependencies on the combination of the entity ID and the name of the requested field, so cached query results will remain valid as long as the specific fields they used have not changed.

Furthermore, the `EntityCache#set` method has been replaced by a method called `merge`, which intelligently updates the normalized data to incorporate a set of new fields, automatically invalidating dependencies for any fields whose values are modified by the merge.

For backwards compatibility, if a consumer chooses to continue using the `EntityCache#get(id)` method instead of `getFieldValue(id, fieldName)`, ID-based dependencies will be registered (and later invalidated), exactly as before.