### PR TITLE
Rename EntityCache to EntityStore.

### DIFF
--- a/src/cache/inmemory/__tests__/diffAgainstStore.ts
+++ b/src/cache/inmemory/__tests__/diffAgainstStore.ts
@@ -1,7 +1,7 @@
 import gql, { disableFragmentWarnings } from 'graphql-tag';
 
 import { Reference, makeReference, isReference } from '../../../utilities/graphql/storeUtils';
-import { defaultNormalizedCacheFactory } from '../entityCache';
+import { defaultNormalizedCacheFactory } from '../entityStore';
 import { StoreReader } from '../readFromStore';
 import { StoreWriter } from '../writeToStore';
 import { defaultDataIdFromObject } from '../policies';

--- a/src/cache/inmemory/__tests__/entityStore.ts
+++ b/src/cache/inmemory/__tests__/entityStore.ts
@@ -1,22 +1,22 @@
 import gql from 'graphql-tag';
-import { EntityCache, supportsResultCaching } from '../entityCache';
+import { EntityStore, supportsResultCaching } from '../entityStore';
 import { InMemoryCache } from '../inMemoryCache';
 
-describe('EntityCache', () => {
+describe('EntityStore', () => {
   it('should support result caching if so configured', () => {
-    const cacheWithResultCaching = new EntityCache.Root({
+    const storeWithResultCaching = new EntityStore.Root({
       resultCaching: true,
     });
 
-    const cacheWithoutResultCaching = new EntityCache.Root({
+    const storeWithoutResultCaching = new EntityStore.Root({
       resultCaching: false,
     });
 
     expect(supportsResultCaching({ some: "arbitrary object " })).toBe(false);
-    expect(supportsResultCaching(cacheWithResultCaching)).toBe(true);
-    expect(supportsResultCaching(cacheWithoutResultCaching)).toBe(false);
+    expect(supportsResultCaching(storeWithResultCaching)).toBe(true);
+    expect(supportsResultCaching(storeWithoutResultCaching)).toBe(false);
 
-    const layerWithCaching = cacheWithResultCaching.addLayer("with caching", () => {});
+    const layerWithCaching = storeWithResultCaching.addLayer("with caching", () => {});
     expect(supportsResultCaching(layerWithCaching)).toBe(true);
     const anotherLayer = layerWithCaching.addLayer("another layer", () => {});
     expect(supportsResultCaching(anotherLayer)).toBe(true);
@@ -24,13 +24,13 @@ describe('EntityCache', () => {
       anotherLayer
         .removeLayer("with caching")
         .removeLayer("another layer")
-    ).toBe(cacheWithResultCaching);
-    expect(supportsResultCaching(cacheWithResultCaching)).toBe(true);
+    ).toBe(storeWithResultCaching);
+    expect(supportsResultCaching(storeWithResultCaching)).toBe(true);
 
-    const layerWithoutCaching = cacheWithoutResultCaching.addLayer("with caching", () => {});
+    const layerWithoutCaching = storeWithoutResultCaching.addLayer("with caching", () => {});
     expect(supportsResultCaching(layerWithoutCaching)).toBe(false);
-    expect(layerWithoutCaching.removeLayer("with caching")).toBe(cacheWithoutResultCaching);
-    expect(supportsResultCaching(cacheWithoutResultCaching)).toBe(false);
+    expect(layerWithoutCaching.removeLayer("with caching")).toBe(storeWithoutResultCaching);
+    expect(supportsResultCaching(storeWithoutResultCaching)).toBe(false);
   });
 
   function newBookAuthorCache() {

--- a/src/cache/inmemory/__tests__/readFromStore.ts
+++ b/src/cache/inmemory/__tests__/readFromStore.ts
@@ -5,7 +5,7 @@ import { stripSymbols } from '../../../utilities/testing/stripSymbols';
 import { StoreObject } from '../types';
 import { StoreReader } from '../readFromStore';
 import { makeReference } from '../../../utilities/graphql/storeUtils';
-import { defaultNormalizedCacheFactory } from '../entityCache';
+import { defaultNormalizedCacheFactory } from '../entityStore';
 import { withError } from './diffAgainstStore';
 import { Policies } from '../policies';
 

--- a/src/cache/inmemory/__tests__/recordingCache.ts
+++ b/src/cache/inmemory/__tests__/recordingCache.ts
@@ -1,8 +1,8 @@
 import { NormalizedCacheObject } from '../types';
-import { EntityCache } from '../entityCache';
+import { EntityStore } from '../entityStore';
 
-describe('OptimisticCacheLayer', () => {
-  function makeLayer(root: EntityCache) {
+describe('Optimistic EntityStore layering', () => {
+  function makeLayer(root: EntityStore) {
     return root.addLayer('whatever', () => {});
   }
 
@@ -16,31 +16,31 @@ describe('OptimisticCacheLayer', () => {
       Human: { __typename: 'Human', name: 'John' },
     };
 
-    const underlyingCache = new EntityCache.Root({ seed: data });
+    const underlyingStore = new EntityStore.Root({ seed: data });
 
-    let cache = makeLayer(underlyingCache);
+    let store = makeLayer(underlyingStore);
     beforeEach(() => {
-      cache = makeLayer(underlyingCache);
+      store = makeLayer(underlyingStore);
     });
 
     it('should passthrough values if not defined in recording', () => {
-      expect(cache.get('Human')).toBe(data.Human);
-      expect(cache.get('Animal')).toBe(data.Animal);
+      expect(store.get('Human')).toBe(data.Human);
+      expect(store.get('Animal')).toBe(data.Animal);
     });
 
     it('should return values defined during recording', () => {
-      cache.merge('Human', dataToRecord.Human);
-      expect(cache.get('Human')).toEqual(dataToRecord.Human);
-      expect(underlyingCache.get('Human')).toBe(data.Human);
+      store.merge('Human', dataToRecord.Human);
+      expect(store.get('Human')).toEqual(dataToRecord.Human);
+      expect(underlyingStore.get('Human')).toBe(data.Human);
     });
 
     it('should return undefined for values deleted during recording', () => {
-      expect(cache.get('Animal')).toBe(data.Animal);
+      expect(store.get('Animal')).toBe(data.Animal);
       // delete should be registered in the recording:
-      cache.delete('Animal');
-      expect(cache.get('Animal')).toBeUndefined();
-      expect(cache.toObject()).toHaveProperty('Animal');
-      expect(underlyingCache.get('Animal')).toBe(data.Animal);
+      store.delete('Animal');
+      expect(store.get('Animal')).toBeUndefined();
+      expect(store.toObject()).toHaveProperty('Animal');
+      expect(underlyingStore.get('Animal')).toBe(data.Animal);
     });
   });
 
@@ -54,15 +54,15 @@ describe('OptimisticCacheLayer', () => {
       Human: { __typename: 'Human', name: 'John' },
     };
 
-    const underlyingCache = new EntityCache.Root({ seed: data });
-    let cache = makeLayer(underlyingCache);
+    const underlyingStore = new EntityStore.Root({ seed: data });
+    let store = makeLayer(underlyingStore);
     let recording: NormalizedCacheObject;
 
     beforeEach(() => {
-      cache = makeLayer(underlyingCache);
-      cache.merge('Human', dataToRecord.Human);
-      cache.delete('Animal');
-      recording = cache.toObject();
+      store = makeLayer(underlyingStore);
+      store.merge('Human', dataToRecord.Human);
+      store.delete('Animal');
+      recording = store.toObject();
     });
 
     it('should contain the property indicating deletion', () => {
@@ -77,7 +77,7 @@ describe('OptimisticCacheLayer', () => {
     });
 
     it('should keep the original data unaffected', () => {
-      expect(underlyingCache.toObject()).toEqual(data);
+      expect(underlyingStore.toObject()).toEqual(data);
     });
   });
 });

--- a/src/cache/inmemory/__tests__/roundtrip.ts
+++ b/src/cache/inmemory/__tests__/roundtrip.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 
 import { withError } from './diffAgainstStore';
 import { withWarning } from './writeToStore';
-import { EntityCache } from '../entityCache';
+import { EntityStore } from '../entityStore';
 import { StoreReader } from '../readFromStore';
 import { StoreWriter } from '../writeToStore';
 import { Policies } from '../policies';
@@ -42,7 +42,7 @@ function storeRoundtrip(query: DocumentNode, result: any, variables = {}) {
 
   // Make sure the result is identical if we haven't written anything new
   // to the store. https://github.com/apollographql/apollo-client/pull/3394
-  expect(store).toBeInstanceOf(EntityCache);
+  expect(store).toBeInstanceOf(EntityStore);
   expect(reader.readQueryFromStore(readOptions)).toBe(reconstructedResult);
 
   const immutableResult = reader.readQueryFromStore(readOptions);

--- a/src/cache/inmemory/__tests__/writeToStore.ts
+++ b/src/cache/inmemory/__tests__/writeToStore.ts
@@ -16,7 +16,7 @@ import {
 import { addTypenameToDocument } from '../../../utilities/graphql/transform';
 import { cloneDeep } from '../../../utilities/common/cloneDeep';
 import { StoreWriter } from '../writeToStore';
-import { defaultNormalizedCacheFactory } from '../entityCache';
+import { defaultNormalizedCacheFactory } from '../entityStore';
 import { InMemoryCache } from '../inMemoryCache';
 import { Policies } from '../policies';
 

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -15,7 +15,7 @@ import {
 } from './types';
 import { StoreReader } from './readFromStore';
 import { StoreWriter } from './writeToStore';
-import { EntityCache, supportsResultCaching } from './entityCache';
+import { EntityStore, supportsResultCaching } from './entityStore';
 import {
   defaultDataIdFromObject,
   PossibleTypesMap,
@@ -37,8 +37,8 @@ const defaultConfig: InMemoryCacheConfig = {
 };
 
 export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
-  private data: EntityCache;
-  private optimisticData: EntityCache;
+  private data: EntityStore;
+  private optimisticData: EntityStore;
 
   protected config: InMemoryCacheConfig;
   private watches = new Set<Cache.WatchOptions>();
@@ -68,7 +68,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     // Passing { resultCaching: false } in the InMemoryCache constructor options
     // will completely disable dependency tracking, which will improve memory
     // usage but worsen the performance of repeated reads.
-    this.data = new EntityCache.Root({
+    this.data = new EntityStore.Root({
       resultCaching: this.config.resultCaching,
     });
 
@@ -230,7 +230,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     // from duplicating this implementation in recordOptimisticTransaction.
     optimisticId?: string,
   ) {
-    const perform = (layer?: EntityCache) => {
+    const perform = (layer?: EntityStore) => {
       const proxy: InMemoryCache = Object.create(this);
       proxy.silenceBroadcast = true;
       if (layer) {

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -36,7 +36,7 @@ import {
   StoreObject,
   NormalizedCache,
 } from './types';
-import { supportsResultCaching } from './entityCache';
+import { supportsResultCaching } from './entityStore';
 import { getTypenameFromStoreObject } from './helpers';
 import { Policies } from './policies';
 

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -25,7 +25,7 @@ import { DeepMerger } from '../../utilities/common/mergeDeep';
 import { shouldInclude } from '../../utilities/graphql/directives';
 import { cloneDeep } from '../../utilities/common/cloneDeep';
 
-import { defaultNormalizedCacheFactory } from './entityCache';
+import { defaultNormalizedCacheFactory } from './entityStore';
 import { NormalizedCache, StoreObject } from './types';
 import { Policies, StoreValueMergeFunction } from './policies';
 


### PR DESCRIPTION
_This PR builds on #5617, but you do not need to review those changes first._

I believe the job of a GraphQL cache is not simply to remember the results of past GraphQL queries, but to ingest those queries into a **client-side data graph** that faithfully replicates a subset of the complete data graph described by your schema.

To that end, the name `EntityCache` feels slightly inaccurate, because this data structure is the source of truth for your client-side data graph, which consists of entity objects, their fields, and their references to each other, to name just a few concepts that transcend the particulars of caching GraphQL results.

Instead, I think `EntityStore` more accurately reflects the first-class status of the client-side data graph, with the `InMemoryCache` as a wrapper of the `EntityStore` and a consumer of the entity objects that reside within it.

If you're curious about the philosophy behind this separation of concerns, check out [my talk from GraphQL Summit](https://youtu.be/n_j8QckQN5I?t=114).

If you don't care about the names of these abstractions, you can rest easy knowing that this change is (in some sense) purely cosmetic. ✨