### PR TITLE
Deep-freeze existing values passed to read and merge functions.

### DIFF
--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -539,6 +539,7 @@ describe("type policies", function () {
                 keyArgs: [],
 
                 read(existing: any[], { args, toReference }) {
+                  expect(!existing || Object.isFrozen(existing)).toBe(true);
                   expect(typeof toReference).toBe("function");
                   const slice = existing.slice(
                     args.offset,
@@ -549,6 +550,7 @@ describe("type policies", function () {
                 },
 
                 merge(existing: any[], incoming: any[], { args, toReference }) {
+                  expect(!existing || Object.isFrozen(existing)).toBe(true);
                   expect(typeof toReference).toBe("function");
                   const copy = existing ? existing.slice(0) : [];
                   const limit = args.offset + args.limit;

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -229,18 +229,23 @@ export class StoreReader {
     // Provides a uniform interface from reading field values, whether or
     // not the parent object is a normalized entity object.
     function getFieldValue(fieldName: string): StoreValue {
+      let fieldValue: StoreValue;
       if (isReference(objectOrReference)) {
         const dataId = objectOrReference.__ref;
-        const fieldValue = store.getFieldValue(dataId, fieldName);
+        fieldValue = store.getFieldValue(dataId, fieldName);
         if (fieldValue === void 0 && fieldName === "__typename") {
           // We can infer the __typename of singleton root objects like
           // ROOT_QUERY ("Query") and ROOT_MUTATION ("Mutation"), even if
           // we have never written that information into the cache.
           return policies.rootTypenamesById[dataId];
         }
-        return fieldValue;
+      } else {
+        fieldValue = objectOrReference && objectOrReference[fieldName];
       }
-      return objectOrReference && objectOrReference[fieldName];
+      if (process.env.NODE_ENV !== "production") {
+        maybeDeepFreeze(fieldValue);
+      }
+      return fieldValue;
     }
 
     const typename = getFieldValue("__typename") as string;

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -24,6 +24,7 @@ import {
 import { DeepMerger } from '../../utilities/common/mergeDeep';
 import { shouldInclude } from '../../utilities/graphql/directives';
 import { cloneDeep } from '../../utilities/common/cloneDeep';
+import { maybeDeepFreeze } from '../../utilities/common/maybeDeepFreeze';
 
 import { defaultNormalizedCacheFactory } from './entityCache';
 import { NormalizedCache, StoreObject } from './types';
@@ -344,6 +345,13 @@ function walkWithMergeOverrides(
       walkWithMergeOverrides(existingValue, incomingValue, child);
     }
     if (merge) {
+      if (process.env.NODE_ENV !== "production") {
+        // It may be tempting to modify existing data directly, for
+        // example by pushing more elements onto an existing array, but
+        // merge functions are expected to be pure, so it's important that
+        // we enforce immutability in development.
+        maybeDeepFreeze(existingValue);
+      }
       incomingObject[name] = merge(existingValue, incomingValue);
     }
   });


### PR DESCRIPTION
_This PR builds on #5617, so you might want to review that one first._

On the writing side, this change prevents `merge` functions from destructively modifying the existing data, which is a very real temptation given the history of mutability in Apollo Client.

On the reading side, the risk is less worrisome, but it still makes sense to freeze any existing data exposed to untrusted code. The recently introduced `getFieldValue` helper function provides a convenient bottleneck for calling `maybeDeepFreeze`.

Because of the `process.env.NODE_ENV` guards (and runtime checks within `maybeDeepFreeze`), this freezing happens only in development, so it has no cost in production.

The `InMemoryCache` implementation (`EntityStore`, `StoreReader`, `StoreWriter`, etc.) will never destructively modify `StoreObject` data in the cache, so this change serves primarily to defend against rogue `read`/`merge` functions mishandling immutable data.