### PR TITLE
Support cache.identify(entity) for computing entity ID strings.

### DIFF
--- a/src/cache/inmemory/__tests__/entityStore.ts
+++ b/src/cache/inmemory/__tests__/entityStore.ts
@@ -857,25 +857,6 @@ describe('EntityStore', () => {
       "Missing field b while computing key fields",
     );
 
-    function check(query: DocumentNode, object: Record<string, any>) {
-      const rootSelectionSet = getOperationDefinition(query).selectionSet;
-      const abcsSelectionSet = (rootSelectionSet.selections[0] as FieldNode).selectionSet;
-      const fragmentMap = createFragmentMap(getFragmentDefinitions(query));
-
-      expect(cache.identify(object, abcsSelectionSet, fragmentMap)).toBe(
-        'ABCs:{"b":"bee","a":"ay","c":"see"}',
-      );
-    }
-
-    check(queryWithAliases, ABCs);
-
-    check(queryWithoutAliases, {
-      __typename: "ABCs",
-      a: "ay",
-      b: "bee",
-      c: "see",
-    });
-
     expect(cache.readFragment({
       id: cache.identify({
         __typename: "ABCs",

--- a/src/cache/inmemory/__tests__/entityStore.ts
+++ b/src/cache/inmemory/__tests__/entityStore.ts
@@ -1,6 +1,9 @@
 import gql from 'graphql-tag';
 import { EntityStore, supportsResultCaching } from '../entityStore';
 import { InMemoryCache } from '../inMemoryCache';
+import { DocumentNode, FieldNode } from 'graphql';
+import { getOperationDefinition, getFragmentDefinitions } from '../../../utilities/graphql/getFromAST';
+import { createFragmentMap } from '../../../utilities/graphql/fragments';
 
 describe('EntityStore', () => {
   it('should support result caching if so configured', () => {
@@ -592,18 +595,22 @@ describe('EntityStore', () => {
   it('allows cache eviction', () => {
     const { cache, query } = newBookAuthorCache();
 
+    const cuckoosCallingBook = {
+      __typename: "Book",
+      isbn: "031648637X",
+      title: "The Cuckoo's Calling",
+      author: {
+        __typename: "Author",
+        name: "Robert Galbraith",
+      },
+    };
+
+    expect(cache.identify(cuckoosCallingBook)).toBe("Book:031648637X");
+
     cache.writeQuery({
       query,
       data: {
-        book: {
-          __typename: "Book",
-          isbn: "031648637X",
-          title: "The Cuckoo's Calling",
-          author: {
-            __typename: "Author",
-            name: "Robert Galbraith",
-          },
-        },
+        book: cuckoosCallingBook,
       },
     });
 
@@ -618,7 +625,7 @@ describe('EntityStore', () => {
     `;
 
     const fragmentResult = cache.readFragment({
-      id: "Book:031648637X",
+      id: cache.identify(cuckoosCallingBook),
       fragment: bookAuthorFragment,
     });
 
@@ -632,7 +639,7 @@ describe('EntityStore', () => {
 
     cache.recordOptimisticTransaction(proxy => {
       proxy.writeFragment({
-        id: "Book:031648637X",
+        id: cache.identify(cuckoosCallingBook),
         fragment: bookAuthorFragment,
         data: {
           ...fragmentResult,
@@ -703,7 +710,7 @@ describe('EntityStore', () => {
     });
 
     cache.writeFragment({
-      id: "Book:031648637X",
+      id: cache.identify(cuckoosCallingBook),
       fragment: bookAuthorFragment,
       data: {
         ...fragmentResult,
@@ -745,13 +752,177 @@ describe('EntityStore', () => {
       },
     });
 
-    expect(cache.retain("Book:031648637X")).toBe(2);
-    expect(cache.release("Book:031648637X")).toBe(1);
-    expect(cache.release("Book:031648637X")).toBe(0);
+    const ccId = cache.identify(cuckoosCallingBook);
+    expect(cache.retain(ccId)).toBe(2);
+    expect(cache.release(ccId)).toBe(1);
+    expect(cache.release(ccId)).toBe(0);
 
     expect(cache.gc().sort()).toEqual([
       "Author:J.K. Rowling",
-      "Book:031648637X",
+      ccId,
     ]);
+  });
+
+  it("supports cache.identify(object)", () => {
+    const queryWithAliases: DocumentNode = gql`
+      query {
+        abcs {
+          first: a
+          second: b
+          ...Rest
+        }
+      }
+      fragment Rest on ABCs {
+        third: c
+      }
+    `;
+
+    const queryWithoutAliases: DocumentNode = gql`
+      query {
+        abcs {
+          a
+          b
+          ...Rest
+        }
+      }
+      fragment Rest on ABCs {
+        c
+      }
+    `;
+
+    const cache = new InMemoryCache({
+      typePolicies: {
+        ABCs: {
+          keyFields: ["b", "a", "c"],
+        },
+      },
+    });
+
+    const ABCs = {
+      __typename: "ABCs",
+      first: "ay",
+      second: "bee",
+      third: "see",
+    };
+
+    cache.writeQuery({
+      query: queryWithAliases,
+      data: {
+        abcs: ABCs,
+      },
+    });
+
+    expect(cache.extract()).toEqual({
+      ROOT_QUERY: {
+        __typename: "Query",
+        abcs: {
+          __ref: 'ABCs:{"b":"bee","a":"ay","c":"see"}',
+        },
+      },
+      'ABCs:{"b":"bee","a":"ay","c":"see"}': {
+        __typename: "ABCs",
+        a: "ay",
+        b: "bee",
+        c: "see",
+      },
+    });
+
+    const resultWithAliases = cache.readQuery({
+      query: queryWithAliases,
+    });
+
+    expect(resultWithAliases).toEqual({ abcs: ABCs });
+
+    const resultWithoutAliases = cache.readQuery({
+      query: queryWithoutAliases,
+    });
+
+    expect(resultWithoutAliases).toEqual({
+      abcs: {
+        __typename: "ABCs",
+        a: "ay",
+        b: "bee",
+        c: "see",
+      },
+    });
+
+    expect(cache.identify({
+      __typename: "ABCs",
+      a: 1,
+      b: 2,
+      c: 3,
+    })).toBe('ABCs:{"b":2,"a":1,"c":3}');
+
+    expect(() => cache.identify(ABCs)).toThrow(
+      "Missing field b while computing key fields",
+    );
+
+    function check(query: DocumentNode, object: Record<string, any>) {
+      const rootSelectionSet = getOperationDefinition(query).selectionSet;
+      const abcsSelectionSet = (rootSelectionSet.selections[0] as FieldNode).selectionSet;
+      const fragmentMap = createFragmentMap(getFragmentDefinitions(query));
+
+      expect(cache.identify(object, abcsSelectionSet, fragmentMap)).toBe(
+        'ABCs:{"b":"bee","a":"ay","c":"see"}',
+      );
+    }
+
+    check(queryWithAliases, ABCs);
+
+    check(queryWithoutAliases, {
+      __typename: "ABCs",
+      a: "ay",
+      b: "bee",
+      c: "see",
+    });
+
+    expect(cache.readFragment({
+      id: cache.identify({
+        __typename: "ABCs",
+        a: "ay",
+        b: "bee",
+        c: "see",
+      }),
+      fragment: gql`
+        fragment JustB on ABCs {
+          b
+        }
+      `,
+    })).toEqual({
+      __typename: "ABCs",
+      b: "bee",
+    });
+
+    expect(cache.readQuery({
+      query: queryWithAliases,
+    })).toBe(resultWithAliases);
+
+    expect(cache.readQuery({
+      query: queryWithoutAliases,
+    })).toBe(resultWithoutAliases);
+
+    cache.evict(cache.identify({
+      __typename: "ABCs",
+      a: "ay",
+      b: "bee",
+      c: "see",
+    }));
+
+    expect(cache.extract()).toEqual({
+      ROOT_QUERY: {
+        __typename: "Query",
+        abcs: {
+          __ref: 'ABCs:{"b":"bee","a":"ay","c":"see"}',
+        },
+      },
+    });
+
+    expect(() => cache.readQuery({
+      query: queryWithAliases,
+    })).toThrow(/Can't find field a on object/);
+
+    expect(() => cache.readQuery({
+      query: queryWithoutAliases,
+    })).toThrow(/Can't find field a on object/);
   });
 });

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -1,14 +1,13 @@
 // Make builtins like Map and Set safe to use with non-extensible objects.
 import './fixPolyfills';
 
-import { DocumentNode, SelectionSetNode } from 'graphql';
+import { DocumentNode } from 'graphql';
 import { wrap } from 'optimism';
 import { KeyTrie } from 'optimism';
 
 import { ApolloCache, Transaction } from '../core/cache';
 import { Cache } from '../core/types/Cache';
 import { addTypenameToDocument } from '../../utilities/graphql/transform';
-import { FragmentMap } from '../../utilities/graphql/fragments';
 import { canUseWeakMap } from '../../utilities/common/canUse';
 import {
   ApolloReducerConfig,

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -1,17 +1,19 @@
 // Make builtins like Map and Set safe to use with non-extensible objects.
 import './fixPolyfills';
 
-import { DocumentNode } from 'graphql';
+import { DocumentNode, SelectionSetNode } from 'graphql';
 import { wrap } from 'optimism';
 import { KeyTrie } from 'optimism';
 
 import { ApolloCache, Transaction } from '../core/cache';
 import { Cache } from '../core/types/Cache';
 import { addTypenameToDocument } from '../../utilities/graphql/transform';
+import { FragmentMap } from '../../utilities/graphql/fragments';
 import { canUseWeakMap } from '../../utilities/common/canUse';
 import {
   ApolloReducerConfig,
   NormalizedCacheObject,
+  StoreObject,
 } from './types';
 import { StoreReader } from './readFromStore';
 import { StoreWriter } from './writeToStore';
@@ -194,6 +196,14 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
   // count, in case that's useful.
   public release(rootId: string, optimistic?: boolean): number {
     return (optimistic ? this.optimisticData : this.data).release(rootId);
+  }
+
+  public identify(
+    object: StoreObject,
+    selectionSet?: SelectionSetNode,
+    fragmentMap?: FragmentMap,
+  ) {
+    return this.policies.identify(object, selectionSet, fragmentMap);
   }
 
   public evict(dataId: string): boolean {

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -198,12 +198,13 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     return (optimistic ? this.optimisticData : this.data).release(rootId);
   }
 
-  public identify(
-    object: StoreObject,
-    selectionSet?: SelectionSetNode,
-    fragmentMap?: FragmentMap,
-  ) {
-    return this.policies.identify(object, selectionSet, fragmentMap);
+  // Returns the canonical ID for a given StoreObject, obeying typePolicies
+  // and keyFields (and dataIdFromObject, if you still use that). At minimum,
+  // the object must contain a __typename and any primary key fields required
+  // to identify entities of that type. If you pass a query result object, be
+  // sure that none of the primary key fields have been renamed by aliasing.
+  public identify(object: StoreObject): string | null {
+    return this.policies.identify(object);
   }
 
   public evict(dataId: string): boolean {


### PR DESCRIPTION
After you've specified accurate [`keyFields` policies](https://github.com/apollographql/apollo-client/blob/release-3.0/docs/source/caching/cache-configuration.md#customizing-identifier-generation-by-type) for your types, the last thing you want is for application code to reimplement that logic just to compute IDs to use with methods like `InMemoryCache#evict`.

This commit introduces a method called `InMemoryCache#identify`, which takes a result object and computes its ID based on its `__typename` and primary key fields, so that you can do `cache.evict(cache.identify(entity))` to evict an object from the cache, without any manual string manipulation.