### PR TITLE
Support eviction of specific entity fields.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     {
       "name": "apollo-client",
       "path": "./dist/apollo-client.cjs.min.js",
-      "maxSize": "23.75 kB"
+      "maxSize": "23.9 kB"
     }
   ],
   "peerDependencies": {

--- a/src/__tests__/__snapshots__/client.ts.snap
+++ b/src/__tests__/__snapshots__/client.ts.snap
@@ -4,7 +4,7 @@ exports[`@connection should run a query with the @connection directive and write
 Object {
   "ROOT_QUERY": Object {
     "__typename": "Query",
-    "abc": Array [
+    "books:abc": Array [
       Object {
         "__typename": "Book",
         "name": "abcd",
@@ -18,7 +18,7 @@ exports[`@connection should run a query with the connection directive and filter
 Object {
   "ROOT_QUERY": Object {
     "__typename": "Query",
-    "abc({\\"order\\":\\"popularity\\"})": Array [
+    "books:abc({\\"order\\":\\"popularity\\"})": Array [
       Object {
         "__typename": "Book",
         "name": "abcd",

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -18,8 +18,12 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
   ): void;
   public abstract diff<T>(query: Cache.DiffOptions): Cache.DiffResult<T>;
   public abstract watch(watch: Cache.WatchOptions): () => void;
-  public abstract evict(dataId: string): boolean;
   public abstract reset(): Promise<void>;
+
+  // If called with only one argument, removes the entire entity
+  // identified by dataId. If called with a fieldName as well, removes all
+  // fields of the identified entity whose store names match fieldName.
+  public abstract evict(dataId: string, fieldName?: string): boolean;
 
   // intializer / offline / ssr API
   /**

--- a/src/cache/inmemory/__tests__/readFromStore.ts
+++ b/src/cache/inmemory/__tests__/readFromStore.ts
@@ -743,7 +743,7 @@ describe('reading from the store', () => {
   it('properly handles the @connection directive', () => {
     const store = defaultNormalizedCacheFactory({
       ROOT_QUERY: {
-        abc: [
+        'books:abc': [
           {
             name: 'efgh',
           },
@@ -778,6 +778,9 @@ describe('reading from the store', () => {
           Query: {
             fields: {
               books: {
+                // Even though we're returning an arbitrary string here,
+                // the InMemoryCache will ensure the actual key begins
+                // with "books".
                 keyArgs: () => "abc",
               },
             },
@@ -788,7 +791,7 @@ describe('reading from the store', () => {
 
     const store = defaultNormalizedCacheFactory({
       ROOT_QUERY: {
-        abc: [
+        "books:abc": [
           {
             name: 'efgh',
           },

--- a/src/cache/inmemory/__tests__/writeToStore.ts
+++ b/src/cache/inmemory/__tests__/writeToStore.ts
@@ -1806,7 +1806,7 @@ describe('writing to the store', () => {
     expect(store.toObject()).toEqual({
       ROOT_QUERY: {
         __typename: "Query",
-        abc: [
+        'books:abc': [
           {
             name: 'efgh',
           },
@@ -1852,7 +1852,7 @@ describe('writing to the store', () => {
     expect(store.toObject()).toEqual({
       ROOT_QUERY: {
         __typename: "Query",
-        abc: [
+        "books:abc": [
           {
             name: 'abcd',
           },
@@ -1881,7 +1881,7 @@ describe('writing to the store', () => {
     expect(store.toObject()).toEqual({
       ROOT_QUERY: {
         __typename: "Query",
-        abc: [
+        "books:abc": [
           {
             name: 'efgh',
           },

--- a/src/cache/inmemory/helpers.ts
+++ b/src/cache/inmemory/helpers.ts
@@ -9,3 +9,9 @@ export function getTypenameFromStoreObject(
     ? store.getFieldValue(objectOrReference.__ref, "__typename") as string
     : objectOrReference && objectOrReference.__typename;
 }
+
+const FieldNamePattern = /^[_A-Za-z0-9]+/;
+export function fieldNameFromStoreName(storeFieldName: string) {
+  const match = storeFieldName.match(FieldNamePattern);
+  return match && match[0];
+}

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -206,12 +206,12 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     return this.policies.identify(object);
   }
 
-  public evict(dataId: string): boolean {
+  public evict(dataId: string, fieldName?: string): boolean {
     if (this.optimisticData.has(dataId)) {
       // Note that this deletion does not trigger a garbage collection, which
       // is convenient in cases where you want to evict multiple entities before
       // performing a single garbage collection.
-      this.optimisticData.delete(dataId);
+      this.optimisticData.delete(dataId, fieldName);
       this.broadcastWatches();
       return !this.optimisticData.has(dataId);
     }

--- a/src/cache/inmemory/types.ts
+++ b/src/cache/inmemory/types.ts
@@ -22,7 +22,7 @@ export interface NormalizedCache {
   get(dataId: string): StoreObject;
   getFieldValue(dataId: string, storeFieldName: string): StoreValue;
   merge(dataId: string, incoming: StoreObject): void;
-  delete(dataId: string): void;
+  delete(dataId: string, fieldName?: string): void;
   clear(): void;
 
   // non-Map elements:

--- a/src/cache/inmemory/types.ts
+++ b/src/cache/inmemory/types.ts
@@ -57,7 +57,7 @@ export interface NormalizedCacheObject {
 
 export interface StoreObject {
   __typename?: string;
-  [storeFieldKey: string]: StoreValue;
+  [storeFieldName: string]: StoreValue;
 }
 
 export type OptimisticStoreItem = {

--- a/src/cache/inmemory/types.ts
+++ b/src/cache/inmemory/types.ts
@@ -20,7 +20,7 @@ export declare type IdGetter = (
 export interface NormalizedCache {
   has(dataId: string): boolean;
   get(dataId: string): StoreObject;
-  getFieldValue(dataId: string, fieldName: string): StoreValue;
+  getFieldValue(dataId: string, storeFieldName: string): StoreValue;
   merge(dataId: string, incoming: StoreObject): void;
   delete(dataId: string): void;
   clear(): void;


### PR DESCRIPTION
This PR adds an additional (optional) parameter to the `cache.evict` method, to delete a specific field from a normalized entity by calling `cache.evict(id, fieldName)`. The shorter `cache.evict(id)` version works as before.

Please read the commit messages to understand what was tricky/subtle about implementing this interface. In particular, `fieldName` is the actual name of the field, as defined in your schema, and thus it may refer to multiple field values (if the field takes arguments), all of which should be invalidated when the field is deleted.