### PR TITLE
Stop paying attention to previousResult in InMemoryCache.

### DIFF
--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -26,7 +26,6 @@ import {
   getMainDefinition,
   getQueryDefinition,
 } from '../../utilities/graphql/getFromAST';
-import { isEqual } from '../../utilities/common/isEqual';
 import { maybeDeepFreeze } from '../../utilities/common/maybeDeepFreeze';
 import { mergeDeepArray } from '../../utilities/common/mergeDeep';
 import { Cache } from '../core/types/Cache';
@@ -141,10 +140,6 @@ export class StoreReader {
    *
    * @param {Object} [variables] A map from the name of a variable to its value. These variables can
    * be referenced by the query document.
-   *
-   * @param {any} previousResult The previous result returned by this function for the same query.
-   * If nothing in the store changed since that previous result then values from the previous result
-   * will be returned to preserve referential equality.
    */
   public readQueryFromStore<QueryType>(
     options: ReadQueryOptions,
@@ -160,14 +155,12 @@ export class StoreReader {
    * identify if any data was missing from the store.
    * @param  {DocumentNode} query A parsed GraphQL query document
    * @param  {Store} store The Apollo Client store object
-   * @param  {any} previousResult The previous result returned by this function for the same query
    * @return {result: Object, complete: [boolean]}
    */
   public diffQueryAgainstStore<T>({
     store,
     query,
     variables,
-    previousResult,
     returnPartialData = true,
     rootId = 'ROOT_QUERY',
     config,
@@ -203,12 +196,6 @@ export class StoreReader {
           )}.`,
         );
       });
-    }
-
-    if (previousResult) {
-      if (isEqual(previousResult, execResult.result)) {
-        execResult.result = previousResult;
-      }
     }
 
     return {


### PR DESCRIPTION
The `previousResult` option was originally a way to ensure referential identity of structurally equivalent cache results, before the result caching system was introduced in #3394. It worked by returning `previousResult` whenever it was deeply equal to the new result.

The result caching system works a bit differently, and in particular never needs to do a deep comparison of results. However, there were still a few (test) cases where `previousResult` seemed to have a positive effect, and removing it seemed like a breaking change, so we kept it around.

In the meantime, the equality check has continued to waste CPU cycles, and the behavior of `previousResult` has undermined other improvements, such as freezing cache results (#4514). Even worse, `previousResult` effectively disabled an optimization that allowed `broadcastWatches` to skip unchanged queries (see [comments I removed](https://github.com/apollographql/apollo-client/pull/5644#discussion_r352922315) if curious). This commit restores that optimization.

I realized eliminating `previousResult` might finally be possible while working on PR #5617, which made the result caching system more precise by depending on IDs+fields rather than just IDs. This additional precision seems to have eliminated the few remaining cases where `previousResult` had
any meaningful benefit, as evidenced by the lack of any test changes in this commit… _even among the many direct tests of `previousResult` in `src/cache/inmemory/__tests__/diffAgainstStore.ts`!_

The removal of `previousResult` is definitely a breaking change (appropriate for Apollo Client 3.0), because you can still contrive cases where some never-before-seen `previousResult` object just happens to be deeply equal to the new result. Also, it's fair to say that this removal will strongly discourage disabling the result caching system (which is still possible for diagnostic purposes), since we rely on result caching to get the benefits that `previousResult` provided. Despite those modest theoretical drawbacks, it would be a relief to be done with `previousResult`, and I doubt we will find a better opportunity than AC3.