### PR TITLE
Improve optimistic result caching by limiting cache key diversity.

### DIFF
--- a/src/cache/inmemory/__tests__/optimistic.ts
+++ b/src/cache/inmemory/__tests__/optimistic.ts
@@ -427,7 +427,7 @@ describe('optimistic cache layers', () => {
     const spinelessAfterRemovingBuzz = readSpinelessFragment();
     expect(spinelessBeforeRemovingBuzz).toEqual(spinelessAfterRemovingBuzz);
     expect(spinelessBeforeRemovingBuzz).not.toBe(spinelessAfterRemovingBuzz);
-    expect(spinelessBeforeRemovingBuzz.author).not.toBe(
+    expect(spinelessBeforeRemovingBuzz.author).toBe(
       spinelessAfterRemovingBuzz.author,
     );
 

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -3,12 +3,10 @@ import './fixPolyfills';
 
 import { DocumentNode } from 'graphql';
 import { wrap } from 'optimism';
-import { KeyTrie } from 'optimism';
 
 import { ApolloCache, Transaction } from '../core/cache';
 import { Cache } from '../core/types/Cache';
 import { addTypenameToDocument } from '../../utilities/graphql/transform';
-import { canUseWeakMap } from '../../utilities/common/canUse';
 import {
   ApolloReducerConfig,
   NormalizedCacheObject,
@@ -49,7 +47,6 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
   private typenameDocumentCache = new Map<DocumentNode, DocumentNode>();
   private storeReader: StoreReader;
   private storeWriter: StoreWriter;
-  private cacheKeyRoot = new KeyTrie<object>(canUseWeakMap);
 
   // Set this while in a transaction to prevent broadcasts...
   // don't forget to turn it back on!
@@ -86,7 +83,6 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
 
     this.storeReader = new StoreReader({
       addTypename: this.addTypename,
-      cacheKeyRoot: this.cacheKeyRoot,
       policies: this.policies,
     });
 
@@ -101,8 +97,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
         const store = c.optimistic ? cache.optimisticData : cache.data;
         if (supportsResultCaching(store)) {
           const { optimistic, rootId, variables } = c;
-          return cache.cacheKeyRoot.lookup(
-            store.group,
+          return store.makeCacheKey(
             c.query,
             JSON.stringify({ optimistic, rootId, variables }),
           );

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -102,8 +102,8 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
         if (supportsResultCaching(store)) {
           const { optimistic, rootId, variables } = c;
           return cache.cacheKeyRoot.lookup(
+            store.group,
             c.query,
-            store,
             JSON.stringify({ optimistic, rootId, variables }),
           );
         }

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -105,7 +105,13 @@ export class StoreReader {
       }: ExecSelectionSetOptions) {
         if (supportsResultCaching(context.store)) {
           return cacheKeyRoot.lookup(
-            context.store,
+            // EntityStore objects share the same store.group if their
+            // dependencies are tracked together (for example, optimistic
+            // versus non-optimistic data), so we can reduce cache key
+            // diversity by using context.store.group here instead of just
+            // context.store, which promotes reusability of cached
+            // optimistic results.
+            context.store.group,
             selectionSet,
             JSON.stringify(context.variables),
             isReference(objectOrReference) ? objectOrReference.__ref : objectOrReference,
@@ -120,7 +126,9 @@ export class StoreReader {
       makeCacheKey({ field, array, context }) {
         if (supportsResultCaching(context.store)) {
           return cacheKeyRoot.lookup(
-            context.store,
+            // See comment above about why context.store.group is used
+            // here, instead of context.store.
+            context.store.group,
             field,
             array,
             JSON.stringify(context.variables),

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -5,7 +5,7 @@ import {
   InlineFragmentNode,
   SelectionSetNode,
 } from 'graphql';
-import { wrap, KeyTrie } from 'optimism';
+import { wrap } from 'optimism';
 import { invariant } from 'ts-invariant';
 
 import {
@@ -17,7 +17,6 @@ import {
   makeReference,
   StoreValue,
 } from '../../utilities/graphql/storeUtils';
-import { canUseWeakMap } from '../../utilities/common/canUse';
 import { createFragmentMap, FragmentMap } from '../../utilities/graphql/fragments';
 import { shouldInclude } from '../../utilities/graphql/directives';
 import {
@@ -75,20 +74,12 @@ type ExecSubSelectedArrayOptions = {
 
 export interface StoreReaderConfig {
   addTypename?: boolean;
-  cacheKeyRoot?: KeyTrie<object>;
   policies: Policies;
 }
 
 export class StoreReader {
   constructor(private config: StoreReaderConfig) {
-    const cacheKeyRoot =
-      config && config.cacheKeyRoot || new KeyTrie<object>(canUseWeakMap);
-
-    this.config = {
-      addTypename: true,
-      cacheKeyRoot,
-      ...config,
-    };
+    this.config = { addTypename: true, ...config };
 
     const {
       executeSelectionSet,
@@ -104,17 +95,12 @@ export class StoreReader {
         context,
       }: ExecSelectionSetOptions) {
         if (supportsResultCaching(context.store)) {
-          return cacheKeyRoot.lookup(
-            // EntityStore objects share the same store.group if their
-            // dependencies are tracked together (for example, optimistic
-            // versus non-optimistic data), so we can reduce cache key
-            // diversity by using context.store.group here instead of just
-            // context.store, which promotes reusability of cached
-            // optimistic results.
-            context.store.group,
+          return context.store.makeCacheKey(
             selectionSet,
             JSON.stringify(context.variables),
-            isReference(objectOrReference) ? objectOrReference.__ref : objectOrReference,
+            isReference(objectOrReference)
+              ? objectOrReference.__ref
+              : objectOrReference,
           );
         }
       }
@@ -125,10 +111,7 @@ export class StoreReader {
     }, {
       makeCacheKey({ field, array, context }) {
         if (supportsResultCaching(context.store)) {
-          return cacheKeyRoot.lookup(
-            // See comment above about why context.store.group is used
-            // here, instead of context.store.
-            context.store.group,
+          return context.store.makeCacheKey(
             field,
             array,
             JSON.stringify(context.variables),


### PR DESCRIPTION
This PR restores the full benefits of result caching (#3394) when optimistic updates are pending, which should significantly improve the performance of optimistic updates. Apollo Client 2.x did not attempt to apply result caching to optimistic data, and the `EntityStore` (fka `EntityCache`; see #5618) introduced by Apollo Client 3.0 has been getting the cache key logic slightly wrong since it was first implemented, so the problem addressed by this PR falls somewhere between a bug and an optimization opportunity.

Details can be found in the commit messages, reproduced here:

### Divide `EntityStore` into optimistic and non-optimistic `CacheGroup`s

The result caching system introduced by #3394 gained the ability to cache optimistic results (rather than just non-optimistic results) in #5197, but since then has suffered from unnecessary cache key diversity during optimistic updates, because every `EntityStore.Layer` object (corresponding to a single optimistic update) counts as a distinct cache key, which prevents cached results from being reused if they were originally read from a different `Layer` object.

This commit introduces the concept of a `CacheGroup`, `store.group`, which manages dependency tracking and also serves as a source of keys for the result caching system. While the `Root` object has its own `CacheGroup`, `Layer` objects share a `CacheGroup` object, which is the key to limiting diversity of cache keys when more than one optimistic update is pending.

This separation allows the `InMemoryCache` to enjoy the full benefits of result caching for both optimistic (`Layer`) and non-optimistic (`Root`) data, separately.

### Implement `EntityStore#makeCacheKey` to simplify result caching

Although all the components of a key returned by `makeCacheKey` are important, there's usually one that "anchors" the rest, because it survives the longest and changes the least. In the case of the result caching system, the current `EntityStore` object is that anchor.

This commit formalizes that anchoring role by making the `EntityStore` literally responsible for generating cache keys based on query AST objects, variables, and other frequently changing inputs.

Especially given the recent introduction of `CacheGroup` logic, it's easier to reason about the `makeCacheKey` functions if we put part of their implementation behind an abstraction. This abstraction also means we no longer need to pass a `KeyTrie` into the `StoreReader` constructor, as the `KeyTrie` (`context.store.group.keyMaker`) now resides within the `EntityStore`, which is provided to `StoreReader` as part of the `ExecContext` (`context.store`).