### PR TITLE
Allow getFieldValue to read from foreign Reference objects.

### DIFF
--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -206,8 +206,12 @@ export class StoreReader {
 
     // Provides a uniform interface from reading field values, whether or
     // not the parent object is a normalized entity object.
-    function getFieldValue(fieldName: string): StoreValue {
+    function getFieldValue(
+      fieldName: string,
+      foreignRef?: Reference,
+    ): StoreValue {
       let fieldValue: StoreValue;
+      if (foreignRef) objectOrReference = foreignRef;
       if (isReference(objectOrReference)) {
         const dataId = objectOrReference.__ref;
         fieldValue = store.getFieldValue(dataId, fieldName);


### PR DESCRIPTION
The `getFieldValue(fieldName)` helper function was introduced in #5617 for reading fields from the current `StoreObject` during `read` functions.

This commit adds a second parameter to `getFieldValue`, `foreignRef`, which is an optional `Reference`. When `foreignRef` is provided, `getFieldValue` will read the specified field from the `StoreObject` identified by the `foreignRef`, instead of reading from the current `StoreObject`.

In either case, `getFieldValue` reads an existing value from the cache, without invoking any `read` functions, so you cannot use `getFieldValue` to set up expensive (and potentially cyclic) chains of `read` functions.

With this new ability to read fields from arbitrary `Reference` objects, `read` functions can explore the entire reachable cache without having to call `cache.readQuery`. The beauty of this system is that every field reading operation requires a function call (`getFieldValue`), which allows the result caching system to know which fields were read from which entities, so future changes to those fields can properly invalidate any cached results that involved the original `read` function.

I recommend reading through the included tests to get a concrete sense for how everything works.