### PR TITLE
Storage and invalidation for custom field read functions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     {
       "name": "apollo-client",
       "path": "./dist/apollo-client.cjs.min.js",
-      "maxSize": "23.95 kB"
+      "maxSize": "24 kB"
     }
   ],
   "peerDependencies": {

--- a/src/cache/inmemory/__tests__/diffAgainstStore.ts
+++ b/src/cache/inmemory/__tests__/diffAgainstStore.ts
@@ -959,14 +959,14 @@ describe('diffing queries against the store', () => {
         typePolicies: {
           Query: {
             fields: {
-              person(_, { args, toReference, getFieldValue, isReference }) {
+              person(_, { args, isReference, toReference, readField }) {
                 expect(typeof args.id).toBe('number');
                 const ref = toReference({ __typename: 'Person', id: args.id });
                 expect(isReference(ref)).toBe(true);
                 expect(ref).toEqual({
                   __ref: `Person:${JSON.stringify({ id: args.id })}`,
                 });
-                const found = (getFieldValue("people") as Reference[]).find(
+                const found = readField<Reference[]>("people").find(
                   person => person.__ref === ref.__ref);
                 expect(found).toBeTruthy();
                 return found;

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -1,7 +1,7 @@
 import gql from "graphql-tag";
 import { InMemoryCache } from "../inMemoryCache";
 import { StoreValue } from "../../../utilities";
-import { FieldPolicy } from "../policies";
+import { FieldPolicy, Policies } from "../policies";
 import { Reference } from "../../../utilities/graphql/storeUtils";
 
 describe("type policies", function () {
@@ -159,6 +159,7 @@ describe("type policies", function () {
           keyFields(book, context) {
             expect(context.selectionSet.kind).toBe("SelectionSet");
             expect(context.fragmentMap).toEqual({});
+            expect(context.policies).toBeInstanceOf(Policies);
             return context.typename + ":" + book.isbn;
           },
         },
@@ -538,9 +539,15 @@ describe("type policies", function () {
               todos: {
                 keyArgs: [],
 
-                read(existing: any[], { args, toReference, isReference }) {
+                read(existing: any[], {
+                  args,
+                  toReference,
+                  isReference,
+                  policies,
+                }) {
                   expect(!existing || Object.isFrozen(existing)).toBe(true);
                   expect(typeof toReference).toBe("function");
+                  expect(policies).toBeInstanceOf(Policies);
                   const slice = existing.slice(
                     args.offset,
                     args.offset + args.limit,
@@ -553,9 +560,11 @@ describe("type policies", function () {
                   args,
                   toReference,
                   isReference,
+                  policies,
                 }) {
                   expect(!existing || Object.isFrozen(existing)).toBe(true);
                   expect(typeof toReference).toBe("function");
+                  expect(policies).toBeInstanceOf(Policies);
                   const copy = existing ? existing.slice(0) : [];
                   const limit = args.offset + args.limit;
                   for (let i = args.offset; i < limit; ++i) {

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -123,13 +123,14 @@ interface ReadFunctionOptions extends FieldFunctionOptions {
   // good way to deliver asynchronous results.
   invalidate(): void;
 
-  // Gets the existing StoreValue for a given field within the current
-  // object, without calling any read functions (to prevent any risk of
-  // infinite recursion). If the provided FieldNode has arguments, the
-  // same options.variables will be used to compute the argument values.
-  // If a foreignRef is provided, the value will be read from that object
+  // Helper function for reading other fields within the current object.
+  // If a foreignRef is provided, the field will be read from that object
   // instead of the current object, so this function can be used (together
   // with isReference) to examine the cache outside the current entity.
+  // If a FieldNode is passed instead of a string, and that FieldNode has
+  // arguments, the same options.variables will be used to compute the
+  // argument values. Note that this function will invoke custom read
+  // functions for other fields, if defined.
   readField<T = StoreValue>(
     nameOrField: string | FieldNode,
     foreignRef?: Reference,

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -114,13 +114,15 @@ type StorageType = Record<string, any>;
 
 interface ReadFunctionOptions extends FieldFunctionOptions {
   // A handy place to put field-specific data that you want to survive
-  // across multiple read function calls. Useful for caching.
+  // across multiple read function calls. Useful for field-level caching,
+  // if your read function does any expensive work.
   storage: StorageType;
 
   // Call this function to invalidate any cached queries that previously
-  // consumed this field. If you use options.storage as a cache, setting a
-  // new value in the cache and then calling options.invalidate() can be a
-  // good way to deliver asynchronous results.
+  // consumed this field. If you use options.storage to cache the result
+  // of an expensive read function, updating options.storage and then
+  // calling options.invalidate() can be a good way to deliver the new
+  // result asynchronously.
   invalidate(): void;
 
   // Helper function for reading other fields within the current object.

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -33,7 +33,10 @@ import {
 } from "./types";
 
 import { fieldNameFromStoreName } from './helpers';
-import { FieldValueGetter } from './readFromStore';
+import {
+  FieldValueGetter,
+  FieldStorageGetter,
+} from './readFromStore';
 
 const hasOwn = Object.prototype.hasOwnProperty;
 
@@ -105,6 +108,10 @@ interface FieldFunctionOptions {
 }
 
 interface ReadFunctionOptions extends FieldFunctionOptions {
+  // A handy place to put field-specific data that you want to survive
+  // across multiple read function calls. Useful for caching.
+  storage: ReturnType<FieldStorageGetter>;
+
   // Gets the existing StoreValue for a given field within the current
   // object, without calling any read functions (to prevent any risk of
   // infinite recursion). If the provided FieldNode has arguments, the
@@ -415,6 +422,7 @@ export class Policies {
   public readField(
     field: FieldNode,
     getFieldValue: FieldValueGetter,
+    getFieldStorage: FieldStorageGetter,
     typename = getFieldValue("__typename") as string,
     variables?: Record<string, any>,
   ): StoreValue {
@@ -431,6 +439,7 @@ export class Policies {
         policies,
         isReference,
         toReference: policies.toReference,
+        storage: getFieldStorage(storeFieldName),
         getFieldValue(nameOrField, foreignRef) {
           return getFieldValue(
             typeof nameOrField === "string" ? nameOrField :

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -433,18 +433,18 @@ export class Policies {
   private storageTrie = new KeyTrie<StorageType>(true);
   private fieldDep = dep<StorageType>();
 
-  public readField(
+  public readField<V = StoreValue>(
     objectOrReference: StoreObject | Reference,
     nameOrField: string | FieldNode,
     getFieldValue: FieldValueGetter,
     variables?: Record<string, any>,
-  ): StoreValue {
+  ): Readonly<V> {
     const policies = this;
     const typename = getFieldValue<string>(objectOrReference, "__typename");
     const storeFieldName = typeof nameOrField === "string" ? nameOrField
       : policies.getStoreFieldName(typename, nameOrField, variables);
     const fieldName = fieldNameFromStoreName(storeFieldName);
-    const existing = getFieldValue(objectOrReference, storeFieldName);
+    const existing = getFieldValue<V>(objectOrReference, storeFieldName);
     const policy = policies.getFieldPolicy(typename, fieldName, false);
     const read = policy && policy.read;
 
@@ -473,17 +473,17 @@ export class Policies {
         // I'm not sure why it's necessary to repeat the parameter types
         // here, but TypeScript complains if I leave them out.
         readField<T>(nameOrField: string | FieldNode, ref?: Reference) {
-          return policies.readField(
+          return policies.readField<T>(
             ref || objectOrReference,
             nameOrField,
             getFieldValue,
             variables,
-          ) as Readonly<T>;
+          );
         },
         invalidate() {
           policies.fieldDep.dirty(storage);
         },
-      });
+      }) as Readonly<V>;
     }
 
     return existing;

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -441,9 +441,9 @@ export class Policies {
     nameOrField: string | FieldNode,
     getFieldValue: FieldValueGetter,
     variables?: Record<string, any>,
+    typename = getFieldValue<string>(objectOrReference, "__typename"),
   ): Readonly<V> {
     const policies = this;
-    const typename = getFieldValue<string>(objectOrReference, "__typename");
     const storeFieldName = typeof nameOrField === "string" ? nameOrField
       : policies.getStoreFieldName(typename, nameOrField, variables);
     const fieldName = fieldNameFromStoreName(storeFieldName);

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -470,13 +470,15 @@ export class Policies {
         isReference,
         toReference: policies.toReference,
         storage,
-        readField(nameOrField, foreignRef) {
+        // I'm not sure why it's necessary to repeat the parameter types
+        // here, but TypeScript complains if I leave them out.
+        readField<T>(nameOrField: string | FieldNode, ref?: Reference) {
           return policies.readField(
-            foreignRef || objectOrReference,
+            ref || objectOrReference,
             nameOrField,
             getFieldValue,
             variables,
-          ) as any;
+          ) as Readonly<T>;
         },
         invalidate() {
           policies.fieldDep.dirty(storage);

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -412,7 +412,7 @@ export class Policies {
       : fieldName + ":" + storeFieldName;
   }
 
-  public readFieldFromStoreObject(
+  public readField(
     field: FieldNode,
     getFieldValue: FieldValueGetter,
     typename = getFieldValue("__typename") as string,

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -238,7 +238,7 @@ export class StoreReader {
       if (!shouldInclude(selection, variables)) return;
 
       if (isField(selection)) {
-        let fieldValue = policies.readFieldFromStoreObject(
+        let fieldValue = policies.readField(
           selection,
           getFieldValue,
           typename,

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -237,6 +237,7 @@ export class StoreReader {
           selection,
           getFieldValue,
           variables,
+          typename,
         );
 
         if (fieldValue === void 0) {

--- a/src/core/__tests__/QueryManager/links.ts
+++ b/src/core/__tests__/QueryManager/links.ts
@@ -330,10 +330,10 @@ describe('Link interactions', () => {
         typePolicies: {
           Query: {
             fields: {
-              book(_, { args, toReference, getFieldValue }) {
+              book(_, { args, toReference, readField }) {
                 const ref = toReference({ __typename: "Book", id: args.id });
                 expect(ref).toEqual({ __ref: `Book:${args.id}` });
-                const found = (getFieldValue("books") as Reference[]).find(
+                const found = readField<Reference[]>("books").find(
                   book => book.__ref === ref.__ref);
                 expect(found).toBeTruthy();
                 return found;


### PR DESCRIPTION
Custom field `read` functions might need to perform expensive computations, so caching the results of `read` functions is encouraged. Unfortunately, there is no good way for the `InMemoryCache` to provide that caching automatically, since `read` function results could depend on any/all/some/none of the arguments passed to the field, and only the application developer knows which arguments are important.

At this point you might be thinking, "Doesn't the developer already have an opportunity to tell the cache which arguments are important by configuring `keyArgs: [...]` in the field policy?" While that statement is true, it's only the beginning of the story. When you specify `keyArgs`, you're telling the cache how to distinguish multiple values for a given field, but the `read` and `merge` functions have access to the complete set of arguments, so `keyArgs` alone is not enough to differentiate between all possible `read` function return values.

In fact, a common pattern when implementing custom `read` and `merge` functions is to pass `keyArgs: false` to disable the default argument-based differentiation entirely, so the `read` and `merge` functions can take full responsibility for interpreting the arguments passed to the field. In this common scenario, the cache knows nothing about how `read` results should be stored. In short, `read` function caching is a responsibility that must be left to the `read` function.

To resolve this seemingly unresolvable conundrum, I've adopted a simple but flexible policy: every `read` function now has access to a private `options.storage` object, which is a `Record<string, any>` where the `read` function can stash any information it wants to preserve across multiple invocations of the `read` function. This `options.storage` object is unique to the current entity object and the current field name (plus any additional information specified via `keyArgs`). In other words, you can think of this `options.storage` object as storing mutable metadata about the immutable `existing` field value.

Here's an example of a cached `read` function for a `WorkItem.expensiveResult` field:
```ts
const cache = new InMemoryCache({
  typePolicies: {
    WorkItem: {
      fields: {
        expensiveResult: {
          keyArgs: false, // read function assumes full responsibility for args handling
          read(existing, { args, storage }) {
            const key = makeKeyFromArgs(args); // user-defined
            if (key in storage) return storage[key];
            return storage[key] = expensiveComputation(existing, args);
          },
        },
      },
    },
  },
});
```

To complement the `options.storage` object, this PR also introduces an `options.invalidate()` function that can be called to invalidate any cached query results that previously consumed the field value, which is especially useful when the `read` function uses external data sources that might change over time. Specifically, calling `invalidate()` will invalidate any results that were computed using the same `options.storage` object:
```ts
const cache = new InMemoryCache({
  typePolicies: {
    WorkItem: {
      fields: {
        expensiveResult: {
          keyArgs: false,
          read(existing, { args, storage, invalidate }) {
            const key = makeKeyFromArgs(args);
            if (key in storage) return storage[key];
            // Suppose the expensiveComputation takes a callback function that will
            // be called whenever the result of the computation may have changed:
            return storage[key] = expensiveComputation(existing, args, newResult => {
              // If a new result is not available, delete storage[key] instead.
              storage[key] = newResult;
              invalidate();
            });
          },
        },
      },
    },
  },
});
```

Finally, this PR renames the `options.getFieldValue` helper function to `options.readField`, and allows it to invoke custom `read` functions for any fields that it reads, rather than just retrieving the `existing` field value. See the commit message and tests included in 5219e36244676f1d6f86317c8177abd3b5e7c8f8 to understand why this change was important.