### PR TITLE
Assume keyArgs:false when read or merge functions are defined.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     {
       "name": "apollo-client",
       "path": "./dist/apollo-client.cjs.min.js",
-      "maxSize": "24 kB"
+      "maxSize": "24.05 kB"
     }
   ],
   "peerDependencies": {

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -300,10 +300,18 @@ export class Policies {
               // compute a composite identity for the field.
               Array.isArray(keyArgs) ? keyArgsFnFromSpecifier(keyArgs) :
               // Pass a function to take full control over field identity.
-              typeof keyArgs === "function" ? keyArgs : void 0;
+              typeof keyArgs === "function" ? keyArgs :
+              // Leave existing.keyFn unchanged if all above cases fail.
+              existing.keyFn;
 
             if (typeof read === "function") existing.read = read;
             if (typeof merge === "function") existing.merge = merge;
+          }
+
+          if (existing.read || existing.merge) {
+            // If we have a read or merge function, assume keyArgs:false
+            // unless existing.keyFn has already been explicitly set.
+            existing.keyFn = existing.keyFn || simpleKeyArgsFn;
           }
         });
       }


### PR DESCRIPTION
As I've been working with the new `typePolicies` configuration API, I've become increasingly convinced that the presence of a `read` or `merge` function in a `FieldPolicy` should imply `keyArgs: false` by default, because those functions will almost always want full control over the interpretation of arguments, and it's annoying to have to pass `keyArgs: false` every time (with an obligatory comment explaining what it does), just to get that desired behavior.

If the developer has defined a `read` or `merge` function but still wants the cache to differentiate field values according to certain arguments, that's easy: just add an explicit `keyArgs: [...]` property to the `FieldPolicy`, to override the inferred `keyArgs: false`.