### PR TITLE
Skip running client resolvers when mutation has failed

### DIFF
--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1201,6 +1201,9 @@ export class QueryManager<TStore> {
     const { clientQuery } = this.transform(query);
     if (clientQuery) {
       observable = asyncMap(observable, result => {
+        if (result.errors) {
+          return result;
+        }
         return this.localState.runResolvers({
           document: clientQuery,
           remoteResult: result,

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1201,7 +1201,7 @@ export class QueryManager<TStore> {
     const { clientQuery } = this.transform(query);
     if (clientQuery) {
       observable = asyncMap(observable, result => {
-        if (result.errors) {
+        if (graphQLResultHasError(result)) {
           return result;
         }
         return this.localState.runResolvers({

--- a/src/core/__tests__/QueryManager/index.ts
+++ b/src/core/__tests__/QueryManager/index.ts
@@ -1600,6 +1600,8 @@ describe('QueryManager', () => {
       }).then(resolve, reject);
   });
 
+  it.todo('skip running client resolver and forward original error when the mutation has failed');
+
   itAsync(`doesn't return data while query is loading`, (resolve, reject) => {
     const query1 = gql`
       {


### PR DESCRIPTION
First of all, thank you for creating awesome library and building great community.

I'm using Apollo stack, include client state with the apollo-client for my recent project. 

And It's works quite well for many cases, but still need workarounds for many known bugs (like fragment duplication, etc) and sometimes bit hard to figure problem in the apollo client.

This is a patch solve a critical problem in my project: 

When a mutation output has client extensions and throw errors as result. Apollo client doesn't provide original error correctly to components.

expected result: ApolloError contains graphlErrors.

actual result: The networkError is set instead of graphqlErrors, and message `Cannot read property 'updatePost' of null`

```gql
extend type Post {
  preview: String!
}

mutation UpdatePostTitle($id: String!, newTitle: String!) {
  updatePost(id: $id, title: $newTitle) {
    id # field known as remote schema
    preview @client 
  }
}
```

![image](https://user-images.githubusercontent.com/9696352/70799675-a6233000-1ded-11ea-8f79-c4edc5278c08.png)


The first error object in screenshot is logged by apollo-link-error and second is what I've actually got from `useMutation()`

This caused by inside of QueryManager trying to resolve client query even the result of root mutation has failed and the field set as null.

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests

I am not sure about test, there's no existing test for local state in QueryManager. so I left it as jest `todo()` for now. Any guides will be helpful. 
