### PR TITLE
Fully eliminate the concept of heuristic fragment matching.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     {
       "name": "apollo-client",
       "path": "./dist/apollo-client.cjs.min.js",
-      "maxSize": "24.05 kB"
+      "maxSize": "24 kB"
     }
   ],
   "peerDependencies": {

--- a/src/cache/inmemory/__tests__/diffAgainstStore.ts
+++ b/src/cache/inmemory/__tests__/diffAgainstStore.ts
@@ -258,7 +258,7 @@ describe('diffing queries against the store', () => {
         returnPartialData: false,
       });
 
-      expect(complete).toBe(false);
+      expect(complete).toBe(true);
     });
   });
 
@@ -306,7 +306,7 @@ describe('diffing queries against the store', () => {
       query: unionQuery,
     });
 
-    expect(complete).toBe(false);
+    expect(complete).toBe(true);
   });
 
   it('throws an error on a query with fields missing from matching named fragments', () => {

--- a/src/cache/inmemory/__tests__/entityStore.ts
+++ b/src/cache/inmemory/__tests__/entityStore.ts
@@ -1199,10 +1199,16 @@ describe('EntityStore', () => {
 
     expect(() => cache.readQuery({
       query: queryWithAliases,
-    })).toThrow(/Can't find field a on object/);
+    })).toThrow(
+      "Attempted to match fragment Rest with type condition ABCs against " +
+        "object with unknown __typename"
+    );
 
     expect(() => cache.readQuery({
       query: queryWithoutAliases,
-    })).toThrow(/Can't find field a on object/);
+    })).toThrow(
+      "Attempted to match fragment Rest with type condition ABCs against " +
+        "object with unknown __typename"
+    );
   });
 });

--- a/src/cache/inmemory/__tests__/roundtrip.ts
+++ b/src/cache/inmemory/__tests__/roundtrip.ts
@@ -21,7 +21,12 @@ function assertDeeplyFrozen(value: any, stack: any[] = []) {
 }
 
 function storeRoundtrip(query: DocumentNode, result: any, variables = {}) {
-  const policies = new Policies();
+  const policies = new Policies({
+    possibleTypes: {
+      Character: ["Jedi", "Droid"],
+    },
+  });
+
   const reader = new StoreReader({ policies });
   const writer = new StoreWriter({ policies });
 
@@ -338,7 +343,7 @@ describe('roundtrip', () => {
     // XXX this test is weird because it assumes the server returned an incorrect result
     // However, the user may have written this result with client.writeQuery.
     it('should throw an error on two of the same inline fragment types', () => {
-      return expect(() => {
+      return withWarning(() => expect(() => {
         storeRoundtrip(
           gql`
             query {
@@ -364,7 +369,7 @@ describe('roundtrip', () => {
             ],
           },
         );
-      }).toThrowError(/Can\'t find field rank on object/);
+      }).toThrowError(/Can\'t find field rank on object/));
     });
 
     it('should resolve fields it can on interface with non matching inline fragments', () => {
@@ -469,6 +474,7 @@ describe('roundtrip', () => {
                 __typename: 'Droid',
                 name: 'R2D2',
                 model: 'astromech',
+                side: 'bright',
               },
             ],
           },
@@ -477,7 +483,7 @@ describe('roundtrip', () => {
     });
 
     it('should throw on error on two of the same spread fragment types', () => {
-      expect(() =>
+      withWarning(() => expect(() => {
         storeRoundtrip(
           gql`
             fragment jediSide on Jedi {
@@ -506,8 +512,8 @@ describe('roundtrip', () => {
               },
             ],
           },
-        ),
-      ).toThrowError(/Can\'t find field rank on object/);
+        );
+      }).toThrowError(/Can\'t find field rank on object/));
     });
 
     it('should resolve on @include and @skip with inline fragments', () => {

--- a/src/cache/inmemory/__tests__/roundtrip.ts
+++ b/src/cache/inmemory/__tests__/roundtrip.ts
@@ -308,8 +308,8 @@ describe('roundtrip', () => {
       );
     });
 
-    it('should resolve on union types with inline fragments without typenames with warning', () => {
-      return withWarning(() => {
+    it('should error on union types with inline fragments without typenames', () => {
+      return expect(() => {
         storeRoundtrip(
           gql`
             query {
@@ -337,7 +337,10 @@ describe('roundtrip', () => {
             ],
           },
         );
-      });
+      }).toThrowError(
+        'Attempted to match fragment with type condition Jedi against ' +
+          'object with unknown __typename'
+      );
     });
 
     // XXX this test is weird because it assumes the server returned an incorrect result

--- a/src/cache/inmemory/__tests__/writeToStore.ts
+++ b/src/cache/inmemory/__tests__/writeToStore.ts
@@ -1546,7 +1546,7 @@ describe('writing to the store', () => {
       expect(newStore.get('1')).toEqual(result.todos[0]);
     });
 
-    it('should warn when it receives the wrong data with non-union fragments (using an heuristic matcher)', () => {
+    it('should warn when it receives the wrong data with non-union fragments', () => {
       const result = {
         todos: [
           {
@@ -1573,7 +1573,7 @@ describe('writing to the store', () => {
       }, /Missing field description/);
     });
 
-    it('should warn when it receives the wrong data inside a fragment (using an introspection matcher)', () => {
+    it('should warn when it receives the wrong data inside a fragment', () => {
       const queryWithInterface = gql`
         query {
           todos {
@@ -1627,7 +1627,7 @@ describe('writing to the store', () => {
       }, /Missing field price/);
     });
 
-    it('should warn if a result is missing __typename when required (using an heuristic matcher)', () => {
+    it('should warn if a result is missing __typename when required', () => {
       const result: any = {
         todos: [
           {

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -381,6 +381,14 @@ export class Policies {
     if (!fragment.typeCondition) return true;
 
     const supertype = fragment.typeCondition.name.value;
+
+    invariant(
+      typename,
+      `Attempted to match fragment ${
+        fragment.kind === "InlineFragment" ? "" : fragment.name.value + " "
+      }with type condition ${supertype} against object with unknown __typename`,
+    );
+
     if (typename === supertype) return true;
 
     if (this.usingPossibleTypes) {

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -377,7 +377,7 @@ export class Policies {
   public fragmentMatches(
     fragment: InlineFragmentNode | FragmentDefinitionNode,
     typename: string,
-  ): boolean | "heuristic" {
+  ): boolean {
     if (!fragment.typeCondition) return true;
 
     const supertype = fragment.typeCondition.name.value;
@@ -399,12 +399,9 @@ export class Policies {
           });
         }
       }
-      // When possibleTypes is defined, we always either return true from the
-      // loop above or return false here (never 'heuristic' below).
-      return false;
     }
 
-    return "heuristic";
+    return false;
   }
 
   public getStoreFieldName(

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -298,25 +298,14 @@ export class StoreReader {
           );
         }
 
-        const match = policies.fragmentMatches(fragment, typename);
-
-        if (match) {
-          let fragmentExecResult = this.executeSelectionSet({
-            selectionSet: fragment.selectionSet,
-            objectOrReference,
-            context,
-          });
-
-          if (match === 'heuristic' && fragmentExecResult.missing) {
-            fragmentExecResult = {
-              ...fragmentExecResult,
-              missing: fragmentExecResult.missing.map(info => {
-                return { ...info, tolerable: true };
-              }),
-            };
-          }
-
-          objectsToMerge.push(handleMissing(fragmentExecResult));
+        if (policies.fragmentMatches(fragment, typename)) {
+          objectsToMerge.push(handleMissing(
+            this.executeSelectionSet({
+              selectionSet: fragment.selectionSet,
+              objectOrReference,
+              context,
+            })
+          ));
         }
       }
     });

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -6,7 +6,7 @@ import {
   SelectionSetNode,
 } from 'graphql';
 import { wrap } from 'optimism';
-import { invariant } from 'ts-invariant';
+import { invariant, InvariantError } from 'ts-invariant';
 
 import {
   isField,
@@ -51,7 +51,6 @@ interface ExecContext {
 export type ExecResultMissingField = {
   object: StoreObject;
   fieldName: string;
-  tolerable: boolean;
 };
 
 export type ExecResult<R = any> = {
@@ -178,14 +177,11 @@ export class StoreReader {
 
     if (hasMissingFields && ! returnPartialData) {
       execResult.missing!.forEach(info => {
-        invariant(
-          info.tolerable,
-          `Can't find field ${info.fieldName} on object ${JSON.stringify(
-            info.object,
-            null,
-            2,
-          )}.`,
-        );
+        throw new InvariantError(`Can't find field ${
+          info.fieldName
+        } on object ${
+          JSON.stringify(info.object, null, 2)
+        }.`);
       });
     }
 
@@ -244,7 +240,6 @@ export class StoreReader {
           getMissing().push({
             object: objectOrReference as StoreObject,
             fieldName: selection.name.value,
-            tolerable: false,
           });
 
         } else if (Array.isArray(fieldValue)) {

--- a/src/utilities/graphql/storeUtils.ts
+++ b/src/utilities/graphql/storeUtils.ts
@@ -265,6 +265,10 @@ export function getTypenameFromResult(
   selectionSet: SelectionSetNode,
   fragmentMap: FragmentMap,
 ): string | undefined {
+  if (typeof result.__typename === 'string') {
+    return result.__typename;
+  }
+
   for (const selection of selectionSet.selections) {
     if (isField(selection)) {
       if (selection.name.value === '__typename') {
@@ -280,10 +284,6 @@ export function getTypenameFromResult(
         return typename;
       }
     }
-  }
-  // TODO Move this first?
-  if (typeof result.__typename === 'string') {
-    return result.__typename;
   }
 }
 


### PR DESCRIPTION
Although we removed the `FragmentMatcher` abstraction in PR #5073, and the `HeuristicFragmentMatcher` no longer exists, we kept trying to match fragments whenever all their fields matched, even if the fragment type condition was not satisfied by the `__typename` of the object in question.

I recently came to appreciate just how harmful this best-effort matching can be, when I realized that it means we call `executeSelectionSet` (on the reading side) and `processSelectionSet` (on the writing side) for *every* unmatched fragment, and then just throw away the result if any fields are missing, but not before recording those fields as missing in a weaker way than usual, using the `ExecResultMissingField.tolerable` boolean.

Not only is this strategy potentially costly for queries with lots of fragments that really should not match, it also only ever made sense on the writing side, where the fields of the fragment can be compared to the fields of a single incoming result object, so the presence of all the fragment's fields is a pretty good indication that the fragment matched. On the reading side, we're comparing the fields of the fragment to _all the fields we've written into the cache so far_, which means heuristic fragment matching is sensitive to the whole history of cache writes for the entity in question, not just the current query.

We could eliminate heuristic fragment matching just for reading, but then we'd have to tell people to start passing [`possibleTypes`](https://github.com/apollographql/apollo-client/blob/release-3.0/docs/source/data/fragments.md#using-fragments-with-unions-and-interfaces) to the `InMemoryCache` constructor (the correct, non-heuristic solution), which would simultaneously make heuristic fragment matching unnecessary on the writing side, so we might as well completely eliminate heuristic matching altogether.