### PR TITLE
Unify FieldFunctionOptions between read and merge functions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     {
       "name": "apollo-client",
       "path": "./dist/apollo-client.cjs.min.js",
-      "maxSize": "24 kB"
+      "maxSize": "24.1 kB"
     }
   ],
   "peerDependencies": {


### PR DESCRIPTION
Although the needs of `read` functions are not exactly the same as those of `merge` functions, I have recently come to realize that the extra properties of `ReadFunctionOptions` as compared with the shared `FieldFunctionOptions` (`readField`, `storage`, and `invalidate`) actually do make sense for `merge` functions in some relatively obscure but nevertheless legitimate scenarios, and the prospect of using the same interface for both sets of options (that is, just `FieldFunctionOptions`) is appealing for all sorts of reasons: symmetry, simplicity, explainability, and even code sharing.

Specifically, `readField` is useful for `merge` functions that maintain a paginated *set* of child objects (as opposed to a simple list), and need to read fields from those objects (which might be `Reference` objects) in order to deduplicate them. The `storage` and `invalidate` options are useful when a `merge` function is cooperating closely with a companion `read` function, and cannot simply communicate via the underlying cache data. For example, if `options.storage` is being used as a cache, the `merge` function might want to delete some cached data from it, to help the `read` function avoid reusing stale data.

I'm not ruling out the possibility that these options interfaces will diverge again in the future. For example, I think the `foreignObjOrRef` argument passed to the `options.readField` function for `merge` functions should not be optional, as it is for `read` functions, but it seems acceptable to enforce that expectation with a runtime `invariant`, rather than using the type system. Also, it feels a little weird that the `options.storage` object can sometimes be `null` for `merge` functions, but I think my implementation comments adequately justify that choice.

For now, I'd like to see how far we can get before this new-found symmetry becomes impractical again.