### PR TITLE
Use `getIntrospectionQuery` rather than `introspectionQuery` constant.

### DIFF
--- a/src/__tests__/local-state/general.ts
+++ b/src/__tests__/local-state/general.ts
@@ -1,6 +1,6 @@
 import gql from 'graphql-tag';
 import { DocumentNode, GraphQLError } from 'graphql';
-import { introspectionQuery } from 'graphql/utilities';
+import { getIntrospectionQuery } from 'graphql/utilities';
 
 import { Observable } from '../../utilities/observables/Observable';
 import { ApolloLink } from '../../link/core/ApolloLink';
@@ -71,7 +71,7 @@ describe('General functionality', () => {
 
   it('should not interfere with server introspection queries', () => {
     const query = gql`
-      ${introspectionQuery}
+      ${getIntrospectionQuery()}
     `;
 
     const error = new GraphQLError('no introspection result found');


### PR DESCRIPTION
The next major version of `graphql-js` deprecates the `introspectionQuery` constant (thanks to https://github.com/graphql/graphql-js/pull/2124) that was previously leveraged in Apollo Client tests for obtaining the introspection query (to be clear, this is the query used to introspect a server, not the result of the introspection itself) in one particular test.

This deprecation isn't entirely surprising since the `getIntrospectionQuery` utility method has existed since `graphql@0.12` and is the recommended way to obtain this query in more recent versions of `graphql`, so this changes that test to use that new method.

I discovered this while investigating our compatibility with the most recently published `graphql@15.0.0-alpha.2` on `apollo-server`, `apollo-tooling` and `apollo-client`.  Other than this, I didn't encounter any test failures when updating the root `graphql` dev-dependency to `graphql@15.0.0-alpha.2`!

Deprecated by: https://github.com/graphql/graphql-js/pull/2124
In Response to: https://github.com/graphql/graphql-js/issues/2303
Relates to: https://github.com/apollographql/apollo-server/pull/3649
Relates to: https://github.com/apollographql/apollo-tooling/pull/1743