### PR TITLE
simplify rollup external configuration

### DIFF
--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -8,27 +8,21 @@ import packageJson from '../package.json';
 
 const distDir = './dist';
 
-const globals = {
-  tslib: 'tslib',
-  'ts-invariant': 'invariant',
-  'symbol-observable': '$$observable',
-  'graphql/language/printer': 'print',
-  optimism: 'optimism',
-  'graphql/language/visitor': 'visitor',
-  'graphql/execution/execute': 'execute',
-  'graphql-tag': 'graphqlTag',
-  'fast-json-stable-stringify': 'stringify',
-  '@wry/equality': 'wryEquality',
-  graphql: 'graphql',
-  react: 'React',
-  'zen-observable': 'Observable',
-};
-
-const hasOwn = Object.prototype.hasOwnProperty;
-
-function external(id) {
-  return hasOwn.call(globals, id);
-}
+const external = [
+  'tslib',
+  'ts-invariant',
+  'symbol-observable',
+  'graphql/language/printer',
+  'optimism',
+  'graphql/language/visitor',
+  'graphql/execution/execute',
+  'graphql-tag',
+  'fast-json-stable-stringify',
+  '@wry/equality',
+  'graphql',
+  'react',
+  'zen-observable'
+];
 
 function prepareESM(input, outputDir) {
   return {

--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -15,11 +15,9 @@ const external = [
   'graphql/language/printer',
   'optimism',
   'graphql/language/visitor',
-  'graphql/execution/execute',
   'graphql-tag',
   'fast-json-stable-stringify',
   '@wry/equality',
-  'graphql',
   'react',
   'zen-observable'
 ];


### PR DESCRIPTION
This project no longer produces a UMD rollup bundle so the existing `globals` configuration is obsolete and can be confusing. In this case we can replace the `external` function with an array of module names. Thanks!