### PR TITLE
Fix broken link in queries documentation

### DIFF
--- a/docs/source/data/queries.mdx
+++ b/docs/source/data/queries.mdx
@@ -385,7 +385,7 @@ const DogPhoto = ({ breed }) => (
 </div>
 </MultiCodeBlock>
 
-The `networkStatus` property is an enum with number values from `1` to `8` that represent different loading states. `4` corresponds to a refetch, but there are also values for polling and pagination. For a full list of all the possible loading states, check out the [source](https://github.com/apollographql/apollo-client/blob/master/packages/apollo-client/src/core/networkStatus.ts).
+The `networkStatus` property is an enum with number values from `1` to `8` that represent different loading states. `4` corresponds to a refetch, but there are also values for polling and pagination. For a full list of all the possible loading states, check out the [source](https://github.com/apollographql/apollo-client/blob/master/src/core/networkStatus.ts).
 
 ## Inspecting error states
 


### PR DESCRIPTION
First of all, thank you for all your great work!

The link to networkStatus.ts file was broken in queries documentation. This PR fix the broken link to a working one.

