### PR TITLE
Publish es2015 source

### DIFF
--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -151,6 +151,7 @@ function prepareTesting() {
 function rollup() {
   return [
     prepareESM(packageJson.module, distDir),
+    prepareESM('./dist/_es2015/index.js', './dist/_es2015'),
     prepareCJS(packageJson.module, packageJson.main),
     prepareCJSMinified(packageJson.main),
     prepareUtilities(),

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://www.apollographql.com",
   "scripts": {
     "prebuild": "npm run clean",
-    "build": "npx tsc",
+    "build": "npx tsc && npx tsc --declaration false --declarationMap false --target es2015 --outDir dist/_es2015",
     "postbuild": "npm run bundle && npm run prepdist",
     "watch": "npx tsc-watch --onSuccess \"npm run postbuild\"",
     "clean": "npx rimraf -r dist coverage lib",


### PR DESCRIPTION
Feel free to close and let me know if this is more appropriate for the 
apollo-feature-requests repo. 

There isn't a standard way of doing this yet but have you considered publishing source that targets ES2015 or newer? Targeting ES2015 instead of ES5 can reduce the size of the library about 10% and having access to the source could be useful in to some users that are bundle-size sensitive.

It would takes some extra configuration but this would be most useful when using Babel's `preset-modules` or `preset-env` targeting modern browsers. We could probably also target ES2017 or newer but that looks like it would require some tweaks to the rollup/acorn configuration. My actual implementation here isn't meant to be final and the `_es2015` folder conventions is something I saw in the rxjs package.

Thanks!