### PR TITLE
Unify EntityStore#{get,getFieldValue} methods.

### DIFF
--- a/src/cache/inmemory/helpers.ts
+++ b/src/cache/inmemory/helpers.ts
@@ -8,7 +8,7 @@ export function getTypenameFromStoreObject(
   objectOrReference: StoreObject | Reference,
 ): string | undefined {
   return isReference(objectOrReference)
-    ? store.getFieldValue(objectOrReference.__ref, "__typename") as string
+    ? store.get(objectOrReference.__ref, "__typename") as string
     : objectOrReference && objectOrReference.__typename;
 }
 

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -432,7 +432,7 @@ export class Policies {
       let fieldValue: StoreValue;
       if (isReference(objectOrReference)) {
         const dataId = objectOrReference.__ref;
-        fieldValue = store.getFieldValue(dataId, storeFieldName);
+        fieldValue = store.get(dataId, storeFieldName);
         if (fieldValue === void 0 && storeFieldName === "__typename") {
           // We can infer the __typename of singleton root objects like
           // ROOT_QUERY ("Query") and ROOT_MUTATION ("Mutation"), even if

--- a/src/cache/inmemory/types.ts
+++ b/src/cache/inmemory/types.ts
@@ -18,9 +18,9 @@ export declare type IdGetter = (
  * StoreObjects from the cache
  */
 export interface NormalizedCache {
-  has(dataId: string): boolean;
+  has(dataId: string, fieldName?: string): boolean;
   get(dataId: string): StoreObject;
-  getFieldValue(dataId: string, storeFieldName: string): StoreValue;
+  get(dataId: string, fieldName: string): StoreValue;
   merge(dataId: string, incoming: StoreObject): void;
   delete(dataId: string, fieldName?: string): void;
   clear(): void;


### PR DESCRIPTION
When I originally wrote this code, I was motivated to keep the `get` and `getFieldValue` methods separate because they had different return types. [Method signature overloading](https://medium.com/@kevinkreuzer/typescript-method-overloading-c256dd63245a) solves that problem using just the type system, so we can have one method implementation rather than two.

At the same time, I was able to eliminate unnecessary inheritance and method overriding in the `Layer` subclass by using an `instanceof` check in `EntityStore#get`.