### PR TITLE
Avoid inheritance/overriding in EntityStore#getRootIdSet.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     {
       "name": "apollo-client",
       "path": "./dist/apollo-client.cjs.min.js",
-      "maxSize": "24.1 kB"
+      "maxSize": "24 kB"
     }
   ],
   "peerDependencies": {

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -207,10 +207,14 @@ export abstract class EntityStore implements NormalizedCache {
     return 0;
   }
 
-  // This method will be overridden in the Layer class to merge root IDs for all
-  // layers (including the root).
-  public getRootIdSet() {
-    return new Set(Object.keys(this.rootIds));
+  // Return a Set<string> of all the ID strings that have been retained by
+  // this layer/root *and* any layers/roots beneath it.
+  public getRootIdSet(ids = new Set<string>()) {
+    Object.keys(this.rootIds).forEach(ids.add, ids);
+    if (this instanceof Layer) {
+      this.parent.getRootIdSet(ids);
+    }
+    return ids;
   }
 
   // The goal of garbage collection is to remove IDs from the Root layer of the
@@ -401,14 +405,6 @@ class Layer extends EntityStore {
       ...this.parent.toObject(),
       ...this.data,
     };
-  }
-
-  // Return a Set<string> of all the ID strings that have been retained by this
-  // Layer *and* any layers/roots beneath it.
-  public getRootIdSet(): Set<string> {
-    const ids = this.parent.getRootIdSet();
-    super.getRootIdSet().forEach(ids.add, ids);
-    return ids;
   }
 
   public findChildRefIds(dataId: string): Record<string, true> {


### PR DESCRIPTION
Explicit `instanceof` checks are so much more readable and less surprising than multiple method implementations spread across different classes. This implementation also avoids creating multiple `Set` objects when there are any active optimistic `Layer`s.