### PR TITLE
fix error when ssr mode and pollInterval

### DIFF
--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -559,7 +559,7 @@ export class ObservableQuery<
       queryManager.addObservableQuery<TData>(queryId, this);
     }
 
-    if (this.options.pollInterval) {
+    if (this.options.pollInterval && !this.queryManager.ssrMode) {
       assertNotCacheFirstOrOnly(this);
       queryManager.startPollingQuery(this.options, queryId);
     }

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -506,7 +506,7 @@ export class ObservableQuery<
   }
 
   public startPolling(pollInterval: number) {
-    assertNotCacheFirstOrOnly(this);
+    //assertNotCacheFirstOrOnly(this);
     this.options.pollInterval = pollInterval;
     this.queryManager.startPollingQuery(this.options, this.queryId);
   }
@@ -559,8 +559,8 @@ export class ObservableQuery<
       queryManager.addObservableQuery<TData>(queryId, this);
     }
 
-    if (this.options.pollInterval && !this.queryManager.ssrMode) {
-      assertNotCacheFirstOrOnly(this);
+    if (this.options.pollInterval) {
+      //assertNotCacheFirstOrOnly(this);
       queryManager.startPollingQuery(this.options, queryId);
     }
 


### PR DESCRIPTION
It will throw "Queries that specify the cache-first and cache-only fetchPolicies cannot also be polling queries" when ssr mode and pollInterval is setting

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

