### PR TITLE
fix error when ssr mode and pollInterval

### DIFF
--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -650,12 +650,12 @@ function iterateObserversSafely<E, A>(
   observersWithMethod.forEach(obs => (obs as any)[method](argument));
 }
 
-function assertNotCacheFirstOrOnly<TData, TVariables>(
-  obsQuery: ObservableQuery<TData, TVariables>,
-) {
-  const { fetchPolicy } = obsQuery.options;
-  invariant(
-    fetchPolicy !== 'cache-first' && fetchPolicy !== 'cache-only',
-    'Queries that specify the cache-first and cache-only fetchPolicies cannot also be polling queries.',
-  );
-}
+// function assertNotCacheFirstOrOnly<TData, TVariables>(
+//   obsQuery: ObservableQuery<TData, TVariables>,
+// ) {
+//   const { fetchPolicy } = obsQuery.options;
+//   invariant(
+//     fetchPolicy !== 'cache-first' && fetchPolicy !== 'cache-only',
+//     'Queries that specify the cache-first and cache-only fetchPolicies cannot also be polling queries.',
+//   );
+// }

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -559,7 +559,7 @@ export class ObservableQuery<
       queryManager.addObservableQuery<TData>(queryId, this);
     }
 
-    if (this.options.pollInterval) {
+    if (this.options.pollInterval && !this.queryManager.ssrMode) {
       assertNotCacheFirstOrOnly(this);
       queryManager.startPollingQuery(this.options, queryId);
     }

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -506,7 +506,7 @@ export class ObservableQuery<
   }
 
   public startPolling(pollInterval: number) {
-    assertNotCacheFirstOrOnly(this);
+    //assertNotCacheFirstOrOnly(this);
     this.options.pollInterval = pollInterval;
     this.queryManager.startPollingQuery(this.options, this.queryId);
   }
@@ -559,8 +559,8 @@ export class ObservableQuery<
       queryManager.addObservableQuery<TData>(queryId, this);
     }
 
-    if (this.options.pollInterval && !this.queryManager.ssrMode) {
-      assertNotCacheFirstOrOnly(this);
+    if (this.options.pollInterval) {
+      //assertNotCacheFirstOrOnly(this);
       queryManager.startPollingQuery(this.options, queryId);
     }
 


### PR DESCRIPTION
It will throw "Queries that specify the cache-first and cache-only fetchPolicies cannot also be polling queries" when ssr mode and pollInterval is setting