### PR TITLE
Allow missing __typename if field added by addTypenameToDocument.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,8 @@
 - `useMutation` adjustments to help avoid an infinite loop / too many renders issue, caused by unintentionally modifying the `useState` based mutation result directly.  <br/>
   [@hwillson](https://github/com/hwillson) in [#5770](https://github.com/apollographql/apollo-client/pull/5770)
 
+- Missing `__typename` fields no longer cause the `InMemoryCache#diff` result to be marked `complete: false`, if those fields were added by `InMemoryCache#transformDocument` (which calls `addTypenameToDocument`). <br/>
+  [@benjamn](https://github.com/benjamn) in [#5787](https://github.com/apollographql/apollo-client/pull/5787)
 
 ## Apollo Client 2.6.8
 

--- a/src/__tests__/local-state/resolvers.ts
+++ b/src/__tests__/local-state/resolvers.ts
@@ -681,8 +681,15 @@ describe('Writing cache data from resolvers', () => {
               console.warn = originalWarn;
 
               cache.writeData({
-                id: '$ROOT_QUERY.obj',
-                data: { field: { field2: 2, __typename: 'Field' } },
+                id: 'ROOT_QUERY',
+                data: {
+                  obj: {
+                    field: {
+                      field2: 2,
+                      __typename: 'Field',
+                    },
+                  },
+                },
               });
               return { start: true };
             },

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -18,6 +18,7 @@ import {
 } from '../../utilities/graphql/storeUtils';
 import { createFragmentMap, FragmentMap } from '../../utilities/graphql/fragments';
 import { shouldInclude } from '../../utilities/graphql/directives';
+import { addTypenameToDocument } from '../../utilities/graphql/transform';
 import {
   getDefaultValues,
   getFragmentDefinitions,
@@ -237,10 +238,12 @@ export class StoreReader {
         );
 
         if (fieldValue === void 0) {
-          getMissing().push({
-            object: objectOrReference as StoreObject,
-            fieldName: selection.name.value,
-          });
+          if (!addTypenameToDocument.added(selection)) {
+            getMissing().push({
+              object: objectOrReference as StoreObject,
+              fieldName: selection.name.value,
+            });
+          }
 
         } else if (Array.isArray(fieldValue)) {
           fieldValue = handleMissing(this.executeSubSelectedArray({

--- a/src/utilities/graphql/transform.ts
+++ b/src/utilities/graphql/transform.ts
@@ -261,6 +261,13 @@ export function addTypenameToDocument(doc: DocumentNode): DocumentNode {
   });
 }
 
+export interface addTypenameToDocument {
+  added(field: FieldNode): boolean;
+}
+addTypenameToDocument.added = function (field: FieldNode) {
+  return field === TYPENAME_FIELD;
+};
+
 const connectionRemoveConfig = {
   test: (directive: DirectiveNode) => {
     const willRemove = directive.name.value === 'connection';


### PR DESCRIPTION
Solves #5781 by keeping data written by `cache.writeData` from appearing incomplete just because it does not have `__typename` fields that were not explicitly present in the original query.

Since `InMemoryCache#transformDocument` is responsible for adding these `__typename` fields automatically, it makes sense for the `StoreReader` belonging to the `InMemoryCache` to detect and ignore those fields later, rather than handling this somewhere else, such as the `QueryManager#transform` method, where `transformDocument` is called.

@hwillson Another way of looking at this issue is that this bit of code in the `queryListenerForObserver` callback is mishandling "incomplete" data, as we've observed before:
```ts
const resultFromStore: ApolloQueryResult<T> = {
  data: stale ? lastResult && lastResult.data : data,
  ...
```
The changes in this commit work around the problem by removing a category of `__typename`-related reasons why `stale` might be true here, but I think we still need to decide what staleness should mean for this logic.