### PR TITLE
Read from cache again in ObservableQuery#getCurrentResult.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,9 +54,6 @@
 - `ApolloClient` is now only available as a named export. The default `ApolloClient` export has been removed. <br/>
   [@hwillson](https://github.com/hwillson) in [#5425](https://github.com/apollographql/apollo-client/pull/5425)
 
-- The `ObservableQuery#getCurrentResult` method no longer falls back to reading from the cache, so calling it immediately after `client.watchQuery` will consistently return a `loading: true` result. When the `fetchPolicy` permits cached results, those results will be delivered via the `next` method of the `ObservableQuery`, and can be obtained by `getCurrentResult` after they have been delivered. This change prevents race conditions where the initial behavior of one query could depend on the timing of cache writes associated with other queries. </br>
-  [@benjamn](https://github.com/benjamn) in [#5565](https://github.com/apollographql/apollo-client/pull/5565)
-
 - The `QueryOptions`, `MutationOptions`, and `SubscriptionOptions` React Apollo interfaces have been renamed to `QueryDataOptions`, `MutationDataOptions`, and `SubscriptionDataOptions` (to avoid conflicting with similarly named and exported Apollo Client interfaces).
 
 - `InMemoryCache` will no longer merge the fields of written objects unless the objects are known to have the same identity, and the values of fields with the same name will not be recursively merged unless a custom `merge` function is defined by a field policy for that field, within a type policy associated with the `__typename` of the parent object. <br/>

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     {
       "name": "apollo-client",
       "path": "./dist/apollo-client.cjs.min.js",
-      "maxSize": "24 kB"
+      "maxSize": "24.05 kB"
     }
   ],
   "peerDependencies": {

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1052,7 +1052,7 @@ export class QueryManager<TStore> {
     this.queries.delete(queryId);
   }
 
-  private getCurrentQueryResult<T>(
+  public getCurrentQueryResult<T>(
     observableQuery: ObservableQuery<T>,
     optimistic: boolean = true,
   ): {

--- a/src/react/data/QueryData.ts
+++ b/src/react/data/QueryData.ts
@@ -353,7 +353,7 @@ export class QueryData<TData, TVariables> extends OperationData {
     } else {
       // Fetch the current result (if any) from the store.
       const currentResult = this.currentObservable.query!.getCurrentResult();
-      const { loading, networkStatus, errors } = currentResult;
+      const { loading, partial, networkStatus, errors } = currentResult;
       let { error, data } = currentResult;
 
       // Until a set naming convention for networkError and graphQLErrors is
@@ -390,6 +390,7 @@ export class QueryData<TData, TVariables> extends OperationData {
         const { partialRefetch } = options;
         if (
           partialRefetch &&
+          partial &&
           (!data || Object.keys(data).length === 0) &&
           fetchPolicy !== 'cache-only'
         ) {


### PR DESCRIPTION
This partially reverts two commits from PR #5565, preserving related improvements that have happened in the meantime:
* Revert "Remove partial field from `ApolloCurrentQueryResult` type."
  This reverts commit ca2cef659210dc77b21f251d97d69eefcc8f18e0.
* Revert "Stop reading from cache in `ObservableQuery#getCurrentResult`."
  This reverts commit 01376a3ad09e1a806d7517cad44502b4355456af.

One of the motivations behind the original changes was to lay the foundations for eventually supporting asynchronous (specifically, `Promise`-based) cache reads, but that form of asynchrony is no longer a goal of Apollo Client 3.0 or any planned future version (there will be other ways to deliver results asynchronously, without requiring every cache read to return a `Promise`), so there's not as much benefit to weakening `getCurrentResult` in this way.

On the other hand, allowing `getCurrentResult` to read synchronously from the cache ensures that custom field `read` functions can return new results immediately, which helps with issues like #5782.

Immediate cache reads have also been the behavior of Apollo Client for much longer than #5565, which makes this change appealing from an ease-of-upgrading perspective.