### PR TITLE
Implement reactive variables for tracking local state.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,17 @@
 - Removed `apollo-boost` since Apollo Client 3.0 provides a boost like getting started experience out of the box.  <br/>
   [@hwillson](https://github.com/hwillson) in [#5217](https://github.com/apollographql/apollo-client/pull/5217)
 
+- `InMemoryCache` provides a new API for storing local state that can be easily updated by external code:
+  ```ts
+  const lv = cache.makeLocalVar(123)
+  console.log(lv()) // 123
+  console.log(lv(lv() + 1)) // 124
+  console.log(lv()) // 124
+  lv("asdf") // TS type error
+  ```
+  These local variables are _reactive_ in the sense that updating their values invalidates any previously cached query results that depended on the old values. <br/>
+  [@benjamn](https://github.com/benjamn) in [#5799](https://github.com/apollographql/apollo-client/pull/5799)
+
 - The `queryManager` property of `ApolloClient` instances is now marked as
   `private`, paving the way for a more aggressive redesign of its API.
 

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -2,7 +2,7 @@
 import './fixPolyfills';
 
 import { DocumentNode } from 'graphql';
-import { wrap } from 'optimism';
+import { dep, wrap } from 'optimism';
 
 import { ApolloCache, Transaction } from '../core/cache';
 import { Cache } from '../core/types/Cache';
@@ -298,4 +298,21 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
       }),
     );
   }
+
+  public makeLocalVar<T>(value: T): LocalVar<T> {
+    return function LocalVar(newValue) {
+      if (arguments.length > 0) {
+        if (value !== newValue) {
+          value = newValue;
+          localVarDep.dirty(LocalVar);
+        }
+      } else {
+        localVarDep(LocalVar);
+      }
+      return value;
+    };
+  }
 }
+
+const localVarDep = dep<LocalVar<any>>();
+export type LocalVar<T> = (newValue?: T) => T;


### PR DESCRIPTION
Reactive local variables are functions that allow you to store local state in a well-known, private location, outside of the cache, consume that state while reading queries from the cache, and update the state whenever you like.

Basic usage:
```ts
const lv = cache.makeLocalVar(123)
console.log(lv()) // 123
console.log(lv(lv() + 1)) // 124
console.log(lv()) // 124
lv("asdf") // TS type error
```
TypeScript infers the value type of the variable based on the initial value, which is why switching from a number to a string is a type error here.

Any parts of any queries that relied upon the value of the variable will be invalidated when/if the variable's value is updated:
```ts
const cache: InMemoryCache = new InMemoryCache({
  typePolicies: {
    Person: {
      fields: {
        name() {
          return nameVar();
        },
      },
    },
  },
});

const nameVar = cache.makeLocalVar("Ben");

const query = gql`
  query {
    onCall {
      name @client
    }
  }
`;

cache.writeQuery({
  query,
  data: {
    onCall: {
      __typename: "Person",
    },
  },
});

expect(cache.readQuery({ query })).toEqual({
  onCall: {
    __typename: "Person",
    name: "Ben",
  },
});

nameVar("Hugh");

expect(cache.readQuery({ query })).toEqual({
  onCall: {
    __typename: "Person",
    name: "Hugh",
  },
});
```
With this new primitive available, it should not be necessary to construct awkward queries just to read and write local state, since you can read the variable directly with `nameVar()` and update its value by calling `nameVar(newValue)`.