### PR TITLE
Export Reference type and related utilities from @apollo/client/cache.

### DIFF
--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -3,6 +3,12 @@ export { Cache } from './core/types/Cache';
 export { DataProxy } from './core/types/DataProxy';
 
 export {
+  Reference,
+  isReference,
+  makeReference,
+} from '../utilities/graphql/storeUtils';
+
+export {
   InMemoryCache,
   InMemoryCacheConfig,
 } from './inmemory/inMemoryCache';

--- a/src/cache/inmemory/types.ts
+++ b/src/cache/inmemory/types.ts
@@ -2,6 +2,7 @@ import { DocumentNode } from 'graphql';
 
 import { Transaction } from '../core/cache';
 import { StoreValue } from '../../utilities/graphql/storeUtils';
+export { StoreValue }
 
 export interface IdGetterObj extends Object {
   __typename?: string;

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -71,11 +71,6 @@ export { ServerError, throwServerError } from '../link/utils/throwServerError';
 
 export { Observable } from '../utilities/observables/Observable';
 export { getMainDefinition } from '../utilities/graphql/getFromAST';
-export {
-  Reference,
-  isReference,
-  makeReference,
-} from '../utilities/graphql/storeUtils';
 
 /* Supporting */
 


### PR DESCRIPTION
This is a follow-up to commit 451a22f89e694c4c6bb059a716fd76b10daa9bb1, which exported these items from `@apollo/client`, but not from `@apollo/client/cache`, which can be used in isolation from `@apollo/client`. Now, the same exports are exported both ways.

This should help with using the `Reference` type for parameters of `read` and `merge` functions, since the type can be more easily imported now:
```ts
// Either of these import styles works:
import { Reference, isReference, makeReference } from "@apollo/client"
import { Reference, isReference, makeReference } from "@apollo/client/cache"
```