### PR TITLE
Fix mutate API not triggering update or writing to cache

### DIFF
--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -251,7 +251,7 @@ export class QueryManager<TStore> {
 
           self.mutationStore.markMutationResult(mutationId);
 
-          if (fetchPolicy !== 'no-cache') {
+          if (fetchPolicy === 'no-cache') {
             markMutationResult({
               mutationId,
               result,


### PR DESCRIPTION
Hello, first off I wanted to say thanks for all the hard work the team has done on Apollo Client, our organization has really appreciated its robust feature set. I've recently been working on writing an optimistic mutation in our application using the `apolloClient.mutate` function found [here](https://github.com/apollographql/apollo-client/blob/master/src/ApolloClient.ts#L341). I've run into an issue where the `update` handler I provide is only invoked for the `optimisticResponse` and not after the mutation result is returned from the server, and additionally the client cache isn't being written to after the mutation either so my entity has stale information in the cache until I query for the data again.

I have a mutation with both `optimisticResponse` as well as an `update` option like the following:
```
 const financialData = await apolloClient.mutate({
          mutation: UPDATE_FINANCIAL_TRANSACTION,
          variables: {
            transactionId,
            isHidden,
          },
          optimisticResponse: {
            __typename: 'Mutation',
            updateFinancialTransactionVisibility: {
              __typename: 'FinancialTransaction',
              id: transactionId,
              isHidden: true
            },
          },
          update: () => { },
        });
```

The `update` function gets called once for the optimistic data as part of the [markMutationResult](https://github.com/apollographql/apollo-client/blob/136ce43a4600db5df16c6217d1ca47563a540093/packages/apollo-client/src/data/store.ts#L95) invocation done for optimistic responses which then triggers it [here](https://github.com/apollographql/apollo-client/blob/136ce43a4600db5df16c6217d1ca47563a540093/packages/apollo-client/src/data/store.ts#L171)

but, it never gets triggered again when the mutation comes back from the server. Stepping through the code, it looks like it's because of [this line](https://github.com/apollographql/apollo-client/blob/136ce43a4600db5df16c6217d1ca47563a540093/packages/apollo-client/src/core/QueryManager.ts#L233). When it receives the emitted data from the observable, it only marks the mutation result if the fetch policy was not `no-cache` which seems like a bug since this code lives in the `mutate` API, something that inherently will be `no-cache` since it's a mutation.

I tried providing another `fetchPolicy` but it never reaches here because of an assertion saying a mutation **must** have `fetchPolicy: no-cache`.

Since it does not call `markMutationResult` again, the `update` handler code is never reached [here](https://github.com/apollographql/apollo-client/blob/136ce43a4600db5df16c6217d1ca47563a540093/packages/apollo-client/src/data/store.ts#L171) so I never receive the data result from the server and additionally, the line above for updating the cache itself isn't executed [here](https://github.com/apollographql/apollo-client/blob/136ce43a4600db5df16c6217d1ca47563a540093/packages/apollo-client/src/data/store.ts#L164) causing the cache to be stale and not automatically updating the entity after the mutation.

By changing the line to `fetchPolicy === 'no-cache'` it marks the mutation result and both re-triggers the update handler and updates the cache with the result of the mutation from the server as expected, so I suspect that this was a bug?

Let me know thanks.

<img width="981" alt="Screen Shot 2020-01-17 at 3 20 46 PM" src="https://user-images.githubusercontent.com/2192930/72643566-f6d1ff80-393c-11ea-9334-853a6362b154.png">

