### PR TITLE
simplify justTypenameQuery

### DIFF
--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -6,7 +6,7 @@ import { Cache } from './types/Cache';
 import { queryFromPojo, fragmentFromPojo } from './utils';
 
 import gql from 'graphql-tag';
-const justTypenameQuery = gql`query { __typename }`;
+const justTypenameQuery = gql`{ __typename }`;
 
 export type Transaction<T> = (c: ApolloCache<T>) => void;
 


### PR DESCRIPTION
I'm not convinced that the `justTypenameQuery` implementation is worth the `graphql-tag` dependency (see #5806) but if byte savings is the goal we can drop the `query` operation type and use the shorthand query syntax. Thanks! 