### PR TITLE
Remove unused docs config option

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -27,8 +27,7 @@ module.exports = {
           ],
         },
         typescriptApiBox: {
-          data: require('./docs.json'),
-          filepathPrefix: 'src/',
+          data: require('./docs.json')
         },
         sidebarCategories: {
           null: ['index', 'why-apollo', 'get-started'],


### PR DESCRIPTION
This branch removes the now-unused `filepathPrefix` option from the docs`TypescriptApiBox` component config.