### PR TITLE
Disallow reading entire StoreObject from EntityStore by ID.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@
 - `@apollo/client/cache` can be used to import the Apollo Client cache without importing other parts of the Apollo Client codebase. <br/>
   [@hwillson](https://github.com/hwillson) in [#5577](https://github.com/apollographql/apollo-client/pull/5577)
 
+- The result caching system (introduced in [#3394](https://github.com/apollographql/apollo-client/pull/3394)) now tracks dependencies at the field level, rather than at the level of whole entity objects, allowing the cache to return identical (`===`) results much more often than before. <br/>
+  [@benjamn](https://github.com/benjamn) in [#5617](https://github.com/apollographql/apollo-client/pull/5617)
+
 - `InMemoryCache` provides a new API for storing local state that can be easily updated by external code:
   ```ts
   const lv = cache.makeLocalVar(123)

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     {
       "name": "apollo-client",
       "path": "./dist/apollo-client.cjs.min.js",
-      "maxSize": "24.05 kB"
+      "maxSize": "24.1 kB"
     }
   ],
   "peerDependencies": {

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -1,4 +1,5 @@
 import { DocumentNode } from 'graphql';
+import { wrap } from 'optimism';
 
 import { getFragmentQueryDocument } from '../../utilities/graphql/fragments';
 import { DataProxy } from './types/DataProxy';
@@ -98,12 +99,16 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
     });
   }
 
+  // Make sure we compute the same (===) fragment query document every
+  // time we receive the same fragment in readFragment.
+  private getFragmentDoc = wrap(getFragmentQueryDocument);
+
   public readFragment<FragmentType, TVariables = any>(
     options: DataProxy.Fragment<TVariables>,
     optimistic: boolean = false,
   ): FragmentType | null {
     return this.read({
-      query: getFragmentQueryDocument(options.fragment, options.fragmentName),
+      query: this.getFragmentDoc(options.fragment, options.fragmentName),
       variables: options.variables,
       rootId: options.id,
       optimistic,

--- a/src/cache/inmemory/__tests__/diffAgainstStore.ts
+++ b/src/cache/inmemory/__tests__/diffAgainstStore.ts
@@ -179,7 +179,7 @@ describe('diffing queries against the store', () => {
     });
 
     expect(complete).toBeTruthy();
-    expect(store.get('Person:{"id":"1"}')).toEqual({
+    expect((store as any).lookup('Person:{"id":"1"}')).toEqual({
       __typename: 'Person',
       id: '1',
       name: 'Luke Skywalker',

--- a/src/cache/inmemory/__tests__/optimistic.ts
+++ b/src/cache/inmemory/__tests__/optimistic.ts
@@ -426,10 +426,7 @@ describe('optimistic cache layers', () => {
     cache.removeOptimistic('buzz book');
     const spinelessAfterRemovingBuzz = readSpinelessFragment();
     expect(spinelessBeforeRemovingBuzz).toEqual(spinelessAfterRemovingBuzz);
-    expect(spinelessBeforeRemovingBuzz).not.toBe(spinelessAfterRemovingBuzz);
-    expect(spinelessBeforeRemovingBuzz.author).toBe(
-      spinelessAfterRemovingBuzz.author,
-    );
+    expect(spinelessBeforeRemovingBuzz).toBe(spinelessAfterRemovingBuzz);
 
     const resultAfterRemovingBuzzLayer = readWithAuthors();
     expect(resultAfterRemovingBuzzLayer).toEqual(resultWithBuzz);

--- a/src/cache/inmemory/__tests__/recordingCache.ts
+++ b/src/cache/inmemory/__tests__/recordingCache.ts
@@ -1,9 +1,13 @@
-import { NormalizedCacheObject } from '../types';
+import { NormalizedCacheObject, StoreObject } from '../types';
 import { EntityStore } from '../entityStore';
 
 describe('Optimistic EntityStore layering', () => {
   function makeLayer(root: EntityStore) {
     return root.addLayer('whatever', () => {});
+  }
+
+  function lookup(store: EntityStore, dataId: string) {
+    return (store as any).lookup(dataId) as StoreObject;
   }
 
   describe('returns correct values during recording', () => {
@@ -24,23 +28,23 @@ describe('Optimistic EntityStore layering', () => {
     });
 
     it('should passthrough values if not defined in recording', () => {
-      expect(store.get('Human')).toBe(data.Human);
-      expect(store.get('Animal')).toBe(data.Animal);
+      expect(lookup(store, 'Human')).toBe(data.Human);
+      expect(lookup(store, 'Animal')).toBe(data.Animal);
     });
 
     it('should return values defined during recording', () => {
       store.merge('Human', dataToRecord.Human);
-      expect(store.get('Human')).toEqual(dataToRecord.Human);
-      expect(underlyingStore.get('Human')).toBe(data.Human);
+      expect(lookup(store, 'Human')).toEqual(dataToRecord.Human);
+      expect(lookup(underlyingStore, 'Human')).toBe(data.Human);
     });
 
     it('should return undefined for values deleted during recording', () => {
-      expect(store.get('Animal')).toBe(data.Animal);
+      expect(lookup(store, 'Animal')).toBe(data.Animal);
       // delete should be registered in the recording:
       store.delete('Animal');
-      expect(store.get('Animal')).toBeUndefined();
+      expect(lookup(store, 'Animal')).toBeUndefined();
       expect(store.toObject()).toHaveProperty('Animal');
-      expect(underlyingStore.get('Animal')).toBe(data.Animal);
+      expect(lookup(underlyingStore, 'Animal')).toBe(data.Animal);
     });
   });
 

--- a/src/cache/inmemory/__tests__/writeToStore.ts
+++ b/src/cache/inmemory/__tests__/writeToStore.ts
@@ -1507,7 +1507,7 @@ describe('writing to the store', () => {
     });
 
     Object.keys(store.toObject()).forEach(field => {
-      expect(store.get(field)).toEqual(newStore.get(field));
+      expect((store as any).lookup(field)).toEqual((newStore as any).lookup(field));
     });
   });
 
@@ -1543,7 +1543,7 @@ describe('writing to the store', () => {
         result,
       });
 
-      expect(newStore.get('1')).toEqual(result.todos[0]);
+      expect((newStore as any).lookup('1')).toEqual(result.todos[0]);
     });
 
     it('should warn when it receives the wrong data with non-union fragments', () => {
@@ -1569,7 +1569,7 @@ describe('writing to the store', () => {
           result,
         });
 
-        expect(newStore.get('1')).toEqual(result.todos[0]);
+        expect((newStore as any).lookup('1')).toEqual(result.todos[0]);
       }, /Missing field description/);
     });
 
@@ -1623,7 +1623,7 @@ describe('writing to the store', () => {
           result,
         });
 
-        expect(newStore.get('1')).toEqual(result.todos[0]);
+        expect((newStore as any).lookup('1')).toEqual(result.todos[0]);
       }, /Missing field price/);
     });
 
@@ -1651,7 +1651,7 @@ describe('writing to the store', () => {
           result,
         });
 
-        expect(newStore.get('1')).toEqual(result.todos[0]);
+        expect((newStore as any).lookup('1')).toEqual(result.todos[0]);
       }, /Missing field __typename/);
     });
 
@@ -1671,7 +1671,7 @@ describe('writing to the store', () => {
         result,
       });
 
-      expect(newStore.get('ROOT_QUERY')).toEqual({
+      expect((newStore as any).lookup('ROOT_QUERY')).toEqual({
         __typename: 'Query',
         todos: null,
       });
@@ -1700,7 +1700,7 @@ describe('writing to the store', () => {
         result,
       });
 
-      expect(newStore.get('ROOT_QUERY')).toEqual({ __typename: 'Query', id: 1 });
+      expect((newStore as any).lookup('ROOT_QUERY')).toEqual({ __typename: 'Query', id: 1 });
       expect(console.warn).not.toBeCalled();
       console.warn = originalWarn;
     });

--- a/src/cache/inmemory/types.ts
+++ b/src/cache/inmemory/types.ts
@@ -19,8 +19,7 @@ export declare type IdGetter = (
  * StoreObjects from the cache
  */
 export interface NormalizedCache {
-  has(dataId: string, fieldName?: string): boolean;
-  get(dataId: string): StoreObject;
+  has(dataId: string): boolean;
   get(dataId: string, fieldName: string): StoreValue;
   merge(dataId: string, incoming: StoreObject): void;
   delete(dataId: string, fieldName?: string): boolean;


### PR DESCRIPTION
One of the most important internal changes in Apollo Client 3.0 is that the result caching system (introduced in #3394) now tracks its dependencies at the field level, rather than at the level of whole entity objects, thanks to #5617.

As proof that this transformation is complete, we can finally remove the ability to read entire entity objects from the `EntityStore` by ID, so that the only way to read from the store is by providing both an ID and the name of a field. The logic I improved in #5772 is now even simpler, without needing multiple overloaded `EntityStore#get` signatures.

In the process, I noticed that the `EntityStore#has(ID)` method was accidentally depending on any changes to the contents of the identified entity, even though `store.has` only "cares" about the existence of the ID in the store. This was a problem only if we called `store.has` during a larger read operation, which currently only happens during `readFragment`, which [calls `InMemoryCache#read` with `options.rootId`](https://github.com/apollographql/apollo-client/blob/0f78cc62403e8648eb3fe3b29af9e8e48c7fd63c/src/cache/inmemory/inMemoryCache.ts#L127).

The symptoms of this oversight went unnoticed for two reasons:

0. The `ApolloCache#readFragment` method was computing a fresh fragment query document every time it was called, even if it had seen the given fragment document before (see f039d404211032d84ceb547873680b56b3ebdc44). In other words, fragments were not benefitting from result caching at all, which masked the problem of result caching being too sensitive for fragments.
1. With that bug fixed, the caching of `readFragment` results was still unnecessarily sensitive to changes to unrelated fields within the given entity, due to the problem with `store.has`. The results themselves were still logically correct, but their caching was not as effective as it could be. Fortunately, I was able to model this dependency with an ID plus a fake field name called `__exists`, which is only dirtied when the ID is newly added to (or removed from) the store.

That's the beauty and the curse of caching: you might not notice when it isn't working, because all your tests still pass, and nobody complains that their application is broken. Now we have more aggressive tests of fragment result caching behavior, so this kind of oversight won't happen again.