### PR TITLE
Check correct store in InMemoryCache#read.

### DIFF
--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -123,13 +123,12 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
   }
 
   public read<T>(options: Cache.ReadOptions): T | null {
-    if (typeof options.rootId === 'string' &&
-        !this.data.has(options.rootId)) {
+    const store = options.optimistic ? this.optimisticData : this.data;
+    if (typeof options.rootId === 'string' && !store.has(options.rootId)) {
       return null;
     }
-
     return this.storeReader.readQueryFromStore({
-      store: options.optimistic ? this.optimisticData : this.data,
+      store,
       query: options.query,
       variables: options.variables,
       rootId: options.rootId,


### PR DESCRIPTION
I would ideally like to push this check down into `readQueryFromStore`, but for now it seems worthwhile to fix this bug in the simplest way possible.

This seems like it could help with #4402, though the original reporter found another way to work around that problem.