### PR TITLE
Add toplevel:true to terser options.compress as well as .mangle.

### DIFF
--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -91,6 +91,7 @@ function prepareCJSMinified(input) {
           toplevel: true,
         },
         compress: {
+          toplevel: true,
           global_defs: {
             '@process.env.NODE_ENV': JSON.stringify('production'),
           },


### PR DESCRIPTION
I don't know who needs to hear this, but apparently `options.mangle.toplevel` only mangles (shortens the names of) top-level variable and function declarations. To fully prune the unused declarations from your bundle, you need `options.compress.toplevel` as well!