### PR TITLE
Small utilities export changes

### DIFF
--- a/docs/source/data/subscriptions.mdx
+++ b/docs/source/data/subscriptions.mdx
@@ -84,7 +84,8 @@ const wsLink = new WebSocketLink({
 ```
 
 ```js
-import { split, HttpLink, getMainDefinition } from '@apollo/client';
+import { split, HttpLink } from '@apollo/client';
+import { getMainDefinition } from '@apollo/client/utilities';
 import { WebSocketLink } from '@apollo/link-ws';
 
 // Create an http link:

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -66,11 +66,7 @@ export { createHttpLink } from '../link/http/createHttpLink';
 export { HttpLink } from '../link/http/HttpLink';
 export { fromError } from '../link/utils/fromError';
 export { ServerError, throwServerError } from '../link/utils/throwServerError';
-
-/* Utilities */
-
 export { Observable } from '../utilities/observables/Observable';
-export { getMainDefinition } from '../utilities/graphql/getFromAST';
 
 /* Supporting */
 


### PR DESCRIPTION
A few small changes to enforce that graphql utilities should be imported from `@apollo/client/utilities` (instead of being available through the main `@apollo/client` bundle).