### PR TITLE
Re-export all public `graphql-tag` exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,9 @@
 - Utilities that were previously externally available through the `apollo-utilities` package are now only available by importing from `@apollo/client/utilities`. <br/>
   [@hwillson](https://github.com/hwillson) in [#5683](https://github.com/apollographql/apollo-client/pull/5683)
 
+- Make sure all `graphql-tag` public exports are re-exported.  <br/>
+  [@hwillson](https://github.com/hwillson) in [#5861](https://github.com/apollographql/apollo-client/pull/5861)
+
 - Fully removed `prettier`. The Apollo Client team has decided to no longer automatically enforce code formatting across the codebase. In most cases existing code styles should be followed as much as possible, but this is not a hard and fast rule.  <br/>
   [@hwillson](https://github.com/hwillson) in [#5227](https://github.com/apollographql/apollo-client/pull/5227)
 

--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -1,7 +1,6 @@
 import nodeResolve from 'rollup-plugin-node-resolve';
 import invariantPlugin from 'rollup-plugin-invariant';
 import { terser as minify } from 'rollup-plugin-terser';
-import cjs from 'rollup-plugin-commonjs';
 import fs from 'fs';
 
 import packageJson from '../package.json';
@@ -47,12 +46,7 @@ function prepareESM(input, outputDir) {
         // errors back to the unminified code where they were thrown,
         // where the full error string can be found. See #4519.
         errorCodes: true,
-      }),
-      cjs({
-        namedExports: {
-          'graphql-tag': ['gql'],
-        },
-      }),
+      })
     ],
   };
 }
@@ -69,11 +63,6 @@ function prepareCJS(input, output) {
     },
     plugins: [
       nodeResolve(),
-      cjs({
-        namedExports: {
-          'graphql-tag': ['gql'],
-        },
-      }),
     ],
   };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2988,23 +2988,6 @@
         "isobject": "^3.0.1"
       }
     },
-    "is-reference": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.1.4.tgz",
-      "integrity": "sha512-uJA/CDPO3Tao3GTrxYn6AwkM4nUPJiGGYu5+cB8qbC7WGFlrKZbiRo7SFKxUAEpFUfiHofWCXBUNhvYJMh+6zw==",
-      "dev": true,
-      "requires": {
-        "@types/estree": "0.0.39"
-      },
-      "dependencies": {
-        "@types/estree": {
-          "version": "0.0.39",
-          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-          "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
-          "dev": true
-        }
-      }
-    },
     "is-regex": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
@@ -4451,15 +4434,6 @@
         "yallist": "^2.1.2"
       }
     },
-    "magic-string": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.4.tgz",
-      "integrity": "sha512-oycWO9nEVAP2RVPbIoDoA4Y7LFIJ3xRYov93gAyJhZkET1tNuB0u7uWkZS2LpBWTJUWnmau/To8ECWRC+jKNfw==",
-      "dev": true,
-      "requires": {
-        "sourcemap-codec": "^1.4.4"
-      }
-    },
     "make-dir": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -5901,27 +5875,6 @@
         }
       }
     },
-    "rollup-plugin-commonjs": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-10.1.0.tgz",
-      "integrity": "sha512-jlXbjZSQg8EIeAAvepNwhJj++qJWNJw1Cl0YnOqKtP5Djx+fFGkp3WRh+W0ASCaFG5w1jhmzDxgu3SJuVxPF4Q==",
-      "dev": true,
-      "requires": {
-        "estree-walker": "^0.6.1",
-        "is-reference": "^1.1.2",
-        "magic-string": "^0.25.2",
-        "resolve": "^1.11.0",
-        "rollup-pluginutils": "^2.8.1"
-      },
-      "dependencies": {
-        "estree-walker": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-          "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
-          "dev": true
-        }
-      }
-    },
     "rollup-plugin-invariant": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/rollup-plugin-invariant/-/rollup-plugin-invariant-0.5.6.tgz",
@@ -6311,12 +6264,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-      "dev": true
-    },
-    "sourcemap-codec": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.6.tgz",
-      "integrity": "sha512-1ZooVLYFxC448piVLBbtOxFcXwnymH9oUF8nRd3CuYDVvkRBxRl6pB4Mtas5a4drtL+E8LDgFkQNcgIw6tc8Hg==",
       "dev": true
     },
     "spdx-correct": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "recast": "0.18.5",
     "rimraf": "3.0.0",
     "rollup": "1.29.1",
-    "rollup-plugin-commonjs": "10.1.0",
     "rollup-plugin-invariant": "0.5.6",
     "rollup-plugin-node-resolve": "5.2.0",
     "rollup-plugin-terser": "5.1.3",

--- a/src/config/jest/setup.ts
+++ b/src/config/jest/setup.ts
@@ -1,6 +1,6 @@
-import { disableFragmentWarnings } from 'graphql-tag';
+import gql from 'graphql-tag';
 
 // Turn off warnings for repeated fragment names
-disableFragmentWarnings();
+gql.disableFragmentWarnings();
 
 process.on('unhandledRejection', () => {});

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -71,4 +71,29 @@ export { Observable } from '../utilities/observables/Observable';
 
 /* Supporting */
 
-export { default as gql } from 'graphql-tag';
+// Note that importing `gql` by itself, then destructuring
+// additional properties separately before exporting, is intentional.
+// Due to the way the `graphql-tag` library is setup, certain bundlers
+// can't find the properties added to the exported `gql` function without
+// additional guidance (e.g. Rollup - see
+// https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module).
+// Instead of having people that are using bundlers with `@apollo/client` add
+// extra bundler config to help `graphql-tag` exports be found (which would be
+// awkward since they aren't importing `graphql-tag` themselves), this
+// workaround of pulling the extra properties off the `gql` function,
+// then re-exporting them separately, helps keeps bundlers happy without any
+// additional config changes.
+import gql from 'graphql-tag';
+const {
+  resetCaches,
+  disableFragmentWarnings,
+  enableExperimentalFragmentVariables,
+  disableExperimentalFragmentVariables
+} = gql;
+export {
+  gql,
+  resetCaches,
+  disableFragmentWarnings,
+  enableExperimentalFragmentVariables,
+  disableExperimentalFragmentVariables
+};

--- a/src/types/graphql-tag.d.ts
+++ b/src/types/graphql-tag.d.ts
@@ -1,0 +1,16 @@
+// The `graphql-tag` package currently ships with types that aren't quite
+// representative of how the package is setup, and its exports are handled.
+// This type file is intended to better reflect how the package is setup,
+// but should be considered temporary. At some point `graphql-tag` will
+// be fully updated to use Typescript, and these discrepancies will be fixed.
+
+declare module 'graphql-tag' {
+  function gql(literals: any, ...placeholders: any[]): any;
+  namespace gql {
+    export function resetCaches(): void;
+    export function disableFragmentWarnings(): void;
+    export function enableExperimentalFragmentVariables(): void;
+    export function disableExperimentalFragmentVariables(): void;
+  }
+  export default gql;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,11 @@
     "esModuleInterop": true,
     "outDir": "./dist",
     "lib": ["es2015", "esnext.asynciterable", "dom"],
-    "jsx": "react"
+    "jsx": "react",
+    "typeRoots": [
+      "src/types",
+      "node_modules/@types"
+    ]
   },
   "include": ["src/**/*.ts"],
   "exclude": [


### PR DESCRIPTION
Make sure we're re-exporting all public `graphql-tag` exports, while ensuring that valid types exist.