### PR TITLE
Add test validating `useQuery` returns a result upon first call, when available

### DIFF
--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -88,6 +88,40 @@ describe('useQuery Hook', () => {
       return wait();
     });
 
+    it('should return a result upon first call, if data is available', async () => {
+      // This test verifies that the `useQuery` hook returns a result upon its first
+      // invocation if the data is available in the cache. This is essential for SSR
+      // to work properly, since effects are not run during SSR.
+
+      const Component = ({ expectData }: { expectData: boolean }) => {
+        const { data } = useQuery(CAR_QUERY);
+        if (expectData) {
+          expect(data).toEqual(CAR_RESULT_DATA);
+        }
+        return null;
+      };
+
+      // Common cache instance to use across render passes.
+      // The cache will be warmed with the result of the query on the second pass.
+      const cache = new InMemoryCache();
+
+      render(
+        <MockedProvider mocks={CAR_MOCKS} cache={cache}>
+          <Component expectData={false} />
+        </MockedProvider>
+      );
+
+      await wait();
+
+      render(
+        <MockedProvider mocks={CAR_MOCKS} cache={cache}>
+          <Component expectData={true} />
+        </MockedProvider>
+      );
+
+      return wait();
+    });
+
     it('should ensure ObservableQuery fields have a stable identity', async () => {
       let refetchFn: any;
       let fetchMoreFn: any;


### PR DESCRIPTION
This is as it says on the box.

Essentially, SSR rehydration won't work if `useQuery` doesn't return `data` upon the first invocation when it's available. This was a problem in `3.0.0-beta.22` and seems to have been fixed now, but I wanted to ensure there was a regression test in place to avoid future issue.