### PR TITLE
Minor export changes

### DIFF
--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -5,7 +5,11 @@ import { tryFunctionOrLogError } from '../utilities/common/errorHandling';
 import { cloneDeep } from '../utilities/common/cloneDeep';
 import { getOperationDefinition } from '../utilities/graphql/getFromAST';
 import { NetworkStatus, isNetworkRequestInFlight } from './networkStatus';
-import { Observable, Observer, Subscription } from '../utilities/observables/Observable';
+import {
+  Observable,
+  Observer,
+  ObservableSubscription
+} from '../utilities/observables/Observable';
 import { ApolloError } from '../errors/ApolloError';
 import { QueryManager } from './QueryManager';
 import { ApolloQueryResult, FetchType, OperationVariables } from './types';
@@ -65,7 +69,7 @@ export class ObservableQuery<
   private isTornDown: boolean;
   private queryManager: QueryManager<any>;
   private observers = new Set<Observer<ApolloQueryResult<TData>>>();
-  private subscriptions = new Set<Subscription>();
+  private subscriptions = new Set<ObservableSubscription>();
 
   private lastResult: ApolloQueryResult<TData>;
   private lastResultSnapshot: ApolloQueryResult<TData>;

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -23,7 +23,11 @@ import {
 import { removeConnectionDirectiveFromDocument } from '../utilities/graphql/transform';
 import { canUseWeakMap } from '../utilities/common/canUse';
 import { isApolloError, ApolloError } from '../errors/ApolloError';
-import { Observer, Subscription, Observable } from '../utilities/observables/Observable';
+import {
+  Observer,
+  ObservableSubscription,
+  Observable
+} from '../utilities/observables/Observable';
 import { MutationStore } from '../data/mutations';
 import { QueryStore, QueryStoreValue } from '../data/queries';
 import {
@@ -59,7 +63,7 @@ export interface QueryInfo {
   // these to keep track of queries that are inflight and error on the observers associated
   // with them in case of some destabalizing action (e.g. reset of the Apollo store).
   observableQuery: ObservableQuery<any> | null;
-  subscriptions: Set<Subscription>;
+  subscriptions: Set<ObservableSubscription>;
   cancel?: () => void;
 }
 
@@ -1018,7 +1022,7 @@ export class QueryManager<TStore> {
       ).then(makeObservable);
 
       return new Observable<FetchResult<T>>(observer => {
-        let sub: Subscription | null = null;
+        let sub: ObservableSubscription | null = null;
         observablePromise.then(
           observable => sub = observable.subscribe(observer),
           observer.error,
@@ -1331,7 +1335,7 @@ export class QueryManager<TStore> {
         newData: null,
         lastRequestId: 1,
         observableQuery: null,
-        subscriptions: new Set<Subscription>(),
+        subscriptions: new Set<ObservableSubscription>(),
       }
     );
   }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -67,7 +67,11 @@ export { HttpLink } from '../link/http/HttpLink';
 export { fromError } from '../link/utils/fromError';
 export { toPromise } from '../link/utils/toPromise';
 export { ServerError, throwServerError } from '../link/utils/throwServerError';
-export { Observable } from '../utilities/observables/Observable';
+export {
+  Observable,
+  Observer,
+  ObservableSubscription
+} from '../utilities/observables/Observable';
 
 /* Supporting */
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -88,16 +88,10 @@ export {
 // then re-exporting them separately, helps keeps bundlers happy without any
 // additional config changes.
 import gql from 'graphql-tag';
-const {
+export const {
   resetCaches,
   disableFragmentWarnings,
   enableExperimentalFragmentVariables,
   disableExperimentalFragmentVariables
 } = gql;
-export {
-  gql,
-  resetCaches,
-  disableFragmentWarnings,
-  enableExperimentalFragmentVariables,
-  disableExperimentalFragmentVariables
-};
+export { gql };

--- a/src/types/graphql-tag.d.ts
+++ b/src/types/graphql-tag.d.ts
@@ -5,7 +5,7 @@
 // be fully updated to use Typescript, and these discrepancies will be fixed.
 
 declare module 'graphql-tag' {
-  function gql(literals: any, ...placeholders: any[]): any;
+  function gql(literals: string[], ...placeholders: any[]): any;
   namespace gql {
     export function resetCaches(): void;
     export function disableFragmentWarnings(): void;

--- a/src/utilities/observables/Observable.ts
+++ b/src/utilities/observables/Observable.ts
@@ -4,7 +4,7 @@ import Observable from 'zen-observable';
 // proposal (https://github.com/zenparsing/es-observable)
 import 'symbol-observable';
 
-export type Subscription = ZenObservable.Subscription;
+export type ObservableSubscription = ZenObservable.Subscription;
 export type Observer<T> = ZenObservable.Observer<T>;
 
 // Use global module augmentation to add RxJS interop functionality. By

--- a/src/utilities/observables/observables.ts
+++ b/src/utilities/observables/observables.ts
@@ -1,10 +1,10 @@
-import { Observable, Observer, Subscription } from './Observable';
+import { Observable, Observer, ObservableSubscription } from './Observable';
 
 // Returns a normal Observable that can have any number of subscribers,
 // while ensuring the original Observable gets subscribed to at most once.
 export function multiplex<T>(inner: Observable<T>): Observable<T> {
   const observers = new Set<Observer<T>>();
-  let sub: Subscription | null = null;
+  let sub: ObservableSubscription | null = null;
   return new Observable<T>(observer => {
     observers.add(observer);
     sub = sub || inner.subscribe({

--- a/src/utilities/testing/observableToPromise.ts
+++ b/src/utilities/testing/observableToPromise.ts
@@ -1,6 +1,6 @@
 import { ObservableQuery } from '../../core/ObservableQuery';
 import { ApolloQueryResult } from '../../core/types';
-import { Subscription } from '../../utilities/observables/Observable';
+import { ObservableSubscription } from '../../utilities/observables/Observable';
 
 /**
  *
@@ -27,8 +27,8 @@ export type ResultCallback = ((result: ApolloQueryResult<any>) => any);
 export function observableToPromiseAndSubscription(
   { observable, shouldResolve = true, wait = -1, errorCallbacks = [] }: Options,
   ...cbs: ResultCallback[]
-): { promise: Promise<any[]>; subscription: Subscription } {
-  let subscription: Subscription = null as never;
+): { promise: Promise<any[]>; subscription: ObservableSubscription } {
+  let subscription: ObservableSubscription = null as never;
   const promise = new Promise<any[]>((resolve, reject) => {
     let errorIndex = 0;
     let cbIndex = 0;

--- a/src/utilities/testing/subscribeAndCount.ts
+++ b/src/utilities/testing/subscribeAndCount.ts
@@ -1,13 +1,13 @@
 import { ObservableQuery } from '../../core/ObservableQuery';
 import { ApolloQueryResult } from '../../core/types';
-import { Subscription } from '../../utilities/observables/Observable';
+import { ObservableSubscription } from '../../utilities/observables/Observable';
 import { asyncMap } from '../../utilities/observables/observables';
 
 export default function subscribeAndCount(
   reject: (reason: any) => any,
   observable: ObservableQuery<any>,
   cb: (handleCount: number, result: ApolloQueryResult<any>) => any,
-): Subscription {
+): ObservableSubscription {
   let handleCount = 0;
   const subscription = asyncMap(
     observable,


### PR DESCRIPTION
A few minor export changes:

- Re-export `ZenObservable.Observer` and `ZenObservable.Subscription` as `Observer` and `ObservableSubscription` (see https://github.com/apollographql/apollo-client/commit/739f0fa6c529d962d9c40032f7caa812f49651d5 for an explanation of the naming)
- Simplify/cleanup the `graphql-tag` re-exports