### PR TITLE
Eliminate options.invalidate function in favor of local variables.

### DIFF
--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -302,7 +302,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     );
   }
 
-  public makeLocalVar<T>(value: T): LocalVar<T> {
+  public makeLocalVar<T>(value?: T): LocalVar<T> {
     return function LocalVar(newValue) {
       if (arguments.length > 0) {
         if (value !== newValue) {

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -354,9 +354,10 @@ export class Policies {
     typename: string,
     createIfMissing: boolean,
   ): Policies["typePolicies"][string] {
-    const { typePolicies } = this;
-    return typePolicies[typename] || (
-      createIfMissing && (typePolicies[typename] = Object.create(null)));
+    if (typename) {
+      return this.typePolicies[typename] || (
+        createIfMissing && (this.typePolicies[typename] = Object.create(null)));
+    }
   }
 
   private getSubtypeSet(


### PR DESCRIPTION
Every use case for `options.invalidate` (introduced in #5667) can be handled more precisely using
local variables (introduced in #5799).

There's no reason to invalidate every query that consumed the field when you can invalidate just the queries that depended on specific local variables. In the case where a field's `read` function only consumes a single local variable, the effect of updating that variable is the same as calling `options.invalidate`.

Storing local variables in the `options.storage` object is still often a good idea, because that way they're scoped to the field, rather than being shared global variables. You can see an example of that in the tests that I updated in this PR.

This change should also make it easier to explain field invalidation in our documentation, because we can just build on the explanation of local variables, rather than introducing a new but redundant concept.