### PR TITLE
Address feedback on pagination examples raised in #5881.

### DIFF
--- a/docs/source/caching/cache-field-behavior.md
+++ b/docs/source/caching/cache-field-behavior.md
@@ -336,7 +336,8 @@ const cache = new InMemoryCache({
           merge(existing: any[], incoming: any[], { args }) {
             const merged = existing ? existing.slice(0) : [];
             // Insert the incoming elements in the right places, according to args.
-            for (let i = args.offset; i < args.offset + args.limit; ++i) {
+            const end = args.offset + Math.min(args.limit, incoming.length);
+            for (let i = args.offset; i < end; ++i) {
               merged[i] = incoming[i - args.offset];
             }
             return merged;
@@ -346,10 +347,16 @@ const cache = new InMemoryCache({
             // If we read the field before any data has been written to the
             // cache, this function will return undefined, which correctly
             // indicates that the field is missing.
-            return existing && existing.slice(
+            const page = existing && existing.slice(
               args.offset,
               args.offset + args.limit,
             );
+            // If we ask for a page outside the bounds of the existing array,
+            // page.length will be 0, and we should return undefined instead of
+            // the empty array.
+            if (page && page.length > 0) {
+              return page;
+            }
           },
         },
       },
@@ -394,10 +401,13 @@ const cache = new InMemoryCache({
               const afterIndex = existing.findIndex(
                 task => args.afterId === readField("id", task));
               if (afterIndex >= 0) {
-                return existing.slice(
+                const page = existing.slice(
                   afterIndex + 1,
                   afterIndex + 1 + args.limit,
                 );
+                if (page && page.length > 0) {
+                  return page;
+                }
               }
             }
           },


### PR DESCRIPTION
Thanks to @tafelito for actually trying out the code examples in the new cache policies documentation (see #5881)! I have simplified the suggested edits to the examples, but (I hope) preserved their intent.

As for the TypeScript changes, we were previously defaulting `TExisting` to `StoreValue`, and `TIncoming` to `TExisting`, but that was never really helpful (and sometimes just frustrating), because the definition of the [`StoreValue`](https://github.com/apollographql/apollo-client/blob/2c5374b78ef7be17cc84b145fcdddd9c4618ee5e/src/utilities/graphql/storeUtils.ts#L36-L45) type reads like an incomplete list of some of the types you might find inside the cache:
```ts
export type StoreValue =
  | number
  | string
  | string[]
  | Reference
  | Reference[]
  | null
  | undefined
  | void
  | Object;
```
When you're writing a specific `read` or `merge` function, you almost always have a much better idea what type of data you're dealing with, so there's pretty much zero value in thinking through these cases, when you can just name your own parameter types and be done with it.

This is one of those rare cases when defaulting to `any` is a good option, because it places the responsibility on the developer to handle all possible cases, using their application-level knowledge.