### PR TITLE
Provide options.mergeObjects for easy and correct recursive merging.

### DIFF
--- a/docs/source/caching/cache-field-behavior.md
+++ b/docs/source/caching/cache-field-behavior.md
@@ -234,7 +234,7 @@ When you use `{ ...existing, ...incoming }`, `Author` objects with differing fie
 
 But what if the `Author` type defines its own custom `merge` functions for fields of the `incoming` object? Since we're using [object spread syntax](https://2ality.com/2016/10/rest-spread-properties.html), such fields will immediately overwrite fields in `existing`, without triggering any nested `merge` functions. The `{ ...existing, ...incoming }` syntax may be an improvement, but it is not fully correct.
 
-Fortunately, you can find a helper function called `options.merge` in the options passed to the `merge` function, which generally behaves the same as `{ ...existing, ...incoming }`, except when the `incoming` fields have custom `merge` functions. When `options.merge` encounters custom `merge` functions for any of the fields in its second argument (`incoming`), those nested `merge` functions will be called before combining the fields of `existing` and `incoming`, as desired:
+Fortunately, you can find a helper function called `options.mergeObjects` in the options passed to the `merge` function, which generally behaves the same as `{ ...existing, ...incoming }`, except when the `incoming` fields have custom `merge` functions. When `options.mergeObjects` encounters custom `merge` functions for any of the fields in its second argument (`incoming`), those nested `merge` functions will be called before combining the fields of `existing` and `incoming`, as desired:
 
 ```ts
 const cache = new InMemoryCache({
@@ -242,9 +242,9 @@ const cache = new InMemoryCache({
     Book: {
       fields: {
         author: {
-          merge(existing, incoming, { merge }) {
+          merge(existing, incoming, { mergeObjects }) {
             // Correct, thanks to invoking nested merge functions.
-            return merge(existing, incoming);
+            return mergeObjects(existing, incoming);
           },
         },
       },
@@ -291,7 +291,7 @@ const cache = new InMemoryCache({
     Book: {
       fields: {
         authors: {
-          merge(existing: any[], incoming: any[], { readField, merge }) {
+          merge(existing: any[], incoming: any[], { readField, mergeObjects }) {
             const merged: any[] = existing ? existing.slice(0) : [];
             const authorNameToIndex: Record<string, number> = Object.create(null);
             if (existing) {
@@ -304,7 +304,7 @@ const cache = new InMemoryCache({
               const index = authorNameToIndex[name];
               if (typeof index === "number") {
                 // Merge the new author data with the existing author data.
-                merged[index] = merge(merged[index], author);
+                merged[index] = mergeObjects(merged[index], author);
               } else {
                 // First time we've seen this author in this array.
                 authorNameToIndex[name] = merged.length;

--- a/docs/source/caching/cache-field-behavior.md
+++ b/docs/source/caching/cache-field-behavior.md
@@ -201,6 +201,7 @@ const cache = new InMemoryCache({
       fields: {
         author: {
           merge(existing, incoming) {
+            // Better, but not quite correct.
             return { ...existing, ...incoming };
           },
         },
@@ -210,9 +211,7 @@ const cache = new InMemoryCache({
 });
 ```
 
-This policy allows the cache to safely merge the `author` objects of any two `Book` objects that have the same identity.
-
-If you would prefer to keep the default replacement behavior while silencing the warnings, the following `merge` function will explicitly permit replacement:
+Alternatively, if you prefer to keep the default behavior of completely replacing the `existing` data with the `incoming` data, while also silencing the warnings, the following `merge` function will explicitly permit replacement:
 
 ```ts
 const cache = new InMemoryCache({
@@ -220,7 +219,8 @@ const cache = new InMemoryCache({
     Book: {
       fields: {
         author: {
-          merge(_ignored, incoming) {
+          merge(existing, incoming) {
+            // Equivalent to what happens if there is no custom merge function.
             return incoming;
           },
         },
@@ -230,7 +230,32 @@ const cache = new InMemoryCache({
 });
 ```
 
-Of course, you can implement your `merge` functions however you like&mdash;these are just the simplest and most common implementations.
+When you use `{ ...existing, ...incoming }`, `Author` objects with differing fields (`name`, `dateOfBirth`) can be combined without losing fields, which is definitely an improvement over blind replacement.
+
+But what if the `Author` type defines its own custom `merge` functions for fields of the `incoming` object? Since we're using [object spread syntax](https://2ality.com/2016/10/rest-spread-properties.html), such fields will immediately overwrite fields in `existing`, without triggering any nested `merge` functions. The `{ ...existing, ...incoming }` syntax may be an improvement, but it is not fully correct.
+
+Fortunately, you can find a helper function called `options.merge` in the options passed to the `merge` function, which generally behaves the same as `{ ...existing, ...incoming }`, except when the `incoming` fields have custom `merge` functions. When `options.merge` encounters custom `merge` functions for any of the fields in its second argument (`incoming`), those nested `merge` functions will be called before combining the fields of `existing` and `incoming`, as desired:
+
+```ts
+const cache = new InMemoryCache({
+  typePolicies: {
+    Book: {
+      fields: {
+        author: {
+          merge(existing, incoming, { merge }) {
+            // Correct, thanks to invoking nested merge functions.
+            return merge(existing, incoming);
+          },
+        },
+      },
+    },
+  },
+});
+```
+
+Because this `Book.author` field policy has no `Book`- or `Author`-specific logic in it, you can reuse this `merge` function for any field that needs this kind of handling.
+
+In summary, the `Book.author` policy above allows the cache to safely merge the `author` objects of any two `Book` objects that have the same identity.
 
 #### Merging arrays of non-normalized objects
 
@@ -266,25 +291,26 @@ const cache = new InMemoryCache({
     Book: {
       fields: {
         authors: {
-          merge(existing: any[] = [], incoming: any[], { readField }) {
-            const merged: any[] = [];
-            const authors = new Map<string, any>();
-            function add(author: any) {
+          merge(existing: any[], incoming: any[], { readField, merge }) {
+            const merged: any[] = existing ? existing.slice(0) : [];
+            const authorNameToIndex = new Map<string, number>();
+            if (existing) {
+              existing.forEach((author, i) => {
+                authors.set(readField<string>("name", author), i);
+              });
+            }
+            incoming.forEach(author => {
               const name = readField<string>("name", author);
               if (authors.has(name)) {
                 // Merge the new author data with the existing author data.
-                authors.set(name, {
-                  ...authors.get(name),
-                  ...author,
-                });
+                const i = authors.get(name);
+                merged[i] = merge(merged[i], author);
               } else {
                 // First time we've seen this author in this array.
-                authors.set(name, author);
+                authors.set(name, merged.length);
                 merged.push(author);
               }
-            }
-            existing.forEach(add);
-            incoming.forEach(add);
+            });
             return merged;
           },
         },

--- a/docs/source/caching/cache-field-behavior.md
+++ b/docs/source/caching/cache-field-behavior.md
@@ -293,21 +293,21 @@ const cache = new InMemoryCache({
         authors: {
           merge(existing: any[], incoming: any[], { readField, merge }) {
             const merged: any[] = existing ? existing.slice(0) : [];
-            const authorNameToIndex = new Map<string, number>();
+            const authorNameToIndex: Record<string, number> = Object.create(null);
             if (existing) {
-              existing.forEach((author, i) => {
-                authors.set(readField<string>("name", author), i);
+              existing.forEach((author, index) => {
+                authorNameToIndex[readField<string>("name", author)] = index;
               });
             }
             incoming.forEach(author => {
               const name = readField<string>("name", author);
-              if (authors.has(name)) {
+              const index = authorNameToIndex[name];
+              if (typeof index === "number") {
                 // Merge the new author data with the existing author data.
-                const i = authors.get(name);
-                merged[i] = merge(merged[i], author);
+                merged[index] = merge(merged[index], author);
               } else {
                 // First time we've seen this author in this array.
-                authors.set(name, merged.length);
+                authorNameToIndex[name] = merged.length;
                 merged.push(author);
               }
             });

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -2353,7 +2353,13 @@ describe("type policies", function () {
             keyFields: ["isbn"],
             fields: {
               author: {
-                merge(existing, incoming, { merge }) {
+                merge(existing, incoming, { readField, merge }) {
+                  expect(merge(void 0, null)).toBe(null);
+                  expect(() => {
+                    // The type system does a pretty good job of defending
+                    // against this mistake.
+                    merge([1, 2, 3] as any as StoreObject, [4] as any as StoreObject);
+                  }).toThrow(/Cannot automatically merge arrays/);
                   return merge(existing, incoming);
                 },
               },

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -2353,21 +2353,21 @@ describe("type policies", function () {
             keyFields: ["isbn"],
             fields: {
               author: {
-                merge(existing: StoreObject, incoming: StoreObject, { merge }) {
-                  expect(merge(void 0, null)).toBe(null);
+                merge(existing: StoreObject, incoming: StoreObject, { mergeObjects }) {
+                  expect(mergeObjects(void 0, null)).toBe(null);
 
                   expect(() => {
                     // The type system does a pretty good job of defending
                     // against this mistake.
-                    merge([1, 2, 3] as any as StoreObject, [4] as any as StoreObject);
+                    mergeObjects([1, 2, 3] as any as StoreObject, [4] as any as StoreObject);
                   }).toThrow(/Cannot automatically merge arrays/);
 
                   const a = { __typename: "A", a: "ay" };
                   const b = { __typename: "B", a: "bee" };
-                  expect(merge(a, b)).toBe(b);
-                  expect(merge(b, a)).toBe(a);
+                  expect(mergeObjects(a, b)).toBe(b);
+                  expect(mergeObjects(b, a)).toBe(a);
 
-                  return merge(existing, incoming);
+                  return mergeObjects(existing, incoming);
                 },
               },
             },

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -2355,11 +2355,18 @@ describe("type policies", function () {
               author: {
                 merge(existing: StoreObject, incoming: StoreObject, { merge }) {
                   expect(merge(void 0, null)).toBe(null);
+
                   expect(() => {
                     // The type system does a pretty good job of defending
                     // against this mistake.
                     merge([1, 2, 3] as any as StoreObject, [4] as any as StoreObject);
                   }).toThrow(/Cannot automatically merge arrays/);
+
+                  const a = { __typename: "A", a: "ay" };
+                  const b = { __typename: "B", a: "bee" };
+                  expect(merge(a, b)).toBe(b);
+                  expect(merge(b, a)).toBe(a);
+
                   return merge(existing, incoming);
                 },
               },

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -2,7 +2,7 @@ import gql from "graphql-tag";
 import { InMemoryCache, LocalVar } from "../inMemoryCache";
 import { StoreValue } from "../../../utilities";
 import { FieldPolicy, Policies } from "../policies";
-import { Reference } from "../../../core";
+import { Reference, StoreObject } from "../../../core";
 
 function reverse(s: string) {
   return s.split("").reverse().join("");
@@ -2353,7 +2353,7 @@ describe("type policies", function () {
             keyFields: ["isbn"],
             fields: {
               author: {
-                merge(existing, incoming, { readField, merge }) {
+                merge(existing: StoreObject, incoming: StoreObject, { merge }) {
                   expect(merge(void 0, null)).toBe(null);
                   expect(() => {
                     // The type system does a pretty good job of defending

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -6,7 +6,7 @@ import {
 } from "graphql";
 
 import { KeyTrie } from 'optimism';
-import invariant from 'ts-invariant';
+import { invariant, InvariantError } from 'ts-invariant';
 
 import {
   FragmentMap,
@@ -155,6 +155,14 @@ interface FieldFunctionOptions {
   // across multiple read function calls. Useful for field-level caching,
   // if your read function does any expensive work.
   storage: StorageType;
+
+  // Instead of just merging objects with { ...existing, ...incoming }, this
+  // helper function can be used to merge objects in a way that respects any
+  // custom merge functions defined for their fields.
+  merge<T extends StoreObject>(
+    existing: T,
+    incoming: T,
+  ): T;
 }
 
 export type FieldReadFunction<TExisting = any, TReadResult = TExisting> = (
@@ -679,7 +687,38 @@ function makeFieldFunctionOptions(
         variables,
       );
     },
+    merge(existing, incoming) {
+      if (Array.isArray(existing) || Array.isArray(incoming)) {
+        throw new InvariantError("Cannot automatically merge arrays");
+      }
+
+      const eType = getFieldValue(existing, "__typename");
+      const iType = getFieldValue(incoming, "__typename");
+      const typesDiffer = eType && iType && eType !== iType;
+
+      const applied = policies.applyMerges(
+        typesDiffer ? void 0 : existing,
+        incoming,
+        getFieldValue,
+        variables,
+      );
+
+      if (
+        typesDiffer ||
+        !canBeMerged(existing) ||
+        !canBeMerged(applied)
+      ) {
+        return applied;
+      }
+
+      return { ...existing, ...applied };
+    }
   };
+}
+
+function canBeMerged(obj: StoreValue): boolean {
+  return obj && typeof obj === "object" &&
+    !isReference(obj) && !Array.isArray(obj);
 }
 
 function keyArgsFnFromSpecifier(

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -676,6 +676,7 @@ function makeFieldFunctionOptions(
     isReference,
     toReference: policies.toReference,
     storage,
+
     readField<T>(
       nameOrField: string | FieldNode,
       foreignObjOrRef: StoreObject | Reference,
@@ -687,31 +688,37 @@ function makeFieldFunctionOptions(
         variables,
       );
     },
+
     merge(existing, incoming) {
       if (Array.isArray(existing) || Array.isArray(incoming)) {
         throw new InvariantError("Cannot automatically merge arrays");
       }
 
-      const eType = getFieldValue(existing, "__typename");
-      const iType = getFieldValue(incoming, "__typename");
-      const typesDiffer = eType && iType && eType !== iType;
+      if (existing && typeof existing === "object" &&
+          incoming && typeof incoming === "object") {
+        const eType = getFieldValue(existing, "__typename");
+        const iType = getFieldValue(incoming, "__typename");
+        const typesDiffer = eType && iType && eType !== iType;
 
-      const applied = policies.applyMerges(
-        typesDiffer ? void 0 : existing,
-        incoming,
-        getFieldValue,
-        variables,
-      );
+        const applied = policies.applyMerges(
+          typesDiffer ? void 0 : existing,
+          incoming,
+          getFieldValue,
+          variables,
+        );
 
-      if (
-        typesDiffer ||
-        !canBeMerged(existing) ||
-        !canBeMerged(applied)
-      ) {
-        return applied;
+        if (
+          typesDiffer ||
+          !canBeMerged(existing) ||
+          !canBeMerged(applied)
+        ) {
+          return applied;
+        }
+
+        return { ...existing, ...applied };
       }
 
-      return { ...existing, ...applied };
+      return incoming;
     }
   };
 }

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -159,7 +159,7 @@ interface FieldFunctionOptions {
   // Instead of just merging objects with { ...existing, ...incoming }, this
   // helper function can be used to merge objects in a way that respects any
   // custom merge functions defined for their fields.
-  merge<T extends StoreObject | Reference>(
+  mergeObjects<T extends StoreObject | Reference>(
     existing: T,
     incoming: T,
   ): T;
@@ -689,11 +689,15 @@ function makeFieldFunctionOptions(
       );
     },
 
-    merge(existing, incoming) {
+    mergeObjects(existing, incoming) {
       if (Array.isArray(existing) || Array.isArray(incoming)) {
         throw new InvariantError("Cannot automatically merge arrays");
       }
 
+      // These dynamic checks are necessary because the parameters of a
+      // custom merge function can easily have the any type, so the type
+      // system cannot always enforce the StoreObject | Reference
+      // parameter types of options.mergeObjects.
       if (existing && typeof existing === "object" &&
           incoming && typeof incoming === "object") {
         const eType = getFieldValue(existing, "__typename");

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -159,7 +159,7 @@ interface FieldFunctionOptions {
   // Instead of just merging objects with { ...existing, ...incoming }, this
   // helper function can be used to merge objects in a way that respects any
   // custom merge functions defined for their fields.
-  merge<T extends StoreObject>(
+  merge<T extends StoreObject | Reference>(
     existing: T,
     incoming: T,
   ): T;


### PR DESCRIPTION
One of the benefits of #5880 is that any custom `merge` function gets to see its `incoming` data before any nested `merge` functions have been run, so `merge` functions have full control over how the contents of their input arguments get combined, in principle.

In practice, it's actually pretty tricky to implement a correct custom `merge` function that might encounter any non-normalized data, because even non-normalized objects can have custom `merge` functions for their fields, which must be called.

We've been (briefly) recommending that people ignore this edge case and simply return `{ ...existing, ...incoming }` when combining non-normalized objects, so that no fields are lost. However, this style ignores the possibility that the `existing` and `incoming` objects might have totally different `__typename`s, risks combining `{ __ref }` objects with non-reference objects, and does not invoke any nested `merge` functions. A rat's nest of edge cases!

This PR introduces a general-purpose `options.mergeObjects` helper function to enable easy and correct merges of `existing` and `incoming` values. It also comes in handy when merging specific elements from two arrays, which is something the cache cannot do automatically.