### PR TITLE
export fromPromise

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -66,6 +66,7 @@ export { createHttpLink } from '../link/http/createHttpLink';
 export { HttpLink } from '../link/http/HttpLink';
 export { fromError } from '../link/utils/fromError';
 export { toPromise } from '../link/utils/toPromise';
+export { fromPromise } from '../link/utils/fromPromise';
 export { ServerError, throwServerError } from '../link/utils/throwServerError';
 export {
   Observable,


### PR DESCRIPTION
Fixes #5889 

We're already exporting `toPromise` and it's likely that there are many custom links out there that rely on `fromPromise` so this makes sense.
