### PR TITLE
Simplify EntityStore#merge.

### DIFF
--- a/src/cache/inmemory/__tests__/__snapshots__/roundtrip.ts.snap
+++ b/src/cache/inmemory/__tests__/__snapshots__/roundtrip.ts.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`writing to the store throws when trying to write an object without id that was previously queried with id 1`] = `"Store error: the application attempted to write an object with no provided id but the store already contains an id of abcd for this object."`;

--- a/src/cache/inmemory/__tests__/__snapshots__/writeToStore.ts.snap
+++ b/src/cache/inmemory/__tests__/__snapshots__/writeToStore.ts.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`writing to the store throws when trying to write an object without id that was previously queried with id 1`] = `"Store error: the application attempted to write an object with no provided id but the store already contains an id of abcd for this object."`;

--- a/src/cache/inmemory/__tests__/writeToStore.ts
+++ b/src/cache/inmemory/__tests__/writeToStore.ts
@@ -1706,64 +1706,6 @@ describe('writing to the store', () => {
     });
   });
 
-  it('throws when trying to write an object without id that was previously queried with id', () => {
-    const store = defaultNormalizedCacheFactory({
-      ROOT_QUERY: {
-        __typename: 'Query',
-        item: makeReference('abcd'),
-      },
-      abcd: {
-        id: 'abcd',
-        __typename: 'Item',
-        stringField: 'This is a string!',
-      },
-    });
-
-    const writer = new StoreWriter({
-      policies: new Policies({
-        dataIdFromObject: getIdField,
-      }),
-    });
-
-    expect(() => {
-      writer.writeQueryToStore({
-        store,
-        result: {
-          item: {
-            __typename: 'Item',
-            stringField: 'This is still a string!',
-          },
-        },
-        query: gql`
-          query Failure {
-            item {
-              stringField
-            }
-          }
-        `,
-      });
-    }).toThrowErrorMatchingSnapshot();
-
-    expect(() => {
-      writer.writeQueryToStore({
-        store,
-        query: gql`
-          query {
-            item {
-              stringField
-            }
-          }
-        `,
-        result: {
-          item: {
-            __typename: 'Item',
-            stringField: 'This is still a string!',
-          },
-        },
-      });
-    }).toThrowError(/contains an id of abcd/g);
-  });
-
   it('properly handles the @connection directive', () => {
     const store = defaultNormalizedCacheFactory();
 

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -1,18 +1,11 @@
 import { dep, OptimisticDependencyFunction, KeyTrie } from 'optimism';
-import { invariant } from 'ts-invariant';
 import { equal } from '@wry/equality';
 
 import { isReference, StoreValue } from '../../utilities/graphql/storeUtils';
-import {
-  DeepMerger,
-  ReconcilerFunction,
-} from '../../utilities/common/mergeDeep';
+import { DeepMerger } from '../../utilities/common/mergeDeep';
 import { canUseWeakMap } from '../../utilities/common/canUse';
 import { NormalizedCache, NormalizedCacheObject, StoreObject } from './types';
-import {
-  getTypenameFromStoreObject,
-  fieldNameFromStoreName,
-} from './helpers';
+import { fieldNameFromStoreName } from './helpers';
 
 const hasOwn = Object.prototype.hasOwnProperty;
 
@@ -66,24 +59,27 @@ export abstract class EntityStore implements NormalizedCache {
 
   public merge(dataId: string, incoming: StoreObject): void {
     const existing = this.lookup(dataId);
-    const merged = new DeepMerger(storeObjectReconciler).merge(existing, incoming, this);
+    const merged = new DeepMerger(storeObjectReconciler).merge(existing, incoming);
     // Even if merged === existing, existing may have come from a lower
     // layer, so we always need to set this.data[dataId] on this level.
     this.data[dataId] = merged;
     if (merged !== existing) {
       delete this.refs[dataId];
       if (this.group.caching) {
+        const fieldsToDirty: Record<string, 1> = Object.create(null);
         // If we added a new StoreObject where there was previously none, dirty
         // anything that depended on the existence of this dataId, such as the
         // EntityStore#has method.
-        if (!existing) this.group.dirty(dataId, "__exists");
-        // Now invalidate dependents who called getFieldValue for any
-        // fields that are changing as a result of this merge.
+        if (!existing) fieldsToDirty.__exists = 1;
+        // Now invalidate dependents who called getFieldValue for any fields
+        // that are changing as a result of this merge.
         Object.keys(incoming).forEach(storeFieldName => {
-          if (!existing || incoming[storeFieldName] !== existing[storeFieldName]) {
-            this.group.dirty(dataId, storeFieldName);
+          if (!existing || existing[storeFieldName] !== merged[storeFieldName]) {
+            fieldsToDirty[fieldNameFromStoreName(storeFieldName)] = 1;
           }
         });
+        Object.keys(fieldsToDirty).forEach(
+          fieldName => this.group.dirty(dataId, fieldName));
       }
     }
   }
@@ -426,57 +422,19 @@ class Layer extends EntityStore {
   }
 }
 
-const storeObjectReconciler: ReconcilerFunction<[EntityStore]> = function (
-  existingObject,
-  incomingObject,
-  property,
-  // This parameter comes from the additional argument we pass to the
-  // merge method in context.mergeStoreObjects (see writeQueryToStore).
-  store,
-) {
-  // In the future, reconciliation logic may depend on the type of the parent
-  // StoreObject, not just the values of the given property.
-  const existing = existingObject[property];
-  const incoming = incomingObject[property];
-
-  if (
-    existing !== incoming &&
-    // The DeepMerger class has various helpful utilities that we might as
-    // well reuse here.
-    this.isObject(existing) &&
-    this.isObject(incoming)
-  ) {
-    const eType = getTypenameFromStoreObject(store, existing);
-    const iType = getTypenameFromStoreObject(store, incoming);
-    // If both objects have a typename and the typename is different, let the
-    // incoming object win. The typename can change when a different subtype
-    // of a union or interface is written to the store.
-    if (
-      typeof eType === 'string' &&
-      typeof iType === 'string' &&
-      eType !== iType
-    ) {
-      return incoming;
-    }
-
-    invariant(
-      !isReference(existing) || isReference(incoming),
-      `Store error: the application attempted to write an object with no provided id but the store already contains an id of ${existing.__ref} for this object.`,
-    );
-
-    // It's worth checking deep equality here (even though blindly
-    // returning incoming would be logically correct) because preserving
-    // the referential identity of existing data can prevent needless
-    // rereading and rerendering.
-    if (equal(existing, incoming)) {
-      return existing;
-    }
-  }
-
-  // In all other cases, incoming replaces existing without any effort to
-  // merge them deeply, since custom merge functions have already been
-  // applied to the incoming data by walkWithMergeOverrides.
-  return incoming;
+function storeObjectReconciler(
+  existingObject: StoreObject,
+  incomingObject: StoreObject,
+  property: string | number,
+): StoreValue {
+  const existingValue = existingObject[property];
+  const incomingValue = incomingObject[property];
+  // Wherever there is a key collision, prefer the incoming value, unless
+  // it is deeply equal to the existing value. It's worth checking deep
+  // equality here (even though blindly returning incoming would be
+  // logically correct) because preserving the referential identity of
+  // existing data can prevent needless rereading and rerendering.
+  return equal(existingValue, incomingValue) ? existingValue : incomingValue;
 }
 
 export function supportsResultCaching(store: any): store is EntityStore {

--- a/src/core/__tests__/QueryManager/index.ts
+++ b/src/core/__tests__/QueryManager/index.ts
@@ -2312,69 +2312,6 @@ describe('QueryManager', () => {
     ]).then(resolve, reject);
   });
 
-  itAsync('should error if we replace a real id node in the store with a generated id node', (resolve, reject) => {
-    const queryWithId = gql`
-      query {
-        author {
-          firstName
-          lastName
-          __typename
-          id
-        }
-      }
-    `;
-    const dataWithId = {
-      author: {
-        firstName: 'John',
-        lastName: 'Smith',
-        id: '129',
-        __typename: 'Author',
-      },
-    };
-    const queryWithoutId = gql`
-      query {
-        author {
-          address
-        }
-      }
-    `;
-    const dataWithoutId = {
-      author: {
-        address: 'fake address',
-      },
-    };
-    const reducerConfig = { dataIdFromObject };
-    const queryManager = createQueryManager({
-      link: mockSingleLink({
-        request: { query: queryWithId },
-        result: { data: dataWithId },
-      }, {
-        request: { query: queryWithoutId },
-        result: { data: dataWithoutId },
-      }).setOnError(reject),
-      config: reducerConfig,
-    });
-
-    const observableWithId = queryManager.watchQuery<any>({
-      query: queryWithId,
-    });
-    const observableWithoutId = queryManager.watchQuery<any>({
-      query: queryWithoutId,
-    });
-
-    // I'm not sure the waiting 60 here really is required, but the test used to do it
-    return Promise.all([
-      observableToPromise({ observable: observableWithId, wait: 60 }, result =>
-        expect(stripSymbols(result.data)).toEqual(dataWithId),
-      ),
-      observableToPromise({
-        observable: observableWithoutId,
-        errorCallbacks: [error => expect(error.message).toMatch('Store error')],
-        wait: 60,
-      }),
-    ]).then(resolve, reject);
-  });
-
   itAsync('should not error when replacing unidentified data with a normalized ID', (resolve, reject) => {
     const queryWithoutId = gql`
       query {


### PR DESCRIPTION
More meaningful warnings are coming (#5833) when merging non-normalized data in the cache, and we can save some code by not worrying about edge cases that don't matter.