### PR TITLE
Implement InMemoryCache#modify for surgically transforming fields.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@
     },
   });
   ```
-  This API gracefully handles cases where multiple field values are associated with a single field name, and also removes the need for updating the cache by reading a query or fragment, modifying the result, and writing the modified result back into the cache. <br/>
+  This API gracefully handles cases where multiple field values are associated with a single field name, and also removes the need for updating the cache by reading a query or fragment, modifying the result, and writing the modified result back into the cache. Behind the scenes, the `cache.evict` method is now implemented in terms of `cache.modify`. <br/>
   [@benjamn](https://github.com/benjamn) in [#5909](https://github.com/apollographql/apollo-client/pull/5909)
 
 - `InMemoryCache` provides a new API for storing local state that can be easily updated by external code:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,17 @@
 - The result caching system (introduced in [#3394](https://github.com/apollographql/apollo-client/pull/3394)) now tracks dependencies at the field level, rather than at the level of whole entity objects, allowing the cache to return identical (`===`) results much more often than before. <br/>
   [@benjamn](https://github.com/benjamn) in [#5617](https://github.com/apollographql/apollo-client/pull/5617)
 
+- `InMemoryCache` now has a method called `modify` which can be used to update the value of a specific field within a specific entity object:
+  ```ts
+  cache.modify(cache.identify(post), {
+    comments(comments: Reference[], { readField }) {
+      return comments.filter(comment => idToRemove !== readField("id", comment));
+    },
+  });
+  ```
+  This API gracefully handles cases where multiple field values are associated with a single field name, and also removes the need for updating the cache by reading a query or fragment, modifying the result, and writing the modified result back into the cache. <br/>
+  [@benjamn](https://github.com/benjamn) in [#5909](https://github.com/apollographql/apollo-client/pull/5909)
+
 - `InMemoryCache` provides a new API for storing local state that can be easily updated by external code:
   ```ts
   const lv = cache.makeLocalVar(123)

--- a/src/cache/core/types/Cache.ts
+++ b/src/cache/core/types/Cache.ts
@@ -21,6 +21,7 @@ export namespace Cache {
   }
 
   export interface WatchOptions extends ReadOptions {
+    immediate?: boolean;
     callback: WatchCallback;
   }
 

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -290,25 +290,20 @@ export abstract class EntityStore implements NormalizedCache {
   public makeCacheKey(...args: any[]) {
     return this.group.keyMaker.lookupArray(args);
   }
-}
 
-export type FieldValueGetter = ReturnType<typeof makeFieldValueGetter>;
-
-export function makeFieldValueGetter(store: NormalizedCache) {
-  // Provides a uniform interface for reading field values, whether or not
-  // objectOrReference is a normalized entity.
-  return function getFieldValue<T = StoreValue>(
+  // Bound function that can be passed around to provide easy access to fields
+  // of Reference objects as well as ordinary objects.
+  public getFieldValue = <T = StoreValue>(
     objectOrReference: StoreObject | Reference,
     storeFieldName: string,
-  ): SafeReadonly<T> {
-    // Enforce Readonly<T> at runtime, in development.
-    return maybeDeepFreeze(
-      isReference(objectOrReference)
-        ? store.get(objectOrReference.__ref, storeFieldName)
-        : objectOrReference && objectOrReference[storeFieldName]
-    ) as SafeReadonly<T>;
-  };
+  ) => maybeDeepFreeze(
+    isReference(objectOrReference)
+      ? this.get(objectOrReference.__ref, storeFieldName)
+      : objectOrReference && objectOrReference[storeFieldName]
+  ) as SafeReadonly<T>;
 }
+
+export type FieldValueGetter = EntityStore["getFieldValue"];
 
 // A single CacheGroup represents a set of one or more EntityStore objects,
 // typically the Root store in a CacheGroup by itself, and all active Layer

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -14,7 +14,7 @@ import {
 } from './types';
 import { StoreReader } from './readFromStore';
 import { StoreWriter } from './writeToStore';
-import { EntityStore, supportsResultCaching } from './entityStore';
+import { EntityStore, supportsResultCaching, Modifiers, Modifier } from './entityStore';
 import {
   defaultDataIdFromObject,
   PossibleTypesMap,
@@ -151,6 +151,19 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     });
 
     this.broadcastWatches();
+  }
+
+  public modify(
+    dataId: string,
+    modifiers: Modifier<any> | Modifiers,
+    optimistic = false,
+  ): boolean {
+    const store = optimistic ? this.optimisticData : this.data;
+    if (store.modify(dataId, modifiers)) {
+      this.broadcastWatches();
+      return true;
+    }
+    return false;
   }
 
   public diff<T>(options: Cache.DiffOptions): Cache.DiffResult<T> {

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -165,7 +165,9 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
 
   public watch(watch: Cache.WatchOptions): () => void {
     this.watches.add(watch);
-
+    if (watch.immediate) {
+      this.maybeBroadcastWatch(watch);
+    }
     return () => {
       this.watches.delete(watch);
     };

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -113,6 +113,9 @@ export interface FieldFunctionOptions<
   // processing. Always a string, even when options.field is null.
   fieldName: string;
 
+  // The full field key used internally, including serialized key arguments.
+  storeFieldName: string;
+
   // The FieldNode object used to read this field. Useful if you need to
   // know about other attributes of the field, such as its directives. This
   // option will be null when a string was passed to options.readField.
@@ -642,6 +645,7 @@ function makeFieldFunctionOptions(
       argumentsObjectFromField(nameOrField, variables),
     field: typeof nameOrField === "string" ? null : nameOrField,
     fieldName,
+    storeFieldName,
     variables,
     policies,
     isReference,

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -34,7 +34,7 @@ import {
   StoreObject,
   NormalizedCache,
 } from './types';
-import { supportsResultCaching, FieldValueGetter, makeFieldValueGetter } from './entityStore';
+import { supportsResultCaching } from './entityStore';
 import { getTypenameFromStoreObject } from './helpers';
 import { Policies } from './policies';
 
@@ -46,7 +46,6 @@ interface ExecContext {
   policies: Policies;
   fragmentMap: FragmentMap;
   variables: VariableMap;
-  getFieldValue: FieldValueGetter;
 };
 
 export type ExecResult<R = any> = {
@@ -165,7 +164,6 @@ export class StoreReader {
           ...variables,
         },
         fragmentMap: createFragmentMap(getFragmentDefinitions(query)),
-        getFieldValue: makeFieldValueGetter(store),
       },
     });
 
@@ -197,10 +195,10 @@ export class StoreReader {
       };
     }
 
-    const { fragmentMap, variables, policies, getFieldValue } = context;
+    const { fragmentMap, variables, policies, store } = context;
     const objectsToMerge: { [key: string]: any }[] = [];
     const finalResult: ExecResult = { result: null };
-    const typename = getFieldValue<string>(objectOrReference, "__typename");
+    const typename = store.getFieldValue<string>(objectOrReference, "__typename");
 
     if (this.config.addTypename &&
         typeof typename === "string" &&
@@ -231,7 +229,7 @@ export class StoreReader {
         let fieldValue = policies.readField(
           objectOrReference,
           selection,
-          getFieldValue,
+          store.getFieldValue,
           variables,
           typename,
         );

--- a/src/cache/inmemory/types.ts
+++ b/src/cache/inmemory/types.ts
@@ -2,7 +2,7 @@ import { DocumentNode } from 'graphql';
 
 import { Transaction } from '../core/cache';
 import { StoreValue } from '../../utilities/graphql/storeUtils';
-import { FieldValueGetter } from './entityStore';
+import { Modifiers, Modifier, FieldValueGetter } from './entityStore';
 export { StoreValue }
 
 export interface IdGetterObj extends Object {
@@ -23,6 +23,7 @@ export interface NormalizedCache {
   has(dataId: string): boolean;
   get(dataId: string, fieldName: string): StoreValue;
   merge(dataId: string, incoming: StoreObject): void;
+  modify(dataId: string, modifiers: Modifier<any> | Modifiers): boolean;
   delete(dataId: string, fieldName?: string): boolean;
   clear(): void;
 

--- a/src/cache/inmemory/types.ts
+++ b/src/cache/inmemory/types.ts
@@ -2,6 +2,7 @@ import { DocumentNode } from 'graphql';
 
 import { Transaction } from '../core/cache';
 import { StoreValue } from '../../utilities/graphql/storeUtils';
+import { FieldValueGetter } from './entityStore';
 export { StoreValue }
 
 export interface IdGetterObj extends Object {
@@ -45,6 +46,8 @@ export interface NormalizedCache {
    */
   retain(rootId: string): number;
   release(rootId: string): number;
+
+  getFieldValue: FieldValueGetter;
 }
 
 /**

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -25,7 +25,7 @@ import { shouldInclude } from '../../utilities/graphql/directives';
 import { cloneDeep } from '../../utilities/common/cloneDeep';
 
 import { Policies } from './policies';
-import { defaultNormalizedCacheFactory, FieldValueGetter, makeFieldValueGetter } from './entityStore';
+import { defaultNormalizedCacheFactory } from './entityStore';
 import { NormalizedCache, StoreObject } from './types';
 import { makeProcessedFieldsMerger } from './helpers';
 
@@ -36,7 +36,6 @@ export type WriteContext = {
   };
   readonly variables?: any;
   readonly fragmentMap?: FragmentMap;
-  getFieldValue: FieldValueGetter;
   // General-purpose deep-merge function for use during writes.
   merge<T>(existing: T, incoming: T): T;
 };
@@ -101,7 +100,6 @@ export class StoreWriter {
           ...variables,
         },
         fragmentMap: createFragmentMap(getFragmentDefinitions(query)),
-        getFieldValue: makeFieldValueGetter(store),
       },
     });
   }
@@ -135,7 +133,7 @@ export class StoreWriter {
       getTypenameFromResult(result, selectionSet, context.fragmentMap) ||
       // If the entity identified by dataId has a __typename in the store,
       // fall back to that.
-      context.getFieldValue<string>(entityRef, "__typename");
+      store.getFieldValue<string>(entityRef, "__typename");
 
     store.merge(
       dataId,
@@ -147,7 +145,7 @@ export class StoreWriter {
           context,
           typename,
         }),
-        context.getFieldValue,
+        store.getFieldValue,
         context.variables,
       ),
     );

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -127,18 +127,17 @@ export class StoreWriter {
     if (sets.indexOf(selectionSet) >= 0) return store;
     sets.push(selectionSet);
 
-    const entityRef = makeReference(dataId);
     const typename =
       // If the result has a __typename, trust that.
       getTypenameFromResult(result, selectionSet, context.fragmentMap) ||
       // If the entity identified by dataId has a __typename in the store,
       // fall back to that.
-      store.getFieldValue<string>(entityRef, "__typename");
+      store.get(dataId, "__typename") as string;
 
     store.merge(
       dataId,
       policies.applyMerges(
-        entityRef,
+        makeReference(dataId),
         this.processSelectionSet({
           result,
           selectionSet,


### PR DESCRIPTION
The `cache.writeQuery` and `cache.writeFragment` methods do a great job of adding data to the cache, but their behavior can be frustrating when you're trying to _remove_ specific data from a field. The typical cycle of reading data, modifying it, and writing it back into the cache does not always simply replace the old data, because it may trigger custom `merge` functions which attempt to combine `incoming` data with `existing` data, leading to confusion.

For cases when you want to apply a specific transformation to an existing field value in the cache, we are introducing a new API, `cache.modify(id, modifiers)`, which takes an entity ID and an object mapping field names to modifier functions. Each modifier function will be called with the current value of the field, and should return a new field value, without modifying the existing value (which will be frozen in development).

For example, here's how you might remove a `Comment` from a paginated `Thread.comments` array:
```ts
cache.modify(cache.identify(thread), {
  comments(comments: Reference[], { readField }) {
    return comments.filter(comment => idToRemove !== readField("id", comment));
  },
});
```
In addition to the field value, modifier functions receive a `details` object that contains various helpers familiar from `read`/`merge` functions: `fieldName`, `storeFieldName`, `isReference`, `toReference`, and `readField`; plus a sentinel object (`details.DELETE`) that can be returned to delete the field from the entity object:
```ts
cache.modify(id, {
  fieldNameToDelete(_, { DELETE }) {
    return DELETE;
  },
});
```
As always, modifications are applied to the cache in a non-destructive fashion, without altering any data previously returned by `cache.extract()`. Any fields whose values change as a result of calling `cache.modify` will trigger invalidation of cached queries that previously consumed those fields.

As evidence of the usefulness and generality of this API, I was able to reimplement `cache.delete` almost entirely in terms of `cache.modify`. Next, I plan to eliminate the foot-seeking missile known as `cache.writeData`, and show that `cache.modify` can handle all of its use cases, too.