### PR TITLE
Simplify makeFieldValueGetter.

### DIFF
--- a/src/cache/inmemory/__tests__/entityStore.ts
+++ b/src/cache/inmemory/__tests__/entityStore.ts
@@ -2,16 +2,19 @@ import gql from 'graphql-tag';
 import { EntityStore, supportsResultCaching } from '../entityStore';
 import { InMemoryCache } from '../inMemoryCache';
 import { DocumentNode, FieldNode } from 'graphql';
-import { getOperationDefinition, getFragmentDefinitions } from '../../../utilities/graphql/getFromAST';
-import { createFragmentMap } from '../../../utilities/graphql/fragments';
+import { Policies } from '../policies';
+import { StoreObject } from '../types';
+import { ApolloCache } from '../../core/cache';
 
 describe('EntityStore', () => {
   it('should support result caching if so configured', () => {
     const storeWithResultCaching = new EntityStore.Root({
+      policies: new Policies,
       resultCaching: true,
     });
 
     const storeWithoutResultCaching = new EntityStore.Root({
+      policies: new Policies,
       resultCaching: false,
     });
 
@@ -624,7 +627,7 @@ describe('EntityStore', () => {
       }
     `;
 
-    const fragmentResult = cache.readFragment({
+    const fragmentResult = cache.readFragment<StoreObject>({
       id: cache.identify(cuckoosCallingBook),
       fragment: bookAuthorFragment,
     });

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -71,6 +71,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     // will completely disable dependency tracking, which will improve memory
     // usage but worsen the performance of repeated reads.
     this.data = new EntityStore.Root({
+      policies: this.policies,
       resultCaching: this.config.resultCaching,
     });
 

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -34,9 +34,9 @@ import {
   StoreObject,
   NormalizedCache,
 } from './types';
-import { supportsResultCaching } from './entityStore';
+import { supportsResultCaching, FieldValueGetter, makeFieldValueGetter } from './entityStore';
 import { getTypenameFromStoreObject } from './helpers';
-import { Policies, FieldValueGetter } from './policies';
+import { Policies } from './policies';
 
 export type VariableMap = { [name: string]: any };
 
@@ -165,7 +165,7 @@ export class StoreReader {
           ...variables,
         },
         fragmentMap: createFragmentMap(getFragmentDefinitions(query)),
-        getFieldValue: policies.makeFieldValueGetter(store),
+        getFieldValue: makeFieldValueGetter(store),
       },
     });
 

--- a/src/cache/inmemory/types.ts
+++ b/src/cache/inmemory/types.ts
@@ -60,6 +60,15 @@ export interface StoreObject {
   [storeFieldName: string]: StoreValue;
 }
 
+// The Readonly<T> type only really works for object types, since it marks
+// all of the object's properties as readonly, but there are many cases when
+// a generic type parameter like TExisting might be a string or some other
+// primitive type, in which case we need to avoid wrapping it with Readonly.
+// SafeReadonly<string> collapses to just string, which makes string
+// assignable to SafeReadonly<any>, whereas string is not assignable to
+// Readonly<any>, somewhat surprisingly.
+export type SafeReadonly<T> = T extends object ? Readonly<T> : T;
+
 export type OptimisticStoreItem = {
   id: string;
   data: NormalizedCacheObject;

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -24,8 +24,8 @@ import {
 import { shouldInclude } from '../../utilities/graphql/directives';
 import { cloneDeep } from '../../utilities/common/cloneDeep';
 
-import { Policies, FieldValueGetter } from './policies';
-import { defaultNormalizedCacheFactory } from './entityStore';
+import { Policies } from './policies';
+import { defaultNormalizedCacheFactory, FieldValueGetter, makeFieldValueGetter } from './entityStore';
 import { NormalizedCache, StoreObject } from './types';
 import { makeProcessedFieldsMerger } from './helpers';
 
@@ -101,7 +101,7 @@ export class StoreWriter {
           ...variables,
         },
         fragmentMap: createFragmentMap(getFragmentDefinitions(query)),
-        getFieldValue: this.policies.makeFieldValueGetter(store),
+        getFieldValue: makeFieldValueGetter(store),
       },
     });
   }


### PR DESCRIPTION
This is truly an implementation detail / refactoring, with no observable behavioral changes, but I didn't want to sneak it into an unrelated PR, where it would clutter the changes.

The commit messages should explain everything, for anyone who is curious.

Thanks to better minification, this PR saves 14 bytes (minified + gzip), a very small but nice bonus.