### PR TITLE
AC3 apollo-link-rest doc updates

### DIFF
--- a/docs/source/api/link/apollo-link-rest.md
+++ b/docs/source/api/link/apollo-link-rest.md
@@ -12,7 +12,7 @@ Calling REST APIs from a GraphQL client opens the benefits of GraphQL for more p
 * You have an existing codebase, but you're looking to evaluate whether GraphQL can work for your needs.
 * You have a large codebase, and the GraphQL migration is happening on the backend, but you want to use GraphQL *now* without waiting!
 
-With `@apollo/link-rest`, you can call your endpoints inside your GraphQL queries and have all your data managed by Apollo Client. `@apollo/link-rest` is suitable for just dipping your toes in the water, or doing a full-steam ahead integration, and then later on migrating to a backend-driven GraphQL experience.
+With `apollo-link-rest`, you can call your endpoints inside your GraphQL queries and have all your data managed by Apollo Client. `apollo-link-rest` is suitable for just dipping your toes in the water, or doing a full-steam ahead integration, and then later on migrating to a backend-driven GraphQL experience.
 
 > For more advanced or complex back-ends, you may want to consider using [`apollo-server`](https://www.apollographql.com/docs/apollo-server/).
 
@@ -21,14 +21,14 @@ With `@apollo/link-rest`, you can call your endpoints inside your GraphQL querie
 To get started, first install Apollo Client and any `peerDependencies` we need:
 
 ```bash
-npm install --save @apollo/client @apollo/link-rest graphql qs
+npm install --save @apollo/client apollo-link-rest graphql qs
 ```
 
 After this, you're ready to setup the Apollo Client instance:
 
 ```js
 import { ApolloClient } from '@apollo/client';
-import { RestLink } from '@apollo/link-rest';
+import { RestLink } from 'apollo-link-rest';
 
 // Set `RestLink` with your endpoint
 const restLink = new RestLink({ uri: "https://swapi.co/api/" });
@@ -442,7 +442,7 @@ const client = new ApolloClient({
 
 ## Link order
 
-If you are using multiple link types, `restLink` should go before `httpLink`, as `httpLink` will swallow any calls that should be routed through `@apollo/link-rest`.
+If you are using multiple link types, `restLink` should go before `httpLink`, as `httpLink` will swallow any calls that should be routed through `apollo-link-rest`.
 
 For example:
 
@@ -671,7 +671,7 @@ const QUERY = gql`
 
 ## Mutations
 
-You can write also mutations with the @apollo/link-rest, for example:
+You can write also mutations with the apollo-link-rest, for example:
 
 ```graphql
   mutation deletePost($id: ID!) {
@@ -684,7 +684,7 @@ You can write also mutations with the @apollo/link-rest, for example:
 
 ## Troubleshooting
 
-Here are a few common `@apollo/link-rest` problems and solutions.
+Here are a few common `apollo-link-rest` problems and solutions.
 
 * `Missing field __typename in ...` -- If you see this, it's possible you haven't provided `type:` to the [`@rest(...)`](#rest-directive)-directive. Alternately you need to set up a [`typePatcher`](#typename-patching).
 * `Headers is undefined` -- If you see something like this, you're running in a browser or other Javascript environment that does not yet support the full specification for the `Headers` API.

--- a/docs/source/data/local-state.mdx
+++ b/docs/source/data/local-state.mdx
@@ -552,7 +552,7 @@ Apollo Client supports the merging of local `@client` results and remote results
 
 Apollo Client supports asynchronous local resolver functions. These functions can either be `async` functions or ordinary functions that return a `Promise`. Asynchronous resolvers are useful when they need to return data from an asynchronous API.
 
-> ⚠️ If you would like to hit a REST endpoint from your resolver, [we recommend checking out `@apollo/link-rest`](https://github.com/apollographql/apollo-link-rest) instead, which is a more complete solution for using REST endpoints with Apollo Client.
+> ⚠️ If you would like to hit a REST endpoint from your resolver, [we recommend checking out `apollo-link-rest`](https://github.com/apollographql/apollo-link-rest) instead, which is a more complete solution for using REST endpoints with Apollo Client.
 
 For React Native and most browser APIs, you should set up a listener in a component lifecycle method and pass in your mutation trigger function as the callback instead of using an async resolver. However, an `async` resolver function is often the most convenient way to consume asynchronous device APIs:
 

--- a/docs/source/migrating/apollo-client-3-migration.md
+++ b/docs/source/migrating/apollo-client-3-migration.md
@@ -124,6 +124,8 @@ To continue using `apollo-link` packages besides `apollo-link-http`, replace eac
 
 These packages provide the same functionality as their non-`@apollo` counterparts, but they’re updated for compatibility with the `@apollo/client` package.
 
+`apollo-link-rest` has also been updated to use `@apollo/client`, but does not use `@apollo/link-X` naming. It should still be referenced using `apollo-link-rest`, and updated to its `latest` version.
+
 ### graphql-anywhere
 
 The `graphql-anywhere` package’s functionality is no longer included with Apollo Client. You can continue to use the `graphql-anywhere` package, but Apollo no longer uses it and will not actively support it moving forward.


### PR DESCRIPTION
This PR addresses the suggestions made in https://github.com/apollographql/apollo-link-rest/issues/237#issuecomment-580301418:

- Change all erroneous `@apollo/link-rest` name references back to `apollo-link-rest` (since the `@apollo` namespace is reserved for Apollo (the company) maintained projects)
- Add a small mention of `apollo-link-rest` in the Migration Guide, explaining how to use the AC3 ready version

Note that the AC3 ready version of `apollo-link-rest` hasn’t been published yet, but is ready in https://github.com/apollographql/apollo-link-rest/pull/241.