### PR TITLE
Allow cache.{read,write}Query to take options.id.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,9 @@
   These local variables are _reactive_ in the sense that updating their values invalidates any previously cached query results that depended on the old values. <br/>
   [@benjamn](https://github.com/benjamn) in [#5799](https://github.com/apollographql/apollo-client/pull/5799)
 
+- The `cache.readQuery` and `cache.writeQuery` methods now accept an `options.id` string, which eliminates most use cases for `cache.readFragment` and `cache.writeFragment`, and skips the implicit conversion of fragment documents to query documents performed by `cache.{read,write}Fragment`. <br/>
+  [@benjamn](https://github.com/benjamn) in [#5930](https://github.com/apollographql/apollo-client/pull/5930)
+
 - Several deprecated methods have been fully removed:
   - `ApolloClient#initQueryManager`
   - `QueryManager#startQuery`
@@ -98,7 +101,7 @@
 - Improve optimistic update performance by limiting cache key diversity. <br/>
   [@benjamn](https://github.com/benjamn) in [#5648](https://github.com/apollographql/apollo-client/pull/5648)
 
-- Custom field `read` functions can read from neighboring fields using the `getFieldValue(fieldName)` helper, and may also read fields from other entities by calling `getFieldValue(fieldName, foreignReference)`. <br/>
+- Custom field `read` functions can read from neighboring fields using the `readField(fieldName)` helper, and may also read fields from other entities by calling `readField(fieldName, objectOrReference)`. <br/>
   [@benjamn](https://github.com/benjamn) in [#5651](https://github.com/apollographql/apollo-client/pull/5651)
 
 - Utilities that were previously externally available through the `apollo-utilities` package are now only available by importing from `@apollo/client/utilities`. <br/>

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -2338,14 +2338,7 @@ describe('client', () => {
       expect(count).toEqual(0);
       await delay(11).then(() => count++);
       expect(count).toEqual(2);
-
-      try {
-        client.readQuery({ query });
-        fail('should not see any data');
-      } catch (e) {
-        expect(e.message).toMatch(/Can't find field author on ROOT_QUERY object/);
-      }
-
+      expect(client.readQuery({ query })).toBe(null);
       client.cache.writeQuery({ query, data: data2 });
     });
 

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -93,6 +93,7 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
     optimistic: boolean = false,
   ): QueryType | null {
     return this.read({
+      rootId: options.id || 'ROOT_QUERY',
       query: options.query,
       variables: options.variables,
       optimistic,
@@ -119,7 +120,7 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
     options: Cache.WriteQueryOptions<TData, TVariables>,
   ): void {
     this.write({
-      dataId: 'ROOT_QUERY',
+      dataId: options.id || 'ROOT_QUERY',
       result: options.data,
       query: options.query,
       variables: options.variables,

--- a/src/cache/core/types/DataProxy.ts
+++ b/src/cache/core/types/DataProxy.ts
@@ -13,6 +13,13 @@ export namespace DataProxy {
      * Any variables that the GraphQL query may depend on.
      */
     variables?: TVariables;
+
+    /**
+     * The root id to be used. Defaults to "ROOT_QUERY", which is the ID of the
+     * root query object. This property makes writeQuery capable of writing data
+     * to any object in the cache, which renders writeFragment mostly useless.
+     */
+    id?: string;
   }
 
   export interface Fragment<TVariables> {

--- a/src/cache/inmemory/__tests__/cache.ts
+++ b/src/cache/inmemory/__tests__/cache.ts
@@ -603,18 +603,6 @@ describe('Cache', () => {
         resultCaching: true,
       });
 
-      const firstNameFragment = gql`
-        fragment FirstNameFragment on Person {
-          firstName
-        }
-      `;
-
-      const lastNameFragment = gql`
-        fragment LastNameFragment on Person {
-          lastName
-        }
-      `;
-
       const bothNamesData = {
         __typename: "Person",
         id: 123,
@@ -622,11 +610,14 @@ describe('Cache', () => {
         lastName: "Newman",
       };
 
+      const firstNameQuery = gql`{ firstName }`;
+      const lastNameQuery = gql`{ lastName }`;
+
       const id = cache.identify(bothNamesData);
 
-      cache.writeFragment({
+      cache.writeQuery({
         id,
-        fragment: firstNameFragment,
+        query: firstNameQuery,
         data: bothNamesData,
       });
 
@@ -637,9 +628,9 @@ describe('Cache', () => {
         },
       });
 
-      const firstNameResult = cache.readFragment({
+      const firstNameResult = cache.readQuery({
         id,
-        fragment: firstNameFragment,
+        query: firstNameQuery,
       });
 
       expect(firstNameResult).toEqual({
@@ -647,9 +638,9 @@ describe('Cache', () => {
         firstName: "Ben",
       });
 
-      cache.writeFragment({
+      cache.writeQuery({
         id,
-        fragment: lastNameFragment,
+        query: lastNameQuery,
         data: bothNamesData,
       });
 
@@ -663,14 +654,14 @@ describe('Cache', () => {
 
       // This is the crucial test: modifying the lastName field should not
       // invalidate results that did not depend on the lastName field.
-      expect(cache.readFragment({
+      expect(cache.readQuery({
         id,
-        fragment: firstNameFragment,
+        query: firstNameQuery,
       })).toBe(firstNameResult);
 
-      const lastNameResult = cache.readFragment({
+      const lastNameResult = cache.readQuery({
         id,
-        fragment: lastNameFragment,
+        query: lastNameQuery,
       });
 
       expect(lastNameResult).toEqual({
@@ -678,9 +669,9 @@ describe('Cache', () => {
         lastName: "Newman",
       });
 
-      cache.writeFragment({
+      cache.writeQuery({
         id,
-        fragment: firstNameFragment,
+        query: firstNameQuery,
         data: {
           ...bothNamesData,
           firstName: "Benjamin",
@@ -695,9 +686,9 @@ describe('Cache', () => {
         },
       });
 
-      const benjaminResult = cache.readFragment({
+      const benjaminResult = cache.readQuery({
         id,
-        fragment: firstNameFragment,
+        query: firstNameQuery,
       });
 
       expect(benjaminResult).toEqual({
@@ -713,9 +704,9 @@ describe('Cache', () => {
 
       // Updating the firstName should not have invalidated the
       // previously-read lastNameResult.
-      expect(cache.readFragment({
+      expect(cache.readQuery({
         id,
-        fragment: lastNameFragment,
+        query: lastNameQuery,
       })).toBe(lastNameResult);
     });
 

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -2313,9 +2313,7 @@ describe("type policies", function () {
         });
       }
 
-      expect(read).toThrow(
-        /Dangling reference to missing Book:{"isbn":"156858217X"} object/
-      );
+      expect(read()).toBe(null);
 
       cache.writeQuery({
         query,

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -169,6 +169,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
   public diff<T>(options: Cache.DiffOptions): Cache.DiffResult<T> {
     return this.storeReader.diffQueryAgainstStore({
       store: options.optimistic ? this.optimisticData : this.data,
+      rootId: options.id || "ROOT_QUERY",
       query: options.query,
       variables: options.variables,
       returnPartialData: options.returnPartialData,

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -145,10 +145,9 @@ export class StoreReader {
   public diffQueryAgainstStore<T>({
     store,
     query,
+    rootId = 'ROOT_QUERY',
     variables,
     returnPartialData = true,
-    rootId = 'ROOT_QUERY',
-    config,
   }: DiffQueryAgainstStoreOptions): Cache.DiffResult<T> {
     const { policies } = this.config;
 


### PR DESCRIPTION
Writing data to a specific entity object in the cache should not require the additional boilerplate of creating a named fragment with a type condition.

All the cache really cares about is the top-level selection set of the query or fragment used to read or write data, and from that perspective queries are an almost perfect substitute for fragments, in almost all cases.

In other words, this code
```ts
cache.writeFragment({
  id,
  fragment: gql`
    fragment UnnecessaryFragmentName on UnnecessaryType {
      firstName
      lastName
    }
  `,
  data: {
    __typename: "UnnecessaryType",
    firstName,
    lastName,
  },
});
```
can now be written as just
```ts
cache.writeQuery({
  id,
  query: gql`{ firstName lastName }`,
  data: { firstName, lastName },
});
```
Once you get used to using queries instead of fragments, you may begin to wonder why you ever thought fragments were a good idea. To save you some existential turmoil: fragments are still a good idea if you really need their type condition behavior (that is, if you want the fragment to match only when the `on SomeType` condition holds), but otherwise passing `options.id` and `options.query` to `cache.readQuery` or `cache.writeQuery` is a lot simpler and just as powerful.

If you need further convincing, the `cache.readFragment` and `cache.writeFragment` methods actually convert the given `options.fragment` document to a query document (using `getFragmentQueryDocument`) which includes the given `options.fragment` as a `...field`. You can skip that needless conversion by just providing `options.query` to `readQuery` or `writeQuery`, and reserving `readFragment` and `writeFragment` for the rare cases where fragments actually have advantages over queries.

We are not removing the `cache.readFragment` and `cache.writeFragment` methods at this time, though we may consider deprecating them in the future.

As a side benefit, these changes happen to solve our longest outstanding feature request, https://github.com/apollographql/apollo-feature-requests/issues/1, which recently inspired https://github.com/apollographql/apollo-client/pull/5866. That's because `options.rootId` is now always defined when we do [this check](https://github.com/apollographql/apollo-client/blob/9cd5e8f7552db65437b5e59b605268a336977e45/src/cache/inmemory/inMemoryCache.ts#L130-L134).