### PR TITLE
feat(useMutation): provide ability to reset mutation to initial state

### DIFF
--- a/src/react/data/MutationData.ts
+++ b/src/react/data/MutationData.ts
@@ -44,7 +44,8 @@ export class MutationData<
     this.verifyDocumentType(this.getOptions().mutation, DocumentType.Mutation);
     return [
       this.runMutation,
-      { ...result, client: this.refreshClient().client }
+      { ...result, client: this.refreshClient().client },
+      this.resetMutation
     ] as MutationTuple<TData, TVariables>;
   }
 
@@ -75,6 +76,21 @@ export class MutationData<
         this.onMutationError(error, mutationId);
         if (!this.getOptions().onError) throw error;
       });
+  };
+
+  private resetMutation = () => {
+    if (this.previousResult.loading) {
+      // TODO: is it OK to do nothing with pending mutation, or should it be aborted?
+      return;
+    }
+    if (!this.getOptions().ignoreResults) {
+      this.updateResult({
+        loading: false,
+        error: undefined,
+        data: undefined,
+        called: false
+      });
+    }
   };
 
   private mutate(
@@ -179,8 +195,8 @@ export class MutationData<
       this.isMounted &&
       (!this.previousResult || !equal(this.previousResult, result))
     ) {
-      this.setResult(result);
       this.previousResult = result;
+      this.setResult(result);
     }
   }
 }

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -271,6 +271,118 @@ describe('useMutation Hook', () => {
     });
   });
 
+  describe('Reset mutation', () => {
+    it('should reset finished mutation properly', async () => {
+      const variables = {
+        description: 'Get milk!'
+      };
+
+      const mocks = [
+        {
+          request: {
+            query: CREATE_TODO_MUTATION,
+            variables
+          },
+          result: { data: CREATE_TODO_RESULT }
+        }
+      ];
+
+      let renderCount = 0;
+      const Component = () => {
+        const [createTodo, { loading, data, error, called }, resetCreateTodoMutation] = useMutation(
+            CREATE_TODO_MUTATION
+        );
+        switch (renderCount) {
+          case 0:
+            expect(loading).toBeFalsy();
+            expect(data).toBeUndefined();
+            createTodo({ variables });
+            break;
+          case 1:
+            expect(loading).toBeTruthy();
+            expect(data).toBeUndefined();
+            break;
+          case 2:
+            expect(loading).toBeFalsy();
+            expect(data).toEqual(CREATE_TODO_RESULT);
+            resetCreateTodoMutation();
+            break;
+          case 3:
+            expect(loading).toBeFalsy();
+            expect(data).toBeUndefined();
+            expect(error).toBeUndefined();
+            expect(called).toBeFalsy();
+          default:
+        }
+        renderCount += 1;
+        return null;
+      };
+
+      render(
+          <MockedProvider mocks={mocks}>
+            <Component />
+          </MockedProvider>
+      );
+
+      return wait(() => {
+        expect(renderCount).toBe(4);
+      });
+    });
+
+    it('should not reset pending mutation', async () => {
+      const variables = {
+        description: 'Get milk!'
+      };
+
+      const mocks = [
+        {
+          request: {
+            query: CREATE_TODO_MUTATION,
+            variables
+          },
+          result: { data: CREATE_TODO_RESULT }
+        }
+      ];
+
+      let renderCount = 0;
+      const Component = () => {
+        const [createTodo, { loading, data }, resetCreateTodoMutation] = useMutation(
+            CREATE_TODO_MUTATION
+        );
+        switch (renderCount) {
+          case 0:
+            expect(loading).toBeFalsy();
+            expect(data).toBeUndefined();
+            createTodo({ variables });
+            break;
+          case 1:
+            expect(loading).toBeTruthy();
+            expect(data).toBeUndefined();
+            resetCreateTodoMutation();
+            break;
+          case 2:
+            expect(loading).toBeFalsy();
+            expect(data).toEqual(CREATE_TODO_RESULT);
+            break;
+          default:
+        }
+        renderCount += 1;
+        return null;
+      };
+
+      render(
+          <MockedProvider mocks={mocks}>
+            <Component />
+          </MockedProvider>
+      );
+
+      return wait(() => {
+        expect(renderCount).toBe(3);
+      });
+    });
+  });
+
+
   describe('Optimistic response', () => {
     itAsync('should support optimistic response handling', async (resolve, reject) => {
       const optimisticResponse = {

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -197,7 +197,8 @@ export type MutationTuple<TData, TVariables> = [
   (
     options?: MutationFunctionOptions<TData, TVariables>
   ) => Promise<FetchResult<TData>>,
-  MutationResult<TData>
+  MutationResult<TData>,
+  () => void
 ];
 
 /* Subscription types */


### PR DESCRIPTION
RELATED TICKET: https://github.com/apollographql/apollo-feature-requests/issues/170

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
