### PR TITLE
tighten QueryTuple to indicate observable fields may be absent

### DIFF
--- a/src/react/data/QueryData.ts
+++ b/src/react/data/QueryData.ts
@@ -18,7 +18,8 @@ import {
   QueryCurrentObservable,
   QueryTuple,
   QueryLazyOptions,
-  ObservableQueryFields
+  ObservableQueryFields,
+  LazyQueryResult
 } from '../types/types';
 import { OperationData } from './OperationData';
 
@@ -68,7 +69,7 @@ export class QueryData<TData, TVariables> extends OperationData {
             networkStatus: NetworkStatus.ready,
             called: false,
             data: undefined
-          } as QueryResult<TData, TVariables>
+          }
         ]
       : [this.runLazyQuery, this.execute()];
   }
@@ -84,13 +85,13 @@ export class QueryData<TData, TVariables> extends OperationData {
     queryResult,
     lazy = false,
   }: {
-    queryResult: QueryResult<TData, TVariables>;
+    queryResult: QueryResult<TData, TVariables> | LazyQueryResult<TData, TVariables>;
     lazy?: boolean;
   }) {
     this.isMounted = true;
 
     if (!lazy || this.runLazy) {
-      this.handleErrorOrCompleted(queryResult);
+      this.handleErrorOrCompleted(queryResult as QueryResult<TData, TVariables>);
 
       // When the component is done rendering stored query errors, we'll
       // remove those errors from the `ObservableQuery` query store, so they

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -123,9 +123,32 @@ export interface QueryLazyOptions<TVariables> {
   context?: Context;
 }
 
+type UnexecutedLazyFields = {
+  loading: false;
+  networkStatus: NetworkStatus.ready;
+  called: false;
+  data: undefined;
+}
+
+type Impartial<T> = {
+  [P in keyof T]?: never;
+}
+
+type AbsentLazyResultFields =
+  Omit<
+    Impartial<QueryResult<unknown, unknown>>,
+    keyof UnexecutedLazyFields>
+
+type UnexecutedLazyResult =
+   UnexecutedLazyFields & AbsentLazyResultFields
+
+export type LazyQueryResult<TData, TVariables> =
+  | UnexecutedLazyResult
+  | QueryResult<TData, TVariables>;
+
 export type QueryTuple<TData, TVariables> = [
   (options?: QueryLazyOptions<TVariables>) => void,
-  QueryResult<TData, TVariables>
+  LazyQueryResult<TData, TVariables>
 ];
 
 /* Mutation types */

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -82,7 +82,7 @@ export interface QueryResult<TData = any, TVariables = OperationVariables>
   error?: ApolloError;
   loading: boolean;
   networkStatus: NetworkStatus;
-  called: boolean;
+  called: true;
 }
 
 export interface QueryDataOptions<TData = any, TVariables = OperationVariables>


### PR DESCRIPTION
fixes #5933

`npm t` and `npm run build` both came back clean for me.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
<!-- not sure this is relevant? - [ ] Make sure all of the significant new logic is covered by tests -->
