### PR TITLE
fix(QueryManager): Unhandled promise rejection during refetch when awaitRefetchQueries is enabled

### DIFF
--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -350,7 +350,7 @@ export class QueryManager<TStore> {
             }
 
             resolve(storeResult!);
-          });
+          }, reject);
         },
       });
     });


### PR DESCRIPTION
### Problem
During a mutation, when `refetchQueries` are set and `awaitRefetchQueries` is enabled, it is impossible to handle the error that came from any of the refetch queries.
See https://github.com/apollographql/apollo-client/issues/3631

### Solution
I added a simple error catch that resolves the chain properly after `Promise.all(...`.

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
