### PR TITLE
Various cache read and write performance optimizations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,9 @@
   These local variables are _reactive_ in the sense that updating their values invalidates any previously cached query results that depended on the old values. <br/>
   [@benjamn](https://github.com/benjamn) in [#5799](https://github.com/apollographql/apollo-client/pull/5799)
 
+- Various cache read and write performance optimizations, cutting read and write times by more than 50% in larger benchmarks. <br/>
+  [@benjamn](https://github.com/benjamn) in [#5948](https://github.com/apollographql/apollo-client/pull/5948)
+
 - The `cache.readQuery` and `cache.writeQuery` methods now accept an `options.id` string, which eliminates most use cases for `cache.readFragment` and `cache.writeFragment`, and skips the implicit conversion of fragment documents to query documents performed by `cache.{read,write}Fragment`. <br/>
   [@benjamn](https://github.com/benjamn) in [#5930](https://github.com/apollographql/apollo-client/pull/5930)
 

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -364,7 +364,7 @@ function makeDepKey(dataId: string, storeFieldName: string) {
   // Since field names cannot have newline characters in them, this method
   // of joining the field name and the ID should be unambiguous, and much
   // cheaper than JSON.stringify([dataId, fieldName]).
-  return fieldNameFromStoreName(storeFieldName) + "\n" + dataId;
+  return fieldNameFromStoreName(storeFieldName) + "#" + dataId;
 }
 
 export namespace EntityStore {

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -361,7 +361,10 @@ class CacheGroup {
 }
 
 function makeDepKey(dataId: string, storeFieldName: string) {
-  return JSON.stringify([dataId, fieldNameFromStoreName(storeFieldName)]);
+  // Since field names cannot have newline characters in them, this method
+  // of joining the field name and the ID should be unambiguous, and much
+  // cheaper than JSON.stringify([dataId, fieldName]).
+  return fieldNameFromStoreName(storeFieldName) + "\n" + dataId;
 }
 
 export namespace EntityStore {

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -212,12 +212,8 @@ export class Policies {
     };
   } = Object.create(null);
 
-  public readonly rootTypenamesById: Readonly<Record<string, string>> = {
-    __proto__: null, // Equivalent to Object.create(null)
-    ROOT_QUERY: "Query",
-    ROOT_MUTATION: "Mutation",
-    ROOT_SUBSCRIPTION: "Subscription",
-  };
+  public readonly rootIdsByTypename: Record<string, string> = Object.create(null);
+  public readonly rootTypenamesById: Record<string, string> = Object.create(null);
 
   public readonly usingPossibleTypes = false;
 
@@ -230,6 +226,10 @@ export class Policies {
       dataIdFromObject: defaultDataIdFromObject,
       ...config,
     };
+
+    this.setRootTypename("Query");
+    this.setRootTypename("Mutation");
+    this.setRootTypename("Subscription");
 
     if (config.possibleTypes) {
       this.addPossibleTypes(config.possibleTypes);
@@ -346,13 +346,14 @@ export class Policies {
 
   private setRootTypename(
     which: "Query" | "Mutation" | "Subscription",
-    typename: string,
+    typename: string = which,
   ) {
     const rootId = "ROOT_" + which.toUpperCase();
     const old = this.rootTypenamesById[rootId];
     if (typename !== old) {
-      invariant(old === which, `Cannot change root ${which} __typename more than once`);
-      (this.rootTypenamesById as any)[rootId] = typename;
+      invariant(!old || old === which, `Cannot change root ${which} __typename more than once`);
+      this.rootIdsByTypename[typename] = rootId;
+      this.rootTypenamesById[rootId] = typename;
     }
   }
 

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -222,16 +222,12 @@ export class StoreReader {
       return result.result;
     }
 
-    const selections = selectionSet.selections.slice(0);
+    const workSet = new Set(selectionSet.selections);
 
-    // Reevaluating selections.length each time is important, because we
-    // add additional selections in the fragment case below.
-    for (let s = 0; s < selections.length; ++s) {
-      const selection = selections[s];
-
+    workSet.forEach(selection => {
       // Omit fields with directives @skip(if: <truthy value>) or
       // @include(if: <falsy value>).
-      if (!shouldInclude(selection, variables)) continue;
+      if (!shouldInclude(selection, variables)) return;
 
       if (isField(selection)) {
         let fieldValue = policies.readField(
@@ -305,10 +301,10 @@ export class StoreReader {
         }
 
         if (policies.fragmentMatches(fragment, typename)) {
-          selections.push(...fragment.selectionSet.selections);
+          fragment.selectionSet.selections.forEach(workSet.add, workSet);
         }
       }
-    }
+    });
 
     // Perform a single merge at the end so that we can avoid making more
     // defensive shallow copies than necessary.

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -206,9 +206,7 @@ export class StoreReader {
 
     if (this.config.addTypename &&
         typeof typename === "string" &&
-        Object.values(
-          policies.rootTypenamesById
-        ).indexOf(typename) < 0) {
+        !policies.rootIdsByTypename[typename]) {
       // Ensure we always include a default value for the __typename
       // field, if we have one, and this.config.addTypename is true. Note
       // that this field can be overridden by other merged objects.

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -27,7 +27,7 @@ import { cloneDeep } from '../../utilities/common/cloneDeep';
 import { Policies } from './policies';
 import { defaultNormalizedCacheFactory } from './entityStore';
 import { NormalizedCache, StoreObject } from './types';
-import { makeProcessedFieldsMerger } from './helpers';
+import { makeProcessedFieldsMerger, FieldValueToBeMerged } from './helpers';
 
 export type WriteContext = {
   readonly store: NormalizedCache;
@@ -39,6 +39,16 @@ export type WriteContext = {
   // General-purpose deep-merge function for use during writes.
   merge<T>(existing: T, incoming: T): T;
 };
+
+interface ProcessSelectionSetOptions {
+  result: Record<string, any>;
+  selectionSet: SelectionSetNode;
+  context: WriteContext;
+  typename: string;
+  out: {
+    shouldApplyMerges?: boolean;
+  };
+}
 
 export interface StoreWriterConfig {
   policies: Policies;
@@ -134,20 +144,26 @@ export class StoreWriter {
       // fall back to that.
       store.get(dataId, "__typename") as string;
 
-    store.merge(
-      dataId,
-      policies.applyMerges(
+    const out: ProcessSelectionSetOptions["out"] = Object.create(null);
+
+    let processed = this.processSelectionSet({
+      result,
+      selectionSet,
+      context,
+      typename,
+      out,
+    });
+
+    if (out.shouldApplyMerges) {
+      processed = policies.applyMerges(
         makeReference(dataId),
-        this.processSelectionSet({
-          result,
-          selectionSet,
-          context,
-          typename,
-        }),
+        processed,
         store.getFieldValue,
         context.variables,
-      ),
-    );
+      );
+    }
+
+    store.merge(dataId, processed);
 
     return store;
   }
@@ -157,12 +173,10 @@ export class StoreWriter {
     selectionSet,
     context,
     typename,
-  }: {
-    result: Record<string, any>;
-    selectionSet: SelectionSetNode;
-    context: WriteContext;
-    typename: string;
-  }): StoreObject {
+    // This object allows processSelectionSet to report useful information
+    // to its callers without explicitly returning that information.
+    out,
+  }: ProcessSelectionSetOptions): StoreObject {
     let mergedFields: StoreObject = Object.create(null);
     if (typeof typename === "string") {
       mergedFields.__typename = typename;
@@ -186,22 +200,27 @@ export class StoreWriter {
             context.variables,
           );
 
-          const incomingValue =
-            this.processFieldValue(value, selection, context);
+          let incomingValue =
+            this.processFieldValue(value, selection, context, out);
 
-          mergedFields = context.merge(mergedFields, {
+          if (policies.hasMergeFunction(typename, selection.name.value)) {
             // If a custom merge function is defined for this field, store
             // a special FieldValueToBeMerged object, so that we can run
             // the merge function later, after all processSelectionSet
             // work is finished.
-            [storeFieldName]: policies.hasMergeFunction(
-              typename,
-              selection.name.value,
-            ) ? {
+            incomingValue = {
               __field: selection,
               __typename: typename,
               __value: incomingValue,
-            } : incomingValue,
+            } as FieldValueToBeMerged;
+
+            // Communicate to the caller that mergedFields contains at
+            // least one FieldValueToBeMerged.
+            out.shouldApplyMerges = true;
+          }
+
+          mergedFields = context.merge(mergedFields, {
+            [storeFieldName]: incomingValue,
           });
 
         } else if (
@@ -240,6 +259,7 @@ export class StoreWriter {
               selectionSet: fragment.selectionSet,
               context,
               typename,
+              out,
             }),
           );
         }
@@ -253,6 +273,7 @@ export class StoreWriter {
     value: any,
     field: FieldNode,
     context: WriteContext,
+    out: ProcessSelectionSetOptions["out"],
   ): StoreValue {
     if (!field.selectionSet || value === null) {
       // In development, we need to clone scalar values so that they can be
@@ -262,7 +283,8 @@ export class StoreWriter {
     }
 
     if (Array.isArray(value)) {
-      return value.map((item, i) => this.processFieldValue(item, field, context));
+      return value.map(
+        (item, i) => this.processFieldValue(item, field, context, out));
     }
 
     if (value) {
@@ -291,6 +313,7 @@ export class StoreWriter {
       context,
       typename: getTypenameFromResult(
         value, field.selectionSet, context.fragmentMap),
+      out,
     });
   }
 }

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -183,14 +183,10 @@ export class StoreWriter {
     }
 
     const { policies } = this;
-    const selections = selectionSet.selections.slice(0);
+    const workSet = new Set(selectionSet.selections);
 
-    // Reevaluating selections.length each time is important, because we
-    // add additional selections in the fragment case below.
-    for (let s = 0; s < selections.length; ++s) {
-      const selection = selections[s];
-
-      if (!shouldInclude(selection, context.variables)) continue;
+    workSet.forEach(selection => {
+      if (!shouldInclude(selection, context.variables)) return;
 
       if (isField(selection)) {
         const resultFieldKey = resultKeyNameFromField(selection);
@@ -255,10 +251,10 @@ export class StoreWriter {
         );
 
         if (policies.fragmentMatches(fragment, typename)) {
-          selections.push(...fragment.selectionSet.selections);
+          fragment.selectionSet.selections.forEach(workSet.add, workSet);
         }
       }
-    }
+    });
 
     return mergedFields;
   }

--- a/src/utilities/common/mergeDeep.ts
+++ b/src/utilities/common/mergeDeep.ts
@@ -64,8 +64,6 @@ const defaultReconciler: ReconcilerFunction<any[]> =
   };
 
 export class DeepMerger<TContextArgs extends any[]> {
-  private pastCopies: any[] = [];
-
   constructor(
     private reconciler: ReconcilerFunction<TContextArgs> = defaultReconciler,
   ) {}
@@ -101,12 +99,10 @@ export class DeepMerger<TContextArgs extends any[]> {
 
   public isObject = isObject;
 
+  private pastCopies = new Set<any>();
+
   public shallowCopyForMerge<T>(value: T): T {
-    if (
-      value !== null &&
-      typeof value === 'object' &&
-      this.pastCopies.indexOf(value) < 0
-    ) {
+    if (isObject(value) && !this.pastCopies.has(value)) {
       if (Array.isArray(value)) {
         value = (value as any).slice(0);
       } else {
@@ -115,7 +111,7 @@ export class DeepMerger<TContextArgs extends any[]> {
           ...value,
         };
       }
-      this.pastCopies.push(value);
+      this.pastCopies.add(value);
     }
     return value;
   }


### PR DESCRIPTION
Although we've been building Apollo Client 3.0 with performance in mind, making sure (for example) that you only pay for the features you use, we haven't focused on optimizing raw performance per se, until now.

Using an especially large query and response object provided by a customer/contributor, I was able to reduce initial (cold) execution times for the following write/read round-trip from ~150ms (measured using the latest published beta, `@apollo/client@3.0.0-beta.34`) to to ~95ms, a 37% improvement, and average (warm) execution times from ~105ms to ~25ms, a 76% improvement:
```ts
const start = Date.now();

cache.writeQuery({
  query,
  data: result.data,
  variables,
});

cache.watch({
  query,
  variables,
  optimistic: true,
  immediate: true,
  callback(data) {
    console.log(Date.now() - start, "ms");
  },
});
```
For this benchmark, I created a new `InMemoryCache` object for each run, so the results are not skewed by the benefits of result caching (see #3394) though result caching can have huge benefits for actual applications.

As always with performance, exact numbers will vary from query to query and machine to machine, but I used a 2014 dual-core 3GHz MacBook Pro, a 36KB query with lots of fragments, and a 500KB JSON-encoded result.

It's worth reviewing each of these commits separately, as they do not really follow a common theme (except for speeeed :feelsgood:).