### PR TITLE
Support toReference(obj, true) to persist obj into cache.

### DIFF
--- a/docs/source/caching/cache-field-behavior.md
+++ b/docs/source/caching/cache-field-behavior.md
@@ -533,7 +533,12 @@ interface FieldFunctionOptions {
 
   // Utilities for handling { __ref: string } references.
   isReference(obj: any): obj is Reference;
-  toReference(obj: StoreObject): Reference;
+  // Returns a Reference object if obj can be identified, which requires,
+  // at minimum, a __typename and any necessary key fields. If true is
+  // passed for the optional mergeIntoStore argument, the object's fields
+  // will also be persisted into the cache, which can be useful to ensure
+  // the Reference actually refers to data stored in the cache.
+  toReference(obj: StoreObject, mergeIntoStore?: boolean): Reference;
 
   // Helper function for reading other fields within the current object.
   // If a foreign object or reference is provided, the field will be read

--- a/src/cache/core/types/common.ts
+++ b/src/cache/core/types/common.ts
@@ -1,12 +1,11 @@
-import { SelectionSetNode } from 'graphql';
-
 import {
   isReference,
   StoreValue,
   StoreObject,
   Reference
 } from '../../../utilities/graphql/storeUtils';
-import { FragmentMap } from '../../../utilities/graphql/fragments';
+
+import { ToReferenceFunction } from '../../inmemory/entityStore';
 
 // The Readonly<T> type only really works for object types, since it marks
 // all of the object's properties as readonly, but there are many cases when
@@ -22,11 +21,7 @@ export type Modifier<T> = (value: T, details: {
   fieldName: string;
   storeFieldName: string;
   isReference: typeof isReference;
-  toReference(
-    object: StoreObject,
-    selectionSet?: SelectionSetNode,
-    fragmentMap?: FragmentMap,
-  ): Reference;
+  toReference: ToReferenceFunction;
   readField<V = StoreValue>(
     fieldName: string,
     objOrRef?: StoreObject | Reference,

--- a/src/cache/inmemory/__tests__/writeToStore.ts
+++ b/src/cache/inmemory/__tests__/writeToStore.ts
@@ -1248,7 +1248,7 @@ describe('writing to the store', () => {
       const expStore = defaultNormalizedCacheFactory({
         ROOT_QUERY: {
           __typename: 'Query',
-          author: policies.toReference(data.author),
+          author: makeReference(policies.identify(data.author)),
         },
         [policies.identify(data.author)!]: {
           firstName: data.author.firstName,
@@ -1288,7 +1288,7 @@ describe('writing to the store', () => {
       const expStore = defaultNormalizedCacheFactory({
         ROOT_QUERY: {
           __typename: 'Query',
-          author: policies.toReference(data.author),
+          author: makeReference(policies.identify(data.author)),
         },
         [policies.identify(data.author)!]: {
           __typename: data.author.__typename,

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -139,7 +139,7 @@ export abstract class EntityStore implements NormalizedCache {
               fieldName,
               storeFieldName,
               isReference,
-              toReference: this.policies.toReference,
+              toReference: this.toReference,
               readField,
             });
           if (newValue === DELETE) newValue = void 0;
@@ -310,7 +310,24 @@ export abstract class EntityStore implements NormalizedCache {
       ? this.get(objectOrReference.__ref, storeFieldName)
       : objectOrReference && objectOrReference[storeFieldName]
   ) as SafeReadonly<T>;
+
+  // Bound function that converts an object with a __typename and primary
+  // key fields to a Reference object. Pass true for mergeIntoStore if you
+  // would also like this object to be persisted into the store.
+  public toReference = (
+    object: StoreObject,
+    mergeIntoStore?: boolean,
+  ) => {
+    const id = this.policies.identify(object);
+    const ref = id && makeReference(id);
+    if (ref && mergeIntoStore) {
+      this.merge(id, object);
+    }
+    return ref;
+  }
 }
+
+export type ToReferenceFunction = EntityStore["toReference"];
 
 export type FieldValueGetter = EntityStore["getFieldValue"];
 

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -36,11 +36,11 @@ import {
 } from './types';
 import { supportsResultCaching } from './entityStore';
 import { getTypenameFromStoreObject } from './helpers';
-import { Policies } from './policies';
+import { Policies, ReadMergeContext } from './policies';
 
 export type VariableMap = { [name: string]: any };
 
-interface ExecContext {
+interface ExecContext extends ReadMergeContext {
   query: DocumentNode;
   store: NormalizedCache;
   policies: Policies;
@@ -168,6 +168,8 @@ export class StoreReader {
         variables,
         varString: JSON.stringify(variables),
         fragmentMap: createFragmentMap(getFragmentDefinitions(query)),
+        toReference: store.toReference,
+        getFieldValue: store.getFieldValue,
       },
     });
 
@@ -233,9 +235,9 @@ export class StoreReader {
         let fieldValue = policies.readField(
           objectOrReference,
           selection,
-          store.getFieldValue,
-          variables,
-          typename,
+          // Since ExecContext extends ReadMergeContext, we can pass it
+          // here without any modifications.
+          context,
         );
 
         if (fieldValue === void 0) {

--- a/src/cache/inmemory/types.ts
+++ b/src/cache/inmemory/types.ts
@@ -3,8 +3,8 @@ import { DocumentNode } from 'graphql';
 import { Transaction } from '../core/cache';
 import { Modifier, Modifiers } from '../core/types/common';
 import { StoreValue, StoreObject } from '../../utilities/graphql/storeUtils';
-import { FieldValueGetter } from './entityStore';
-export { StoreValue }
+import { FieldValueGetter, ToReferenceFunction } from './entityStore';
+export { StoreObject, StoreValue }
 
 export interface IdGetterObj extends Object {
   __typename?: string;
@@ -50,6 +50,7 @@ export interface NormalizedCache {
   release(rootId: string): number;
 
   getFieldValue: FieldValueGetter;
+  toReference: ToReferenceFunction;
 }
 
 /**

--- a/src/core/LocalState.ts
+++ b/src/core/LocalState.ts
@@ -29,6 +29,7 @@ import {
   resultKeyNameFromField,
   isField,
   isInlineFragment,
+  StoreObject,
 } from '../utilities/graphql/storeUtils';
 import { ApolloClient } from '../ApolloClient';
 import { Resolvers, OperationVariables } from './types';
@@ -179,26 +180,16 @@ export class LocalState<TCacheShape> {
     return this.resolvers ? removeClientSetsFromDocument(document) : document;
   }
 
-  public prepareContext(context = {}) {
+  public prepareContext(context?: Record<string, any>) {
     const { cache } = this;
-
-    const newContext = {
+    return {
       ...context,
       cache,
       // Getting an entry's cache key is useful for local state resolvers.
-      getCacheKey: (obj: { __typename: string; id: string | number }) => {
-        if ((cache as any).config) {
-          return (cache as any).config.dataIdFromObject(obj);
-        } else {
-          invariant(false,
-            'To use context.getCacheKey, you need to use a cache that has ' +
-              'a configurable dataIdFromObject, like apollo-cache-inmemory.',
-          );
-        }
+      getCacheKey(obj: StoreObject) {
+        return cache.identify(obj);
       },
     };
-
-    return newContext;
   }
 
   // To support `@client @export(as: "someVar")` syntax, we'll first resolve


### PR DESCRIPTION
The `options.toReference` helper function is provided to custom `read` and `merge` functions via their `options` parameter, as well as to `cache.modify` modifier functions, via their `details` parameter (#5909). See the tests included in this commit for examples of all three usages.

The original purpose of `toReference` was to return a `Reference` object, `{ __ref: <entity ID> }`, given an object with a `__typename` and the necessary key fields for that type. If these expectations are not met, `toReference(obj)` can return `null`, to indicate that the object could not be identified.

Another `toReference` failure mode (besides returning `null`) is returning a `Reference` object that doesn't actually refer to anything stored in the cache. While this case is handled gracefully during cache reads (the non-existent object simply appears empty), you may have encountered cases where you _do_ want to persist the object that was passed to `toReference` into the cache, such as when a custom `read` function knows how to provide a perfectly adequate default object based on `options.args`.

For those use cases, you can now call `toReference(object, true)` to merge the fields of the object into the cache, assuming it could be identified. Because this merging uses the same `EntityStore#merge` method as any other cache update, any dependent queries will be appropriately invalidated.

The fields of the object are merged into the cache as-is, without any transformations to handle field arguments, aliases, directives, or variables. For those cases, `cache.writeQuery` or `cache.writeFragment` are still the best options. Also, `toReference` is not exposed outside of
`read`/`merge`/`modify` functions, so if you're not in one of those functions you will have to call the normal `writeQuery` or `writeFragment` methods.

Implementation-wise, since `toReference` may now need to call `store.merge`, it was most convenient to move the definition of the `toReference` method from the `Policies` class to the `EntityStore` class.