### PR TITLE
Set loading to false if data is already in cache

### DIFF
--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -166,9 +166,12 @@ export class ObservableQuery<
 
     const { data, partial } = this.queryManager.getCurrentQueryResult(this);
     Object.assign(result, { data, partial });
-
-    const queryStoreValue = this.queryManager.queryStore.get(this.queryId);
-    if (queryStoreValue) {
+    let queryStoreValue: QueryStoreValue;
+    if (!partial && data !== undefined) {
+      // we already have the completed data:
+      result.loading = false;
+      result.networkStatus = NetworkStatus.ready;
+    } else if (queryStoreValue = this.queryManager.queryStore.get(this.queryId)) {
       const { networkStatus } = queryStoreValue;
 
       if (hasError(queryStoreValue, this.options.errorPolicy)) {


### PR DESCRIPTION
This is a work-in-progress PR to fix #5869 (and possibly #5835 and #5947): useQuery currently returns `loading: true` even if the data is already in the cache (and then re-renders with `loading: false`, causing a flash with the loading UI.)

I narrowed it down to ObservableQuery.getCurrentResult - it gets the `data` and `partial` from the QueryManager (which gets it from the cache). If we know we already have the complete data, I think we can short-circuit the queryStore.get() flow and return result with `loading: false`. I've tested this locally with various scenarios, and am able to get back to v2's behavior (only one render with `loading: false`).

Please let me know if this is the correct approach. If it is, I can fix the tests and send an update to this PR (it's failing because `currentResult` no longer matches observableQuery.next - I'd also like some pointers on how best to fix this.)

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
