### PR TITLE
Make updating cache.makeVar variables broadcast watches.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,15 +70,15 @@
   This API gracefully handles cases where multiple field values are associated with a single field name, and also removes the need for updating the cache by reading a query or fragment, modifying the result, and writing the modified result back into the cache. Behind the scenes, the `cache.evict` method is now implemented in terms of `cache.modify`. <br/>
   [@benjamn](https://github.com/benjamn) in [#5909](https://github.com/apollographql/apollo-client/pull/5909)
 
-- `InMemoryCache` provides a new API for storing local state that can be easily updated by external code:
+- `InMemoryCache` provides a new API for storing client state that can be updated from anywhere:
   ```ts
-  const lv = cache.makeLocalVar(123)
-  console.log(lv()) // 123
-  console.log(lv(lv() + 1)) // 124
-  console.log(lv()) // 124
-  lv("asdf") // TS type error
+  const v = cache.makeVar(123)
+  console.log(v()) // 123
+  console.log(v(v() + 1)) // 124
+  console.log(v()) // 124
+  v("asdf") // TS type error
   ```
-  These local variables are _reactive_ in the sense that updating their values invalidates any previously cached query results that depended on the old values. <br/>
+  These variables are _reactive_ in the sense that updating their values invalidates any previously cached query results that depended on the old values. <br/>
   [@benjamn](https://github.com/benjamn) in [#5799](https://github.com/apollographql/apollo-client/pull/5799)
 
 - Various cache read and write performance optimizations, cutting read and write times by more than 50% in larger benchmarks. <br/>

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -11,7 +11,7 @@ export {
 export {
   InMemoryCache,
   InMemoryCacheConfig,
-  LocalVar,
+  ReactiveVar,
 } from './inmemory/inMemoryCache';
 
 export {

--- a/src/cache/inmemory/__tests__/cache.ts
+++ b/src/cache/inmemory/__tests__/cache.ts
@@ -2293,7 +2293,7 @@ describe("InMemoryCache#modify", () => {
   });
 });
 
-describe("cache.makeLocalVar", () => {
+describe("cache.makeVar", () => {
   function makeCacheAndVar(resultCaching: boolean) {
     const cache: InMemoryCache = new InMemoryCache({
       resultCaching,
@@ -2308,7 +2308,7 @@ describe("cache.makeLocalVar", () => {
       },
     });
 
-    const nameVar = cache.makeLocalVar("Ben");
+    const nameVar = cache.makeVar("Ben");
 
     const query = gql`
       query {

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -1,7 +1,7 @@
 import gql from "graphql-tag";
-import { InMemoryCache, LocalVar } from "../inMemoryCache";
-import { StoreValue } from "../../../utilities";
-import { FieldPolicy, Policies } from "../policies";
+
+import { InMemoryCache } from "../inMemoryCache";
+import { Policies } from "../policies";
 import { Reference, StoreObject } from "../../../core";
 
 function reverse(s: string) {
@@ -925,7 +925,7 @@ describe("type policies", function () {
               result: {
                 read(_, { storage }) {
                   if (!storage.jobName) {
-                    storage.jobName = cache.makeLocalVar<string>();
+                    storage.jobName = cache.makeVar<string>();
                   }
                   return storage.jobName();
                 },
@@ -933,7 +933,7 @@ describe("type policies", function () {
                   if (storage.jobName) {
                     storage.jobName(incoming);
                   } else {
-                    storage.jobName = cache.makeLocalVar(incoming);
+                    storage.jobName = cache.makeVar(incoming);
                   }
                 },
               },
@@ -1439,11 +1439,11 @@ describe("type policies", function () {
       // Rather than writing ownTime data into the cache, we maintain it
       // externally in this object:
       const ownTimes = {
-        "parent task": cache.makeLocalVar(2),
-        "child task 1": cache.makeLocalVar(3),
-        "child task 2": cache.makeLocalVar(4),
-        "grandchild task": cache.makeLocalVar(5),
-        "independent task": cache.makeLocalVar(11),
+        "parent task": cache.makeVar(2),
+        "child task 1": cache.makeVar(3),
+        "child task 2": cache.makeVar(4),
+        "grandchild task": cache.makeVar(5),
+        "independent task": cache.makeVar(11),
       };
 
       cache.writeQuery({

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -319,21 +319,25 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     );
   }
 
+  private varDep = dep<ReactiveVar<any>>();
+
   public makeVar<T>(value?: T): ReactiveVar<T> {
+    const cache = this;
     return function rv(newValue) {
       if (arguments.length > 0) {
         if (value !== newValue) {
           value = newValue;
-          varDep.dirty(rv);
+          cache.varDep.dirty(rv);
+          // In order to perform several ReactiveVar updates without
+          // broadcasting each time, use cache.performTransaction.
+          cache.broadcastWatches();
         }
       } else {
-        varDep(rv);
+        cache.varDep(rv);
       }
       return value;
     };
   }
 }
-
-const varDep = dep<ReactiveVar<any>>();
 
 export type ReactiveVar<T> = (newValue?: T) => T;

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -319,20 +319,21 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     );
   }
 
-  public makeLocalVar<T>(value?: T): LocalVar<T> {
-    return function LocalVar(newValue) {
+  public makeVar<T>(value?: T): ReactiveVar<T> {
+    return function rv(newValue) {
       if (arguments.length > 0) {
         if (value !== newValue) {
           value = newValue;
-          localVarDep.dirty(LocalVar);
+          varDep.dirty(rv);
         }
       } else {
-        localVarDep(LocalVar);
+        varDep(rv);
       }
       return value;
     };
   }
 }
 
-const localVarDep = dep<LocalVar<any>>();
-export type LocalVar<T> = (newValue?: T) => T;
+const varDep = dep<ReactiveVar<any>>();
+
+export type ReactiveVar<T> = (newValue?: T) => T;


### PR DESCRIPTION
This PR makes two user-visible changes:
* The `cache.makeLocalVar` API introduced in #5799 has been renamed to `cache.makeVar`, for brevity and to avoid direct association with Apollo Client 2.x local state. Reactive variables should replace most use cases for local state, but they have many other potential uses. The type of the returned variable is now `ReactiveVar<T>` instead of `LocalVar<T>`.
* Updating a reactive variable with a new value will now trigger a call to `cache.broadcastWatches()`. Because the `ApolloCache` API is mostly synchronous, this broadcast is also synchronous, but it's possible to batch multiple variable updates together by performing them within a `cache.performTransaction` block.

These changes are vital for making reactive variables truly reactive, but we still have some work to do to make sure broadcasting watched query data from the cache reliably pushes the new data into the view layer.