### PR TITLE
docs: fix link to NetworkStatus.ts in `Inspecting Loading States` section

### DIFF
--- a/docs/source/data/queries.mdx
+++ b/docs/source/data/queries.mdx
@@ -384,7 +384,7 @@ const DogPhoto = ({ breed }) => (
 </div>
 </MultiCodeBlock>
 
-The `networkStatus` property is an enum with number values from `1` to `8` that represent different loading states. `4` corresponds to a refetch, but there are also values for polling and pagination. For a full list of all the possible loading states, check out the [source](https://github.com/apollographql/apollo-client/blob/master/packages/apollo-client/src/core/networkStatus.ts).
+The `networkStatus` property is an enum with number values from `1` to `8` that represent different loading states. `4` corresponds to a refetch, but there are also values for polling and pagination. For a full list of all the possible loading states, check out the [source](https://github.com/apollographql/apollo-client/blob/master/src/core/networkStatus.ts).
 
 ## Inspecting error states
 


### PR DESCRIPTION
Fixed incorrect link at https://www.apollographql.com/docs/react/data/queries/#inspecting-loading-states

https://github.com/apollographql/apollo-client/issues/5994
