### PR TITLE
improved QueryResult type for better loading/error/data inference

### DIFF
--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -75,15 +75,30 @@ export type ObservableQueryFields<TData, TVariables> = Pick<
     ) => Promise<ApolloQueryResult<TData2>>);
 };
 
-export interface QueryResult<TData = any, TVariables = OperationVariables>
-  extends ObservableQueryFields<TData, TVariables> {
+export type QueryResult<
+  TData = any,
+  TVariables = OperationVariables
+> = ObservableQueryFields<TData, TVariables> & {
   client: ApolloClient<any>;
-  data: TData | undefined;
-  error?: ApolloError;
-  loading: boolean;
   networkStatus: NetworkStatus;
   called: true;
-}
+} & (
+    | {
+        data?: TData;
+        error?: ApolloError;
+        loading: true;
+      }
+    | {
+        data?: TData;
+        error: ApolloError;
+        loading: false;
+      }
+    | {
+        data: TData;
+        error: undefined;
+        loading: false;
+      }
+  );
 
 export interface QueryDataOptions<TData = any, TVariables = OperationVariables>
   extends QueryFunctionOptions<TData, TVariables> {


### PR DESCRIPTION
Here's typical useQuery use case:

```javascript
const DataFetchingComponent = () => {

  const { loading, error, data } = useQuery<myQueryResultType>(
    myQuery
  );

  if (loading)
    return <div>Loading...</div>;

  if (error)
    return <div>{`Error! ${error.message}`}</div>;
  
  return <DataRenderingComponent data={data}/>
};
```

It has one problem: currently data always has type TData | undefined, even when loading is false and there is no error which is clearly not something that should happen in runtime so it'd be awesome if typescript could realize that as well. Right now I have to use non-null assertion operator to convince typescript everything is okay:

```javascript
  return <DataRenderingComponent data={data!}/>
```

But it appears to me that this issue is rather simple to fix on typings level which I've tried my best to do in this PR.