### PR TITLE
fix: Allow fetchMore() to be used with 'no-cache' fetchPolicy

### DIFF
--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -521,7 +521,6 @@ export class ObservableQuery<
 
       queryManager.broadcastQueries();
     }
-
   }
 
   public stopPolling() {

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1339,7 +1339,7 @@ export class QueryManager<TStore> {
     );
   }
 
-  private setQuery<T extends keyof QueryInfo>(
+  public setQuery<T extends keyof QueryInfo>(
     queryId: string,
     updater: (prev: QueryInfo) => Pick<QueryInfo, T> | void,
   ) {


### PR DESCRIPTION
Happy to add test(s) if someone could verify that I've provided a valid fix for the issue.

This PR is basically a continuation of https://github.com/apollographql/apollo-client/issues/5239#issuecomment-595248035

Fixes #5239

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
