### PR TITLE
Add missing import to Authentication doc

### DIFF
--- a/docs/source/networking/authentication.mdx
+++ b/docs/source/networking/authentication.mdx
@@ -43,6 +43,7 @@ Another common way to identify yourself when using HTTP is to send along an auth
 
 ```js
 import { ApolloClient, createHttpLink, InMemoryCache } from '@apollo/client';
+import { setContext } from "@apollo/link-context";
 
 const httpLink = createHttpLink({
   uri: '/graphql',


### PR DESCRIPTION
Required for [this line](https://github.com/apollographql/apollo-client/pull/6030/files#diff-bf8e692b928feeb0576ccccb09dd407eR52) to work 