### PR TITLE
More tests of automatic broadcast for cache.{writeQuery,modify,evict}.

### DIFF
--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -191,6 +191,11 @@ export abstract class EntityStore implements NormalizedCache {
     if (this instanceof Layer) {
       evicted = this.parent.evict(dataId, fieldName) || evicted;
     }
+    // Always invalidate the field to trigger rereading of watched
+    // queries, even if no cache data was modified by the eviction,
+    // because queries may depend on computed fields with custom read
+    // functions, whose values are not stored in the EntityStore.
+    this.group.dirty(dataId, fieldName || "__exists");
     return evicted;
   }
 

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -220,7 +220,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
 
   public evict(dataId: string, fieldName?: string): boolean {
     const evicted = this.optimisticData.evict(dataId, fieldName);
-    if (evicted) this.broadcastWatches();
+    this.broadcastWatches();
     return evicted;
   }
 

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -159,8 +159,9 @@ export class QueryInfo {
 
     if (this.shouldNotify() && this.getDiff()) {
       this.listeners.forEach(listener => listener(this));
-      this.dirty = false;
     }
+
+    this.dirty = false;
   }
 
   private shouldNotify() {

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -111,7 +111,7 @@ export class QueryInfo {
   setDiff(diff: Cache.DiffResult<any> | null) {
     const oldDiff = this.diff;
     this.diff = diff;
-    if (!this.dirty && !equal(diff, oldDiff)) {
+    if (!this.dirty && diff?.result !== oldDiff?.result) {
       this.setDirty();
     }
   }

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -90,10 +90,6 @@ export class QueryInfo {
 
   private dirty: boolean = false;
 
-  public isDirty() {
-    return this.dirty;
-  }
-
   public setDirty(): this {
     if (!this.dirty) {
       this.dirty = true;

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -919,21 +919,11 @@ export class QueryManager<TStore> {
   } {
     const { variables, query, fetchPolicy, returnPartialData } = observableQuery.options;
     const lastResult = observableQuery.getLastResult();
-    const info = this.getQuery(observableQuery.queryId);
 
-    const isNetworkOnly =
-      fetchPolicy === 'no-cache' ||
-      fetchPolicy === 'network-only';
-
-    if (isNetworkOnly || info.isDirty()) {
-      const diff = info.getDiff();
-      if (diff?.complete) {
-        return { data: diff.result, partial: false };
-      }
-    }
-
-    if (isNetworkOnly) {
-      return { data: undefined, partial: false };
+    if (fetchPolicy === 'no-cache' ||
+        fetchPolicy === 'network-only') {
+      const diff = this.getQuery(observableQuery.queryId).getDiff();
+      return { data: diff?.result, partial: false };
     }
 
     const { result, complete } = this.cache.diff<T>({


### PR DESCRIPTION
As the discussion in https://github.com/apollographql/apollo-client/pull/5909#issuecomment-598752881 makes clear, there are still some gaps preventing some cache modifications from being successfully broadcast by the `QueryManager`. This PR adds additional (failing) tests for other important methods that modify the cache, as well as additional commits that attempt to fix those problems.