### PR TITLE
Stop delivering "stale" results to ObservableQuery.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@
 - **[BREAKING]** `client|cache.writeData` have been fully removed. `writeData` usage is one of the easiest ways to turn faulty assumptions about how the cache represents data internally, into cache inconsistency and corruption. `client|cache.writeQuery`, `client|cache.writeFragment`, and/or `cache.modify` can be used to update the cache.  <br/>
   [@benjamn](https://github.com/benjamn) in [#5923](https://github.com/apollographql/apollo-client/pull/5923)
 
+- **[BREAKING]** Apollo Client will no longer deliver "stale" results to `ObservableQuery` consumers, but will instead log more helpful errors about which cache fields were missing. <br/>
+  [@benjamn](https://github.com/benjamn) in [#6058](https://github.com/apollographql/apollo-client/pull/6058)
+
 - `InMemoryCache` now supports tracing garbage collection and eviction. Note that the signature of the `evict` method has been simplified in a potentially backwards-incompatible way. <br/>
   [@benjamn](https://github.com/benjamn) in [#5310](https://github.com/apollographql/apollo-client/pull/5310)
 

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -1654,14 +1654,10 @@ describe('client', () => {
       });
 
       subscribeAndCount(reject, obs, (handleCount, result) => {
-        if (handleCount === 1) {
-          expect(result.data).toBe(undefined);
-          expect(result.loading).toBe(true);
-        } else if (handleCount === 2) {
-          expect(stripSymbols(result.data)).toEqual(networkFetch);
-          expect(result.loading).toBe(false);
-          resolve();
-        }
+        expect(handleCount).toBe(1);
+        expect(stripSymbols(result.data)).toEqual(networkFetch);
+        expect(result.loading).toBe(false);
+        resolve();
       });
     });
 
@@ -1677,17 +1673,13 @@ describe('client', () => {
         fetchPolicy: 'cache-and-network',
       });
 
-      let count = 0;
       obs.subscribe({
-        next: result => {
-          expect(result.data).toBe(undefined);
-          expect(result.loading).toBe(true);
-          count++;
-        },
         error: e => {
-          expect(e.message).toMatch(/No more mocked responses/);
-          expect(count).toBe(1); // make sure next was called.
-          setTimeout(resolve, 100);
+          if (!/No more mocked responses/.test(e.message)) {
+            reject(e);
+          } else {
+            resolve();
+          }
         },
       });
     });

--- a/src/__tests__/local-state/general.ts
+++ b/src/__tests__/local-state/general.ts
@@ -422,7 +422,6 @@ describe('Cache manipulation', () => {
           },
           loading: false,
           networkStatus: 7,
-          stale: false,
         });
 
         if (selectedItemId !== 123) {

--- a/src/__tests__/subscribeToMore.ts
+++ b/src/__tests__/subscribeToMore.ts
@@ -101,7 +101,6 @@ describe('subscribeToMore', () => {
         data: { entry: { value: 'Amanda Liu' } },
         loading: false,
         networkStatus: 7,
-        stale: false,
       });
       resolve();
     }, 15);
@@ -157,7 +156,6 @@ describe('subscribeToMore', () => {
         data: { entry: { value: 'Amanda Liu' } },
         loading: false,
         networkStatus: 7,
-        stale: false,
       });
       expect(counter).toBe(2);
       expect(errorCount).toBe(1);
@@ -217,7 +215,6 @@ describe('subscribeToMore', () => {
         data: { entry: { value: '1' } },
         loading: false,
         networkStatus: 7,
-        stale: false,
       });
       expect(counter).toBe(1);
       expect(errorCount).toBe(1);
@@ -323,7 +320,6 @@ describe('subscribeToMore', () => {
       },
       loading: false,
       networkStatus: 7,
-      stale: false,
     });
     resolve();
   });
@@ -391,7 +387,6 @@ describe('subscribeToMore', () => {
         data: { entry: { value: 'Amanda Liu' } },
         loading: false,
         networkStatus: 7,
-        stale: false,
       });
       resolve();
     }, 15);

--- a/src/cache/core/types/DataProxy.ts
+++ b/src/cache/core/types/DataProxy.ts
@@ -1,5 +1,7 @@
 import { DocumentNode } from 'graphql'; // eslint-disable-line import/no-extraneous-dependencies, import/no-unresolved
 
+import { MissingFieldError } from './common';
+
 export namespace DataProxy {
   export interface Query<TVariables> {
     /**
@@ -70,7 +72,8 @@ export namespace DataProxy {
   export type DiffResult<T> = {
     result?: T;
     complete?: boolean;
-  };
+    missing?: MissingFieldError[];
+  }
 }
 
 /**

--- a/src/cache/core/types/common.ts
+++ b/src/cache/core/types/common.ts
@@ -1,3 +1,5 @@
+import { DocumentNode } from 'graphql';
+
 import {
   isReference,
   StoreValue,
@@ -30,4 +32,13 @@ export type Modifier<T> = (value: T, details: {
 
 export type Modifiers = {
   [fieldName: string]: Modifier<any>;
+}
+
+export class MissingFieldError {
+  constructor(
+    public readonly message: string,
+    public readonly path: (string | number)[],
+    public readonly query: DocumentNode,
+    public readonly variables: Record<string, any>,
+  ) {}
 }

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -1,6 +1,7 @@
 export { Transaction, ApolloCache } from './core/cache';
 export { Cache } from './core/types/Cache';
 export { DataProxy } from './core/types/DataProxy';
+export { MissingFieldError } from './core/types/common';
 
 export {
   Reference,

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -3,6 +3,7 @@ import gql from "graphql-tag";
 import { InMemoryCache } from "../inMemoryCache";
 import { Policies } from "../policies";
 import { Reference, StoreObject } from "../../../core";
+import { MissingFieldError } from "../..";
 
 function reverse(s: string) {
   return s.split("").reverse().join("");
@@ -997,6 +998,15 @@ describe("type policies", function () {
 
       expect(cache.extract()).toEqual(snapshot1);
 
+      function makeMissingError(jobNumber: number) {
+        return new MissingFieldError(
+          `Can't find field 'result' on Job:{"name":"Job #${jobNumber}"} object`,
+          ["jobs", jobNumber - 1, "result"],
+          expect.anything(),
+          expect.anything(),
+        );
+      }
+
       expect(cache.diff({
         query,
         optimistic: false,
@@ -1015,6 +1025,11 @@ describe("type policies", function () {
           }],
         },
         complete: false,
+        missing: [
+          makeMissingError(1),
+          makeMissingError(2),
+          makeMissingError(3),
+        ],
       });
 
       function setResult(jobNum: number) {
@@ -1061,6 +1076,10 @@ describe("type policies", function () {
           }],
         },
         complete: false,
+        missing: [
+          makeMissingError(1),
+          makeMissingError(3),
+        ],
       });
 
       cache.writeQuery({
@@ -1114,6 +1133,10 @@ describe("type policies", function () {
           }],
         },
         complete: false,
+        missing: [
+          makeMissingError(1),
+          makeMissingError(3),
+        ],
       });
 
       setResult(1);

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -568,10 +568,6 @@ export class ObservableQuery<
 
   private observer: Observer<ApolloQueryResult<TData>> = {
     next: result => {
-      if (result.stale && !(result.errors && result.errors.length > 0)) {
-        return;
-      }
-
       if (this.lastError || this.isDifferentFromLastResult(result)) {
         const { queryManager } = this;
         const { query, variables, fetchPolicy } = this.options;

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -568,6 +568,10 @@ export class ObservableQuery<
 
   private observer: Observer<ApolloQueryResult<TData>> = {
     next: result => {
+      if (result.stale && !(result.errors && result.errors.length > 0)) {
+        return;
+      }
+
       if (this.lastError || this.isDifferentFromLastResult(result)) {
         const { queryManager } = this;
         const { query, variables, fetchPolicy } = this.options;

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -157,7 +157,6 @@ export class ObservableQuery<
       error: lastError,
       loading: isNetworkRequestInFlight(networkStatus),
       networkStatus,
-      stale: lastResult ? lastResult.stale : false,
     };
 
     if (this.isTornDown) {
@@ -205,7 +204,6 @@ export class ObservableQuery<
     }
 
     if (!partial) {
-      result.stale = false;
       this.updateLastResult(result);
     }
 
@@ -220,7 +218,6 @@ export class ObservableQuery<
       snapshot &&
       newResult &&
       snapshot.networkStatus === newResult.networkStatus &&
-      snapshot.stale === newResult.stale &&
       equal(snapshot.data, newResult.data)
     );
   }

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -562,7 +562,6 @@ export class QueryManager<TStore> {
           data: diff.result,
           loading: isNetworkRequestInFlight(networkStatus),
           networkStatus: networkStatus!,
-          stale: false,
         };
 
         // If the query wants updates on errors, add them to the result.
@@ -1163,7 +1162,6 @@ export class QueryManager<TStore> {
             errors: errorsFromStore,
             loading: false,
             networkStatus: NetworkStatus.ready,
-            stale: false,
           });
         },
       });

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1,5 +1,6 @@
 import { ExecutionResult, DocumentNode } from 'graphql';
 import { invariant, InvariantError } from 'ts-invariant';
+import equal from '@wry/equality';
 
 import { ApolloLink } from '../link/core/ApolloLink';
 import { execute } from '../link/core/execute';
@@ -571,8 +572,12 @@ export class QueryManager<TStore> {
 
         observer.next && observer.next(result);
 
-      } else {
-        // TODO Warn in this case, or call observer.error?
+      } else if (process.env.NODE_ENV !== 'production' &&
+                 isNonEmptyArray(diff.missing) &&
+                 !equal(diff.result, {})) {
+        invariant.warn(`Missing cache result fields: ${
+          diff.missing.map(m => m.path.join('.')).join(', ')
+        }`, diff.missing);
       }
     };
   }

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -1205,7 +1205,6 @@ describe('ObservableQuery', () => {
               data: {},
               loading: true,
               networkStatus: NetworkStatus.loading,
-              stale: false,
             });
           } else if (handleCount === 2) {
             expect(result).toEqual({
@@ -1214,7 +1213,6 @@ describe('ObservableQuery', () => {
               },
               loading: true,
               networkStatus: NetworkStatus.loading,
-              stale: false,
             });
           } else if (handleCount === 3) {
             expect(result).toEqual({
@@ -1224,7 +1222,6 @@ describe('ObservableQuery', () => {
               },
               loading: false,
               networkStatus: NetworkStatus.ready,
-              stale: false,
             });
 
             // Make the next network request fail.
@@ -1251,7 +1248,6 @@ describe('ObservableQuery', () => {
               },
               loading: true,
               networkStatus: NetworkStatus.refetch,
-              stale: false,
             });
           } else if (handleCount === 5) {
             expect(result).toEqual({
@@ -1261,7 +1257,6 @@ describe('ObservableQuery', () => {
               },
               loading: true,
               networkStatus: NetworkStatus.refetch,
-              stale: false,
             });
 
             resolve();
@@ -1371,7 +1366,6 @@ describe('ObservableQuery', () => {
             data,
             loading,
             networkStatus,
-            stale: false,
           });
         } catch (e) {
           reject(e);
@@ -1401,7 +1395,6 @@ describe('ObservableQuery', () => {
           data: dataOne,
           loading: false,
           networkStatus: 7,
-          stale: false,
           partial: false,
         });
         resolve();
@@ -1411,7 +1404,6 @@ describe('ObservableQuery', () => {
         loading: true,
         data: undefined,
         networkStatus: 1,
-        stale: false,
         partial: true,
       });
 
@@ -1421,7 +1413,6 @@ describe('ObservableQuery', () => {
             loading: true,
             data: undefined,
             networkStatus: 1,
-            stale: false,
             partial: true,
           });
         }),
@@ -1440,7 +1431,6 @@ describe('ObservableQuery', () => {
           data: dataOne,
           loading: false,
           networkStatus: 7,
-          stale: false,
         });
         const observable = queryManager.watchQuery({
           query,
@@ -1450,7 +1440,6 @@ describe('ObservableQuery', () => {
           data: dataOne,
           loading: true,
           networkStatus: NetworkStatus.loading,
-          stale: false,
           partial: false,
         });
       }).then(resolve, reject);
@@ -1585,7 +1574,6 @@ describe('ObservableQuery', () => {
           data: dataOne,
           loading: true,
           networkStatus: 1,
-          stale: false,
           partial: true,
         });
 
@@ -1596,7 +1584,6 @@ describe('ObservableQuery', () => {
             data,
             loading,
             networkStatus,
-            stale: false,
           });
 
           if (handleCount === 1) {
@@ -1604,7 +1591,6 @@ describe('ObservableQuery', () => {
               data: dataOne,
               loading: true,
               networkStatus: 1,
-              stale: false,
             });
 
           } else if (handleCount === 2) {
@@ -1612,7 +1598,6 @@ describe('ObservableQuery', () => {
               data: superDataOne,
               loading: false,
               networkStatus: 7,
-              stale: false,
             });
             resolve();
           }
@@ -1643,7 +1628,6 @@ describe('ObservableQuery', () => {
           data: undefined,
           loading: true,
           networkStatus: 1,
-          stale: false,
           partial: false,
         });
 
@@ -1659,7 +1643,6 @@ describe('ObservableQuery', () => {
               data,
               loading,
               networkStatus,
-              stale: false,
               partial: false,
             });
           } else if (handleCount === 2) {
@@ -1667,7 +1650,6 @@ describe('ObservableQuery', () => {
               data: dataTwo,
               loading: false,
               networkStatus: 7,
-              stale: false,
             });
             resolve();
           }
@@ -1698,7 +1680,6 @@ describe('ObservableQuery', () => {
           data: undefined,
           loading: true,
           networkStatus: 1,
-          stale: false,
           partial: false,
         });
 
@@ -1714,7 +1695,6 @@ describe('ObservableQuery', () => {
               data,
               loading,
               networkStatus,
-              stale: false,
               partial: false,
             });
           } else if (handleCount === 2) {
@@ -1722,7 +1702,6 @@ describe('ObservableQuery', () => {
               data: dataTwo,
               loading: false,
               networkStatus: 7,
-              stale: false,
             });
             resolve();
           }
@@ -1781,7 +1760,6 @@ describe('ObservableQuery', () => {
             data,
             loading,
             networkStatus,
-            stale: false,
           });
 
           if (count === 1) {
@@ -1789,7 +1767,6 @@ describe('ObservableQuery', () => {
               data: dataOne,
               loading: false,
               networkStatus: 7,
-              stale: false,
             });
             queryManager.mutate({
               mutation,

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -1126,23 +1126,20 @@ describe('ObservableQuery', () => {
 
       subscribeAndCount(reject, observable, (handleCount, result) => {
         if (handleCount === 1) {
-          expect(result.data).toBeUndefined();
-          expect(result.loading).toBe(true);
-        } else if (handleCount === 2) {
           expect(stripSymbols(result.data)).toEqual(data);
           expect(result.loading).toBe(false);
           observable.refetch(variables2);
-        } else if (handleCount === 3) {
+        } else if (handleCount === 2) {
           expect(stripSymbols(result.data)).toEqual(data);
           expect(result.loading).toBe(true);
-        } else if (handleCount === 4) {
+        } else if (handleCount === 3) {
           expect(stripSymbols(result.data)).toEqual(data2);
           expect(result.loading).toBe(false);
           observable.refetch(variables1);
-        } else if (handleCount === 5) {
+        } else if (handleCount === 4) {
           expect(stripSymbols(result.data)).toEqual(data2);
           expect(result.loading).toBe(true);
-        } else if (handleCount === 6) {
+        } else if (handleCount === 5) {
           expect(stripSymbols(result.data)).toEqual(data);
           expect(result.loading).toBe(false);
           resolve();

--- a/src/core/__tests__/QueryManager/index.ts
+++ b/src/core/__tests__/QueryManager/index.ts
@@ -8,6 +8,7 @@ import { DocumentNode, ExecutionResult, GraphQLError } from 'graphql';
 import { Observable, Observer } from '../../../utilities/observables/Observable';
 import { ApolloLink } from '../../../link/core/ApolloLink';
 import { Operation } from '../../../link/core/types';
+import { MissingFieldError } from '../../../cache';
 import { InMemoryCache } from '../../../cache/inmemory/inMemoryCache';
 import {
   ApolloReducerConfig,

--- a/src/core/__tests__/QueryManager/index.ts
+++ b/src/core/__tests__/QueryManager/index.ts
@@ -487,7 +487,7 @@ describe('QueryManager', () => {
     observable.pipe(map(result => assign({ fromRx: true }, result))).subscribe({
       next: wrap(reject, newResult => {
         const expectedResult = assign(
-          { fromRx: true, loading: false, networkStatus: 7, stale: false },
+          { fromRx: true, loading: false, networkStatus: 7 },
           expResult,
         );
         expect(stripSymbols(newResult)).toEqual(expectedResult);
@@ -2106,7 +2106,6 @@ describe('QueryManager', () => {
             data: data1,
             loading: false,
             networkStatus: NetworkStatus.ready,
-            stale: false,
           });
         },
       ),
@@ -2120,7 +2119,6 @@ describe('QueryManager', () => {
             data: data2,
             loading: false,
             networkStatus: NetworkStatus.ready,
-            stale: false,
           });
         },
       ),
@@ -2201,7 +2199,6 @@ describe('QueryManager', () => {
             data: {},
             loading: true,
             networkStatus: NetworkStatus.loading,
-            stale: false,
           });
         },
         result => {
@@ -2209,7 +2206,6 @@ describe('QueryManager', () => {
             data: data1,
             loading: false,
             networkStatus: NetworkStatus.ready,
-            stale: false,
           });
         },
         result => {
@@ -2217,7 +2213,6 @@ describe('QueryManager', () => {
             data: data2,
             loading: false,
             networkStatus: NetworkStatus.ready,
-            stale: false,
           });
         },
       ),
@@ -2231,7 +2226,6 @@ describe('QueryManager', () => {
             data: data2,
             loading: false,
             networkStatus: NetworkStatus.ready,
-            stale: false,
           });
         },
       ),

--- a/src/core/__tests__/QueryManager/recycler.ts
+++ b/src/core/__tests__/QueryManager/recycler.ts
@@ -49,7 +49,6 @@ describe('Subscription lifecycles', () => {
     });
 
     const observableQueries = [];
-    let count = 0;
 
     const resubscribe = () => {
       const { observableQuery, subscription } = observableQueries.pop();
@@ -65,41 +64,34 @@ describe('Subscription lifecycles', () => {
 
     const sub = observable.subscribe({
       next: result => {
-        count++;
-        if (count === 1) {
-          expect(result.data).toBeUndefined();
-          expect(result.loading).toBe(true);
-        }
-        if (count === 2) {
-          expect(result.loading).toBe(false);
-          expect(stripSymbols(result.data)).toEqual(initialData);
-          expect(stripSymbols(observable.getCurrentResult().data)).toEqual(
-            initialData,
-          );
+        expect(result.loading).toBe(false);
+        expect(stripSymbols(result.data)).toEqual(initialData);
+        expect(stripSymbols(observable.getCurrentResult().data)).toEqual(
+          initialData,
+        );
 
-          // step 2, recycle it
-          observable.setOptions({
-            fetchPolicy: 'standby',
-            pollInterval: 0,
-          });
+        // step 2, recycle it
+        observable.setOptions({
+          fetchPolicy: 'standby',
+          pollInterval: 0,
+        });
 
-          observableQueries.push({
-            observableQuery: observable,
-            subscription: observable.subscribe({}),
-          });
+        observableQueries.push({
+          observableQuery: observable,
+          subscription: observable.subscribe({}),
+        });
 
-          // step 3, unsubscribe from observable
-          sub.unsubscribe();
+        // step 3, unsubscribe from observable
+        sub.unsubscribe();
 
-          setTimeout(() => {
-            // step 4, start new Subscription;
-            const recyled = resubscribe();
-            const currentResult = recyled.getCurrentResult();
-            expect(recyled.isTornDown).toEqual(false);
-            expect(stripSymbols(currentResult.data)).toEqual(initialData);
-            done();
-          }, 10);
-        }
+        setTimeout(() => {
+          // step 4, start new Subscription;
+          const recyled = resubscribe();
+          const currentResult = recyled.getCurrentResult();
+          expect(recyled.isTornDown).toEqual(false);
+          expect(stripSymbols(currentResult.data)).toEqual(initialData);
+          done();
+        }, 10);
       },
     });
 

--- a/src/core/__tests__/fetchPolicies.ts
+++ b/src/core/__tests__/fetchPolicies.ts
@@ -378,7 +378,6 @@ describe('cache-and-network', function() {
           data: dataWithId(1),
           loading: false,
           networkStatus: NetworkStatus.ready,
-          stale: false,
         });
         return observable.setVariables({ id: '2' });
       } else if (count === 2) {
@@ -386,14 +385,12 @@ describe('cache-and-network', function() {
           data: dataWithId(1),
           loading: true,
           networkStatus: NetworkStatus.setVariables,
-          stale: false,
         });
       } else if (count === 3) {
         expect(result).toEqual({
           data: dataWithId(2),
           loading: false,
           networkStatus: NetworkStatus.ready,
-          stale: false,
         });
         return observable.refetch();
       } else if (count === 4) {
@@ -401,14 +398,12 @@ describe('cache-and-network', function() {
           data: dataWithId(2),
           loading: true,
           networkStatus: NetworkStatus.refetch,
-          stale: false,
         });
       } else if (count === 5) {
         expect(result).toEqual({
           data: dataWithId(2),
           loading: false,
           networkStatus: NetworkStatus.ready,
-          stale: false,
         });
         return observable.refetch({ id: '3' });
       } else if (count === 6) {
@@ -416,14 +411,12 @@ describe('cache-and-network', function() {
           data: dataWithId(2),
           loading: true,
           networkStatus: NetworkStatus.setVariables,
-          stale: false,
         });
       } else if (count === 7) {
         expect(result).toEqual({
           data: dataWithId(3),
           loading: false,
           networkStatus: NetworkStatus.ready,
-          stale: false,
         });
         resolve();
       }

--- a/src/core/__tests__/fetchPolicies.ts
+++ b/src/core/__tests__/fetchPolicies.ts
@@ -375,27 +375,20 @@ describe('cache-and-network', function() {
     subscribeAndCount(reject, observable, (count, result) => {
       if (count === 1) {
         expect(result).toEqual({
-          data: void 0,
-          loading: true,
-          networkStatus: NetworkStatus.loading,
-          stale: true,
-        });
-      } else if (count === 2) {
-        expect(result).toEqual({
           data: dataWithId(1),
           loading: false,
           networkStatus: NetworkStatus.ready,
           stale: false,
         });
         return observable.setVariables({ id: '2' });
-      } else if (count === 3) {
+      } else if (count === 2) {
         expect(result).toEqual({
           data: dataWithId(1),
           loading: true,
           networkStatus: NetworkStatus.setVariables,
           stale: false,
         });
-      } else if (count === 4) {
+      } else if (count === 3) {
         expect(result).toEqual({
           data: dataWithId(2),
           loading: false,
@@ -403,14 +396,14 @@ describe('cache-and-network', function() {
           stale: false,
         });
         return observable.refetch();
-      } else if (count === 5) {
+      } else if (count === 4) {
         expect(result).toEqual({
           data: dataWithId(2),
           loading: true,
           networkStatus: NetworkStatus.refetch,
           stale: false,
         });
-      } else if (count === 6) {
+      } else if (count === 5) {
         expect(result).toEqual({
           data: dataWithId(2),
           loading: false,
@@ -418,14 +411,14 @@ describe('cache-and-network', function() {
           stale: false,
         });
         return observable.refetch({ id: '3' });
-      } else if (count === 7) {
+      } else if (count === 6) {
         expect(result).toEqual({
           data: dataWithId(2),
           loading: true,
           networkStatus: NetworkStatus.setVariables,
           stale: false,
         });
-      } else if (count === 8) {
+      } else if (count === 7) {
         expect(result).toEqual({
           data: dataWithId(3),
           loading: false,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -20,7 +20,6 @@ export type ApolloQueryResult<T> = {
   errors?: ReadonlyArray<GraphQLError>;
   loading: boolean;
   networkStatus: NetworkStatus;
-  stale: boolean;
 };
 
 export enum FetchType {

--- a/src/errors/ApolloError.ts
+++ b/src/errors/ApolloError.ts
@@ -58,13 +58,7 @@ export class ApolloError extends Error {
     super(errorMessage);
     this.graphQLErrors = graphQLErrors || [];
     this.networkError = networkError || null;
-
-    if (!errorMessage) {
-      this.message = generateErrorMessage(this);
-    } else {
-      this.message = errorMessage;
-    }
-
+    this.message = errorMessage || generateErrorMessage(this);
     this.extraInfo = extraInfo;
 
     // We're not using `Object.setPrototypeOf` here as it isn't fully

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -443,9 +443,6 @@ describe('useQuery Hook', () => {
             onErrorPromise.then(() => refetch());
             break;
           case 3:
-            expect(loading).toBeTruthy();
-            break;
-          case 4:
             expect(loading).toBeFalsy();
             expect(data).toEqual(resultData);
             break;
@@ -462,7 +459,7 @@ describe('useQuery Hook', () => {
       );
 
       return wait(() => {
-        expect(renderCount).toBe(4);
+        expect(renderCount).toBe(3);
       });
     });
 
@@ -617,12 +614,12 @@ describe('useQuery Hook', () => {
           notifyOnNetworkStatusChange: true
         });
 
-        switch (renderCount) {
-          case 0:
+        switch (++renderCount) {
+          case 1:
             expect(loading).toBeTruthy();
             expect(error).toBeUndefined();
             break;
-          case 1:
+          case 2:
             expect(loading).toBeFalsy();
             expect(error).toBeDefined();
             expect(error!.message).toEqual('GraphQL error: an error 1');
@@ -630,9 +627,6 @@ describe('useQuery Hook', () => {
               // catch here to avoid failing due to 'uncaught promise rejection'
               refetch().catch(() => {});
             });
-            break;
-          case 2:
-            expect(loading).toBeTruthy();
             break;
           case 3:
             expect(loading).toBeFalsy();
@@ -642,7 +636,6 @@ describe('useQuery Hook', () => {
           default: // Do nothing
         }
 
-        renderCount += 1;
         return null;
       }
 
@@ -653,11 +646,11 @@ describe('useQuery Hook', () => {
       );
 
       return wait(() => {
-        expect(renderCount).toBe(4);
+        expect(renderCount).toBe(3);
       });
     });
 
-    it('should render errors (same error messages) with loading done on refetch', async () => {
+    itAsync('should not re-render same error message on refetch', (resolve, reject) => {
       const query = gql`
         query SomeQuery {
           stuff {
@@ -687,32 +680,24 @@ describe('useQuery Hook', () => {
           notifyOnNetworkStatusChange: true
         });
 
-        switch (renderCount) {
-          case 0:
+        switch (++renderCount) {
+          case 1:
             expect(loading).toBeTruthy();
             expect(error).toBeUndefined();
             break;
-          case 1:
-            expect(loading).toBeFalsy();
-            expect(error).toBeDefined();
-            expect(error!.message).toEqual('GraphQL error: same error message');
-            setTimeout(() => {
-              // catch here to avoid failing due to 'uncaught promise rejection'
-              refetch().catch(() => {});
-            });
-            break;
           case 2:
-            expect(loading).toBeTruthy();
-            break;
-          case 3:
             expect(loading).toBeFalsy();
             expect(error).toBeDefined();
             expect(error!.message).toEqual('GraphQL error: same error message');
+            refetch().catch(error => {
+              if (error.message !== 'GraphQL error: same error message') {
+                reject(error);
+              }
+            });
             break;
           default: // Do nothing
         }
 
-        renderCount += 1;
         return null;
       }
 
@@ -723,8 +708,8 @@ describe('useQuery Hook', () => {
       );
 
       return wait(() => {
-        expect(renderCount).toBe(4);
-      });
+        expect(renderCount).toBe(2);
+      }).then(resolve, reject);
     });
 
     it('should render both success and errors (same error messages) with loading done on refetch', async () => {
@@ -755,12 +740,12 @@ describe('useQuery Hook', () => {
           notifyOnNetworkStatusChange: true
         });
 
-        switch (renderCount) {
-          case 0:
+        switch (++renderCount) {
+          case 1:
             expect(loading).toBeTruthy();
             expect(error).toBeUndefined();
             break;
-          case 1:
+          case 2:
             expect(loading).toBeFalsy();
             expect(error).toBeDefined();
             expect(error!.message).toEqual('GraphQL error: same error message');
@@ -768,9 +753,6 @@ describe('useQuery Hook', () => {
               // catch here to avoid failing due to 'uncaught promise rejection'
               refetch().catch(() => {});
             });
-            break;
-          case 2:
-            expect(loading).toBeTruthy();
             break;
           case 3:
             expect(loading).toBeFalsy();
@@ -792,7 +774,6 @@ describe('useQuery Hook', () => {
           default: // Do nothing
         }
 
-        renderCount += 1;
         return null;
       }
 
@@ -803,7 +784,7 @@ describe('useQuery Hook', () => {
       );
 
       return wait(() => {
-        expect(renderCount).toBe(6);
+        expect(renderCount).toBe(5);
       });
     });
   });

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -113,11 +113,6 @@ export interface QueryPreviousData<TData, TVariables> {
   error?: ApolloError;
 }
 
-export interface QueryCurrentObservable<TData, TVariables> {
-  query?: ObservableQuery<TData, TVariables> | null;
-  subscription?: ZenObservable.Subscription;
-}
-
 export interface QueryLazyOptions<TVariables> {
   variables?: TVariables;
   context?: Context;

--- a/src/utilities/testing/observableToPromise.ts
+++ b/src/utilities/testing/observableToPromise.ts
@@ -74,7 +74,7 @@ export function observableToPromiseAndSubscription(
         queue = queue.then(() => {
           const errorCb = errorCallbacks[errorIndex++];
           if (errorCb) return errorCb(error);
-          reject(new Error(`Observable 'error' method called more than ${errorCallbacks.length} times`));
+          reject(error);
         }).then(
           tryToResolve,
           reject,


### PR DESCRIPTION
One of the most counterintuitive and confusing behaviors of Apollo Client is to silently re-deliver previous results whenever an incomplete result is read from the cache [here](https://github.com/apollographql/apollo-client/blob/9df809bd36c892653871a30df4d559222ee16458/src/core/QueryManager.ts#L556-L578):
```ts
      // If there is some data missing and the user has told us that they
      // do not tolerate partial data then we want to return the previous
      // result and mark it as stale.
      const stale = !diff.complete && !(
        returnPartialData ||
        partialRefetch ||
        fetchPolicy === 'cache-only'
      );

      const lastResult = observableQuery.getLastResult();
      const resultFromStore: ApolloQueryResult<T> = {
        data: stale ? lastResult && lastResult.data : diff.result,
        loading: isNetworkRequestInFlight(networkStatus),
        networkStatus,
        stale,
      };

      // If the query wants updates on errors, add them to the result.
      if (errorPolicy === 'all' && hasGraphQLErrors) {
        resultFromStore.errors = graphQLErrors;
      }

      observer.next(resultFromStore);
```
Consider how pointless this is: we obtain `observableQuery.getLastResult()` and then send it immediately back to the `ObservableQuery`, just because it doesn't seem safe to send the incomplete `diff.result`.

Instead, we should never be sending stale or incomplete results to the `ObservableQuery`. And instead of silently dropping the stale results, we should report appropriate errors to the `ObservableQuery` via `observer.error`, so that the application can handle them. That's what this PR does.

I have not finished validating these changes against @ahrnee's reproduction in https://github.com/apollographql/apollo-client/issues/5991 (hence the WIP status of the PR), but that's my first priority tomorrow.