### PR TITLE
Make ObservableQuery.variables a getter for this.options.variables.

### DIFF
--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -419,7 +419,6 @@ export class ObservableQuery<
         oldFetchPolicy === 'standby' ||
         fetchPolicy === 'network-only'
       ),
-      opts.fetchResults,
     );
   }
 
@@ -447,13 +446,10 @@ export class ObservableQuery<
    * @param tryFetch: Try and fetch new results even if the variables haven't
    * changed (we may still just hit the store, but if there's nothing in there
    * this will refetch)
-   *
-   * @param fetchResults: Option to ignore fetching results when updating variables
    */
   public setVariables(
     variables: TVariables,
     tryFetch: boolean = false,
-    fetchResults = true,
   ): Promise<ApolloQueryResult<TData> | void> {
     // since setVariables restarts the subscription, we reset the tornDown status
     this.isTornDown = false;
@@ -464,7 +460,7 @@ export class ObservableQuery<
       // If we have no observers, then we don't actually want to make a network
       // request. As soon as someone observes the query, the request will kick
       // off. For now, we just store any changes. (See #1077)
-      return this.observers.size && fetchResults
+      return this.observers.size
         ? this.result()
         : Promise.resolve();
     }

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -61,10 +61,11 @@ export class ObservableQuery<
   public readonly queryName?: string;
   public readonly watching: boolean;
 
-  /**
-   * The current value of the variables for this query. Can change.
-   */
-  public variables: TVariables;
+  // Computed shorthand for this.options.variables, preserved for
+  // backwards compatibility.
+  public get variables(): TVariables {
+    return this.options.variables;
+  }
 
   private isTornDown: boolean;
   private queryManager: QueryManager<any>;
@@ -93,7 +94,6 @@ export class ObservableQuery<
 
     // query information
     this.options = options;
-    this.variables = options.variables || ({} as TVariables);
     this.queryId = queryManager.generateQueryId();
     this.watching = shouldSubscribe;
 
@@ -188,7 +188,7 @@ export class ObservableQuery<
       // the original `ObservableQuery`. We'll update the observable query
       // variables here to match, so retrieving from the cache doesn't fail.
       if (queryStoreValue.variables) {
-        this.variables = this.options.variables = {
+        this.options.variables = {
           ...this.options.variables,
           ...(queryStoreValue.variables as TVariables),
         };
@@ -274,19 +274,11 @@ export class ObservableQuery<
       fetchPolicy = 'network-only';
     }
 
-    if (!equal(this.variables, variables)) {
-      // update observable variables
-      this.variables = {
-        ...this.variables,
-        ...variables,
-      };
-    }
-
-    if (!equal(this.options.variables, this.variables)) {
+    if (!equal(this.options.variables, variables)) {
       // Update the existing options with new variables
       this.options.variables = {
         ...this.options.variables,
-        ...this.variables,
+        ...variables,
       };
     }
 
@@ -306,7 +298,7 @@ export class ObservableQuery<
         ...this.options,
         ...fetchMoreOptions,
         variables: {
-          ...this.variables,
+          ...this.options.variables,
           ...fetchMoreOptions.variables,
         },
       }),
@@ -396,7 +388,11 @@ export class ObservableQuery<
   public setOptions(
     opts: WatchQueryOptions,
   ): Promise<ApolloQueryResult<TData> | void> {
-    const { fetchPolicy: oldFetchPolicy } = this.options;
+    const {
+      fetchPolicy: oldFetchPolicy,
+      variables: oldVariables,
+    } = this.options;
+
     this.options = {
       ...this.options,
       ...opts,
@@ -408,17 +404,17 @@ export class ObservableQuery<
       this.stopPolling();
     }
 
-    const { fetchPolicy } = opts;
+    // Try to fetch the query if fetchPolicy changed from either cache-only
+    // or standby to something else, or changed to network-only.
+    const fetchPolicyChanged = oldFetchPolicy !== opts.fetchPolicy && (
+      oldFetchPolicy === 'cache-only' ||
+      oldFetchPolicy === 'standby' ||
+      opts.fetchPolicy === 'network-only'
+    );
 
     return this.setVariables(
       this.options.variables as TVariables,
-      // Try to fetch the query if fetchPolicy changed from either cache-only
-      // or standby to something else, or changed to network-only.
-      oldFetchPolicy !== fetchPolicy && (
-        oldFetchPolicy === 'cache-only' ||
-        oldFetchPolicy === 'standby' ||
-        fetchPolicy === 'network-only'
-      ),
+      fetchPolicyChanged || !equal(this.variables, oldVariables),
     );
   }
 
@@ -449,14 +445,12 @@ export class ObservableQuery<
    */
   public setVariables(
     variables: TVariables,
-    tryFetch: boolean = false,
+    tryFetch = !equal(this.variables, variables),
   ): Promise<ApolloQueryResult<TData> | void> {
     // since setVariables restarts the subscription, we reset the tornDown status
     this.isTornDown = false;
 
-    variables = variables || this.variables;
-
-    if (!tryFetch && equal(variables, this.variables)) {
+    if (!tryFetch) {
       // If we have no observers, then we don't actually want to make a network
       // request. As soon as someone observes the query, the request will kick
       // off. For now, we just store any changes. (See #1077)
@@ -465,7 +459,7 @@ export class ObservableQuery<
         : Promise.resolve();
     }
 
-    this.variables = this.options.variables = variables;
+    this.options.variables = variables;
 
     // See comment above
     if (!this.observers.size) {
@@ -601,7 +595,7 @@ export class ObservableQuery<
                 iterateObserversSafely(this.observers, 'next', updatedResult);
               });
             } else {
-              this.variables = this.options.variables = variables;
+              this.options.variables = variables;
               iterateObserversSafely(this.observers, 'next', result);
             }
           });

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -602,41 +602,12 @@ describe('ObservableQuery', () => {
           return;
         }
         observable
-          .setOptions({ fetchPolicy: 'cache-and-network', fetchResults: true })
+          .setOptions({ fetchPolicy: 'cache-and-network' })
           .then(res => {
             // returns dataOne from cache
             expect(stripSymbols(res.data)).toEqual(dataOne);
             resolve();
           });
-      });
-    });
-
-    itAsync('can bypass looking up results if passed to options', (resolve, reject) => {
-      const observable: ObservableQuery<any> = mockWatchQuery(
-        reject,
-        {
-          request: { query, variables },
-          result: { data: dataOne },
-        },
-        {
-          request: { query, variables },
-          result: { data: dataTwo },
-        },
-      );
-
-      let errored = false;
-      subscribeAndCount(reject, observable, handleCount => {
-        if (handleCount === 1) {
-          observable
-            .setOptions({ fetchResults: false, fetchPolicy: 'standby' })
-            .then(res => {
-              expect(res).toBeUndefined();
-              setTimeout(() => !errored && resolve(), 5);
-            });
-        } else if (handleCount > 1) {
-          errored = true;
-          throw new Error('Handle should not be called twice');
-        }
       });
     });
   });

--- a/src/core/__tests__/QueryManager/recycler.ts
+++ b/src/core/__tests__/QueryManager/recycler.ts
@@ -81,7 +81,6 @@ describe('Subscription lifecycles', () => {
           observable.setOptions({
             fetchPolicy: 'standby',
             pollInterval: 0,
-            fetchResults: false,
           });
 
           observableQueries.push({

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -55,11 +55,6 @@ export interface QueryBaseOptions<TVariables = OperationVariables> {
   errorPolicy?: ErrorPolicy;
 
   /**
-   * Whether or not to fetch results
-   */
-  fetchResults?: boolean;
-
-  /**
    * Context to be passed to link execution chain
    */
   context?: any;


### PR DESCRIPTION
#### Make `ObservableQuery.variables` a getter for `this.options.variables` (5463d66352039971b61230361c08bf9c63d818fc)

The `ObservableQuery` class currently has two different ways of referring to the same variables, and goes to considerable trouble to keep `this.variables` and `this.options.variables` in sync.

We can eliminate this confusion by making `this.variables` a getter for `this.options.variables`, so only `this.options.variables` ever needs to be updated.

Getter functions have been supported [since ECMAScript 5, including Internet Explorer 9](https://caniuse.com/#feat=mdn-javascript_builtins_object_defineproperty), thanks to the `Object.defineProperty` API, which is how TypeScript compiles the code:
```js
    Object.defineProperty(ObservableQuery.prototype, "variables", {
        get: function () {
            return this.options.variables;
        },
        enumerable: true,
        configurable: true
    });
```

Normally I would prefer to remove the `variables` property, but the `ObservableQuery` class is a public API (it's what `client.watchQuery` returns), so I think there's value in preserving both ways of accessing the variables, for now. If we ever decide to remove `variables`, we can add a deprecation warning to the getter function first.

#### Eliminate `WatchQueryOptions.fetchResults` (eabf3e916bbd967e0f129f296c8681bef5ffed4f)

The trickiest part of the `variables` changes was making sure the right thing happened in the `setVariables` method, and reasoning about that method was complicated by the presence of two unrelated but interacting boolean parameters, `tryFetch` and `fetchResults`. After reviewing the histories of these parameters, I concluded that `WatchQueryOptions.fetchResults` is a vestigial option (introduced by #1752) that is not examined in enough places to have a consistent effect on client behavior, so it would be much cleaner to remove it completely than to pretend to support it any longer.