### PR TITLE
Changes children to ReactNode

### DIFF
--- a/src/utilities/testing/mocking/MockedProvider.tsx
+++ b/src/utilities/testing/mocking/MockedProvider.tsx
@@ -16,7 +16,7 @@ export interface MockedProviderProps<TSerializedCache = {}> {
   cache?: ApolloCache<TSerializedCache>;
   resolvers?: Resolvers;
   childProps?: object;
-  children?: React.ReactElement;
+  children?: React.ReactNode;
   link?: ApolloLink;
 }
 


### PR DESCRIPTION
Potentially fixes #6087.

This better matches [the children property in ApolloProvider](https://github.com/apollographql/apollo-client/blob/c14c94b73ada83c92d75271d3a5dc17b03ccb85f/src/react/context/ApolloProvider.tsx#L9).