### PR TITLE
Expose rewriteURIForGET at base module level

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -45,6 +45,7 @@ export { concat } from '../link/core/concat';
 export { execute } from '../link/core/execute';
 export { ApolloLink } from '../link/core/ApolloLink';
 export * from '../link/core/types';
+export { rewriteURIForGET } from '../link/http/rewriteURIForGET';
 export {
   parseAndCheckHttpResponse,
   ServerParseError


### PR DESCRIPTION
Expose rewriteURIForGET so deep linking is not required. Specifically to address update of apollo-upload-client to support Apollo Client v3.

Addresses issue:
#5958 

apollo-upload-client related PR:
https://github.com/jaydenseric/apollo-upload-client/pull/175

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
