### PR TITLE
Strict null and typings in tests

### DIFF
--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
   },
   globals: {
     'ts-jest': {
-      diagnostics: false,
+      diagnostics: true,
     },
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'json'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -667,6 +667,12 @@
       "integrity": "sha512-mky/O83TXmGY39P1H9YbUpjV6l6voRYlufqfFCvel8l1phuy8HRjdWc1rrPuN53ITBJlbyMSV6z3niOySO5pgQ==",
       "dev": true
     },
+    "@types/fetch-mock": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@types/fetch-mock/-/fetch-mock-7.3.2.tgz",
+      "integrity": "sha512-NCEfv49jmDsBAixjMjEHKVgmVQlJ+uK56FOc+2roYPExnXCZDpi6mJOHQ3v23BiO84hBDStND9R2itJr7PNoow==",
+      "dev": true
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
   "devDependencies": {
     "@testing-library/react": "9.4.1",
     "@types/fast-json-stable-stringify": "2.0.0",
+    "@types/fetch-mock": "^7.3.2",
     "@types/jest": "24.0.25",
     "@types/lodash": "4.14.149",
     "@types/node": "12.12.36",

--- a/src/__tests__/ApolloClient.ts
+++ b/src/__tests__/ApolloClient.ts
@@ -16,7 +16,7 @@ describe('ApolloClient', () => {
 
     beforeEach(() => {
       oldFetch = window.fetch;
-      window.fetch = () => null;
+      window.fetch = () => null as any;
     })
 
     afterEach(() => {
@@ -1175,7 +1175,6 @@ describe('ApolloClient', () => {
               if (result.id && result.__typename) {
                 return result.__typename + result.id;
               }
-              return null;
             },
             addTypename: true,
           }),
@@ -1202,7 +1201,7 @@ describe('ApolloClient', () => {
                 expect(stripSymbols(readData)).toEqual(data);
 
                 // modify readData and writeQuery
-                const bestFriends = readData.people.friends.filter(
+                const bestFriends = readData!.people.friends.filter(
                   x => x.type === 'best',
                 );
                 // this should re call next
@@ -1254,7 +1253,7 @@ describe('ApolloClient', () => {
                 expect(stripSymbols(readData)).toEqual(data);
 
                 // modify readData and writeQuery
-                const friends = readData.people.friends;
+                const friends = readData!.people.friends;
                 friends[0].type = 'okayest';
                 friends[1].type = 'okayest';
 
@@ -1290,13 +1289,13 @@ describe('ApolloClient', () => {
                   type: 'okayest',
                 };
                 const nextFriends = stripSymbols(
-                  nextResult.data.people.friends,
+                  nextResult.data!.people.friends,
                 );
                 expect(nextFriends[0]).toEqual(expectation0);
                 expect(nextFriends[1]).toEqual(expectation1);
 
                 const readFriends = stripSymbols(
-                  client.readQuery<Data>({ query }).people.friends,
+                  client.readQuery<Data>({ query })!.people.friends,
                 );
                 expect(readFriends[0]).toEqual(expectation0);
                 expect(readFriends[1]).toEqual(expectation1);
@@ -1319,12 +1318,12 @@ describe('ApolloClient', () => {
                 expect(stripSymbols(observable.getCurrentResult().data)).toEqual(
                   data,
                 );
-                const bestFriends = result.data.people.friends.filter(
+                const bestFriends = result.data!.people.friends.filter(
                   x => x.type === 'best',
                 );
                 // this should re call next
                 client.writeFragment({
-                  id: `Person${result.data.people.id}`,
+                  id: `Person${result.data!.people.id}`,
                   fragment: gql`
                     fragment bestFriends on Person {
                       friends {
@@ -1349,7 +1348,7 @@ describe('ApolloClient', () => {
               }
 
               if (count === 2) {
-                expect(stripSymbols(result.data.people.friends)).toEqual([
+                expect(stripSymbols(result.data!.people.friends)).toEqual([
                   bestFriend,
                 ]);
                 done();
@@ -1370,11 +1369,11 @@ describe('ApolloClient', () => {
                 expect(stripSymbols(observable.getCurrentResult().data)).toEqual(
                   data,
                 );
-                const friends = result.data.people.friends;
+                const friends = result.data!.people.friends;
 
                 // this should re call next
                 client.writeFragment({
-                  id: `Person${result.data.people.id}`,
+                  id: `Person${result.data!.people.id}`,
                   fragment: gql`
                     fragment bestFriends on Person {
                       friends {
@@ -1403,7 +1402,7 @@ describe('ApolloClient', () => {
               }
 
               if (count === 2) {
-                const nextFriends = stripSymbols(result.data.people.friends);
+                const nextFriends = stripSymbols(result.data!.people.friends);
                 expect(nextFriends[0]).toEqual({
                   ...bestFriend,
                   type: 'okayest',
@@ -2216,8 +2215,11 @@ describe('ApolloClient', () => {
           }
         `,
       };
-      const _query = client.queryManager!.query;
-      client.queryManager!.query = options => {
+
+      // @ts-ignore
+      const queryManager = client.queryManager;
+      const _query = queryManager.query;
+      queryManager.query = options => {
         queryOptions = options;
         return _query(options);
       };

--- a/src/__tests__/fetchMore.ts
+++ b/src/__tests__/fetchMore.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 
 import { mockSingleLink } from '../utilities/testing/mocking/mockLink';
 import { InMemoryCache } from '../cache/inmemory/inMemoryCache';
-import { ApolloClient, NetworkStatus, ObservableQuery } from '../';
+import { ApolloClient, ApolloError, NetworkStatus, ObservableQuery } from '../';
 import { itAsync } from '../utilities/testing/itAsync';
 
 describe('updateQuery on a simple query', () => {
@@ -198,7 +198,7 @@ describe('fetchMore on an observable query', () => {
 
   let latestResult: any = null;
 
-  let client: ApolloClient;
+  let client: ApolloClient<any>;
   let link: any;
   let sub: any;
 
@@ -251,7 +251,7 @@ describe('fetchMore on an observable query', () => {
         watchedQuery.fetchMore({
           // Rely on the fact that the original variables had limit: 10
           variables: { start: 10 },
-          updateQuery: (prev, options) => {
+          updateQuery: (prev: any, options: any) => {
             expect(options.variables).toEqual(variablesMore);
 
             const state = cloneDeep(prev) as any;
@@ -289,7 +289,7 @@ describe('fetchMore on an observable query', () => {
       .then(watchedQuery => {
         return watchedQuery.fetchMore({
           variables: { start: 10 }, // rely on the fact that the original variables had limit: 10
-          updateQuery: (prev, options) => {
+          updateQuery: (prev: any, options: any) => {
             const state = cloneDeep(prev) as any;
             state.entry.comments = [
               ...state.entry.comments,
@@ -325,7 +325,7 @@ describe('fetchMore on an observable query', () => {
         return watchedQuery.fetchMore({
           query: query2,
           variables: variables2,
-          updateQuery: (prev, options) => {
+          updateQuery: (prev: any, options: any) => {
             const state = cloneDeep(prev) as any;
             state.entry.comments = [
               ...state.entry.comments,
@@ -376,7 +376,7 @@ describe('fetchMore on an observable query', () => {
             expect((data as any).entry.comments.length).toBe(10);
             observable.fetchMore({
               variables: { start: 10 },
-              updateQuery: (prev, options) => {
+              updateQuery: (prev: any, options: any) => {
                 const state = cloneDeep(prev) as any;
                 state.entry.comments = [
                   ...state.entry.comments,
@@ -403,7 +403,7 @@ describe('fetchMore on an observable query', () => {
             reject(new Error('`next` called too many times'));
         }
       },
-      error: error => reject(error),
+      error: (error: any) => reject(error),
       complete: () => reject(new Error('Should not have completed')),
     });
   });
@@ -437,7 +437,7 @@ describe('fetchMore on an observable query', () => {
             observable
               .fetchMore({
                 variables: { start: 10 },
-                updateQuery: (prev, options) => {
+                updateQuery: (prev: any, options: any) => {
                   const state = cloneDeep(prev) as any;
                   state.entry.comments = [
                     ...state.entry.comments,
@@ -446,7 +446,7 @@ describe('fetchMore on an observable query', () => {
                   return state;
                 },
               })
-              .catch(e => {
+              .catch((e: ApolloError) => {
                 expect(e.networkError).toBe(fetchMoreError);
               });
             break;
@@ -474,7 +474,7 @@ describe('fetchMore on an observable query', () => {
 
   itAsync('will not leak fetchMore query', (resolve, reject) => {
     latestResult = null;
-    var beforeQueryCount;
+    let beforeQueryCount: number;
     return setup(reject, {
       request: {
         query,
@@ -484,11 +484,12 @@ describe('fetchMore on an observable query', () => {
     })
       .then(watchedQuery => {
         beforeQueryCount = Object.keys(
-          client.queryManager.getQueryStore(),
+            // @ts-ignore
+            client.queryManager.getQueryStore(),
         ).length;
         return watchedQuery.fetchMore({
           variables: { start: 10 }, // rely on the fact that the original variables had limit: 10
-          updateQuery: (prev, options) => {
+          updateQuery: (prev: any, options: any) => {
             const state = cloneDeep(prev) as any;
             state.entry.comments = [
               ...state.entry.comments,
@@ -499,8 +500,9 @@ describe('fetchMore on an observable query', () => {
         });
       })
       .then(data => {
-        var afterQueryCount = Object.keys(
-          client.queryManager.getQueryStore(),
+        let afterQueryCount = Object.keys(
+            // @ts-ignore
+            client.queryManager.getQueryStore(),
         ).length;
         expect(afterQueryCount).toBe(beforeQueryCount);
         unsetup();
@@ -565,7 +567,7 @@ describe('fetchMore on an observable query with connection', () => {
 
   let latestResult: any = null;
 
-  let client: ApolloClient;
+  let client: ApolloClient<any>;
   let link: any;
   let sub: any;
 
@@ -617,7 +619,7 @@ describe('fetchMore on an observable query with connection', () => {
       .then(watchedQuery => {
         return watchedQuery.fetchMore({
           variables: { start: 10 }, // rely on the fact that the original variables had limit: 10
-          updateQuery: (prev, options) => {
+          updateQuery: (prev: any, options: any) => {
             const state = cloneDeep(prev) as any;
             state.entry.comments = [
               ...state.entry.comments,
@@ -667,7 +669,7 @@ describe('fetchMore on an observable query with connection', () => {
             expect((data as any).entry.comments.length).toBe(10);
             observable.fetchMore({
               variables: { start: 10 },
-              updateQuery: (prev, options) => {
+              updateQuery: (prev: any, options: any) => {
                 const state = cloneDeep(prev) as any;
                 state.entry.comments = [
                   ...state.entry.comments,
@@ -694,7 +696,7 @@ describe('fetchMore on an observable query with connection', () => {
             reject(new Error('`next` called too many times'));
         }
       },
-      error: error => reject(error),
+      error: (error: any) => reject(error),
       complete: () => reject(new Error('Should not have completed')),
     });
   });
@@ -728,7 +730,7 @@ describe('fetchMore on an observable query with connection', () => {
             observable
               .fetchMore({
                 variables: { start: 10 },
-                updateQuery: (prev, options) => {
+                updateQuery: (prev: any, options: any) => {
                   const state = cloneDeep(prev) as any;
                   state.entry.comments = [
                     ...state.entry.comments,
@@ -737,7 +739,7 @@ describe('fetchMore on an observable query with connection', () => {
                   return state;
                 },
               })
-              .catch(e => {
+              .catch((e: ApolloError) => {
                 expect(e.networkError).toBe(fetchMoreError);
               });
             break;

--- a/src/__tests__/graphqlSubscriptions.ts
+++ b/src/__tests__/graphqlSubscriptions.ts
@@ -1,8 +1,7 @@
 import gql from 'graphql-tag';
 
 import {
-  mockObservableLink,
-  MockedSubscription
+  mockObservableLink
 } from '../utilities/testing/mocking/mockSubscriptionLink';
 import { InMemoryCache } from '../cache/inmemory/inMemoryCache';
 import { ApolloClient } from '../';
@@ -16,26 +15,9 @@ describe('GraphQL Subscriptions', () => {
     'Amanda Liu',
   ].map(name => ({ result: { data: { user: { name } } }, delay: 10 }));
 
-  let sub1: MockedSubscription;
   let options: any;
   let defaultOptions: any;
-  let defaultSub1: MockedSubscription;
   beforeEach(() => {
-    sub1 = {
-      request: {
-        query: gql`
-          subscription UserInfo($name: String) {
-            user(name: $name) {
-              name
-            }
-          }
-        `,
-        variables: {
-          name: 'Changping Chen',
-        },
-      },
-    };
-
     options = {
       query: gql`
         subscription UserInfo($name: String) {
@@ -46,21 +28,6 @@ describe('GraphQL Subscriptions', () => {
       `,
       variables: {
         name: 'Changping Chen',
-      },
-    };
-
-    defaultSub1 = {
-      request: {
-        query: gql`
-          subscription UserInfo($name: String = "Changping Chen") {
-            user(name: $name) {
-              name
-            }
-          }
-        `,
-        variables: {
-          name: 'Changping Chen',
-        },
       },
     };
 
@@ -76,7 +43,7 @@ describe('GraphQL Subscriptions', () => {
   });
 
   it('should start a subscription on network interface and unsubscribe', done => {
-    const link = mockObservableLink(defaultSub1);
+    const link = mockObservableLink();
     // This test calls directly through Apollo Client
     const client = new ApolloClient({
       link,
@@ -102,7 +69,7 @@ describe('GraphQL Subscriptions', () => {
   });
 
   it('should subscribe with default values', done => {
-    const link = mockObservableLink(sub1);
+    const link = mockObservableLink();
     // This test calls directly through Apollo Client
     const client = new ApolloClient({
       link,
@@ -128,7 +95,7 @@ describe('GraphQL Subscriptions', () => {
   });
 
   it('should multiplex subscriptions', done => {
-    const link = mockObservableLink(sub1);
+    const link = mockObservableLink();
     const queryManager = new QueryManager({
       link,
       cache: new InMemoryCache({ addTypename: false }),
@@ -165,7 +132,7 @@ describe('GraphQL Subscriptions', () => {
   });
 
   it('should receive multiple results for a subscription', done => {
-    const link = mockObservableLink(sub1);
+    const link = mockObservableLink();
     let numResults = 0;
     const queryManager = new QueryManager({
       link,
@@ -189,7 +156,7 @@ describe('GraphQL Subscriptions', () => {
   });
 
   it('should not cache subscription data if a `no-cache` fetch policy is used', done => {
-    const link = mockObservableLink(sub1);
+    const link = mockObservableLink();
     const cache = new InMemoryCache({ addTypename: false });
     const client = new ApolloClient({
       link,
@@ -211,7 +178,7 @@ describe('GraphQL Subscriptions', () => {
   });
 
   it('should throw an error if the result has errors on it', () => {
-    const link = mockObservableLink(sub1);
+    const link = mockObservableLink();
     const queryManager = new QueryManager({
       link,
       cache: new InMemoryCache({ addTypename: false }),
@@ -250,7 +217,7 @@ describe('GraphQL Subscriptions', () => {
               },
             ],
             path: ['result'],
-          },
+          } as any,
         ],
       },
     };

--- a/src/__tests__/local-state/general.ts
+++ b/src/__tests__/local-state/general.ts
@@ -8,7 +8,6 @@ import { Operation } from '../../link/core/types';
 import { ApolloClient } from '../..';
 import { ApolloCache } from '../../cache/core/cache';
 import { InMemoryCache } from '../../cache/inmemory/inMemoryCache';
-import { hasDirectives } from '../../utilities/graphql/directives';
 import { itAsync } from '../../utilities/testing/itAsync';
 
 describe('General functionality', () => {

--- a/src/__tests__/local-state/resolvers.ts
+++ b/src/__tests__/local-state/resolvers.ts
@@ -1109,7 +1109,7 @@ describe('Async resolvers', () => {
       },
     });
 
-    const { data: { isLoggedIn } } = await client.query({ query });
+    const { data: { isLoggedIn } } = await client.query({ query })!;
     expect(isLoggedIn).toBe(true);
     return resolve();
   });
@@ -1159,7 +1159,7 @@ describe('Async resolvers', () => {
         },
       });
 
-      const { data: { member } } = await client.query({ query });
+      const { data: { member } } = await client.query({ query })!;
       expect(member.name).toBe(testMember.name);
       expect(member.isLoggedIn).toBe(testMember.isLoggedIn);
       expect(member.sessionCount).toBe(testMember.sessionCount);

--- a/src/__tests__/local-state/resolvers.ts
+++ b/src/__tests__/local-state/resolvers.ts
@@ -610,12 +610,12 @@ describe('Writing cache data from resolvers', () => {
                 },
               },
             });
-            cache.modify('Object:uniqueId', {
-              field(value) {
+            cache.modify({
+              field(value: { field2: number }) {
                 expect(value.field2).toBe(1);
                 return { ...value, field2: 2 };
               },
-            });
+            }, 'Object:uniqueId');
             return { start: true };
           },
         },

--- a/src/__tests__/mutationResults.ts
+++ b/src/__tests__/mutationResults.ts
@@ -1,7 +1,7 @@
 import { cloneDeep } from 'lodash';
 import gql from 'graphql-tag';
 
-import { Observable, Subscription } from '../utilities/observables/Observable';
+import { Observable, ObservableSubscription as Subscription } from '../utilities/observables/Observable';
 import { ApolloLink } from '../link/core/ApolloLink';
 import { mockSingleLink } from '../utilities/testing/mocking/mockLink';
 import { ApolloClient } from '..';
@@ -288,7 +288,7 @@ describe('mutation results', () => {
       next: result => {
         if (count === 0) {
           client.mutate({ mutation, variables: { signature: '1234' } });
-          expect(result.data.mini.cover).toBe('image');
+          expect(result.data!.mini.cover).toBe('image');
 
           setTimeout(() => {
             if (count === 0)
@@ -298,7 +298,7 @@ describe('mutation results', () => {
           }, 250);
         }
         if (count === 1) {
-          expect(result.data.mini.cover).toBe('image2');
+          expect(result.data!.mini.cover).toBe('image2');
           resolve();
         }
         count++;
@@ -310,7 +310,6 @@ describe('mutation results', () => {
   itAsync("should warn when the result fields don't match the query fields", (resolve, reject) => {
     let handle: any;
     let subscriptionHandle: Subscription;
-    let counter = 0;
 
     const queryTodos = gql`
       query todos {
@@ -375,7 +374,6 @@ describe('mutation results', () => {
         handle = client.watchQuery({ query: queryTodos });
         subscriptionHandle = handle.subscribe({
           next(res: any) {
-            counter++;
             resolve(res);
           },
         });
@@ -1360,8 +1358,8 @@ describe('mutation results', () => {
       client.mutate<{ foo: { bar: string; }; }>({
         mutation: mutation,
       }).then(result => {
-        // This next line should **not** raise "TS2533: Object is possibly 'null' or 'undefined'."
-        if (result.data.foo.bar) {
+        // This next line should **not** raise "TS2533: Object is possibly 'null' or 'undefined'.", even without `!` operator
+        if (result.data!.foo.bar) {
           resolve();
         }
       }, reject);

--- a/src/__tests__/optimistic.ts
+++ b/src/__tests__/optimistic.ts
@@ -5,7 +5,7 @@ import gql from 'graphql-tag';
 
 import { mockSingleLink } from '../utilities/testing/mocking/mockLink';
 import { MutationQueryReducersMap } from '../core/types';
-import { Subscription } from '../utilities/observables/Observable';
+import { ObservableSubscription as Subscription } from '../utilities/observables/Observable';
 import { ApolloClient } from '../';
 import { addTypenameToDocument } from '../utilities/graphql/transform';
 import { makeReference } from '../core';
@@ -97,7 +97,7 @@ describe('optimistic mutation results', () => {
     },
   };
 
-  let client: ApolloClient;
+  let client: ApolloClient<any>;
   let link: any;
 
   function setup(
@@ -239,7 +239,7 @@ describe('optimistic mutation results', () => {
         await new Promise(resolve => {
           const handle = client.watchQuery({ query });
           subscriptionHandle = handle.subscribe({
-            next(res) {
+            next(res: any) {
               resolve(res);
             },
           });
@@ -251,7 +251,7 @@ describe('optimistic mutation results', () => {
             optimisticResponse,
             updateQueries,
           })
-          .catch(err => {
+          .catch((err: any) => {
             // it is ok to fail here
             expect(err).toBeInstanceOf(Error);
             expect(err.message).toBe('forbidden (test error)');
@@ -275,7 +275,7 @@ describe('optimistic mutation results', () => {
 
         await Promise.all([promise, promise2]);
 
-        subscriptionHandle.unsubscribe();
+        subscriptionHandle!.unsubscribe();
         {
           const dataInStore = (client.cache as InMemoryCache).extract(true);
           expect((dataInStore['TodoList5'] as any).todos.length).toBe(4);
@@ -329,7 +329,7 @@ describe('optimistic mutation results', () => {
         await new Promise(resolve => {
           const handle = client.watchQuery({ query });
           subscriptionHandle = handle.subscribe({
-            next(res) {
+            next(res: any) {
               resolve(res);
             },
           });
@@ -341,11 +341,13 @@ describe('optimistic mutation results', () => {
             optimisticResponse,
             updateQueries,
           })
-          .then(res => {
+          .then((res: any) => {
             checkBothMutationsAreApplied(
               'This one was created with a mutation.',
               'Optimistically generated 2',
             );
+
+            // @ts-ignore
             const latestState = client.queryManager.mutationStore;
             expect(latestState.get('5').loading).toBe(false);
             expect(latestState.get('6').loading).toBe(true);
@@ -359,11 +361,13 @@ describe('optimistic mutation results', () => {
             optimisticResponse: optimisticResponse2,
             updateQueries,
           })
-          .then(res => {
+          .then((res: any) => {
             checkBothMutationsAreApplied(
               'This one was created with a mutation.',
               'Second mutation.',
             );
+
+            // @ts-ignore
             const latestState = client.queryManager.mutationStore;
             expect(latestState.get('5').loading).toBe(false);
             expect(latestState.get('6').loading).toBe(false);
@@ -371,6 +375,7 @@ describe('optimistic mutation results', () => {
             return res;
           });
 
+        // @ts-ignore
         const mutationsState = client.queryManager.mutationStore;
         expect(mutationsState.get('5').loading).toBe(true);
         expect(mutationsState.get('6').loading).toBe(true);
@@ -382,7 +387,7 @@ describe('optimistic mutation results', () => {
 
         await Promise.all([promise, promise2]);
 
-        subscriptionHandle.unsubscribe();
+        subscriptionHandle!.unsubscribe();
         checkBothMutationsAreApplied(
           'This one was created with a mutation.',
           'Second mutation.',
@@ -476,7 +481,7 @@ describe('optimistic mutation results', () => {
         await new Promise(resolve => {
           const handle = client.watchQuery({ query });
           subscriptionHandle = handle.subscribe({
-            next(res) {
+            next(res: any) {
               resolve(res);
             },
           });
@@ -488,7 +493,7 @@ describe('optimistic mutation results', () => {
             optimisticResponse,
             update,
           })
-          .catch(err => {
+          .catch((err: any) => {
             // it is ok to fail here
             expect(err).toBeInstanceOf(Error);
             expect(err.message).toBe('forbidden (test error)');
@@ -512,7 +517,7 @@ describe('optimistic mutation results', () => {
 
         await Promise.all([promise, promise2]);
 
-        subscriptionHandle.unsubscribe();
+        subscriptionHandle!.unsubscribe();
         {
           const dataInStore = (client.cache as InMemoryCache).extract(true);
           expect((dataInStore['TodoList5'] as any).todos.length).toBe(4);
@@ -565,7 +570,7 @@ describe('optimistic mutation results', () => {
           return new Promise(resolve => {
             const handle = client.watchQuery({ query });
             subscriptionHandle = handle.subscribe({
-              next(res) {
+              next(res: any) {
                 resolve(res);
               },
             });
@@ -578,11 +583,13 @@ describe('optimistic mutation results', () => {
             optimisticResponse,
             update,
           })
-          .then(res => {
+          .then((res: any) => {
             checkBothMutationsAreApplied(
               'This one was created with a mutation.',
               'Optimistically generated 2',
             );
+
+            // @ts-ignore
             const latestState = client.queryManager.mutationStore;
             expect(latestState.get('5').loading).toBe(false);
             expect(latestState.get('6').loading).toBe(true);
@@ -596,11 +603,13 @@ describe('optimistic mutation results', () => {
             optimisticResponse: optimisticResponse2,
             update,
           })
-          .then(res => {
+          .then((res: any) => {
             checkBothMutationsAreApplied(
               'This one was created with a mutation.',
               'Second mutation.',
             );
+
+            // @ts-ignore
             const latestState = client.queryManager.mutationStore;
             expect(latestState.get('5').loading).toBe(false);
             expect(latestState.get('6').loading).toBe(false);
@@ -608,6 +617,7 @@ describe('optimistic mutation results', () => {
             return res;
           });
 
+        // @ts-ignore
         const mutationsState = client.queryManager.mutationStore;
         expect(mutationsState.get('5').loading).toBe(true);
         expect(mutationsState.get('6').loading).toBe(true);
@@ -619,7 +629,7 @@ describe('optimistic mutation results', () => {
 
         await Promise.all([promise, promise2]);
 
-        subscriptionHandle.unsubscribe();
+        subscriptionHandle!.unsubscribe();
         checkBothMutationsAreApplied(
           'This one was created with a mutation.',
           'Second mutation.',
@@ -708,7 +718,7 @@ describe('optimistic mutation results', () => {
           return client.mutate({
             mutation: todoListMutation,
             optimisticResponse: todoListOptimisticResponse,
-            update: (proxy, mResult: any) => {
+            update: (proxy: any, mResult: any) => {
               const data = proxy.readQuery({ query: todoListQuery }, true);
               expect(data.todoList.todos[0].text).toEqual(
                 todoListOptimisticResponse.createTodo.todos[0].text,
@@ -731,7 +741,7 @@ describe('optimistic mutation results', () => {
           return client.mutate({
             mutation: todoListMutation,
             optimisticResponse: todoListOptimisticResponse,
-            update: (proxy, mResult: any) => {
+            update: (proxy: any, mResult: any) => {
               const incomingText = mResult.data.createTodo.todos[0].text;
               const data = proxy.readQuery({ query: todoListQuery }, false);
               expect(data.todoList.todos[0].text).toEqual(incomingText);
@@ -764,7 +774,7 @@ describe('optimistic mutation results', () => {
           return client.mutate({
             mutation: todoListMutation,
             optimisticResponse: todoListOptimisticResponse,
-            update: (proxy, mResult: any) => {
+            update: (proxy: any, mResult: any) => {
               const data: any = proxy.readFragment(
                 {
                   id: 'TodoList5',
@@ -793,7 +803,7 @@ describe('optimistic mutation results', () => {
           return client.mutate({
             mutation: todoListMutation,
             optimisticResponse: todoListOptimisticResponse,
-            update: (proxy, mResult: any) => {
+            update: (proxy: any, mResult: any) => {
               const incomingText = mResult.data.createTodo.todos[0].text;
               const data: any = proxy.readFragment(
                 {
@@ -859,7 +869,7 @@ describe('optimistic mutation results', () => {
       await new Promise(resolve => {
         const handle = client.watchQuery({ query });
         subscriptionHandle = handle.subscribe({
-          next(res) {
+          next(res: any) {
             resolve(res);
           },
         });
@@ -869,7 +879,7 @@ describe('optimistic mutation results', () => {
         mutation,
         variables,
         optimisticResponse,
-        update: (proxy, mResult: any) => {
+        update: (proxy: any, mResult: any) => {
           expect(mResult.data.createTodo.id).toBe('99');
 
           const id = 'TodoList5';
@@ -907,7 +917,7 @@ describe('optimistic mutation results', () => {
 
       const newResult: any = await client.query({ query });
 
-      subscriptionHandle.unsubscribe();
+      subscriptionHandle!.unsubscribe();
       // There should be one more todo item than before
       expect(newResult.data.todoList.todos.length).toEqual(4);
 
@@ -997,7 +1007,7 @@ describe('optimistic mutation results', () => {
       await new Promise(resolve => {
         const handle = client.watchQuery({ query });
         subscriptionHandle = handle.subscribe({
-          next(res) {
+          next(res: any) {
             resolve(res);
           },
         });
@@ -1007,7 +1017,7 @@ describe('optimistic mutation results', () => {
         mutation,
         optimisticResponse,
         updateQueries: {
-          todoList(prev, options) {
+          todoList(prev: any, options: any) {
             const mResult = options.mutationResult as any;
             expect(mResult.data.createTodo.id).toEqual('99');
             return {
@@ -1034,7 +1044,7 @@ describe('optimistic mutation results', () => {
 
       const newResult: any = await client.query({ query });
 
-      subscriptionHandle.unsubscribe();
+      subscriptionHandle!.unsubscribe();
       // There should be one more todo item than before
       expect(newResult.data.todoList.todos.length).toEqual(4);
 
@@ -1066,7 +1076,7 @@ describe('optimistic mutation results', () => {
       await new Promise(resolve => {
         const handle = client.watchQuery({ query });
         subscriptionHandle = handle.subscribe({
-          next(res) {
+          next(res: any) {
             resolve(res);
           },
         });
@@ -1091,7 +1101,7 @@ describe('optimistic mutation results', () => {
           optimisticResponse,
           updateQueries,
         })
-        .then(res => {
+        .then((res: any) => {
           const currentDataInStore = (client.cache as InMemoryCache).extract(
             true,
           );
@@ -1126,7 +1136,7 @@ describe('optimistic mutation results', () => {
 
       const newResult: any = await client.query({ query });
 
-      subscriptionHandle.unsubscribe();
+      subscriptionHandle!.unsubscribe();
       // There should be one more todo item than before
       expect(newResult.data.todoList.todos.length).toEqual(5);
 
@@ -1165,7 +1175,7 @@ describe('optimistic mutation results', () => {
       await new Promise(resolve => {
         const handle = client.watchQuery({ query });
         subscriptionHandle = handle.subscribe({
-          next(res) {
+          next(res: any) {
             resolve(res);
           },
         });
@@ -1190,7 +1200,7 @@ describe('optimistic mutation results', () => {
           optimisticResponse,
           updateQueries,
         })
-        .catch(err => {
+        .catch((err: any) => {
           // it is ok to fail here
           expect(err).toBeInstanceOf(Error);
           expect(err.message).toEqual('forbidden (test error)');
@@ -1214,7 +1224,7 @@ describe('optimistic mutation results', () => {
 
       await Promise.all([promise, promise2]);
 
-      subscriptionHandle.unsubscribe();
+      subscriptionHandle!.unsubscribe();
       {
         const dataInStore = (client.cache as InMemoryCache).extract(true);
         expect((dataInStore['TodoList5'] as any).todos.length).toEqual(4);
@@ -1292,9 +1302,9 @@ describe('optimistic mutation results', () => {
       });
 
       // wrap the QueryObservable with an rxjs observable
-      const promise = from(client.watchQuery({ query }))
+      const promise = from(client.watchQuery({ query }) as any)
         .pipe(
-          map(value => stripSymbols(value.data.todoList.todos)),
+          map((value: any) => stripSymbols(value.data.todoList.todos)),
           take(5),
           toArray(),
         )
@@ -1303,7 +1313,7 @@ describe('optimistic mutation results', () => {
       // Mutations will not trigger a watchQuery with the results of an optimistic response
       // if set in the same tick of the event loop.
       // https://github.com/apollographql/apollo-client/issues/3723
-      await new Promise(setTimeout);
+      await new Promise(resolve => setTimeout(resolve));
 
       client.mutate({
         mutation,
@@ -1411,7 +1421,7 @@ describe('optimistic mutation results', () => {
       await new Promise(resolve => {
         const handle = client.watchQuery({ query });
         subscriptionHandle = handle.subscribe({
-          next(res) {
+          next(res: any) {
             resolve(res);
           },
         });
@@ -1422,7 +1432,7 @@ describe('optimistic mutation results', () => {
       const promise = client.mutate({
         mutation,
         optimisticResponse,
-        update: (proxy, mResult: any) => {
+        update: (proxy: any, mResult: any) => {
           const after = Date.now();
           const duration = after - before;
           if (firstTime) {
@@ -1456,7 +1466,7 @@ describe('optimistic mutation results', () => {
       );
       await promise;
       await client.query({ query }).then((newResult: any) => {
-        subscriptionHandle.unsubscribe();
+        subscriptionHandle!.unsubscribe();
         // There should be one more todo item than before
         expect(newResult.data.todoList.todos.length).toBe(4);
 
@@ -1489,7 +1499,7 @@ describe('optimistic mutation results', () => {
       await new Promise(resolve => {
         const handle = client.watchQuery({ query });
         subscriptionHandle = handle.subscribe({
-          next(res) {
+          next(res: any) {
             resolve(res);
           },
         });
@@ -1534,7 +1544,7 @@ describe('optimistic mutation results', () => {
           optimisticResponse,
           update,
         })
-        .then(res => {
+        .then((res: any) => {
           const currentDataInStore = (client.cache as InMemoryCache).extract(
             true,
           );
@@ -1567,7 +1577,7 @@ describe('optimistic mutation results', () => {
 
       const newResult: any = await client.query({ query });
 
-      subscriptionHandle.unsubscribe();
+      subscriptionHandle!.unsubscribe();
       // There should be one more todo item than before
       expect(newResult.data.todoList.todos.length).toBe(5);
 
@@ -1606,7 +1616,7 @@ describe('optimistic mutation results', () => {
       await new Promise(resolve => {
         const handle = client.watchQuery({ query });
         subscriptionHandle = handle.subscribe({
-          next(res) {
+          next(res: any) {
             resolve(res);
           },
         });
@@ -1651,7 +1661,7 @@ describe('optimistic mutation results', () => {
           optimisticResponse,
           update,
         })
-        .catch(err => {
+        .catch((err: any) => {
           // it is ok to fail here
           expect(err).toBeInstanceOf(Error);
           expect(err.message).toBe('forbidden (test error)');
@@ -1675,7 +1685,7 @@ describe('optimistic mutation results', () => {
 
       await Promise.all([promise, promise2]);
 
-      subscriptionHandle.unsubscribe();
+      subscriptionHandle!.unsubscribe();
       {
         const dataInStore = (client.cache as InMemoryCache).extract(true);
         expect((dataInStore['TodoList5'] as any).todos.length).toBe(4);
@@ -1769,17 +1779,15 @@ describe('optimistic mutation results', () => {
         }),
       });
 
-      let count = 0;
-
-      const promise = from(client.watchQuery({ query }))
+      const promise = from(client.watchQuery({ query }) as any)
         .pipe(
-          map(value => stripSymbols(value.data.todoList.todos)),
+          map((value: any) => stripSymbols(value.data.todoList.todos)),
           take(5),
           toArray(),
         )
         .toPromise();
 
-      await new Promise(setTimeout);
+      await new Promise(resolve => setTimeout(resolve));
 
       client.mutate({
         mutation,
@@ -1873,7 +1881,7 @@ describe('optimistic mutation - githunt comments', () => {
     },
   };
 
-  let client: ApolloClient;
+  let client: ApolloClient<any>;
   let link: any;
 
   function setup(
@@ -1988,7 +1996,7 @@ describe('optimistic mutation - githunt comments', () => {
     await new Promise(resolve => {
       const handle = client.watchQuery({ query, variables });
       subscriptionHandle = handle.subscribe({
-        next(res) {
+        next(res: any) {
           resolve(res);
         },
       });
@@ -2003,7 +2011,7 @@ describe('optimistic mutation - githunt comments', () => {
 
     const newResult: any = await client.query({ query, variables });
 
-    subscriptionHandle.unsubscribe();
+    subscriptionHandle!.unsubscribe();
     expect(newResult.data.entry.comments.length).toBe(2);
 
     resolve();

--- a/src/cache/core/__tests__/cache.ts
+++ b/src/cache/core/__tests__/cache.ts
@@ -1,21 +1,66 @@
 import gql from 'graphql-tag';
+import { ApolloCache  } from '../cache';
+import { Cache, DataProxy } from '../..';
 
-import { ApolloCache as Cache } from '../cache';
+class TestCache extends ApolloCache<unknown> {
+  constructor() {
+    super();
+  }
 
-class TestCache extends Cache {}
+  public diff<T>(query: Cache.DiffOptions): DataProxy.DiffResult<T> {
+    return {};
+  }
 
+  public evict(dataId: string, fieldName?: string): boolean {
+    return false;
+  }
+
+  public extract(optimistic?: boolean): unknown {
+    return undefined;
+  }
+
+  public performTransaction(transaction: <TSerialized>(c: ApolloCache<TSerialized>) => void): void {
+  }
+
+  public read<T, TVariables = any>(query: Cache.ReadOptions<TVariables>): T | null {
+    return null;
+  }
+
+  public recordOptimisticTransaction(transaction: <TSerialized>(c: ApolloCache<TSerialized>) => void, id: string): void {
+  }
+
+  public removeOptimistic(id: string): void {
+  }
+
+  public reset(): Promise<void> {
+    return new Promise<void>(() => null);
+  }
+
+  public restore(serializedState: unknown): ApolloCache<unknown> {
+    return this;
+  }
+
+  public watch(watch: Cache.WatchOptions): () => void {
+    return function () {
+    };
+  }
+
+  public write<TResult = any, TVariables = any>(write: Cache.WriteOptions<TResult, TVariables>): void {
+  }
+}
+const query = gql`{ a }`;
 describe('abstract cache', () => {
   describe('transformDocument', () => {
     it('returns the document', () => {
       const test = new TestCache();
-      expect(test.transformDocument('a')).toBe('a');
+      expect(test.transformDocument(query)).toBe(query);
     });
   });
 
   describe('transformForLink', () => {
     it('returns the document', () => {
       const test = new TestCache();
-      expect(test.transformForLink('a')).toBe('a');
+      expect(test.transformForLink(query)).toBe(query);
     });
   });
 
@@ -24,16 +69,16 @@ describe('abstract cache', () => {
       const test = new TestCache();
       test.read = jest.fn();
 
-      test.readQuery({});
+      test.readQuery({query});
       expect(test.read).toBeCalled();
     });
 
     it('defaults optimistic to false', () => {
       const test = new TestCache();
-      test.read = ({ optimistic }) => optimistic;
+      test.read = ({ optimistic }) => optimistic as any;
 
-      expect(test.readQuery({})).toBe(false);
-      expect(test.readQuery({}, true)).toBe(true);
+      expect(test.readQuery({query})).toBe(false);
+      expect(test.readQuery({query}, true)).toBe(true);
     });
   });
 
@@ -56,7 +101,7 @@ describe('abstract cache', () => {
 
     it('defaults optimistic to false', () => {
       const test = new TestCache();
-      test.read = ({ optimistic }) => optimistic;
+      test.read = ({ optimistic }) => optimistic as any;
       const fragment = {
         id: 'frag',
         fragment: gql`
@@ -76,7 +121,10 @@ describe('abstract cache', () => {
       const test = new TestCache();
       test.write = jest.fn();
 
-      test.writeQuery({});
+      test.writeQuery({
+        query: query,
+        data: 'foo',
+      });
       expect(test.write).toBeCalled();
     });
   });
@@ -92,6 +140,7 @@ describe('abstract cache', () => {
             name
           }
         `,
+        data: 'foo',
       };
 
       test.writeFragment(fragment);

--- a/src/cache/inmemory/__tests__/cache.ts
+++ b/src/cache/inmemory/__tests__/cache.ts
@@ -2076,8 +2076,8 @@ describe("InMemoryCache#modify", () => {
     expect(aResults).toEqual([a123]);
     expect(bResults).toEqual([b321]);
 
-    const aId = cache.identify({ __typename: "A", id: 1 })!;
-    const bId = cache.identify({ __typename: "B", id: 1 })!;
+    const aId = cache.identify({ __typename: "A", id: 1 });
+    const bId = cache.identify({ __typename: "B", id: 1 });
 
     cache.modify({
       value(x: number) {

--- a/src/cache/inmemory/__tests__/cache.ts
+++ b/src/cache/inmemory/__tests__/cache.ts
@@ -727,7 +727,7 @@ describe('Cache', () => {
         lastName: "Willson",
       };
 
-      const id = cache.identify(data);
+      const id = cache.identify(data)!;
 
       cache.recordOptimisticTransaction(proxy => {
         proxy.writeFragment({ id, fragment, data });
@@ -1410,7 +1410,7 @@ describe("InMemoryCache#broadcastWatches", function () {
     const receivedCallbackResults: [string, number, any][] = [];
 
     let nextWatchId = 1;
-    function watch(arg) {
+    function watch(arg: number) {
       const watchId = `id${nextWatchId++}`;
       cache.watch({
         query,
@@ -1690,7 +1690,7 @@ describe("InMemoryCache#modify", () => {
       },
     });
 
-    const authorId = cache.identify(currentlyReading.author);
+    const authorId = cache.identify(currentlyReading.author)!;
     expect(authorId).toBe('Author:{"name":"Ezra Klein"}');
 
     cache.modify({
@@ -1709,7 +1709,7 @@ describe("InMemoryCache#modify", () => {
       yearOfBirth: 1984,
     });
 
-    const bookId = cache.identify(currentlyReading);
+    const bookId = cache.identify(currentlyReading)!;
 
     // Modifying the Book in order to modify the Author is fancier than
     // necessary, but we want fancy use cases to work, too.
@@ -1731,8 +1731,8 @@ describe("InMemoryCache#modify", () => {
     }, bookId);
 
     const snapshotWithoutYOB = cache.extract();
-    expect(snapshotWithoutYOB[authorId].yearOfBirth).toBeUndefined();
-    expect("yearOfBirth" in snapshotWithoutYOB[authorId]).toBe(false);
+    expect(snapshotWithoutYOB[authorId]!.yearOfBirth).toBeUndefined();
+    expect("yearOfBirth" in snapshotWithoutYOB[authorId]!).toBe(false);
     expect(snapshotWithoutYOB).toEqual({
       ROOT_QUERY: {
         __typename: "Query",
@@ -1806,17 +1806,17 @@ describe("InMemoryCache#modify", () => {
             comments: {
               merge(existing: Reference[], incoming: Reference[], { args, mergeObjects }) {
                 const merged = existing ? existing.slice(0) : [];
-                const end = args.offset + Math.min(args.limit, incoming.length);
-                for (let i = args.offset; i < end; ++i) {
-                  merged[i] = mergeObjects(merged[i], incoming[i - args.offset]);
+                const end = args!.offset + Math.min(args!.limit, incoming.length);
+                for (let i = args!.offset; i < end; ++i) {
+                  merged[i] = mergeObjects(merged[i], incoming[i - args!.offset]) as Reference;
                 }
                 return merged;
               },
 
               read(existing: Reference[], { args }) {
                 const page = existing && existing.slice(
-                  args.offset,
-                  args.offset + args.limit,
+                  args!.offset,
+                  args!.offset + args!.limit,
                 );
                 if (page && page.length > 0) {
                   return page;
@@ -2034,7 +2034,7 @@ describe("InMemoryCache#modify", () => {
       },
     });
 
-    let aResults = [];
+    let aResults: any[] = [];
     cache.watch({
       query: queryA,
       optimistic: true,
@@ -2044,7 +2044,7 @@ describe("InMemoryCache#modify", () => {
       },
     });
 
-    let bResults = [];
+    let bResults: any[] = [];
     cache.watch({
       query: queryB,
       optimistic: true,
@@ -2076,8 +2076,8 @@ describe("InMemoryCache#modify", () => {
     expect(aResults).toEqual([a123]);
     expect(bResults).toEqual([b321]);
 
-    const aId = cache.identify({ __typename: "A", id: 1 });
-    const bId = cache.identify({ __typename: "B", id: 1 });
+    const aId = cache.identify({ __typename: "A", id: 1 })!;
+    const bId = cache.identify({ __typename: "B", id: 1 })!;
 
     cache.modify({
       value(x: number) {

--- a/src/cache/inmemory/__tests__/diffAgainstStore.ts
+++ b/src/cache/inmemory/__tests__/diffAgainstStore.ts
@@ -1,6 +1,6 @@
 import gql, { disableFragmentWarnings } from 'graphql-tag';
 
-import { Reference, makeReference } from '../../../core';
+import { Reference } from '../../../core';
 import { defaultNormalizedCacheFactory } from '../entityStore';
 import { StoreReader } from '../readFromStore';
 import { StoreWriter } from '../writeToStore';
@@ -960,14 +960,14 @@ describe('diffing queries against the store', () => {
           Query: {
             fields: {
               person(_, { args, isReference, toReference, readField }) {
-                expect(typeof args.id).toBe('number');
-                const ref = toReference({ __typename: 'Person', id: args.id });
+                expect(typeof args!.id).toBe('number');
+                const ref = toReference({ __typename: 'Person', id: args!.id });
                 expect(isReference(ref)).toBe(true);
                 expect(ref).toEqual({
-                  __ref: `Person:${JSON.stringify({ id: args.id })}`,
+                  __ref: `Person:${JSON.stringify({ id: args!.id })}`,
                 });
                 const found = readField<Reference[]>("people").find(
-                  person => person.__ref === ref.__ref);
+                  person => ref && person.__ref === ref.__ref);
                 expect(found).toBeTruthy();
                 return found;
               },

--- a/src/cache/inmemory/__tests__/diffAgainstStore.ts
+++ b/src/cache/inmemory/__tests__/diffAgainstStore.ts
@@ -509,7 +509,7 @@ describe('diffing queries against the store', () => {
       result: queryResult,
     });
 
-    const { result } = reader.diffQueryAgainstStore({
+    const { result } = reader.diffQueryAgainstStore<any>({
       store,
       query,
     });
@@ -596,7 +596,7 @@ describe('diffing queries against the store', () => {
         c: { d: 20, e: { f: 3 } },
       };
 
-      const { result } = reader.diffQueryAgainstStore({
+      const { result } = reader.diffQueryAgainstStore<any>({
         store,
         query,
         previousResult,
@@ -677,7 +677,7 @@ describe('diffing queries against the store', () => {
         a: [{ b: 1.1 }, { b: 1.2 }, { b: 1.3 }],
       };
 
-      const { result } = reader.diffQueryAgainstStore({
+      const { result } = reader.diffQueryAgainstStore<any>({
         store,
         query,
         previousResult,
@@ -770,7 +770,7 @@ describe('diffing queries against the store', () => {
         },
       };
 
-      const { result } = reader.diffQueryAgainstStore({
+      const { result } = reader.diffQueryAgainstStore<any>({
         store,
         query,
         previousResult,
@@ -860,7 +860,7 @@ describe('diffing queries against the store', () => {
         },
       };
 
-      const { result } = reader.diffQueryAgainstStore({
+      const { result } = reader.diffQueryAgainstStore<any>({
         store,
         query,
         previousResult,
@@ -911,7 +911,7 @@ describe('diffing queries against the store', () => {
         d: { e: 50, f: { x: 6, y: 7, z: 8 } },
       };
 
-      const { result } = reader.diffQueryAgainstStore({
+      const { result } = reader.diffQueryAgainstStore<any>({
         store,
         query,
         previousResult,
@@ -966,7 +966,7 @@ describe('diffing queries against the store', () => {
                 expect(ref).toEqual({
                   __ref: `Person:${JSON.stringify({ id: args!.id })}`,
                 });
-                const found = readField<Reference[]>("people").find(
+                const found = readField<Reference[]>("people")!.find(
                   person => ref && person.__ref === ref.__ref);
                 expect(found).toBeTruthy();
                 return found;

--- a/src/cache/inmemory/__tests__/entityStore.ts
+++ b/src/cache/inmemory/__tests__/entityStore.ts
@@ -972,11 +972,11 @@ describe('EntityStore', () => {
 
     cache.evict("ROOT_QUERY", "publisherOfBook");
 
-    function withoutPublisherOfBook(obj: object) {
+    function withoutPublisherOfBook(obj: {[key: string]: any}) {
       const clean = { ...obj };
       Object.keys(obj).forEach(key => {
         if (key.startsWith("publisherOfBook")) {
-          delete (clean as any)[key];
+          delete clean[key];
         }
       });
       return clean;
@@ -1403,7 +1403,7 @@ describe('EntityStore', () => {
               expect(readField("__typename", ref)).toEqual("Book");
               const isbn = readField<string>("isbn", ref);
               expect(isbn).toEqual(args!.isbn);
-              expect(readField("title", ref)).toBe(titlesByISBN.get(isbn));
+              expect(readField("title", ref)).toBe(titlesByISBN.get(isbn!));
 
               return ref;
             },

--- a/src/cache/inmemory/__tests__/entityStore.ts
+++ b/src/cache/inmemory/__tests__/entityStore.ts
@@ -972,7 +972,7 @@ describe('EntityStore', () => {
 
     cache.evict("ROOT_QUERY", "publisherOfBook");
 
-    function withoutPublisherOfBook(obj: {[key: string]: any}) {
+    function withoutPublisherOfBook(obj: Record<string, any>) {
       const clean = { ...obj };
       Object.keys(obj).forEach(key => {
         if (key.startsWith("publisherOfBook")) {

--- a/src/cache/inmemory/__tests__/entityStore.ts
+++ b/src/cache/inmemory/__tests__/entityStore.ts
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag';
 import { EntityStore, supportsResultCaching } from '../entityStore';
 import { InMemoryCache } from '../inMemoryCache';
-import { DocumentNode, FieldNode } from 'graphql';
+import { DocumentNode } from 'graphql';
 import { Policies } from '../policies';
 import { StoreObject } from '../types';
 import { ApolloCache } from '../../core/cache';
@@ -630,7 +630,7 @@ describe('EntityStore', () => {
     `;
 
     const fragmentResult = cache.readFragment<StoreObject>({
-      id: cache.identify(cuckoosCallingBook),
+      id: cache.identify(cuckoosCallingBook)!,
       fragment: bookAuthorFragment,
     });
 
@@ -644,7 +644,7 @@ describe('EntityStore', () => {
 
     cache.recordOptimisticTransaction(proxy => {
       proxy.writeFragment({
-        id: cache.identify(cuckoosCallingBook),
+        id: cache.identify(cuckoosCallingBook)!,
         fragment: bookAuthorFragment,
         data: {
           ...fragmentResult,
@@ -713,7 +713,7 @@ describe('EntityStore', () => {
     });
 
     cache.writeFragment({
-      id: cache.identify(cuckoosCallingBook),
+      id: cache.identify(cuckoosCallingBook)!,
       fragment: bookAuthorFragment,
       data: {
         ...fragmentResult,
@@ -771,7 +771,7 @@ describe('EntityStore', () => {
       },
     });
 
-    const ccId = cache.identify(cuckoosCallingBook);
+    const ccId = cache.identify(cuckoosCallingBook)!;
     expect(cache.retain(ccId)).toBe(2);
     expect(cache.release(ccId)).toBe(1);
     expect(cache.release(ccId)).toBe(0);
@@ -929,7 +929,7 @@ describe('EntityStore', () => {
       cache.identify({
         __typename: "Publisher",
         name: "Alfred A. Knopf",
-      }),
+      })!,
       "yearOfFounding",
     );
 
@@ -954,7 +954,7 @@ describe('EntityStore', () => {
     cache.evict(cache.identify({
       __typename: "Publisher",
       name: "Melville House",
-    }));
+    })!);
 
     expect(cache.extract()).toEqual({
       ROOT_QUERY: {
@@ -976,7 +976,7 @@ describe('EntityStore', () => {
       const clean = { ...obj };
       Object.keys(obj).forEach(key => {
         if (key.startsWith("publisherOfBook")) {
-          delete clean[key];
+          delete (clean as any)[key];
         }
       });
       return clean;
@@ -1050,7 +1050,7 @@ describe('EntityStore', () => {
     };
 
     cache.evict(
-      cache.identify(tedWithoutHobby),
+      cache.identify(tedWithoutHobby)!,
       "hobby",
     );
 
@@ -1195,7 +1195,7 @@ describe('EntityStore', () => {
         a: "ay",
         b: "bee",
         c: "see",
-      }),
+      })!,
       fragment: gql`
         fragment JustB on ABCs {
           b
@@ -1219,7 +1219,7 @@ describe('EntityStore', () => {
       a: "ay",
       b: "bee",
       c: "see",
-    }));
+    })!);
 
     expect(cache.extract()).toEqual({
       ROOT_QUERY: {
@@ -1294,7 +1294,7 @@ describe('EntityStore', () => {
     const authorId = cache.identify({
       __typename: "Author",
       id: 2,
-    });
+    })!;
 
     expect(cache.evict(authorId)).toBe(true);
 
@@ -1397,13 +1397,13 @@ describe('EntityStore', () => {
             }) {
               const ref = toReference({
                 __typename: "Book",
-                isbn: args.isbn,
-              }, true);
+                isbn: args!.isbn,
+              }, true) as Reference;
 
               expect(readField("__typename", ref)).toEqual("Book");
               const isbn = readField<string>("isbn", ref);
-              expect(isbn).toEqual(args.isbn);
-              expect(readField("title", ref)).toBe(titlesByISBN[isbn]);
+              expect(isbn).toEqual(args!.isbn);
+              expect(readField("title", ref)).toBe(titlesByISBN.get(isbn));
 
               return ref;
             },
@@ -1421,9 +1421,9 @@ describe('EntityStore', () => {
 
                 const refs = incoming.map(book => toReference({
                   __typename: "Book",
-                  title: titlesByISBN[book.isbn],
+                  title: titlesByISBN.get(book.isbn),
                   ...book,
-                }, true));
+                }, true) as Reference);
 
                 refs.forEach((ref, i) => {
                   expect(isReference(ref)).toBe(true);
@@ -1462,11 +1462,11 @@ describe('EntityStore', () => {
       }
     `;
 
-    const titlesByISBN = {
-      9781451673319: "Fahrenheit 451",
-      1603589082: "Eager",
-      1760641790: "How To Do Nothing",
-    };
+    const titlesByISBN = new Map<string, string>([
+      ["9781451673319", 'Fahrenheit 451'],
+      ["1603589082", 'Eager'],
+      ["1760641790", 'How To Do Nothing'],
+    ]);
 
     cache.writeQuery({
       query: booksQuery,
@@ -1601,7 +1601,7 @@ describe('EntityStore', () => {
     const cuckoosCallingId = cache.identify({
       __typename: "Book",
       isbn: "031648637X",
-    });
+    })!;
 
     expect(cuckoosCallingId).toBe('Book:{"isbn":"031648637X"}');
 
@@ -1640,14 +1640,14 @@ describe('EntityStore', () => {
         // persisted into the store.
         const refWithoutAuthor = toReference(book);
         expect(isReference(refWithoutAuthor)).toBe(true);
-        expect(readField("author", refWithoutAuthor)).toBeUndefined();
+        expect(readField("author", refWithoutAuthor as Reference)).toBeUndefined();
 
         // Update this very Book entity before we modify its title.
         // Passing true for the second argument causes the extra
         // book.author field to be persisted into the store.
         const ref = toReference(book, true);
         expect(isReference(ref)).toBe(true);
-        expect(readField("author", ref)).toBe("J.K. Rowling");
+        expect(readField("author", ref as Reference)).toBe("J.K. Rowling");
 
         // In fact, readField doesn't need the ref if we're reading from
         // the same entity that we're modifying.

--- a/src/cache/inmemory/__tests__/optimistic.ts
+++ b/src/cache/inmemory/__tests__/optimistic.ts
@@ -65,7 +65,7 @@ describe('optimistic cache layers', () => {
     expect(result1984).toBe(readOptimistic(cache));
     expect(result1984).toBe(readRealistic(cache));
 
-    let result2666InTransaction: ReturnType<typeof readOptimistic>;
+    let result2666InTransaction: ReturnType<typeof readOptimistic> | null = null;
     cache.performTransaction(proxy => {
       expect(readOptimistic(cache)).toEqual(result1984);
 
@@ -101,7 +101,7 @@ describe('optimistic cache layers', () => {
 
     expect(result1984).toBe(readRealistic(cache));
 
-    let resultCatch22: ReturnType<typeof readOptimistic>;
+    let resultCatch22: ReturnType<typeof readOptimistic> | null = null;
     cache.performTransaction(proxy => {
       proxy.writeQuery({
         query,
@@ -118,7 +118,8 @@ describe('optimistic cache layers', () => {
         },
       });
 
-      expect((resultCatch22 = readOptimistic(proxy))).toEqual({
+      resultCatch22 = readOptimistic(proxy);
+      expect(resultCatch22).toEqual({
         book: {
           __typename: 'Book',
           title: 'Catch-22',
@@ -273,7 +274,7 @@ describe('optimistic cache layers', () => {
     });
 
     function read() {
-      return cache.readQuery<Q>({ query }, true);
+      return cache.readQuery<Q>({ query }, true)!;
     }
 
     const result = read();
@@ -344,7 +345,7 @@ describe('optimistic cache layers', () => {
     function readWithAuthors(optimistic = true) {
       return cache.readQuery<Q>({
         query: queryWithAuthors,
-      }, optimistic);
+      }, optimistic)!;
     }
 
     function withoutISBN(data: any) {

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -164,7 +164,7 @@ describe("type policies", function () {
         Book: {
           keyFields(book, context) {
             expect(context.typename).toBe("Book");
-            expect(context.selectionSet.kind).toBe("SelectionSet");
+            expect(context.selectionSet!.kind).toBe("SelectionSet");
             expect(context.fragmentMap).toEqual({});
             expect(context.policies).toBeInstanceOf(Policies);
             return ["isbn"];
@@ -474,8 +474,8 @@ describe("type policies", function () {
           Query: {
             fields: {
               types(existing: any[], { args }) {
-                const fromCode = args.from.charCodeAt(0);
-                const toCode = args.to.charCodeAt(0);
+                const fromCode = args!.from.charCodeAt(0);
+                const toCode = args!.to.charCodeAt(0);
                 let e = 0;
                 for (let code = fromCode; code <= toCode; ++code) {
                   const upper = String.fromCharCode(code).toUpperCase();
@@ -597,11 +597,11 @@ describe("type policies", function () {
                   expect(context.variables).toEqual({});
                   expect(context.policies).toBeInstanceOf(Policies);
 
-                  if (typeof args.limit === "number") {
-                    if (typeof args.offset === "number") {
+                  if (typeof args!.limit === "number") {
+                    if (typeof args!.offset === "number") {
                       return ["offset", "limit"];
                     }
-                    if (args.beforeId) {
+                    if (args!.beforeId) {
                       return ["beforeId", "limit"];
                     }
                   }
@@ -701,7 +701,7 @@ describe("type policies", function () {
     });
 
     it("can use stable storage in read functions", function () {
-      const storageSet = new Set<Record<string, any>>();
+      const storageSet = new Set<Record<string, any> | null>();
 
       const cache = new InMemoryCache({
         typePolicies: {
@@ -709,8 +709,8 @@ describe("type policies", function () {
             fields: {
               result(existing, { args, storage }) {
                 storageSet.add(storage);
-                if (storage.result) return storage.result;
-                return storage.result = compute(args);
+                if (storage?.result) return storage.result;
+                return storage!.result = compute();
               },
             },
           },
@@ -718,7 +718,7 @@ describe("type policies", function () {
       });
 
       let computeCount = 0;
-      function compute(args) {
+      function compute() {
         return `expensive result ${++computeCount}`;
       }
 
@@ -804,7 +804,9 @@ describe("type policies", function () {
 
       // Clear the cached results.
       storageSet.forEach(storage => {
-        delete storage.result;
+        if (storage) {
+          delete storage.result;
+        }
       });
 
       const result3 = cache.readQuery({
@@ -927,16 +929,16 @@ describe("type policies", function () {
             fields: {
               result: {
                 read(_, { storage }) {
-                  if (!storage.jobName) {
-                    storage.jobName = cache.makeVar<string>();
+                  if (!storage!.jobName) {
+                    storage!.jobName = cache.makeVar(undefined);
                   }
-                  return storage.jobName();
+                  return storage!.jobName();
                 },
                 merge(_, incoming: string, { storage }) {
-                  if (storage.jobName) {
-                    storage.jobName(incoming);
+                  if (storage!.jobName) {
+                    storage!.jobName(incoming);
                   } else {
-                    storage.jobName = cache.makeVar(incoming);
+                    storage!.jobName = cache.makeVar(incoming);
                   }
                 },
               },
@@ -1037,7 +1039,7 @@ describe("type policies", function () {
           id: cache.identify({
             __typename: "Job",
             name: `Job #${jobNum}`,
-          }),
+          })!,
           fragment: gql`
             fragment JobResult on Job {
               result
@@ -1440,7 +1442,7 @@ describe("type policies", function () {
                   toReference({
                     __typename: "Task",
                     id: readField("id"),
-                  }),
+                  }) as Reference,
                 ]);
               },
 
@@ -1464,7 +1466,7 @@ describe("type policies", function () {
 
       // Rather than writing ownTime data into the cache, we maintain it
       // externally in this object:
-      const ownTimes = {
+      const ownTimes: any = {
         "parent task": cache.makeVar(2),
         "child task 1": cache.makeVar(3),
         "child task 2": cache.makeVar(4),
@@ -1587,8 +1589,8 @@ describe("type policies", function () {
         }
       `;
 
-      function read() {
-        return cache.readQuery<{ agenda: any }>({ query });
+      function read(): { agenda: any } | null {
+        return cache.readQuery({ query });
       }
 
       const firstResult = read();
@@ -1654,10 +1656,10 @@ describe("type policies", function () {
           }],
         },
       });
-      expect(secondResult.agenda.tasks[0]).not.toBe(firstResult.agenda.tasks[0]);
-      expect(secondResult.agenda.tasks[1]).toBe(firstResult.agenda.tasks[1]);
-      expect(secondResult.agenda.tasks[2]).not.toBe(firstResult.agenda.tasks[2]);
-      expect(secondResult.agenda.tasks[3]).toBe(firstResult.agenda.tasks[3]);
+      expect(secondResult!.agenda.tasks[0]).not.toBe(firstResult!.agenda.tasks[0]);
+      expect(secondResult!.agenda.tasks[1]).toBe(firstResult!.agenda.tasks[1]);
+      expect(secondResult!.agenda.tasks[2]).not.toBe(firstResult!.agenda.tasks[2]);
+      expect(secondResult!.agenda.tasks[3]).toBe(firstResult!.agenda.tasks[3]);
 
       ownTimes["grandchild task"](7);
 
@@ -1806,7 +1808,7 @@ describe("type policies", function () {
 
       function checkFirstFourIdentical(result: ReturnType<typeof read>) {
         for (let i = 0; i < 4; ++i) {
-          expect(result.agenda.tasks[i]).toBe(thirdResult.agenda.tasks[i]);
+          expect(result!.agenda.tasks[i]).toBe(thirdResult!.agenda.tasks[i]);
         }
       }
       // The four original task results should not have been altered by
@@ -1823,10 +1825,10 @@ describe("type policies", function () {
           __typename: "Agenda",
           taskCount: 5,
           tasks: [
-            fourthResult.agenda.tasks[0],
-            fourthResult.agenda.tasks[1],
-            fourthResult.agenda.tasks[2],
-            fourthResult.agenda.tasks[3],
+            fourthResult!.agenda.tasks[0],
+            fourthResult!.agenda.tasks[1],
+            fourthResult!.agenda.tasks[2],
+            fourthResult!.agenda.tasks[3],
             {
               __typename: "Task",
               description: "independent task",
@@ -1915,8 +1917,8 @@ describe("type policies", function () {
                   expect(typeof toReference).toBe("function");
                   expect(policies).toBeInstanceOf(Policies);
                   const slice = existing.slice(
-                    args.offset,
-                    args.offset + args.limit,
+                    args!.offset,
+                    args!.offset + args!.limit,
                   );
                   slice.forEach(ref => expect(isReference(ref)).toBe(true));
                   return slice;
@@ -1932,9 +1934,9 @@ describe("type policies", function () {
                   expect(typeof toReference).toBe("function");
                   expect(policies).toBeInstanceOf(Policies);
                   const copy = existing ? existing.slice(0) : [];
-                  const limit = args.offset + args.limit;
-                  for (let i = args.offset; i < limit; ++i) {
-                    copy[i] = incoming[i - args.offset];
+                  const limit = args!.offset + args!.limit;
+                  for (let i = args!.offset; i < limit; ++i) {
+                    copy[i] = incoming[i - args!.offset];
                   }
                   copy.forEach(todo => expect(isReference(todo)).toBe(true));
                   return copy;
@@ -2322,7 +2324,7 @@ describe("type policies", function () {
                 read(existing, { args, toReference }) {
                   return existing || toReference({
                     __typename: "Book",
-                    isbn: args.isbn,
+                    isbn: args!.isbn,
                   });
                 },
               },
@@ -2377,7 +2379,7 @@ describe("type policies", function () {
         author: "Abbie Hoffman",
       };
 
-      const stealThisID = cache.identify(stealThisData);
+      const stealThisID = cache.identify(stealThisData)!;
 
       cache.writeFragment({
         id: stealThisID,
@@ -2513,7 +2515,7 @@ describe("type policies", function () {
             fields: {
               author: {
                 merge(existing: StoreObject, incoming: StoreObject, { mergeObjects }) {
-                  expect(mergeObjects(void 0, null)).toBe(null);
+                  expect(mergeObjects(void 0 as any, null)).toBe(null);
 
                   expect(() => {
                     // The type system does a pretty good job of defending
@@ -2887,7 +2889,7 @@ describe("type policies", function () {
             // Reference with the earliest year, which requires reading
             // fields from foreign references.
             firstBook(_, { isReference, readField }) {
-              let firstBook: Reference;
+              let firstBook: Reference | null = null;
               let firstYear: number;
               const bookRefs = readField<Reference[]>("books") || [];
               bookRefs.forEach(bookRef => {
@@ -2911,7 +2913,7 @@ describe("type policies", function () {
       },
     });
 
-    function addBook(bookData) {
+    function addBook(bookData: { __typename: 'Book'; isbn: string; title: string; year: number; }) {
       cache.writeQuery({
         query: gql`
           query {
@@ -3010,7 +3012,7 @@ describe("type policies", function () {
     function readFirstBookResult() {
       return cache.readQuery<{ author: any }>({
         query: firstBookQuery,
-      });
+      })!;
     }
 
     const firstBookResult = readFirstBookResult();
@@ -3030,6 +3032,7 @@ describe("type policies", function () {
 
     // Add an even earlier book.
     addBook({
+      __typename: "Book",
       isbn: "1420959719",
       title: "The Voyage Out",
       year: 1915,
@@ -3066,7 +3069,7 @@ describe("type policies", function () {
       id: cache.identify({
         __typename: "Author",
         name: "Virginia Woolf",
-      }),
+      })!,
       fragment: gql`
         fragment AfraidFragment on Author {
           name
@@ -3085,6 +3088,7 @@ describe("type policies", function () {
 
     // Add another book, not published first.
     addBook({
+      __typename: "Book",
       isbn: "9780156949606",
       title: "The Waves",
       year: 1931,

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -1467,7 +1467,7 @@ describe("type policies", function () {
 
       // Rather than writing ownTime data into the cache, we maintain it
       // externally in this object:
-      const ownTimes: { [key: string]: ReactiveVar<number>} = {
+      const ownTimes: Record<string, ReactiveVar<number>> = {
         "parent task": cache.makeVar(2),
         "child task 1": cache.makeVar(3),
         "child task 2": cache.makeVar(4),

--- a/src/cache/inmemory/__tests__/recordingCache.ts
+++ b/src/cache/inmemory/__tests__/recordingCache.ts
@@ -1,5 +1,6 @@
 import { NormalizedCacheObject, StoreObject } from '../types';
 import { EntityStore } from '../entityStore';
+import { Policies } from '../policies';
 
 describe('Optimistic EntityStore layering', () => {
   function makeLayer(root: EntityStore) {
@@ -20,7 +21,7 @@ describe('Optimistic EntityStore layering', () => {
       Human: { __typename: 'Human', name: 'John' },
     };
 
-    const underlyingStore = new EntityStore.Root({ seed: data });
+    const underlyingStore = new EntityStore.Root({ seed: data, policies: new Policies() });
 
     let store = makeLayer(underlyingStore);
     beforeEach(() => {
@@ -58,7 +59,7 @@ describe('Optimistic EntityStore layering', () => {
       Human: { __typename: 'Human', name: 'John' },
     };
 
-    const underlyingStore = new EntityStore.Root({ seed: data });
+    const underlyingStore = new EntityStore.Root({ seed: data, policies: new Policies() });
     let store = makeLayer(underlyingStore);
     let recording: NormalizedCacheObject;
 

--- a/src/cache/inmemory/__tests__/writeToStore.ts
+++ b/src/cache/inmemory/__tests__/writeToStore.ts
@@ -1233,7 +1233,7 @@ describe('writing to the store', () => {
       const expStore = defaultNormalizedCacheFactory({
         ROOT_QUERY: {
           __typename: 'Query',
-          author: makeReference(policies.identify(data.author)),
+          author: makeReference(policies.identify(data.author)[0]!),
         },
         [policies.identify(data.author)[0]!]: {
           firstName: data.author.firstName,
@@ -1273,7 +1273,7 @@ describe('writing to the store', () => {
       const expStore = defaultNormalizedCacheFactory({
         ROOT_QUERY: {
           __typename: 'Query',
-          author: makeReference(policies.identify(data.author)),
+          author: makeReference(policies.identify(data.author)[0]!),
         },
         [policies.identify(data.author)[0]!]: {
           __typename: data.author.__typename,

--- a/src/core/__tests__/LocalState.ts
+++ b/src/core/__tests__/LocalState.ts
@@ -4,7 +4,7 @@ import { ApolloClient, InMemoryCache, gql } from '../..';
  * Creates an apollo-client instance with a local query resolver named 'localQuery'.
  * @param localQueryResolver resolver function to run for "localQuery" query.
  */
-const setupClientWithLocalQueryResolver = localQueryResolver => {
+const setupClientWithLocalQueryResolver = (localQueryResolver: any) => {
   const cache = new InMemoryCache();
 
   const resolvers = {

--- a/src/core/__tests__/QueryManager/links.ts
+++ b/src/core/__tests__/QueryManager/links.ts
@@ -339,7 +339,7 @@ describe('Link interactions', () => {
                 }
 
                 expect(ref).toEqual({ __ref: `Book:${args.id}` });
-                const found = readField<Reference[]>("books").find(
+                const found = readField<Reference[]>("books")!.find(
                   book => book.__ref === ref.__ref);
                 expect(found).toBeTruthy();
                 return found;

--- a/src/core/__tests__/QueryManager/links.ts
+++ b/src/core/__tests__/QueryManager/links.ts
@@ -11,7 +11,7 @@ import { MockSubscriptionLink } from '../../../utilities/testing/mocking/mockSub
 
 // core
 import { QueryManager } from '../../QueryManager';
-import { Reference } from '../../../core';
+import { NextLink, Operation, Reference } from '../../../core';
 
 describe('Link interactions', () => {
   it('includes the cache on the context for eviction links', done => {
@@ -33,7 +33,7 @@ describe('Link interactions', () => {
       },
     };
 
-    const evictionLink = (operation, forward) => {
+    const evictionLink = (operation: Operation, forward: NextLink) => {
       const { cache } = operation.getContext();
       expect(cache).toBeDefined();
       return forward(operation).map(result => {
@@ -105,7 +105,7 @@ describe('Link interactions', () => {
     });
 
     let count = 0;
-    let four;
+    let four: ZenObservable.Subscription;
     // first watch
     const one = observable.subscribe(result => count++);
     // second watch
@@ -176,14 +176,13 @@ describe('Link interactions', () => {
     });
 
     let count = 0;
-    let four;
-    let finished = false;
+    let four: ZenObservable.Subscription;
     // first watch
     const one = observable.subscribe(result => count++);
     // second watch
-    const two = observable.subscribe({
-      next: result => count++,
-      error: e => {
+    observable.subscribe({
+      next: () => count++,
+      error: () => {
         count = 0;
       },
     });
@@ -213,7 +212,6 @@ describe('Link interactions', () => {
 
     link.onUnsubscribe(() => {
       expect(count).toEqual(4);
-      finished = true;
     });
   });
   it('includes the cache on the context for mutations', done => {
@@ -235,7 +233,7 @@ describe('Link interactions', () => {
       },
     };
 
-    const evictionLink = (operation, forward) => {
+    const evictionLink = (operation: Operation, forward: NextLink) => {
       const { cache } = operation.getContext();
       expect(cache).toBeDefined();
       done();
@@ -273,7 +271,7 @@ describe('Link interactions', () => {
       },
     };
 
-    const evictionLink = (operation, forward) => {
+    const evictionLink = (operation: Operation, forward: NextLink) => {
       const { planet } = operation.getContext();
       expect(planet).toBe('Tatooine');
       done();
@@ -331,7 +329,15 @@ describe('Link interactions', () => {
           Query: {
             fields: {
               book(_, { args, toReference, readField }) {
+                if (!args){
+                  throw new Error('arg must never be null');
+                }
+
                 const ref = toReference({ __typename: "Book", id: args.id });
+                if (!ref){
+                  throw new Error('ref must never be null');
+                }
+
                 expect(ref).toEqual({ __ref: `Book:${args.id}` });
                 const found = readField<Reference[]>("books").find(
                   book => book.__ref === ref.__ref);
@@ -349,9 +355,7 @@ describe('Link interactions', () => {
     return queryManager
       .query({ query: shouldHitCacheResolver })
       .then(({ data }) => {
-        expect({
-          ...data,
-        }).toMatchObject({
+        expect(data).toMatchObject({
           book: { title: 'Woo', __typename: 'Book' },
         });
       });

--- a/src/core/__tests__/QueryManager/live.ts
+++ b/src/core/__tests__/QueryManager/live.ts
@@ -119,7 +119,7 @@ describe('Live queries', () => {
       });
 
       // Observable => subscribe
-      const sub = observable.subscribe(result => {
+      observable.subscribe(result => {
         count++;
         if (count === 2) {
           expect(stripSymbols(result.data)).toEqual(laterData);

--- a/src/core/__tests__/QueryManager/multiple-results.ts
+++ b/src/core/__tests__/QueryManager/multiple-results.ts
@@ -10,6 +10,7 @@ import {
 
 // core
 import { QueryManager } from '../../QueryManager';
+import { GraphQLError } from 'graphql';
 
 describe('mutiple results', () => {
   it('allows multiple query results from link', done => {
@@ -116,7 +117,7 @@ describe('mutiple results', () => {
         if (count === 1) {
           // this shouldn't fire the next event again
           link.simulateResult({
-            result: { errors: [new Error('defer failed')] },
+            result: { errors: [new GraphQLError('defer failed')] },
           });
           setTimeout(() => {
             link.simulateResult({ result: { data: laterData } });
@@ -187,7 +188,7 @@ describe('mutiple results', () => {
           expect(stripSymbols(result.data)).toEqual(initialData);
           // this should fire the `next` event without this error
           link.simulateResult({
-            result: { errors: [new Error('defer failed')], data: laterData },
+            result: { errors: [new GraphQLError('defer failed')], data: laterData },
           });
         }
         if (count === 2) {
@@ -257,7 +258,7 @@ describe('mutiple results', () => {
             expect(result.errors).toBeUndefined();
             // this should fire the next event again
             link.simulateResult({
-              result: { errors: [new Error('defer failed')] },
+              error: new Error('defer failed'),
             });
           }
           if (count === 2) {
@@ -303,13 +304,6 @@ describe('mutiple results', () => {
       },
     };
 
-    const laterData = {
-      people_one: {
-        // XXX true defer's wouldn't send this
-        name: 'Luke Skywalker',
-        friends: [{ name: 'Leia Skywalker' }],
-      },
-    };
     const link = new MockSubscriptionLink();
     const queryManager = new QueryManager({
       cache: new InMemoryCache({ addTypename: false }),
@@ -331,7 +325,7 @@ describe('mutiple results', () => {
           expect(result.errors).toBeUndefined();
           // this should fire the next event again
           link.simulateResult({
-            result: { errors: [new Error('defer failed')] },
+            error: new Error('defer failed'),
           });
         }
         if (count === 2) {

--- a/src/core/__tests__/fetchPolicies.ts
+++ b/src/core/__tests__/fetchPolicies.ts
@@ -168,11 +168,8 @@ describe('network-only', () => {
   });
 
   itAsync('updates the cache on a mutation', (resolve, reject) => {
-    let called = 0;
     const inspector = new ApolloLink((operation, forward) => {
-      called++;
       return forward(operation).map(result => {
-        called++;
         return result;
       });
     });
@@ -302,11 +299,8 @@ describe('no-cache', () => {
   });
 
   itAsync('does not update the cache on a mutation', (resolve, reject) => {
-    let called = 0;
     const inspector = new ApolloLink((operation, forward) => {
-      called++;
       return forward(operation).map(result => {
-        called++;
         return result;
       });
     });

--- a/src/core/__tests__/scheduler.ts
+++ b/src/core/__tests__/scheduler.ts
@@ -89,9 +89,7 @@ describe('QueryScheduler', () => {
       link: link,
     });
     let timesFired = 0;
-    queryManager.startPollingQuery(queryOptions, 'fake-id', () => {
-      timesFired += 1;
-    });
+    queryManager.startPollingQuery(queryOptions, 'fake-id');
     setTimeout(() => {
       expect(timesFired).toBeGreaterThanOrEqual(0);
       queryManager.stop();

--- a/src/errors/__tests__/ApolloError.ts
+++ b/src/errors/__tests__/ApolloError.ts
@@ -1,10 +1,11 @@
 import { ApolloError } from '../ApolloError';
+import { GraphQLError } from 'graphql';
 
 describe('ApolloError', () => {
   it('should construct itself correctly', () => {
     const graphQLErrors = [
-      new Error('Something went wrong with GraphQL'),
-      new Error('Something else went wrong with GraphQL'),
+      new GraphQLError('Something went wrong with GraphQL'),
+      new GraphQLError('Something else went wrong with GraphQL'),
     ];
     const networkError = new Error('Network error');
     const errorMessage = 'this is an error message';
@@ -28,7 +29,7 @@ describe('ApolloError', () => {
   });
 
   it('should add a graphql error to the message', () => {
-    const graphQLErrors = [new Error('this is an error message')];
+    const graphQLErrors = [new GraphQLError('this is an error message')];
     const apolloError = new ApolloError({
       graphQLErrors,
     });
@@ -37,7 +38,7 @@ describe('ApolloError', () => {
   });
 
   it('should add multiple graphql errors to the message', () => {
-    const graphQLErrors = [new Error('this is new'), new Error('this is old')];
+    const graphQLErrors = [new GraphQLError('this is new'), new GraphQLError('this is old')];
     const apolloError = new ApolloError({
       graphQLErrors,
     });
@@ -48,7 +49,7 @@ describe('ApolloError', () => {
   });
 
   it('should add both network and graphql errors to the message', () => {
-    const graphQLErrors = [new Error('graphql error message')];
+    const graphQLErrors = [new GraphQLError('graphql error message')];
     const networkError = new Error('network error message');
     const apolloError = new ApolloError({
       graphQLErrors,
@@ -61,7 +62,7 @@ describe('ApolloError', () => {
   });
 
   it('should contain a stack trace', () => {
-    const graphQLErrors = [new Error('graphql error message')];
+    const graphQLErrors = [new GraphQLError('graphql error message')];
     const networkError = new Error('network error message');
     const apolloError = new ApolloError({
       graphQLErrors,

--- a/src/link/core/ApolloLink.ts
+++ b/src/link/core/ApolloLink.ts
@@ -37,7 +37,7 @@ export class ApolloLink {
     return new ApolloLink(() => Observable.of());
   }
 
-  public static from(links: ApolloLink[]): ApolloLink {
+  public static from(links: (ApolloLink | RequestHandler)[]): ApolloLink {
     if (links.length === 0) return ApolloLink.empty();
     return links.map(toLink).reduce((x, y) => x.concat(y)) as ApolloLink;
   }

--- a/src/link/core/__tests__/ApolloLink.ts
+++ b/src/link/core/__tests__/ApolloLink.ts
@@ -4,6 +4,7 @@ import { print } from 'graphql/language/printer';
 import { Observable } from '../../../utilities/observables/Observable';
 import { FetchResult, Operation, NextLink, GraphQLRequest } from '../types';
 import { ApolloLink } from '../ApolloLink';
+import { DocumentNode } from 'graphql';
 
 export class SetContextLink extends ApolloLink {
   constructor(
@@ -39,7 +40,7 @@ function checkCalls<T>(calls: any[] = [], results: Array<T>) {
 interface TestResultType {
   link: ApolloLink;
   results?: any[];
-  query?: string;
+  query?: DocumentNode;
   done?: () => void;
   context?: any;
   variables?: any;
@@ -54,7 +55,7 @@ export function testLinkResults(params: TestResultType) {
   const spy = jest.fn();
   ApolloLink.execute(link, { query, context, variables }).subscribe({
     next: spy,
-    error: error => {
+    error: (error: any) => {
       expect(error).toEqual(results.pop());
       checkCalls(spy.mock.calls[0], results);
       if (done) {
@@ -77,7 +78,7 @@ describe('ApolloClient', () => {
     it('should merge context when using a function', done => {
       const returnOne = new SetContextLink(setContext);
       const mock = new ApolloLink((op, forward) => {
-        op.setContext(({ add }) => ({ add: add + 2 }));
+        op.setContext((context: { add: number; }) => ({ add: context.add + 2 }));
         op.setContext(() => ({ substract: 1 }));
 
         return forward(op);
@@ -171,7 +172,7 @@ describe('ApolloClient', () => {
     it('should concat a Link and function', done => {
       const returnOne = new SetContextLink(setContext);
       const mock = new ApolloLink((op, forward) => {
-        op.setContext(({ add }) => ({ add: add + 2 }));
+        op.setContext((context: { add: number; }) => ({ add: context.add + 2 }));
         return forward(op);
       });
       const link = returnOne.concat(mock).concat(op => {
@@ -380,13 +381,13 @@ describe('ApolloClient', () => {
             }
           `,
         };
-        const link = new ApolloLink(op => {
-          expect(operation['operationName']).toBeUndefined();
-          expect(operation['variables']).toBeUndefined();
-          expect(operation['context']).toBeUndefined();
-          expect(operation['extensions']).toBeUndefined();
+        const link = new ApolloLink((op: Operation) => {
+          expect((operation as any)['operationName']).toBeUndefined();
+          expect((operation as any)['variables']).toBeUndefined();
+          expect((operation as any)['context']).toBeUndefined();
+          expect((operation as any)['extensions']).toBeUndefined();
           expect(op['variables']).toBeDefined();
-          expect(op['context']).toBeUndefined();
+          expect((op as any)['context']).toBeUndefined();
           expect(op['extensions']).toBeDefined();
           return Observable.of();
         });
@@ -564,11 +565,11 @@ describe('ApolloClient', () => {
 
     it('should chain together a function with links', done => {
       const add1 = new ApolloLink((operation: Operation, forward: NextLink) => {
-        operation.setContext(({ num }) => ({ num: num + 1 }));
+        operation.setContext((context: { num: number; }) => ({ num: context.num + 1 }));
         return forward(operation);
       });
       const add1Link = new ApolloLink((operation, forward) => {
-        operation.setContext(({ num }) => ({ num: num + 1 }));
+        operation.setContext((context: { num: number; }) => ({ num: context.num + 1 }));
         return forward(operation);
       });
 
@@ -692,11 +693,11 @@ describe('ApolloClient', () => {
         .split(
           operation => operation.getContext().test,
           (operation, forward) => {
-            operation.setContext(({ add }) => ({ add: add + 1 }));
+            operation.setContext((context: { add: number; }) => ({ add: context.add + 1 }));
             return forward(operation);
           },
           (operation, forward) => {
-            operation.setContext(({ add }) => ({ add: add + 2 }));
+            operation.setContext((context: { add: number; }) => ({ add: context.add + 2 }));
             return forward(operation);
           },
         )
@@ -868,7 +869,7 @@ describe('ApolloClient', () => {
         operation => operation.getContext().test,
         (operation, forward) =>
           forward(operation).map(data => ({
-            data: { count: data.data.count + 1 },
+            data: { count: data.data!.count + 1 },
           })),
       ).concat(() => Observable.of({ data: { count: 1 } }));
 

--- a/src/link/http/__tests__/HttpLink.ts
+++ b/src/link/http/__tests__/HttpLink.ts
@@ -7,6 +7,10 @@ import { ApolloLink } from '../../core/ApolloLink';
 import { execute } from '../../core/execute';
 import { HttpLink } from '../HttpLink';
 import { createHttpLink } from '../createHttpLink';
+import { ClientParseError } from '../serializeFetchParameter';
+import { ServerParseError } from '../parseAndCheckHttpResponse';
+import { ServerError } from '../../..';
+import DoneCallback = jest.DoneCallback;
 
 const sampleQuery = gql`
   query SampleQuery {
@@ -24,8 +28,8 @@ const sampleMutation = gql`
   }
 `;
 
-const makeCallback = (done, body) => {
-  return (...args) => {
+function makeCallback(done: DoneCallback, body: (...args: any[]) => void) {
+  return (...args: any[]) => {
     try {
       body(...args);
       done();
@@ -33,22 +37,22 @@ const makeCallback = (done, body) => {
       done.fail(error);
     }
   };
-};
+}
 
-const convertBatchedBody = body => {
-  const parsed = JSON.parse(body);
-  return parsed;
-};
+function convertBatchedBody(body: BodyInit | null | undefined) {
+  return JSON.parse(body as string);
+}
 
-const makePromise =
-  res => new Promise((resolve) => setTimeout(() => resolve(res)));
+function makePromise(res: any) {
+  return new Promise((resolve) => setTimeout(() => resolve(res)));
+}
 
 describe('HttpLink', () => {
   describe('General', () => {
     const data = { data: { hello: 'world' } };
     const data2 = { data: { hello: 'everyone' } };
     const mockError = { throws: new TypeError('mock me') };
-    let subscriber;
+    let subscriber: ZenObservable.Observer<any>;
 
     beforeEach(() => {
       fetchMock.restore();
@@ -106,9 +110,9 @@ describe('HttpLink', () => {
       });
 
       execute(link, { query: sampleQuery, variables, extensions }).subscribe({
-        next: makeCallback(done, result => {
-          const [uri, options] = fetchMock.lastCall();
-          const { method, body } = options;
+        next: makeCallback(done, () => {
+          const [uri, options] = fetchMock.lastCall()!;
+          const { method, body } = options!;
           expect(body).toBeUndefined();
           expect(method).toBe('GET');
           expect(uri).toBe(
@@ -128,9 +132,9 @@ describe('HttpLink', () => {
       });
 
       execute(link, { query: sampleQuery, variables }).subscribe({
-        next: makeCallback(done, result => {
-          const [uri, options] = fetchMock.lastCall();
-          const { method, body } = options;
+        next: makeCallback(done, () => {
+          const [uri, options] = fetchMock.lastCall()!;
+          const { method, body } = options!;
           expect(body).toBeUndefined();
           expect(method).toBe('GET');
           expect(uri).toBe(
@@ -154,9 +158,9 @@ describe('HttpLink', () => {
           fetchOptions: { method: 'GET' },
         },
       }).subscribe(
-        makeCallback(done, result => {
-          const [uri, options] = fetchMock.lastCall();
-          const { method, body } = options;
+        makeCallback(done, () => {
+          const [uri, options] = fetchMock.lastCall()!;
+          const { method, body } = options!;
           expect(body).toBeUndefined();
           expect(method).toBe('GET');
           expect(uri).toBe(
@@ -177,9 +181,9 @@ describe('HttpLink', () => {
         query: sampleQuery,
         variables,
       }).subscribe(
-        makeCallback(done, result => {
-          const [uri, options] = fetchMock.lastCall();
-          const { method, body } = options;
+        makeCallback(done, () => {
+          const [uri, options] = fetchMock.lastCall()!;
+          const { method, body } = options!;
           expect(body).toBeUndefined();
           expect(method).toBe('GET');
           expect(uri).toBe(
@@ -200,9 +204,9 @@ describe('HttpLink', () => {
         query: sampleMutation,
         variables,
       }).subscribe(
-        makeCallback(done, result => {
-          const [uri, options] = fetchMock.lastCall();
-          const { method, body } = options;
+        makeCallback(done, () => {
+          const [uri, options] = fetchMock.lastCall()!;
+          const { method, body } = options!;
           expect(body).toBeDefined();
           expect(method).toBe('POST');
           expect(uri).toBe('/data');
@@ -228,9 +232,9 @@ describe('HttpLink', () => {
           clientAwareness,
         },
       }).subscribe(
-        makeCallback(done, result => {
-          const [uri, options] = fetchMock.lastCall();
-          const { headers } = options;
+        makeCallback(done, () => {
+          const [, options] = fetchMock.lastCall()!;
+          const { headers } = options as any;
           expect(headers['apollographql-client-name']).toBeDefined();
           expect(headers['apollographql-client-name']).toEqual(
             clientAwareness.name,
@@ -258,9 +262,9 @@ describe('HttpLink', () => {
           clientAwareness,
         },
       }).subscribe(
-        makeCallback(done, result => {
-          const [uri, options] = fetchMock.lastCall();
-          const { headers } = options;
+        makeCallback(done, () => {
+          const [, options] = fetchMock.lastCall()!;
+          const { headers } = options as any;
           expect(hasOwn.call(headers, 'apollographql-client-name')).toBe(false);
           expect(hasOwn.call(headers, 'apollographql-client-version')).toBe(
             false,
@@ -276,7 +280,7 @@ describe('HttpLink', () => {
       });
 
       let b;
-      const a = { b };
+      const a: any = { b };
       b = { a };
       a.b = b;
       const variables = {
@@ -287,7 +291,7 @@ describe('HttpLink', () => {
         result => {
           done.fail('next should have been thrown from the link');
         },
-        makeCallback(done, e => {
+        makeCallback(done, (e: ClientParseError) => {
           expect(e.message).toMatch(/Variables map is not serializable/);
           expect(e.parseError.message).toMatch(
             /Converting circular structure to JSON/,
@@ -304,7 +308,7 @@ describe('HttpLink', () => {
       });
 
       let b;
-      const a = { b };
+      const a: any = { b };
       b = { a };
       a.b = b;
       const extensions = {
@@ -315,7 +319,7 @@ describe('HttpLink', () => {
         result => {
           done.fail('next should have been thrown from the link');
         },
-        makeCallback(done, e => {
+        makeCallback(done, (e: ClientParseError) => {
           expect(e.message).toMatch(/Extensions map is not serializable/);
           expect(e.parseError.message).toMatch(
             /Converting circular structure to JSON/,
@@ -327,7 +331,7 @@ describe('HttpLink', () => {
     it('raises warning if called with concat', () => {
       const link = createHttpLink();
       const _warn = console.warn;
-      console.warn = warning => expect(warning['message']).toBeDefined();
+      console.warn = (warning: any) => expect(warning['message']).toBeDefined();
       expect(link.concat((operation, forward) => forward(operation))).toEqual(
         link,
       );
@@ -360,7 +364,7 @@ describe('HttpLink', () => {
       });
       observable.subscribe(
         result => done.fail('next should not have been called'),
-        makeCallback(done, error => {
+        makeCallback(done, (error: TypeError) => {
           expect(error).toEqual(mockError.throws);
         }),
         () => done.fail('complete should not have been called'),
@@ -374,7 +378,7 @@ describe('HttpLink', () => {
       });
       observable.subscribe(
         result => done.fail('next should not have been called'),
-        makeCallback(done, error => {
+        makeCallback(done, (error: TypeError) => {
           expect(error).toEqual(mockError.throws);
         }),
         () => done.fail('complete should not have been called'),
@@ -416,7 +420,7 @@ describe('HttpLink', () => {
         error: error => done.fail(error),
         complete: () => {
           try {
-            let body = convertBatchedBody(fetchMock.lastCall()[1].body);
+            let body = convertBatchedBody(fetchMock.lastCall()![1]!.body);
             expect(body.query).toBe(print(sampleMutation));
             expect(body.variables).toEqual(variables);
             expect(body.context).not.toBeDefined();
@@ -538,8 +542,8 @@ describe('HttpLink', () => {
       const link = middleware.concat(createHttpLink({ uri: 'data' }));
 
       execute(link, { query: sampleQuery, variables }).subscribe(
-        makeCallback(done, result => {
-          const headers = fetchMock.lastCall()[1].headers;
+        makeCallback(done, () => {
+          const headers = fetchMock.lastCall()![1]!.headers as any;
           expect(headers.authorization).toBe('1234');
           expect(headers['content-type']).toBe('application/json');
           expect(headers.accept).toBe('*/*');
@@ -555,8 +559,8 @@ describe('HttpLink', () => {
       });
 
       execute(link, { query: sampleQuery, variables }).subscribe(
-        makeCallback(done, result => {
-          const headers = fetchMock.lastCall()[1].headers;
+        makeCallback(done, () => {
+          const headers = fetchMock.lastCall()![1]!.headers as any;
           expect(headers.authorization).toBe('1234');
           expect(headers['content-type']).toBe('application/json');
           expect(headers.accept).toBe('*/*');
@@ -577,8 +581,8 @@ describe('HttpLink', () => {
       );
 
       execute(link, { query: sampleQuery, variables }).subscribe(
-        makeCallback(done, result => {
-          const headers = fetchMock.lastCall()[1].headers;
+        makeCallback(done, () => {
+          const headers = fetchMock.lastCall()![1]!.headers as any;
           expect(headers.authorization).toBe('1234');
           expect(headers['content-type']).toBe('application/json');
           expect(headers.accept).toBe('*/*');
@@ -598,8 +602,8 @@ describe('HttpLink', () => {
         variables,
         context,
       }).subscribe(
-        makeCallback(done, result => {
-          const headers = fetchMock.lastCall()[1].headers;
+        makeCallback(done, () => {
+          const headers = fetchMock.lastCall()![1]!.headers as any;
           expect(headers.authorization).toBe('1234');
           expect(headers['content-type']).toBe('application/json');
           expect(headers.accept).toBe('*/*');
@@ -618,8 +622,8 @@ describe('HttpLink', () => {
       const link = middleware.concat(createHttpLink({ uri: 'data' }));
 
       execute(link, { query: sampleQuery, variables }).subscribe(
-        makeCallback(done, result => {
-          const creds = fetchMock.lastCall()[1].credentials;
+        makeCallback(done, () => {
+          const creds = fetchMock.lastCall()![1]!.credentials;
           expect(creds).toBe('same-team-yo');
         }),
       );
@@ -630,8 +634,8 @@ describe('HttpLink', () => {
       const link = createHttpLink({ uri: 'data', credentials: 'same-team-yo' });
 
       execute(link, { query: sampleQuery, variables }).subscribe(
-        makeCallback(done, result => {
-          const creds = fetchMock.lastCall()[1].credentials;
+        makeCallback(done, () => {
+          const creds = fetchMock.lastCall()![1]!.credentials;
           expect(creds).toBe('same-team-yo');
         }),
       );
@@ -650,8 +654,8 @@ describe('HttpLink', () => {
       );
 
       execute(link, { query: sampleQuery, variables }).subscribe(
-        makeCallback(done, result => {
-          const creds = fetchMock.lastCall()[1].credentials;
+        makeCallback(done, () => {
+          const creds = fetchMock.lastCall()![1]!.credentials;
           expect(creds).toBe('same-team-yo');
         }),
       );
@@ -668,7 +672,7 @@ describe('HttpLink', () => {
       const link = middleware.concat(createHttpLink());
 
       execute(link, { query: sampleQuery, variables }).subscribe(
-        makeCallback(done, result => {
+        makeCallback(done, () => {
           const uri = fetchMock.lastUrl();
           expect(uri).toBe('/data');
         }),
@@ -680,7 +684,7 @@ describe('HttpLink', () => {
       const link = createHttpLink({ uri: 'data' });
 
       execute(link, { query: sampleQuery, variables }).subscribe(
-        makeCallback(done, result => {
+        makeCallback(done, () => {
           const uri = fetchMock.lastUrl();
           expect(uri).toBe('/data');
         }),
@@ -700,7 +704,7 @@ describe('HttpLink', () => {
       );
 
       execute(link, { query: sampleQuery, variables }).subscribe(
-        makeCallback(done, result => {
+        makeCallback(done, () => {
           const uri = fetchMock.lastUrl();
 
           expect(uri).toBe('/apollo');
@@ -710,8 +714,8 @@ describe('HttpLink', () => {
 
     it('allows uri to be a function', done => {
       const variables = { params: 'stub' };
-      const customFetch = (uri, options) => {
-        const { operationName } = convertBatchedBody(options.body);
+      const customFetch: WindowOrWorkerGlobalScope['fetch'] = (uri, options) => {
+        const { operationName } = convertBatchedBody(options!.body);
         try {
           expect(operationName).toBe('SampleQuery');
         } catch (e) {
@@ -723,8 +727,7 @@ describe('HttpLink', () => {
       const link = createHttpLink({ fetch: customFetch });
 
       execute(link, { query: sampleQuery, variables }).subscribe(
-        makeCallback(done, result => {
-          const uri = fetchMock.lastUrl();
+        makeCallback(done, () => {
           expect(fetchMock.lastUrl()).toBe('/dataFunc');
         }),
       );
@@ -738,8 +741,8 @@ describe('HttpLink', () => {
       });
 
       execute(link, { query: sampleQuery, variables }).subscribe(
-        makeCallback(done, result => {
-          const { someOption, mode, headers } = fetchMock.lastCall()[1];
+        makeCallback(done, () => {
+          const { someOption, mode, headers } = fetchMock.lastCall()![1] as any;
           expect(someOption).toBe('foo');
           expect(mode).toBe('no-cors');
           expect(headers['content-type']).toBe('application/json');
@@ -760,8 +763,8 @@ describe('HttpLink', () => {
       const link = middleware.concat(createHttpLink({ uri: 'data' }));
 
       execute(link, { query: sampleQuery, variables }).subscribe(
-        makeCallback(done, result => {
-          const { someOption } = fetchMock.lastCall()[1];
+        makeCallback(done, () => {
+          const { someOption } = fetchMock.lastCall()![1] as any;
           expect(someOption).toBe('foo');
           done();
         }),
@@ -783,8 +786,8 @@ describe('HttpLink', () => {
       );
 
       execute(link, { query: sampleQuery, variables }).subscribe(
-        makeCallback(done, result => {
-          const { someOption } = fetchMock.lastCall()[1];
+        makeCallback(done, () => {
+          const { someOption } = fetchMock.lastCall()![1] as any;
           expect(someOption).toBe('foo');
         }),
       );
@@ -805,8 +808,8 @@ describe('HttpLink', () => {
       const link = middleware.concat(createHttpLink({ uri: 'data' }));
 
       execute(link, { query: sampleQuery, variables }).subscribe(
-        makeCallback(done, result => {
-          let body = convertBatchedBody(fetchMock.lastCall()[1].body);
+        makeCallback(done, () => {
+          let body = convertBatchedBody(fetchMock.lastCall()![1]!.body);
 
           expect(body.query).not.toBeDefined();
           expect(body.extensions).toEqual({ persistedQuery: { hash: '1234' } });
@@ -822,7 +825,7 @@ describe('HttpLink', () => {
           const sub = op.subscribe({
             next: ob.next.bind(ob),
             error: ob.error.bind(ob),
-            complete: makeCallback(done, e => {
+            complete: makeCallback(done, () => {
               expect(operation.getContext().response.headers.toBeDefined);
               ob.complete();
             }),
@@ -846,7 +849,7 @@ describe('HttpLink', () => {
   });
 
   describe('Dev warnings', () => {
-    let oldFetch;
+    let oldFetch: WindowOrWorkerGlobalScope['fetch'];;
     beforeEach(() => {
       oldFetch = window.fetch;
       delete window.fetch;
@@ -858,7 +861,7 @@ describe('HttpLink', () => {
 
     it('warns if fetch is undeclared', done => {
       try {
-        const link = createHttpLink({ uri: 'data' });
+        createHttpLink({ uri: 'data' });
         done.fail("warning wasn't called");
       } catch (e) {
         makeCallback(done, () =>
@@ -868,9 +871,9 @@ describe('HttpLink', () => {
     });
 
     it('warns if fetch is undefined', done => {
-      window.fetch = undefined;
+      window.fetch = undefined as any;
       try {
-        const link = createHttpLink({ uri: 'data' });
+        createHttpLink({ uri: 'data' });
         done.fail("warning wasn't called");
       } catch (e) {
         makeCallback(done, () =>
@@ -881,13 +884,13 @@ describe('HttpLink', () => {
 
     it('does not warn if fetch is undeclared but a fetch is passed', () => {
       expect(() => {
-        const link = createHttpLink({ uri: 'data', fetch: () => {} });
+        createHttpLink({ uri: 'data', fetch: (() => {}) as any });
       }).not.toThrow();
     });
   });
 
   describe('Error handling', () => {
-    let responseBody;
+    let responseBody: any;
     const text = jest.fn(() => {
       const responseBodyText = '{}';
       responseBody = JSON.parse(responseBodyText);
@@ -922,7 +925,7 @@ describe('HttpLink', () => {
           const op = forward(operation);
           const sub = op.subscribe({
             next: ob.next.bind(ob),
-            error: makeCallback(done, e => {
+            error: makeCallback(done, (e: ServerError) => {
               expect(e.message).toMatch(/Received status code 401/);
               expect(e.statusCode).toEqual(401);
               ob.error(e);
@@ -936,7 +939,7 @@ describe('HttpLink', () => {
         });
       });
 
-      const link = middleware.concat(createHttpLink({ uri: 'data', fetch }));
+      const link = middleware.concat(createHttpLink({ uri: 'data', fetch: fetch as any }));
 
       execute(link, { query: sampleQuery }).subscribe(
         result => {
@@ -948,13 +951,13 @@ describe('HttpLink', () => {
 
     it('throws an error if response code is > 300', done => {
       fetch.mockReturnValueOnce(Promise.resolve({ status: 400, text }));
-      const link = createHttpLink({ uri: 'data', fetch });
+      const link = createHttpLink({ uri: 'data', fetch: fetch as any });
 
       execute(link, { query: sampleQuery }).subscribe(
         result => {
           done.fail('next should have been thrown from the network');
         },
-        makeCallback(done, e => {
+        makeCallback(done, (e: ServerError) => {
           expect(e.message).toMatch(/Received status code 400/);
           expect(e.statusCode).toBe(400);
           expect(e.result).toEqual(responseBody);
@@ -966,7 +969,7 @@ describe('HttpLink', () => {
         Promise.resolve({ status: 400, text: textWithData }),
       );
 
-      const link = createHttpLink({ uri: 'data', fetch });
+      const link = createHttpLink({ uri: 'data', fetch: fetch as any });
 
       let called = false;
 
@@ -989,9 +992,7 @@ describe('HttpLink', () => {
         Promise.resolve({ status: 400, text: textWithErrors }),
       );
 
-      const link = createHttpLink({ uri: 'data', fetch });
-
-      let called = false;
+      const link = createHttpLink({ uri: 'data', fetch: fetch as any });
 
       execute(link, { query: sampleQuery }).subscribe(
         result => {
@@ -1008,13 +1009,13 @@ describe('HttpLink', () => {
     it('throws an error if empty response from the server ', done => {
       fetch.mockReturnValueOnce(Promise.resolve({ text }));
       text.mockReturnValueOnce(Promise.resolve('{ "body": "boo" }'));
-      const link = createHttpLink({ uri: 'data', fetch });
+      const link = createHttpLink({ uri: 'data', fetch: fetch as any });
 
       execute(link, { query: sampleQuery }).subscribe(
         result => {
           done.fail('next should have been thrown from the network');
         },
-        makeCallback(done, e => {
+        makeCallback(done, (e: Error) => {
           expect(e.message).toMatch(
             /Server response was missing for query 'SampleQuery'/,
           );
@@ -1023,10 +1024,10 @@ describe('HttpLink', () => {
     });
     it("throws if the body can't be stringified", done => {
       fetch.mockReturnValueOnce(Promise.resolve({ data: {}, text }));
-      const link = createHttpLink({ uri: 'data', fetch });
+      const link = createHttpLink({ uri: 'data', fetch: fetch as any });
 
       let b;
-      const a = { b };
+      const a: any = { b };
       b = { a };
       a.b = b;
       const variables = {
@@ -1037,7 +1038,7 @@ describe('HttpLink', () => {
         result => {
           done.fail('next should have been thrown from the link');
         },
-        makeCallback(done, e => {
+        makeCallback(done, (e: ClientParseError) => {
           expect(e.message).toMatch(/Payload is not serializable/);
           expect(e.parseError.message).toMatch(
             /Converting circular structure to JSON/,
@@ -1046,7 +1047,7 @@ describe('HttpLink', () => {
       );
     });
     it('supports being cancelled and does not throw', done => {
-      let called;
+      let called = false;
       class AbortController {
         signal: {};
         abort = () => {
@@ -1054,14 +1055,14 @@ describe('HttpLink', () => {
         };
       }
 
-      global.AbortController = AbortController;
+      (global as any).AbortController = AbortController;
 
       fetch.mockReturnValueOnce(Promise.resolve({ text }));
       text.mockReturnValueOnce(
         Promise.resolve('{ "data": { "hello": "world" } }'),
       );
 
-      const link = createHttpLink({ uri: 'data', fetch });
+      const link = createHttpLink({ uri: 'data', fetch: fetch as any });
 
       const sub = execute(link, { query: sampleQuery }).subscribe({
         next: result => {
@@ -1078,7 +1079,7 @@ describe('HttpLink', () => {
 
       setTimeout(
         makeCallback(done, () => {
-          delete global.AbortController;
+          delete (global as any).AbortController;
           expect(called).toBe(true);
           fetch.mockReset();
           text.mockReset();
@@ -1093,13 +1094,13 @@ describe('HttpLink', () => {
       fetch.mockReturnValueOnce(
         Promise.resolve({ status: 400, text: unparsableJson }),
       );
-      const link = createHttpLink({ uri: 'data', fetch });
+      const link = createHttpLink({ uri: 'data', fetch: fetch as any });
 
       execute(link, { query: sampleQuery }).subscribe(
         result => {
           done.fail('next should have been thrown from the network');
         },
-        makeCallback(done, e => {
+        makeCallback(done, (e: ServerParseError) => {
           expect(e.message).toMatch(/JSON/);
           expect(e.statusCode).toBe(400);
           expect(e.response).toBeDefined();

--- a/src/link/http/__tests__/checkFetcher.ts
+++ b/src/link/http/__tests__/checkFetcher.ts
@@ -1,7 +1,7 @@
 import { checkFetcher } from '../checkFetcher';
 
 describe('checkFetcher', () => {
-  let oldFetch;
+  let oldFetch: WindowOrWorkerGlobalScope['fetch'];
   beforeEach(() => {
     oldFetch = window.fetch;
     delete window.fetch;
@@ -18,6 +18,6 @@ describe('checkFetcher', () => {
   });
 
   it('does not throws if no fetch is present but a fetch is passed', () => {
-    expect(() => checkFetcher(() => {})).not.toThrow();
+    expect(() => checkFetcher((() => {}) as any)).not.toThrow();
   });
 });

--- a/src/link/http/__tests__/selectHttpOptionsAndBody.ts
+++ b/src/link/http/__tests__/selectHttpOptionsAndBody.ts
@@ -16,7 +16,7 @@ const query = gql`
 
 describe('selectHttpOptionsAndBody', () => {
   it('includeQuery allows the query to be ignored', () => {
-    const { options, body } = selectHttpOptionsAndBody(
+    const { body } = selectHttpOptionsAndBody(
       createOperation({}, { query }),
       { http: { includeQuery: false } },
     );
@@ -25,7 +25,7 @@ describe('selectHttpOptionsAndBody', () => {
 
   it('includeExtensions allows the extensions to be added', () => {
     const extensions = { yo: 'what up' };
-    const { options, body } = selectHttpOptionsAndBody(
+    const { body } = selectHttpOptionsAndBody(
       createOperation({}, { query, extensions }),
       { http: { includeExtensions: true } },
     );

--- a/src/link/utils/__tests__/fromError.ts
+++ b/src/link/utils/__tests__/fromError.ts
@@ -6,7 +6,7 @@ describe('fromError', () => {
     const error = new Error('I always error');
     const observable = fromError(error);
     return toPromise(observable)
-      .then(expect.fail)
+      .then(fail)
       .catch(actualError => expect(error).toEqual(actualError));
   });
 });

--- a/src/link/utils/__tests__/fromPromise.ts
+++ b/src/link/utils/__tests__/fromPromise.ts
@@ -19,7 +19,7 @@ describe('fromPromise', () => {
   it('return Promise rejection as error call', () => {
     const observable = fromPromise(Promise.reject(error));
     return toPromise(observable)
-      .then(expect.fail)
+      .then(fail)
       .catch(actualError => expect(error).toEqual(actualError));
   });
 });

--- a/src/link/utils/__tests__/toPromise.ts
+++ b/src/link/utils/__tests__/toPromise.ts
@@ -18,7 +18,7 @@ describe('toPromise', () => {
 
   it('return error call as Promise rejection', () => {
     return toPromise(fromError(error))
-      .then(expect.fail)
+      .then(fail)
       .catch(actualError => expect(error).toEqual(actualError));
   });
 

--- a/src/link/utils/__tests__/validateOperation.ts
+++ b/src/link/utils/__tests__/validateOperation.ts
@@ -1,4 +1,5 @@
 import { validateOperation, } from '../validateOperation';
+import gql from "graphql-tag";
 
 describe('validateOperation', () => {
   it('should throw when invalid field in operation', () => {
@@ -8,7 +9,13 @@ describe('validateOperation', () => {
   it('should not throw when valid fields in operation', () => {
     expect(() =>
       validateOperation({
-        query: '1234',
+        query: gql`
+            query SampleQuery {
+                stub {
+                    id
+                }
+            }
+        `,
         context: {},
         variables: {},
       }),

--- a/src/react/context/__tests__/ApolloProvider.test.tsx
+++ b/src/react/context/__tests__/ApolloProvider.test.tsx
@@ -18,43 +18,6 @@ describe('<ApolloProvider /> Component', () => {
     link: new ApolloLink((o, f) => (f ? f(o) : null))
   });
 
-  class Child extends React.Component<any, { store: any; client: any }> {
-    static contextType = getApolloContext();
-
-    componentDidUpdate() {
-      if (this.props.data) this.props.data.refetch();
-    }
-
-    render() {
-      return null;
-    }
-  }
-
-  interface Props {
-    client: ApolloClient<any>;
-  }
-
-  class Container extends React.Component<Props, any> {
-    constructor(props: Props) {
-      super(props);
-      this.state = {};
-    }
-
-    componentDidMount() {
-      this.setState({
-        client: this.props.client
-      });
-    }
-
-    render() {
-      return (
-        <ApolloProvider client={this.state.client || this.props.client}>
-          <Child />
-        </ApolloProvider>
-      );
-    }
-  }
-
   it('should render children components', () => {
     const { getByText } = render(
       <ApolloProvider client={client}>

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -337,7 +337,7 @@ describe('useMutation Hook', () => {
             expect(data!.createTodo.description).toEqual(
               CREATE_TODO_RESULT.createTodo.description
             );
-            expect(errors[0].message).toEqual(
+            expect(errors![0].message).toEqual(
               expect.stringContaining(CREATE_TODO_ERROR)
             );
           }

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -12,6 +12,7 @@ import { InMemoryCache } from '../../../cache/inmemory/inMemoryCache';
 import { ApolloProvider } from '../../context/ApolloProvider';
 import { useQuery } from '../useQuery';
 import { requireReactLazily } from '../../react';
+import { QueryFunctionOptions } from '../..';
 
 const React = requireReactLazily();
 const { useState, useReducer, Fragment } = React;
@@ -205,7 +206,7 @@ describe('useQuery Hook', () => {
 
       const hookResponse = jest.fn().mockReturnValue(null);
 
-      function Component({ id, children }) {
+      function Component({ id, children }: any) {
         const { data, loading, error } = useQuery(CAR_QUERY_BY_ID, {
           variables: { id },
         });
@@ -273,7 +274,7 @@ describe('useQuery Hook', () => {
 
       const hookResponse = jest.fn().mockReturnValue(null);
 
-      function Component({ id, children, skip = false }) {
+      function Component({ id, children, skip = false }: any) {
         const { data, loading, error } = useQuery(CAR_QUERY_BY_ID, {
           variables: { id },
           skip,
@@ -629,12 +630,12 @@ describe('useQuery Hook', () => {
         cache: new InMemoryCache()
       });
 
-      let onError;
+      let onError: QueryFunctionOptions['onError'];
       const onErrorPromise = new Promise(resolve => onError = resolve);
 
       let renderCount = 0;
       const Component = () => {
-        const { loading, error, refetch, data, networkStatus } = useQuery(
+        const { loading, error, refetch, data } = useQuery(
           query,
           {
             onError,
@@ -693,7 +694,7 @@ describe('useQuery Hook', () => {
 
       let renderCount = 0;
       function App() {
-        const [_, forceUpdate] = useReducer(x => x + 1, 0);
+        const [, forceUpdate] = useReducer(x => x + 1, 0);
         const { loading, error } = useQuery(query);
 
         switch (renderCount) {
@@ -753,7 +754,7 @@ describe('useQuery Hook', () => {
 
         let renderCount = 0;
         function App() {
-          const [_, forceUpdate] = useReducer(x => x + 1, 0);
+          const [, forceUpdate] = useReducer(x => x + 1, 0);
           const { loading, error } = useQuery(query, {
             onError: () => {},
             onCompleted: () => {}

--- a/src/utilities/common/__tests__/cloneDeep.ts
+++ b/src/utilities/common/__tests__/cloneDeep.ts
@@ -54,7 +54,7 @@ describe('cloneDeep', () => {
   });
 
   it('should not attempt to follow circular references', () => {
-    const someObject = {
+    const someObject: any = {
       prop1: 'value1',
       anotherObject: null,
     };
@@ -62,9 +62,8 @@ describe('cloneDeep', () => {
       someObject,
     };
     someObject.anotherObject = anotherObject;
-    let chk;
     expect(() => {
-      chk = cloneDeep(someObject);
+      cloneDeep(someObject);
     }).not.toThrow();
   });
 });

--- a/src/utilities/common/__tests__/mergeDeep.ts
+++ b/src/utilities/common/__tests__/mergeDeep.ts
@@ -271,7 +271,7 @@ describe('mergeDeep', function() {
     };
 
     const shallowContextValues: any[] = [];
-    const shallowMerger = new DeepMerger(
+    const shallowMerger = new DeepMerger<typeof contextObject[]>(
       function(target, source, property, context: typeof contextObject) {
         shallowContextValues.push(context);
         // Deliberately not passing context down to nested levels.
@@ -280,7 +280,7 @@ describe('mergeDeep', function() {
     );
 
     const typicalContextValues: any[] = [];
-    const typicalMerger = new DeepMerger<typeof contextObject>(
+    const typicalMerger = new DeepMerger<typeof contextObject[]>(
       function(target, source, property, context) {
         typicalContextValues.push(context);
         // Passing context down this time.

--- a/src/utilities/graphql/__tests__/transform.ts
+++ b/src/utilities/graphql/__tests__/transform.ts
@@ -35,7 +35,7 @@ describe('removeArgumentsFromDocument', () => {
         network
       }
     `;
-    const doc = removeArgumentsFromDocument([{ name: 'variable' }], query);
+    const doc = removeArgumentsFromDocument([{ name: 'variable' }], query)!;
     expect(print(doc)).toBe(print(expected));
   });
 
@@ -57,7 +57,7 @@ describe('removeArgumentsFromDocument', () => {
     const doc = removeArgumentsFromDocument(
       [{ name: 'variable', remove: true }],
       query,
-    );
+    )!;
     expect(print(doc)).toBe(print(expected));
   });
 });
@@ -97,7 +97,7 @@ describe('removeFragmentSpreadFromDocument', () => {
     const doc = removeFragmentSpreadFromDocument(
       [{ name: 'FragmentSpread', remove: true }],
       query,
-    );
+    )!;
     expect(print(doc)).toBe(print(expected));
   });
 });
@@ -117,7 +117,7 @@ describe('removeDirectivesFromDocument', () => {
       }
     `;
 
-    const doc = removeDirectivesFromDocument([{ name: 'client' }], query);
+    const doc = removeDirectivesFromDocument([{ name: 'client' }], query)!;
     expect(print(doc)).toBe(print(expected));
   });
 
@@ -138,7 +138,7 @@ describe('removeDirectivesFromDocument', () => {
     const doc = removeDirectivesFromDocument(
       [{ name: 'client', remove: true }],
       query,
-    );
+    )!;
     expect(print(doc)).toBe(print(expected));
   });
 
@@ -159,7 +159,7 @@ describe('removeDirectivesFromDocument', () => {
     const doc = removeDirectivesFromDocument(
       [{ name: 'client', remove: true }],
       query,
-    );
+    )!;
     expect(print(doc)).toBe(print(expected));
   });
 
@@ -187,7 +187,7 @@ describe('removeDirectivesFromDocument', () => {
     const doc = removeDirectivesFromDocument(
       [{ name: 'client', remove: true }],
       query,
-    );
+    )!;
     expect(print(doc)).toBe(print(expected));
   });
 
@@ -224,7 +224,7 @@ describe('removeDirectivesFromDocument', () => {
     const doc = removeDirectivesFromDocument(
       [{ name: 'client', remove: true }],
       query,
-    );
+    )!;
     expect(print(doc)).toBe(print(expected));
   });
 
@@ -240,7 +240,7 @@ describe('removeDirectivesFromDocument', () => {
         field
       }
     `;
-    const doc = removeDirectivesFromDocument([{ name: 'storage' }], query);
+    const doc = removeDirectivesFromDocument([{ name: 'storage' }], query)!;
     expect(print(doc)).toBe(print(expected));
   });
 
@@ -257,7 +257,7 @@ describe('removeDirectivesFromDocument', () => {
       }
     `;
     const test = ({ name: { value } }: { name: any }) => value === 'storage';
-    const doc = removeDirectivesFromDocument([{ test }], query);
+    const doc = removeDirectivesFromDocument([{ test }], query)!;
     expect(print(doc)).toBe(print(expected));
   });
 
@@ -275,7 +275,7 @@ describe('removeDirectivesFromDocument', () => {
         field
       }
     `;
-    const doc = removeDirectivesFromDocument([{ name: 'storage' }], query);
+    const doc = removeDirectivesFromDocument([{ name: 'storage' }], query)!;
     expect(print(doc)).toBe(print(expected));
   });
 
@@ -294,7 +294,7 @@ describe('removeDirectivesFromDocument', () => {
       }
     `;
     const test = ({ name: { value } }: { name: any }) => value === 'storage';
-    const doc = removeDirectivesFromDocument([{ test }], query);
+    const doc = removeDirectivesFromDocument([{ test }], query)!;
     expect(print(doc)).toBe(print(expected));
   });
 
@@ -312,7 +312,7 @@ describe('removeDirectivesFromDocument', () => {
         other: field
       }
     `;
-    const doc = removeDirectivesFromDocument([{ name: 'storage' }], query);
+    const doc = removeDirectivesFromDocument([{ name: 'storage' }], query)!;
     expect(print(doc)).toBe(print(expected));
   });
 
@@ -338,7 +338,7 @@ describe('removeDirectivesFromDocument', () => {
         test: (directive: any) => directive.name.value === 'client',
       },
     ];
-    const doc = removeDirectivesFromDocument(removed, query);
+    const doc = removeDirectivesFromDocument(removed, query)!;
     expect(print(doc)).toBe(print(expected));
   });
 
@@ -358,7 +358,7 @@ describe('removeDirectivesFromDocument', () => {
     const doc = removeDirectivesFromDocument(
       [{ name: 'storage', remove: true }],
       query,
-    );
+    )!;
     expect(print(doc)).toBe(print(expected));
   });
 
@@ -376,7 +376,7 @@ describe('removeDirectivesFromDocument', () => {
       }
     `;
     const test = ({ name: { value } }: { name: any }) => value === 'storage';
-    const doc = removeDirectivesFromDocument([{ test, remove: true }], query);
+    const doc = removeDirectivesFromDocument([{ test, remove: true }], query)!;
     expect(print(doc)).toBe(print(expected));
   });
 
@@ -421,8 +421,7 @@ describe('removeDirectivesFromDocument', () => {
     const doc = removeDirectivesFromDocument(
       [{ name: 'storage', remove: true }],
       query,
-    );
-
+    )!;
     expect(print(doc)).toBe(print(query));
   });
 
@@ -481,8 +480,7 @@ describe('removeDirectivesFromDocument', () => {
     const doc = removeDirectivesFromDocument(
       [{ name: 'storage', remove: true }],
       query,
-    );
-
+    )!;
     expect(print(doc)).toBe(print(expectedQuery));
   });
 
@@ -784,7 +782,7 @@ describe('query transforms', () => {
         }
       }
     `;
-    const newQueryDoc = removeConnectionDirectiveFromDocument(testQuery);
+    const newQueryDoc = removeConnectionDirectiveFromDocument(testQuery)!;
 
     const expectedQuery = gql`
       query {
@@ -816,7 +814,7 @@ describe('removeClientSetsFromDocument', () => {
         name
       }
     `;
-    const doc = removeClientSetsFromDocument(query);
+    const doc = removeClientSetsFromDocument(query)!;
     expect(print(doc)).toBe(print(expected));
   });
 
@@ -833,7 +831,7 @@ describe('removeClientSetsFromDocument', () => {
         name
       }
     `;
-    const doc = removeClientSetsFromDocument(query);
+    const doc = removeClientSetsFromDocument(query)!;
     expect(print(doc)).toBe(print(expected));
   });
 });

--- a/src/utilities/testing/mocking/mockLink.ts
+++ b/src/utilities/testing/mocking/mockLink.ts
@@ -159,7 +159,7 @@ export class MockLink extends ApolloLink {
   }
 }
 
-interface MockApolloLink extends ApolloLink {
+export interface MockApolloLink extends ApolloLink {
   operation?: Operation;
 }
 


### PR DESCRIPTION
This is a ~~Work In Progress~~ PR to re-enable `strictNullChecks` and typings in general in our tests.

It is a follow-up to https://github.com/apollographql/apollo-client/pull/6080, but this time not for src code, but the test code.

It is not ready for review, but contributions are most welcome since they are still many errors to be tackled.

It already unearthed issues of typings in the public API, in the class `ApolloLink`:

```diff
-  public static from(links: ApolloLink[]): ApolloLink {
+  public static from(links: (ApolloLink | RequestHandler)[]): ApolloLink {
```

And also fix misuses of public API which might give a bad example to people trying to learn from test cases, such as:

```diff
           observable.setOptions({
+            query,
             fetchPolicy: 'standby',
             pollInterval: 0,
           });
```