### PR TITLE
Compare entire result objects in isDifferentFromLastResult.

### DIFF
--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -213,13 +213,7 @@ export class ObservableQuery<
   // Compares newResult to the snapshot we took of this.lastResult when it was
   // first received.
   public isDifferentFromLastResult(newResult: ApolloQueryResult<TData>) {
-    const { lastResultSnapshot: snapshot } = this;
-    return !(
-      snapshot &&
-      newResult &&
-      snapshot.networkStatus === newResult.networkStatus &&
-      equal(snapshot.data, newResult.data)
-    );
+    return !equal(this.lastResultSnapshot, newResult);
   }
 
   // Returns the last result that observer.next was called with. This is not the same as


### PR DESCRIPTION
Fixes #6106, as confirmed using @huchenme's excellent [reproduction](https://codesandbox.io/s/client-3-hook-0r52i), because we are no longer skipping the comparison of properties like `this.lastResultSnapshot.loading` and `newResult.loading`.