### PR TITLE
[3.0] Eviction of fields by specific arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,9 @@
 - `InMemoryCache` now supports tracing garbage collection and eviction. Note that the signature of the `evict` method has been simplified in a potentially backwards-incompatible way. <br/>
   [@benjamn](https://github.com/benjamn) in [#5310](https://github.com/apollographql/apollo-client/pull/5310)
 
+- The `cache.evict` method can optionally take an arguments object as its third parameter (following the entity ID and field name), to delete only those field values with specific arguments. <br/>
+  [@danReynolds](https://github.com/danReynolds) in [#6141](https://github.com/apollographql/apollo-client/pull/6141)
+
 - The contents of the `@apollo/react-hooks` package have been merged into `@apollo/client`, enabling the following all-in-one `import`:
   ```ts
   import { ApolloClient, ApolloProvider, useQuery } from '@apollo/client';

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "watch": "tsc-watch --onSuccess \"npm run postbuild\"",
     "clean": "rimraf -r dist coverage lib",
     "test": "jest --config ./config/jest.config.js",
+    "test:debug": "BABEL_ENV=server node --inspect-brk node_modules/.bin/jest --config ./config/jest.config.js --runInBand",
     "test:ci": "npm run coverage -- --ci --maxWorkers=2 --reporters=default --reporters=jest-junit",
     "test:watch": "jest --config ./config/jest.config.js --watch",
     "bundle": "rollup -c ./config/rollup.config.js",

--- a/src/cache/inmemory/__tests__/entityStore.ts
+++ b/src/cache/inmemory/__tests__/entityStore.ts
@@ -1215,6 +1215,19 @@ describe('EntityStore', () => {
     expect(cache.extract()).toEqual({
       ROOT_QUERY: {
         __typename: "Query",
+        "authorOfBook({\"isbn\":\"2\"})": {
+          __typename: "Author",
+          name: "Isaac Asimov",
+          hobby: "chemistry",
+        },
+      },
+    });
+
+    cache.evict('ROOT_QUERY', 'authorOfBook');;
+
+    expect(cache.extract()).toEqual({
+      ROOT_QUERY: {
+        __typename: "Query",
       },
     });
   });

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -593,15 +593,16 @@ describe("type policies", function () {
                 keyArgs(args, context) {
                   expect(context.typename).toBe("Thread");
                   expect(context.fieldName).toBe("comments");
-                  expect(context.field.name.value).toBe("comments");
-                  expect(context.variables).toEqual({});
+                  expect(context.field!.name.value).toBe("comments");
                   expect(context.policies).toBeInstanceOf(Policies);
 
                   if (typeof args!.limit === "number") {
                     if (typeof args!.offset === "number") {
+                      expect(args).toEqual({ offset: 0, limit: 2 });
                       return ["offset", "limit"];
                     }
                     if (args!.beforeId) {
+                      expect(args).toEqual({ beforeId: "asdf", limit: 2 });
                       return ["beforeId", "limit"];
                     }
                   }

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -179,21 +179,30 @@ export abstract class EntityStore implements NormalizedCache {
   // fieldNameFromStoreName helper function. If called with a fieldName
   // and variables, removes all fields of that entity whose names match fieldName
   // and whose arguments when cached exactly match the variables passed.
-  public delete(dataId: string, fieldName?: string, variables?: Record<string, any>) {
-    const storeFieldName = fieldName && variables ?
-      this.policies.getStoreFieldName(dataId, fieldName, variables) : fieldName;
+  public delete(
+    dataId: string,
+    fieldName?: string,
+    args?: Record<string, any>,
+  ) {
+    const storeFieldName = fieldName && args
+      ? this.policies.getStoreFieldName(dataId, fieldName, args)
+      : fieldName;
     return this.modify(dataId, storeFieldName ? {
       [storeFieldName]: delModifier,
     } : delModifier);
   }
 
-  public evict(dataId: string, fieldName?: string, variables?: Record<string, any>): boolean {
+  public evict(
+    dataId: string,
+    fieldName?: string,
+    args?: Record<string, any>,
+  ): boolean {
     let evicted = false;
     if (hasOwn.call(this.data, dataId)) {
-      evicted = this.delete(dataId, fieldName, variables);
+      evicted = this.delete(dataId, fieldName, args);
     }
     if (this instanceof Layer) {
-      evicted = this.parent.evict(dataId, fieldName, variables) || evicted;
+      evicted = this.parent.evict(dataId, fieldName, args) || evicted;
     }
     // Always invalidate the field to trigger rereading of watched
     // queries, even if no cache data was modified by the eviction,

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -131,7 +131,7 @@ export abstract class EntityStore implements NormalizedCache {
         if (fieldValue === void 0) return;
         const modify: Modifier<StoreValue> = typeof modifiers === "function"
           ? modifiers
-          : modifiers[fieldName];
+          : modifiers[storeFieldName] || modifiers[fieldName];
         if (modify) {
           let newValue = modify === delModifier ? DELETE :
             modify(maybeDeepFreeze(fieldValue), {
@@ -176,20 +176,24 @@ export abstract class EntityStore implements NormalizedCache {
   // If called with only one argument, removes the entire entity
   // identified by dataId. If called with a fieldName as well, removes all
   // fields of that entity whose names match fieldName according to the
-  // fieldNameFromStoreName helper function.
-  public delete(dataId: string, fieldName?: string) {
-    return this.modify(dataId, fieldName ? {
-      [fieldName]: delModifier,
+  // fieldNameFromStoreName helper function. If called with a fieldName
+  // and variables, removes all fields of that entity whose names match fieldName
+  // and whose arguments when cached exactly match the variables passed.
+  public delete(dataId: string, fieldName?: string, variables?: Record<string, any>) {
+    const storeFieldName = fieldName && variables ?
+      this.policies.getStoreFieldName(dataId, fieldName, variables) : fieldName;
+    return this.modify(dataId, storeFieldName ? {
+      [storeFieldName]: delModifier,
     } : delModifier);
   }
 
-  public evict(dataId: string, fieldName?: string): boolean {
+  public evict(dataId: string, fieldName?: string, variables?: Record<string, any>): boolean {
     let evicted = false;
     if (hasOwn.call(this.data, dataId)) {
-      evicted = this.delete(dataId, fieldName);
+      evicted = this.delete(dataId, fieldName, variables);
     }
     if (this instanceof Layer) {
-      evicted = this.parent.evict(dataId, fieldName) || evicted;
+      evicted = this.parent.evict(dataId, fieldName, variables) || evicted;
     }
     // Always invalidate the field to trigger rereading of watched
     // queries, even if no cache data was modified by the eviction,

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -224,8 +224,12 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     return this.policies.identify(object)[0];
   }
 
-  public evict(dataId: string, fieldName?: string, variables?: Record<string, any>): boolean {
-    const evicted = this.optimisticData.evict(dataId, fieldName, variables);
+  public evict(
+    dataId: string,
+    fieldName?: string,
+    args?: Record<string, any>,
+  ): boolean {
+    const evicted = this.optimisticData.evict(dataId, fieldName, args);
     this.broadcastWatches();
     return evicted;
   }

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -224,8 +224,8 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     return this.policies.identify(object)[0];
   }
 
-  public evict(dataId: string, fieldName?: string): boolean {
-    const evicted = this.optimisticData.evict(dataId, fieldName);
+  public evict(dataId: string, fieldName?: string, variables?: Record<string, any>): boolean {
+    const evicted = this.optimisticData.evict(dataId, fieldName, variables);
     this.broadcastWatches();
     return evicted;
   }

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -13,6 +13,7 @@ import {
   getFragmentFromSelection,
 } from '../../utilities/graphql/fragments';
 import {
+  fieldNodeFromName,
   isField,
   getTypenameFromResult,
   storeKeyNameFromField,
@@ -430,9 +431,10 @@ export class Policies {
 
   public getStoreFieldName(
     typename: string | undefined,
-    field: FieldNode,
+    nameOrField: string | FieldNode,
     variables: Record<string, any>,
   ): string {
+    const field = typeof nameOrField === 'string' ? fieldNodeFromName(nameOrField, variables) : nameOrField;
     const fieldName = field.name.value;
     const policy = this.getFieldPolicy(typename, fieldName, false);
     let storeFieldName: string | undefined;

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -13,7 +13,6 @@ import {
   getFragmentFromSelection,
 } from '../../utilities/graphql/fragments';
 import {
-  fieldNodeFromName,
   isField,
   getTypenameFromResult,
   storeKeyNameFromField,
@@ -22,6 +21,7 @@ import {
   argumentsObjectFromField,
   Reference,
   isReference,
+  getStoreKeyName,
 } from '../../utilities/graphql/storeUtils';
 import { canUseWeakMap } from '../../utilities/common/canUse';
 import { IdGetter } from "./types";
@@ -82,8 +82,7 @@ export type KeyArgsFunction = (
   context: {
     typename: string;
     fieldName: string;
-    field: FieldNode;
-    variables: Record<string, any>;
+    field: FieldNode | null;
     policies: Policies;
   },
 ) => KeySpecifier | ReturnType<IdGetter>;
@@ -432,17 +431,27 @@ export class Policies {
   public getStoreFieldName(
     typename: string | undefined,
     nameOrField: string | FieldNode,
-    variables: Record<string, any>,
+    // If nameOrField is a string, argsOrVars should be an object of
+    // arguments. If nameOrField is a FieldNode, argsOrVars should be the
+    // variables to use when computing the arguments of the field.
+    argsOrVars: Record<string, any>,
   ): string {
-    const field = typeof nameOrField === 'string' ? fieldNodeFromName(nameOrField, variables) : nameOrField;
-    const fieldName = field.name.value;
+    let field: FieldNode | null;
+    let fieldName: string;
+    if (typeof nameOrField === "string") {
+      field = null;
+      fieldName = nameOrField;
+    } else {
+      field = nameOrField;
+      fieldName = field.name.value;
+    }
     const policy = this.getFieldPolicy(typename, fieldName, false);
     let storeFieldName: string | undefined;
 
     let keyFn = policy && policy.keyFn;
     if (keyFn && typename) {
-      const args = argumentsObjectFromField(field, variables);
-      const context = { typename, fieldName, field, variables, policies: this };
+      const args = field ? argumentsObjectFromField(field, argsOrVars) : argsOrVars;
+      const context = { typename, fieldName, field, policies: this };
       while (keyFn) {
         const specifierOrString = keyFn(args, context);
         if (Array.isArray(specifierOrString)) {
@@ -457,7 +466,9 @@ export class Policies {
     }
 
     if (storeFieldName === void 0) {
-      storeFieldName = storeKeyNameFromField(field, variables);
+      storeFieldName = field
+        ? storeKeyNameFromField(field, argsOrVars)
+        : getStoreKeyName(fieldName, argsOrVars);
     }
 
     // Make sure custom field names start with the actual field.name.value
@@ -708,11 +719,9 @@ function keyArgsFnFromSpecifier(
   specifier: KeySpecifier,
 ): KeyArgsFunction {
   return (args, context) => {
-    const field = context.field;
-    const fieldName = field.name.value;
-    return args ? `${fieldName}:${
+    return args ? `${context.fieldName}:${
       JSON.stringify(computeKeyObject(args, specifier))
-    }` : fieldName;
+    }` : context.fieldName;
   };
 }
 

--- a/src/utilities/graphql/storeUtils.ts
+++ b/src/utilities/graphql/storeUtils.ts
@@ -291,30 +291,3 @@ export function isInlineFragment(
 }
 
 export type VariableValue = (node: VariableNode) => any;
-
-export function fieldNodeFromName(fieldName: string, variables: Record<string, any>): FieldNode {
-  return {
-    kind: 'Field',
-    name: {
-      kind: "Name",
-      value: fieldName,
-    },
-    arguments: Object.keys(variables).reduce((args, key) => ([
-      ...args,
-      {
-        kind: 'Argument',
-        name: {
-          kind: 'Name',
-          value: key,
-        },
-        value: {
-          kind: 'Variable',
-          name: {
-            kind: 'Name',
-            value: key,
-          }
-        }
-      }
-    ]), [])
-  };
-}

--- a/src/utilities/graphql/storeUtils.ts
+++ b/src/utilities/graphql/storeUtils.ts
@@ -292,3 +292,29 @@ export function isInlineFragment(
 
 export type VariableValue = (node: VariableNode) => any;
 
+export function fieldNodeFromName(fieldName: string, variables: Record<string, any>): FieldNode {
+  return {
+    kind: 'Field',
+    name: {
+      kind: "Name",
+      value: fieldName,
+    },
+    arguments: Object.keys(variables).reduce((args, key) => ([
+      ...args,
+      {
+        kind: 'Argument',
+        name: {
+          kind: 'Name',
+          value: key,
+        },
+        value: {
+          kind: 'Variable',
+          name: {
+            kind: 'Name',
+            value: key,
+          }
+        }
+      }
+    ]), [])
+  };
+}


### PR DESCRIPTION
Implementation of eviction by arguments API discussed here: https://github.com/apollographql/apollo-client/issues/6098.

Evicts entities in the cache with exact matches of field names and arguments.