### PR TITLE
Mark that FieldFunctionOptions.readField can return undefined

### DIFF
--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -142,7 +142,7 @@ export interface FieldFunctionOptions<
   readField<T = StoreValue>(
     nameOrField: string | FieldNode,
     foreignObjOrRef?: StoreObject | Reference,
-  ): SafeReadonly<T>;
+  ): SafeReadonly<T> | undefined;
 
   // A handy place to put field-specific data that you want to survive
   // across multiple read function calls. Useful for field-level caching,


### PR DESCRIPTION
This appears to occur when the field is not in the cache based on experiments.