### PR TITLE
Make dataId parameter of cache.modify optional.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,14 +73,15 @@
 
 - `InMemoryCache` now has a method called `modify` which can be used to update the value of a specific field within a specific entity object:
   ```ts
-  cache.modify(cache.identify(post), {
+  cache.modify({
     comments(comments: Reference[], { readField }) {
       return comments.filter(comment => idToRemove !== readField("id", comment));
     },
-  });
+  }, cache.identify(post));
   ```
   This API gracefully handles cases where multiple field values are associated with a single field name, and also removes the need for updating the cache by reading a query or fragment, modifying the result, and writing the modified result back into the cache. Behind the scenes, the `cache.evict` method is now implemented in terms of `cache.modify`. <br/>
   [@benjamn](https://github.com/benjamn) in [#5909](https://github.com/apollographql/apollo-client/pull/5909)
+  and [#6178](https://github.com/apollographql/apollo-client/pull/6178)
 
 - `InMemoryCache` provides a new API for storing client state that can be updated from anywhere:
   ```ts

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -2994,7 +2994,7 @@ describe('@connection', () => {
     checkLastResult(abResults, a456bOyez);
     const cSee = checkLastResult(cResults, { c: "see" });
 
-    cache.modify("ROOT_QUERY", {
+    cache.modify({
       c(value) {
         expect(value).toBe("see");
         return "saw";

--- a/src/__tests__/local-state/resolvers.ts
+++ b/src/__tests__/local-state/resolvers.ts
@@ -553,12 +553,12 @@ describe('Writing cache data from resolvers', () => {
               },
             });
 
-            cache.modify('Object:uniqueId', {
+            cache.modify({
               field(value) {
                 expect(value).toBe(1);
                 return 2;
               },
-            })
+            }, 'Object:uniqueId');
 
             return { start: true };
           },

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -70,9 +70,9 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
   }
 
   public modify(
-    dataId: string,
     modifiers: Modifier<any> | Modifiers,
-    optimistic = false,
+    dataId?: string,
+    optimistic?: boolean,
   ): boolean {
     return false;
   }

--- a/src/cache/inmemory/__tests__/entityStore.ts
+++ b/src/cache/inmemory/__tests__/entityStore.ts
@@ -1623,7 +1623,7 @@ describe('EntityStore', () => {
       },
     });
 
-    cache.modify(cuckoosCallingId, {
+    cache.modify({
       title(title: string, {
         isReference,
         toReference,
@@ -1656,7 +1656,7 @@ describe('EntityStore', () => {
         // Typography matters!
         return title.split("'").join("’");
       },
-    });
+    }, cuckoosCallingId);
 
     expect(cache.extract()).toEqual({
       ...threeBookSnapshot,

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -151,10 +151,16 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
   }
 
   public modify(
-    dataId: string,
     modifiers: Modifier<any> | Modifiers,
+    dataId = "ROOT_QUERY",
     optimistic = false,
   ): boolean {
+    if (typeof modifiers === "string") {
+      // In beta testing of Apollo Client 3, the dataId parameter used to
+      // come before the modifiers. The type system should complain about
+      // this, but it doesn't have to be fatal if we fix it here.
+      [modifiers, dataId] = [dataId as any, modifiers];
+    }
     const store = optimistic ? this.optimisticData : this.data;
     if (store.modify(dataId, modifiers)) {
       this.broadcastWatches();


### PR DESCRIPTION
Most importantly, this change allows callers of `cache.modify` (#5909) to avoid passing `"ROOT_QUERY"` as the ID for modifications of root Query data.

Making the `dataId` parameter optional and moving it after the `modifiers` parameter felt much more idiomatic and understandable than than trying to support two conflicting type signatures for the `modify` method, even though that extra effort could have avoided the breaking change.

Please remember that the `cache.modify` API was added relatively recently in `@apollo/client@3.0.0-beta.34` by PR #5909, so it has never been out of beta testing, so breaking changes like this are still fair game.