### PR TITLE
Supply TData generic removed in GraphQL v15

### DIFF
--- a/src/core/LocalState.ts
+++ b/src/core/LocalState.ts
@@ -1,5 +1,4 @@
 import {
-  ExecutionResult,
   DocumentNode,
   OperationDefinitionNode,
   SelectionSetNode,
@@ -33,6 +32,7 @@ import {
 } from '../utilities/graphql/storeUtils';
 import { ApolloClient } from '../ApolloClient';
 import { Resolvers, OperationVariables } from './types';
+import { FetchResult } from '../link/core/types';
 
 export type Resolver = (
   rootValue?: any,
@@ -128,11 +128,11 @@ export class LocalState<TCacheShape> {
     onlyRunForcedResolvers = false,
   }: {
     document: DocumentNode | null;
-    remoteResult: ExecutionResult<TData>;
+    remoteResult: FetchResult<TData>;
     context?: Record<string, any>;
     variables?: Record<string, any>;
     onlyRunForcedResolvers?: boolean;
-  }): Promise<ExecutionResult<TData>> {
+  }): Promise<FetchResult<TData>> {
     if (document) {
       return this.resolveDocument(
         document,

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -1,4 +1,4 @@
-import { DocumentNode, ExecutionResult } from 'graphql';
+import { DocumentNode } from 'graphql';
 
 import { ApolloCache } from '../cache/core/cache';
 import { FetchResult } from '../link/core/types';
@@ -193,7 +193,7 @@ export interface MutationBaseOptions<
    * once these queries return.
    */
   refetchQueries?:
-    | ((result: ExecutionResult<T>) => RefetchQueryDescription)
+    | ((result: FetchResult<T>) => RefetchQueryDescription)
     | RefetchQueryDescription;
 
   /**

--- a/src/link/core/types.ts
+++ b/src/link/core/types.ts
@@ -25,7 +25,8 @@ export type FetchResult<
   TData = { [key: string]: any },
   C = Record<string, any>,
   E = Record<string, any>
-> = ExecutionResult<TData> & {
+> = ExecutionResult & {
+  data?: TData | null;
   extensions?: E;
   context?: C;
 };

--- a/src/link/core/types.ts
+++ b/src/link/core/types.ts
@@ -1,6 +1,6 @@
 import { DocumentNode } from 'graphql/language/ast';
 import { ExecutionResult } from 'graphql/execution/execute';
-export { ExecutionResult, DocumentNode };
+export { DocumentNode };
 
 import { Observable } from '../../utilities/observables/Observable';
 
@@ -21,11 +21,11 @@ export interface Operation {
   getContext: () => Record<string, any>;
 }
 
-export type FetchResult<
+export interface FetchResult<
   TData = { [key: string]: any },
   C = Record<string, any>,
   E = Record<string, any>
-> = ExecutionResult & {
+> extends ExecutionResult {
   data?: TData | null;
   extensions?: E;
   context?: C;


### PR DESCRIPTION
Sets typings for `data` to pre graphql@15 state and consistent with https://github.com/graphql/graphql-js/blob/master/src/execution/execute.d.ts#L48
Related to #6111