### PR TITLE
docs: use NetworkStatus enum rather than numbers

### DIFF
--- a/docs/source/data/queries.mdx
+++ b/docs/source/data/queries.mdx
@@ -329,6 +329,8 @@ of this information, we need to set the `notifyOnNetworkStatusChange` option to 
 <div data-language="hooks-js">
 
 ```jsx:title=index.js
+import { NetworkStatus } from '@apollo/client';
+
 function DogPhoto({ breed }) {
   const { loading, error, data, refetch, networkStatus } = useQuery(
     GET_DOG_PHOTO,
@@ -339,7 +341,7 @@ function DogPhoto({ breed }) {
     },
   );
 
-  if (networkStatus === 4) return 'Refetching!';
+  if (networkStatus === NetworkStatus.refetch) return 'Refetching!';
   if (loading) return null;
   if (error) return `Error! ${error}`;
 
@@ -356,6 +358,8 @@ function DogPhoto({ breed }) {
 <div data-language="js">
 
 ```jsx:title=index.js
+import { NetworkStatus } from '@apollo/client';
+
 const DogPhoto = ({ breed }) => (
   <Query
     query={GET_DOG_PHOTO}
@@ -364,7 +368,7 @@ const DogPhoto = ({ breed }) => (
     notifyOnNetworkStatusChange
   >
     {({ loading, error, data, refetch, networkStatus }) => {
-      if (networkStatus === 4) return 'Refetching!';
+      if (networkStatus === NetworkStatus.refetch) return 'Refetching!';
       if (loading) return null;
       if (error) return `Error! ${error}`;
 
@@ -385,7 +389,7 @@ const DogPhoto = ({ breed }) => (
 </div>
 </MultiCodeBlock>
 
-The `networkStatus` property is an enum with number values from `1` to `8` that represent different loading states. `4` corresponds to a refetch, but there are also values for polling and pagination. For a full list of all the possible loading states, check out the [source](https://github.com/apollographql/apollo-client/blob/master/src/core/networkStatus.ts).
+The `networkStatus` property is a `NetworkStatus` enum that represents different loading states. Refetch is represented by `NetworkStatus.refetch`, and there are also values for polling and pagination. For a full list of all the possible loading states, check out the [source](https://github.com/apollographql/apollo-client/blob/master/src/core/networkStatus.ts).
 
 ## Inspecting error states
 


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

This updates the docs talking about `networkStatus` to import and use the `NetworkStatus` enum rather than the number `4` for readability.

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests

