### PR TITLE
Avoid creating throwaway ObservableQuery for single queries.

### DIFF
--- a/src/ApolloClient.ts
+++ b/src/ApolloClient.ts
@@ -325,7 +325,7 @@ export class ApolloClient<TCacheShape> implements DataProxy {
       options = { ...options, fetchPolicy: 'cache-first' };
     }
 
-    return this.queryManager.query<T>(options);
+    return this.queryManager.query<T, TVariables>(options);
   }
 
   /**

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -61,7 +61,6 @@ export class ObservableQuery<
   public readonly options: WatchQueryOptions<TVariables>;
   public readonly queryId: string;
   public readonly queryName?: string;
-  public readonly watching: boolean;
 
   // Computed shorthand for this.options.variables, preserved for
   // backwards compatibility.
@@ -81,11 +80,9 @@ export class ObservableQuery<
   constructor({
     queryManager,
     options,
-    shouldSubscribe = true,
   }: {
     queryManager: QueryManager<any>;
     options: WatchQueryOptions<TVariables>;
-    shouldSubscribe?: boolean;
   }) {
     super((observer: Observer<ApolloQueryResult<TData>>) =>
       this.onSubscribe(observer),
@@ -97,7 +94,6 @@ export class ObservableQuery<
     // query information
     this.options = options;
     this.queryId = queryManager.generateQueryId();
-    this.watching = shouldSubscribe;
 
     const opDef = getOperationDefinition(options.query);
     this.queryName = opDef && opDef.name && opDef.name.value;

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -169,8 +169,7 @@ export class QueryManager<TStore> {
 
       if (updateQueriesByName) {
         this.queries.forEach(({ observableQuery }, queryId) => {
-          if (observableQuery &&
-              observableQuery.watching) {
+          if (observableQuery) {
             const { queryName } = observableQuery;
             if (
               queryName &&
@@ -303,7 +302,6 @@ export class QueryManager<TStore> {
               if (typeof refetchQuery === 'string') {
                 self.queries.forEach(({ observableQuery }) => {
                   if (observableQuery &&
-                      observableQuery.watching &&
                       observableQuery.queryName === refetchQuery) {
                     refetchQueryPromises.push(observableQuery.refetch());
                   }
@@ -434,16 +432,8 @@ export class QueryManager<TStore> {
     };
   }
 
-  // The shouldSubscribe option is a temporary fix that tells us whether watchQuery was called
-  // directly (i.e. through ApolloClient) or through the query method within QueryManager.
-  // Currently, the query method uses watchQuery in order to handle non-network errors correctly
-  // but we don't want to keep track observables issued for the query method since those aren't
-  // supposed to be refetched in the event of a store reset. Once we unify error handling for
-  // network errors and non-network errors, the shouldSubscribe option will go away.
-
   public watchQuery<T, TVariables = OperationVariables>(
     options: WatchQueryOptions<TVariables>,
-    shouldSubscribe = true,
   ): ObservableQuery<T, TVariables> {
     // assign variable default values if supplied
     options = {
@@ -461,7 +451,6 @@ export class QueryManager<TStore> {
     const observable = new ObservableQuery<T, TVariables>({
       queryManager: this,
       options,
-      shouldSubscribe: shouldSubscribe,
     });
 
     this.getQuery(observable.queryId).init({
@@ -544,8 +533,7 @@ export class QueryManager<TStore> {
     ));
 
     this.queries.forEach(queryInfo => {
-      if (queryInfo.observableQuery &&
-          queryInfo.observableQuery.watching) {
+      if (queryInfo.observableQuery) {
         // Set loading to true so listeners don't trigger unless they want
         // results with partial data.
         queryInfo.networkStatus = NetworkStatus.loading;
@@ -578,8 +566,7 @@ export class QueryManager<TStore> {
     const observableQueryPromises: Promise<ApolloQueryResult<any>>[] = [];
 
     this.queries.forEach(({ observableQuery }, queryId) => {
-      if (observableQuery &&
-          observableQuery.watching) {
+      if (observableQuery) {
         const fetchPolicy = observableQuery.options.fetchPolicy;
 
         observableQuery.resetLastResults();

--- a/src/core/__tests__/QueryManager/index.ts
+++ b/src/core/__tests__/QueryManager/index.ts
@@ -3784,7 +3784,7 @@ describe('QueryManager', () => {
             // refetch observed queries as soon as we hear about the query
             queryManager.reFetchObservableQueries();
             observer.next({ data });
-            return;
+            observer.complete();
           }),
       );
 


### PR DESCRIPTION
Once upon a time, reusing the `watchQuery` code path for both `QueryManager#query` and `QueryManager#watchQuery` seemed to make things simpler, even though it involved unnecessary work for the `query` case. In reality, it made things more complicated, because we needed to distinguish `ObservableQuery`s we were actually observing (and might refetch) from those that we created for a single query and then threw away. If we call `fetchQuery` instead of `watchQuery` in the `query` method, we don't end up with any special non-observing/refetching `ObservableQuery` objects. Bonus: -104 bytes minified+gzip bundle size!