### PR TITLE
fix: queryDeduplication from context

### DIFF
--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -1356,20 +1356,23 @@ describe('client', () => {
       },
     };
 
-    // we have two responses for identical queries, but only the first should be requested.
-    // the second one should never make it through to the network interface.
-    const link = mockSingleLink({
-      request: { query: queryDoc },
-      result: { data },
-      delay: 10,
-    }, {
-      request: { query: queryDoc },
-      result: { data: data2 },
-    }).setOnError(reject);
+    // we have two responses for identical queries, and both should be requested.
+    // the second one should make it through to the network interface.
+    const link = mockSingleLink(
+      {
+        request: { query: queryDoc },
+        result: { data },
+        delay: 10,
+      },
+      {
+        request: { query: queryDoc },
+        result: { data: data2 },
+      },
+    ).setOnError(reject);
+
     const client = new ApolloClient({
       link,
       cache: new InMemoryCache({ addTypename: false }),
-
       queryDeduplication: false,
     });
 
@@ -1424,6 +1427,103 @@ describe('client', () => {
     return Promise.all([q1, q2]).then(([result1, result2]) => {
       expect(result1.data).toEqual(result2.data);
     }).then(resolve, reject);
+  });
+
+  it('deduplicates queries if query context.queryDeduplication is set to true', () => {
+    const queryDoc = gql`
+      query {
+        author {
+          name
+        }
+      }
+    `;
+    const data = {
+      author: {
+        name: 'Jonas',
+      },
+    };
+    const data2 = {
+      author: {
+        name: 'Dhaivat',
+      },
+    };
+
+    // we have two responses for identical queries, but only the first should be requested.
+    // the second one should never make it through to the network interface.
+    const link = mockSingleLink(
+      {
+        request: { query: queryDoc },
+        result: { data },
+        delay: 10,
+      },
+      {
+        request: { query: queryDoc },
+        result: { data: data2 },
+      },
+    );
+    const client = new ApolloClient({
+      link,
+      cache: new InMemoryCache({ addTypename: false }),
+      queryDeduplication: false,
+    });
+
+    // Both queries need to be deduplicated, otherwise only one gets tracked
+    const q1 = client.query({ query: queryDoc, context: { queryDeduplication: true } });
+    const q2 = client.query({ query: queryDoc, context: { queryDeduplication: true } });
+
+    // if deduplication happened, result2.data will equal data.
+    return Promise.all([q1, q2]).then(([result1, result2]) => {
+      expect(stripSymbols(result1.data)).toEqual(data);
+      expect(stripSymbols(result2.data)).toEqual(data);
+    });
+  });
+
+  it('does not deduplicate queries if query context.queryDeduplication is set to false', () => {
+    const queryDoc = gql`
+      query {
+        author {
+          name
+        }
+      }
+    `;
+    const data = {
+      author: {
+        name: 'Jonas',
+      },
+    };
+    const data2 = {
+      author: {
+        name: 'Dhaivat',
+      },
+    };
+
+    // we have two responses for identical queries, and both should be requested.
+    // the second one should make it through to the network interface.
+    const link = mockSingleLink(
+      {
+        request: { query: queryDoc },
+        result: { data },
+        delay: 10,
+      },
+      {
+        request: { query: queryDoc },
+        result: { data: data2 },
+      },
+    );
+    const client = new ApolloClient({
+      link,
+      cache: new InMemoryCache({ addTypename: false }),
+    });
+
+    // The first query gets tracked in the dedup logic, the second one ignores it and runs anyways
+    const q1 = client.query({ query: queryDoc });
+    const q2 = client.query({ query: queryDoc, context: { queryDeduplication: false } });
+
+    // if deduplication happened, result2.data will equal data.
+    return Promise.all([q1, q2]).then(([result1, result2]) => {
+      expect(stripSymbols(result1.data)).toEqual(data);
+      expect(stripSymbols(result2.data)).toEqual(data2);
+    });
   });
 
   itAsync('unsubscribes from deduplicated observables only once', (resolve, reject) => {

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -687,8 +687,8 @@ export class QueryManager<TStore> {
 
     // Set default deduplication value if arg was not passed
     if(typeof deduplication === 'undefined') {
-      if(typeof context === 'object' && 'forceFetch' in context) {
-        deduplication = !context.forceFetch
+      if(typeof context === 'object' && 'queryDeduplication' in context) {
+        deduplication = context.queryDeduplication
       } else {
         deduplication = this.queryDeduplication
       }

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -681,9 +681,18 @@ export class QueryManager<TStore> {
     query: DocumentNode,
     context: any,
     variables?: OperationVariables,
-    deduplication: boolean = this.queryDeduplication,
+    deduplication?: boolean,
   ): Observable<FetchResult<T>> {
     let observable: Observable<FetchResult<T>>;
+
+    // Set default deduplication value if arg was not passed
+    if(typeof deduplication === 'undefined') {
+      if(typeof context === 'object' && 'forceFetch' in context) {
+        deduplication = !context.forceFetch
+      } else {
+        deduplication = this.queryDeduplication
+      }
+    }
 
     const { serverQuery } = this.transform(query);
     if (serverQuery) {

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -681,18 +681,12 @@ export class QueryManager<TStore> {
     query: DocumentNode,
     context: any,
     variables?: OperationVariables,
-    deduplication?: boolean,
+    deduplication: boolean =
+      // Prefer context.queryDeduplication if specified.
+      context?.queryDeduplication ??
+      this.queryDeduplication,
   ): Observable<FetchResult<T>> {
     let observable: Observable<FetchResult<T>>;
-
-    // Set default deduplication value if arg was not passed
-    if(typeof deduplication === 'undefined') {
-      if(typeof context === 'object' && 'queryDeduplication' in context) {
-        deduplication = context.queryDeduplication
-      } else {
-        deduplication = this.queryDeduplication
-      }
-    }
 
     const { serverQuery } = this.transform(query);
     if (serverQuery) {

--- a/src/core/__tests__/QueryManager/index.ts
+++ b/src/core/__tests__/QueryManager/index.ts
@@ -5039,4 +5039,46 @@ describe('QueryManager', () => {
       });
     });
   });
+
+  describe('queryDeduplication', () => {
+    it('should be true when context is true, default is false and agrument not provided', () => {
+      const query = gql`
+        query {
+          author {
+            firstName
+          }
+        }
+      `;
+      const queryManager = createQueryManager({
+        link: mockSingleLink({
+          request: { query },
+          result: { author: { firstName: 'John' } },
+        }),
+      });
+
+      queryManager.getObservableFromLink(query, { queryDeduplication: true })
+
+      expect(queryManager.inFlightLinkObservables.size).toBe(1)
+    });
+    it('should be false when context is false, default is true and agrument not provided', () => {
+      const query = gql`
+        query {
+          author {
+            firstName
+          }
+        }
+      `;
+      const queryManager = createQueryManager({
+        link: mockSingleLink({
+          request: { query },
+          result: { author: { firstName: 'John' } },
+        }),
+      });
+      queryManager.queryDeduplication = true
+
+      queryManager.getObservableFromLink(query, { queryDeduplication: false })
+
+      expect(queryManager.inFlightLinkObservables.size).toBe(0)
+    });
+  })
 });

--- a/src/core/__tests__/QueryManager/index.ts
+++ b/src/core/__tests__/QueryManager/index.ts
@@ -62,15 +62,18 @@ describe('QueryManager', () => {
     link,
     config = {},
     clientAwareness = {},
+    queryDeduplication = false,
   }: {
     link: ApolloLink;
     config?: Partial<InMemoryCacheConfig>;
     clientAwareness?: { [key: string]: string };
+    queryDeduplication?: boolean;
   }) => {
     return new QueryManager({
       link,
       cache: new InMemoryCache({ addTypename: false, ...config }),
       clientAwareness,
+      queryDeduplication,
     });
   };
 
@@ -5041,7 +5044,7 @@ describe('QueryManager', () => {
   });
 
   describe('queryDeduplication', () => {
-    it('should be true when context is true, default is false and agrument not provided', () => {
+    it('should be true when context is true, default is false and argument not provided', () => {
       const query = gql`
         query {
           author {
@@ -5056,11 +5059,11 @@ describe('QueryManager', () => {
         }),
       });
 
-      queryManager.getObservableFromLink(query, { queryDeduplication: true })
+      queryManager.query({ query, context: { queryDeduplication: true } })
 
-      expect(queryManager.inFlightLinkObservables.size).toBe(1)
+      expect(queryManager['inFlightLinkObservables'].size).toBe(1)
     });
-    it('should be false when context is false, default is true and agrument not provided', () => {
+    it('should allow overriding global queryDeduplication: true to false', () => {
       const query = gql`
         query {
           author {
@@ -5073,12 +5076,12 @@ describe('QueryManager', () => {
           request: { query },
           result: { author: { firstName: 'John' } },
         }),
+        queryDeduplication: true,
       });
-      queryManager.queryDeduplication = true
 
-      queryManager.getObservableFromLink(query, { queryDeduplication: false })
+      queryManager.query({ query, context: { queryDeduplication: false } })
 
-      expect(queryManager.inFlightLinkObservables.size).toBe(0)
+      expect(queryManager['inFlightLinkObservables'].size).toBe(0)
     });
   })
 });


### PR DESCRIPTION
**Overview**
As mentioned in this article, https://www.apollographql.com/docs/react/networking/network-layer/#query-deduplication, if we want to override our default queryManager's queryDeduplication property, we should pass to request's context { queryDeduplication: boolean }.

**The problem**
It seems like getObservableFromLink did not handle the property from the context and just passed { forceFetch: [arg queryDeduplication / default queryDeduplication] }

**The solution**
Make getObservableFromLink's deduplication smarter
```
    if(typeof deduplication === 'undefined') { // else, is passed as an argument
      if(typeof context === 'object' && 'queryDeduplication' in context) {
        deduplication = context.queryDeduplication
      } else {
        deduplication = this.queryDeduplication
      }
    }
```
**Issues**
https://github.com/apollographql/apollo-link/issues/517
https://github.com/apollographql/apollo-client/issues/4150
https://github.com/apollographql/apollo-feature-requests/issues/40

**Edit**
It seems like tests are failing because of the use of private class properties.
Those properties were changes and that's why they need to be tested.