### PR TITLE
Describe what `false` does for keyFields

### DIFF
--- a/docs/source/caching/cache-configuration.md
+++ b/docs/source/caching/cache-configuration.md
@@ -149,7 +149,7 @@ A `TypePolicy` object can include the following fields:
 type TypePolicy = {
   // Allows defining the primary key fields for this type, either using an
   // array of field names, a function that returns an arbitrary string, or
-  // false to disable caching for the field.
+  // false to disable caching for the type.
   keyFields?: KeySpecifier | KeyFieldsFunction | false;
 
   // If your schema uses a custom __typename for any of the root Query,

--- a/docs/source/caching/cache-configuration.md
+++ b/docs/source/caching/cache-configuration.md
@@ -149,7 +149,7 @@ A `TypePolicy` object can include the following fields:
 type TypePolicy = {
   // Allows defining the primary key fields for this type, either using an
   // array of field names, a function that returns an arbitrary string, or
-  // false to disable caching for the type.
+  // false to disable normalization for objects of this type.
   keyFields?: KeySpecifier | KeyFieldsFunction | false;
 
   // If your schema uses a custom __typename for any of the root Query,

--- a/docs/source/caching/cache-configuration.md
+++ b/docs/source/caching/cache-configuration.md
@@ -148,7 +148,8 @@ A `TypePolicy` object can include the following fields:
 ```ts
 type TypePolicy = {
   // Allows defining the primary key fields for this type, either using an
-  // array of field names or a function that returns an arbitrary string.
+  // array of field names, a function that returns an arbitrary string, or
+  // false to disable caching for the field.
   keyFields?: KeySpecifier | KeyFieldsFunction | false;
 
   // If your schema uses a custom __typename for any of the root Query,


### PR DESCRIPTION
The docs indicate you can set `keyFields: false`, but the description of that field doesn't tell you what setting `false` actually does. I'm making the assumption here that this change correctly describes what `false` does.

Can a maintainer confirm this is accurate before merging? I didn't actually confirm my change is accurate, but it's what I assume happens based on the context.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->
