### PR TITLE
Optimization: skip writing still-fresh result objects back into the EntityStore.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -808,9 +808,9 @@
       "integrity": "sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg=="
     },
     "@wry/context": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.5.0.tgz",
-      "integrity": "sha512-yW5XFrWbRvv2/f86+g0YAfko7671SQg7Epn8lYjux4MZmIvtPvK2ts+vG1QAPu2w6GuBioEJknRa7K2LFj2kQw==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.5.2.tgz",
+      "integrity": "sha512-B/JLuRZ/vbEKHRUiGj6xiMojST1kHhu4WcreLfNN7q9DqQFrb97cWgf/kiYsPSUCAMVN0HzfFc8XjJdzgZzfjw==",
       "requires": {
         "tslib": "^1.9.3"
       }
@@ -5210,11 +5210,11 @@
       }
     },
     "optimism": {
-      "version": "0.11.5",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.11.5.tgz",
-      "integrity": "sha512-twCHmBb64DYzEZ8A3O+TLCuF/RmZPBhXPQYv4agoiALRLlW9SidMzd7lwUP9mL0jOZhzhnBmb8ajqA00ECo/7g==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.12.1.tgz",
+      "integrity": "sha512-t8I7HM1dw0SECitBYAqFOVHoBAHEQBTeKjIL9y9ImHzAVkdyPK4ifTgM4VJRDtTUY4r/u5Eqxs4XcGPHaoPkeQ==",
       "requires": {
-        "@wry/context": "^0.5.0"
+        "@wry/context": "^0.5.2"
       }
     },
     "optionator": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@wry/equality": "^0.1.9",
     "fast-json-stable-stringify": "^2.0.0",
     "graphql-tag": "^2.10.2",
-    "optimism": "^0.11.5",
+    "optimism": "^0.12.1",
     "symbol-observable": "^1.2.0",
     "ts-invariant": "^0.4.4",
     "tslib": "^1.10.0",

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -81,11 +81,10 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
 
     this.storeWriter = new StoreWriter({
       policies: this.policies,
-    });
-
-    this.storeReader = new StoreReader({
-      addTypename: this.addTypename,
-      policies: this.policies,
+      reader: this.storeReader = new StoreReader({
+        addTypename: this.addTypename,
+        policies: this.policies,
+      }),
     });
 
     const cache = this;

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -640,6 +640,8 @@ export class Policies {
 
 export interface ReadMergeContext {
   variables: Record<string, any>;
+  // A JSON.stringify-serialized version of context.variables.
+  varString: string;
   toReference: ToReferenceFunction;
   getFieldValue: FieldValueGetter;
 }

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -161,6 +161,23 @@ export class StoreReader {
     };
   }
 
+  public isFresh(
+    result: Record<string, any>,
+    store: NormalizedCache,
+    parent: StoreObject | Reference,
+    selectionSet: SelectionSetNode,
+    varString: string,
+  ): boolean {
+    if (supportsResultCaching(store)) {
+      const latest = this.executeSelectionSet.peek(
+        store, selectionSet, parent, varString);
+      if (latest && result === latest.result) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   // Cached version of execSelectionSetImpl.
   private executeSelectionSet: OptimisticWrapperFunction<
     [ExecSelectionSetOptions], // Actual arguments tuple type.

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -47,8 +47,6 @@ interface ExecContext extends ReadMergeContext {
   policies: Policies;
   fragmentMap: FragmentMap;
   variables: VariableMap;
-  // A JSON.stringify-serialized version of context.variables.
-  varString: string;
   path: (string | number)[];
 };
 

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -166,7 +166,8 @@ export class StoreReader {
     selectionSet: SelectionSetNode,
     varString: string,
   ): boolean {
-    if (supportsResultCaching(store)) {
+    if (supportsResultCaching(store) &&
+        this.knownResults.get(result) === selectionSet) {
       const latest = this.executeSelectionSet.peek(
         store, selectionSet, parent, varString);
       if (latest && result === latest.result) {
@@ -347,8 +348,14 @@ export class StoreReader {
       Object.freeze(finalResult.result);
     }
 
+    // Store this result with its selection set so that we can quickly
+    // recognize it again in the StoreReader#isFresh method.
+    this.knownResults.set(finalResult.result, selectionSet);
+
     return finalResult;
   }
+
+  private knownResults = new WeakMap<Record<string, any>, SelectionSetNode>();
 
   // Cached version of execSubSelectedArrayImpl.
   private executeSubSelectedArray = wrap((options: ExecSubSelectedArrayOptions) => {

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -30,6 +30,7 @@ import { Policies, ReadMergeContext } from './policies';
 import { EntityStore } from './entityStore';
 import { NormalizedCache } from './types';
 import { makeProcessedFieldsMerger, FieldValueToBeMerged } from './helpers';
+import { StoreReader } from './readFromStore';
 
 export interface WriteContext extends ReadMergeContext {
   readonly store: NormalizedCache;
@@ -53,15 +54,12 @@ interface ProcessSelectionSetOptions {
 }
 
 export interface StoreWriterConfig {
+  reader?: StoreReader;
   policies: Policies;
 };
 
 export class StoreWriter {
-  private policies: Policies;
-
-  constructor(config: StoreWriterConfig) {
-    this.policies = config.policies;
-  }
+  constructor(private config: StoreWriterConfig) {}
 
   /**
    * Writes the result of a query to the store.
@@ -80,7 +78,7 @@ export class StoreWriter {
     result,
     dataId = 'ROOT_QUERY',
     store = new EntityStore.Root({
-      policies: this.policies,
+      policies: this.config.policies,
     }),
     variables,
   }: {
@@ -109,7 +107,7 @@ export class StoreWriter {
       // If dataId is a well-known root ID such as ROOT_QUERY, we can
       // infer its __typename immediately here. Otherwise, the __typename
       // will be determined in processSelectionSet, as usual.
-      typename: this.policies.rootTypenamesById[dataId],
+      typename: this.config.policies.rootTypenamesById[dataId],
       context: {
         store,
         written: Object.create(null),
@@ -141,7 +139,7 @@ export class StoreWriter {
       shouldApplyMerges: false,
     },
   }: ProcessSelectionSetOptions): StoreObject | Reference {
-    const { policies } = this;
+    const { policies, reader } = this.config;
 
     // This mergedFields variable will be repeatedly updated using context.merge
     // to accumulate all fields that need to be written into the store.
@@ -169,8 +167,20 @@ export class StoreWriter {
       // size of this array is likely to be very small, meaning indexOf is
       // likely to be faster than Set.prototype.has.
       const sets = context.written[dataId] || (context.written[dataId] = []);
-      if (sets.indexOf(selectionSet) >= 0) return makeReference(dataId);
+      const ref = makeReference(dataId);
+      if (sets.indexOf(selectionSet) >= 0) return ref;
       sets.push(selectionSet);
+
+      if (reader && reader.isFresh(
+        result,
+        context.store,
+        ref,
+        selectionSet,
+        // TODO Precompute this.
+        JSON.stringify(context.variables),
+      )) {
+        return ref;
+      }
     }
 
     // If typename was not passed in, infer it. Note that typename is

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -97,6 +97,11 @@ export class StoreWriter {
 
     const merger = makeProcessedFieldsMerger();
 
+    variables = {
+      ...getDefaultValues(operationDefinition),
+      ...variables,
+    };
+
     this.processSelectionSet({
       result: result || Object.create(null),
       // Since we already know the dataId here, pass it to
@@ -114,10 +119,8 @@ export class StoreWriter {
         merge<T>(existing: T, incoming: T) {
           return merger.merge(existing, incoming) as T;
         },
-        variables: {
-          ...getDefaultValues(operationDefinition),
-          ...variables,
-        },
+        variables,
+        varString: JSON.stringify(variables),
         fragmentMap: createFragmentMap(getFragmentDefinitions(query)),
         toReference: store.toReference,
         getFieldValue: store.getFieldValue,
@@ -176,8 +179,7 @@ export class StoreWriter {
         context.store,
         ref,
         selectionSet,
-        // TODO Precompute this.
-        JSON.stringify(context.variables),
+        context.varString,
       )) {
         return ref;
       }

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -174,6 +174,11 @@ export class StoreWriter {
       if (sets.indexOf(selectionSet) >= 0) return ref;
       sets.push(selectionSet);
 
+      // If we're about to write a result object into the store, but we
+      // happen to know that the exact same (===) result object would be
+      // returned if we were to reread the result with the same inputs,
+      // then we can skip the rest of the processSelectionSet work for
+      // this object, and immediately return a Reference to it.
       if (reader && reader.isFresh(
         result,
         context.store,

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -277,8 +277,7 @@ export class StoreWriter {
     }
 
     if (Array.isArray(value)) {
-      return value.map(
-        (item, i) => this.processFieldValue(item, field, context, out));
+      return value.map(item => this.processFieldValue(item, field, context, out));
     }
 
     return this.processSelectionSet({


### PR DESCRIPTION
If we're about to write a result object into the store, but we happen to know that the exact same (`===`) result object would be returned if we were to reread the result with the same inputs right now, then we can skip the rest of the `processSelectionSet` work for this object, and immediately return a `Reference` to it.

Note that this trick only works because result objects are immutable (frozen in development), which allows us to assume the structure of a `===` result object has not changed since it was originally returned.

The `executeSelectionSet.peek` method is also vital here, since we need a way to check the latest cached result without recomputing the result if it's missing or dirty. This PR depends on these two recent `optimism` PRs: https://github.com/benjamn/optimism/pull/65, https://github.com/benjamn/optimism/pull/66.

This optimization promises to make the `readQuery`-transform-`writeQuery` pattern much cheaper when the written data contain lots of unmodified result objects that we recently read from the cache, such as when you append a single `Todo` object to a long list of existing `Todo` objects.