### PR TITLE
[Docs] pascal case fragments in docs

### DIFF
--- a/docs/source/features/caching.md
+++ b/docs/source/features/caching.md
@@ -70,7 +70,7 @@ This method allows you great flexibility around the data in your cache. Whereas 
 const todo = client.readFragment({
   id: ..., // `id` is any id that could be returned by `dataIdFromObject`.
   fragment: gql`
-    fragment myTodo on Todo {
+    fragment MyTodo on Todo {
       id
       text
       completed
@@ -92,9 +92,9 @@ const client = new ApolloClient({
 
 ```js
 const todo = client.readFragment({
-  id: '5',
+  id: "5",
   fragment: gql`
-    fragment myTodo on Todo {
+    fragment MyTodo on Todo {
       id
       text
       completed
@@ -115,15 +115,15 @@ The beauty of `readFragment` is that the todo could have come from anywhere! The
 
 ## `writeQuery` and `writeFragment`
 
-Not only can you read arbitrary data from the Apollo Client cache, but you can also write any data that you would like to the cache. The methods you use to do this are `writeQuery` and `writeFragment`. They will allow you to change data in your local cache, but it is important to remember that *they will not change any data on your server*. If you reload your environment then changes made with `writeQuery` and `writeFragment` will disappear.
+Not only can you read arbitrary data from the Apollo Client cache, but you can also write any data that you would like to the cache. The methods you use to do this are `writeQuery` and `writeFragment`. They will allow you to change data in your local cache, but it is important to remember that _they will not change any data on your server_. If you reload your environment then changes made with `writeQuery` and `writeFragment` will disappear.
 
 These methods have the same signature as their `readQuery` and `readFragment` counterparts except they also require an additional `data` variable. So for example, if you wanted to update the `completed` flag locally for your todo with id `'5'` you could execute the following:
 
 ```js
 client.writeFragment({
-  id: '5',
+  id: "5",
   fragment: gql`
-    fragment myTodo on Todo {
+    fragment MyTodo on Todo {
       completed
     }
   `,
@@ -135,7 +135,7 @@ client.writeFragment({
 
 Any subscriber to the Apollo Client store will instantly see this update and render new UI accordingly.
 
-> **Note:** Again, remember that using `writeQuery` or `writeFragment` only changes data *locally*. If you reload your environment then changes made with these methods will no longer exist.
+> **Note:** Again, remember that using `writeQuery` or `writeFragment` only changes data _locally_. If you reload your environment then changes made with these methods will no longer exist.
 
 Or if you wanted to add a new todo to a list fetched from the server, you could use `readQuery` and `writeQuery` together.
 
@@ -153,8 +153,8 @@ const query = gql`
 const data = client.readQuery({ query });
 
 const myNewTodo = {
-  id: '6',
-  text: 'Start using Apollo Client.',
+  id: "6",
+  text: "Start using Apollo Client.",
   completed: false,
 };
 
@@ -206,7 +206,7 @@ At the end of our mutation we want our query to include the new todo like we had
 // We assume that the GraphQL operations `TodoCreateMutation` and
 // `TodoAppQuery` have already been defined using the `gql` tag.
 
-const text = 'Hello, world!';
+const text = "Hello, world!";
 
 client.mutate({
   mutation: TodoCreateMutation,
@@ -228,12 +228,12 @@ client.mutate({
 
 The first `proxy` argument is an instance of `DataProxy` and has the same for methods that we just learned exist on the Apollo Client: `readQuery`, `readFragment`, `writeQuery`, and `writeFragment`. The reason we call them on a `proxy` object here instead of on our `client` instance is that we can easily apply optimistic updates (which we will demonstrate in a bit). The `proxy` object also provides an isolated transaction which shields you from any other mutations going on at the same time, and the `proxy` object also batches writes together until the very end.
 
-If you provide an `optimisticResponse` option to the mutation then the `update` function will be run twice. Once immediately after you call `client.mutate` with the data from `optimisticResponse`. After the mutation successfully executes against the server the changes made in the first call to `update` will be rolled back and `update` will be called with the *actual* data returned by the mutation and not just the optimistic response.
+If you provide an `optimisticResponse` option to the mutation then the `update` function will be run twice. Once immediately after you call `client.mutate` with the data from `optimisticResponse`. After the mutation successfully executes against the server the changes made in the first call to `update` will be rolled back and `update` will be called with the _actual_ data returned by the mutation and not just the optimistic response.
 
 Putting it all together:
 
 ```js
-const text = 'Hello, world!';
+const text = "Hello, world!";
 
 client.mutate({
   mutation: TodoCreateMutation,


### PR DESCRIPTION
This PR changes some examples of fragments in the docs to use PascalCase.