### PR TITLE
Adjust defaultDataIdFromObject to set context.keyObject.

### DIFF
--- a/src/cache/inmemory/__tests__/cache.ts
+++ b/src/cache/inmemory/__tests__/cache.ts
@@ -624,6 +624,7 @@ describe('Cache', () => {
       expect(cache.extract()).toEqual({
         "Person:123": {
           __typename: "Person",
+          id: 123,
           firstName: "Ben",
         },
       });
@@ -647,6 +648,7 @@ describe('Cache', () => {
       expect(cache.extract()).toEqual({
         "Person:123": {
           __typename: "Person",
+          id: 123,
           firstName: "Ben",
           lastName: "Newman",
         },
@@ -681,6 +683,7 @@ describe('Cache', () => {
       expect(cache.extract()).toEqual({
         "Person:123": {
           __typename: "Person",
+          id: 123,
           firstName: "Benjamin",
           lastName: "Newman",
         },
@@ -737,6 +740,7 @@ describe('Cache', () => {
       expect(cache.extract(true)).toEqual({
         "Person:321": {
           __typename: "Person",
+          id: 321,
           firstName: "Hugh",
           lastName: "Willson",
         },
@@ -2026,10 +2030,12 @@ describe("InMemoryCache#modify", () => {
       },
       "A:1": {
         __typename: "A",
+        id: 1,
         value: 123,
       },
       "B:1": {
         __typename: "B",
+        id: 1,
         value: 321,
       },
     });

--- a/src/cache/inmemory/__tests__/entityStore.ts
+++ b/src/cache/inmemory/__tests__/entityStore.ts
@@ -1416,10 +1416,12 @@ describe('EntityStore', () => {
     expect(cache.extract(true)).toEqual({
       "Author:2": {
         __typename: "Author",
+        id: 2,
         name: "Geoffrey Chaucer",
       },
       "Book:1": {
         __typename: "Book",
+        id: 1,
         author: { __ref: "Author:2" },
       },
       ROOT_QUERY: {
@@ -1438,6 +1440,7 @@ describe('EntityStore', () => {
     expect(cache.extract(true)).toEqual({
       "Book:1": {
         __typename: "Book",
+        id: 1,
         author: { __ref: "Author:2" },
       },
       ROOT_QUERY: {
@@ -1479,6 +1482,7 @@ describe('EntityStore', () => {
     expect(cache.extract(true)).toEqual({
       "Book:1": {
         __typename: "Book",
+        id: 1,
         author: { __ref: "Author:2" },
       },
       ROOT_QUERY: {

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -2249,6 +2249,7 @@ describe("type policies", function () {
         },
         "Event:123": {
           __typename: "Event",
+          id: 123,
           name: "One-person party",
           attendees: [
             { __ref: "Attendee:234" },
@@ -2256,6 +2257,7 @@ describe("type policies", function () {
         },
         "Attendee:234": {
           __typename: "Attendee",
+          id: 234,
           name: "Ben Newman",
           events: [
             { __ref: "Event:123" },
@@ -2314,6 +2316,7 @@ describe("type policies", function () {
         },
         "Event:123": {
           __typename: "Event",
+          id: 123,
           name: "One-person party",
           attendees: [
             { __ref: "Attendee:234" },
@@ -2321,6 +2324,7 @@ describe("type policies", function () {
         },
         "Event:345": {
           __typename: "Event",
+          id: 345,
           attendees: [
             { __ref: "Attendee:456" },
             { __ref: "Attendee:234" },
@@ -2328,6 +2332,7 @@ describe("type policies", function () {
         },
         "Attendee:234": {
           __typename: "Attendee",
+          id: 234,
           name: "Ben Newman",
           events: [
             { __ref: "Event:123" },
@@ -2336,6 +2341,7 @@ describe("type policies", function () {
         },
         "Attendee:456": {
           __typename: "Attendee",
+          id: 456,
           name: "Inspector Beckett",
         },
       });
@@ -3196,6 +3202,7 @@ describe("type policies", function () {
     expect(snapshot).toEqual({
       "Person:1234": {
         __typename: "Person",
+        id: 1234,
         currentTask: {
           __typename: "Task",
           description: "writing tests",

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -180,13 +180,26 @@ export type FieldMergeFunction<TExisting = any, TIncoming = TExisting> = (
   options: FieldFunctionOptions,
 ) => TExisting;
 
-export function defaultDataIdFromObject(object: StoreObject) {
-  const { __typename, id, _id } = object;
+export const defaultDataIdFromObject: KeyFieldsFunction = (
+  { __typename, id, _id },
+  context,
+) => {
   if (typeof __typename === "string") {
-    if (id !== void 0) return `${__typename}:${id}`;
-    if (_id !== void 0) return `${__typename}:${_id}`;
+    if (context) {
+      context.keyObject =
+         id !== void 0 ? {  id } :
+        _id !== void 0 ? { _id } :
+        void 0;
+    }
+    const idValue = id || _id;
+    if (idValue !== void 0) {
+      return `${__typename}:${(
+        typeof idValue === "number" ||
+        typeof idValue === "string"
+      ) ? idValue : JSON.stringify(idValue)}`;
+    }
   }
-}
+};
 
 const nullKeyFieldsFn: KeyFieldsFunction = () => void 0;
 const simpleKeyArgsFn: KeyArgsFunction = (_args, context) => context.fieldName;


### PR DESCRIPTION
First introduced by PR #6078, the `context.keyObject` property allows `KeyFieldsFunction` functions to report the primary keys that they used to compute the ID, which allows the `StoreWriter` to make sure those fields are always written into the cache, even if they were not mentioned in the query used for writing.

Reporting of `context.keyObject` happens automatically when you specify `keyFields` in a type policy, but `defaultDataIdFromObject` (which is called when there is no `keyFields` configured for a given `__typename`) was missing this functionality, prior to this commit.

While I was working with this code, I noticed that `defaultDataIdFromObject` was probably not doing the right thing for `id` or `_id` fields that are objects rather than strings or numbers (such as the MongoDB `ObjectId`, which was the original motivation for supporting `_id` by default), so I changed the logic to call `JSON.stringify` in that case.