### PR TITLE
Remove experimental cache.modify method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
 - **[BREAKING]** `InMemoryCache` now _throws_ when data with missing or undefined query fields is written into the cache, rather than just warning in development. <br/>
   [@benjamn](https://github.com/benjamn) in [#6055](https://github.com/apollographql/apollo-client/pull/6055)
 
-- **[BREAKING]** `client|cache.writeData` have been fully removed. `writeData` usage is one of the easiest ways to turn faulty assumptions about how the cache represents data internally, into cache inconsistency and corruption. `client|cache.writeQuery`, `client|cache.writeFragment`, and/or `cache.modify` can be used to update the cache.  <br/>
+- **[BREAKING]** The `client|cache.writeData` methods have been fully removed, as `writeData` is one of the easiest ways to turn faulty assumptions about how the cache represents data internally into cache inconsistency and corruption. Instead, use `client|cache.writeQuery` or `client|cache.writeFragment` to update the cache. <br/>
   [@benjamn](https://github.com/benjamn) in [#5923](https://github.com/apollographql/apollo-client/pull/5923)
 
 - **[BREAKING]** Apollo Client will no longer deliver "stale" results to `ObservableQuery` consumers, but will instead log more helpful errors about which cache fields were missing. <br/>
@@ -85,18 +85,6 @@
 
 - The result caching system (introduced in [#3394](https://github.com/apollographql/apollo-client/pull/3394)) now tracks dependencies at the field level, rather than at the level of whole entity objects, allowing the cache to return identical (`===`) results much more often than before. <br/>
   [@benjamn](https://github.com/benjamn) in [#5617](https://github.com/apollographql/apollo-client/pull/5617)
-
-- `InMemoryCache` now has a method called `modify` which can be used to update the value of a specific field within a specific entity object:
-  ```ts
-  cache.modify({
-    comments(comments: Reference[], { readField }) {
-      return comments.filter(comment => idToRemove !== readField("id", comment));
-    },
-  }, cache.identify(post));
-  ```
-  This API gracefully handles cases where multiple field values are associated with a single field name, and also removes the need for updating the cache by reading a query or fragment, modifying the result, and writing the modified result back into the cache. Behind the scenes, the `cache.evict` method is now implemented in terms of `cache.modify`. <br/>
-  [@benjamn](https://github.com/benjamn) in [#5909](https://github.com/apollographql/apollo-client/pull/5909)
-  and [#6178](https://github.com/apollographql/apollo-client/pull/6178)
 
 - `InMemoryCache` provides a new API for storing client state that can be updated from anywhere:
   ```ts
@@ -150,7 +138,7 @@
 - Make sure `ApolloContext` plays nicely with IE11 when storing the shared context.  <br/>
   [@ms](https://github.com/ms) in [#5840](https://github.com/apollographql/apollo-client/pull/5840)
 
-- Expose cache `modify` and `identify` to the mutate `update` function.  <br/>
+- Expose `cache.identify` to the mutation `update` function. <br/>
   [@hwillson](https://github.com/hwillson) in [#5956](https://github.com/apollographql/apollo-client/pull/5956)
 
 - Add a default `gc` implementation to `ApolloCache`.  <br/>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@
 - **[BREAKING?]** Refactor `QueryManager` to make better use of observables and enforce `fetchPolicy` more reliably. <br/>
   [@benjamn](https://github.com/benjamn) in [#6221](https://github.com/apollographql/apollo-client/pull/6221)
 
+- **[beta-BREAKING]** The experimental `cache.modify` method, first introduced in [PR #5909](https://github.com/apollographql/apollo-client/pull/5909), has been removed. <br/>
+  [@benjamn](https://github.com/benjamn) in [#6289](https://github.com/apollographql/apollo-client/pull/6289)
+
 - `InMemoryCache` now supports tracing garbage collection and eviction. Note that the signature of the `evict` method has been simplified in a potentially backwards-incompatible way. <br/>
   [@benjamn](https://github.com/benjamn) in [#5310](https://github.com/apollographql/apollo-client/pull/5310)
 

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -2942,19 +2942,6 @@ describe('@connection', () => {
     checkLastResult(abResults, a456bOyez);
     checkLastResult(cResults, { c: "see" });
 
-    cache.modify({
-      c(value) {
-        expect(value).toBe("see");
-        return "saw";
-      },
-    });
-    await wait();
-
-    checkLastResult(aResults, a456);
-    checkLastResult(bResults, bOyez);
-    checkLastResult(abResults, a456bOyez);
-    checkLastResult(cResults, { c: "saw" });
-
     client.cache.evict("ROOT_QUERY", "c");
     await wait();
 
@@ -2991,7 +2978,6 @@ describe('@connection', () => {
     expect(cResults).toEqual([
       {},
       { c: "see" },
-      { c: "saw" },
       {},
     ]);
 

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -5,7 +5,6 @@ import { getFragmentQueryDocument } from '../../utilities/graphql/fragments';
 import { StoreObject } from '../../utilities/graphql/storeUtils';
 import { DataProxy } from './types/DataProxy';
 import { Cache } from './types/Cache';
-import { Modifier, Modifiers } from './types/common';
 
 export type Transaction<T> = (c: ApolloCache<T>) => void;
 
@@ -77,14 +76,6 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
 
   public identify(object: StoreObject): string | undefined {
     return;
-  }
-
-  public modify(
-    modifiers: Modifier<any> | Modifiers,
-    dataId?: string,
-    optimistic?: boolean,
-  ): boolean {
-    return false;
   }
   
   public gc(): string[] {

--- a/src/cache/core/types/common.ts
+++ b/src/cache/core/types/common.ts
@@ -1,14 +1,5 @@
 import { DocumentNode } from 'graphql';
 
-import {
-  isReference,
-  StoreValue,
-  StoreObject,
-  Reference
-} from '../../../utilities/graphql/storeUtils';
-
-import { ToReferenceFunction } from '../../inmemory/entityStore';
-
 // The Readonly<T> type only really works for object types, since it marks
 // all of the object's properties as readonly, but there are many cases when
 // a generic type parameter like TExisting might be a string or some other
@@ -17,22 +8,6 @@ import { ToReferenceFunction } from '../../inmemory/entityStore';
 // assignable to SafeReadonly<any>, whereas string is not assignable to
 // Readonly<any>, somewhat surprisingly.
 export type SafeReadonly<T> = T extends object ? Readonly<T> : T;
-
-export type Modifier<T> = (value: T, details: {
-  DELETE: any;
-  fieldName: string;
-  storeFieldName: string;
-  isReference: typeof isReference;
-  toReference: ToReferenceFunction;
-  readField<V = StoreValue>(
-    fieldName: string,
-    objOrRef?: StoreObject | Reference,
-  ): SafeReadonly<V>;
-}) => T;
-
-export type Modifiers = {
-  [fieldName: string]: Modifier<any>;
-}
 
 export class MissingFieldError {
   constructor(

--- a/src/cache/inmemory/__tests__/cache.ts
+++ b/src/cache/inmemory/__tests__/cache.ts
@@ -4,6 +4,7 @@ import { stripSymbols } from '../../../utilities/testing/stripSymbols';
 import { cloneDeep } from '../../../utilities/common/cloneDeep';
 import { makeReference, Reference } from '../../../core';
 import { InMemoryCache, InMemoryCacheConfig } from '../inMemoryCache';
+import { fieldNameFromStoreName } from '../helpers';
 
 disableFragmentWarnings();
 
@@ -1538,268 +1539,6 @@ describe("InMemoryCache#broadcastWatches", function () {
 });
 
 describe("InMemoryCache#modify", () => {
-  it("should work with single modifier function", () => {
-    const cache = new InMemoryCache;
-    const query = gql`
-      query {
-        a
-        b
-        c
-      }
-    `;
-
-    cache.writeQuery({
-      query,
-      data: {
-        a: 0,
-        b: 0,
-        c: 0,
-      },
-    });
-
-    const resultBeforeModify = cache.readQuery({ query });
-    expect(resultBeforeModify).toEqual({ a: 0, b: 0, c: 0 });
-
-    cache.modify((value, { fieldName }) => {
-      switch (fieldName) {
-        case "a": return value + 1;
-        case "b": return value - 1;
-        default: return value;
-      }
-    });
-
-    expect(cache.extract()).toEqual({
-      ROOT_QUERY: {
-        __typename: "Query",
-        a: 1,
-        b: -1,
-        c: 0,
-      },
-    });
-
-    const resultAfterModify = cache.readQuery({ query });
-    expect(resultAfterModify).toEqual({ a: 1, b: -1, c: 0 });
-  });
-
-  it("should work with multiple modifier functions", () => {
-    const cache = new InMemoryCache;
-    const query = gql`
-      query {
-        a
-        b
-        c
-      }
-    `;
-
-    cache.writeQuery({
-      query,
-      data: {
-        a: 0,
-        b: 0,
-        c: 0,
-      },
-    });
-
-    const resultBeforeModify = cache.readQuery({ query });
-    expect(resultBeforeModify).toEqual({ a: 0, b: 0, c: 0 });
-
-    let checkedTypename = false;
-    cache.modify({
-      a(value) { return value + 1 },
-      b(value) { return value - 1 },
-      __typename(t: string, { readField }) {
-        expect(t).toBe("Query");
-        expect(readField("c")).toBe(0);
-        checkedTypename = true;
-        return t;
-      },
-    });
-    expect(checkedTypename).toBe(true);
-
-    expect(cache.extract()).toEqual({
-      ROOT_QUERY: {
-        __typename: "Query",
-        a: 1,
-        b: -1,
-        c: 0,
-      },
-    });
-
-    const resultAfterModify = cache.readQuery({ query });
-    expect(resultAfterModify).toEqual({ a: 1, b: -1, c: 0 });
-  });
-
-  it("should allow deletion using details.DELETE", () => {
-    const cache = new InMemoryCache({
-      typePolicies: {
-        Book: {
-          keyFields: ["isbn"],
-        },
-        Author: {
-          keyFields: ["name"],
-        },
-      },
-    });
-
-    const query = gql`
-      query {
-        currentlyReading {
-          title
-          isbn
-          author {
-            name
-            yearOfBirth
-          }
-        }
-      }
-    `;
-
-    const currentlyReading = {
-      __typename: "Book",
-      isbn: "147670032X",
-      title: "Why We're Polarized",
-      author: {
-        __typename: "Author",
-        name: "Ezra Klein",
-        yearOfBirth: 1983,
-      },
-    };
-
-    cache.writeQuery({
-      query,
-      data: {
-        currentlyReading,
-      }
-    });
-
-    expect(cache.extract()).toEqual({
-      ROOT_QUERY: {
-        __typename: "Query",
-        currentlyReading: {
-          __ref: 'Book:{"isbn":"147670032X"}',
-        },
-      },
-      'Book:{"isbn":"147670032X"}': {
-        __typename: "Book",
-        isbn: "147670032X",
-        author: {
-          __ref: 'Author:{"name":"Ezra Klein"}',
-        },
-        title: "Why We're Polarized",
-      },
-      'Author:{"name":"Ezra Klein"}': {
-        __typename: "Author",
-        name: "Ezra Klein",
-        yearOfBirth: 1983,
-      },
-    });
-
-    const authorId = cache.identify(currentlyReading.author)!;
-    expect(authorId).toBe('Author:{"name":"Ezra Klein"}');
-
-    cache.modify({
-      yearOfBirth(yob) {
-        return yob + 1;
-      },
-    }, authorId);
-
-    const yobResult = cache.readFragment({
-      id: authorId,
-      fragment: gql`fragment YOB on Author { yearOfBirth }`,
-    });
-
-    expect(yobResult).toEqual({
-      __typename: "Author",
-      yearOfBirth: 1984,
-    });
-
-    const bookId = cache.identify(currentlyReading)!;
-
-    // Modifying the Book in order to modify the Author is fancier than
-    // necessary, but we want fancy use cases to work, too.
-    cache.modify({
-      author(author: Reference, { readField }) {
-        expect(readField("title")).toBe("Why We're Polarized");
-        expect(readField("name", author)).toBe("Ezra Klein");
-        cache.modify({
-          yearOfBirth(yob, { DELETE }) {
-            expect(yob).toBe(1984);
-            return DELETE;
-          },
-        }, cache.identify({
-          __typename: readField("__typename", author),
-          name: readField("name", author),
-        }));
-        return author;
-      }
-    }, bookId);
-
-    const snapshotWithoutYOB = cache.extract();
-    expect(snapshotWithoutYOB[authorId]!.yearOfBirth).toBeUndefined();
-    expect("yearOfBirth" in snapshotWithoutYOB[authorId]!).toBe(false);
-    expect(snapshotWithoutYOB).toEqual({
-      ROOT_QUERY: {
-        __typename: "Query",
-        currentlyReading: {
-          __ref: 'Book:{"isbn":"147670032X"}',
-        },
-      },
-      'Book:{"isbn":"147670032X"}': {
-        __typename: "Book",
-        isbn: "147670032X",
-        author: {
-          __ref: 'Author:{"name":"Ezra Klein"}',
-        },
-        title: "Why We're Polarized",
-      },
-      'Author:{"name":"Ezra Klein"}': {
-        __typename: "Author",
-        name: "Ezra Klein",
-        // yearOfBirth is gone now
-      },
-    });
-
-    // Delete the whole Book.
-    cache.modify((_, { DELETE }) => DELETE, bookId);
-
-    const snapshotWithoutBook = cache.extract();
-    expect(snapshotWithoutBook[bookId]).toBeUndefined();
-    expect(bookId in snapshotWithoutBook).toBe(false);
-    expect(snapshotWithoutBook).toEqual({
-      ROOT_QUERY: {
-        __typename: "Query",
-        currentlyReading: {
-          __ref: 'Book:{"isbn":"147670032X"}',
-        },
-      },
-      'Author:{"name":"Ezra Klein"}': {
-        __typename: "Author",
-        name: "Ezra Klein",
-      },
-    });
-
-    // Delete all fields of the Author, which also removes the object.
-    cache.modify({
-      __typename(_, { DELETE }) { return DELETE },
-      name(_, { DELETE }) { return DELETE },
-    }, authorId);
-
-    const snapshotWithoutAuthor = cache.extract();
-    expect(snapshotWithoutAuthor[authorId]).toBeUndefined();
-    expect(authorId in snapshotWithoutAuthor).toBe(false);
-    expect(snapshotWithoutAuthor).toEqual({
-      ROOT_QUERY: {
-        __typename: "Query",
-        currentlyReading: {
-          __ref: 'Book:{"isbn":"147670032X"}',
-        },
-      },
-    });
-
-    cache.modify((_, { DELETE }) => DELETE);
-    expect(cache.extract()).toEqual({});
-  });
-
   it("can remove specific items from paginated lists", () => {
     const cache = new InMemoryCache({
       typePolicies: {
@@ -1908,21 +1647,59 @@ describe("InMemoryCache#modify", () => {
       },
     });
 
-    cache.modify({
-      comments(comments: Reference[], { readField }) {
-        debugger;
-        expect(Object.isFrozen(comments)).toBe(true);
-        expect(comments.length).toBe(3);
-        const filtered = comments.filter(comment => {
-          return readField("id", comment) !== "c1";
-        });
-        expect(filtered.length).toBe(2);
-        return filtered;
-      },
-    }, cache.identify({
+    const threadId = cache.identify({
       __typename: "Thread",
       tid: 123,
-    }));
+    })!;
+
+    const threadCommentsFragment = gql`
+      fragment Comments on Thread {
+        comments(offset: $offset, limit: $limit) {
+          id
+          text
+        }
+      }
+    `;
+
+    const threadWithComments = cache.readFragment<{
+      comments: any[],
+    }>({
+      id: threadId,
+      fragment: threadCommentsFragment,
+      variables: {
+        offset: 0,
+        // There are only three comments at this point, but let's pretend
+        // we don't know that.
+        limit: 10,
+      },
+    })!;
+
+    // First evict the comments field, so the Thread.comments merge
+    // function does not try to combine the existing (unfiltered) comments
+    // list with the incoming (filtered) comments list when we call
+    // writeFragment below.
+    expect(cache.evict({
+      id: threadId,
+      fieldName: "comments",
+      broadcast: false,
+    })).toBe(true);
+
+    const commentsWithoutC1 =
+      threadWithComments.comments.filter(comment => {
+        return comment.id !== "c1";
+      });
+
+    cache.writeFragment({
+      id: threadId,
+      fragment: threadCommentsFragment,
+      data: {
+        comments: commentsWithoutC1,
+      },
+      variables: {
+        offset: 0,
+        limit: commentsWithoutC1.length,
+      },
+    });
 
     expect(cache.gc()).toEqual(['Comment:{"id":"c1"}']);
 
@@ -1952,47 +1729,6 @@ describe("InMemoryCache#modify", () => {
         text: "friendly ping",
       },
     });
-  });
-
-  it("should not revisit deleted fields", () => {
-    const cache = new InMemoryCache;
-    const query = gql`query { a b c }`;
-
-    cache.recordOptimisticTransaction(cache => {
-      cache.writeQuery({
-        query,
-        data: {
-          a: 1,
-          b: 2,
-          c: 3,
-        },
-      })
-    }, "transaction");
-
-    cache.modify({
-      b(value, { DELETE }) {
-        expect(value).toBe(2);
-        return DELETE;
-      },
-    }, "ROOT_QUERY", true);
-
-    expect(cache.extract(true)).toEqual({
-      ROOT_QUERY: {
-        __typename: "Query",
-        a: 1,
-        c: 3,
-      },
-    });
-
-    cache.modify((value, { fieldName }) => {
-      expect(fieldName).not.toBe("b");
-      if (fieldName === "a") expect(value).toBe(1);
-      if (fieldName === "c") expect(value).toBe(3);
-    }, "ROOT_QUERY", true);
-
-    cache.removeOptimistic("transaction");
-
-    expect(cache.extract(true)).toEqual({});
   });
 
   it("should broadcast watches for queries with changed fields", () => {
@@ -2082,25 +1818,28 @@ describe("InMemoryCache#modify", () => {
     expect(aResults).toEqual([a123]);
     expect(bResults).toEqual([b321]);
 
-    const aId = cache.identify({ __typename: "A", id: 1 });
-    const bId = cache.identify({ __typename: "B", id: 1 });
+    const aId = cache.identify({ __typename: "A", id: 1 })!;
+    expect(aId).toBe("A:1");
 
-    cache.modify({
-      value(x: number) {
-        return x + 1;
-      },
-    }, aId);
+    const bId = cache.identify({ __typename: "B", id: 1 })!;
+    expect(bId).toBe("B:1");
+
+    cache.writeFragment({
+      id: aId,
+      fragment: gql`fragment AValue on A { value }`,
+      data: { value: a123.result.a.value + 1 },
+    });
 
     const a124 = makeResult("A", 124);
 
     expect(aResults).toEqual([a123, a124]);
     expect(bResults).toEqual([b321]);
 
-    cache.modify({
-      value(x: number) {
-        return x + 1;
-      },
-    }, bId);
+    cache.writeFragment({
+      id: bId,
+      fragment: gql`fragment BValue on B { value }`,
+      data: { value: b321.result.b.value + 1 },
+    });
 
     const b322 = makeResult("B", 322);
 
@@ -2184,40 +1923,22 @@ describe("InMemoryCache#modify", () => {
     expect(cache.extract()).toEqual(fullSnapshot);
 
     function check(isbnToDelete?: string) {
-      let bookCount = 0;
+      if (isbnToDelete) {
+        cache.evict({
+          id: "ROOT_QUERY",
+          fieldName: "book",
+          args: { isbn: isbnToDelete },
+        });
+      }
 
-      cache.modify({
-        book(book: Reference, {
-          fieldName,
-          storeFieldName,
-          isReference,
-          readField,
-          DELETE,
-        }) {
-          expect(fieldName).toBe("book");
-          expect(isReference(book)).toBe(true);
-          expect(typeof readField("title", book)).toBe("string");
-          expect(readField("__typename", book)).toBe("Book");
-
-          const parts = storeFieldName.split(":");
-          expect(parts.shift()).toBe("book");
-          const keyArgs = JSON.parse(parts.join(":"));
-          expect(typeof keyArgs.isbn).toBe("string");
-          expect(Object.keys(keyArgs)).toEqual(["isbn"]);
-
-          expect(readField("isbn", book)).toBe(keyArgs.isbn);
-
-          if (isbnToDelete === keyArgs.isbn) {
-            return DELETE;
-          }
-
-          ++bookCount;
-
-          return book;
-        },
-      });
-
-      return bookCount;
+      return Object.keys(
+        cache.extract().ROOT_QUERY!
+      ).reduce((count: number, storeFieldName: string) => {
+        if ("book" === fieldNameFromStoreName(storeFieldName)) {
+          ++count;
+        }
+        return count;
+      }, 0);
     }
 
     // No change from repeatedly calling check().

--- a/src/cache/inmemory/__tests__/entityStore.ts
+++ b/src/cache/inmemory/__tests__/entityStore.ts
@@ -1917,51 +1917,5 @@ describe('EntityStore', () => {
         title: "The Cuckoo's Calling",
       },
     });
-
-    cache.modify({
-      title(title: string, {
-        isReference,
-        toReference,
-        readField,
-      }) {
-        const book = {
-          __typename: "Book",
-          isbn: readField("isbn"),
-          author: "J.K. Rowling",
-        };
-
-        // By not passing true as the second argument to toReference, we
-        // get back a Reference object, but the book.author field is not
-        // persisted into the store.
-        const refWithoutAuthor = toReference(book);
-        expect(isReference(refWithoutAuthor)).toBe(true);
-        expect(readField("author", refWithoutAuthor as Reference)).toBeUndefined();
-
-        // Update this very Book entity before we modify its title.
-        // Passing true for the second argument causes the extra
-        // book.author field to be persisted into the store.
-        const ref = toReference(book, true);
-        expect(isReference(ref)).toBe(true);
-        expect(readField("author", ref as Reference)).toBe("J.K. Rowling");
-
-        // In fact, readField doesn't need the ref if we're reading from
-        // the same entity that we're modifying.
-        expect(readField("author")).toBe("J.K. Rowling");
-
-        // Typography matters!
-        return title.split("'").join("’");
-      },
-    }, cuckoosCallingId);
-
-    expect(cache.extract()).toEqual({
-      ...threeBookSnapshot,
-      // This book was added as a side effect of the read function.
-      'Book:{"isbn":"031648637X"}': {
-        __typename: "Book",
-        isbn: "031648637X",
-        title: "The Cuckoo’s Calling",
-        author: "J.K. Rowling",
-      },
-    });
   });
 });

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -12,15 +12,10 @@ import { DeepMerger } from '../../utilities/common/mergeDeep';
 import { maybeDeepFreeze } from '../../utilities/common/maybeDeepFreeze';
 import { canUseWeakMap } from '../../utilities/common/canUse';
 import { NormalizedCache, NormalizedCacheObject } from './types';
-import { fieldNameFromStoreName } from './helpers';
+import { hasOwn, fieldNameFromStoreName } from './helpers';
 import { Policies } from './policies';
-import { Modifier, Modifiers, SafeReadonly } from '../core/types/common';
+import { SafeReadonly } from '../core/types/common';
 import { Cache } from '../core/types/Cache';
-
-const hasOwn = Object.prototype.hasOwnProperty;
-
-const DELETE: any = Object.create(null);
-const delModifier: Modifier<any> = () => DELETE;
 
 export abstract class EntityStore implements NormalizedCache {
   protected data: NormalizedCacheObject = Object.create(null);
@@ -77,101 +72,43 @@ export abstract class EntityStore implements NormalizedCache {
       this instanceof Layer ? this.parent.lookup(dataId, dependOnExistence) : void 0;
   }
 
-  public merge(dataId: string, incoming: StoreObject): void {
+  public merge(dataId: string, incoming: StoreObject): StoreObject {
     const existing = this.lookup(dataId);
-    const merged = new DeepMerger(storeObjectReconciler).merge(existing, incoming);
+    const merged: StoreObject =
+      new DeepMerger(storeObjectReconciler).merge(existing, incoming);
+
     // Even if merged === existing, existing may have come from a lower
     // layer, so we always need to set this.data[dataId] on this level.
     this.data[dataId] = merged;
+
     if (merged !== existing) {
       delete this.refs[dataId];
-      if (this.group.caching) {
-        const fieldsToDirty: Record<string, 1> = Object.create(null);
-        // If we added a new StoreObject where there was previously none, dirty
-        // anything that depended on the existence of this dataId, such as the
-        // EntityStore#has method.
-        if (!existing) fieldsToDirty.__exists = 1;
-        // Now invalidate dependents who called getFieldValue for any fields
-        // that are changing as a result of this merge.
-        Object.keys(incoming).forEach(storeFieldName => {
-          if (!existing || existing[storeFieldName] !== merged[storeFieldName]) {
-            fieldsToDirty[fieldNameFromStoreName(storeFieldName)] = 1;
-            // If merged[storeFieldName] has become undefined, and this is the
-            // Root layer, actually delete the property from the merged object,
-            // which is guaranteed to have been created fresh in this method.
-            if (merged[storeFieldName] === void 0 && !(this instanceof Layer)) {
-              delete merged[storeFieldName];
-            }
+      const fieldsToDirty: Record<string, 1> = Object.create(null);
+
+      // If we added a new StoreObject where there was previously none,
+      // dirty anything that depended on the existence of this dataId,
+      // such as the EntityStore#has method.
+      if (!existing) fieldsToDirty.__exists = 1;
+
+      // Now invalidate dependents who called getFieldValue for any fields
+      // that are changing as a result of this merge.
+      Object.keys(incoming).forEach(storeFieldName => {
+        if (!existing || existing[storeFieldName] !== merged[storeFieldName]) {
+          fieldsToDirty[fieldNameFromStoreName(storeFieldName)] = 1;
+
+          // If merged[storeFieldName] has become undefined, and this is the
+          // Root layer, actually delete the property from the merged object,
+          // which is guaranteed to have been created fresh in this method.
+          if (merged[storeFieldName] === void 0 && !(this instanceof Layer)) {
+            delete merged[storeFieldName];
           }
-        });
-        Object.keys(fieldsToDirty).forEach(
-          fieldName => this.group.dirty(dataId, fieldName));
-      }
-    }
-  }
-
-  public modify(
-    dataId: string,
-    modifiers: Modifier<any> | Modifiers,
-  ): boolean {
-    const storeObject = this.lookup(dataId);
-
-    if (storeObject) {
-      const changedFields: Record<string, any> = Object.create(null);
-      let needToMerge = false;
-      let allDeleted = true;
-
-      const readField = <V = StoreValue>(
-        fieldName: string,
-        objOrRef?: StoreObject | Reference,
-      ) => this.getFieldValue<V>(objOrRef || makeReference(dataId), fieldName);
-
-      Object.keys(storeObject).forEach(storeFieldName => {
-        const fieldName = fieldNameFromStoreName(storeFieldName);
-        let fieldValue = storeObject[storeFieldName];
-        if (fieldValue === void 0) return;
-        const modify: Modifier<StoreValue> = typeof modifiers === "function"
-          ? modifiers
-          : modifiers[storeFieldName] || modifiers[fieldName];
-        if (modify) {
-          let newValue = modify === delModifier ? DELETE :
-            modify(maybeDeepFreeze(fieldValue), {
-              DELETE,
-              fieldName,
-              storeFieldName,
-              isReference,
-              toReference: this.toReference,
-              readField,
-            });
-          if (newValue === DELETE) newValue = void 0;
-          if (newValue !== fieldValue) {
-            changedFields[storeFieldName] = newValue;
-            needToMerge = true;
-            fieldValue = newValue;
-          }
-        }
-        if (fieldValue !== void 0) {
-          allDeleted = false;
         }
       });
 
-      if (needToMerge) {
-        this.merge(dataId, changedFields);
-
-        if (allDeleted) {
-          if (this instanceof Layer) {
-            this.data[dataId] = void 0;
-          } else {
-            delete this.data[dataId];
-          }
-          this.group.dirty(dataId, "__exists");
-        }
-
-        return true;
-      }
+      Object.keys(fieldsToDirty).forEach(
+        fieldName => this.group.dirty(dataId, fieldName));
     }
-
-    return false;
+    return merged;
   }
 
   // If called with only one argument, removes the entire entity
@@ -186,15 +123,46 @@ export abstract class EntityStore implements NormalizedCache {
     args?: Record<string, any>,
   ) {
     const storeObject = this.lookup(dataId);
-    if (storeObject) {
-      const typename = this.getFieldValue<string>(storeObject, "__typename");
-      const storeFieldName = fieldName && args
-        ? this.policies.getStoreFieldName({ typename, fieldName, args })
-        : fieldName;
-      return this.modify(dataId, storeFieldName ? {
-        [storeFieldName]: delModifier,
-      } : delModifier);
+    if (!storeObject) return false;
+
+    const changedFields: Record<string, any> = Object.create(null);
+
+    if (fieldName && args) {
+      // Since we have args, we can compute the specific storeFieldName to
+      // be deleted (if it exists).
+      const storeFieldName = this.policies.getStoreFieldName({
+        typename: this.getFieldValue<string>(storeObject, "__typename"),
+        fieldName,
+        args,
+      });
+      if (storeObject[storeFieldName] !== void 0) {
+        changedFields[storeFieldName] = void 0;
+      }
+    } else {
+      // Since we don't have specific args, loop over all the keys of
+      // storeObject and delete the ones that match fieldName.
+      Object.keys(storeObject).forEach(storeFieldName => {
+        if (storeObject[storeFieldName] !== void 0 &&
+            (!fieldName || // If no fieldName, all fields match.
+             fieldName === fieldNameFromStoreName(storeFieldName))) {
+          changedFields[storeFieldName] = void 0;
+        }
+      });
     }
+
+    if (Object.keys(changedFields).length) {
+      const merged = this.merge(dataId, changedFields);
+      if (Object.keys(merged).every(key => merged[key] === void 0)) {
+        if (this instanceof Layer) {
+          this.data[dataId] = void 0;
+        } else {
+          delete this.data[dataId];
+        }
+        this.group.dirty(dataId, "__exists");
+      }
+      return true;
+    }
+
     return false;
   }
 

--- a/src/cache/inmemory/helpers.ts
+++ b/src/cache/inmemory/helpers.ts
@@ -10,6 +10,8 @@ import {
 } from '../../utilities/graphql/storeUtils';
 import { DeepMerger, ReconcilerFunction } from '../../utilities/common/mergeDeep';
 
+export const hasOwn = Object.prototype.hasOwnProperty;
+
 export function getTypenameFromStoreObject(
   store: NormalizedCache,
   objectOrReference: StoreObject | Reference,

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -6,7 +6,6 @@ import { dep, wrap } from 'optimism';
 
 import { ApolloCache, Transaction } from '../core/cache';
 import { Cache } from '../core/types/Cache';
-import { Modifier, Modifiers } from '../core/types/common';
 import { addTypenameToDocument } from '../../utilities/graphql/transform';
 import { StoreObject }  from '../../utilities/graphql/storeUtils';
 import {
@@ -149,25 +148,6 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     if (options.broadcast !== false) {
       this.broadcastWatches();
     }
-  }
-
-  public modify(
-    modifiers: Modifier<any> | Modifiers,
-    dataId = "ROOT_QUERY",
-    optimistic = false,
-  ): boolean {
-    if (typeof modifiers === "string") {
-      // In beta testing of Apollo Client 3, the dataId parameter used to
-      // come before the modifiers. The type system should complain about
-      // this, but it doesn't have to be fatal if we fix it here.
-      [modifiers, dataId] = [dataId as any, modifiers];
-    }
-    const store = optimistic ? this.optimisticData : this.data;
-    if (store.modify(dataId, modifiers)) {
-      this.broadcastWatches();
-      return true;
-    }
-    return false;
   }
 
   public diff<T>(options: Cache.DiffOptions): Cache.DiffResult<T> {

--- a/src/cache/inmemory/types.ts
+++ b/src/cache/inmemory/types.ts
@@ -1,7 +1,6 @@
 import { DocumentNode } from 'graphql';
 
 import { Transaction } from '../core/cache';
-import { Modifier, Modifiers } from '../core/types/common';
 import { StoreValue, StoreObject } from '../../utilities/graphql/storeUtils';
 import { FieldValueGetter, ToReferenceFunction } from './entityStore';
 import { KeyFieldsFunction } from './policies';
@@ -24,9 +23,7 @@ export declare type IdGetter = (
 export interface NormalizedCache {
   has(dataId: string): boolean;
   get(dataId: string, fieldName: string): StoreValue;
-  merge(dataId: string, incoming: StoreObject): void;
-  modify(dataId: string, modifiers: Modifier<any> | Modifiers): boolean;
-  delete(dataId: string, fieldName?: string): boolean;
+  merge(dataId: string, incoming: StoreObject): StoreObject;
   clear(): void;
 
   // non-Map elements:


### PR DESCRIPTION
The `cache.modify` API was first introduced in #5909 as a quick way to transform the values of specific existing fields in the cache. At the time, `cache.modify` seemed promising as an alternative to the `readQuery`-transform-`writeQuery` pattern, but feedback has been mixed, most importantly from our developer experience team, who have helped me understand why `cache.modify` would be difficult to learn and to teach.

While my refactoring in #6221 addressed concerns about broadcasting `cache.modify` updates automatically, the bigger problem with `cache.modify` is simply that it requires knowledge of the internal workings of the cache, making it nearly impossible to explain to developers who are not already Apollo Client 3 experts. As much as I wanted `cache.modify` to be a selling point for Apollo Client 3, it simply wasn't safe to use without a firm understanding of concepts like cache normalization, references, field identity (`keyArgs`), read/merge functions and their options API, and the `options.toReference(object, true)` helper function (#5970).

By contrast, the `readQuery`-transform-`writeQuery` pattern may be a bit more verbose, but it has none of these problems, because these older methods work in terms of GraphQL result objects, rather than exposing the internal data format of the `EntityStore`.

Since `cache.modify` was motivated to some extent by vague power-user performance concerns, it's worth noting that we recently made `writeQuery` and `writeFragment` even more efficient when rewriting unchanged results (#6274), so whatever performance gap there might have been between `cache.modify` and `readQuery`/`writeQuery` should now be even less noticeable.

One final reason that `cache.modify` seemed like a good idea was that custom `merge` functions can interfere with certain `writeQuery` patterns, such as deleting an item from a paginated list. If you run into trouble with `merge` functions running when you don't want them to, we recommend calling `cache.evict` before `cache.writeQuery` to ensure your `merge` function won't be confused by existing field data when you write your modified data back into the cache.