### PR TITLE
chore: use `import type`

### DIFF
--- a/src/ApolloClient.ts
+++ b/src/ApolloClient.ts
@@ -1,21 +1,21 @@
-import { ExecutionResult, DocumentNode } from 'graphql';
+import type { ExecutionResult, DocumentNode } from 'graphql';
 import { invariant, InvariantError } from 'ts-invariant';
 
 import { ApolloLink } from './link/core/ApolloLink';
-import { FetchResult, GraphQLRequest } from './link/core/types';
+import type { FetchResult, GraphQLRequest } from './link/core/types';
 import { execute } from './link/core/execute';
-import { ApolloCache } from './cache/core/cache';
-import { DataProxy } from './cache/core/types/DataProxy';
+import type { ApolloCache } from './cache/core/cache';
+import type { DataProxy } from './cache/core/types/DataProxy';
 import { QueryManager } from './core/QueryManager';
-import {
+import type {
   ApolloQueryResult,
   OperationVariables,
   Resolvers,
 } from './core/types';
-import { ObservableQuery } from './core/ObservableQuery';
+import type { ObservableQuery } from './core/ObservableQuery';
 import { LocalState, FragmentMatcher } from './core/LocalState';
-import { Observable } from './utilities/observables/Observable';
-import {
+import type { Observable } from './utilities/observables/Observable';
+import type {
   QueryOptions,
   WatchQueryOptions,
   SubscriptionOptions,
@@ -24,7 +24,7 @@ import {
 } from './core/watchQueryOptions';
 import { version } from './version';
 import { HttpLink } from './link/http/HttpLink';
-import { UriFunction } from './link/http/selectHttpOptionsAndBody';
+import type { UriFunction } from './link/http/selectHttpOptionsAndBody';
 
 export interface DefaultOptions {
   watchQuery?: Partial<WatchQueryOptions>;

--- a/src/__tests__/ApolloClient.ts
+++ b/src/__tests__/ApolloClient.ts
@@ -7,8 +7,8 @@ import { HttpLink } from '../link/http/HttpLink';
 import { InMemoryCache } from '../cache/inmemory/inMemoryCache';
 import { stripSymbols } from '../utilities/testing/stripSymbols';
 import { ApolloClient } from '../';
-import { DefaultOptions } from '../ApolloClient';
-import { FetchPolicy, QueryOptions } from '../core/watchQueryOptions';
+import type { DefaultOptions } from '../ApolloClient';
+import type { FetchPolicy, QueryOptions } from '../core/watchQueryOptions';
 
 describe('ApolloClient', () => {
   describe('constructor', () => {

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -6,13 +6,13 @@ import { Observable, ObservableSubscription } from '../utilities/observables/Obs
 import { ApolloLink } from '../link/core/ApolloLink';
 import { InMemoryCache } from '../cache/inmemory/inMemoryCache';
 import { stripSymbols } from '../utilities/testing/stripSymbols';
-import { FetchPolicy, WatchQueryFetchPolicy, QueryOptions } from '../core/watchQueryOptions';
-import { ApolloError } from '../errors/ApolloError';
+import type { FetchPolicy, WatchQueryFetchPolicy, QueryOptions } from '../core/watchQueryOptions';
+import type { ApolloError } from '../errors/ApolloError';
 import { ApolloClient } from '..';
 import subscribeAndCount from '../utilities/testing/subscribeAndCount';
 import { itAsync } from '../utilities/testing/itAsync';
 import { mockSingleLink } from '../utilities/testing/mocking/mockLink';
-import { ObservableQuery, PossibleTypesMap } from '../core';
+import type { ObservableQuery, PossibleTypesMap } from '../core';
 
 describe('client', () => {
   it('can be loaded via require', () => {

--- a/src/__tests__/local-state/general.ts
+++ b/src/__tests__/local-state/general.ts
@@ -4,9 +4,9 @@ import { getIntrospectionQuery } from 'graphql/utilities';
 
 import { Observable } from '../../utilities/observables/Observable';
 import { ApolloLink } from '../../link/core/ApolloLink';
-import { Operation } from '../../link/core/types';
+import type { Operation } from '../../link/core/types';
 import { ApolloClient } from '../..';
-import { ApolloCache } from '../../cache/core/cache';
+import type { ApolloCache } from '../../cache/core/cache';
 import { InMemoryCache } from '../../cache/inmemory/inMemoryCache';
 import { itAsync } from '../../utilities/testing/itAsync';
 

--- a/src/__tests__/local-state/resolvers.ts
+++ b/src/__tests__/local-state/resolvers.ts
@@ -1,5 +1,5 @@
 import gql from 'graphql-tag';
-import { DocumentNode, ExecutionResult } from 'graphql';
+import type { DocumentNode, ExecutionResult } from 'graphql';
 import { assign } from 'lodash';
 
 import { Observable, Observer } from '../../utilities/observables/Observable';
@@ -8,8 +8,8 @@ import { ApolloClient } from '../..';
 import mockQueryManager from '../../utilities/testing/mocking/mockQueryManager';
 import wrap from '../../utilities/testing/wrap';
 import { itAsync } from '../../utilities/testing/itAsync';
-import { ApolloQueryResult, Resolvers } from '../../core/types';
-import { WatchQueryOptions } from '../../core/watchQueryOptions';
+import type { ApolloQueryResult, Resolvers } from '../../core/types';
+import type { WatchQueryOptions } from '../../core/watchQueryOptions';
 import { LocalState } from '../../core/LocalState';
 import { InMemoryCache } from '../../cache/inmemory/inMemoryCache';
 

--- a/src/__tests__/optimistic.ts
+++ b/src/__tests__/optimistic.ts
@@ -4,15 +4,15 @@ import { assign, cloneDeep } from 'lodash';
 import gql from 'graphql-tag';
 
 import { mockSingleLink } from '../utilities/testing/mocking/mockLink';
-import { MutationQueryReducersMap } from '../core/types';
-import { ObservableSubscription as Subscription } from '../utilities/observables/Observable';
+import type { MutationQueryReducersMap } from '../core/types';
+import type { ObservableSubscription as Subscription } from '../utilities/observables/Observable';
 import { ApolloClient } from '../';
 import { addTypenameToDocument } from '../utilities/graphql/transform';
 import { makeReference } from '../core';
 import { stripSymbols } from '../utilities/testing/stripSymbols';
 import { itAsync } from '../utilities/testing/itAsync';
 import { InMemoryCache } from '../cache/inmemory/inMemoryCache';
-import { QueryManager } from '../core/QueryManager';
+import type { QueryManager } from '../core/QueryManager';
 
 describe('optimistic mutation results', () => {
   const query = gql`

--- a/src/__tests__/subscribeToMore.ts
+++ b/src/__tests__/subscribeToMore.ts
@@ -1,8 +1,8 @@
 import gql from 'graphql-tag';
-import { DocumentNode, OperationDefinitionNode } from 'graphql';
+import type { DocumentNode, OperationDefinitionNode } from 'graphql';
 
 import { ApolloLink } from '../link/core/ApolloLink';
-import { Operation } from '../link/core/types';
+import type { Operation } from '../link/core/types';
 import { mockSingleLink } from '../utilities/testing/mocking/mockLink';
 import { mockObservableLink } from '../utilities/testing/mocking/mockSubscriptionLink';
 import { ApolloClient } from '../';

--- a/src/cache/core/__tests__/cache.ts
+++ b/src/cache/core/__tests__/cache.ts
@@ -1,6 +1,6 @@
 import gql from 'graphql-tag';
 import { ApolloCache  } from '../cache';
-import { Cache, DataProxy } from '../..';
+import type { Cache, DataProxy } from '../..';
 
 class TestCache extends ApolloCache<unknown> {
   constructor() {

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -1,10 +1,10 @@
-import { DocumentNode } from 'graphql';
+import type { DocumentNode } from 'graphql';
 import { wrap } from 'optimism';
 
 import { getFragmentQueryDocument } from '../../utilities/graphql/fragments';
-import { StoreObject } from '../../utilities/graphql/storeUtils';
-import { DataProxy } from './types/DataProxy';
-import { Cache } from './types/Cache';
+import type { StoreObject } from '../../utilities/graphql/storeUtils';
+import type { DataProxy } from './types/DataProxy';
+import type { Cache } from './types/Cache';
 
 export type Transaction<T> = (c: ApolloCache<T>) => void;
 
@@ -77,7 +77,7 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
   public identify(object: StoreObject): string | undefined {
     return;
   }
-  
+
   public gc(): string[] {
     return [];
   }

--- a/src/cache/core/types/Cache.ts
+++ b/src/cache/core/types/Cache.ts
@@ -1,4 +1,4 @@
-import { DataProxy } from './DataProxy';
+import type { DataProxy } from './DataProxy';
 
 export namespace Cache {
   export type WatchCallback = (diff: Cache.DiffResult<any>) => void;
@@ -33,8 +33,8 @@ export namespace Cache {
     broadcast?: boolean;
   }
 
-  export import DiffResult = DataProxy.DiffResult;
-  export import WriteQueryOptions = DataProxy.WriteQueryOptions;
-  export import WriteFragmentOptions = DataProxy.WriteFragmentOptions;
-  export import Fragment = DataProxy.Fragment;
+  export type DiffResult<T> = DataProxy.DiffResult<T>;
+  export type WriteQueryOptions<TData, TVariables> = DataProxy.WriteQueryOptions<TData, TVariables>;
+  export type WriteFragmentOptions<TData, TVariables> = DataProxy.WriteFragmentOptions<TData, TVariables>;
+  export type Fragment<TVariables> = DataProxy.Fragment<TVariables>;
 }

--- a/src/cache/core/types/DataProxy.ts
+++ b/src/cache/core/types/DataProxy.ts
@@ -1,6 +1,6 @@
-import { DocumentNode } from 'graphql'; // eslint-disable-line import/no-extraneous-dependencies, import/no-unresolved
+import type { DocumentNode } from 'graphql'; // eslint-disable-line import/no-extraneous-dependencies, import/no-unresolved
 
-import { MissingFieldError } from './common';
+import type { MissingFieldError } from './common';
 
 export namespace DataProxy {
   export interface Query<TVariables> {

--- a/src/cache/core/types/common.ts
+++ b/src/cache/core/types/common.ts
@@ -1,4 +1,4 @@
-import { DocumentNode } from 'graphql';
+import type { DocumentNode } from 'graphql';
 
 // The Readonly<T> type only really works for object types, since it marks
 // all of the object's properties as readonly, but there are many cases when

--- a/src/cache/inmemory/__tests__/diffAgainstStore.ts
+++ b/src/cache/inmemory/__tests__/diffAgainstStore.ts
@@ -1,11 +1,11 @@
 import gql, { disableFragmentWarnings } from 'graphql-tag';
 
-import { Reference } from '../../../core';
+import type { Reference } from '../../../core';
 import { defaultNormalizedCacheFactory } from '../entityStore';
 import { StoreReader } from '../readFromStore';
 import { StoreWriter } from '../writeToStore';
 import { defaultDataIdFromObject } from '../policies';
-import { NormalizedCache } from '../types';
+import type { NormalizedCache } from '../types';
 import { Policies } from '../policies';
 
 disableFragmentWarnings();

--- a/src/cache/inmemory/__tests__/entityStore.ts
+++ b/src/cache/inmemory/__tests__/entityStore.ts
@@ -1,11 +1,11 @@
 import gql from 'graphql-tag';
 import { EntityStore, supportsResultCaching } from '../entityStore';
 import { InMemoryCache } from '../inMemoryCache';
-import { DocumentNode } from 'graphql';
+import type { DocumentNode } from 'graphql';
 import { Policies } from '../policies';
-import { StoreObject } from '../types';
-import { ApolloCache } from '../../core/cache';
-import { Reference } from '../../../utilities/graphql/storeUtils';
+import type { StoreObject } from '../types';
+import type { ApolloCache } from '../../core/cache';
+import type { Reference } from '../../../utilities/graphql/storeUtils';
 import { MissingFieldError } from '../..';
 
 describe('EntityStore', () => {

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -1,7 +1,7 @@
 import gql from "graphql-tag";
 
 import { InMemoryCache, ReactiveVar } from "../inMemoryCache";
-import { Reference, StoreObject } from "../../../core";
+import type { Reference, StoreObject } from "../../../core";
 import { MissingFieldError } from "../..";
 
 function reverse(s: string) {

--- a/src/cache/inmemory/__tests__/readFromStore.ts
+++ b/src/cache/inmemory/__tests__/readFromStore.ts
@@ -2,7 +2,7 @@ import { assign, omit } from 'lodash';
 import gql from 'graphql-tag';
 
 import { stripSymbols } from '../../../utilities/testing/stripSymbols';
-import { StoreObject } from '../types';
+import type { StoreObject } from '../types';
 import { StoreReader } from '../readFromStore';
 import { makeReference } from '../../../core';
 import { defaultNormalizedCacheFactory } from '../entityStore';

--- a/src/cache/inmemory/__tests__/recordingCache.ts
+++ b/src/cache/inmemory/__tests__/recordingCache.ts
@@ -1,4 +1,4 @@
-import { NormalizedCacheObject, StoreObject } from '../types';
+import type { NormalizedCacheObject, StoreObject } from '../types';
 import { EntityStore } from '../entityStore';
 import { Policies } from '../policies';
 

--- a/src/cache/inmemory/__tests__/roundtrip.ts
+++ b/src/cache/inmemory/__tests__/roundtrip.ts
@@ -1,4 +1,4 @@
-import { DocumentNode } from 'graphql';
+import type { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
 
 import { withError } from './diffAgainstStore';

--- a/src/cache/inmemory/__tests__/writeToStore.ts
+++ b/src/cache/inmemory/__tests__/writeToStore.ts
@@ -1,5 +1,5 @@
 import { assign, omit } from 'lodash';
-import {
+import type {
   SelectionNode,
   FieldNode,
   DefinitionNode,

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -11,11 +11,11 @@ import {
 import { DeepMerger } from '../../utilities/common/mergeDeep';
 import { maybeDeepFreeze } from '../../utilities/common/maybeDeepFreeze';
 import { canUseWeakMap } from '../../utilities/common/canUse';
-import { NormalizedCache, NormalizedCacheObject } from './types';
+import type { NormalizedCache, NormalizedCacheObject } from './types';
 import { hasOwn, fieldNameFromStoreName } from './helpers';
 import { Policies } from './policies';
-import { SafeReadonly } from '../core/types/common';
-import { Cache } from '../core/types/Cache';
+import type { SafeReadonly } from '../core/types/common';
+import type { Cache } from '../core/types/Cache';
 
 export abstract class EntityStore implements NormalizedCache {
   protected data: NormalizedCacheObject = Object.create(null);

--- a/src/cache/inmemory/helpers.ts
+++ b/src/cache/inmemory/helpers.ts
@@ -1,6 +1,6 @@
-import { FieldNode } from 'graphql';
+import type { FieldNode } from 'graphql';
 
-import { NormalizedCache } from './types';
+import type { NormalizedCache } from './types';
 import {
   Reference,
   isReference,

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -1,14 +1,14 @@
 // Make builtins like Map and Set safe to use with non-extensible objects.
 import './fixPolyfills';
 
-import { DocumentNode } from 'graphql';
+import type { DocumentNode } from 'graphql';
 import { dep, wrap } from 'optimism';
 
 import { ApolloCache, Transaction } from '../core/cache';
-import { Cache } from '../core/types/Cache';
+import type { Cache } from '../core/types/Cache';
 import { addTypenameToDocument } from '../../utilities/graphql/transform';
-import { StoreObject }  from '../../utilities/graphql/storeUtils';
-import {
+import type { StoreObject }  from '../../utilities/graphql/storeUtils';
+import type {
   ApolloReducerConfig,
   NormalizedCacheObject,
 } from './types';

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   InlineFragmentNode,
   FragmentDefinitionNode,
   SelectionSetNode,
@@ -24,15 +24,15 @@ import {
   getStoreKeyName,
 } from '../../utilities/graphql/storeUtils';
 import { canUseWeakMap } from '../../utilities/common/canUse';
-import { IdGetter } from "./types";
+import type { IdGetter } from "./types";
 import {
   fieldNameFromStoreName,
   FieldValueToBeMerged,
   isFieldValueToBeMerged,
   storeValueIsStoreObject,
 } from './helpers';
-import { FieldValueGetter, ToReferenceFunction } from './entityStore';
-import { SafeReadonly } from '../core/types/common';
+import type { FieldValueGetter, ToReferenceFunction } from './entityStore';
+import type { SafeReadonly } from '../core/types/common';
 
 const hasOwn = Object.prototype.hasOwnProperty;
 

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   DocumentNode,
   FieldNode,
   FragmentDefinitionNode,
@@ -28,15 +28,15 @@ import {
 } from '../../utilities/graphql/getFromAST';
 import { maybeDeepFreeze } from '../../utilities/common/maybeDeepFreeze';
 import { mergeDeepArray } from '../../utilities/common/mergeDeep';
-import { Cache } from '../core/types/Cache';
-import {
+import type { Cache } from '../core/types/Cache';
+import type {
   DiffQueryAgainstStoreOptions,
   ReadQueryOptions,
   NormalizedCache,
 } from './types';
 import { supportsResultCaching } from './entityStore';
 import { getTypenameFromStoreObject } from './helpers';
-import { Policies, ReadMergeContext } from './policies';
+import type { Policies, ReadMergeContext } from './policies';
 import { MissingFieldError } from '../core/types/common';
 
 export type VariableMap = { [name: string]: any };

--- a/src/cache/inmemory/types.ts
+++ b/src/cache/inmemory/types.ts
@@ -1,9 +1,9 @@
-import { DocumentNode } from 'graphql';
+import type { DocumentNode } from 'graphql';
 
-import { Transaction } from '../core/cache';
-import { StoreValue, StoreObject } from '../../utilities/graphql/storeUtils';
-import { FieldValueGetter, ToReferenceFunction } from './entityStore';
-import { KeyFieldsFunction } from './policies';
+import type { Transaction } from '../core/cache';
+import type { StoreValue, StoreObject } from '../../utilities/graphql/storeUtils';
+import type { FieldValueGetter, ToReferenceFunction } from './entityStore';
+import type { KeyFieldsFunction } from './policies';
 export { StoreObject, StoreValue }
 
 export interface IdGetterObj extends Object {

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -1,4 +1,4 @@
-import { SelectionSetNode, FieldNode, DocumentNode } from 'graphql';
+import type { SelectionSetNode, FieldNode, DocumentNode } from 'graphql';
 import { InvariantError } from 'ts-invariant';
 
 import {
@@ -26,11 +26,11 @@ import {
 import { shouldInclude, hasDirectives } from '../../utilities/graphql/directives';
 import { cloneDeep } from '../../utilities/common/cloneDeep';
 
-import { Policies, ReadMergeContext } from './policies';
+import type { Policies, ReadMergeContext } from './policies';
 import { EntityStore } from './entityStore';
-import { NormalizedCache } from './types';
+import type { NormalizedCache } from './types';
 import { makeProcessedFieldsMerger, FieldValueToBeMerged } from './helpers';
-import { StoreReader } from './readFromStore';
+import type { StoreReader } from './readFromStore';
 
 export interface WriteContext extends ReadMergeContext {
   readonly store: NormalizedCache;
@@ -40,7 +40,7 @@ export interface WriteContext extends ReadMergeContext {
   readonly fragmentMap?: FragmentMap;
   // General-purpose deep-merge function for use during writes.
   merge<T>(existing: T, incoming: T): T;
-};
+}
 
 interface ProcessSelectionSetOptions {
   dataId?: string,

--- a/src/core/LocalState.ts
+++ b/src/core/LocalState.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   DocumentNode,
   OperationDefinitionNode,
   SelectionSetNode,
@@ -11,7 +11,7 @@ import {
 import { visit, BREAK } from 'graphql/language/visitor';
 import { invariant } from 'ts-invariant';
 
-import { ApolloCache } from '../cache/core/cache';
+import type { ApolloCache } from '../cache/core/cache';
 import {
   getMainDefinition,
   getFragmentDefinitions,
@@ -30,9 +30,9 @@ import {
   isInlineFragment,
   StoreObject,
 } from '../utilities/graphql/storeUtils';
-import { ApolloClient } from '../ApolloClient';
-import { Resolvers, OperationVariables } from './types';
-import { FetchResult } from '../link/core/types';
+import type { ApolloClient } from '../ApolloClient';
+import type { Resolvers, OperationVariables } from './types';
+import type { FetchResult } from '../link/core/types';
 
 export type Resolver = (
   rootValue?: any,

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -12,15 +12,15 @@ import {
 } from '../utilities/observables/Observable';
 import { iterateObserversSafely } from '../utilities/observables/iteration';
 import { ApolloError } from '../errors/ApolloError';
-import { QueryManager } from './QueryManager';
-import { ApolloQueryResult, OperationVariables } from './types';
-import {
+import type { QueryManager } from './QueryManager';
+import type { ApolloQueryResult, OperationVariables } from './types';
+import type {
   WatchQueryOptions,
   FetchMoreQueryOptions,
   SubscribeToMoreOptions,
   ErrorPolicy,
 } from './watchQueryOptions';
-import { QueryStoreValue } from './QueryInfo';
+import type { QueryStoreValue } from './QueryInfo';
 import { isNonEmptyArray } from '../utilities/common/arrays';
 import { Reobserver } from './Reobserver';
 

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -1,20 +1,20 @@
-import { DocumentNode, GraphQLError } from 'graphql';
+import type { DocumentNode, GraphQLError } from 'graphql';
 import { equal } from "@wry/equality";
 
-import { Cache } from '../cache/core/types/Cache';
-import { ApolloCache } from '../cache/core/cache';
-import { WatchQueryOptions } from './watchQueryOptions';
-import { ObservableQuery } from './ObservableQuery';
-import { QueryListener } from './types';
-import { FetchResult } from '../link/core/types';
-import { ObservableSubscription } from '../utilities/observables/Observable';
+import type { Cache } from '../cache/core/types/Cache';
+import type { ApolloCache } from '../cache/core/cache';
+import type { WatchQueryOptions } from './watchQueryOptions';
+import type { ObservableQuery } from './ObservableQuery';
+import type { QueryListener } from './types';
+import type { FetchResult } from '../link/core/types';
+import type { ObservableSubscription } from '../utilities/observables/Observable';
 import { isNonEmptyArray } from '../utilities/common/arrays';
 import { graphQLResultHasError } from '../utilities/common/errorHandling';
 import {
   NetworkStatus,
   isNetworkRequestInFlight,
 } from './networkStatus';
-import { ApolloError } from '../errors/ApolloError';
+import type { ApolloError } from '../errors/ApolloError';
 
 export type QueryStoreValue = Pick<QueryInfo,
   | "variables"

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1,11 +1,11 @@
-import { DocumentNode } from 'graphql';
+import type { DocumentNode } from 'graphql';
 import { invariant, InvariantError } from 'ts-invariant';
 import { equal } from '@wry/equality';
 
-import { ApolloLink } from '../link/core/ApolloLink';
+import type { ApolloLink } from '../link/core/ApolloLink';
 import { execute } from '../link/core/execute';
-import { FetchResult } from '../link/core/types';
-import { Cache } from '../cache/core/types/Cache';
+import type { FetchResult } from '../link/core/types';
+import type { Cache } from '../cache/core/types/Cache';
 
 import {
   getDefaultValues,
@@ -27,7 +27,7 @@ import {
   Observable,
 } from '../utilities/observables/Observable';
 import { MutationStore } from '../data/mutations';
-import {
+import type {
   QueryOptions,
   WatchQueryOptions,
   SubscriptionOptions,
@@ -37,7 +37,7 @@ import {
 } from './watchQueryOptions';
 import { ObservableQuery } from './ObservableQuery';
 import { NetworkStatus, isNetworkRequestInFlight } from './networkStatus';
-import {
+import type {
   QueryListener,
   ApolloQueryResult,
   OperationVariables,
@@ -50,7 +50,7 @@ import {
   ConcastSourcesIterable,
 } from '../utilities/observables/Concast';
 import { isNonEmptyArray } from '../utilities/common/arrays';
-import { ApolloCache } from '../cache/core/cache';
+import type { ApolloCache } from '../cache/core/cache';
 
 import { QueryInfo, QueryStoreValue } from './QueryInfo';
 

--- a/src/core/Reobserver.ts
+++ b/src/core/Reobserver.ts
@@ -1,8 +1,8 @@
-import { WatchQueryOptions } from './watchQueryOptions';
+import type { WatchQueryOptions } from './watchQueryOptions';
 import { NetworkStatus } from './networkStatus';
-import { ApolloQueryResult } from './types';
-import { Observer } from '../utilities/observables/Observable';
-import { Concast } from '../utilities/observables/Concast';
+import type { ApolloQueryResult } from './types';
+import type { Observer } from '../utilities/observables/Observable';
+import type { Concast } from '../utilities/observables/Concast';
 import { invariant } from 'ts-invariant';
 
 // Given that QueryManager#fetchQueryObservable returns only a single

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -8,7 +8,7 @@ import mockQueryManager from '../../utilities/testing/mocking/mockQueryManager';
 import mockWatchQuery from '../../utilities/testing/mocking/mockWatchQuery';
 import { mockSingleLink } from '../../utilities/testing/mocking/mockLink';
 
-import { ObservableQuery } from '../ObservableQuery';
+import type { ObservableQuery } from '../ObservableQuery';
 import { NetworkStatus } from '../networkStatus';
 import { QueryManager } from '../QueryManager';
 import { ApolloClient, NormalizedCacheObject } from '../../';

--- a/src/core/__tests__/QueryManager/index.ts
+++ b/src/core/__tests__/QueryManager/index.ts
@@ -7,9 +7,9 @@ import { DocumentNode, GraphQLError } from 'graphql';
 
 import { Observable, Observer } from '../../../utilities/observables/Observable';
 import { ApolloLink } from '../../../link/core/ApolloLink';
-import { GraphQLRequest, FetchResult } from '../../../link/core/types';
+import type { GraphQLRequest, FetchResult } from '../../../link/core/types';
 import { InMemoryCache } from '../../../cache/inmemory/inMemoryCache';
-import {
+import type {
   ApolloReducerConfig,
   NormalizedCacheObject
 } from '../../../cache/inmemory/types';
@@ -20,13 +20,13 @@ import mockWatchQuery from '../../../utilities/testing/mocking/mockWatchQuery';
 import { MockApolloLink, mockSingleLink } from '../../../utilities/testing/mocking/mockLink';
 
 // core
-import { ApolloQueryResult } from '../../types';
+import type { ApolloQueryResult } from '../../types';
 import { NetworkStatus } from '../../networkStatus';
-import { ObservableQuery } from '../../ObservableQuery';
-import { MutationBaseOptions, MutationOptions, WatchQueryOptions } from '../../watchQueryOptions';
+import type { ObservableQuery } from '../../ObservableQuery';
+import type { MutationBaseOptions, MutationOptions, WatchQueryOptions } from '../../watchQueryOptions';
 import { QueryManager } from '../../QueryManager';
 
-import { ApolloError } from '../../../errors/ApolloError';
+import type { ApolloError } from '../../../errors/ApolloError';
 
 // testing utils
 import wrap from '../../../utilities/testing/wrap';

--- a/src/core/__tests__/QueryManager/links.ts
+++ b/src/core/__tests__/QueryManager/links.ts
@@ -11,7 +11,7 @@ import { MockSubscriptionLink } from '../../../utilities/testing/mocking/mockSub
 
 // core
 import { QueryManager } from '../../QueryManager';
-import { NextLink, Operation, Reference } from '../../../core';
+import type { NextLink, Operation, Reference } from '../../../core';
 
 describe('Link interactions', () => {
   it('includes the cache on the context for eviction links', done => {

--- a/src/core/__tests__/QueryManager/recycler.ts
+++ b/src/core/__tests__/QueryManager/recycler.ts
@@ -14,7 +14,7 @@ import {
 
 // core
 import { QueryManager } from '../../QueryManager';
-import { ObservableQuery } from '../../ObservableQuery';
+import type { ObservableQuery } from '../../ObservableQuery';
 
 describe('Subscription lifecycles', () => {
   it('cleans up and reuses data like QueryRecycler wants', done => {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,9 +1,9 @@
-import { DocumentNode, GraphQLError } from 'graphql';
+import type { DocumentNode, GraphQLError } from 'graphql';
 
-import { FetchResult } from '../link/core/types';
-import { QueryInfo } from './QueryInfo';
-import { NetworkStatus } from './networkStatus';
-import { Resolver } from './LocalState';
+import type { FetchResult } from '../link/core/types';
+import type { QueryInfo } from './QueryInfo';
+import type { NetworkStatus } from './networkStatus';
+import type { Resolver } from './LocalState';
 
 export type QueryListener = (queryInfo: QueryInfo) => void;
 

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -1,9 +1,9 @@
-import { DocumentNode } from 'graphql';
+import type { DocumentNode } from 'graphql';
 
-import { ApolloCache } from '../cache/core/cache';
-import { FetchResult } from '../link/core/types';
-import { MutationQueryReducersMap } from './types';
-import { PureQueryOptions, OperationVariables } from './types';
+import type { ApolloCache } from '../cache/core/cache';
+import type { FetchResult } from '../link/core/types';
+import type { MutationQueryReducersMap } from './types';
+import type { PureQueryOptions, OperationVariables } from './types';
 
 /**
  * fetchPolicy determines where the client may return a result from. The options are:

--- a/src/data/mutations.ts
+++ b/src/data/mutations.ts
@@ -1,4 +1,4 @@
-import { DocumentNode } from 'graphql';
+import type { DocumentNode } from 'graphql';
 
 export class MutationStore {
   private store: { [mutationId: string]: MutationStoreValue } = {};

--- a/src/errors/ApolloError.ts
+++ b/src/errors/ApolloError.ts
@@ -1,4 +1,4 @@
-import { GraphQLError } from 'graphql';
+import type { GraphQLError } from 'graphql';
 
 import { isNonEmptyArray } from '../utilities/common/arrays';
 

--- a/src/link/core/ApolloLink.ts
+++ b/src/link/core/ApolloLink.ts
@@ -1,7 +1,7 @@
 import { InvariantError, invariant } from 'ts-invariant';
 
 import { Observable } from '../../utilities/observables/Observable';
-import {
+import type {
   NextLink,
   Operation,
   RequestHandler,

--- a/src/link/core/__tests__/ApolloLink.ts
+++ b/src/link/core/__tests__/ApolloLink.ts
@@ -2,9 +2,9 @@ import gql from 'graphql-tag';
 import { print } from 'graphql/language/printer';
 
 import { Observable } from '../../../utilities/observables/Observable';
-import { FetchResult, Operation, NextLink, GraphQLRequest } from '../types';
+import type { FetchResult, Operation, NextLink, GraphQLRequest } from '../types';
 import { ApolloLink } from '../ApolloLink';
-import { DocumentNode } from 'graphql';
+import type { DocumentNode } from 'graphql';
 
 export class SetContextLink extends ApolloLink {
   constructor(

--- a/src/link/core/types.ts
+++ b/src/link/core/types.ts
@@ -1,8 +1,8 @@
-import { DocumentNode } from 'graphql/language/ast';
-import { ExecutionResult } from 'graphql/execution/execute';
+import type { DocumentNode } from 'graphql/language/ast';
+import type { ExecutionResult } from 'graphql/execution/execute';
 export { DocumentNode };
 
-import { Observable } from '../../utilities/observables/Observable';
+import type { Observable } from '../../utilities/observables/Observable';
 
 export interface GraphQLRequest {
   query: DocumentNode;

--- a/src/link/http/HttpLink.ts
+++ b/src/link/http/HttpLink.ts
@@ -1,6 +1,6 @@
 import { ApolloLink } from '../core/ApolloLink';
-import { RequestHandler } from '../core/types';
-import { HttpOptions } from './selectHttpOptionsAndBody';
+import type { RequestHandler } from '../core/types';
+import type { HttpOptions } from './selectHttpOptionsAndBody';
 import { createHttpLink } from './createHttpLink';
 
 export class HttpLink extends ApolloLink {

--- a/src/link/http/__tests__/HttpLink.ts
+++ b/src/link/http/__tests__/HttpLink.ts
@@ -7,9 +7,9 @@ import { ApolloLink } from '../../core/ApolloLink';
 import { execute } from '../../core/execute';
 import { HttpLink } from '../HttpLink';
 import { createHttpLink } from '../createHttpLink';
-import { ClientParseError } from '../serializeFetchParameter';
-import { ServerParseError } from '../parseAndCheckHttpResponse';
-import { ServerError } from '../../..';
+import type { ClientParseError } from '../serializeFetchParameter';
+import type { ServerParseError } from '../parseAndCheckHttpResponse';
+import type { ServerError } from '../../..';
 import DoneCallback = jest.DoneCallback;
 
 const sampleQuery = gql`

--- a/src/link/http/createHttpLink.ts
+++ b/src/link/http/createHttpLink.ts
@@ -1,4 +1,4 @@
-import { DefinitionNode } from 'graphql';
+import type { DefinitionNode } from 'graphql';
 
 import { Observable } from '../../utilities/observables/Observable';
 import { serializeFetchParameter } from './serializeFetchParameter';

--- a/src/link/http/parseAndCheckHttpResponse.ts
+++ b/src/link/http/parseAndCheckHttpResponse.ts
@@ -1,4 +1,4 @@
-import { Operation } from '../core/types';
+import type { Operation } from '../core/types';
 import { throwServerError } from '../utils/throwServerError';
 
 const { hasOwnProperty } = Object.prototype;

--- a/src/link/http/rewriteURIForGET.ts
+++ b/src/link/http/rewriteURIForGET.ts
@@ -1,5 +1,5 @@
 import { serializeFetchParameter } from './serializeFetchParameter';
-import { Body } from './selectHttpOptionsAndBody';
+import type { Body } from './selectHttpOptionsAndBody';
 
 // For GET operations, returns the given URI rewritten with parameters, or a
 // parse error.

--- a/src/link/http/selectHttpOptionsAndBody.ts
+++ b/src/link/http/selectHttpOptionsAndBody.ts
@@ -1,6 +1,6 @@
 import { print } from 'graphql/language/printer';
 
-import { Operation } from '../core/types';
+import type { Operation } from '../core/types';
 
 export interface UriFunction {
   (operation: Operation): string;

--- a/src/link/http/selectURI.ts
+++ b/src/link/http/selectURI.ts
@@ -1,4 +1,4 @@
-import { Operation } from '../core/types';
+import type { Operation } from '../core/types';
 
 export const selectURI = (
   operation: Operation,

--- a/src/link/utils/createOperation.ts
+++ b/src/link/utils/createOperation.ts
@@ -1,4 +1,4 @@
-import { GraphQLRequest, Operation } from '../core/types';
+import type { GraphQLRequest, Operation } from '../core/types';
 
 export function createOperation(
   starting: any,

--- a/src/link/utils/toPromise.ts
+++ b/src/link/utils/toPromise.ts
@@ -1,6 +1,6 @@
 import { invariant } from 'ts-invariant';
 
-import { Observable } from '../../utilities/observables/Observable';
+import type { Observable } from '../../utilities/observables/Observable';
 
 export function toPromise<R>(observable: Observable<R>): Promise<R> {
   let completed = false;

--- a/src/link/utils/transformOperation.ts
+++ b/src/link/utils/transformOperation.ts
@@ -1,4 +1,4 @@
-import { GraphQLRequest, Operation } from '../core/types';
+import type { GraphQLRequest, Operation } from '../core/types';
 import { getOperationName } from '../../utilities/graphql/getFromAST';
 
 export function transformOperation(operation: GraphQLRequest): GraphQLRequest {

--- a/src/link/utils/validateOperation.ts
+++ b/src/link/utils/validateOperation.ts
@@ -1,6 +1,6 @@
 import { InvariantError } from 'ts-invariant';
 
-import { GraphQLRequest } from '../core/types';
+import type { GraphQLRequest } from '../core/types';
 
 export function validateOperation(operation: GraphQLRequest): GraphQLRequest {
   const OPERATION_FIELDS = [

--- a/src/react/context/ApolloConsumer.tsx
+++ b/src/react/context/ApolloConsumer.tsx
@@ -1,6 +1,6 @@
 import { invariant } from 'ts-invariant';
 
-import { ApolloClient } from '../../ApolloClient';
+import type { ApolloClient } from '../../ApolloClient';
 import { getApolloContext } from './ApolloContext';
 import { requireReactLazily } from '../react';
 

--- a/src/react/context/ApolloContext.ts
+++ b/src/react/context/ApolloContext.ts
@@ -1,4 +1,4 @@
-import { ApolloClient } from '../../ApolloClient';
+import type { ApolloClient } from '../../ApolloClient';
 import { requireReactLazily } from '../react';
 
 export interface ApolloContextValue {

--- a/src/react/context/ApolloProvider.tsx
+++ b/src/react/context/ApolloProvider.tsx
@@ -1,6 +1,6 @@
 import { invariant } from 'ts-invariant';
 
-import { ApolloClient } from '../../ApolloClient';
+import type { ApolloClient } from '../../ApolloClient';
 import { getApolloContext } from './ApolloContext';
 import { requireReactLazily } from '../react';
 

--- a/src/react/data/MutationData.ts
+++ b/src/react/data/MutationData.ts
@@ -2,15 +2,15 @@ import { equal } from '@wry/equality';
 
 import { DocumentType } from '../parser/parser';
 import { ApolloError } from '../../errors/ApolloError';
-import {
+import type {
   MutationDataOptions,
   MutationTuple,
   MutationFunctionOptions,
   MutationResult
 } from '../types/types';
 import { OperationData } from './OperationData';
-import { OperationVariables } from '../../core/types';
-import { FetchResult } from '../../link/core/types';
+import type { OperationVariables } from '../../core/types';
+import type { FetchResult } from '../../link/core/types';
 
 export class MutationData<
   TData = any,

--- a/src/react/data/OperationData.ts
+++ b/src/react/data/OperationData.ts
@@ -1,10 +1,10 @@
-import { DocumentNode } from 'graphql';
+import type { DocumentNode } from 'graphql';
 import { equal } from '@wry/equality';
 import { invariant } from 'ts-invariant';
 
-import { ApolloClient } from '../../ApolloClient';
+import type { ApolloClient } from '../../ApolloClient';
 import { DocumentType, parser, operationName } from '../parser/parser';
-import { CommonOptions } from '../types/types';
+import type { CommonOptions } from '../types/types';
 
 export abstract class OperationData<TOptions = any> {
   public isMounted: boolean = false;

--- a/src/react/data/QueryData.ts
+++ b/src/react/data/QueryData.ts
@@ -2,22 +2,22 @@ import { equal } from '@wry/equality';
 
 import { ApolloError } from '../../errors/ApolloError';
 import { NetworkStatus } from '../../core/networkStatus';
-import {
+import type {
   FetchMoreQueryOptions,
   SubscribeToMoreOptions
 } from '../../core/watchQueryOptions';
-import {
+import type {
   ObservableQuery,
   FetchMoreOptions,
   UpdateQueryOptions
 } from '../../core/ObservableQuery';
 
-import {
+import type {
   ObservableSubscription
 } from '../../utilities/observables/Observable';
 
 import { DocumentType } from '../parser/parser';
-import {
+import type {
   QueryResult,
   QueryPreviousData,
   QueryDataOptions,

--- a/src/react/data/SubscriptionData.ts
+++ b/src/react/data/SubscriptionData.ts
@@ -1,7 +1,7 @@
 import { equal } from '@wry/equality';
 
 import { OperationData } from './OperationData';
-import {
+import type {
   SubscriptionCurrentObservable,
   SubscriptionDataOptions,
   SubscriptionResult

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -1,4 +1,4 @@
-import { DocumentNode } from 'graphql';
+import type { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
 import { render, wait } from '@testing-library/react';
 

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -12,7 +12,7 @@ import { InMemoryCache } from '../../../cache/inmemory/inMemoryCache';
 import { ApolloProvider } from '../../context/ApolloProvider';
 import { useQuery } from '../useQuery';
 import { requireReactLazily } from '../../react';
-import { QueryFunctionOptions } from '../..';
+import type { QueryFunctionOptions } from '../..';
 import { NetworkStatus } from '../../../core/networkStatus';
 
 const React = requireReactLazily();

--- a/src/react/hooks/useApolloClient.ts
+++ b/src/react/hooks/useApolloClient.ts
@@ -1,6 +1,6 @@
 import { invariant } from 'ts-invariant';
 
-import { ApolloClient } from '../../ApolloClient';
+import type { ApolloClient } from '../../ApolloClient';
 import { getApolloContext } from '../context/ApolloContext';
 import { requireReactLazily } from '../react';
 

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -1,8 +1,8 @@
-import { DocumentNode } from 'graphql';
+import type { DocumentNode } from 'graphql';
 
-import { LazyQueryHookOptions, QueryTuple } from '../types/types';
+import type { LazyQueryHookOptions, QueryTuple } from '../types/types';
 import { useBaseQuery } from './utils/useBaseQuery';
-import { OperationVariables } from '../../core/types';
+import type { OperationVariables } from '../../core/types';
 
 export function useLazyQuery<TData = any, TVariables = OperationVariables>(
   query: DocumentNode,

--- a/src/react/hooks/useMutation.ts
+++ b/src/react/hooks/useMutation.ts
@@ -1,8 +1,8 @@
-import { DocumentNode } from 'graphql';
+import type { DocumentNode } from 'graphql';
 
-import { MutationHookOptions, MutationTuple } from '../types/types';
+import type { MutationHookOptions, MutationTuple } from '../types/types';
 import { MutationData } from '../data/MutationData';
-import { OperationVariables } from '../../core/types';
+import type { OperationVariables } from '../../core/types';
 import { getApolloContext } from '../context/ApolloContext';
 import { requireReactLazily } from '../react';
 

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -1,8 +1,8 @@
-import { DocumentNode } from 'graphql';
+import type { DocumentNode } from 'graphql';
 
-import { QueryHookOptions, QueryResult } from '../types/types';
+import type { QueryHookOptions, QueryResult } from '../types/types';
 import { useBaseQuery } from './utils/useBaseQuery';
-import { OperationVariables } from '../../core/types';
+import type { OperationVariables } from '../../core/types';
 
 export function useQuery<TData = any, TVariables = OperationVariables>(
   query: DocumentNode,

--- a/src/react/hooks/useSubscription.ts
+++ b/src/react/hooks/useSubscription.ts
@@ -1,8 +1,8 @@
-import { DocumentNode } from 'graphql';
+import type { DocumentNode } from 'graphql';
 
-import { SubscriptionHookOptions } from '../types/types';
+import type { SubscriptionHookOptions } from '../types/types';
 import { SubscriptionData } from '../data/SubscriptionData';
-import { OperationVariables } from '../../core/types';
+import type { OperationVariables } from '../../core/types';
 import { getApolloContext } from '../context/ApolloContext';
 import { requireReactLazily } from '../react';
 

--- a/src/react/hooks/utils/useBaseQuery.ts
+++ b/src/react/hooks/utils/useBaseQuery.ts
@@ -1,6 +1,6 @@
-import { DocumentNode } from 'graphql';
+import type { DocumentNode } from 'graphql';
 
-import {
+import type {
   QueryHookOptions,
   QueryDataOptions,
   QueryTuple,
@@ -8,7 +8,7 @@ import {
 } from '../../types/types';
 import { QueryData } from '../../data/QueryData';
 import { useDeepMemo } from './useDeepMemo';
-import { OperationVariables } from '../../../core/types';
+import type { OperationVariables } from '../../../core/types';
 import { getApolloContext } from '../../context/ApolloContext';
 import { requireReactLazily } from '../../react';
 

--- a/src/react/parser/parser.ts
+++ b/src/react/parser/parser.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   DocumentNode,
   DefinitionNode,
   VariableDefinitionNode,

--- a/src/react/ssr/RenderPromises.ts
+++ b/src/react/ssr/RenderPromises.ts
@@ -1,8 +1,8 @@
-import { DocumentNode } from 'graphql';
+import type { DocumentNode } from 'graphql';
 
-import { ObservableQuery } from '../../core/ObservableQuery';
-import { QueryDataOptions } from '../types/types';
-import { QueryData } from '../data/QueryData';
+import type { ObservableQuery } from '../../core/ObservableQuery';
+import type { QueryDataOptions } from '../types/types';
+import type { QueryData } from '../data/QueryData';
 
 type QueryInfo = {
   seen: boolean;

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -1,24 +1,24 @@
-import { ReactNode } from 'react';
-import { DocumentNode } from 'graphql';
+import type { ReactNode } from 'react';
+import type { DocumentNode } from 'graphql';
 
-import { Observable } from '../../utilities/observables/Observable';
-import { FetchResult } from '../../link/core/types';
-import { ApolloClient } from '../../ApolloClient';
-import {
+import type { Observable } from '../../utilities/observables/Observable';
+import type { FetchResult } from '../../link/core/types';
+import type { ApolloClient } from '../../ApolloClient';
+import type {
   ApolloQueryResult,
   PureQueryOptions,
   OperationVariables
 } from '../../core/types';
-import { ApolloError } from '../../errors/ApolloError';
-import {
+import type { ApolloError } from '../../errors/ApolloError';
+import type {
   FetchPolicy,
   WatchQueryFetchPolicy,
   ErrorPolicy,
   FetchMoreQueryOptions,
   MutationUpdaterFn,
 } from '../../core/watchQueryOptions';
-import { FetchMoreOptions, ObservableQuery } from '../../core/ObservableQuery';
-import { NetworkStatus } from '../../core/networkStatus';
+import type { FetchMoreOptions, ObservableQuery } from '../../core/ObservableQuery';
+import type { NetworkStatus } from '../../core/networkStatus';
 
 /* Common types */
 

--- a/src/utilities/common/errorHandling.ts
+++ b/src/utilities/common/errorHandling.ts
@@ -1,4 +1,4 @@
-import { ExecutionResult } from 'graphql';
+import type { ExecutionResult } from 'graphql';
 
 export function tryFunctionOrLogError(f: Function) {
   try {

--- a/src/utilities/graphql/__tests__/getFromAST.ts
+++ b/src/utilities/graphql/__tests__/getFromAST.ts
@@ -1,6 +1,6 @@
 import { print } from 'graphql/language/printer';
 import gql from 'graphql-tag';
-import { FragmentDefinitionNode, OperationDefinitionNode } from 'graphql';
+import type { FragmentDefinitionNode, OperationDefinitionNode } from 'graphql';
 
 import {
   checkDocument,

--- a/src/utilities/graphql/directives.ts
+++ b/src/utilities/graphql/directives.ts
@@ -1,6 +1,6 @@
 // Provides the methods that allow QueryManager to handle the `skip` and
 // `include` directives within GraphQL.
-import {
+import type {
   SelectionNode,
   VariableNode,
   BooleanValueNode,

--- a/src/utilities/graphql/fragments.ts
+++ b/src/utilities/graphql/fragments.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   DocumentNode,
   FragmentDefinitionNode,
   InlineFragmentNode,

--- a/src/utilities/graphql/getFromAST.ts
+++ b/src/utilities/graphql/getFromAST.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   DocumentNode,
   OperationDefinitionNode,
   FragmentDefinitionNode,

--- a/src/utilities/graphql/storeUtils.ts
+++ b/src/utilities/graphql/storeUtils.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   DirectiveNode,
   FieldNode,
   IntValueNode,

--- a/src/utilities/graphql/transform.ts
+++ b/src/utilities/graphql/transform.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   DocumentNode,
   SelectionNode,
   SelectionSetNode,

--- a/src/utilities/observables/iteration.ts
+++ b/src/utilities/observables/iteration.ts
@@ -1,4 +1,4 @@
-import { Observer } from "./Observable";
+import type { Observer } from "./Observable";
 
 export function iterateObserversSafely<E, A>(
   observers: Set<Observer<E>>,

--- a/src/utilities/testing/mocking/MockedProvider.tsx
+++ b/src/utilities/testing/mocking/MockedProvider.tsx
@@ -4,10 +4,10 @@ import { ApolloClient, DefaultOptions } from '../../../ApolloClient';
 import { InMemoryCache as Cache } from '../../../cache/inmemory/inMemoryCache';
 import { ApolloProvider } from '../../../react/context/ApolloProvider';
 import { MockLink } from '../../../utilities/testing/mocking/mockLink';
-import { ApolloLink } from '../../../link/core/ApolloLink';
-import { Resolvers } from '../../../core/types';
-import { ApolloCache } from '../../../cache/core/cache';
-import { MockedResponse } from '../../../utilities/testing/mocking/mockLink';
+import type { ApolloLink } from '../../../link/core/ApolloLink';
+import type { Resolvers } from '../../../core/types';
+import type { ApolloCache } from '../../../cache/core/cache';
+import type { MockedResponse } from '../../../utilities/testing/mocking/mockLink';
 
 export interface MockedProviderProps<TSerializedCache = {}> {
   mocks?: ReadonlyArray<MockedResponse>;

--- a/src/utilities/testing/mocking/mockClient.ts
+++ b/src/utilities/testing/mocking/mockClient.ts
@@ -1,8 +1,8 @@
-import { DocumentNode } from 'graphql';
+import type { DocumentNode } from 'graphql';
 
 import { ApolloClient } from '../../../ApolloClient';
 import { InMemoryCache } from '../../../cache/inmemory/inMemoryCache';
-import { NormalizedCacheObject } from '../../../cache/inmemory/types';
+import type { NormalizedCacheObject } from '../../../cache/inmemory/types';
 import { mockSingleLink } from '../../../utilities/testing/mocking/mockLink';
 
 export function createMockClient<TData>(

--- a/src/utilities/testing/mocking/mockLink.ts
+++ b/src/utilities/testing/mocking/mockLink.ts
@@ -3,7 +3,7 @@ import { equal } from '@wry/equality';
 
 import { Observable } from '../../../utilities/observables/Observable';
 import { ApolloLink } from '../../../link/core/ApolloLink';
-import {
+import type {
   Operation,
   GraphQLRequest,
   FetchResult,

--- a/src/utilities/testing/mocking/mockSubscriptionLink.ts
+++ b/src/utilities/testing/mocking/mockSubscriptionLink.ts
@@ -1,6 +1,6 @@
 import { Observable } from '../../../utilities/observables/Observable';
 import { ApolloLink } from '../../../link/core/ApolloLink';
-import { FetchResult, Operation } from '../../../link/core/types';
+import type { FetchResult, Operation } from '../../../link/core/types';
 
 export interface MockedSubscription {
   request: Operation;

--- a/src/utilities/testing/mocking/mockWatchQuery.ts
+++ b/src/utilities/testing/mocking/mockWatchQuery.ts
@@ -1,6 +1,6 @@
-import { MockedResponse } from './mockLink';
+import type { MockedResponse } from './mockLink';
 import mockQueryManager from './mockQueryManager';
-import { ObservableQuery } from '../../../core/ObservableQuery';
+import type { ObservableQuery } from '../../../core/ObservableQuery';
 
 export default (
   reject: (reason: any) => any,

--- a/src/utilities/testing/observableToPromise.ts
+++ b/src/utilities/testing/observableToPromise.ts
@@ -1,6 +1,6 @@
-import { ObservableQuery } from '../../core/ObservableQuery';
-import { ApolloQueryResult } from '../../core/types';
-import { ObservableSubscription } from '../../utilities/observables/Observable';
+import type { ObservableQuery } from '../../core/ObservableQuery';
+import type { ApolloQueryResult } from '../../core/types';
+import type { ObservableSubscription } from '../../utilities/observables/Observable';
 
 /**
  *

--- a/src/utilities/testing/subscribeAndCount.ts
+++ b/src/utilities/testing/subscribeAndCount.ts
@@ -1,6 +1,6 @@
-import { ObservableQuery } from '../../core/ObservableQuery';
-import { ApolloQueryResult } from '../../core/types';
-import { ObservableSubscription } from '../../utilities/observables/Observable';
+import type { ObservableQuery } from '../../core/ObservableQuery';
+import type { ApolloQueryResult } from '../../core/types';
+import type { ObservableSubscription } from '../../utilities/observables/Observable';
 import { asyncMap } from '../../utilities/observables/asyncMap';
 
 export default function subscribeAndCount(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "target": "es5",
     "module": "es2015",
     "esModuleInterop": true,
+    "importsNotUsedAsValues": "error",
     "outDir": "./dist",
     "lib": ["es2015", "esnext.asynciterable", "dom"],
     "jsx": "react"


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests

This helps strip out imports that aren't used at runtime.

Before: `./dist/apollo-client.cjs.min.js: 23.89KB < maxSize 24KB (gzip`
After: `./dist/apollo-client.cjs.min.js: 23.88KB < maxSize 24KB (gzip)`

So not a huge difference, but it also avoids the footgun where you import some file for types and it ends up running with side effects.

Note that this requires consumers to have at least TS@3.8, not sure if you have a minimum TS version now?