### PR TITLE
Expand error types to match actual error data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,6 +173,9 @@
 - `useQuery`: Prevent new data re-render attempts during an existing render. This helps avoid React 16.13.0's "Cannot update a component from inside the function body of a different component" warning (https://github.com/facebook/react/pull/17099). <br/>
   [@hwillson](https://github.com/hwillson) in [#6107](https://github.com/apollographql/apollo-client/pull/6107)
 
+- Expand `ApolloError` typings to include `ServerError` and `ServerParseError`.  <br/>
+  [@dmarkow](https://github.com/dmarkow) in [#6319](https://github.com/apollographql/apollo-client/pull/6319)
+
 ## Apollo Client 2.6.8
 
 ### Apollo Client (2.6.8)

--- a/src/errors/ApolloError.ts
+++ b/src/errors/ApolloError.ts
@@ -1,6 +1,8 @@
 import { GraphQLError } from 'graphql';
 
 import { isNonEmptyArray } from '../utilities/common/arrays';
+import { ServerParseError } from '../link/http/parseAndCheckHttpResponse';
+import { ServerError } from '../link/utils/throwServerError';
 
 export function isApolloError(err: Error): err is ApolloError {
   return err.hasOwnProperty('graphQLErrors');
@@ -34,7 +36,7 @@ const generateErrorMessage = (err: ApolloError) => {
 export class ApolloError extends Error {
   public message: string;
   public graphQLErrors: ReadonlyArray<GraphQLError>;
-  public networkError: Error | null;
+  public networkError: Error | ServerParseError | ServerError | null;
 
   // An object that can be used to provide some additional information
   // about an error, e.g. specifying the type of error this is. Used
@@ -51,7 +53,7 @@ export class ApolloError extends Error {
     extraInfo,
   }: {
     graphQLErrors?: ReadonlyArray<GraphQLError>;
-    networkError?: Error | null;
+    networkError?: Error | ServerParseError | ServerError | null;
     errorMessage?: string;
     extraInfo?: any;
   }) {


### PR DESCRIPTION
Expands typing of `ApolloError` to include `ServerError` and `ServerParseError`. Fixes #6309