### PR TITLE
Update .vscode/launch.json to match official recipe.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,17 +2,21 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Test",
-      "request": "launch",
       "type": "node",
-      "program":
-        "${workspaceRoot}/packages/apollo-client/node_modules/jest/bin/jest.js",
-      "internalConsoleOptions": "openOnSessionStart",
-      "stopOnEntry": false,
-      "args": ["-i"],
-      "cwd": "${workspaceRoot}/packages/apollo-client",
-      "sourceMaps": true,
-      "outFiles": ["${workspaceRoot}/lib/**/*"]
+      "request": "launch",
+      "name": "Jest Current File",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": [
+        "${fileBasenameNoExtension}",
+        "--config",
+        "./config/jest.config.js"
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true,
+      "windows": {
+        "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+      }
     }
   ]
 }


### PR DESCRIPTION
I've found F5 doesn't start test correctly.
It seems this setting is outdated.
I've just copied from the official recipe and changed jest config path to ./config/jest.config.js.

https://github.com/microsoft/vscode-recipes/tree/485d405916e82919d845d2fd038b77f32d5191e8/debugging-jest-tests#configure-launchjson-file-for-your-test-framework