### PR TITLE
Check Symbol.for exists in addition to Symbol before using it.

### DIFF
--- a/src/react/context/ApolloContext.ts
+++ b/src/react/context/ApolloContext.ts
@@ -15,7 +15,7 @@ export interface ApolloContextValue {
 
 // If Symbol's aren't available, we'll use a fallback string as the context
 // property (we're looking at you, IE11).
-const contextSymbol = typeof Symbol === 'function' ?
+const contextSymbol = typeof Symbol === 'function' && Symbol.for ?
   Symbol.for('__APOLLO_CONTEXT__') :
   '__APOLLO_CONTEXT__';
 


### PR DESCRIPTION
In some cases, Symbol may be shimmed but not Symbol.for. In those cases,
the existing code would throw on platforms with no native Symbol (IE11).

This change ensures `Symbol.for` exists before using it, preventing the
issue.

We encountered this issue because of a deferred script partially shimming Symbol. After trying to load Apollo code asynchronously, IE11 would occasionally throw.
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
