### PR TITLE
Document .modifiers renaming for local-state

### DIFF
--- a/docs/source/data/local-state.mdx
+++ b/docs/source/data/local-state.mdx
@@ -181,7 +181,7 @@ const client = new ApolloClient({
             __typename: 'TodoItem',
             id: variables.id,
           }),
-          modifiers: {
+          fields: {
             completed: value => !value,
           },
         });
@@ -1095,7 +1095,7 @@ const client = new ApolloClient({
 };
 ```
 
-The `cache.writeQuery` and `cache.writeFragment` methods should cover most of your needs; however, there are some cases where the data you're writing to the cache depends on the data that's already there. In that scenario, you can either use a combination of `cache.read{Query,Fragment}` followed by `cache.write{Query,Fragment}`, or use `cache.modify({ id, modifiers })` to update specific fields within the entity object identified by `id`.
+The `cache.writeQuery` and `cache.writeFragment` methods should cover most of your needs; however, there are some cases where the data you're writing to the cache depends on the data that's already there. In that scenario, you can either use a combination of `cache.read{Query,Fragment}` followed by `cache.write{Query,Fragment}`, or use `cache.modify({ id, fields })` to update specific fields within the entity object identified by `id`.
 
 ### writeQuery and readQuery
 


### PR DESCRIPTION
Follow up to: https://github.com/apollographql/apollo-client/pull/6350/commits/806b077a65179b8d06b70295ba50bd4cf69a562e
It looks like we forgot to document renaming of `modifiers` to `fields` in `local-state` docs. 
This small PR fixes the issue.
Thanks a lot for reinstating `cache.modify` @benjamn 