### PR TITLE
Removed broken/nonexistent example URLs from React Native docs.

### DIFF
--- a/docs/source/integrations/react-native.md
+++ b/docs/source/integrations/react-native.md
@@ -30,12 +30,6 @@ AppRegistry.registerComponent('MyApplication', () => App);
 
 If you are new to using Apollo with React, you should probably read the [React guide](/).
 
-## Examples
-
-There are some Apollo examples written in React Native that you may wish to refer to:
-
-1. The ["Hello World" example](https://github.com/apollographql/frontpage-react-native-app) used at dev.apollodata.com.
-2. A [GitHub API Example](https://github.com/apollographql/GitHub-GraphQL-API-Example) built to work with GitHub's new GraphQL API.
 
 ## Apollo Dev Tools
 


### PR DESCRIPTION
Related to [6321](https://github.com/apollographql/apollo-client/issues/6321)

I tried to dig if there are any official examples, but with no success so I believe the most proper thing to do is to remove the non-existent ones.