### PR TITLE
Hoist cache.modify method declaration to ApolloCache.

### DIFF
--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -82,6 +82,10 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
     return [];
   }
 
+  public modify(options: Cache.ModifyOptions): boolean {
+    return false;
+  }
+
   // Experimental API
 
   public transformForLink(document: DocumentNode): DocumentNode {

--- a/src/cache/core/types/Cache.ts
+++ b/src/cache/core/types/Cache.ts
@@ -1,4 +1,5 @@
 import { DataProxy } from './DataProxy';
+import { Modifier, Modifiers } from './common';
 
 export namespace Cache {
   export type WatchCallback = (diff: Cache.DiffResult<any>) => void;
@@ -30,6 +31,13 @@ export namespace Cache {
     id: string;
     fieldName?: string;
     args?: Record<string, any>;
+    broadcast?: boolean;
+  }
+
+  export interface ModifyOptions {
+    id?: string;
+    fields: Modifiers | Modifier<any>;
+    optimistic?: boolean;
     broadcast?: boolean;
   }
 

--- a/src/cache/core/types/common.ts
+++ b/src/cache/core/types/common.ts
@@ -1,3 +1,12 @@
+import { FieldNode } from 'graphql';
+
+import {
+  Reference,
+  StoreObject,
+  StoreValue,
+  isReference,
+} from '../../../core';
+
 // The Readonly<T> type only really works for object types, since it marks
 // all of the object's properties as readonly, but there are many cases when
 // a generic type parameter like TExisting might be a string or some other
@@ -15,3 +24,41 @@ export class MissingFieldError {
     public readonly variables?: Record<string, any>,
   ) {}
 }
+
+export interface FieldSpecifier {
+  typename?: string;
+  fieldName: string;
+  field?: FieldNode;
+  args?: Record<string, any>;
+  variables?: Record<string, any>;
+}
+
+export interface ReadFieldOptions extends FieldSpecifier {
+  from?: StoreObject | Reference;
+}
+
+export interface ReadFieldFunction {
+  <V = StoreValue>(options: ReadFieldOptions): SafeReadonly<V> | undefined;
+  <V = StoreValue>(
+    fieldName: string,
+    from?: StoreObject | Reference,
+  ): SafeReadonly<V> | undefined;
+}
+
+export type ToReferenceFunction = (
+  object: StoreObject,
+  mergeIntoStore?: boolean,
+) => Reference | undefined;
+
+export type Modifier<T> = (value: T, details: {
+  DELETE: any;
+  fieldName: string;
+  storeFieldName: string;
+  readField: ReadFieldFunction;
+  isReference: typeof isReference;
+  toReference: ToReferenceFunction;
+}) => T;
+
+export type Modifiers = {
+  [fieldName: string]: Modifier<any>;
+};

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -11,7 +11,6 @@ import { StoreObject, Reference }  from '../../utilities/graphql/storeUtils';
 import {
   ApolloReducerConfig,
   NormalizedCacheObject,
-  ModifyOptions,
 } from './types';
 import { StoreReader } from './readFromStore';
 import { StoreWriter } from './writeToStore';
@@ -156,7 +155,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     }
   }
 
-  public modify(options: ModifyOptions): boolean {
+  public modify(options: Cache.ModifyOptions): boolean {
     if (hasOwn.call(options, "id") && !options.id) {
       // To my knowledge, TypeScript does not currently provide a way to
       // enforce that an optional property?:type must *not* be undefined

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -24,12 +24,7 @@ import {
   getStoreKeyName,
 } from '../../utilities/graphql/storeUtils';
 import { canUseWeakMap } from '../../utilities/common/canUse';
-import {
-  IdGetter,
-  FieldSpecifier,
-  ReadFieldOptions,
-  ReadFieldFunction,
-} from "./types";
+import { IdGetter } from "./types";
 import {
   hasOwn,
   fieldNameFromStoreName,
@@ -37,9 +32,15 @@ import {
   isFieldValueToBeMerged,
   storeValueIsStoreObject,
 } from './helpers';
-import { FieldValueGetter, ToReferenceFunction } from './entityStore';
+import { FieldValueGetter } from './entityStore';
 import { InMemoryCache } from './inMemoryCache';
-import { SafeReadonly } from '../core/types/common';
+import {
+  SafeReadonly,
+  FieldSpecifier,
+  ToReferenceFunction,
+  ReadFieldFunction,
+  ReadFieldOptions,
+} from '../core/types/common';
 
 export type TypePolicies = {
   [__typename: string]: TypePolicy;

--- a/src/cache/inmemory/types.ts
+++ b/src/cache/inmemory/types.ts
@@ -1,15 +1,14 @@
-import { DocumentNode, FieldNode } from 'graphql';
+import { DocumentNode } from 'graphql';
 
 import { Transaction } from '../core/cache';
 import {
   StoreObject,
   StoreValue,
-  isReference,
   Reference,
 } from '../../utilities/graphql/storeUtils';
-import { FieldValueGetter, ToReferenceFunction } from './entityStore';
+import { FieldValueGetter } from './entityStore';
 import { KeyFieldsFunction } from './policies';
-import { SafeReadonly } from '../core/types/common';
+import { ToReferenceFunction, Modifier, Modifiers } from '../core/types/common';
 export { StoreObject, StoreValue, Reference }
 
 export interface IdGetterObj extends Object {
@@ -30,7 +29,7 @@ export interface NormalizedCache {
   has(dataId: string): boolean;
   get(dataId: string, fieldName: string): StoreValue;
   merge(dataId: string, incoming: StoreObject): void;
-  modify(dataId: string, modifiers: Modifier<any> | Modifiers): boolean;
+  modify(dataId: string, fields: Modifiers | Modifier<any>): boolean;
   delete(dataId: string, fieldName?: string): boolean;
   clear(): void;
 
@@ -106,43 +105,3 @@ export type CacheResolverMap = {
 // backwards compat
 export type CustomResolver = CacheResolver;
 export type CustomResolverMap = CacheResolverMap;
-
-export interface FieldSpecifier {
-  typename?: string;
-  fieldName: string;
-  field?: FieldNode;
-  args?: Record<string, any>;
-  variables?: Record<string, any>;
-}
-
-export interface ReadFieldOptions extends FieldSpecifier {
-  from?: StoreObject | Reference;
-}
-
-export interface ReadFieldFunction {
-  <V = StoreValue>(options: ReadFieldOptions): SafeReadonly<V> | undefined;
-  <V = StoreValue>(
-    fieldName: string,
-    from?: StoreObject | Reference,
-  ): SafeReadonly<V> | undefined;
-}
-
-export interface ModifyOptions {
-  id?: string;
-  fields: Modifiers | Modifier<any>;
-  optimistic?: boolean;
-  broadcast?: boolean;
-}
-
-export type Modifier<T> = (value: T, details: {
-  DELETE: any;
-  fieldName: string;
-  storeFieldName: string;
-  isReference: typeof isReference;
-  toReference: ToReferenceFunction;
-  readField: ReadFieldFunction;
-}) => T;
-
-export type Modifiers = {
-  [fieldName: string]: Modifier<any>;
-}


### PR DESCRIPTION
Background: https://github.com/apollographql/apollo-client/pull/6350#issuecomment-635666826

The `cache.modify` method and its related types are fairly `InMemoryCache`-specific, which is why it felt safest to confine `cache.modify` to `InMemoryCache` when I brought it back in #6350. In practice, however, that confinement just makes `cache.modify` harder to use (annoyingly, not helpfully) in cases where an `ApolloCache` is all that's available.

You could also argue that `cache.modify` has roughly the same standing (in terms of `InMemoryCache`-specificity) as `cache.identify` or `cache.gc`, which are also part of the "Optional API" of the `ApolloCache` base class. In that sense, `cache.modify` is simply joining those other AC3 APIs as part of `ApolloCache` (and thus also `InMemoryCache`).