### PR TITLE
Stop treating dangling references differently from empty objects.

### DIFF
--- a/src/cache/inmemory/__tests__/entityStore.ts
+++ b/src/cache/inmemory/__tests__/entityStore.ts
@@ -1524,11 +1524,11 @@ describe('EntityStore', () => {
 
     expect(() => cache.readQuery({
       query: queryWithAliases,
-    })).toThrow(/Dangling reference to missing ABCs:.* object/);
+    })).toThrow(/Can't find field 'a' on ABCs:.* object/);
 
     expect(() => cache.readQuery({
       query: queryWithoutAliases,
-    })).toThrow(/Dangling reference to missing ABCs:.* object/);
+    })).toThrow(/Can't find field 'a' on ABCs:.* object/);
   });
 
   it("gracefully handles eviction amid optimistic updates", () => {
@@ -1608,8 +1608,8 @@ describe('EntityStore', () => {
 
     const missing = [
       new MissingFieldError(
-        "Dangling reference to missing Author:2 object",
-        ["book", "author"],
+        "Can't find field 'name' on Author:2 object",
+        ["book", "author", "name"],
         expect.anything(),
         expect.anything(),
       ),

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -2397,7 +2397,7 @@ describe("type policies", function () {
       });
 
       expect(read).toThrow(
-        /Dangling reference to missing Book:{"isbn":"156858217X"} object/
+        /Can't find field 'title' on Book:{"isbn":"156858217X"} object/
       );
 
       const stealThisData = {
@@ -2527,11 +2527,11 @@ describe("type policies", function () {
       });
 
       expect(() => read("0393354326")).toThrow(
-        /Dangling reference to missing Book:{"isbn":"0393354326"} object/
+        /Can't find field 'title' on Book:{"isbn":"0393354326"} object/
       );
 
       expect(() => read("156858217X")).toThrow(
-        /Dangling reference to missing Book:{"isbn":"156858217X"} object/
+        /Can't find field 'title' on Book:{"isbn":"156858217X"} object/
       );
     });
 

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -213,20 +213,6 @@ export class StoreReader {
     objectOrReference,
     context,
   }: ExecSelectionSetOptions): ExecResult {
-    if (isReference(objectOrReference) &&
-        !context.policies.rootTypenamesById[objectOrReference.__ref] &&
-        !context.store.has(objectOrReference.__ref)) {
-      return {
-        result: {},
-        missing: [missingFromInvariant(
-          new InvariantError(
-            `Dangling reference to missing ${objectOrReference.__ref} object`
-          ),
-          context,
-        )],
-      };
-    }
-
     const { fragmentMap, variables, policies, store } = context;
     const objectsToMerge: { [key: string]: any }[] = [];
     const finalResult: ExecResult = { result: null };


### PR DESCRIPTION
Question: When `cache.read{Query,Fragment}` encounters a dangling reference (one that does not currently refer to any normalized entity object in the cache), should the cache behave as if the (nonexistent) target of the reference was an empty object, and report any requested fields as missing, or should the cache generate some other kind of error that reflects the the absence of the whole object?

I think we could answer this question either way, but I'm leaning towards the first option.

Note: it's normal for the cache to end up with dangling references when whole entity objects are evicted, or when a reference is created (e.g. by `toReference` in a `read` function) without writing any data into the cache. Cleaning up dangling references is a tricky problem, requiring application-level reasoning—and not even always desirable, since the data could always come back into the cache later, restoring the validity of the reference.

Previously, I thought it would be helpful to distinguish between the absence of an entity object and the object simply being empty, but I no longer think this distinction (which only affected the wording of the `MissingFieldError` description) matters very much, and we can simplify everything by adopting the following policy:

> During cache reads, a dangling `Reference` should behave as much as possible like a `Reference` to an entity object that happens to contain zero fields.

I'm optimistic this policy may help with issues like #6325. At the very least, it means there's now only one flavor of `MissingFieldError`, which should reduce confusion.