### PR TITLE
Revert PR #6365

### DIFF
--- a/src/cache/inmemory/__tests__/entityStore.ts
+++ b/src/cache/inmemory/__tests__/entityStore.ts
@@ -1555,11 +1555,11 @@ describe('EntityStore', () => {
 
     expect(() => cache.readQuery({
       query: queryWithAliases,
-    })).toThrow(/Can't find field 'a' on ABCs:.* object/);
+    })).toThrow(/Dangling reference to missing ABCs:.* object/);
 
     expect(() => cache.readQuery({
       query: queryWithoutAliases,
-    })).toThrow(/Can't find field 'a' on ABCs:.* object/);
+    })).toThrow(/Dangling reference to missing ABCs:.* object/);
   });
 
   it("gracefully handles eviction amid optimistic updates", () => {
@@ -1639,8 +1639,8 @@ describe('EntityStore', () => {
 
     const missing = [
       new MissingFieldError(
-        "Can't find field 'name' on Author:2 object",
-        ["book", "author", "name"],
+        "Dangling reference to missing Author:2 object",
+        ["book", "author"],
         expect.anything(),
         expect.anything(),
       ),

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -2397,7 +2397,7 @@ describe("type policies", function () {
       });
 
       expect(read).toThrow(
-        /Can't find field 'title' on Book:{"isbn":"156858217X"} object/
+        /Dangling reference to missing Book:{"isbn":"156858217X"} object/
       );
 
       const stealThisData = {
@@ -2529,11 +2529,11 @@ describe("type policies", function () {
       });
 
       expect(() => read("0393354326")).toThrow(
-        /Can't find field 'title' on Book:{"isbn":"0393354326"} object/
+        /Dangling reference to missing Book:{"isbn":"0393354326"} object/
       );
 
       expect(() => read("156858217X")).toThrow(
-        /Can't find field 'title' on Book:{"isbn":"156858217X"} object/
+        /Dangling reference to missing Book:{"isbn":"156858217X"} object/
       );
     });
 

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -213,6 +213,20 @@ export class StoreReader {
     objectOrReference,
     context,
   }: ExecSelectionSetOptions): ExecResult {
+    if (isReference(objectOrReference) &&
+        !context.policies.rootTypenamesById[objectOrReference.__ref] &&
+        !context.store.has(objectOrReference.__ref)) {
+      return {
+        result: {},
+        missing: [missingFromInvariant(
+          new InvariantError(
+            `Dangling reference to missing ${objectOrReference.__ref} object`
+          ),
+          context,
+        )],
+      };
+    }
+
     const { fragmentMap, variables, policies, store } = context;
     const objectsToMerge: { [key: string]: any }[] = [];
     const finalResult: ExecResult = { result: null };


### PR DESCRIPTION
This reverts commit c81071374225a2f94e86a6f0693fe99f17b1724f, introduced recently in PR #6365. My optimism that #6365 was an improvement seems to have been misplaced, since it caused the regression reported in #6368. We're too close to the AC3 RC/release to be floating risky changes like these without clear and compelling justifications.