### PR TITLE
Warn when clobbering non-normalized data in the cache.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,9 @@
 - Cache methods that would normally trigger a broadcast, like `cache.evict`, `cache.writeQuery`, and `cache.writeFragment`, can now be called with a named options object, which supports a `broadcast: boolean` property that can be used to silence the broadcast, for situations where you want to update the cache multiple times without triggering a broadcast each time. <br/>
   [@benjamn](https://github.com/benjamn) in [#6288](https://github.com/apollographql/apollo-client/pull/6288)
 
+- `InMemoryCache` now `console.warn`s in development whenever non-normalized data is dangerously overwritten, with helpful links to documentation about normalization and custom `merge` functions. <br/>
+  [@benjamn](https://github.com/benjamn) in [#6372](https://github.com/apollographql/apollo-client/pull/6372)
+
 - The contents of the `@apollo/react-hooks` package have been merged into `@apollo/client`, enabling the following all-in-one `import`:
   ```ts
   import { ApolloClient, ApolloProvider, useQuery } from '@apollo/client';

--- a/src/__tests__/ApolloClient.ts
+++ b/src/__tests__/ApolloClient.ts
@@ -668,7 +668,21 @@ describe('ApolloClient', () => {
     it('will write some deeply nested data to the store', () => {
       const client = new ApolloClient({
         link: ApolloLink.empty(),
-        cache: new InMemoryCache(),
+        cache: new InMemoryCache({
+          typePolicies: {
+            Query: {
+              fields: {
+                d: {
+                  // Silence "Cache data may be lost..."  warnings by
+                  // unconditionally favoring the incoming data.
+                  merge(_, incoming) {
+                    return incoming;
+                  },
+                },
+              },
+            },
+          },
+        }),
       });
 
       client.writeQuery({
@@ -1171,6 +1185,20 @@ describe('ApolloClient', () => {
         return new ApolloClient({
           link,
           cache: new InMemoryCache({
+            typePolicies: {
+              Person: {
+                fields: {
+                  friends: {
+                    // Deliberately silence "Cache data may be lost..."
+                    // warnings by preferring the incoming data, rather
+                    // than (say) concatenating the arrays together.
+                    merge(_, incoming) {
+                      return incoming;
+                    },
+                  },
+                },
+              },
+            },
             dataIdFromObject: result => {
               if (result.id && result.__typename) {
                 return result.__typename + result.id;

--- a/src/__tests__/optimistic.ts
+++ b/src/__tests__/optimistic.ts
@@ -110,6 +110,20 @@ describe('optimistic mutation results', () => {
     const client = new ApolloClient({
       link,
       cache: new InMemoryCache({
+        typePolicies: {
+          TodoList: {
+            fields: {
+              todos: {
+                // Deliberately silence "Cache data may be lost..."
+                // warnings by favoring the incoming data, rather than
+                // (say) concatenating the arrays together.
+                merge(_, incoming) {
+                  return incoming;
+                },
+              },
+            },
+          },
+        },
         dataIdFromObject: (obj: any) => {
           if (obj.id && obj.__typename) {
             return obj.__typename + obj.id;

--- a/src/utilities/graphql/storeUtils.ts
+++ b/src/utilities/graphql/storeUtils.ts
@@ -30,7 +30,7 @@ export function makeReference(id: string): Reference {
 }
 
 export function isReference(obj: any): obj is Reference {
-  return obj && typeof obj === 'object' && typeof obj.__ref === 'string';
+  return Boolean(obj && typeof obj === 'object' && typeof obj.__ref === 'string');
 }
 
 export type StoreValue =


### PR DESCRIPTION
> This is a revival of PR #5833, which has accumulated too many merge conflicts over the last few months to be worth rebasing.

One consequence of #5603 is that replacing non-normalized data in the cache can result in loss of useful data, which is preferable to mistakenly  merging unrelated objects, but not ideal.

In almost every case, the right solution is to make sure the data can be normalized, or (if that isn't possible) to define a custom `merge` function for the field in question, within the parent type policy.

It turns out we can give a very detailed warning about such situations in development, and that's what this commit does. For example:
```
Cache data may be lost when replacing the d field of a Query object.

To address this problem (which is not a bug in Apollo Client), either ensure all
objects of type D have IDs, or define a custom merge function for the Query.d
field, so InMemoryCache can safely merge these objects:

  existing: {"__typename":"D","e":4}
  incoming: {"__typename":"D","h":{"__typename":"H","i":7}}

For more information about these options, please refer to the documentation:

  * Ensuring entity objects have IDs: https://go.apollo.dev/c/generating-unique-identifiers
  * Defining custom merge functions: https://go.apollo.dev/c/merging-non-normalized-objects
```
Looking at the output for our test suite, every warning seems legitimate and worth fixing. I will resolve the warnings in subsequent commits.