### PR TITLE
Fix defaultDataIdFromObject type declaration

### DIFF
--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -183,9 +183,9 @@ export type FieldMergeFunction<TExisting = any, TIncoming = TExisting> = (
   options: FieldFunctionOptions,
 ) => TExisting;
 
-export const defaultDataIdFromObject: KeyFieldsFunction = (
-  { __typename, id, _id },
-  context,
+export const defaultDataIdFromObject = (
+  { __typename, id, _id }: Readonly<StoreObject>,
+  context?: KeyFieldsContext,
 ) => {
   if (typeof __typename === "string") {
     if (context) {


### PR DESCRIPTION
Minor tweaks to `defaultDataIdFromObject`'s type:
- there's a conditional for the presence of `context` in the function body, so it can be made optional
- the function always returns `string | undefined`, so the return type should reflect that