### PR TITLE
Let maybeBroadcastWatch broadcast older results, even if unchanged.

### DIFF
--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -87,32 +87,6 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
         addTypename: this.addTypename,
       }),
     );
-
-    const cache = this;
-    const { maybeBroadcastWatch } = cache;
-    this.maybeBroadcastWatch = wrap((c: Cache.WatchOptions) => {
-      return maybeBroadcastWatch.call(this, c);
-    }, {
-      makeCacheKey(c: Cache.WatchOptions) {
-        // Return a cache key (thus enabling result caching) only if we're
-        // currently using a data store that can track cache dependencies.
-        const store = c.optimistic ? cache.optimisticData : cache.data;
-        if (supportsResultCaching(store)) {
-          const { optimistic, rootId, variables } = c;
-          return store.makeCacheKey(
-            c.query,
-            // Different watches can have the same query, optimistic
-            // status, rootId, and variables, but if their callbacks are
-            // different, the (identical) result needs to be delivered to
-            // each distinct callback. The easiest way to achieve that
-            // separation is to include c.callback in the cache key for
-            // maybeBroadcastWatch calls. See issue #5733.
-            c.callback,
-            JSON.stringify({ optimistic, rootId, variables }),
-          );
-        }
-      }
-    });
   }
 
   public restore(data: NormalizedCacheObject): this {
@@ -342,16 +316,38 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     }
   }
 
+  private maybeBroadcastWatch = wrap((c: Cache.WatchOptions) => {
+    return this.broadcastWatch.call(this, c);
+  }, {
+    makeCacheKey: (c: Cache.WatchOptions) => {
+      // Return a cache key (thus enabling result caching) only if we're
+      // currently using a data store that can track cache dependencies.
+      const store = c.optimistic ? this.optimisticData : this.data;
+      if (supportsResultCaching(store)) {
+        const { optimistic, rootId, variables } = c;
+        return store.makeCacheKey(
+          c.query,
+          // Different watches can have the same query, optimistic
+          // status, rootId, and variables, but if their callbacks are
+          // different, the (identical) result needs to be delivered to
+          // each distinct callback. The easiest way to achieve that
+          // separation is to include c.callback in the cache key for
+          // maybeBroadcastWatch calls. See issue #5733.
+          c.callback,
+          JSON.stringify({ optimistic, rootId, variables }),
+        );
+      }
+    }
+  });
+
   // This method is wrapped in the constructor so that it will be called only
   // if the data that would be broadcast has changed.
-  private maybeBroadcastWatch(c: Cache.WatchOptions) {
-    c.callback(
-      this.diff({
-        query: c.query,
-        variables: c.variables,
-        optimistic: c.optimistic,
-      }),
-    );
+  private broadcastWatch(c: Cache.WatchOptions) {
+    c.callback(this.diff({
+      query: c.query,
+      variables: c.variables,
+      optimistic: c.optimistic,
+    }));
   }
 
   private varDep = dep<ReactiveVar<any>>();


### PR DESCRIPTION
This is a failing test for issue #5790 that demonstrates an optimistic rollback issue when an error is received.