### PR TITLE
Allow onNewData to be called when unmounted, during SSR.

### DIFF
--- a/src/react/data/QueryData.ts
+++ b/src/react/data/QueryData.ts
@@ -133,7 +133,9 @@ export class QueryData<TData, TVariables> extends OperationData {
     this.cleanup();
     this.runLazy = true;
     this.lazyOptions = options;
-    if (this.isMounted) this.onNewData();
+    if (this.isMounted || this.ssrInitiated()) {
+      this.onNewData();
+    }
   };
 
   private getExecuteResult(): QueryResult<TData, TVariables> {
@@ -291,7 +293,9 @@ export class QueryData<TData, TVariables> extends OperationData {
           return;
         }
 
-        if (this.isMounted) onNewData();
+        if (this.isMounted || this.ssrInitiated()) {
+          onNewData();
+        }
       },
       error: error => {
         this.resubscribeToQuery();
@@ -303,7 +307,9 @@ export class QueryData<TData, TVariables> extends OperationData {
           !equal(error, this.previousData.error)
         ) {
           this.previousData.error = error;
-          if (this.isMounted) onNewData();
+          if (this.isMounted || this.ssrInitiated()) {
+            onNewData();
+          }
         }
       }
     });


### PR DESCRIPTION
PR #6216 introduced these `isMounted` guards, and was merged just before the `v3.0.0-rc.0` release. It appears (see #6386) that requiring the component to be mounted is too restrictive, specifically when doing server-side rendering, since the concept of mounting doesn't make sense without a DOM.