### PR TITLE
Removed deprecated withClientState from boost migration

### DIFF
--- a/docs/source/migrating/boost-migration.md
+++ b/docs/source/migrating/boost-migration.md
@@ -121,7 +121,7 @@ const client = new ApolloClient({
 To create a client with the same defaults as Apollo Boost, first you need to install some packages:
 
 ```bash
-npm install apollo-client apollo-cache-inmemory apollo-link-http apollo-link apollo-link-state apollo-link-error graphql-tag --save
+npm install apollo-client apollo-cache-inmemory apollo-link-http apollo-link apollo-link-error graphql-tag --save
 ```
 
 Here's how we would create our new client using the configuration options above from Apollo Boost:
@@ -131,7 +131,6 @@ import { ApolloClient } from 'apollo-client';
 import { InMemoryCache } from 'apollo-cache-inmemory';
 import { HttpLink } from 'apollo-link-http';
 import { onError } from 'apollo-link-error';
-import { withClientState } from 'apollo-link-state';
 import { ApolloLink, Observable } from 'apollo-link';
 
 const cache = new InMemoryCache({
@@ -183,25 +182,25 @@ const client = new ApolloClient({
       }
     }),
     requestLink,
-    withClientState({
-      defaults: {
-        isConnected: true
-      },
-      resolvers: {
-        Mutation: {
-          updateNetworkStatus: (_, { isConnected }, { cache }) => {
-            cache.writeData({ data: { isConnected }});
-            return null;
-          }
-        }
-      },
-      cache
-    }),
     new HttpLink({
       uri: 'https://w5xlvm3vzz.lp.gql.zone/graphql',
       credentials: 'include'
     })
   ]),
-  cache
+  cache,
+  resolvers: {
+    Mutation: {
+      updateNetworkStatus: (_, { isConnected }, { cache }) => {
+        cache.writeData({ data: { isConnected }});
+        return null;
+      }
+    }
+  },
+});
+
+cache.writeData({
+  data: {
+    isConnected: true
+  }
 });
 ```


### PR DESCRIPTION
### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests

Looks like the Apollo Boost migration guide wasn't updated along when `apollo-link-state` was deprecated. I just did the migration myself and noticed this warning `Found @client directives in a query but no ApolloClient resolvers were specified. This means ApolloClient local resolver handling has been disabled, and @client directives will be passed through to your link chain.` so after digging in a bit I found the relevant [docs page](https://www.apollographql.com/docs/react/data/local-state/#migrating-from-apollo-link-state) that mentioned that it's now deprecated and how to migrate from it.

Hopefully this will save other people time 😃