### PR TITLE
Revert #6388 and #6216, fixing #6386 and #6385.

### DIFF
--- a/src/react/data/QueryData.ts
+++ b/src/react/data/QueryData.ts
@@ -133,9 +133,7 @@ export class QueryData<TData, TVariables> extends OperationData {
     this.cleanup();
     this.runLazy = true;
     this.lazyOptions = options;
-    if (this.isMounted || this.ssrInitiated()) {
-      this.onNewData();
-    }
+    this.onNewData();
   };
 
   private getExecuteResult(): QueryResult<TData, TVariables> {
@@ -293,9 +291,7 @@ export class QueryData<TData, TVariables> extends OperationData {
           return;
         }
 
-        if (this.isMounted || this.ssrInitiated()) {
-          onNewData();
-        }
+        onNewData();
       },
       error: error => {
         this.resubscribeToQuery();
@@ -307,9 +303,7 @@ export class QueryData<TData, TVariables> extends OperationData {
           !equal(error, this.previousData.error)
         ) {
           this.previousData.error = error;
-          if (this.isMounted || this.ssrInitiated()) {
-            onNewData();
-          }
+          onNewData();
         }
       }
     });

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -15,7 +15,6 @@ import { useQuery } from '../useQuery';
 import { useMutation } from '../useMutation';
 import { QueryFunctionOptions } from '../..';
 import { NetworkStatus } from '../../../core/networkStatus';
-import { FetchResult } from '../../../link/core/types';
 import { Reference } from '../../../utilities/graphql/storeUtils';
 
 describe('useQuery Hook', () => {
@@ -380,48 +379,6 @@ describe('useQuery Hook', () => {
       }).finally(() => {
         console.error = consoleError;
       }).then(resolve, reject);
-    });
-
-    itAsync('should not log a React warning in StrictMode when unmounted before a query is resolved', async (resolve, reject) => {
-      jest.spyOn(console, 'error');
-
-      const Component = () => {
-        useQuery(CAR_QUERY);
-
-        return null;
-      };
-
-      const observable = new Observable<FetchResult>((observer) => {
-        const timer = setTimeout(() => {
-          observer.next({ data: CAR_RESULT_DATA });
-          observer.complete();
-        }, 0);
-
-        // On unsubscription, cancel the timer
-        return () => clearTimeout(timer);
-      });
-
-      const link = new ApolloLink(() => observable)
-
-      const client = new ApolloClient({
-        cache: new InMemoryCache(),
-        link,
-      });
-
-      const { unmount } = render(
-        <React.StrictMode>
-          <ApolloProvider client={client}>
-            <Component />
-          </ApolloProvider>
-        </React.StrictMode>
-      );
-
-      unmount();
-      await wait()
-
-      expect(console.error).not.toHaveBeenCalled();
-
-      resolve()
     });
   });
 


### PR DESCRIPTION
This reverts commits b6da9c89a9e6f75dc6799e7bf2668bbbcbab7e9d (#6388) and c76804eea2afcd3df4e01d5a8db3ae2c4c553aee (#6216).

Preventing StrictMode warnings in React is not worth introducing bugs that break applications. We will need to reconsider how best to prevent warnings for unmounted components.