### PR TITLE
docs: remove obsolete toKey docs

### DIFF
--- a/docs/source/api/link/introduction.md
+++ b/docs/source/api/link/introduction.md
@@ -64,7 +64,6 @@ The `Operation` object includes the following fields:
 | `extensions`  |  A map to store extensions data to be sent to the server. |
 | `getContext`  | A function to return the context of the request. This context can be used by links to determine which actions to perform. See [Managing context](#managing-context). |
 | `setContext`  |  A function that takes either a new context object, or a function which takes in the previous context and returns a new one. See [Managing context](#managing-context). |
-| `toKey`  | A function to convert the current operation into a string to be used as a unique identifier.  |
 
 #### The `forward` function
 


### PR DESCRIPTION
It looks like `toKey()` was remove in https://github.com/apollographql/apollo-client/commit/07463bcb0acd21d59f08c8213facf49e10f0b3e4 so this documentation can be removed. 

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
