### PR TITLE
Support options.isReference(ref, true) to check Reference validity.

### DIFF
--- a/src/cache/core/types/common.ts
+++ b/src/cache/core/types/common.ts
@@ -4,7 +4,6 @@ import {
   Reference,
   StoreObject,
   StoreValue,
-  isReference,
 } from '../../../core';
 
 // The Readonly<T> type only really works for object types, since it marks
@@ -50,12 +49,17 @@ export type ToReferenceFunction = (
   mergeIntoStore?: boolean,
 ) => Reference | undefined;
 
+export type IsReferenceFunction = (
+  candidate: any,
+  mustBeValid?: boolean,
+) => candidate is Reference;
+
 export type Modifier<T> = (value: T, details: {
   DELETE: any;
   fieldName: string;
   storeFieldName: string;
   readField: ReadFieldFunction;
-  isReference: typeof isReference;
+  isReference: IsReferenceFunction;
   toReference: ToReferenceFunction;
 }) => T;
 

--- a/src/cache/inmemory/__tests__/readFromStore.ts
+++ b/src/cache/inmemory/__tests__/readFromStore.ts
@@ -923,24 +923,26 @@ describe('reading from the store', () => {
         Deity: {
           keyFields: ["name"],
           fields: {
-            children(offspring: Reference[], { readField }) {
-              return offspring ? offspring.filter(child => {
-                // TODO Improve this test? Maybe isReference(ref, true)?
-                return void 0 !== readField("__typename", child);
-              }) : [];
+            children(offspring: Reference[], { isReference }) {
+              return offspring ? offspring.filter(
+                // The true argument here makes isReference return true
+                // only if child is a Reference object that points to
+                // valid entity data in the EntityStore (that is, not a
+                // dangling reference).
+                child => isReference(child, true)
+              ) : [];
             },
           },
         },
 
         Query: {
           fields: {
-            ruler(ruler, { toReference, readField }) {
-              // TODO Improve this test? Maybe !isReference(ruler, true)?
-              if (!ruler || void 0 === readField("__typename", ruler)) {
-                // If there's no official ruler, promote Apollo!
-                return toReference({ __typename: "Deity", name: "Apollo" });
-              }
-              return ruler;
+            ruler(ruler, { isReference, toReference }) {
+              // If the throne is empty, promote Apollo!
+              return isReference(ruler, true) ? ruler : toReference({
+                __typename: "Deity",
+                name: "Apollo",
+              });
             },
           },
         },

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -142,6 +142,7 @@ export class StoreReader {
         variables,
         varString: JSON.stringify(variables),
         fragmentMap: createFragmentMap(getFragmentDefinitions(query)),
+        isReference: store.isReference,
         toReference: store.toReference,
         getFieldValue: store.getFieldValue,
         path: [],

--- a/src/cache/inmemory/types.ts
+++ b/src/cache/inmemory/types.ts
@@ -8,7 +8,12 @@ import {
 } from '../../utilities/graphql/storeUtils';
 import { FieldValueGetter } from './entityStore';
 import { KeyFieldsFunction } from './policies';
-import { ToReferenceFunction, Modifier, Modifiers } from '../core/types/common';
+import {
+  Modifier,
+  Modifiers,
+  ToReferenceFunction,
+  IsReferenceFunction,
+} from '../core/types/common';
 export { StoreObject, StoreValue, Reference }
 
 export interface IdGetterObj extends Object {
@@ -55,6 +60,7 @@ export interface NormalizedCache {
   release(rootId: string): number;
 
   getFieldValue: FieldValueGetter;
+  isReference: IsReferenceFunction;
   toReference: ToReferenceFunction;
 }
 

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -112,6 +112,7 @@ export class StoreWriter {
         variables,
         varString: JSON.stringify(variables),
         fragmentMap: createFragmentMap(getFragmentDefinitions(query)),
+        isReference: store.isReference,
         toReference: store.toReference,
         getFieldValue: store.getFieldValue,
       },


### PR DESCRIPTION
The story we're telling in #6412 about using custom `read` functions to filter out dangling references works best if there's an easy way to check whether a `Reference` points to existing data in the cache. Although we could have introduced a new `options.isValidReference` helper function, I think it makes sense to let the existing `options.isReference` function handle this use case as well.