### PR TITLE
Add mocking utility for Reactive Vars

### DIFF
--- a/src/utilities/testing/__tests__/mockReactiveVars.ts
+++ b/src/utilities/testing/__tests__/mockReactiveVars.ts
@@ -1,0 +1,35 @@
+
+import { createMockReactiveVar } from '../mocking/mockReactiveVar'
+
+type Todo = { id: number, text: string, completed: boolean };
+type Todos = Todo[];
+
+const mockTodosVar = createMockReactiveVar<Todos>([]);
+
+describe('Testing mock reactive variables', () => {
+  beforeEach(() => mockTodosVar([]));
+
+  it('should set the current value if provided', () => {
+    mockTodosVar([{ id: 0, text: 'First todo', completed: false }]);
+    expect(mockTodosVar()?.length).toEqual(1);
+  })
+
+  it('should overwrite the current value', () => {
+    mockTodosVar([{ id: 0, text: 'First todo', completed: false }]);
+    expect(mockTodosVar()?.length).toEqual(1);
+
+    mockTodosVar([{ id: 1, text: 'Second todo', completed: false }]);
+    expect(mockTodosVar()?.length).toEqual(1);
+  });
+
+  it('should not overwrite the current value if no value provided', () => {
+    mockTodosVar([
+      { id: 0, text: 'First todo', completed: false },
+      { id: 1, text: 'Second todo', completed: false }
+    ]);
+    expect(mockTodosVar()?.length).toEqual(2);
+
+    mockTodosVar();
+    expect(mockTodosVar()?.length).toEqual(2);
+  })
+})

--- a/src/utilities/testing/index.ts
+++ b/src/utilities/testing/index.ts
@@ -5,4 +5,5 @@ export {
   mockObservableLink
 } from './mocking/mockSubscriptionLink';
 export { createMockClient } from './mocking/mockClient';
+export { createMockReactiveVar } from './mocking/mockReactiveVar'
 export { stripSymbols } from './stripSymbols';

--- a/src/utilities/testing/mocking/mockReactiveVar.ts
+++ b/src/utilities/testing/mocking/mockReactiveVar.ts
@@ -1,0 +1,18 @@
+
+import { ReactiveVar } from '../../../core';
+
+// It's a good idea to provide the ability to mock Reactive Vars so that
+// we can test the behaviour of our interaction logic.
+
+export function createMockReactiveVar<T> (defaultValue?: T): ReactiveVar<T> {
+  let currentValue: T | undefined = defaultValue;
+
+  return function mockReactiveVar (
+    newValue?: T
+  ) : T {
+    if (newValue) {
+      currentValue = newValue;
+    }
+    return currentValue as T;
+  }
+}


### PR DESCRIPTION
This PR adds a `createMockReactiveVar` so that users can test the _behavior_ of their **interaction logic** without needing a concrete reactive variable.

_Interaction logic_ is something I'm playing with formalizing in the best practices guide, as a policy that dictates _if_ and _how_ an operation (which would be either a command or query as per the [CQS principle](https://en.wikipedia.org/wiki/Command%E2%80%93query_separation#:~:text=Command%E2%80%93query%20separation%20(CQS),the%20caller%2C%20but%20not%20both.)) executes. The idea is that when users invoke `command`-like operations such as `editTodo`, `removeTodo`, `deleteTodo`- if they're using Reactive Variables to model that data, then the logic that dictates how that variable changes, is _interaction logic_.

Here's an example of that, from [ac3-state-management-examples](https://github.com/apollographql/ac3-state-management-examples/blob/master/apollo-local-state/src/operations/mutations/addTodo/addTodo.tsx),

```typescript
import { Todos, Todo } from "../../../models/Todos";
import { ReactiveVar } from "@apollo/client";

export default function createAddTodo (todosVar: ReactiveVar<Todos>) {
  const createNewTodoId = (allTodos: Todos) => {
    return allTodos.reduce(
        (maxId: number, todo: Todo) => Math.max(todo.id, maxId),
        -1
      ) + 1;
  }
  
  const createNewTodo = (text: string, allTodos: Todos) => {
    return { text, completed: false, id: createNewTodoId(allTodos) }
  }
  
  return (text: string) => {
    const allTodos = todosVar();
    todosVar(allTodos.concat([createNewTodo(text, allTodos)]));
  };
```

This is the closest thing we have to **business logic** on the client-side, and we'd certainly like to write tests for it. By prompting users to inject a reactive variable into their interaction logic functions (which could also be written as React hooks instead of stray functions like this), we can _dependency inject_ a mock variable to test it.

```typescript
import createAddTodo from './addTodo'
import { mockTodosVar } from '../../../tests/mocks/mockTodosVar';

const addTodo = createAddTodo(mockTodosVar);

describe('addTodos hook', () => {
  beforeEach(() => mockTodosVar([]));
  
  it('should add a todo', () => {
    addTodo('First todo')
    expect(
      mockTodosVar()
    ).toHaveLength(1)

    expect(
      mockTodosVar()[0].id
    ).toEqual(0)

    expect(
      mockTodosVar()[0].completed
    ).toEqual(false)

    expect(
      mockTodosVar()[0].text
    ).toEqual('First todo')
  })
})
```

Originally, I had written some machinery to create mock reactive variables over on the [ac3-examples](https://github.com/apollographql/ac3-state-management-examples/blob/master/apollo-local-state/src/tests/createMockReactiveVar.ts) repo, but I'm proposing that we expose this functionality as a testing utility so that they don't have to write it themselves.

I'd love to hear what y'all think.

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
