### PR TITLE
Ensure last results are reset when working with partial data

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     {
       "name": "apollo-client",
       "path": "./dist/apollo-client.cjs.min.js",
-      "maxSize": "24.1 kB"
+      "maxSize": "24.2 kB"
     }
   ],
   "peerDependencies": {

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -201,7 +201,9 @@ export class ObservableQuery<
       }
     }
 
-    if (!partial) {
+    if (partial) {
+      this.resetLastResults();
+    } else {
       this.updateLastResult(result);
     }
 


### PR DESCRIPTION
Issue #6334 exposed a problem where the `lastResult` mechanism we use to prevent duplicate subscription notifications (when data hasn't changed) can unintentionally block certain results from propagating through Apollo Client. This leads to issues like loading states not being updated properly, due to new partial results looking similar to last results.

This commit ensures that last results are properly cleared out when new partial results come in.

Fixes #6334