### PR TITLE
Add tests for errorPolicy:none and fix ObservableQuery bug with unpersisted error

### DIFF
--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -533,9 +533,12 @@ export class ObservableQuery<
     const first = !this.observers.size;
     this.observers.add(observer);
 
-    // Deliver initial result
-    if (observer.error && this.lastError) observer.error(this.lastError);
-    if (observer.next && this.lastResult) observer.next(this.lastResult);
+    // Deliver most recent error or result.
+    if (this.lastError) {
+      observer.error && observer.error(this.lastError);
+    } else if (this.lastResult) {
+      observer.next && observer.next(this.lastResult);
+    }
 
     // Initiate observation of this query if it hasn't been reported to
     // the QueryManager yet.

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -534,8 +534,8 @@ export class ObservableQuery<
     this.observers.add(observer);
 
     // Deliver initial result
-    if (observer.next && this.lastResult) observer.next(this.lastResult);
     if (observer.error && this.lastError) observer.error(this.lastError);
+    if (observer.next && this.lastResult) observer.next(this.lastResult);
 
     // Initiate observation of this query if it hasn't been reported to
     // the QueryManager yet.


### PR DESCRIPTION
In my codebase, we keep references to ObservableQuery objects and occasionally use them multiple times via `.result()` (to get a promise).

We noticed that when `errorPolicy` is `none`, the second call to `.result()` does _not_ yield a rejected promise but a resolved one, as if `errorPolicy` were `all`.

Added failing tests in the first commit (see CI result) and what I hope will fix the issue in the second commit. Feels like inverting the order of the calls may have unintended consequences but locally tests seem to pass.

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
