### PR TITLE
Partially backpeddle #5603

### DIFF
--- a/src/__tests__/__snapshots__/ApolloClient.ts.snap
+++ b/src/__tests__/__snapshots__/ApolloClient.ts.snap
@@ -339,6 +339,7 @@ Object {
     "a": 1,
     "d": Object {
       "__typename": "D",
+      "e": 4,
       "h": Object {
         "__typename": "H",
         "i": 7,

--- a/src/cache/inmemory/__tests__/cache.ts
+++ b/src/cache/inmemory/__tests__/cache.ts
@@ -928,6 +928,7 @@ describe('Cache', () => {
           // The new value for d overwrites the old value, since there
           // is no custom merge function defined for Query.d.
           d: {
+            e: 4,
             h: {
               i: 7,
             },

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -72,7 +72,7 @@ export abstract class EntityStore implements NormalizedCache {
     }
   }
 
-  protected lookup(dataId: string, dependOnExistence?: boolean): StoreObject | undefined {
+  public lookup = (dataId: string, dependOnExistence?: boolean): StoreObject | undefined => {
     // The has method (above) calls lookup with dependOnExistence = true, so
     // that it can later be invalidated when we add or remove a StoreObject for
     // this dataId. Any consumer who cares about the contents of the StoreObject
@@ -81,7 +81,7 @@ export abstract class EntityStore implements NormalizedCache {
     if (dependOnExistence) this.group.depend(dataId, "__exists");
     return hasOwn.call(this.data, dataId) ? this.data[dataId] :
       this instanceof Layer ? this.parent.lookup(dataId, dependOnExistence) : void 0;
-  }
+  };
 
   public merge(dataId: string, incoming: StoreObject): void {
     const existing = this.lookup(dataId);
@@ -139,6 +139,7 @@ export abstract class EntityStore implements NormalizedCache {
           canRead: this.canRead,
           toReference: this.toReference,
           getFieldValue: this.getFieldValue,
+          lookup: this.lookup
         },
       );
 
@@ -380,6 +381,7 @@ export abstract class EntityStore implements NormalizedCache {
 }
 
 export type FieldValueGetter = EntityStore["getFieldValue"];
+export type LookupFunction = EntityStore["lookup"];
 
 // A single CacheGroup represents a set of one or more EntityStore objects,
 // typically the Root store in a CacheGroup by itself, and all active Layer

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -558,10 +558,10 @@ export class Policies {
     if (isFieldValueToBeMerged(incoming)) {
       const field = incoming.__field;
       const fieldName = field.name.value;
-
-      const defaultMerge:FieldMergeFunction<any, any> = (existing, incoming, { mergeObjects }) => mergeObjects(existing, incoming)
-      const { merge = defaultMerge } = this.getFieldPolicy(
-        incoming.__typename, fieldName, false) || {};
+      // This policy and its merge function are guaranteed to exist
+      // because the incoming value is a FieldValueToBeMerged object.
+      const { merge } = this.getFieldPolicy(
+        incoming.__typename, fieldName, false)!;
 
       // If storage ends up null, that just means no options.storage object
       // has ever been created for a read function for this field before, so

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -145,6 +145,7 @@ export class StoreReader {
         toReference: store.toReference,
         canRead: store.canRead,
         getFieldValue: store.getFieldValue,
+        lookup: store.lookup,
         path: [],
       },
     });

--- a/src/cache/inmemory/types.ts
+++ b/src/cache/inmemory/types.ts
@@ -33,6 +33,7 @@ export declare type IdGetter = (
 export interface NormalizedCache {
   has(dataId: string): boolean;
   get(dataId: string, fieldName: string): StoreValue;
+  lookup(dataId: string, dependOnExistence?: boolean): StoreObject | undefined;
   merge(dataId: string, incoming: StoreObject): void;
   modify(dataId: string, fields: Modifiers | Modifier<any>): boolean;
   delete(dataId: string, fieldName?: string): boolean;

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -30,7 +30,7 @@ import { cloneDeep } from '../../utilities/common/cloneDeep';
 
 import { ReadMergeContext } from './policies';
 import { NormalizedCache } from './types';
-import { makeProcessedFieldsMerger, FieldValueToBeMerged, fieldNameFromStoreName } from './helpers';
+import { makeProcessedFieldsMerger, FieldValueToBeMerged, fieldNameFromStoreName, storeValueIsStoreObject } from './helpers';
 import { StoreReader } from './readFromStore';
 import { InMemoryCache } from './inMemoryCache';
 
@@ -115,6 +115,7 @@ export class StoreWriter {
         toReference: store.toReference,
         canRead: store.canRead,
         getFieldValue: store.getFieldValue,
+        lookup: store.lookup,
       },
     });
 
@@ -221,6 +222,10 @@ export class StoreWriter {
           let incomingValue =
             this.processFieldValue(value, selection, context, out);
 
+          if(storeValueIsStoreObject(incomingValue)) {
+            // Merge unidentified types
+            out.shouldApplyMerges = true;
+          }
           if (policies.hasMergeFunction(typename, selection.name.value)) {
             // If a custom merge function is defined for this field, store
             // a special FieldValueToBeMerged object, so that we can run


### PR DESCRIPTION
Solves infinite loops when more than one query with different fields on an unidentified object

Fixes #6370

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

This is probably controversial since it is claimed to not be a bug. So I'll call this a feature request because I expect the number of graphql API's the existing behaviour will cause infinite request loops with is high.