### PR TITLE
Clear setTimeout handle in stopPollingQuery()

### DIFF
--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -1403,6 +1403,10 @@ export class QueryManager<TStore> {
   }
 
   public stopPollingQuery(queryId: string) {
+    const info = this.pollingInfoByQueryId.get(queryId)
+    if (info){
+      clearTimeout(info.timeout)
+    }
     this.pollingInfoByQueryId.delete(queryId);
   }
 }

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -1403,9 +1403,9 @@ export class QueryManager<TStore> {
   }
 
   public stopPollingQuery(queryId: string) {
-    const info = this.pollingInfoByQueryId.get(queryId)
-    if (info){
-      clearTimeout(info.timeout)
+    const info = this.pollingInfoByQueryId.get(queryId);
+    if (info) {
+      clearTimeout(info.timeout);
     }
     this.pollingInfoByQueryId.delete(queryId);
   }


### PR DESCRIPTION
This PR fixes #4948 and #5444, when `startPolling()` is called immediately after `stopPolling()`, it tricks `maybeFetch()` into believing the scheduled task is still valid (as it takes pollingInfo's existence before go ahead to call `fetchQuery()`).

This leads to extra query be fetched.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
