### PR TITLE
Refactor ReadMergeContext to ReadMergeModifyContext.

### DIFF
--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -135,11 +135,7 @@ export abstract class EntityStore implements NormalizedCache {
           fieldName: fieldNameOrOptions,
           from: from || makeReference(dataId),
         } : fieldNameOrOptions,
-        {
-          canRead: this.canRead,
-          toReference: this.toReference,
-          getFieldValue: this.getFieldValue,
-        },
+        { store: this },
       );
 
       Object.keys(storeObject).forEach(storeFieldName => {

--- a/src/cache/inmemory/types.ts
+++ b/src/cache/inmemory/types.ts
@@ -95,19 +95,3 @@ export type ApolloReducerConfig = {
   dataIdFromObject?: KeyFieldsFunction;
   addTypename?: boolean;
 };
-
-export type CacheResolver = (
-  rootValue: any,
-  args: { [argName: string]: any },
-  context: any,
-) => any;
-
-export type CacheResolverMap = {
-  [typeName: string]: {
-    [fieldName: string]: CacheResolver;
-  };
-};
-
-// backwards compat
-export type CustomResolver = CacheResolver;
-export type CustomResolverMap = CacheResolverMap;

--- a/src/cache/inmemory/types.ts
+++ b/src/cache/inmemory/types.ts
@@ -95,3 +95,10 @@ export type ApolloReducerConfig = {
   dataIdFromObject?: KeyFieldsFunction;
   addTypename?: boolean;
 };
+
+export interface ReadMergeModifyContext {
+  store: NormalizedCache;
+  variables?: Record<string, any>;
+  // A JSON.stringify-serialized version of context.variables.
+  varString?: string;
+}


### PR DESCRIPTION
Similar to `ReadMergeContext` before it, the `ReadMergeModifyContext` type contains field declarations needed by `read`, `merge`, and `modify` functions, most importantly the `NormalizedCache` object, `context.store`, which provides one-stop access to important methods like `context.store.{getFieldValue,toReference,canRead}`.

`ReadMergeModifyContext` also serves as a supertype for the `ReadContext` and `WriteContext` types used during reading and writing of queries and fragments, allowing existing `ReadContext` and `WriteContext` objects to be passed without modification as `ReadMergeModifyContext` objects to `policies.readField` and `policies.applyMerges`.