### PR TITLE
Allow cache.identify to take Reference objects.

### DIFF
--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -66,7 +66,7 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
     return document;
   }
 
-  public identify(object: StoreObject): string | undefined {
+  public identify(object: StoreObject | Reference): string | undefined {
     return;
   }
   

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -7,7 +7,7 @@ import { dep, wrap } from 'optimism';
 import { ApolloCache, Transaction } from '../core/cache';
 import { Cache } from '../core/types/Cache';
 import { addTypenameToDocument } from '../../utilities/graphql/transform';
-import { StoreObject, Reference }  from '../../utilities/graphql/storeUtils';
+import { StoreObject, Reference, isReference }  from '../../utilities/graphql/storeUtils';
 import {
   ApolloReducerConfig,
   NormalizedCacheObject,
@@ -206,8 +206,9 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
   // the object must contain a __typename and any primary key fields required
   // to identify entities of that type. If you pass a query result object, be
   // sure that none of the primary key fields have been renamed by aliasing.
-  public identify(object: StoreObject): string | undefined {
-    return this.policies.identify(object)[0];
+  public identify(object: StoreObject | Reference): string | undefined {
+    return isReference(object) ? object.__ref :
+      this.policies.identify(object)[0];
   }
 
   public evict(options: Cache.EvictOptions): boolean {

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -206,6 +206,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
   // the object must contain a __typename and any primary key fields required
   // to identify entities of that type. If you pass a query result object, be
   // sure that none of the primary key fields have been renamed by aliasing.
+  // If you pass a Reference object, its __ref ID string will be returned.
   public identify(object: StoreObject | Reference): string | undefined {
     return isReference(object) ? object.__ref :
       this.policies.identify(object)[0];


### PR DESCRIPTION
There are a number of scenarios where an object found in the cache will have the union type `StoreObject | Reference`. Rather than forcing application code to check `isReference` and access the `reference.__ref` property manually, we can simply make `cache.identify` work for both `StoreObject` and `Reference` objects.