### PR TITLE
Automatically filter out dangling references from arrays.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@
     [@danReynolds](https://github.com/danReynolds) in [#6141](https://github.com/apollographql/apollo-client/pull/6141)
     [@benjamn](https://github.com/benjamn) in [#6364](https://github.com/apollographql/apollo-client/pull/6364)
 
-  - Removing an entity object using the `cache.evict` method does not automatically remove dangling references to that entity elsewhere in the cache, since the appropriate removal behavior is inherently application-dependent. Instead, you should define a custom field `read` function for the affected fields. See [#6412](https://github.com/apollographql/apollo-client/pull/6412) for further explanation.
+  - Removing an entity object using the `cache.evict` method does not automatically remove dangling references to that entity elsewhere in the cache, but dangling references will be automatically filtered from lists whenever those lists are read from the cache. You can define a custom field `read` function to customize this behavior. See [#6412](https://github.com/apollographql/apollo-client/pull/6412), [#6425](https://github.com/apollographql/apollo-client/pull/6425), and [#6454](https://github.com/apollographql/apollo-client/pull/6454) for further explanation.
 
 - Cache methods that would normally trigger a broadcast, like `cache.evict`, `cache.writeQuery`, and `cache.writeFragment`, can now be called with a named options object, which supports a `broadcast: boolean` property that can be used to silence the broadcast, for situations where you want to update the cache multiple times without triggering a broadcast each time. <br/>
   [@benjamn](https://github.com/benjamn) in [#6288](https://github.com/apollographql/apollo-client/pull/6288)

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     {
       "name": "apollo-client",
       "path": "./dist/apollo-client.cjs.min.js",
-      "maxSize": "24.2 kB"
+      "maxSize": "24.25 kB"
     }
   ],
   "peerDependencies": {

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -386,6 +386,10 @@ export class StoreReader {
       return childResult.result;
     }
 
+    if (field.selectionSet) {
+      array = array.filter(context.store.canRead);
+    }
+
     array = array.map((item, i) => {
       // null value in array
       if (item === null) {


### PR DESCRIPTION
This commit implements the proposal for automatic filtering of dangling references that I described in https://github.com/apollographql/apollo-client/pull/6425#issuecomment-642200353.

The filtering functionality demonstrated by #6412 (and updated by #6425) seems useful enough that we might as well make it the default behavior for any array-valued field consumed by a selection set. Note: the presence of `field.selectionSet` implies the author of the query expects the elements to be objects (or references) rather than scalar values. A list of scalar values should not be filtered, since it cannot contain dangling references.

By making `.filter(canRead)` automatic, we free developers from having to worry about manually removing references from lists after evicting entities from the cache. Instead, those dangling references will simply (appear to) disappear from cache results, which is almost always the desired behavior. Fields whose values hold single (non-list) dangling references cannot be easily filtered in the same way, but you can always write a custom `read` function for the field, and it's somewhat more likely that a refetch will fix those fields correctly.

In case the automatic list filtering is not desired, a custom `read` function can be used to _override_ the filtering, since `read` functions run before this filtering happens. This commit includes tests demonstrating several options for replacing/filtering dangling references in non-default ways.