### PR TITLE
Change refetch() arg to use Partial<TVariables>

### DIFF
--- a/docs/shared/query-result.mdx
+++ b/docs/shared/query-result.mdx
@@ -5,7 +5,7 @@
 | `error` | ApolloError | A runtime error with `graphQLErrors` and `networkError` properties |
 | `variables` | { [key: string]: any } | An object containing the variables the query was called with |
 | `networkStatus` | NetworkStatus | A number from 1-8 corresponding to the detailed state of your network request. Includes information about refetching and polling status. Used in conjunction with the `notifyOnNetworkStatusChange` prop. |
-| `refetch` | (variables?: TVariables) => Promise&lt;ApolloQueryResult&gt; | A function that allows you to refetch the query and optionally pass in new variables |
+| `refetch` | (variables?: Partial&lt;TVariables&gt;) => Promise&lt;ApolloQueryResult&gt; | A function that allows you to refetch the query and optionally pass in new variables |
 | `fetchMore` | ({ query?: DocumentNode, variables?: TVariables, updateQuery: Function}) => Promise&lt;ApolloQueryResult&gt; | A function that enables [pagination](/features/pagination/) for your query |
 | `startPolling` | (interval: number) => void | This function sets up an interval in ms and fetches the query each time the specified interval passes. |
 | `stopPolling` | () => void | This function stops the query from polling. |

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -248,7 +248,7 @@ export class ObservableQuery<
    * @param variables: The new set of variables. If there are missing variables,
    * the previous values of those variables will be used.
    */
-  public refetch(variables?: TVariables): Promise<ApolloQueryResult<TData>> {
+  public refetch(variables?: Partial<TVariables>): Promise<ApolloQueryResult<TData>> {
     let { fetchPolicy } = this.options;
     // early return if trying to read from cache during refetch
     if (fetchPolicy === 'cache-only') {
@@ -270,7 +270,7 @@ export class ObservableQuery<
       this.options.variables = {
         ...this.options.variables,
         ...variables,
-      };
+      } as TVariables;
     }
 
     return this.newReobserver(false).reobserve({

--- a/src/react/data/QueryData.ts
+++ b/src/react/data/QueryData.ts
@@ -460,7 +460,7 @@ export class QueryData<TData, TVariables> extends OperationData {
     }
   }
 
-  private obsRefetch = (variables?: TVariables) =>
+  private obsRefetch = (variables?: Partial<TVariables>) =>
     this.currentObservable!.refetch(variables);
 
   private obsFetchMore = <K extends keyof TVariables>(


### PR DESCRIPTION
`refetch()` can be called with a subset of the variables so it seems appropriate to use a `Partial<>` here to prevent TypeScript errors. Please let me know if I'm mistaken or if there is a better practice here. Thanks!

