### PR TITLE
Deprecate fetchMore updateQuery function, and provide basic field policy helper functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,48 +1,15 @@
 # Apollo Client 3.0.0 (TBD - not yet released)
 
-⚠️ **Note:** As of 3.0.0, Apollo Client uses a new package name: [`@apollo/client`](https://www.npmjs.com/package/@apollo/client)
-
 ## Improvements
 
-- **[BREAKING]** `InMemoryCache` will no longer merge the fields of written objects unless the objects are known to have the same identity, and the values of fields with the same name will not be recursively merged unless a custom `merge` function is defined by a field policy for that field, within a type policy associated with the `__typename` of the parent object. <br/>
-  [@benjamn](https://github.com/benjamn) in [#5603](https://github.com/apollographql/apollo-client/pull/5603)
+> ⚠️ **Note:** As of 3.0.0, Apollo Client uses a new package name: [`@apollo/client`](https://www.npmjs.com/package/@apollo/client)
 
-- **[BREAKING]** Eliminate "generated" cache IDs to avoid normalizing objects with no meaningful ID, significantly reducing cache memory usage. This is a backwards-incompatible change if your code depends on the precise internal representation of normalized data in the cache. <br/>
-  [@benjamn](https://github.com/benjamn) in [#5146](https://github.com/apollographql/apollo-client/pull/5146)
-
-- **[BREAKING]** Removed `graphql-anywhere` since it's no longer used by Apollo Client.  <br/>
-  [@hwillson](https://github.com/hwillson) in [#5159](https://github.com/apollographql/apollo-client/pull/5159)
-
-- **[BREAKING]** Removed `apollo-boost` since Apollo Client 3.0 provides a boost like getting started experience out of the box.  <br/>
-  [@hwillson](https://github.com/hwillson) in [#5217](https://github.com/apollographql/apollo-client/pull/5217)
-
-- **[BREAKING]** The `queryManager` property of `ApolloClient` instances is now marked as `private`, paving the way for a more aggressive redesign of its API.
-
-- **[BREAKING]** `FragmentMatcher`, `HeuristicFragmentMatcher`, and `IntrospectionFragmentMatcher` have all been removed. We now recommend using `InMemoryCache`’s `possibleTypes` option instead. For more information see the [Defining `possibleTypes` manually](https://www.apollographql.com/docs/react/v3.0-beta/data/fragments/#defining-possibletypes-manually) section of the docs. <br/>
-  [@benjamn](https://github.com/benjamn) in [#5073](https://github.com/apollographql/apollo-client/pull/5073)
-
-- **[BREAKING]** As promised in the [Apollo Client 2.6 blog post](https://blog.apollographql.com/whats-new-in-apollo-client-2-6-b3acf28ecad1), all cache results are now frozen/immutable. <br/>
-  [@benjamn](https://github.com/benjamn) in [#5153](https://github.com/apollographql/apollo-client/pull/5153)
+### `ApolloClient`
 
 - **[BREAKING]** `ApolloClient` is now only available as a named export. The default `ApolloClient` export has been removed. <br/>
   [@hwillson](https://github.com/hwillson) in [#5425](https://github.com/apollographql/apollo-client/pull/5425)
 
-- **[BREAKING]** The `QueryOptions`, `MutationOptions`, and `SubscriptionOptions` React Apollo interfaces have been renamed to `QueryDataOptions`, `MutationDataOptions`, and `SubscriptionDataOptions` (to avoid conflicting with similarly named and exported Apollo Client interfaces).
-
-- **[BREAKING]** We are no longer exporting certain (intended to be) internal utilities. If you are depending on some of the lesser known exports from `apollo-cache`, `apollo-cache-inmemory`, or `apollo-utilities`, they may no longer be available from `@apollo/client`. <br/>
-  [@hwillson](https://github.com/hwillson) in [#5437](https://github.com/apollographql/apollo-client/pull/5437) and [#5514](https://github.com/apollographql/apollo-client/pull/5514)
-
-- **[BREAKING?]** Remove `fixPolyfills.ts`, except when bundling for React Native. If you have trouble with `Map` or `Set` operations due to frozen key objects in React Native, either update React Native to version 0.59.0 (or 0.61.x, if possible) or investigate why `fixPolyfills.native.js` is not included in your bundle. <br/>
-  [@benjamn](https://github.com/benjamn) in [#5962](https://github.com/apollographql/apollo-client/pull/5962)
-
-- **[BREAKING]** Apollo Client 2.x allowed `@client` fields to be passed into the `link` chain if `resolvers` were not set in the constructor. This allowed `@client` fields to be passed into Links like `apollo-link-state`. Apollo Client 3 enforces that `@client` fields are local only, meaning they are no longer passed into the `link` chain, under any circumstances.  <br/>
-  [@hwillson](https://github.com/hwillson) in [#5982](https://github.com/apollographql/apollo-client/pull/5982)
-
-- **[BREAKING]** `InMemoryCache` now _throws_ when data with missing or undefined query fields is written into the cache, rather than just warning in development. <br/>
-  [@benjamn](https://github.com/benjamn) in [#6055](https://github.com/apollographql/apollo-client/pull/6055)
-
-- **[BREAKING]** `client|cache.writeData` have been fully removed. `writeData` usage is one of the easiest ways to turn faulty assumptions about how the cache represents data internally, into cache inconsistency and corruption. `client|cache.writeQuery`, `client|cache.writeFragment`, and/or `cache.modify` can be used to update the cache.  <br/>
-  [@benjamn](https://github.com/benjamn) in [#5923](https://github.com/apollographql/apollo-client/pull/5923)
+- **[BREAKING]** The `queryManager` property of `ApolloClient` instances is now marked as `private`, paving the way for a more aggressive redesign of its API.
 
 - **[BREAKING]** Apollo Client will no longer deliver "stale" results to `ObservableQuery` consumers, but will instead log more helpful errors about which cache fields were missing. <br/>
   [@benjamn](https://github.com/benjamn) in [#6058](https://github.com/apollographql/apollo-client/pull/6058)
@@ -53,8 +20,59 @@
 - **[BREAKING]** Support for the `@live` directive has been removed, but might be restored in the future if a more thorough implementation is proposed. <br/>
   [@benjamn](https://github.com/benjamn) in [#6221](https://github.com/apollographql/apollo-client/pull/6221)
 
+- **[BREAKING]** Apollo Client 2.x allowed `@client` fields to be passed into the `link` chain if `resolvers` were not set in the constructor. This allowed `@client` fields to be passed into Links like `apollo-link-state`. Apollo Client 3 enforces that `@client` fields are local only, meaning they are no longer passed into the `link` chain, under any circumstances.  <br/>
+  [@hwillson](https://github.com/hwillson) in [#5982](https://github.com/apollographql/apollo-client/pull/5982)
+
 - **[BREAKING?]** Refactor `QueryManager` to make better use of observables and enforce `fetchPolicy` more reliably. <br/>
   [@benjamn](https://github.com/benjamn) in [#6221](https://github.com/apollographql/apollo-client/pull/6221)
+
+- Updated to work with `graphql@15`.  <br/>
+  [@durchanek](https://github.com/durchanek) in [#6194](https://github.com/apollographql/apollo-client/pull/6194) and [#6279](https://github.com/apollographql/apollo-client/pull/6279) <br/>
+  [@hagmic](https://github.com/hagmic) in [#6328](https://github.com/apollographql/apollo-client/pull/6328)
+
+- Apollo Link core and HTTP related functionality has been merged into `@apollo/client`. Functionality that was previously available through the `apollo-link`, `apollo-link-http-common` and `apollo-link-http` packages is now directly available from `@apollo/client` (e.g. `import { HttpLink } from '@apollo/client'`). The `ApolloClient` constructor has also been updated to accept new `uri`, `headers` and `credentials` options. If `uri` is specified, Apollo Client will take care of creating the necessary `HttpLink` behind the scenes. <br/>
+  [@hwillson](https://github.com/hwillson) in [#5412](https://github.com/apollographql/apollo-client/pull/5412)
+
+- The `gql` template tag should now be imported from the `@apollo/client` package, rather than the `graphql-tag` package. Although the `graphql-tag` package still works for now, future versions of `@apollo/client` may change the implementation details of `gql` without a major version bump. <br/>
+  [@hwillson](https://github.com/hwillson) in [#5451](https://github.com/apollographql/apollo-client/pull/5451)
+
+- `@apollo/client/core` can be used to import the Apollo Client core, which includes everything the main `@apollo/client` package does, except for all React related functionality.  <br/>
+  [@kamilkisiela](https://github.com/kamilkisiela) in [#5541](https://github.com/apollographql/apollo-client/pull/5541)
+
+- Several deprecated methods have been fully removed:
+  - `ApolloClient#initQueryManager`
+  - `QueryManager#startQuery`
+  - `ObservableQuery#currentResult`
+
+- Apollo Client now supports setting a new `ApolloLink` (or link chain) after `new ApolloClient()` has been called, using the `ApolloClient#setLink` method.  <br/>
+  [@hwillson](https://github.com/hwillson) in [#6193](https://github.com/apollographql/apollo-client/pull/6193)
+
+### `InMemoryCache`
+
+> ⚠️ **Note:** `InMemoryCache` has been significantly redesigned and rewritten in Apollo Client 3.0. Please consult the [migration guide](https://www.apollographql.com/docs/react/v3.0-beta/migrating/apollo-client-3-migration/#cache-improvements) and read the new [documentation](https://www.apollographql.com/docs/react/v3.0-beta/caching/cache-configuration/) to understand everything that has been improved.
+
+- The `InMemoryCache` constructor should now be imported directly from `@apollo/client`, rather than from a separate package. The `apollo-cache-inmemory` package is no longer supported.
+
+  > The `@apollo/client/cache` entry point can be used to import `InMemoryCache` without importing other parts of the Apollo Client codebase. <br/>
+    [@hwillson](https://github.com/hwillson) in [#5577](https://github.com/apollographql/apollo-client/pull/5577)
+
+- **[BREAKING]** `FragmentMatcher`, `HeuristicFragmentMatcher`, and `IntrospectionFragmentMatcher` have all been removed. We now recommend using `InMemoryCache`’s `possibleTypes` option instead. For more information see the [Defining `possibleTypes` manually](https://www.apollographql.com/docs/react/v3.0-beta/data/fragments/#defining-possibletypes-manually) section of the docs. <br/>
+  [@benjamn](https://github.com/benjamn) in [#5073](https://github.com/apollographql/apollo-client/pull/5073)
+
+- **[BREAKING]** As promised in the [Apollo Client 2.6 blog post](https://blog.apollographql.com/whats-new-in-apollo-client-2-6-b3acf28ecad1), all cache results are now frozen/immutable. <br/>
+  [@benjamn](https://github.com/benjamn) in [#5153](https://github.com/apollographql/apollo-client/pull/5153)
+
+- **[BREAKING]** Eliminate "generated" cache IDs to avoid normalizing objects with no meaningful ID, significantly reducing cache memory usage. This might be a backwards-incompatible change if your code depends on the precise internal representation of normalized data in the cache. <br/>
+  [@benjamn](https://github.com/benjamn) in [#5146](https://github.com/apollographql/apollo-client/pull/5146)
+
+- **[BREAKING]** `InMemoryCache` will no longer merge the fields of written objects unless the objects are known to have the same identity, and the values of fields with the same name will not be recursively merged unless a custom `merge` function is defined by a field policy for that field, within a type policy associated with the `__typename` of the parent object. <br/>
+  [@benjamn](https://github.com/benjamn) in [#5603](https://github.com/apollographql/apollo-client/pull/5603)
+
+- **[BREAKING]** `InMemoryCache` now _throws_ when data with missing or undefined query fields is written into the cache, rather than just warning in development. <br/>
+  [@benjamn](https://github.com/benjamn) in [#6055](https://github.com/apollographql/apollo-client/pull/6055)
+
+- **[BREAKING]** `client|cache.writeData` have been fully removed. `writeData` usage is one of the easiest ways to turn faulty assumptions about how the cache represents data internally, into cache inconsistency and corruption. `client|cache.writeQuery`, `client|cache.writeFragment`, and/or `cache.modify` can be used to update the cache.  <br/>
+  [@benjamn](https://github.com/benjamn) in [#5923](https://github.com/apollographql/apollo-client/pull/5923)
 
 - `InMemoryCache` now supports tracing garbage collection and eviction. Note that the signature of the `evict` method has been simplified in a potentially backwards-incompatible way. <br/>
   [@benjamn](https://github.com/benjamn) in [#5310](https://github.com/apollographql/apollo-client/pull/5310)
@@ -70,24 +88,6 @@
 
 - `InMemoryCache` now `console.warn`s in development whenever non-normalized data is dangerously overwritten, with helpful links to documentation about normalization and custom `merge` functions. <br/>
   [@benjamn](https://github.com/benjamn) in [#6372](https://github.com/apollographql/apollo-client/pull/6372)
-
-- The contents of the `@apollo/react-hooks` package have been merged into `@apollo/client`, enabling the following all-in-one `import`:
-  ```ts
-  import { ApolloClient, ApolloProvider, useQuery } from '@apollo/client';
-  ```
-  [@hwillson](https://github.com/hwillson) in [#5357](https://github.com/apollographql/apollo-client/pull/5357)
-
-- Apollo Link core and HTTP related functionality has been merged into `@apollo/client`. Functionality that was previously available through the `apollo-link`, `apollo-link-http-common` and `apollo-link-http` packages is now directly available from `@apollo/client` (e.g. `import { HttpLink } from '@apollo/client'`). The `ApolloClient` constructor has also been updated to accept new `uri`, `headers` and `credentials` options. If `uri` is specified, Apollo Client will take care of creating the necessary `HttpLink` behind the scenes. <br/>
-  [@hwillson](https://github.com/hwillson) in [#5412](https://github.com/apollographql/apollo-client/pull/5412)
-
-- The `gql` template tag should now be imported from the `@apollo/client` package, rather than the `graphql-tag` package. Although the `graphql-tag` package still works for now, future versions of `@apollo/client` may change the implementation details of `gql` without a major version bump. <br/>
-  [@hwillson](https://github.com/hwillson) in [#5451](https://github.com/apollographql/apollo-client/pull/5451)
-
-- `@apollo/client/core` can be used to import the Apollo Client core, which includes everything the main `@apollo/client` package does, except for all React related functionality.  <br/>
-  [@kamilkisiela](https://github.com/kamilkisiela) in [#5541](https://github.com/apollographql/apollo-client/pull/5541)
-
-- `@apollo/client/cache` can be used to import the Apollo Client cache without importing other parts of the Apollo Client codebase. <br/>
-  [@hwillson](https://github.com/hwillson) in [#5577](https://github.com/apollographql/apollo-client/pull/5577)
 
 - The result caching system (introduced in [#3394](https://github.com/apollographql/apollo-client/pull/3394)) now tracks dependencies at the field level, rather than at the level of whole entity objects, allowing the cache to return identical (`===`) results much more often than before. <br/>
   [@benjamn](https://github.com/benjamn) in [#5617](https://github.com/apollographql/apollo-client/pull/5617)
@@ -124,11 +124,6 @@
 - The `cache.readQuery` and `cache.writeQuery` methods now accept an `options.id` string, which eliminates most use cases for `cache.readFragment` and `cache.writeFragment`, and skips the implicit conversion of fragment documents to query documents performed by `cache.{read,write}Fragment`. <br/>
   [@benjamn](https://github.com/benjamn) in [#5930](https://github.com/apollographql/apollo-client/pull/5930)
 
-- Several deprecated methods have been fully removed:
-  - `ApolloClient#initQueryManager`
-  - `QueryManager#startQuery`
-  - `ObservableQuery#currentResult`
-
 - Support `cache.identify(entity)` for easily computing entity ID strings. <br/>
   [@benjamn](https://github.com/benjamn) in [#5642](https://github.com/apollographql/apollo-client/pull/5642)
 
@@ -147,8 +142,38 @@
 - Custom field `read` functions can read from neighboring fields using the `readField(fieldName)` helper, and may also read fields from other entities by calling `readField(fieldName, objectOrReference)`. <br/>
   [@benjamn](https://github.com/benjamn) in [#5651](https://github.com/apollographql/apollo-client/pull/5651)
 
-- Utilities that were previously externally available through the `apollo-utilities` package are now only available by importing from `@apollo/client/utilities`. <br/>
-  [@hwillson](https://github.com/hwillson) in [#5683](https://github.com/apollographql/apollo-client/pull/5683)
+- Expose cache `modify` and `identify` to the mutate `update` function.  <br/>
+  [@hwillson](https://github.com/hwillson) in [#5956](https://github.com/apollographql/apollo-client/pull/5956)
+
+- Add a default `gc` implementation to `ApolloCache`.  <br/>
+  [@justinwaite](https://github.com/justinwaite) in [#5974](https://github.com/apollographql/apollo-client/pull/5974)
+
+### React
+
+- **[BREAKING]** The `QueryOptions`, `MutationOptions`, and `SubscriptionOptions` React Apollo interfaces have been renamed to `QueryDataOptions`, `MutationDataOptions`, and `SubscriptionDataOptions` (to avoid conflicting with similarly named and exported Apollo Client interfaces).
+
+- **[BREAKING?]** Remove `fixPolyfills.ts`, except when bundling for React Native. If you have trouble with `Map` or `Set` operations due to frozen key objects in React Native, either update React Native to version 0.59.0 (or 0.61.x, if possible) or investigate why `fixPolyfills.native.js` is not included in your bundle. <br/>
+  [@benjamn](https://github.com/benjamn) in [#5962](https://github.com/apollographql/apollo-client/pull/5962)
+
+- The contents of the `@apollo/react-hooks` package have been merged into `@apollo/client`, enabling the following all-in-one `import`:
+  ```ts
+  import { ApolloClient, ApolloProvider, useQuery } from '@apollo/client';
+  ```
+  [@hwillson](https://github.com/hwillson) in [#5357](https://github.com/apollographql/apollo-client/pull/5357)
+
+### General
+
+- **[BREAKING]** Removed `graphql-anywhere` since it's no longer used by Apollo Client.  <br/>
+  [@hwillson](https://github.com/hwillson) in [#5159](https://github.com/apollographql/apollo-client/pull/5159)
+
+- **[BREAKING]** Removed `apollo-boost` since Apollo Client 3.0 provides a boost like getting started experience out of the box.  <br/>
+  [@hwillson](https://github.com/hwillson) in [#5217](https://github.com/apollographql/apollo-client/pull/5217)
+
+- **[BREAKING]** We are no longer exporting certain (intended to be) internal utilities. If you are depending on some of the lesser known exports from `apollo-cache`, `apollo-cache-inmemory`, or `apollo-utilities`, they may no longer be available from `@apollo/client`. <br/>
+  [@hwillson](https://github.com/hwillson) in [#5437](https://github.com/apollographql/apollo-client/pull/5437) and [#5514](https://github.com/apollographql/apollo-client/pull/5514)
+
+  > Utilities that were previously externally available through the `apollo-utilities` package are now only available by importing from `@apollo/client/utilities`. <br/>
+    [@hwillson](https://github.com/hwillson) in [#5683](https://github.com/apollographql/apollo-client/pull/5683)
 
 - Make sure all `graphql-tag` public exports are re-exported.  <br/>
   [@hwillson](https://github.com/hwillson) in [#5861](https://github.com/apollographql/apollo-client/pull/5861)
@@ -158,19 +183,6 @@
 
 - Make sure `ApolloContext` plays nicely with IE11 when storing the shared context.  <br/>
   [@ms](https://github.com/ms) in [#5840](https://github.com/apollographql/apollo-client/pull/5840)
-
-- Expose cache `modify` and `identify` to the mutate `update` function.  <br/>
-  [@hwillson](https://github.com/hwillson) in [#5956](https://github.com/apollographql/apollo-client/pull/5956)
-
-- Add a default `gc` implementation to `ApolloCache`.  <br/>
-  [@justinwaite](https://github.com/justinwaite) in [#5974](https://github.com/apollographql/apollo-client/pull/5974)
-
-- Updated to work with `graphql@15`.  <br/>
-  [@durchanek](https://github.com/durchanek) in [#6194](https://github.com/apollographql/apollo-client/pull/6194) and [#6279](https://github.com/apollographql/apollo-client/pull/6279) <br/>
-  [@hagmic](https://github.com/hagmic) in [#6328](https://github.com/apollographql/apollo-client/pull/6328)
-
-- Apollo Client now supports setting a new `ApolloLink` (or link chain) after `new ApolloClient()` has been called, using the `ApolloClient#setLink` method.  <br/>
-  [@hwillson](https://github.com/hwillson) in [#6193](https://github.com/apollographql/apollo-client/pull/6193)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@
 - **[BREAKING?]** Refactor `QueryManager` to make better use of observables and enforce `fetchPolicy` more reliably. <br/>
   [@benjamn](https://github.com/benjamn) in [#6221](https://github.com/apollographql/apollo-client/pull/6221)
 
+- The `updateQuery` function previously required by `fetchMore` has been deprecated with a warning, and will be removed in the next major version of Apollo Client. Please consider using a `merge` function to handle incoming data instead of relying on `updateQuery`. <br/>
+  [@benjamn](https://github.com/benjamn) in [#6464](https://github.com/apollographql/apollo-client/pull/6464)
+
 - Updated to work with `graphql@15`.  <br/>
   [@durchanek](https://github.com/durchanek) in [#6194](https://github.com/apollographql/apollo-client/pull/6194) and [#6279](https://github.com/apollographql/apollo-client/pull/6279) <br/>
   [@hagmic](https://github.com/hagmic) in [#6328](https://github.com/apollographql/apollo-client/pull/6328)

--- a/src/__tests__/fetchMore.ts
+++ b/src/__tests__/fetchMore.ts
@@ -3,10 +3,10 @@ import gql from 'graphql-tag';
 
 import { mockSingleLink } from '../utilities/testing/mocking/mockLink';
 import subscribeAndCount from '../utilities/testing/subscribeAndCount';
-import { InMemoryCache } from '../cache/inmemory/inMemoryCache';
+import { InMemoryCache, InMemoryCacheConfig } from '../cache/inmemory/inMemoryCache';
 import { ApolloClient, NetworkStatus, ObservableQuery } from '../';
 import { itAsync } from '../utilities/testing/itAsync';
-import { offsetLimitPagination } from '../utilities';
+import { offsetLimitPagination, concatPagination } from '../utilities';
 
 describe('updateQuery on a simple query', () => {
   const query = gql`
@@ -233,82 +233,181 @@ describe('fetchMore on an observable query', () => {
     });
   }
 
-  itAsync('triggers new result withAsync new variables', (resolve, reject) => {
-    const observable = setup(reject, {
-      request: {
-        query,
-        variables: variablesMore,
-      },
-      result: resultMore,
+  function setupWithCacheConfig(
+    reject: (reason: any) => any,
+    cacheConfig: InMemoryCacheConfig,
+    ...mockedResponses: any[]
+  ) {
+    const client = new ApolloClient({
+      link: mockSingleLink({
+        request: {
+          query,
+          variables,
+        },
+        result,
+      }, ...mockedResponses).setOnError(reject),
+      cache: new InMemoryCache(cacheConfig),
     });
 
-    let latestResult: any;
-    observable.subscribe({
-      next(result: any) {
-        latestResult = result;
-      },
+    return client.watchQuery<any>({
+      query,
+      variables,
+    });
+  }
+
+  describe('triggers new result with async new variables', () => {
+    itAsync('updateQuery', (resolve, reject) => {
+      const observable = setup(reject, {
+        request: {
+          query,
+          variables: variablesMore,
+        },
+        result: resultMore,
+      });
+
+      let latestResult: any;
+      observable.subscribe({
+        next(result: any) {
+          latestResult = result;
+        },
+      });
+
+      return observable.fetchMore({
+        // Rely on the fact that the original variables had limit: 10
+        variables: { start: 10 },
+        updateQuery: (prev, options) => {
+          expect(options.variables).toEqual(variablesMore);
+
+          const state = cloneDeep(prev) as any;
+          state.entry.comments = [
+            ...state.entry.comments,
+            ...(options.fetchMoreResult as any).entry.comments,
+          ];
+          return state;
+        },
+      }).then(data => {
+        // This is the server result
+        expect(data.data.entry.comments).toHaveLength(10);
+        expect(data.loading).toBe(false);
+        const comments = latestResult.data.entry.comments;
+        expect(comments).toHaveLength(20);
+        for (let i = 1; i <= 20; i++) {
+          expect(comments[i - 1].text).toEqual(`comment ${i}`);
+        }
+      }).then(resolve, reject);
     });
 
-    return observable.fetchMore({
-      // Rely on the fact that the original variables had limit: 10
-      variables: { start: 10 },
-      updateQuery: (prev, options) => {
-        expect(options.variables).toEqual(variablesMore);
+    itAsync('field policy', (resolve, reject) => {
+      const observable = setupWithCacheConfig(reject, {
+        typePolicies: {
+          Entry: {
+            fields: {
+              comments: concatPagination(),
+            },
+          },
+        },
+      }, {
+        request: { query, variables: variablesMore },
+        result: resultMore,
+      });
 
-        const state = cloneDeep(prev) as any;
-        state.entry.comments = [
-          ...state.entry.comments,
-          ...(options.fetchMoreResult as any).entry.comments,
-        ];
-        return state;
-      },
-    }).then(data => {
-      // This is the server result
-      expect(data.data.entry.comments).toHaveLength(10);
-      expect(data.loading).toBe(false);
-      const comments = latestResult.data.entry.comments;
-      expect(comments).toHaveLength(20);
-      for (let i = 1; i <= 20; i++) {
-        expect(comments[i - 1].text).toEqual(`comment ${i}`);
-      }
-    }).then(resolve, reject);
+      let latestResult: any;
+      observable.subscribe({
+        next(result: any) {
+          latestResult = result;
+        },
+      });
+
+      return observable.fetchMore({
+        // Rely on the fact that the original variables had limit: 10
+        variables: { start: 10 },
+      }).then(data => {
+        // This is the server result
+        expect(data.data.entry.comments).toHaveLength(10);
+        expect(data.loading).toBe(false);
+        const comments = latestResult.data.entry.comments;
+        expect(comments).toHaveLength(20);
+        for (let i = 1; i <= 20; i++) {
+          expect(comments[i - 1].text).toEqual(`comment ${i}`);
+        }
+      }).then(resolve, reject);
+    });
   });
 
-  itAsync('basic fetchMore results merging', (resolve, reject) => {
-    const observable = setup(reject, {
-      request: {
-        query,
-        variables: variablesMore,
-      },
-      result: resultMore,
+  describe('basic fetchMore results merging', () => {
+    itAsync('updateQuery', (resolve, reject) => {
+      const observable = setup(reject, {
+        request: {
+          query,
+          variables: variablesMore,
+        },
+        result: resultMore,
+      });
+
+      let latestResult: any;
+      observable.subscribe({
+        next(result: any) {
+          latestResult = result;
+        },
+      });
+
+      return observable.fetchMore({
+        variables: { start: 10 }, // rely on the fact that the original variables had limit: 10
+        updateQuery: (prev, options) => {
+          const state = cloneDeep(prev) as any;
+          state.entry.comments = [
+            ...state.entry.comments,
+            ...(options.fetchMoreResult as any).entry.comments,
+          ];
+          return state;
+        },
+      }).then(data => {
+        expect(data.data.entry.comments).toHaveLength(10); // this is the server result
+        expect(data.loading).toBe(false);
+        const comments = latestResult.data.entry.comments;
+        expect(comments).toHaveLength(20);
+        for (let i = 1; i <= 20; i++) {
+          expect(comments[i - 1].text).toEqual(`comment ${i}`);
+        }
+      }).then(resolve, reject);
     });
 
-    let latestResult: any;
-    observable.subscribe({
-      next(result: any) {
-        latestResult = result;
-      },
-    });
+    itAsync('field policy', (resolve, reject) => {
+      const observable = setupWithCacheConfig(reject, {
+        typePolicies: {
+          Entry: {
+            fields: {
+              comments: concatPagination(),
+            },
+          },
+        },
+      }, {
+        request: {
+          query,
+          variables: variablesMore,
+        },
+        result: resultMore,
+      });
 
-    return observable.fetchMore({
-      variables: { start: 10 }, // rely on the fact that the original variables had limit: 10
-      updateQuery: (prev, options) => {
-        const state = cloneDeep(prev) as any;
-        state.entry.comments = [
-          ...state.entry.comments,
-          ...(options.fetchMoreResult as any).entry.comments,
-        ];
-        return state;
-      },
-    }).then(data => {
-      expect(data.data.entry.comments).toHaveLength(10); // this is the server result
-      expect(data.loading).toBe(false);
-      const comments = latestResult.data.entry.comments;
-      expect(comments).toHaveLength(20);
-      for (let i = 1; i <= 20; i++) {
-        expect(comments[i - 1].text).toEqual(`comment ${i}`);
-      }
-    }).then(resolve, reject);
+      let latestResult: any;
+      observable.subscribe({
+        next(result: any) {
+          latestResult = result;
+        },
+      });
+
+      return observable.fetchMore({
+        variables: { start: 10 }, // rely on the fact that the original variables had limit: 10
+      }).then(data => {
+        expect(data.data.entry.comments).toHaveLength(10); // this is the server result
+        expect(data.loading).toBe(false);
+        const comments = latestResult.data.entry.comments;
+        expect(comments).toHaveLength(20);
+        for (let i = 1; i <= 20; i++) {
+          expect(comments[i - 1].text).toEqual(`comment ${i}`);
+        }
+      }).then(resolve, reject);
+    });
   });
 
   itAsync('fetchMore passes new args to field merge function', (resolve, reject) => {
@@ -513,57 +612,128 @@ describe('fetchMore on an observable query', () => {
     }).then(resolve, reject);
   });
 
-  itAsync('will not get an error from `fetchMore` if thrown', (resolve, reject) => {
-    const fetchMoreError = new Error('Uh, oh!');
-    const link = mockSingleLink({
-      request: { query, variables },
-      result,
-      delay: 5,
-    }, {
-      request: { query, variables: variablesMore },
-      error: fetchMoreError,
-      delay: 5,
-    }).setOnError(reject);
+  describe('will not get an error from `fetchMore` if thrown', () => {
+    itAsync('updateQuery', (resolve, reject) => {
+      const fetchMoreError = new Error('Uh, oh!');
+      const link = mockSingleLink({
+        request: { query, variables },
+        result,
+        delay: 5,
+      }, {
+        request: { query, variables: variablesMore },
+        error: fetchMoreError,
+        delay: 5,
+      }).setOnError(reject);
 
-    const client = new ApolloClient({
-      link,
-      cache: new InMemoryCache(),
+      const client = new ApolloClient({
+        link,
+        cache: new InMemoryCache(),
+      });
+
+      const observable = client.watchQuery({
+        query,
+        variables,
+        notifyOnNetworkStatusChange: true,
+      });
+
+      let count = 0;
+      observable.subscribe({
+        next: ({ data, networkStatus }) => {
+          switch (++count) {
+            case 1:
+              expect(networkStatus).toBe(NetworkStatus.ready);
+              expect((data as any).entry.comments.length).toBe(10);
+              observable.fetchMore({
+                variables: { start: 10 },
+                updateQuery: prev => {
+                  reject(new Error("should not have called updateQuery"));
+                  return prev;
+                },
+              }).catch(e => {
+                expect(e.networkError).toBe(fetchMoreError);
+                resolve();
+              });
+              break;
+          }
+        },
+        error: () => {
+          reject(new Error('`error` called when it wasn’t supposed to be.'));
+        },
+        complete: () => {
+          reject(
+            new Error('`complete` called when it wasn’t supposed to be.'),
+          );
+        },
+      });
     });
 
-    const observable = client.watchQuery({
-      query,
-      variables,
-      notifyOnNetworkStatusChange: true,
-    });
+    itAsync('field policy', (resolve, reject) => {
+      const fetchMoreError = new Error('Uh, oh!');
+      const link = mockSingleLink({
+        request: { query, variables },
+        result,
+        delay: 5,
+      }, {
+        request: { query, variables: variablesMore },
+        error: fetchMoreError,
+        delay: 5,
+      }).setOnError(reject);
 
-    let count = 0;
-    observable.subscribe({
-      next: ({ data, networkStatus }) => {
-        switch (++count) {
-        case 1:
-          expect(networkStatus).toBe(NetworkStatus.ready);
-          expect((data as any).entry.comments.length).toBe(10);
-          observable.fetchMore({
-            variables: { start: 10 },
-            updateQuery: prev => {
-              reject(new Error("should not have called updateQuery"));
-              return prev;
+      let calledFetchMore = false;
+
+      const client = new ApolloClient({
+        link,
+        cache: new InMemoryCache({
+          typePolicies: {
+            Entry: {
+              fields: {
+                comments: {
+                  keyArgs: false,
+                  merge(_, incoming) {
+                    if (calledFetchMore) {
+                      reject(new Error("should not have called merge"));
+                    }
+                    return incoming;
+                  },
+                },
+              },
             },
-          }).catch(e => {
-            expect(e.networkError).toBe(fetchMoreError);
-            resolve();
-          });
-          break;
-        }
-      },
-      error: () => {
-        reject(new Error('`error` called when it wasn’t supposed to be.'));
-      },
-      complete: () => {
-        reject(
-          new Error('`complete` called when it wasn’t supposed to be.'),
-        );
-      },
+          },
+        }),
+      });
+
+      const observable = client.watchQuery({
+        query,
+        variables,
+        notifyOnNetworkStatusChange: true,
+      });
+
+      let count = 0;
+      observable.subscribe({
+        next: ({ data, networkStatus }) => {
+          switch (++count) {
+            case 1:
+              expect(networkStatus).toBe(NetworkStatus.ready);
+              expect((data as any).entry.comments.length).toBe(10);
+              calledFetchMore = true;
+              observable.fetchMore({
+                variables: { start: 10 },
+              }).catch(e => {
+                expect(e.networkError).toBe(fetchMoreError);
+                resolve();
+              });
+              break;
+          }
+        },
+        error: () => {
+          reject(new Error('`error` called when it wasn’t supposed to be.'));
+        },
+        complete: () => {
+          reject(
+            new Error('`complete` called when it wasn’t supposed to be.'),
+          );
+        },
+      });
     });
   });
 
@@ -679,95 +849,213 @@ describe('fetchMore on an observable query with connection', () => {
     });
   }
 
-  itAsync('fetchMore with connection results merging', (resolve, reject) => {
-    const observable = setup(reject, {
-      request: {
-        query: transformedQuery,
-        variables: variablesMore,
-      },
-      result: resultMore,
-    })
-
-    let latestResult: any;
-    observable.subscribe({
-      next(result: any) {
-        latestResult = result;
-      },
-    });
-
-    return observable.fetchMore({
-      variables: { start: 10 }, // rely on the fact that the original variables had limit: 10
-      updateQuery: (prev, options) => {
-        const state = cloneDeep(prev) as any;
-        state.entry.comments = [
-          ...state.entry.comments,
-          ...(options.fetchMoreResult as any).entry.comments,
-        ];
-        return state;
-      },
-    }).then(data => {
-      expect(data.data.entry.comments).toHaveLength(10); // this is the server result
-      expect(data.loading).toBe(false);
-      const comments = latestResult.data.entry.comments;
-      expect(comments).toHaveLength(20);
-      for (let i = 1; i <= 20; i++) {
-        expect(comments[i - 1].text).toBe(`comment ${i}`);
-      }
-    }).then(resolve, reject);
-  });
-
-  itAsync('will set the network status to `fetchMore`', (resolve, reject) => {
-    const link = mockSingleLink({
-      request: { query: transformedQuery, variables },
-      result,
-      delay: 5,
-    }, {
-      request: { query: transformedQuery, variables: variablesMore },
-      result: resultMore,
-      delay: 5,
-    }).setOnError(reject);
-
+  function setupWithCacheConfig(
+    reject: (reason: any) => any,
+    cacheConfig: InMemoryCacheConfig,
+    ...mockedResponses: any[]
+  ) {
     const client = new ApolloClient({
-      link,
-      cache: new InMemoryCache(),
+      link: mockSingleLink({
+        request: {
+          query: transformedQuery,
+          variables,
+        },
+        result,
+      }, ...mockedResponses).setOnError(reject),
+      cache: new InMemoryCache(cacheConfig),
     });
 
-    const observable = client.watchQuery({
+    return client.watchQuery<any>({
       query,
       variables,
-      notifyOnNetworkStatusChange: true,
+    });
+  }
+
+  describe('fetchMore with connection results merging', () => {
+    itAsync('updateQuery', (resolve, reject) => {
+      const observable = setup(reject, {
+        request: {
+          query: transformedQuery,
+          variables: variablesMore,
+        },
+        result: resultMore,
+      })
+
+      let latestResult: any;
+      observable.subscribe({
+        next(result: any) {
+          latestResult = result;
+        },
+      });
+
+      return observable.fetchMore({
+        variables: { start: 10 }, // rely on the fact that the original variables had limit: 10
+        updateQuery: (prev, options) => {
+          const state = cloneDeep(prev) as any;
+          state.entry.comments = [
+            ...state.entry.comments,
+            ...(options.fetchMoreResult as any).entry.comments,
+          ];
+          return state;
+        },
+      }).then(data => {
+        expect(data.data.entry.comments).toHaveLength(10); // this is the server result
+        expect(data.loading).toBe(false);
+        const comments = latestResult.data.entry.comments;
+        expect(comments).toHaveLength(20);
+        for (let i = 1; i <= 20; i++) {
+          expect(comments[i - 1].text).toBe(`comment ${i}`);
+        }
+      }).then(resolve, reject);
     });
 
-    let count = 0;
-    observable.subscribe({
-      next: ({ data, networkStatus }) => {
-        switch (count++) {
-          case 0:
-            expect(networkStatus).toBe(NetworkStatus.ready);
-            expect((data as any).entry.comments.length).toBe(10);
-            observable.fetchMore({
-              variables: { start: 10 },
-              updateQuery: (prev: any, options: any) => {
-                const state = cloneDeep(prev) as any;
-                state.entry.comments = [
-                  ...state.entry.comments,
-                  ...(options.fetchMoreResult as any).entry.comments,
-                ];
-                return state;
-              },
-            });
-            break;
-          case 1:
-            expect(networkStatus).toBe(NetworkStatus.ready);
-            expect((data as any).entry.comments.length).toBe(20);
-            resolve();
-            break;
-          default:
-            reject(new Error('`next` called too many times'));
+    itAsync('field policy', (resolve, reject) => {
+      const observable = setupWithCacheConfig(reject, {
+        typePolicies: {
+          Entry: {
+            fields: {
+              comments: concatPagination(),
+            },
+          },
+        },
+      }, {
+        request: {
+          query: transformedQuery,
+          variables: variablesMore,
+        },
+        result: resultMore,
+      })
+
+      let latestResult: any;
+      observable.subscribe({
+        next(result: any) {
+          latestResult = result;
+        },
+      });
+
+      return observable.fetchMore({
+        variables: { start: 10 }, // rely on the fact that the original variables had limit: 10
+      }).then(data => {
+        expect(data.data.entry.comments).toHaveLength(10); // this is the server result
+        expect(data.loading).toBe(false);
+        const comments = latestResult.data.entry.comments;
+        expect(comments).toHaveLength(20);
+        for (let i = 1; i <= 20; i++) {
+          expect(comments[i - 1].text).toBe(`comment ${i}`);
         }
-      },
-      error: (error: any) => reject(error),
-      complete: () => reject(new Error('Should not have completed')),
+      }).then(resolve, reject);
+    });
+  });
+
+  describe('will set the network status to `fetchMore`', () => {
+    itAsync('updateQuery', (resolve, reject) => {
+      const link = mockSingleLink({
+        request: { query: transformedQuery, variables },
+        result,
+        delay: 5,
+      }, {
+        request: { query: transformedQuery, variables: variablesMore },
+        result: resultMore,
+        delay: 5,
+      }).setOnError(reject);
+
+      const client = new ApolloClient({
+        link,
+        cache: new InMemoryCache(),
+      });
+
+      const observable = client.watchQuery({
+        query,
+        variables,
+        notifyOnNetworkStatusChange: true,
+      });
+
+      let count = 0;
+      observable.subscribe({
+        next: ({ data, networkStatus }) => {
+          switch (count++) {
+            case 0:
+              expect(networkStatus).toBe(NetworkStatus.ready);
+              expect((data as any).entry.comments.length).toBe(10);
+              observable.fetchMore({
+                variables: { start: 10 },
+                updateQuery: (prev: any, options: any) => {
+                  const state = cloneDeep(prev) as any;
+                  state.entry.comments = [
+                    ...state.entry.comments,
+                    ...(options.fetchMoreResult as any).entry.comments,
+                  ];
+                  return state;
+                },
+              });
+              break;
+            case 1:
+              expect(networkStatus).toBe(NetworkStatus.ready);
+              expect((data as any).entry.comments.length).toBe(20);
+              resolve();
+              break;
+            default:
+              reject(new Error('`next` called too many times'));
+          }
+        },
+        error: (error: any) => reject(error),
+        complete: () => reject(new Error('Should not have completed')),
+      });
+    });
+
+    itAsync('field policy', (resolve, reject) => {
+      const link = mockSingleLink({
+        request: { query: transformedQuery, variables },
+        result,
+        delay: 5,
+      }, {
+        request: { query: transformedQuery, variables: variablesMore },
+        result: resultMore,
+        delay: 5,
+      }).setOnError(reject);
+
+      const client = new ApolloClient({
+        link,
+        cache: new InMemoryCache({
+          typePolicies: {
+            Entry: {
+              fields: {
+                comments: concatPagination(),
+              },
+            },
+          },
+        }),
+      });
+
+      const observable = client.watchQuery({
+        query,
+        variables,
+        notifyOnNetworkStatusChange: true,
+      });
+
+      let count = 0;
+      observable.subscribe({
+        next: ({ data, networkStatus }) => {
+          switch (count++) {
+            case 0:
+              expect(networkStatus).toBe(NetworkStatus.ready);
+              expect((data as any).entry.comments.length).toBe(10);
+              observable.fetchMore({
+                variables: { start: 10 },
+              });
+              break;
+            case 1:
+              expect(networkStatus).toBe(NetworkStatus.ready);
+              expect((data as any).entry.comments.length).toBe(20);
+              resolve();
+              break;
+            default:
+              reject(new Error('`next` called too many times'));
+          }
+        },
+        error: (error: any) => reject(error),
+        complete: () => reject(new Error('Should not have completed')),
+      });
     });
   });
 });

--- a/src/__tests__/fetchMore.ts
+++ b/src/__tests__/fetchMore.ts
@@ -5,6 +5,7 @@ import { mockSingleLink } from '../utilities/testing/mocking/mockLink';
 import { InMemoryCache } from '../cache/inmemory/inMemoryCache';
 import { ApolloClient, NetworkStatus, ObservableQuery } from '../';
 import { itAsync } from '../utilities/testing/itAsync';
+import { offsetLimitPagination } from '../utilities';
 
 describe('updateQuery on a simple query', () => {
   const query = gql`

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -186,7 +186,7 @@ export type FieldMergeFunction<TExisting = any, TIncoming = TExisting> = (
   // reasons discussed in FieldReadFunction above.
   incoming: SafeReadonly<TIncoming>,
   options: FieldFunctionOptions,
-) => TExisting;
+) => SafeReadonly<TExisting>;
 
 export const defaultDataIdFromObject = (
   { __typename, id, _id }: Readonly<StoreObject>,

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -63,5 +63,6 @@ export {
 } from './graphql/transform';
 
 export {
+  concatPagination,
   offsetLimitPagination,
 } from './policies/pagination';

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -61,3 +61,7 @@ export {
   removeFragmentSpreadFromDocument,
   removeClientSetsFromDocument,
 } from './graphql/transform';
+
+export {
+  offsetLimitPagination,
+} from './policies/pagination';

--- a/src/utilities/policies/pagination.ts
+++ b/src/utilities/policies/pagination.ts
@@ -1,0 +1,24 @@
+import { FieldPolicy, Reference } from '../../cache';
+
+type KeyArgs = FieldPolicy<any>["keyArgs"];
+
+// A basic field policy that uses options.args.{offset,limit} to splice
+// the incoming data into the existing array. If your arguments are called
+// something different (like args.{start,count}), feel free to copy/paste
+// this implementation and make the appropriate changes.
+export function offsetLimitPagination<T = Reference>(
+  keyArgs: KeyArgs = false,
+): FieldPolicy<T[]> {
+  return {
+    keyArgs,
+    merge(existing, incoming, { args }) {
+      const merged = existing ? existing.slice(0) : [];
+      const start = args ? args.offset : merged.length;
+      const end = start + incoming.length;
+      for (let i = start; i < end; ++i) {
+        merged[i] = incoming[i - start];
+      }
+      return merged;
+    },
+  };
+}

--- a/src/utilities/policies/pagination.ts
+++ b/src/utilities/policies/pagination.ts
@@ -2,6 +2,22 @@ import { FieldPolicy, Reference } from '../../cache';
 
 type KeyArgs = FieldPolicy<any>["keyArgs"];
 
+// A very basic pagination field policy that always concatenates new
+// results onto the existing array, without examining options.args.
+export function concatPagination<T = Reference>(
+  keyArgs: KeyArgs = false,
+): FieldPolicy<T[]> {
+  return {
+    keyArgs,
+    merge(existing, incoming) {
+      return existing ? [
+        ...existing,
+        ...incoming,
+      ] : incoming;
+    },
+  };
+}
+
 // A basic field policy that uses options.args.{offset,limit} to splice
 // the incoming data into the existing array. If your arguments are called
 // something different (like args.{start,count}), feel free to copy/paste


### PR DESCRIPTION
What began as an attempt to fix #5951 ultimately turned into the realization that the `updateQuery` function used by `fetchMore` is worse in almost every way than an equivalent field policy `merge` function.

Not only do you have to pass `updateQuery` every time you call `fetchMore`, but that repetition encourages a dangerously simplistic strategy of just concatenating the arrays together.

By contrast, a field policy needs to be defined only once, operates at the field level rather than the query level, and has a chance to examine field arguments to guide the merging process. Also, the `keyFields: false` default configuration allows the field policy to avoid the awful `fetchMore` hack of cramming additional results into the original array (keyed by the original arguments, which `fetchMore` does not update).

Since we are in the RC phase of AC3 testing, we are not removing or changing the behavior of `updateQuery` at this time, but a warning will be displayed (in development, at most once) to encourage switching to a field policy.

The tests included in this PR contain numerous side-by-side examples of the transition from `updateQuery` to a field policy, using both `concatPagination` and `offsetLimitPagination`.