### PR TITLE
Implement a relayStylePagination field policy helper function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@
 - The `updateQuery` function previously required by `fetchMore` has been deprecated with a warning, and will be removed in the next major version of Apollo Client. Please consider using a `merge` function to handle incoming data instead of relying on `updateQuery`. <br/>
   [@benjamn](https://github.com/benjamn) in [#6464](https://github.com/apollographql/apollo-client/pull/6464)
 
-  - Helper functions for generating common pagination-related field policies may be imported from `@apollo/client/utilities`. The most basic helper is `concatPagination`, which emulates the concatenation behavior of typical `updateQuery` functions. A more sophisticated helper is `offsetLimitPagination`, which implements offset/limit-baed pagination. Feel free to modify [these helper functions](https://github.com/apollographql/apollo-client/blob/master/src/utilities/policies/pagination.ts) to suit your needs.
+  - Helper functions for generating common pagination-related field policies may be imported from `@apollo/client/utilities`. The most basic helper is `concatPagination`, which emulates the concatenation behavior of typical `updateQuery` functions. A more sophisticated helper is `offsetLimitPagination`, which implements offset/limit-based pagination. If you are consuming paginated data from a Relay-friendly API, use `relayStylePagination`. Feel free to use [these helper functions](https://github.com/apollographql/apollo-client/blob/master/src/utilities/policies/pagination.ts) as inspiration for your own field policies, and/or modify them to suit your needs. <br/>
+    [@benjamn](https://github.com/benjamn) in [#6465](https://github.com/apollographql/apollo-client/pull/6465)
 
 - Updated to work with `graphql@15`.  <br/>
   [@durchanek](https://github.com/durchanek) in [#6194](https://github.com/apollographql/apollo-client/pull/6194) and [#6279](https://github.com/apollographql/apollo-client/pull/6279) <br/>

--- a/src/cache/inmemory/__tests__/__snapshots__/policies.ts.snap
+++ b/src/cache/inmemory/__tests__/__snapshots__/policies.ts.snap
@@ -1,0 +1,591 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`type policies field policies can handle Relay-style pagination 1`] = `
+Object {
+  "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}": Object {
+    "__typename": "Artist",
+    "bio": "American, 1960-1988, New York, New York, based in New York, New York",
+    "displayLabel": "Jean-Michel Basquiat",
+    "href": "/artist/jean-michel-basquiat",
+  },
+  "ROOT_QUERY": Object {
+    "__typename": "Query",
+    "search:basquiat": Object {
+      "edges": Array [
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
+          "node": Object {
+            "__ref": "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
+            "displayLabel": "ephemera BASQUIAT",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjI=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
+            "displayLabel": "Jean-Michel Basquiat | Xerox",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "__typename": "PageInfo",
+        "endCursor": "YXJyYXljb25uZWN0aW9uOjI=",
+        "hasNextPage": true,
+        "hasPreviousPage": false,
+        "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
+      },
+    },
+  },
+}
+`;
+
+exports[`type policies field policies can handle Relay-style pagination 2`] = `
+Object {
+  "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}": Object {
+    "__typename": "Artist",
+    "bio": "American, 1960-1988, New York, New York, based in New York, New York",
+    "displayLabel": "Jean-Michel Basquiat",
+    "href": "/artist/jean-michel-basquiat",
+  },
+  "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}": Object {
+    "__typename": "Artist",
+    "bio": "",
+    "displayLabel": "Reminiscent of Basquiat",
+    "href": "/artist/reminiscent-of-basquiat",
+  },
+  "ROOT_QUERY": Object {
+    "__typename": "Query",
+    "search:basquiat": Object {
+      "edges": Array [
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
+          "node": Object {
+            "__ref": "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
+            "displayLabel": "ephemera BASQUIAT",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjI=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
+            "displayLabel": "Jean-Michel Basquiat | Xerox",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Banksy, SEEN, JonOne and QUIK at Artrust Oct 8th – Dec 16th 2017",
+            "displayLabel": "STREET ART: From Basquiat to Banksy",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Jean-Michel Basquiat, Shepard Fairey, COPE2, Pure Evil, Sickboy, Blade, Kurar, and LARS at Artrust",
+            "displayLabel": "STREET ART 2: From Basquiat to Banksy",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjU=",
+          "node": Object {
+            "__ref": "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "__typename": "PageInfo",
+        "endCursor": "YXJyYXljb25uZWN0aW9uOjU=",
+        "hasNextPage": true,
+        "hasPreviousPage": false,
+        "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
+      },
+    },
+  },
+}
+`;
+
+exports[`type policies field policies can handle Relay-style pagination 3`] = `
+Object {
+  "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}": Object {
+    "__typename": "Artist",
+    "bio": "American, 1960-1988, New York, New York, based in New York, New York",
+    "displayLabel": "Jean-Michel Basquiat",
+    "href": "/artist/jean-michel-basquiat",
+  },
+  "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}": Object {
+    "__typename": "Artist",
+    "bio": "",
+    "displayLabel": "Reminiscent of Basquiat",
+    "href": "/artist/reminiscent-of-basquiat",
+  },
+  "ROOT_QUERY": Object {
+    "__typename": "Query",
+    "search:basquiat": Object {
+      "edges": Array [
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjE=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
+            "displayLabel": "ephemera BASQUIAT",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
+            "displayLabel": "Jean-Michel Basquiat | Xerox",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Banksy, SEEN, JonOne and QUIK at Artrust Oct 8th – Dec 16th 2017",
+            "displayLabel": "STREET ART: From Basquiat to Banksy",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Jean-Michel Basquiat, Shepard Fairey, COPE2, Pure Evil, Sickboy, Blade, Kurar, and LARS at Artrust",
+            "displayLabel": "STREET ART 2: From Basquiat to Banksy",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjU=",
+          "node": Object {
+            "__ref": "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "__typename": "PageInfo",
+        "endCursor": "YXJyYXljb25uZWN0aW9uOjU=",
+        "hasNextPage": true,
+        "hasPreviousPage": true,
+        "startCursor": "YXJyYXljb25uZWN0aW9uOjE=",
+      },
+    },
+  },
+}
+`;
+
+exports[`type policies field policies can handle Relay-style pagination 4`] = `
+Object {
+  "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}": Object {
+    "__typename": "Artist",
+    "bio": "American, 1960-1988, New York, New York, based in New York, New York",
+    "displayLabel": "Jean-Michel Basquiat",
+    "href": "/artist/jean-michel-basquiat",
+  },
+  "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}": Object {
+    "__typename": "Artist",
+    "bio": "",
+    "displayLabel": "Reminiscent of Basquiat",
+    "href": "/artist/reminiscent-of-basquiat",
+  },
+  "ROOT_QUERY": Object {
+    "__typename": "Query",
+    "search:basquiat": Object {
+      "edges": Array [
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
+          "node": Object {
+            "__ref": "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjE=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
+            "displayLabel": "ephemera BASQUIAT",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
+            "displayLabel": "Jean-Michel Basquiat | Xerox",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Banksy, SEEN, JonOne and QUIK at Artrust Oct 8th – Dec 16th 2017",
+            "displayLabel": "STREET ART: From Basquiat to Banksy",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Jean-Michel Basquiat, Shepard Fairey, COPE2, Pure Evil, Sickboy, Blade, Kurar, and LARS at Artrust",
+            "displayLabel": "STREET ART 2: From Basquiat to Banksy",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjU=",
+          "node": Object {
+            "__ref": "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "__typename": "PageInfo",
+        "endCursor": "YXJyYXljb25uZWN0aW9uOjU=",
+        "hasNextPage": true,
+        "hasPreviousPage": false,
+        "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
+      },
+    },
+  },
+}
+`;
+
+exports[`type policies field policies can handle Relay-style pagination 5`] = `
+Object {
+  "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}": Object {
+    "__typename": "Artist",
+    "bio": "American, 1960-1988, New York, New York, based in New York, New York",
+    "displayLabel": "Jean-Michel Basquiat",
+    "href": "/artist/jean-michel-basquiat",
+  },
+  "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}": Object {
+    "__typename": "Artist",
+    "bio": "",
+    "displayLabel": "Reminiscent of Basquiat",
+    "href": "/artist/reminiscent-of-basquiat",
+  },
+  "ROOT_QUERY": Object {
+    "__typename": "Query",
+    "search:basquiat": Object {
+      "edges": Array [
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
+          "node": Object {
+            "__ref": "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjE=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
+            "displayLabel": "ephemera BASQUIAT",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
+            "displayLabel": "Jean-Michel Basquiat | Xerox",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Banksy, SEEN, JonOne and QUIK at Artrust Oct 8th – Dec 16th 2017",
+            "displayLabel": "STREET ART: From Basquiat to Banksy",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Jean-Michel Basquiat, Shepard Fairey, COPE2, Pure Evil, Sickboy, Blade, Kurar, and LARS at Artrust",
+            "displayLabel": "STREET ART 2: From Basquiat to Banksy",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjU=",
+          "node": Object {
+            "__ref": "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjY=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Jean-Michel Basquiat at Brooklyn Museum Apr 3rd – Aug 23rd 2015",
+            "displayLabel": "Basquiat: The Unknown Notebooks",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "__typename": "PageInfo",
+        "endCursor": "YXJyYXljb25uZWN0aW9uOjY=",
+        "hasNextPage": true,
+        "hasPreviousPage": false,
+        "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
+      },
+    },
+  },
+}
+`;
+
+exports[`type policies field policies can handle Relay-style pagination 6`] = `
+Object {
+  "Artist:{\\"href\\":\\"/artist/james-turrell\\"}": Object {
+    "__typename": "Artist",
+    "bio": "American, born 1943, Los Angeles, California",
+    "displayLabel": "James Turrell",
+    "href": "/artist/james-turrell",
+  },
+  "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}": Object {
+    "__typename": "Artist",
+    "bio": "American, 1960-1988, New York, New York, based in New York, New York",
+    "displayLabel": "Jean-Michel Basquiat",
+    "href": "/artist/jean-michel-basquiat",
+  },
+  "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}": Object {
+    "__typename": "Artist",
+    "bio": "",
+    "displayLabel": "Reminiscent of Basquiat",
+    "href": "/artist/reminiscent-of-basquiat",
+  },
+  "ROOT_QUERY": Object {
+    "__typename": "Query",
+    "search:basquiat": Object {
+      "edges": Array [
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
+          "node": Object {
+            "__ref": "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjE=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
+            "displayLabel": "ephemera BASQUIAT",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
+            "displayLabel": "Jean-Michel Basquiat | Xerox",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Banksy, SEEN, JonOne and QUIK at Artrust Oct 8th – Dec 16th 2017",
+            "displayLabel": "STREET ART: From Basquiat to Banksy",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Jean-Michel Basquiat, Shepard Fairey, COPE2, Pure Evil, Sickboy, Blade, Kurar, and LARS at Artrust",
+            "displayLabel": "STREET ART 2: From Basquiat to Banksy",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjU=",
+          "node": Object {
+            "__ref": "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjY=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Jean-Michel Basquiat at Brooklyn Museum Apr 3rd – Aug 23rd 2015",
+            "displayLabel": "Basquiat: The Unknown Notebooks",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "__typename": "PageInfo",
+        "endCursor": "YXJyYXljb25uZWN0aW9uOjY=",
+        "hasNextPage": true,
+        "hasPreviousPage": false,
+        "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
+      },
+    },
+    "search:james turrell": Object {
+      "edges": Array [
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
+          "node": Object {
+            "__ref": "Artist:{\\"href\\":\\"/artist/james-turrell\\"}",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "__typename": "PageInfo",
+        "endCursor": "YXJyYXljb25uZWN0aW9uOjA=",
+        "hasNextPage": true,
+        "hasPreviousPage": false,
+        "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
+      },
+    },
+  },
+}
+`;
+
+exports[`type policies field policies can handle Relay-style pagination 7`] = `
+Object {
+  "Artist:{\\"href\\":\\"/artist/james-turrell\\"}": Object {
+    "__typename": "Artist",
+    "bio": "American, born 1943, Los Angeles, California",
+    "displayLabel": "James Turrell",
+    "href": "/artist/james-turrell",
+  },
+  "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}": Object {
+    "__typename": "Artist",
+    "bio": "",
+    "displayLabel": "Reminiscent of Basquiat",
+    "href": "/artist/reminiscent-of-basquiat",
+  },
+  "ROOT_QUERY": Object {
+    "__typename": "Query",
+    "search:basquiat": Object {
+      "edges": Array [
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
+          "node": Object {
+            "__ref": "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjE=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
+            "displayLabel": "ephemera BASQUIAT",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
+            "displayLabel": "Jean-Michel Basquiat | Xerox",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Banksy, SEEN, JonOne and QUIK at Artrust Oct 8th – Dec 16th 2017",
+            "displayLabel": "STREET ART: From Basquiat to Banksy",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Jean-Michel Basquiat, Shepard Fairey, COPE2, Pure Evil, Sickboy, Blade, Kurar, and LARS at Artrust",
+            "displayLabel": "STREET ART 2: From Basquiat to Banksy",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjU=",
+          "node": Object {
+            "__ref": "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjY=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Jean-Michel Basquiat at Brooklyn Museum Apr 3rd – Aug 23rd 2015",
+            "displayLabel": "Basquiat: The Unknown Notebooks",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "__typename": "PageInfo",
+        "endCursor": "YXJyYXljb25uZWN0aW9uOjY=",
+        "hasNextPage": true,
+        "hasPreviousPage": false,
+        "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
+      },
+    },
+    "search:james turrell": Object {
+      "edges": Array [
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
+          "node": Object {
+            "__ref": "Artist:{\\"href\\":\\"/artist/james-turrell\\"}",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "__typename": "PageInfo",
+        "endCursor": "YXJyYXljb25uZWN0aW9uOjA=",
+        "hasNextPage": true,
+        "hasPreviousPage": false,
+        "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
+      },
+    },
+  },
+}
+`;

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -1,8 +1,12 @@
 import gql from "graphql-tag";
 
 import { InMemoryCache, ReactiveVar } from "../inMemoryCache";
-import { Reference, StoreObject } from "../../../core";
+import { Reference, StoreObject, ApolloClient, NetworkStatus } from "../../../core";
 import { MissingFieldError } from "../..";
+import { relayStylePagination } from "../../../utilities";
+import { MockLink } from '../../../utilities/testing/mocking/mockLink';
+import subscribeAndCount from '../../../utilities/testing/subscribeAndCount';
+import { itAsync } from '../../../utilities/testing/itAsync';
 
 function reverse(s: string) {
   return s.split("").reverse().join("");
@@ -2167,6 +2171,575 @@ describe("type policies", function () {
             { __typename: "Todo", text: "Submit pull request" },
           ],
         },
+      });
+    });
+
+    itAsync("can handle Relay-style pagination", (resolve, reject) => {
+      const cache = new InMemoryCache({
+        addTypename: false,
+        typePolicies: {
+          Query: {
+            fields: {
+              search: relayStylePagination((args, { fieldName }) => {
+                expect(typeof args!.query).toBe("string");
+                expect(fieldName).toBe("search");
+                // Normalize the search query by lower-casing it.
+                return args!.query.toLowerCase();
+              }),
+            },
+          },
+
+          Artist: {
+            keyFields: ["href"],
+          },
+        },
+      });
+
+      const query = gql`
+        query ArtsySearch(
+          $query: String!,
+          $after: String, $first: Int,
+          $before: String, $last: Int,
+        ) {
+          search(
+            query: $query,
+            after: $after, first: $first,
+            before: $before, last: $last,
+          ) {
+            edges {
+              __typename
+              node {
+                __typename
+                displayLabel
+                ... on Artist { __typename href bio }
+                ... on SearchableItem { __typename description }
+              }
+            }
+            pageInfo {
+              __typename
+              startCursor
+              endCursor
+              hasPreviousPage
+              hasNextPage
+            }
+          }
+        }
+      `;
+
+      const firstVariables = {
+        query: "Basquiat",
+        first: 3,
+      };
+
+      const firstEdges = [
+        {
+          __typename: "SearchableEdge",
+          node: {
+            __typename: "Artist",
+            href: "/artist/jean-michel-basquiat",
+            displayLabel: "Jean-Michel Basquiat",
+            bio: "American, 1960-1988, New York, New York, based in New York, New York"
+          }
+        },
+        {
+          __typename: "SearchableEdge",
+          node: {
+            displayLabel: "ephemera BASQUIAT",
+            __typename: "SearchableItem",
+            description: "Past show featuring works by Damien Hirst, " +
+              "James Rosenquist, David Salle, Andy Warhol, Jeff Koons, " +
+              "Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, " +
+              "Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, " +
+              "David Wojnarowicz, Taylor Mead, William S. Burroughs, " +
+              "Michael Halsband, Rene Ricard, and Chris DAZE Ellis"
+          }
+        },
+        {
+          __typename: "SearchableEdge",
+          node: {
+            displayLabel: "Jean-Michel Basquiat | Xerox",
+            __typename: "SearchableItem",
+            description: "Past show featuring works by Jean-Michel " +
+              "Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019"
+          }
+        }
+      ];
+
+      const firstPageInfo = {
+        __typename: "PageInfo",
+        startCursor: "YXJyYXljb25uZWN0aW9uOjA=",
+        endCursor: "YXJyYXljb25uZWN0aW9uOjI=",
+        hasPreviousPage: false,
+        hasNextPage: true,
+      };
+
+      const secondVariables = {
+        query: "Basquiat",
+        after: firstPageInfo.endCursor,
+        first: 3,
+      };
+
+      const secondEdges = [
+        {
+          __typename: "SearchableEdge",
+          node: {
+            displayLabel: "STREET ART: From Basquiat to Banksy",
+            __typename: "SearchableItem",
+            description: "Past show featuring works by Banksy, SEEN, " +
+              "JonOne and QUIK at Artrust Oct 8th – Dec 16th 2017",
+          }
+        },
+        {
+          __typename: "SearchableEdge",
+          node: {
+            __typename: "SearchableItem",
+            displayLabel: "STREET ART 2: From Basquiat to Banksy",
+            description: "Past show featuring works by Jean-Michel Basquiat, " +
+              "Shepard Fairey, COPE2, Pure Evil, Sickboy, Blade, " +
+              "Kurar, and LARS at Artrust",
+          }
+        },
+        {
+          __typename: "SearchableEdge",
+          node: {
+            __typename: "Artist",
+            href: "/artist/reminiscent-of-basquiat",
+            displayLabel: "Reminiscent of Basquiat",
+            bio: ""
+          }
+        }
+      ];
+
+      const secondPageInfo = {
+        __typename: "PageInfo",
+        startCursor: "YXJyYXljb25uZWN0aW9uOjM=",
+        endCursor: "YXJyYXljb25uZWN0aW9uOjU=",
+        hasPreviousPage: false,
+        hasNextPage: true,
+      };
+
+      const thirdVariables = {
+        // Intentionally lower-case Basquiat here to make sure the results
+        // end up merged with other capitalized results.
+        query: "basquiat",
+        before: secondPageInfo.startCursor,
+        last: 2,
+        // Make sure these variables are not inherited.
+        after: void 0,
+        first: void 0,
+      };
+
+      const thirdEdges = firstEdges.slice(1);
+
+      const thirdPageInfo = {
+        __typename: "PageInfo",
+        startCursor: "YXJyYXljb25uZWN0aW9uOjE=",
+        endCursor: "YXJyYXljb25uZWN0aW9uOjM=",
+        hasPreviousPage: true,
+        hasNextPage: true,
+      };
+
+      const fourthVariables = {
+        query: "basquiat",
+        before: thirdPageInfo.startCursor,
+        last: 1,
+        // Make sure these variables are not inherited.
+        after: void 0,
+        first: void 0,
+      };
+
+      // Just the initial Basquiat Artist edge.
+      const fourthEdges = firstEdges.slice(0, 1);
+
+      const fourthPageInfo = {
+        __typename: "PageInfo",
+        startCursor: "YXJyYXljb25uZWN0aW9uOjA=",
+        endCursor: "YXJyYXljb25uZWN0aW9uOjA=",
+        hasPreviousPage: false,
+        hasNextPage: true,
+      };
+
+      const fifthVariables = {
+        query: "Basquiat",
+        after: secondPageInfo.endCursor,
+        first: 1,
+      };
+
+      const fifthEdges = [{
+        __typename: "SearchableEdge",
+        node: {
+          __typename: "SearchableItem",
+          displayLabel: "Basquiat: The Unknown Notebooks",
+          description: "Past show featuring works by Jean-Michel Basquiat " +
+            "at Brooklyn Museum Apr 3rd – Aug 23rd 2015",
+        },
+      }];
+
+      const fifthPageInfo = {
+        __typename: "PageInfo",
+        startCursor: "YXJyYXljb25uZWN0aW9uOjY=",
+        endCursor: "YXJyYXljb25uZWN0aW9uOjY=",
+        hasPreviousPage: true,
+        hasNextPage: true,
+      };
+
+      const turrellVariables = {
+        query: "James Turrell",
+        first: 1,
+      };
+
+      const turrellEdges = [{
+        __typename: "SearchableEdge",
+        node: {
+          __typename: "Artist",
+          href: "/artist/james-turrell",
+          displayLabel: "James Turrell",
+          bio: "American, born 1943, Los Angeles, California",
+        },
+      }];
+
+      const turrellPageInfo = {
+        __typename: "PageInfo",
+        startCursor: "YXJyYXljb25uZWN0aW9uOjA=",
+        endCursor: "YXJyYXljb25uZWN0aW9uOjA=",
+        hasPreviousPage: false,
+        hasNextPage: true,
+      };
+
+      const link = new MockLink([
+        {
+          request: {
+            query,
+            variables: firstVariables,
+          },
+          result: {
+            data: {
+              search: {
+                edges: firstEdges,
+                pageInfo: firstPageInfo,
+              }
+            }
+          },
+        },
+        {
+          request: {
+            query,
+            variables: secondVariables,
+          },
+          result: {
+            data: {
+              search: {
+                edges: secondEdges,
+                pageInfo: secondPageInfo,
+              },
+            },
+          },
+        },
+        {
+          request: {
+            query,
+            variables: thirdVariables,
+          },
+          result: {
+            data: {
+              search: {
+                edges: thirdEdges,
+                pageInfo: thirdPageInfo,
+              },
+            },
+          },
+        },
+        {
+          request: {
+            query,
+            variables: fourthVariables,
+          },
+          result: {
+            data: {
+              search: {
+                edges: fourthEdges,
+                pageInfo: fourthPageInfo,
+              },
+            },
+          },
+        },
+        {
+          request: {
+            query,
+            variables: fifthVariables,
+          },
+          result: {
+            data: {
+              search: {
+                edges: fifthEdges,
+                pageInfo: fifthPageInfo,
+              },
+            },
+          },
+        },
+        {
+          request: {
+            query,
+            variables: turrellVariables,
+          },
+          result: {
+            data: {
+              search: {
+                edges: turrellEdges,
+                pageInfo: turrellPageInfo,
+              },
+            },
+          },
+        },
+      ]).setOnError(reject);
+
+      const client = new ApolloClient({ link, cache });
+
+      const observable = client.watchQuery<any, {
+        query: string,
+        after?: string,
+        first?: number,
+        before?: string,
+        last?: number,
+      }>({
+        query,
+        variables: {
+          query: "Basquiat",
+          first: 3,
+        },
+      });
+
+      subscribeAndCount(reject, observable, (count, result) => {
+        if (count === 1) {
+          expect(result).toEqual({
+            loading: false,
+            networkStatus: NetworkStatus.ready,
+            data: {
+              search: {
+                edges: firstEdges,
+                pageInfo: firstPageInfo,
+              },
+            },
+          });
+
+          expect(cache.extract()).toMatchSnapshot();
+
+          observable.fetchMore({
+            variables: secondVariables,
+          });
+
+        } else if (count === 2) {
+          expect(result).toEqual({
+            loading: false,
+            networkStatus: NetworkStatus.ready,
+            data: {
+              search: {
+                edges: [
+                  ...firstEdges,
+                  ...secondEdges,
+                ],
+                pageInfo: {
+                  __typename: "PageInfo",
+                  startCursor: firstPageInfo.startCursor,
+                  endCursor: secondPageInfo.endCursor,
+                  hasPreviousPage: false,
+                  hasNextPage: true,
+                },
+              },
+            },
+          });
+
+          expect(cache.extract()).toMatchSnapshot();
+
+          observable.fetchMore({
+            variables: thirdVariables,
+          });
+
+        } else if (count === 3) {
+          expect(result.data.search.edges.length).toBe(5);
+
+          expect(result).toEqual({
+            loading: false,
+            networkStatus: NetworkStatus.ready,
+            data: {
+              search: {
+                edges: [
+                  ...thirdEdges,
+                  ...secondEdges,
+                ],
+                pageInfo: {
+                  __typename: "PageInfo",
+                  startCursor: thirdPageInfo.startCursor,
+                  endCursor: secondPageInfo.endCursor,
+                  hasPreviousPage: true,
+                  hasNextPage: true,
+                },
+              },
+            },
+          });
+
+          expect(cache.extract()).toMatchSnapshot();
+
+          observable.fetchMore({
+            variables: fourthVariables,
+          });
+
+        } else if (count === 4) {
+          expect(result).toEqual({
+            loading: false,
+            networkStatus: NetworkStatus.ready,
+            data: {
+              search: {
+                edges: [
+                  ...fourthEdges,
+                  ...thirdEdges,
+                  ...secondEdges,
+                ],
+                pageInfo: {
+                  __typename: "PageInfo",
+                  startCursor: firstPageInfo.startCursor,
+                  endCursor: secondPageInfo.endCursor,
+                  hasPreviousPage: false,
+                  hasNextPage: true,
+                },
+              },
+            },
+          });
+
+          expect(result.data.search.edges).toEqual([
+            ...firstEdges,
+            ...secondEdges,
+          ]);
+
+          expect(cache.extract()).toMatchSnapshot();
+
+          observable.fetchMore({
+            variables: fifthVariables,
+          });
+
+        } else if (count === 5) {
+          expect(result.data.search.edges.length).toBe(7);
+
+          expect(result).toEqual({
+            loading: false,
+            networkStatus: NetworkStatus.ready,
+            data: {
+              search: {
+                edges: [
+                  ...firstEdges,
+                  ...secondEdges,
+                  ...fifthEdges,
+                ],
+                pageInfo: {
+                  __typename: "PageInfo",
+                  startCursor: firstPageInfo.startCursor,
+                  endCursor: fifthPageInfo.endCursor,
+                  hasPreviousPage: false,
+                  hasNextPage: true,
+                },
+              },
+            },
+          });
+
+          expect(cache.extract()).toMatchSnapshot();
+
+          // Now search for a different artist to verify that they keyArgs
+          // function we passed to relayStylePagination above keeps
+          // different search queries separate in the cache.
+          client.query({
+            query,
+            variables: {
+              query: "James Turrell",
+              first: 1,
+            },
+          }).then(result => {
+            expect(result).toEqual({
+              loading: false,
+              networkStatus: NetworkStatus.ready,
+              data: {
+                search: {
+                  edges: turrellEdges,
+                  pageInfo: turrellPageInfo,
+                },
+              },
+            });
+
+            const snapshot = cache.extract();
+            expect(snapshot).toMatchSnapshot();
+            expect(
+              // Note that Turrell's name has been lower-cased.
+              snapshot.ROOT_QUERY!["search:james turrell"]
+            ).toEqual({
+              edges: turrellEdges.map(edge => ({
+                ...edge,
+                // The relayStylePagination merge function updates the
+                // edge.cursor field of the first and last edge, even if
+                // the query did not request the edge.cursor field, if
+                // pageInfo.{start,end}Cursor are defined.
+                cursor: turrellPageInfo.startCursor,
+                // Artist objects are normalized by HREF:
+                node: { __ref: 'Artist:{"href":"/artist/james-turrell"}' },
+              })),
+              pageInfo: turrellPageInfo,
+            });
+
+            // Evict the Basquiat entity to verify that the dangling
+            // edge.node Reference gets automatically elided from the
+            // Basquiat search results, thanks to the read function
+            // generated by the relayStylePagination helper.
+            expect(cache.evict({
+              id: cache.identify({
+                __typename: "Artist",
+                href: "/artist/jean-michel-basquiat",
+              }),
+            })).toBe(true);
+          }, reject);
+
+        } else if (count === 6) {
+          // Same full list of edges that we saw in the previous case.
+          const edges = [
+            ...firstEdges,
+            ...secondEdges,
+            ...fifthEdges,
+          ];
+
+          // Remove the Basquiat edge, which we know to be first.
+          expect(edges.shift()).toEqual({
+            __typename: "SearchableEdge",
+            node: {
+              __typename: "Artist",
+              href: "/artist/jean-michel-basquiat",
+              displayLabel: "Jean-Michel Basquiat",
+              bio: "American, 1960-1988, New York, New York, based in New York, New York",
+            },
+          });
+
+          expect(result).toEqual({
+            loading: false,
+            networkStatus: NetworkStatus.ready,
+            data: {
+              search: {
+                edges,
+                pageInfo: {
+                  __typename: "PageInfo",
+                  startCursor: thirdPageInfo.startCursor,
+                  endCursor: fifthPageInfo.endCursor,
+                  hasPreviousPage: false,
+                  hasNextPage: true,
+                },
+              },
+            },
+          });
+
+          expect(cache.extract()).toMatchSnapshot();
+
+          // Wait a bit to make sure there are no additional results for
+          // Basquiat.
+          setTimeout(resolve, 100);
+
+        } else {
+          reject("should not receive another result for Basquiat");
+        }
       });
     });
 

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -65,4 +65,5 @@ export {
 export {
   concatPagination,
   offsetLimitPagination,
+  relayStylePagination,
 } from './policies/pagination';

--- a/src/utilities/policies/pagination.ts
+++ b/src/utilities/policies/pagination.ts
@@ -38,3 +38,115 @@ export function offsetLimitPagination<T = Reference>(
     },
   };
 }
+
+type TInternalRelay<TNode> = Readonly<{
+  edges: Array<{
+    cursor: string;
+    node: TNode;
+  }>;
+  pageInfo: Readonly<{
+    hasPreviousPage: boolean;
+    hasNextPage: boolean;
+    startCursor?: string;
+    endCursor?: string;
+  }>;
+}>;
+
+// As proof of the flexibility of field policies, this function generates
+// one that handles Relay-style pagination, without Apollo Client knowing
+// anything about connections, edges, cursors, or pageInfo objects.
+export function relayStylePagination<TNode = Reference>(
+  keyArgs: KeyArgs = false,
+): FieldPolicy<TInternalRelay<TNode>> {
+  return {
+    keyArgs,
+
+    read(existing = makeEmptyData(), { canRead }) {
+      const edges = existing.edges.filter(edge => canRead(edge.node));
+      return {
+        edges,
+        pageInfo: {
+          ...existing.pageInfo,
+          startCursor: edges[0]?.cursor,
+          endCursor: edges[edges.length - 1]?.cursor,
+        },
+      };
+    },
+
+    merge(existing = makeEmptyData(), incoming, { args }) {
+      if (!args) return existing; // TODO Maybe throw?
+
+      const incomingEdges = incoming.edges.slice(0);
+      if (incoming.pageInfo) {
+        updateCursor(incomingEdges, 0, incoming.pageInfo.startCursor);
+        updateCursor(incomingEdges, -1, incoming.pageInfo.endCursor);
+      }
+
+      let prefix = existing.edges;
+      let suffix: typeof prefix = [];
+
+      if (args.after) {
+        const index = prefix.findIndex(edge => edge.cursor === args.after);
+        if (index >= 0) {
+          prefix = prefix.slice(0, index + 1);
+          // suffix = []; // already true
+        }
+      } else if (args.before) {
+        const index = prefix.findIndex(edge => edge.cursor === args.before);
+        suffix = index < 0 ? prefix : prefix.slice(index);
+        prefix = [];
+      }
+
+      const edges = [
+        ...prefix,
+        ...incomingEdges,
+        ...suffix,
+      ];
+
+      const pageInfo = {
+        ...incoming.pageInfo,
+        ...existing.pageInfo,
+        startCursor: edges[0]?.cursor,
+        endCursor: edges[edges.length - 1]?.cursor,
+      };
+
+      const updatePageInfo = (name: keyof TInternalRelay<TNode>["pageInfo"]) => {
+        const value = incoming.pageInfo[name];
+        if (value !== void 0) {
+          (pageInfo as any)[name] = value;
+        }
+      };
+      if (!prefix.length) updatePageInfo("hasPreviousPage");
+      if (!suffix.length) updatePageInfo("hasNextPage");
+
+      return {
+        ...existing,
+        ...incoming,
+        edges,
+        pageInfo,
+      };
+    },
+  };
+}
+
+function makeEmptyData() {
+  return {
+    edges: [],
+    pageInfo: {
+      hasPreviousPage: false,
+      hasNextPage: true,
+    },
+  };
+}
+
+function updateCursor<TNode>(
+  edges: TInternalRelay<TNode>["edges"],
+  index: number,
+  cursor: string | undefined,
+) {
+  if (index < 0) index += edges.length;
+  const edge = edges[index];
+  if (cursor && cursor !== edge.cursor) {
+    edges[index] = { ...edge, cursor };
+  }
+}


### PR DESCRIPTION
This helper function makes it very easy to consume paginated lists from Relay-friendly GraphQL servers, such as the [Artsy search API](https://metaphysics-production.artsy.net):
```ts
import { InMemoryCache } from "@apollo/client"
import { relayStylePagination } from "@apollo/client/utilities"

const cache = new InMemoryCache({
  typePolicies: {
    Query: {
      fields: {
        // The ["query"] argument keeps searches separated by args.query (but not
        // by any other arguments, since the field policy will handle them).
        search: relayStylePagination(["query"]),
      },
    },
  },
});
```
With this field policy in place, you never need to provide an `updateQuery` function when calling `fetchMore` for the `Query.search` field, since the `merge` function handles that logic far more reliably than any `updateQuery` function can. Also, you do not need to use any `@connection` directives in your queries for the field, because that information is expressed by the `keyArgs` passed to the `relayStylePagination` function (the `["query"]` above).

I made this helper function an export of the `@apollo/client/utilities` entry point (along with `concatPagination` and `offsetLimitPagination` from #6464) so those functions will not be included in your application bundle unless you import and use them. We hope you will find them useable and useful, but we also encourage using them for guidance/inspiration when writing your own custom field policy helper functions.

Note that Apollo Client has no hard-coded logic for Relay connections, `edges`, `node`s, `pageInfo`, `cursor`s, or forward and backward pagination, because it doesn't need to know anything about these concepts. With enough care, anyone could write the field policy generated by this helper function, which is a considerable testament to the power and flexibility of field policies.