### PR TITLE
Fix Rest Link URL

### DIFF
--- a/docs/source/api/link/apollo-link-rest.md
+++ b/docs/source/api/link/apollo-link-rest.md
@@ -31,7 +31,7 @@ import { ApolloClient } from '@apollo/client';
 import { RestLink } from 'apollo-link-rest';
 
 // Set `RestLink` with your endpoint
-const restLink = new RestLink({ uri: "https://swapi.co/api/" });
+const restLink = new RestLink({ uri: "https://swapi.dev/api/" });
 
 // Setup your client
 const client = new ApolloClient({


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests


Going through the Apollo Link Rest docs, I've found that swapi.co has migrated to swapi.dev.
The new URI is https://swapi.dev/api/
This PR updates the URL in the tutorial to match the new URL.