### PR TITLE
Allow toReference to accept an id or Reference

### DIFF
--- a/src/cache/core/types/common.ts
+++ b/src/cache/core/types/common.ts
@@ -46,7 +46,7 @@ export interface ReadFieldFunction {
 }
 
 export type ToReferenceFunction = (
-  object: StoreObject,
+  object: StoreObject | string | Reference,
   mergeIntoStore?: boolean,
 ) => Reference | undefined;
 

--- a/src/cache/core/types/common.ts
+++ b/src/cache/core/types/common.ts
@@ -46,7 +46,7 @@ export interface ReadFieldFunction {
 }
 
 export type ToReferenceFunction = (
-  object: StoreObject | string | Reference,
+  objOrIdOrRef: StoreObject | string | Reference,
   mergeIntoStore?: boolean,
 ) => Reference | undefined;
 

--- a/src/cache/inmemory/__tests__/entityStore.ts
+++ b/src/cache/inmemory/__tests__/entityStore.ts
@@ -2046,7 +2046,7 @@ describe('EntityStore', () => {
             favorited(_, { readField, toReference }) {
               const rootQueryRef = toReference("ROOT_QUERY");
               expect(rootQueryRef).toEqual(makeReference("ROOT_QUERY"));
-              const favoritedBooks = readField<[]>("favoritedBooks", rootQueryRef);
+              const favoritedBooks = readField<Reference[]>("favoritedBooks", rootQueryRef);
               return favoritedBooks!.some(bookRef => {
                 return readField("isbn") === readField("isbn", bookRef);
               });
@@ -2064,7 +2064,7 @@ describe('EntityStore', () => {
                 __typename: "Book",
                 isbn: args!.isbn,
                 title: titlesByISBN.get(args!.isbn),
-              }, true) as Reference;
+              }, true);
 
               return ref;
             },

--- a/src/cache/inmemory/__tests__/entityStore.ts
+++ b/src/cache/inmemory/__tests__/entityStore.ts
@@ -2037,4 +2037,101 @@ describe('EntityStore', () => {
       },
     });
   });
+
+  it("supports toReference(id)", () => {
+    const cache = new InMemoryCache({
+      typePolicies: {
+        Book: {
+          fields: {
+            favorited(_, { readField, toReference }) {
+              const rootQueryRef = toReference("ROOT_QUERY");
+              expect(rootQueryRef).toEqual(makeReference("ROOT_QUERY"));
+              const favoritedBooks = readField<[]>("favoritedBooks", rootQueryRef);
+              return favoritedBooks!.some(bookRef => {
+                return readField("isbn") === readField("isbn", bookRef);
+              });
+            },
+          },
+          keyFields: ["isbn"],
+        },
+        Query: {
+          fields: {
+            book(_, {
+              args,
+              toReference,
+            }) {
+              const ref = toReference({
+                __typename: "Book",
+                isbn: args!.isbn,
+                title: titlesByISBN.get(args!.isbn),
+              }, true) as Reference;
+
+              return ref;
+            },
+          },
+        }
+      }
+    });
+
+    cache.writeQuery({
+      query: gql`{
+        favoritedBooks {
+          isbn
+          title
+        }
+      }`,
+      data: {
+        favoritedBooks: [{
+          __typename: "Book",
+          isbn: "9781784295547",
+          title: "Shrill",
+          author: "Lindy West",
+        }],
+      },
+    });
+
+    const titlesByISBN = new Map<string, string>([
+      ["9780062569714", 'Hunger'],
+      ["9781784295547", 'Shrill'],
+      ["9780807083109", 'Kindred'],
+    ]);
+
+    const bookQuery = gql`
+      query {
+        book(isbn: $isbn) {
+          isbn
+          title
+          favorited @client
+        }
+      }
+    `;
+
+    const shrillResult = cache.readQuery({
+      query: bookQuery,
+      variables: {
+        isbn: "9781784295547"
+      }
+    });
+
+    expect(shrillResult).toEqual({book: {
+      __typename: "Book",
+      isbn: "9781784295547",
+      title: "Shrill",
+      favorited: true,
+    }});
+
+    const kindredResult = cache.readQuery({
+      query: bookQuery,
+      variables: {
+        isbn: "9780807083109"
+      }
+    });
+
+    expect(kindredResult).toEqual({book: {
+      __typename: "Book",
+      isbn: "9780807083109",
+      title: "Kindred",
+      favorited: false,
+    }});
+  });
 });

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -357,18 +357,28 @@ export abstract class EntityStore implements NormalizedCache {
       : typeof objOrRef === "object";
   };
 
-  // Bound function that converts an object with a __typename and primary
-  // key fields to a Reference object. Pass true for mergeIntoStore if you
-  // would also like this object to be persisted into the store.
+  // Bound function that converts an id or an object with a __typename and
+  // primary key fields to a Reference object. If called with a Reference object,
+  // that same Reference object is returned. Pass true for mergeIntoStore to persist
+  // an object into the store.
   public toReference: ToReferenceFunction = (
-    object,
+    objOrIdOrRef,
     mergeIntoStore,
   ) => {
-    const [id] = this.policies.identify(object);
+    if (typeof objOrIdOrRef === "string") {
+      return makeReference(objOrIdOrRef);
+    }
+
+    if (isReference(objOrIdOrRef)) {
+      return objOrIdOrRef;
+    }
+
+    const [id] = this.policies.identify(objOrIdOrRef);
+
     if (id) {
       const ref = makeReference(id);
       if (mergeIntoStore) {
-        this.merge(id, object);
+        this.merge(id, objOrIdOrRef);
       }
       return ref;
     }


### PR DESCRIPTION
Previous to this PR, `toReference` accepted objects with a `__typename` and primary key fields. Creating references for a StoreObject _without_ a `__typename` meant importing `makeReference`. In lieu of that, we decided to modify `toReference` to accept an id (in which case, it calls `makeReference` and returns the result) or a Reference object (in which case, it returns that object as-is).