### PR TITLE
Let relayStylePagination read function return extra connection fields.

### DIFF
--- a/src/cache/inmemory/__tests__/__snapshots__/policies.ts.snap
+++ b/src/cache/inmemory/__tests__/__snapshots__/policies.ts.snap
@@ -44,6 +44,7 @@ Object {
         "hasPreviousPage": false,
         "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
       },
+      "totalCount": 1292,
     },
   },
 }
@@ -123,6 +124,7 @@ Object {
         "hasPreviousPage": false,
         "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
       },
+      "totalCount": 1292,
     },
   },
 }
@@ -196,6 +198,7 @@ Object {
         "hasPreviousPage": true,
         "startCursor": "YXJyYXljb25uZWN0aW9uOjE=",
       },
+      "totalCount": 1292,
     },
   },
 }
@@ -276,6 +279,7 @@ Object {
         "hasPreviousPage": false,
         "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
       },
+      "totalCount": 1292,
     },
   },
 }
@@ -365,6 +369,7 @@ Object {
         "hasPreviousPage": false,
         "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
       },
+      "totalCount": 1292,
     },
   },
 }
@@ -460,6 +465,7 @@ Object {
         "hasPreviousPage": false,
         "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
       },
+      "totalCount": 1292,
     },
     "search:james turrell": Object {
       "edges": Array [
@@ -478,6 +484,7 @@ Object {
         "hasPreviousPage": false,
         "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
       },
+      "totalCount": 13531,
     },
   },
 }
@@ -567,6 +574,7 @@ Object {
         "hasPreviousPage": false,
         "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
       },
+      "totalCount": 1292,
     },
     "search:james turrell": Object {
       "edges": Array [
@@ -585,6 +593,7 @@ Object {
         "hasPreviousPage": false,
         "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
       },
+      "totalCount": 13531,
     },
   },
 }

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -2222,6 +2222,7 @@ describe("type policies", function () {
               hasPreviousPage
               hasNextPage
             }
+            totalCount
           }
         }
       `;
@@ -2417,6 +2418,7 @@ describe("type policies", function () {
               search: {
                 edges: firstEdges,
                 pageInfo: firstPageInfo,
+                totalCount: 1292,
               }
             }
           },
@@ -2431,6 +2433,7 @@ describe("type policies", function () {
               search: {
                 edges: secondEdges,
                 pageInfo: secondPageInfo,
+                totalCount: 1292,
               },
             },
           },
@@ -2445,6 +2448,7 @@ describe("type policies", function () {
               search: {
                 edges: thirdEdges,
                 pageInfo: thirdPageInfo,
+                totalCount: 1292,
               },
             },
           },
@@ -2459,6 +2463,7 @@ describe("type policies", function () {
               search: {
                 edges: fourthEdges,
                 pageInfo: fourthPageInfo,
+                totalCount: 1292,
               },
             },
           },
@@ -2473,6 +2478,7 @@ describe("type policies", function () {
               search: {
                 edges: fifthEdges,
                 pageInfo: fifthPageInfo,
+                totalCount: 1292,
               },
             },
           },
@@ -2487,6 +2493,7 @@ describe("type policies", function () {
               search: {
                 edges: turrellEdges,
                 pageInfo: turrellPageInfo,
+                totalCount: 13531,
               },
             },
           },
@@ -2518,6 +2525,7 @@ describe("type policies", function () {
               search: {
                 edges: firstEdges,
                 pageInfo: firstPageInfo,
+                totalCount: 1292,
               },
             },
           });
@@ -2545,6 +2553,7 @@ describe("type policies", function () {
                   hasPreviousPage: false,
                   hasNextPage: true,
                 },
+                totalCount: 1292,
               },
             },
           });
@@ -2574,6 +2583,7 @@ describe("type policies", function () {
                   hasPreviousPage: true,
                   hasNextPage: true,
                 },
+                totalCount: 1292,
               },
             },
           });
@@ -2602,6 +2612,7 @@ describe("type policies", function () {
                   hasPreviousPage: false,
                   hasNextPage: true,
                 },
+                totalCount: 1292,
               },
             },
           });
@@ -2637,6 +2648,7 @@ describe("type policies", function () {
                   hasPreviousPage: false,
                   hasNextPage: true,
                 },
+                totalCount: 1292,
               },
             },
           });
@@ -2660,6 +2672,7 @@ describe("type policies", function () {
                 search: {
                   edges: turrellEdges,
                   pageInfo: turrellPageInfo,
+                  totalCount: 13531,
                 },
               },
             });
@@ -2681,6 +2694,7 @@ describe("type policies", function () {
                 node: { __ref: 'Artist:{"href":"/artist/james-turrell"}' },
               })),
               pageInfo: turrellPageInfo,
+              totalCount: 13531,
             });
 
             // Evict the Basquiat entity to verify that the dangling
@@ -2727,6 +2741,7 @@ describe("type policies", function () {
                   hasPreviousPage: false,
                   hasNextPage: true,
                 },
+                totalCount: 1292,
               },
             },
           });

--- a/src/utilities/policies/pagination.ts
+++ b/src/utilities/policies/pagination.ts
@@ -64,6 +64,10 @@ export function relayStylePagination<TNode = Reference>(
     read(existing = makeEmptyData(), { canRead }) {
       const edges = existing.edges.filter(edge => canRead(edge.node));
       return {
+        // Some implementations return additional Connection fields, such
+        // as existing.totalCount. These fields are saved by the merge
+        // function, so the read function should also preserve them.
+        ...existing,
         edges,
         pageInfo: {
           ...existing.pageInfo,


### PR DESCRIPTION
Should fix #6477.

Fields like `connection.totalCount` are not part of the official Relay connection [specification](https://relay.dev/graphql/connections.htm), but it seems most servers support `totalCount`, judging by this official documentation: https://graphql.org/learn/pagination/#end-of-list-counts-and-connections

Note that our `relayStylePagination` helper function does not need to know about `totalCount` specifically, but merely saves any extra connection fields in the `merge` function and later returns them from the `read` function.