### PR TITLE
promise.allSettled instead of promise.all consumeAndAwaitPromises

### DIFF
--- a/src/react/ssr/RenderPromises.ts
+++ b/src/react/ssr/RenderPromises.ts
@@ -80,7 +80,7 @@ export class RenderPromises {
       promises.push(promise);
     });
     this.queryPromises.clear();
-    return Promise.all(promises);
+    return Promise.allSettled(promises);
   }
 
   private lookupQueryInfo<TData, TVariables>(

--- a/src/react/ssr/RenderPromises.ts
+++ b/src/react/ssr/RenderPromises.ts
@@ -80,7 +80,18 @@ export class RenderPromises {
       promises.push(promise);
     });
     this.queryPromises.clear();
-    return Promise.allSettled(promises);
+    return Promise.all(
+      promises.map(promise => promise.then(
+        value => ({
+          status: "fulfilled",
+          value,
+        }),
+        reason => ({
+          status: "rejected",
+          reason,
+        }),
+      ))
+    );
   }
 
   private lookupQueryInfo<TData, TVariables>(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "module": "es2015",
     "esModuleInterop": true,
     "outDir": "./dist",
-    "lib": ["es2015", "esnext.asynciterable", "dom"],
+    "lib": ["es2015", "esnext.asynciterable", "dom", "es2020.promise"],
     "jsx": "react"
   },
   "include": ["src/**/*.ts"],


### PR DESCRIPTION
When using the getDataFromThree method for SSR, if one query returns an error (even graphql errors like "user not authorized"), the whole SSR fails or is only partially rendered.
With promise allSettled getDataFromThree will no longer break SSR because of single query.
 Connected issues:
https://github.com/apollographql/react-apollo/issues/3678
https://github.com/apollographql/react-apollo/issues/1403
