### PR TITLE
Make makeVar a global function instead of a method of InMemoryCache.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,14 +115,18 @@
 
 - `InMemoryCache` provides a new API for storing client state that can be updated from anywhere:
   ```ts
-  const v = cache.makeVar(123)
+  import { makeVar } from "@apollo/client"
+  const v = makeVar(123)
   console.log(v()) // 123
   console.log(v(v() + 1)) // 124
   console.log(v()) // 124
   v("asdf") // TS type error
   ```
   These variables are _reactive_ in the sense that updating their values invalidates any previously cached query results that depended on the old values. <br/>
-  [@benjamn](https://github.com/benjamn) in [#5799](https://github.com/apollographql/apollo-client/pull/5799)
+  [@benjamn](https://github.com/benjamn) in
+  [#5799](https://github.com/apollographql/apollo-client/pull/5799),
+  [#5976](https://github.com/apollographql/apollo-client/pull/5976), and
+  [#6512](https://github.com/apollographql/apollo-client/pull/6512)
 
 - Various cache read and write performance optimizations, cutting read and write times by more than 50% in larger benchmarks. <br/>
   [@benjamn](https://github.com/benjamn) in [#5948](https://github.com/apollographql/apollo-client/pull/5948)

--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -16,6 +16,7 @@ const external = [
   'graphql/language/visitor',
   'graphql-tag',
   'fast-json-stable-stringify',
+  '@wry/context',
   '@wry/equality',
   'react',
   'zen-observable'

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     {
       "name": "apollo-client",
       "path": "./dist/apollo-client.cjs.min.js",
-      "maxSize": "24.25 kB"
+      "maxSize": "24.5 kB"
     }
   ],
   "peerDependencies": {

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -12,7 +12,7 @@ import { ApolloClient } from '..';
 import subscribeAndCount from '../utilities/testing/subscribeAndCount';
 import { itAsync } from '../utilities/testing/itAsync';
 import { mockSingleLink } from '../utilities/testing/mocking/mockLink';
-import { ObservableQuery, PossibleTypesMap } from '../core';
+import { ObservableQuery, PossibleTypesMap, makeVar } from '../core';
 
 describe('client', () => {
   it('can be loaded via require', () => {
@@ -2815,6 +2815,8 @@ describe('@connection', () => {
   });
 
   itAsync('should broadcast changes for reactive variables', async (resolve, reject) => {
+    const aVar = makeVar(123);
+    const bVar = makeVar("asdf");
     const cache: InMemoryCache = new InMemoryCache({
       typePolicies: {
         Query: {
@@ -2829,9 +2831,6 @@ describe('@connection', () => {
         },
       },
     });
-
-    const aVar = cache.makeVar(123);
-    const bVar = cache.makeVar("asdf");
 
     const client = new ApolloClient({ cache });
 

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -12,8 +12,12 @@ export {
 export {
   InMemoryCache,
   InMemoryCacheConfig,
-  ReactiveVar,
 } from './inmemory/inMemoryCache';
+
+export {
+  ReactiveVar,
+  makeVar,
+} from './inmemory/reactiveVars';
 
 export {
   defaultDataIdFromObject,

--- a/src/cache/inmemory/__tests__/cache.ts
+++ b/src/cache/inmemory/__tests__/cache.ts
@@ -2,7 +2,7 @@ import gql, { disableFragmentWarnings } from 'graphql-tag';
 
 import { stripSymbols } from '../../../utilities/testing/stripSymbols';
 import { cloneDeep } from '../../../utilities/common/cloneDeep';
-import { makeReference, Reference } from '../../../core';
+import { makeReference, Reference, makeVar } from '../../../core';
 import { InMemoryCache, InMemoryCacheConfig } from '../inMemoryCache';
 
 disableFragmentWarnings();
@@ -2393,8 +2393,9 @@ describe("InMemoryCache#modify", () => {
   });
 });
 
-describe("cache.makeVar", () => {
+describe("ReactiveVar and makeVar", () => {
   function makeCacheAndVar(resultCaching: boolean) {
+    const nameVar = makeVar("Ben");
     const cache: InMemoryCache = new InMemoryCache({
       resultCaching,
       typePolicies: {
@@ -2407,8 +2408,6 @@ describe("cache.makeVar", () => {
         },
       },
     });
-
-    const nameVar = cache.makeVar("Ben");
 
     const query = gql`
       query {

--- a/src/cache/inmemory/reactiveVars.ts
+++ b/src/cache/inmemory/reactiveVars.ts
@@ -1,0 +1,46 @@
+import { Slot } from "@wry/context";
+import { dep } from "optimism";
+import { InMemoryCache } from "./inMemoryCache";
+
+export type ReactiveVar<T> = (newValue?: T) => T;
+
+const varDep = dep<ReactiveVar<any>>();
+
+// Contextual Slot that acquires its value when custom read functions are
+// called in Policies#readField.
+export const cacheSlot = new Slot<InMemoryCache>();
+
+export function makeVar<T>(value: T): ReactiveVar<T> {
+  const caches = new Set<InMemoryCache>();
+
+  return function rv(newValue) {
+    if (arguments.length > 0) {
+      if (value !== newValue) {
+        value = newValue!;
+        varDep.dirty(rv);
+        // Trigger broadcast for any caches that were previously involved
+        // in reading this variable.
+        caches.forEach(broadcast);
+      }
+    } else {
+      // When reading from the variable, obtain the current InMemoryCache
+      // from context via cacheSlot. This isn't entirely foolproof, but
+      // it's the same system that powers varDep.
+      const cache = cacheSlot.getValue();
+      if (cache) caches.add(cache);
+      varDep(rv);
+    }
+
+    return value;
+  };
+}
+
+type Broadcastable = InMemoryCache & {
+  // This method is protected in InMemoryCache, which we are ignoring, but
+  // we still want some semblance of type safety when we call it.
+  broadcastWatches: InMemoryCache["broadcastWatches"];
+};
+
+function broadcast(cache: Broadcastable) {
+  cache.broadcastWatches();
+}


### PR DESCRIPTION
The `makeVar` method was originally attached to `InMemoryCache` so that we could call `cache.broadcastWatches()` whenever the variable was updated. See #5799 and #5976 for background.

However, as a number of developers have reported, requiring access to an `InMemoryCache` to create a `ReactiveVar` can be awkward, since the code that calls `makeVar` may not be colocated with the code that creates the cache, and it is often desirable to create and initialize reactive variables before the cache has even been created.

As this commit shows, the `ReactiveVar` function can infer the current `InMemoryCache` from a contextual `Slot<InMemoryCache>`, when called without arguments (that is, when reading the variable). When the variable is updated (by passing a new value to the `ReactiveVar` function), any caches that previously read the variable will be notified of the update. Since this logic happens at variable access time rather than variable creation time, `makeVar` can be a free-floating global function, importable directly from `@apollo/client`.

This new system allows the variable to become associated with any number of `InMemoryCache` instances, whereas previously a given variable was only ever associated with one `InMemoryCache`. Note: when I say "any number" I very much mean to include zero, since a `ReactiveVar` that has not been associated with any caches yet can still be used as a container, and will not trigger any broadcasts when updated.

The `Slot` class that makes this all work may seem like magic, but we have been using it ever since Apollo Client 2.5 (#3394, via the `optimism` library), so it has been amply battle-tested. This magic works.