### PR TITLE
Fix forceFetch option to allow disabling deduplication on a per-query basis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### `ApolloClient`
 
+- The query manager now respects the [forceFetch](https://www.apollographql.com/docs/link/links/dedup/#context) option, disabling the deduplication logic when provided. <br/>
+  [@Kujawadl](httpsp://github.com/Kujawadl) in [#6519](https://github.com/apollographql/apollo-client/pull/6519)
+
 - **[BREAKING]** `ApolloClient` is now only available as a named export. The default `ApolloClient` export has been removed. <br/>
   [@hwillson](https://github.com/hwillson) in [#5425](https://github.com/apollographql/apollo-client/pull/5425)
 

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -700,14 +700,15 @@ export class QueryManager<TStore> {
         variables,
         operationName: getOperationName(serverQuery) || void 0,
         context: this.prepareContext({
-          ...context,
-          forceFetch: !deduplication
+          forceFetch: !deduplication,
+          ...context
         }),
       };
 
       context = operation.context;
 
-      if (deduplication) {
+      // Bypass deduplication logic if forceFetch is specified
+      if (deduplication && !context.forceFetch) {
         const byVariables = inFlightLinkObservables.get(serverQuery) || new Map();
         inFlightLinkObservables.set(serverQuery, byVariables);
 


### PR DESCRIPTION
### Bug

For our use case, we need to be able to cancel a very long-running query (optimizing the query execution time is out of our control) in certain edge cases. Per [this comment](https://github.com/apollographql/apollo-client/issues/4150#issuecomment-500127694), this can be achieved using `watchQuery`'s observable's `unsubscribe` function, but only if query deduplication is disabled.

Per [these docs](https://www.apollographql.com/docs/link/links/dedup/#context), it should be possible to disable query deduplication on a per-query basis using the `forceFetch` option in context. However, in my testing, I found that is not the case; only disabling it globally worked.

### Fix

After digging into the code a bit, I found that the query manager is actually overwriting the `forceFetch` value with `!deduplicate`, and then ignoring the `forceFetch` when it considers whether to run the deduplication logic. I fixed the overwrite, and added a check to ensure that the deduplication logic only runs if deduplicate is set globally *and* `forceFetch` is not true.

### Tests

I also added a new unit test to cover this case (mostly just copy/pasted from the unit test that covers the global deduplication option).

### Docs

Concerning the steps on how to cancel a currently-running query (from the [linked comment](https://github.com/apollographql/apollo-client/issues/4150#issuecomment-500127694)), please let me know if this is something you would like formally documented. I'm more than happy to add that to the docs as part of this PR, or as a separate PR.

### Checklist:

- [x] Make sure all of the significant new logic is covered by tests

<hr />

Another dev wrote a PR to fix this as well, #6261; however, their PR adds a new option, rather than fixing the one that is already documented. So this PR will also allow us to close #6261.

Fixes #4150
Closes #6261

Thanks in advance for your time.