### PR TITLE
Fix: queryDeduplication from context

### DIFF
--- a/packages/apollo-client/src/__tests__/client.ts
+++ b/packages/apollo-client/src/__tests__/client.ts
@@ -1508,8 +1508,8 @@ describe('client', () => {
       },
     };
 
-    // we have two responses for identical queries, but only the first should be requested.
-    // the second one should never make it through to the network interface.
+    // we have two responses for identical queries, and both should be requested.
+    // the second one should make it through to the network interface.
     const link = mockSingleLink(
       {
         request: { query: queryDoc },
@@ -1581,6 +1581,103 @@ describe('client', () => {
     // if deduplication didn't happen, result.data will equal data2.
     return Promise.all([q1, q2]).then(([result1, result2]) => {
       expect(result1.data).toEqual(result2.data);
+    });
+  });
+
+  it('deduplicates queries if query context.queryDeduplication is set to true', () => {
+    const queryDoc = gql`
+      query {
+        author {
+          name
+        }
+      }
+    `;
+    const data = {
+      author: {
+        name: 'Jonas',
+      },
+    };
+    const data2 = {
+      author: {
+        name: 'Dhaivat',
+      },
+    };
+
+    // we have two responses for identical queries, but only the first should be requested.
+    // the second one should never make it through to the network interface.
+    const link = mockSingleLink(
+      {
+        request: { query: queryDoc },
+        result: { data },
+        delay: 10,
+      },
+      {
+        request: { query: queryDoc },
+        result: { data: data2 },
+      },
+    );
+    const client = new ApolloClient({
+      link,
+      cache: new InMemoryCache({ addTypename: false }),
+      queryDeduplication: false,
+    });
+
+    // Both queries need to be deduplicated, otherwise only one gets tracked
+    const q1 = client.query({ query: queryDoc, context: { queryDeduplication: true } });
+    const q2 = client.query({ query: queryDoc, context: { queryDeduplication: true } });
+
+    // if deduplication happened, result2.data will equal data.
+    return Promise.all([q1, q2]).then(([result1, result2]) => {
+      expect(stripSymbols(result1.data)).toEqual(data);
+      expect(stripSymbols(result2.data)).toEqual(data);
+    });
+  });
+
+  it('does not deduplicate queries if query context.queryDeduplication is set to false', () => {
+    const queryDoc = gql`
+      query {
+        author {
+          name
+        }
+      }
+    `;
+    const data = {
+      author: {
+        name: 'Jonas',
+      },
+    };
+    const data2 = {
+      author: {
+        name: 'Dhaivat',
+      },
+    };
+
+    // we have two responses for identical queries, and both should be requested.
+    // the second one should make it through to the network interface.
+    const link = mockSingleLink(
+      {
+        request: { query: queryDoc },
+        result: { data },
+        delay: 10,
+      },
+      {
+        request: { query: queryDoc },
+        result: { data: data2 },
+      },
+    );
+    const client = new ApolloClient({
+      link,
+      cache: new InMemoryCache({ addTypename: false }),
+    });
+
+    // The first query gets tracked in the dedup logic, the second one ignores it and runs anyways
+    const q1 = client.query({ query: queryDoc });
+    const q2 = client.query({ query: queryDoc, context: { queryDeduplication: false } });
+
+    // if deduplication happened, result2.data will equal data.
+    return Promise.all([q1, q2]).then(([result1, result2]) => {
+      expect(stripSymbols(result1.data)).toEqual(data);
+      expect(stripSymbols(result2.data)).toEqual(data2);
     });
   });
 

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -1108,9 +1108,18 @@ export class QueryManager<TStore> {
     query: DocumentNode,
     context: any,
     variables?: OperationVariables,
-    deduplication: boolean = this.queryDeduplication,
+    deduplication?: boolean,
   ): Observable<FetchResult<T>> {
     let observable: Observable<FetchResult<T>>;
+
+    // Set default deduplication value if arg was not passed
+    if(typeof deduplication === 'undefined') {
+      if(typeof context === 'object' && 'forceFetch' in context) {
+        deduplication = !context.forceFetch
+      } else {
+        deduplication = this.queryDeduplication
+      }
+    }
 
     const { serverQuery } = this.transform(query);
     if (serverQuery) {

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -1108,18 +1108,12 @@ export class QueryManager<TStore> {
     query: DocumentNode,
     context: any,
     variables?: OperationVariables,
-    deduplication?: boolean,
+    deduplication: boolean =
+      // Prefer context.queryDeduplication if specified.
+      context?.queryDeduplication ??
+      this.queryDeduplication,
   ): Observable<FetchResult<T>> {
     let observable: Observable<FetchResult<T>>;
-
-    // Set default deduplication value if arg was not passed
-    if(typeof deduplication === 'undefined') {
-      if(typeof context === 'object' && 'queryDeduplication' in context) {
-        deduplication = context.queryDeduplication
-      } else {
-        deduplication = this.queryDeduplication
-      }
-    }
 
     const { serverQuery } = this.transform(query);
     if (serverQuery) {

--- a/packages/apollo-client/src/core/QueryManager.ts
+++ b/packages/apollo-client/src/core/QueryManager.ts
@@ -1114,8 +1114,8 @@ export class QueryManager<TStore> {
 
     // Set default deduplication value if arg was not passed
     if(typeof deduplication === 'undefined') {
-      if(typeof context === 'object' && 'forceFetch' in context) {
-        deduplication = !context.forceFetch
+      if(typeof context === 'object' && 'queryDeduplication' in context) {
+        deduplication = context.queryDeduplication
       } else {
         deduplication = this.queryDeduplication
       }

--- a/packages/apollo-client/src/core/__tests__/QueryManager/index.ts
+++ b/packages/apollo-client/src/core/__tests__/QueryManager/index.ts
@@ -53,10 +53,12 @@ describe('QueryManager', () => {
     link,
     config = {},
     clientAwareness = {},
+    queryDeduplication = false,
   }: {
     link?: ApolloLink;
     config?: ApolloReducerConfig;
     clientAwareness?: { [key: string]: string };
+    queryDeduplication?: boolean;
   }) => {
     return new QueryManager({
       link: link || mockSingleLink(),
@@ -64,6 +66,7 @@ describe('QueryManager', () => {
         new InMemoryCache({ addTypename: false, ...config }),
       ),
       clientAwareness,
+      queryDeduplication,
     });
   };
 
@@ -5159,7 +5162,7 @@ describe('QueryManager', () => {
   });
 
   describe('queryDeduplication', () => {
-    it('should be true when context is true, default is false and agrument not provided', () => {
+    it('should be true when context is true, default is false and argument not provided', () => {
       const query = gql`
         query {
           author {
@@ -5174,11 +5177,11 @@ describe('QueryManager', () => {
         }),
       });
 
-      queryManager.getObservableFromLink(query, { queryDeduplication: true })
+      queryManager.query({ query, context: { queryDeduplication: true } })
 
-      expect(queryManager.inFlightLinkObservables.size).toBe(1)
+      expect(queryManager['inFlightLinkObservables'].size).toBe(1)
     });
-    it('should be false when context is false, default is true and agrument not provided', () => {
+    it('should allow overriding global queryDeduplication: true to false', () => {
       const query = gql`
         query {
           author {
@@ -5191,12 +5194,12 @@ describe('QueryManager', () => {
           request: { query },
           result: { author: { firstName: 'John' } },
         }),
+        queryDeduplication: true,
       });
-      queryManager.queryDeduplication = true
 
-      queryManager.getObservableFromLink(query, { queryDeduplication: false })
+      queryManager.query({ query, context: { queryDeduplication: false } })
 
-      expect(queryManager.inFlightLinkObservables.size).toBe(0)
+      expect(queryManager['inFlightLinkObservables'].size).toBe(0)
     });
   })
 });

--- a/packages/apollo-client/src/core/__tests__/QueryManager/index.ts
+++ b/packages/apollo-client/src/core/__tests__/QueryManager/index.ts
@@ -5157,4 +5157,46 @@ describe('QueryManager', () => {
       });
     });
   });
+
+  describe('queryDeduplication', () => {
+    it('should be true when context is true, default is false and agrument not provided', () => {
+      const query = gql`
+        query {
+          author {
+            firstName
+          }
+        }
+      `;
+      const queryManager = createQueryManager({
+        link: mockSingleLink({
+          request: { query },
+          result: { author: { firstName: 'John' } },
+        }),
+      });
+
+      queryManager.getObservableFromLink(query, { queryDeduplication: true })
+
+      expect(queryManager.inFlightLinkObservables.size).toBe(1)
+    });
+    it('should be false when context is false, default is true and agrument not provided', () => {
+      const query = gql`
+        query {
+          author {
+            firstName
+          }
+        }
+      `;
+      const queryManager = createQueryManager({
+        link: mockSingleLink({
+          request: { query },
+          result: { author: { firstName: 'John' } },
+        }),
+      });
+      queryManager.queryDeduplication = true
+
+      queryManager.getObservableFromLink(query, { queryDeduplication: false })
+
+      expect(queryManager.inFlightLinkObservables.size).toBe(0)
+    });
+  })
 });


### PR DESCRIPTION
This is the same as #6261, except with the target branch set to version-2.6 in the hopes that we can get a 2.6 release with this included. Our team is not ready to transition to v3, but we still need this bug fixed.

Please let me know if this isn't typically how things are done here.