### PR TITLE
Install root dependencies before running typedoc

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,7 @@
     "start": "gatsby develop",
     "build": "gatsby build",
     "serve": "gatsby serve",
-    "types": "cd .. && typedoc --json ./docs/src/gatsby-theme-apollo-docs/docs.json --ignoreCompilerErrors ./src/index.ts"
+    "types": "cd .. && npm install && typedoc --json ./docs/src/gatsby-theme-apollo-docs/docs.json --ignoreCompilerErrors ./src/index.ts"
   },
   "dependencies": {
     "gatsby": "2.23.11",


### PR DESCRIPTION
This branch updates the `types` npm script to avoid an error that is breaking builds.