### PR TITLE
Run final mutation update against non-optimistic data.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@
 - Apollo Client now supports setting a new `ApolloLink` (or link chain) after `new ApolloClient()` has been called, using the `ApolloClient#setLink` method.  <br/>
   [@hwillson](https://github.com/hwillson) in [#6193](https://github.com/apollographql/apollo-client/pull/6193)
 
+- The final time a mutation `update` function is called, it can no longer accidentally read optimistic data from other concurrent mutations, which ensures the use of optimistic updates has no lasting impact on the state of the cache after mutations have finished. <br/>
+  [@benjamn](https://github.com/benjamn) in [#6551](https://github.com/apollographql/apollo-client/pull/6551)
+
 ### `InMemoryCache`
 
 > ⚠️ **Note:** `InMemoryCache` has been significantly redesigned and rewritten in Apollo Client 3.0. Please consult the [migration guide](https://www.apollographql.com/docs/react/v3.0-beta/migrating/apollo-client-3-migration/#cache-improvements) and read the new [documentation](https://www.apollographql.com/docs/react/v3.0-beta/caching/cache-configuration/) to understand everything that has been improved.

--- a/src/__tests__/mutationResults.ts
+++ b/src/__tests__/mutationResults.ts
@@ -654,12 +654,6 @@ describe('mutation results', () => {
     });
 
     itAsync('error handling in reducer functions', (resolve, reject) => {
-      const oldError = console.error;
-      const errors: any[] = [];
-      console.error = (msg: string) => {
-        errors.push(msg);
-      };
-
       let subscriptionHandle: Subscription;
       const { client, obsQuery } = setupObsQuery(reject, {
         request: { query: mutation },
@@ -685,9 +679,10 @@ describe('mutation results', () => {
         },
       })).then(() => {
         subscriptionHandle.unsubscribe();
-        expect(errors).toHaveLength(1);
-        expect(errors[0].message).toBe(`Hello... It's me.`);
-        console.error = oldError;
+        reject("should have thrown");
+      }, error => {
+        subscriptionHandle.unsubscribe();
+        expect(error.message).toBe(`Hello... It's me.`);
       }).then(resolve, reject);
     });
   });
@@ -1289,12 +1284,6 @@ describe('mutation results', () => {
     });
 
     itAsync('error handling in reducer functions', (resolve, reject) => {
-      const oldError = console.error;
-      const errors: any[] = [];
-      console.error = (msg: string) => {
-        errors.push(msg);
-      };
-
       let subscriptionHandle: Subscription;
       const { client, obsQuery } = setupObsQuery(reject, {
         request: { query: mutation },
@@ -1318,9 +1307,10 @@ describe('mutation results', () => {
         },
       })).then(() => {
         subscriptionHandle.unsubscribe();
-        expect(errors).toHaveLength(1);
-        expect(errors[0].message).toBe(`Hello... It's me.`);
-        console.error = oldError;
+        reject("should have thrown");
+      }, error => {
+        subscriptionHandle.unsubscribe();
+        expect(error.message).toBe(`Hello... It's me.`);
       }).then(resolve, reject);
     });
 

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -53,12 +53,22 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
 
   public abstract performTransaction(
     transaction: Transaction<TSerialized>,
+    // Although subclasses may implement recordOptimisticTransaction
+    // however they choose, the default implementation simply calls
+    // performTransaction with a string as the second argument, allowing
+    // performTransaction to handle both optimistic and non-optimistic
+    // (broadcast-batching) transactions. Passing null for optimisticId is
+    // also allowed, and indicates that performTransaction should apply
+    // the transaction non-optimistically (ignoring optimistic data).
+    optimisticId?: string | null,
   ): void;
 
-  public abstract recordOptimisticTransaction(
+  public recordOptimisticTransaction(
     transaction: Transaction<TSerialized>,
-    id: string,
-  ): void;
+    optimisticId: string,
+  ) {
+    this.performTransaction(transaction, optimisticId);
+  }
 
   // Optional API
 

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -39,7 +39,7 @@ export abstract class EntityStore implements NormalizedCache {
   public abstract addLayer(
     layerId: string,
     replay: (layer: EntityStore) => any,
-  ): EntityStore;
+  ): Layer;
 
   public abstract removeLayer(layerId: string): EntityStore;
 
@@ -458,7 +458,7 @@ export namespace EntityStore {
     public addLayer(
       layerId: string,
       replay: (layer: EntityStore) => any,
-    ): EntityStore {
+    ): Layer {
       // The replay function will be called in the Layer constructor.
       return new Layer(layerId, this, replay, this.sharedLayerGroup);
     }
@@ -486,7 +486,7 @@ class Layer extends EntityStore {
   public addLayer(
     layerId: string,
     replay: (layer: EntityStore) => any,
-  ): EntityStore {
+  ): Layer {
     return new Layer(layerId, this, replay, this.group);
   }
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1,7 +1,6 @@
 import { invariant, InvariantError } from 'ts-invariant';
 import { equal } from '@wry/equality';
 
-import { tryFunctionOrLogError } from '../utilities/common/errorHandling';
 import { cloneDeep } from '../utilities/common/cloneDeep';
 import { getOperationDefinition } from '../utilities/graphql/getFromAST';
 import { NetworkStatus, isNetworkRequestInFlight } from './networkStatus';
@@ -476,11 +475,9 @@ once, rather than every time you call fetchMore.`);
   ): void {
     const { queryManager } = this;
     const previousResult = this.getCurrentQueryResult(false).data;
-    const newResult = tryFunctionOrLogError(
-      () => mapFn(previousResult!, {
-        variables: (this as any).variables,
-      }),
-    );
+    const newResult = mapFn(previousResult!, {
+      variables: (this as any).variables,
+    });
 
     if (newResult) {
       queryManager.cache.writeQuery({

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1155,6 +1155,6 @@ function markMutationResult<TStore, TData>(
       if (update) {
         update(c, mutation.result);
       }
-    });
+    }, /* non-optimistic transaction: */ null);
   }
 }

--- a/src/utilities/common/errorHandling.ts
+++ b/src/utilities/common/errorHandling.ts
@@ -1,15 +1,5 @@
 import { ExecutionResult } from 'graphql';
 
-export function tryFunctionOrLogError(f: Function) {
-  try {
-    return f();
-  } catch (e) {
-    if (console.error) {
-      console.error(e);
-    }
-  }
-}
-
 export function graphQLResultHasError(result: ExecutionResult): boolean {
   return (result.errors && result.errors.length > 0) || false;
 }


### PR DESCRIPTION
Providing an `optimisticResponse` when performing a mutation is never mandatory, since optimistic updates are an optimization for perceived performance. By corollary, if you switch back and forth between providing an `optimisticResponse` and simply waiting for the mutation to finish, that choice should have no lasting impact on the final state of the cache. After the mutation finishes, you should not be able to tell that there was ever an `optimisticResponse`.

`InMemoryCache` maintains a system of layered `EntityStore` objects to represent optimistic updates, so it can easily throw individual layers away when a mutation finishes, ultimately leaving only the "realistic" data behind. However, in cases where two or more optimistic mutations are running at the same time, directly competing to update the same data, it is possible for the final `update` function call for one mutation to leak still-active optimistic data from the other mutation into the root layer of the cache. This leaking of optimistic data poses a subtle problem for the goals described above, because it means using an optimistic response can have lasting effects on non-optimistic cache data.

To address this problem, we need to make optimistic data invisible to the final (non-optimistic) invocation of the mutation `update` function, somehow. Because of the layering of the `InMemoryCache`, this turns out to be relatively straightforward, since the root layer is accessible in isolation from any optimistic data that might be layered on top of it.

Specifically, the final time we call the `update` function for the mutation, we do so within a cache transaction where `cache.optimisticData` is temporarily set to refer to the same root `EntityStore` object as `cache.data`, so a typical `readQuery`-transform-`writeQuery` update pattern cannot accidentally read from the optimistic data of other concurrent mutations. Note that we do not need to wait for all optimistic mutations to finish before running the final `update` function for an individual mutation, because we have the ability to hide optimistic data without removing it (yet).

This bug is relatively rare because it requires two or more optimistic mutations to be competing to update the same data at the same time, which is uncommon. However, the bug is reliably reproducible under such circumstances, and is now adequately regression-tested (see tests included in this PR).