### PR TITLE
Fix @client(always: true) bug with useQuery, and add regression test.

### DIFF
--- a/src/__tests__/local-state/general.ts
+++ b/src/__tests__/local-state/general.ts
@@ -439,6 +439,99 @@ describe('Cache manipulation', () => {
       },
     });
   });
+
+  itAsync("should rerun @client(always: true) fields on entity update", (resolve, reject) => {
+    const query = gql`
+      query GetClientData($id: ID) {
+        clientEntity(id: $id) @client(always: true) {
+          id
+          title
+          titleLength @client(always: true)
+        }
+      }
+    `;
+
+    const mutation = gql`
+      mutation AddOrUpdate {
+        addOrUpdate(id: $id, title: $title) @client
+      }
+    `;
+
+    const fragment = gql`
+    fragment ClientDataFragment on ClientData {
+      id
+      title
+    }
+    `
+    const client = new ApolloClient({
+      cache: new InMemoryCache(),
+      link: new ApolloLink(() => Observable.of({ data: { } })),
+      resolvers: {
+        ClientData: {
+          titleLength(data) {
+            return data.title.length
+          }
+        },
+        Query: {
+          clientEntity(_root, {id}, {cache}) {
+            return cache.readFragment({
+              id: cache.identify({id, __typename: "ClientData"}),
+              fragment,
+            });
+          },
+        },
+        Mutation: {
+          addOrUpdate(_root, {id, title}, {cache}) {
+            return cache.writeFragment({
+              id: cache.identify({id, __typename: "ClientData"}),
+              fragment,
+              data: {id, title, __typename: "ClientData"},
+            });
+          },
+        }
+      },
+    });
+
+    const entityId = 1;
+    const shortTitle = "Short";
+    const longerTitle = "A little longer";
+    client.mutate({
+      mutation,
+      variables: {
+        id: entityId,
+        title: shortTitle,
+      },
+    });
+    let mutated = false;
+    client.watchQuery({ query, variables: {id: entityId}}).subscribe({
+      next(result) {
+        if (!mutated) {
+          expect(result.data.clientEntity).toEqual({
+            id: entityId,
+            title: shortTitle,
+            titleLength: shortTitle.length,
+            __typename: "ClientData",
+          });
+          client.mutate({
+            mutation,
+            variables: {
+              id: entityId,
+              title: longerTitle,
+            }
+          });
+          mutated = true;
+        } else if (mutated) {
+          expect(result.data.clientEntity).toEqual({
+            id: entityId,
+            title: longerTitle,
+            titleLength: longerTitle.length,
+            __typename: "ClientData",
+          });
+          resolve();
+        }
+      },
+    });
+  });
 });
 
 describe('Sample apps', () => {


### PR DESCRIPTION
useQuery fails to get updated values for forced client-side resolvers
watchQuery performs as expected

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
