### PR TITLE
Stop delivering previous data in unrelated loading results.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,9 @@
 
 - **[BREAKING]** The `QueryOptions`, `MutationOptions`, and `SubscriptionOptions` React Apollo interfaces have been renamed to `QueryDataOptions`, `MutationDataOptions`, and `SubscriptionDataOptions` (to avoid conflicting with similarly named and exported Apollo Client interfaces).
 
+- **[BREAKING]** Results with `loading: true` will no longer redeliver previous data, though they may provide partial data from the cache, when available. <br/>
+  [@benjamn](https://github.com/benjamn) in [#6566](https://github.com/apollographql/apollo-client/pull/6566)
+
 - **[BREAKING?]** Remove `fixPolyfills.ts`, except when bundling for React Native. If you have trouble with `Map` or `Set` operations due to frozen key objects in React Native, either update React Native to version 0.59.0 (or 0.61.x, if possible) or investigate why `fixPolyfills.native.js` is not included in your bundle. <br/>
   [@benjamn](https://github.com/benjamn) in [#5962](https://github.com/apollographql/apollo-client/pull/5962)
 

--- a/src/react/components/__tests__/client/Query.test.tsx
+++ b/src/react/components/__tests__/client/Query.test.tsx
@@ -1273,10 +1273,23 @@ describe('Query component', () => {
           return (
             <AllPeopleQuery query={query} variables={variables}>
               {(result: any) => {
-                if (result.loading && count === 2) {
-                  expect(stripSymbols(result.data)).toEqual(data1);
+                if (count === 0) {
+                  expect(result.loading).toBe(true);
+                  expect(result.data).toBeUndefined();
+                  expect(result.networkStatus).toBe(NetworkStatus.loading);
+                } else if (count === 1) {
+                  expect(result.loading).toBe(false);
+                  expect(result.data).toEqual(data1);
+                  expect(result.networkStatus).toBe(NetworkStatus.ready);
+                } else if (count === 2) {
+                  expect(result.loading).toBe(true);
+                  expect(result.data).toBeUndefined();
+                  expect(result.networkStatus).toBe(NetworkStatus.setVariables);
+                } else if (count === 3) {
+                  expect(result.loading).toBe(false);
+                  expect(result.data).toEqual(data2);
+                  expect(result.networkStatus).toBe(NetworkStatus.ready);
                 }
-
                 count++;
                 return null;
               }}

--- a/src/react/data/QueryData.ts
+++ b/src/react/data/QueryData.ts
@@ -350,8 +350,8 @@ export class QueryData<TData, TVariables> extends OperationData {
     } else if (this.currentObservable) {
       // Fetch the current result (if any) from the store.
       const currentResult = this.currentObservable.getCurrentResult();
-      const { loading, partial, networkStatus, errors } = currentResult;
-      let { error, data } = currentResult;
+      const { data, loading, partial, networkStatus, errors } = currentResult;
+      let { error } = currentResult;
 
       // Until a set naming convention for networkError and graphQLErrors is
       // decided upon, we map errors (graphQLErrors) to the error options.
@@ -361,6 +361,7 @@ export class QueryData<TData, TVariables> extends OperationData {
 
       result = {
         ...result,
+        data,
         loading,
         networkStatus,
         error,
@@ -368,15 +369,7 @@ export class QueryData<TData, TVariables> extends OperationData {
       };
 
       if (loading) {
-        const previousData =
-          this.previousData.result && this.previousData.result.data;
-        result.data =
-          previousData && data
-            ? {
-                ...previousData,
-                ...data
-              }
-            : previousData || data;
+        // Fall through without modifying result...
       } else if (error) {
         Object.assign(result, {
           data: (this.currentObservable.getLastResult() || ({} as any))
@@ -406,8 +399,6 @@ export class QueryData<TData, TVariables> extends OperationData {
           result.refetch();
           return result;
         }
-
-        result.data = data;
       }
     }
 

--- a/src/react/hoc/__tests__/queries/lifecycle.test.tsx
+++ b/src/react/hoc/__tests__/queries/lifecycle.test.tsx
@@ -7,7 +7,6 @@ import { ApolloClient } from '../../../../ApolloClient';
 import { ApolloProvider } from '../../../context/ApolloProvider';
 import { InMemoryCache as Cache } from '../../../../cache/inmemory/inMemoryCache';
 import { mockSingleLink } from '../../../../utilities/testing/mocking/mockLink';
-import { stripSymbols } from '../../../../utilities/testing/stripSymbols';
 import { Query as QueryComponent } from '../../../components/Query';
 import { graphql } from '../../graphql';
 import { ChildProps } from '../../types';
@@ -56,12 +55,14 @@ describe('[queries] lifecycle', () => {
         componentDidUpdate(prevProps: ChildProps<Vars, Data, Vars>) {
           const { data } = this.props;
           // loading is true, but data still there
-          if (count === 1 && data!.loading) {
-            expect(stripSymbols(data!.allPeople)).toEqual(data1.allPeople);
-          }
-          if (count === 1 && !data!.loading && prevProps.data!.loading) {
-            expect(stripSymbols(data!.allPeople)).toEqual(data2.allPeople);
-            done = true;
+          if (count === 1) {
+            if (data!.loading) {
+              expect(data!.allPeople).toBeUndefined();
+            } else {
+              expect(prevProps.data!.loading).toBe(true);
+              expect(data!.allPeople).toEqual(data2.allPeople);
+              done = true;
+            }
           }
         }
         render() {
@@ -197,12 +198,14 @@ describe('[queries] lifecycle', () => {
         componentDidUpdate(prevProps: ChildProps<Vars, Data, Vars>) {
           const { data } = this.props;
           // loading is true, but data still there
-          if (count === 1 && data!.loading) {
-            expect(stripSymbols(data!.allPeople)).toEqual(data1.allPeople);
-          }
-          if (count === 1 && !data!.loading && prevProps.data!.loading) {
-            expect(stripSymbols(data!.allPeople)).toEqual(data2.allPeople);
-            done = true;
+          if (count === 1) {
+            if (data!.loading) {
+              expect(data!.allPeople).toBeUndefined();
+            } else {
+              expect(prevProps.data!.loading).toBe(true);
+              expect(data!.allPeople).toEqual(data2.allPeople);
+              done = true;
+            }
           }
         }
         render() {
@@ -272,12 +275,14 @@ describe('[queries] lifecycle', () => {
         componentDidUpdate(prevProps: ChildProps<Vars, Data, Vars>) {
           const { data } = this.props;
           // loading is true, but data still there
-          if (count === 1 && data!.loading) {
-            expect(stripSymbols(data!.allPeople)).toEqual(data1.allPeople);
-          }
-          if (count === 1 && !data!.loading && prevProps.data!.loading) {
-            expect(stripSymbols(data!.allPeople)).toEqual(data2.allPeople);
-            done = true;
+          if (count === 1) {
+            if (data!.loading) {
+              expect(data!.allPeople).toBeUndefined();
+            } else {
+              expect(prevProps.data!.loading).toBe(true);
+              expect(data!.allPeople).toEqual(data2.allPeople);
+              done = true;
+            }
           }
         }
         render() {
@@ -352,21 +357,21 @@ describe('[queries] lifecycle', () => {
             if (count === 1) {
               expect(props.foo).toEqual(42);
               expect(props.data!.loading).toEqual(false);
-              expect(stripSymbols(props.data!.allPeople)).toEqual(
+              expect(props.data!.allPeople).toEqual(
                 data1.allPeople
               );
               props.changeState();
             } else if (count === 2) {
               expect(props.foo).toEqual(43);
               expect(props.data!.loading).toEqual(false);
-              expect(stripSymbols(props.data!.allPeople)).toEqual(
+              expect(props.data!.allPeople).toEqual(
                 data1.allPeople
               );
               props.data!.refetch();
             } else if (count === 3) {
               expect(props.foo).toEqual(43);
               expect(props.data!.loading).toEqual(false);
-              expect(stripSymbols(props.data!.allPeople)).toEqual(
+              expect(props.data!.allPeople).toEqual(
                 data2.allPeople
               );
             }

--- a/src/react/hoc/__tests__/queries/loading.test.tsx
+++ b/src/react/hoc/__tests__/queries/loading.test.tsx
@@ -7,7 +7,6 @@ import { ApolloClient } from '../../../../ApolloClient';
 import { ApolloProvider } from '../../../context/ApolloProvider';
 import { InMemoryCache as Cache } from '../../../../cache/inmemory/inMemoryCache';
 import { mockSingleLink } from '../../../../utilities/testing/mocking/mockLink';
-import { stripSymbols } from '../../../../utilities/testing/stripSymbols';
 import { graphql } from '../../graphql';
 import { ChildProps } from '../../types';
 import { itAsync } from '../../../../utilities/testing/itAsync';
@@ -185,15 +184,16 @@ describe('[queries] loading', () => {
         componentDidUpdate(prevProps: ChildProps<Vars, Data, Vars>) {
           const { data } = this.props;
           // variables changed, new query is loading, but old data is still there
-          if (count === 1 && data!.loading) {
-            expect(data!.networkStatus).toBe(2);
-            expect(stripSymbols(data!.allPeople)).toEqual(data1.allPeople);
-          }
-          // query with new variables is loaded
-          if (count === 1 && !data!.loading && prevProps.data!.loading) {
-            expect(data!.networkStatus).toBe(7);
-            expect(stripSymbols(data!.allPeople)).toEqual(data2.allPeople);
-            done = true;
+          if (count === 1) {
+            if (data!.loading) {
+              expect(data!.networkStatus).toBe(2);
+              expect(data!.allPeople).toBeUndefined();
+            } else {
+              expect(prevProps.data!.loading).toBe(true);
+              expect(data!.networkStatus).toBe(7);
+              expect(data!.allPeople).toEqual(data2.allPeople);
+              done = true;
+            }
           }
         }
         render() {
@@ -268,12 +268,12 @@ describe('[queries] loading', () => {
             case 1:
               expect(data!.loading).toBeTruthy();
               expect(data!.networkStatus).toBe(4);
-              expect(stripSymbols(data!.allPeople)).toEqual(data!.allPeople);
+              expect(data!.allPeople).toEqual(data!.allPeople);
               break;
             case 2:
               expect(data!.loading).toBeFalsy();
               expect(data!.networkStatus).toBe(7);
-              expect(stripSymbols(data!.allPeople)).toEqual(data2.allPeople);
+              expect(data!.allPeople).toEqual(data2.allPeople);
               break;
             default:
               reject(new Error('Too many props updates'));


### PR DESCRIPTION
Ever since https://github.com/apollographql/react-apollo/pull/1639, Apollo's React functionality has preserved a strange and nonsensical policy of falling back to the _previous_ data for `loading: true` results, even though the previous data may have nothing to do with the current request, as #6039 demonstrates. Results with `loading: true` may provide `data` from the cache (if any), but they should never simply reuse data from a previous result, which may have been derived using different variables. Instead, `result.data` should be undefined for loading states that do not have any partial cache data to provide.

This is potentially a breaking change for code that blindly relied on `result.data` being defined whenever `result.loading` is `true`, but I believe the bugs this change will fix are much more serious than the inconvenience of checking the truthiness of `result.data` before using it. Still, I wish I'd gotten to this sooner.

Fixes #6039, as verified by the [reproduction](https://codesandbox.io/s/changing-variables-demo-obykj) provided by @davismariotti (thanks!).