### PR TITLE
Support async render function in getDataFromTree / getMarkupFromTree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
 - Make the `client` field of the `MutationResult` type non-optional, since it is always provided. <br/>
   [@glasser](https://github.com/glasser) in [#6617](https://github.com/apollographql/apollo-client/pull/6617)
 
+- Allow passing an asynchronous `options.renderFunction` to `getMarkupFromTree`. <br/>
+  [@richardscarrott](https://github.com/richardscarrott) in [#6576](https://github.com/apollographql/apollo-client/pull/6576)
+
 ## Apollo Client 3.0.2
 
 ## Bug Fixes

--- a/src/react/ssr/getDataFromTree.ts
+++ b/src/react/ssr/getDataFromTree.ts
@@ -18,7 +18,7 @@ export function getDataFromTree(
 export type GetMarkupFromTreeOptions = {
   tree: React.ReactNode;
   context?: { [key: string]: any };
-  renderFunction?: (tree: React.ReactElement<any>) => string;
+  renderFunction?: (tree: React.ReactElement<any>) => string | Promise<string>;
 };
 
 export function getMarkupFromTree({
@@ -31,14 +31,14 @@ export function getMarkupFromTree({
 }: GetMarkupFromTreeOptions): Promise<string> {
   const renderPromises = new RenderPromises();
 
-  function process(): Promise<string> | string {
+  async function process(): Promise<string> {
     // Always re-render from the rootElement, even though it might seem
     // better to render the children of the component responsible for the
     // promise, because it is not possible to reconstruct the full context
     // of the original rendering (including all unknown context provider
     // elements) for a subtree of the original component tree.
     const ApolloContext = getApolloContext();
-    const html = renderFunction(
+    const html = await renderFunction(
       React.createElement(
         ApolloContext.Provider,
         { value: { ...context, renderPromises } },

--- a/src/react/ssr/getDataFromTree.ts
+++ b/src/react/ssr/getDataFromTree.ts
@@ -18,7 +18,9 @@ export function getDataFromTree(
 export type GetMarkupFromTreeOptions = {
   tree: React.ReactNode;
   context?: { [key: string]: any };
-  renderFunction?: (tree: React.ReactElement<any>) => string | Promise<string>;
+  renderFunction?: (
+    tree: React.ReactElement<any>,
+  ) => string | PromiseLike<string>;
 };
 
 export function getMarkupFromTree({


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

We've found `React.renderToString` / `React.renderToStaticMarkup` is a) very expensive and b) blocking, so we're looking to replace it [with a non-blocking async version](https://github.com/richardscarrott/react-render-to-string-async).

However, the most costly call site is in `getDataFromTree` due to the recursive nature, so it would be great if Apollo Client would support async render functions -- I don't believe there will be any performance penalty for those using sync functions as it's already running in a microtask.

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
