### PR TITLE
Merge remaining links from the `apollo-link` repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@
 - The final time a mutation `update` function is called, it can no longer accidentally read optimistic data from other concurrent mutations, which ensures the use of optimistic updates has no lasting impact on the state of the cache after mutations have finished. <br/>
   [@benjamn](https://github.com/benjamn) in [#6551](https://github.com/apollographql/apollo-client/pull/6551)
 
+- Apollo links that were previously maintained in https://github.com/apollographql/apollo-link have been merged into the Apollo Client project. They should be accessed using the new entry points listed in the [migration guide](./docs/source/migrating/apollo-client-3-migration.md).  <br/>
+  [@hwillson](https://github.com/hwillson) in [#](TODO)
+
 ### `InMemoryCache`
 
 > ⚠️ **Note:** `InMemoryCache` has been significantly redesigned and rewritten in Apollo Client 3.0. Please consult the [migration guide](https://www.apollographql.com/docs/react/v3.0-beta/migrating/apollo-client-3-migration/#cache-improvements) and read the new [documentation](https://www.apollographql.com/docs/react/v3.0-beta/caching/cache-configuration/) to understand everything that has been improved.

--- a/config/prepareDist.js
+++ b/config/prepareDist.js
@@ -101,10 +101,8 @@ function writeCjsIndex(bundleName, exportNames, includeNames = true) {
 // Create individual bundle package.json files, storing them in their
 // associated dist directory. This helps provide a way for the Apollo Client
 // core to be used without React, as well as AC's cache, utilities, SSR,
-// components, and HOC to be used by themselves, via the `core.cjs.js`,
-// `cache.cjs.js`, `utilities.cjs.js`, `ssr.cjs.js`, `components.cjs.js`, and
-// `hoc.cjs.js` CommonJS entry point files that only include the exports needed
-// for each bundle.
+// components, HOC, and various links to be used by themselves, via CommonJS
+// entry point files that only include the exports needed for each bundle.
 
 // @apollo/client/core
 fs.writeFileSync(`${distRoot}/core/package.json`, buildPackageJson('core'));
@@ -136,4 +134,46 @@ fs.writeFileSync(
 fs.writeFileSync(
   `${distRoot}/react/hoc/package.json`,
   buildPackageJson('hoc', 'react/hoc')
+);
+
+// @apollo/client/link/batch
+fs.writeFileSync(
+  `${distRoot}/link/batch/package.json`,
+  buildPackageJson('batch', 'link/batch')
+);
+
+// @apollo/client/link/batch-http
+fs.writeFileSync(
+  `${distRoot}/link/batch-http/package.json`,
+  buildPackageJson('batch-http', 'link/batch-http')
+);
+
+// @apollo/client/link/context
+fs.writeFileSync(
+  `${distRoot}/link/context/package.json`,
+  buildPackageJson('context', 'link/context')
+);
+
+// @apollo/client/link/error
+fs.writeFileSync(
+  `${distRoot}/link/error/package.json`,
+  buildPackageJson('error', 'link/error')
+);
+
+// @apollo/client/link/retry
+fs.writeFileSync(
+  `${distRoot}/link/retry/package.json`,
+  buildPackageJson('retry', 'link/retry')
+);
+
+// @apollo/client/link/schema
+fs.writeFileSync(
+  `${distRoot}/link/schema/package.json`,
+  buildPackageJson('schema', 'link/schema')
+);
+
+// @apollo/client/link/ws
+fs.writeFileSync(
+  `${distRoot}/link/ws/package.json`,
+  buildPackageJson('ws', 'link/ws')
 );

--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -21,7 +21,8 @@ const external = [
   'react',
   'zen-observable',
   'prop-types',
-  'hoist-non-react-statics'
+  'hoist-non-react-statics',
+  'subscriptions-transport-ws'
 ];
 
 function prepareESM(input, outputDir) {
@@ -174,47 +175,13 @@ function prepareTesting() {
   };
 }
 
-function prepareReactSSR() {
-  const ssrDistDir = `${distDir}/react/ssr`;
+function prepareBundle(name, path) {
+  const dir = `${distDir}/${path}`;
   return {
-    input: `${ssrDistDir}/index.js`,
+    input: `${dir}/index.js`,
     external,
     output: {
-      file: `${ssrDistDir}/ssr.cjs.js`,
-      format: 'cjs',
-      sourcemap: true,
-      exports: 'named',
-    },
-    plugins: [
-      nodeResolve(),
-    ],
-  };
-}
-
-function prepareReactComponents() {
-  const componentsDistDir = `${distDir}/react/components`;
-  return {
-    input: `${componentsDistDir}/index.js`,
-    external,
-    output: {
-      file: `${componentsDistDir}/components.cjs.js`,
-      format: 'cjs',
-      sourcemap: true,
-      exports: 'named',
-    },
-    plugins: [
-      nodeResolve(),
-    ],
-  };
-}
-
-function prepareReactHoc() {
-  const hocDistDir = `${distDir}/react/hoc`;
-  return {
-    input: `${hocDistDir}/index.js`,
-    external,
-    output: {
-      file: `${hocDistDir}/hoc.cjs.js`,
+      file: `${dir}/${name}.cjs.js`,
       format: 'cjs',
       sourcemap: true,
       exports: 'named',
@@ -232,9 +199,16 @@ function rollup() {
     prepareCJSMinified(packageJson.main),
     prepareUtilities(),
     prepareTesting(),
-    prepareReactSSR(),
-    prepareReactComponents(),
-    prepareReactHoc(),
+    prepareBundle('ssr', 'react/ssr'),
+    prepareBundle('components', 'react/components'),
+    prepareBundle('hoc', 'react/hoc'),
+    prepareBundle('batch', 'link/batch'),
+    prepareBundle('batch-http', 'link/batch-http'),
+    prepareBundle('context', 'link/context'),
+    prepareBundle('error', 'link/error'),
+    prepareBundle('retry', 'link/retry'),
+    prepareBundle('schema', 'link/schema'),
+    prepareBundle('ws', 'link/ws'),
   ];
 }
 

--- a/docs/source/api/link/apollo-link-batch-http.mdx
+++ b/docs/source/api/link/apollo-link-batch-http.mdx
@@ -5,12 +5,12 @@ description: Batch multiple operations into a single HTTP request
 
 ## Overview
 
-`@apollo/link-batch-http` is a terminating link that combines multiple GraphQL
+`@apollo/client/link/batch-http` is a terminating link that combines multiple GraphQL
 operations into a single HTTP request. This link batches individual
 operations together into an array that is sent to a single GraphQL endpoint.
 
 ```js
-import { BatchHttpLink } from "@apollo/link-batch-http";
+import { BatchHttpLink } from "@apollo/client/link/batch-http";
 
 const link = new BatchHttpLink({ uri: "/graphql" });
 ```

--- a/docs/source/api/link/apollo-link-context.md
+++ b/docs/source/api/link/apollo-link-context.md
@@ -8,7 +8,7 @@ description: Easily set a context on your operation, which is used by other link
 The `setContext` function accepts a function that returns either an object or a promise, which then returns an object to set the new context of a request. It receives two arguments: the GraphQL request being executed, and the previous context. This link makes it easy to perform the asynchronous lookup of things like authentication tokens and more.
 
 ```js
-import { setContext } from "@apollo/link-context";
+import { setContext } from "@apollo/client/link/context";
 
 const setAuthorizationLink = setContext((request, previousContext) => ({
   headers: {authorization: "1234"}
@@ -32,8 +32,8 @@ Typically async actions can be expensive and may not need to be called for every
 Take for example a user auth token being found, cached, then removed on a 401 response:
 
 ```js
-import { setContext } from "@apollo/link-context";
-import { onError } from "@apollo/link-error";
+import { setContext } from "@apollo/client/link/context";
+import { onError } from "@apollo/client/link/error";
 
 // cached storage for the user token
 let token;

--- a/docs/source/api/link/apollo-link-error.md
+++ b/docs/source/api/link/apollo-link-error.md
@@ -8,7 +8,7 @@ description: Handle and inspect errors in your GraphQL network stack.
 Use this link to perform some custom logic when a GraphQL or network error happens:
 
 ```js
-import { onError } from "@apollo/link-error";
+import { onError } from "@apollo/client/link/error";
 
 const link = onError(({ graphQLErrors, networkError }) => {
   if (graphQLErrors)
@@ -71,7 +71,7 @@ onError(({ graphQLErrors, networkError, operation, forward }) => {
     console.log(`[Network error]: ${networkError}`);
     // if you would also like to retry automatically on
     // network errors, we recommend that you use
-    // @apollo/link-retry
+    // @apollo/client/link/retry
   }
 });
 ```

--- a/docs/source/api/link/apollo-link-rest.md
+++ b/docs/source/api/link/apollo-link-rest.md
@@ -394,7 +394,7 @@ const link = new RestLink({
 
 ## Link Context
 
-`RestLink` has an [interface `LinkChainContext`](https://github.com/apollographql/apollo-link-rest/blob/1824da47d5db77a2259f770d9c9dd60054c4bb1c/src/restLink.ts#L557-L570) which it uses as the structure of things that it will look for in the `context`, as it decides how to fulfill a specific `RestLink` request. (Please see the [`@apollo/link-context`](./apollo-link-context) page for a discussion of why you might want this).
+`RestLink` has an [interface `LinkChainContext`](https://github.com/apollographql/apollo-link-rest/blob/1824da47d5db77a2259f770d9c9dd60054c4bb1c/src/restLink.ts#L557-L570) which it uses as the structure of things that it will look for in the `context`, as it decides how to fulfill a specific `RestLink` request. (Please see the [`@apollo/client/link/context`](./apollo-link-context) page for a discussion of why you might want this).
 
 | Option | Type | Description |
 | - | - | - |
@@ -406,7 +406,7 @@ const link = new RestLink({
 
 ### Example
 
-`RestLink` uses the `headers` field on the [`@apollo/link-context`](./apollo-link-context) so you can compose other links that provide additional & dynamic headers to a given query.
+`RestLink` uses the `headers` field on the [`@apollo/client/link/context`](./apollo-link-context) so you can compose other links that provide additional & dynamic headers to a given query.
 
 Here is one way to add request `headers` to the context and retrieve the response headers of the operation:
 
@@ -458,7 +458,7 @@ const client = new ApolloClient({
 });
 ```
 
-_Note: you should also consider this if you're using [`@apollo/link-context`](./apollo-link-context) to set `Headers`, you need that link to be before `restLink` as well._
+_Note: you should also consider this if you're using [`@apollo/client/link/context`](./apollo-link-context) to set `Headers`, you need that link to be before `restLink` as well._
 
 ## @rest directive
 
@@ -509,7 +509,7 @@ query PostTitle {
 Things to note:
 
 1. This will be converted into `/search?query=some%20key%20words&page_size=5&lang=en`
-2. The `context.language / lang=en` is extracting an object from the Apollo Context, that was added via an `@apollo/link-context` Link.
+2. The `context.language / lang=en` is extracting an object from the Apollo Context, that was added via an `@apollo/client/link/context` Link.
 3. The query string arguments are assembled by npm:qs and have `encodeURIComponent` called on them.
 
 The available variable sources are:
@@ -518,7 +518,7 @@ The available variable sources are:
 | - | - |
 | `args` | These are the things passed directly to this field parameters. In the above example `postSearch` had `query` and `page_size` in args. |
 | `exportVariables` | These are the things in the parent context that were tagged as `@export(as: ...)` |
-| `context` | These are the apollo-context, so you can have globals set up via `@apollo/link-context` |
+| `context` | These are the apollo-context, so you can have globals set up via `@apollo/client/link/context` |
 | `@rest` | These include any other parameters you pass to the `@rest()` directive. This is probably more useful when working with `pathBuilder`, documented below. |
 
 #### `pathBuilder`

--- a/docs/source/api/link/apollo-link-retry.md
+++ b/docs/source/api/link/apollo-link-retry.md
@@ -5,12 +5,12 @@ description: Attempt an operation multiple times if it fails due to network or s
 
 ## Overview
 
-`@apollo/link-retry` can be used to retry an operation a certain amount of times. This comes in handy when dealing with unreliable communication situations, where you would rather wait longer than explicitly fail an operation. `@apollo/link-retry` provides exponential backoff, and jitters delays between attempts by default. It does not (currently) handle retries for GraphQL errors in the response, only for network errors.
+`@apollo/client/link/retry` can be used to retry an operation a certain amount of times. This comes in handy when dealing with unreliable communication situations, where you would rather wait longer than explicitly fail an operation. `@apollo/client/link/retry` provides exponential backoff, and jitters delays between attempts by default. It does not (currently) handle retries for GraphQL errors in the response, only for network errors.
 
 An example use case is to hold on to a request while a network connection is offline, and retry until it comes back online.
 
 ```js
-import { RetryLink } from "@apollo/link-retry";
+import { RetryLink } from "@apollo/client/link/retry";
 
 const link = new RetryLink();
 ```
@@ -67,7 +67,7 @@ Instead of the options object, you may pass a function for `delay` and/or `attem
 The `attempts` function should return a boolean indicating whether the response should be retried. If yes, the `delay` function is then called, and should return the number of milliseconds to delay by.
 
 ```js
-import { RetryLink } from "@apollo/link-retry";
+import { RetryLink } from "@apollo/client/link/retry";
 
 const link = new RetryLink({
   attempts: (count, operation, error) => {

--- a/docs/source/api/link/apollo-link-schema.md
+++ b/docs/source/api/link/apollo-link-schema.md
@@ -11,7 +11,7 @@ The schema link provides a [graphql execution environment](http://graphql.org/gr
 
 ## Installation
 
-`npm install @apollo/link-schema --save`
+`npm install @apollo/client --save`
 
 ## Usage
 
@@ -21,7 +21,7 @@ When performing SSR _on the same server_, you can use this library to avoid maki
 
 ```js
 import { ApolloClient } from '@apollo/client';
-import { SchemaLink } from '@apollo/link-schema';
+import { SchemaLink } from '@apollo/client/link/schema';
 
 import schema from './path/to/your/schema';
 
@@ -37,7 +37,7 @@ For more detailed information about mocking, refer to the [graphql-tools documen
 
 ```js
 import { ApolloClient, InMemoryCache } from '@apollo/client';
-import { SchemaLink } from '@apollo/link-schema';
+import { SchemaLink } from '@apollo/client/link/schema';
 import { makeExecutableSchema, addMockFunctionsToSchema } from 'graphql-tools';
 
 const typeDefs = `

--- a/docs/source/api/link/apollo-link-ws.md
+++ b/docs/source/api/link/apollo-link-ws.md
@@ -8,7 +8,7 @@ description: Send GraphQL operations over a WebSocket. Works with GraphQL Subscr
 This link is particularly useful to use with GraphQL Subscriptions, but it will also allow you to send GraphQL queries and mutations over WebSockets.
 
 ```js
-import { WebSocketLink } from "@apollo/link-ws";
+import { WebSocketLink } from "@apollo/client/link/ws";
 import { SubscriptionClient } from "subscriptions-transport-ws";
 
 const GRAPHQL_ENDPOINT = "ws://localhost:3000/graphql";
@@ -22,7 +22,7 @@ const link = new WebSocketLink(client);
 
 ## Options
 
-`@apollo/link-ws` takes either a subscription client, or an object with three options, to customize the behavior of the link.
+`@apollo/client/link/ws` takes either a subscription client, or an object with three options, to customize the behavior of the link.
 
 | Option | Description |
 | - | - |

--- a/docs/source/api/link/introduction.md
+++ b/docs/source/api/link/introduction.md
@@ -92,7 +92,7 @@ If you have a collection of two or more links that should always be executed in 
 
 ```js
 import { from, HttpLink } from '@apollo/client';
-import { RetryLink } from '@apollo/link-retry';
+import { RetryLink } from '@apollo/client/link/retry';
 import MyAuthLink from '../auth';
 
 const link = from([
@@ -116,7 +116,7 @@ In the following example, a `RetryLink` passes execution along to one of two dif
 
 ```js
 import { ApolloLink, HttpLink } from '@apollo/client';
-import { RetryLink } from '@apollo/link-retry';
+import { RetryLink } from '@apollo/client/link/retry';
 
 const link = new RetryLink().split(
   (operation) => operation.getContext().version === 1,

--- a/docs/source/data/error-handling.mdx
+++ b/docs/source/data/error-handling.mdx
@@ -86,12 +86,12 @@ Any errors reported will come under an `error` prop along side the data returned
 
 ## Network Errors
 
-When using Apollo Link, the ability to handle network errors is way more powerful. The best way to do this is to use the `@apollo/link-error` to catch and handle server errors, network errors, and GraphQL errors. If you would like to combine with other links, see [Composing a link chain](../api/link/introduction/#composing-a-link-chain).
+When using Apollo Link, the ability to handle network errors is way more powerful. The best way to do this is to use the `@apollo/client/link/error` to catch and handle server errors, network errors, and GraphQL errors. If you would like to combine with other links, see [Composing a link chain](../api/link/introduction/#composing-a-link-chain).
 
 #### Usage
 
 ```js
-import { onError } from "@apollo/link-error";
+import { onError } from "@apollo/client/link/error";
 
 const link = onError(({ graphQLErrors, networkError }) => {
   if (graphQLErrors)

--- a/docs/source/data/subscriptions.mdx
+++ b/docs/source/data/subscriptions.mdx
@@ -75,12 +75,12 @@ Because subscriptions maintain a persistent connection, they can't use the defau
 
 ### 1. Install required libraries
 
-**Apollo Link** is a collection of libraries that help you customize Apollo Client's network communication. One of these libraries is `@apollo/link-ws`, which enables communication over WebSocket.
+**Apollo Link** is a collection of libraries that help you customize Apollo Client's network communication. One of these libraries is `@apollo/client/link/ws`, which enables communication over WebSocket.
 
-Install both `@apollo/link-ws` and `subscriptions-transport-ws` in your project, like so:
+Install both `@apollo/client/link/ws` and `subscriptions-transport-ws` in your project, like so:
 
 ```bash
-npm install @apollo/link-ws subscriptions-transport-ws
+npm install @apollo/client subscriptions-transport-ws
 ```
 
 ### 2. Initialize a `WebSocketLink`
@@ -88,7 +88,7 @@ npm install @apollo/link-ws subscriptions-transport-ws
 Import and initialize a `WebSocketLink` object in the same project file where you initialize `ApolloClient`:
 
 ```js
-import { WebSocketLink } from '@apollo/link-ws';
+import { WebSocketLink } from '@apollo/client/link/ws';
 
 const wsLink = new WebSocketLink({
   uri: `ws://localhost:5000/`,
@@ -109,7 +109,7 @@ The following example expands on the previous one by initializing both a `WebSoc
 ```js
 import { split, HttpLink } from '@apollo/client';
 import { getMainDefinition } from '@apollo/client/utilities';
-import { WebSocketLink } from '@apollo/link-ws';
+import { WebSocketLink } from '@apollo/client/link/ws';
 
 const httpLink = new HttpLink({
   uri: 'http://localhost:3000/'
@@ -147,7 +147,7 @@ Using this logic, queries and mutations will use HTTP as normal, and subscriptio
 It is often necessary to authenticate a client before allowing it to receive subscription results. To do this, you can provide a `connectionParams` option to the `WebSocketLink` constructor, like so:
 
 ```js{7-9}
-import { WebSocketLink } from '@apollo/link-ws';
+import { WebSocketLink } from '@apollo/client/link/ws';
 
 const wsLink = new WebSocketLink({
   uri: `ws://localhost:5000/`,

--- a/docs/source/migrating/apollo-client-3-migration.md
+++ b/docs/source/migrating/apollo-client-3-migration.md
@@ -120,20 +120,17 @@ These options are passed into a new `HttpLink` instance behind the scenes, which
 
 ### apollo-link-*
 
-To continue using `apollo-link` packages besides `apollo-link-http`, replace each existing dependency with the corresponding package under the `@apollo` namespace:
+The separate `apollo-link-*` packages, that were previously maintained in the https://github.com/apollographql/apollo-link repo, have been merged into the Apollo Client project. These links now have their own nested `@apollo/client` entry points. Imports should be updated as follows:
 
-* `@apollo/link-batch-http`
-* `@apollo/link-context`
-* `@apollo/link-error`
-* `@apollo/link-retry`
-* `@apollo/link-schema`
-* `@apollo/link-ws`
+* `apollo-link-batch` is now `@apollo/client/link/batch`
+* `apollo-link-batch-http` is now `@apollo/client/link/batch-http`
+* `apollo-link-context` is now `@apollo/client/link/context`
+* `apollo-link-error` is now `@apollo/client/link/error`
+* `apollo-link-retry` is now `@apollo/client/link/retry`
+* `apollo-link-schema` is now `@apollo/client/link/schema`
+* `apollo-link-ws` is now `@apollo/client/link/ws`
 
-These packages provide the same functionality as their non-`@apollo` counterparts, but they’re updated for compatibility with the `@apollo/client` package.
-
-`apollo-link-rest` has also been updated to use `@apollo/client`, but does not use `@apollo/link-X` naming. It should still be referenced using `apollo-link-rest`, and updated to its `latest` version.
-
-It is important to note that Apollo Client 3 no longer allows `@client` fields to be passed through a Link chain. While Apollo Client 2 made it possible to intercept `@client` fields in Link's like `apollo-link-state` and `@apollo/link-schema`, Apollo Client 3 enforces that `@client` fields are local only. This helps ensure Apollo Client's local state story is easier to understand, and prevents unwanted fields from accidentally ending up in network requests ([PR #5982](https://github.com/apollographql/apollo-client/pull/5982)).
+It is important to note that Apollo Client 3 no longer allows `@client` fields to be passed through a Link chain. While Apollo Client 2 made it possible to intercept `@client` fields in Link's like `apollo-link-state` and `apollo-link-schema`, Apollo Client 3 enforces that `@client` fields are local only. This helps ensure Apollo Client's local state story is easier to understand, and prevents unwanted fields from accidentally ending up in network requests ([PR #5982](https://github.com/apollographql/apollo-client/pull/5982)).
 
 ### graphql-anywhere
 

--- a/docs/source/networking/advanced-http-networking.md
+++ b/docs/source/networking/advanced-http-networking.md
@@ -80,11 +80,11 @@ In the example above, the `authMiddleware` link sets each request's `Authorizati
 
 You can also use Apollo Link to customize Apollo Client's behavior whenever it receives a response from a request.
 
-The following example demonstrates using [`@apollo/link-error`](../api/link/apollo-link-error/) to handle network errors that are included in a response:
+The following example demonstrates using [`@apollo/client/link/error`](../api/link/apollo-link-error/) to handle network errors that are included in a response:
 
 ```js
 import { ApolloClient, HttpLink } from '@apollo/client';
-import { onError } from '@apollo/link-error';
+import { onError } from '@apollo/client/link/error';
 
 import { logout } from './logout';
 

--- a/docs/source/networking/authentication.mdx
+++ b/docs/source/networking/authentication.mdx
@@ -43,7 +43,7 @@ Another common way to identify yourself when using HTTP is to send along an auth
 
 ```js
 import { ApolloClient, createHttpLink, InMemoryCache } from '@apollo/client';
-import { setContext } from '@apollo/link-context';
+import { setContext } from '@apollo/client/link/context';
 
 const httpLink = createHttpLink({
   uri: '/graphql',

--- a/docs/source/performance/server-side-rendering.mdx
+++ b/docs/source/performance/server-side-rendering.mdx
@@ -223,7 +223,7 @@ One solution to this problem is to use an Apollo Link to fetch data using a loca
 
 ```js
 import { ApolloClient } from '@apollo/client'
-import { SchemaLink } from '@apollo/link-schema';
+import { SchemaLink } from '@apollo/client/link/schema';
 
 // ...
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1213,11 +1213,33 @@
         "websocket": "1.0.31"
       },
       "dependencies": {
+        "subscriptions-transport-ws": {
+          "version": "0.9.16",
+          "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.16.tgz",
+          "integrity": "sha512-pQdoU7nC+EpStXnCfh/+ho0zE0Z+ma+i7xvj7bkXKb1dvYHSZxgRPaU6spRP+Bjzow67c/rRDoix5RT0uU9omw==",
+          "dev": true,
+          "requires": {
+            "backo2": "^1.0.2",
+            "eventemitter3": "^3.1.0",
+            "iterall": "^1.2.1",
+            "symbol-observable": "^1.0.4",
+            "ws": "^5.2.0"
+          }
+        },
         "tslib": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz",
           "integrity": "sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==",
           "dev": true
+        },
+        "ws": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+          "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+          "dev": true,
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
         }
       }
     },
@@ -9745,9 +9767,9 @@
       "dev": true
     },
     "subscriptions-transport-ws": {
-      "version": "0.9.16",
-      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.16.tgz",
-      "integrity": "sha512-pQdoU7nC+EpStXnCfh/+ho0zE0Z+ma+i7xvj7bkXKb1dvYHSZxgRPaU6spRP+Bjzow67c/rRDoix5RT0uU9omw==",
+      "version": "0.9.17",
+      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.17.tgz",
+      "integrity": "sha512-hNHi2N80PBz4T0V0QhnnsMGvG3XDFDS9mS6BhZ3R12T6EBywC8d/uJscsga0cVO4DKtXCkCRrWm2sOYrbOdhEA==",
       "dev": true,
       "requires": {
         "backo2": "^1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,12 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@ardatan/aggregate-error": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@ardatan/aggregate-error/-/aggregate-error-0.0.1.tgz",
+      "integrity": "sha512-UQ9BequOTIavs0pTHLMwQwKQF8tTV1oezY/H2O9chA+JNPFZSua55xpU5dPSjAU9/jLJ1VwU+HJuTVN8u7S6Fg==",
+      "dev": true
+    },
     "@babel/code-frame": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
@@ -124,6 +130,61 @@
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
+      }
+    },
+    "@babel/helper-annotate-as-pure": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz",
+      "integrity": "sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-builder-react-jsx": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.10.4.tgz",
+      "integrity": "sha512-5nPcIZ7+KKDxT1427oBivl9V9YTal7qk0diccnh7RrcgrT/pGFOjgGw1dgryyx1GvHEpXVfoDF6Ak3rTiWh8Rg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-builder-react-jsx-experimental": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.10.4.tgz",
+      "integrity": "sha512-LyacH/kgQPgLAuaWrvvq1+E7f5bLyT8jXCh7nM67sRsy2cpIGfgWJ+FCnAKQXfY+F0tXUaN6FqLkp4JiCzdK8Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.10.4",
+        "@babel/helper-module-imports": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-create-class-features-plugin": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.10.4.tgz",
+      "integrity": "sha512-9raUiOsXPxzzLjCXeosApJItoMnX3uyT4QdM2UldffuGApNrF8e938MwNpDCK9CPoyxrEoCgT+hObJc3mZa6lQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.10.4",
+        "@babel/helper-member-expression-to-functions": "^7.10.4",
+        "@babel/helper-optimise-call-expression": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-replace-supers": "^7.10.4",
+        "@babel/helper-split-export-declaration": "^7.10.4"
+      }
+    },
+    "@babel/helper-define-map": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.10.4.tgz",
+      "integrity": "sha512-nIij0oKErfCnLUCWaCaHW0Bmtl2RO9cN7+u2QT8yqTywgALKlyUVOvHDElh+b5DwVC6YB1FOYFOTWcN/+41EDA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.10.4",
+        "@babel/types": "^7.10.4",
+        "lodash": "^4.17.13"
       }
     },
     "@babel/helper-function-name": {
@@ -287,6 +348,27 @@
       "integrity": "sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA==",
       "dev": true
     },
+    "@babel/plugin-proposal-class-properties": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.10.4.tgz",
+      "integrity": "sha512-vhwkEROxzcHGNu2mzUC0OFFNXdZ4M23ib8aRRcJSsW8BZK9pQMD7QB7csl97NBbgGZO7ZyHUyKDnxzOaP4IrCg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-proposal-object-rest-spread": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.10.4.tgz",
+      "integrity": "sha512-6vh4SqRuLLarjgeOf4EaROJAHjvu9Gl+/346PbDH9yWbJyfnJ/ah3jmYKYtswEyCoWZiidvVHjHshd4WgjB9BA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+        "@babel/plugin-transform-parameters": "^7.10.4"
+      }
+    },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
@@ -314,6 +396,15 @@
         "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
+    "@babel/plugin-syntax-flow": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.10.4.tgz",
+      "integrity": "sha512-yxQsX1dJixF4qEEdzVbst3SZQ58Nrooz8NV9Z9GL4byTE25BvJgl5lf0RECUf0fh28rZBb/RYTWn/eeKwCMrZQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
     "@babel/plugin-syntax-import-meta": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
@@ -330,6 +421,15 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-jsx": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.10.4.tgz",
+      "integrity": "sha512-KCg9mio9jwiARCB7WAcQ7Y1q+qicILjoK8LP/VkPkEKaf5dkaZZK1EcTe91a3JJlZ3qy6L5s9X52boEYi8DM9g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-syntax-logical-assignment-operators": {
@@ -384,6 +484,205 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-transform-arrow-functions": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.10.4.tgz",
+      "integrity": "sha512-9J/oD1jV0ZCBcgnoFWFq1vJd4msoKb/TCpGNFyyLt0zABdcvgK3aYikZ8HjzB14c26bc7E3Q1yugpwGy2aTPNA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.10.4.tgz",
+      "integrity": "sha512-WzXDarQXYYfjaV1szJvN3AD7rZgZzC1JtjJZ8dMHUyiK8mxPRahynp14zzNjU3VkPqPsO38CzxiWO1c9ARZ8JA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-block-scoping": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.10.4.tgz",
+      "integrity": "sha512-J3b5CluMg3hPUii2onJDRiaVbPtKFPLEaV5dOPY5OeAbDi1iU/UbbFFTgwb7WnanaDy7bjU35kc26W3eM5Qa0A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "lodash": "^4.17.13"
+      }
+    },
+    "@babel/plugin-transform-classes": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.10.4.tgz",
+      "integrity": "sha512-2oZ9qLjt161dn1ZE0Ms66xBncQH4In8Sqw1YWgBUZuGVJJS5c0OFZXL6dP2MRHrkU/eKhWg8CzFJhRQl50rQxA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.10.4",
+        "@babel/helper-define-map": "^7.10.4",
+        "@babel/helper-function-name": "^7.10.4",
+        "@babel/helper-optimise-call-expression": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-replace-supers": "^7.10.4",
+        "@babel/helper-split-export-declaration": "^7.10.4",
+        "globals": "^11.1.0"
+      }
+    },
+    "@babel/plugin-transform-computed-properties": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.10.4.tgz",
+      "integrity": "sha512-JFwVDXcP/hM/TbyzGq3l/XWGut7p46Z3QvqFMXTfk6/09m7xZHJUN9xHfsv7vqqD4YnfI5ueYdSJtXqqBLyjBw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-destructuring": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.10.4.tgz",
+      "integrity": "sha512-+WmfvyfsyF603iPa6825mq6Qrb7uLjTOsa3XOFzlYcYDHSS4QmpOWOL0NNBY5qMbvrcf3tq0Cw+v4lxswOBpgA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-flow-strip-types": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.10.4.tgz",
+      "integrity": "sha512-XTadyuqNst88UWBTdLjM+wEY7BFnY2sYtPyAidfC7M/QaZnSuIZpMvLxqGT7phAcnGyWh/XQFLKcGf04CnvxSQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-syntax-flow": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-for-of": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.10.4.tgz",
+      "integrity": "sha512-ItdQfAzu9AlEqmusA/65TqJ79eRcgGmpPPFvBnGILXZH975G0LNjP1yjHvGgfuCxqrPPueXOPe+FsvxmxKiHHQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-function-name": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.10.4.tgz",
+      "integrity": "sha512-OcDCq2y5+E0dVD5MagT5X+yTRbcvFjDI2ZVAottGH6tzqjx/LKpgkUepu3hp/u4tZBzxxpNGwLsAvGBvQ2mJzg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-literals": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.10.4.tgz",
+      "integrity": "sha512-Xd/dFSTEVuUWnyZiMu76/InZxLTYilOSr1UlHV+p115Z/Le2Fi1KXkJUYz0b42DfndostYlPub3m8ZTQlMaiqQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-member-expression-literals": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.10.4.tgz",
+      "integrity": "sha512-0bFOvPyAoTBhtcJLr9VcwZqKmSjFml1iVxvPL0ReomGU53CX53HsM4h2SzckNdkQcHox1bpAqzxBI1Y09LlBSw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-modules-commonjs": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.10.4.tgz",
+      "integrity": "sha512-Xj7Uq5o80HDLlW64rVfDBhao6OX89HKUmb+9vWYaLXBZOma4gA6tw4Ni1O5qVDoZWUV0fxMYA0aYzOawz0l+1w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-simple-access": "^7.10.4",
+        "babel-plugin-dynamic-import-node": "^2.3.3"
+      }
+    },
+    "@babel/plugin-transform-object-super": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.10.4.tgz",
+      "integrity": "sha512-5iTw0JkdRdJvr7sY0vHqTpnruUpTea32JHmq/atIWqsnNussbRzjEDyWep8UNztt1B5IusBYg8Irb0bLbiEBCQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-replace-supers": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-parameters": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.10.4.tgz",
+      "integrity": "sha512-RurVtZ/D5nYfEg0iVERXYKEgDFeesHrHfx8RT05Sq57ucj2eOYAP6eu5fynL4Adju4I/mP/I6SO0DqNWAXjfLQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-property-literals": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.10.4.tgz",
+      "integrity": "sha512-ofsAcKiUxQ8TY4sScgsGeR2vJIsfrzqvFb9GvJ5UdXDzl+MyYCaBj/FGzXuv7qE0aJcjWMILny1epqelnFlz8g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-react-display-name": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.10.4.tgz",
+      "integrity": "sha512-Zd4X54Mu9SBfPGnEcaGcOrVAYOtjT2on8QZkLKEq1S/tHexG39d9XXGZv19VfRrDjPJzFmPfTAqOQS1pfFOujw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-react-jsx": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.10.4.tgz",
+      "integrity": "sha512-L+MfRhWjX0eI7Js093MM6MacKU4M6dnCRa/QPDwYMxjljzSCzzlzKzj9Pk4P3OtrPcxr2N3znR419nr3Xw+65A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-builder-react-jsx": "^7.10.4",
+        "@babel/helper-builder-react-jsx-experimental": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-syntax-jsx": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-shorthand-properties": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.10.4.tgz",
+      "integrity": "sha512-AC2K/t7o07KeTIxMoHneyX90v3zkm5cjHJEokrPEAGEy3UCp8sLKfnfOIGdZ194fyN4wfX/zZUWT9trJZ0qc+Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-spread": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.10.4.tgz",
+      "integrity": "sha512-1e/51G/Ni+7uH5gktbWv+eCED9pP8ZpRhZB3jOaI3mmzfvJTWHkuyYTv0Z5PYtyM+Tr2Ccr9kUdQxn60fI5WuQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-template-literals": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.10.4.tgz",
+      "integrity": "sha512-4NErciJkAYe+xI5cqfS8pV/0ntlY5N5Ske/4ImxAVX7mk9Rxt2bwDTGv1Msc2BRJvWQcmYEC+yoMLdX22aE4VQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/runtime": {
@@ -569,6 +868,388 @@
       "requires": {
         "exec-sh": "^0.3.2",
         "minimist": "^1.2.0"
+      }
+    },
+    "@graphql-tools/code-file-loader": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-6.0.12.tgz",
+      "integrity": "sha512-rr9+8ALI8rpZxXtYHbaYexgwKYUulWDRZAkTr1noPjutZR5712yOqyd1oV6s1aP3wMRZZ42m07jHiiGZOpEI6g==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/graphql-tag-pluck": "6.0.12",
+        "@graphql-tools/utils": "6.0.12",
+        "fs-extra": "9.0.1",
+        "tslib": "~2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz",
+          "integrity": "sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/delegate": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-6.0.12.tgz",
+      "integrity": "sha512-52bac1Ct1s0c8aSTVCbnc5FI2LC+NqUFSs+5/mP1k5hIEW2GROGBeZdbRs2GQaHir1vKUYIyHzlZIIBMzOZ/gA==",
+      "dev": true,
+      "requires": {
+        "@ardatan/aggregate-error": "0.0.1",
+        "@graphql-tools/schema": "6.0.12",
+        "@graphql-tools/utils": "6.0.12",
+        "tslib": "~2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz",
+          "integrity": "sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/git-loader": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/git-loader/-/git-loader-6.0.12.tgz",
+      "integrity": "sha512-zhBOiwPjlb7HFn8jAi8YwCOrM9uP4IJTH0IIAPQg/vRxLWD+JDUcD7fne5QNPWevTGWxyZ7vb+CsWb5JBUUDqg==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/graphql-tag-pluck": "6.0.12",
+        "@graphql-tools/utils": "6.0.12",
+        "simple-git": "2.11.0"
+      }
+    },
+    "@graphql-tools/github-loader": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/github-loader/-/github-loader-6.0.12.tgz",
+      "integrity": "sha512-KGVT+gZyLqyfRgoU/59UPEkg4c1HchVp4JARnYIBz3YHQBh50I+OckP/GjApMg2DBjJXtWuCFpZpoOcj9xOt6w==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/graphql-tag-pluck": "6.0.12",
+        "@graphql-tools/utils": "6.0.12",
+        "cross-fetch": "3.0.5"
+      }
+    },
+    "@graphql-tools/graphql-file-loader": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-6.0.12.tgz",
+      "integrity": "sha512-DUoby0HXQ5fGR9U3tMN3V/6l1XdRzg2XF0kuZy/9TUEH9VBFKYT7PLEVb6ZKDh9xWe0OgHUjgpfJhjtcJwn+fw==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/import": "6.0.12",
+        "@graphql-tools/utils": "6.0.12",
+        "fs-extra": "9.0.1",
+        "tslib": "~2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz",
+          "integrity": "sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/graphql-tag-pluck": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-6.0.12.tgz",
+      "integrity": "sha512-9BAQfV6tEzfV3C/+al2Bg8NzTnPyow5VWQT3mozKo2lCLBxzske1zw5v3H1N6M4eNpJFpZ4D55IcusAGEXhuew==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "7.10.4",
+        "@babel/traverse": "7.10.4",
+        "@babel/types": "7.10.4",
+        "@graphql-tools/utils": "6.0.12",
+        "vue-template-compiler": "^2.6.11"
+      }
+    },
+    "@graphql-tools/import": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.0.12.tgz",
+      "integrity": "sha512-tSY8EVTl4UDo4cwbKfMfyGqd0aPd4GH81YcYIgoy4hXMJPZyImGWjjChM0A579IsI7NFzm8eXzDU2dIFb8QSWA==",
+      "dev": true,
+      "requires": {
+        "fs-extra": "9.0.1",
+        "resolve-from": "5.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/json-file-loader": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-6.0.12.tgz",
+      "integrity": "sha512-WLSqEfcHcu8LYMdtz3ipzu3CdlkhuHqvuCmCUt5Yq3SvLhWXu+39BLVS6FtfQdNAdM2Bl+C7YRrYYsDA9Rzeag==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/utils": "6.0.12",
+        "fs-extra": "9.0.1",
+        "tslib": "~2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz",
+          "integrity": "sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/links": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/links/-/links-6.0.12.tgz",
+      "integrity": "sha512-G2VwNUSPcz9c17VTS32b35sMjyKS/dwnMh/0DPZOpoc04Y4MnvNnxWEIy4LnKJ3RXXTB3LJuZivtTy7siyj4ug==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/utils": "6.0.12",
+        "apollo-link": "1.2.14",
+        "apollo-upload-client": "13.0.0",
+        "cross-fetch": "3.0.5",
+        "form-data": "3.0.0",
+        "tslib": "~2.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "tslib": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz",
+          "integrity": "sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/load": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-6.0.12.tgz",
+      "integrity": "sha512-BlGptzuY6+/SunejobN+P3RTxl5QKiMrIikttUZROrgObOBlkSFxsjW1cOw+HX2BL4dPUyN9usOKYoMxKHoWpA==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/merge": "6.0.12",
+        "@graphql-tools/utils": "6.0.12",
+        "globby": "11.0.1",
+        "import-from": "3.0.0",
+        "is-glob": "4.0.1",
+        "p-limit": "3.0.1",
+        "tslib": "~2.0.0",
+        "unixify": "1.0.0",
+        "valid-url": "1.0.9"
+      },
+      "dependencies": {
+        "p-limit": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.1.tgz",
+          "integrity": "sha512-mw/p92EyOzl2MhauKodw54Rx5ZK4624rNfgNaBguFZkHzyUG9WsDzFF5/yQVEJinbJDdP4jEfMN+uBquiGnaLg==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "tslib": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz",
+          "integrity": "sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/load-files": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/load-files/-/load-files-6.0.12.tgz",
+      "integrity": "sha512-6EEeE3xMhY34TFCew+kDBtF5JP0dIu7jWwQ96ZxJ56OhYuWxD+T3WHmtbqkgv3MIplPberSObjWiWol+uvZ0cA==",
+      "dev": true,
+      "requires": {
+        "fs-extra": "9.0.1",
+        "globby": "11.0.1",
+        "unixify": "1.0.0"
+      }
+    },
+    "@graphql-tools/merge": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-6.0.12.tgz",
+      "integrity": "sha512-GGvdIoTad6PJk/d1omPlGQ25pCFWmjuGkARYZ71qWI/c4FEA8EdGoOoPz3shhaKXyLdRiu84S758z4ZtDQiYVw==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/schema": "6.0.12",
+        "@graphql-tools/utils": "6.0.12",
+        "tslib": "~2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz",
+          "integrity": "sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/mock": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/mock/-/mock-6.0.12.tgz",
+      "integrity": "sha512-g4QEoUNusHAHRGRAl9p/jR06efcWoes48qsMq1bWuJJiSX4N6OepHzWVDZqDWD5RwuPVv8ugvVXLeSFRWZQDbQ==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/schema": "6.0.12",
+        "@graphql-tools/utils": "6.0.12",
+        "tslib": "~2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz",
+          "integrity": "sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/module-loader": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/module-loader/-/module-loader-6.0.12.tgz",
+      "integrity": "sha512-CAYdAlnNPyr+Ja2HKXunQbdWGkf/hoPh4KDLKOe1apL3n/518icmdBC2Sjs0SfEDOl0B9Q8hx19GgCGFn/WdVA==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/utils": "6.0.12",
+        "tslib": "~2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz",
+          "integrity": "sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/relay-operation-optimizer": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-6.0.12.tgz",
+      "integrity": "sha512-wL/anOi4OQxW727I86fqx3iOaK97WXPrC8f1ogruDCmhCiU8pP6OKPpopp6BiJP1VvJI0CZt7LTZlFnJOFKhGQ==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/utils": "6.0.12",
+        "relay-compiler": "9.1.0"
+      }
+    },
+    "@graphql-tools/resolvers-composition": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/resolvers-composition/-/resolvers-composition-6.0.12.tgz",
+      "integrity": "sha512-7b1Rbljh2WhZFgguEKuUzVQbysGIKaQSCQmGMm7eloZUhJ8TAtKhuoUoHl5r6LDacUngAeLe3HApCJjTGC2frA==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/utils": "6.0.12",
+        "lodash": "4.17.15"
+      }
+    },
+    "@graphql-tools/schema": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-6.0.12.tgz",
+      "integrity": "sha512-XUmKJ+ipENaxuXIX4GapsLAUl1dFQBUg+S4ZbgtKVlwrPhZJ9bkjIqnUHk3wg4S4VXqzLX97ol1e4g9N6XLkYg==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/utils": "6.0.12",
+        "tslib": "~2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz",
+          "integrity": "sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/stitch": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/stitch/-/stitch-6.0.12.tgz",
+      "integrity": "sha512-I+9l5Ws30Fn3nx0CIDUDMGP0nhexMEJyzfQn1t9DuOTy2QHPQ5YpaZ8hxv6y5+X23EJBU9AebqvNSvWNEO6XJQ==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/delegate": "6.0.12",
+        "@graphql-tools/merge": "6.0.12",
+        "@graphql-tools/schema": "6.0.12",
+        "@graphql-tools/utils": "6.0.12",
+        "@graphql-tools/wrap": "6.0.12",
+        "tslib": "~2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz",
+          "integrity": "sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/url-loader": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-6.0.12.tgz",
+      "integrity": "sha512-XK3D9oXshhlwQCNA92qqRIGPwCrhZGrGguYEkCyvEB4Y4e/MbzRPCExyeiZLI8mEepMJKhbAfx0ieQFPRbhx9Q==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/delegate": "6.0.12",
+        "@graphql-tools/utils": "6.0.12",
+        "@graphql-tools/wrap": "6.0.12",
+        "@types/websocket": "1.0.0",
+        "cross-fetch": "3.0.5",
+        "subscriptions-transport-ws": "0.9.16",
+        "tslib": "~2.0.0",
+        "valid-url": "1.0.9",
+        "websocket": "1.0.31"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz",
+          "integrity": "sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/utils": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-6.0.12.tgz",
+      "integrity": "sha512-MuFSkxXCe2QoD5QJPJ/1WIm0YnBzzXpkq9d/XznVAWptHFRwtwIbZ1xcREjYquFvoZ7ddsjZfyvUN/5ulmHhhg==",
+      "dev": true,
+      "requires": {
+        "@ardatan/aggregate-error": "0.0.1",
+        "camel-case": "4.1.1"
+      }
+    },
+    "@graphql-tools/wrap": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-6.0.12.tgz",
+      "integrity": "sha512-x/t6004aNLzTbOFzZiau15fY2+TBy0wbFqP2du+I+yh8j6KmAU1YkPolBJ4bAI04WD3qcLNh7Rai+VhOxidOkw==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/delegate": "6.0.12",
+        "@graphql-tools/schema": "6.0.12",
+        "@graphql-tools/utils": "6.0.12",
+        "aggregate-error": "3.0.1",
+        "tslib": "~2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz",
+          "integrity": "sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==",
+          "dev": true
+        }
       }
     },
     "@istanbuljs/load-nyc-config": {
@@ -1281,6 +1962,82 @@
         "@types/yargs": "^13.0.0"
       }
     },
+    "@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+      "dev": true
+    },
+    "@mrmlnc/readdir-enhanced": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+      "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+      "dev": true,
+      "requires": {
+        "call-me-maybe": "^1.0.1",
+        "glob-to-regexp": "^0.3.0"
+      },
+      "dependencies": {
+        "glob-to-regexp": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+          "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
+          "dev": true
+        }
+      }
+    },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+      "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.3",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+      "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+      "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+      "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.3",
+        "fastq": "^1.6.0"
+      }
+    },
     "@sheerun/mutationobserver-shim": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz",
@@ -1623,6 +2380,15 @@
         "pretty-format": "^25.1.0"
       }
     },
+    "@types/websocket": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.0.tgz",
+      "integrity": "sha512-MLr8hDM8y7vvdAdnoDEP5LotRoYJj7wgT6mWzCUQH/gHqzS4qcnOT/K4dhC0WimWIUiA3Arj9QAJGGKNRiRZKA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/yargs": {
       "version": "13.0.8",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
@@ -1687,6 +2453,16 @@
       "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
       "dev": true
     },
+    "aggregate-error": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
+      "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+      "dev": true,
+      "requires": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      }
+    },
     "ajv": {
       "version": "6.12.3",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
@@ -1739,6 +2515,64 @@
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
+      }
+    },
+    "apollo-link": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.14.tgz",
+      "integrity": "sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==",
+      "dev": true,
+      "requires": {
+        "apollo-utilities": "^1.3.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3",
+        "zen-observable-ts": "^0.8.21"
+      }
+    },
+    "apollo-link-http-common": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/apollo-link-http-common/-/apollo-link-http-common-0.2.16.tgz",
+      "integrity": "sha512-2tIhOIrnaF4UbQHf7kjeQA/EmSorB7+HyJIIrUjJOKBgnXwuexi8aMecRlqTIDWcyVXCeqLhUnztMa6bOH/jTg==",
+      "dev": true,
+      "requires": {
+        "apollo-link": "^1.2.14",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "apollo-upload-client": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/apollo-upload-client/-/apollo-upload-client-13.0.0.tgz",
+      "integrity": "sha512-lJ9/bk1BH1lD15WhWRha2J3+LrXrPIX5LP5EwiOUHv8PCORp4EUrcujrA3rI5hZeZygrTX8bshcuMdpqpSrvtA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "apollo-link": "^1.2.12",
+        "apollo-link-http-common": "^0.2.14",
+        "extract-files": "^8.0.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.4.tgz",
+          "integrity": "sha512-UpTN5yUJr9b4EX2CnGNWIvER7Ab83ibv0pcvvHc4UOdrBI5jb8bj+32cCwPX6xu0mt2daFNjYhoi+X7beH0RSw==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "apollo-utilities": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.4.tgz",
+      "integrity": "sha512-pk2hiWrCXMAy2fRPwEyhvka+mqwzeP60Jr1tRYi5xru+3ko94HI9o6lK0CT33/w4RDlxWchmdhDCrvdr+pHCig==",
+      "dev": true,
+      "requires": {
+        "@wry/equality": "^0.1.2",
+        "fast-json-stable-stringify": "^2.0.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.10.0"
       }
     },
     "aproba": {
@@ -1794,6 +2628,12 @@
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
+    "array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true
+    },
     "array-unique": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
@@ -1833,10 +2673,22 @@
       "integrity": "sha512-XTZ7xGML849LkQP86sWdQzfhwbt3YwIO6MqbX9mUNYY98VKaaVZP7YNNm70IpwecbkkxmfC5IYAzOQ/2p29zRA==",
       "dev": true
     },
+    "async-limiter": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
+      "dev": true
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
       "dev": true
     },
     "atob": {
@@ -1940,6 +2792,15 @@
         }
       }
     },
+    "babel-plugin-dynamic-import-node": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+      "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
+      "dev": true,
+      "requires": {
+        "object.assign": "^4.1.0"
+      }
+    },
     "babel-plugin-istanbul": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",
@@ -1964,6 +2825,12 @@
         "@types/babel__core": "^7.0.0",
         "@types/babel__traverse": "^7.0.6"
       }
+    },
+    "babel-plugin-syntax-trailing-function-commas": {
+      "version": "7.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz",
+      "integrity": "sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==",
+      "dev": true
     },
     "babel-polyfill": {
       "version": "6.26.0",
@@ -2003,6 +2870,41 @@
         "@babel/plugin-syntax-optional-chaining": "^7.8.3"
       }
     },
+    "babel-preset-fbjs": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-3.3.0.tgz",
+      "integrity": "sha512-7QTLTCd2gwB2qGoi5epSULMHugSVgpcVt5YAeiFO9ABLrutDQzKfGwzxgZHLpugq8qMdg/DhRZDZ5CLKxBkEbw==",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-proposal-class-properties": "^7.0.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+        "@babel/plugin-syntax-class-properties": "^7.0.0",
+        "@babel/plugin-syntax-flow": "^7.0.0",
+        "@babel/plugin-syntax-jsx": "^7.0.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+        "@babel/plugin-transform-arrow-functions": "^7.0.0",
+        "@babel/plugin-transform-block-scoped-functions": "^7.0.0",
+        "@babel/plugin-transform-block-scoping": "^7.0.0",
+        "@babel/plugin-transform-classes": "^7.0.0",
+        "@babel/plugin-transform-computed-properties": "^7.0.0",
+        "@babel/plugin-transform-destructuring": "^7.0.0",
+        "@babel/plugin-transform-flow-strip-types": "^7.0.0",
+        "@babel/plugin-transform-for-of": "^7.0.0",
+        "@babel/plugin-transform-function-name": "^7.0.0",
+        "@babel/plugin-transform-literals": "^7.0.0",
+        "@babel/plugin-transform-member-expression-literals": "^7.0.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.0.0",
+        "@babel/plugin-transform-object-super": "^7.0.0",
+        "@babel/plugin-transform-parameters": "^7.0.0",
+        "@babel/plugin-transform-property-literals": "^7.0.0",
+        "@babel/plugin-transform-react-display-name": "^7.0.0",
+        "@babel/plugin-transform-react-jsx": "^7.0.0",
+        "@babel/plugin-transform-shorthand-properties": "^7.0.0",
+        "@babel/plugin-transform-spread": "^7.0.0",
+        "@babel/plugin-transform-template-literals": "^7.0.0",
+        "babel-plugin-syntax-trailing-function-commas": "^7.0.0-beta.0"
+      }
+    },
     "babel-preset-jest": {
       "version": "26.1.0",
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.1.0.tgz",
@@ -2030,6 +2932,12 @@
           "dev": true
         }
       }
+    },
+    "backo2": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -2229,6 +3137,12 @@
         "unset-value": "^1.0.0"
       }
     },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+      "dev": true
+    },
     "caller-callsite": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
@@ -2252,6 +3166,16 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
       "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
       "dev": true
+    },
+    "camel-case": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.1.tgz",
+      "integrity": "sha512-7fa2WcG4fYFkclIvEmxBbTvmibwF2/agfEBc6q3lOpVu0A13ltLsA+Hr/8Hp6kp5f+G7hKi6t8lys6XxP+1K6Q==",
+      "dev": true,
+      "requires": {
+        "pascal-case": "^3.1.1",
+        "tslib": "^1.10.0"
+      }
     },
     "camelcase": {
       "version": "5.3.1",
@@ -2363,6 +3287,12 @@
           }
         }
       }
+    },
+    "clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true
     },
     "cliui": {
       "version": "6.0.0",
@@ -2581,6 +3511,16 @@
       "integrity": "sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==",
       "dev": true
     },
+    "d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "dev": true,
+      "requires": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
+      }
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -2628,6 +3568,13 @@
           }
         }
       }
+    },
+    "de-indent": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
+      "integrity": "sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=",
+      "dev": true,
+      "optional": true
     },
     "debug": {
       "version": "3.1.0",
@@ -2685,6 +3632,15 @@
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
       "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
       "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
     },
     "define-property": {
       "version": "2.0.2",
@@ -2756,6 +3712,15 @@
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
       "integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
       "dev": true
+    },
+    "dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "requires": {
+        "path-type": "^4.0.0"
+      }
     },
     "dom-accessibility-api": {
       "version": "0.3.0",
@@ -2829,6 +3794,38 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "es5-ext": {
+      "version": "0.10.53",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+      "dev": true,
+      "requires": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.3",
+        "next-tick": "~1.0.0"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "dev": true,
+      "requires": {
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
+      }
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -2886,6 +3883,12 @@
         "stream-combiner": "~0.0.4",
         "through": "~2.3.1"
       }
+    },
+    "eventemitter3": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+      "dev": true
     },
     "exec-sh": {
       "version": "0.3.4",
@@ -3042,6 +4045,23 @@
         }
       }
     },
+    "ext": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+      "dev": true,
+      "requires": {
+        "type": "^2.0.0"
+      },
+      "dependencies": {
+        "type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
+          "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==",
+          "dev": true
+        }
+      }
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -3134,6 +4154,12 @@
         }
       }
     },
+    "extract-files": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-8.1.0.tgz",
+      "integrity": "sha512-PTGtfthZK79WUMk+avLmwx3NGdU8+iVFXC2NMGxKsn0MnihOG2lvumj+AZo8CTwTrwjXDgZ5tztbRlEdRjBonQ==",
+      "dev": true
+    },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -3146,6 +4172,20 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
+    "fast-glob": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+      "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.0",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.2",
+        "picomatch": "^2.2.1"
+      }
+    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -3156,6 +4196,15 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fastq": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
+      "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.4"
+      }
     },
     "fb-watchman": {
       "version": "2.0.1",
@@ -3188,6 +4237,12 @@
           "dev": true
         }
       }
+    },
+    "fbjs-css-vars": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
+      "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==",
+      "dev": true
     },
     "fetch-mock": {
       "version": "7.7.3",
@@ -3275,6 +4330,18 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true
     },
+    "fs-extra": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+      "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+      "dev": true,
+      "requires": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^1.0.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3287,6 +4354,12 @@
       "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
       "dev": true,
       "optional": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "gauge": {
       "version": "2.7.4",
@@ -3387,6 +4460,15 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "glob-parent": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
     "glob-to-regexp": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
@@ -3398,6 +4480,20 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
+    },
+    "globby": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
+      "integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
+      "dev": true,
+      "requires": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.1.1",
+        "ignore": "^5.1.4",
+        "merge2": "^1.3.0",
+        "slash": "^3.0.0"
+      }
     },
     "graceful-fs": {
       "version": "4.2.4",
@@ -3415,6 +4511,35 @@
       "version": "2.10.4",
       "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.4.tgz",
       "integrity": "sha512-O7vG5BT3w6Sotc26ybcvLKNTdfr4GfsIVMD+LdYqXCeJIYPRyp8BIsDOUtxw7S1PYvRw5vH3278J2EDezR6mfA=="
+    },
+    "graphql-tools": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-6.0.12.tgz",
+      "integrity": "sha512-3KKyt4Z+YItCyzSw9W78ksSuGFYNkrZoaDK+rrsFNM0J0fvAvY1n5rPRKKV+fOC8f2FOPac6vF9fLMw5k7x2OQ==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/code-file-loader": "6.0.12",
+        "@graphql-tools/delegate": "6.0.12",
+        "@graphql-tools/git-loader": "6.0.12",
+        "@graphql-tools/github-loader": "6.0.12",
+        "@graphql-tools/graphql-file-loader": "6.0.12",
+        "@graphql-tools/graphql-tag-pluck": "6.0.12",
+        "@graphql-tools/import": "6.0.12",
+        "@graphql-tools/json-file-loader": "6.0.12",
+        "@graphql-tools/links": "6.0.12",
+        "@graphql-tools/load": "6.0.12",
+        "@graphql-tools/load-files": "6.0.12",
+        "@graphql-tools/merge": "6.0.12",
+        "@graphql-tools/mock": "6.0.12",
+        "@graphql-tools/module-loader": "6.0.12",
+        "@graphql-tools/relay-operation-optimizer": "6.0.12",
+        "@graphql-tools/resolvers-composition": "6.0.12",
+        "@graphql-tools/schema": "6.0.12",
+        "@graphql-tools/stitch": "6.0.12",
+        "@graphql-tools/url-loader": "6.0.12",
+        "@graphql-tools/utils": "6.0.12",
+        "@graphql-tools/wrap": "6.0.12"
+      }
     },
     "growly": {
       "version": "1.3.0",
@@ -3453,6 +4578,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
       "dev": true
     },
     "has-unicode": {
@@ -3519,6 +4650,13 @@
         }
       }
     },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "optional": true
+    },
     "hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -3574,6 +4712,12 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ignore": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "dev": true
+    },
     "iltorb": {
       "version": "2.4.5",
       "resolved": "https://registry.npmjs.org/iltorb/-/iltorb-2.4.5.tgz",
@@ -3587,6 +4731,12 @@
         "which-pm-runs": "^1.0.0"
       }
     },
+    "immutable": {
+      "version": "3.7.6",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
+      "integrity": "sha1-E7TTyxK++hVIKib+Gy665kAHHks=",
+      "dev": true
+    },
     "import-fresh": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
@@ -3595,6 +4745,23 @@
       "requires": {
         "caller-path": "^2.0.0",
         "resolve-from": "^3.0.0"
+      }
+    },
+    "import-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-3.0.0.tgz",
+      "integrity": "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==",
+      "dev": true,
+      "requires": {
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        }
       }
     },
     "import-local": {
@@ -3611,6 +4778,12 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
       "dev": true
     },
     "inflight": {
@@ -3752,6 +4925,12 @@
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true
     },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -3766,6 +4945,15 @@
       "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
       "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
     },
     "is-module": {
       "version": "1.0.0",
@@ -3942,6 +5130,12 @@
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
       }
+    },
+    "iterall": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
+      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
+      "dev": true
     },
     "jest": {
       "version": "26.1.0",
@@ -6093,6 +7287,16 @@
         "minimist": "^1.2.5"
       }
     },
+    "jsonfile": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+      "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^1.0.0"
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -6180,6 +7384,15 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
+    "lower-case": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
+      "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.10.0"
+      }
+    },
     "lru-cache": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
@@ -6247,6 +7460,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true
     },
     "micromatch": {
@@ -6374,11 +7593,27 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "dev": true
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "no-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
+      "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
+      "dev": true,
+      "requires": {
+        "lower-case": "^2.0.1",
+        "tslib": "^1.10.0"
+      }
     },
     "node-abi": {
       "version": "2.15.0",
@@ -6492,6 +7727,12 @@
         "set-blocking": "~2.0.0"
       }
     },
+    "nullthrows": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
+      "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
+      "dev": true
+    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -6552,6 +7793,12 @@
         }
       }
     },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
     "object-visit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
@@ -6559,6 +7806,18 @@
       "dev": true,
       "requires": {
         "isobject": "^3.0.0"
+      }
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
       }
     },
     "object.pick": {
@@ -6662,10 +7921,26 @@
       "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
       "dev": true
     },
+    "pascal-case": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.1.tgz",
+      "integrity": "sha512-XIeHKqIrsquVTQL2crjq3NfJUxmdLasn3TYOU0VBM+UX2a6ztAWBlJQBePLGY7VHW8+2dRadeIPK5+KImwTxQA==",
+      "dev": true,
+      "requires": {
+        "no-case": "^3.0.3",
+        "tslib": "^1.10.0"
+      }
+    },
     "pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true
+    },
+    "path-dirname": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
       "dev": true
     },
     "path-exists": {
@@ -6696,6 +7971,12 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
       "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==",
+      "dev": true
+    },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
     },
     "pause-stream": {
@@ -7119,6 +8400,375 @@
         "safe-regex": "^1.1.0"
       }
     },
+    "relay-compiler": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/relay-compiler/-/relay-compiler-9.1.0.tgz",
+      "integrity": "sha512-jsJx0Ux5RoxM+JFm3M3xl7UfZAJ0kUTY/r6jqOpcYgVI3GLJthvNI4IoziFRlWbhizEzGFbpkdshZcu9IObJYA==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.0.0",
+        "@babel/generator": "^7.5.0",
+        "@babel/parser": "^7.0.0",
+        "@babel/runtime": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "@babel/types": "^7.0.0",
+        "babel-preset-fbjs": "^3.3.0",
+        "chalk": "^2.4.1",
+        "fast-glob": "^2.2.2",
+        "fb-watchman": "^2.0.0",
+        "fbjs": "^1.0.0",
+        "immutable": "~3.7.6",
+        "nullthrows": "^1.1.1",
+        "relay-runtime": "9.1.0",
+        "signedsource": "^1.0.0",
+        "yargs": "^14.2.0"
+      },
+      "dependencies": {
+        "@nodelib/fs.stat": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
+          "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "dev": true,
+          "requires": {
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
+          }
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "fast-glob": {
+          "version": "2.2.7",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
+          "integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
+          "dev": true,
+          "requires": {
+            "@mrmlnc/readdir-enhanced": "^2.2.1",
+            "@nodelib/fs.stat": "^1.1.2",
+            "glob-parent": "^3.1.0",
+            "is-glob": "^4.0.0",
+            "merge2": "^1.2.3",
+            "micromatch": "^3.1.10"
+          }
+        },
+        "fbjs": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-1.0.0.tgz",
+          "integrity": "sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==",
+          "dev": true,
+          "requires": {
+            "core-js": "^2.4.1",
+            "fbjs-css-vars": "^1.0.0",
+            "isomorphic-fetch": "^2.1.1",
+            "loose-envify": "^1.0.0",
+            "object-assign": "^4.1.0",
+            "promise": "^7.1.1",
+            "setimmediate": "^1.0.5",
+            "ua-parser-js": "^0.7.18"
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "glob-parent": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "dev": true,
+          "requires": {
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "dev": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "dev": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "yargs": {
+          "version": "14.2.3",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
+          "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^15.0.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "15.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
+          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
+    "relay-runtime": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/relay-runtime/-/relay-runtime-9.1.0.tgz",
+      "integrity": "sha512-6FE5YlZpR/b3R/HzGly85V+c4MdtLJhFY/outQARgxXonomrwqEik0Cr34LnPK4DmGS36cMLUliqhCs/DZyPVw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "fbjs": "^1.0.0"
+      },
+      "dependencies": {
+        "fbjs": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-1.0.0.tgz",
+          "integrity": "sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==",
+          "dev": true,
+          "requires": {
+            "core-js": "^2.4.1",
+            "fbjs-css-vars": "^1.0.0",
+            "isomorphic-fetch": "^2.1.1",
+            "loose-envify": "^1.0.0",
+            "object-assign": "^4.1.0",
+            "promise": "^7.1.1",
+            "setimmediate": "^1.0.5",
+            "ua-parser-js": "^0.7.18"
+          }
+        }
+      }
+    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -7271,6 +8921,12 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
     },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true
+    },
     "rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -7363,6 +9019,12 @@
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+      "dev": true
+    },
+    "run-parallel": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
       "dev": true
     },
     "rxjs": {
@@ -7636,6 +9298,12 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
+    "signedsource": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/signedsource/-/signedsource-1.0.0.tgz",
+      "integrity": "sha1-HdrOSYF5j5O9gzlzgD2A1S6TrWo=",
+      "dev": true
+    },
     "simple-concat": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
@@ -7651,6 +9319,34 @@
         "decompress-response": "^4.2.0",
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
+      }
+    },
+    "simple-git": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.11.0.tgz",
+      "integrity": "sha512-wFePCEQYY6BzVOg/BuUVEhr3jZPF/cPG/BN2UXgax6NHc3bJ9UrDc5AME281gs2C7J1UZ6BGRJYT64khx9T+ng==",
+      "dev": true,
+      "requires": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.0.1",
+        "debug": "^4.1.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
       }
     },
     "sisteransi": {
@@ -8048,6 +9744,30 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
+    "subscriptions-transport-ws": {
+      "version": "0.9.16",
+      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.16.tgz",
+      "integrity": "sha512-pQdoU7nC+EpStXnCfh/+ho0zE0Z+ma+i7xvj7bkXKb1dvYHSZxgRPaU6spRP+Bjzow67c/rRDoix5RT0uU9omw==",
+      "dev": true,
+      "requires": {
+        "backo2": "^1.0.2",
+        "eventemitter3": "^3.1.0",
+        "iterall": "^1.2.1",
+        "symbol-observable": "^1.0.4",
+        "ws": "^5.2.0"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+          "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+          "dev": true,
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
+        }
+      }
+    },
     "supports-color": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
@@ -8340,6 +10060,12 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
+    "type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
+      "dev": true
+    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -8392,6 +10118,32 @@
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
         "set-value": "^2.0.1"
+      }
+    },
+    "universalify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+      "dev": true
+    },
+    "unixify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unixify/-/unixify-1.0.0.tgz",
+      "integrity": "sha1-OmQcjC/7zk2mg6XHDwOkYpQMIJA=",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^2.1.1"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
+        }
       }
     },
     "unset-value": {
@@ -8487,6 +10239,12 @@
         }
       }
     },
+    "valid-url": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+      "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA=",
+      "dev": true
+    },
     "validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -8506,6 +10264,17 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      }
+    },
+    "vue-template-compiler": {
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.11.tgz",
+      "integrity": "sha512-KIq15bvQDrcCjpGjrAhx4mUlyyHfdmTaoNfeoATHLAiWB+MU3cx4lOzMwrnUh9cCxy0Lt1T11hAFY6TQgroUAA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "de-indent": "^1.0.2",
+        "he": "^1.1.0"
       }
     },
     "w3c-hr-time": {
@@ -8546,6 +10315,30 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
       "dev": true
+    },
+    "websocket": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.31.tgz",
+      "integrity": "sha512-VAouplvGKPiKFDTeCCO65vYHsyay8DqoBSlzIO3fayrfOgU94lQN5a1uWVnFrMLceTJw/+fQXR5PGbUVRaHshQ==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.2.0",
+        "es5-ext": "^0.10.50",
+        "nan": "^2.14.0",
+        "typedarray-to-buffer": "^3.1.5",
+        "yaeti": "^0.0.6"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
     },
     "whatwg-encoding": {
       "version": "1.0.5",
@@ -8742,6 +10535,12 @@
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
     },
+    "yaeti": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
+      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=",
+      "dev": true
+    },
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
@@ -8823,6 +10622,16 @@
       "version": "0.8.15",
       "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
       "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
+    },
+    "zen-observable-ts": {
+      "version": "0.8.21",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.21.tgz",
+      "integrity": "sha512-Yj3yXweRc8LdRMrCC8nIc4kkjWecPAUVh0TI0OUrWXx6aX790vLcDlWca6I4vsyCGH3LpWxq0dJRcMOFoVqmeg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.3",
+        "zen-observable": "^0.8.0"
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10301,6 +10301,15 @@
       "integrity": "sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==",
       "dev": true
     },
+    "wait-for-observables": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/wait-for-observables/-/wait-for-observables-1.0.3.tgz",
+      "integrity": "sha1-Oz3vX1VrS2QR9giJl0bdOc/cw/M=",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.0"
+      }
+    },
     "walker": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,8 @@
     "rxjs": "6.6.0",
     "ts-jest": "26.1.1",
     "tsc-watch": "3.0.1",
-    "typescript": "3.9.6"
+    "typescript": "3.9.6",
+    "wait-for-observables": "^1.0.3"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
   ],
   "peerDependencies": {
     "graphql": "^14.0.0 || ^15.0.0",
-    "react": "^16.8.0"
+    "react": "^16.8.0",
+    "subscriptions-transport-ws": "^0.9.0"
   },
   "peerDependenciesMeta": {
     "react": {
@@ -106,6 +107,7 @@
     "rollup-plugin-node-resolve": "5.2.0",
     "rollup-plugin-terser": "5.1.3",
     "rxjs": "6.6.0",
+    "subscriptions-transport-ws": "^0.9.17",
     "ts-jest": "26.1.1",
     "tsc-watch": "3.0.1",
     "typescript": "3.9.6",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "cross-fetch": "3.0.5",
     "fetch-mock": "7.7.3",
     "graphql": "15.3.0",
+    "graphql-tools": "^6.0.12",
     "jest": "26.1.0",
     "jest-junit": "11.0.1",
     "lodash": "4.17.15",

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -38,36 +38,9 @@ export * from '../cache';
 
 /* Link */
 
-export { empty } from '../link/core/empty';
-export { from } from '../link/core/from';
-export { split } from '../link/core/split';
-export { concat } from '../link/core/concat';
-export { execute } from '../link/core/execute';
-export { ApolloLink } from '../link/core/ApolloLink';
-export * from '../link/core/types';
-export {
-  parseAndCheckHttpResponse,
-  ServerParseError
-} from '../link/http/parseAndCheckHttpResponse';
-export {
-  serializeFetchParameter,
-  ClientParseError
-} from '../link/http/serializeFetchParameter';
-export {
-  HttpOptions,
-  fallbackHttpConfig,
-  selectHttpOptionsAndBody,
-  UriFunction
-} from '../link/http/selectHttpOptionsAndBody';
-export { checkFetcher } from '../link/http/checkFetcher';
-export { createSignalIfSupported } from '../link/http/createSignalIfSupported';
-export { selectURI } from '../link/http/selectURI';
-export { createHttpLink } from '../link/http/createHttpLink';
-export { HttpLink } from '../link/http/HttpLink';
-export { fromError } from '../link/utils/fromError';
-export { toPromise } from '../link/utils/toPromise';
-export { fromPromise } from '../link/utils/fromPromise';
-export { ServerError, throwServerError } from '../link/utils/throwServerError';
+export * from '../link/core';
+export * from '../link/http';
+export * from '../link/utils';
 export {
   Observable,
   Observer,

--- a/src/link/batch-http/__tests__/batchHttpLink.ts
+++ b/src/link/batch-http/__tests__/batchHttpLink.ts
@@ -1,0 +1,812 @@
+import fetchMock from 'fetch-mock';
+import gql from 'graphql-tag';
+import { print } from 'graphql';
+
+import { ApolloLink } from '../../core/ApolloLink';
+import { execute } from '../../core/execute';
+import { Observable } from '../../../utilities/observables/Observable';
+import { BatchHttpLink } from '../batchHttpLink';
+
+const sampleQuery = gql`
+  query SampleQuery {
+    stub {
+      id
+    }
+  }
+`;
+
+const sampleMutation = gql`
+  mutation SampleMutation {
+    stub {
+      id
+    }
+  }
+`;
+
+const makeCallback = (done: any, body: any) => {
+  return (...args: any[]) => {
+    try {
+      body(...args);
+      done();
+    } catch (error) {
+      done.fail(error);
+    }
+  };
+};
+
+describe('BatchHttpLink', () => {
+  beforeAll(() => {
+    jest.resetModules();
+  });
+
+  const headers = { cookie: 'monster' };
+  const data = { data: { hello: 'world' } };
+  const data2 = { data: { hello: 'everyone' } };
+  const roflData = { data: { haha: 'hehe' } };
+  const lawlData = { data: { tehe: 'haaa' } };
+  const makePromise = (res: any) =>
+    new Promise((resolve, reject) =>
+      setTimeout(() =>
+        resolve({
+          headers,
+          body: res,
+        }),
+      ),
+    );
+
+  beforeEach(() => {
+    fetchMock.restore();
+    fetchMock.post('begin:/batch', makePromise([data, data2]));
+    fetchMock.post('begin:/rofl', makePromise([roflData, roflData]));
+    fetchMock.post('begin:/lawl', makePromise([lawlData, lawlData]));
+  });
+
+  it('does not need any constructor arguments', () => {
+    expect(() => new BatchHttpLink()).not.toThrow();
+  });
+
+  it('handles batched requests', done => {
+    const clientAwareness = {
+      name: 'Some Client Name',
+      version: '1.0.1',
+    };
+
+    const link = new BatchHttpLink({
+      uri: '/batch',
+      batchInterval: 0,
+      batchMax: 2,
+    });
+
+    let nextCalls = 0;
+    let completions = 0;
+    const next = (expectedData: any) => (data: any) => {
+      try {
+        expect(data).toEqual(expectedData);
+        nextCalls++;
+      } catch (error) {
+        done.fail(error);
+      }
+    };
+
+    const complete = () => {
+      try {
+        const calls = fetchMock.calls('begin:/batch');
+        expect(calls.length).toBe(1);
+        expect(nextCalls).toBe(2);
+
+        const options: any = fetchMock.lastOptions('begin:/batch');
+        expect(options.credentials).toEqual('two');
+
+        const { headers } = options;
+        expect(headers['apollographql-client-name']).toBeDefined();
+        expect(headers['apollographql-client-name']).toEqual(
+          clientAwareness.name,
+        );
+        expect(headers['apollographql-client-version']).toBeDefined();
+        expect(headers['apollographql-client-version']).toEqual(
+          clientAwareness.version,
+        );
+
+        completions++;
+
+        if (completions === 2) {
+          done();
+        }
+      } catch (error) {
+        done.fail(error);
+      }
+    };
+
+    const error = (error: any) => {
+      done.fail(error);
+    };
+
+    execute(link, {
+      query: sampleQuery,
+      context: {
+        credentials: 'two',
+        clientAwareness,
+      },
+    }).subscribe(next(data), error, complete);
+
+    execute(link, {
+      query: sampleQuery,
+      context: { credentials: 'two' },
+    }).subscribe(next(data2), error, complete);
+  });
+
+  it('errors on an incorrect number of results for a batch', done => {
+    const link = new BatchHttpLink({
+      uri: '/batch',
+      batchInterval: 0,
+      batchMax: 3,
+    });
+
+    let errors = 0;
+    const next = (data: any) => {
+      done.fail('next should not have been called');
+    };
+
+    const complete = () => {
+      done.fail('complete should not have been called');
+    };
+
+    const error = (error: any) => {
+      errors++;
+
+      if (errors === 3) {
+        done();
+      }
+    };
+
+    execute(link, { query: sampleQuery }).subscribe(next, error, complete);
+    execute(link, { query: sampleQuery }).subscribe(next, error, complete);
+    execute(link, { query: sampleQuery }).subscribe(next, error, complete);
+  });
+
+  describe('batchKey', () => {
+    const query = gql`
+      query {
+        author {
+          firstName
+          lastName
+        }
+      }
+    `;
+
+    it('should batch queries with different options separately', done => {
+      let key = true;
+      const batchKey = () => {
+        key = !key;
+        return '' + !key;
+      };
+
+      const link = ApolloLink.from([
+        new BatchHttpLink({
+          uri: operation => {
+            return operation.variables.endpoint;
+          },
+          batchInterval: 1,
+          //if batchKey does not work, then the batch size would be 3
+          batchMax: 3,
+          batchKey,
+        }),
+      ]);
+
+      let count = 0;
+      const next = (expected: any) => (received: any) => {
+        try {
+          expect(received).toEqual(expected);
+        } catch (e) {
+          done.fail(e);
+        }
+      };
+      const complete = () => {
+        count++;
+        if (count === 4) {
+          try {
+            const lawlCalls = fetchMock.calls('begin:/lawl');
+            expect(lawlCalls.length).toBe(1);
+            const roflCalls = fetchMock.calls('begin:/rofl');
+            expect(roflCalls.length).toBe(1);
+            done();
+          } catch (e) {
+            done.fail(e);
+          }
+        }
+      };
+
+      [1, 2].forEach(x => {
+        execute(link, {
+          query,
+          variables: { endpoint: '/rofl' },
+        }).subscribe({
+          next: next(roflData),
+          error: done.fail,
+          complete,
+        });
+
+        execute(link, {
+          query,
+          variables: { endpoint: '/lawl' },
+        }).subscribe({
+          next: next(lawlData),
+          error: done.fail,
+          complete,
+        });
+      });
+    });
+  });
+});
+
+const convertBatchedBody = (body: any) => {
+  const parsed = JSON.parse(body);
+  expect(Array.isArray(parsed));
+  expect(parsed.length).toBe(1);
+  return parsed.pop();
+};
+
+const createHttpLink = (httpArgs?: any) => {
+  const args = {
+    ...httpArgs,
+    batchInterval: 0,
+    batchMax: 1,
+  };
+  return new BatchHttpLink(args);
+};
+
+describe('SharedHttpTest', () => {
+  const data = { data: { hello: 'world' } };
+  const data2 = { data: { hello: 'everyone' } };
+  const mockError = { throws: new TypeError('mock me') };
+
+  const makePromise = (res: any) =>
+    new Promise((resolve, reject) => setTimeout(() => resolve(res)));
+
+  let subscriber: any;
+
+  beforeEach(() => {
+    fetchMock.restore();
+    fetchMock.post('begin:/data2', makePromise(data2));
+    fetchMock.post('begin:/data', makePromise(data));
+    fetchMock.post('begin:/error', mockError);
+    fetchMock.post('begin:/apollo', makePromise(data));
+
+    fetchMock.get('begin:/data', makePromise(data));
+    fetchMock.get('begin:/data2', makePromise(data2));
+
+    const next = jest.fn();
+    const error = jest.fn();
+    const complete = jest.fn();
+
+    subscriber = {
+      next,
+      error,
+      complete,
+    };
+  });
+
+  afterEach(() => {
+    fetchMock.restore();
+  });
+
+  it('raises warning if called with concat', () => {
+    const link = createHttpLink();
+    const _warn = console.warn;
+    console.warn = (warning: any) => expect(warning['message']).toBeDefined();
+    expect(link.concat((operation, forward) => forward(operation))).toEqual(
+      link,
+    );
+    console.warn = _warn;
+  });
+
+  it('does not need any constructor arguments', () => {
+    expect(() => createHttpLink()).not.toThrow();
+  });
+
+  it('calls next and then complete', done => {
+    const next = jest.fn();
+    const link = createHttpLink({ uri: '/data' });
+    const observable = execute(link, {
+      query: sampleQuery,
+    });
+    observable.subscribe({
+      next,
+      error: error => done.fail(error),
+      complete: makeCallback(done, () => {
+        expect(next).toHaveBeenCalledTimes(1);
+      }),
+    });
+  });
+
+  it('calls error when fetch fails', done => {
+    const link = createHttpLink({ uri: '/error' });
+    const observable = execute(link, {
+      query: sampleQuery,
+    });
+    observable.subscribe(
+      result => done.fail('next should not have been called'),
+      makeCallback(done, (error: any) => {
+        expect(error).toEqual(mockError.throws);
+      }),
+      () => done.fail('complete should not have been called'),
+    );
+  });
+
+  it('calls error when fetch fails', done => {
+    const link = createHttpLink({ uri: '/error' });
+    const observable = execute(link, {
+      query: sampleMutation,
+    });
+    observable.subscribe(
+      result => done.fail('next should not have been called'),
+      makeCallback(done, (error: any) => {
+        expect(error).toEqual(mockError.throws);
+      }),
+      () => done.fail('complete should not have been called'),
+    );
+  });
+
+  it('unsubscribes without calling subscriber', done => {
+    const link = createHttpLink({ uri: '/data' });
+    const observable = execute(link, {
+      query: sampleQuery,
+    });
+    const subscription = observable.subscribe(
+      result => done.fail('next should not have been called'),
+      error => done.fail(error),
+      () => done.fail('complete should not have been called'),
+    );
+    subscription.unsubscribe();
+    expect(subscription.closed).toBe(true);
+    setTimeout(done, 50);
+  });
+
+  const verifyRequest = (
+    link: ApolloLink,
+    after: () => void,
+    includeExtensions: boolean,
+    done: any,
+  ) => {
+    const next = jest.fn();
+    const context = { info: 'stub' };
+    const variables = { params: 'stub' };
+
+    const observable = execute(link, {
+      query: sampleMutation,
+      context,
+      variables,
+    });
+    observable.subscribe({
+      next,
+      error: error => done.fail(error),
+      complete: () => {
+        try {
+          let body = convertBatchedBody(fetchMock.lastCall()![1]!.body);
+          expect(body.query).toBe(print(sampleMutation));
+          expect(body.variables).toEqual(variables);
+          expect(body.context).not.toBeDefined();
+          if (includeExtensions) {
+            expect(body.extensions).toBeDefined();
+          } else {
+            expect(body.extensions).not.toBeDefined();
+          }
+          expect(next).toHaveBeenCalledTimes(1);
+
+          after();
+        } catch (e) {
+          done.fail(e);
+        }
+      },
+    });
+  };
+
+  it('passes all arguments to multiple fetch body including extensions', done => {
+    debugger;
+    const link = createHttpLink({ uri: '/data', includeExtensions: true });
+    verifyRequest(
+      link,
+      () => verifyRequest(link, done, true, done),
+      true,
+      done,
+    );
+  });
+
+  it('passes all arguments to multiple fetch body excluding extensions', done => {
+    const link = createHttpLink({ uri: '/data' });
+    verifyRequest(
+      link,
+      () => verifyRequest(link, done, false, done),
+      false,
+      done,
+    );
+  });
+
+  it('calls multiple subscribers', done => {
+    const link = createHttpLink({ uri: '/data' });
+    const context = { info: 'stub' };
+    const variables = { params: 'stub' };
+
+    const observable = execute(link, {
+      query: sampleMutation,
+      context,
+      variables,
+    });
+    observable.subscribe(subscriber);
+    observable.subscribe(subscriber);
+
+    setTimeout(() => {
+      expect(subscriber.next).toHaveBeenCalledTimes(2);
+      expect(subscriber.complete).toHaveBeenCalledTimes(2);
+      expect(subscriber.error).not.toHaveBeenCalled();
+      done();
+    }, 50);
+  });
+
+  it('calls remaining subscribers after unsubscribe', done => {
+    const link = createHttpLink({ uri: '/data' });
+    const context = { info: 'stub' };
+    const variables = { params: 'stub' };
+
+    const observable = execute(link, {
+      query: sampleMutation,
+      context,
+      variables,
+    });
+
+    observable.subscribe(subscriber);
+
+    setTimeout(() => {
+      const subscription = observable.subscribe(subscriber);
+      subscription.unsubscribe();
+    }, 10);
+
+    setTimeout(
+      makeCallback(done, () => {
+        expect(subscriber.next).toHaveBeenCalledTimes(1);
+        expect(subscriber.complete).toHaveBeenCalledTimes(1);
+        expect(subscriber.error).not.toHaveBeenCalled();
+        done();
+      }),
+      50,
+    );
+  });
+
+  it('allows for dynamic endpoint setting', done => {
+    const variables = { params: 'stub' };
+    const link = createHttpLink({ uri: '/data' });
+
+    execute(link, {
+      query: sampleQuery,
+      variables,
+      context: { uri: '/data2' },
+    }).subscribe(result => {
+      expect(result).toEqual(data2);
+      done();
+    });
+  });
+
+  it('adds headers to the request from the context', done => {
+    const variables = { params: 'stub' };
+    const middleware = new ApolloLink((operation, forward) => {
+      operation.setContext({
+        headers: { authorization: '1234' },
+      });
+      return forward(operation).map(result => {
+        const { headers } = operation.getContext();
+        try {
+          expect(headers).toBeDefined();
+        } catch (e) {
+          done.fail(e);
+        }
+        return result;
+      });
+    });
+    const link = middleware.concat(createHttpLink({ uri: '/data' }));
+
+    execute(link, { query: sampleQuery, variables }).subscribe(
+      makeCallback(done, (result: any) => {
+        const headers: any = fetchMock.lastCall()![1]!.headers;
+        expect(headers.authorization).toBe('1234');
+        expect(headers['content-type']).toBe('application/json');
+        expect(headers.accept).toBe('*/*');
+      }),
+    );
+  });
+
+  it('adds headers to the request from the setup', done => {
+    const variables = { params: 'stub' };
+    const link = createHttpLink({
+      uri: '/data',
+      headers: { authorization: '1234' },
+    });
+
+    execute(link, { query: sampleQuery, variables }).subscribe(
+      makeCallback(done, (result: any) => {
+        const headers: any = fetchMock.lastCall()![1]!.headers;
+        expect(headers.authorization).toBe('1234');
+        expect(headers['content-type']).toBe('application/json');
+        expect(headers.accept).toBe('*/*');
+      }),
+    );
+  });
+
+  it('prioritizes context headers over setup headers', done => {
+    const variables = { params: 'stub' };
+    const middleware = new ApolloLink((operation, forward) => {
+      operation.setContext({
+        headers: { authorization: '1234' },
+      });
+      return forward(operation);
+    });
+    const link = middleware.concat(
+      createHttpLink({ uri: '/data', headers: { authorization: 'no user' } }),
+    );
+
+    execute(link, { query: sampleQuery, variables }).subscribe(
+      makeCallback(done, (result: any) => {
+        const headers: any = fetchMock.lastCall()![1]!.headers;
+        expect(headers.authorization).toBe('1234');
+        expect(headers['content-type']).toBe('application/json');
+        expect(headers.accept).toBe('*/*');
+      }),
+    );
+  });
+
+  it('adds headers to the request from the context on an operation', done => {
+    const variables = { params: 'stub' };
+    const link = createHttpLink({ uri: '/data' });
+
+    const context = {
+      headers: { authorization: '1234' },
+    };
+    execute(link, {
+      query: sampleQuery,
+      variables,
+      context,
+    }).subscribe(
+      makeCallback(done, (result: any) => {
+        const headers: any = fetchMock.lastCall()![1]!.headers;
+        expect(headers.authorization).toBe('1234');
+        expect(headers['content-type']).toBe('application/json');
+        expect(headers.accept).toBe('*/*');
+      }),
+    );
+  });
+
+  it('adds creds to the request from the context', done => {
+    const variables = { params: 'stub' };
+    const middleware = new ApolloLink((operation, forward) => {
+      operation.setContext({
+        credentials: 'same-team-yo',
+      });
+      return forward(operation);
+    });
+    const link = middleware.concat(createHttpLink({ uri: '/data' }));
+
+    execute(link, { query: sampleQuery, variables }).subscribe(
+      makeCallback(done, (result: any) => {
+        const creds = fetchMock.lastCall()![1]!.credentials;
+        expect(creds).toBe('same-team-yo');
+      }),
+    );
+  });
+
+  it('adds creds to the request from the setup', done => {
+    const variables = { params: 'stub' };
+    const link = createHttpLink({ uri: '/data', credentials: 'same-team-yo' });
+
+    execute(link, { query: sampleQuery, variables }).subscribe(
+      makeCallback(done, (result: any) => {
+        const creds = fetchMock.lastCall()![1]!.credentials;
+        expect(creds).toBe('same-team-yo');
+      }),
+    );
+  });
+
+  it('prioritizes creds from the context over the setup', done => {
+    const variables = { params: 'stub' };
+    const middleware = new ApolloLink((operation, forward) => {
+      operation.setContext({
+        credentials: 'same-team-yo',
+      });
+      return forward(operation);
+    });
+    const link = middleware.concat(
+      createHttpLink({ uri: '/data', credentials: 'error' }),
+    );
+
+    execute(link, { query: sampleQuery, variables }).subscribe(
+      makeCallback(done, (result: any) => {
+        const creds = fetchMock.lastCall()![1]!.credentials;
+        expect(creds).toBe('same-team-yo');
+      }),
+    );
+  });
+
+  it('adds uri to the request from the context', done => {
+    const variables = { params: 'stub' };
+    const middleware = new ApolloLink((operation, forward) => {
+      operation.setContext({
+        uri: '/data',
+      });
+      return forward(operation);
+    });
+    const link = middleware.concat(createHttpLink());
+
+    execute(link, { query: sampleQuery, variables }).subscribe(
+      makeCallback(done, (result: any) => {
+        const uri = fetchMock.lastUrl();
+        expect(uri).toBe('/data');
+      }),
+    );
+  });
+
+  it('adds uri to the request from the setup', done => {
+    const variables = { params: 'stub' };
+    const link = createHttpLink({ uri: '/data' });
+
+    execute(link, { query: sampleQuery, variables }).subscribe(
+      makeCallback(done, (result: any) => {
+        const uri = fetchMock.lastUrl();
+        expect(uri).toBe('/data');
+      }),
+    );
+  });
+
+  it('prioritizes context uri over setup uri', done => {
+    const variables = { params: 'stub' };
+    const middleware = new ApolloLink((operation, forward) => {
+      operation.setContext({
+        uri: '/apollo',
+      });
+      return forward(operation);
+    });
+    const link = middleware.concat(
+      createHttpLink({ uri: '/data', credentials: 'error' }),
+    );
+
+    execute(link, { query: sampleQuery, variables }).subscribe(
+      makeCallback(done, (result: any) => {
+        const uri = fetchMock.lastUrl();
+
+        expect(uri).toBe('/apollo');
+      }),
+    );
+  });
+
+  it('allows uri to be a function', done => {
+    const variables = { params: 'stub' };
+    const customFetch = (_uri: any, options: any) => {
+      const { operationName } = convertBatchedBody(options.body);
+      try {
+        expect(operationName).toBe('SampleQuery');
+      } catch (e) {
+        done.fail(e);
+      }
+      return fetch('/dataFunc', options);
+    };
+
+    const link = createHttpLink({ fetch: customFetch });
+
+    execute(link, { query: sampleQuery, variables }).subscribe(
+      makeCallback(done, (result: any) => {
+        expect(fetchMock.lastUrl()).toBe('/dataFunc');
+      }),
+    );
+  });
+
+  it('adds fetchOptions to the request from the setup', done => {
+    const variables = { params: 'stub' };
+    const link = createHttpLink({
+      uri: '/data',
+      fetchOptions: { someOption: 'foo', mode: 'no-cors' },
+    });
+
+    execute(link, { query: sampleQuery, variables }).subscribe(
+      makeCallback(done, (result: any) => {
+        const { someOption, mode, headers } = fetchMock.lastCall()![1]! as any;
+        expect(someOption).toBe('foo');
+        expect(mode).toBe('no-cors');
+        expect(headers['content-type']).toBe('application/json');
+      }),
+    );
+  });
+
+  it('adds fetchOptions to the request from the context', done => {
+    const variables = { params: 'stub' };
+    const middleware = new ApolloLink((operation, forward) => {
+      operation.setContext({
+        fetchOptions: {
+          someOption: 'foo',
+        },
+      });
+      return forward(operation);
+    });
+    const link = middleware.concat(createHttpLink({ uri: '/data' }));
+
+    execute(link, { query: sampleQuery, variables }).subscribe(
+      makeCallback(done, (result: any) => {
+        const { someOption } = fetchMock.lastCall()![1]! as any;
+        expect(someOption).toBe('foo');
+        done();
+      }),
+    );
+  });
+
+  it('prioritizes context over setup', done => {
+    const variables = { params: 'stub' };
+    const middleware = new ApolloLink((operation, forward) => {
+      operation.setContext({
+        fetchOptions: {
+          someOption: 'foo',
+        },
+      });
+      return forward(operation);
+    });
+    const link = middleware.concat(
+      createHttpLink({ uri: '/data', fetchOptions: { someOption: 'bar' } }),
+    );
+
+    execute(link, { query: sampleQuery, variables }).subscribe(
+      makeCallback(done, (result: any) => {
+        const { someOption } = fetchMock.lastCall()![1]! as any;
+        expect(someOption).toBe('foo');
+      }),
+    );
+  });
+
+  it('allows for not sending the query with the request', done => {
+    const variables = { params: 'stub' };
+    const middleware = new ApolloLink((operation, forward) => {
+      operation.setContext({
+        http: {
+          includeQuery: false,
+          includeExtensions: true,
+        },
+      });
+      operation.extensions.persistedQuery = { hash: '1234' };
+      return forward(operation);
+    });
+    const link = middleware.concat(createHttpLink({ uri: '/data' }));
+
+    execute(link, { query: sampleQuery, variables }).subscribe(
+      makeCallback(done, (result: any) => {
+        let body = convertBatchedBody(fetchMock.lastCall()![1]!.body);
+
+        expect(body.query).not.toBeDefined();
+        expect(body.extensions).toEqual({ persistedQuery: { hash: '1234' } });
+        done();
+      }),
+    );
+  });
+
+  it('sets the raw response on context', done => {
+    const middleware = new ApolloLink((operation, forward) => {
+      return new Observable(ob => {
+        const op = forward(operation);
+        const sub = op.subscribe({
+          next: ob.next.bind(ob),
+          error: ob.error.bind(ob),
+          complete: makeCallback(done, (e: any) => {
+            expect(operation.getContext().response.headers.toBeDefined);
+            ob.complete();
+          }),
+        });
+
+        return () => {
+          sub.unsubscribe();
+        };
+      });
+    });
+
+    const link = middleware.concat(createHttpLink({ uri: '/data', fetch }));
+
+    execute(link, { query: sampleQuery }).subscribe(
+      result => {
+        done();
+      },
+      () => {},
+    );
+  });
+});

--- a/src/link/batch-http/batchHttpLink.ts
+++ b/src/link/batch-http/batchHttpLink.ts
@@ -1,0 +1,233 @@
+import { ApolloLink } from '../core/ApolloLink';
+import { Operation, FetchResult } from '../core/types';
+import { Observable } from '../../utilities/observables/Observable';
+import { fromError } from '../utils/fromError';
+import { serializeFetchParameter } from '../http/serializeFetchParameter';
+import { selectURI } from '../http/selectURI';
+import { parseAndCheckHttpResponse } from '../http/parseAndCheckHttpResponse';
+import { checkFetcher } from '../http/checkFetcher';
+import {
+  selectHttpOptionsAndBody,
+  fallbackHttpConfig,
+  HttpOptions
+} from '../http/selectHttpOptionsAndBody';
+import { createSignalIfSupported } from '../http/createSignalIfSupported';
+import { BatchLink } from '../batch/batchLink';
+
+export namespace BatchHttpLink {
+  export interface Options extends HttpOptions {
+    /**
+     * The maximum number of operations to include in one fetch.
+     *
+     * Defaults to 10.
+     */
+    batchMax?: number;
+
+    /**
+     * The interval at which to batch, in milliseconds.
+     *
+     * Defaults to 10.
+     */
+    batchInterval?: number;
+
+    /**
+     * Sets the key for an Operation, which specifies the batch an operation is included in
+     */
+    batchKey?: (operation: Operation) => string;
+  }
+}
+
+/**
+ * Transforms Operation for into HTTP results.
+ * context can include the headers property, which will be passed to the fetch function
+ */
+export class BatchHttpLink extends ApolloLink {
+  private batchInterval: number;
+  private batchMax: number;
+  private batcher: ApolloLink;
+
+  constructor(fetchParams?: BatchHttpLink.Options) {
+    super();
+
+    let {
+      uri = '/graphql',
+      // use default global fetch if nothing is passed in
+      fetch: fetcher,
+      includeExtensions,
+      batchInterval,
+      batchMax,
+      batchKey,
+      ...requestOptions
+    } = fetchParams || ({} as BatchHttpLink.Options);
+
+    // dev warnings to ensure fetch is present
+    checkFetcher(fetcher);
+
+    //fetcher is set here rather than the destructuring to ensure fetch is
+    //declared before referencing it. Reference in the destructuring would cause
+    //a ReferenceError
+    if (!fetcher) {
+      fetcher = fetch;
+    }
+
+    const linkConfig = {
+      http: { includeExtensions },
+      options: requestOptions.fetchOptions,
+      credentials: requestOptions.credentials,
+      headers: requestOptions.headers,
+    };
+
+    this.batchInterval = batchInterval || 10;
+    this.batchMax = batchMax || 10;
+
+    const batchHandler = (operations: Operation[]) => {
+      const chosenURI = selectURI(operations[0], uri);
+
+      const context = operations[0].getContext();
+
+      const clientAwarenessHeaders: {
+        'apollographql-client-name'?: string;
+        'apollographql-client-version'?: string;
+      } = {};
+      if (context.clientAwareness) {
+        const { name, version } = context.clientAwareness;
+        if (name) {
+          clientAwarenessHeaders['apollographql-client-name'] = name;
+        }
+        if (version) {
+          clientAwarenessHeaders['apollographql-client-version'] = version;
+        }
+      }
+
+      const contextConfig = {
+        http: context.http,
+        options: context.fetchOptions,
+        credentials: context.credentials,
+        headers: { ...clientAwarenessHeaders, ...context.headers },
+      };
+
+      //uses fallback, link, and then context to build options
+      const optsAndBody = operations.map(operation =>
+        selectHttpOptionsAndBody(
+          operation,
+          fallbackHttpConfig,
+          linkConfig,
+          contextConfig,
+        ),
+      );
+
+      const loadedBody = optsAndBody.map(({ body }) => body);
+      const options = optsAndBody[0].options;
+
+      // There's no spec for using GET with batches.
+      if (options.method === 'GET') {
+        return fromError<FetchResult[]>(
+          new Error('apollo-link-batch-http does not support GET requests'),
+        );
+      }
+
+      try {
+        (options as any).body = serializeFetchParameter(loadedBody, 'Payload');
+      } catch (parseError) {
+        return fromError<FetchResult[]>(parseError);
+      }
+
+      let controller: any;
+      if (!(options as any).signal) {
+        const { controller: _controller, signal } = createSignalIfSupported();
+        controller = _controller;
+        if (controller) (options as any).signal = signal;
+      }
+
+      return new Observable<FetchResult[]>(observer => {
+        fetcher!(chosenURI, options)
+          .then(response => {
+            // Make the raw response available in the context.
+            operations.forEach(operation => operation.setContext({ response }));
+            return response;
+          })
+          .then(parseAndCheckHttpResponse(operations))
+          .then(result => {
+            // we have data and can send it to back up the link chain
+            observer.next(result);
+            observer.complete();
+            return result;
+          })
+          .catch(err => {
+            // fetch was cancelled so its already been cleaned up in the unsubscribe
+            if (err.name === 'AbortError') return;
+            // if it is a network error, BUT there is graphql result info
+            // fire the next observer before calling error
+            // this gives apollo-client (and react-apollo) the `graphqlErrors` and `networErrors`
+            // to pass to UI
+            // this should only happen if we *also* have data as part of the response key per
+            // the spec
+            if (err.result && err.result.errors && err.result.data) {
+              // if we dont' call next, the UI can only show networkError because AC didn't
+              // get andy graphqlErrors
+              // this is graphql execution result info (i.e errors and possibly data)
+              // this is because there is no formal spec how errors should translate to
+              // http status codes. So an auth error (401) could have both data
+              // from a public field, errors from a private field, and a status of 401
+              // {
+              //  user { // this will have errors
+              //    firstName
+              //  }
+              //  products { // this is public so will have data
+              //    cost
+              //  }
+              // }
+              //
+              // the result of above *could* look like this:
+              // {
+              //   data: { products: [{ cost: "$10" }] },
+              //   errors: [{
+              //      message: 'your session has timed out',
+              //      path: []
+              //   }]
+              // }
+              // status code of above would be a 401
+              // in the UI you want to show data where you can, errors as data where you can
+              // and use correct http status codes
+              observer.next(err.result);
+            }
+
+            observer.error(err);
+          });
+
+        return () => {
+          // XXX support canceling this request
+          // https://developers.google.com/web/updates/2017/09/abortable-fetch
+          if (controller) controller.abort();
+        };
+      });
+    };
+
+    batchKey =
+      batchKey ||
+      ((operation: Operation) => {
+        const context = operation.getContext();
+
+        const contextConfig = {
+          http: context.http,
+          options: context.fetchOptions,
+          credentials: context.credentials,
+          headers: context.headers,
+        };
+
+        //may throw error if config not serializable
+        return selectURI(operation, uri) + JSON.stringify(contextConfig);
+      });
+
+    this.batcher = new BatchLink({
+      batchInterval: this.batchInterval,
+      batchMax: this.batchMax,
+      batchKey,
+      batchHandler,
+    });
+  }
+
+  public request(operation: Operation): Observable<FetchResult> | null {
+    return this.batcher.request(operation);
+  }
+}

--- a/src/link/batch-http/index.ts
+++ b/src/link/batch-http/index.ts
@@ -1,0 +1,1 @@
+export * from './batchHttpLink';

--- a/src/link/batch/__tests__/batchLink.ts
+++ b/src/link/batch/__tests__/batchLink.ts
@@ -1,0 +1,758 @@
+import gql from 'graphql-tag';
+import { print } from 'graphql/language/printer';
+
+import { ApolloLink } from '../../core/ApolloLink';
+import { execute } from '../../core/execute';
+import { Operation, FetchResult, GraphQLRequest } from '../../core/types';
+import { Observable } from '../../../utilities/observables/Observable';
+import {
+  BatchLink,
+  OperationBatcher,
+  BatchHandler,
+  BatchableRequest,
+} from '../batchLink';
+
+interface MockedResponse {
+  request: GraphQLRequest;
+  result?: FetchResult;
+  error?: Error;
+  delay?: number;
+}
+
+function getKey(operation: GraphQLRequest) {
+  // XXX We're assuming here that query and variables will be serialized in
+  // the same order, which might not always be true.
+  const { query, variables, operationName } = operation;
+  return JSON.stringify([operationName, query, variables]);
+}
+
+export function createOperation(
+  starting: any,
+  operation: GraphQLRequest,
+): Operation {
+  let context = { ...starting };
+  const setContext = (next: any) => {
+    if (typeof next === 'function') {
+      context = { ...context, ...next(context) };
+    } else {
+      context = { ...context, ...next };
+    }
+  };
+  const getContext = () => ({ ...context });
+
+  Object.defineProperty(operation, 'setContext', {
+    enumerable: false,
+    value: setContext,
+  });
+
+  Object.defineProperty(operation, 'getContext', {
+    enumerable: false,
+    value: getContext,
+  });
+
+  Object.defineProperty(operation, 'toKey', {
+    enumerable: false,
+    value: () => getKey(operation),
+  });
+
+  return operation as Operation;
+}
+
+const terminatingCheck = (done: any, body: any) => {
+  return (...args: any[]) => {
+    try {
+      body(...args);
+      done();
+    } catch (error) {
+      done.fail(error);
+    }
+  };
+};
+
+function requestToKey(request: GraphQLRequest): string {
+  const queryString =
+    typeof request.query === 'string' ? request.query : print(request.query);
+
+  return JSON.stringify({
+    variables: request.variables || {},
+    query: queryString,
+  });
+}
+
+function createMockBatchHandler(...mockedResponses: MockedResponse[]) {
+  const mockedResponsesByKey: { [key: string]: MockedResponse[] } = {};
+
+  const mockBatchHandler: BatchHandler = (operations: Operation[]) => {
+    return new Observable(observer => {
+      const results = operations.map(operation => {
+        const key = requestToKey(operation);
+        const responses = mockedResponsesByKey[key];
+        if (!responses || responses.length === 0) {
+          throw new Error(
+            `No more mocked responses for the query: ${print(
+              operation.query,
+            )}, variables: ${JSON.stringify(operation.variables)}`,
+          );
+        }
+
+        const { result, error } = responses.shift()!;
+
+        if (!result && !error) {
+          throw new Error(
+            `Mocked response should contain either result or error: ${key}`,
+          );
+        }
+
+        if (error) {
+          observer.error(error);
+        }
+
+        return result;
+      }) as any;
+
+      observer.next(results);
+    });
+  };
+
+  (mockBatchHandler as any).addMockedResponse = (
+    mockedResponse: MockedResponse,
+  ) => {
+    const key = requestToKey(mockedResponse.request);
+    let _mockedResponses = mockedResponsesByKey[key];
+    if (!_mockedResponses) {
+      _mockedResponses = [];
+      mockedResponsesByKey[key] = _mockedResponses;
+    }
+    _mockedResponses.push(mockedResponse);
+  };
+
+  mockedResponses.map((mockBatchHandler as any).addMockedResponse);
+
+  return mockBatchHandler;
+}
+
+describe('OperationBatcher', () => {
+  it('should construct', () => {
+    expect(() => {
+      const querySched = new OperationBatcher({
+        batchInterval: 10,
+        batchHandler: () => null,
+      });
+      querySched.consumeQueue('');
+    }).not.toThrow();
+  });
+
+  it('should not do anything when faced with an empty queue', () => {
+    const batcher = new OperationBatcher({
+      batchInterval: 10,
+      batchHandler: () => {
+        return null;
+      },
+      batchKey: () => 'yo',
+    });
+
+    expect(batcher.queuedRequests.get('')).toBeUndefined();
+    expect(batcher.queuedRequests.get('yo')).toBeUndefined();
+    batcher.consumeQueue();
+    expect(batcher.queuedRequests.get('')).toBeUndefined();
+    expect(batcher.queuedRequests.get('yo')).toBeUndefined();
+  });
+
+  it('should be able to add to the queue', () => {
+    const batcher = new OperationBatcher({
+      batchInterval: 10,
+      batchHandler: () => {
+        return null;
+      },
+    });
+
+    const query = gql`
+      query {
+        author {
+          firstName
+          lastName
+        }
+      }
+    `;
+
+    const request: BatchableRequest = {
+      operation: createOperation({}, { query }),
+    };
+
+    expect(batcher.queuedRequests.get('')).toBeUndefined();
+    batcher.enqueueRequest(request).subscribe({});
+    expect(batcher.queuedRequests.get('')!.length).toBe(1);
+    batcher.enqueueRequest(request).subscribe({});
+    expect(batcher.queuedRequests.get('')!.length).toBe(2);
+  });
+
+  describe('request queue', () => {
+    const query = gql`
+      query {
+        author {
+          firstName
+          lastName
+        }
+      }
+    `;
+    const data = {
+      author: {
+        firstName: 'John',
+        lastName: 'Smith',
+      },
+    };
+    const batchHandler = createMockBatchHandler(
+      {
+        request: { query },
+        result: { data },
+      },
+      {
+        request: { query },
+        result: { data },
+      },
+    );
+    const operation: Operation = createOperation(
+      {},
+      {
+        query,
+      },
+    );
+
+    it('should be able to consume from a queue containing a single query', done => {
+      const myBatcher = new OperationBatcher({
+        batchInterval: 10,
+        batchHandler,
+      });
+
+      myBatcher.enqueueRequest({ operation }).subscribe(
+        terminatingCheck(done, (resultObj: any) => {
+          expect(myBatcher.queuedRequests.get('')).toBeUndefined();
+          expect(resultObj).toEqual({ data });
+        }),
+      );
+      const observables: (
+        | Observable<FetchResult>
+        | undefined)[] = myBatcher.consumeQueue()!;
+
+      try {
+        expect(observables.length).toBe(1);
+      } catch (e) {
+        done.fail(e);
+      }
+    });
+
+    it('should be able to consume from a queue containing multiple queries', done => {
+      const request2: Operation = createOperation(
+        {},
+        {
+          query,
+        },
+      );
+
+      const BH = createMockBatchHandler(
+        {
+          request: { query },
+          result: { data },
+        },
+        {
+          request: { query },
+          result: { data },
+        },
+      );
+
+      const myBatcher = new OperationBatcher({
+        batchInterval: 10,
+        batchMax: 10,
+        batchHandler: BH,
+      });
+      const observable1 = myBatcher.enqueueRequest({ operation });
+      const observable2 = myBatcher.enqueueRequest({ operation: request2 });
+      let notify = false;
+      observable1.subscribe(resultObj1 => {
+        try {
+          expect(resultObj1).toEqual({ data });
+        } catch (e) {
+          done.fail(e);
+        }
+
+        if (notify) {
+          done();
+        } else {
+          notify = true;
+        }
+      });
+
+      observable2.subscribe(resultObj2 => {
+        try {
+          expect(resultObj2).toEqual({ data });
+        } catch (e) {
+          done.fail(e);
+        }
+
+        if (notify) {
+          done();
+        } else {
+          notify = true;
+        }
+      });
+
+      try {
+        expect(myBatcher.queuedRequests.get('')!.length).toBe(2);
+        const observables: (
+          | Observable<FetchResult>
+          | undefined)[] = myBatcher.consumeQueue()!;
+        expect(myBatcher.queuedRequests.get('')).toBeUndefined();
+        expect(observables.length).toBe(2);
+      } catch (e) {
+        done.fail(e);
+      }
+    });
+
+    it('should return a promise when we enqueue a request and resolve it with a result', done => {
+      const BH = createMockBatchHandler({
+        request: { query },
+        result: { data },
+      });
+      const myBatcher = new OperationBatcher({
+        batchInterval: 10,
+        batchHandler: BH,
+      });
+      const observable = myBatcher.enqueueRequest({ operation });
+      observable.subscribe(
+        terminatingCheck(done, (result: any) => {
+          expect(result).toEqual({ data });
+        }),
+      );
+      myBatcher.consumeQueue();
+    });
+  });
+
+  it('should work when single query', done => {
+    const data = {
+      lastName: 'Ever',
+      firstName: 'Greatest',
+    };
+    const batcher = new OperationBatcher({
+      batchInterval: 10,
+      batchHandler: () =>
+        new Observable(observer => {
+          observer.next([{ data }]);
+          setTimeout(observer.complete.bind(observer));
+        }),
+    });
+    const query = gql`
+      query {
+        author {
+          firstName
+          lastName
+        }
+      }
+    `;
+    const operation: Operation = createOperation({}, { query });
+
+    batcher.enqueueRequest({ operation }).subscribe({});
+    try {
+      expect(batcher.queuedRequests.get('')!.length).toBe(1);
+    } catch (e) {
+      done.fail(e);
+    }
+
+    setTimeout(
+      terminatingCheck(done, () => {
+        expect(batcher.queuedRequests.get('')).toBeUndefined();
+      }),
+      20,
+    );
+  });
+
+  it('should correctly batch multiple queries', done => {
+    const data = {
+      lastName: 'Ever',
+      firstName: 'Greatest',
+    };
+    const data2 = {
+      lastName: 'Hauser',
+      firstName: 'Evans',
+    };
+    const batcher = new OperationBatcher({
+      batchInterval: 10,
+      batchHandler: () =>
+        new Observable(observer => {
+          observer.next([{ data }, { data: data2 }, { data }]);
+          setTimeout(observer.complete.bind(observer));
+        }),
+    });
+    const query = gql`
+      query {
+        author {
+          firstName
+          lastName
+        }
+      }
+    `;
+    const operation: Operation = createOperation({}, { query });
+    const operation2: Operation = createOperation({}, { query });
+    const operation3: Operation = createOperation({}, { query });
+
+    batcher.enqueueRequest({ operation }).subscribe({});
+    batcher.enqueueRequest({ operation: operation2 }).subscribe({});
+    try {
+      expect(batcher.queuedRequests.get('')!.length).toBe(2);
+    } catch (e) {
+      done.fail(e);
+    }
+
+    setTimeout(() => {
+      // The batch shouldn't be fired yet, so we can add one more request.
+      batcher.enqueueRequest({ operation: operation3 }).subscribe({});
+      try {
+        expect(batcher.queuedRequests.get('')!.length).toBe(3);
+      } catch (e) {
+        done.fail(e);
+      }
+    }, 5);
+
+    setTimeout(
+      terminatingCheck(done, () => {
+        // The batch should've been fired by now.
+        expect(batcher.queuedRequests.get('')).toBeUndefined();
+      }),
+      20,
+    );
+  });
+
+  it('should reject the promise if there is a network error', done => {
+    const query = gql`
+      query {
+        author {
+          firstName
+          lastName
+        }
+      }
+    `;
+    const operation: Operation = createOperation({}, { query });
+    const error = new Error('Network error');
+    const BH = createMockBatchHandler({
+      request: { query },
+      error,
+    });
+    const batcher = new OperationBatcher({
+      batchInterval: 10,
+      batchHandler: BH,
+    });
+
+    const observable = batcher.enqueueRequest({ operation });
+    observable.subscribe({
+      error: terminatingCheck(done, (resError: Error) => {
+        expect(resError.message).toBe('Network error');
+      }),
+    });
+    batcher.consumeQueue();
+  });
+});
+
+describe('BatchLink', () => {
+  const query = gql`
+    {
+      id
+    }
+  `;
+
+  it('does not need any constructor arguments', () => {
+    expect(
+      () => new BatchLink({ batchHandler: () => Observable.of() }),
+    ).not.toThrow();
+  });
+
+  it('passes forward on', done => {
+    const link = ApolloLink.from([
+      new BatchLink({
+        batchInterval: 0,
+        batchMax: 1,
+        batchHandler: (operation, forward) => {
+          try {
+            expect(forward!.length).toBe(1);
+            expect(operation.length).toBe(1);
+          } catch (e) {
+            done.fail(e);
+          }
+          return forward![0]!(operation[0]).map(result => [result]);
+        },
+      }),
+      new ApolloLink(operation => {
+        terminatingCheck(done, () => {
+          expect(operation.query).toEqual(query);
+        })();
+        return null;
+      }),
+    ]);
+
+    execute(
+      link,
+      createOperation(
+        {},
+        {
+          query,
+        },
+      ),
+    ).subscribe(result => done.fail());
+  });
+
+  it('raises warning if terminating', () => {
+    let calls = 0;
+    const link_full = new BatchLink({
+      batchHandler: (operation, forward) =>
+        forward![0]!(operation[0]).map(r => [r]),
+    });
+    const link_one_op = new BatchLink({
+      batchHandler: operation => Observable.of(),
+    });
+    const link_no_op = new BatchLink({ batchHandler: () => Observable.of() });
+    const _warn = console.warn;
+    console.warn = (warning: any) => {
+      calls++;
+      expect(warning.message).toBeDefined();
+    };
+    expect(
+      link_one_op.concat((operation, forward) => forward(operation)),
+    ).toEqual(link_one_op);
+    expect(
+      link_no_op.concat((operation, forward) => forward(operation)),
+    ).toEqual(link_no_op);
+    console.warn = (warning: any) => {
+      throw Error('non-terminating link should not throw');
+    };
+    expect(
+      link_full.concat((operation, forward) => forward(operation)),
+    ).not.toEqual(link_full);
+    console.warn = _warn;
+    expect(calls).toBe(2);
+  });
+
+  it('correctly uses batch size', done => {
+    const sizes = [1, 2, 3];
+    const terminating = new ApolloLink(operation => {
+      try {
+        expect(operation.query).toEqual(query);
+      } catch (e) {
+        done.fail(e);
+      }
+      return Observable.of(operation.variables.count);
+    });
+
+    let runBatchSize = () => {
+      const size = sizes.pop();
+      if (!size) done();
+
+      const batchHandler = jest.fn((operation, forward) => {
+        try {
+          expect(operation.length).toBe(size);
+          expect(forward.length).toBe(size);
+        } catch (e) {
+          done.fail(e);
+        }
+        const observables = forward.map((f: any, i: any) => f(operation[i]));
+        return new Observable(observer => {
+          const data: any[] = [];
+          observables.forEach((obs: any) =>
+            obs.subscribe((d: any) => {
+              data.push(d);
+              if (data.length === observables.length) {
+                observer.next(data);
+                observer.complete();
+              }
+            }),
+          );
+        });
+      }) as any;
+
+      const link = ApolloLink.from([
+        new BatchLink({
+          batchInterval: 1000,
+          batchMax: size,
+          batchHandler,
+        }),
+        terminating,
+      ]);
+
+      Array.from(new Array(size)).forEach((_, i) => {
+        execute(link, {
+          query,
+          variables: { count: i },
+        }).subscribe({
+          next: data => {
+            expect(data).toBe(i);
+          },
+          complete: () => {
+            try {
+              expect(batchHandler.mock.calls.length).toBe(1);
+            } catch (e) {
+              done.fail(e);
+            }
+            runBatchSize();
+          },
+        });
+      });
+    };
+
+    runBatchSize();
+  });
+
+  it('correctly follows batch interval', done => {
+    const intervals = [10, 20, 30];
+
+    const runBatchInterval = () => {
+      const mock = jest.fn();
+
+      const batchInterval = intervals.pop();
+      if (!batchInterval) return done();
+
+      const batchHandler = jest.fn((operation, forward) => {
+        try {
+          expect(operation.length).toBe(1);
+          expect(forward.length).toBe(1);
+        } catch (e) {
+          done.fail(e);
+        }
+
+        return forward[0](operation[0]).map((d: any) => [d]);
+      });
+
+      const link = ApolloLink.from([
+        new BatchLink({
+          batchInterval,
+          batchMax: 0,
+          batchHandler,
+        }),
+        () => Observable.of(42) as any,
+      ]);
+
+      execute(
+        link,
+        createOperation(
+          {},
+          {
+            query,
+          },
+        ),
+      ).subscribe({
+        next: data => {
+          try {
+            expect(data).toBe(42);
+          } catch (e) {
+            done.fail(e);
+          }
+        },
+        complete: () => {
+          mock(batchHandler.mock.calls.length);
+        },
+      });
+
+      setTimeout(() => {
+        const checkCalls = mock.mock.calls.slice(0, -1);
+        try {
+          expect(checkCalls.length).toBe(2);
+          checkCalls.forEach(args => expect(args[0]).toBe(0));
+          expect(mock).lastCalledWith(1);
+          expect(batchHandler.mock.calls.length).toBe(1);
+        } catch (e) {
+          done.fail(e);
+        }
+
+        runBatchInterval();
+      }, batchInterval + 5);
+
+      setTimeout(() => mock(batchHandler.mock.calls.length), batchInterval - 5);
+      setTimeout(() => mock(batchHandler.mock.calls.length), batchInterval / 2);
+    };
+    runBatchInterval();
+  });
+
+  it('throws an error when more requests than results', done => {
+    const result = [{ data: {} }];
+    const batchHandler = jest.fn(op => Observable.of(result));
+
+    const link = ApolloLink.from([
+      new BatchLink({
+        batchInterval: 10,
+        batchMax: 2,
+        batchHandler,
+      }),
+    ]);
+
+    [1, 2].forEach(x => {
+      execute(link, {
+        query,
+      }).subscribe({
+        next: data => {
+          done.fail('next should not be called');
+        },
+        error: terminatingCheck(done, (error: any) => {
+          expect(error).toBeDefined();
+          expect(error.result).toEqual(result);
+        }),
+        complete: () => {
+          done.fail('complete should not be called');
+        },
+      });
+    });
+  });
+
+  describe('batchKey', () => {
+    it('should allow different batches to be created separately', done => {
+      const data = { data: {} };
+      const result = [data, data];
+
+      const batchHandler = jest.fn(op => {
+        try {
+          expect(op.length).toBe(2);
+        } catch (e) {
+          done.fail(e);
+        }
+        return Observable.of(result);
+      });
+      let key = true;
+      const batchKey = () => {
+        key = !key;
+        return '' + !key;
+      };
+
+      const link = ApolloLink.from([
+        new BatchLink({
+          batchInterval: 1,
+          //if batchKey does not work, then the batch size would be 3
+          batchMax: 3,
+          batchHandler,
+          batchKey,
+        }),
+      ]);
+
+      let count = 0;
+      [1, 2, 3, 4].forEach(x => {
+        execute(link, {
+          query,
+        }).subscribe({
+          next: d => {
+            try {
+              expect(d).toEqual(data);
+            } catch (e) {
+              done.fail(e);
+            }
+          },
+          error: done.fail,
+          complete: () => {
+            count++;
+            if (count === 4) {
+              try {
+                expect(batchHandler.mock.calls.length).toBe(2);
+                done();
+              } catch (e) {
+                done.fail(e);
+              }
+            }
+          },
+        });
+      });
+    });
+  });
+});

--- a/src/link/batch/batchLink.ts
+++ b/src/link/batch/batchLink.ts
@@ -1,0 +1,71 @@
+import { ApolloLink } from '../core/ApolloLink';
+import { Operation, FetchResult } from '../core/types';
+import { Observable } from '../../utilities/observables/Observable';
+import { NextLink } from '../core/types';
+import { OperationBatcher, BatchHandler } from './batching';
+export { OperationBatcher, BatchableRequest, BatchHandler } from './batching';
+
+export namespace BatchLink {
+  export interface Options {
+    /**
+     * The interval at which to batch, in milliseconds.
+     *
+     * Defaults to 10.
+     */
+    batchInterval?: number;
+
+    /**
+     * The maximum number of operations to include in one fetch.
+     *
+     * Defaults to 0 (infinite operations within the interval).
+     */
+    batchMax?: number;
+
+    /**
+     * The handler that should execute a batch of operations.
+     */
+    batchHandler?: BatchHandler;
+
+    /**
+     * creates the key for a batch
+     */
+    batchKey?: (operation: Operation) => string;
+  }
+}
+
+export class BatchLink extends ApolloLink {
+  private batcher: OperationBatcher;
+
+  constructor(fetchParams?: BatchLink.Options) {
+    super();
+
+    const {
+      batchInterval = 10,
+      batchMax = 0,
+      batchHandler = () => null,
+      batchKey = () => '',
+    } = fetchParams || {};
+
+    this.batcher = new OperationBatcher({
+      batchInterval,
+      batchMax,
+      batchHandler,
+      batchKey,
+    });
+
+    //make this link terminating
+    if (fetchParams!.batchHandler!.length <= 1) {
+      this.request = operation => this.batcher.enqueueRequest({ operation });
+    }
+  }
+
+  public request(
+    operation: Operation,
+    forward?: NextLink,
+  ): Observable<FetchResult> | null {
+    return this.batcher.enqueueRequest({
+      operation,
+      forward,
+    });
+  }
+}

--- a/src/link/batch/batching.ts
+++ b/src/link/batch/batching.ts
@@ -1,0 +1,196 @@
+import { Operation, FetchResult } from '../core/types';
+import { Observable } from '../../utilities/observables/Observable';
+import { NextLink } from '../core/types';
+
+export type BatchHandler = (
+  operations: Operation[],
+  forward?: (NextLink | undefined)[],
+) => Observable<FetchResult[]> | null;
+
+export interface BatchableRequest {
+  operation: Operation;
+  forward?: NextLink;
+
+  // promise is created when the query fetch request is
+  // added to the queue and is resolved once the result is back
+  // from the server.
+  observable?: Observable<FetchResult>;
+  next?: Array<(result: FetchResult) => void>;
+  error?: Array<(error: Error) => void>;
+  complete?: Array<() => void>;
+}
+
+// QueryBatcher doesn't fire requests immediately. Requests that were enqueued within
+// a certain amount of time (configurable through `batchInterval`) will be batched together
+// into one query.
+export class OperationBatcher {
+  // Queue on which the QueryBatcher will operate on a per-tick basis.
+  // Public only for testing
+  public queuedRequests: Map<string, BatchableRequest[]>;
+
+  private batchInterval?: number;
+  private batchMax: number;
+
+  //This function is called to the queries in the queue to the server.
+  private batchHandler: BatchHandler;
+  private batchKey: (operation: Operation) => string;
+
+  constructor({
+    batchInterval,
+    batchMax,
+    batchHandler,
+    batchKey,
+  }: {
+    batchInterval?: number;
+    batchMax?: number;
+    batchHandler: BatchHandler;
+    batchKey?: (operation: Operation) => string;
+  }) {
+    this.queuedRequests = new Map();
+    this.batchInterval = batchInterval;
+    this.batchMax = batchMax || 0;
+    this.batchHandler = batchHandler;
+    this.batchKey = batchKey || (() => '');
+  }
+
+  public enqueueRequest(request: BatchableRequest): Observable<FetchResult> {
+    const requestCopy = {
+      ...request,
+    };
+    let queued = false;
+
+    const key = this.batchKey(request.operation);
+
+    if (!requestCopy.observable) {
+      requestCopy.observable = new Observable<FetchResult>(observer => {
+        if (!this.queuedRequests.has(key)) {
+          this.queuedRequests.set(key, []);
+        }
+
+        if (!queued) {
+          this.queuedRequests.get(key)!.push(requestCopy);
+          queued = true;
+        }
+
+        //called for each subscriber, so need to save all listeners(next, error, complete)
+        requestCopy.next = requestCopy.next || [];
+        if (observer.next) requestCopy.next.push(observer.next.bind(observer));
+
+        requestCopy.error = requestCopy.error || [];
+        if (observer.error)
+          requestCopy.error.push(observer.error.bind(observer));
+
+        requestCopy.complete = requestCopy.complete || [];
+        if (observer.complete)
+          requestCopy.complete.push(observer.complete.bind(observer));
+
+        // The first enqueued request triggers the queue consumption after `batchInterval` milliseconds.
+        if (this.queuedRequests.get(key)!.length === 1) {
+          this.scheduleQueueConsumption(key);
+        }
+
+        // When amount of requests reaches `batchMax`, trigger the queue consumption without waiting on the `batchInterval`.
+        if (this.queuedRequests.get(key)!.length === this.batchMax) {
+          this.consumeQueue(key);
+        }
+      });
+    }
+
+    return requestCopy.observable;
+  }
+
+  // Consumes the queue.
+  // Returns a list of promises (one for each query).
+  public consumeQueue(
+    key?: string,
+  ): (Observable<FetchResult> | undefined)[] | undefined {
+    const requestKey = key || '';
+    const queuedRequests = this.queuedRequests.get(requestKey);
+
+    if (!queuedRequests) {
+      return;
+    }
+
+    this.queuedRequests.delete(requestKey);
+
+    const requests: Operation[] = queuedRequests.map(
+      queuedRequest => queuedRequest.operation,
+    );
+
+    const forwards: (NextLink | undefined)[] = queuedRequests.map(
+      queuedRequest => queuedRequest.forward,
+    );
+
+    const observables: (Observable<FetchResult> | undefined)[] = [];
+    const nexts: any[] = [];
+    const errors: any[] = [];
+    const completes: any[] = [];
+    queuedRequests.forEach((batchableRequest, index) => {
+      observables.push(batchableRequest.observable);
+      nexts.push(batchableRequest.next);
+      errors.push(batchableRequest.error);
+      completes.push(batchableRequest.complete);
+    });
+
+    const batchedObservable =
+      this.batchHandler(requests, forwards) || Observable.of();
+
+    const onError = (error: any) => {
+      //each callback list in batch
+      errors.forEach(rejecters => {
+        if (rejecters) {
+          //each subscriber to request
+          rejecters.forEach((e: any) => e(error));
+        }
+      });
+    };
+
+    batchedObservable.subscribe({
+      next: results => {
+        if (!Array.isArray(results)) {
+          results = [results];
+        }
+
+        if (nexts.length !== results.length) {
+          const error = new Error(
+            `server returned results with length ${
+              results.length
+            }, expected length of ${nexts.length}`,
+          );
+          (error as any).result = results;
+
+          return onError(error);
+        }
+
+        results.forEach((result, index) => {
+          if (nexts[index]) {
+            nexts[index].forEach((next: any) => next(result));
+          }
+        });
+      },
+      error: onError,
+      complete: () => {
+        completes.forEach(complete => {
+          if (complete) {
+            //each subscriber to request
+            complete.forEach((c: any) => c());
+          }
+        });
+      },
+    });
+
+    return observables;
+  }
+
+  private scheduleQueueConsumption(key?: string): void {
+    const requestKey = key || '';
+    setTimeout(() => {
+      if (
+        this.queuedRequests.get(requestKey) &&
+        this.queuedRequests.get(requestKey)!.length
+      ) {
+        this.consumeQueue(requestKey);
+      }
+    }, this.batchInterval);
+  }
+}

--- a/src/link/batch/index.ts
+++ b/src/link/batch/index.ts
@@ -1,0 +1,1 @@
+export * from './batchLink';

--- a/src/link/context/__tests__/index.ts
+++ b/src/link/context/__tests__/index.ts
@@ -1,0 +1,207 @@
+import gql from 'graphql-tag';
+
+import { ApolloLink } from '../../core/ApolloLink';
+import { Observable } from '../../../utilities/observables/Observable';
+import { execute } from '../../core/execute';
+import { setContext } from '../index';
+
+const sleep = (ms: number) => new Promise(s => setTimeout(s, ms));
+const query = gql`
+  query Test {
+    foo {
+      bar
+    }
+  }
+`;
+const data = {
+  foo: { bar: true },
+};
+
+it('can be used to set the context with a simple function', done => {
+  const withContext = setContext(() => ({ dynamicallySet: true }));
+
+  const mockLink = new ApolloLink(operation => {
+    expect(operation.getContext().dynamicallySet).toBe(true);
+    return Observable.of({ data });
+  });
+
+  const link = withContext.concat(mockLink);
+
+  execute(link, { query }).subscribe(result => {
+    expect(result.data).toEqual(data);
+    done();
+  });
+});
+
+it('can be used to set the context with a function returning a promise', done => {
+  const withContext = setContext(() =>
+    Promise.resolve({ dynamicallySet: true }),
+  );
+
+  const mockLink = new ApolloLink(operation => {
+    expect(operation.getContext().dynamicallySet).toBe(true);
+    return Observable.of({ data });
+  });
+
+  const link = withContext.concat(mockLink);
+
+  execute(link, { query }).subscribe(result => {
+    expect(result.data).toEqual(data);
+    done();
+  });
+});
+
+it('can be used to set the context with a function returning a promise that is delayed', done => {
+  const withContext = setContext(() =>
+    sleep(25).then(() => ({ dynamicallySet: true })),
+  );
+
+  const mockLink = new ApolloLink(operation => {
+    expect(operation.getContext().dynamicallySet).toBe(true);
+    return Observable.of({ data });
+  });
+
+  const link = withContext.concat(mockLink);
+
+  execute(link, { query }).subscribe(result => {
+    expect(result.data).toEqual(data);
+    done();
+  });
+});
+
+it('handles errors in the lookup correclty', done => {
+  const withContext = setContext(() =>
+    sleep(5).then(() => {
+      throw new Error('dang');
+    }),
+  );
+
+  const mockLink = new ApolloLink(operation => {
+    return Observable.of({ data });
+  });
+
+  const link = withContext.concat(mockLink);
+
+  execute(link, { query }).subscribe(done.fail as any, e => {
+    expect(e.message).toBe('dang');
+    done();
+  });
+});
+it('handles errors in the lookup correclty with a normal function', done => {
+  const withContext = setContext(() => {
+    throw new Error('dang');
+  });
+
+  const mockLink = new ApolloLink(operation => {
+    return Observable.of({ data });
+  });
+
+  const link = withContext.concat(mockLink);
+
+  execute(link, { query }).subscribe(done.fail as any, e => {
+    expect(e.message).toBe('dang');
+    done();
+  });
+});
+
+it('has access to the request information', done => {
+  const withContext = setContext(({ operationName, query, variables }) =>
+    sleep(1).then(() =>
+      Promise.resolve({
+        variables: variables ? true : false,
+        operation: query ? true : false,
+        operationName: operationName!.toUpperCase(),
+      }),
+    ),
+  );
+
+  const mockLink = new ApolloLink(op => {
+    const { variables, operation, operationName } = op.getContext();
+    expect(variables).toBe(true);
+    expect(operation).toBe(true);
+    expect(operationName).toBe('TEST');
+    return Observable.of({ data });
+  });
+
+  const link = withContext.concat(mockLink);
+
+  execute(link, { query, variables: { id: 1 } }).subscribe(result => {
+    expect(result.data).toEqual(data);
+    done();
+  });
+});
+it('has access to the context at execution time', done => {
+  const withContext = setContext((_, { count }) =>
+    sleep(1).then(() => ({ count: count + 1 })),
+  );
+
+  const mockLink = new ApolloLink(operation => {
+    const { count } = operation.getContext();
+    expect(count).toEqual(2);
+    return Observable.of({ data });
+  });
+
+  const link = withContext.concat(mockLink);
+
+  execute(link, { query, context: { count: 1 } }).subscribe(result => {
+    expect(result.data).toEqual(data);
+    done();
+  });
+});
+
+it('unsubscribes correctly', done => {
+  const withContext = setContext((_, { count }) =>
+    sleep(1).then(() => ({ count: count + 1 })),
+  );
+
+  const mockLink = new ApolloLink(operation => {
+    const { count } = operation.getContext();
+    expect(count).toEqual(2);
+    return Observable.of({ data });
+  });
+
+  const link = withContext.concat(mockLink);
+
+  let handle = execute(link, {
+    query,
+    context: { count: 1 },
+  }).subscribe(result => {
+    expect(result.data).toEqual(data);
+    handle.unsubscribe();
+    done();
+  });
+});
+
+it('unsubscribes without throwing before data', done => {
+  let called: boolean;
+  const withContext = setContext((_, { count }) => {
+    called = true;
+    return sleep(1).then(() => ({ count: count + 1 }));
+  });
+
+  const mockLink = new ApolloLink(operation => {
+    const { count } = operation.getContext();
+    expect(count).toEqual(2);
+    return new Observable(obs => {
+      setTimeout(() => {
+        obs.next({ data });
+        obs.complete();
+      }, 25);
+    });
+  });
+
+  const link = withContext.concat(mockLink);
+
+  let handle = execute(link, {
+    query,
+    context: { count: 1 },
+  }).subscribe(result => {
+    done.fail('should have unsubscribed');
+  });
+
+  setTimeout(() => {
+    handle.unsubscribe();
+    expect(called).toBe(true);
+    done();
+  }, 10);
+});

--- a/src/link/context/index.ts
+++ b/src/link/context/index.ts
@@ -1,0 +1,34 @@
+import { ApolloLink } from '../core/ApolloLink';
+import { Operation, GraphQLRequest } from '../core/types';
+import { Observable } from '../../utilities/observables/Observable';
+import { NextLink } from '../core/types';
+
+export type ContextSetter = (
+  operation: GraphQLRequest,
+  prevContext: any,
+) => Promise<any> | any;
+
+export function setContext(setter: ContextSetter): ApolloLink {
+  return new ApolloLink((operation: Operation, forward: NextLink) => {
+    const { ...request } = operation;
+
+    return new Observable(observer => {
+      let handle: ZenObservable.Subscription;
+      Promise.resolve(request)
+        .then(req => setter(req, operation.getContext()))
+        .then(operation.setContext)
+        .then(() => {
+          handle = forward(operation).subscribe({
+            next: observer.next.bind(observer),
+            error: observer.error.bind(observer),
+            complete: observer.complete.bind(observer),
+          });
+        })
+        .catch(observer.error.bind(observer));
+
+      return () => {
+        if (handle) handle.unsubscribe();
+      };
+    });
+  });
+}

--- a/src/link/core/index.ts
+++ b/src/link/core/index.ts
@@ -1,0 +1,8 @@
+export { empty } from './empty';
+export { from } from './from';
+export { split } from './split';
+export { concat } from './concat';
+export { execute } from './execute';
+export { ApolloLink } from './ApolloLink';
+
+export * from './types';

--- a/src/link/error/__tests__/index.ts
+++ b/src/link/error/__tests__/index.ts
@@ -1,0 +1,607 @@
+import gql from 'graphql-tag';
+
+import { ApolloLink } from '../../core/ApolloLink';
+import { execute } from '../../core/execute';
+import { ServerError, throwServerError } from '../../utils/throwServerError';
+import { Observable } from '../../../utilities/observables/Observable';
+import { onError, ErrorLink } from '../';
+
+describe('error handling', () => {
+  it('has an easy way to handle GraphQL errors', done => {
+    const query = gql`
+      {
+        foo {
+          bar
+        }
+      }
+    `;
+
+    let called: boolean;
+    const errorLink = onError(({ graphQLErrors, networkError }) => {
+      expect(graphQLErrors![0].message).toBe('resolver blew up');
+      called = true;
+    });
+
+    const mockLink = new ApolloLink(operation =>
+      Observable.of({
+        errors: [
+          {
+            message: 'resolver blew up',
+          },
+        ],
+      } as any),
+    );
+
+    const link = errorLink.concat(mockLink);
+
+    execute(link, { query }).subscribe(result => {
+      expect(result.errors![0].message).toBe('resolver blew up');
+      expect(called).toBe(true);
+      done();
+    });
+  });
+  it('has an easy way to log client side (network) errors', done => {
+    const query = gql`
+      query Foo {
+        foo {
+          bar
+        }
+      }
+    `;
+
+    let called: boolean;
+    const errorLink = onError(({ operation, networkError }) => {
+      expect(networkError!.message).toBe('app is crashing');
+      expect(operation.operationName).toBe('Foo');
+      called = true;
+    });
+
+    const mockLink = new ApolloLink(operation => {
+      throw new Error('app is crashing');
+    });
+
+    const link = errorLink.concat(mockLink);
+
+    execute(link, { query }).subscribe({
+      error: e => {
+        expect(e.message).toBe('app is crashing');
+        expect(called).toBe(true);
+        done();
+      },
+    });
+  });
+  it('captures errors within links', done => {
+    const query = gql`
+      query Foo {
+        foo {
+          bar
+        }
+      }
+    `;
+
+    let called: boolean;
+    const errorLink = onError(({ operation, networkError }) => {
+      expect(networkError!.message).toBe('app is crashing');
+      expect(operation.operationName).toBe('Foo');
+      called = true;
+    });
+
+    const mockLink = new ApolloLink(operation => {
+      return new Observable(obs => {
+        throw new Error('app is crashing');
+      });
+    });
+
+    const link = errorLink.concat(mockLink);
+
+    execute(link, { query }).subscribe({
+      error: e => {
+        expect(e.message).toBe('app is crashing');
+        expect(called).toBe(true);
+        done();
+      },
+    });
+  });
+  it('captures networkError.statusCode within links', done => {
+    const query = gql`
+      query Foo {
+        foo {
+          bar
+        }
+      }
+    `;
+
+    let called: boolean;
+    const errorLink = onError(({ operation, networkError }) => {
+      expect(networkError!.message).toBe('app is crashing');
+      expect(networkError!.name).toBe('ServerError');
+      expect((networkError as ServerError).statusCode).toBe(500);
+      expect((networkError as ServerError).response.ok).toBe(false);
+      expect(operation.operationName).toBe('Foo');
+      called = true;
+    });
+
+    const mockLink = new ApolloLink(operation => {
+      return new Observable(obs => {
+        const response = { status: 500, ok: false } as Response;
+        throwServerError(response, 'ServerError', 'app is crashing');
+      });
+    });
+
+    const link = errorLink.concat(mockLink);
+
+    execute(link, { query }).subscribe({
+      error: e => {
+        expect(e.message).toBe('app is crashing');
+        expect(called).toBe(true);
+        done();
+      },
+    });
+  });
+  it('completes if no errors', done => {
+    const query = gql`
+      {
+        foo {
+          bar
+        }
+      }
+    `;
+
+    const errorLink = onError(({ graphQLErrors, networkError }) => {
+      expect(networkError!.message).toBe('app is crashing');
+    });
+
+    const mockLink = new ApolloLink(operation => {
+      return Observable.of({ data: { foo: { id: 1 } } });
+    });
+
+    const link = errorLink.concat(mockLink);
+
+    execute(link, { query }).subscribe({
+      complete: done,
+    });
+  });
+  it('allows an error to be ignored', done => {
+    const query = gql`
+      {
+        foo {
+          bar
+        }
+      }
+    `;
+
+    const errorLink = onError(({ graphQLErrors, response }) => {
+      expect(graphQLErrors![0].message).toBe('ignore');
+      // ignore errors
+      response!.errors = null as any;
+    });
+
+    const mockLink = new ApolloLink(operation => {
+      return Observable.of({
+        data: { foo: { id: 1 } },
+        errors: [{ message: 'ignore' } as any],
+      });
+    });
+
+    const link = errorLink.concat(mockLink);
+
+    execute(link, { query }).subscribe({
+      next: ({ errors, data }) => {
+        expect(errors).toBe(null);
+        expect(data).toEqual({ foo: { id: 1 } });
+      },
+      complete: done,
+    });
+  });
+
+  it('can be unsubcribed', done => {
+    const query = gql`
+      {
+        foo {
+          bar
+        }
+      }
+    `;
+
+    const errorLink = onError(({ networkError }) => {
+      expect(networkError!.message).toBe('app is crashing');
+    });
+
+    const mockLink = new ApolloLink(operation => {
+      return new Observable(obs => {
+        setTimeout(() => {
+          obs.next({ data: { foo: { id: 1 } } });
+          obs.complete();
+        }, 5);
+      });
+    });
+
+    const link = errorLink.concat(mockLink);
+
+    const sub = execute(link, { query }).subscribe({
+      complete: () => {
+        done.fail('completed');
+      },
+    });
+
+    sub.unsubscribe();
+
+    setTimeout(done, 10);
+  });
+
+  it('includes the operation and any data along with a graphql error', done => {
+    const query = gql`
+      query Foo {
+        foo {
+          bar
+        }
+      }
+    `;
+
+    let called: boolean;
+    const errorLink = onError(({ graphQLErrors, response, operation }) => {
+      expect(graphQLErrors![0].message).toBe('resolver blew up');
+      expect(response!.data!.foo).toBe(true);
+      expect(operation.operationName).toBe('Foo');
+      expect(operation.getContext().bar).toBe(true);
+      called = true;
+    });
+
+    const mockLink = new ApolloLink(operation =>
+      Observable.of({
+        data: { foo: true },
+        errors: [
+          {
+            message: 'resolver blew up',
+          },
+        ],
+      } as any),
+    );
+
+    const link = errorLink.concat(mockLink);
+
+    execute(link, { query, context: { bar: true } }).subscribe(result => {
+      expect(result.errors![0].message).toBe('resolver blew up');
+      expect(called).toBe(true);
+      done();
+    });
+  });
+});
+
+describe('error handling with class', () => {
+  it('has an easy way to handle GraphQL errors', done => {
+    const query = gql`
+      {
+        foo {
+          bar
+        }
+      }
+    `;
+
+    let called: boolean;
+    const errorLink = new ErrorLink(({ graphQLErrors, networkError }) => {
+      expect(graphQLErrors![0].message).toBe('resolver blew up');
+      called = true;
+    });
+
+    const mockLink = new ApolloLink(operation =>
+      Observable.of({
+        errors: [
+          {
+            message: 'resolver blew up',
+          },
+        ],
+      } as any),
+    );
+
+    const link = errorLink.concat(mockLink);
+
+    execute(link, { query }).subscribe(result => {
+      expect(result!.errors![0].message).toBe('resolver blew up');
+      expect(called).toBe(true);
+      done();
+    });
+  });
+  it('has an easy way to log client side (network) errors', done => {
+    const query = gql`
+      {
+        foo {
+          bar
+        }
+      }
+    `;
+
+    let called: boolean;
+    const errorLink = new ErrorLink(({ networkError }) => {
+      expect(networkError!.message).toBe('app is crashing');
+      called = true;
+    });
+
+    const mockLink = new ApolloLink(operation => {
+      throw new Error('app is crashing');
+    });
+
+    const link = errorLink.concat(mockLink);
+
+    execute(link, { query }).subscribe({
+      error: e => {
+        expect(e.message).toBe('app is crashing');
+        expect(called).toBe(true);
+        done();
+      },
+    });
+  });
+  it('captures errors within links', done => {
+    const query = gql`
+      {
+        foo {
+          bar
+        }
+      }
+    `;
+
+    let called: boolean;
+    const errorLink = new ErrorLink(({ networkError }) => {
+      expect(networkError!.message).toBe('app is crashing');
+      called = true;
+    });
+
+    const mockLink = new ApolloLink(operation => {
+      return new Observable(obs => {
+        throw new Error('app is crashing');
+      });
+    });
+
+    const link = errorLink.concat(mockLink);
+
+    execute(link, { query }).subscribe({
+      error: e => {
+        expect(e.message).toBe('app is crashing');
+        expect(called).toBe(true);
+        done();
+      },
+    });
+  });
+  it('completes if no errors', done => {
+    const query = gql`
+      {
+        foo {
+          bar
+        }
+      }
+    `;
+
+    const errorLink = new ErrorLink(({ networkError }) => {
+      expect(networkError!.message).toBe('app is crashing');
+    });
+
+    const mockLink = new ApolloLink(operation => {
+      return Observable.of({ data: { foo: { id: 1 } } });
+    });
+
+    const link = errorLink.concat(mockLink);
+
+    execute(link, { query }).subscribe({
+      complete: done,
+    });
+  });
+  it('can be unsubcribed', done => {
+    const query = gql`
+      {
+        foo {
+          bar
+        }
+      }
+    `;
+
+    const errorLink = new ErrorLink(({ networkError }) => {
+      expect(networkError!.message).toBe('app is crashing');
+    });
+
+    const mockLink = new ApolloLink(operation => {
+      return new Observable(obs => {
+        setTimeout(() => {
+          obs.next({ data: { foo: { id: 1 } } });
+          obs.complete();
+        }, 5);
+      });
+    });
+
+    const link = errorLink.concat(mockLink);
+
+    const sub = execute(link, { query }).subscribe({
+      complete: () => {
+        done.fail('completed');
+      },
+    });
+
+    sub.unsubscribe();
+
+    setTimeout(done, 10);
+  });
+});
+
+describe('support for request retrying', () => {
+  const QUERY = gql`
+    query Foo {
+      foo {
+        bar
+      }
+    }
+  `;
+  const ERROR_RESPONSE = {
+    errors: [
+      {
+        name: 'something bad happened',
+        message: 'resolver blew up',
+      },
+    ],
+  };
+  const GOOD_RESPONSE = {
+    data: { foo: true },
+  };
+  const NETWORK_ERROR = {
+    message: 'some other error',
+  };
+
+  it('returns the retried request when forward(operation) is called', done => {
+    let errorHandlerCalled = false;
+
+    let timesCalled = 0;
+    const mockHttpLink = new ApolloLink(operation => {
+      if (timesCalled === 0) {
+        timesCalled++;
+        // simulate the first request being an error
+        return new Observable(observer => {
+          observer.next(ERROR_RESPONSE as any);
+          observer.complete();
+        });
+      } else {
+        return new Observable(observer => {
+          observer.next(GOOD_RESPONSE);
+          observer.complete();
+        });
+      }
+    });
+
+    const errorLink = new ErrorLink(
+      ({ graphQLErrors, response, operation, forward }) => {
+        try {
+          if (graphQLErrors) {
+            errorHandlerCalled = true;
+            expect(graphQLErrors).toEqual(ERROR_RESPONSE.errors);
+            expect(response!.data).not.toBeDefined();
+            expect(operation.operationName).toBe('Foo');
+            expect(operation.getContext().bar).toBe(true);
+            // retry operation if it resulted in an error
+            return forward(operation);
+          }
+        } catch (error) {
+          done.fail(error);
+        }
+      },
+    );
+
+    const link = errorLink.concat(mockHttpLink);
+
+    execute(link, { query: QUERY, context: { bar: true } }).subscribe({
+      next(result) {
+        try {
+          expect(errorHandlerCalled).toBe(true);
+          expect(result).toEqual(GOOD_RESPONSE);
+        } catch (error) {
+          return done.fail(error);
+        }
+      },
+      complete() {
+        done();
+      },
+    });
+  });
+
+  it('supports retrying when the initial request had networkError', done => {
+    let errorHandlerCalled = false;
+
+    let timesCalled = 0;
+    const mockHttpLink = new ApolloLink(operation => {
+      if (timesCalled === 0) {
+        timesCalled++;
+        // simulate the first request being an error
+        return new Observable(observer => {
+          observer.error(NETWORK_ERROR);
+        });
+      } else {
+        return new Observable(observer => {
+          observer.next(GOOD_RESPONSE);
+          observer.complete();
+        });
+      }
+    });
+
+    const errorLink = new ErrorLink(
+      ({ networkError, response, operation, forward }) => {
+        try {
+          if (networkError) {
+            errorHandlerCalled = true;
+            expect(networkError).toEqual(NETWORK_ERROR);
+            return forward(operation);
+          }
+        } catch (error) {
+          done.fail(error);
+        }
+      },
+    );
+
+    const link = errorLink.concat(mockHttpLink);
+
+    execute(link, { query: QUERY, context: { bar: true } }).subscribe({
+      next(result) {
+        try {
+          expect(errorHandlerCalled).toBe(true);
+          expect(result).toEqual(GOOD_RESPONSE);
+        } catch (error) {
+          return done.fail(error);
+        }
+      },
+      complete() {
+        done();
+      },
+    });
+  });
+
+  it('returns errors from retried requests', done => {
+    let errorHandlerCalled = false;
+
+    let timesCalled = 0;
+    const mockHttpLink = new ApolloLink(operation => {
+      if (timesCalled === 0) {
+        timesCalled++;
+        // simulate the first request being an error
+        return new Observable(observer => {
+          observer.next(ERROR_RESPONSE as any);
+          observer.complete();
+        });
+      } else {
+        return new Observable(observer => {
+          observer.error(NETWORK_ERROR);
+        });
+      }
+    });
+
+    const errorLink = new ErrorLink(
+      ({ graphQLErrors, networkError, response, operation, forward }) => {
+        try {
+          if (graphQLErrors) {
+            errorHandlerCalled = true;
+            expect(graphQLErrors).toEqual(ERROR_RESPONSE.errors);
+            expect(response!.data).not.toBeDefined();
+            expect(operation.operationName).toBe('Foo');
+            expect(operation.getContext().bar).toBe(true);
+            // retry operation if it resulted in an error
+            return forward(operation);
+          }
+        } catch (error) {
+          done.fail(error);
+        }
+      },
+    );
+
+    const link = errorLink.concat(mockHttpLink);
+
+    let observerNextCalled = false;
+    execute(link, { query: QUERY, context: { bar: true } }).subscribe({
+      next(result) {
+        // should not be called
+        observerNextCalled = true;
+      },
+      error(error) {
+        // note that complete will not be after an error
+        // therefore we should end the test here with done()
+        expect(errorHandlerCalled).toBe(true);
+        expect(observerNextCalled).toBe(false);
+        expect(error).toEqual(NETWORK_ERROR);
+        done();
+      },
+    });
+  });
+});

--- a/src/link/error/index.ts
+++ b/src/link/error/index.ts
@@ -1,0 +1,115 @@
+import { GraphQLError, ExecutionResult } from 'graphql';
+
+import { ApolloLink } from '../core/ApolloLink';
+import { Observable } from '../../utilities/observables/Observable';
+import { Operation, FetchResult } from '../core/types';
+import { NextLink } from '../core/types';
+
+import { ServerError } from '../utils/throwServerError';
+import { ServerParseError } from '../http/parseAndCheckHttpResponse';
+
+export interface ErrorResponse {
+  graphQLErrors?: ReadonlyArray<GraphQLError>;
+  networkError?: Error | ServerError | ServerParseError;
+  response?: ExecutionResult;
+  operation: Operation;
+  forward: NextLink;
+}
+
+export namespace ErrorLink {
+  /**
+   * Callback to be triggered when an error occurs within the link stack.
+   */
+  export interface ErrorHandler {
+    (error: ErrorResponse): Observable<FetchResult> | void;
+  }
+}
+
+// For backwards compatibility.
+export import ErrorHandler = ErrorLink.ErrorHandler;
+
+export function onError(errorHandler: ErrorHandler): ApolloLink {
+  return new ApolloLink((operation, forward) => {
+    return new Observable(observer => {
+      let sub: any;
+      let retriedSub: any;
+      let retriedResult: any;
+
+      try {
+        sub = forward(operation).subscribe({
+          next: result => {
+            if (result.errors) {
+              retriedResult = errorHandler({
+                graphQLErrors: result.errors,
+                response: result,
+                operation,
+                forward,
+              });
+
+              if (retriedResult) {
+                retriedSub = retriedResult.subscribe({
+                  next: observer.next.bind(observer),
+                  error: observer.error.bind(observer),
+                  complete: observer.complete.bind(observer),
+                });
+                return;
+              }
+            }
+            observer.next(result);
+          },
+          error: networkError => {
+            retriedResult = errorHandler({
+              operation,
+              networkError,
+              //Network errors can return GraphQL errors on for example a 403
+              graphQLErrors:
+                networkError &&
+                networkError.result &&
+                networkError.result.errors,
+              forward,
+            });
+            if (retriedResult) {
+              retriedSub = retriedResult.subscribe({
+                next: observer.next.bind(observer),
+                error: observer.error.bind(observer),
+                complete: observer.complete.bind(observer),
+              });
+              return;
+            }
+            observer.error(networkError);
+          },
+          complete: () => {
+            // disable the previous sub from calling complete on observable
+            // if retry is in flight.
+            if (!retriedResult) {
+              observer.complete.bind(observer)();
+            }
+          },
+        });
+      } catch (e) {
+        errorHandler({ networkError: e, operation, forward });
+        observer.error(e);
+      }
+
+      return () => {
+        if (sub) sub.unsubscribe();
+        if (retriedSub) sub.unsubscribe();
+      };
+    });
+  });
+}
+
+export class ErrorLink extends ApolloLink {
+  private link: ApolloLink;
+  constructor(errorHandler: ErrorLink.ErrorHandler) {
+    super();
+    this.link = onError(errorHandler);
+  }
+
+  public request(
+    operation: Operation,
+    forward: NextLink,
+  ): Observable<FetchResult> | null {
+    return this.link.request(operation, forward);
+  }
+}

--- a/src/link/http/index.ts
+++ b/src/link/http/index.ts
@@ -1,0 +1,19 @@
+export {
+  parseAndCheckHttpResponse,
+  ServerParseError
+} from './parseAndCheckHttpResponse';
+export {
+  serializeFetchParameter,
+  ClientParseError
+} from './serializeFetchParameter';
+export {
+  HttpOptions,
+  fallbackHttpConfig,
+  selectHttpOptionsAndBody,
+  UriFunction
+} from './selectHttpOptionsAndBody';
+export { checkFetcher } from './checkFetcher';
+export { createSignalIfSupported } from './createSignalIfSupported';
+export { selectURI } from './selectURI';
+export { createHttpLink } from './createHttpLink';
+export { HttpLink } from './HttpLink';

--- a/src/link/retry/__tests__/delayFunction.ts
+++ b/src/link/retry/__tests__/delayFunction.ts
@@ -1,0 +1,82 @@
+import { buildDelayFunction } from '../delayFunction';
+
+describe('buildDelayFunction', () => {
+  // For easy testing of just the delay component, which is all we care about in
+  // the default implementation.
+  interface SimpleDelayFunction {
+    (count: number): number;
+  }
+
+  function delayRange(delayFunction: SimpleDelayFunction, count: number) {
+    const results = [];
+    for (let i = 1; i <= count; i++) {
+      results.push(delayFunction(i));
+    }
+    return results;
+  }
+
+  describe('without jitter', () => {
+    it('grows exponentially up to maxDelay', () => {
+      const delayFunction = buildDelayFunction({
+        jitter: false,
+        initial: 100,
+        max: 1000,
+      }) as SimpleDelayFunction;
+
+      expect(delayRange(delayFunction, 6)).toEqual([
+        100,
+        200,
+        400,
+        800,
+        1000,
+        1000,
+      ]);
+    });
+  });
+
+  describe('with jitter', () => {
+    let mockRandom: any, origRandom: any;
+    beforeEach(() => {
+      mockRandom = jest.fn();
+      origRandom = Math.random;
+      Math.random = mockRandom;
+    });
+
+    afterEach(() => {
+      Math.random = origRandom;
+    });
+
+    it('jitters, on average, exponentially up to maxDelay', () => {
+      const delayFunction = buildDelayFunction({
+        jitter: true,
+        initial: 100,
+        max: 1000,
+      }) as SimpleDelayFunction;
+
+      mockRandom.mockReturnValue(0.5);
+      expect(delayRange(delayFunction, 5)).toEqual([100, 200, 400, 500, 500]);
+    });
+
+    it('can have instant retries as the low end of the jitter range', () => {
+      const delayFunction = buildDelayFunction({
+        jitter: true,
+        initial: 100,
+        max: 1000,
+      }) as SimpleDelayFunction;
+
+      mockRandom.mockReturnValue(0);
+      expect(delayRange(delayFunction, 5)).toEqual([0, 0, 0, 0, 0]);
+    });
+
+    it('uses double the calculated delay as the high end of the jitter range, up to maxDelay', () => {
+      const delayFunction = buildDelayFunction({
+        jitter: true,
+        initial: 100,
+        max: 1000,
+      }) as SimpleDelayFunction;
+
+      mockRandom.mockReturnValue(1);
+      expect(delayRange(delayFunction, 5)).toEqual([200, 400, 800, 1000, 1000]);
+    });
+  });
+});

--- a/src/link/retry/__tests__/retryFunction.ts
+++ b/src/link/retry/__tests__/retryFunction.ts
@@ -1,0 +1,39 @@
+import { Operation } from '../../core/types';
+
+import { buildRetryFunction } from '../retryFunction';
+
+describe('buildRetryFunction', () => {
+  const operation = { operationName: 'foo' } as Operation;
+
+  it('stops after hitting maxTries', () => {
+    const retryFunction = buildRetryFunction({ max: 3 });
+
+    expect(retryFunction(2, operation, {})).toEqual(true);
+    expect(retryFunction(3, operation, {})).toEqual(false);
+    expect(retryFunction(4, operation, {})).toEqual(false);
+  });
+
+  it('skips retries if there was no error, by default', () => {
+    const retryFunction = buildRetryFunction();
+
+    expect(retryFunction(1, operation, undefined)).toEqual(false);
+    expect(retryFunction(1, operation, {})).toEqual(true);
+  });
+
+  it('supports custom predicates, but only if max is not exceeded', () => {
+    const stub = jest.fn(() => true);
+    const retryFunction = buildRetryFunction({ max: 3, retryIf: stub });
+
+    expect(retryFunction(2, operation, null)).toEqual(true);
+    expect(retryFunction(3, operation, null)).toEqual(false);
+  });
+
+  it('passes the error and operation through to custom predicates', () => {
+    const stub = jest.fn(() => true);
+    const retryFunction = buildRetryFunction({ max: 3, retryIf: stub });
+
+    const error = { message: 'bewm' };
+    retryFunction(1, operation, error);
+    expect(stub).toHaveBeenCalledWith(error, operation);
+  });
+});

--- a/src/link/retry/__tests__/retryLink.ts
+++ b/src/link/retry/__tests__/retryLink.ts
@@ -1,0 +1,191 @@
+import gql from 'graphql-tag';
+import waitFor from 'wait-for-observables';
+
+import { ApolloLink } from '../../core/ApolloLink';
+import { execute } from '../../core/execute';
+import { Observable } from '../../../utilities/observables/Observable';
+import { fromError } from '../../utils/fromError';
+import { RetryLink } from '../retryLink';
+
+const query = gql`
+  {
+    sample {
+      id
+    }
+  }
+`;
+
+const standardError = new Error('I never work');
+
+describe('RetryLink', () => {
+  it('fails for unreachable endpoints', async () => {
+    const max = 10;
+    const retry = new RetryLink({ delay: { initial: 1 }, attempts: { max } });
+    const stub = jest.fn(() => fromError(standardError)) as any;
+    const link = ApolloLink.from([retry, stub]);
+
+    const [{ error }] = await waitFor(execute(link, { query })) as any;
+    expect(error).toEqual(standardError);
+    expect(stub).toHaveBeenCalledTimes(max);
+  });
+
+  it('returns data from the underlying link on a successful operation', async () => {
+    const retry = new RetryLink();
+    const data = { data: { hello: 'world' } };
+    const stub = jest.fn(() => Observable.of(data));
+    const link = ApolloLink.from([retry, stub]);
+
+    const [{ values }] = await waitFor(execute(link, { query })) as any;
+    expect(values).toEqual([data]);
+    expect(stub).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns data from the underlying link on a successful retry', async () => {
+    const retry = new RetryLink({
+      delay: { initial: 1 },
+      attempts: { max: 2 },
+    });
+    const data = { data: { hello: 'world' } };
+    const stub = jest.fn();
+    stub.mockReturnValueOnce(fromError(standardError));
+    stub.mockReturnValueOnce(Observable.of(data));
+    const link = ApolloLink.from([retry, stub]);
+
+    const [{ values }] = await waitFor(execute(link, { query })) as any;
+    expect(values).toEqual([data]);
+    expect(stub).toHaveBeenCalledTimes(2);
+  });
+
+  it('calls unsubscribe on the appropriate downstream observable', async () => {
+    const retry = new RetryLink({
+      delay: { initial: 1 },
+      attempts: { max: 2 },
+    });
+    const data = { data: { hello: 'world' } };
+    const unsubscribeStub = jest.fn();
+
+    const firstTry = fromError(standardError);
+    // Hold the test hostage until we're hit
+    let secondTry;
+    const untilSecondTry = new Promise(resolve => {
+      secondTry = {
+        subscribe(observer: any) {
+          resolve(); // Release hold on test.
+
+          Promise.resolve().then(() => {
+            observer.next(data);
+            observer.complete();
+          });
+          return { unsubscribe: unsubscribeStub };
+        },
+      };
+    });
+
+    const stub = jest.fn();
+    stub.mockReturnValueOnce(firstTry);
+    stub.mockReturnValueOnce(secondTry);
+    const link = ApolloLink.from([retry, stub]);
+
+    const subscription = execute(link, { query }).subscribe({});
+    await untilSecondTry;
+    subscription.unsubscribe();
+    expect(unsubscribeStub).toHaveBeenCalledTimes(1);
+  });
+
+  it('supports multiple subscribers to the same request', async () => {
+    const retry = new RetryLink({
+      delay: { initial: 1 },
+      attempts: { max: 5 },
+    });
+    const data = { data: { hello: 'world' } };
+    const stub = jest.fn();
+    stub.mockReturnValueOnce(fromError(standardError));
+    stub.mockReturnValueOnce(fromError(standardError));
+    stub.mockReturnValueOnce(Observable.of(data));
+    const link = ApolloLink.from([retry, stub]);
+
+    const observable = execute(link, { query });
+    const [result1, result2] = await waitFor(observable, observable) as any;
+    expect(result1.values).toEqual([data]);
+    expect(result2.values).toEqual([data]);
+    expect(stub).toHaveBeenCalledTimes(3);
+  });
+
+  it('retries independently for concurrent requests', async () => {
+    const retry = new RetryLink({
+      delay: { initial: 1 },
+      attempts: { max: 5 },
+    });
+    const stub = jest.fn(() => fromError(standardError)) as any;
+    const link = ApolloLink.from([retry, stub]);
+
+    const [result1, result2] = await waitFor(
+      execute(link, { query }),
+      execute(link, { query }),
+    ) as any;
+    expect(result1.error).toEqual(standardError);
+    expect(result2.error).toEqual(standardError);
+    expect(stub).toHaveBeenCalledTimes(10);
+  });
+
+  it('supports custom delay functions', async () => {
+    const delayStub = jest.fn(() => 1);
+    const retry = new RetryLink({ delay: delayStub, attempts: { max: 3 } });
+    const linkStub = jest.fn(() => fromError(standardError)) as any;
+    const link = ApolloLink.from([retry, linkStub]);
+    const [{ error }] = await waitFor(execute(link, { query })) as any;
+
+    expect(error).toEqual(standardError);
+    const operation = (delayStub.mock.calls[0] as any)[1];
+    expect(delayStub.mock.calls).toEqual([
+      [1, operation, standardError],
+      [2, operation, standardError],
+    ]);
+  });
+
+  it('supports custom attempt functions', async () => {
+    const attemptStub = jest.fn();
+    attemptStub.mockReturnValueOnce(true);
+    attemptStub.mockReturnValueOnce(true);
+    attemptStub.mockReturnValueOnce(false);
+
+    const retry = new RetryLink({
+      delay: { initial: 1 },
+      attempts: attemptStub,
+    });
+    const linkStub = jest.fn(() => fromError(standardError)) as any;
+    const link = ApolloLink.from([retry, linkStub]);
+    const [{ error }] = await waitFor(execute(link, { query })) as any;
+
+    expect(error).toEqual(standardError);
+    const operation = attemptStub.mock.calls[0][1];
+    expect(attemptStub.mock.calls).toEqual([
+      [1, operation, standardError],
+      [2, operation, standardError],
+      [3, operation, standardError],
+    ]);
+  });
+
+  it('supports custom attempt functions that return either Promises or booleans', async () => {
+    const attemptStub = jest.fn();
+    attemptStub.mockReturnValueOnce(true);
+    attemptStub.mockReturnValueOnce(Promise.resolve(true));
+    attemptStub.mockReturnValueOnce(Promise.resolve(false));
+
+    const retry = new RetryLink({
+      delay: { initial: 1 },
+      attempts: attemptStub,
+    });
+    const linkStub = jest.fn(() => new Observable(o => o.error(standardError))) as any;
+    const link = ApolloLink.from([retry, linkStub]);
+    const [{ error }] = await waitFor(execute(link, { query })) as any;
+
+    expect(error).toEqual(standardError);
+    const operation = attemptStub.mock.calls[0][1];
+    expect(attemptStub.mock.calls).toEqual([
+      [1, operation, standardError],
+      [2, operation, standardError],
+      [3, operation, standardError],
+    ]);
+  });
+});

--- a/src/link/retry/delayFunction.ts
+++ b/src/link/retry/delayFunction.ts
@@ -1,0 +1,64 @@
+import { Operation } from '../core/types';
+
+/**
+ * Advanced mode: a function that implements the strategy for calculating delays
+ * for particular responses.
+ */
+export interface DelayFunction {
+  (count: number, operation: Operation, error: any): number;
+}
+
+export interface DelayFunctionOptions {
+  /**
+   * The number of milliseconds to wait before attempting the first retry.
+   *
+   * Delays will increase exponentially for each attempt.  E.g. if this is
+   * set to 100, subsequent retries will be delayed by 200, 400, 800, etc,
+   * until they reach maxDelay.
+   *
+   * Note that if jittering is enabled, this is the _average_ delay.
+   *
+   * Defaults to 300.
+   */
+  initial?: number;
+
+  /**
+   * The maximum number of milliseconds that the link should wait for any
+   * retry.
+   *
+   * Defaults to Infinity.
+   */
+  max?: number;
+
+  /**
+   * Whether delays between attempts should be randomized.
+   *
+   * This helps avoid thundering herd type situations by better distributing
+   * load during major outages.
+   *
+   * Defaults to true.
+   */
+  jitter?: boolean;
+}
+
+export function buildDelayFunction(
+  delayOptions?: DelayFunctionOptions,
+): DelayFunction {
+  const { initial = 300, jitter = true, max = Infinity } = delayOptions || {};
+  // If we're jittering, baseDelay is half of the maximum delay for that
+  // attempt (and is, on average, the delay we will encounter).
+  // If we're not jittering, adjust baseDelay so that the first attempt
+  // lines up with initialDelay, for everyone's sanity.
+  const baseDelay = jitter ? initial : initial / 2;
+
+  return function delayFunction(count: number) {
+    let delay = Math.min(max, baseDelay * 2 ** count);
+    if (jitter) {
+      // We opt for a full jitter approach for a mostly uniform distribution,
+      // but bound it within initialDelay and delay for everyone's sanity.
+      delay = Math.random() * delay;
+    }
+
+    return delay;
+  };
+}

--- a/src/link/retry/index.ts
+++ b/src/link/retry/index.ts
@@ -1,0 +1,1 @@
+export * from './retryLink';

--- a/src/link/retry/retryFunction.ts
+++ b/src/link/retry/retryFunction.ts
@@ -1,0 +1,41 @@
+import { Operation } from '../core/types';
+
+/**
+ * Advanced mode: a function that determines both whether a particular
+ * response should be retried.
+ */
+export interface RetryFunction {
+  (count: number, operation: Operation, error: any): boolean | Promise<boolean>;
+}
+
+export interface RetryFunctionOptions {
+  /**
+   * The max number of times to try a single operation before giving up.
+   *
+   * Note that this INCLUDES the initial request as part of the count.
+   * E.g. maxTries of 1 indicates no retrying should occur.
+   *
+   * Defaults to 5.  Pass Infinity for infinite retries.
+   */
+  max?: number;
+
+  /**
+   * Predicate function that determines whether a particular error should
+   * trigger a retry.
+   *
+   * For example, you may want to not retry 4xx class HTTP errors.
+   *
+   * By default, all errors are retried.
+   */
+  retryIf?: (error: any, operation: Operation) => boolean | Promise<boolean>;
+}
+
+export function buildRetryFunction(
+  retryOptions?: RetryFunctionOptions,
+): RetryFunction {
+  const { retryIf, max = 5 } = retryOptions || ({} as RetryFunctionOptions);
+  return function retryFunction(count, operation, error) {
+    if (count >= max) return false;
+    return retryIf ? retryIf(error, operation) : !!error;
+  };
+}

--- a/src/link/retry/retryLink.ts
+++ b/src/link/retry/retryLink.ts
@@ -1,0 +1,210 @@
+import { ApolloLink } from '../core/ApolloLink';
+import { Operation, FetchResult } from '../core/types';
+import { Observable } from '../../utilities/observables/Observable';
+import { NextLink } from '../core/types';
+import {
+  DelayFunction,
+  DelayFunctionOptions,
+  buildDelayFunction,
+} from './delayFunction';
+import {
+  RetryFunction,
+  RetryFunctionOptions,
+  buildRetryFunction,
+} from './retryFunction';
+
+export namespace RetryLink {
+  export interface Options {
+    /**
+     * Configuration for the delay strategy to use, or a custom delay strategy.
+     */
+    delay?: DelayFunctionOptions | DelayFunction;
+
+    /**
+     * Configuration for the retry strategy to use, or a custom retry strategy.
+     */
+    attempts?: RetryFunctionOptions | RetryFunction;
+  }
+}
+
+/**
+ * Tracking and management of operations that may be (or currently are) retried.
+ */
+class RetryableOperation<TValue = any> {
+  private retryCount: number = 0;
+  private values: any[] = [];
+  private error: any;
+  private complete = false;
+  private canceled = false;
+  private observers: (ZenObservable.Observer<TValue> | null)[] = [];
+  private currentSubscription: ZenObservable.Subscription | null = null;
+  private timerId: number | undefined;
+
+  constructor(
+    private operation: Operation,
+    private nextLink: NextLink,
+    private delayFor: DelayFunction,
+    private retryIf: RetryFunction,
+  ) {}
+
+  /**
+   * Register a new observer for this operation.
+   *
+   * If the operation has previously emitted other events, they will be
+   * immediately triggered for the observer.
+   */
+  public subscribe(observer: ZenObservable.Observer<TValue>) {
+    if (this.canceled) {
+      throw new Error(
+        `Subscribing to a retryable link that was canceled is not supported`,
+      );
+    }
+    this.observers.push(observer);
+
+    // If we've already begun, catch this observer up.
+    for (const value of this.values) {
+      observer.next!(value);
+    }
+
+    if (this.complete) {
+      observer.complete!();
+    } else if (this.error) {
+      observer.error!(this.error);
+    }
+  }
+
+  /**
+   * Remove a previously registered observer from this operation.
+   *
+   * If no observers remain, the operation will stop retrying, and unsubscribe
+   * from its downstream link.
+   */
+  public unsubscribe(observer: ZenObservable.Observer<TValue>) {
+    const index = this.observers.indexOf(observer);
+    if (index < 0) {
+      throw new Error(
+        `RetryLink BUG! Attempting to unsubscribe unknown observer!`,
+      );
+    }
+    // Note that we are careful not to change the order of length of the array,
+    // as we are often mid-iteration when calling this method.
+    this.observers[index] = null;
+
+    // If this is the last observer, we're done.
+    if (this.observers.every(o => o === null)) {
+      this.cancel();
+    }
+  }
+
+  /**
+   * Start the initial request.
+   */
+  public start() {
+    if (this.currentSubscription) return; // Already started.
+
+    this.try();
+  }
+
+  /**
+   * Stop retrying for the operation, and cancel any in-progress requests.
+   */
+  public cancel() {
+    if (this.currentSubscription) {
+      this.currentSubscription.unsubscribe();
+    }
+    clearTimeout(this.timerId);
+    this.timerId = undefined;
+    this.currentSubscription = null;
+    this.canceled = true;
+  }
+
+  private try() {
+    this.currentSubscription = this.nextLink(this.operation).subscribe({
+      next: this.onNext,
+      error: this.onError,
+      complete: this.onComplete,
+    });
+  }
+
+  private onNext = (value: any) => {
+    this.values.push(value);
+    for (const observer of this.observers) {
+      if (!observer) continue;
+      observer.next!(value);
+    }
+  };
+
+  private onComplete = () => {
+    this.complete = true;
+    for (const observer of this.observers) {
+      if (!observer) continue;
+      observer.complete!();
+    }
+  };
+
+  private onError = async (error: any) => {
+    this.retryCount += 1;
+
+    // Should we retry?
+    const shouldRetry = await this.retryIf(
+      this.retryCount,
+      this.operation,
+      error,
+    );
+    if (shouldRetry) {
+      this.scheduleRetry(this.delayFor(this.retryCount, this.operation, error));
+      return;
+    }
+
+    this.error = error;
+    for (const observer of this.observers) {
+      if (!observer) continue;
+      observer.error!(error);
+    }
+  };
+
+  private scheduleRetry(delay: number) {
+    if (this.timerId) {
+      throw new Error(`RetryLink BUG! Encountered overlapping retries`);
+    }
+
+    this.timerId = (setTimeout(() => {
+      this.timerId = undefined;
+      this.try();
+    }, delay) as any) as number;
+  }
+}
+
+export class RetryLink extends ApolloLink {
+  private delayFor: DelayFunction;
+  private retryIf: RetryFunction;
+
+  constructor(options?: RetryLink.Options) {
+    super();
+    const { attempts, delay } = options || ({} as RetryLink.Options);
+    this.delayFor =
+      typeof delay === 'function' ? delay : buildDelayFunction(delay);
+    this.retryIf =
+      typeof attempts === 'function' ? attempts : buildRetryFunction(attempts);
+  }
+
+  public request(
+    operation: Operation,
+    nextLink: NextLink,
+  ): Observable<FetchResult> {
+    const retryable = new RetryableOperation(
+      operation,
+      nextLink,
+      this.delayFor,
+      this.retryIf,
+    );
+    retryable.start();
+
+    return new Observable(observer => {
+      retryable.subscribe(observer);
+      return () => {
+        retryable.unsubscribe(observer);
+      };
+    });
+  }
+}

--- a/src/link/schema/__tests__/schemaLink.ts
+++ b/src/link/schema/__tests__/schemaLink.ts
@@ -1,0 +1,195 @@
+import { makeExecutableSchema } from 'graphql-tools';
+import gql from 'graphql-tag';
+
+import { execute } from '../../core/execute';
+import { SchemaLink } from '../';
+
+const sampleQuery = gql`
+  query SampleQuery {
+    sampleQuery {
+      id
+    }
+  }
+`;
+
+const typeDefs = `
+type Stub {
+  id: String
+}
+
+type Query {
+  sampleQuery: Stub
+}
+`;
+
+const schema = makeExecutableSchema({ typeDefs });
+
+describe('SchemaLink', () => {
+  const mockError = { throws: new TypeError('mock me') };
+
+  it('raises warning if called with concat', () => {
+    const link = new SchemaLink({ schema });
+    const _warn = console.warn;
+    console.warn = (warning: any) => expect(warning['message']).toBeDefined();
+    expect(link.concat((operation, forward) => forward(operation))).toEqual(
+      link,
+    );
+    console.warn = _warn;
+  });
+
+  it('throws if no arguments given', () => {
+    expect(() => new (SchemaLink as any)()).toThrow();
+  });
+
+  it('correctly receives the constructor arguments', () => {
+    let rootValue = {};
+    let link = new SchemaLink({ schema, rootValue });
+    expect(link.rootValue).toEqual(rootValue);
+    expect(link.schema).toEqual(schema);
+  });
+
+  it('calls next and then complete', done => {
+    const next = jest.fn();
+    const link = new SchemaLink({ schema });
+    const observable = execute(link, {
+      query: sampleQuery,
+    });
+    observable.subscribe({
+      next,
+      error: error => expect(false),
+      complete: () => {
+        expect(next).toHaveBeenCalledTimes(1);
+        done();
+      },
+    });
+  });
+
+  it('calls error when fetch fails', done => {
+    const badSchema = makeExecutableSchema({ typeDefs });
+
+    const link = new SchemaLink({ schema: badSchema });
+    const observable = execute(link, {
+      query: sampleQuery,
+    });
+    observable.subscribe(
+      result => expect(false),
+      error => {
+        expect(error).toEqual(mockError.throws);
+        done();
+      },
+      () => {
+        expect(false);
+        done();
+      },
+    );
+  });
+
+  it('supports query which is executed synchronously', done => {
+    const next = jest.fn();
+    const link = new SchemaLink({ schema });
+    const introspectionQuery = gql`
+      query IntrospectionQuery {
+        __schema {
+          types {
+            name
+          }
+        }
+      }
+    `;
+    const observable = execute(link, {
+      query: introspectionQuery,
+    });
+    observable.subscribe(
+      next,
+      error => expect(false),
+      () => {
+        expect(next).toHaveBeenCalledTimes(1);
+        done();
+      },
+    );
+  });
+
+  it('passes operation context into execute with context function', done => {
+    const next = jest.fn();
+    const contextValue = { some: 'value' };
+    const contextProvider = jest.fn(operation => operation.getContext());
+    const resolvers = {
+      Query: {
+        sampleQuery: (root: any, args: any, context: any) => {
+          try {
+            expect(context).toEqual(contextValue);
+          } catch (error) {
+            done.fail('Should pass context into resolver');
+          }
+        },
+      },
+    };
+    const schemaWithResolvers = makeExecutableSchema({
+      typeDefs,
+      resolvers,
+    });
+    const link = new SchemaLink({
+      schema: schemaWithResolvers,
+      context: contextProvider,
+    });
+    const observable = execute(link, {
+      query: sampleQuery,
+      context: contextValue,
+    });
+    observable.subscribe(
+      next,
+      error => done.fail("Shouldn't call onError"),
+      () => {
+        try {
+          expect(next).toHaveBeenCalledTimes(1);
+          expect(contextProvider).toHaveBeenCalledTimes(1);
+          done();
+        } catch (e) {
+          done.fail(e);
+        }
+      },
+    );
+  });
+
+  it('passes static context into execute', done => {
+    const next = jest.fn();
+    const contextValue = { some: 'value' };
+    const resolver = jest.fn((root, args, context) => {
+      try {
+        expect(context).toEqual(contextValue);
+      } catch (error) {
+        done.fail('Should pass context into resolver');
+      }
+    });
+
+    const resolvers = {
+      Query: {
+        sampleQuery: resolver,
+      },
+    };
+    const schemaWithResolvers = makeExecutableSchema({
+      typeDefs,
+      resolvers,
+    });
+    const link = new SchemaLink({
+      schema: schemaWithResolvers,
+      context: contextValue,
+    });
+    const observable = execute(link, {
+      query: sampleQuery,
+    });
+    observable.subscribe(
+      next,
+      error => done.fail("Shouldn't call onError"),
+      () => {
+        try {
+          expect(next).toHaveBeenCalledTimes(1);
+          expect(resolver).toHaveBeenCalledTimes(1);
+          done();
+        } catch (e) {
+          done.fail(e);
+        }
+      },
+    );
+  });
+});

--- a/src/link/schema/index.ts
+++ b/src/link/schema/index.ts
@@ -1,0 +1,71 @@
+import { execute } from 'graphql/execution/execute';
+import { GraphQLSchema } from 'graphql/type/schema';
+
+import { ApolloLink } from '../core/ApolloLink';
+import { Operation, FetchResult } from '../core/types';
+import { Observable } from '../../utilities/observables/Observable';
+
+export namespace SchemaLink {
+  export type ResolverContextFunction = (
+    operation: Operation,
+  ) => Record<string, any>;
+
+  export interface Options {
+    /**
+     * The schema to generate responses from.
+     */
+    schema: GraphQLSchema;
+
+    /**
+     * The root value to use when generating responses.
+     */
+    rootValue?: any;
+
+    /**
+     * A context to provide to resolvers declared within the schema.
+     */
+    context?: ResolverContextFunction | Record<string, any>;
+  }
+}
+
+export class SchemaLink extends ApolloLink {
+  public schema: GraphQLSchema;
+  public rootValue: any;
+  public context: SchemaLink.ResolverContextFunction | any;
+
+  constructor({ schema, rootValue, context }: SchemaLink.Options) {
+    super();
+
+    this.schema = schema;
+    this.rootValue = rootValue;
+    this.context = context;
+  }
+
+  public request(operation: Operation): Observable<FetchResult> | null {
+    return new Observable<FetchResult>(observer => {
+      Promise.resolve(
+        execute(
+          this.schema,
+          operation.query,
+          this.rootValue,
+          typeof this.context === 'function'
+            ? this.context(operation)
+            : this.context,
+          operation.variables,
+          operation.operationName,
+        ),
+      )
+        .then(data => {
+          if (!observer.closed) {
+            observer.next(data);
+            observer.complete();
+          }
+        })
+        .catch(error => {
+          if (!observer.closed) {
+            observer.error(error);
+          }
+        });
+    });
+  }
+}

--- a/src/link/utils/index.ts
+++ b/src/link/utils/index.ts
@@ -1,0 +1,4 @@
+export { fromError } from './fromError';
+export { toPromise } from './toPromise';
+export { fromPromise } from './fromPromise';
+export { ServerError, throwServerError } from './throwServerError';

--- a/src/link/ws/__tests__/webSocketLink.ts
+++ b/src/link/ws/__tests__/webSocketLink.ts
@@ -1,0 +1,124 @@
+import { SubscriptionClient } from 'subscriptions-transport-ws';
+import { ExecutionResult } from 'graphql';
+import gql from 'graphql-tag';
+
+import { Observable } from '../../../utilities/observables/Observable';
+import { execute } from '../../core/execute';
+import { WebSocketLink } from '../webSocketLink';
+
+const query = gql`
+  query SampleQuery {
+    stub {
+      id
+    }
+  }
+`;
+
+const mutation = gql`
+  mutation SampleMutation {
+    stub {
+      id
+    }
+  }
+`;
+
+const subscription = gql`
+  subscription SampleSubscription {
+    stub {
+      id
+    }
+  }
+`;
+
+describe('WebSocketLink', () => {
+  it('constructs', () => {
+    const client: any = {};
+    client.__proto__ = SubscriptionClient.prototype;
+    expect(() => new WebSocketLink(client)).not.toThrow();
+  });
+
+  // TODO some sort of dependency injection
+
+  // it('should pass the correct initialization parameters to the Subscription Client', () => {
+  // });
+
+  it('should call request on the client for a query', done => {
+    const result = { data: { data: 'result' } };
+    const client: any = {};
+    const observable = Observable.of(result);
+    client.__proto__ = SubscriptionClient.prototype;
+    client.request = jest.fn();
+    client.request.mockReturnValueOnce(observable);
+    const link = new WebSocketLink(client);
+
+    const obs = execute(link, { query });
+    expect(obs).toEqual(observable);
+    obs.subscribe(data => {
+      expect(data).toEqual(result);
+      expect(client.request).toHaveBeenCalledTimes(1);
+      done();
+    });
+  });
+
+  it('should call query on the client for a mutation', done => {
+    const result = { data: { data: 'result' } };
+    const client: any = {};
+    const observable = Observable.of(result);
+    client.__proto__ = SubscriptionClient.prototype;
+    client.request = jest.fn();
+    client.request.mockReturnValueOnce(observable);
+    const link = new WebSocketLink(client);
+
+    const obs = execute(link, { query: mutation });
+    expect(obs).toEqual(observable);
+    obs.subscribe(data => {
+      expect(data).toEqual(result);
+      expect(client.request).toHaveBeenCalledTimes(1);
+      done();
+    });
+  });
+
+  it('should call request on the subscriptions client for subscription', done => {
+    const result = { data: { data: 'result' } };
+    const client: any = {};
+    const observable = Observable.of(result);
+    client.__proto__ = SubscriptionClient.prototype;
+    client.request = jest.fn();
+    client.request.mockReturnValueOnce(observable);
+    const link = new WebSocketLink(client);
+
+    const obs = execute(link, { query: mutation });
+    expect(obs).toEqual(observable);
+    obs.subscribe(data => {
+      expect(data).toEqual(result);
+      expect(client.request).toHaveBeenCalledTimes(1);
+      done();
+    });
+  });
+
+  it('should call next with multiple results for subscription', done => {
+    const results = [
+      { data: { data: 'result1' } },
+      { data: { data: 'result2' } },
+    ];
+    const client: any = {};
+    client.__proto__ = SubscriptionClient.prototype;
+    client.request = jest.fn(() => {
+      const copy = [...results];
+      return new Observable<ExecutionResult>(observer => {
+        observer.next(copy[0]);
+        observer.next(copy[1]);
+      });
+    });
+
+    const link = new WebSocketLink(client);
+
+    execute(link, { query: subscription }).subscribe(data => {
+      expect(client.request).toHaveBeenCalledTimes(1);
+      expect(data).toEqual(results.shift());
+      if (results.length === 0) {
+        done();
+      }
+    });
+  });
+});

--- a/src/link/ws/index.ts
+++ b/src/link/ws/index.ts
@@ -1,0 +1,1 @@
+export * from './webSocketLink';

--- a/src/link/ws/webSocketLink.ts
+++ b/src/link/ws/webSocketLink.ts
@@ -1,0 +1,56 @@
+import { ApolloLink } from '../core/ApolloLink';
+import { Operation, FetchResult } from '../core/types';
+import { Observable } from '../../utilities/observables/Observable';
+
+import { SubscriptionClient, ClientOptions } from 'subscriptions-transport-ws';
+
+export namespace WebSocketLink {
+  /**
+   * Configuration to use when constructing the subscription client (subscriptions-transport-ws).
+   */
+  export interface Configuration {
+    /**
+     * The endpoint to connect to.
+     */
+    uri: string;
+
+    /**
+     * Options to pass when constructing the subscription client.
+     */
+    options?: ClientOptions;
+
+    /**
+     * A custom WebSocket implementation to use.
+     */
+    webSocketImpl?: any;
+  }
+}
+
+// For backwards compatibility.
+export import WebSocketParams = WebSocketLink.Configuration;
+
+export class WebSocketLink extends ApolloLink {
+  private subscriptionClient: SubscriptionClient;
+
+  constructor(
+    paramsOrClient: WebSocketLink.Configuration | SubscriptionClient,
+  ) {
+    super();
+
+    if (paramsOrClient instanceof SubscriptionClient) {
+      this.subscriptionClient = paramsOrClient;
+    } else {
+      this.subscriptionClient = new SubscriptionClient(
+        paramsOrClient.uri,
+        paramsOrClient.options,
+        paramsOrClient.webSocketImpl,
+      );
+    }
+  }
+
+  public request(operation: Operation): Observable<FetchResult> | null {
+    return this.subscriptionClient.request(operation) as Observable<
+      FetchResult
+    >;
+  }
+}


### PR DESCRIPTION
This PR merges the remaining [`apollo-link`](https://github.com/apollographql/apollo-link) links into Apollo Client, giving each of them their own bundle/entry point:

* `apollo-link-batch` is now accessible via `@apollo/client/link/batch`
* `apollo-link-batch-http` is now accessible via `@apollo/client/link/batch-http`
* `apollo-link-context` is now accessible via `@apollo/client/link/context`
* `apollo-link-error` is now accessible via `@apollo/client/link/error`
* `apollo-link-retry` is now accessible via `@apollo/client/link/retry`
* `apollo-link-schema` is now accessible via `@apollo/client/link/schema`
* `apollo-link-ws` is now accessible via `@apollo/client/link/ws`

We were previously planning on leaving these links in the `apollo-link` repo, and publishing them with new `@apollo/link-X` naming. We have since decided that there is more value in managing these links as part of the Apollo Client project, to help streamline library maintenance, and pave the way for tighter / more efficient Apollo Client interactions.

A quick note for reviewers (@benjamn @jcreighton): I've migrated the code as is (updating whatever needed updating to get the tests to pass), so you might want to skip over the link code / tests. https://github.com/apollographql/apollo-client/commit/044db31a7ed6148d62db7a53931b0e91334ae6e8 and https://github.com/apollographql/apollo-client/commit/f5dba6e27833875412288c4abf7fc55c7da6c306 are the main commits to review. Thanks!