### PR TITLE
Stop blocking duplicate renders based on skip settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -238,6 +238,9 @@
 - Expand `ApolloError` typings to include `ServerError` and `ServerParseError`.  <br/>
   [@dmarkow](https://github.com/dmarkow) in [#6319](https://github.com/apollographql/apollo-client/pull/6319)
 
+- Fast responses received over the link chain will no longer conflict with `skip` settings.  <br/>
+  [@hwillson](https://github.com/hwillson) in [#6587](https://github.com/apollographql/apollo-client/pull/6587)
+
 ## Apollo Client 2.6.8
 
 ### Apollo Client (2.6.8)

--- a/src/react/data/QueryData.ts
+++ b/src/react/data/QueryData.ts
@@ -279,18 +279,6 @@ export class QueryData<TData, TVariables> extends OperationData {
           return;
         }
 
-        // If we skipped previously, `previousResult.data` is set to undefined.
-        // When this subscription is run after skipping, Apollo Client sends
-        // the last query result data alongside the `loading` true state. This
-        // means the previous skipped `data` of undefined and the incoming
-        // data won't match, which would normally mean we want to trigger a
-        // render to show the new data. In this case however we're already
-        // showing the loading state, and want to avoid triggering an
-        // additional and unnecessary render showing the same loading state.
-        if (this.previousOptions.skip) {
-          return;
-        }
-
         onNewData();
       },
       error: error => {

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -2073,27 +2073,29 @@ describe('useQuery Hook', () => {
   describe('Skipping', () => {
     itAsync('should skip running a query when `skip` is `true`', (resolve, reject) => {
       let renderCount = 0;
+
       const Component = () => {
         const [skip, setSkip] = useState(true);
         const { loading, data } = useQuery(CAR_QUERY, { skip });
-        switch (renderCount) {
-          case 0:
+
+        switch (++renderCount) {
+          case 1:
             expect(loading).toBeFalsy();
             expect(data).toBeUndefined();
             setTimeout(() => setSkip(false));
             break;
-          case 1:
+          case 2:
             expect(loading).toBeTruthy();
             expect(data).toBeUndefined();
             break;
-          case 2:
+          case 3:
             expect(loading).toBeFalsy();
             expect(data).toEqual(CAR_RESULT_DATA);
             break;
           default:
+            reject("too many renders");
         }
 
-        renderCount += 1;
         return null;
       };
 
@@ -2103,7 +2105,9 @@ describe('useQuery Hook', () => {
         </MockedProvider>
       );
 
-      return wait(() => expect(renderCount).toBe(3)).then(resolve, reject);
+      return wait(() => {
+        expect(renderCount).toBe(3);
+      }).then(resolve, reject);
     });
   });
 });

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -2069,4 +2069,41 @@ describe('useQuery Hook', () => {
       }).then(resolve, reject);
     });
   });
+
+  describe('Skipping', () => {
+    itAsync('should skip running a query when `skip` is `true`', (resolve, reject) => {
+      let renderCount = 0;
+      const Component = () => {
+        const [skip, setSkip] = useState(true);
+        const { loading, data } = useQuery(CAR_QUERY, { skip });
+        switch (renderCount) {
+          case 0:
+            expect(loading).toBeFalsy();
+            expect(data).toBeUndefined();
+            setTimeout(() => setSkip(false));
+            break;
+          case 1:
+            expect(loading).toBeTruthy();
+            expect(data).toBeUndefined();
+            break;
+          case 2:
+            expect(loading).toBeFalsy();
+            expect(data).toEqual(CAR_RESULT_DATA);
+            break;
+          default:
+        }
+
+        renderCount += 1;
+        return null;
+      };
+
+      render(
+        <MockedProvider mocks={CAR_MOCKS}>
+          <Component />
+        </MockedProvider>
+      );
+
+      return wait(() => expect(renderCount).toBe(3)).then(resolve, reject);
+    });
+  });
 });


### PR DESCRIPTION
Recent Apollo Client core refactoring has made it unnecessary to attempt to block duplicate `useQuery` renders when `skip` is `true`.

Fixes #5877