### PR TITLE
Ignore option callbacks when deciding to update a query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Rework interdependencies between `@apollo/client/*` entry points, so that CommonJS and ESM modules are supported equally well, without any duplication of shared code. <br/>
   [@benjamn](https://github.com/benjamn) in [#6058](https://github.com/apollographql/apollo-client/pull/6058)
 
+- Tolerate `!==` callback functions (like `onCompleted` and `onError`) in `useQuery` options, since those functions are almost always freshly evaluated each time `useQuery` is called. <br/>
+  [@hwillson](https://github.com/hwillson) and [@benjamn](https://github.com/benjamn) in [#6588](https://github.com/apollographql/apollo-client/pull/6588)
+
 ## Apollo Client 3.0.2
 
 ## Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -2523,9 +2523,9 @@
       }
     },
     "@wry/equality": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.9.tgz",
-      "integrity": "sha512-mB6ceGjpMGz1ZTza8HYnrPGos2mC6So4NhS1PtZ8s4Qt0K7fBiIGhpSxUbQmhwcSWE3no+bYxmI2OL6KuXYmoQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.2.0.tgz",
+      "integrity": "sha512-Y4d+WH6hs+KZJUC8YKLYGarjGekBrhslDbf/R20oV+AakHPINSitHfDRQz3EGcEWc1luXYNUvMhawWtZVWNGvQ==",
       "requires": {
         "tslib": "^1.9.3"
       }
@@ -2678,6 +2678,17 @@
         "fast-json-stable-stringify": "^2.0.0",
         "ts-invariant": "^0.4.0",
         "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "@wry/equality": {
+          "version": "0.1.11",
+          "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.11.tgz",
+          "integrity": "sha512-mwEVBDUVODlsQQ5dfuLUS5/Tf7jqUKyhKYHmVi4fPB6bDMOfWvUPJmKgS1Z7Za/sOI3vzWt4+O7yCiL/70MogA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.3"
+          }
+        }
       }
     },
     "aproba": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "dependencies": {
     "@types/zen-observable": "^0.8.0",
     "@wry/context": "^0.5.2",
-    "@wry/equality": "^0.1.9",
+    "@wry/equality": "^0.2.0",
     "fast-json-stable-stringify": "^2.0.0",
     "graphql-tag": "^2.10.4",
     "hoist-non-react-statics": "^3.3.2",

--- a/src/react/data/QueryData.ts
+++ b/src/react/data/QueryData.ts
@@ -26,6 +26,8 @@ import {
 } from '../types/types';
 import { OperationData } from './OperationData';
 
+const stripFns = ({ onCompleted, onError, ...rest }: any = {}) => rest;
+
 export class QueryData<TData, TVariables> extends OperationData {
   public onNewData: () => void;
 
@@ -238,12 +240,15 @@ export class QueryData<TData, TVariables> extends OperationData {
       children: null
     };
 
-    if (
-      !equal(
-        newObservableQueryOptions,
-        this.previousData.observableQueryOptions
-      )
-    ) {
+    // When comparing new options against previously stored options,
+    // we'll ignore callback functions since their identities are not
+    // stable, meaning they'll always show as being different. Ignoring
+    // them when determining if options have changed is okay however, as
+    // callback functions are not normally changed between renders.
+    if (!equal(
+      stripFns(newObservableQueryOptions),
+      stripFns(this.previousData.observableQueryOptions),
+    )) {
       this.previousData.observableQueryOptions = newObservableQueryOptions;
       this.currentObservable
         .setOptions(newObservableQueryOptions)

--- a/src/react/data/QueryData.ts
+++ b/src/react/data/QueryData.ts
@@ -26,8 +26,6 @@ import {
 } from '../types/types';
 import { OperationData } from './OperationData';
 
-const stripFns = ({ onCompleted, onError, ...rest }: any = {}) => rest;
-
 export class QueryData<TData, TVariables> extends OperationData {
   public onNewData: () => void;
 
@@ -240,15 +238,12 @@ export class QueryData<TData, TVariables> extends OperationData {
       children: null
     };
 
-    // When comparing new options against previously stored options,
-    // we'll ignore callback functions since their identities are not
-    // stable, meaning they'll always show as being different. Ignoring
-    // them when determining if options have changed is okay however, as
-    // callback functions are not normally changed between renders.
-    if (!equal(
-      stripFns(newObservableQueryOptions),
-      stripFns(this.previousData.observableQueryOptions),
-    )) {
+    if (
+      !equal(
+        newObservableQueryOptions,
+        this.previousData.observableQueryOptions
+      )
+    ) {
       this.previousData.observableQueryOptions = newObservableQueryOptions;
       this.currentObservable
         .setOptions(newObservableQueryOptions)

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -1814,6 +1814,43 @@ describe('useQuery Hook', () => {
 
       return wait().then(resolve, reject);
     });
+
+    itAsync(
+      'should not make extra network requests when `onCompleted` is ' +
+      'defined with a `network-only` fetch policy',
+      (resolve, reject) => {
+        let renderCount = 0;
+        function Component() {
+          const { loading, data } = useQuery(CAR_QUERY, {
+            fetchPolicy: 'network-only',
+            onCompleted: () => undefined
+          });
+          switch (++renderCount) {
+            case 1:
+              expect(loading).toBeTruthy();
+              break;
+            case 2:
+              expect(loading).toBeFalsy();
+              expect(data).toEqual(CAR_RESULT_DATA);
+              break;
+            case 3:
+              fail('Too many renders');
+            default:
+          }
+          return null;
+        }
+
+        render(
+          <MockedProvider mocks={CAR_MOCKS}>
+            <Component />
+          </MockedProvider>
+        );
+
+        return wait(() => {
+          expect(renderCount).toBe(2);
+        }).then(resolve, reject);
+      }
+    );
   });
 
   describe('Optimistic data', () => {


### PR DESCRIPTION
`QueryData` stores last used options to help decide when it should re-run. If new options (when compared against the previously stored last options) are found, `QueryData` will make sure the new options are passed into Apollo Client for processing. When `onCompleted` and/or `onError` options are set however, `QueryData` thinks the options received on each render are new as these callback functions don't have a stable identity. This can then lead to infinite re-renders.

This commit adjusts the `QueryData` option equality check to ignore option callbacks. During normal use of `useQuery` it should be okay to ignore callbacks like this, as they don't normally change between renders.

Fixes #6301