### PR TITLE
Create a `@apollo/client/link/http` CJS bundle

### DIFF
--- a/config/prepareDist.js
+++ b/config/prepareDist.js
@@ -177,3 +177,9 @@ fs.writeFileSync(
   `${distRoot}/link/ws/package.json`,
   buildPackageJson('ws', 'link/ws')
 );
+
+// @apollo/client/link/http
+fs.writeFileSync(
+  `${distRoot}/link/http/package.json`,
+  buildPackageJson('http', 'link/http')
+);

--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -209,6 +209,7 @@ function rollup() {
     prepareBundle('retry', 'link/retry'),
     prepareBundle('schema', 'link/schema'),
     prepareBundle('ws', 'link/ws'),
+    prepareBundle('http', 'link/http'),
   ];
 }
 

--- a/src/link/http/index.ts
+++ b/src/link/http/index.ts
@@ -17,3 +17,4 @@ export { createSignalIfSupported } from './createSignalIfSupported';
 export { selectURI } from './selectURI';
 export { createHttpLink } from './createHttpLink';
 export { HttpLink } from './HttpLink';
+export { rewriteURIForGET } from './rewriteURIForGET';


### PR DESCRIPTION
Since the HTTP link is required by Apollo Client, its contents are already requireable when using CJS with the `@apollo/client` CJS bundle. There might be cases where people want to import HTTP link functionality directly however, so we'll also create a HTTP link CJS bundle. While we're in here, let's also expose `rewriteURIForGET` (since this was exposed in `apollo-link-http`).

Fixes #6109