### PR TITLE
Replace existing edges when args.{after,before} not provided.

### DIFF
--- a/src/cache/inmemory/__tests__/__snapshots__/policies.ts.snap
+++ b/src/cache/inmemory/__tests__/__snapshots__/policies.ts.snap
@@ -598,3 +598,120 @@ Object {
   },
 }
 `;
+
+exports[`type policies field policies can handle Relay-style pagination 8`] = `
+Object {
+  "Artist:{\\"href\\":\\"/artist/james-turrell\\"}": Object {
+    "__typename": "Artist",
+    "bio": "American, born 1943, Los Angeles, California",
+    "displayLabel": "James Turrell",
+    "href": "/artist/james-turrell",
+  },
+  "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}": Object {
+    "__typename": "Artist",
+    "bio": "",
+    "displayLabel": "Reminiscent of Basquiat",
+    "href": "/artist/reminiscent-of-basquiat",
+  },
+  "ROOT_QUERY": Object {
+    "__typename": "Query",
+    "search:basquiat": Object {
+      "edges": Array [
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
+          "node": Object {
+            "__ref": "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjE=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
+            "displayLabel": "ephemera BASQUIAT",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
+            "displayLabel": "Jean-Michel Basquiat | Xerox",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Banksy, SEEN, JonOne and QUIK at Artrust Oct 8th – Dec 16th 2017",
+            "displayLabel": "STREET ART: From Basquiat to Banksy",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Jean-Michel Basquiat, Shepard Fairey, COPE2, Pure Evil, Sickboy, Blade, Kurar, and LARS at Artrust",
+            "displayLabel": "STREET ART 2: From Basquiat to Banksy",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjU=",
+          "node": Object {
+            "__ref": "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjY=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Jean-Michel Basquiat at Brooklyn Museum Apr 3rd – Aug 23rd 2015",
+            "displayLabel": "Basquiat: The Unknown Notebooks",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "__typename": "PageInfo",
+        "endCursor": "YXJyYXljb25uZWN0aW9uOjY=",
+        "hasNextPage": true,
+        "hasPreviousPage": false,
+        "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
+      },
+      "totalCount": 1292,
+    },
+    "search:james turrell": Object {
+      "edges": Array [
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
+          "node": Object {
+            "__ref": "Artist:{\\"href\\":\\"/artist/james-turrell\\"}",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjEx",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "displayLabel": "James Turrell: Light knows when we’re looking",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "__typename": "PageInfo",
+        "endCursor": "YXJyYXljb25uZWN0aW9uOjEx",
+        "hasNextPage": true,
+        "hasPreviousPage": false,
+        "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
+      },
+      "totalCount": 13531,
+    },
+  },
+}
+`;

--- a/src/utilities/policies/pagination.ts
+++ b/src/utilities/policies/pagination.ts
@@ -99,6 +99,11 @@ export function relayStylePagination<TNode = Reference>(
         const index = prefix.findIndex(edge => edge.cursor === args.before);
         suffix = index < 0 ? prefix : prefix.slice(index);
         prefix = [];
+      } else {
+        // If we have neither args.after nor args.before, the incoming
+        // edges cannot be spliced into the existing edges, so they must
+        // replace the existing edges. See #6592 for a motivating example.
+        prefix = [];
       }
 
       const edges = [


### PR DESCRIPTION
If the `relayStylePagination` `merge` function receives neither `args.after` nor `args.before`, the incoming edges cannot be spliced into the existing edges by cursor, so they must replace the existing edges.

Should fix #6592.