### PR TITLE
Docs: Add skip to subscription options

### DIFF
--- a/docs/shared/subscription-options.mdx
+++ b/docs/shared/subscription-options.mdx
@@ -3,7 +3,7 @@
 | `subscription` | DocumentNode | A GraphQL subscription document parsed into an AST by `graphql-tag`. **Optional** for the `useSubscription` Hook since the subscription can be passed in as the first parameter to the Hook. **Required** for the `Subscription` component. |
 | `variables` | { [key: string]: any } | An object containing all of the variables your subscription needs to execute |
 | `shouldResubscribe` | boolean | Determines if your subscription should be unsubscribed and subscribed again |
-| `skip` | boolean | If skip is true, the subscription will be skipped entirely |
+| `skip` | boolean | If `skip` is `true`, the subscription will be skipped entirely |
 | `onSubscriptionData` | (options: OnSubscriptionDataOptions&lt;TData&gt;) => any | Allows the registration of a callback function, that will be triggered each time the `useSubscription` Hook / `Subscription` component receives data. The callback `options` object param consists of the current Apollo Client instance in `client`, and the received subscription data in `subscriptionData`. |
 | `fetchPolicy` | FetchPolicy | How you want your component to interact with the Apollo cache. Defaults to "cache-first". |
 | `client` | ApolloClient | An `ApolloClient` instance. By default `useSubscription` / `Subscription` uses the client passed down via context, but a different client can be passed in. |

--- a/docs/shared/subscription-options.mdx
+++ b/docs/shared/subscription-options.mdx
@@ -3,6 +3,7 @@
 | `subscription` | DocumentNode | A GraphQL subscription document parsed into an AST by `graphql-tag`. **Optional** for the `useSubscription` Hook since the subscription can be passed in as the first parameter to the Hook. **Required** for the `Subscription` component. |
 | `variables` | { [key: string]: any } | An object containing all of the variables your subscription needs to execute |
 | `shouldResubscribe` | boolean | Determines if your subscription should be unsubscribed and subscribed again |
+| `skip` | boolean | If skip is true, the subscription will be skipped entirely |
 | `onSubscriptionData` | (options: OnSubscriptionDataOptions&lt;TData&gt;) => any | Allows the registration of a callback function, that will be triggered each time the `useSubscription` Hook / `Subscription` component receives data. The callback `options` object param consists of the current Apollo Client instance in `client`, and the received subscription data in `subscriptionData`. |
 | `fetchPolicy` | FetchPolicy | How you want your component to interact with the Apollo cache. Defaults to "cache-first". |
 | `client` | ApolloClient | An `ApolloClient` instance. By default `useSubscription` / `Subscription` uses the client passed down via context, but a different client can be passed in. |


### PR DESCRIPTION
The `skip` options was added to `useSubscription` towards the end of last year. This just updates the docs for that change.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
