### PR TITLE
Update migrating guide for SSR

### DIFF
--- a/docs/source/migrating/hooks-migration.md
+++ b/docs/source/migrating/hooks-migration.md
@@ -49,10 +49,10 @@ npm install @apollo/client @apollo/react-components @apollo/react-hoc
 
 ## Server-side rendering
 
-The `getDataFromTree` and `renderToStringWithData` React SSR functions are not bundled with Apollo Client, in order to help reduce bundle sizes for those who aren't using SSR. If you want to use these functions, you'll need to add in the `@apollo/react-ssr` package:
+The `getDataFromTree`, `getMarkupFromTree`, and `renderToStringWithData` React SSR functions are bundled with Apollo Client 3. If you want to use these functions, you'll need to import them from `@apollo/client/react/ssr`:
 
 ```
-npm install @apollo/react-ssr
+import { getDataFromTree } from "@apollo/client/react/ssr";
 ```
 
 ## Testing


### PR DESCRIPTION
The Apollo Client SSR functionality is migrated into `@apollo/client` - @hwillson in [#6499](https://github.com/apollographql/apollo-client/issues/6499). This PR updates the migration guide page in the v3 documentation.
