### PR TITLE
Revert "Update package.json peerDependencies (#6594)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,9 +55,9 @@
     }
   ],
   "peerDependencies": {
-    "graphql": ">=14.0.0",
-    "react": ">=16.8.0",
-    "subscriptions-transport-ws": ">=0.9.0"
+    "graphql": "^14.0.0 || ^15.0.0",
+    "react": "^16.8.0",
+    "subscriptions-transport-ws": "^0.9.0"
   },
   "peerDependenciesMeta": {
     "react": {


### PR DESCRIPTION
This reverts commit 831b7abce7a3dea09398dd8c2fc53638a1b3f3f9.

We rushed this in just before the AC3 launch without fully thinking through the consequences. From https://github.com/apollographql/apollo-client/pull/6594#issuecomment-658797100:

> I think you ought to reconsider this change. See [this explanation](https://github.com/jaydenseric/apollo-upload-client/pull/201#issuecomment-657916102). It's also been rejected in other prominent repos like [React](https://github.com/facebook/react/pull/19356).
> 
> tl;dr: it's likely that at some point in the future, a new major version of at least one of these peer dependencies will be released that isn't compatible with Apollo Client's use of it. This will cause Apollo Client to break without warning if the consumer upgrades this dependency. It's essentially the same reason why one wouldn't want to use `>=` for regular dependencies.

Thanks for catching this @billyjanitsch!