### PR TITLE
react: MutationResult.client is always set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 - Tolerate `!==` callback functions (like `onCompleted` and `onError`) in `useQuery` options, since those functions are almost always freshly evaluated each time `useQuery` is called. <br/>
   [@hwillson](https://github.com/hwillson) and [@benjamn](https://github.com/benjamn) in [#6588](https://github.com/apollographql/apollo-client/pull/6588)
 
+## Improvements
+
+- Make the `client` field of the `MutationResult` type non-optional, since it is always provided. <br/>
+  [@glasser](https://github.com/glasser) in [#6617](https://github.com/apollographql/apollo-client/pull/6617)
+
 ## Apollo Client 3.0.2
 
 ## Bug Fixes

--- a/src/react/data/MutationData.ts
+++ b/src/react/data/MutationData.ts
@@ -6,20 +6,22 @@ import {
   MutationDataOptions,
   MutationTuple,
   MutationFunctionOptions,
-  MutationResult
+  MutationResult,
 } from '../types/types';
 import { OperationData } from './OperationData';
 import { OperationVariables } from '../../core';
 import { FetchResult } from '../../link/core';
+
+type MutationResultWithoutClient<TData = any> = Omit<MutationResult<TData>, 'client'>;
 
 export class MutationData<
   TData = any,
   TVariables = OperationVariables
 > extends OperationData {
   private mostRecentMutationId: number;
-  private result: MutationResult<TData>;
-  private previousResult?: MutationResult<TData>;
-  private setResult: (result: MutationResult<TData>) => any;
+  private result: MutationResultWithoutClient<TData>;
+  private previousResult?: MutationResultWithoutClient<TData>;
+  private setResult: (result: MutationResultWithoutClient<TData>) => any;
 
   constructor({
     options,
@@ -29,8 +31,8 @@ export class MutationData<
   }: {
     options: MutationDataOptions<TData, TVariables>;
     context: any;
-    result: MutationResult<TData>;
-    setResult: (result: MutationResult<TData>) => any;
+    result: MutationResultWithoutClient<TData>;
+    setResult: (result: MutationResultWithoutClient<TData>) => any;
   }) {
     super(options, context);
     this.verifyDocumentType(options.mutation, DocumentType.Mutation);
@@ -39,7 +41,7 @@ export class MutationData<
     this.mostRecentMutationId = 0;
   }
 
-  public execute(result: MutationResult<TData>) {
+  public execute(result: MutationResultWithoutClient<TData>): MutationTuple<TData, TVariables> {
     this.isMounted = true;
     this.verifyDocumentType(this.getOptions().mutation, DocumentType.Mutation);
     return [
@@ -148,7 +150,7 @@ export class MutationData<
     return this.mostRecentMutationId === mutationId;
   }
 
-  private updateResult(result: MutationResult<TData>) {
+  private updateResult(result: MutationResultWithoutClient<TData>) {
     if (
       this.isMounted &&
       (!this.previousResult || !equal(this.previousResult, result))

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -188,7 +188,7 @@ export interface MutationResult<TData = any> {
   error?: ApolloError;
   loading: boolean;
   called: boolean;
-  client?: ApolloClient<object>;
+  client: ApolloClient<object>;
 }
 
 export declare type MutationFunction<


### PR DESCRIPTION
As far as I can tell, whenever a MutationResult is provided to the user of
useMutation (or the component or HOC), it always contains a `client`; eg,
OperationData.refreshClient checks this invariant.

MutationResult is also used to type an internal state variable used by
MutationData and useMutation; this one doesn't contain a `client`. This PR
changes that variable to different type without `client`, and the actual exposed
MutationResult now has a non-optional `client`. This makes it match
`QueryResult`.

Now TypeScript consumers of `useMutation` don't need to check to see if `client`
exists before using it.
