### PR TITLE
Add graphql/execution/execute to external list in rollup.config.js.

### DIFF
--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -8,21 +8,22 @@ import packageJson from '../package.json';
 const distDir = './dist';
 
 const external = [
-  'tslib',
-  'ts-invariant',
-  'symbol-observable',
-  'graphql/language/printer',
-  'optimism',
-  'graphql/language/visitor',
-  'graphql-tag',
-  'fast-json-stable-stringify',
   '@wry/context',
   '@wry/equality',
-  'react',
-  'zen-observable',
-  'prop-types',
+  'fast-json-stable-stringify',
+  'graphql-tag',
+  'graphql/execution/execute',
+  'graphql/language/printer',
+  'graphql/language/visitor',
   'hoist-non-react-statics',
-  'subscriptions-transport-ws'
+  'optimism',
+  'prop-types',
+  'react',
+  'subscriptions-transport-ws',
+  'symbol-observable',
+  'ts-invariant',
+  'tslib',
+  'zen-observable',
 ];
 
 function prepareESM(input, outputDir) {

--- a/docs/source/api/link/apollo-link-schema.md
+++ b/docs/source/api/link/apollo-link-schema.md
@@ -11,7 +11,7 @@ The schema link provides a [graphql execution environment](http://graphql.org/gr
 
 ## Installation
 
-`npm install @apollo/link-schema --save`
+`npm install @apollo/client --save`
 
 ## Usage
 
@@ -21,7 +21,7 @@ When performing SSR _on the same server_, you can use this library to avoid maki
 
 ```js
 import { ApolloClient, InMemoryCache } from '@apollo/client';
-import { SchemaLink } from '@apollo/link-schema';
+import { SchemaLink } from '@apollo/client/link/schema';
 
 import schema from './path/to/your/schema';
 
@@ -38,7 +38,7 @@ For more detailed information about mocking, refer to the [graphql-tools documen
 
 ```js
 import { ApolloClient, InMemoryCache } from '@apollo/client';
-import { SchemaLink } from '@apollo/link-schema';
+import { SchemaLink } from '@apollo/client/link/schema';
 import { makeExecutableSchema, addMockFunctionsToSchema } from 'graphql-tools';
 
 const typeDefs = `


### PR DESCRIPTION
This prevents the `@apollo/client/link/schema` CommonJS bundle (which is used by Node.js) from accidentally pulling in the entire dependency tree of `graphql/execution/execute`.

This duplication not only increased the `@apollo/client/link/schema` CJS bundle size from 1.31kB to a whopping 22.6kB, but also caused `instanceof` to stop working reliably for types like `GraphQLSchema`, because there might be more than one definition of that constructor in play, and `instanceof` is sensitive to the exact constructor function you pass as the right-hand argument.

Should fix #6621, allowing us to revert #6622. Thanks to @stolinski for surfacing this issue.