### PR TITLE
Export `Observable` from `@apollo/client/utilities`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,18 @@
-## Apollo Client 3.0.2
+# Apollo Client vNEXT
+
+## Improvements
+
+- Export `Observable` from the `@apollo/client/utilities` entry point.  <br/>
+  [@hwillson](https://github.com/hwillson) in [#6642](https://github.com/apollographql/apollo-client/pull/6642)
+
+# Apollo Client 3.0.2
 
 ## Bug Fixes
 
 - Avoid duplicating `graphql/execution/execute` dependency in CommonJS bundle for `@apollo/client/link/schema`, fixing `instanceof` errors reported in [#6621](https://github.com/apollographql/apollo-client/issues/6621) and [#6614](https://github.com/apollographql/apollo-client/issues/6614). <br/>
   [@benjamn](https://github.com/benjamn) in [#6624](https://github.com/apollographql/apollo-client/pull/6624)
 
-## Apollo Client 3.0.1
+# Apollo Client 3.0.1
 
 ## Bug Fixes
 

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -67,3 +67,5 @@ export {
   offsetLimitPagination,
   relayStylePagination,
 } from './policies/pagination';
+
+export { Observable } from './observables/Observable';


### PR DESCRIPTION
This allows people to access `Observable` from the utilities entry point directly, which can come in handy if they're only using utilities and don't want to bring in the rest of the `@apollo/client` package.

Related discussion: #5686