### PR TITLE
Change `optimisticResponse` type to be consistent and less restrictive.

### DIFF
--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -176,7 +176,7 @@ export interface MutationFunctionOptions<
   TVariables = OperationVariables
 > {
   variables?: TVariables;
-  optimisticResponse?: TData | ((vars: TVariables | {}) => TData);
+  optimisticResponse?: TData | ((vars: TVariables) => TData);
   refetchQueries?: Array<string | PureQueryOptions> | RefetchQueriesFunction;
   awaitRefetchQueries?: boolean;
   update?: MutationUpdaterFn<TData>;


### PR DESCRIPTION
Per https://github.com/apollographql/apollo-client/issues/6390, the extra `| {}` makes certain semantically correct patterns that used to be okay in Typescript 3.7 illegal in 3.9. The difference between the two definitions of `optimisticResponse` in this file appears to have been a simple oversight when they were added in https://github.com/apollographql/react-apollo/pull/3257.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] ~~If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)~~ n/a
- [x] ~~Make sure all of the significant new logic is covered by tests~~ n/a
