### PR TITLE
Process ESM .js modules in ./dist with Rollup, again.

### DIFF
--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -93,6 +93,30 @@ function prepareBundle({
   };
 }
 
+// Resolve indirect imports and exports to the original exporting module,
+// so that more imports are explicitly named (fewer *s), and all source
+// module identifiers have file extensions.
+function resolveESMImportsAndFileExtensions(input, outputDir) {
+  return {
+    input,
+    external(id) {
+      return externalPackages.has(id);
+    },
+    output: {
+      dir: outputDir,
+      format: 'esm',
+      sourcemap: true,
+    },
+    // By setting preserveModules to true, we're making sure Rollup
+    // doesn't attempt to create a single combined ESM bundle with the
+    // final result of running this job.
+    preserveModules: true,
+    plugins: [
+      nodeResolve(),
+    ],
+  };
+}
+
 export default [
   ...entryPoints.map(prepareBundle),
   // Convert the ESM entry point to a single CJS bundle.
@@ -104,4 +128,5 @@ export default [
   prepareCJSMinified(
     './dist/apollo-client.cjs.js',
   ),
+  resolveESMImportsAndFileExtensions(packageJson.module, distDir),
 ];


### PR DESCRIPTION
This partially reverts commit 627bd1b983b3084f05da6b7e8c92db294c3e3a8e from PR #6656.

PR #6656 removed a function called `prepareESM`, which was no longer needed for the sake of running `rollup-plugin-invariant`, but which had another benefit: Rollup would replace imports/exports like
```js
// Example exports from ./dist/index.js:
export * from './core'
export * from './react'
```
with their fully-expanded (and file-extensioned) equivalents:
```js
...
export { makeVar } from './cache/inmemory/reactiveVars.js';
export { defaultDataIdFromObject } from './cache/inmemory/policies.js';
export { InMemoryCache } from './cache/inmemory/inMemoryCache.js';
export { ApolloClient } from './core/ApolloClient.js';
...
```
Although this may look like more code, it effectively saves the bundler/browser work by reducing indirection, and including the `.js` file extensions makes this code a little more browser- and Rollup-friendly (that is, you shouldn't have to use `@rollup/plugin-node-resolve` to bundle `@apollo/client` with Rollup).

The expanded imports/exports are also closer to the ESM code shipped with `@apollo/client@3.0.x`, so restoring this behavior helps with the goal of keeping the changes in #6656 backwards-compatible for v3.1.0.

Note that the CommonJS bundles used by Node.js are built before this step, so this expansion of imports does not affect how Node.js consumes CommonJS.