### PR TITLE
Avoid defaulting to empty data in relayStylePagination read function.

### DIFF
--- a/src/utilities/policies/pagination.ts
+++ b/src/utilities/policies/pagination.ts
@@ -61,7 +61,8 @@ export function relayStylePagination<TNode = Reference>(
   return {
     keyArgs,
 
-    read(existing = makeEmptyData(), { canRead }) {
+    read(existing, { canRead }) {
+      if (!existing) return;
       const edges = existing.edges.filter(edge => canRead(edge.node));
       return {
         // Some implementations return additional Connection fields, such


### PR DESCRIPTION
Fixes #6611, thanks to this astute comment from @fracmak: https://github.com/apollographql/apollo-client/issues/6611#issuecomment-662676848

Returning `undefined` from a field read function indicates to the `StoreReader` that the field is missing, and usually means the query will be (re)fetched from the server. When we haven't yet written any data to a field that's paginated by `relayStylePagination`, requesting data from the server is almost always better than providing any kind of default data, so we should avoid using `makeEmptyData()` as a default value for the `existing` parameter.