### PR TITLE
fix(QueryManager): Allow consumers to handle promise rejection when waitRefetchQueries is enabled

### DIFF
--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -326,7 +326,7 @@ export class QueryManager<TStore> {
             }
 
             resolve(storeResult!);
-          });
+          }, reject);
         },
       });
     });


### PR DESCRIPTION
Closes #3631 

This PR was initially created by @KrumTy [4 months ago](https://github.com/apollographql/apollo-client/pull/5944), but had not been rebase for quite some time, and was missing a type definition around the test parameters. This is a bug that's been affecting myself and others, and wanted to make sure this fix got in.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->
