### PR TITLE
Keep policies.rootIdsByTypename unique by ID as well as __typename.

### DIFF
--- a/src/cache/inmemory/__tests__/__snapshots__/policies.ts.snap
+++ b/src/cache/inmemory/__tests__/__snapshots__/policies.ts.snap
@@ -2,6 +2,10 @@
 
 exports[`type policies can alter the root query __typename 1`] = `
 Object {
+  "Query:0": Object {
+    "__typename": "Query",
+    "id": 0,
+  },
   "Query:1": Object {
     "__typename": "Query",
     "id": 1,
@@ -20,8 +24,7 @@ Object {
       Object {
         "id": 0,
         "query": Object {
-          "__typename": "Query",
-          "id": 0,
+          "__ref": "Query:0",
         },
       },
       Object {

--- a/src/cache/inmemory/__tests__/__snapshots__/policies.ts.snap
+++ b/src/cache/inmemory/__tests__/__snapshots__/policies.ts.snap
@@ -1,5 +1,52 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`type policies can alter the root query __typename 1`] = `
+Object {
+  "Query:1": Object {
+    "__typename": "Query",
+    "id": 1,
+  },
+  "Query:2": Object {
+    "__typename": "Query",
+    "id": 2,
+  },
+  "Query:3": Object {
+    "__typename": "Query",
+    "id": 3,
+  },
+  "ROOT_QUERY": Object {
+    "__typename": "RootQuery",
+    "items": Array [
+      Object {
+        "id": 0,
+        "query": Object {
+          "__typename": "Query",
+          "id": 0,
+        },
+      },
+      Object {
+        "id": 1,
+        "query": Object {
+          "__ref": "Query:1",
+        },
+      },
+      Object {
+        "id": 2,
+        "query": Object {
+          "__ref": "Query:2",
+        },
+      },
+      Object {
+        "id": 3,
+        "query": Object {
+          "__ref": "Query:3",
+        },
+      },
+    ],
+  },
+}
+`;
+
 exports[`type policies field policies can handle Relay-style pagination 1`] = `
 Object {
   "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}": Object {

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -3968,4 +3968,63 @@ describe("type policies", function () {
     // Unchanged because the merge function prefers the existing object.
     expect(cache.extract()).toEqual(snapshot);
   });
+
+  it("can alter the root query __typename", function () {
+    const cache = new InMemoryCache({
+      typePolicies: {
+        RootQuery: {
+          queryType: true,
+        },
+      }
+    });
+
+    const ALL_ITEMS = gql`
+      query Items {
+        __typename
+        items {
+          id
+          query {
+            id
+          }
+        }
+      }
+    `;
+
+    function makeItem(id: number) {
+      return {
+        id,
+        query: {
+          __typename: "Query",
+          id,
+        },
+      };
+    }
+
+    cache.writeQuery({
+      query: ALL_ITEMS,
+      data: {
+        __typename: "RootQuery",
+        items: [
+          makeItem(0),
+          makeItem(1),
+          makeItem(2),
+          makeItem(3),
+        ],
+      },
+    });
+
+    expect(cache.extract()).toMatchSnapshot();
+
+    expect(cache.readQuery({
+      query: ALL_ITEMS,
+    })).toEqual({
+      __typename: "RootQuery",
+      items: [
+        makeItem(0),
+        makeItem(1),
+        makeItem(2),
+        makeItem(3),
+      ],
+    });
+  });
 });

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -198,12 +198,13 @@ export const defaultDataIdFromObject = (
         _id !== void 0 ? { _id } :
         void 0;
     }
-    const idValue = id || _id;
-    if (idValue !== void 0) {
+    // If there is no object.id, fall back to object._id.
+    if (id === void 0) id = _id;
+    if (id !== void 0) {
       return `${__typename}:${(
-        typeof idValue === "number" ||
-        typeof idValue === "string"
-      ) ? idValue : JSON.stringify(idValue)}`;
+        typeof id === "number" ||
+        typeof id === "string"
+      ) ? id : JSON.stringify(id)}`;
     }
   }
 };

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -372,7 +372,12 @@ export class Policies {
     const old = this.rootTypenamesById[rootId];
     if (typename !== old) {
       invariant(!old || old === which, `Cannot change root ${which} __typename more than once`);
+      // First, delete any old __typename associated with this rootId from
+      // rootIdsByTypename.
+      if (old) delete this.rootIdsByTypename[old];
+      // Now make this the only __typename that maps to this rootId.
       this.rootIdsByTypename[typename] = rootId;
+      // Finally, update the __typename associated with this rootId.
       this.rootTypenamesById[rootId] = typename;
     }
   }


### PR DESCRIPTION
Although the `__typename` of the root query, mutation, and subscription types are almost always `Query`, `Mutation`, and `Subscription`, respectively, it is possible to declare different names for those root types in your schema, which will affect queries like
```gql
query { __typename }
```
This query isn't normally very remarkable or useful, except that it happens to be the smallest legal GraphQL query.

Note that a configuration like
```ts
new InMemoryCache({
  typePolicies: {
    RootQuery: {
      queryType: true,
    },
  },
})
```
is necessary to let `InMemoryCache` know that `RootQuery` is the name of the root query type, rather than `Query`. This non-default behavior is not something the cache can safely figure out without some help.

Thankfully, we have been very careful not to hard-code the default `__typename` values for these root types, but #6685 demonstrates that this generic system was not working entirely correctly.

The `policies.rootTypenamesById` map will always have exactly three keys, since there are only three root IDs. However, `policies.rootIdsByTypename` had a bug where more than one `__typename` could map to the same root ID, so you could end up with both `Query` and `RootQuery` mapping to `ROOT_QUERY`, for example, which was a problem for code that needed to detect whether a given `__typename` corresponded to a root type or not.

We could have fixed this by getting rid of the `rootIdsByTypename` lookup table, and just computing its information from `rootTypenamesById` whenever we needed it, but that computation is somewhat performance-sensitive, so I would prefer to keep the two tables in (inverse) sync with each other.

Fixes #6685.