### PR TITLE
Ability to dynamically match mocks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,6 @@
   "typescript.tsdk": "../node_modules/typescript/lib",
   "cSpell.enableFiletypes": [
     "mdx"
-  ]
+  ],
+  "deno.enable": false
 }

--- a/docs/source/development-testing/testing.mdx
+++ b/docs/source/development-testing/testing.mdx
@@ -117,7 +117,7 @@ it('renders without error', () => {
 });
 ```
 
-The `mocks` array takes objects with specific `request`s and their associated `result`s.  When the provider receives a `GET_DOG_QUERY` with matching `variables`, it returns the corresponding object from the `result` key. A `result` may alternatively be a function returning the object:
+The `mocks` array takes objects with specific `request`s and their associated `result`s.  When the provider receives a `GET_DOG_QUERY` with matching `variables`, it returns the corresponding object from the `result` key. A `result` may alternatively be a function that takes variables and returns the object:
 
 ```js
 const mocks = [
@@ -245,6 +245,43 @@ const dogMock = {
     errors: [new GraphQLError('Error!')],
   },
 };
+```
+
+## Testing with dynamic variables
+
+Sometimes, the exact value of the variables being passed are not known. The `MockedResponse` object takes a `variableMatcher` property that is a function that takes the variables and return a bool indication if this mock should match the invocation for the provided query.
+You cannot specify this parameter and `request.variables`:
+
+For example, this mock will match all dog queries:
+
+```js
+const dogMock = {
+  request: {
+    query: GET_DOG_QUERY
+  },
+  variableMatcher (variables) => true,
+  result: {
+    data: { dog: { id: 1, name: 'Buck', breed: 'poodle' } },
+  },
+};
+```
+
+This can also be useful for asserting specific variables individually:
+
+```js
+const dogMock = {
+  request: {
+    query: GET_DOG_QUERY
+  },
+  variableMatcher: jest.fn().mockReturnValue(true),
+  result: {
+    data: { dog: { id: 1, name: 'Buck', breed: 'poodle' } },
+  },
+};
+
+expect(variableMatcher).toHaveBeenCalledWith(expect.objectContaining({
+  name: 'Buck'
+}));
 ```
 
 ## Testing mutation components

--- a/src/utilities/testing/mocking/__tests__/MockedProvider.test.tsx
+++ b/src/utilities/testing/mocking/__tests__/MockedProvider.test.tsx
@@ -384,12 +384,7 @@ describe('General use', () => {
     }).then(resolve, reject);
   });
 
-  itAsync('should error if both variables and a variableMatcher are provided', async (resolve, reject) => {
-    function Component({ ...variables }: Variables) {
-      useQuery<Data, Variables>(query, { variables });
-      return null;
-    }
-
+  it('should error if both variables and a variableMatcher are provided', () => {
     const mock2: MockedResponse<Data, Variables> = {
       request: {
         query,
@@ -399,17 +394,8 @@ describe('General use', () => {
       result: { data: { user } }
     };
 
-    const link = ApolloLink.from([errorLink, new MockLink([mock2])]);
-
-    render(
-      <MockedProvider link={link}>
-        <Component {...variables} />
-      </MockedProvider>
-    );
-
-    return wait(() => {
-      expect(errorThrown).toBeTruthy();
-    }).then(resolve, reject);
+    expect(() => new MockLink([mock2]))
+      .toThrow('Mocked response should contain either variableMatcher or request.variables');
   });
 
   it('should pass down props prop in mock as props for the component', () => {

--- a/src/utilities/testing/mocking/__tests__/MockedProvider.test.tsx
+++ b/src/utilities/testing/mocking/__tests__/MockedProvider.test.tsx
@@ -94,6 +94,31 @@ describe('General use', () => {
     return wait().then(resolve, reject);
   });
 
+  itAsync('should pass the variables to the result function', async (resolve, reject) => {
+    function Component({ ...variables }: Variables) {
+      useQuery<Data, Variables>(query, { variables });
+      return null;
+    }
+
+    const mock2: MockedResponse<Data, Variables> = {
+      request: {
+        query,
+        variables
+      },
+      result: jest.fn().mockResolvedValue({ data: { user } })
+    };
+
+    render(
+      <MockedProvider mocks={[mock2]}>
+        <Component {...variables} />
+      </MockedProvider>
+    );
+
+    return wait(() => {
+      expect(mock2.result as jest.Mock).toHaveBeenCalledWith(variables);
+    }).then(resolve, reject);
+  });
+
   itAsync('should pass the variables to the variableMatcher', async (resolve, reject) => {
     function Component({ ...variables }: Variables) {
       useQuery<Data, Variables>(query, { variables });

--- a/src/utilities/testing/mocking/__tests__/__snapshots__/MockedProvider.test.tsx.snap
+++ b/src/utilities/testing/mocking/__tests__/__snapshots__/MockedProvider.test.tsx.snap
@@ -22,3 +22,10 @@ Object {
   },
 }
 `;
+
+exports[`General use should use a mock if the variableMatcher returns true 1`] = `
+Object {
+  "__typename": "User",
+  "id": "user_id",
+}
+`;

--- a/src/utilities/testing/mocking/mockLink.ts
+++ b/src/utilities/testing/mocking/mockLink.ts
@@ -19,11 +19,14 @@ import {
 
 export type ResultFunction<T> = () => T;
 
-export interface MockedResponse<TData = Record<string, any>> {
+export type VariableMatcher<V> = (variables: V) => boolean;
+
+export interface MockedResponse<TData = Record<string, any>, TVariables = Record<string, any>> {
   request: GraphQLRequest;
   result?: FetchResult<TData> | ResultFunction<FetchResult<TData>>;
   error?: Error;
   delay?: number;
+  variableMatcher?: VariableMatcher<TVariables>,
   newData?: ResultFunction<FetchResult>;
 }
 

--- a/src/utilities/testing/mocking/mockLink.ts
+++ b/src/utilities/testing/mocking/mockLink.ts
@@ -17,13 +17,13 @@ import {
   cloneDeep,
 } from '../../../utilities';
 
-export type ResultFunction<T> = () => T;
+export type ResultFunction<T, V = Record<string, any>> = (variables: V) => T;
 
 export type VariableMatcher<V> = (variables: V) => boolean;
 
 export interface MockedResponse<TData = Record<string, any>, TVariables = Record<string, any>> {
   request: GraphQLRequest;
-  result?: FetchResult<TData> | ResultFunction<FetchResult<TData>>;
+  result?: FetchResult<TData> | ResultFunction<FetchResult<TData>, TVariables>;
   error?: Error;
   delay?: number;
   variableMatcher?: VariableMatcher<TVariables>,
@@ -100,7 +100,7 @@ export class MockLink extends ApolloLink {
     const { newData } = response!;
 
     if (newData) {
-      response!.result = newData();
+      response!.result = newData(operation.variables);
       this.mockedResponsesByKey[key].push(response!);
     }
 
@@ -121,7 +121,7 @@ export class MockLink extends ApolloLink {
             if (result) {
               observer.next(
                 typeof result === 'function'
-                  ? (result as ResultFunction<FetchResult>)()
+                  ? (result as ResultFunction<FetchResult>)(operation.variables)
                   : result
               );
             }


### PR DESCRIPTION
This PR provides the functionality outlined in https://github.com/apollographql/apollo-feature-requests/issues/245

It adds support for a new property `MockedResponse.variableMatcher` that is a function that takes variables and returns if they should match for this mock. A user cannot specify both this property as well as `response.variables` in the same mock.

It also passes the variables into the `ResultFunction` so that a function is able to use them to dynamically build a response. Passing these parameters also allows for the use of a mock for the result function and then asserting that specific variables were passed. This testing strategy results in a cleaner error message for mutations if the correct data is not passed and allows for partial matches using jests "objectContaining" and others.

My team found testing using the MockProvider to be difficult in several situations and these small changes would have greatly  improved our ability to test with the ApolloClient.