### PR TITLE
Refactor ObservableQuery#getCurrentResult to reenable immediate delivery of warm cache results.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
   [@igaloly](https://github.com/igaloly) in [#6261](https://github.com/apollographql/apollo-client/pull/6261) and
   [@Kujawadl](https://github.com/Kujawadl) in [#6526](https://github.com/apollographql/apollo-client/pull/6526)
 
+- Refactor `ObservableQuery#getCurrentResult` to reenable immediate delivery of warm cache results. <br/>
+  [@benjamn](https://github.com/benjamn) in [#6710](https://github.com/apollographql/apollo-client/pull/6710)
+
 ## Improvements
 
 - Errors of the form `Invariant Violation: 42` thrown in production can now be looked up much more easily, by consulting the auto-generated `@apollo/client/invariantErrorCodes.js` file specific to your `@apollo/client` version. <br/>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
   [@igaloly](https://github.com/igaloly) in [#6261](https://github.com/apollographql/apollo-client/pull/6261) and
   [@Kujawadl](https://github.com/Kujawadl) in [#6526](https://github.com/apollographql/apollo-client/pull/6526)
 
-- Refactor `ObservableQuery#getCurrentResult` to reenable immediate delivery of warm cache results. <br/>
+- Refactor `ObservableQuery#getCurrentResult` to reenable immediate delivery of warm cache results. As part of this refactoring, the `ApolloCurrentQueryResult` type was eliminated in favor of `ApolloQueryResult`. <br/>
   [@benjamn](https://github.com/benjamn) in [#6710](https://github.com/apollographql/apollo-client/pull/6710)
 
 ## Improvements

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -503,8 +503,15 @@ once, rather than every time you call fetchMore.`);
     ) => TData,
   ): void {
     const { queryManager } = this;
-    const previousResult = this.getCurrentQueryResult(false).data;
-    const newResult = mapFn(previousResult!, {
+    const { result } = queryManager.cache.diff<TData>({
+      query: this.options.query,
+      variables: this.variables,
+      previousResult: this.lastResult?.data,
+      returnPartialData: true,
+      optimistic: false,
+    });
+
+    const newResult = mapFn(result!, {
       variables: (this as any).variables,
     });
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -138,7 +138,7 @@ export class ObservableQuery<
       return result;
     }
 
-    const { fetchPolicy } = this.options;
+    const { fetchPolicy = 'cache-first' } = this.options;
     if (fetchPolicy === 'no-cache' ||
         fetchPolicy === 'network-only') {
       result.partial = false;
@@ -159,6 +159,16 @@ export class ObservableQuery<
         diff.complete ||
         this.options.returnPartialData
       ) ? diff.result : void 0;
+      // If the cache diff is complete, and we're using a FetchPolicy that
+      // terminates after a complete cache read, we can assume the next
+      // result we receive will have NetworkStatus.ready and !loading.
+      if (diff.complete &&
+          result.networkStatus === NetworkStatus.loading &&
+          (fetchPolicy === 'cache-first' ||
+           fetchPolicy === 'cache-only')) {
+        result.networkStatus = NetworkStatus.ready;
+        result.loading = false;
+      }
     }
 
     this.updateLastResult(result);

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -20,6 +20,7 @@ import {
   SubscribeToMoreOptions,
 } from './watchQueryOptions';
 import { Reobserver } from './Reobserver';
+import { QueryInfo } from './QueryInfo';
 
 export interface FetchMoreOptions<
   TData = any,
@@ -62,12 +63,15 @@ export class ObservableQuery<
   private lastResult: ApolloQueryResult<TData>;
   private lastResultSnapshot: ApolloQueryResult<TData>;
   private lastError: ApolloError;
+  private queryInfo: QueryInfo;
 
   constructor({
     queryManager,
+    queryInfo,
     options,
   }: {
     queryManager: QueryManager<any>;
+    queryInfo: QueryInfo;
     options: WatchQueryOptions<TVariables>;
   }) {
     super((observer: Observer<ApolloQueryResult<TData>>) =>
@@ -86,6 +90,8 @@ export class ObservableQuery<
 
     // related classes
     this.queryManager = queryManager;
+
+    this.queryInfo = queryInfo;
   }
 
   public result(): Promise<ApolloQueryResult<TData>> {

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -127,7 +127,7 @@ export class ObservableQuery<
 
   public getCurrentResult(): ApolloQueryResult<TData> {
     const { lastResult, lastError } = this;
-    const networkStatus = this.queryManager.getNetworkStatus(this.queryId);
+    const networkStatus = this.queryInfo.networkStatus || NetworkStatus.ready;
     const result: ApolloQueryResult<TData> = {
       ...(lastError ? { error: lastError } : lastResult),
       loading: isNetworkRequestInFlight(networkStatus),
@@ -250,7 +250,7 @@ export class ObservableQuery<
       // trigger a notification, even though it does trigger a cache
       // broadcast. This is a good thing, because it means we won't see
       // intervening query notifications while fetchMore is pending.
-      this.queryManager.setNetworkStatus(this.queryId, NetworkStatus.fetchMore);
+      this.queryInfo.networkStatus = NetworkStatus.fetchMore;
 
       // Simulate a loading result for the original query with
       // networkStatus === NetworkStatus.fetchMore.
@@ -597,8 +597,7 @@ once, rather than every time you call fetchMore.`);
       },
       // Avoid polling during SSR and when the query is already in flight.
       !queryManager.ssrMode && (
-        () => !isNetworkRequestInFlight(
-          queryManager.getNetworkStatus(queryId))),
+        () => !isNetworkRequestInFlight(this.queryInfo.networkStatus))
     );
   }
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -477,13 +477,7 @@ once, rather than every time you call fetchMore.`);
       };
     }
 
-    let { result, complete } = this.queryManager.cache.diff<TData>({
-      query: this.options.query,
-      variables: this.variables,
-      previousResult: this.lastResult?.data,
-      returnPartialData: true,
-      optimistic,
-    });
+    let { result, complete } = this.queryInfo.getDiff();
 
     if (lastData &&
         !this.lastError &&

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -23,11 +23,6 @@ import {
 import { QueryStoreValue } from './QueryInfo';
 import { Reobserver } from './Reobserver';
 
-export type ApolloCurrentQueryResult<T> = ApolloQueryResult<T> & {
-  error?: ApolloError;
-  partial?: boolean;
-};
-
 export interface FetchMoreOptions<
   TData = any,
   TVariables = OperationVariables
@@ -134,7 +129,7 @@ export class ObservableQuery<
     });
   }
 
-  public getCurrentResult(): ApolloCurrentQueryResult<TData> {
+  public getCurrentResult(): ApolloQueryResult<TData> {
     const {
       lastResult,
       lastError,
@@ -151,8 +146,8 @@ export class ObservableQuery<
       isNetworkFetchPolicy ? NetworkStatus.loading :
       NetworkStatus.ready;
 
-    const result: ApolloCurrentQueryResult<TData> = {
-      data: !lastError && lastResult && lastResult.data || void 0,
+    const result: ApolloQueryResult<TData> = {
+      ...(lastError ? null : lastResult),
       error: lastError,
       loading: isNetworkRequestInFlight(networkStatus),
       networkStatus,

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -133,6 +133,7 @@ export class QueryInfo {
     (this as any).observableQuery = oq;
 
     if (oq) {
+      oq["queryInfo"] = this;
       this.listeners.add(this.oqListener = () => oq.reobserve());
     } else {
       delete this.oqListener;

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -194,6 +194,10 @@ export class QueryInfo {
   private lastWatch?: Cache.WatchOptions;
 
   private updateWatch(variables = this.variables) {
+    const oq = this.observableQuery;
+    if (oq && oq.options.fetchPolicy === "no-cache") {
+      return;
+    }
     if (!this.lastWatch ||
         this.lastWatch.query !== this.document ||
         !equal(variables, this.lastWatch.variables)) {

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -176,14 +176,6 @@ export class QueryInfo {
     // QueryInfo.prototype.
     delete this.cancel;
 
-    this.variables =
-    this.networkStatus =
-    this.networkError =
-    this.graphQLErrors =
-    this.lastWatch =
-    this.lastWrittenResult =
-    this.lastWrittenVars = void 0;
-
     const oq = this.observableQuery;
     if (oq) oq.stopPolling();
   }

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -965,14 +965,9 @@ export class QueryManager<TStore> {
       variables,
       lastRequestId: this.generateRequestId(),
       networkStatus,
-    }).updateWatch(variables);
-
-    const readCache = () => this.cache.diff<any>({
-      query,
-      variables,
-      returnPartialData: true,
-      optimistic: true,
     });
+
+    const readCache = () => queryInfo.getDiff(variables);
 
     const resultsFromCache = (
       diff: Cache.DiffResult<TData>,

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -456,12 +456,16 @@ export class QueryManager<TStore> {
       options.notifyOnNetworkStatusChange = false;
     }
 
+    const queryInfo = new QueryInfo(this.cache);
     const observable = new ObservableQuery<T, TVariables>({
       queryManager: this,
+      queryInfo,
       options,
     });
 
-    this.getQuery(observable.queryId).init({
+    this.queries.set(observable.queryId, queryInfo);
+
+    queryInfo.init({
       document: options.query,
       observableQuery: observable,
       variables: options.variables,

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -364,19 +364,6 @@ export class QueryManager<TStore> {
     }
   }
 
-  public getNetworkStatus(queryId: string): NetworkStatus {
-    const queryInfo = this.queries.get(queryId);
-    const status = queryInfo && queryInfo.networkStatus;
-    return status || NetworkStatus.ready;
-  }
-
-  public setNetworkStatus(queryId: string, status: NetworkStatus) {
-    const queryInfo = this.queries.get(queryId);
-    if (queryInfo) {
-      queryInfo.networkStatus = status;
-    }
-  }
-
   private transformCache = new (canUseWeakMap ? WeakMap : Map)<
     DocumentNode,
     Readonly<{

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -33,7 +33,6 @@ import {
 import { ObservableQuery } from './ObservableQuery';
 import { NetworkStatus, isNetworkRequestInFlight } from './networkStatus';
 import {
-  QueryListener,
   ApolloQueryResult,
   OperationVariables,
   MutationQueryReducer,
@@ -525,10 +524,6 @@ export class QueryManager<TStore> {
   private stopQueryInStoreNoBroadcast(queryId: string) {
     const queryInfo = this.queries.get(queryId);
     if (queryInfo) queryInfo.stop();
-  }
-
-  public addQueryListener(queryId: string, listener: QueryListener) {
-    this.getQuery(queryId).listeners.add(listener);
   }
 
   public clearStore(): Promise<void> {

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -357,8 +357,25 @@ export class QueryManager<TStore> {
     return store;
   }
 
-  public getQueryStoreValue(queryId: string): QueryStoreValue | undefined {
-    return queryId ? this.queries.get(queryId) : undefined;
+  public resetErrors(queryId: string) {
+    const queryInfo = this.queries.get(queryId);
+    if (queryInfo) {
+      queryInfo.networkError = undefined;
+      queryInfo.graphQLErrors = [];
+    }
+  }
+
+  public getNetworkStatus(queryId: string): NetworkStatus {
+    const queryInfo = this.queries.get(queryId);
+    const status = queryInfo && queryInfo.networkStatus;
+    return status || NetworkStatus.ready;
+  }
+
+  public setNetworkStatus(queryId: string, status: NetworkStatus) {
+    const queryInfo = this.queries.get(queryId);
+    if (queryInfo) {
+      queryInfo.networkStatus = status;
+    }
   }
 
   private transformCache = new (canUseWeakMap ? WeakMap : Map)<
@@ -1065,16 +1082,6 @@ export class QueryManager<TStore> {
       ...newContext,
       clientAwareness: this.clientAwareness,
     };
-  }
-
-  public checkInFlight(queryId: string): boolean {
-    const query = this.getQueryStoreValue(queryId);
-    return (
-      !!query &&
-      !!query.networkStatus &&
-      query.networkStatus !== NetworkStatus.ready &&
-      query.networkStatus !== NetworkStatus.error
-    );
   }
 }
 

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -975,6 +975,7 @@ export class QueryManager<TStore> {
         data,
         loading: isNetworkRequestInFlight(networkStatus),
         networkStatus,
+        ...(diff.complete ? null : { partial: true }),
       } as ApolloQueryResult<TData>);
 
       if (this.transform(query).hasForcedResolvers) {

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -1176,6 +1176,7 @@ describe('ObservableQuery', () => {
               },
               loading: true,
               networkStatus: NetworkStatus.loading,
+              partial: true,
             });
           } else if (handleCount === 2) {
             expect(result).toEqual({
@@ -1597,6 +1598,7 @@ describe('ObservableQuery', () => {
               data: dataOne,
               loading: true,
               networkStatus: 1,
+              partial: true,
             });
 
           } else if (handleCount === 2) {

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -1396,8 +1396,8 @@ describe('ObservableQuery', () => {
         });
         expect(stripSymbols(observable.getCurrentResult())).toEqual({
           data: dataOne,
-          loading: true,
-          networkStatus: NetworkStatus.loading,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
           partial: false,
         });
       }).then(resolve, reject);

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -1887,11 +1887,11 @@ describe('ObservableQuery', () => {
       observable.subscribe({
         error() {
           const { queryManager } = (observable as any);
-          const queryStore = queryManager.getQueryStoreValue(observable.queryId);
-          expect(queryStore.graphQLErrors).toEqual([graphQLError]);
+          const queryInfo = queryManager["queries"].get(observable.queryId);
+          expect(queryInfo.graphQLErrors).toEqual([graphQLError]);
 
           observable.resetQueryStoreErrors();
-          expect(queryStore.graphQLErrors).toEqual([]);
+          expect(queryInfo.graphQLErrors).toEqual([]);
 
           resolve();
         }
@@ -1909,10 +1909,10 @@ describe('ObservableQuery', () => {
       observable.subscribe({
         next() {
           const { queryManager } = (observable as any);
-          const queryStore = queryManager.getQueryStoreValue(observable.queryId);
-          queryStore.networkError = networkError;
+          const queryInfo = queryManager["queries"].get(observable.queryId);
+          queryInfo.networkError = networkError;
           observable.resetQueryStoreErrors();
-          expect(queryStore.networkError).toBeUndefined();
+          expect(queryInfo.networkError).toBeUndefined();
           resolve();
         }
       });

--- a/src/core/__tests__/QueryManager/index.ts
+++ b/src/core/__tests__/QueryManager/index.ts
@@ -191,8 +191,15 @@ describe('QueryManager', () => {
 
   function getCurrentQueryResult<TData, TVars>(
     observableQuery: ObservableQuery<TData, TVars>,
-  ): ReturnType<ObservableQuery<TData, TVars>["getCurrentQueryResult"]> {
-    return (observableQuery as any).getCurrentQueryResult();
+  ): {
+    data?: TData;
+    partial: boolean;
+  } {
+    const result = observableQuery.getCurrentResult();
+    return {
+      data: result.data,
+      partial: !!result.partial,
+    };
   }
 
   itAsync('handles GraphQL errors', (resolve, reject) => {

--- a/src/core/__tests__/QueryManager/index.ts
+++ b/src/core/__tests__/QueryManager/index.ts
@@ -2128,6 +2128,7 @@ describe('QueryManager', () => {
             data: {},
             loading: true,
             networkStatus: NetworkStatus.loading,
+            partial: true,
           });
         },
         result => {
@@ -2202,6 +2203,7 @@ describe('QueryManager', () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           data: {},
+          partial: true,
         });
       } else if (count === 2) {
         expect(result).toEqual({
@@ -2220,6 +2222,7 @@ describe('QueryManager', () => {
           data: {
             info: {},
           },
+          partial: true,
         });
       } else if (count === 4) {
         expect(result).toEqual({
@@ -2243,6 +2246,7 @@ describe('QueryManager', () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           data: {},
+          partial: true,
         });
       } else if (count === 2) {
         expect(result).toEqual({

--- a/src/core/__tests__/fetchPolicies.ts
+++ b/src/core/__tests__/fetchPolicies.ts
@@ -494,6 +494,7 @@ describe('cache-and-network', function() {
           data: {},
           loading: true,
           networkStatus: NetworkStatus.setVariables,
+          partial: true,
         });
       } else if (count === 3) {
         expect(result).toEqual({
@@ -520,6 +521,7 @@ describe('cache-and-network', function() {
           data: {},
           loading: true,
           networkStatus: NetworkStatus.setVariables,
+          partial: true,
         });
       } else if (count === 7) {
         expect(result).toEqual({

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -9,7 +9,6 @@ export {
   ObservableQuery,
   FetchMoreOptions,
   UpdateQueryOptions,
-  ApolloCurrentQueryResult,
 } from './ObservableQuery';
 export {
   QueryBaseOptions,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,6 +1,7 @@
 import { DocumentNode, GraphQLError } from 'graphql';
 
 import { FetchResult } from '../link/core';
+import { ApolloError } from '../errors';
 import { QueryInfo } from './QueryInfo';
 import { NetworkStatus } from './networkStatus';
 import { Resolver } from './LocalState';
@@ -18,8 +19,13 @@ export type PureQueryOptions = {
 export type ApolloQueryResult<T> = {
   data?: T;
   errors?: ReadonlyArray<GraphQLError>;
+  error?: ApolloError;
   loading: boolean;
   networkStatus: NetworkStatus;
+  // If result.data was read from the cache with missing fields,
+  // result.partial will be true. Otherwise, result.partial will be falsy
+  // (usually because the property is absent from the result object).
+  partial?: boolean;
 };
 
 // This is part of the public API, people write these functions in `updateQueries`.

--- a/src/react/components/__tests__/client/Query.test.tsx
+++ b/src/react/components/__tests__/client/Query.test.tsx
@@ -1674,9 +1674,6 @@ describe('Query component', () => {
               });
               break;
             case 4:
-              expect(props.loading).toBeTruthy();
-              break;
-            case 5:
               // Good result should be received without any errors.
               expect(props.error).toBeFalsy();
               expect(props.data.allPeople).toBeTruthy();
@@ -1698,7 +1695,7 @@ describe('Query component', () => {
         </Query>
       );
 
-      return wait(() => expect(count).toBe(6)).then(resolve, reject);
+      return wait(() => expect(count).toBe(5)).then(resolve, reject);
     }
   );
 

--- a/src/react/hoc/__tests__/mutations/recycled-queries.test.tsx
+++ b/src/react/hoc/__tests__/mutations/recycled-queries.test.tsx
@@ -162,9 +162,6 @@ describe('graphql(mutation) update queries', () => {
               });
               break;
             case 3:
-              expect(this.props.data!.loading).toBeTruthy();
-              break;
-            case 4:
               expect(stripSymbols(this.props.data!.todo_list)).toEqual({
                 id: '123',
                 title: 'how to apollo',
@@ -228,7 +225,6 @@ describe('graphql(mutation) update queries', () => {
               expect(todoUpdateQueryCount).toBe(2);
               expect(queryMountCount).toBe(2);
               expect(queryUnmountCount).toBe(2);
-              expect(queryRenderCount).toBe(5);
             }, 5);
           }, 5);
         }, 5);
@@ -236,7 +232,7 @@ describe('graphql(mutation) update queries', () => {
     }, 5);
 
     return wait(() => {
-      expect(queryRenderCount).toBe(5);
+      expect(queryRenderCount).toBe(4);
     });
   });
 
@@ -359,12 +355,6 @@ describe('graphql(mutation) update queries', () => {
               );
               break;
             case 3:
-              expect(this.props.data!.loading).toBeTruthy();
-              expect(stripSymbols(this.props.data!.todo_list)).toEqual(
-                updatedData.todo_list
-              );
-              break;
-            case 4:
               expect(this.props.data!.loading).toBeFalsy();
               expect(stripSymbols(this.props.data!.todo_list)).toEqual(
                 updatedData.todo_list
@@ -405,7 +395,7 @@ describe('graphql(mutation) update queries', () => {
     });
 
     return wait(() => {
-      expect(queryRenderCount).toBe(5);
+      expect(queryRenderCount).toBe(4);
     });
   });
 });

--- a/src/react/hoc/__tests__/queries/observableQuery.test.tsx
+++ b/src/react/hoc/__tests__/queries/observableQuery.test.tsx
@@ -321,9 +321,6 @@ describe('[queries] observableQuery', () => {
               expect(stripSymbols(allPeople)).toEqual(data.allPeople);
               break;
             case 3:
-              expect(loading).toBe(true);
-              break;
-            case 4:
               expect(loading).toBe(false);
               expect(stripSymbols(allPeople)).toEqual(data.allPeople);
               break;

--- a/src/react/hoc/__tests__/queries/skip.test.tsx
+++ b/src/react/hoc/__tests__/queries/skip.test.tsx
@@ -619,32 +619,35 @@ describe('[queries] skip', () => {
     })(
       class extends React.Component<any> {
         render() {
-          switch (count) {
-            case 0:
-              expect(this.props.data.loading).toBeTruthy();
+          switch (++count) {
+            case 1:
+              expect(this.props.data.loading).toBe(true);
               expect(ranQuery).toBe(1);
               break;
-            case 1:
-              expect(this.props.data.loading).toBeFalsy();
+            case 2:
+              expect(this.props.data.loading).toBe(false);
               expect(ranQuery).toBe(1);
               setTimeout(() => {
                 this.props.setSkip(true);
               });
               break;
-            case 2:
+            case 3:
               expect(this.props.data).toBeUndefined();
               expect(ranQuery).toBe(1);
               setTimeout(() => {
                 this.props.setSkip(false);
               });
               break;
-            case 3:
-              expect(this.props.data!.loading).toBeFalsy();
-              expect(ranQuery).toBe(2);
+            case 4:
+              expect(this.props.data!.loading).toBe(true);
+              expect(ranQuery).toBe(3);
+              break;
+            case 5:
+              expect(this.props.data!.loading).toBe(false);
+              expect(ranQuery).toBe(3);
               break;
             default:
           }
-          count += 1;
           return null;
         }
       }
@@ -669,7 +672,7 @@ describe('[queries] skip', () => {
     );
 
     await wait(() => {
-      expect(count).toEqual(4);
+      expect(count).toEqual(5);
     });
   });
 


### PR DESCRIPTION
The crucial commit is the final one, which fixes #6659 and #6686 by making the `getCurrentResult` method of `ObservableQuery` return a result with `loading: false` when the cache provides complete data, assuming the `FetchPolicy` is `cache-first` or `cache-only` (the two policies that allow for non-loading results from the cache).

The general principle here is that `getCurrentResult` should return either the result most recently delivered to the `ObservableQuery`, or (if no result has been delivered yet) the next result that will be delivered. In cases where the cache is already primed with the necessary data (perhaps by a parent UI component), that next result can have `loading: false`, so it's important that `getCurrentResult` also returns a `loading: false` result in those cases.

Since `queryInfo.networkStatus` defaults to `NetworkStatus.loading` when `QueryInfo` objects are first initialized in `QueryManager#watchQuery`, `getCurrentResult` code was confused by `queryInfo.networkStatus`, and missed the opportunity to deliver non-loading results when the cache is warm.

I've never been happy with `getCurrentResult` and `getCurrentQueryResult`, so I also took this opportunity to unify those methods and simplify the surrounding logic.