### PR TITLE
Ergonomic improvements for field policy merge and keyArgs functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@
 - Allow passing an asynchronous `options.renderFunction` to `getMarkupFromTree`. <br/>
   [@richardscarrott](https://github.com/richardscarrott) in [#6576](https://github.com/apollographql/apollo-client/pull/6576)
 
+- Ergonomic improvements for `merge` and `keyArgs` functions in cache field policies. <br/>
+  [@benjamn](https://github.com/benjamn) in [#6714](https://github.com/apollographql/apollo-client/pull/6714)
+
 ## Apollo Client 3.0.2
 
 ## Bug Fixes

--- a/src/__tests__/ApolloClient.ts
+++ b/src/__tests__/ApolloClient.ts
@@ -679,9 +679,7 @@ describe('ApolloClient', () => {
                 d: {
                   // Silence "Cache data may be lost..."  warnings by
                   // unconditionally favoring the incoming data.
-                  merge(_, incoming) {
-                    return incoming;
-                  },
+                  merge: false,
                 },
               },
             },
@@ -1196,9 +1194,7 @@ describe('ApolloClient', () => {
                     // Deliberately silence "Cache data may be lost..."
                     // warnings by preferring the incoming data, rather
                     // than (say) concatenating the arrays together.
-                    merge(_, incoming) {
-                      return incoming;
-                    },
+                    merge: false,
                   },
                 },
               },

--- a/src/__tests__/fetchMore.ts
+++ b/src/__tests__/fetchMore.ts
@@ -2,7 +2,7 @@ import { assign, cloneDeep } from 'lodash';
 import gql from 'graphql-tag';
 
 import { itAsync, mockSingleLink, subscribeAndCount } from '../testing';
-import { InMemoryCache, InMemoryCacheConfig } from '../cache';
+import { InMemoryCache, InMemoryCacheConfig, FieldMergeFunction } from '../cache';
 import { ApolloClient, NetworkStatus, ObservableQuery } from '../core';
 import { offsetLimitPagination, concatPagination } from '../utilities';
 
@@ -412,7 +412,8 @@ describe('fetchMore on an observable query', () => {
     const { merge } = groceriesFieldPolicy;
     groceriesFieldPolicy.merge = function (existing, incoming, options) {
       mergeArgsHistory.push(options.args);
-      return (merge as any).call(this, existing, incoming, options);
+      return (merge as FieldMergeFunction<any>).call(
+        this, existing, incoming, options);
     };
 
     const cache = new InMemoryCache({

--- a/src/__tests__/fetchMore.ts
+++ b/src/__tests__/fetchMore.ts
@@ -215,9 +215,7 @@ describe('fetchMore on an observable query', () => {
           Query: {
             fields: {
               entry: {
-                merge(_, incoming) {
-                  return incoming;
-                },
+                merge: false,
               },
             },
           },
@@ -414,7 +412,7 @@ describe('fetchMore on an observable query', () => {
     const { merge } = groceriesFieldPolicy;
     groceriesFieldPolicy.merge = function (existing, incoming, options) {
       mergeArgsHistory.push(options.args);
-      return merge!.call(this, existing, incoming, options);
+      return (merge as any).call(this, existing, incoming, options);
     };
 
     const cache = new InMemoryCache({
@@ -831,9 +829,7 @@ describe('fetchMore on an observable query with connection', () => {
           Query: {
             fields: {
               entry: {
-                merge(_, incoming) {
-                  return incoming;
-                },
+                merge: false,
               },
             },
           },

--- a/src/__tests__/optimistic.ts
+++ b/src/__tests__/optimistic.ts
@@ -135,9 +135,7 @@ describe('optimistic mutation results', () => {
                 // Deliberately silence "Cache data may be lost..."
                 // warnings by favoring the incoming data, rather than
                 // (say) concatenating the arrays together.
-                merge(_, incoming) {
-                  return incoming;
-                },
+                merge: false,
               },
             },
           },

--- a/src/cache/inmemory/__tests__/cache.ts
+++ b/src/cache/inmemory/__tests__/cache.ts
@@ -876,9 +876,7 @@ describe('Cache', () => {
               d: {
                 // Deliberately silence "Cache data may be lost..."
                 // warnings by unconditionally favoring the incoming data.
-                merge(_, incoming) {
-                  return incoming;
-                },
+                merge: false,
               },
             },
           },

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -624,6 +624,9 @@ describe("type policies", function () {
                   expect(context.typename).toBe("Thread");
                   expect(context.fieldName).toBe("comments");
                   expect(context.field!.name.value).toBe("comments");
+                  expect(context.variables).toEqual({
+                    unused: "check me",
+                  });
 
                   if (typeof args!.limit === "number") {
                     if (typeof args!.offset === "number") {
@@ -681,6 +684,9 @@ describe("type policies", function () {
               author: { name: "Hobbes" },
             }],
           },
+        },
+        variables: {
+          unused: "check me",
         },
       });
 

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -88,6 +88,7 @@ export type KeyArgsFunction = (
     typename: string;
     fieldName: string;
     field: FieldNode | null;
+    variables?: Record<string, any>;
   },
 ) => KeySpecifier | ReturnType<IdGetter>;
 
@@ -492,6 +493,7 @@ export class Policies {
         typename,
         fieldName,
         field: fieldSpec.field || null,
+        variables: fieldSpec.variables,
       };
       const args = argsFromFieldSpecifier(fieldSpec);
       while (keyFn) {

--- a/src/core/__tests__/QueryManager/index.ts
+++ b/src/core/__tests__/QueryManager/index.ts
@@ -2167,9 +2167,7 @@ describe('QueryManager', () => {
         Query: {
           fields: {
             info: {
-              merge(_, incoming) {
-                return incoming;
-              },
+              merge: false,
             },
           },
         },


### PR DESCRIPTION
This PR introduces two minor improvements for `merge` and `keyArgs` functions in [field policies](https://www.apollographql.com/docs/react/caching/cache-field-behavior/).

First, if you need to write a custom [`keyArgs`](https://deploy-preview-6714--apollo-client-docs.netlify.app/docs/react/caching/cache-field-behavior/#specifying-key-arguments) function (unusual), you can now access the variables of the current read/write operation through `context.variables`.

Second, you can now write
```ts
new InMemoryCache({
  typePolicies: {
    Book: {
      fields: {
        author: {
          merge: true,
        },
      },
    },
  },
})
```
as a shorthand for
```ts
new InMemoryCache({
  typePolicies: {
    Book: {
      fields: {
        author: {
          merge(existing, incoming, { mergeObjects }) {
            return mergeObjects(existing, incoming);
          },
        },
      },
    },
  },
})
```
to enable merging of `author` objects associated with a given `Book`.

You can also specify `merge: false` to do the opposite:
```ts
new InMemoryCache({
  typePolicies: {
    CourtCase: {
      fields: {
        verdict: {
          merge: false,
        },
      },
    },
  },
})
```
This ensures the `verdict` field of the `CourtCase` object always overwrites any existing `verdict`, without warning about clobbering data (see #6372). In other words, `merge: false` is a shorthand for
```ts
new InMemoryCache({
  typePolicies: {
    CourtCase: {
      fields: {
        verdict: {
          merge(_, incoming) {
            return incoming;
          },
        },
      },
    },
  },
})
```