### PR TITLE
Update why-apollo.mdx

### DIFF
--- a/docs/source/why-apollo.mdx
+++ b/docs/source/why-apollo.mdx
@@ -68,7 +68,7 @@ Here's what our query for one dog looks like:
 
 ```js
 const GET_DOG = gql`
-  query GetAllDogs {
+  query GetDog {
     dog(id: "abc") {
       id
       breed


### PR DESCRIPTION
I may be confused about how to name queries, but if the Apollo Cache stores data based on `id` and `__typename`, then the actual name of the query would not need to be the same as the plural form of the query. And in this case, I think the more semantically appropriate name would be GET_DOG. 

If I am misunderstanding naming rules, then it may be helpful to clarify the rules.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
