### PR TITLE
Avoid evaluating `it` unless/until itAsync called.

### DIFF
--- a/src/utilities/testing/itAsync.ts
+++ b/src/utilities/testing/itAsync.ts
@@ -1,6 +1,4 @@
-function wrap<TResult>(
-  original: (...args: any[]) => TResult,
-) {
+function wrap<TResult>(key?: "only" | "skip" | "todo") {
   return (
     message: string,
     callback: (
@@ -8,20 +6,20 @@ function wrap<TResult>(
       reject: (reason?: any) => void,
     ) => any,
     timeout?: number,
-  ) => original(message, function () {
+  ) => (key ? it[key] : it)(message, function () {
     return new Promise(
       (resolve, reject) => callback.call(this, resolve, reject),
     );
   }, timeout);
 }
 
-const wrappedIt = wrap(it);
+const wrappedIt = wrap();
 export function itAsync(...args: Parameters<typeof wrappedIt>) {
   return wrappedIt.apply(this, args);
 }
 
 export namespace itAsync {
-  export const only = wrap(it.only);
-  export const skip = wrap(it.skip);
-  export const todo = wrap(it.todo);
+  export const only = wrap("only");
+  export const skip = wrap("skip");
+  export const todo = wrap("todo");
 }


### PR DESCRIPTION
A safer way to solve https://github.com/apollographql/apollo-client/pull/6576#issuecomment-664510739, given that 458960673148b70051315a4c0e73f9f22d749e2d had to be reverted. This change makes it safe to import the `@apollo/client/testing` entry point in environments that don't define `global.it`.