### PR TITLE
Re-export cache types from @apollo/client/core, again.

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -34,13 +34,28 @@ export { isApolloError, ApolloError } from '../errors';
 /* Cache */
 
 export {
+  // All the exports (types and values) from ../cache, minus cacheSlot,
+  // which we want to keep semi-private.
   Cache,
   ApolloCache,
+  Transaction,
+  DataProxy,
   InMemoryCache,
+  InMemoryCacheConfig,
   MissingFieldError,
   defaultDataIdFromObject,
+  ReactiveVar,
   makeVar,
+  TypePolicies,
+  TypePolicy,
+  FieldPolicy,
+  FieldReadFunction,
+  FieldMergeFunction,
+  FieldFunctionOptions,
+  PossibleTypesMap,
 } from '../cache';
+
+export * from '../cache/inmemory/types';
 
 /* Link */
 


### PR DESCRIPTION
These types were lost in #6656 when I switched from
```ts
export * from '../cache'
```
to using named exports. There are some `@apollo/client/cache` exports that I wanted to omit from `@apollo/client/core` (like `cacheSlot`), but I definitely did not intend to omit these types!

Fixes #6723.