### PR TITLE
Fix wrong import in cache persintence docs

### DIFF
--- a/docs/source/caching/advanced-topics.mdx
+++ b/docs/source/caching/advanced-topics.mdx
@@ -352,7 +352,7 @@ To get started, simply pass your Apollo Cache and a storage provider to `persist
 
 ```js
 import { AsyncStorage } from 'react-native';
-import { InMemoryCache } from '@apollo/cache';
+import { InMemoryCache } from '@apollo/client';
 import { persistCache } from 'apollo-cache-persist';
 
 const cache = new InMemoryCache();


### PR DESCRIPTION
`@apollo/cache` package does not exists.
Also previous examples are importing `InMemmoryCache` from `@apollo/client`

Thanks :heart: