### PR TITLE
Avoid making network requests when skip is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Apollo Client 3.1.2 (not yet released)
+
+## Bug Fixes
+
+- Avoid making network requests when `skip` is `true`.  <br/>
+  [@hwillson](https://github.com/hwillson) in [#6752](https://github.com/apollographql/apollo-client/pull/6752)
+
 ## Apollo Client 3.1.1
 
 ## Bug Fixes

--- a/src/react/data/QueryData.ts
+++ b/src/react/data/QueryData.ts
@@ -227,6 +227,8 @@ export class QueryData<TData, TVariables> extends OperationData {
   }
 
   private updateObservableQuery() {
+    if (this.getOptions().skip) return;
+
     // If we skipped initially, we may not have yet created the observable
     if (!this.currentObservable) {
       this.initializeObservableQuery();
@@ -326,6 +328,13 @@ export class QueryData<TData, TVariables> extends OperationData {
     // When skipping a query (ie. we're not querying for data but still want
     // to render children), make sure the `data` is cleared out and
     // `loading` is set to `false` (since we aren't loading anything).
+    //
+    // NOTE: We no longer think this is the correct behavior. Skipping should
+    // not automatically set `data` to `undefined`, but instead leave the
+    // previous data in place. In other words, skipping should not mandate
+    // that previously received data is all of a sudden removed. Unfortunately,
+    // changing this is breaking, so we'll have to wait until Apollo Client
+    // 4.0 to address this.
     if (options.skip) {
       result = {
         ...result,

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -2162,5 +2162,68 @@ describe('useQuery Hook', () => {
         expect(renderCount).toBe(3);
       }).then(resolve, reject);
     });
+
+    itAsync('should not make network requests when `skip` is `true`', (resolve, reject) => {
+      let networkRequestCount = 0;
+      const link = new ApolloLink((o, f) => {
+        networkRequestCount += 1;
+        return f ? f(o) : null;
+      }).concat(mockSingleLink(
+        {
+          request: {
+            query: CAR_QUERY,
+            variables: { someVar: true }
+          },
+          result: { data: CAR_RESULT_DATA }
+        }
+      ));
+
+      const client = new ApolloClient({
+        link,
+        cache: new InMemoryCache()
+      });
+
+      let renderCount = 0;
+      const Component = () => {
+        const [skip, setSkip] = useState(false);
+        const { loading, data } = useQuery(CAR_QUERY, {
+          fetchPolicy: 'no-cache',
+          skip,
+          variables: { someVar: !skip }
+        });
+
+        switch (++renderCount) {
+          case 1:
+            expect(loading).toBeTruthy();
+            expect(data).toBeUndefined();
+            break;
+          case 2:
+            expect(loading).toBeFalsy();
+            expect(data).toEqual(CAR_RESULT_DATA);
+            expect(networkRequestCount).toBe(1);
+            setTimeout(() => setSkip(true));
+            break;
+          case 3:
+            expect(loading).toBeFalsy();
+            expect(data).toBeUndefined();
+            expect(networkRequestCount).toBe(1);
+            break;
+          default:
+            reject('too many renders');
+        }
+
+        return null;
+      };
+
+      render(
+        <ApolloProvider client={client}>
+          <Component />
+        </ApolloProvider>
+      );
+
+      return wait(() => {
+        expect(renderCount).toBe(3);
+      }).then(resolve, reject);
+    });
   });
 });


### PR DESCRIPTION
When skip is set to true but other updated options have been passed into `useQuery` (like updated variables), `useQuery` will still make a network request, even though it will skip the handling of the response. This commit makes sure `useQuery` doesn't make unnecessary `skip` network requests.

Fixes #6670
Fixes #6190
Fixes #6572