### PR TITLE
Add description & example of how to handle multiple parameters in read() when declaring typePolicies.

### DIFF
--- a/docs/source/caching/cache-field-behavior.mdx
+++ b/docs/source/caching/cache-field-behavior.mdx
@@ -79,6 +79,43 @@ const cache = new InMemoryCache({
 });
 ```
 
+If a field requires numerous parameters then each parameter must be wrapped in a variable that is then destructured and returned.
+Each parameter will be available as individual subfields.
+
+The following `read` function assigns a default value of `UNKNOWN FIRST_NAME` to the `first_name` subfield of a `fullName` field and a `UNKNOWN LAST_NAME` to the `last_name` of a `fullName` field.
+
+```ts
+const cache = new InMemoryCache({
+  typePolicies: {
+    Person: {
+      fields: {
+        fullName: {
+          read(full_name = {
+            first_name: "UNKNOWN FIRST_NAME",
+            last_name: "UNKNOWN LAST_NAME",
+          }) {
+            return { ...full_name };
+          },
+        },
+      },
+    },
+  },
+});
+```
+
+The following `query` returns the `first_name` and `last_name` subfields from the `fullName` field:
+
+```graphql
+query personWithFullName {
+  fullName {
+    first_name
+    last_name
+  }
+}
+```
+
+If a field accepts arguments, the second parameter includes the values of those arguments. The following `read` function checks to see if the `maxLength` argument is provided when the `name` field is queried. If it is, the function returns only the first `maxLength` characters of the person's name. Otherwise, the person's full name is returned.
+
 You can define a `read` function for a field that isn't even defined in your schema. For example, the following `read` function enables you to query a `userId` field that is always populated with locally stored data:
 
 ```ts


### PR DESCRIPTION
The official documentation lacked an example and description of how to handle multiple parameters within the read() function when defining typePolicies. 
The proposed change addresses that by both showcasing that it is possible to handle multiple parameters and how to do so (using a syntax that was previously undocumented). 

I struggled for a while when it came to understanding how to handle this use case, so I am more than happy to share my findings while improving the docs with the hope of helping others that might find themselves in the same situation. 😃

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
