### PR TITLE
Import missing JSX namespace from react

### DIFF
--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { JSX, ReactNode } from 'react';
 import { DocumentNode } from 'graphql';
 
 import { Observable } from '../../utilities';


### PR DESCRIPTION
On line 261 JSX.Element is used but the JSX namespace is never imported.

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
