### PR TITLE
Settle Feuds with Data

### DIFF
--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -235,7 +235,8 @@ export class QueryInfo {
         // of writeQuery, so we can store the new diff quietly and ignore
         // it when we receive it redundantly from the watch callback.
         this.cache.performTransaction(cache => {
-          if (equal(result?.data, this.lastWrittenResult?.data) &&
+          if (this.lastWrittenResult &&
+              equal(result.data, this.lastWrittenResult.data) &&
               equal(options.variables, this.lastWrittenVars)) {
             // If result is the same as the last result we received from
             // the network (and the variables match too), avoid writing

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -235,7 +235,7 @@ export class QueryInfo {
         // of writeQuery, so we can store the new diff quietly and ignore
         // it when we receive it redundantly from the watch callback.
         this.cache.performTransaction(cache => {
-          if (equal(result, this.lastWrittenResult) &&
+          if (equal(result?.data, this.lastWrittenResult?.data) &&
               equal(options.variables, this.lastWrittenVars)) {
             // If result is the same as the last result we received from
             // the network (and the variables match too), avoid writing


### PR DESCRIPTION
Ran into a scenario as described by @benjamn here: https://github.com/apollographql/apollo-client/blob/master/src/core/QueryInfo.ts#L237

where queries were feuding over a piece of data in the cache, causing an infinite loop of network requests. Normally this mechanism would have prevented them from continuing on in that loop because they were returning the same network result data every time, however, our Apollo server has tracing extensions applied as described here: https://github.com/apollographql/apollo-tracing

which causes this check to fail:
https://github.com/apollographql/apollo-client/blob/master/src/core/QueryInfo.ts#L238

since the result objects include the extensions and the extensions include unique time sensitive data like query durations and start/end time. The simple fix is to check for equality of the data properties of the results rather than the entire result objects. If that has consequences I'm not aware of, then it might be better to check equality of the objects, omitting the extensions property.