### PR TITLE
Update import for `makeVar` in documetation

### DIFF
--- a/docs/source/local-state/reactive-variables.mdx
+++ b/docs/source/local-state/reactive-variables.mdx
@@ -26,7 +26,7 @@ This code creates a reactive variable with an empty array as its initial value.
 To read the value of your reactive variable, call the function returned by `makeVar` with zero arguments:
 
 ```js
-const cartItems = cache.makeVar([]);
+const cartItems = makeVar([]);
 
 // Output: []
 console.log(cartItems());
@@ -37,7 +37,7 @@ console.log(cartItems());
 To modify the value of your reactive variable, call the function returned by `makeVar` with one argument (the variable's new value):
 
 ```js
-const cartItems = cache.makeVar([]);
+const cartItems = makeVar([]);
 
 cartItems([100, 101, 102]);
 


### PR DESCRIPTION
`makeVar` was originally being used as `cache.makeVar` which is using the old import style which is no longer in Apollo 3. This should instead just be invoked as `makeVar` because it is imported as `import { makeVar } from "@apollo/client";`

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests

(Checklist seems to not apply as this is a documentation change)