### PR TITLE
Disable feud-stopping logic after any cache eviction.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Substantially improve type inference for data and variables types using `TypedDocumentNode<Data, Variables>` type instead of `DocumentNode`. <br/>
   [@dotansimha](https://github.com/dotansimha) in [#6720](https://github.com/apollographql/apollo-client/pull/6720)
 
+- Disable feud-stopping logic after any cache eviction. <br/>
+  [@benjamn](https://github.com/benjamn) in [#6817](https://github.com/apollographql/apollo-client/pull/6817)
+
 ## Apollo Client 3.1.3
 
 ## Bug Fixes


### PR DESCRIPTION
When application code evicts an object or its fields from the cache, and those evictions trigger network requests, the network data is often vital for repairing the damage done by the eviction, even if the network data look exactly the same as the previously-written data.

In other words, after any cache eviction, we should disable the logic introduced in PR #6448 to stop query feuds. This exception is reasonable because feuding queries only write additional data into the cache, rather than evicting anything, so we can safely assume evictions do not contribute to a cycle of competing cache updates.

I freely admit the method of counting evictions that I've implemented here is a bit of a hack, but it works for any `ApolloCache` implementation, without requiring the public `ApolloCache` API to support any new functionality. If we identify any other potential consumers of this information, we might consider a more official API.