### PR TITLE
Adjust wording to stop misleading "errors stored in cache" concept

### DIFF
--- a/docs/source/data/error-handling.mdx
+++ b/docs/source/data/error-handling.mdx
@@ -13,11 +13,11 @@ Any application, from simple to complex, can have its fair share of errors. It i
 
 ## Error policies
 
-Much like `fetchPolicy`, `errorPolicy` allows you to control how GraphQL Errors from the server are sent to your UI code. By default, the error policy treats any GraphQL Errors as network errors and ends the request chain. It doesn't save any data in the cache, and renders your UI with the `error` prop to be an ApolloError. By changing this policy per request, you can adjust how GraphQL Errors are managed in the cache and your UI. The possible options for `errorPolicy` are:
+Much like `fetchPolicy`, `errorPolicy` allows you to control how GraphQL Errors from the server are sent to your UI code. By default, the error policy treats any GraphQL Errors as network errors and ends the request chain. It doesn't save any data in the cache, and renders your UI with the `error` prop to be an ApolloError. By changing this policy per request, you can adjust how GraphQL Errors are managed by your UI. The possible options for `errorPolicy` are:
 
 - `none`: This is the default policy to match how Apollo Client 1.0 worked. Any GraphQL Errors are treated the same as network errors and any data is ignored from the response.
 - `ignore`: Ignore allows you to read any data that is returned alongside GraphQL Errors, but doesn't save the errors or report them to your UI.
-- `all`: Using the `all` policy is the best way to notify your users of potential issues while still showing as much data as possible from your server. It saves both data and errors into the Apollo Cache so your UI can use them.
+- `all`: Using the `all` policy is the best way to notify your users of potential issues while still showing as much data as possible from your server. It saves both data and errors so your UI can use them.
 
 You can set `errorPolicy` on each request like so:
 


### PR DESCRIPTION
Errors are saved in memory for use by an application's UI, but they are not stored in the actual cache itself. The original wording here leads people to believe they are, so this PR tweaks the wording a bit.

Related to: #4806