### PR TITLE
Avoid full reobservation for optimistic mutation results.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Disable feud-stopping logic after any cache eviction. <br/>
   [@benjamn](https://github.com/benjamn) in [#6817](https://github.com/apollographql/apollo-client/pull/6817)
 
+- Prevent full reobservation of queries affected by optimistic mutation updates, while still delivering results from the cache. <br/>
+  [@benjamn](https://github.com/benjamn) in [#6854](https://github.com/apollographql/apollo-client/pull/6854)
+
 ## Apollo Client 3.1.3
 
 ## Bug Fixes

--- a/src/__tests__/optimistic.ts
+++ b/src/__tests__/optimistic.ts
@@ -1334,7 +1334,7 @@ describe('optimistic mutation results', () => {
         client.watchQuery({ query }) as any as ObservableInput<any>,
       ).pipe(
         map(value => stripSymbols(value.data.todoList.todos)),
-        take(4),
+        take(5),
         toArray(),
       ).toPromise();
 
@@ -1360,6 +1360,10 @@ describe('optimistic mutation results', () => {
 
       expect(responses).toEqual([
         defaultTodos,
+        [
+          customOptimisticResponse1.createTodo,
+          ...defaultTodos,
+        ],
         [
           customOptimisticResponse2.createTodo,
           customOptimisticResponse1.createTodo,
@@ -1811,7 +1815,7 @@ describe('optimistic mutation results', () => {
         client.watchQuery({ query }) as any as ObservableInput<any>,
       ).pipe(
         map(value => stripSymbols(value.data.todoList.todos)),
-        take(4),
+        take(5),
         toArray(),
       ).toPromise();
 
@@ -1833,6 +1837,10 @@ describe('optimistic mutation results', () => {
       const defaultTodos = stripSymbols(result.data.todoList.todos);
       expect(responses).toEqual([
         defaultTodos,
+        [
+          customOptimisticResponse1.createTodo,
+          ...defaultTodos,
+        ],
         [
           customOptimisticResponse2.createTodo,
           customOptimisticResponse1.createTodo,

--- a/src/__tests__/optimistic.ts
+++ b/src/__tests__/optimistic.ts
@@ -1937,6 +1937,7 @@ describe('optimistic mutation results', () => {
       expect(optimisticDiffs).toEqual([
         {
           complete: true,
+          fromOptimisticTransaction: true,
           result: {
             items: manualItems,
           },
@@ -2099,12 +2100,14 @@ describe('optimistic mutation results', () => {
         expect(optimisticDiffs).toEqual([
           {
             complete: true,
+            fromOptimisticTransaction: true,
             result: {
               items: manualItems,
             },
           },
           {
             complete: true,
+            fromOptimisticTransaction: true,
             result: {
               items: [...manualItems, optimisticItem],
             },

--- a/src/cache/core/types/DataProxy.ts
+++ b/src/cache/core/types/DataProxy.ts
@@ -82,6 +82,7 @@ export namespace DataProxy {
     result?: T;
     complete?: boolean;
     missing?: MissingFieldError[];
+    fromOptimisticTransaction?: boolean;
   }
 }
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -125,7 +125,7 @@ export class ObservableQuery<
     });
   }
 
-  public getCurrentResult(saveAsLastResult?: boolean): ApolloQueryResult<TData> {
+  public getCurrentResult(saveAsLastResult = true): ApolloQueryResult<TData> {
     const { lastResult, lastError } = this;
     const networkStatus = this.queryInfo.networkStatus || NetworkStatus.ready;
     const result: ApolloQueryResult<TData> = {
@@ -176,7 +176,7 @@ export class ObservableQuery<
       }
     }
 
-    if (saveAsLastResult !== false) {
+    if (saveAsLastResult) {
       this.updateLastResult(result);
     }
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -585,7 +585,7 @@ once, rather than every time you call fetchMore.`);
 
   // Pass the current result to this.observer.next without applying any
   // fetch policies, bypassing the Reobserver.
-  public observe() {
+  private observe() {
     // Passing false is important so that this.getCurrentResult doesn't
     // save the fetchMore result as this.lastResult, causing it to be
     // ignored due to the this.isDifferentFromLastResult check in

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -125,7 +125,7 @@ export class ObservableQuery<
     });
   }
 
-  public getCurrentResult(): ApolloQueryResult<TData> {
+  public getCurrentResult(saveAsLastResult?: boolean): ApolloQueryResult<TData> {
     const { lastResult, lastError } = this;
     const networkStatus = this.queryInfo.networkStatus || NetworkStatus.ready;
     const result: ApolloQueryResult<TData> = {
@@ -176,7 +176,9 @@ export class ObservableQuery<
       }
     }
 
-    this.updateLastResult(result);
+    if (saveAsLastResult !== false) {
+      this.updateLastResult(result);
+    }
 
     return result;
   }
@@ -276,36 +278,11 @@ export class ObservableQuery<
 
     const qid = this.queryManager.generateQueryId();
 
+    // Simulate a loading result for the original query with
+    // result.networkStatus === NetworkStatus.fetchMore.
     if (combinedOptions.notifyOnNetworkStatusChange) {
-      const currentResult = this.getCurrentResult();
-
-      // If we neglect to update queryInfo.networkStatus here,
-      // getCurrentResult may return a loading:false result while
-      // fetchMore is in progress, since getCurrentResult also consults
-      // queryInfo.networkStatus. Note: setting queryInfo.networkStatus
-      // to an in-flight status means that QueryInfo#shouldNotify will
-      // return false while fetchMore is in progress, which is why we
-      // call this.reobserve() explicitly in the .finally callback after
-      // fetchMore (below), since the cache write will not automatically
-      // trigger a notification, even though it does trigger a cache
-      // broadcast. This is a good thing, because it means we won't see
-      // intervening query notifications while fetchMore is pending.
       this.queryInfo.networkStatus = NetworkStatus.fetchMore;
-
-      // Simulate a loading result for the original query with
-      // networkStatus === NetworkStatus.fetchMore.
-      this.observer.next!({
-        // Note that currentResult is an ApolloCurrentQueryResult<TData>,
-        // whereas this.observer.next expects an ApolloQueryResult<TData>.
-        // Fortunately, ApolloCurrentQueryResult is a subtype of
-        // ApolloQueryResult (with additional .error and .partial fields),
-        // so TypeScript has no problem with this sleight of hand.
-        // TODO Consolidate these two types into a single type (most
-        // likely just ApolloQueryResult) after AC3 is released.
-        ...currentResult,
-        loading: true,
-        networkStatus: NetworkStatus.fetchMore,
-      });
+      this.observe();
     }
 
     return this.queryManager.fetchQuery(
@@ -606,8 +583,18 @@ once, rather than every time you call fetchMore.`);
     return this.getReobserver().reobserve(newOptions, newNetworkStatus);
   }
 
-  private observer: Observer<ApolloQueryResult<TData>> = {
-    next: result => {
+  // Pass the current result to this.observer.next without applying any
+  // fetch policies, bypassing the Reobserver.
+  public observe() {
+    // Passing false is important so that this.getCurrentResult doesn't
+    // save the fetchMore result as this.lastResult, causing it to be
+    // ignored due to the this.isDifferentFromLastResult check in
+    // this.observer.next.
+    this.observer.next(this.getCurrentResult(false));
+  }
+
+  private observer = {
+    next: (result: ApolloQueryResult<TData>) => {
       if (this.lastError || this.isDifferentFromLastResult(result)) {
         this.updateLastResult(result);
         iterateObserversSafely(this.observers, 'next', result);

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -160,7 +160,18 @@ export class QueryInfo {
 
     if (oq) {
       oq["queryInfo"] = this;
-      this.listeners.add(this.oqListener = () => oq.reobserve());
+      this.listeners.add(this.oqListener = () => {
+        // If this.diff came from an optimistic transaction, deliver the
+        // current cache data to the ObservableQuery, but don't perform a
+        // full reobservation, since oq.reobserve might make a network
+        // request, and we don't want to trigger network requests for
+        // optimistic updates.
+        if (this.getDiff().fromOptimisticTransaction) {
+          oq.observe();
+        } else {
+          oq.reobserve();
+        }
+      });
     } else {
       delete this.oqListener;
     }

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -167,7 +167,7 @@ export class QueryInfo {
         // request, and we don't want to trigger network requests for
         // optimistic updates.
         if (this.getDiff().fromOptimisticTransaction) {
-          oq.observe();
+          oq["observe"]();
         } else {
           oq.reobserve();
         }

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -1361,7 +1361,6 @@ describe('ObservableQuery', () => {
           data: dataOne,
           loading: false,
           networkStatus: 7,
-          partial: false,
         });
         resolve();
       });
@@ -1406,7 +1405,6 @@ describe('ObservableQuery', () => {
           data: dataOne,
           loading: false,
           networkStatus: NetworkStatus.ready,
-          partial: false,
         });
       }).then(resolve, reject);
     });
@@ -1502,7 +1500,7 @@ describe('ObservableQuery', () => {
       const queryManager = mockQueryManager(reject, {
         request: { query, variables },
         result: { data: dataOne, errors: [error] },
-      }, 
+      },
       // FIXME: We shouldn't need a second mock, there should only be one network request
       {
         request: { query, variables },
@@ -1651,7 +1649,6 @@ describe('ObservableQuery', () => {
           data: void 0,
           loading: true,
           networkStatus: 1,
-          partial: false,
         });
 
         subscribeAndCount(reject, observable, (handleCount, subResult) => {
@@ -1659,7 +1656,6 @@ describe('ObservableQuery', () => {
             expect(subResult).toEqual({
               loading: true,
               networkStatus: NetworkStatus.loading,
-              partial: false,
             });
           } else if (handleCount === 2) {
             expect(subResult).toEqual({
@@ -1696,7 +1692,6 @@ describe('ObservableQuery', () => {
           data: undefined,
           loading: true,
           networkStatus: 1,
-          partial: false,
         });
 
         subscribeAndCount(reject, observable, (handleCount, subResult) => {
@@ -1711,7 +1706,6 @@ describe('ObservableQuery', () => {
               data,
               loading,
               networkStatus,
-              partial: false,
             });
           } else if (handleCount === 2) {
             expect(stripSymbols(subResult)).toEqual({


### PR DESCRIPTION
While all four commits are worthwhile and relevant, the key change is in the third commit (97f3caf57ded838c840bf33ae069d46af11ef247):

> ### Avoid full reobservation for broadcasts from optimistic transactions.
>
> I first attempted to solve this bug in #6419, but that approach was
flawed, and we ultimately reverted it in #6493. Both of these changes
happened shortly before the AC3 launch (`rc.3` and `rc.9`, respectively).
>
> The key to this solution is that `diff.fromOptimisticTransaction` is only
ever set by the `InMemoryCache` broadcast code, when we know that we've just
performed an optimistic transaction, and we're broadcasting to a query
watcher that requested `optimistic` data. The `QueryInfo` class receives this
broadcast, and uses `diff.fromOptimisticTransaction` to decide whether to do
a full reapplication of the chosen fetch policy by calling `oq.reobserve()`,
or simply to deliver a single cache result by calling `oq.observe()`.

I suggest reading the other commit messages for more details.

Thanks again to @darkbasic for first reporting this issue in https://github.com/apollographql/apollo-client/issues/6183#issuecomment-630108767.