### PR TITLE
Throw when writeFragment cannot identify object

### DIFF
--- a/src/cache/inmemory/__tests__/writeToStore.ts
+++ b/src/cache/inmemory/__tests__/writeToStore.ts
@@ -2325,4 +2325,17 @@ describe('writing to the store', () => {
       },
     });
   });
+
+  it("writeFragment should warn if it cannot identify the result object", () => {
+    const cache = new InMemoryCache;
+
+    expect(() => {
+      cache.writeFragment({
+        fragment: gql`fragment Count on Counter { count }`,
+        data: {
+          count: 1,
+        },
+      });
+    }).toThrowError(/writeFragment could not identify object/);
+  });
 });

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -105,6 +105,10 @@ export class StoreWriter {
       },
     });
 
+    if (typeof dataId === 'undefined' && !isReference(objOrRef)) {
+      throw new InvariantError("writeFragment could not identify object");
+    }
+
     const ref = isReference(objOrRef) ? objOrRef :
       dataId && makeReference(dataId) || void 0;
 


### PR DESCRIPTION
As noted in https://github.com/apollographql/apollo-client/issues/6706, writeFragment can fail to identify the object and return `undefined`. This can be a pain to debug so we now warn when that's the case.

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests