### PR TITLE
Add subscriptions-transport-ws in get-started.mdx

### DIFF
--- a/docs/source/get-started.mdx
+++ b/docs/source/get-started.mdx
@@ -17,6 +17,7 @@ npm install @apollo/client graphql subscriptions-transport-ws
 
 - `@apollo/client`: This single package contains virtually everything you need to set up Apollo Client. It includes the in-memory cache, local state management, error handling, and a React-based view layer.
 - `graphql`: This package provides logic for parsing GraphQL queries.
+- `subscriptions-transport-ws`: This package provides support for [GraphQL subscriptions](https://www.apollographql.com/docs/react/data/subscriptions/) over a WebSocket connection.
 
 > If you'd like to walk through this tutorial yourself, we recommend either running a new React project locally with [Create React App](https://create-react-app.dev/) or creating a new React sandbox on [CodeSandbox](https://codesandbox.io/). For reference, we will be using [this CodeSandbox](https://codesandbox.io/s/practical-snyder-48p1r2roz4) as our GraphQL server for our sample app, which pulls exchange rate data from the Coinbase API. If you'd like to skip ahead and see the app we're about to build, you can [view it on CodeSandbox](https://codesandbox.io/s/get-started-coinbase-client-73r10).
 

--- a/docs/source/get-started.mdx
+++ b/docs/source/get-started.mdx
@@ -12,7 +12,7 @@ Hello! This short tutorial gets you up and running with Apollo Client.
 First, let's install the packages we need:
 
 ```bash
-npm install @apollo/client graphql
+npm install @apollo/client graphql subscriptions-transport-ws
 ```
 
 - `@apollo/client`: This single package contains virtually everything you need to set up Apollo Client. It includes the in-memory cache, local state management, error handling, and a React-based view layer.


### PR DESCRIPTION
As `@apollo/client` has required peer dependency on `subscriptions-transport-ws@^0.9.0`, it should be installed as a peer alongside `graphql` on any new project. Otherwise, the following warning will appear upon installing:

```
npm WARN @apollo/client@3.1.3 requires a peer of subscriptions-transport-ws@^0.9.0 but none is installed. You must install peer dependencies yourself.
```

Side note: Ideally, `subscriptions-transport-ws` would be an optional peer dependency as it is likely to be used only in a minority of projects.