### PR TITLE
Switch to application/x-www-form-urlencoded encoding in rewriteURIForGet.ts

### DIFF
--- a/src/link/http/__tests__/HttpLink.ts
+++ b/src/link/http/__tests__/HttpLink.ts
@@ -116,7 +116,7 @@ describe('HttpLink', () => {
           expect(body).toBeUndefined();
           expect(method).toBe('GET');
           expect(uri).toBe(
-            '/data?query=query%20SampleQuery%20%7B%0A%20%20stub%20%7B%0A%20%20%20%20id%0A%20%20%7D%0A%7D%0A&operationName=SampleQuery&variables=%7B%22params%22%3A%22stub%22%7D&extensions=%7B%22myExtension%22%3A%22foo%22%7D',
+            '/data?query=query+SampleQuery+%7B%0A++stub+%7B%0A++++id%0A++%7D%0A%7D%0A&operationName=SampleQuery&variables=%7B%22params%22%3A%22stub%22%7D&extensions=%7B%22myExtension%22%3A%22foo%22%7D',
           );
         }),
         error: error => done.fail(error),
@@ -138,7 +138,7 @@ describe('HttpLink', () => {
           expect(body).toBeUndefined();
           expect(method).toBe('GET');
           expect(uri).toBe(
-            '/data?foo=bar&query=query%20SampleQuery%20%7B%0A%20%20stub%20%7B%0A%20%20%20%20id%0A%20%20%7D%0A%7D%0A&operationName=SampleQuery&variables=%7B%22params%22%3A%22stub%22%7D',
+            '/data?foo=bar&query=query+SampleQuery+%7B%0A++stub+%7B%0A++++id%0A++%7D%0A%7D%0A&operationName=SampleQuery&variables=%7B%22params%22%3A%22stub%22%7D',
           );
         }),
         error: error => done.fail(error),
@@ -164,7 +164,7 @@ describe('HttpLink', () => {
           expect(body).toBeUndefined();
           expect(method).toBe('GET');
           expect(uri).toBe(
-            '/data?query=query%20SampleQuery%20%7B%0A%20%20stub%20%7B%0A%20%20%20%20id%0A%20%20%7D%0A%7D%0A&operationName=SampleQuery&variables=%7B%22params%22%3A%22stub%22%7D',
+            '/data?query=query+SampleQuery+%7B%0A++stub+%7B%0A++++id%0A++%7D%0A%7D%0A&operationName=SampleQuery&variables=%7B%22params%22%3A%22stub%22%7D',
           );
         }),
       );
@@ -187,7 +187,7 @@ describe('HttpLink', () => {
           expect(body).toBeUndefined();
           expect(method).toBe('GET');
           expect(uri).toBe(
-            '/data?query=query%20SampleQuery%20%7B%0A%20%20stub%20%7B%0A%20%20%20%20id%0A%20%20%7D%0A%7D%0A&operationName=SampleQuery&variables=%7B%22params%22%3A%22stub%22%7D',
+            '/data?query=query+SampleQuery+%7B%0A++stub+%7B%0A++++id%0A++%7D%0A%7D%0A&operationName=SampleQuery&variables=%7B%22params%22%3A%22stub%22%7D',
           );
         }),
       );

--- a/src/link/http/rewriteURIForGET.ts
+++ b/src/link/http/rewriteURIForGET.ts
@@ -2,20 +2,18 @@ import { serializeFetchParameter } from './serializeFetchParameter';
 import { Body } from './selectHttpOptionsAndBody';
 
 // For GET operations, returns the given URI rewritten with parameters, or a
-// parse error.
+// parse error. Requires polyfills for URL and URLSearchParams in browsers
+// that don't have native support (ex: IE11)
 export function rewriteURIForGET(chosenURI: string, body: Body) {
   // Implement the standard HTTP GET serialization, plus 'extensions'. Note
   // the extra level of JSON serialization!
-  const queryParams: string[] = [];
-  const addQueryParam = (key: string, value: string) => {
-    queryParams.push(`${key}=${encodeURIComponent(value)}`);
-  };
+  const url = new URL(chosenURI, 'https://www.ignored-base');
 
   if ('query' in body) {
-    addQueryParam('query', body.query!);
+    url.searchParams.set('query', body.query!);
   }
   if (body.operationName) {
-    addQueryParam('operationName', body.operationName);
+    url.searchParams.set('operationName', body.operationName);
   }
   if (body.variables) {
     let serializedVariables;
@@ -27,7 +25,7 @@ export function rewriteURIForGET(chosenURI: string, body: Body) {
     } catch (parseError) {
       return { parseError };
     }
-    addQueryParam('variables', serializedVariables);
+    url.searchParams.set('variables', serializedVariables);
   }
   if (body.extensions) {
     let serializedExtensions;
@@ -39,24 +37,8 @@ export function rewriteURIForGET(chosenURI: string, body: Body) {
     } catch (parseError) {
       return { parseError };
     }
-    addQueryParam('extensions', serializedExtensions);
+    url.searchParams.set('extensions', serializedExtensions);
   }
 
-  // Reconstruct the URI with added query params.
-  // XXX This assumes that the URI is well-formed and that it doesn't
-  //     already contain any of these query params. We could instead use the
-  //     URL API and take a polyfill (whatwg-url@6) for older browsers that
-  //     don't support URLSearchParams. Note that some browsers (and
-  //     versions of whatwg-url) support URL but not URLSearchParams!
-  let fragment = '',
-    preFragment = chosenURI;
-  const fragmentStart = chosenURI.indexOf('#');
-  if (fragmentStart !== -1) {
-    fragment = chosenURI.substr(fragmentStart);
-    preFragment = chosenURI.substr(0, fragmentStart);
-  }
-  const queryParamsPrefix = preFragment.indexOf('?') === -1 ? '?' : '&';
-  const newURI =
-    preFragment + queryParamsPrefix + queryParams.join('&') + fragment;
-  return { newURI };
+  return { newURI: `${url.pathname}?${url.searchParams}` };
 }


### PR DESCRIPTION
Hey there 👋 

## Change
When `useGETForQueries` is enabled, `application/x-www-form-urlencoded` encoding is now used when serializing query parameters (`query`/`operationName`/`variables`) instead of URL percent encoding via `encodeURIComponent`.

## Why
When shoving a larger query into the URL, there is a risk of exceeding URL size limits anywhere past where TLS terminates. For example, I'm currently contributing to a platform that uses Fastly for caching, which [has a cap of 4kb](https://support.fastly.com/hc/en-us/community/posts/360040168371-General-size-limits-Cookies-headers-URLs).

The biggest wins here come from space characters being replaced with `+` instead of `%20`. `apollo-client` currently serializes ASTs to pretty-formatted queries (at runtime) before sending them over the network, so there's a significant amount of white-space that gets encoded.

## Alternative Solution
Users of `apollo-client` could alternatively switch to [persisted queries](https://www.apollographql.com/docs/apollo-server/performance/apq/), but this is a significantly larger change for existing applications that are just attempting to increase cache hit rates. 

## Implementation Notes
1. This change depends on the `URL` and `URLSearchParams` constructors, along with `URLSearchParams.prototype.set`. I believe these are supported in all target browsers _except_ IE11. This is likely a breaking change for anyone that would need to add polyfills.

   It's possible to work around this by manually implementing [`application/x-www-form-urlencoded` serialization](https://url.spec.whatwg.org/#urlencoded-serializing) (or at least a subset of it).

1. The `https://www.ignored-base` used as a `base` in the `URL` constructor is pretty hacky looking, but I figured (since there's now a dependency on `URLSearchParams`) we could fix some of the assumptions left in code comments (current code assumes a well-formed URI is always passed in). Happy to undo this or welcome suggestions for improvements

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
