### PR TITLE
Check structural equality in QueryInfo#setDiff.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Apollo Client 3.2.0 (not yet released)
 
+## Bug Fixes
+
+- Check structural equality of diff results in `QueryInfo#setDiff` instead of reference equality. <br/>
+  [@benjamn](https://github.com/benjamn) in [#6891](https://github.com/apollographql/apollo-client/pull/6891)
+
 ## Improvements
 
 - Substantially improve type inference for data and variables types using `TypedDocumentNode<Data, Variables>` type instead of `DocumentNode`. <br/>

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -3028,11 +3028,9 @@ describe('@connection', () => {
     client.cache.evict({ fieldName: "a" });
     await wait();
 
-    // The results are structurally the same, but the result objects have
-    // been recomputed for queries that involved the ROOT_QUERY.a field.
-    expect(checkLastResult(aResults, a456)).not.toBe(a456);
+    expect(checkLastResult(aResults, a456)).toBe(a456);
     expect(checkLastResult(bResults, bOyez)).toBe(bOyez);
-    expect(checkLastResult(abResults, a456bOyez)).not.toBe(a456bOyez);
+    expect(checkLastResult(abResults, a456bOyez)).toBe(a456bOyez);
 
     const cQuery = gql`{ c }`;
     // Passing cache-only as the fetchPolicy allows the { c: "see" }
@@ -3081,15 +3079,11 @@ describe('@connection', () => {
       { a: 123 },
       { a: 234 },
       { a: 456 },
-      // Delivered again because we explicitly called resetLastResults.
-      { a: 456 },
     ]);
 
     expect(bResults).toEqual([
       { b: "asdf" },
       { b: "ASDF" },
-      { b: "oyez" },
-      // Delivered again because we explicitly called resetLastResults.
       { b: "oyez" },
     ]);
 
@@ -3097,8 +3091,6 @@ describe('@connection', () => {
       { a: 123, b: "asdf" },
       { a: 234, b: "asdf" },
       { a: 234, b: "ASDF" },
-      { a: 456, b: "oyez" },
-      // Delivered again because we explicitly called resetLastResults.
       { a: 456, b: "oyez" },
     ]);
 

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -138,7 +138,9 @@ export class QueryInfo {
   setDiff(diff: Cache.DiffResult<any> | null) {
     const oldDiff = this.diff;
     this.diff = diff;
-    if (!this.dirty && diff?.result !== oldDiff?.result) {
+    if (!this.dirty &&
+        !equal(oldDiff && oldDiff.result,
+               diff && diff.result)) {
       this.dirty = true;
       if (!this.notifyTimeout) {
         this.notifyTimeout = setTimeout(() => this.notify(), 0);


### PR DESCRIPTION
Should help with #6888, which demonstrates that `===` disagrees with `equal` in some important cases, even though the cache is often able to provide `===` results when nothing has changed.