### PR TITLE
Improvements to options.nextFetchPolicy.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,16 @@
 - Check structural equality of diff results in `QueryInfo#setDiff` instead of reference equality. <br/>
   [@benjamn](https://github.com/benjamn) in [#6891](https://github.com/apollographql/apollo-client/pull/6891)
 
+- Use `options.nextFetchPolicy` internally to restore original `FetchPolicy` after polling with `fetchPolicy: "network-only"`, so that polling does not interfere with normal query watching. <br/>
+  [@benjamn](https://github.com/benjamn) in [#6893](https://github.com/apollographql/apollo-client/pull/6893)
+
 ## Improvements
 
 - Substantially improve type inference for data and variables types using `TypedDocumentNode<Data, Variables>` type instead of `DocumentNode`. <br/>
   [@dotansimha](https://github.com/dotansimha) in [#6720](https://github.com/apollographql/apollo-client/pull/6720)
+
+- Allow `options.nextFetchPolicy` to be a function that takes the current `FetchPolicy` and returns a new (or the same) `FetchPolicy`, making `nextFetchPolicy` more suitable for global use in `defaultOptions.watchQuery`. <br/>
+  [@benjamn](https://github.com/benjamn) in [#6893](https://github.com/apollographql/apollo-client/pull/6893)
 
 - Disable feud-stopping logic after any cache eviction. <br/>
   [@benjamn](https://github.com/benjamn) in [#6817](https://github.com/apollographql/apollo-client/pull/6817)

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -3164,6 +3164,96 @@ describe('@connection', () => {
       });
     });
 
+    itAsync('allows setting nextFetchPolicy in defaultOptions', (resolve, reject) => {
+      let networkCounter = 0;
+      let nextFetchPolicyCallCount = 0;
+
+      const client = new ApolloClient({
+        link: new ApolloLink(operation => new Observable(observer => {
+          observer.next({
+            data: {
+              count: networkCounter++,
+            },
+          });
+          observer.complete();
+        })),
+
+        cache: new InMemoryCache,
+
+        defaultOptions: {
+          watchQuery: {
+            nextFetchPolicy(fetchPolicy) {
+              expect(++nextFetchPolicyCallCount).toBe(1);
+              expect(this.query).toBe(query);
+              expect(fetchPolicy).toBe("cache-first");
+              // Usually options.nextFetchPolicy applies only once, but a
+              // nextFetchPolicy function can set this.nextFetchPolicy
+              // again to perform an additional transition.
+              this.nextFetchPolicy = fetchPolicy => {
+                ++nextFetchPolicyCallCount;
+                expect(fetchPolicy).toBe("cache-and-network");
+                return "cache-first";
+              };
+              return "cache-and-network";
+            },
+          },
+        },
+      });
+
+      const query = gql`
+        query {
+          count
+        }
+      `;
+
+      client.writeQuery({
+        query,
+        data: {
+          count: "initial",
+        },
+      });
+
+      const obs = client.watchQuery({ query });
+
+      subscribeAndCount(reject, obs, (handleCount, result) => {
+        if (handleCount === 1) {
+          expect(nextFetchPolicyCallCount).toBe(1);
+          expect(result.data).toEqual({ count: "initial" });
+          // Refetching makes a copy of the current options, which
+          // includes options.nextFetchPolicy, so the inner
+          // nextFetchPolicy function ends up getting called twice.
+          obs.refetch();
+        } else if (handleCount === 2) {
+          expect(result.data).toEqual({ count: "initial" });
+          expect(nextFetchPolicyCallCount).toBe(2);
+        } else if (handleCount === 3) {
+          expect(result.data).toEqual({ count: 0 });
+          expect(nextFetchPolicyCallCount).toBe(2);
+          client.writeQuery({
+            query,
+            data: {
+              count: "secondary",
+            },
+          });
+        } else if (handleCount === 4) {
+          expect(result.data).toEqual({ count: "secondary" });
+          expect(nextFetchPolicyCallCount).toBe(3);
+        } else if (handleCount === 5) {
+          expect(result.data).toEqual({ count: 1 });
+          expect(nextFetchPolicyCallCount).toBe(3);
+          client.cache.evict({ fieldName: "count" });
+        } else if (handleCount === 6) {
+          expect(result.data).toEqual({ count: 2 });
+          expect(nextFetchPolicyCallCount).toBe(3);
+          expect(obs.options.fetchPolicy).toBe("cache-first");
+          expect(obs.options.nextFetchPolicy).toBeUndefined();
+          setTimeout(resolve, 50);
+        } else {
+          reject("too many results");
+        }
+      });
+    });
+
     itAsync('allows setting default options for query', (resolve, reject) => {
       const errors = [{ message: 'failure', name: 'failure' }];
       const link = mockSingleLink({

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -238,7 +238,7 @@ export class ObservableQuery<
         fetchPolicy !== 'cache-and-network') {
       reobserveOptions.fetchPolicy = 'network-only';
       // Go back to the original options.fetchPolicy after this refetch.
-      reobserveOptions.nextFetchPolicy = fetchPolicy;
+      reobserveOptions.nextFetchPolicy = fetchPolicy || "cache-first";
     }
 
     if (variables && !equal(this.options.variables, variables)) {
@@ -436,16 +436,22 @@ once, rather than every time you call fetchMore.`);
     }
 
     let { fetchPolicy = 'cache-first' } = this.options;
+    const reobserveOptions: Partial<WatchQueryOptions<TVariables, TData>> = {
+      fetchPolicy,
+      variables,
+    };
+
     if (fetchPolicy !== 'cache-first' &&
         fetchPolicy !== 'no-cache' &&
         fetchPolicy !== 'network-only') {
-      fetchPolicy = 'cache-and-network';
+      reobserveOptions.fetchPolicy = 'cache-and-network';
+      reobserveOptions.nextFetchPolicy = fetchPolicy;
     }
 
-    return this.reobserve({
-      fetchPolicy,
-      variables,
-    }, NetworkStatus.setVariables);
+    return this.reobserve(
+      reobserveOptions,
+      NetworkStatus.setVariables,
+    );
   }
 
   public updateQuery<TVars = TVariables>(

--- a/src/core/Reobserver.ts
+++ b/src/core/Reobserver.ts
@@ -133,6 +133,7 @@ export class Reobserver<TData, TVars> {
         if (this.shouldFetch && this.shouldFetch()) {
           this.reobserve({
             fetchPolicy: "network-only",
+            nextFetchPolicy: this.options.fetchPolicy || "cache-first",
           }, NetworkStatus.poll).then(poll, poll);
         } else {
           poll();

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -115,7 +115,10 @@ export interface WatchQueryOptions<TVariables = OperationVariables, TData = any>
   /**
    * Specifies the {@link FetchPolicy} to be used after this query has completed.
    */
-  nextFetchPolicy?: WatchQueryFetchPolicy;
+  nextFetchPolicy?: WatchQueryFetchPolicy | ((
+    this: WatchQueryOptions<TVariables, TData>,
+    lastFetchPolicy: WatchQueryFetchPolicy,
+  ) => WatchQueryFetchPolicy);
 }
 
 export interface FetchMoreQueryOptions<TVariables, K extends keyof TVariables, TData = any> {


### PR DESCRIPTION
When we introduced `options.nextFetchPolicy` in #6712, it could only be a string, so you needed to have some way of also knowing the current `fetchPolicy`, in order to be sure `nextFetchPolicy` was appropriate.

Since there has been some interest in setting `defaultOptions.watchQuery.nextFetchPolicy` as a global option (e.g. https://github.com/apollographql/apollo-client/pull/6712#issuecomment-672578444), we want to be sure that's possible without making blind guesses about the current `options.fetchPolicy`. To that end, `nextFetchPolicy` can now be a function that takes the current `FetchPolicy` (which defaults to `cache-first`) and returns a new `FetchPolicy` based on the current one (possibly leaving it unchanged). For example, this allows you to transition from `cache-and-network` or `network-only` to `cache-first`, but leave other policies the same.

The other commits in this PR use `nextFetchPolicy` to fix some bugs in our polling implementation, and in `ObservableQuery#{refetch,setVariables}`. With any luck, these changes will help with #6858.