### PR TITLE
Ensure SubscriptionData error is actually an ApolloError

### DIFF
--- a/src/react/data/SubscriptionData.ts
+++ b/src/react/data/SubscriptionData.ts
@@ -6,6 +6,7 @@ import {
   SubscriptionDataOptions,
   SubscriptionResult
 } from '../types/types';
+import { ApolloError, isApolloError } from '../../core';
 
 export class SubscriptionData<
   TData = any,
@@ -128,10 +129,14 @@ export class SubscriptionData<
     }
   }
 
-  private updateError(error: any) {
+  private updateError(graphQLError: any) {
+    const apolloError = isApolloError(graphQLError)
+      ? graphQLError
+      : new ApolloError({ graphQLErrors: [graphQLError] });
+
     this.updateResult({
-      error,
-      loading: false
+      error: apolloError,
+      loading: false,
     });
   }
 


### PR DESCRIPTION
Fix for #6801 

The core issues it that when a websocket gets a message like:
```
{
  payload: {
    errors: [{message: "", extensions: [""]}]
  }
}
```
the subscription client ends up triggering an error with `{message: "", extensions: [""]}` which looks like an individual `GraphQLError`. This PR only ensures that anything coming in on subscriptions can't masquerade as `ApolloError` causing issues further on in the app, but more work is needed to properly convert that payload into an ApolloError with `graphQLErrors` property.