### PR TITLE
Bring back heuristic fragment matching, with a twist.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - Substantially improve type inference for data and variables types using `TypedDocumentNode<Data, Variables>` type instead of `DocumentNode`. <br/>
   [@dotansimha](https://github.com/dotansimha) in [#6720](https://github.com/apollographql/apollo-client/pull/6720)
 
+- Bring back an improved form of heuristic fragment matching, by allowing `possibleTypes` to specify subtype regular expression strings, which count as matches if the written result object has all the fields expected for the fragment. <br/>
+  [@benjamn](https://github.com/benjamn) in [#6901](https://github.com/apollographql/apollo-client/pull/6901)
+
 - Allow `options.nextFetchPolicy` to be a function that takes the current `FetchPolicy` and returns a new (or the same) `FetchPolicy`, making `nextFetchPolicy` more suitable for global use in `defaultOptions.watchQuery`. <br/>
   [@benjamn](https://github.com/benjamn) in [#6893](https://github.com/apollographql/apollo-client/pull/6893)
 

--- a/src/cache/inmemory/__tests__/__snapshots__/fragmentMatcher.ts.snap
+++ b/src/cache/inmemory/__tests__/__snapshots__/fragmentMatcher.ts.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`policies.fragmentMatches can infer fuzzy subtypes heuristically 1`] = `
+Object {
+  "ROOT_QUERY": Object {
+    "__typename": "Query",
+    "objects": Array [
+      Object {
+        "__typename": "E",
+        "c": "ce",
+      },
+      Object {
+        "__typename": "F",
+        "c": "cf",
+      },
+      Object {
+        "__typename": "G",
+        "c": "cg",
+      },
+      Object {
+        "__typename": "TooLong",
+      },
+      Object {
+        "__typename": "H",
+      },
+    ],
+  },
+}
+`;

--- a/src/cache/inmemory/__tests__/fragmentMatcher.ts
+++ b/src/cache/inmemory/__tests__/fragmentMatcher.ts
@@ -1,6 +1,8 @@
 import gql from 'graphql-tag';
 
 import { InMemoryCache } from '../inMemoryCache';
+import { visit, FragmentDefinitionNode } from 'graphql';
+import { hasOwn } from '../helpers';
 
 describe('fragment matching', () => {
   it('can match exact types with or without possibleTypes', () => {
@@ -221,5 +223,341 @@ describe('fragment matching', () => {
 
     cache.writeQuery({ query, data });
     expect(cache.readQuery({ query })).toEqual(data);
+  });
+
+});
+
+describe("policies.fragmentMatches", () => {
+  const warnings: any[] = [];
+  const { warn } = console;
+
+  beforeEach(() => {
+    warnings.length = 0;
+    console.warn = function (message: any) {
+      warnings.push(message);
+    };
+  });
+
+  afterEach(() => {
+    console.warn = warn;
+  });
+
+  it("can infer fuzzy subtypes heuristically", () => {
+    const cache = new InMemoryCache({
+      possibleTypes: {
+        A: ["B", "C"],
+        B: ["D"],
+        C: ["[E-Z]"],
+      },
+    });
+
+    const fragments = gql`
+      fragment FragA on A { a }
+      fragment FragB on B { b }
+      fragment FragC on C { c }
+      fragment FragD on D { d }
+      fragment FragE on E { e }
+      fragment FragF on F { f }
+    `;
+
+    function checkTypes(
+      expected: Record<string, Record<string, boolean>>,
+    ) {
+      const checked = new Set<FragmentDefinitionNode>();
+
+      visit(fragments, {
+        FragmentDefinition(frag) {
+          function check(typename: string, result: boolean) {
+            if (result !== cache.policies.fragmentMatches(frag, typename)) {
+              fail(`fragment ${
+                frag.name.value
+              } should${result ? "" : " not"} have matched typename ${typename}`);
+            }
+          }
+
+          const supertype = frag.typeCondition.name.value;
+          expect("ABCDEF".split("")).toContain(supertype);
+
+          if (hasOwn.call(expected, supertype)) {
+            Object.keys(expected[supertype]).forEach(subtype => {
+              check(subtype, expected[supertype][subtype]);
+            });
+
+            checked.add(frag);
+          }
+        },
+      });
+
+      return checked;
+    }
+
+    expect(checkTypes({
+      A: {
+        A: true,
+        B: true,
+        C: true,
+        D: true,
+        E: false,
+        F: false,
+        G: false,
+      },
+      B: {
+        A: false,
+        B: true,
+        C: false,
+        D: true,
+        E: false,
+        F: false,
+        G: false,
+      },
+      C: {
+        A: false,
+        B: false,
+        C: true,
+        D: false,
+        E: false,
+        F: false,
+        G: false,
+      },
+      D: {
+        A: false,
+        B: false,
+        C: false,
+        D: true,
+        E: false,
+        F: false,
+        G: false,
+      },
+      E: {
+        A: false,
+        B: false,
+        C: false,
+        D: false,
+        E: true,
+        F: false,
+        G: false,
+      },
+      F: {
+        A: false,
+        B: false,
+        C: false,
+        D: false,
+        E: false,
+        F: true,
+        G: false,
+      },
+      G: {
+        A: false,
+        B: false,
+        C: false,
+        D: false,
+        E: false,
+        F: false,
+        G: true,
+      },
+    }).size).toBe("ABCDEF".length);
+
+    cache.writeQuery({
+      query: gql`
+        query {
+          objects {
+            ...FragC
+          }
+        }
+        ${fragments}
+      `,
+      data: {
+        objects: [
+          { __typename: "E", c: "ce" },
+          { __typename: "F", c: "cf" },
+          { __typename: "G", c: "cg" },
+          // The /[E-Z]/ subtype pattern specified for the C supertype
+          // must match the entire subtype string.
+          { __typename: "TooLong", c: "nope" },
+          // The H typename matches the regular expression for C, but it
+          // does not pass the heuristic test of having all the fields
+          // expected if FragC matched.
+          { __typename: "H", h: "not c" },
+        ],
+      },
+    });
+
+    expect(warnings).toEqual([
+      "Inferring subtype E of supertype C",
+      "Inferring subtype F of supertype C",
+      "Inferring subtype G of supertype C",
+      // Note that TooLong is not inferred here.
+    ]);
+
+    expect(checkTypes({
+      A: {
+        A: true,
+        B: true,
+        C: true,
+        D: true,
+        E: true,
+        F: true,
+        G: true,
+        H: false,
+      },
+      B: {
+        A: false,
+        B: true,
+        C: false,
+        D: true,
+        E: false,
+        F: false,
+        G: false,
+        H: false,
+      },
+      C: {
+        A: false,
+        B: false,
+        C: true,
+        D: false,
+        E: true,
+        F: true,
+        G: true,
+        H: false,
+      },
+      D: {
+        A: false,
+        B: false,
+        C: false,
+        D: true,
+        E: false,
+        F: false,
+        G: false,
+        H: false,
+      },
+      E: {
+        A: false,
+        B: false,
+        C: false,
+        D: false,
+        E: true,
+        F: false,
+        G: false,
+        H: false,
+      },
+      F: {
+        A: false,
+        B: false,
+        C: false,
+        D: false,
+        E: false,
+        F: true,
+        G: false,
+        H: false,
+      },
+      G: {
+        A: false,
+        B: false,
+        C: false,
+        D: false,
+        E: false,
+        F: true,
+        G: true,
+        H: false,
+      },
+    }).size).toBe("ABCDEF".length);
+
+    expect(cache.extract()).toMatchSnapshot();
+
+    // Now add the TooLong subtype of C explicitly.
+    cache.policies.addPossibleTypes({
+      C: ["TooLong"],
+    });
+
+    expect(checkTypes({
+      A: {
+        A: true,
+        B: true,
+        C: true,
+        D: true,
+        E: true,
+        F: true,
+        G: true,
+        TooLong: true,
+        H: false,
+      },
+      B: {
+        A: false,
+        B: true,
+        C: false,
+        D: true,
+        E: false,
+        F: false,
+        G: false,
+        TooLong: false,
+        H: false,
+      },
+      C: {
+        A: false,
+        B: false,
+        C: true,
+        D: false,
+        E: true,
+        F: true,
+        G: true,
+        TooLong: true,
+        H: false,
+      },
+      D: {
+        A: false,
+        B: false,
+        C: false,
+        D: true,
+        E: false,
+        F: false,
+        G: false,
+        TooLong: false,
+        H: false,
+      },
+      E: {
+        A: false,
+        B: false,
+        C: false,
+        D: false,
+        E: true,
+        F: false,
+        G: false,
+        TooLong: false,
+        H: false,
+      },
+      F: {
+        A: false,
+        B: false,
+        C: false,
+        D: false,
+        E: false,
+        F: true,
+        G: false,
+        TooLong: false,
+        H: false,
+      },
+      G: {
+        A: false,
+        B: false,
+        C: false,
+        D: false,
+        E: false,
+        F: true,
+        G: true,
+        TooLong: false,
+        H: false,
+      },
+      H: {
+        A: false,
+        B: false,
+        C: false,
+        D: false,
+        E: false,
+        F: false,
+        G: false,
+        TooLong: false,
+        H: true,
+      },
+    }).size).toBe("ABCDEF".length);
   });
 });

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -420,6 +420,11 @@ export class Policies {
   public addPossibleTypes(possibleTypes: PossibleTypesMap) {
     (this.usingPossibleTypes as boolean) = true;
     Object.keys(possibleTypes).forEach(supertype => {
+      // Make sure all types have an entry in this.supertypeMap, even if
+      // their supertype set is empty, so we can return false immediately
+      // from policies.fragmentMatches for unknown supertypes.
+      this.getSupertypeSet(supertype, true);
+
       possibleTypes[supertype].forEach(subtype => {
         this.getSupertypeSet(subtype, true)!.add(supertype);
         const match = subtype.match(TypeOrFieldNameRegExp);
@@ -488,12 +493,15 @@ export class Policies {
     // Common case: fragment type condition and __typename are the same.
     if (typename === supertype) return true;
 
-    if (this.usingPossibleTypes) {
+    if (this.usingPossibleTypes &&
+        this.supertypeMap.has(supertype)) {
       const typenameSupertypeSet = this.getSupertypeSet(typename, true)!;
       const workQueue = [typenameSupertypeSet];
       const maybeEnqueue = (subtype: string) => {
         const supertypeSet = this.getSupertypeSet(subtype, false);
-        if (supertypeSet && workQueue.indexOf(supertypeSet) < 0) {
+        if (supertypeSet &&
+            supertypeSet.size &&
+            workQueue.indexOf(supertypeSet) < 0) {
           workQueue.push(supertypeSet);
         }
       };


### PR DESCRIPTION
Easily the biggest breaking change for fragment matching in Apollo Client 3.0 was the removal of the `FragmentMatcher` abstraction (#5073), along with its subclasses `HeuristicFragmentMatcher` and `IntrospectionFragmentmatcher` (#5684), which were replaced by the declarative [`possibleTypes`](https://www.apollographql.com/docs/react/data/fragments/#using-fragments-with-unions-and-interfaces) configuration.

The `HeuristicFragmentMatcher` was so named because it attempted to perform fragment matching without any actual knowledge of supertype/subtype relationships in your schema (for example, abstract interfaces implemented by concrete object subtypes, or unions with multiple alternative member types), checking instead whether all the fields of a given fragment were present in the result object, which is often a relatively strong signal that the fragment probably matched.

The `HeuristicFragmentMatcher` could be fooled by [field aliases](https://spec.graphql.org/June2018/#sec-Field-Alias) and accidental sharing of field names between different fragments, but it was also relatively resilient to adding new subtypes on the server, because heuristic matching doesn't care what the true subtypes of a supertype are, so what's one more?

Another big drawback of the `HeuristicFragmentMatcher` was that it applied the same fuzzy logic to _reading_ from the cache, where the heuristic makes a lot less sense. If an individual query result that you're writing into the cache has all the keys you'd expect if a certain fragment matched, that's a pretty good sign that the fragment matched. But when you have a lot of data in your cache, from lots of different queries, it's not as meaningful to observe that all the fields required by some fragment you're reading are present in an object, since they might be there just because they've been written into the cache by other queries over time, not because the fragment actually matches the `__typename` of the object.

In moving to the more exact `possibleTypes` system, we gave up both the benefits and the drawbacks of the `HeuristicFragmentMatcher`, replacing it with something functionally similar to the `IntrospectionFragmentmatcher`, but with a much simpler configuration API.

As #5750 demonstrates, the exactness of the `possibleTypes` system makes it challenging for existing clients to adapt when a new subtype is added on the server. Is there any way to make this system more flexible, like the `HeuristicFragmentMatcher`, but without the drawbacks? I believe so!

This PR improves the `possibleTypes` API by allowing "fuzzy" subtype strings, which are interpreted as regular expressions for type names, rather than as actual `__typename` strings. If a fuzzy subtype matches the `__typename` of an object, fragments on supertypes of that fuzzy subtype are allowed to match the object—provided the result _also_ has all the keys
required by the fragment.

In other words, if you previously configured the following `possibleTypes`:
```ts
new InMemoryCache({
  possibleTypes: {
    Character: ["Jedi", "Droid"],
    Test: ["PassingTest", "FailingTest", "SkippedTest"],
    Snake: ["Viper", "Python"],
  },
})
```
and you wanted to relax the `Test` supertype slightly, you could opt into fuzzy/heuristic matching by using a regular expression, while still enforcing a certain suffix:
```ts
new InMemoryCache({
  possibleTypes: {
    Character: ["Jedi", "Droid"],
    Test: ["PassingTest", "FailingTest", ".*Test"],
    Snake: ["Viper", "Python"],
  },
})
```
Since the `".*Test"` string is not a valid type name, it is interpreted as the regular expression `new RegExp(".*Test")`. In order to count as a match, the regular expression must match the entire `__typename` string, and the match will only be honored if all the fragment's fields are actually present in the result object. Because `PassingTest` and `FailingTest` are still specified explicitly, they will continue to match immediately, without any fuzzy logic, but an object with `__typename` equal to `SkippedTest` or `WishfulTest` would now have a chance of qualifying as a `Test` for the purposes of fragment matching.

Likewise, if you added `Python: ["^[A-Z].*Python"]` to the `possibleTypes` list above, a `fragment SnakeFragment on Snake` could match an object with a `__typename` of `ReticulatedPython`, provided that object has all the necessary fragment fields.

The key advantages of this new system compared to the `HeuristicFragmentMatcher` are that (1) you can specify fuzzy subtypes for specific supertypes (rather than applying heuristic matching for all types by default), and (2) that it "learns" about fuzzy subtypes while writing (where the heuristic tends to work well), and then merely _uses_ those inferred supertype/subtype relationships when reading, so there is no need to perform heuristic matching while reading. This is the "twist" mentioned in the title of this PR. When one of these inferences happens, you'll see a warning in the console (in development).

Unlike the old `HeuristicFragmentMatcher`, which provided the default behavior for all fragment matching, you do have to opt into fuzzy matching with `possibleTypes`, but it can be a useful strategy for preparing your clients for upcoming server changes, or for relaxing the rules for a particular supertype, in cases when you anticipate the subtypes may soon change on the server.