### PR TITLE
Mention useApolloClient hook in caching docs

### DIFF
--- a/docs/source/caching/cache-interaction.md
+++ b/docs/source/caching/cache-interaction.md
@@ -11,7 +11,7 @@ Apollo Client provides the following methods for reading and writing data to the
 
 These methods are described in detail below.
 
-All code samples below assume that you have initialized an instance of  `ApolloClient` and that you have imported the `gql` function from `@apollo/client`.
+All code samples below assume that you have initialized an instance of  `ApolloClient` and that you have imported the `gql` function from `@apollo/client`. You can access your instance of `ApolloClient` with the [`useApolloClient`](https://www.apollographql.com/docs/react/api/react/hooks/#useapolloclient) hook.
 
 ## `readQuery`
 

--- a/docs/source/caching/cache-interaction.md
+++ b/docs/source/caching/cache-interaction.md
@@ -11,7 +11,9 @@ Apollo Client provides the following methods for reading and writing data to the
 
 These methods are described in detail below.
 
-All code samples below assume that you have initialized an instance of  `ApolloClient` and that you have imported the `gql` function from `@apollo/client`. You can access your instance of `ApolloClient` with the [`useApolloClient`](https://www.apollographql.com/docs/react/api/react/hooks/#useapolloclient) hook.
+All code samples below assume that you have initialized an instance of  `ApolloClient` and that you have imported the `gql` function from `@apollo/client`.
+
+> In a React component, you can access your instance of `ApolloClient` using [`ApolloProvider`](https://www.apollographql.com/docs/react/api/react/hooks/#apolloprovider) and the [`useApolloClient`](https://www.apollographql.com/docs/react/api/react/hooks/#useapolloclient) hook.
 
 ## `readQuery`
 


### PR DESCRIPTION
As someone new to apollo it took me a bit to figure out the best way of accessing the instance of `client` within a component. I think `useApolloClient` would be worth mentioning here. 

The other places I see this hook mentioned are in the [local-resolvers](https://www.apollographql.com/docs/react/local-state/local-resolvers/#updating-local-state) section and the [Apollo Basics > 8. Update data with mutations](https://www.apollographql.com/docs/tutorial/mutations/#update-data-with-usemutation) sections.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
