### PR TITLE
Restrict root object identification to ROOT_QUERY.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Apollo Client 3.1.4
+
+## Bug Fixes
+
+- Restrict root object identification to `ROOT_QUERY` (the ID corresponding to the root `Query` object), allowing `Mutation` and `Subscription` as user-defined types. <br/>
+  [@benjamn](https://github.com/benjamn) in [#6914](https://github.com/apollographql/apollo-client/pull/6914)
+
 ## Apollo Client 3.1.3
 
 ## Bug Fixes

--- a/src/cache/inmemory/__tests__/__snapshots__/writeToStore.ts.snap
+++ b/src/cache/inmemory/__tests__/__snapshots__/writeToStore.ts.snap
@@ -1,0 +1,81 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`writing to the store user objects should be able to have { __typename: "Mutation" } 1`] = `
+Object {
+  "Gene:{\\"id\\":\\"SLC45A2\\"}": Object {
+    "__typename": "Gene",
+    "id": "SLC45A2",
+  },
+  "Gene:{\\"id\\":\\"SNAI2\\"}": Object {
+    "__typename": "Gene",
+    "id": "SNAI2",
+  },
+  "Mutation:{\\"gene\\":{\\"id\\":\\"SLC45A2\\"},\\"name\\":\\"albinism\\"}": Object {
+    "__typename": "Mutation",
+    "gene": Object {
+      "__ref": "Gene:{\\"id\\":\\"SLC45A2\\"}",
+      "id": "SLC45A2",
+    },
+    "name": "albinism",
+  },
+  "Mutation:{\\"gene\\":{\\"id\\":\\"SNAI2\\"},\\"name\\":\\"piebaldism\\"}": Object {
+    "__typename": "Mutation",
+    "gene": Object {
+      "__ref": "Gene:{\\"id\\":\\"SNAI2\\"}",
+      "id": "SNAI2",
+    },
+    "name": "piebaldism",
+  },
+  "ROOT_QUERY": Object {
+    "__typename": "Query",
+    "mutations": Array [
+      Object {
+        "__ref": "Mutation:{\\"gene\\":{\\"id\\":\\"SLC45A2\\"},\\"name\\":\\"albinism\\"}",
+      },
+      Object {
+        "__ref": "Mutation:{\\"gene\\":{\\"id\\":\\"SNAI2\\"},\\"name\\":\\"piebaldism\\"}",
+      },
+    ],
+  },
+}
+`;
+
+exports[`writing to the store user objects should be able to have { __typename: "Subscription" } 1`] = `
+Object {
+  "ROOT_QUERY": Object {
+    "__typename": "Query",
+    "subscriptions": Array [
+      Object {
+        "__ref": "Subscription:{\\"subId\\":1}",
+      },
+      Object {
+        "__ref": "Subscription:{\\"subId\\":2}",
+      },
+      Object {
+        "__ref": "Subscription:{\\"subId\\":3}",
+      },
+    ],
+  },
+  "Subscription:{\\"subId\\":1}": Object {
+    "__typename": "Subscription",
+    "subId": 1,
+    "subscriber": Object {
+      "name": "Alice",
+    },
+  },
+  "Subscription:{\\"subId\\":2}": Object {
+    "__typename": "Subscription",
+    "subId": 2,
+    "subscriber": Object {
+      "name": "Bob",
+    },
+  },
+  "Subscription:{\\"subId\\":3}": Object {
+    "__typename": "Subscription",
+    "subId": 3,
+    "subscriber": Object {
+      "name": "Clytemnestra",
+    },
+  },
+}
+`;

--- a/src/cache/inmemory/__tests__/writeToStore.ts
+++ b/src/cache/inmemory/__tests__/writeToStore.ts
@@ -2325,4 +2325,126 @@ describe('writing to the store', () => {
       },
     });
   });
+
+  it('user objects should be able to have { __typename: "Subscription" }', () => {
+    const cache = new InMemoryCache({
+      typePolicies: {
+        Subscription: {
+          keyFields: ["subId"],
+        },
+      },
+    });
+
+    const query = gql`
+      query {
+        subscriptions {
+          __typename
+          subscriber {
+            name
+          }
+        }
+      }
+    `;
+
+    cache.writeQuery({
+      query,
+      data: {
+        subscriptions: [
+          {
+            __typename: "Subscription",
+            subId: 1,
+            subscriber: {
+              name: "Alice",
+            },
+          },
+          {
+            __typename: "Subscription",
+            subId: 2,
+            subscriber: {
+              name: "Bob",
+            },
+          },
+          {
+            __typename: "Subscription",
+            subId: 3,
+            subscriber: {
+              name: "Clytemnestra",
+            },
+          },
+        ],
+      },
+    });
+
+    expect(cache.extract()).toMatchSnapshot();
+    expect(cache.readQuery({ query })).toEqual({
+      subscriptions: [
+        { __typename: "Subscription", subscriber: { name: "Alice" }},
+        { __typename: "Subscription", subscriber: { name: "Bob" }},
+        { __typename: "Subscription", subscriber: { name: "Clytemnestra" }},
+      ],
+    });
+  });
+
+  it('user objects should be able to have { __typename: "Mutation" }', () => {
+    const cache = new InMemoryCache({
+      typePolicies: {
+        Mutation: {
+          keyFields: ["gene", ["id"], "name"],
+        },
+        Gene: {
+          keyFields: ["id"],
+        },
+      },
+    });
+
+    const query = gql`
+      query {
+        mutations {
+          __typename
+          gene { id }
+          name
+        }
+      }
+    `;
+
+    cache.writeQuery({
+      query,
+      data: {
+        mutations: [
+          {
+            __typename: "Mutation",
+            gene: {
+              __typename: "Gene",
+              id: "SLC45A2",
+            },
+            name: "albinism",
+          },
+          {
+            __typename: "Mutation",
+            gene: {
+              __typename: "Gene",
+              id: "SNAI2",
+            },
+            name: "piebaldism",
+          },
+        ],
+      },
+    });
+
+    expect(cache.extract()).toMatchSnapshot();
+    expect(cache.readQuery({ query })).toEqual({
+      mutations: [
+        {
+          __typename: "Mutation",
+          gene: { __typename: "Gene", id: "SLC45A2" },
+          name: "albinism",
+        },
+        {
+          __typename: "Mutation",
+          gene: { __typename: "Gene", id: "SNAI2" },
+          name: "piebaldism",
+        },
+      ],
+    });
+  });
 });

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -282,9 +282,14 @@ export class Policies {
       ? getTypenameFromResult(object, selectionSet, fragmentMap)
       : object.__typename;
 
-    if (typename) {
-      const rootId = this.rootIdsByTypename[typename];
-      if ("string" === typeof rootId) return [rootId];
+    // It should be possible to write root Query fields with
+    // writeFragment, using { __typename: "Query", ... } as the data, but
+    // it does not make sense to allow the same identification behavior
+    // for the Mutation and Subscription types, since application code
+    // should never be writing directly to (or reading directly from)
+    // those root objects.
+    if (typename === this.rootTypenamesById.ROOT_QUERY) {
+      return ["ROOT_QUERY"];
     }
 
     const context: KeyFieldsContext = {


### PR DESCRIPTION
Although "Mutation" and "Subscription" are technically the default names for the root mutation and subscription types, there should never be any need to refer to those objects, read from them, or write to them, outside the normal process of sending and receiving mutations and subscriptions.

If you think those use cases have any value, #6911 will quickly convince you that the downsides of monopolizing types like `Subscription` and `Mutation` (e.g. assuming they are always singletons) dramatically outweigh the benefits.

In fact, it's not even possible to request the `__typename` field for the root `Subscription` object, according to the GraphQL specification: https://spec.graphql.org/June2018/#sec-Single-root-field

In particular, whereas
```graphql
query { __typename }
```
can be used to find out the `__typename` of the root query object (which might be something other than "Query" in rare situations), the following operation is illegal, because a subscription must have only a single root field:
```graphql
subscription MessagesSub {
  __typename
  messages {
    source
    payload
  }
}
```
This means the only way to find out that the root `Subscription` type has a `__typename` other than "Subscription" would be through an introspection query, which is typically disallowed in production.