### PR TITLE
Fix crash when pageInfo and empty edges are given to relayStylePagination

### DIFF
--- a/src/utilities/policies/pagination.ts
+++ b/src/utilities/policies/pagination.ts
@@ -167,7 +167,7 @@ function updateCursor<TNode>(
 ) {
   if (index < 0) index += edges.length;
   const edge = edges[index];
-  if (cursor && cursor !== edge.cursor) {
+  if (cursor && edge && cursor !== edge.cursor) {
     edges[index] = { ...edge, cursor };
   }
 }


### PR DESCRIPTION
This is a simple fix for an issue with the relayStylePagination around this piece of code
```typescript
      const incomingEdges = incoming.edges.slice(0);
      if (incoming.pageInfo) {
        updateCursor(incomingEdges, 0, incoming.pageInfo.startCursor);
        updateCursor(incomingEdges, -1, incoming.pageInfo.endCursor);
      }
```
where if the server returns pageInfo, but an empty edges list, it'll crash in the updateCursor code because it assumes edges exist. 