### PR TITLE
allow querying connection metadata and then subsequent data in relayStylePagination

### DIFF
--- a/src/cache/inmemory/__tests__/__snapshots__/policies.ts.snap
+++ b/src/cache/inmemory/__tests__/__snapshots__/policies.ts.snap
@@ -765,3 +765,35 @@ Object {
   },
 }
 `;
+
+exports[`type policies field policies can handle Relay-style pagination without args 1`] = `
+Object {
+  "ROOT_QUERY": Object {
+    "__typename": "Query",
+    "todos": Object {
+      "edges": Array [
+        Object {
+          "__typename": "TodoEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjI=",
+          "node": Object {
+            "__ref": "Todo:1",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "__typename": "PageInfo",
+        "endCursor": "YXJyYXljb25uZWN0aW9uOjI=",
+        "hasNextPage": true,
+        "hasPreviousPage": false,
+        "startCursor": "YXJyYXljb25uZWN0aW9uOjI=",
+      },
+      "totalCount": 1292,
+    },
+  },
+  "Todo:1": Object {
+    "__typename": "Todo",
+    "id": "1",
+    "title": "Fix the tests",
+  },
+}
+`;

--- a/src/cache/inmemory/__tests__/__snapshots__/policies.ts.snap
+++ b/src/cache/inmemory/__tests__/__snapshots__/policies.ts.snap
@@ -797,3 +797,36 @@ Object {
   },
 }
 `;
+
+exports[`type policies field policies can handle Relay-style pagination without args 2`] = `
+Object {
+  "ROOT_QUERY": Object {
+    "__typename": "Query",
+    "todos": Object {
+      "edges": Array [
+        Object {
+          "__typename": "TodoEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjI=",
+          "node": Object {
+            "__ref": "Todo:1",
+          },
+        },
+      ],
+      "extraMetaData": "extra",
+      "pageInfo": Object {
+        "__typename": "PageInfo",
+        "endCursor": "YXJyYXljb25uZWN0aW9uOjI=",
+        "hasNextPage": true,
+        "hasPreviousPage": false,
+        "startCursor": "YXJyYXljb25uZWN0aW9uOjI=",
+      },
+      "totalCount": 1293,
+    },
+  },
+  "Todo:1": Object {
+    "__typename": "Todo",
+    "id": "1",
+    "title": "Fix the tests",
+  },
+}
+`;

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -2177,6 +2177,146 @@ describe("type policies", function () {
       });
     });
 
+    itAsync("can handle Relay-style pagination without args", (resolve, reject) => {
+      const cache = new InMemoryCache({
+        addTypename: false,
+        typePolicies: {
+          Query: {
+            fields: {
+              todos: relayStylePagination(),
+            },
+          },
+        },
+      });
+
+      const initialQuery = gql`
+        query TodoQuery {
+          todos {
+            totalCount
+          }
+        }
+      `
+
+      const query = gql`
+        query TodoQuery {
+          todos(after: $after, first: $first) {
+            pageInfo {
+              __typename
+              hasNextPage
+              endCursor
+            }
+            totalCount
+            edges {
+              __typename
+              node {
+                __typename
+                id
+                title
+              }
+            }
+          }
+        }
+      `
+
+      const firstVariables = {
+        first: 1,
+      };
+
+      const firstEdges = [
+        {
+          __typename: "TodoEdge",
+          node: {
+            __typename: "Todo",
+            id: '1',
+            title: 'Fix the tests'
+          }
+        },
+      ];
+
+      const firstPageInfo = {
+        __typename: "PageInfo",
+        endCursor: "YXJyYXljb25uZWN0aW9uOjI=",
+        hasNextPage: true,
+      };
+
+      const link = new MockLink([
+        {
+          request: {
+            query: initialQuery,
+          },
+          result: {
+            data: {
+              todos: {
+                totalCount: 1292
+              }
+            }
+          }
+        },
+        {
+          request: {
+            query,
+            variables: firstVariables,
+          },
+          result: {
+            data: {
+              todos: {
+                edges: firstEdges,
+                pageInfo: firstPageInfo,
+                totalCount: 1292,
+              }
+            }
+          },
+        },
+      ]).setOnError(reject);
+
+      const client = new ApolloClient({ link, cache });
+
+      client.query({query: initialQuery}).then(result => {
+        expect(result).toEqual({
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          data: {
+            todos: {
+              totalCount: 1292
+            }
+          }
+        })
+
+        expect(cache.extract()).toEqual({
+          ROOT_QUERY: {
+            __typename: "Query",
+            todos: {
+              edges: [],
+              pageInfo: {
+                "endCursor": "",
+                "hasNextPage": true,
+                "hasPreviousPage": false,
+                "startCursor": "",
+               },
+               totalCount: 1292
+             },
+          }
+        });
+
+        client.query({query, variables: firstVariables}).then(result => {
+          expect(result).toEqual({
+            loading: false,
+            networkStatus: NetworkStatus.ready,
+            data: {
+              todos: {
+                edges: firstEdges,
+                pageInfo: firstPageInfo,
+                totalCount: 1292,
+              }
+            }
+          })
+
+          expect(cache.extract()).toMatchSnapshot()
+          resolve()
+        })
+      })
+    })
+
     itAsync("can handle Relay-style pagination", (resolve, reject) => {
       const cache = new InMemoryCache({
         addTypename: false,

--- a/src/utilities/policies/pagination.ts
+++ b/src/utilities/policies/pagination.ts
@@ -79,7 +79,7 @@ export function relayStylePagination<TNode = Reference>(
     },
 
     merge(existing = makeEmptyData(), incoming, { args }) {
-      if (!args) return {...existing, ...incoming}; // TODO Maybe throw?
+      if (!args) return {...existing, ...incoming};
 
       const incomingEdges = (incoming.edges || []).slice(0);
       if (incoming.pageInfo) {

--- a/src/utilities/policies/pagination.ts
+++ b/src/utilities/policies/pagination.ts
@@ -79,8 +79,8 @@ export function relayStylePagination<TNode = Reference>(
     },
 
     merge(existing = makeEmptyData(), incoming, { args }) {
-      const incomingEdges = incoming.edges?.slice(0);
-      if (incoming.pageInfo && incomingEdges) {
+      const incomingEdges = incoming.edges ? incoming.edges.slice(0) : [];
+      if (incoming.pageInfo) {
         updateCursor(incomingEdges, 0, incoming.pageInfo.startCursor);
         updateCursor(incomingEdges, -1, incoming.pageInfo.endCursor);
       }
@@ -88,27 +88,26 @@ export function relayStylePagination<TNode = Reference>(
       let prefix = existing.edges;
       let suffix: typeof prefix = [];
 
-      if (args?.after) {
+      if (args && args.after) {
         const index = prefix.findIndex(edge => edge.cursor === args.after);
         if (index >= 0) {
           prefix = prefix.slice(0, index + 1);
           // suffix = []; // already true
         }
-      } else if (args?.before) {
+      } else if (args && args.before) {
         const index = prefix.findIndex(edge => edge.cursor === args.before);
         suffix = index < 0 ? prefix : prefix.slice(index);
         prefix = [];
-      } else {
+      } else if (incoming.edges) {
         // If we have neither args.after nor args.before, the incoming
         // edges cannot be spliced into the existing edges, so they must
         // replace the existing edges. See #6592 for a motivating example.
-        if(incomingEdges)
-          prefix = [];
+        prefix = [];
       }
 
       const edges = [
         ...prefix,
-        ...(incomingEdges || []),
+        ...incomingEdges,
         ...suffix,
       ];
 

--- a/src/utilities/policies/pagination.ts
+++ b/src/utilities/policies/pagination.ts
@@ -79,9 +79,9 @@ export function relayStylePagination<TNode = Reference>(
     },
 
     merge(existing = makeEmptyData(), incoming, { args }) {
-      if (!args) return existing; // TODO Maybe throw?
+      if (!args) return {...existing, ...incoming}; // TODO Maybe throw?
 
-      const incomingEdges = incoming.edges.slice(0);
+      const incomingEdges = (incoming.edges || []).slice(0);
       if (incoming.pageInfo) {
         updateCursor(incomingEdges, 0, incoming.pageInfo.startCursor);
         updateCursor(incomingEdges, -1, incoming.pageInfo.endCursor);
@@ -121,7 +121,7 @@ export function relayStylePagination<TNode = Reference>(
       };
 
       const updatePageInfo = (name: keyof TInternalRelay<TNode>["pageInfo"]) => {
-        const value = incoming.pageInfo[name];
+        const value = incoming.pageInfo && incoming.pageInfo[name];
         if (value !== void 0) {
           (pageInfo as any)[name] = value;
         }


### PR DESCRIPTION
Currently if you try to query relay connection metadata with no arguments

```
query todos{
  totalCount
}
```

And then query for the edges/data
```
query todos{
  totalCount
  edges {
    node {
      title
    }
  }
}
```

The cache will never have any todo items and both ```data``` and ```error``` returned by the cache will always be undefined.

This attempts to fix this.
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
