### PR TITLE
Improve 'No more mocked responses' error message

### DIFF
--- a/src/utilities/testing/mocking/__tests__/MockedProvider.test.tsx
+++ b/src/utilities/testing/mocking/__tests__/MockedProvider.test.tsx
@@ -11,7 +11,7 @@ import { InMemoryCache } from '../../../../cache/inmemory/inMemoryCache';
 import { ApolloLink } from '../../../../link/core';
 
 const variables = {
-  username: 'mock_username'
+  username: 'mock_username',
 };
 
 const userWithoutTypeName = {
@@ -154,7 +154,8 @@ describe('General use', () => {
     }
 
     const variables2 = {
-      username: 'other_user'
+      username: 'mock_username',
+      age: undefined
     };
 
     const link = ApolloLink.from([errorLink, new MockLink(mocks)]);
@@ -222,7 +223,7 @@ describe('General use', () => {
           query,
           variables: {
             age: 13,
-            username: 'some_user'
+            username: 'some_user',
           }
         },
         result: { data: { user } }
@@ -231,7 +232,7 @@ describe('General use', () => {
 
     const variables2 = {
       username: 'some_user',
-      age: 13
+      age: 13,
     };
 
     render(

--- a/src/utilities/testing/mocking/mockLink.ts
+++ b/src/utilities/testing/mocking/mockLink.ts
@@ -103,7 +103,6 @@ export class MockLink extends ApolloLink {
           : ""
         }`
       )
-      console.log(error)
       this.onError(error);
       return null;
     }

--- a/src/utilities/testing/mocking/mockLink.ts
+++ b/src/utilities/testing/mocking/mockLink.ts
@@ -88,20 +88,23 @@ export class MockLink extends ApolloLink {
     );
 
     if (!response || typeof responseIndex === 'undefined') {
-      this.onError(new Error(
+      const replacer = (key: string, value: any) =>
+        typeof value === 'undefined' ? "undefined" : value;
+      const error = new Error(
         `No more mocked responses for the query: ${print(
           operation.query
-        )}\nExpected variables:\n\t${JSON.stringify(operation.variables)}${
+        )}\nExpected variables:\n\t${JSON.stringify(operation.variables, replacer)}${
         diffs.length > 0
           ? `\nFound ${diffs.length} mock${
           diffs.length > 1 ? "s" : ""
           } with variables:\n${diffs.map(
-            (d, i) => `\t${i + 1}: ${JSON.stringify(d)}\n`
+            (d, i) => `\t${i + 1}: ${JSON.stringify(d, replacer)}\n`
           )}`
           : ""
         }`
       )
-      );
+      console.log(error)
+      this.onError(error);
       return null;
     }
 


### PR DESCRIPTION
Improves the error message when no more mocked responses are found.

2nd commit addressing: https://github.com/apollographql/apollo-client/issues/6771

Example from tests:
```
Error: No more mocked responses for the query: query GetUser($username: String!) {
  user(username: $username) {
    id
    __typename
  }
}

Expected variables:
  {"username":"mock_username","age":"undefined"}
Found 1 mock with variables:
  1: {"username":"mock_username"}
```
```
Error: No more mocked responses for the query: query GetUser($username: String!) {
  user(username: $username) {
    id
    __typename
  }
}

Expected variables:
  {"username":"some_user","age":42}
Found 1 mock with variables:
  1: {"age":13,"username":"some_user"}
```
```
Error: No more mocked responses for the query: query GetUser($username: String!) {
  user(username: $username) {
    id
    __typename
  }
}

Expected variables:
  {"username":"mock_username"}
```

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
