### PR TITLE
Improvements for cache.modify: details.storage and details.INVALIDATE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@
 - Throw if `writeFragment` cannot identify `options.data` when no `options.id` provided. <br/>
   [@jcreighton](https://github.com/jcreighton) in [#6859](https://github.com/apollographql/apollo-client/pull/6859)
 
+- Provide `options.storage` object to `cache.modify` functions, as provided to `read` and `merge` functions. <br/>
+  [@benjamn](https://github.com/benjamn) in [#6991](https://github.com/apollographql/apollo-client/pull/6991)
+
+- Allow `cache.modify` functions to return `details.INVALIDATE` (similar to `details.DELETE`) to invalidate the current field, causing affected queries to rerun, even if the field's value is unchanged. <br/>
+  [@benjamn](https://github.com/benjamn) in [#6991](https://github.com/apollographql/apollo-client/pull/6991)
+
 ## Apollo Client 3.1.4
 
 ## Bug Fixes

--- a/docs/source/api/cache/InMemoryCache.mdx
+++ b/docs/source/api/cache/InMemoryCache.mdx
@@ -207,6 +207,7 @@ The first parameter of a modifier function is the current value of the field bei
 | `canRead` | `CanReadFunction` | Returns `true` for non-normalized `StoreObjects` and non-dangling `Reference`s, indicating that `readField(name, objOrRef)` has a chance of working. Useful for filtering out dangling references from lists. |
 | `isReference` | `boolean` | Utility to check if an object is a `{ __ref }` object. |
 | `DELETE` | `any` | Sentinel object that can be returned from a modifier function to delete the field being modified. |
+| `INVALIDATE` | `any` | Sentinel object that can be returned from a modifier function to invalidate the field, causing affected queries to rerun, without changing or deleting the field value. |
 
 `Modifier` functions should return the value that is to be written into the cache for the field being modified, or a `DELETE` sentinel to remove the field.
 

--- a/docs/source/caching/cache-interaction.md
+++ b/docs/source/caching/cache-interaction.md
@@ -316,6 +316,36 @@ cache.modify({
 });
 ```
 
+### Example: Invalidating fields within a cached object
+
+Normally, changing or deleting a field's value also _invalidates_ the field, causing watched queries to be reread if they previously consumed the field.
+
+Using `cache.modify`, it's also possible to invalidate the field without changing or deleting its value, by returning the `INVALIDATE` sentinel:
+
+```js
+cache.modify({
+  id: cache.identify(myPost),
+  fields: {
+    comments(existingCommentRefs, { INVALIDATE }) {
+      return INVALIDATE;
+    },
+  },
+});
+```
+
+If you need to invalidate all fields within the given object, you can pass a modifier function as the value of the `fields` option:
+
+```js
+cache.modify({
+  id: cache.identify(myPost),
+  fields(fieldValue, details) {
+    return details.INVALIDATE;
+  },
+});
+```
+
+When using this form of `cache.modify`, you can determine the individual field names using `details.fieldName`. This technique works for any modifier function, not just those that return `INVALIDATE`.
+
 ## Obtaining an object's custom ID
 
 If a type in your cache uses a [custom identifier](./cache-configuration/#customizing-identifier-generation-by-type) (or even if it doesn't), you can use the `cache.identify` method to obtain the identifier for an object of that type. This method takes an object and computes its ID based on both its `__typename` and its identifier field(s). This means you don't have to keep track of which fields make up each type's identifier.

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     {
       "name": "apollo-client",
       "path": "./dist/apollo-client.cjs.min.js",
-      "maxSize": "24.5 kB"
+      "maxSize": "24.7 kB"
     }
   ],
   "peerDependencies": {

--- a/src/cache/core/types/common.ts
+++ b/src/cache/core/types/common.ts
@@ -55,6 +55,7 @@ export type CanReadFunction = (value: StoreValue) => boolean;
 
 export type Modifier<T> = (value: T, details: {
   DELETE: any;
+  INVALIDATE: any;
   fieldName: string;
   storeFieldName: string;
   readField: ReadFieldFunction;

--- a/src/cache/core/types/common.ts
+++ b/src/cache/core/types/common.ts
@@ -7,6 +7,8 @@ import {
   isReference,
 } from '../../../utilities';
 
+import { StorageType } from '../../inmemory/policies';
+
 // The Readonly<T> type only really works for object types, since it marks
 // all of the object's properties as readonly, but there are many cases when
 // a generic type parameter like TExisting might be a string or some other
@@ -62,6 +64,7 @@ export type Modifier<T> = (value: T, details: {
   canRead: CanReadFunction;
   isReference: typeof isReference;
   toReference: ToReferenceFunction;
+  storage: StorageType;
 }) => T;
 
 export type Modifiers = {

--- a/src/cache/inmemory/__tests__/__snapshots__/cache.ts.snap
+++ b/src/cache/inmemory/__tests__/__snapshots__/cache.ts.snap
@@ -228,6 +228,29 @@ Object {
 }
 `;
 
+exports[`InMemoryCache#modify should allow invalidation using details.INVALIDATE 1`] = `
+Object {
+  "Author:{\\"name\\":\\"Maria Dahvana Headley\\"}": Object {
+    "__typename": "Author",
+    "name": "Maria Dahvana Headley",
+  },
+  "Book:{\\"isbn\\":\\"0374110034\\"}": Object {
+    "__typename": "Book",
+    "author": Object {
+      "__ref": "Author:{\\"name\\":\\"Maria Dahvana Headley\\"}",
+    },
+    "isbn": "0374110034",
+    "title": "Beowulf: A New Translation",
+  },
+  "ROOT_QUERY": Object {
+    "__typename": "Query",
+    "currentlyReading": Object {
+      "__ref": "Book:{\\"isbn\\":\\"0374110034\\"}",
+    },
+  },
+}
+`;
+
 exports[`TypedDocumentNode<Data, Variables> should determine Data and Variables types of {write,read}{Query,Fragment} 1`] = `
 Object {
   "Author:{\\"name\\":\\"John C. Mitchell\\"}": Object {

--- a/src/cache/inmemory/__tests__/__snapshots__/policies.ts.snap
+++ b/src/cache/inmemory/__tests__/__snapshots__/policies.ts.snap
@@ -765,3 +765,25 @@ Object {
   },
 }
 `;
+
+exports[`type policies field policies read, merge, and modify functions can access options.storage 1`] = `
+Object {
+  "ROOT_QUERY": Object {
+    "__typename": "Query",
+    "mergeModify": 11,
+    "mergeRead": 1,
+    "mergeReadModify": 101,
+  },
+}
+`;
+
+exports[`type policies field policies read, merge, and modify functions can access options.storage 2`] = `
+Object {
+  "ROOT_QUERY": Object {
+    "__typename": "Query",
+    "mergeModify": 11,
+    "mergeRead": 1,
+    "mergeReadModify": 101,
+  },
+}
+`;

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -736,8 +736,8 @@ describe("type policies", function () {
       });
     });
 
-    it("can use stable storage in read functions", function () {
-      const storageSet = new Set<Record<string, any> | null>();
+    it("can use options.storage in read functions", function () {
+      const storageSet = new Set<Record<string, any>>();
 
       const cache = new InMemoryCache({
         typePolicies: {
@@ -745,8 +745,8 @@ describe("type policies", function () {
             fields: {
               result(existing, { args, storage }) {
                 storageSet.add(storage);
-                if (storage?.result) return storage.result;
-                return storage!.result = compute();
+                if (storage.result) return storage.result;
+                return storage.result = compute();
               },
             },
           },
@@ -840,9 +840,7 @@ describe("type policies", function () {
 
       // Clear the cached results.
       storageSet.forEach(storage => {
-        if (storage) {
-          delete storage.result;
-        }
+        delete storage.result;
       });
 
       const result3 = cache.readQuery({
@@ -965,16 +963,16 @@ describe("type policies", function () {
             fields: {
               result: {
                 read(_, { storage }) {
-                  if (!storage!.jobName) {
-                    storage!.jobName = makeVar(undefined);
+                  if (!storage.jobName) {
+                    storage.jobName = makeVar(undefined);
                   }
-                  return storage!.jobName();
+                  return storage.jobName();
                 },
                 merge(_, incoming: string, { storage }) {
-                  if (storage!.jobName) {
-                    storage!.jobName(incoming);
+                  if (storage.jobName) {
+                    storage.jobName(incoming);
                   } else {
-                    storage!.jobName = makeVar(incoming);
+                    storage.jobName = makeVar(incoming);
                   }
                 },
               },

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -2,12 +2,13 @@ import gql from "graphql-tag";
 
 import { InMemoryCache } from "../inMemoryCache";
 import { ReactiveVar, makeVar } from "../reactiveVars";
-import { Reference, StoreObject, ApolloClient, NetworkStatus } from "../../../core";
+import { Reference, StoreObject, ApolloClient, NetworkStatus, TypedDocumentNode } from "../../../core";
 import { MissingFieldError } from "../..";
 import { relayStylePagination } from "../../../utilities";
 import { MockLink } from '../../../utilities/testing/mocking/mockLink';
 import subscribeAndCount from '../../../utilities/testing/subscribeAndCount';
 import { itAsync } from '../../../utilities/testing/itAsync';
+import { FieldPolicy, StorageType } from "../policies";
 
 function reverse(s: string) {
   return s.split("").reverse().join("");
@@ -1225,6 +1226,157 @@ describe("type policies", function () {
           result: "result for job 4",
         }],
       });
+    });
+
+    it("read, merge, and modify functions can access options.storage", function () {
+      const storageByFieldName = new Map<string, StorageType>();
+
+      function recordStorageOnce(fieldName: string, storage: StorageType) {
+        if (storageByFieldName.has(fieldName)) {
+          expect(storageByFieldName.get(fieldName)).toBe(storage);
+        } else {
+          storageByFieldName.set(fieldName, storage);
+        }
+      }
+
+      function makeFieldPolicy(): FieldPolicy<number> {
+        return {
+          read(existing = 0, { fieldName, storage }) {
+            storage.readCount = (storage.readCount|0) + 1;
+            recordStorageOnce(fieldName, storage);
+            return existing;
+          },
+          merge(existing = 0, incoming, { fieldName, storage }) {
+            storage.mergeCount = (storage.mergeCount|0) + 1;
+            recordStorageOnce(fieldName, storage);
+            return existing + incoming;
+          },
+        };
+      };
+
+      const cache = new InMemoryCache({
+        typePolicies: {
+          Query: {
+            fields: {
+              mergeRead: makeFieldPolicy(),
+              mergeModify: makeFieldPolicy(),
+              mergeReadModify: makeFieldPolicy(),
+            },
+          },
+        },
+      });
+
+      const query: TypedDocumentNode<{
+        mergeRead: number;
+        mergeModify: number;
+        mergeReadModify: number;
+      }> = gql`
+        query {
+          mergeRead
+          mergeModify
+          mergeReadModify
+        }
+      `;
+
+      cache.writeQuery({
+        query,
+        data: {
+          mergeRead: 1,
+          mergeModify: 10,
+          mergeReadModify: 100,
+        },
+      });
+
+      expect(storageByFieldName.get("mergeRead")).toEqual({
+        mergeCount: 1,
+      });
+
+      expect(storageByFieldName.get("mergeModify")).toEqual({
+        mergeCount: 1,
+      });
+
+      expect(storageByFieldName.get("mergeReadModify")).toEqual({
+        mergeCount: 1,
+      });
+
+      expect(cache.readQuery({
+        query: gql`query { mergeRead mergeReadModify }`,
+      })).toEqual({
+        mergeRead: 1,
+        mergeReadModify: 100,
+      });
+
+      expect(storageByFieldName.get("mergeRead")).toEqual({
+        mergeCount: 1,
+        readCount: 1,
+      });
+
+      expect(storageByFieldName.get("mergeModify")).toEqual({
+        mergeCount: 1,
+      });
+
+      expect(storageByFieldName.get("mergeReadModify")).toEqual({
+        mergeCount: 1,
+        readCount: 1,
+      });
+
+      expect(cache.modify({
+        fields: {
+          mergeModify(value, { fieldName, storage }) {
+            storage.modifyCount = (storage.modifyCount|0) + 1;
+            recordStorageOnce(fieldName, storage);
+            return value + 1;
+          },
+          mergeReadModify(value, { fieldName, storage }) {
+            storage.modifyCount = (storage.modifyCount|0) + 1;
+            recordStorageOnce(fieldName, storage);
+            return value + 1;
+          },
+        },
+      })).toBe(true);
+
+      expect(cache.extract()).toMatchSnapshot();
+
+      expect(storageByFieldName.get("mergeRead")).toEqual({
+        mergeCount: 1,
+        readCount: 1,
+      });
+
+      expect(storageByFieldName.get("mergeModify")).toEqual({
+        mergeCount: 1,
+        modifyCount: 1,
+      });
+
+      expect(storageByFieldName.get("mergeReadModify")).toEqual({
+        mergeCount: 1,
+        readCount: 1,
+        modifyCount: 1,
+      });
+
+      expect(cache.readQuery({ query })).toEqual({
+        mergeRead: 1,
+        mergeModify: 11,
+        mergeReadModify: 101,
+      });
+
+      expect(storageByFieldName.get("mergeRead")).toEqual({
+        mergeCount: 1,
+        readCount: 2,
+      });
+
+      expect(storageByFieldName.get("mergeModify")).toEqual({
+        mergeCount: 1,
+        modifyCount: 1,
+        readCount: 1,
+      });
+
+      expect(storageByFieldName.get("mergeReadModify")).toEqual({
+        mergeCount: 1,
+        readCount: 2,
+        modifyCount: 1,
+      });
+
+      expect(cache.extract()).toMatchSnapshot();
     });
 
     it("merge functions can deduplicate items using readField", function () {

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -158,6 +158,8 @@ export abstract class EntityStore implements NormalizedCache {
               ...sharedDetails,
               fieldName,
               storeFieldName,
+              storage: this.policies["storageTrie"]
+                .lookup(dataId, storeFieldName),
             });
           if (newValue === INVALIDATE) {
             this.group.dirty(dataId, storeFieldName);

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -26,6 +26,7 @@ import {
 
 const DELETE: any = Object.create(null);
 const delModifier: Modifier<any> = () => DELETE;
+const INVALIDATE: any = Object.create(null);
 
 export abstract class EntityStore implements NormalizedCache {
   protected data: NormalizedCacheObject = Object.create(null);
@@ -128,6 +129,7 @@ export abstract class EntityStore implements NormalizedCache {
 
       const sharedDetails = {
         DELETE,
+        INVALIDATE,
         isReference,
         toReference: this.toReference,
         canRead: this.canRead,
@@ -157,11 +159,15 @@ export abstract class EntityStore implements NormalizedCache {
               fieldName,
               storeFieldName,
             });
-          if (newValue === DELETE) newValue = void 0;
-          if (newValue !== fieldValue) {
-            changedFields[storeFieldName] = newValue;
-            needToMerge = true;
-            fieldValue = newValue;
+          if (newValue === INVALIDATE) {
+            this.group.dirty(dataId, storeFieldName);
+          } else {
+            if (newValue === DELETE) newValue = void 0;
+            if (newValue !== fieldValue) {
+              changedFields[storeFieldName] = newValue;
+              needToMerge = true;
+              fieldValue = newValue;
+            }
           }
         }
         if (fieldValue !== void 0) {

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -138,7 +138,7 @@ export interface FieldFunctionOptions<
   // A handy place to put field-specific data that you want to survive
   // across multiple read function calls. Useful for field-level caching,
   // if your read function does any expensive work.
-  storage: StorageType | null;
+  storage: StorageType;
 
   cache: InMemoryCache;
 
@@ -598,17 +598,6 @@ export class Policies {
       const { merge } = this.getFieldPolicy(
         incoming.__typename, fieldName, false)!;
 
-      // If storage ends up null, that just means no options.storage object
-      // has ever been created for a read function for this field before, so
-      // there's nothing this merge function could do with options.storage
-      // that would help the read function do its work. Most merge functions
-      // will never need to worry about options.storage, but if you're reading
-      // this comment then you probably have good reasons for wanting to know
-      // esoteric details like these, you wizard, you.
-      const storage = storageKeys
-        ? this.storageTrie.lookupArray(storageKeys)
-        : null;
-
       incoming = merge!(existing, incoming.__value, makeFieldFunctionOptions(
         this,
         // Unlike options.readField for read functions, we do not fall
@@ -628,7 +617,9 @@ export class Policies {
           field,
           variables: context.variables },
         context,
-        storage,
+        storageKeys
+          ? this.storageTrie.lookupArray(storageKeys)
+          : Object.create(null),
       )) as T;
     }
 
@@ -695,7 +686,7 @@ function makeFieldFunctionOptions(
   objectOrReference: StoreObject | Reference | undefined,
   fieldSpec: FieldSpecifier,
   context: ReadMergeModifyContext,
-  storage: StorageType | null,
+  storage: StorageType,
 ): FieldFunctionOptions {
   const storeFieldName = policies.getStoreFieldName(fieldSpec);
   const fieldName = fieldNameFromStoreName(storeFieldName);

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -528,8 +528,6 @@ export class Policies {
       : fieldName + ":" + storeFieldName;
   }
 
-  private storageTrie = new KeyTrie<StorageType>(true);
-
   public readField<V = StoreValue>(
     options: ReadFieldOptions,
     context: ReadMergeModifyContext,
@@ -557,7 +555,7 @@ export class Policies {
         objectOrReference,
         options,
         context,
-        this.storageTrie.lookup(
+        context.store.getStorage(
           isReference(objectOrReference)
             ? objectOrReference.__ref
             : objectOrReference,
@@ -618,7 +616,7 @@ export class Policies {
           variables: context.variables },
         context,
         storageKeys
-          ? this.storageTrie.lookupArray(storageKeys)
+          ? context.store.getStorage(...storageKeys)
           : Object.create(null),
       )) as T;
     }

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -102,7 +102,7 @@ export type FieldPolicy<
   merge?: FieldMergeFunction<TExisting, TIncoming> | boolean;
 };
 
-type StorageType = Record<string, any>;
+export type StorageType = Record<string, any>;
 
 function argsFromFieldSpecifier(spec: FieldSpecifier) {
   return spec.args !== void 0 ? spec.args :

--- a/src/cache/inmemory/types.ts
+++ b/src/cache/inmemory/types.ts
@@ -7,7 +7,7 @@ import {
   Reference,
 } from '../../utilities';
 import { FieldValueGetter } from './entityStore';
-import { KeyFieldsFunction } from './policies';
+import { KeyFieldsFunction, StorageType } from './policies';
 import {
   Modifier,
   Modifiers,
@@ -62,6 +62,11 @@ export interface NormalizedCache {
   getFieldValue: FieldValueGetter;
   toReference: ToReferenceFunction;
   canRead: CanReadFunction;
+
+  getStorage(
+    idOrObj: string | StoreObject,
+    storeFieldName: string,
+  ): StorageType;
 }
 
 /**


### PR DESCRIPTION
This PR brings the [`options.storage`](https://www.apollographql.com/docs/react/caching/cache-field-behavior/#fieldpolicy-api-reference) object from `read` and `merge` functions to `cache.modify` functions, improving consistency between those APIs.

Also, `cache.modify` modifier functions can now return `details.INVALIDATE` (similar to `details.DELETE`) to invalidate the current field, causing affected queries to rerun, even if the field's value is unchanged. Previously, changing or deleting the field's value was the only way to invalidate the field.