### PR TITLE
docs: update MutationOptions

### DIFF
--- a/docs/shared/mutation-result.mdx
+++ b/docs/shared/mutation-result.mdx
@@ -2,7 +2,7 @@
 
 | Property | Type | Description |
 | - | - | - |
-| `mutate` | (options?: MutationOptions) => Promise&lt;FetchResult&gt; | A function to trigger a mutation from your UI. You can optionally pass `variables`, `optimisticResponse`, `refetchQueries`, and `update` in as options, which will override options/props passed to `useMutation` / `Mutation`. The function returns a promise that fulfills with your mutation result. |
+| `mutate` | (options?: MutationOptions) => Promise&lt;FetchResult&gt; | A function to trigger a mutation from your UI. You can optionally pass `awaitRefetchQueries`, `context`, `fetchPolicy`, `optimisticResponse`, `refetchQueries`, `update`, and `variables` in as options, which will override options/props passed to `useMutation` / `Mutation`. The function returns a promise that fulfills with your mutation result. |
 
 **Mutation result:**
 


### PR DESCRIPTION
# update MutationOptions
Adds additional options to the documentation according to the interface `MutationFunctionOptions`

```ts
export interface MutationFunctionOptions<
  TData = any,
  TVariables = OperationVariables
> {
  variables?: TVariables;
  optimisticResponse?: TData | ((vars: TVariables) => TData);
  refetchQueries?: Array<string | PureQueryOptions> | RefetchQueriesFunction;
  awaitRefetchQueries?: boolean;
  update?: MutationUpdaterFn<TData>;
  context?: Context;
  fetchPolicy?: WatchQueryFetchPolicy;
}
```
