### PR TITLE
Make ApolloQueryResult.data field non-optional again.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Apollo Client 3.1.5
+
+## Bug Fixes
+
+- Make `ApolloQueryResult.data` field non-optional again. <br/>
+  [@benjamn](https://github.com/benjamn) in [#6997](https://github.com/apollographql/apollo-client/pull/6997)
+
 ## Apollo Client 3.1.4
 
 ## Bug Fixes

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -126,9 +126,15 @@ export class ObservableQuery<
   }
 
   public getCurrentResult(): ApolloQueryResult<TData> {
-    const networkStatus = this.queryInfo.networkStatus || NetworkStatus.ready;
+    const { lastResult } = this;
+
+    const networkStatus =
+      this.queryInfo.networkStatus ||
+      (lastResult && lastResult.networkStatus) ||
+      NetworkStatus.ready;
+
     const result: ApolloQueryResult<TData> = {
-      ...this.lastResult,
+      ...lastResult,
       loading: isNetworkRequestInFlight(networkStatus),
       networkStatus,
     };

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -133,10 +133,6 @@ export class ObservableQuery<
       networkStatus,
     };
 
-    if (this.lastError) {
-      result.error = this.lastError;
-    }
-
     if (this.isTornDown) {
       return result;
     }
@@ -617,6 +613,7 @@ once, rather than every time you call fetchMore.`);
       // must mirror the updates that occur in QueryStore.markQueryError here
       this.updateLastResult({
         ...this.lastResult,
+        error,
         errors: error.graphQLErrors,
         networkStatus: NetworkStatus.error,
         loading: false,

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -126,13 +126,16 @@ export class ObservableQuery<
   }
 
   public getCurrentResult(): ApolloQueryResult<TData> {
-    const { lastResult, lastError } = this;
     const networkStatus = this.queryInfo.networkStatus || NetworkStatus.ready;
     const result: ApolloQueryResult<TData> = {
-      ...(lastError ? { error: lastError } : lastResult),
+      ...this.lastResult,
       loading: isNetworkRequestInFlight(networkStatus),
       networkStatus,
     };
+
+    if (this.lastError) {
+      result.error = this.lastError;
+    }
 
     if (this.isTornDown) {
       return result;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -17,7 +17,7 @@ export type PureQueryOptions = {
 };
 
 export type ApolloQueryResult<T> = {
-  data?: T;
+  data: T;
   errors?: ReadonlyArray<GraphQLError>;
   error?: ApolloError;
   loading: boolean;


### PR DESCRIPTION
Fixes #6939.

This change snuck in with 144155c5b16dd36f052d8f7f9401bde51162b8b4, which was part of the effort in #6080 to reenable TypeScript strict null checks.

The consequences of this change were likely hidden until the `ApolloCurrentQueryResult` and `ApolloQueryResult` types were unified in 513d733cf0162c86d2b7d56547c20bb03287a472, which was first released in @apollo/client@3.1.0.

As I explained in https://github.com/apollographql/apollo-client/issues/6993#issuecomment-689750542, this change should be backwards compatible, since it strictly reduces the number of possible `data` values that need to be handled.