### PR TITLE
fix: Initialize query on updateObservableQuery even if skip is true

### DIFF
--- a/src/react/data/QueryData.ts
+++ b/src/react/data/QueryData.ts
@@ -227,13 +227,13 @@ export class QueryData<TData, TVariables> extends OperationData {
   }
 
   private updateObservableQuery() {
-    if (this.getOptions().skip) return;
-
     // If we skipped initially, we may not have yet created the observable
     if (!this.currentObservable) {
       this.initializeObservableQuery();
       return;
     }
+
+    if (this.getOptions().skip) return;
 
     const newObservableQueryOptions = {
       ...this.prepareObservableQueryOptions(),


### PR DESCRIPTION
Solves #6816, #6796

If `skip` option is true at the first rendering, the `initializeObservableQuery` will not be triggered. And even if the `skip` value changes to false later, calling `refetch` throws the following error:

```
Uncaught TypeError: Cannot read property 'refetch' of undefined
    at QueryData._this.obsRefetch
```

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
