### PR TITLE
Respect errorPolicy for mutation and subscription results.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@
 - Move `apollo-link-persisted-queries` implementation to `@apollo/client/link/persisted-queries`. Try running our [automated imports transform](https://github.com/apollographql/apollo-client/tree/main/codemods/ac2-to-ac3) to handle this conversion, if you're using `apollo-link-persisted-queries`. <br/>
   [@hwillson](https://github.com/hwillson) in [#6837](https://github.com/apollographql/apollo-client/pull/6837)
 
+- Support non-default `ErrorPolicy` values (that is, `"ignore"` and `"all"`, in addition to the default value `"none"`) for mutations and subscriptions, like we do for queries. <br/>
+  [@benjamn](https://github.com/benjamn) in [#7003](https://github.com/apollographql/apollo-client/pull/7003)
+
 - Remove invariant forbidding a `FetchPolicy` of `cache-only` in `ObservableQuery#refetch`. <br/>
   [@benjamn](https://github.com/benjamn) in [ccb0a79a](https://github.com/apollographql/apollo-client/pull/6774/commits/ccb0a79a588721f08bf87a131c31bf37fa3238e5), fixing [#6702](https://github.com/apollographql/apollo-client/issues/6702)
 

--- a/src/__tests__/__snapshots__/mutationResults.ts.snap
+++ b/src/__tests__/__snapshots__/mutationResults.ts.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`mutation results should write results to cache according to errorPolicy 1`] = `Object {}`;
+
+exports[`mutation results should write results to cache according to errorPolicy 2`] = `
+Object {
+  "Person:{\\"name\\":\\"Jenn Creighton\\"}": Object {
+    "__typename": "Person",
+    "name": "Jenn Creighton",
+  },
+  "ROOT_MUTATION": Object {
+    "__typename": "Mutation",
+    "newPerson({\\"name\\":\\"Jenn Creighton\\"})": Object {
+      "__ref": "Person:{\\"name\\":\\"Jenn Creighton\\"}",
+    },
+  },
+}
+`;
+
+exports[`mutation results should write results to cache according to errorPolicy 3`] = `
+Object {
+  "Person:{\\"name\\":\\"Ellen Shapiro\\"}": Object {
+    "__typename": "Person",
+    "name": "Ellen Shapiro",
+  },
+  "Person:{\\"name\\":\\"Jenn Creighton\\"}": Object {
+    "__typename": "Person",
+    "name": "Jenn Creighton",
+  },
+  "ROOT_MUTATION": Object {
+    "__typename": "Mutation",
+    "newPerson({\\"name\\":\\"Ellen Shapiro\\"})": Object {
+      "__ref": "Person:{\\"name\\":\\"Ellen Shapiro\\"}",
+    },
+    "newPerson({\\"name\\":\\"Jenn Creighton\\"})": Object {
+      "__ref": "Person:{\\"name\\":\\"Jenn Creighton\\"}",
+    },
+  },
+}
+`;

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -170,6 +170,11 @@ export interface SubscriptionOptions<TVariables = OperationVariables, TData = an
   fetchPolicy?: FetchPolicy;
 
   /**
+   * Specifies the {@link ErrorPolicy} to be used for this operation
+   */
+  errorPolicy?: ErrorPolicy;
+
+  /**
    * Context object to be passed through the link execution chain.
    */
   context?: Record<string, any>;


### PR DESCRIPTION
Using the default `ErrorPolicy` of "none" for queries means no data will be written to the cache when a GraphQL result has errors.

Queries can use `errorPolicy: "ignore"` and `errorPolicy: "all"` to ensure data is written to the cache in spite of GraphQL errors, but mutations and subscriptions were previously limited to the default policy, "none".

This commit makes mutations and subscriptions respect the non-default "ignore" and "all" `ErrorPolicy` values, just as queries do, hopefully addressing #6965.

Since these changes did not cause any tests to fail, clearly we need more and better tests of non-default `ErrorPolicy` usage by mutations and subscriptions.