### PR TITLE
Fix zen-observable import

### DIFF
--- a/src/utilities/observables/Observable.ts
+++ b/src/utilities/observables/Observable.ts
@@ -1,4 +1,4 @@
-import Observable from 'zen-observable';
+import * as Observable from 'zen-observable';
 
 // This simplified polyfill attempts to follow the ECMAScript Observable
 // proposal (https://github.com/zenparsing/es-observable)


### PR DESCRIPTION
The old import causes the following error:
```
node_modules/@apollo/client/utilities/observables/Observable.d.ts:1:8 - error TS1259: Module '".../node_modules/@types/zen-observable/index"' can only be default-imported using the 'allowSyntheticDefaultImports' flag

1 import Observable from 'zen-observable';
         ~~~~~~~~~~

  node_modules/@types/zen-observable/index.d.ts:69:1
    69 export = Observable;
       ~~~~~~~~~~~~~~~~~~~~
    This module is declared with using 'export =', and can only be used with a default import when using the 'allowSyntheticDefaultImports' flag.
```