### PR TITLE
Move response splice after new data check

### DIFF
--- a/src/utilities/testing/mocking/mockLink.ts
+++ b/src/utilities/testing/mocking/mockLink.ts
@@ -94,12 +94,12 @@ export class MockLink extends ApolloLink {
       return null;
     }
 
-    this.mockedResponsesByKey[key].splice(responseIndex, 1);
 
     const { newData } = response!;
 
     if (newData) {
       response!.result = newData();
+      this.mockedResponsesByKey[key].splice(responseIndex, 1);
       this.mockedResponsesByKey[key].push(response!);
     }
 


### PR DESCRIPTION
This was causing the response to be removed from the array and future requests to fail

I believe this could be one of the causes of a lot of the MockedProvider errors showing up in the issues list.
