### PR TITLE
Fix relayStylePagination so it works even if edges have id's

### DIFF
--- a/src/cache/inmemory/__tests__/__snapshots__/policies.ts.snap
+++ b/src/cache/inmemory/__tests__/__snapshots__/policies.ts.snap
@@ -773,11 +773,8 @@ Object {
     "todos": Object {
       "edges": Array [
         Object {
-          "__typename": "TodoEdge",
+          "__ref": "TodoEdge:edge1",
           "cursor": "YXJyYXljb25uZWN0aW9uOjI=",
-          "node": Object {
-            "__ref": "Todo:1",
-          },
         },
       ],
       "pageInfo": Object {
@@ -795,6 +792,13 @@ Object {
     "id": "1",
     "title": "Fix the tests",
   },
+  "TodoEdge:edge1": Object {
+    "__typename": "TodoEdge",
+    "id": "edge1",
+    "node": Object {
+      "__ref": "Todo:1",
+    },
+  },
 }
 `;
 
@@ -805,11 +809,8 @@ Object {
     "todos": Object {
       "edges": Array [
         Object {
-          "__typename": "TodoEdge",
+          "__ref": "TodoEdge:edge1",
           "cursor": "YXJyYXljb25uZWN0aW9uOjI=",
-          "node": Object {
-            "__ref": "Todo:1",
-          },
         },
       ],
       "extraMetaData": "extra",
@@ -827,6 +828,13 @@ Object {
     "__typename": "Todo",
     "id": "1",
     "title": "Fix the tests",
+  },
+  "TodoEdge:edge1": Object {
+    "__typename": "TodoEdge",
+    "id": "edge1",
+    "node": Object {
+      "__ref": "Todo:1",
+    },
   },
 }
 `;

--- a/src/cache/inmemory/__tests__/__snapshots__/policies.ts.snap
+++ b/src/cache/inmemory/__tests__/__snapshots__/policies.ts.snap
@@ -61,32 +61,6 @@ Object {
   "ROOT_QUERY": Object {
     "__typename": "Query",
     "search:basquiat": Object {
-      "edges": Array [
-        Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
-          "node": Object {
-            "__ref": "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "node": Object {
-            "__typename": "SearchableItem",
-            "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
-            "displayLabel": "ephemera BASQUIAT",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjI=",
-          "node": Object {
-            "__typename": "SearchableItem",
-            "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
-            "displayLabel": "Jean-Michel Basquiat | Xerox",
-          },
-        },
-      ],
       "pageInfo": Object {
         "__typename": "PageInfo",
         "endCursor": "YXJyYXljb25uZWN0aW9uOjI=",
@@ -95,6 +69,39 @@ Object {
         "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
       },
       "totalCount": 1292,
+      "wrappers": Array [
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__ref": "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}",
+            },
+          },
+        },
+        Object {
+          "cursor": undefined,
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__typename": "SearchableItem",
+              "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
+              "displayLabel": "ephemera BASQUIAT",
+            },
+          },
+        },
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjI=",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__typename": "SearchableItem",
+              "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
+              "displayLabel": "Jean-Michel Basquiat | Xerox",
+            },
+          },
+        },
+      ],
     },
   },
 }
@@ -117,56 +124,6 @@ Object {
   "ROOT_QUERY": Object {
     "__typename": "Query",
     "search:basquiat": Object {
-      "edges": Array [
-        Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
-          "node": Object {
-            "__ref": "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "node": Object {
-            "__typename": "SearchableItem",
-            "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
-            "displayLabel": "ephemera BASQUIAT",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjI=",
-          "node": Object {
-            "__typename": "SearchableItem",
-            "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
-            "displayLabel": "Jean-Michel Basquiat | Xerox",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
-          "node": Object {
-            "__typename": "SearchableItem",
-            "description": "Past show featuring works by Banksy, SEEN, JonOne and QUIK at Artrust Oct 8th – Dec 16th 2017",
-            "displayLabel": "STREET ART: From Basquiat to Banksy",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "node": Object {
-            "__typename": "SearchableItem",
-            "description": "Past show featuring works by Jean-Michel Basquiat, Shepard Fairey, COPE2, Pure Evil, Sickboy, Blade, Kurar, and LARS at Artrust",
-            "displayLabel": "STREET ART 2: From Basquiat to Banksy",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjU=",
-          "node": Object {
-            "__ref": "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}",
-          },
-        },
-      ],
       "pageInfo": Object {
         "__typename": "PageInfo",
         "endCursor": "YXJyYXljb25uZWN0aW9uOjU=",
@@ -175,6 +132,70 @@ Object {
         "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
       },
       "totalCount": 1292,
+      "wrappers": Array [
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__ref": "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}",
+            },
+          },
+        },
+        Object {
+          "cursor": undefined,
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__typename": "SearchableItem",
+              "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
+              "displayLabel": "ephemera BASQUIAT",
+            },
+          },
+        },
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjI=",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__typename": "SearchableItem",
+              "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
+              "displayLabel": "Jean-Michel Basquiat | Xerox",
+            },
+          },
+        },
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__typename": "SearchableItem",
+              "description": "Past show featuring works by Banksy, SEEN, JonOne and QUIK at Artrust Oct 8th – Dec 16th 2017",
+              "displayLabel": "STREET ART: From Basquiat to Banksy",
+            },
+          },
+        },
+        Object {
+          "cursor": undefined,
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__typename": "SearchableItem",
+              "description": "Past show featuring works by Jean-Michel Basquiat, Shepard Fairey, COPE2, Pure Evil, Sickboy, Blade, Kurar, and LARS at Artrust",
+              "displayLabel": "STREET ART 2: From Basquiat to Banksy",
+            },
+          },
+        },
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjU=",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__ref": "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}",
+            },
+          },
+        },
+      ],
     },
   },
 }
@@ -197,50 +218,6 @@ Object {
   "ROOT_QUERY": Object {
     "__typename": "Query",
     "search:basquiat": Object {
-      "edges": Array [
-        Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjE=",
-          "node": Object {
-            "__typename": "SearchableItem",
-            "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
-            "displayLabel": "ephemera BASQUIAT",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
-          "node": Object {
-            "__typename": "SearchableItem",
-            "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
-            "displayLabel": "Jean-Michel Basquiat | Xerox",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
-          "node": Object {
-            "__typename": "SearchableItem",
-            "description": "Past show featuring works by Banksy, SEEN, JonOne and QUIK at Artrust Oct 8th – Dec 16th 2017",
-            "displayLabel": "STREET ART: From Basquiat to Banksy",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "node": Object {
-            "__typename": "SearchableItem",
-            "description": "Past show featuring works by Jean-Michel Basquiat, Shepard Fairey, COPE2, Pure Evil, Sickboy, Blade, Kurar, and LARS at Artrust",
-            "displayLabel": "STREET ART 2: From Basquiat to Banksy",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjU=",
-          "node": Object {
-            "__ref": "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}",
-          },
-        },
-      ],
       "pageInfo": Object {
         "__typename": "PageInfo",
         "endCursor": "YXJyYXljb25uZWN0aW9uOjU=",
@@ -249,6 +226,61 @@ Object {
         "startCursor": "YXJyYXljb25uZWN0aW9uOjE=",
       },
       "totalCount": 1292,
+      "wrappers": Array [
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjE=",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__typename": "SearchableItem",
+              "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
+              "displayLabel": "ephemera BASQUIAT",
+            },
+          },
+        },
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__typename": "SearchableItem",
+              "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
+              "displayLabel": "Jean-Michel Basquiat | Xerox",
+            },
+          },
+        },
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__typename": "SearchableItem",
+              "description": "Past show featuring works by Banksy, SEEN, JonOne and QUIK at Artrust Oct 8th – Dec 16th 2017",
+              "displayLabel": "STREET ART: From Basquiat to Banksy",
+            },
+          },
+        },
+        Object {
+          "cursor": undefined,
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__typename": "SearchableItem",
+              "description": "Past show featuring works by Jean-Michel Basquiat, Shepard Fairey, COPE2, Pure Evil, Sickboy, Blade, Kurar, and LARS at Artrust",
+              "displayLabel": "STREET ART 2: From Basquiat to Banksy",
+            },
+          },
+        },
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjU=",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__ref": "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}",
+            },
+          },
+        },
+      ],
     },
   },
 }
@@ -271,57 +303,6 @@ Object {
   "ROOT_QUERY": Object {
     "__typename": "Query",
     "search:basquiat": Object {
-      "edges": Array [
-        Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
-          "node": Object {
-            "__ref": "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjE=",
-          "node": Object {
-            "__typename": "SearchableItem",
-            "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
-            "displayLabel": "ephemera BASQUIAT",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
-          "node": Object {
-            "__typename": "SearchableItem",
-            "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
-            "displayLabel": "Jean-Michel Basquiat | Xerox",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
-          "node": Object {
-            "__typename": "SearchableItem",
-            "description": "Past show featuring works by Banksy, SEEN, JonOne and QUIK at Artrust Oct 8th – Dec 16th 2017",
-            "displayLabel": "STREET ART: From Basquiat to Banksy",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "node": Object {
-            "__typename": "SearchableItem",
-            "description": "Past show featuring works by Jean-Michel Basquiat, Shepard Fairey, COPE2, Pure Evil, Sickboy, Blade, Kurar, and LARS at Artrust",
-            "displayLabel": "STREET ART 2: From Basquiat to Banksy",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjU=",
-          "node": Object {
-            "__ref": "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}",
-          },
-        },
-      ],
       "pageInfo": Object {
         "__typename": "PageInfo",
         "endCursor": "YXJyYXljb25uZWN0aW9uOjU=",
@@ -330,6 +311,70 @@ Object {
         "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
       },
       "totalCount": 1292,
+      "wrappers": Array [
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__ref": "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}",
+            },
+          },
+        },
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjE=",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__typename": "SearchableItem",
+              "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
+              "displayLabel": "ephemera BASQUIAT",
+            },
+          },
+        },
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__typename": "SearchableItem",
+              "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
+              "displayLabel": "Jean-Michel Basquiat | Xerox",
+            },
+          },
+        },
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__typename": "SearchableItem",
+              "description": "Past show featuring works by Banksy, SEEN, JonOne and QUIK at Artrust Oct 8th – Dec 16th 2017",
+              "displayLabel": "STREET ART: From Basquiat to Banksy",
+            },
+          },
+        },
+        Object {
+          "cursor": undefined,
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__typename": "SearchableItem",
+              "description": "Past show featuring works by Jean-Michel Basquiat, Shepard Fairey, COPE2, Pure Evil, Sickboy, Blade, Kurar, and LARS at Artrust",
+              "displayLabel": "STREET ART 2: From Basquiat to Banksy",
+            },
+          },
+        },
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjU=",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__ref": "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}",
+            },
+          },
+        },
+      ],
     },
   },
 }
@@ -352,66 +397,6 @@ Object {
   "ROOT_QUERY": Object {
     "__typename": "Query",
     "search:basquiat": Object {
-      "edges": Array [
-        Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
-          "node": Object {
-            "__ref": "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjE=",
-          "node": Object {
-            "__typename": "SearchableItem",
-            "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
-            "displayLabel": "ephemera BASQUIAT",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
-          "node": Object {
-            "__typename": "SearchableItem",
-            "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
-            "displayLabel": "Jean-Michel Basquiat | Xerox",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
-          "node": Object {
-            "__typename": "SearchableItem",
-            "description": "Past show featuring works by Banksy, SEEN, JonOne and QUIK at Artrust Oct 8th – Dec 16th 2017",
-            "displayLabel": "STREET ART: From Basquiat to Banksy",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "node": Object {
-            "__typename": "SearchableItem",
-            "description": "Past show featuring works by Jean-Michel Basquiat, Shepard Fairey, COPE2, Pure Evil, Sickboy, Blade, Kurar, and LARS at Artrust",
-            "displayLabel": "STREET ART 2: From Basquiat to Banksy",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjU=",
-          "node": Object {
-            "__ref": "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjY=",
-          "node": Object {
-            "__typename": "SearchableItem",
-            "description": "Past show featuring works by Jean-Michel Basquiat at Brooklyn Museum Apr 3rd – Aug 23rd 2015",
-            "displayLabel": "Basquiat: The Unknown Notebooks",
-          },
-        },
-      ],
       "pageInfo": Object {
         "__typename": "PageInfo",
         "endCursor": "YXJyYXljb25uZWN0aW9uOjY=",
@@ -420,6 +405,81 @@ Object {
         "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
       },
       "totalCount": 1292,
+      "wrappers": Array [
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__ref": "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}",
+            },
+          },
+        },
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjE=",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__typename": "SearchableItem",
+              "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
+              "displayLabel": "ephemera BASQUIAT",
+            },
+          },
+        },
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__typename": "SearchableItem",
+              "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
+              "displayLabel": "Jean-Michel Basquiat | Xerox",
+            },
+          },
+        },
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__typename": "SearchableItem",
+              "description": "Past show featuring works by Banksy, SEEN, JonOne and QUIK at Artrust Oct 8th – Dec 16th 2017",
+              "displayLabel": "STREET ART: From Basquiat to Banksy",
+            },
+          },
+        },
+        Object {
+          "cursor": undefined,
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__typename": "SearchableItem",
+              "description": "Past show featuring works by Jean-Michel Basquiat, Shepard Fairey, COPE2, Pure Evil, Sickboy, Blade, Kurar, and LARS at Artrust",
+              "displayLabel": "STREET ART 2: From Basquiat to Banksy",
+            },
+          },
+        },
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjU=",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__ref": "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}",
+            },
+          },
+        },
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjY=",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__typename": "SearchableItem",
+              "description": "Past show featuring works by Jean-Michel Basquiat at Brooklyn Museum Apr 3rd – Aug 23rd 2015",
+              "displayLabel": "Basquiat: The Unknown Notebooks",
+            },
+          },
+        },
+      ],
     },
   },
 }
@@ -448,66 +508,6 @@ Object {
   "ROOT_QUERY": Object {
     "__typename": "Query",
     "search:basquiat": Object {
-      "edges": Array [
-        Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
-          "node": Object {
-            "__ref": "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjE=",
-          "node": Object {
-            "__typename": "SearchableItem",
-            "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
-            "displayLabel": "ephemera BASQUIAT",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
-          "node": Object {
-            "__typename": "SearchableItem",
-            "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
-            "displayLabel": "Jean-Michel Basquiat | Xerox",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
-          "node": Object {
-            "__typename": "SearchableItem",
-            "description": "Past show featuring works by Banksy, SEEN, JonOne and QUIK at Artrust Oct 8th – Dec 16th 2017",
-            "displayLabel": "STREET ART: From Basquiat to Banksy",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "node": Object {
-            "__typename": "SearchableItem",
-            "description": "Past show featuring works by Jean-Michel Basquiat, Shepard Fairey, COPE2, Pure Evil, Sickboy, Blade, Kurar, and LARS at Artrust",
-            "displayLabel": "STREET ART 2: From Basquiat to Banksy",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjU=",
-          "node": Object {
-            "__ref": "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjY=",
-          "node": Object {
-            "__typename": "SearchableItem",
-            "description": "Past show featuring works by Jean-Michel Basquiat at Brooklyn Museum Apr 3rd – Aug 23rd 2015",
-            "displayLabel": "Basquiat: The Unknown Notebooks",
-          },
-        },
-      ],
       "pageInfo": Object {
         "__typename": "PageInfo",
         "endCursor": "YXJyYXljb25uZWN0aW9uOjY=",
@@ -516,17 +516,83 @@ Object {
         "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
       },
       "totalCount": 1292,
-    },
-    "search:james turrell": Object {
-      "edges": Array [
+      "wrappers": Array [
         Object {
-          "__typename": "SearchableEdge",
           "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
-          "node": Object {
-            "__ref": "Artist:{\\"href\\":\\"/artist/james-turrell\\"}",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__ref": "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}",
+            },
+          },
+        },
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjE=",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__typename": "SearchableItem",
+              "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
+              "displayLabel": "ephemera BASQUIAT",
+            },
+          },
+        },
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__typename": "SearchableItem",
+              "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
+              "displayLabel": "Jean-Michel Basquiat | Xerox",
+            },
+          },
+        },
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__typename": "SearchableItem",
+              "description": "Past show featuring works by Banksy, SEEN, JonOne and QUIK at Artrust Oct 8th – Dec 16th 2017",
+              "displayLabel": "STREET ART: From Basquiat to Banksy",
+            },
+          },
+        },
+        Object {
+          "cursor": undefined,
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__typename": "SearchableItem",
+              "description": "Past show featuring works by Jean-Michel Basquiat, Shepard Fairey, COPE2, Pure Evil, Sickboy, Blade, Kurar, and LARS at Artrust",
+              "displayLabel": "STREET ART 2: From Basquiat to Banksy",
+            },
+          },
+        },
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjU=",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__ref": "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}",
+            },
+          },
+        },
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjY=",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__typename": "SearchableItem",
+              "description": "Past show featuring works by Jean-Michel Basquiat at Brooklyn Museum Apr 3rd – Aug 23rd 2015",
+              "displayLabel": "Basquiat: The Unknown Notebooks",
+            },
           },
         },
       ],
+    },
+    "search:james turrell": Object {
       "pageInfo": Object {
         "__typename": "PageInfo",
         "endCursor": "YXJyYXljb25uZWN0aW9uOjA=",
@@ -535,6 +601,17 @@ Object {
         "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
       },
       "totalCount": 13531,
+      "wrappers": Array [
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__ref": "Artist:{\\"href\\":\\"/artist/james-turrell\\"}",
+            },
+          },
+        },
+      ],
     },
   },
 }
@@ -557,66 +634,6 @@ Object {
   "ROOT_QUERY": Object {
     "__typename": "Query",
     "search:basquiat": Object {
-      "edges": Array [
-        Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
-          "node": Object {
-            "__ref": "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjE=",
-          "node": Object {
-            "__typename": "SearchableItem",
-            "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
-            "displayLabel": "ephemera BASQUIAT",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
-          "node": Object {
-            "__typename": "SearchableItem",
-            "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
-            "displayLabel": "Jean-Michel Basquiat | Xerox",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
-          "node": Object {
-            "__typename": "SearchableItem",
-            "description": "Past show featuring works by Banksy, SEEN, JonOne and QUIK at Artrust Oct 8th – Dec 16th 2017",
-            "displayLabel": "STREET ART: From Basquiat to Banksy",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "node": Object {
-            "__typename": "SearchableItem",
-            "description": "Past show featuring works by Jean-Michel Basquiat, Shepard Fairey, COPE2, Pure Evil, Sickboy, Blade, Kurar, and LARS at Artrust",
-            "displayLabel": "STREET ART 2: From Basquiat to Banksy",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjU=",
-          "node": Object {
-            "__ref": "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjY=",
-          "node": Object {
-            "__typename": "SearchableItem",
-            "description": "Past show featuring works by Jean-Michel Basquiat at Brooklyn Museum Apr 3rd – Aug 23rd 2015",
-            "displayLabel": "Basquiat: The Unknown Notebooks",
-          },
-        },
-      ],
       "pageInfo": Object {
         "__typename": "PageInfo",
         "endCursor": "YXJyYXljb25uZWN0aW9uOjY=",
@@ -625,17 +642,83 @@ Object {
         "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
       },
       "totalCount": 1292,
-    },
-    "search:james turrell": Object {
-      "edges": Array [
+      "wrappers": Array [
         Object {
-          "__typename": "SearchableEdge",
           "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
-          "node": Object {
-            "__ref": "Artist:{\\"href\\":\\"/artist/james-turrell\\"}",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__ref": "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}",
+            },
+          },
+        },
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjE=",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__typename": "SearchableItem",
+              "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
+              "displayLabel": "ephemera BASQUIAT",
+            },
+          },
+        },
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__typename": "SearchableItem",
+              "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
+              "displayLabel": "Jean-Michel Basquiat | Xerox",
+            },
+          },
+        },
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__typename": "SearchableItem",
+              "description": "Past show featuring works by Banksy, SEEN, JonOne and QUIK at Artrust Oct 8th – Dec 16th 2017",
+              "displayLabel": "STREET ART: From Basquiat to Banksy",
+            },
+          },
+        },
+        Object {
+          "cursor": undefined,
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__typename": "SearchableItem",
+              "description": "Past show featuring works by Jean-Michel Basquiat, Shepard Fairey, COPE2, Pure Evil, Sickboy, Blade, Kurar, and LARS at Artrust",
+              "displayLabel": "STREET ART 2: From Basquiat to Banksy",
+            },
+          },
+        },
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjU=",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__ref": "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}",
+            },
+          },
+        },
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjY=",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__typename": "SearchableItem",
+              "description": "Past show featuring works by Jean-Michel Basquiat at Brooklyn Museum Apr 3rd – Aug 23rd 2015",
+              "displayLabel": "Basquiat: The Unknown Notebooks",
+            },
           },
         },
       ],
+    },
+    "search:james turrell": Object {
       "pageInfo": Object {
         "__typename": "PageInfo",
         "endCursor": "YXJyYXljb25uZWN0aW9uOjA=",
@@ -644,6 +727,17 @@ Object {
         "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
       },
       "totalCount": 13531,
+      "wrappers": Array [
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__ref": "Artist:{\\"href\\":\\"/artist/james-turrell\\"}",
+            },
+          },
+        },
+      ],
     },
   },
 }
@@ -666,66 +760,6 @@ Object {
   "ROOT_QUERY": Object {
     "__typename": "Query",
     "search:basquiat": Object {
-      "edges": Array [
-        Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
-          "node": Object {
-            "__ref": "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjE=",
-          "node": Object {
-            "__typename": "SearchableItem",
-            "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
-            "displayLabel": "ephemera BASQUIAT",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
-          "node": Object {
-            "__typename": "SearchableItem",
-            "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
-            "displayLabel": "Jean-Michel Basquiat | Xerox",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
-          "node": Object {
-            "__typename": "SearchableItem",
-            "description": "Past show featuring works by Banksy, SEEN, JonOne and QUIK at Artrust Oct 8th – Dec 16th 2017",
-            "displayLabel": "STREET ART: From Basquiat to Banksy",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "node": Object {
-            "__typename": "SearchableItem",
-            "description": "Past show featuring works by Jean-Michel Basquiat, Shepard Fairey, COPE2, Pure Evil, Sickboy, Blade, Kurar, and LARS at Artrust",
-            "displayLabel": "STREET ART 2: From Basquiat to Banksy",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjU=",
-          "node": Object {
-            "__ref": "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}",
-          },
-        },
-        Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjY=",
-          "node": Object {
-            "__typename": "SearchableItem",
-            "description": "Past show featuring works by Jean-Michel Basquiat at Brooklyn Museum Apr 3rd – Aug 23rd 2015",
-            "displayLabel": "Basquiat: The Unknown Notebooks",
-          },
-        },
-      ],
       "pageInfo": Object {
         "__typename": "PageInfo",
         "endCursor": "YXJyYXljb25uZWN0aW9uOjY=",
@@ -734,25 +768,83 @@ Object {
         "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
       },
       "totalCount": 1292,
-    },
-    "search:james turrell": Object {
-      "edges": Array [
+      "wrappers": Array [
         Object {
-          "__typename": "SearchableEdge",
           "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
-          "node": Object {
-            "__ref": "Artist:{\\"href\\":\\"/artist/james-turrell\\"}",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__ref": "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}",
+            },
           },
         },
         Object {
-          "__typename": "SearchableEdge",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjEx",
-          "node": Object {
-            "__typename": "SearchableItem",
-            "displayLabel": "James Turrell: Light knows when we’re looking",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjE=",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__typename": "SearchableItem",
+              "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
+              "displayLabel": "ephemera BASQUIAT",
+            },
+          },
+        },
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__typename": "SearchableItem",
+              "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
+              "displayLabel": "Jean-Michel Basquiat | Xerox",
+            },
+          },
+        },
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__typename": "SearchableItem",
+              "description": "Past show featuring works by Banksy, SEEN, JonOne and QUIK at Artrust Oct 8th – Dec 16th 2017",
+              "displayLabel": "STREET ART: From Basquiat to Banksy",
+            },
+          },
+        },
+        Object {
+          "cursor": undefined,
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__typename": "SearchableItem",
+              "description": "Past show featuring works by Jean-Michel Basquiat, Shepard Fairey, COPE2, Pure Evil, Sickboy, Blade, Kurar, and LARS at Artrust",
+              "displayLabel": "STREET ART 2: From Basquiat to Banksy",
+            },
+          },
+        },
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjU=",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__ref": "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}",
+            },
+          },
+        },
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjY=",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__typename": "SearchableItem",
+              "description": "Past show featuring works by Jean-Michel Basquiat at Brooklyn Museum Apr 3rd – Aug 23rd 2015",
+              "displayLabel": "Basquiat: The Unknown Notebooks",
+            },
           },
         },
       ],
+    },
+    "search:james turrell": Object {
       "pageInfo": Object {
         "__typename": "PageInfo",
         "endCursor": "YXJyYXljb25uZWN0aW9uOjEx",
@@ -761,6 +853,27 @@ Object {
         "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
       },
       "totalCount": 13531,
+      "wrappers": Array [
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__ref": "Artist:{\\"href\\":\\"/artist/james-turrell\\"}",
+            },
+          },
+        },
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjEx",
+          "edge": Object {
+            "__typename": "SearchableEdge",
+            "node": Object {
+              "__typename": "SearchableItem",
+              "displayLabel": "James Turrell: Light knows when we’re looking",
+            },
+          },
+        },
+      ],
     },
   },
 }
@@ -771,12 +884,6 @@ Object {
   "ROOT_QUERY": Object {
     "__typename": "Query",
     "todos": Object {
-      "edges": Array [
-        Object {
-          "__ref": "TodoEdge:edge1",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjI=",
-        },
-      ],
       "pageInfo": Object {
         "__typename": "PageInfo",
         "endCursor": "YXJyYXljb25uZWN0aW9uOjI=",
@@ -785,6 +892,14 @@ Object {
         "startCursor": "YXJyYXljb25uZWN0aW9uOjI=",
       },
       "totalCount": 1292,
+      "wrappers": Array [
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjI=",
+          "edge": Object {
+            "__ref": "TodoEdge:edge1",
+          },
+        },
+      ],
     },
   },
   "Todo:1": Object {
@@ -807,12 +922,6 @@ Object {
   "ROOT_QUERY": Object {
     "__typename": "Query",
     "todos": Object {
-      "edges": Array [
-        Object {
-          "__ref": "TodoEdge:edge1",
-          "cursor": "YXJyYXljb25uZWN0aW9uOjI=",
-        },
-      ],
       "extraMetaData": "extra",
       "pageInfo": Object {
         "__typename": "PageInfo",
@@ -822,6 +931,14 @@ Object {
         "startCursor": "YXJyYXljb25uZWN0aW9uOjI=",
       },
       "totalCount": 1293,
+      "wrappers": Array [
+        Object {
+          "cursor": "YXJyYXljb25uZWN0aW9uOjI=",
+          "edge": Object {
+            "__ref": "TodoEdge:edge1",
+          },
+        },
+      ],
     },
   },
   "Todo:1": Object {

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -2461,7 +2461,7 @@ describe("type policies", function () {
           ROOT_QUERY: {
             __typename: "Query",
             todos: {
-              edges: [],
+              wrappers: [],
               pageInfo: {
                 "endCursor": "",
                 "hasNextPage": true,
@@ -3049,15 +3049,17 @@ describe("type policies", function () {
               // Note that Turrell's name has been lower-cased.
               snapshot.ROOT_QUERY!["search:james turrell"]
             ).toEqual({
-              edges: turrellEdges.slice(0, 1).map(edge => ({
-                ...edge,
+              wrappers: turrellEdges.slice(0, 1).map(edge => ({
                 // The relayStylePagination merge function updates the
                 // edge.cursor field of the first and last edge, even if
                 // the query did not request the edge.cursor field, if
                 // pageInfo.{start,end}Cursor are defined.
                 cursor: turrellPageInfo1.startCursor,
-                // Artist objects are normalized by HREF:
-                node: { __ref: 'Artist:{"href":"/artist/james-turrell"}' },
+                edge: {
+                  ...edge,
+                  // Artist objects are normalized by HREF:
+                  node: { __ref: 'Artist:{"href":"/artist/james-turrell"}' },
+                },
               })),
               pageInfo: turrellPageInfo1,
               totalCount: 13531,
@@ -3141,20 +3143,22 @@ describe("type policies", function () {
               // Note that Turrell's name has been lower-cased.
               snapshot.ROOT_QUERY!["search:james turrell"]
             ).toEqual({
-              edges: turrellEdges.map((edge, i) => ({
-                ...edge,
+              wrappers: turrellEdges.map((edge, i) => ({
                 // This time the cursors are different depending on which
                 // of the two edges we're considering.
                 cursor: [
                   turrellPageInfo2.startCursor,
                   turrellPageInfo2.endCursor,
                 ][i],
-                node: [
-                  // Artist objects are normalized by HREF:
-                  { __ref: 'Artist:{"href":"/artist/james-turrell"}' },
-                  // However, SearchableItem objects are not normalized.
-                  edge.node,
-                ][i],
+                edge: {
+                  ...edge,
+                  node: [
+                    // Artist objects are normalized by HREF:
+                    { __ref: 'Artist:{"href":"/artist/james-turrell"}' },
+                    // However, SearchableItem objects are not normalized.
+                    edge.node,
+                  ][i],
+                },
               })),
               pageInfo: turrellPageInfo2,
               totalCount: 13531,

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -2359,6 +2359,7 @@ describe("type policies", function () {
             totalCount
             edges {
               __typename
+              id
               node {
                 __typename
                 id
@@ -2385,6 +2386,7 @@ describe("type policies", function () {
       const secondEdges = [
         {
           __typename: "TodoEdge",
+          id: "edge1",
           node: {
             __typename: "Todo",
             id: '1',

--- a/src/utilities/policies/pagination.ts
+++ b/src/utilities/policies/pagination.ts
@@ -61,9 +61,12 @@ export function relayStylePagination<TNode = Reference>(
   return {
     keyArgs,
 
-    read(existing) {
+    read(existing, { canRead, readField }) {
       if (!existing) return;
-      const edges = existing.edges;
+      const edges = existing.edges.filter(
+        // Edges themselves could be Reference objects, so it's important
+        // to use readField to access the edge.node property.
+        edge => canRead(readField("node", edge)));
       return {
         // Some implementations return additional Connection fields, such
         // as existing.totalCount. These fields are saved by the merge

--- a/src/utilities/policies/pagination.ts
+++ b/src/utilities/policies/pagination.ts
@@ -61,9 +61,9 @@ export function relayStylePagination<TNode = Reference>(
   return {
     keyArgs,
 
-    read(existing, { canRead }) {
+    read(existing) {
       if (!existing) return;
-      const edges = existing.edges.filter(edge => canRead(edge.node));
+      const edges = existing.edges;
       return {
         // Some implementations return additional Connection fields, such
         // as existing.totalCount. These fields are saved by the merge

--- a/src/utilities/policies/pagination.ts
+++ b/src/utilities/policies/pagination.ts
@@ -1,3 +1,5 @@
+import { __rest } from "tslib";
+
 import { FieldPolicy, Reference } from '../../cache';
 
 type KeyArgs = FieldPolicy<any>["keyArgs"];
@@ -205,12 +207,8 @@ export function relayStylePagination<TNode = Reference>(
 }
 
 // Returns any unrecognized properties of the given object.
-const getExtras = ({
-  edges,
-  wrappers,
-  pageInfo,
-  ...extras
-}: Record<string, any>) => extras;
+const getExtras = (obj: Record<string, any>) => __rest(obj, notExtras);
+const notExtras = ["edges", "wrappers", "pageInfo"];
 
 function makeEmptyData(): TExistingRelay<any> {
   return {

--- a/src/utilities/policies/pagination.ts
+++ b/src/utilities/policies/pagination.ts
@@ -71,7 +71,7 @@ export function relayStylePagination<TNode = Reference>(
         // Some implementations return additional Connection fields, such
         // as existing.totalCount. These fields are saved by the merge
         // function, so the read function should also preserve them.
-        ...existing,
+        ...getExtras(existing),
         edges,
         pageInfo: {
           ...existing.pageInfo,
@@ -131,14 +131,22 @@ export function relayStylePagination<TNode = Reference>(
       if (!suffix.length) updatePageInfo("hasNextPage");
 
       return {
-        ...existing,
-        ...incoming,
+        ...getExtras(existing),
+        ...getExtras(incoming),
         edges,
         pageInfo,
       };
     },
   };
 }
+
+// Returns any unrecognized properties of the given object.
+const getExtras = ({
+  edges,
+  wrappers,
+  pageInfo,
+  ...extras
+}: Record<string, any>) => extras;
 
 function makeEmptyData() {
   return {

--- a/src/utilities/policies/pagination.ts
+++ b/src/utilities/policies/pagination.ts
@@ -39,34 +39,72 @@ export function offsetLimitPagination<T = Reference>(
   };
 }
 
-type TInternalRelay<TNode> = Readonly<{
-  edges: Array<{
-    cursor: string;
-    node: TNode;
-  }>;
-  pageInfo: Readonly<{
-    hasPreviousPage: boolean;
-    hasNextPage: boolean;
-    startCursor: string;
-    endCursor: string;
-  }>;
+type TEdge<TNode> = {
+  cursor?: string;
+  node: TNode;
+} | Reference;
+
+// This object is an internal structure that's slightly different from the
+// GraphQL response format for edges. Each actual edge gets wrapped in a
+// wrapper object that can safely store a cursor string (possibly inferred
+// from pageInfo), which makes things easier when the actual edge happens
+// to be a normalized Reference, since updating fields of an object behind
+// a Reference is tricky in a merge function.
+type TEdgeWrapper<TNode> = {
+  cursor?: string;
+  edge: TEdge<TNode>;
+};
+
+type TPageInfo = {
+  hasPreviousPage: boolean;
+  hasNextPage: boolean;
+  startCursor: string;
+  endCursor: string;
+};
+
+type TExistingRelay<TNode> = Readonly<{
+  wrappers: TEdgeWrapper<TNode>[];
+  pageInfo: TPageInfo;
 }>;
+
+type TIncomingRelay<TNode> = {
+  edges?: TEdge<TNode>[];
+  pageInfo?: TPageInfo;
+};
+
+type RelayFieldPolicy<TNode> = FieldPolicy<
+  TExistingRelay<TNode>,
+  TIncomingRelay<TNode>,
+  TIncomingRelay<TNode>
+>;
 
 // As proof of the flexibility of field policies, this function generates
 // one that handles Relay-style pagination, without Apollo Client knowing
 // anything about connections, edges, cursors, or pageInfo objects.
 export function relayStylePagination<TNode = Reference>(
   keyArgs: KeyArgs = false,
-): FieldPolicy<TInternalRelay<TNode>, Partial<TInternalRelay<TNode>>> {
+): RelayFieldPolicy<TNode> {
   return {
     keyArgs,
 
     read(existing, { canRead, readField }) {
       if (!existing) return;
-      const edges = existing.edges.filter(
+
+      const edges: TEdge<TNode>[] = [];
+      let startCursor = "";
+      let endCursor = "";
+      existing.wrappers.forEach(wrapper => {
         // Edges themselves could be Reference objects, so it's important
-        // to use readField to access the edge.node property.
-        edge => canRead(readField("node", edge)));
+        // to use readField to access the wrapper.edge.node property.
+        if (canRead(readField("node", wrapper.edge))) {
+          edges.push(wrapper.edge);
+          if (wrapper.cursor) {
+            startCursor = startCursor || wrapper.cursor;
+            endCursor = wrapper.cursor;
+          }
+        }
+      });
+
       return {
         // Some implementations return additional Connection fields, such
         // as existing.totalCount. These fields are saved by the merge
@@ -75,30 +113,48 @@ export function relayStylePagination<TNode = Reference>(
         edges,
         pageInfo: {
           ...existing.pageInfo,
-          startCursor: cursorFromEdge(edges, 0),
-          endCursor: cursorFromEdge(edges, -1),
+          startCursor,
+          endCursor,
         },
       };
     },
 
-    merge(existing = makeEmptyData(), incoming, { args }) {
-      const incomingEdges = incoming.edges ? incoming.edges.slice(0) : [];
+    merge(existing = makeEmptyData(), incoming, { args, readField }) {
+      // Convert incoming.edges to an array of TEdgeWrapper objects, so
+      // that we can merge the incoming wrappers into existing.wrappers.
+      const incomingWrappers: TEdgeWrapper<TNode>[] =
+        incoming.edges ? incoming.edges.map(edge => ({
+          edge,
+          // In case edge is a Reference, we lift out its cursor field and
+          // store it in the TEdgeWrapper object.
+          cursor: readField<string>("cursor", edge),
+        })) : [];
+
       if (incoming.pageInfo) {
-        updateCursor(incomingEdges, 0, incoming.pageInfo.startCursor);
-        updateCursor(incomingEdges, -1, incoming.pageInfo.endCursor);
+        // In case we did not request the cursor field for edges in this
+        // query, we can still infer some of those cursors from pageInfo.
+        const { startCursor, endCursor } = incoming.pageInfo;
+        const firstWrapper = incomingWrappers[0];
+        if (firstWrapper && startCursor) {
+          firstWrapper.cursor = startCursor;
+        }
+        const lastWrapper = incomingWrappers[incomingWrappers.length - 1];
+        if (lastWrapper && endCursor) {
+          lastWrapper.cursor = endCursor;
+        }
       }
 
-      let prefix = existing.edges;
+      let prefix = existing.wrappers;
       let suffix: typeof prefix = [];
 
       if (args && args.after) {
-        const index = prefix.findIndex(edge => edge.cursor === args.after);
+        const index = prefix.findIndex(wrapper => wrapper.cursor === args.after);
         if (index >= 0) {
           prefix = prefix.slice(0, index + 1);
           // suffix = []; // already true
         }
       } else if (args && args.before) {
-        const index = prefix.findIndex(edge => edge.cursor === args.before);
+        const index = prefix.findIndex(wrapper => wrapper.cursor === args.before);
         suffix = index < 0 ? prefix : prefix.slice(index);
         prefix = [];
       } else if (incoming.edges) {
@@ -108,32 +164,40 @@ export function relayStylePagination<TNode = Reference>(
         prefix = [];
       }
 
-      const edges = [
+      const wrappers = [
         ...prefix,
-        ...incomingEdges,
+        ...incomingWrappers,
         ...suffix,
       ];
 
-      const pageInfo = {
-        ...(incoming.pageInfo || {}),
+      const firstWrapper = wrappers[0];
+      const lastWrapper = wrappers[wrappers.length - 1];
+
+      const pageInfo: TPageInfo = {
+        ...incoming.pageInfo,
         ...existing.pageInfo,
-        startCursor: cursorFromEdge(edges, 0),
-        endCursor: cursorFromEdge(edges, -1),
+        startCursor: firstWrapper && firstWrapper.cursor || "",
+        endCursor: lastWrapper && lastWrapper.cursor || "",
       };
 
-      const updatePageInfo = (name: keyof TInternalRelay<TNode>["pageInfo"]) => {
-        const value = incoming.pageInfo && incoming.pageInfo[name];
-        if (value !== void 0) {
-          (pageInfo as any)[name] = value;
+      if (incoming.pageInfo) {
+        const { hasPreviousPage, hasNextPage } = incoming.pageInfo;
+        // Keep existing.pageInfo.has{Previous,Next}Page unless the
+        // placement of the incoming edges means incoming.hasPreviousPage
+        // or incoming.hasNextPage should become the new values for those
+        // properties in existing.pageInfo.
+        if (!prefix.length && hasPreviousPage !== void 0) {
+          pageInfo.hasPreviousPage = hasPreviousPage;
         }
-      };
-      if (!prefix.length) updatePageInfo("hasPreviousPage");
-      if (!suffix.length) updatePageInfo("hasNextPage");
+        if (!suffix.length && hasNextPage !== void 0) {
+          pageInfo.hasNextPage = hasNextPage;
+        }
+      }
 
       return {
         ...getExtras(existing),
         ...getExtras(incoming),
-        edges,
+        wrappers,
         pageInfo,
       };
     },
@@ -148,9 +212,9 @@ const getExtras = ({
   ...extras
 }: Record<string, any>) => extras;
 
-function makeEmptyData() {
+function makeEmptyData(): TExistingRelay<any> {
   return {
-    edges: [],
+    wrappers: [],
     pageInfo: {
       hasPreviousPage: false,
       hasNextPage: true,
@@ -158,25 +222,4 @@ function makeEmptyData() {
       endCursor: "",
     },
   };
-}
-
-function cursorFromEdge<TNode>(
-  edges: TInternalRelay<TNode>["edges"],
-  index: number,
-): string {
-  if (index < 0) index += edges.length;
-  const edge = edges[index];
-  return edge && edge.cursor || "";
-}
-
-function updateCursor<TNode>(
-  edges: TInternalRelay<TNode>["edges"],
-  index: number,
-  cursor: string | undefined,
-) {
-  if (index < 0) index += edges.length;
-  const edge = edges[index];
-  if (cursor && edge && cursor !== edge.cursor) {
-    edges[index] = { ...edge, cursor };
-  }
 }


### PR DESCRIPTION
### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [X] Make sure all of the significant new logic is covered by tests

Right now.  If you are using relayStylePagination and you query the connection metadata(eg. totalCount) and then query edges that have an ```id``` field, the edges will always be an empty array(see test change).

I have found that this is due to the ```canRead``` in the read function of relayStylePagination.  This attempts to fix the issue by removing the canRead call.  Not sure if this is the correct approach but it seems to work in my case.

Fixes #7026.