### PR TITLE
Adjust SSR restore docs to parse stringified cache state

### DIFF
--- a/docs/source/caching/advanced-topics.mdx
+++ b/docs/source/caching/advanced-topics.mdx
@@ -324,24 +324,6 @@ export default withApollo(Foo);
 If you want to clear the store but don't want to refetch active queries, use
 `client.clearStore()` instead of `client.resetStore()`.
 
-## Server side rendering
-
-First, you will need to initialize an `InMemoryCache` on the server and create an instance of `ApolloClient`. In the initial serialized HTML payload from the server, you should include a script tag that extracts the data from the cache. (The `.replace()` is necessary to prevent script injection attacks)
-
-```js
-`<script>
-  window.__APOLLO_STATE__=${JSON.stringify(cache.extract()).replace(/</g, '\\u003c')}
-</script>`
-```
-
-On the client, you can rehydrate the cache using the initial data passed from the server:
-
-```js
-cache: new Cache().restore(JSON.parse(window.__APOLLO_STATE__))
-```
-
-If you would like to learn more about server side rendering, please check out our more in depth guide [here](../performance/server-side-rendering/).
-
 ## Cache persistence
 
 If you would like to persist and rehydrate your Apollo Cache from a storage provider like `AsyncStorage` or `localStorage`, you can use [`apollo-cache-persist`](https://github.com/apollographql/apollo-cache-persist). `apollo-cache-persist` works with all Apollo caches, including `InMemoryCache` & `Hermes`, and a variety of different [storage providers](https://github.com/apollographql/apollo-cache-persist#storage-providers).

--- a/docs/source/caching/advanced-topics.mdx
+++ b/docs/source/caching/advanced-topics.mdx
@@ -337,7 +337,7 @@ First, you will need to initialize an `InMemoryCache` on the server and create a
 On the client, you can rehydrate the cache using the initial data passed from the server:
 
 ```js
-cache: new Cache().restore(window.__APOLLO_STATE__)
+cache: new Cache().restore(JSON.parse(window.__APOLLO_STATE__))
 ```
 
 If you would like to learn more about server side rendering, please check out our more in depth guide [here](../performance/server-side-rendering/).

--- a/docs/source/performance/server-side-rendering.mdx
+++ b/docs/source/performance/server-side-rendering.mdx
@@ -25,7 +25,7 @@ You can then rehydrate the client using the initial state passed from the server
 
 ```js
 const client = new ApolloClient({
-  cache: new InMemoryCache().restore(window.__APOLLO_STATE__),
+  cache: new InMemoryCache().restore(JSON.parse(window.__APOLLO_STATE__)),
   link,
 });
 ```
@@ -38,7 +38,7 @@ If you are using `fetchPolicy: network-only` or `fetchPolicy: cache-and-network`
 
 ```js
 const client = new ApolloClient({
-  cache: new InMemoryCache().restore(window.__APOLLO_STATE__),
+  cache: new InMemoryCache().restore(JSON.parse(window.__APOLLO_STATE__)),
   link,
   ssrForceFetchDelay: 100,
 });


### PR DESCRIPTION
Small tweaks to make sure the SSR cache `restore` examples show to `parse` the JSON stringified cache state.

Fixes #6996