### PR TITLE
mark subscriptions-transport-ws peerDependency as optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,9 @@
   "peerDependenciesMeta": {
     "react": {
       "optional": true
+    },
+    "subscriptions-transport-ws": {
+      "optional": true
     }
   },
   "dependencies": {


### PR DESCRIPTION
This marks the `subscriptions-transport-ws` as an optional peer dependency. Given that installation of this package is mentioned only on the [Subscriptions](https://www.apollographql.com/docs/react/data/subscriptions/) page, and that page opens with:

> "In the majority of cases, your client should not use subscriptions to stay up to date with your backend."

It seems then that the majority of users then should not require this package, and having it be a warning when installing the packages is misleading. Additionally, starting with NPM 7+, peer dependencies will be installed by default if not marked as optional and so aiming to avoid having a package added to the stack that is not actually needed by majority of use cases.