### PR TITLE
Disable missing cache fields warning when using returnPartialData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Fix `relayStylePagination` to handle the possibility that edges might be normalized `Reference` objects (uncommon). <br/>
   [@anark](https://github.com/anark) and [@benjamn](https://github.com/benjamn) in [#7023](https://github.com/apollographql/apollo-client/pull/7023)
 
+- Disable "Missing cache result fields" warnings when `returnPartialData` is `true`.  <br/>
+  [@hwillson](https://github.com/hwillson) in [#7055](https://github.com/apollographql/apollo-client/pull/7055)
+
 ## Apollo Client 3.2.0
 
 ## Bug Fixes

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -972,7 +972,8 @@ export class QueryManager<TStore> {
 
       if (process.env.NODE_ENV !== 'production' &&
           isNonEmptyArray(diff.missing) &&
-          !equal(data, {})) {
+          !equal(data, {}) &&
+          !returnPartialData) {
         invariant.warn(`Missing cache result fields: ${
           diff.missing.map(m => m.path.join('.')).join(', ')
         }`, diff.missing);

--- a/src/core/__tests__/QueryManager/index.ts
+++ b/src/core/__tests__/QueryManager/index.ts
@@ -5228,5 +5228,166 @@ describe('QueryManager', () => {
 
       expect(queryManager['inFlightLinkObservables'].size).toBe(0)
     });
-  })
+  });
+
+  describe('warnings', () => {
+    const originalWarn = console.warn;
+    let warnCount = 0;
+
+    beforeEach(() => {
+      warnCount = 0;
+      console.warn = (...args: any[]) => {
+        warnCount += 1;
+      };
+    });
+
+    afterEach(() => {
+      console.warn = originalWarn;
+    });
+
+    itAsync('should show missing cache result fields warning when returnPartialData is false', (resolve, reject) => {
+      const query1 = gql`
+        query {
+          car {
+            make
+            model
+            id
+            __typename
+          }
+        }
+      `;
+
+      const query2 = gql`
+        query {
+          car {
+            make
+            model
+            vin
+            id
+            __typename
+          }
+        }
+      `;
+
+      const data1 = {
+        car: {
+          make: 'Ford',
+          model: 'Pinto',
+          id: 123,
+          __typename: 'Car'
+        },
+      };
+
+      const queryManager = mockQueryManager(
+        reject,
+        {
+          request: { query: query1 },
+          result: { data: data1 },
+        },
+      );
+
+      const observable1 = queryManager.watchQuery<any>({ query: query1 });
+      const observable2 = queryManager.watchQuery<any>({
+        query: query2,
+        fetchPolicy: 'cache-only',
+      });
+
+      observableToPromise(
+        { observable: observable1 },
+        result => {
+          expect(result).toEqual({
+            loading: false,
+            data: data1,
+            networkStatus: NetworkStatus.ready,
+          });
+        },
+      ).then(() => {
+        observableToPromise(
+          { observable: observable2 },
+          result => {
+            expect(result).toEqual({
+              data: data1,
+              loading: false,
+              networkStatus: NetworkStatus.ready,
+              partial: true,
+            });
+            expect(warnCount).toBe(1);
+          },
+        ).then(resolve, reject)
+      });
+    });
+
+    itAsync('should not show missing cache result fields warning when returnPartialData is true', (resolve, reject) => {
+      const query1 = gql`
+        query {
+          car {
+            make
+            model
+            id
+            __typename
+          }
+        }
+      `;
+
+      const query2 = gql`
+        query {
+          car {
+            make
+            model
+            vin
+            id
+            __typename
+          }
+        }
+      `;
+
+      const data1 = {
+        car: {
+          make: 'Ford',
+          model: 'Pinto',
+          id: 123,
+          __typename: 'Car'
+        },
+      };
+
+      const queryManager = mockQueryManager(
+        reject,
+        {
+          request: { query: query1 },
+          result: { data: data1 },
+        },
+      );
+
+      const observable1 = queryManager.watchQuery<any>({ query: query1 });
+      const observable2 = queryManager.watchQuery<any>({
+        query: query2,
+        fetchPolicy: 'cache-only',
+        returnPartialData: true,
+      });
+
+      observableToPromise(
+        { observable: observable1 },
+        result => {
+          expect(result).toEqual({
+            loading: false,
+            data: data1,
+            networkStatus: NetworkStatus.ready,
+          });
+        },
+      ).then(() => {
+        observableToPromise(
+          { observable: observable2 },
+          result => {
+            expect(result).toEqual({
+              data: data1,
+              loading: false,
+              networkStatus: NetworkStatus.ready,
+              partial: true,
+            });
+            expect(warnCount).toBe(0);
+          },
+        ).then(resolve, reject)
+      });
+    });
+  });
 });


### PR DESCRIPTION
If `returnPartialData` is set to `true` for a query, disable the `QueryManager` `Missing cache result fields` warning, since developers have explicitly stated they want to work with partial data.

Fixes #7040