### PR TITLE
Support inheritance of typePolicies, according to possibleTypes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ## Improvements
 
+- Support inheritance of type and field policies, according to `possibleTypes`. <br/>
+  [@benjamn](https://github.com/benjamn) in [#7065](https://github.com/apollographql/apollo-client/pull/7065)
+
 - Shallow-merge `options.variables` when combining existing or default options with newly-provided options, so new variables do not completely overwrite existing variables. <br/>
   [@amannn](https://github.com/amannn) in [#6927](https://github.com/apollographql/apollo-client/pull/6927)
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     {
       "name": "apollo-client",
       "path": "./dist/apollo-client.cjs.min.js",
-      "maxSize": "24.75 kB"
+      "maxSize": "24.9 kB"
     }
   ],
   "peerDependencies": {

--- a/src/cache/inmemory/__tests__/__snapshots__/policies.ts.snap
+++ b/src/cache/inmemory/__tests__/__snapshots__/policies.ts.snap
@@ -977,3 +977,48 @@ Object {
   },
 }
 `;
+
+exports[`type policies support inheritance 1`] = `
+Object {
+  "Cobra:{\\"tagId\\":\\"Egypt30BC\\"}": Object {
+    "__typename": "Cobra",
+    "scientificName": "naja haje",
+    "tagId": "Egypt30BC",
+    "venomous": true,
+  },
+  "Cottonmouth:{\\"tagId\\":\\"CM420\\"}": Object {
+    "__typename": "Cottonmouth",
+    "scientificName": "agkistrodon piscivorus",
+    "tagId": "CM420",
+    "venomous": true,
+  },
+  "Python:{\\"tagId\\":\\"BigHug4U\\"}": Object {
+    "__typename": "Python",
+    "scientificName": "malayopython reticulatus",
+    "tagId": "BigHug4U",
+    "venomous": false,
+  },
+  "ROOT_QUERY": Object {
+    "__typename": "Query",
+    "reptiles": Array [
+      Object {
+        "__ref": "Turtle:{\\"tagId\\":\\"RedEaredSlider42\\"}",
+      },
+      Object {
+        "__ref": "Python:{\\"tagId\\":\\"BigHug4U\\"}",
+      },
+      Object {
+        "__ref": "Cobra:{\\"tagId\\":\\"Egypt30BC\\"}",
+      },
+      Object {
+        "__ref": "Cottonmouth:{\\"tagId\\":\\"CM420\\"}",
+      },
+    ],
+  },
+  "Turtle:{\\"tagId\\":\\"RedEaredSlider42\\"}": Object {
+    "__typename": "Turtle",
+    "scientificName": "trachemys scripta elegans",
+    "tagId": "RedEaredSlider42",
+  },
+}
+`;


### PR DESCRIPTION
Motivating discussion: https://github.com/apollographql/apollo-client/issues/6949#issuecomment-685192249

JavaScript developers will be familiar with the idea of [_inheritance_](https://en.m.wikipedia.org/wiki/Inheritance_(object-oriented_programming)) from the `extends` clause of `class` declarations, or possibly from dealing with prototype chains created by `Object.create`.

Here's how type policy inheritance works for `InMemoryCache`:
```ts
const cache = new InMemoryCache({
  possibleTypes: {
    Reptile: ["Snake", "Turtle"],
    Snake: ["Python", "Viper", "Cobra"],
    Viper: ["Cottonmouth", "DeathAdder"],
  },

  typePolicies: {
    Reptile: {
      // Suppose all our reptiles are captive, and have a tag with an ID.
      keyFields: ["tagId"],
      fields: {
        // Scientific name-related logic can be shared among Reptile subtypes.
        scientificName: {
          merge(_, incoming) {
            // Normalize all scientific names to lower case.
            return incoming.toLowerCase();
          },
        },
      },
    },

    Snake: {
      fields: {
        // Default to a truthy non-boolean value if we don't know
        // whether this snake is venomous.
        venomous(status = "unknown") {
          return status;
        },
      },
    },
  },
});
```

Inheritance is a powerful code-sharing tool, and it works well for Apollo Client for several reasons:

1. `InMemoryCache` already knows about the supertype-subtype relationships (interfaces and unions) in your schema, thanks to [`possibleTypes`](https://www.apollographql.com/docs/react/data/fragments/#using-fragments-with-unions-and-interfaces), so no additional configuration is necessary to provide that information.

2. Inheritance allows a supertype to provide default configuration values to all its subtypes, including `keyFields` and individual field policies, which can be selectively overridden by subtypes that want something different.

3. A single subtype can have multiple supertypes in a GraphQL schema, which is difficult to model using the single inheritance model of `class`es or prototypes. In other words, supporting multiple inheritance in JavaScript requires building a system something like this one, rather than just reusing built-in language features.

4. Developers can add their own client-only supertypes to the `possibleTypes` map, as a way of reusing behavior across types, even if their schema knows nothing about those made-up supertypes.

5. The `possibleTypes` map is currently used only for fragment matching purposes, which is an important but fairly small part of what the client does. Inheritance adds another compelling use for `possibleTypes`, and should drastically reduce repetition of `typePolicies` when used effectively.

Inheritance is a step back (in terms of freedom/power) from the completely dynamic `policyForType` and `policyForField` functions I proposed in https://github.com/apollographql/apollo-client/issues/6808#issuecomment-671388857, but I think inheritable `typePolicies` can address most of the concerns raised in #6808.