### PR TITLE
Allow custom merge functions (including merge:true and merge:false) in type policies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Support inheritance of type and field policies, according to `possibleTypes`. <br/>
   [@benjamn](https://github.com/benjamn) in [#7065](https://github.com/apollographql/apollo-client/pull/7065)
 
+- Allow configuring custom `merge` functions, including the `merge: true` and `merge: false` shorthands, in type policies as well as field policies. <br/>
+  [@benjamn](https://github.com/benjamn) in [#7070](https://github.com/apollographql/apollo-client/pull/7070)
+
 - Shallow-merge `options.variables` when combining existing or default options with newly-provided options, so new variables do not completely overwrite existing variables. <br/>
   [@amannn](https://github.com/amannn) in [#6927](https://github.com/apollographql/apollo-client/pull/6927)
 

--- a/docs/source/caching/cache-field-behavior.md
+++ b/docs/source/caching/cache-field-behavior.md
@@ -269,6 +269,33 @@ const cache = new InMemoryCache({
 
 In summary, the `Book.author` policy above allows the cache to safely merge the `author` objects of any two `Book` objects that have the same identity.
 
+#### Configuring `merge` functions for types rather than fields
+
+Beginning with Apollo Client 3.3, you can avoid having to configure `merge` functions for lots of different fields that might hold an `Author` object, and instead put the `merge` configuration in the `Author` type policy:
+
+```ts{13}
+const cache = new InMemoryCache({
+  typePolicies: {
+    Book: {
+      fields: {
+        // No longer necessary!
+        // author: {
+        //   merge: true,
+        // },
+      },
+    },
+
+    Author: {
+      merge: true,
+    },
+  },
+});
+```
+
+These configurations have the same behavior, but putting the `merge: true` in the `Author` type policy is shorter and easier to maintain, especially when `Author` objects could appear in lots of different fields besides `Book.author`.
+
+Remember that mergeable objects will only be merged with existing objects occupying the same field of the same parent object, and only when the `__typename` of the objects is the same. If you really need to work around these rules, you can write a custom `merge` function to do whatever you want, but `merge: true` follows these rules.
+
 ### Merging arrays of non-normalized objects
 
 Once you're comfortable with the ideas and recommendations from the previous section, consider what happens when a `Book` can have multiple authors:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8317,9 +8317,9 @@
       }
     },
     "optimism": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.12.1.tgz",
-      "integrity": "sha512-t8I7HM1dw0SECitBYAqFOVHoBAHEQBTeKjIL9y9ImHzAVkdyPK4ifTgM4VJRDtTUY4r/u5Eqxs4XcGPHaoPkeQ==",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.12.2.tgz",
+      "integrity": "sha512-k7hFhlmfLl6HNThIuuvYMQodC1c+q6Uc6V9cLVsMWyW514QuaxVJH/khPu2vLRIoDTpFdJ5sojlARhg1rzyGbg==",
       "requires": {
         "@wry/context": "^0.5.2"
       }

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "fast-json-stable-stringify": "^2.0.0",
     "graphql-tag": "^2.11.0",
     "hoist-non-react-statics": "^3.3.2",
-    "optimism": "^0.12.1",
+    "optimism": "^0.12.2",
     "prop-types": "^15.7.2",
     "symbol-observable": "^2.0.0",
     "terser": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     {
       "name": "apollo-client",
       "path": "./dist/apollo-client.cjs.min.js",
-      "maxSize": "24.9 kB"
+      "maxSize": "25 kB"
     }
   ],
   "peerDependencies": {

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -258,7 +258,7 @@ export abstract class EntityStore implements NormalizedCache {
 
   public abstract getStorage(
     idOrObj: string | StoreObject,
-    storeFieldName: string,
+    storeFieldName: string | number,
   ): StorageType;
 
   // Maps root entity IDs to the number of times they have been retained, minus
@@ -353,7 +353,7 @@ export abstract class EntityStore implements NormalizedCache {
   // Bound function that can be passed around to provide easy access to fields
   // of Reference objects as well as ordinary objects.
   public getFieldValue = <T = StoreValue>(
-    objectOrReference: StoreObject | Reference,
+    objectOrReference: StoreObject | Reference | undefined,
     storeFieldName: string,
   ) => maybeDeepFreeze(
     isReference(objectOrReference)
@@ -484,9 +484,14 @@ export namespace EntityStore {
     public readonly storageTrie = new KeyTrie<StorageType>(canUseWeakMap);
     public getStorage(
       idOrObj: string | StoreObject,
-      storeFieldName: string,
+      storeFieldName: string | number,
     ): StorageType {
-      return this.storageTrie.lookup(idOrObj, storeFieldName);
+      return this.storageTrie.lookup(
+        idOrObj,
+        // Normalize numbers to strings, so we don't accidentally end up
+        // with multiple storage objects for the same field.
+        String(storeFieldName),
+      );
     }
   }
 }
@@ -555,7 +560,7 @@ class Layer extends EntityStore {
 
   public getStorage(
     idOrObj: string | StoreObject,
-    storeFieldName: string,
+    storeFieldName: string | number,
   ): StorageType {
     return this.parent.getStorage(idOrObj, storeFieldName);
   }

--- a/src/cache/inmemory/types.ts
+++ b/src/cache/inmemory/types.ts
@@ -7,7 +7,7 @@ import {
   Reference,
 } from '../../utilities';
 import { FieldValueGetter } from './entityStore';
-import { KeyFieldsFunction, StorageType } from './policies';
+import { KeyFieldsFunction, StorageType, FieldMergeFunction } from './policies';
 import {
   Modifier,
   Modifiers,
@@ -104,6 +104,7 @@ export type ApolloReducerConfig = {
 export interface MergeInfo {
   field: FieldNode;
   typename: string | undefined;
+  merge: FieldMergeFunction;
 };
 
 export interface MergeTree {

--- a/src/cache/inmemory/types.ts
+++ b/src/cache/inmemory/types.ts
@@ -65,7 +65,7 @@ export interface NormalizedCache {
 
   getStorage(
     idOrObj: string | StoreObject,
-    storeFieldName: string | number,
+    ...storeFieldNames: (string | number)[]
   ): StorageType;
 }
 

--- a/src/cache/inmemory/types.ts
+++ b/src/cache/inmemory/types.ts
@@ -1,4 +1,4 @@
-import { DocumentNode } from 'graphql';
+import { DocumentNode, FieldNode } from 'graphql';
 
 import { Transaction } from '../core/cache';
 import {
@@ -65,7 +65,7 @@ export interface NormalizedCache {
 
   getStorage(
     idOrObj: string | StoreObject,
-    storeFieldName: string,
+    storeFieldName: string | number,
   ): StorageType;
 }
 
@@ -99,6 +99,16 @@ export type DiffQueryAgainstStoreOptions = ReadQueryOptions & {
 export type ApolloReducerConfig = {
   dataIdFromObject?: KeyFieldsFunction;
   addTypename?: boolean;
+};
+
+export interface MergeInfo {
+  field: FieldNode;
+  typename: string | undefined;
+};
+
+export interface MergeTree {
+  info?: MergeInfo;
+  map: Map<string | number, MergeTree>;
 };
 
 export interface ReadMergeModifyContext {

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -205,7 +205,16 @@ export class StoreWriter {
           let incomingValue =
             this.processFieldValue(value, selection, context, childTree);
 
-          const merge = policies.getMergeFunction(typename, selection.name.value);
+          const childTypename = selection.selectionSet
+            && context.store.getFieldValue<string>(incomingValue as StoreObject, "__typename")
+            || void 0;
+
+          const merge = policies.getMergeFunction(
+            typename,
+            selection.name.value,
+            childTypename,
+          );
+
           if (merge) {
             childTree.info = {
               // TODO Check compatibility against any existing

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -525,7 +525,7 @@ function warnAboutDataLoss(
 To address this problem (which is not a bug in Apollo Client), ${
   childTypenames.length
     ? "either ensure all objects of type " +
-        childTypenames.join(" and ") + " have IDs, or "
+        childTypenames.join(" and ") + " have an ID or a custom merge function, or "
     : ""
 }define a custom merge function for the ${
   typeDotName


### PR DESCRIPTION
If you've ever dealt with the warnings introduced by #6372, you either reconfigured the object type to be normalized, or you had to go find a bunch of fields that might hold an object of the given type, then configure a `merge` function (or `merge: true`) for those fields.

While normalization is still the preferred strategy in most cases, and `merge: true` (introduced by #6714) has made the second option a little easier, it's still not as easy as it could be to say that a specific object type can be safely merged.

In practice, the intuition about merge safety often concerns only the type of the object, and doesn't really have anything to do with the parent field that holds the object. To handle this common case, this PR allows placing a single `merge` configuration in a type policy, rather than configuring the same `merge` function/boolean in multiple field policies.

In other words, instead of
```ts
new InMemoryCache({
  typePolicies: {
    Book: {
      keyFields: ["isbn"],
      fields: {
        author: {
          merge: true,
        },
      },
    },
    Author: {
      keyFields: false,
    },
  },
})
```
you can now write
```ts
new InMemoryCache({
  typePolicies: {
    Book: {
      keyFields: ["isbn"],
    },
    Author: {
      keyFields: false,
      merge: true,
    },
  },
})
```
These configurations have exactly the same semantics, but the second is shorter and arguably easier to maintain, especially when `Author` objects can appear in lots of different fields (not just `Book.author`).

Note that mergeable objects will only be merged with existing objects occupying the same field of the same parent object, and only when the `__typename` of the objects is the same. If you really need to work around these rules, you can write a custom `merge` function to do whatever you want, but `merge: true` follows these rules.

This feature really begins to shine when paired with inheritance (#7065):
```ts
new InMemoryCache({
  typePolicies: {
    Book: {
      keyFields: ["isbn"],
    },

    Author: {
      keyFields: false,
    },

    // Any type policy that inherits from Mergeable (according to possibleTypes)
    // will automatically have merge:true.
    Mergeable: {
      merge: true,
    },
  },

  possibleTypes: {
    // Remember that you can include made-up supertypes like Mergeable
    // in possibleTypes even if they do not exist in your schema.
    Mergeable: ["Author", "Book", ...],
  },
})
```
Since `Book` has `keyFields: ["isbn"]`, `Book` objects will be normalized, which implies mergeability (whenever the ISBNs match), so configuring `merge: true` for the `Book` type is redundant (but harmless).

This PR should help with #6808 and #6949, and was inspired by discussion with @vigie and @tomprats: https://github.com/apollographql/apollo-client/issues/6949#issuecomment-695055680