### PR TITLE
Avoid warning about clobbering scalar fields.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 - Shallow-merge `options.variables` when combining existing or default options with newly-provided options, so new variables do not completely overwrite existing variables. <br/>
   [@amannn](https://github.com/amannn) in [#6927](https://github.com/apollographql/apollo-client/pull/6927)
 
+- Avoid displaying `Cache data may be lost...` warnings for scalar field values that happen to be objects, such as JSON data. <br/>
+  [@benjamn](https://github.com/benjamn) in [#7075](https://github.com/apollographql/apollo-client/pull/7075)
+
 ## Apollo Client 3.2.1
 
 ## Bug Fixes

--- a/src/cache/inmemory/__tests__/__snapshots__/writeToStore.ts.snap
+++ b/src/cache/inmemory/__tests__/__snapshots__/writeToStore.ts.snap
@@ -1,5 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`writing to the store "Cache data maybe lost..." warnings should not warn when scalar fields are updated 1`] = `
+Object {
+  "ROOT_QUERY": Object {
+    "__typename": "Query",
+    "currentTime({\\"tz\\":\\"UTC-5\\"})": Object {
+      "localeString": "9/25/2020, 1:08:33 PM",
+    },
+    "someJSON": Object {
+      "foos": Array [
+        "bar",
+        "baz",
+      ],
+      "oyez": 3,
+    },
+  },
+}
+`;
+
+exports[`writing to the store "Cache data maybe lost..." warnings should not warn when scalar fields are updated 2`] = `
+Object {
+  "ROOT_QUERY": Object {
+    "__typename": "Query",
+    "currentTime({\\"tz\\":\\"UTC-5\\"})": Object {
+      "msSinceEpoch": 1601053713081,
+    },
+    "someJSON": Object {
+      "asdf": "middle",
+      "qwer": "upper",
+      "zxcv": "lower",
+    },
+  },
+}
+`;
+
 exports[`writing to the store user objects should be able to have { __typename: "Mutation" } 1`] = `
 Object {
   "Gene:{\\"id\\":\\"SLC45A2\\"}": Object {

--- a/src/cache/inmemory/__tests__/writeToStore.ts
+++ b/src/cache/inmemory/__tests__/writeToStore.ts
@@ -1619,7 +1619,9 @@ describe('writing to the store', () => {
             foos: ["bar", "baz"],
           },
           currentTime: {
-            localeString: date.toLocaleString("en-US"),
+            localeString: date.toLocaleString("en-US", {
+              timeZone: "America/New_York",
+            }),
           },
         },
       });

--- a/src/cache/inmemory/__tests__/writeToStore.ts
+++ b/src/cache/inmemory/__tests__/writeToStore.ts
@@ -1582,6 +1582,70 @@ describe('writing to the store', () => {
     });
   });
 
+  describe('"Cache data maybe lost..." warnings', () => {
+    const { warn } = console;
+    let warnings: any[][] = [];
+
+    beforeEach(() => {
+      warnings.length = 0;
+      console.warn = (...args: any[]) => {
+        warnings.push(args);
+      };
+    });
+
+    afterEach(() => {
+      console.warn = warn;
+    });
+
+    it("should not warn when scalar fields are updated", () => {
+      const cache = new InMemoryCache;
+
+      const query = gql`
+        query {
+          someJSON
+          currentTime(tz: "UTC-5")
+        }
+      `;
+
+      expect(warnings).toEqual([]);
+
+      const date = new Date(1601053713081);
+
+      cache.writeQuery({
+        query,
+        data: {
+          someJSON: {
+            oyez: 3,
+            foos: ["bar", "baz"],
+          },
+          currentTime: {
+            localeString: date.toLocaleString("en-US"),
+          },
+        },
+      });
+
+      expect(cache.extract()).toMatchSnapshot();
+      expect(warnings).toEqual([]);
+
+      cache.writeQuery({
+        query,
+        data: {
+          someJSON: {
+            qwer: "upper",
+            asdf: "middle",
+            zxcv: "lower",
+          },
+          currentTime: {
+            msSinceEpoch: date.getTime(),
+          },
+        },
+      });
+
+      expect(cache.extract()).toMatchSnapshot();
+      expect(warnings).toEqual([]);
+    });
+  });
+
   describe('writeResultToStore shape checking', () => {
     const query = gql`
       query {


### PR DESCRIPTION
While it is possible to write a custom `merge` function that handles updates for scalar field values, we should treat scalar data as opaque by default, without displaying `Cache data may be lost...` warnings (#6372) that nudge the developer to write an unnecessary `merge` function.

In this context, scalar data means any subtree of a `GraphQL` result object for which the corresponding field in the query does not have a selection set. In particular, JSON data may look like any other GraphQL object, but it should be treated as an opaque value if the query does not apply a nested selection set to the field that holds the JSON data.

Should fix #7071.