### PR TITLE
Provide a previousData property in useQuery/useLazyQuery results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Avoid displaying `Cache data may be lost...` warnings for scalar field values that happen to be objects, such as JSON data. <br/>
   [@benjamn](https://github.com/benjamn) in [#7075](https://github.com/apollographql/apollo-client/pull/7075)
 
-- Alongside their returned `data` property, `useQuery` and `useLazyQuery` now also return a `previousData` property. Before a new `data` value is set, its current value is stored in `previousData`. This allows more fine-grained control over component loading states, where you might want to leverage previous data until new data has fully loaded. <br/>
+- In addition to the `result.data` property, `useQuery` and `useLazyQuery` will now provide a `result.previousData` property, which can be useful when a network request is pending and `result.data` is undefined, since `result.previousData` can be rendered instead of rendering an empty/loading state. <br/>
   [@hwillson](https://github.com/hwillson) in [#7082](https://github.com/apollographql/apollo-client/pull/7082)
 
 ## Apollo Client 3.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
 - Avoid displaying `Cache data may be lost...` warnings for scalar field values that happen to be objects, such as JSON data. <br/>
   [@benjamn](https://github.com/benjamn) in [#7075](https://github.com/apollographql/apollo-client/pull/7075)
 
+- Alongside their returned `data` property, `useQuery` and `useLazyQuery` now also return a `previousData` property. Before a new `data` value is set, its current value is stored in `previousData`. This allows more fine-grained control over component loading states, where you might want to leverage previous data until new data has fully loaded. <br/>
+  [@hwillson](https://github.com/hwillson) in [#7082](https://github.com/apollographql/apollo-client/pull/7082)
+
 ## Apollo Client 3.2.1
 
 ## Bug Fixes

--- a/docs/shared/query-result.mdx
+++ b/docs/shared/query-result.mdx
@@ -1,6 +1,7 @@
 | Property | Type | Description |
 | - | - | - |
 | `data` | TData | An object containing the result of your GraphQL query. Defaults to `undefined`. |
+| `previousData` | TData | An object containing the previous result of your GraphQL query (the last result before a new `data` value was set). Defaults to `undefined`. |
 | `loading` | boolean | A boolean that indicates whether the request is in flight |
 | `error` | ApolloError | A runtime error with `graphQLErrors` and `networkError` properties |
 | `variables` | { [key: string]: any } | An object containing the variables the query was called with |

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     {
       "name": "apollo-client",
       "path": "./dist/apollo-client.cjs.min.js",
-      "maxSize": "25 kB"
+      "maxSize": "25.25 kB"
     }
   ],
   "peerDependencies": {

--- a/src/react/components/__tests__/client/__snapshots__/Query.test.tsx.snap
+++ b/src/react/components/__tests__/client/__snapshots__/Query.test.tsx.snap
@@ -26,6 +26,7 @@ Object {
   "fetchMore": [Function],
   "loading": true,
   "networkStatus": 1,
+  "previousData": undefined,
   "refetch": [Function],
   "startPolling": [Function],
   "stopPolling": [Function],

--- a/src/react/data/QueryData.ts
+++ b/src/react/data/QueryData.ts
@@ -403,6 +403,12 @@ export class QueryData<TData, TVariables> extends OperationData {
     this.setOptions(options, true);
     this.previousData.loading =
       this.previousData.result && this.previousData.result.loading || false;
+
+    // Ensure the returned result contains previous data as a separate
+    // property, to give developers the flexibility of leveraging previous
+    // data when new data is being loaded.
+    result.previousData = this.previousData.result?.data;
+
     this.previousData.result = result;
 
     // Any query errors that exist are now available in `result`, so we'll

--- a/src/react/data/QueryData.ts
+++ b/src/react/data/QueryData.ts
@@ -38,7 +38,7 @@ export class QueryData<TData, TVariables> extends OperationData {
     client?: ApolloClient<object>;
     query?: DocumentNode | TypedDocumentNode<TData, TVariables>;
     observableQueryOptions?: {};
-    result?: QueryResult<TData, TVariables> | null;
+    result?: QueryResult<TData, TVariables>;
     loading?: boolean;
     options?: QueryDataOptions<TData, TVariables>;
     error?: ApolloError;
@@ -410,13 +410,19 @@ export class QueryData<TData, TVariables> extends OperationData {
     result.client = this.client;
     // Store options as this.previousOptions.
     this.setOptions(options, true);
-    this.previous.loading =
-      this.previous.result && this.previous.result.loading || false;
 
-    // Ensure the returned result contains previous data as a separate
-    // property, to give developers the flexibility of leveraging previous
-    // data when new data is being loaded.
-    result.previousData = this.previous.result?.data;
+    const previousResult = this.previous.result;
+
+    this.previous.loading =
+      previousResult && previousResult.loading || false;
+
+    // Ensure the returned result contains previousData as a separate
+    // property, to give developers the flexibility of leveraging outdated
+    // data while new data is loading from the network. Falling back to
+    // previousResult.previousData when previousResult.data is falsy here
+    // allows result.previousData to persist across multiple results.
+    result.previousData = previousResult &&
+      (previousResult.data || previousResult.previousData);
 
     this.previous.result = result;
 

--- a/src/react/data/QueryData.ts
+++ b/src/react/data/QueryData.ts
@@ -3,12 +3,15 @@ import { equal } from '@wry/equality';
 import { ApolloError } from '../../errors';
 
 import {
+  ApolloClient,
   NetworkStatus,
   FetchMoreQueryOptions,
   SubscribeToMoreOptions,
   ObservableQuery,
   FetchMoreOptions,
-  UpdateQueryOptions
+  UpdateQueryOptions,
+  DocumentNode,
+  TypedDocumentNode
 } from '../../core';
 
 import {
@@ -18,7 +21,6 @@ import {
 import { DocumentType } from '../parser';
 import {
   QueryResult,
-  QueryPreviousData,
   QueryDataOptions,
   QueryTuple,
   QueryLazyOptions,
@@ -28,12 +30,19 @@ import { OperationData } from './OperationData';
 
 export class QueryData<TData, TVariables> extends OperationData {
   public onNewData: () => void;
-
-  private previous: QueryPreviousData<TData, TVariables> = {};
   private currentObservable?: ObservableQuery<TData, TVariables>;
   private currentSubscription?: ObservableSubscription;
   private runLazy: boolean = false;
   private lazyOptions?: QueryLazyOptions<TVariables>;
+  private previous: {
+    client?: ApolloClient<object>;
+    query?: DocumentNode | TypedDocumentNode<TData, TVariables>;
+    observableQueryOptions?: {};
+    result?: QueryResult<TData, TVariables> | null;
+    loading?: boolean;
+    options?: QueryDataOptions<TData, TVariables>;
+    error?: ApolloError;
+  } = Object.create(null);
 
   constructor({
     options,

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -6,7 +6,7 @@ import { render, wait } from '@testing-library/react';
 import { ApolloClient } from '../../../core';
 import { InMemoryCache } from '../../../cache';
 import { ApolloProvider } from '../../context';
-import { MockedProvider } from '../../../testing';
+import { itAsync, MockedProvider } from '../../../testing';
 import { useLazyQuery } from '../useLazyQuery';
 
 describe('useLazyQuery Hook', () => {
@@ -391,4 +391,87 @@ describe('useLazyQuery Hook', () => {
       });
     }
   );
+
+  itAsync('should persist previous data when a query is re-run', (resolve, reject) => {
+    const query = gql`
+      query car {
+        car {
+          id
+          make
+        }
+      }
+    `;
+
+    const data1 = {
+      car: {
+        id: 1,
+        make: 'Venturi',
+        __typename: 'Car',
+      }
+    };
+
+    const data2 = {
+      car: {
+        id: 2,
+        make: 'Wiesmann',
+        __typename: 'Car',
+      }
+    };
+
+    const mocks = [
+      { request: { query }, result: { data: data1 } },
+      { request: { query }, result: { data: data2 } }
+    ];
+
+    let renderCount = 0;
+    function App() {
+      const [execute, { loading, data, previousData, refetch }] = useLazyQuery(
+        query,
+        { notifyOnNetworkStatusChange: true },
+      );
+
+      switch (++renderCount) {
+        case 1:
+          expect(loading).toEqual(false);
+          expect(data).toBeUndefined();
+          expect(previousData).toBeUndefined();
+          setTimeout(execute);
+          break;
+        case 2:
+          expect(loading).toBeTruthy();
+          expect(data).toBeUndefined();
+          expect(previousData).toBeUndefined();
+          break;
+        case 3:
+          expect(loading).toBeFalsy();
+          expect(data).toEqual(data1);
+          expect(previousData).toBeUndefined();
+          setTimeout(refetch!);
+          break;
+        case 4:
+          expect(loading).toBeTruthy();
+          expect(data).toEqual(data1);
+          expect(previousData).toEqual(data1);
+          break;
+        case 5:
+          expect(loading).toBeFalsy();
+          expect(data).toEqual(data2);
+          expect(previousData).toEqual(data1);
+          break;
+        default: // Do nothing
+      }
+
+      return null;
+    }
+
+    render(
+      <MockedProvider mocks={mocks}>
+        <App />
+      </MockedProvider>
+    );
+
+    return wait(() => {
+      expect(renderCount).toBe(5);
+    }).then(resolve, reject);
+  });
 });

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -3,7 +3,7 @@ import { DocumentNode, GraphQLError } from 'graphql';
 import gql from 'graphql-tag';
 import { render, cleanup, wait } from '@testing-library/react';
 
-import { ApolloClient, NetworkStatus } from '../../../core';
+import { ApolloClient, NetworkStatus, TypedDocumentNode } from '../../../core';
 import { InMemoryCache } from '../../../cache';
 import { ApolloProvider } from '../../context';
 import { Observable, Reference, concatPagination } from '../../../utilities';
@@ -2301,6 +2301,115 @@ describe('useQuery Hook', () => {
 
       return wait(() => {
         expect(renderCount).toBe(4);
+      }).then(resolve, reject);
+    });
+
+    itAsync('should persist result.previousData across multiple results', (resolve, reject) => {
+      const query: TypedDocumentNode<{
+        car: {
+          id: string;
+          make: string;
+        };
+      }, {
+        vin?: string;
+      }> = gql`
+        query car($vin: String) {
+          car(vin: $vin) {
+            id
+            make
+          }
+        }
+      `;
+
+      const data1 = {
+        car: {
+          id: 1,
+          make: 'Venturi',
+          __typename: 'Car',
+        }
+      };
+
+      const data2 = {
+        car: {
+          id: 2,
+          make: 'Wiesmann',
+          __typename: 'Car',
+        }
+      };
+
+      const data3 = {
+        car: {
+          id: 3,
+          make: 'Beetle',
+          __typename: 'Car',
+        }
+      };
+
+      const mocks = [
+        { request: { query }, result: { data: data1 } },
+        { request: { query }, result: { data: data2 } },
+        {
+          request: {
+            query,
+            variables: { vin: "ABCDEFG0123456789" },
+          },
+          result: { data: data3 },
+        },
+      ];
+
+      let renderCount = 0;
+      function App() {
+        const { loading, data, previousData, refetch } = useQuery(query, {
+          notifyOnNetworkStatusChange: true,
+        });
+
+        switch (++renderCount) {
+          case 1:
+            expect(loading).toBe(true);
+            expect(data).toBeUndefined();
+            expect(previousData).toBeUndefined();
+            break;
+          case 2:
+            expect(loading).toBe(false);
+            expect(data).toEqual(data1);
+            expect(previousData).toBeUndefined();
+            setTimeout(refetch);
+            break;
+          case 3:
+            expect(loading).toBe(true);
+            expect(data).toEqual(data1);
+            expect(previousData).toEqual(data1);
+            // Interrupt the first refetch by refetching again with
+            // variables the cache has not seen before, thereby skipping
+            // data2 entirely.
+            refetch({
+              vin: "ABCDEFG0123456789",
+            });
+            break;
+          case 4:
+            expect(loading).toBe(true);
+            expect(data).toBeUndefined();
+            expect(previousData).toEqual(data1);
+            break;
+          case 5:
+            expect(loading).toBe(false);
+            expect(data).toEqual(data3);
+            expect(previousData).toEqual(data1);
+            break;
+          default: // Do nothing
+        }
+
+        return null;
+      }
+
+      render(
+        <MockedProvider mocks={mocks}>
+          <App />
+        </MockedProvider>
+      );
+
+      return wait(() => {
+        expect(renderCount).toBe(5);
       }).then(resolve, reject);
     });
   });

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -106,16 +106,6 @@ export interface LazyQueryHookOptions<
   query?: DocumentNode | TypedDocumentNode<TData, TVariables>;
 }
 
-export interface QueryPreviousData<TData, TVariables> {
-  client?: ApolloClient<object>;
-  query?: DocumentNode | TypedDocumentNode<TData, TVariables>;
-  observableQueryOptions?: {};
-  result?: QueryResult<TData, TVariables> | null;
-  loading?: boolean;
-  options?: QueryDataOptions<TData, TVariables>;
-  error?: ApolloError;
-}
-
 export interface QueryLazyOptions<TVariables> {
   variables?: TVariables;
   context?: Context;

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -81,6 +81,7 @@ export interface QueryResult<TData = any, TVariables = OperationVariables>
   extends ObservableQueryFields<TData, TVariables> {
   client: ApolloClient<any>;
   data: TData | undefined;
+  previousData?: TData;
   error?: ApolloError;
   loading: boolean;
   networkStatus: NetworkStatus;
@@ -125,6 +126,7 @@ type UnexecutedLazyFields = {
   networkStatus: NetworkStatus.ready;
   called: false;
   data: undefined;
+  previousData?: undefined;
 }
 
 type Impartial<T> = {


### PR DESCRIPTION
Alongside their returned `data` property, `useQuery` and `useLazyQuery` now also return a `previousData` property. Before a new `data` value is set, its current value is stored in `previousData`. This allows more fine-grained control over component loading states, where developers might want to leverage previous data until new data has fully loaded.

@benjamn just a heads up that I did look into moving the `previousData` handling up the chain into the AC `core` itself. The amount of work needed to get this functionality in place would have been more substantial however (as the `lastResult` tracking we’re doing in `ObservableQuery` doesn’t quite line up with what we’re looking for here), so I’ve left it in the React layer for now (where we were already tracking `previousData`, but just not exposing it). This should address most of the oustanding issues around this functionality, and we can always consider this a stepping stone. Changing how this works internally in the future will be hidden from `useQuery` / `useLazyQuery` consumers. Thanks!

Fixes #6603