### PR TITLE
add type example in id for fragment query

### DIFF
--- a/docs/source/caching/cache-interaction.md
+++ b/docs/source/caching/cache-interaction.md
@@ -68,7 +68,7 @@ Here's an example that fetches a particular item from a to-do list:
 
 ```js
 const todo = client.readFragment({
-  id: '5', // The value of the to-do item's unique identifier
+  id: 'Todo:5', // The value of the to-do item's unique identifier
   fragment: gql`
     fragment MyTodo on Todo {
       id


### PR DESCRIPTION
The current docs don't include an example that the fragment query should have it's full key in it, that includes the object type.

Referencing this chat: https://spectrum.chat/apollo/apollo-client/why-doesnt-client-readfragment-work~f405dc79-57dc-412f-b0d2-7262f4bb9ab5