### PR TITLE
fix: check for mounting state before cleanup

### DIFF
--- a/src/react/data/QueryData.ts
+++ b/src/react/data/QueryData.ts
@@ -98,8 +98,10 @@ export class QueryData<TData, TVariables> extends OperationData {
 
   public cleanup() {
     this.removeQuerySubscription();
-    delete this.currentObservable;
-    delete this.previousData.result;
+    if (!this.isMounted) {
+      delete this.currentObservable;
+      delete this.previousData.result;
+    }
   }
 
   public getOptions() {
@@ -447,7 +449,7 @@ export class QueryData<TData, TVariables> extends OperationData {
   }
 
   private removeQuerySubscription() {
-    if (this.currentSubscription) {
+    if (this.currentSubscription && !this.isMounted) {
       this.currentSubscription.unsubscribe();
       delete this.currentSubscription;
     }

--- a/src/react/data/SubscriptionData.ts
+++ b/src/react/data/SubscriptionData.ts
@@ -142,7 +142,7 @@ export class SubscriptionData<
   }
 
   private endSubscription() {
-    if (this.currentObservable.subscription) {
+    if (this.currentObservable.subscription && !this.isMounted) {
       this.currentObservable.subscription.unsubscribe();
       delete this.currentObservable.subscription;
     }


### PR DESCRIPTION
Trying to fix #6405, #6437, potentially https://github.com/apollographql/react-apollo/issues/3931

This works for me when locally linking, but is still:
a) missing tests (although i'm not quite sure how to test it as it relates to fast refresh)
b) i'm not quite sure if the fix in QueryData is appropriate

---

As this is my first contribution in apollo-client, i'd like to remark that contributing here is quite painful due to the missing lint setup.
My vscode is linting a lot of things differently by default and I didn't manage to completely disable linting - also I couldn't find any docs on how "proper" linting would look like. Ended up git resetting hard and applying the relevant changes via a text editor :sweat_smile: 