### PR TITLE
Provide default empty StoreObject for root IDs like ROOT_QUERY.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@
 - In addition to the `result.data` property, `useQuery` and `useLazyQuery` will now provide a `result.previousData` property, which can be useful when a network request is pending and `result.data` is undefined, since `result.previousData` can be rendered instead of rendering an empty/loading state. <br/>
   [@hwillson](https://github.com/hwillson) in [#7082](https://github.com/apollographql/apollo-client/pull/7082)
 
+- Provide default empty cache object for root IDs like `ROOT_QUERY`, to avoid differences in behavior before/after `ROOT_QUERY` data has been written into `InMemoryCache`. <br/>
+  [@benjamn](https://github.com/benjamn) in [#7100](https://github.com/apollographql/apollo-client/pull/7100)
+
 ## Apollo Client 3.2.1
 
 ## Bug Fixes

--- a/src/cache/inmemory/__tests__/readFromStore.ts
+++ b/src/cache/inmemory/__tests__/readFromStore.ts
@@ -1065,6 +1065,58 @@ describe('reading from the store', () => {
     });
   });
 
+  it("read functions for root query fields work with empty cache", () => {
+    const cache = new InMemoryCache({
+      typePolicies: {
+        Query: {
+          fields: {
+            uuid() {
+              return "8d573b9c-cfcf-4e3e-98dd-14d255af577e";
+            },
+            null() {
+              return null;
+            },
+          }
+        },
+      },
+    });
+
+    expect(cache.readQuery({
+      query: gql`query { uuid null }`,
+    })).toEqual({
+      uuid: "8d573b9c-cfcf-4e3e-98dd-14d255af577e",
+      null: null,
+    });
+
+    expect(cache.extract()).toEqual({});
+
+    expect(cache.readFragment({
+      id: "ROOT_QUERY",
+      fragment: gql`
+        fragment UUIDFragment on Query {
+          null
+          uuid
+        }
+      `,
+    })).toEqual({
+      uuid: "8d573b9c-cfcf-4e3e-98dd-14d255af577e",
+      null: null,
+    });
+
+    expect(cache.extract()).toEqual({});
+
+    expect(cache.readFragment({
+      id: "does not exist",
+      fragment: gql`
+        fragment F on Never {
+          whatever
+        }
+      `,
+    })).toBe(null);
+
+    expect(cache.extract()).toEqual({});
+  });
+
   it("custom read functions can map/filter dangling references", () => {
     const cache = new InMemoryCache({
       typePolicies: {

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -79,8 +79,18 @@ export abstract class EntityStore implements NormalizedCache {
     // should not rely on this dependency, since the contents could change
     // without the object being added or removed.
     if (dependOnExistence) this.group.depend(dataId, "__exists");
-    return hasOwn.call(this.data, dataId) ? this.data[dataId] :
-      this instanceof Layer ? this.parent.lookup(dataId, dependOnExistence) : void 0;
+
+    if (hasOwn.call(this.data, dataId)) {
+      return this.data[dataId];
+    }
+
+    if (this instanceof Layer) {
+      return this.parent.lookup(dataId, dependOnExistence);
+    }
+
+    if (this.policies.rootTypenamesById[dataId]) {
+      return Object.create(null);
+    }
   }
 
   public merge(dataId: string, incoming: StoreObject): void {


### PR DESCRIPTION
> Note: this PR builds on #7098.

This change means the existence of root objects like `ROOT_QUERY` and `ROOT_MUTATION` in the `InMemoryCache` will no longer depend on whether other queries/mutations have previously written data into the cache.

This matters because (until just recently: #7098) `cache.read` would return `null` for a completely missing `ROOT_QUERY` object, but throw missing field errors if `ROOT_QUERY` existed but did not have the requested fields:
```ts
const cache = new InMemoryCache(); // empty
const query = gql`query { some fields }`;

// Returns null, as before:
const result = cache.readQuery({ query });

// Before PR #7098, this write would cause the ROOT_QUERY object
// to be created, changing the behavior of cache.readQuery below.
cache.writeQuery({
  query: gql`query { unrelated fields }`,
  data: {...},
});

// Previously threw a missing field error, but now returns null:
const result = cache.readQuery({
  query: gql`query { some fields }`,
});
```
In other words, this commit hides the difference between the absence of `ROOT_QUERY` and its incompleteness, so unrelated cache writes can no longer unexpectedly influence the `null`-returning vs. exception-throwing behavior of `cache.read`.

As an additional motivation, with AC3 field policies, it's possible now to define synthetic root query fields that have a chance of returning useful values even if the cache is completely empty. Providing a default empty object for root IDs like `ROOT_QUERY` is important to let those `read` functions be called, instead of prematurely returning `null` from `cache.read` when `ROOT_QUERY` does not exist.