### PR TITLE
Undo TEdgeWrapper approach for relayStylePagination.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Apollo Client 3.2.2
+
+## Bug Fixes
+
+- Undo `TEdgeWrapper` approach for `relayStylePagination`, introduced by [f41e9efc](https://github.com/apollographql/apollo-client/commit/f41e9efc9e061b80fe5019456c049a3c56661e87) in [#7023](https://github.com/apollographql/apollo-client/pull/7023), since it was an unintended breaking change for existing code that used `cache.modify` to interact with field data managed by `relayStylePagination`. <br/>
+  [@benjamn](https://github.com/benjamn) in [#7103](https://github.com/apollographql/apollo-client/pull/7103)
+
 ## Apollo Client 3.2.1
 
 ## Bug Fixes

--- a/src/cache/inmemory/__tests__/__snapshots__/policies.ts.snap
+++ b/src/cache/inmemory/__tests__/__snapshots__/policies.ts.snap
@@ -61,6 +61,32 @@ Object {
   "ROOT_QUERY": Object {
     "__typename": "Query",
     "search:basquiat": Object {
+      "edges": Array [
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
+          "node": Object {
+            "__ref": "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
+            "displayLabel": "ephemera BASQUIAT",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjI=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
+            "displayLabel": "Jean-Michel Basquiat | Xerox",
+          },
+        },
+      ],
       "pageInfo": Object {
         "__typename": "PageInfo",
         "endCursor": "YXJyYXljb25uZWN0aW9uOjI=",
@@ -69,39 +95,6 @@ Object {
         "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
       },
       "totalCount": 1292,
-      "wrappers": Array [
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__ref": "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}",
-            },
-          },
-        },
-        Object {
-          "cursor": undefined,
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__typename": "SearchableItem",
-              "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
-              "displayLabel": "ephemera BASQUIAT",
-            },
-          },
-        },
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjI=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__typename": "SearchableItem",
-              "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
-              "displayLabel": "Jean-Michel Basquiat | Xerox",
-            },
-          },
-        },
-      ],
     },
   },
 }
@@ -124,6 +117,56 @@ Object {
   "ROOT_QUERY": Object {
     "__typename": "Query",
     "search:basquiat": Object {
+      "edges": Array [
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
+          "node": Object {
+            "__ref": "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
+            "displayLabel": "ephemera BASQUIAT",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjI=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
+            "displayLabel": "Jean-Michel Basquiat | Xerox",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Banksy, SEEN, JonOne and QUIK at Artrust Oct 8th – Dec 16th 2017",
+            "displayLabel": "STREET ART: From Basquiat to Banksy",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Jean-Michel Basquiat, Shepard Fairey, COPE2, Pure Evil, Sickboy, Blade, Kurar, and LARS at Artrust",
+            "displayLabel": "STREET ART 2: From Basquiat to Banksy",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjU=",
+          "node": Object {
+            "__ref": "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}",
+          },
+        },
+      ],
       "pageInfo": Object {
         "__typename": "PageInfo",
         "endCursor": "YXJyYXljb25uZWN0aW9uOjU=",
@@ -132,70 +175,6 @@ Object {
         "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
       },
       "totalCount": 1292,
-      "wrappers": Array [
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__ref": "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}",
-            },
-          },
-        },
-        Object {
-          "cursor": undefined,
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__typename": "SearchableItem",
-              "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
-              "displayLabel": "ephemera BASQUIAT",
-            },
-          },
-        },
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjI=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__typename": "SearchableItem",
-              "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
-              "displayLabel": "Jean-Michel Basquiat | Xerox",
-            },
-          },
-        },
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__typename": "SearchableItem",
-              "description": "Past show featuring works by Banksy, SEEN, JonOne and QUIK at Artrust Oct 8th – Dec 16th 2017",
-              "displayLabel": "STREET ART: From Basquiat to Banksy",
-            },
-          },
-        },
-        Object {
-          "cursor": undefined,
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__typename": "SearchableItem",
-              "description": "Past show featuring works by Jean-Michel Basquiat, Shepard Fairey, COPE2, Pure Evil, Sickboy, Blade, Kurar, and LARS at Artrust",
-              "displayLabel": "STREET ART 2: From Basquiat to Banksy",
-            },
-          },
-        },
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjU=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__ref": "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}",
-            },
-          },
-        },
-      ],
     },
   },
 }
@@ -218,6 +197,50 @@ Object {
   "ROOT_QUERY": Object {
     "__typename": "Query",
     "search:basquiat": Object {
+      "edges": Array [
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjE=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
+            "displayLabel": "ephemera BASQUIAT",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
+            "displayLabel": "Jean-Michel Basquiat | Xerox",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Banksy, SEEN, JonOne and QUIK at Artrust Oct 8th – Dec 16th 2017",
+            "displayLabel": "STREET ART: From Basquiat to Banksy",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Jean-Michel Basquiat, Shepard Fairey, COPE2, Pure Evil, Sickboy, Blade, Kurar, and LARS at Artrust",
+            "displayLabel": "STREET ART 2: From Basquiat to Banksy",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjU=",
+          "node": Object {
+            "__ref": "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}",
+          },
+        },
+      ],
       "pageInfo": Object {
         "__typename": "PageInfo",
         "endCursor": "YXJyYXljb25uZWN0aW9uOjU=",
@@ -226,61 +249,6 @@ Object {
         "startCursor": "YXJyYXljb25uZWN0aW9uOjE=",
       },
       "totalCount": 1292,
-      "wrappers": Array [
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjE=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__typename": "SearchableItem",
-              "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
-              "displayLabel": "ephemera BASQUIAT",
-            },
-          },
-        },
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__typename": "SearchableItem",
-              "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
-              "displayLabel": "Jean-Michel Basquiat | Xerox",
-            },
-          },
-        },
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__typename": "SearchableItem",
-              "description": "Past show featuring works by Banksy, SEEN, JonOne and QUIK at Artrust Oct 8th – Dec 16th 2017",
-              "displayLabel": "STREET ART: From Basquiat to Banksy",
-            },
-          },
-        },
-        Object {
-          "cursor": undefined,
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__typename": "SearchableItem",
-              "description": "Past show featuring works by Jean-Michel Basquiat, Shepard Fairey, COPE2, Pure Evil, Sickboy, Blade, Kurar, and LARS at Artrust",
-              "displayLabel": "STREET ART 2: From Basquiat to Banksy",
-            },
-          },
-        },
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjU=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__ref": "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}",
-            },
-          },
-        },
-      ],
     },
   },
 }
@@ -303,6 +271,57 @@ Object {
   "ROOT_QUERY": Object {
     "__typename": "Query",
     "search:basquiat": Object {
+      "edges": Array [
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
+          "node": Object {
+            "__ref": "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjE=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
+            "displayLabel": "ephemera BASQUIAT",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
+            "displayLabel": "Jean-Michel Basquiat | Xerox",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Banksy, SEEN, JonOne and QUIK at Artrust Oct 8th – Dec 16th 2017",
+            "displayLabel": "STREET ART: From Basquiat to Banksy",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Jean-Michel Basquiat, Shepard Fairey, COPE2, Pure Evil, Sickboy, Blade, Kurar, and LARS at Artrust",
+            "displayLabel": "STREET ART 2: From Basquiat to Banksy",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjU=",
+          "node": Object {
+            "__ref": "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}",
+          },
+        },
+      ],
       "pageInfo": Object {
         "__typename": "PageInfo",
         "endCursor": "YXJyYXljb25uZWN0aW9uOjU=",
@@ -311,70 +330,6 @@ Object {
         "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
       },
       "totalCount": 1292,
-      "wrappers": Array [
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__ref": "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}",
-            },
-          },
-        },
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjE=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__typename": "SearchableItem",
-              "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
-              "displayLabel": "ephemera BASQUIAT",
-            },
-          },
-        },
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__typename": "SearchableItem",
-              "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
-              "displayLabel": "Jean-Michel Basquiat | Xerox",
-            },
-          },
-        },
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__typename": "SearchableItem",
-              "description": "Past show featuring works by Banksy, SEEN, JonOne and QUIK at Artrust Oct 8th – Dec 16th 2017",
-              "displayLabel": "STREET ART: From Basquiat to Banksy",
-            },
-          },
-        },
-        Object {
-          "cursor": undefined,
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__typename": "SearchableItem",
-              "description": "Past show featuring works by Jean-Michel Basquiat, Shepard Fairey, COPE2, Pure Evil, Sickboy, Blade, Kurar, and LARS at Artrust",
-              "displayLabel": "STREET ART 2: From Basquiat to Banksy",
-            },
-          },
-        },
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjU=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__ref": "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}",
-            },
-          },
-        },
-      ],
     },
   },
 }
@@ -397,6 +352,66 @@ Object {
   "ROOT_QUERY": Object {
     "__typename": "Query",
     "search:basquiat": Object {
+      "edges": Array [
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
+          "node": Object {
+            "__ref": "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjE=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
+            "displayLabel": "ephemera BASQUIAT",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
+            "displayLabel": "Jean-Michel Basquiat | Xerox",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Banksy, SEEN, JonOne and QUIK at Artrust Oct 8th – Dec 16th 2017",
+            "displayLabel": "STREET ART: From Basquiat to Banksy",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Jean-Michel Basquiat, Shepard Fairey, COPE2, Pure Evil, Sickboy, Blade, Kurar, and LARS at Artrust",
+            "displayLabel": "STREET ART 2: From Basquiat to Banksy",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjU=",
+          "node": Object {
+            "__ref": "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjY=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Jean-Michel Basquiat at Brooklyn Museum Apr 3rd – Aug 23rd 2015",
+            "displayLabel": "Basquiat: The Unknown Notebooks",
+          },
+        },
+      ],
       "pageInfo": Object {
         "__typename": "PageInfo",
         "endCursor": "YXJyYXljb25uZWN0aW9uOjY=",
@@ -405,81 +420,6 @@ Object {
         "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
       },
       "totalCount": 1292,
-      "wrappers": Array [
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__ref": "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}",
-            },
-          },
-        },
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjE=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__typename": "SearchableItem",
-              "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
-              "displayLabel": "ephemera BASQUIAT",
-            },
-          },
-        },
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__typename": "SearchableItem",
-              "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
-              "displayLabel": "Jean-Michel Basquiat | Xerox",
-            },
-          },
-        },
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__typename": "SearchableItem",
-              "description": "Past show featuring works by Banksy, SEEN, JonOne and QUIK at Artrust Oct 8th – Dec 16th 2017",
-              "displayLabel": "STREET ART: From Basquiat to Banksy",
-            },
-          },
-        },
-        Object {
-          "cursor": undefined,
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__typename": "SearchableItem",
-              "description": "Past show featuring works by Jean-Michel Basquiat, Shepard Fairey, COPE2, Pure Evil, Sickboy, Blade, Kurar, and LARS at Artrust",
-              "displayLabel": "STREET ART 2: From Basquiat to Banksy",
-            },
-          },
-        },
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjU=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__ref": "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}",
-            },
-          },
-        },
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjY=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__typename": "SearchableItem",
-              "description": "Past show featuring works by Jean-Michel Basquiat at Brooklyn Museum Apr 3rd – Aug 23rd 2015",
-              "displayLabel": "Basquiat: The Unknown Notebooks",
-            },
-          },
-        },
-      ],
     },
   },
 }
@@ -508,6 +448,66 @@ Object {
   "ROOT_QUERY": Object {
     "__typename": "Query",
     "search:basquiat": Object {
+      "edges": Array [
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
+          "node": Object {
+            "__ref": "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjE=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
+            "displayLabel": "ephemera BASQUIAT",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
+            "displayLabel": "Jean-Michel Basquiat | Xerox",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Banksy, SEEN, JonOne and QUIK at Artrust Oct 8th – Dec 16th 2017",
+            "displayLabel": "STREET ART: From Basquiat to Banksy",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Jean-Michel Basquiat, Shepard Fairey, COPE2, Pure Evil, Sickboy, Blade, Kurar, and LARS at Artrust",
+            "displayLabel": "STREET ART 2: From Basquiat to Banksy",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjU=",
+          "node": Object {
+            "__ref": "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjY=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Jean-Michel Basquiat at Brooklyn Museum Apr 3rd – Aug 23rd 2015",
+            "displayLabel": "Basquiat: The Unknown Notebooks",
+          },
+        },
+      ],
       "pageInfo": Object {
         "__typename": "PageInfo",
         "endCursor": "YXJyYXljb25uZWN0aW9uOjY=",
@@ -516,83 +516,17 @@ Object {
         "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
       },
       "totalCount": 1292,
-      "wrappers": Array [
+    },
+    "search:james turrell": Object {
+      "edges": Array [
         Object {
+          "__typename": "SearchableEdge",
           "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__ref": "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}",
-            },
-          },
-        },
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjE=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__typename": "SearchableItem",
-              "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
-              "displayLabel": "ephemera BASQUIAT",
-            },
-          },
-        },
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__typename": "SearchableItem",
-              "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
-              "displayLabel": "Jean-Michel Basquiat | Xerox",
-            },
-          },
-        },
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__typename": "SearchableItem",
-              "description": "Past show featuring works by Banksy, SEEN, JonOne and QUIK at Artrust Oct 8th – Dec 16th 2017",
-              "displayLabel": "STREET ART: From Basquiat to Banksy",
-            },
-          },
-        },
-        Object {
-          "cursor": undefined,
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__typename": "SearchableItem",
-              "description": "Past show featuring works by Jean-Michel Basquiat, Shepard Fairey, COPE2, Pure Evil, Sickboy, Blade, Kurar, and LARS at Artrust",
-              "displayLabel": "STREET ART 2: From Basquiat to Banksy",
-            },
-          },
-        },
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjU=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__ref": "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}",
-            },
-          },
-        },
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjY=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__typename": "SearchableItem",
-              "description": "Past show featuring works by Jean-Michel Basquiat at Brooklyn Museum Apr 3rd – Aug 23rd 2015",
-              "displayLabel": "Basquiat: The Unknown Notebooks",
-            },
+          "node": Object {
+            "__ref": "Artist:{\\"href\\":\\"/artist/james-turrell\\"}",
           },
         },
       ],
-    },
-    "search:james turrell": Object {
       "pageInfo": Object {
         "__typename": "PageInfo",
         "endCursor": "YXJyYXljb25uZWN0aW9uOjA=",
@@ -601,17 +535,6 @@ Object {
         "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
       },
       "totalCount": 13531,
-      "wrappers": Array [
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__ref": "Artist:{\\"href\\":\\"/artist/james-turrell\\"}",
-            },
-          },
-        },
-      ],
     },
   },
 }
@@ -634,6 +557,66 @@ Object {
   "ROOT_QUERY": Object {
     "__typename": "Query",
     "search:basquiat": Object {
+      "edges": Array [
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
+          "node": Object {
+            "__ref": "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjE=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
+            "displayLabel": "ephemera BASQUIAT",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
+            "displayLabel": "Jean-Michel Basquiat | Xerox",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Banksy, SEEN, JonOne and QUIK at Artrust Oct 8th – Dec 16th 2017",
+            "displayLabel": "STREET ART: From Basquiat to Banksy",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Jean-Michel Basquiat, Shepard Fairey, COPE2, Pure Evil, Sickboy, Blade, Kurar, and LARS at Artrust",
+            "displayLabel": "STREET ART 2: From Basquiat to Banksy",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjU=",
+          "node": Object {
+            "__ref": "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjY=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Jean-Michel Basquiat at Brooklyn Museum Apr 3rd – Aug 23rd 2015",
+            "displayLabel": "Basquiat: The Unknown Notebooks",
+          },
+        },
+      ],
       "pageInfo": Object {
         "__typename": "PageInfo",
         "endCursor": "YXJyYXljb25uZWN0aW9uOjY=",
@@ -642,83 +625,17 @@ Object {
         "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
       },
       "totalCount": 1292,
-      "wrappers": Array [
+    },
+    "search:james turrell": Object {
+      "edges": Array [
         Object {
+          "__typename": "SearchableEdge",
           "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__ref": "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}",
-            },
-          },
-        },
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjE=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__typename": "SearchableItem",
-              "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
-              "displayLabel": "ephemera BASQUIAT",
-            },
-          },
-        },
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__typename": "SearchableItem",
-              "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
-              "displayLabel": "Jean-Michel Basquiat | Xerox",
-            },
-          },
-        },
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__typename": "SearchableItem",
-              "description": "Past show featuring works by Banksy, SEEN, JonOne and QUIK at Artrust Oct 8th – Dec 16th 2017",
-              "displayLabel": "STREET ART: From Basquiat to Banksy",
-            },
-          },
-        },
-        Object {
-          "cursor": undefined,
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__typename": "SearchableItem",
-              "description": "Past show featuring works by Jean-Michel Basquiat, Shepard Fairey, COPE2, Pure Evil, Sickboy, Blade, Kurar, and LARS at Artrust",
-              "displayLabel": "STREET ART 2: From Basquiat to Banksy",
-            },
-          },
-        },
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjU=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__ref": "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}",
-            },
-          },
-        },
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjY=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__typename": "SearchableItem",
-              "description": "Past show featuring works by Jean-Michel Basquiat at Brooklyn Museum Apr 3rd – Aug 23rd 2015",
-              "displayLabel": "Basquiat: The Unknown Notebooks",
-            },
+          "node": Object {
+            "__ref": "Artist:{\\"href\\":\\"/artist/james-turrell\\"}",
           },
         },
       ],
-    },
-    "search:james turrell": Object {
       "pageInfo": Object {
         "__typename": "PageInfo",
         "endCursor": "YXJyYXljb25uZWN0aW9uOjA=",
@@ -727,17 +644,6 @@ Object {
         "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
       },
       "totalCount": 13531,
-      "wrappers": Array [
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__ref": "Artist:{\\"href\\":\\"/artist/james-turrell\\"}",
-            },
-          },
-        },
-      ],
     },
   },
 }
@@ -760,6 +666,66 @@ Object {
   "ROOT_QUERY": Object {
     "__typename": "Query",
     "search:basquiat": Object {
+      "edges": Array [
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
+          "node": Object {
+            "__ref": "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjE=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
+            "displayLabel": "ephemera BASQUIAT",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
+            "displayLabel": "Jean-Michel Basquiat | Xerox",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Banksy, SEEN, JonOne and QUIK at Artrust Oct 8th – Dec 16th 2017",
+            "displayLabel": "STREET ART: From Basquiat to Banksy",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Jean-Michel Basquiat, Shepard Fairey, COPE2, Pure Evil, Sickboy, Blade, Kurar, and LARS at Artrust",
+            "displayLabel": "STREET ART 2: From Basquiat to Banksy",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjU=",
+          "node": Object {
+            "__ref": "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}",
+          },
+        },
+        Object {
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjY=",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "description": "Past show featuring works by Jean-Michel Basquiat at Brooklyn Museum Apr 3rd – Aug 23rd 2015",
+            "displayLabel": "Basquiat: The Unknown Notebooks",
+          },
+        },
+      ],
       "pageInfo": Object {
         "__typename": "PageInfo",
         "endCursor": "YXJyYXljb25uZWN0aW9uOjY=",
@@ -768,83 +734,25 @@ Object {
         "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
       },
       "totalCount": 1292,
-      "wrappers": Array [
+    },
+    "search:james turrell": Object {
+      "edges": Array [
         Object {
+          "__typename": "SearchableEdge",
           "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__ref": "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}",
-            },
+          "node": Object {
+            "__ref": "Artist:{\\"href\\":\\"/artist/james-turrell\\"}",
           },
         },
         Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjE=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__typename": "SearchableItem",
-              "description": "Past show featuring works by Damien Hirst, James Rosenquist, David Salle, Andy Warhol, Jeff Koons, Jean-Michel Basquiat, Keith Haring, Kiki Smith, Sandro Chia, Kenny Scharf, Mike Bidlo, Jon Schueler, William Wegman, David Wojnarowicz, Taylor Mead, William S. Burroughs, Michael Halsband, Rene Ricard, and Chris DAZE Ellis",
-              "displayLabel": "ephemera BASQUIAT",
-            },
-          },
-        },
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__typename": "SearchableItem",
-              "description": "Past show featuring works by Jean-Michel Basquiat at Nahmad Contemporary Mar 12th – May 31st 2019",
-              "displayLabel": "Jean-Michel Basquiat | Xerox",
-            },
-          },
-        },
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__typename": "SearchableItem",
-              "description": "Past show featuring works by Banksy, SEEN, JonOne and QUIK at Artrust Oct 8th – Dec 16th 2017",
-              "displayLabel": "STREET ART: From Basquiat to Banksy",
-            },
-          },
-        },
-        Object {
-          "cursor": undefined,
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__typename": "SearchableItem",
-              "description": "Past show featuring works by Jean-Michel Basquiat, Shepard Fairey, COPE2, Pure Evil, Sickboy, Blade, Kurar, and LARS at Artrust",
-              "displayLabel": "STREET ART 2: From Basquiat to Banksy",
-            },
-          },
-        },
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjU=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__ref": "Artist:{\\"href\\":\\"/artist/reminiscent-of-basquiat\\"}",
-            },
-          },
-        },
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjY=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__typename": "SearchableItem",
-              "description": "Past show featuring works by Jean-Michel Basquiat at Brooklyn Museum Apr 3rd – Aug 23rd 2015",
-              "displayLabel": "Basquiat: The Unknown Notebooks",
-            },
+          "__typename": "SearchableEdge",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjEx",
+          "node": Object {
+            "__typename": "SearchableItem",
+            "displayLabel": "James Turrell: Light knows when we’re looking",
           },
         },
       ],
-    },
-    "search:james turrell": Object {
       "pageInfo": Object {
         "__typename": "PageInfo",
         "endCursor": "YXJyYXljb25uZWN0aW9uOjEx",
@@ -853,27 +761,6 @@ Object {
         "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
       },
       "totalCount": 13531,
-      "wrappers": Array [
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__ref": "Artist:{\\"href\\":\\"/artist/james-turrell\\"}",
-            },
-          },
-        },
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjEx",
-          "edge": Object {
-            "__typename": "SearchableEdge",
-            "node": Object {
-              "__typename": "SearchableItem",
-              "displayLabel": "James Turrell: Light knows when we’re looking",
-            },
-          },
-        },
-      ],
     },
   },
 }
@@ -884,6 +771,12 @@ Object {
   "ROOT_QUERY": Object {
     "__typename": "Query",
     "todos": Object {
+      "edges": Array [
+        Object {
+          "__ref": "TodoEdge:edge1",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjI=",
+        },
+      ],
       "pageInfo": Object {
         "__typename": "PageInfo",
         "endCursor": "YXJyYXljb25uZWN0aW9uOjI=",
@@ -892,14 +785,6 @@ Object {
         "startCursor": "YXJyYXljb25uZWN0aW9uOjI=",
       },
       "totalCount": 1292,
-      "wrappers": Array [
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjI=",
-          "edge": Object {
-            "__ref": "TodoEdge:edge1",
-          },
-        },
-      ],
     },
   },
   "Todo:1": Object {
@@ -922,6 +807,12 @@ Object {
   "ROOT_QUERY": Object {
     "__typename": "Query",
     "todos": Object {
+      "edges": Array [
+        Object {
+          "__ref": "TodoEdge:edge1",
+          "cursor": "YXJyYXljb25uZWN0aW9uOjI=",
+        },
+      ],
       "extraMetaData": "extra",
       "pageInfo": Object {
         "__typename": "PageInfo",
@@ -931,14 +822,6 @@ Object {
         "startCursor": "YXJyYXljb25uZWN0aW9uOjI=",
       },
       "totalCount": 1293,
-      "wrappers": Array [
-        Object {
-          "cursor": "YXJyYXljb25uZWN0aW9uOjI=",
-          "edge": Object {
-            "__ref": "TodoEdge:edge1",
-          },
-        },
-      ],
     },
   },
   "Todo:1": Object {

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -2461,7 +2461,7 @@ describe("type policies", function () {
           ROOT_QUERY: {
             __typename: "Query",
             todos: {
-              wrappers: [],
+              edges: [],
               pageInfo: {
                 "endCursor": "",
                 "hasNextPage": true,
@@ -3049,17 +3049,15 @@ describe("type policies", function () {
               // Note that Turrell's name has been lower-cased.
               snapshot.ROOT_QUERY!["search:james turrell"]
             ).toEqual({
-              wrappers: turrellEdges.slice(0, 1).map(edge => ({
+              edges: turrellEdges.slice(0, 1).map(edge => ({
+                ...edge,
                 // The relayStylePagination merge function updates the
                 // edge.cursor field of the first and last edge, even if
                 // the query did not request the edge.cursor field, if
                 // pageInfo.{start,end}Cursor are defined.
                 cursor: turrellPageInfo1.startCursor,
-                edge: {
-                  ...edge,
-                  // Artist objects are normalized by HREF:
-                  node: { __ref: 'Artist:{"href":"/artist/james-turrell"}' },
-                },
+                // Artist objects are normalized by HREF:
+                node: { __ref: 'Artist:{"href":"/artist/james-turrell"}' },
               })),
               pageInfo: turrellPageInfo1,
               totalCount: 13531,
@@ -3143,22 +3141,20 @@ describe("type policies", function () {
               // Note that Turrell's name has been lower-cased.
               snapshot.ROOT_QUERY!["search:james turrell"]
             ).toEqual({
-              wrappers: turrellEdges.map((edge, i) => ({
+              edges: turrellEdges.map((edge, i) => ({
+                ...edge,
                 // This time the cursors are different depending on which
                 // of the two edges we're considering.
                 cursor: [
                   turrellPageInfo2.startCursor,
                   turrellPageInfo2.endCursor,
                 ][i],
-                edge: {
-                  ...edge,
-                  node: [
-                    // Artist objects are normalized by HREF:
-                    { __ref: 'Artist:{"href":"/artist/james-turrell"}' },
-                    // However, SearchableItem objects are not normalized.
-                    edge.node,
-                  ][i],
-                },
+                node: [
+                  // Artist objects are normalized by HREF:
+                  { __ref: 'Artist:{"href":"/artist/james-turrell"}' },
+                  // However, SearchableItem objects are not normalized.
+                  edge.node,
+                ][i],
               })),
               pageInfo: turrellPageInfo2,
               totalCount: 13531,

--- a/src/utilities/policies/pagination.ts
+++ b/src/utilities/policies/pagination.ts
@@ -41,21 +41,17 @@ export function offsetLimitPagination<T = Reference>(
   };
 }
 
+// Whether TEdge<TNode> is a normalized Reference or a non-normalized
+// object, it needs a .cursor property where the relayStylePagination
+// merge function can store cursor strings taken from pageInfo. Storing an
+// extra reference.cursor property should be safe, and is easier than
+// attempting to update the cursor field of the normalized StoreObject
+// that the reference refers to, or managing edge wrapper objects
+// (something I attempted in #7023, but abandoned because of #7088).
 type TEdge<TNode> = {
   cursor?: string;
   node: TNode;
-} | Reference;
-
-// This object is an internal structure that's slightly different from the
-// GraphQL response format for edges. Each actual edge gets wrapped in a
-// wrapper object that can safely store a cursor string (possibly inferred
-// from pageInfo), which makes things easier when the actual edge happens
-// to be a normalized Reference, since updating fields of an object behind
-// a Reference is tricky in a merge function.
-type TEdgeWrapper<TNode> = {
-  cursor?: string;
-  edge: TEdge<TNode>;
-};
+} | (Reference & { cursor?: string });
 
 type TPageInfo = {
   hasPreviousPage: boolean;
@@ -65,7 +61,7 @@ type TPageInfo = {
 };
 
 type TExistingRelay<TNode> = Readonly<{
-  wrappers: TEdgeWrapper<TNode>[];
+  edges: TEdge<TNode>[];
   pageInfo: TPageInfo;
 }>;
 
@@ -95,14 +91,14 @@ export function relayStylePagination<TNode = Reference>(
       const edges: TEdge<TNode>[] = [];
       let startCursor = "";
       let endCursor = "";
-      existing.wrappers.forEach(wrapper => {
+      existing.edges.forEach(edge => {
         // Edges themselves could be Reference objects, so it's important
-        // to use readField to access the wrapper.edge.node property.
-        if (canRead(readField("node", wrapper.edge))) {
-          edges.push(wrapper.edge);
-          if (wrapper.cursor) {
-            startCursor = startCursor || wrapper.cursor;
-            endCursor = wrapper.cursor;
+        // to use readField to access the edge.edge.node property.
+        if (canRead(readField("node", edge))) {
+          edges.push(edge);
+          if (edge.cursor) {
+            startCursor = startCursor || edge.cursor;
+            endCursor = edge.cursor;
           }
         }
       });
@@ -121,42 +117,46 @@ export function relayStylePagination<TNode = Reference>(
       };
     },
 
-    merge(existing = makeEmptyData(), incoming, { args, readField }) {
-      // Convert incoming.edges to an array of TEdgeWrapper objects, so
-      // that we can merge the incoming wrappers into existing.wrappers.
-      const incomingWrappers: TEdgeWrapper<TNode>[] =
-        incoming.edges ? incoming.edges.map(edge => ({
-          edge,
-          // In case edge is a Reference, we lift out its cursor field and
-          // store it in the TEdgeWrapper object.
-          cursor: readField<string>("cursor", edge),
-        })) : [];
+    merge(existing = makeEmptyData(), incoming, { args, isReference, readField }) {
+      const incomingEdges = incoming.edges || [];
+      if (incomingEdges.length) {
+        incomingEdges.forEach(edge => {
+          if (isReference(edge)) {
+            // In case edge is a Reference, we read out its cursor field
+            // and store it as an extra property of the Reference object.
+            edge.cursor = readField<string>("cursor", edge);
+          }
+        });
+      }
 
       if (incoming.pageInfo) {
         // In case we did not request the cursor field for edges in this
         // query, we can still infer some of those cursors from pageInfo.
         const { startCursor, endCursor } = incoming.pageInfo;
-        const firstWrapper = incomingWrappers[0];
-        if (firstWrapper && startCursor) {
-          firstWrapper.cursor = startCursor;
+        const firstEdge = incomingEdges[0];
+        if (firstEdge && startCursor) {
+          firstEdge.cursor = startCursor;
         }
-        const lastWrapper = incomingWrappers[incomingWrappers.length - 1];
-        if (lastWrapper && endCursor) {
-          lastWrapper.cursor = endCursor;
+        const lastEdge = incomingEdges[incomingEdges.length - 1];
+        if (lastEdge && endCursor) {
+          lastEdge.cursor = endCursor;
         }
       }
 
-      let prefix = existing.wrappers;
+      let prefix = existing.edges;
       let suffix: typeof prefix = [];
 
       if (args && args.after) {
-        const index = prefix.findIndex(wrapper => wrapper.cursor === args.after);
+        // This comparison does not need to use readField("cursor", edge),
+        // because we stored the cursor field of any Reference edges as an
+        // extra property of the Reference object.
+        const index = prefix.findIndex(edge => edge.cursor === args.after);
         if (index >= 0) {
           prefix = prefix.slice(0, index + 1);
           // suffix = []; // already true
         }
       } else if (args && args.before) {
-        const index = prefix.findIndex(wrapper => wrapper.cursor === args.before);
+        const index = prefix.findIndex(edge => edge.cursor === args.before);
         suffix = index < 0 ? prefix : prefix.slice(index);
         prefix = [];
       } else if (incoming.edges) {
@@ -166,20 +166,20 @@ export function relayStylePagination<TNode = Reference>(
         prefix = [];
       }
 
-      const wrappers = [
+      const edges = [
         ...prefix,
-        ...incomingWrappers,
+        ...incomingEdges,
         ...suffix,
       ];
 
-      const firstWrapper = wrappers[0];
-      const lastWrapper = wrappers[wrappers.length - 1];
+      const firstEdge = edges[0];
+      const lastEdge = edges[edges.length - 1];
 
       const pageInfo: TPageInfo = {
         ...incoming.pageInfo,
         ...existing.pageInfo,
-        startCursor: firstWrapper && firstWrapper.cursor || "",
-        endCursor: lastWrapper && lastWrapper.cursor || "",
+        startCursor: firstEdge && firstEdge.cursor || "",
+        endCursor: lastEdge && lastEdge.cursor || "",
       };
 
       if (incoming.pageInfo) {
@@ -199,7 +199,7 @@ export function relayStylePagination<TNode = Reference>(
       return {
         ...getExtras(existing),
         ...getExtras(incoming),
-        wrappers,
+        edges,
         pageInfo,
       };
     },
@@ -208,11 +208,11 @@ export function relayStylePagination<TNode = Reference>(
 
 // Returns any unrecognized properties of the given object.
 const getExtras = (obj: Record<string, any>) => __rest(obj, notExtras);
-const notExtras = ["edges", "wrappers", "pageInfo"];
+const notExtras = ["edges", "pageInfo"];
 
 function makeEmptyData(): TExistingRelay<any> {
   return {
-    wrappers: [],
+    edges: [],
     pageInfo: {
       hasPreviousPage: false,
       hasNextPage: true,


### PR DESCRIPTION
Idea: https://github.com/apollographql/apollo-client/issues/7088#issuecomment-700752196

This commit undoes the `TEdgeWrapper` logic I added in f41e9efc9e061b80fe5019456c049a3c56661e87 in #7023, while still preserving cursor strings taken from `incoming.pageInfo`.

Changing the shape of the internal data stored by `relayStylePagination` fields was too much of a breaking change for the `@apollo/client@3.2.1` patch release, because it had the potential to break existing `cache.modify` code operating on `relayStylePagination`-managed fields (as reported by @anark in #7088).