### PR TITLE
Update @wry/equality to improve undefined property handling.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2639,9 +2639,9 @@
       }
     },
     "@wry/equality": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.2.0.tgz",
-      "integrity": "sha512-Y4d+WH6hs+KZJUC8YKLYGarjGekBrhslDbf/R20oV+AakHPINSitHfDRQz3EGcEWc1luXYNUvMhawWtZVWNGvQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.3.0.tgz",
+      "integrity": "sha512-DRDAu/e3oWBj826OWNV/GCmSdHD248mASXImgNoLE/3SDvpgb+k6G/+TAmdpIB35ju264+kB22Rx92eXg52DnA==",
       "requires": {
         "tslib": "^1.9.3"
       }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@graphql-typed-document-node/core": "^3.0.0",
     "@types/zen-observable": "^0.8.0",
     "@wry/context": "^0.5.2",
-    "@wry/equality": "^0.2.0",
+    "@wry/equality": "^0.3.0",
     "fast-json-stable-stringify": "^2.0.0",
     "graphql-tag": "^2.11.0",
     "hoist-non-react-statics": "^3.3.2",


### PR DESCRIPTION
See https://github.com/benjamn/wryware/pull/21 for explanation and motivation. Should help with #6771, #6803, #6688, #6378, and #7081, and possibly other regressions that began with @apollo/client@3.1.0.