### PR TITLE
Add /graphql query path to all URIs in subscriptions docs.

### DIFF
--- a/docs/source/data/subscriptions.mdx
+++ b/docs/source/data/subscriptions.mdx
@@ -90,7 +90,7 @@ Import and initialize a `WebSocketLink` object in the same project file where yo
 import { WebSocketLink } from '@apollo/client/link/ws';
 
 const wsLink = new WebSocketLink({
-  uri: `ws://localhost:5000/`,
+  uri: 'ws://localhost:5000/graphql',
   options: {
     reconnect: true
   }
@@ -111,11 +111,11 @@ import { getMainDefinition } from '@apollo/client/utilities';
 import { WebSocketLink } from '@apollo/client/link/ws';
 
 const httpLink = new HttpLink({
-  uri: 'http://localhost:3000/'
+  uri: 'http://localhost:3000/graphql'
 });
 
 const wsLink = new WebSocketLink({
-  uri: `ws://localhost:5000/`,
+  uri: 'ws://localhost:5000/graphql',
   options: {
     reconnect: true
   }
@@ -149,7 +149,7 @@ It is often necessary to authenticate a client before allowing it to receive sub
 import { WebSocketLink } from '@apollo/client/link/ws';
 
 const wsLink = new WebSocketLink({
-  uri: `ws://localhost:5000/`,
+  uri: 'ws://localhost:5000/graphql',
   options: {
     reconnect: true,
     connectionParams: {


### PR DESCRIPTION
I Was facing the error on client after following the subscription setup guide on your docs : 
`ws://localhost:4000/' failed: Error during WebSocket handshake: Unexpected response code: 400`

Seems that more people were facing the same issue : 
https://github.com/apollographql/apollo-client/issues/4778

Adding `graphql` to subscription uri solved it for many, myself included and therefore the PR to add this to docs :)