### PR TITLE
Support includeUnusedVariables option for HttpLink.

### DIFF
--- a/src/link/http/__tests__/HttpLink.ts
+++ b/src/link/http/__tests__/HttpLink.ts
@@ -219,8 +219,14 @@ describe('HttpLink', () => {
       const link = createHttpLink({ uri: '/data' });
 
       const query = gql`
-        query PEOPLE ($declared: Int) {
-          people(surprise: $undeclared) {
+        query PEOPLE (
+          $declaredAndUsed: String,
+          $declaredButUnused: Int,
+        ) {
+          people(
+            surprise: $undeclared,
+            noSurprise: $declaredAndUsed,
+          ) {
             ... on Doctor {
               specialty(var: $usedByInlineFragment)
             }
@@ -234,7 +240,8 @@ describe('HttpLink', () => {
 
       const variables = {
         unused: 'strip',
-        declared: 'keep',
+        declaredButUnused: 'strip',
+        declaredAndUsed: 'keep',
         undeclared: 'keep',
         usedByInlineFragment: 'keep',
         usedByNamedFragment: 'keep',
@@ -251,7 +258,7 @@ describe('HttpLink', () => {
             operationName: "PEOPLE",
             query: print(query),
             variables: {
-              declared: 'keep',
+              declaredAndUsed: 'keep',
               undeclared: 'keep',
               usedByInlineFragment: 'keep',
               usedByNamedFragment: 'keep',

--- a/src/link/http/__tests__/HttpLink.ts
+++ b/src/link/http/__tests__/HttpLink.ts
@@ -107,6 +107,7 @@ describe('HttpLink', () => {
         uri: '/data',
         fetchOptions: { method: 'GET' },
         includeExtensions: true,
+        includeUnusedVariables: true,
       });
 
       execute(link, { query: sampleQuery, variables, extensions }).subscribe({
@@ -138,7 +139,7 @@ describe('HttpLink', () => {
           expect(body).toBeUndefined();
           expect(method).toBe('GET');
           expect(uri).toBe(
-            '/data?foo=bar&query=query%20SampleQuery%20%7B%0A%20%20stub%20%7B%0A%20%20%20%20id%0A%20%20%7D%0A%7D%0A&operationName=SampleQuery&variables=%7B%22params%22%3A%22stub%22%7D',
+            '/data?foo=bar&query=query%20SampleQuery%20%7B%0A%20%20stub%20%7B%0A%20%20%20%20id%0A%20%20%7D%0A%7D%0A&operationName=SampleQuery&variables=%7B%7D',
           );
         }),
         error: error => done.fail(error),
@@ -164,7 +165,7 @@ describe('HttpLink', () => {
           expect(body).toBeUndefined();
           expect(method).toBe('GET');
           expect(uri).toBe(
-            '/data?query=query%20SampleQuery%20%7B%0A%20%20stub%20%7B%0A%20%20%20%20id%0A%20%20%7D%0A%7D%0A&operationName=SampleQuery&variables=%7B%22params%22%3A%22stub%22%7D',
+            '/data?query=query%20SampleQuery%20%7B%0A%20%20stub%20%7B%0A%20%20%20%20id%0A%20%20%7D%0A%7D%0A&operationName=SampleQuery&variables=%7B%7D',
           );
         }),
       );
@@ -187,7 +188,7 @@ describe('HttpLink', () => {
           expect(body).toBeUndefined();
           expect(method).toBe('GET');
           expect(uri).toBe(
-            '/data?query=query%20SampleQuery%20%7B%0A%20%20stub%20%7B%0A%20%20%20%20id%0A%20%20%7D%0A%7D%0A&operationName=SampleQuery&variables=%7B%22params%22%3A%22stub%22%7D',
+            '/data?query=query%20SampleQuery%20%7B%0A%20%20stub%20%7B%0A%20%20%20%20id%0A%20%20%7D%0A%7D%0A&operationName=SampleQuery&variables=%7B%7D',
           );
         }),
       );
@@ -212,6 +213,55 @@ describe('HttpLink', () => {
           expect(uri).toBe('/data');
         }),
       );
+    });
+
+    it('strips unused variables, respecting nested fragments', done => {
+      const link = createHttpLink({ uri: '/data' });
+
+      const query = gql`
+        query PEOPLE ($declared: Int) {
+          people(surprise: $undeclared) {
+            ... on Doctor {
+              specialty(var: $usedByInlineFragment)
+            }
+            ...LawyerFragment
+          }
+        }
+        fragment LawyerFragment on Lawyer {
+          caseCount(var: $usedByNamedFragment)
+        }
+      `;
+
+      const variables = {
+        unused: 'strip',
+        declared: 'keep',
+        undeclared: 'keep',
+        usedByInlineFragment: 'keep',
+        usedByNamedFragment: 'keep',
+      };
+
+      execute(link, {
+        query,
+        variables,
+      }).subscribe({
+        next: makeCallback(done, () => {
+          const [uri, options] = fetchMock.lastCall()!;
+          const { method, body } = options!;
+          expect(JSON.parse(body as string)).toEqual({
+            operationName: "PEOPLE",
+            query: print(query),
+            variables: {
+              declared: 'keep',
+              undeclared: 'keep',
+              usedByInlineFragment: 'keep',
+              usedByNamedFragment: 'keep',
+            },
+          });
+          expect(method).toBe('POST');
+          expect(uri).toBe('/data');
+        }),
+        error: error => done.fail(error),
+      });
     });
 
     it('should add client awareness settings to request headers', done => {
@@ -277,6 +327,7 @@ describe('HttpLink', () => {
       const link = createHttpLink({
         uri: '/data',
         useGETForQueries: true,
+        includeUnusedVariables: true,
       });
 
       let b;
@@ -422,7 +473,7 @@ describe('HttpLink', () => {
           try {
             let body = convertBatchedBody(fetchMock.lastCall()![1]!.body);
             expect(body.query).toBe(print(sampleMutation));
-            expect(body.variables).toEqual(variables);
+            expect(body.variables).toEqual({});
             expect(body.context).not.toBeDefined();
             if (includeExtensions) {
               expect(body.extensions).toBeDefined();
@@ -1024,7 +1075,11 @@ describe('HttpLink', () => {
     });
     it("throws if the body can't be stringified", done => {
       fetch.mockReturnValueOnce(Promise.resolve({ data: {}, text }));
-      const link = createHttpLink({ uri: 'data', fetch: fetch as any });
+      const link = createHttpLink({
+        uri: 'data',
+        fetch: fetch as any,
+        includeUnusedVariables: true,
+      });
 
       let b;
       const a: any = { b };

--- a/src/link/http/createHttpLink.ts
+++ b/src/link/http/createHttpLink.ts
@@ -103,11 +103,10 @@ export const createHttpLink = (linkOptions: HttpOptions = {}) => {
       if (unusedNames.size) {
         // Make a shallow copy of body.variables (with keys in the same
         // order) and then delete unused variables from the copy.
-        const variables = { ...body.variables };
+        body.variables = { ...body.variables };
         unusedNames.forEach(name => {
-          delete variables[name];
+          delete body.variables![name];
         });
-        body.variables = variables;
       }
     }
 

--- a/src/link/http/selectHttpOptionsAndBody.ts
+++ b/src/link/http/selectHttpOptionsAndBody.ts
@@ -54,6 +54,17 @@ export interface HttpOptions {
    * to POST).
    */
   useGETForQueries?: boolean;
+
+  /**
+   * If set to true, the default behavior of stripping unused variables
+   * from the request will be disabled.
+   *
+   * Unused variables are likely to trigger server-side validation errors,
+   * per https://spec.graphql.org/draft/#sec-All-Variables-Used, but this
+   * includeUnusedVariables option can be useful if your server deviates
+   * from the GraphQL specification by not strictly enforcing that rule.
+   */
+  includeUnusedVariables?: boolean;
 }
 
 export interface HttpQueryOptions {


### PR DESCRIPTION
Unused variables are very likely to trigger server-side validation errors, thanks to the [All Variables Used](https://spec.graphql.org/draft/#sec-All-Variables-Used) validation rule.

Since this rule renders unused variables all but useless in GraphQL requests, we (namely @hwillson and I) are increasingly convinced that `HttpLink` should strip unused variables by default, with an option to prevent the stripping in unusual scenarios where your server deviates from the GraphQL specification by not strictly enforcing validation rules.

This automatic stripping of unused variables has the benefit of allowing developers to provide "too many" variables to their queries, knowing `HttpLink` will save them from needless validation errors, automatically sending only the variables that are used, while omitting any extras. It also enables the use of client-only variables for additional control of `read` and `merge` function behavior. Finally, it unlocks query transformations that might remove the last usage of a variable, since that removal no longer leads to validation errors if application code continues to provide a value for the unused variable.

This could technically be a breaking change, but I think it's acceptable in a minor release (v3.3) because the new behavior affects only queries that were previously invalid, and it can be easily disabled using the `includeUnusedVariables` option:
```ts
new ApolloClient({
  link: new HttpLink({
    uri,
    includeUnusedVariables: true,
  }),
  cache: new InMemoryCache({...}),
})
```