### PR TITLE
Default args.offset to 0 in offsetLimitPagination.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Apollo Client 3.2.3
+
+## Improvements
+
+- Default `args.offset` to zero in `offsetLimitPagination`. <br/>
+  [@benjamn](https://github.com/benjamn) in [#7141](https://github.com/apollographql/apollo-client/pull/7141)
+
 ## Apollo Client 3.2.2
 
 ## Bug Fixes

--- a/src/utilities/policies/pagination.ts
+++ b/src/utilities/policies/pagination.ts
@@ -31,10 +31,18 @@ export function offsetLimitPagination<T = Reference>(
     keyArgs,
     merge(existing, incoming, { args }) {
       const merged = existing ? existing.slice(0) : [];
-      const start = args ? args.offset : merged.length;
-      const end = start + incoming.length;
-      for (let i = start; i < end; ++i) {
-        merged[i] = incoming[i - start];
+      if (args) {
+        // Assume an offset of 0 if args.offset omitted.
+        const { offset = 0 } = args;
+        for (let i = 0; i < incoming.length; ++i) {
+          merged[offset + i] = incoming[i];
+        }
+      } else {
+        // It's unusual (probably a mistake) for a paginated field not
+        // to receive any arguments, so you might prefer to throw an
+        // exception here, instead of recovering by appending incoming
+        // onto the existing array.
+        merged.push.apply(merged, incoming);
       }
       return merged;
     },


### PR DESCRIPTION
This makes the field policy returned by [`offsetLimitPagination`](https://github.com/apollographql/apollo-client/blob/ec5c2edf3631ce93200585d9dcc2a3a2086c353f/src/utilities/policies/pagination.ts#L27) tolerant of a missing `args.offset`, by defaulting it to `0`. Motivating discussion: https://github.com/apollographql/apollo-client/issues/7135#issuecomment-706415063.