### PR TITLE
Add reactiveVars persistence options

### DIFF
--- a/src/utilities/common/__tests__/isString.ts
+++ b/src/utilities/common/__tests__/isString.ts
@@ -1,0 +1,11 @@
+import { isString } from '../isString';
+
+describe('isString', () => {
+  it('should indetify strings', () => {
+    const someString = isString("somestring")
+    const notStrings = [{}, [], 0, undefined,null]
+
+    expect(someString).toEqual(true);
+    notStrings.forEach(f => expect(isString(f)).toEqual(false));
+  });
+});

--- a/src/utilities/common/isString.ts
+++ b/src/utilities/common/isString.ts
@@ -1,0 +1,3 @@
+export function isString(value: any) {
+  return Object.prototype.toString.call(value) === '[object String]'
+}


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests

# Summary

This PR extends the current reactive vars API to accept storage options, making it super easy to create persistent reactive variables.

## New API

```ts
import AsyncStorage from '@react-native-community/async-storage'

// still works
const myReactiveVar = makeVar<T>(value)

// optional persistent variable
const [myPersistentReactiveVar, restoreMyPersistentReactiveVar] = makeVar<T>(
  value,
  {
    storage: AsyncStorage,
    storageKey: "@MyPersistentReactiveVar",
  }
)
```

## Restoring example

```tsx
const App: React.FC<Props> = ({ children }) => {
  const [client, setClient] = React.useState<ApolloClient<any> | undefined>(
    undefined
  )

  React.useEffect(() => {
    const setup = async () => {
      await restoreMyPersistentReactiveVar()
      const client = await mySetupApollo()
      setClient(client)
    }

    setup()
  }, [])

  if (!client) {
    return <AppLoading />
  }

  return (
    <ApolloProvider client={client}>
      {children}
    </ApolloProvider>
  )
}
```

## TODO

- [x] code
- [ ] edit docs (waiting feedback from maintainers)
- [ ] tests (if requested by maintainers, but I didn't find tests for reactiveVars)