### PR TITLE
Update optimism and fix potential cache.watch memory leak.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Apollo Client 3.2.4
+
+## Improvements
+
+- Update the `optimism` npm dependency to version 0.13.0 in order to use the new `optimistic.forget` method to fix a potential `cache.watch` memory leak. <br/>
+  [@benjamn](https://github.com/benjamn) in [#7157](https://github.com/apollographql/apollo-client/pull/7157)
+
 ## Apollo Client 3.2.3
 
 ## Improvements

--- a/package-lock.json
+++ b/package-lock.json
@@ -8546,9 +8546,9 @@
       }
     },
     "optimism": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.12.1.tgz",
-      "integrity": "sha512-t8I7HM1dw0SECitBYAqFOVHoBAHEQBTeKjIL9y9ImHzAVkdyPK4ifTgM4VJRDtTUY4r/u5Eqxs4XcGPHaoPkeQ==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.13.0.tgz",
+      "integrity": "sha512-6JAh3dH+YUE4QUdsgUw8nUQyrNeBKfAEKOHMlLkQ168KhIYFIxzPsHakWrRXDnTO+x61RJrS3/2uEt6W0xlocA==",
       "requires": {
         "@wry/context": "^0.5.2"
       }

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "fast-json-stable-stringify": "^2.0.0",
     "graphql-tag": "^2.11.0",
     "hoist-non-react-statics": "^3.3.2",
-    "optimism": "^0.12.1",
+    "optimism": "^0.13.0",
     "prop-types": "^15.7.2",
     "symbol-observable": "^2.0.0",
     "terser": "^5.2.0",

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -181,6 +181,11 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     }
     return () => {
       this.watches.delete(watch);
+      this.watchDep.dirty(watch);
+      // Remove this watch from the LRU cache managed by the
+      // maybeBroadcastWatch OptimisticWrapperFunction, to prevent memory
+      // leaks involving the closure of watch.callback.
+      this.maybeBroadcastWatch.forget(watch);
     };
   }
 


### PR DESCRIPTION
Inspired by @kamilkisiela's [comment](https://github.com/apollographql/apollo-client/issues/7149#issuecomment-707010340), but building on the new `optimistic.forget` method that I added in https://github.com/benjamn/optimism/pull/84. 

Should fix #7149 and #7086.