### PR TITLE
Fix typo in writeQuery documentation

### DIFF
--- a/docs/source/caching/advanced-topics.mdx
+++ b/docs/source/caching/advanced-topics.mdx
@@ -89,7 +89,7 @@ const CommentsPageWithMutations = () => (
               // Add our comment from the mutation to the end.
               const comments = [...data.comments, submitComment];
               // Write our data back to the cache.
-              store.writeQuery({ query: CommentAppQuery, data: { comments }  });
+              store.writeQuery({ query: CommentAppQuery, data: { comments } });
             }
           })
         }

--- a/docs/source/caching/advanced-topics.mdx
+++ b/docs/source/caching/advanced-topics.mdx
@@ -89,7 +89,7 @@ const CommentsPageWithMutations = () => (
               // Add our comment from the mutation to the end.
               const comments = [...data.comments, submitComment];
               // Write our data back to the cache.
-              store.writeQuery({ query: CommentAppQuery, { comments }  });
+              store.writeQuery({ query: CommentAppQuery, data: { comments }  });
             }
           })
         }


### PR DESCRIPTION
When copy pasting this code I noticed it isn't valid js and not in line with the types in the code. This will fix it for future copy pasters

