### PR TITLE
Add testing docs for fragment, typePolicies, possibleTypes

### DIFF
--- a/docs/source/development-testing/testing.mdx
+++ b/docs/source/development-testing/testing.mdx
@@ -445,9 +445,7 @@ export const cache = new ApolloClient({
 })
 ```
 
-You must configure your cache when testing a component which utilizes fragments in its queries, and pass it to the `<MockedProvider>`.
-
-`cache` here must be configured with `possibleTypes` and `typePolicies` just the same as it is for your application:
+You must configure your cache when testing a component which utilizes fragments in its queries, and pass it to the `<MockedProvider>` via the `cache={cache}` attribute, configured with `possibleTypes` and `typePolicies` just the same as in your application:
 ```jsx
 <MockedProvider cache={cache}>
   <DeleteButton />

--- a/docs/source/development-testing/testing.mdx
+++ b/docs/source/development-testing/testing.mdx
@@ -401,6 +401,59 @@ it('should delete and give visual feedback', async () => {
 
 For the sake of simplicity, the error case for mutations hasn't been shown here, but testing `useMutation` errors is exactly the same as testing `useQuery` errors: just add an `error` to the mock, fire the mutation, and check the UI for error messages.
 
+## A note on fragment usage, `typePolicies`, and `possibleTypes`
+
+When using fragments with polymorphic types such as the following:
+```jsx
+// "Dog" supertype can be of type "ShibeInu"
+const ShibeFragment = gql`
+  fragment ShibeInuFields on Dog {
+    ... on ShibeInu {
+      tail {
+        isCurly
+      }
+    }
+  }
+`;
+
+export const GET_DOG_QUERY = gql`
+  query GetDog($name: String) {
+    dog(name: $name) {
+      id
+      name
+      breed
+
+      ...ShibeInuFields
+    }
+  }
+
+  ${ShibeFragment}
+`;
+
+export const cache = new ApolloClient({
+  cache: new InMemoryCache({
+    possibleTypes: {
+      Dog: ['ShibeInu']
+    },
+    // suppose you want you key fields for "Dog" to not be simply "id"
+    typePolicies: {
+      keyFields: {
+        Dog: ['name', 'breed']
+      }
+    }
+  })
+})
+```
+
+You must configure your cache when testing a component which utilizes fragments in its queries, and pass it to the `<MockedProvider>`.
+
+`cache` here must be configured with `possibleTypes` and `typePolicies` just the same as it is for your application:
+```jsx
+<MockedProvider cache={cache}>
+  <DeleteButton />
+</MockedProvider>,
+```
+
 Testing UI components isn't a simple issue, but hopefully these tools will create confidence when testing components that are dependent on data.
 
 For a working example showing how to test components, check out this project on CodeSandbox:


### PR DESCRIPTION
This covers some non-exhaustive documentation about how you must explicitly
configure your `cache` when using `<MockedProvider>` if that cache is
using complex configurations such as `possibleTypes` and `typePolicies`.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
