### PR TITLE
Update references to apollo-cache-persist to apollo3-cache-persist.

### DIFF
--- a/docs/source/caching/advanced-topics.mdx
+++ b/docs/source/caching/advanced-topics.mdx
@@ -344,7 +344,7 @@ If you would like to learn more about server side rendering, please check out ou
 
 ## Cache persistence
 
-If you would like to persist and rehydrate your Apollo Cache from a storage provider like `AsyncStorage` or `localStorage`, you can use [`apollo-cache-persist`](https://github.com/apollographql/apollo-cache-persist). `apollo-cache-persist` works with all Apollo caches, including `InMemoryCache` & `Hermes`, and a variety of different [storage providers](https://github.com/apollographql/apollo-cache-persist#storage-providers).
+If you would like to persist and rehydrate your Apollo Cache from a storage provider like `AsyncStorage` or `localStorage`, you can use [`apollo3-cache-persist`](https://github.com/apollographql/apollo-cache-persist). `apollo3-cache-persist` works with all Apollo caches, including `InMemoryCache` & `Hermes`, and a variety of different [storage providers](https://github.com/apollographql/apollo-cache-persist#storage-providers).
 
 To get started, simply pass your Apollo Cache and a storage provider to `persistCache`. By default, the contents of your Apollo Cache will be immediately restored asynchronously, and persisted upon every write to the cache with a short configurable debounce interval.
 
@@ -353,7 +353,7 @@ To get started, simply pass your Apollo Cache and a storage provider to `persist
 ```js
 import { AsyncStorage } from 'react-native';
 import { InMemoryCache } from '@apollo/client';
-import { persistCache } from 'apollo-cache-persist';
+import { persistCache } from 'apollo3-cache-persist';
 
 const cache = new InMemoryCache();
 
@@ -365,4 +365,4 @@ persistCache({
 })
 ```
 
-For more advanced usage, such as persisting the cache when the app is in the background, and additional configuration options, please check the [README of `apollo-cache-persist`](https://github.com/apollographql/apollo-cache-persist).
+For more advanced usage, such as persisting the cache when the app is in the background, and additional configuration options, please check the [README of `apollo3-cache-persist`](https://github.com/apollographql/apollo-cache-persist).

--- a/docs/source/why-apollo.mdx
+++ b/docs/source/why-apollo.mdx
@@ -128,8 +128,8 @@ By leveraging Apollo Client's local state functionality, you can add client-side
 Apollo Client is easy to get started with, but extensible for when you need to build out more advanced features. If you need custom functionality that isn't covered with `@apollo/client`, such as app-specific middleware or cache persistence, you can leverage the Apollo Link architecture to plug-in new network stack functionality.
 
 This flexibility makes it simple to create your dream client by building extensions on top of Apollo. We're always really impressed by what our contributors have built on top of Apollo - check out some of their packages:
-- [apollo-cache-persist](https://blog.apollographql.com/announcing-apollo-cache-persist-cb05aec16325): Simple persistence for your Apollo cache ([@jamesreggio](https://github.com/jamesreggio))
-- [apollo-storybook-decorator](https://github.com/abhiaiyer91/apollo-storybook-decorator): Wrap your React Storybook stories with Apollo Client ([@abhiaiyer91](https://github.com/abhiaiyer91))
+- [`apollo3-cache-persist`](https://github.com/apollographql/apollo-cache-persist): Simple persistence for your Apollo cache ([@jamesreggio](https://github.com/jamesreggio))
+- [`apollo-storybook-decorator`](https://github.com/abhiaiyer91/apollo-storybook-decorator): Wrap your React Storybook stories with Apollo Client ([@abhiaiyer91](https://github.com/abhiaiyer91))
 - [AppSync by AWS](https://blog.apollographql.com/aws-appsync-powered-by-apollo-df61eb706183): Amazon's real-time GraphQL client uses Apollo Client under the hood
 
 When you choose Apollo to manage your data, you also gain the support of our amazing community. There are thousands of developers in our [Apollo Spectrum community](https://spectrum.chat/apollo) for you to share ideas with. You can also read articles on best practices and our announcements on the [Apollo blog](https://blog.apollographql.com/), updated frequently.


### PR DESCRIPTION
The `apollo-cache-persist` package has been updated to work with Apollo Client 3, but it has a new package name (not unlike our renaming from `apollo-client` to `@apollo/client`).

I've seen multiple folks installing the older `apollo-cache-persist` with `@apollo/client` and noticing problems, so I want to make sure the docs recommend the new package instead.