### PR TITLE
Add nullable check for obsRefetch

### DIFF
--- a/src/react/data/QueryData.ts
+++ b/src/react/data/QueryData.ts
@@ -446,7 +446,7 @@ export class QueryData<TData, TVariables> extends OperationData {
   }
 
   private obsRefetch = (variables?: Partial<TVariables>) =>
-    this.currentObservable!.refetch(variables);
+    this.currentObservable?.refetch(variables);
 
   private obsFetchMore = <K extends keyof TVariables>(
     fetchMoreOptions: FetchMoreQueryOptions<TVariables, K> &


### PR DESCRIPTION
https://github.com/apollographql/apollo-client/issues/5870

To fix the following error when RN's FastRefresh triggers obsRefetch

<img width="250" alt="Screen Shot 2020-10-17 at 17 52 21" src="https://user-images.githubusercontent.com/10094591/96332902-9295c500-10a1-11eb-83e9-409409a85d6c.png">
