### PR TITLE
optionally-chained currentObservable to avoid unexpected crash

### DIFF
--- a/src/react/data/QueryData.ts
+++ b/src/react/data/QueryData.ts
@@ -454,7 +454,7 @@ export class QueryData<TData, TVariables> extends OperationData {
   }
 
   private obsRefetch = (variables?: Partial<TVariables>) =>
-    this.currentObservable!.refetch(variables);
+    this.currentObservable?.refetch(variables);
 
   private obsFetchMore = <K extends keyof TVariables>(
     fetchMoreOptions: FetchMoreQueryOptions<TVariables, K, TData> &


### PR DESCRIPTION
This is to fix the unexpected crashes when `obsRefetch` is invoked while `currentObservable` is not available, especially when being used with hot-reloading features, e.g. [Fast Refresh](https://reactnative.dev/docs/fast-refresh).
