### PR TITLE
make contributions easier for new-comers via automating the dev setup.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,11 @@
+tasks:
+  - name: Build 
+    init: | 
+      npm install
+      gp sync-done install 
+    command: npm run watch
+
+  - name: Test
+    init: gp sync-await install
+    command: npm run test:watch
+    openMode: split-right

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,12 @@ npm run test
 npm run test:watch
 ```
 
+### Online one-click setup
+
+You can use Gitpod(an Online VS Code like IDE) for developing online, with a single click it will launch a workspace and automatically: clone the `apollo-client` repo, install the dependencies, run `npm run watch` and `npm run test:watch`.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
+
 **Run specific tests:**
 
 Call jest directly making sure to pass in the jest config, and use its `testRegex` option:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![npm version](https://badge.fury.io/js/%40apollo%2Fclient.svg)](https://badge.fury.io/js/%40apollo%2Fclient)
 [![Build Status](https://circleci.com/gh/apollographql/apollo-client.svg?style=svg)](https://circleci.com/gh/apollographql/apollo-client)
 [![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/apollo)
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/from-referrer/)
 
 Apollo Client is a fully-featured caching GraphQL client with integrations for React, Angular, and more. It allows you to easily build UI components that fetch data via GraphQL.
 


### PR DESCRIPTION
Hi.

I work for Gitpod and we are currently on a mission to simplify contributors onboarding experience for popular Open-source projects. 

This PR adds gitpod config to the repo to make contributions easier for newcomers i.e with a single click it will launch a workspace and automatically:

- clone the `apollo-client` repo.
- install the dependencies.
- run `npm run watch` and `npm run test:watch` in separate terminals.

This can be helpful for beginners i.e they can start coding instantly without setting anything up.

You can give it a try on my fork of the repo via the following link:

https://gitpod.io/#https://github.com/nisarhassan12/apollo-client

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/96458303-32865680-123a-11eb-974d-07455c78054c.png)


<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
