### PR TITLE
ObservableQuery and QueryInfo stays forever on skip:true

### DIFF
--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -624,7 +624,9 @@ once, rather than every time you call fetchMore.`);
     return this.observers.size > 0;
   }
 
-  public tearDownQuery() {
+  private tearDownQuery() {
+    if (this.isTornDown) return;
+
     const { queryManager } = this;
 
     if (this.reobserver) {

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -624,7 +624,7 @@ once, rather than every time you call fetchMore.`);
     return this.observers.size > 0;
   }
 
-  private tearDownQuery() {
+  public tearDownQuery() {
     const { queryManager } = this;
 
     if (this.reobserver) {

--- a/src/react/data/QueryData.ts
+++ b/src/react/data/QueryData.ts
@@ -472,7 +472,7 @@ export class QueryData<TData, TVariables> extends OperationData {
       this.currentSubscription.unsubscribe();
       delete this.currentSubscription;
     } else if (this.currentObservable && this.getOptions().skip) {
-      this.currentObservable.tearDownQuery();
+      this.currentObservable["tearDownQuery"]();
     }
   }
 

--- a/src/react/data/QueryData.ts
+++ b/src/react/data/QueryData.ts
@@ -471,6 +471,8 @@ export class QueryData<TData, TVariables> extends OperationData {
     if (this.currentSubscription) {
       this.currentSubscription.unsubscribe();
       delete this.currentSubscription;
+    } else if (this.currentObservable && this.getOptions().skip) {
+      this.currentObservable.tearDownQuery();
     }
   }
 

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -2225,6 +2225,30 @@ describe('useQuery Hook', () => {
         expect(renderCount).toBe(3);
       }).then(resolve, reject);
     });
+
+    it('should tear down the query if `skip` is `true`', () => {
+      const client = new ApolloClient({
+        link: new ApolloLink(),
+        cache: new InMemoryCache()
+      });
+
+      const Component = () => {
+        useQuery(CAR_QUERY, { skip: true });
+        return null;
+      };
+
+      const app = render(
+        <ApolloProvider client={client}>
+          <Component />
+        </ApolloProvider>
+      );
+
+      expect(client['queryManager']['queries'].size).toBe(1);
+
+      app.unmount();
+
+      expect(client['queryManager']['queries'].size).toBe(0);
+    });
   });
 
   describe('Previous data', () => {


### PR DESCRIPTION
Issue #7206

Cleanup logic is done on `unsubscribe` but when `skip: true` the component never starts a subscription.

![Leaking](https://media.giphy.com/media/cL1ruhKIUxDyFMqzwd/giphy.gif)

I got the bottle over 3 years ago when Apollo was in very early stage, thank you once again :)