### PR TITLE
Use "Var" suffix for reactive variable names

### DIFF
--- a/docs/source/local-state/reactive-variables.mdx
+++ b/docs/source/local-state/reactive-variables.mdx
@@ -14,7 +14,7 @@ Create a reactive variable with the `makeVar` method, like so:
 ```js
 import { makeVar } from '@apollo/client';
 
-const cartItems = makeVar([]);
+const cartItemsVar = makeVar([]);
 ```
 
 This code creates a reactive variable with an empty array as its initial value. 
@@ -26,10 +26,10 @@ This code creates a reactive variable with an empty array as its initial value.
 To read the value of your reactive variable, call the function returned by `makeVar` with zero arguments:
 
 ```js
-const cartItems = makeVar([]);
+const cartItemsVar = makeVar([]);
 
 // Output: []
-console.log(cartItems());
+console.log(cartItemsVar());
 ```
 
 ## Modifying
@@ -37,17 +37,17 @@ console.log(cartItems());
 To modify the value of your reactive variable, call the function returned by `makeVar` with one argument (the variable's new value):
 
 ```js
-const cartItems = makeVar([]);
+const cartItemsVar = makeVar([]);
 
-cartItems([100, 101, 102]);
+cartItemsVar([100, 101, 102]);
 
 // Output: [100, 101, 102]
-console.log(cartItems());
+console.log(cartItemsVar());
 
-cartItems([456]);
+cartItemsVar([456]);
 
 // Output: [456]
-console.log(cartItems());
+console.log(cartItemsVar());
 ```
 
 ## Reacting


### PR DESCRIPTION
Do we want to recommend/model this convention? It's used in the examples on this page: https://www.apollographql.com/docs/react/local-state/managing-state-with-field-policies/

Alternatives are no recommendation on naming, or a different rec, like `reactiveCartItem`.
