### PR TITLE
Simplify the useLazyQuery example of the Queries section

### DIFF
--- a/docs/source/data/queries.mdx
+++ b/docs/source/data/queries.mdx
@@ -221,18 +221,13 @@ import React, { useState } from 'react';
 import { useLazyQuery } from '@apollo/client';
 
 function DelayedQuery() {
-  const [dog, setDog] = useState(null);
   const [getDog, { loading, data }] = useLazyQuery(GET_DOG_PHOTO);
 
   if (loading) return <p>Loading ...</p>;
 
-  if (data && data.dog && dog !== data.dog) {
-    setDog(data.dog);
-  }
-
   return (
     <div>
-      {dog && <img src={dog.displayImage} />}
+      {data && data.dog && <img src={data.dog.displayImage} />}
       <button onClick={() => getDog({ variables: { breed: 'bulldog' } })}>
         Click me!
       </button>


### PR DESCRIPTION
This PR simplifies [the useLazyQuery example of the Queries section](https://www.apollographql.com/docs/react/data/queries/#executing-queries-manually) as the same as [the useLazyQuey example of the Hook section](https://www.apollographql.com/docs/react/api/react/hooks/#example-3).
Some people may think they should do the same when they use useLazyQuery as the example of Queries section but I don't see any benefit in it, so I think the extra state for a dog should be removed.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
