### PR TITLE
Call this.currentObservable.tearDownQuery more consistently.

### DIFF
--- a/src/react/data/QueryData.ts
+++ b/src/react/data/QueryData.ts
@@ -63,6 +63,7 @@ export class QueryData<TData, TVariables> extends OperationData {
     const { skip, query } = this.getOptions();
     if (skip || query !== this.previous.query) {
       this.removeQuerySubscription();
+      this.removeObservable(!skip);
       this.previous.query = query;
     }
 
@@ -107,7 +108,7 @@ export class QueryData<TData, TVariables> extends OperationData {
 
   public cleanup() {
     this.removeQuerySubscription();
-    delete this.currentObservable;
+    this.removeObservable(true);
     delete this.previous.result;
   }
 
@@ -471,8 +472,15 @@ export class QueryData<TData, TVariables> extends OperationData {
     if (this.currentSubscription) {
       this.currentSubscription.unsubscribe();
       delete this.currentSubscription;
-    } else if (this.currentObservable && this.getOptions().skip) {
+    }
+  }
+
+  private removeObservable(andDelete: boolean) {
+    if (this.currentObservable) {
       this.currentObservable["tearDownQuery"]();
+      if (andDelete) {
+        delete this.currentObservable;
+      }
     }
   }
 


### PR DESCRIPTION
Follow-up to #7205, per my comment https://github.com/apollographql/apollo-client/issues/7254#issuecomment-718977276.

Instead of tearing down `queryData.currentObservable` only when `queryData.getOptions().skip` is true in `removeQuerySubscription` (which was the idea of #7205), I split the tear-down functionality into a separate private method (`removeObservable`), which works regardless of the `skip` status, and is called everywhere `removeQuerySubscription` is called, except in `resubscribeToQuery`, where we specifically want to preserve `this.observableQuery`.