### PR TITLE
Make sure to clean `context` during tearDownQuery

### DIFF
--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -627,23 +627,25 @@ once, rather than every time you call fetchMore.`);
   private tearDownQuery() {
     if (this.isTornDown) return;
 
-    const { queryManager } = this;
-
     if (this.reobserver) {
       this.reobserver.stop();
       delete this.reobserver;
     }
 
-    this.isTornDown = true;
-    this.options.context = undefined;
+    // Since the user-provided context object can retain arbitrarily large
+    // amounts of memory, we delete it when the ObservableQuery is torn
+    // down, to avoid the possibility of memory leaks.
+    delete this.options.context;
 
     // stop all active GraphQL subscriptions
     this.subscriptions.forEach(sub => sub.unsubscribe());
     this.subscriptions.clear();
 
-    queryManager.stopQuery(this.queryId);
+    this.queryManager.stopQuery(this.queryId);
 
     this.observers.clear();
+
+    this.isTornDown = true;
   }
 }
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -635,6 +635,7 @@ once, rather than every time you call fetchMore.`);
     }
 
     this.isTornDown = true;
+    this.options.context = undefined;
 
     // stop all active GraphQL subscriptions
     this.subscriptions.forEach(sub => sub.unsubscribe());


### PR DESCRIPTION
Hi @benjamn 

This PR should ensure that even if `ObservableInfo` remains in memory, it won't hold a reference to user-object `context` after tear-down. 

The background is a memory-leak we are chasing in a large-scale app. I think the existence of the `context` reference in Apollo just makes it harder to detect, since it retaining it with no reason. 
I think even in a use-case of `subscribe` over a `watchQuery` observable, without `unsubscribing` reproduces that, since Apollo isn't removing the `ObservableQuery` while there are subscribers. 