### PR TITLE
Fix query info cache leak

### DIFF
--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -665,7 +665,7 @@ export class QueryManager<TStore> {
     // A query created with `QueryManager.query()` could trigger a `QueryManager.fetchRequest`.
     // The same queryId could have two rejection fns for two promises
     this.fetchCancelFns.delete(queryId);
-    this.getQuery(queryId).subscriptions.forEach(x => x.unsubscribe());
+    this.getQuery(queryId).destroy();
     this.queries.delete(queryId);
   }
 

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -665,7 +665,7 @@ export class QueryManager<TStore> {
     // A query created with `QueryManager.query()` could trigger a `QueryManager.fetchRequest`.
     // The same queryId could have two rejection fns for two promises
     this.fetchCancelFns.delete(queryId);
-    this.getQuery(queryId).destroy();
+    this.getQuery(queryId).stop();
     this.queries.delete(queryId);
   }
 


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests

An unexpected behaviour in my React app revealed some kind of leak in the `QueryInfo` object. One of my component consuming `useQuery` was mounted, then almost immediately unmounted. Mounting back this component led to an infinite query loop. Following the red thread, I've found out that the `QueryManager.removeQuery` was called when the component was unmounted BEFORE receiving the result. What happened in that case was that `QueryInfo.markResult` was called even when `QueryInfo` object was detached, thus keeping the `QueryInfo` object still configured to react to cache updates. In my case, as I'm using a `network-only` fetch policy, mounting back the component led to executing another instance of the same query, updating the cache, then triggering re observability of the previous detached query, which would also update the cache, then trigger the new query observability, and so on. This is my naive take on the problem. What's your opinion on that ?
