### PR TITLE
Add test for MockProvider that shows issue with graphql interfaces

### DIFF
--- a/src/utilities/testing/mocking/MockedProvider.tsx
+++ b/src/utilities/testing/mocking/MockedProvider.tsx
@@ -44,7 +44,10 @@ export class MockedProvider extends React.Component<
     } = this.props;
     const client = new ApolloClient({
       cache: cache || new Cache({ addTypename }),
-      defaultOptions,
+      defaultOptions: defaultOptions || {
+        query: { fetchPolicy: "no-cache" },
+        watchQuery: { fetchPolicy: "no-cache" },
+      },
       link: link || new MockLink(
         mocks || [],
         addTypename,

--- a/src/utilities/testing/mocking/__tests__/MockedProvider.test.tsx
+++ b/src/utilities/testing/mocking/__tests__/MockedProvider.test.tsx
@@ -94,6 +94,35 @@ describe('General use', () => {
     return wait().then(resolve, reject);
   });
 
+  itAsync('should mock the data if interfaces are used', async (resolve, reject) => {
+    const interfaceQuery = gql`
+      { transportations { name ... on Car { numWheels } } }
+    `
+    const interfaceMocks = [
+      { request: { query: interfaceQuery, variables: {} }, result: { data: { transportations: [
+        {
+          name: 'Car',
+          numWheels: 4,
+        }
+        ] } }}
+    ]
+    function Component() {
+      const { loading, data } = useQuery<Data, Variables>(interfaceQuery);
+      if (!loading) {
+        expect(data).toMatchSnapshot()
+      }
+      return null;
+    }
+
+    render(
+      <MockedProvider mocks={interfaceMocks} >
+        <Component />
+      </MockedProvider>
+    );
+
+    return wait().then(resolve, reject);
+  });
+
   itAsync('should allow querying with the typename', async (resolve, reject) => {
     function Component({ username }: Variables) {
       const { loading, data } = useQuery<Data, Variables>(query, { variables });

--- a/src/utilities/testing/mocking/__tests__/__snapshots__/MockedProvider.test.tsx.snap
+++ b/src/utilities/testing/mocking/__tests__/__snapshots__/MockedProvider.test.tsx.snap
@@ -14,6 +14,17 @@ Object {
 }
 `;
 
+exports[`General use should mock the data if interfaces are used 1`] = `
+Object {
+  "transportations": Array [
+    Object {
+      "name": "Car",
+      "numWheels": 4,
+    },
+  ],
+}
+`;
+
 exports[`General use should not error if the variables match but have different order 1`] = `
 Object {
   "user": Object {


### PR DESCRIPTION
Reproduction for a bug https://github.com/apollographql/apollo-client/issues/7281

When interfaces are used in a GraphQL query the mockProvider does not respond with the full set of data. 

E.g. 
Type: 
`
  const typedefs = {
    interface Transportation { name: String }
    type Car implements Transportation { name: String numWheels: int }
    type Bike implements Transportation { name: String color: String }
    Query {
      transportations: [Transportation]
    }
  }
  `
`
// Pseudocode
const query = "{ transportations { name   ... on Car { numWheels } } }"
<MockProvider mocks={[ request: { query }, result: { data: { transportations: [ { name: "Car", numWheels: 4 } ] } } ]}>
  { () => {  const { data } = useQuery(query)} }
</MockProvider>
`

BUG: Only part of the mocked result is returned by the MockProvider. The "numWheels" is missing in the data.