### PR TITLE
Add note about moving pollInterval to startPolling.

### DIFF
--- a/docs/source/data/queries.mdx
+++ b/docs/source/data/queries.mdx
@@ -130,7 +130,7 @@ function DogPhoto({ breed }) {
 
 By setting the `pollInterval` to 500, you'll fetch the current breed's image from the server every 0.5 seconds. Note that if you set `pollInterval` to `0`, the query will **not** poll.
 
-> You can also start and stop polling dynamically with the `startPolling` and `stopPolling` functions that are returned by the [`useQuery` hook](https://www.apollographql.com/docs/react/api/react/hooks/#usequery).
+> You can also start and stop polling dynamically with the `startPolling` and `stopPolling` functions that are returned by the [`useQuery` hook](https://www.apollographql.com/docs/react/api/react/hooks/#usequery). When using these functions, do not set the `pollInterval` configuration option on `useQuery`, but instead, pass it as a parameter of the `startPolling` function.
 
 ### Refetching
 


### PR DESCRIPTION
Hi!

I've made an amend on the page [Queries / Polling](https://www.apollographql.com/docs/react/data/queries/#polling) to make it clearer what to do with the polling interval when using the imperative API (startPolling/stopPolling).

The reasoning is because I wanted to stop polling when my component was unmounted (on useEffect's clean up function), but I had the polling interval defined in the `useQuery` configuration options, and the polling was not stopped when I called `stopPolling`. It took me a while to figure out that I had to remove the polling interval from `useQuery` options, and instead, call `startPolling` with the desired interval. I think this small addition can potentially help more people.

Happy to rephrase it, and no worries if you think it's not a necessary edit.

Thanks for reading!

--
For more context, this is the code that didn't work - where the polling didn't stop when the component was unmounted:

```js
const { ..., stopPolling } = useQuery(GET_DOG_PHOTO, { pollInterval: 5000 });

useEffect(() => {
  return cleanup() {
    stopPolling();
  }
, [stopPolling]);
```

And this is the change that made the polling stop properly when the component is unmounted:

```diff
-const { ..., stopPolling } = useQuery(GET_DOG_PHOTO, { pollInterval: 5000 });
+const { ..., startPolling, stopPolling } = useQuery(GET_DOG_PHOTO);

useEffect(() => {
+ startPolling();

  return cleanup() {
    stopPolling();
  }
-, [stopPolling]);
+, [startPolling, stopPolling]);
```