### PR TITLE
Avoid adding QueryPromise when skip is true on SSR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,9 @@
 - Allow optional arguments in `keyArgs: [...]` arrays for `InMemoryCache` field policies. <br/>
   [@benjamn](https://github.com/benjamn) in [#7109](https://github.com/apollographql/apollo-client/pull/7109)
 
+- Avoid registering `QueryPromise` when `skip` is `true` during server-side rendering. <br/>
+  [@izumin5210](https://github.com/izumin5210) in [#7310](https://github.com/apollographql/apollo-client/pull/7310)
+
 ## Apollo Client 3.2.7
 
 ## Bug Fixes

--- a/src/react/data/QueryData.ts
+++ b/src/react/data/QueryData.ts
@@ -152,7 +152,8 @@ export class QueryData<TData, TVariables> extends OperationData {
   };
 
   private getExecuteSsrResult() {
-    const ssrDisabled = this.getOptions().ssr === false;
+    const { ssr, skip } = this.getOptions();
+    const ssrDisabled = ssr === false || skip;
     const fetchDisabled = this.refreshClient().client.disableNetworkFetches;
 
     const ssrLoading = {

--- a/src/react/ssr/__tests__/useQuery.test.tsx
+++ b/src/react/ssr/__tests__/useQuery.test.tsx
@@ -166,4 +166,29 @@ describe('useQuery Hook SSR', () => {
       });
     }
   );
+
+  it('should skip SSR tree rendering if `skip` option is `true`', async () => {
+    let renderCount = 0;
+    const Component = () => {
+      const { data, loading } = useQuery(CAR_QUERY, { skip: true });
+      renderCount += 1;
+
+      if (!loading) {
+        const { make } = data.cars[0];
+        return <div>{make}</div>;
+      }
+      return null;
+    };
+
+    const app = (
+      <MockedProvider mocks={CAR_MOCKS}>
+        <Component />
+      </MockedProvider>
+    );
+
+    return renderToStringWithData(app).then((result) => {
+      expect(renderCount).toBe(1);
+      expect(result).toEqual('');
+    });
+  });
 });


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

Fixing https://github.com/apollographql/apollo-client/issues/6342

When `skip` is set to true on SSR, `useQuery` skips a network request. But firing `renderToString`.

### Checklist:
only small bugfix

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
