### PR TITLE
Docs: Modifying the response data examples (async/await)

### DIFF
--- a/docs/source/networking/advanced-http-networking.md
+++ b/docs/source/networking/advanced-http-networking.md
@@ -140,9 +140,7 @@ import { asyncMap } from "@apollo/client/utilities";
 
 import { usdToEur } from './currency';
 
-const httpLink = new HttpLink({
-  uri: "https://graphql.anilist.co/"
-});
+const httpLink = new HttpLink({ uri: '/graphql' });
 
 const usdToEurLink = new ApolloLink((operation, forward) => {
   return asyncMap(forward(operation), async (response) => {


### PR DESCRIPTION
I added two examples for response manipulation, one that is synchronous and the other requires async/await. This is crucial since I could not find any documentation on how to manipulate the response in an asynchronous manner, which led me to edit the docs.

See https://github.com/apollographql/apollo-client/issues/7328
