### PR TITLE
Always consider ROOT_{QUERY,MUTATION,...} IDs to be GC roots.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Apollo Client 3.2.6
+
+## Bug Fixes
+
+- Always consider singleton IDs like `ROOT_QUERY` and `ROOT_MUTATION` to be root IDs during `cache.gc` garbage collection, regardless of whether they have been retained or released. <br/>
+  [@benjamn](https://github.com/benjamn) in [#7333](https://github.com/apollographql/apollo-client/pull/7333)
+
 ## Apollo Client 3.2.5
 
 ## Improvements

--- a/src/cache/inmemory/__tests__/__snapshots__/entityStore.ts.snap
+++ b/src/cache/inmemory/__tests__/__snapshots__/entityStore.ts.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EntityStore ignores retainment count for ROOT_QUERY 1`] = `
+Object {
+  "Author:Allie Brosh": Object {
+    "__typename": "Author",
+    "name": "Allie Brosh",
+  },
+  "Book:1982156945": Object {
+    "__typename": "Book",
+    "author": Object {
+      "__ref": "Author:Allie Brosh",
+    },
+    "title": "Solutions and Other Problems",
+  },
+  "ROOT_QUERY": Object {
+    "__typename": "Query",
+    "book": Object {
+      "__ref": "Book:1982156945",
+    },
+  },
+}
+`;

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -287,6 +287,11 @@ export abstract class EntityStore implements NormalizedCache {
     Object.keys(this.rootIds).forEach(ids.add, ids);
     if (this instanceof Layer) {
       this.parent.getRootIdSet(ids);
+    } else {
+      // Official singleton IDs like ROOT_QUERY and ROOT_MUTATION are
+      // always considered roots for garbage collection, regardless of
+      // their retainment counts in this.rootIds.
+      Object.keys(this.policies.rootTypenamesById).forEach(ids.add, ids);
     }
     return ids;
   }

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -109,8 +109,11 @@ export class StoreWriter {
       throw new InvariantError(`Could not identify object ${JSON.stringify(result)}`);
     }
 
-    // Any IDs written explicitly to the cache (including ROOT_QUERY,
-    // most frequently) will be retained as reachable root IDs.
+    // Any IDs written explicitly to the cache will be retained as
+    // reachable root IDs for garbage collection purposes. Although this
+    // logic includes root IDs like ROOT_QUERY and ROOT_MUTATION, their
+    // retainment counts are effectively ignored because cache.gc() always
+    // includes them in its root ID set.
     store.retain(ref.__ref);
 
     return ref;


### PR DESCRIPTION
Partial solution for #7323, as we still need to decide the best way to persist retainment counts for non-`ROOT_*` entity objects written directly with `cache.writeFragment`.