### PR TITLE
Revert "chore(deps): update dependency symbol-observable to v3 (#7299)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Apollo Client 3.2.7
+
+## Bug Fixes
+
+- Revert updating `symbol-observable` from version 2.x to version 3, which caused TypeScript errors with some `@types/node` versions, especially in Angular applications. <br/>
+  [@benjamn](https://github.com/benjamn) in [#7340](https://github.com/apollographql/apollo-client/pull/7340)
+
 ## Apollo Client 3.2.6
 
 ## Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -10620,9 +10620,9 @@
       }
     },
     "symbol-observable": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-3.0.0.tgz",
-      "integrity": "sha512-6tDOXSHiVjuCaasQSWTmHUWn4PuG7qa3+1WT031yTc/swT7+rLiw3GOrFxaH1E3lLP09dH3bVuVDf2gK5rxG3Q=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-2.0.3.tgz",
+      "integrity": "sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA=="
     },
     "symbol-tree": {
       "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "hoist-non-react-statics": "^3.3.2",
     "optimism": "^0.13.0",
     "prop-types": "^15.7.2",
-    "symbol-observable": "^3.0.0",
+    "symbol-observable": "^2.0.0",
     "ts-invariant": "^0.5.0",
     "tslib": "^1.10.0",
     "zen-observable": "^0.8.14"


### PR DESCRIPTION
This reverts commit 2809d6d14fa142247fb8b7ccd21137902d59cdac, hopefully fixing issue #7337. The problem is not the `@types/node` version, as conjectured in #7335, but the incompatibility between the version of `@types/node` used by Angular and the major update of `symbol-observable`, which is a non-dev dependency of `@apollo/client`:
```
ERROR in node_modules/@apollo/client/node_modules/symbol-observable/index.d.ts:6:14 - error TS2717: Subsequent property declarations must have the same type.  Property 'observable' must be of type 'symbol', but here has type 'unique symbol'.

    6     readonly observable: unique symbol;
                   ~~~~~~~~~~

      node_modules/@types/node/globals.d.ts:146:14
        146     readonly observable: symbol;
                         ~~~~~~~~~~
        'observable' was also declared here.
```