### PR TITLE
Cancel queryInfo.notifyTimeout when marking final results.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,9 @@
 - Avoid registering `QueryPromise` when `skip` is `true` during server-side rendering. <br/>
   [@izumin5210](https://github.com/izumin5210) in [#7310](https://github.com/apollographql/apollo-client/pull/7310)
 
+- Cancel `queryInfo.notifyTimeout` in `QueryInfo#markResult` to prevent unnecessary network requests when using a `FetchPolicy` of `cache-and-network` or `network-only` in a React component with multiple `useQuery` calls. <br/>
+  [@benjamn](https://github.com/benjamn) in [#7347](https://github.com/apollographql/apollo-client/pull/7347)
+
 ## Apollo Client 3.2.7
 
 ## Bug Fixes


### PR DESCRIPTION
As the reproduction in #7346 demonstrates, it was possible for the `QueryInfo#notify` timeout set in `QueryInfo#setDiff` on behalf of an earlier `loading: true` result to fire _after_ the final `loading: false` result had been recorded in `QueryInfo#markResult`, which could lead to unnecessary network requests when using a `FetchPolicy` of `cache-and-network` or `network-only`, especially when there are multiple `useQuery` calls in the same React component.

This PR fixes that problem by canceling the timeout in `QueryInfo#markResult` and `markError`, since those methods are called by code that delivers the results through other mechanisms.