### PR TITLE
Allow manually associating caches with reactive variables.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,9 @@
 - Cancel `queryInfo.notifyTimeout` in `QueryInfo#markResult` to prevent unnecessary network requests when using a `FetchPolicy` of `cache-and-network` or `network-only` in a React component with multiple `useQuery` calls. <br/>
   [@benjamn](https://github.com/benjamn) in [#7347](https://github.com/apollographql/apollo-client/pull/7347)
 
+- `ApolloCache` objects (including `InMemoryCache`) may now be associated with or disassociated from individual reactive variables by calling `reactiveVar.attachCache(cache)` and/or `reactiveVar.forgetCache(cache)`. <br/>
+  [@benjamn](https://github.com/benjamn) in [#7350](https://github.com/apollographql/apollo-client/pull/7350)
+
 ## Apollo Client 3.2.7
 
 ## Bug Fixes

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     {
       "name": "apollo-client",
       "path": "./dist/apollo-client.cjs.min.js",
-      "maxSize": "25.4 kB"
+      "maxSize": "25.5 kB"
     }
   ],
   "peerDependencies": {


### PR DESCRIPTION
In the context of a larger cache read operation, accessing a reactive variable automatically associates the variable with the cache, so future updates to the variable can be broadcast to the cache.

Outside this context, it may not be possible for the variable to discover the currently active cache. For example, there is no currently active cache in asynchronous `ApolloLink` code (#7338).

Since we recently added a `reactiveVar.forgetCache(cache)` method in #7279, I think it makes sense to have a manual way to do the opposite, which I have decided to call `reactiveVar.attachCache(cache)`.

Although this attachment is manual at the moment, in a hypothetical future where the client/cache manage the persistence of reactive variables, it should be easy to attach the appropriate cache to those variables when they are first initialized, which would enable reactive updates from literally anywhere, with no additional effort by the developer.