### PR TITLE
Restrict field name over-invalidation to fields without keyArgs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@
 - `ApolloCache` objects (including `InMemoryCache`) may now be associated with or disassociated from individual reactive variables by calling `reactiveVar.attachCache(cache)` and/or `reactiveVar.forgetCache(cache)`. <br/>
   [@benjamn](https://github.com/benjamn) in [#7350](https://github.com/apollographql/apollo-client/pull/7350)
 
+- Modifying `InMemoryCache` fields that have `keyArgs` configured will now invalidate only the field value with matching key arguments, rather than invalidating all field values that share the same field name. If `keyArgs` has not been configured, the cache must err on the side of invalidating by field name, as before. <br/>
+  [@benjamn](https://github.com/benjamn) in [#7351](https://github.com/apollographql/apollo-client/pull/7351)
+
 ## Apollo Client 3.2.7
 
 ## Bug Fixes

--- a/src/cache/inmemory/__tests__/entityStore.ts
+++ b/src/cache/inmemory/__tests__/entityStore.ts
@@ -4,6 +4,7 @@ import { InMemoryCache } from '../inMemoryCache';
 import { DocumentNode } from 'graphql';
 import { StoreObject } from '../types';
 import { ApolloCache } from '../../core/cache';
+import { Cache } from '../../core/types/Cache';
 import { Reference, makeReference, isReference } from '../../../utilities/graphql/storeUtils';
 import { MissingFieldError } from '../..';
 
@@ -2276,5 +2277,143 @@ describe('EntityStore', () => {
       title: "Kindred",
       favorited: false,
     }});
+  });
+
+  it("should not over-invalidate fields with keyArgs", () => {
+    const isbnsWeHaveRead: string[] = [];
+
+    const cache = new InMemoryCache({
+      typePolicies: {
+        Query: {
+          fields: {
+            book: {
+              // The presence of this keyArgs configuration permits the
+              // cache to track result caching dependencies at the level
+              // of individual Books, so writing one Book does not
+              // invalidate other Books with different ISBNs. If the cache
+              // doesn't know which arguments are "important," it can't
+              // make any assumptions about the relationships between
+              // field values with the same field name but different
+              // arguments, so it has to err on the side of invalidating
+              // all Query.book data whenever any Book is written.
+              keyArgs: ["isbn"],
+
+              read(book, { args, toReference }) {
+                isbnsWeHaveRead.push(args!.isbn);
+                return book || toReference({
+                  __typename: "Book",
+                  isbn: args!.isbn,
+                });
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const query = gql`
+      query Book($isbn: string) {
+        book(isbn: $isbn) {
+          title
+          isbn
+          author {
+            name
+          }
+        }
+      }
+    `;
+
+    const diffs: Cache.DiffResult<any>[] = [];
+    cache.watch({
+      query,
+      optimistic: true,
+      variables: {
+        isbn: "1449373321",
+      },
+      callback(diff) {
+        diffs.push(diff);
+      },
+    });
+
+    const ddiaData = {
+      book: {
+        __typename: "Book",
+        isbn: "1449373321",
+        title: "Designing Data-Intensive Applications",
+        author: {
+          __typename: "Author",
+          name: "Martin Kleppmann",
+        },
+      },
+    };
+
+    expect(isbnsWeHaveRead).toEqual([]);
+
+    cache.writeQuery({
+      query,
+      variables: {
+        isbn: "1449373321",
+      },
+      data: ddiaData,
+    });
+
+    expect(isbnsWeHaveRead).toEqual([
+      "1449373321",
+    ]);
+
+    expect(diffs).toEqual([
+      {
+        complete: true,
+        result: ddiaData,
+      },
+    ]);
+
+    const theEndData = {
+      book: {
+        __typename: "Book",
+        isbn: "1982103558",
+        title: "The End of Everything",
+        author: {
+          __typename: "Author",
+          name: "Katie Mack",
+        },
+      },
+    };
+
+    cache.writeQuery({
+      query,
+      variables: {
+        isbn: "1982103558",
+      },
+      data: theEndData,
+    });
+
+    // This list does not include the book we just wrote, because the
+    // cache.watch we started above only depends on the Query.book field
+    // value corresponding to the 1449373321 ISBN.
+    expect(diffs).toEqual([
+      {
+        complete: true,
+        result: ddiaData,
+      },
+    ]);
+
+    // Likewise, this list is unchanged, because we did not need to read
+    // the 1449373321 Book again after writing the 1982103558 data.
+    expect(isbnsWeHaveRead).toEqual([
+      "1449373321",
+    ]);
+
+    expect(cache.readQuery({
+      query,
+      variables: {
+        isbn: "1982103558",
+      },
+    })).toEqual(theEndData);
+
+    expect(isbnsWeHaveRead).toEqual([
+      "1449373321",
+      "1982103558",
+    ]);
   });
 });

--- a/src/cache/inmemory/__tests__/entityStore.ts
+++ b/src/cache/inmemory/__tests__/entityStore.ts
@@ -2443,7 +2443,7 @@ describe('EntityStore', () => {
     ]);
 
     // Evicting the 1982103558 Book should not invalidate the 1449373321
-    // Book, leaving diffs and isbnsWeHaveRead unchanged.
+    // Book, so diffs and isbnsWeHaveRead should remain unchanged.
     expect(cache.evict({
       id: cache.identify({
         __typename: "Book",

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -646,6 +646,11 @@ export class Policies {
     return false;
   }
 
+  public hasKeyArgs(typename: string | undefined, fieldName: string) {
+    const policy = this.getFieldPolicy(typename, fieldName, false);
+    return !!(policy && policy.keyFn);
+  }
+
   public getStoreFieldName(fieldSpec: FieldSpecifier): string {
     const { typename, fieldName } = fieldSpec;
     const policy = this.getFieldPolicy(typename, fieldName, false);


### PR DESCRIPTION
Implementing the idea I described in https://github.com/apollographql/apollo-client/issues/7324#issuecomment-730017281.