### PR TITLE
fix: optionally chain current observable in query data

### DIFF
--- a/src/react/data/QueryData.ts
+++ b/src/react/data/QueryData.ts
@@ -491,14 +491,14 @@ export class QueryData<TData, TVariables> extends OperationData {
   private obsFetchMore = <K extends keyof TVariables>(
     fetchMoreOptions: FetchMoreQueryOptions<TVariables, K, TData> &
       FetchMoreOptions<TData, TVariables>
-  ) => this.currentObservable!.fetchMore(fetchMoreOptions);
+  ) => this.currentObservable?.fetchMore(fetchMoreOptions);
 
   private obsUpdateQuery = <TVars = TVariables>(
     mapFn: (
       previousQueryResult: TData,
       options: UpdateQueryOptions<TVars>
     ) => TData
-  ) => this.currentObservable!.updateQuery(mapFn);
+  ) => this.currentObservable?.updateQuery(mapFn);
 
   private obsStartPolling = (pollInterval: number) => {
     this.currentObservable?.startPolling(pollInterval);
@@ -517,7 +517,7 @@ export class QueryData<TData, TVariables> extends OperationData {
       TSubscriptionVariables,
       TSubscriptionData
     >
-  ) => this.currentObservable!.subscribeToMore(options);
+  ) => this.currentObservable?.subscribeToMore(options);
 
   private observableQueryFields() {
     return {


### PR DESCRIPTION
This PR will fix some more `currentObservable` problems when using the `useQuery` React hook.

Similar pull requests addressed the specific `refetch` issue.
https://github.com/apollographql/apollo-client/pull/6314
https://github.com/apollographql/apollo-client/pull/7186

In the same way, this pull request will address the possibly null `currentObservable` for:
* `fetchMore`
* `updateQuery`
* `subscribeToMore`