### PR TITLE
Set Concast["@@species"] = Observable as well as Symbol.species.

### DIFF
--- a/src/utilities/observables/Concast.ts
+++ b/src/utilities/observables/Concast.ts
@@ -243,11 +243,23 @@ export class Concast<T> extends Observable<T> {
 // Those methods assume (perhaps unwisely?) that they can call the
 // subtype's constructor with an observer registration function, but the
 // Concast constructor uses a different signature. Defining this
-// Symbol.species getter function on the Concast constructor function is
-// a hint to generic Observable code to use the default constructor
-// instead of trying to do `new Concast(observer => ...)`.
-if (typeof Symbol === "function" && Symbol.species) {
-  Object.defineProperty(Concast, Symbol.species, {
-    value: Observable,
-  });
+// Symbol.species property on the Concast constructor function is a hint
+// to generic Observable code to use the default constructor instead of
+// trying to do `new Concast(observer => ...)`.
+function setSpecies(key: symbol | string) {
+  if (key) {
+    // Object.defineProperty is necessary because Concast[Symbol.species]
+    // is a getter by default in modern JS environments, so we can't
+    // assign to it with a normal assignment expression.
+    Object.defineProperty(Concast, key, {
+      value: Observable,
+    });
+  }
 }
+if (typeof Symbol === "function" && Symbol.species) {
+  setSpecies(Symbol.species);
+}
+// The "@@species" string is used as a fake Symbol.species value in some
+// polyfill systems (including the SymbolSpecies variable used by
+// zen-observable), so we might as well make sure we set it as well.
+setSpecies("@@species");


### PR DESCRIPTION
This is an initial attempt to address the problems I speculated about in https://github.com/apollographql/apollo-client/issues/6520#issuecomment-736899757.

Theory: in the Hermes JS engine (used by React Native on Android), [`Symbol.species` is not defined](https://github.com/facebook/hermes/blob/master/doc/Features.md#excluded-from-support), so `Object.defineProperty` was not called by this code, but perhaps `Concast["@@species"]` was getting set somewhere else by a polyfill library, causing the `zen-observable` library to fall back to `"@@species"` in [`getSpecies`](https://github.com/zenparsing/zen-observable/blob/328fb66a99242900c0fd4a330e9ff66ecfa3a887/src/Observable.js#L29-L38) instead of safely ignoring the nonexistent `Concast[Symbol.species]` property.

If that theory is correct, subscriptions will become usable with Hermes on React Native again, fixing #6520. 🤞 