### PR TITLE
Make ApolloLink#onError observer parameter optional.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Apollo Client 3.3.3
+
+## Bug fixes
+
+- Make the `observer` parameter of `ApolloLink#onError` optional, fixing an unnecessary breaking change for any code that called `onError` directly. <br/>
+  [@benjamn](https://github.com/benjamn) in [#7407](https://github.com/apollographql/apollo-client/pull/7407)
+
 ## Apollo Client 3.3.2
 
 > ⚠️ **Note:** This version of `@apollo/client` contains no behavioral changes since version 3.3.1

--- a/src/link/core/ApolloLink.ts
+++ b/src/link/core/ApolloLink.ts
@@ -143,7 +143,7 @@ export class ApolloLink {
 
   protected onError(
     error: any,
-    observer: ZenObservable.Observer<FetchResult>,
+    observer?: ZenObservable.Observer<FetchResult>,
   ): false | void {
     if (observer && observer.error) {
       observer.error(error);


### PR DESCRIPTION
This new parameter could be considered a breaking change (in Apollo Client v3.3) for existing code that called `ApolloLink#onError` directly with only one argument (the error). Fortunately, the implementation of `onError` already tolerates the possibility that `observer` may not be provided, so we can fix this with a TypeScript-only tweak.