### PR TITLE
Update ts-invariant to avoid CSP-violating Function fallback.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Apollo Client 3.3.4
+
+## Improvements
+
+- Update `ts-invariant` to avoid potential [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)-violating `Function` fallback, thanks to [a clever new `globalThis` polyfill technique](https://mathiasbynens.be/notes/globalthis). <br/>
+  [@benjamn](https://github.com/benjamn) in [#7414](https://github.com/apollographql/apollo-client/pull/7414)
+
 ## Apollo Client 3.3.3
 
 ## Bug fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -2708,6 +2708,11 @@
         "pretty-format": "^25.1.0"
       }
     },
+    "@types/ungap__global-this": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@types/ungap__global-this/-/ungap__global-this-0.3.1.tgz",
+      "integrity": "sha512-+/DsiV4CxXl6ZWefwHZDXSe1Slitz21tom38qPCaG0DYCS1NnDPIQDTKcmQ/tvK/edJUKkmuIDBJbmKDiB0r/g=="
+    },
     "@types/websocket": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.0.tgz",
@@ -2736,6 +2741,11 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.0.tgz",
       "integrity": "sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg=="
+    },
+    "@ungap/global-this": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@ungap/global-this/-/global-this-0.4.2.tgz",
+      "integrity": "sha512-uFg7Kz+E12RBlgBLMlWVjmn2OIeE2J1Lzij0RseNcCVsrJX+LEB4fQ9MnoPXkXJmO5cHtTEzI5ATtb3IJfQ9tQ=="
     },
     "@wry/context": {
       "version": "0.5.2",
@@ -10792,10 +10802,12 @@
       }
     },
     "ts-invariant": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.5.1.tgz",
-      "integrity": "sha512-k3UpDNrBZpqJFnAAkAHNmSHtNuCxcU6xLiziPgalHRKZHme6T6jnKC8CcXDmk1zbHLQM8pc+rNC1Q6FvXMAl+g==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.6.0.tgz",
+      "integrity": "sha512-caoafsfgb8QxdrKzFfjKt627m4i8KTtfAiji0DYJfWI4A/S9ORNNpzYuD9br64kyKFgxn9UNaLLbSupam84mCA==",
       "requires": {
+        "@types/ungap__global-this": "^0.3.1",
+        "@ungap/global-this": "^0.4.2",
         "tslib": "^1.9.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "optimism": "^0.13.1",
     "prop-types": "^15.7.2",
     "symbol-observable": "^2.0.0",
-    "ts-invariant": "^0.5.1",
+    "ts-invariant": "^0.6.0",
     "tslib": "^1.10.0",
     "zen-observable": "^0.8.14"
   },


### PR DESCRIPTION
Includes this `ts-invariant` PR: https://github.com/apollographql/invariant-packages/pull/53

This update may also help with issues like #7406, where a _patch_ version update (from 0.5.0 to 0.5.1) is apparently not enough to force a dependency like `ts-invariant` with multiple conflicting version constraints (from `@apollo/client` and `graphql-tools`) to be updated, since version 0.5.0 is still semantically compatible with the desired minimum version 0.5.1, so `ts-invariant` remains outdated after updating `@apollo/client`, despite the new version being clearly mandated in `@apollo/client/package.json`.

After updating the _minor_ version of `ts-invariant` in package.json (to ^0.6.0), there should be no risk of `@apollo/client` incorrectly resolving the older `ts-invariant@0.5.0` version, though there may end up being multiple copies of `ts-invariant` in `node_modules` with different versions, which is fine for this particular package.