### PR TITLE
Feature: add ability to refetch certain queries imperatively

### DIFF
--- a/docs/source/api/core/ApolloClient.mdx
+++ b/docs/source/api/core/ApolloClient.mdx
@@ -101,6 +101,7 @@ different value for the same option in individual function calls.
 <TypescriptApiBox name="ApolloClient.onClearStore" />
 <TypescriptApiBox name="ApolloClient.stop" />
 <TypescriptApiBox name="ApolloClient.reFetchObservableQueries" />
+<TypescriptApiBox name="ApolloClient.reFetchQueries" />
 
 ## Types
 

--- a/docs/source/api/core/ApolloClient.mdx
+++ b/docs/source/api/core/ApolloClient.mdx
@@ -101,7 +101,7 @@ different value for the same option in individual function calls.
 <TypescriptApiBox name="ApolloClient.onClearStore" />
 <TypescriptApiBox name="ApolloClient.stop" />
 <TypescriptApiBox name="ApolloClient.reFetchObservableQueries" />
-<TypescriptApiBox name="ApolloClient.reFetchQueries" />
+<TypescriptApiBox name="ApolloClient.refetchQueries" />
 
 ## Types
 

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -2426,7 +2426,7 @@ describe('client', () => {
     expect(spy).toHaveBeenCalled();
   });
 
-  it('has a reFetchQueries method which calls QueryManager', async () => {
+  it('has a refetchQueries method which calls QueryManager', async () => {
     // TODO(dannycochran)
     const client = new ApolloClient({
       link: ApolloLink.empty(),
@@ -2434,8 +2434,8 @@ describe('client', () => {
     });
 
     // @ts-ignore
-    const spy = jest.spyOn(client.queryManager, 'reFetchQueries');
-    await client.reFetchQueries(['Author1']);
+    const spy = jest.spyOn(client.queryManager, 'refetchQueries');
+    await client.refetchQueries(['Author1']);
     expect(spy).toHaveBeenCalled();
   });
 

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -2426,6 +2426,19 @@ describe('client', () => {
     expect(spy).toHaveBeenCalled();
   });
 
+  it('has a reFetchQueries method which calls QueryManager', async () => {
+    // TODO(dannycochran)
+    const client = new ApolloClient({
+      link: ApolloLink.empty(),
+      cache: new InMemoryCache(),
+    });
+
+    // @ts-ignore
+    const spy = jest.spyOn(client.queryManager, 'reFetchQueries');
+    await client.reFetchQueries(['Author1']);
+    expect(spy).toHaveBeenCalled();
+  });
+
   itAsync('should propagate errors from network interface to observers', (resolve, reject) => {
     const link = ApolloLink.from([
       () =>

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -520,19 +520,19 @@ export class ApolloClient<TCacheShape> implements DataProxy {
   /**
    * Refetches specified active queries. Similar to "reFetchObservableQueries()" but with a specific list of queries.
    *
-   * `reFetchQueries()` is useful for use cases to imperatively refresh a selection of queries.
+   * `refetchQueries()` is useful for use cases to imperatively refresh a selection of queries.
    *
-   * It is important to remember that `reFetchQueries()` *will* refetch specified active
+   * It is important to remember that `refetchQueries()` *will* refetch specified active
    * queries. This means that any components that might be mounted will execute
    * their queries again using your network interface. If you do not want to
    * re-execute any queries then you should make sure to stop watching any
    * active queries.
    * Takes optional parameter `includeStandby` which will include queries in standby-mode when refetching.
    */
-  public reFetchQueries(
+  public refetchQueries(
     queries: RefetchQueryDescription,
   ): Promise<ApolloQueryResult<any>[]> {
-    return Promise.all(this.queryManager.reFetchQueries(queries));
+    return Promise.all(this.queryManager.refetchQueries(queries));
   }
 
   /**

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -22,6 +22,7 @@ import {
   MutationOptions,
   SubscriptionOptions,
   WatchQueryFetchPolicy,
+  RefetchQueryDescription,
 } from './watchQueryOptions';
 
 import {
@@ -514,6 +515,24 @@ export class ApolloClient<TCacheShape> implements DataProxy {
     includeStandby?: boolean,
   ): Promise<ApolloQueryResult<any>[]> {
     return this.queryManager.reFetchObservableQueries(includeStandby);
+  }
+
+  /**
+   * Refetches specified active queries. Similar to "reFetchObservableQueries()" but with a specific list of queries.
+   *
+   * `reFetchQueries()` is useful for use cases to imperatively refresh a selection of queries.
+   *
+   * It is important to remember that `reFetchQueries()` *will* refetch specified active
+   * queries. This means that any components that might be mounted will execute
+   * their queries again using your network interface. If you do not want to
+   * re-execute any queries then you should make sure to stop watching any
+   * active queries.
+   * Takes optional parameter `includeStandby` which will include queries in standby-mode when refetching.
+   */
+  public reFetchQueries(
+    queries: RefetchQueryDescription,
+  ): Promise<ApolloQueryResult<any>[]> {
+    return Promise.all(this.queryManager.reFetchQueries(queries));
   }
 
   /**

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -264,7 +264,7 @@ export class QueryManager<TStore> {
             refetchQueries = refetchQueries(storeResult!);
           }
 
-          const refetchQueryPromises = self.reFetchQueries(refetchQueries);
+          const refetchQueryPromises = self.refetchQueries(refetchQueries);
 
           Promise.all(
             awaitRefetchQueries ? refetchQueryPromises : [],
@@ -997,7 +997,7 @@ export class QueryManager<TStore> {
     return concast;
   }
 
-  public reFetchQueries(queries: RefetchQueryDescription):
+  public refetchQueries(queries: RefetchQueryDescription):
     Promise<ApolloQueryResult<any>>[] {
     const self = this;
     const refetchQueryPromises: Promise<ApolloQueryResult<any>>[] = [];

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -28,6 +28,7 @@ import {
   MutationOptions,
   WatchQueryFetchPolicy,
   ErrorPolicy,
+  RefetchQueryDescription,
 } from './watchQueryOptions';
 import { ObservableQuery } from './ObservableQuery';
 import { NetworkStatus, isNetworkRequestInFlight } from './networkStatus';
@@ -263,34 +264,7 @@ export class QueryManager<TStore> {
             refetchQueries = refetchQueries(storeResult!);
           }
 
-          const refetchQueryPromises: Promise<
-            ApolloQueryResult<any>[] | ApolloQueryResult<{}>
-          >[] = [];
-
-          if (isNonEmptyArray(refetchQueries)) {
-            refetchQueries.forEach(refetchQuery => {
-              if (typeof refetchQuery === 'string') {
-                self.queries.forEach(({ observableQuery }) => {
-                  if (observableQuery &&
-                      observableQuery.queryName === refetchQuery) {
-                    refetchQueryPromises.push(observableQuery.refetch());
-                  }
-                });
-              } else {
-                const queryOptions: QueryOptions = {
-                  query: refetchQuery.query,
-                  variables: refetchQuery.variables,
-                  fetchPolicy: 'network-only',
-                };
-
-                if (refetchQuery.context) {
-                  queryOptions.context = refetchQuery.context;
-                }
-
-                refetchQueryPromises.push(self.query(queryOptions));
-              }
-            });
-          }
+          const refetchQueryPromises = self.reFetchQueries(refetchQueries);
 
           Promise.all(
             awaitRefetchQueries ? refetchQueryPromises : [],
@@ -1021,6 +995,39 @@ export class QueryManager<TStore> {
     });
 
     return concast;
+  }
+
+  public reFetchQueries(queries: RefetchQueryDescription):
+    Promise<ApolloQueryResult<any>>[] {
+    const self = this;
+    const refetchQueryPromises: Promise<ApolloQueryResult<any>>[] = [];
+
+    if (isNonEmptyArray(queries)) {
+      queries.forEach(refetchQuery => {
+        if (typeof refetchQuery === 'string') {
+          self.queries.forEach(({ observableQuery }) => {
+            if (observableQuery &&
+                observableQuery.queryName === refetchQuery) {
+              refetchQueryPromises.push(observableQuery.refetch());
+            }
+          });
+        } else {
+          const queryOptions: QueryOptions = {
+            query: refetchQuery.query,
+            variables: refetchQuery.variables,
+            fetchPolicy: 'network-only',
+          };
+
+          if (refetchQuery.context) {
+            queryOptions.context = refetchQuery.context;
+          }
+
+          refetchQueryPromises.push(self.query(queryOptions));
+        }
+      });
+    }
+
+    return refetchQueryPromises;
   }
 
   private fetchQueryByPolicy<TData, TVars>(

--- a/src/core/__tests__/QueryManager/index.ts
+++ b/src/core/__tests__/QueryManager/index.ts
@@ -4321,7 +4321,7 @@ describe('QueryManager', () => {
         observable.subscribe({ next: () => null });
         observable2.subscribe({ next: () => null });
 
-        return Promise.all(queryManager.reFetchQueries(['GetAuthor', 'GetAuthor2'])).then(() => {
+        return Promise.all(queryManager.refetchQueries(['GetAuthor', 'GetAuthor2'])).then(() => {
           const result = getCurrentQueryResult(observable);
           expect(result.partial).toBe(false);
           expect(stripSymbols(result.data)).toEqual(dataChanged);

--- a/src/core/__tests__/QueryManager/index.ts
+++ b/src/core/__tests__/QueryManager/index.ts
@@ -4243,6 +4243,97 @@ describe('QueryManager', () => {
     });
   });
 
+  describe('refetching specified queries', () => {
+    itAsync('returns a promise resolving when all queries have been refetched', (resolve, reject) => {
+      const query = gql`
+        query GetAuthor {
+          author {
+            firstName
+            lastName
+          }
+        }
+      `;
+
+      const data = {
+        author: {
+          firstName: 'John',
+          lastName: 'Smith',
+        },
+      };
+
+      const dataChanged = {
+        author: {
+          firstName: 'John changed',
+          lastName: 'Smith',
+        },
+      };
+
+      const query2 = gql`
+        query GetAuthor2 {
+          author2 {
+            firstName
+            lastName
+          }
+        }
+      `;
+
+      const data2 = {
+        author2: {
+          firstName: 'John',
+          lastName: 'Smith',
+        },
+      };
+
+      const data2Changed = {
+        author2: {
+          firstName: 'John changed',
+          lastName: 'Smith',
+        },
+      };
+
+      const queryManager = createQueryManager({
+        link: mockSingleLink({
+          request: { query },
+          result: { data },
+        }, {
+          request: { query: query2 },
+          result: { data: data2 },
+        }, {
+          request: { query },
+          result: { data: dataChanged },
+        }, {
+          request: { query: query2 },
+          result: { data: data2Changed },
+        }).setOnError(reject),
+      });
+
+      const observable = queryManager.watchQuery<any>({ query });
+      const observable2 = queryManager.watchQuery<any>({ query: query2 });
+
+      return Promise.all([
+        observableToPromise({ observable }, result =>
+          expect(stripSymbols(result.data)).toEqual(data),
+        ),
+        observableToPromise({ observable: observable2 }, result =>
+          expect(stripSymbols(result.data)).toEqual(data2),
+        ),
+      ]).then(() => {
+        observable.subscribe({ next: () => null });
+        observable2.subscribe({ next: () => null });
+
+        return Promise.all(queryManager.reFetchQueries(['GetAuthor', 'GetAuthor2'])).then(() => {
+          const result = getCurrentQueryResult(observable);
+          expect(result.partial).toBe(false);
+          expect(stripSymbols(result.data)).toEqual(dataChanged);
+
+          const result2 = getCurrentQueryResult(observable2);
+          expect(result2.partial).toBe(false);
+          expect(stripSymbols(result2.data)).toEqual(data2Changed);
+        });
+      }).then(resolve, reject);
+    });
+  });
+
   describe('loading state', () => {
     itAsync('should be passed as false if we are not watching a query', (resolve, reject) => {
       const query = gql`


### PR DESCRIPTION
### Checklist:

- [X] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests **(WIP)**

Relevant issue:
https://github.com/apollographql/apollo-client/issues/7410

This is a WIP, I still need to write tests. But I wanted to start the convo about how this would look.
