### PR TITLE
Replace stray console.debug with invariant.log.

### DIFF
--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -205,26 +205,15 @@ export class ApolloClient<TCacheShape> implements DataProxy {
       if (
         typeof window !== 'undefined' &&
         window.document &&
-        window.top === window.self
+        window.top === window.self &&
+        !(window as any).__APOLLO_DEVTOOLS_GLOBAL_HOOK__ &&
+        window?.navigator?.userAgent?.indexOf('Chrome') > -1
       ) {
-        // First check if devtools is not installed
-        if (
-          typeof (window as any).__APOLLO_DEVTOOLS_GLOBAL_HOOK__ === 'undefined'
-        ) {
-          // Only for Chrome
-          if (
-            window.navigator &&
-            window.navigator.userAgent &&
-            window.navigator.userAgent.indexOf('Chrome') > -1
-          ) {
-            // tslint:disable-next-line
-            console.debug(
-              'Download the Apollo DevTools ' +
-                'for a better development experience: ' +
-                'https://chrome.google.com/webstore/detail/apollo-client-developer-t/jdkknkkbebbapilgoeccciglkfbmbnfm',
-            );
-          }
-        }
+        invariant.log(
+          'Download the Apollo DevTools ' +
+            'for a better development experience: ' +
+            'https://chrome.google.com/webstore/detail/apollo-client-developer-t/jdkknkkbebbapilgoeccciglkfbmbnfm',
+        );
       }
     }
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -85,12 +85,11 @@ export {
 
 // The verbosity of invariant.{log,warn,error} can be controlled globally
 // (for anyone using the same ts-invariant package) by passing "log",
-// "warn", "error", or "silent" to setVerbosity. By default, Apollo Client
-// displays warnings and errors, but hides invariant.log statements. Note
-// that all invariant.* logging is hidden in production.
+// "warn", "error", or "silent" to setVerbosity ("log" is the default).
+// Note that all invariant.* logging is hidden in production.
 import { setVerbosity } from "ts-invariant";
 export { setVerbosity as setLogVerbosity }
-setVerbosity("warn");
+setVerbosity("log");
 
 // Note that importing `gql` by itself, then destructuring
 // additional properties separately before exporting, is intentional.


### PR DESCRIPTION
Fixes #7447 and #7453, since React Native polyfills the console object without providing a `console.debug` method.

Since this message is promotional, I did not feel comfortable using `invariant.warn`, but our default log level of "warn" would have hidden the message unless [`setLogVerbosity("log")`](https://github.com/apollographql/apollo-client/pull/7226) was called.

Since this is the only use of `invariant.log` in the codebase, I believe it's acceptable to lower the default verbosity level to "log" to allow this particular message to be displayed (otherwise, `invariant.log` messages are effectively useless). You can use `setLogVerbosity("warn")` to exclude these `invariant.log` messages if you like.