### PR TITLE
Ensure POST request when sending full query with persisted queries link.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ TBD
 - Allow identical subscriptions to be deduplicated by default, like queries. <br/>
   [@jkossis](https://github.com/jkossis) in [#6910](https://github.com/apollographql/apollo-client/pull/6910)
 
+- Always use `POST` request when falling back to sending full query with `@apollo/client/link/persisted-queries`. <br/>
+  [@rieset](https://github.com/rieset) in [#7456](https://github.com/apollographql/apollo-client/pull/7456)
+
 ### Documentation
 TBD
 

--- a/src/link/persisted-queries/__tests__/index.ts
+++ b/src/link/persisted-queries/__tests__/index.ts
@@ -39,13 +39,12 @@ const errorResponse = JSON.stringify({ errors });
 const giveUpResponse = JSON.stringify({ errors: giveUpErrors });
 const multiResponse = JSON.stringify({ errors: multipleErrors });
 
-let hash: string;
-(async () => {
-  hash = await sha256(queryString);
-})();
-
 describe('happy path', () => {
-  beforeEach(fetch.mockReset);
+  let hash: string;
+  beforeEach(async () => {
+    fetch.mockReset();
+    hash = hash || await sha256(queryString);
+  });
 
   it('sends a sha256 hash of the query under extensions', done => {
     fetch.mockResponseOnce(response);
@@ -221,7 +220,11 @@ describe('happy path', () => {
 });
 
 describe('failure path', () => {
-  beforeEach(fetch.mockReset);
+  let hash: string;
+  beforeEach(async () => {
+    fetch.mockReset();
+    hash = hash || await sha256(queryString);
+  });
 
   it('correctly identifies the error shape from the server', done => {
     fetch.mockResponseOnce(errorResponse);

--- a/src/link/persisted-queries/index.ts
+++ b/src/link/persisted-queries/index.ts
@@ -186,6 +186,12 @@ export const createPersistedQueryLink = (
                 includeQuery: true,
                 includeExtensions: supportsPersistedQueries,
               },
+              fetchOptions: {
+                // Since we're including the full query, which may be
+                // large, we should send it in the body of a POST request.
+                // See issue #7456.
+                method: 'POST',
+              },
             });
             if (setFetchOptions) {
               operation.setContext({ fetchOptions: originalFetchOptions });


### PR DESCRIPTION
The second request after error with full graphql queries should be a POST request. Because there may be more than the limit for a GET request

If using automatic persisted queries, when first request did not find cache (return "PersistedQueryNotFound"). Then second request goes through GET method and if request is big, it falls on limit. The second request must use the POST method