### PR TITLE
Simplify config/jest.config.js to consider only src/ directory.

### DIFF
--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -1,7 +1,7 @@
 const { compilerOptions } = require("../tsconfig.json");
 
 module.exports = {
-  rootDir: '..',
+  rootDir: '../src',
   transform: {
     '.(ts|tsx)': 'ts-jest',
   },
@@ -16,10 +16,5 @@ module.exports = {
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'json'],
   testURL: 'http://localhost',
-  testPathIgnorePatterns: [
-    '/node_modules/',
-    '/dist/'
-  ],
-  modulePathIgnorePatterns: ['/dist/'],
-  setupFiles: ['<rootDir>/src/config/jest/setup.ts'],
+  setupFiles: ['<rootDir>/config/jest/setup.ts'],
 };


### PR DESCRIPTION
Every time I build [`docs/`](https://github.com/apollographql/apollo-client/tree/main/docs) locally, my Jest tests go all haywire because Jest tries to find/run tests in `docs/.cache/`. I'm tired of debugging that problem over and over every few weeks, so I think we should explicitly restrict Jest to the only directory that's supposed to have any tests in it, `src/`.