### PR TITLE
Use Partial<TVariables> typing for fetchMore variables, rather than Pick<TVariables, K>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ TBD
 - Always use `POST` request when falling back to sending full query with `@apollo/client/link/persisted-queries`. <br/>
   [@rieset](https://github.com/rieset) in [#7456](https://github.com/apollographql/apollo-client/pull/7456)
 
+- The `FetchMoreQueryOptions` type now takes two instead of three type parameters (`<TVariables, TData>`), thanks to using `Partial<TVariables>` instead of `K extends typeof TVariables` and `Pick<TVariables, K>`. <br/>
+  [@ArnaudBarre](https://github.com/ArnaudBarre) in [#7476](https://github.com/apollographql/apollo-client/pull/7476)
+
 ### Documentation
 TBD
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -256,8 +256,8 @@ export class ObservableQuery<
     );
   }
 
-  public fetchMore<K extends keyof TVariables>(
-    fetchMoreOptions: FetchMoreQueryOptions<TVariables, K, TData> &
+  public fetchMore(
+    fetchMoreOptions: FetchMoreQueryOptions<TVariables, TData> &
       FetchMoreOptions<TData, TVariables>,
   ): Promise<ApolloQueryResult<TData>> {
     const combinedOptions = {
@@ -412,10 +412,6 @@ once, rather than every time you call fetchMore.`);
    *
    * @param variables: The new set of variables. If there are missing variables,
    * the previous values of those variables will be used.
-   *
-   * @param tryFetch: Try and fetch new results even if the variables haven't
-   * changed (we may still just hit the store, but if there's nothing in there
-   * this will refetch)
    */
   public setVariables(
     variables: TVariables,

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -108,9 +108,9 @@ export interface WatchQueryOptions<TVariables = OperationVariables, TData = any>
   ) => WatchQueryFetchPolicy);
 }
 
-export interface FetchMoreQueryOptions<TVariables, K extends keyof TVariables, TData = any> {
+export interface FetchMoreQueryOptions<TVariables, TData = any> {
   query?: DocumentNode | TypedDocumentNode<TData, TVariables>;
-  variables?: Pick<TVariables, K>;
+  variables?: Partial<TVariables>;
   context?: any;
 }
 

--- a/src/react/data/QueryData.ts
+++ b/src/react/data/QueryData.ts
@@ -493,8 +493,8 @@ export class QueryData<TData, TVariables> extends OperationData {
   private obsRefetch = (variables?: Partial<TVariables>) =>
     this.currentObservable?.refetch(variables);
 
-  private obsFetchMore = <K extends keyof TVariables>(
-    fetchMoreOptions: FetchMoreQueryOptions<TVariables, K, TData> &
+  private obsFetchMore = (
+    fetchMoreOptions: FetchMoreQueryOptions<TVariables, TData> &
       FetchMoreOptions<TData, TVariables>
   ) => this.currentObservable!.fetchMore(fetchMoreOptions);
 

--- a/src/react/hoc/__tests__/queries/api.test.tsx
+++ b/src/react/hoc/__tests__/queries/api.test.tsx
@@ -258,7 +258,7 @@ describe('[queries] api', () => {
     };
 
     type Data = typeof data1;
-    type Variables = typeof vars1;
+    type Variables = { cursor: number | undefined };
 
     const link = mockSingleLink(
       { request: { query, variables: vars1 }, result: { data: data1 } },

--- a/src/react/hoc/types.ts
+++ b/src/react/hoc/types.ts
@@ -24,7 +24,7 @@ export interface QueryControls<
   loading: boolean;
   variables: TGraphQLVariables;
   fetchMore: (
-    fetchMoreOptions: FetchMoreQueryOptions<TGraphQLVariables, any, TData> &
+    fetchMoreOptions: FetchMoreQueryOptions<TGraphQLVariables, TData> &
       FetchMoreOptions<TData, TGraphQLVariables>
   ) => Promise<ApolloQueryResult<TData>>;
   refetch: (variables?: TGraphQLVariables) => Promise<ApolloQueryResult<TData>>;

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -63,14 +63,13 @@ export type ObservableQueryFields<TData, TVariables> = Pick<
   | 'refetch'
   | 'variables'
 > & {
-  fetchMore: (<K extends keyof TVariables>(
-    fetchMoreOptions: FetchMoreQueryOptions<TVariables, K, TData> &
+  fetchMore: ((
+    fetchMoreOptions: FetchMoreQueryOptions<TVariables, TData> &
       FetchMoreOptions<TData, TVariables>
   ) => Promise<ApolloQueryResult<TData>>) &
-    (<TData2, TVariables2, K extends keyof TVariables2>(
+    (<TData2, TVariables2>(
       fetchMoreOptions: { query?: DocumentNode | TypedDocumentNode<TData, TVariables> } & FetchMoreQueryOptions<
         TVariables2,
-        K,
         TData
       > &
         FetchMoreOptions<TData2, TVariables2>


### PR DESCRIPTION
Updating typing to match current behaviour of [merging fetchMore variables with initial variables](https://github.com/apollographql/apollo-client/blob/main/src/core/ObservableQuery.ts#L264-L267).

It's actually [used in test](https://github.com/apollographql/apollo-client/blob/main/src/__tests__/fetchMore.ts#L272-L273)

I don't know if Pick had a different behaviour in past TS version, but [from the documentation](https://www.typescriptlang.org/docs/handbook/utility-types.html#partialtype), Partial is the util to use in that case

NIT: my IDE also warned me about an outdated JS doc for setVariables