### PR TITLE
Bug fix in subscription-hoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Apollo Client 3.4.13 (not yet released)
+
+### Bug Fixes
+
+- Fix `componentDidUpate` typo in `withSubscription` higher-order component. <br/>
+  [@YarBez](https://github.com/YarBez) in [#7506](https://github.com/apollographql/apollo-client/pull/7506)
+
 ## Apollo Client 3.4.12
 
 ### Bug Fixes

--- a/src/react/hoc/subscription-hoc.tsx
+++ b/src/react/hoc/subscription-hoc.tsx
@@ -63,7 +63,7 @@ export function withSubscription<
         this.state = { resubscribe: false };
       }
 
-      componentDidUpate(prevProps: TProps) {
+      componentDidUpdate(prevProps: TProps) {
         if (shouldResubscribe) {
           this.setState({
             resubscribe: shouldResubscribe(prevProps, this.props)

--- a/src/react/hoc/subscription-hoc.tsx
+++ b/src/react/hoc/subscription-hoc.tsx
@@ -63,11 +63,16 @@ export function withSubscription<
         this.state = { resubscribe: false };
       }
 
+      updateResubscribe(value: boolean) {
+        this.setState({
+          resubscribe: value
+        });
+      }
+
       componentDidUpdate(prevProps: TProps) {
-        if (shouldResubscribe) {
-          this.setState({
-            resubscribe: shouldResubscribe(prevProps, this.props)
-          });
+        const resubscribe = !!shouldResubscribe && shouldResubscribe(prevProps, this.props);
+        if (this.state.resubscribe !== resubscribe) {
+          this.updateResubscribe(resubscribe);
         }
       }
 

--- a/src/react/hoc/subscription-hoc.tsx
+++ b/src/react/hoc/subscription-hoc.tsx
@@ -63,14 +63,15 @@ export function withSubscription<
         this.state = { resubscribe: false };
       }
 
-      updateResubscribe(value: boolean) {
-        this.setState({
-          resubscribe: value
-        });
+      updateResubscribe(resubscribe: boolean) {
+        this.setState({ resubscribe });
       }
 
       componentDidUpdate(prevProps: TProps) {
-        const resubscribe = !!shouldResubscribe && shouldResubscribe(prevProps, this.props);
+        const resubscribe = !!(
+          shouldResubscribe &&
+          shouldResubscribe(prevProps, this.props)
+        );
         if (this.state.resubscribe !== resubscribe) {
           this.updateResubscribe(resubscribe);
         }


### PR DESCRIPTION
Bug fix: rename `componentDidUpate` to `componentDidUpdate` in subscription-hoc.tsx
`shouldResubscribe` option does not work because of this.