### PR TITLE
Add onChange to reactiveVars

### DIFF
--- a/src/cache/inmemory/reactiveVars.ts
+++ b/src/cache/inmemory/reactiveVars.ts
@@ -78,11 +78,16 @@ export function makeVar<T>(value: T): ReactiveVar<T> {
       listeners.delete(listener);
     };
   };
-  rv.onChange = (listener) =>
-    rv.onNextChange((...args) => {
+  rv.onChange = (listener) => {
+    let removeListener;
+    const persistentListener = (...args) => {
       listener(...args);
-      rv.onChange(listener);
-    });
+      removeListener = rv.onNextChange(persistentListener);
+    };
+
+    removeListener = rv.onNextChange(persistentListener);
+    return () => removeListener();
+  };
 
   const attach = rv.attachCache = cache => {
     caches.add(cache);

--- a/src/cache/inmemory/reactiveVars.ts
+++ b/src/cache/inmemory/reactiveVars.ts
@@ -77,6 +77,11 @@ export function makeVar<T>(value: T): ReactiveVar<T> {
       listeners.delete(listener);
     };
   };
+  rv.onChange = (listener) =>
+    rv.onNextChange((...args) => {
+      listener(...args);
+      rv.onChange(listener);
+    });
 
   const attach = rv.attachCache = cache => {
     caches.add(cache);

--- a/src/cache/inmemory/reactiveVars.ts
+++ b/src/cache/inmemory/reactiveVars.ts
@@ -6,6 +6,7 @@ import { ApolloCache } from '../../core';
 export interface ReactiveVar<T> {
   (newValue?: T): T;
   onNextChange(listener: ReactiveListener<T>): () => void;
+  onChange(listener: ReactiveListener<T>): () => void;
   attachCache(cache: ApolloCache<any>): this;
   forgetCache(cache: ApolloCache<any>): boolean;
 }


### PR DESCRIPTION
`onNextChange` is very limiting for instance when you want to keep your reactive var in sync with Local Storage. `onChange` simplifies this with a persistent listener.

Demo of onNextChange only working once (by @cornedor): https://codesandbox.io/s/thirsty-pare-vc7r9?file=/src/App.js
Demo of onChange: https://codesandbox.io/s/elastic-wilbur-7se93?file=/src/App.js

In a future change I would also like to fix https://github.com/apollographql/apollo-client/blob/main/src/react/hooks/useReactiveVar.ts#L8 so that it doesn't add a new listener every re-render. Right now I reckon it will only ever remove the listener added in the last render (or maybe first), and leak all other listeners since `mute` is only set as clean up function on initial mount (useEffect like that is only triggered once when mounting, while code in hooks outside of useEffect may be called many many times). Using `onChange`, all of this could go into the useEffect. I kept this change out of this PR since personally all I care about is `onChange` and so I would prefer to have that merged first without delay.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [small change] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [it's not significant, nor do I see a reactiveVars test, nor one for onNextChange] Make sure all of the significant new logic is covered by tests
