### PR TITLE
Add an onChange event to reactiveVar

### DIFF
--- a/src/cache/inmemory/__tests__/reactiveVar.ts
+++ b/src/cache/inmemory/__tests__/reactiveVar.ts
@@ -1,0 +1,58 @@
+import { makeVar } from "../reactiveVars";
+
+describe("reactiveVar", () => {
+  it("should trigger onNextChange only once after a change", function () {
+    const rv = makeVar(1);
+    const spy = jest.fn();
+
+    rv.onNextChange(spy);
+
+    rv(2);
+    rv(3);
+
+    expect(rv()).toBe(3);
+    expect(spy).toBeCalledTimes(1);
+  });
+
+  it("should not trigger onNextChange if the listener is removed first", function () {
+    const rv = makeVar(1);
+    const spy = jest.fn();
+
+    const mute = rv.onNextChange(spy);
+    mute();
+
+    rv(2);
+
+    expect(rv()).toBe(2);
+    expect(spy).not.toBeCalled();
+  });
+
+  it("should trigger onChange for every change", function () {
+    const rv = makeVar(1);
+    const spy = jest.fn();
+
+    rv.onChange(spy);
+
+    rv(2);
+    rv(3);
+
+    expect(rv()).toBe(3);
+    expect(spy).toBeCalledTimes(2);
+  });
+
+  it("should trigger onChange for every change", function () {
+    const rv = makeVar(1);
+    const spy = jest.fn();
+    const onceSpy = jest.fn();
+
+    const mute = rv.onChange(spy);
+    rv.onNextChange(onceSpy);
+    mute();
+
+    rv(2);
+
+    expect(rv()).toBe(2);
+    expect(spy).not.toBeCalled();
+    expect(onceSpy).toBeCalledTimes(1);
+  });
+});


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

This is another shot at https://github.com/apollographql/apollo-client/pull/7508 by @MartijnHols

onNextChange is very limiting for instance when you want to keep your reactive var in sync with Local Storage. onChange simplifies this with a persistent listener.

Demo of onNextChange only working once: https://codesandbox.io/s/thirsty-pare-vc7r9?file=/src/App.js

This could also improve useReactiveVar, see https://github.com/apollographql/apollo-client/pull/7508#issue-544180105 how and why.

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
