### PR TITLE
Add arrow to mutation cache update example function

### DIFF
--- a/docs/source/data/mutations.mdx
+++ b/docs/source/data/mutations.mdx
@@ -183,7 +183,7 @@ const GET_TODOS = gql`
 function AddTodo() {
   let input;
   const [addTodo] = useMutation(ADD_TODO, {
-    update(cache, { data: { addTodo } }) {
+    update(cache, { data: { addTodo } }) => {
       cache.modify({
         fields: {
           todos(existingTodos = []) {


### PR DESCRIPTION
Add arrow to arrow function in mutations.mdx mutation cache update example
