### PR TITLE
More complete documentation for using Subscriptions in React

### DIFF
--- a/docs/source/data/subscriptions.mdx
+++ b/docs/source/data/subscriptions.mdx
@@ -106,19 +106,25 @@ Apollo Client should use your `WebSocketLink` for subscriptions, but it _shouldn
 The following example expands on the previous one by initializing both a `WebSocketLink` _and_ an `HttpLink`. It then uses the `split` function to combine those two `Link`s into a _single_ `Link` that uses one or the other according to the type of operation being executed.
 
 ```js
-import { split, HttpLink } from '@apollo/client';
-import { getMainDefinition } from '@apollo/client/utilities';
-import { WebSocketLink } from '@apollo/client/link/ws';
+import {
+  ApolloClient,
+  ApolloProvider,
+  split,
+  HttpLink,
+  InMemoryCache,
+} from "@apollo/client";
+import { getMainDefinition } from "@apollo/client/utilities";
+import { WebSocketLink } from "@apollo/client/link/ws";
 
 const httpLink = new HttpLink({
-  uri: 'http://localhost:3000/'
+  uri: "http://localhost:3000/",
 });
 
 const wsLink = new WebSocketLink({
-  uri: `ws://localhost:5000/`,
+  uri: `ws://localhost:3000/`, // websocket port can be different from httpLink
   options: {
-    reconnect: true
-  }
+    reconnect: true,
+  },
 });
 
 // The split function takes three parameters:
@@ -130,13 +136,25 @@ const splitLink = split(
   ({ query }) => {
     const definition = getMainDefinition(query);
     return (
-      definition.kind === 'OperationDefinition' &&
-      definition.operation === 'subscription'
+      definition.kind === "OperationDefinition" &&
+      definition.operation === "subscription"
     );
   },
   wsLink,
-  httpLink,
+  httpLink
 );
+
+// Now we can create a new client that will support subscriptions.
+const client = new ApolloClient({
+  splitLink,
+  cache: new InMemoryCache(),
+});
+
+
+// Implementing the provider is the same, passing your client with the split link
+function AppWithApolloProvider() {
+  return <ApolloProvider client={client}>...children</ApolloProvider>;
+}
 ```
 
 Using this logic, queries and mutations will use HTTP as normal, and subscriptions will use WebSocket.


### PR DESCRIPTION
It isn't obvious to newcomers that you can simply use *splitLink* as an argument to ApolloClient in place of a string. Adding a few extra lines of code to complete the example:

```
...
// create an ApolloClient using *splitLink*
const client = new ApolloClient({
  splitLink,
  cache: new InMemoryCache(),
});  
// Implementing the provider is the same, passing your client with the split link
function AppWithApolloProvider() {
  return <ApolloProvider client={client}>...children</ApolloProvider>;
}
```

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
