### PR TITLE
Update queries.mdx

### DIFF
--- a/docs/source/data/queries.mdx
+++ b/docs/source/data/queries.mdx
@@ -198,6 +198,8 @@ function DogPhoto({ breed }) {
 }
 ```
 
+Enabling this option will also ensure that the value of `loading` updates accordingly, even if you don't want to leverage the more fine-grained information provided by the `networkStatus` property.
+
 The `networkStatus` property is a `NetworkStatus` enum that represents different loading states. Refetch is represented by `NetworkStatus.refetch`, and there are also values for polling and pagination. For a full list of all the possible loading states, check out the [source](https://github.com/apollographql/apollo-client/blob/main/src/core/networkStatus.ts).
 
 > To view a complete version of the app we just built, check out the CodeSandbox [here](https://codesandbox.io/s/queries-example-app-final-nrlnl).


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests


Hi, I was reading through the `useQuery` docs [here](https://www.apollographql.com/docs/react/data/queries/#inspecting-loading-states) and thought it would be useful to explicitly say that the value of `loading` updates when you set the `notifyOnNetworkStatusChange` option to `true`. I didn't quite get that from the current wording so I thought this might be a useful addition for other people too.

Thanks.