### PR TITLE
doc: Fix Typo in Testing React components document(Shibe is Shiba)

### DIFF
--- a/docs/source/development-testing/testing.mdx
+++ b/docs/source/development-testing/testing.mdx
@@ -407,10 +407,10 @@ The following sample specifies `possibleTypes` and `typePolicies` in its cache c
 <ExpansionPanel title="Click to expand 🐶">
 
 ```jsx
-// "Dog" supertype can be of type "ShibeInu"
-const ShibeFragment = gql`
-  fragment ShibeInuFields on Dog {
-    ... on ShibeInu {
+// "Dog" supertype can be of type "ShibaInu"
+const ShibaFragment = gql`
+  fragment ShibaInuFields on Dog {
+    ... on ShibaInu {
       tail {
         isCurly
       }
@@ -425,17 +425,17 @@ export const GET_DOG_QUERY = gql`
       name
       breed
 
-      ...ShibeInuFields
+      ...ShibaInuFields
     }
   }
 
-  ${ShibeFragment}
+  ${ShibaFragment}
 `;
 
 export const cache = new ApolloClient({
   cache: new InMemoryCache({
     possibleTypes: {
-      Dog: ['ShibeInu']
+      Dog: ['ShibaInu']
     },
     // suppose you want you key fields for "Dog" to not be simply "id"
     typePolicies: {


### PR DESCRIPTION
Fixes a typo I found in the testing document. 

https://en.wikipedia.org/wiki/Shiba_Inu

Thank you Apollo team for the great work! 

### Checklist:

~~- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)~~
~~- [ ] Make sure all of the significant new logic is covered by tests~~

