### PR TITLE
Support subclassing Observable with non-class constructor functions.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11532,9 +11532,9 @@
       "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
     },
     "zen-observable-ts": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.0.0-beta.4.tgz",
-      "integrity": "sha512-EnhcCIPbNSsAboYr6p9bVMFQ6naMK9Io7Qo8knQ9fFoMYUKgH9FHl+1oZYVV7x9N73LG4qU+kYyCf2Cs9MHqbw==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.0.0-beta.5.tgz",
+      "integrity": "sha512-8EJmjjv0yIsPXta/jn0nFLWfHa0hOqO+6dMqqmHR+Lo5pcrjRFhhOe8sKvzHZDPhCh52R0GMN/4HlaM/ShMRoA==",
       "requires": {
         "@types/zen-observable": "^0.8.2",
         "zen-observable": "^0.8.15"

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "symbol-observable": "^2.0.0",
     "ts-invariant": "^0.6.0",
     "tslib": "^1.10.0",
-    "zen-observable-ts": "^1.0.0-beta.4"
+    "zen-observable-ts": "^1.0.0-beta.5"
   },
   "devDependencies": {
     "@babel/parser": "7.12.11",

--- a/src/utilities/observables/Observable.ts
+++ b/src/utilities/observables/Observable.ts
@@ -2,43 +2,18 @@ import {
   Observable,
   Observer,
   Subscription as ObservableSubscription,
+  Subscriber,
 } from 'zen-observable-ts';
 
 // This simplified polyfill attempts to follow the ECMAScript Observable
 // proposal (https://github.com/zenparsing/es-observable)
 import 'symbol-observable';
 
-export type Subscriber<T> = ZenObservable.Subscriber<T>;
 export type {
   Observer,
   ObservableSubscription,
+  Subscriber,
 };
-
-Observable.call = function<T>(
-  this: typeof Observable,
-  obs: Observable<T>,
-  sub: ZenObservable.Subscriber<T>,
-): Observable<T> {
-  return construct(this, obs, sub);
-};
-
-Observable.apply = function<T>(
-  this: typeof Observable,
-  obs: Observable<T>,
-  args: [ZenObservable.Subscriber<T>],
-): Observable<T> {
-  return construct(this, obs, args[0]);
-}
-
-function construct<T>(
-  Super: typeof Observable,
-  self: Observable<T>,
-  subscriber: ZenObservable.Subscriber<T>,
-): Observable<T> {
-  return typeof Reflect === 'object'
-    ? Reflect.construct(Super, [subscriber], self.constructor)
-    : Function.prototype.call.call(Super, self, subscriber);
-}
 
 // Use global module augmentation to add RxJS interop functionality. By
 // using this approach (instead of subclassing `Observable` and adding an

--- a/src/utilities/observables/Observable.ts
+++ b/src/utilities/observables/Observable.ts
@@ -8,10 +8,37 @@ import {
 // proposal (https://github.com/zenparsing/es-observable)
 import 'symbol-observable';
 
+export type Subscriber<T> = ZenObservable.Subscriber<T>;
 export type {
   Observer,
   ObservableSubscription,
 };
+
+Observable.call = function<T>(
+  this: typeof Observable,
+  obs: Observable<T>,
+  sub: ZenObservable.Subscriber<T>,
+): Observable<T> {
+  return construct(this, obs, sub);
+};
+
+Observable.apply = function<T>(
+  this: typeof Observable,
+  obs: Observable<T>,
+  args: [ZenObservable.Subscriber<T>],
+): Observable<T> {
+  return construct(this, obs, args[0]);
+}
+
+function construct<T>(
+  Super: typeof Observable,
+  self: Observable<T>,
+  subscriber: ZenObservable.Subscriber<T>,
+): Observable<T> {
+  return typeof Reflect === 'object'
+    ? Reflect.construct(Super, [subscriber], self.constructor)
+    : Function.prototype.call.call(Super, self, subscriber);
+}
 
 // Use global module augmentation to add RxJS interop functionality. By
 // using this approach (instead of subclassing `Observable` and adding an

--- a/src/utilities/observables/__tests__/Observable.ts
+++ b/src/utilities/observables/__tests__/Observable.ts
@@ -41,7 +41,7 @@ describe('Observable', () => {
 
     it('simulating super(sub) with Observable.call(this, sub)', () => {
       function SubclassWithSuperCall<T>(sub: Subscriber<T>) {
-        const self = Observable.call(this, sub);
+        const self = Observable.call(this, sub) || this;
         self.sub = sub;
         return self;
       }
@@ -50,7 +50,7 @@ describe('Observable', () => {
 
     it('simulating super(sub) with Observable.apply(this, arguments)', () => {
       function SubclassWithSuperApplyArgs<T>(_sub: Subscriber<T>) {
-        const self = Observable.apply(this, arguments);
+        const self = Observable.apply(this, arguments) || this;
         self.sub = _sub;
         return self;
       }
@@ -59,7 +59,7 @@ describe('Observable', () => {
 
     it('simulating super(sub) with Observable.apply(this, [sub])', () => {
       function SubclassWithSuperApplyArray<T>(...args: [Subscriber<T>]) {
-        const self = Observable.apply(this, args);
+        const self = Observable.apply(this, args) || this;
         self.sub = args[0];
         return self;
       }

--- a/src/utilities/observables/__tests__/Observable.ts
+++ b/src/utilities/observables/__tests__/Observable.ts
@@ -1,0 +1,69 @@
+import { Observable, Subscriber } from '../Observable';
+
+describe('Observable', () => {
+  describe('subclassing by non-class constructor functions', () => {
+    function check(constructor: new <T>(sub: Subscriber<T>) => Observable<T>) {
+      constructor.prototype = Object.create(Observable.prototype, {
+        constructor: {
+          value: constructor,
+        },
+      });
+
+      const subscriber: Subscriber<number> = observer => {
+        observer.next(123);
+        observer.complete();
+      };
+
+      const obs = new constructor(subscriber) as Observable<number>;
+
+      expect(typeof (obs as any).sub).toBe("function");
+      expect((obs as any).sub).toBe(subscriber);
+
+      expect(obs).toBeInstanceOf(Observable);
+      expect(obs).toBeInstanceOf(constructor);
+      expect(obs.constructor).toBe(constructor);
+
+      return new Promise((resolve, reject) => {
+        obs.subscribe({
+          next: resolve,
+          error: reject,
+        });
+      }).then(value => {
+        expect(value).toBe(123);
+      });
+    }
+
+    function newify(
+      constructor: <T>(sub: Subscriber<T>) => void,
+    ): new <T>(sub: Subscriber<T>) => Observable<T> {
+      return constructor as any;
+    }
+
+    it('simulating super(sub) with Observable.call(this, sub)', () => {
+      function SubclassWithSuperCall<T>(sub: Subscriber<T>) {
+        const self = Observable.call(this, sub);
+        self.sub = sub;
+        return self;
+      }
+      return check(newify(SubclassWithSuperCall));
+    });
+
+    it('simulating super(sub) with Observable.apply(this, arguments)', () => {
+      function SubclassWithSuperApplyArgs<T>(_sub: Subscriber<T>) {
+        const self = Observable.apply(this, arguments);
+        self.sub = _sub;
+        return self;
+      }
+      return check(newify(SubclassWithSuperApplyArgs));
+    });
+
+    it('simulating super(sub) with Observable.apply(this, [sub])', () => {
+      function SubclassWithSuperApplyArray<T>(...args: [Subscriber<T>]) {
+        const self = Observable.apply(this, args);
+        self.sub = args[0];
+        return self;
+      }
+      return check(newify(SubclassWithSuperApplyArray));
+    });
+  });
+});


### PR DESCRIPTION
Now that the `zen-observable-ts` package has the ability to export `Observable` as a native ECMAScript `class` (#7615), we need to be careful when extending `Observable` using classes (like `ObservableQuery` and `Concast`) that have been compiled to ES5 constructor functions (rather than native classes), because the generated `_super.call(this, subscriber)` code throws when `_super` is a native class constructor (#7635).

Rather than attempting to change the way the TypeScript compiler transforms `super(subscriber)` calls, this commit wraps `Observable.call` and `Observable.apply` to work as expected, using `Reflect.construct` to invoke the superclass constructor correctly, when the [`Reflect`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect/construct) API is available.

Another option would be to ship native `class` and `super` syntax with `@apollo/client`, by changing the "target" in `tsconfig.json` from "es5" to "es2015" or later, so consumers of `@apollo/client` code would be forced to compile native
`class` syntax however they see fit. That would be a more disruptive change, in part because it would prevent subclassing Apollo Client-exported classes using anything other than native `class` syntax and/or the `Reflect.construct` API, which is the very same problem this commit is trying to fix for the `Observable` class.