### PR TITLE
fix: export more from /cache

### DIFF
--- a/src/__tests__/__snapshots__/exports.ts.snap
+++ b/src/__tests__/__snapshots__/exports.ts.snap
@@ -63,10 +63,13 @@ exports[`exports of public entry points @apollo/client/cache 1`] = `
 Array [
   "ApolloCache",
   "Cache",
+  "EntityStore",
   "InMemoryCache",
   "MissingFieldError",
+  "Policies",
   "cacheSlot",
   "defaultDataIdFromObject",
+  "fieldNameFromStoreName",
   "isReference",
   "makeReference",
   "makeVar",

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -1,13 +1,19 @@
 export { Transaction, ApolloCache } from './core/cache';
 export { Cache } from './core/types/Cache';
 export { DataProxy } from './core/types/DataProxy';
-export { MissingFieldError } from './core/types/common';
+export {
+  MissingFieldError,
+  ReadFieldOptions
+} from './core/types/common';
 
 export {
   Reference,
   isReference,
   makeReference,
 } from '../utilities';
+
+export { EntityStore } from './inmemory/entityStore';
+export { fieldNameFromStoreName } from './inmemory/helpers'
 
 export {
   InMemoryCache,
@@ -29,6 +35,7 @@ export {
   FieldMergeFunction,
   FieldFunctionOptions,
   PossibleTypesMap,
+  Policies,
 } from './inmemory/policies';
 
 export * from './inmemory/types';


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->
### References
https://github.com/apollographql/apollo-client/issues/7639

## Background
Libraries that build on top of Apollo Client's cache may want access to advanced utilities and methods within the Apollo Client codebase, but cannot do so today without failing to run in a node environment due to the lack of transpilation to cjs.

## This PR
Adds a few more entities to the export list of the `@apollo/client/cache` to ensure that these entities are accessible from a cjs context.