### PR TITLE
Reactivate reactive variables when InMemoryCache acquires first watcher.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Catch updates in `useReactiveVar` with an additional check. <br/>
   [@jcreighton](https://github.com/jcreighton) in [#7652](https://github.com/apollographql/apollo-client/pull/7652)
 
+- Reactivate forgotten reactive variables whenever `InMemoryCache` acquires its first watcher. <br/>
+  [@benjamn](https://github.com/benjamn) in [#7657](https://github.com/apollographql/apollo-client/pull/7657)
+
 ## Apollo Client 3.3.7
 
 ### Bug Fixes


### PR DESCRIPTION
Fixes a bug introduced by #7279, which was triggered by calling `this.cancel()` before re-`watch`ing in the [`QueryInfo#updateWatch`](https://github.com/apollographql/apollo-client/blob/541d333c524c0d1384e1d51c81d1c5cf668ac2e8/src/core/QueryInfo.ts#L257-L258) method, causing `cache.watches.size` to drop to zero temporarily, thereby invoking `forgetCache(cache)`. When this happened, reactive variables would stop broadcasting updates to the forgotten cache, even though the unwatching was only momentary, and would not begin broadcasting again until the association was reestablished by other means.

This new implementation uses a `WeakMap` to remember associations between caches and sets of reactive variables, which makes it possible to recall those associations later, provided the cache has not been garbage collected in the meantime.

Should fix #7593 and #7630, though #7622 remains a concern.