### PR TITLE
Backport v3.4 Symbol.species fix for Concast and ObservableQuery.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Reactivate forgotten reactive variables whenever `InMemoryCache` acquires its first watcher. <br/>
   [@benjamn](https://github.com/benjamn) in [#7657](https://github.com/apollographql/apollo-client/pull/7657)
 
+- Backport `Symbol.species` fix for `Concast` and `ObservableQuery` from [`release-3.4`](https://github.com/apollographql/apollo-client/pull/7399), fixing subscriptions in React Native Android when the Hermes JavaScript engine is enabled (among other benefits). <br/>
+  [@benjamn](https://github.com/benjamn) in [#7403](https://github.com/apollographql/apollo-client/pull/7403) and [#7660](https://github.com/apollographql/apollo-client/pull/7660)
+
 ## Apollo Client 3.3.7
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     {
       "name": "apollo-client",
       "path": "./dist/apollo-client.cjs.min.js",
-      "maxSize": "25.5 kB"
+      "maxSize": "25.6 kB"
     }
   ],
   "peerDependencies": {

--- a/src/__tests__/__snapshots__/exports.ts.snap
+++ b/src/__tests__/__snapshots__/exports.ts.snap
@@ -326,6 +326,7 @@ Array [
   "compact",
   "concatPagination",
   "createFragmentMap",
+  "fixObservableSubclass",
   "getDefaultValues",
   "getDirectiveNames",
   "getFragmentDefinition",

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -10,6 +10,7 @@ import {
   ObservableSubscription,
   iterateObserversSafely,
   isNonEmptyArray,
+  fixObservableSubclass,
 } from '../utilities';
 import { ApolloError } from '../errors';
 import { QueryManager } from './QueryManager';
@@ -648,6 +649,10 @@ once, rather than every time you call fetchMore.`);
     this.isTornDown = true;
   }
 }
+
+// Necessary because the ObservableQuery constructor has a different
+// signature than the Observable constructor.
+fixObservableSubclass(ObservableQuery);
 
 function defaultSubscriptionObserverErrorCallback(error: ApolloError) {
   invariant.error('Unhandled error', error.message, error.stack);

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -81,6 +81,7 @@ export * from './common/maybeDeepFreeze';
 export * from './observables/iteration';
 export * from './observables/asyncMap';
 export * from './observables/Concast';
+export * from './observables/subclassing';
 export * from './common/arrays';
 export * from './common/errorHandling';
 export * from './common/canUse';

--- a/src/utilities/observables/Concast.ts
+++ b/src/utilities/observables/Concast.ts
@@ -243,11 +243,19 @@ export class Concast<T> extends Observable<T> {
 // Those methods assume (perhaps unwisely?) that they can call the
 // subtype's constructor with an observer registration function, but the
 // Concast constructor uses a different signature. Defining this
-// Symbol.species getter function on the Concast constructor function is
-// a hint to generic Observable code to use the default constructor
-// instead of trying to do `new Concast(observer => ...)`.
-if (typeof Symbol === "function" && Symbol.species) {
-  Object.defineProperty(Concast, Symbol.species, {
-    value: Observable,
-  });
+// Symbol.species property on the Concast constructor function is a hint
+// to generic Observable code to use the default constructor instead of
+// trying to do `new Concast(observer => ...)`.
+function setSpecies(key: symbol | string) {
+  // Object.defineProperty is necessary because Concast[Symbol.species]
+  // is a getter by default in modern JS environments, so we can't
+  // assign to it with a normal assignment expression.
+  Object.defineProperty(Concast, key, { value: Observable });
 }
+if (typeof Symbol === "function" && Symbol.species) {
+  setSpecies(Symbol.species);
+}
+// The "@@species" string is used as a fake Symbol.species value in some
+// polyfill systems (including the SymbolSpecies variable used by
+// zen-observable), so we should set it as well, to be safe.
+setSpecies("@@species");

--- a/src/utilities/observables/Concast.ts
+++ b/src/utilities/observables/Concast.ts
@@ -143,7 +143,7 @@ export class Concast<T> extends Observable<T> {
   // Any Concast object can be trivially converted to a Promise, without
   // having to create a new wrapper Observable. This promise provides an
   // easy way to observe the final state of the Concast.
-  private resolve: (result?: T) => void;
+  private resolve: (result?: T | PromiseLike<T>) => void;
   private reject: (reason: any) => void;
   public readonly promise = new Promise<T>((resolve, reject) => {
     this.resolve = resolve;

--- a/src/utilities/observables/Observable.ts
+++ b/src/utilities/observables/Observable.ts
@@ -6,6 +6,7 @@ import 'symbol-observable';
 
 export type ObservableSubscription = ZenObservable.Subscription;
 export type Observer<T> = ZenObservable.Observer<T>;
+export type Subscriber<T> = ZenObservable.Subscriber<T>;
 
 // Use global module augmentation to add RxJS interop functionality. By
 // using this approach (instead of subclassing `Observable` and adding an

--- a/src/utilities/observables/__tests__/subclassing.ts
+++ b/src/utilities/observables/__tests__/subclassing.ts
@@ -1,0 +1,31 @@
+import { Observable } from "../Observable";
+import { Concast } from "../Concast";
+
+describe("Observable subclassing", () => {
+  it("Symbol.species is defined for Concast subclass", () => {
+    const concast = new Concast([
+      Observable.of(1, 2, 3),
+      Observable.of(4, 5),
+    ]);
+    expect(concast).toBeInstanceOf(Concast);
+
+    const mapped = concast.map(n => n * 2);
+    expect(mapped).toBeInstanceOf(Observable);
+    expect(mapped).not.toBeInstanceOf(Concast);
+
+    return new Promise<number[]>((resolve, reject) => {
+      const doubles: number[] = [];
+      mapped.subscribe({
+        next(n) {
+          doubles.push(n);
+        },
+        error: reject,
+        complete() {
+          resolve(doubles);
+        }
+      });
+    }).then(doubles => {
+      expect(doubles).toEqual([2, 4, 6, 8, 10]);
+    });
+  });
+});

--- a/src/utilities/observables/__tests__/subclassing.ts
+++ b/src/utilities/observables/__tests__/subclassing.ts
@@ -1,6 +1,21 @@
 import { Observable } from "../Observable";
 import { Concast } from "../Concast";
 
+function toArrayPromise<T>(observable: Observable<T>): Promise<T[]> {
+  return new Promise<T[]>((resolve, reject) => {
+    const values: T[] = [];
+    observable.subscribe({
+      next(value) {
+        values.push(value);
+      },
+      error: reject,
+      complete() {
+        resolve(values);
+      },
+    });
+  });
+}
+
 describe("Observable subclassing", () => {
   it("Symbol.species is defined for Concast subclass", () => {
     const concast = new Concast([
@@ -13,19 +28,18 @@ describe("Observable subclassing", () => {
     expect(mapped).toBeInstanceOf(Observable);
     expect(mapped).not.toBeInstanceOf(Concast);
 
-    return new Promise<number[]>((resolve, reject) => {
-      const doubles: number[] = [];
-      mapped.subscribe({
-        next(n) {
-          doubles.push(n);
-        },
-        error: reject,
-        complete() {
-          resolve(doubles);
-        }
-      });
-    }).then(doubles => {
+    return toArrayPromise(mapped).then(doubles => {
       expect(doubles).toEqual([2, 4, 6, 8, 10]);
+    });
+  });
+
+  it("Inherited Concast.of static method returns a Concast", () => {
+    const concast = Concast.of("asdf", "qwer", "zxcv");
+    expect(concast).toBeInstanceOf(Observable);
+    expect(concast).toBeInstanceOf(Concast);
+
+    return toArrayPromise(concast).then(values => {
+      expect(values).toEqual(["asdf", "qwer", "zxcv"]);
     });
   });
 });

--- a/src/utilities/observables/subclassing.ts
+++ b/src/utilities/observables/subclassing.ts
@@ -1,0 +1,28 @@
+import { Observable } from "./Observable";
+
+// Generic implementations of Observable.prototype methods like map and
+// filter need to know how to create a new Observable from an Observable
+// subclass (like Concast or ObservableQuery). Those methods assume
+// (perhaps unwisely?) that they can call the subtype's constructor with a
+// Subscriber function, even though the subclass constructor might expect
+// different parameters. Defining this static Symbol.species property on
+// the subclass is a hint to generic Observable code to use the default
+// constructor instead of trying to do `new Subclass(observer => ...)`.
+export function fixObservableSubclass<
+  S extends new (...args: any[]) => Observable<any>,
+>(subclass: S): S {
+  function set(key: symbol | string) {
+    // Object.defineProperty is necessary because the Symbol.species
+    // property is a getter by default in modern JS environments, so we
+    // can't assign to it with a normal assignment expression.
+    Object.defineProperty(subclass, key, { value: Observable });
+  }
+  if (typeof Symbol === "function" && Symbol.species) {
+    set(Symbol.species);
+  }
+  // The "@@species" string is used as a fake Symbol.species value in some
+  // polyfill systems (including the SymbolSpecies variable used by
+  // zen-observable), so we should set it as well, to be safe.
+  set("@@species");
+  return subclass;
+}


### PR DESCRIPTION
I landed #7403 on the `release-3.4` branch instead of `main` because I wasn't sure at the time if it would help fix the problem I described in https://github.com/apollographql/apollo-client/issues/6520#issuecomment-736899757. Since then, multiple folks have commented that it did help, so I think it makes sense to backport this change to `main` (3.3.x).

While I was at it, I applied the same logic to `ObservableQuery` (the other `Observable` subclass that Apollo Client uses), and added some regression tests of the `Symbol.species` logic for both `Concast` and `ObservableQuery`.