### PR TITLE
docs: Move fragment template variable up in query

### DIFF
--- a/docs/source/data/fragments.md
+++ b/docs/source/data/fragments.md
@@ -71,15 +71,16 @@ To embed a fragment inside a GraphQL operation, prefix its name with three perio
 
 ```js
 const SUBMIT_COMMENT_MUTATION = gql`
+  ${CommentsPage.fragments.comment}
   mutation SubmitComment($postFullName: String!, $commentContent: String!) {
     submitComment(postFullName: $postFullName, commentContent: $commentContent) {
       ...CommentsPageComment // highlight-line
     }
-  }
-  ${CommentsPage.fragments.comment}
+  } 
 `;
 
 export const COMMENT_QUERY = gql`
+  ${CommentsPage.fragments.comment}
   query Comment($postName: String!) {
     entry(postFullName: $postName) {
       comments {
@@ -87,7 +88,6 @@ export const COMMENT_QUERY = gql`
       }
     }
   }
-  ${CommentsPage.fragments.comment}
 `;
 ```
 
@@ -129,6 +129,8 @@ After you define a fragment in a child component, the parent component can refer
 ```js
 FeedEntry.fragments = {
   entry: gql`
+    ${VoteButtons.fragments.entry}
+    ${RepoInfo.fragments.entry}
     fragment FeedEntryFragment on FeedEntry {
       commentCount
       repository {
@@ -140,9 +142,7 @@ FeedEntry.fragments = {
       }
       ...VoteButtonsFragment
       ...RepoInfoFragment
-    }
-    ${VoteButtons.fragments.entry}
-    ${RepoInfo.fragments.entry}
+    } 
   `,
 };
 ```


### PR DESCRIPTION
I moved the include of the Fragments with `${var}` up in the first line of the queries. For me the Queries are broken when I use them with SSR in Next getServerSidePros. Moving the vars at the top, works for me.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
