### PR TITLE
Revert #7276, but test garbage collection of ObservableQuery.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Apollo Client 3.3.10 (not yet released)
 
+### Bug fixes
+
+- Revert PR [#7276](https://github.com/apollographql/apollo-client/pull/7276), but test that garbage collection reclaims torn-down `ObservableQuery` objects. <br/>
+  [@benjamn](https://github.com/benjamn) in [#7695](https://github.com/apollographql/apollo-client/pull/7695)
+
 ### Improvements
 
 - Avoid calling `forceUpdate` when component is unmounted. <br/>

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -633,11 +633,6 @@ once, rather than every time you call fetchMore.`);
       delete this.reobserver;
     }
 
-    // Since the user-provided context object can retain arbitrarily large
-    // amounts of memory, we delete it when the ObservableQuery is torn
-    // down, to avoid the possibility of memory leaks.
-    delete this.options.context;
-
     // stop all active GraphQL subscriptions
     this.subscriptions.forEach(sub => sub.unsubscribe());
     this.subscriptions.clear();


### PR DESCRIPTION
The deletion of `observableQuery.options.context` introduced by #7276 was a blunt solution to a hypothetical problem, so I agree with @francisu that it should be reverted if/when it causes anyone any problems: https://github.com/apollographql/apollo-client/pull/7276#issuecomment-776144217

Thanks to #7661, we now have a system for programmatically testing garbage collection of discarded objects, so we can actually enforce the expectation that the whole `ObservableQuery` is garbage collected after the last subscriber is removed (which tears down the `ObservableQuery` and removes it from the `QueryManager`).