### PR TITLE
Prefer `import * as` for imports whose types are re-exported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ TBD
 - Allow `merge: true` field policy to merge `Reference` objects with non-normalized objects, and vice-versa. <br/>
   [@benjamn](https://github.com/benjamn) in [#7778](https://github.com/apollographql/apollo-client/pull/7778)
 
+- Prefer `import * as namepace ...` for imports whose types are re-exported (and thus may appear in `.d.ts` files). <br/>
+  [@devrelm](https://github.com/devrelm) in [#7742](https://github.com/apollographql/apollo-client/pull/7742)
+
 ### Documentation
 TBD
 

--- a/src/link/persisted-queries/__tests__/react.tsx
+++ b/src/link/persisted-queries/__tests__/react.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import ReactDOM from 'react-dom/server';
+import * as React from 'react';
+import * as ReactDOM from 'react-dom/server';
 import gql from 'graphql-tag';
 import { print } from 'graphql';
 import { sha256 } from 'crypto-hash';

--- a/src/react/components/Mutation.tsx
+++ b/src/react/components/Mutation.tsx
@@ -1,4 +1,4 @@
-import PropTypes from 'prop-types';
+import * as PropTypes from 'prop-types';
 
 import { OperationVariables } from '../../core';
 import { MutationComponentOptions } from './types';

--- a/src/react/components/Query.tsx
+++ b/src/react/components/Query.tsx
@@ -1,4 +1,4 @@
-import PropTypes from 'prop-types';
+import * as PropTypes from 'prop-types';
 
 import { OperationVariables } from '../../core';
 import { QueryComponentOptions } from './types';

--- a/src/react/components/Subscription.tsx
+++ b/src/react/components/Subscription.tsx
@@ -1,4 +1,4 @@
-import PropTypes from 'prop-types';
+import * as PropTypes from 'prop-types';
 
 import { OperationVariables } from '../../core';
 import { SubscriptionComponentOptions } from './types';

--- a/src/react/context/ApolloConsumer.tsx
+++ b/src/react/context/ApolloConsumer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { invariant } from 'ts-invariant';
 
 import { ApolloClient } from '../../core';

--- a/src/react/context/ApolloContext.ts
+++ b/src/react/context/ApolloContext.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { ApolloClient } from '../../core';
 import { canUseWeakMap } from '../../utilities';
 

--- a/src/react/context/ApolloProvider.tsx
+++ b/src/react/context/ApolloProvider.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { invariant } from 'ts-invariant';
 
 import { ApolloClient } from '../../core';

--- a/src/react/hoc/hoc-utils.tsx
+++ b/src/react/hoc/hoc-utils.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { invariant } from 'ts-invariant';
 import { OperationVariables } from '../../core';
 import { IDocumentDefinition } from '../parser';

--- a/src/react/hoc/mutation-hoc.tsx
+++ b/src/react/hoc/mutation-hoc.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { DocumentNode } from 'graphql';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 

--- a/src/react/hoc/query-hoc.tsx
+++ b/src/react/hoc/query-hoc.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { DocumentNode } from 'graphql';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 

--- a/src/react/hoc/subscription-hoc.tsx
+++ b/src/react/hoc/subscription-hoc.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { DocumentNode } from 'graphql';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 

--- a/src/react/hoc/withApollo.tsx
+++ b/src/react/hoc/withApollo.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import { invariant } from 'ts-invariant';
 

--- a/src/react/hooks/useApolloClient.ts
+++ b/src/react/hooks/useApolloClient.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { invariant } from 'ts-invariant';
 
 import { ApolloClient } from '../../core';

--- a/src/react/ssr/getDataFromTree.ts
+++ b/src/react/ssr/getDataFromTree.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { getApolloContext } from '../context';
 import { RenderPromises } from './RenderPromises';
 

--- a/src/utilities/testing/mocking/MockedProvider.tsx
+++ b/src/utilities/testing/mocking/MockedProvider.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import { ApolloClient, DefaultOptions } from '../../../core';
 import { InMemoryCache as Cache } from '../../../cache';


### PR DESCRIPTION
Fixes #7741

Using `import React from 'react'` causes issues when the import makes
its way into the d.ts file. Users without `esModuleInterop: true` or
`allowSyntheticDefaultImports: true` (or `skipLibCheck: true`) in
their tsconfig files will get errors from typescript about not being
able to default-import using that syntax.

This PR fixes the specific imports that would cause issues due to
their types being re-exported in `@apollo/client`'s types.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] N/A ~If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)~
- [ ] N/A ~Make sure all of the significant new logic is covered by tests~
