### PR TITLE
Do not forceUpdate if consuming component is not mounted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@
 - Fix polling when used with `React.StrictMode`, <br/>
   [@brainkim](https://github.com/brainkim) in [#8414](https://github.com/apollographql/apollo-client/pull/8414)
 
+- Fix the React integration logging `Warning: Can't perform a React state update on an unmounted component`. <br/> [@wuarmin](https://github.com/wuarmin) in [#7745](https://github.com/apollographql/apollo-client/pull/7745)
+
 ### Potentially disruptive changes
 
 - To avoid retaining sensitive information from mutation root field arguments, Apollo Client v3.4 automatically clears any `ROOT_MUTATION` fields from the cache after each mutation finishes. If you need this information to remain in the cache, you can prevent the removal by passing the `keepRootFields: true` option to `client.mutate`. `ROOT_MUTATION` result data are also passed to the mutation `update` function, so we recommend obtaining the results that way, rather than using `keepRootFields: true`, if possible. <br/>

--- a/src/react/hooks/utils/useBaseQuery.ts
+++ b/src/react/hooks/utils/useBaseQuery.ts
@@ -34,8 +34,8 @@ export function useBaseQuery<TData = any, TVariables = OperationVariables>(
           // force that re-render if we're already rendering however so to be
           // safe we'll trigger the re-render in a microtask. In case the
           // component gets unmounted before this callback fires, we re-check
-          // queryDataRef.current before calling forceUpdate().
-          Promise.resolve().then(() => queryDataRef.current && forceUpdate());
+          // queryDataRef.current.isMounted before calling forceUpdate().
+          Promise.resolve().then(() => queryDataRef.current && queryDataRef.current.isMounted && forceUpdate());
         } else {
           // If we're rendering on the server side we can force an update at
           // any point.


### PR DESCRIPTION
This change would fix the occurrence of the warning "Can't perform a React state update on an unmounted component" using `useQuery` in React.StrictMode.

#6209

best regards


