### PR TITLE
Preserve no-cache fetchPolicy with notifyOnNetworkStatusChange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Maintain serial ordering of `asyncMap` mapping function calls, and prevent potential unhandled `Promise` rejection errors. <br/>
   [@benjamn](https://github.com/benjamn) in [#7818](https://github.com/apollographql/apollo-client/pull/7818)
 
+- Preserve fetch policy even when `notifyOnNetworkStatusChange` is set <br />
+  [@jcreighton](https://github.com/jcreighton) in [#7761](https://github.com/apollographql/apollo-client/pull/7761)
 ## Apollo Client 3.3.11
 
 ### Bug fixes

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -914,7 +914,6 @@ export class QueryManager<TStore> {
     const query = this.transform(options.query).document;
     const variables = this.getVariables(query, options.variables) as TVars;
     const queryInfo = this.getQuery(queryId);
-    // const oldNetworkStatus = queryInfo.networkStatus;
 
     let {
       fetchPolicy = "cache-first" as WatchQueryFetchPolicy,

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -914,7 +914,7 @@ export class QueryManager<TStore> {
     const query = this.transform(options.query).document;
     const variables = this.getVariables(query, options.variables) as TVars;
     const queryInfo = this.getQuery(queryId);
-    const oldNetworkStatus = queryInfo.networkStatus;
+    // const oldNetworkStatus = queryInfo.networkStatus;
 
     let {
       fetchPolicy = "cache-first" as WatchQueryFetchPolicy,
@@ -923,26 +923,6 @@ export class QueryManager<TStore> {
       notifyOnNetworkStatusChange = false,
       context = {},
     } = options;
-
-    const mightUseNetwork =
-      fetchPolicy === "cache-first" ||
-      fetchPolicy === "cache-and-network" ||
-      fetchPolicy === "network-only" ||
-      fetchPolicy === "no-cache";
-
-    if (mightUseNetwork &&
-        notifyOnNetworkStatusChange &&
-        typeof oldNetworkStatus === "number" &&
-        oldNetworkStatus !== networkStatus &&
-        isNetworkRequestInFlight(networkStatus)) {
-      // In order to force delivery of an incomplete cache result with
-      // loading:true, we tweak the fetchPolicy to include the cache, and
-      // pretend that returnPartialData was enabled.
-      if (fetchPolicy !== "cache-first") {
-        fetchPolicy = "cache-and-network";
-      }
-      returnPartialData = true;
-    }
 
     const normalized = Object.assign({}, options, {
       query,
@@ -1038,7 +1018,10 @@ export class QueryManager<TStore> {
       errorPolicy,
       returnPartialData,
       context,
+      notifyOnNetworkStatusChange,
     } = options;
+
+    const oldNetworkStatus = queryInfo.networkStatus;
 
     queryInfo.init({
       document: query,
@@ -1092,6 +1075,13 @@ export class QueryManager<TStore> {
         errorPolicy,
       });
 
+    const shouldNotifyOnNetworkStatusChange = () => (
+      notifyOnNetworkStatusChange &&
+      typeof oldNetworkStatus === "number" &&
+      oldNetworkStatus !== networkStatus &&
+      isNetworkRequestInFlight(networkStatus)
+    );
+
     switch (fetchPolicy) {
     default: case "cache-first": {
       const diff = readCache();
@@ -1109,6 +1099,13 @@ export class QueryManager<TStore> {
         ];
       }
 
+      if (shouldNotifyOnNetworkStatusChange()) {
+        return [
+          resultsFromCache(diff),
+          resultsFromLink(true),
+        ];
+      }
+
       return [
         resultsFromLink(true),
       ];
@@ -1117,7 +1114,7 @@ export class QueryManager<TStore> {
     case "cache-and-network": {
       const diff = readCache();
 
-      if (diff.complete || returnPartialData) {
+      if (diff.complete || returnPartialData || shouldNotifyOnNetworkStatusChange()) {
         return [
           resultsFromCache(diff),
           resultsFromLink(true),
@@ -1135,9 +1132,22 @@ export class QueryManager<TStore> {
       ];
 
     case "network-only":
+      if (shouldNotifyOnNetworkStatusChange()) {
+        const diff = readCache();
+
+        return [
+          resultsFromCache(diff),
+          resultsFromLink(true),
+        ];
+      }
+
       return [resultsFromLink(true)];
 
     case "no-cache":
+      if (shouldNotifyOnNetworkStatusChange()) {
+          return [resultsFromCache(queryInfo.getDiff()), resultsFromLink(false)];
+      }
+
       return [resultsFromLink(false)];
 
     case "standby":

--- a/src/core/__tests__/fetchPolicies.ts
+++ b/src/core/__tests__/fetchPolicies.ts
@@ -380,6 +380,106 @@ describe('no-cache', () => {
         }))
         .then(resolve, reject);
     });
+
+    itAsync('gives appropriate networkStatus for watched queries', (resolve, reject) => {
+      const client = new ApolloClient({
+        link: ApolloLink.empty(),
+        cache: new InMemoryCache(),
+        resolvers: {
+          Query: {
+            hero(_data, args) {
+              return {
+                __typename: 'Hero',
+                ...args,
+                name: 'Luke Skywalker',
+              };
+            },
+          },
+        },
+      });
+
+      const observable = client.watchQuery({
+        query: gql`
+          query FetchLuke($id: String) {
+            hero(id: $id) @client {
+              id
+              name
+            }
+          }
+        `,
+        fetchPolicy: 'no-cache',
+        variables: { id: '1' },
+        notifyOnNetworkStatusChange: true,
+      });
+
+      function dataWithId(id: number | string) {
+        return {
+          hero: {
+            __typename: 'Hero',
+            id: String(id),
+            name: 'Luke Skywalker',
+          },
+        };
+      }
+
+      subscribeAndCount(reject, observable, (count, result) => {
+        if (count === 1) {
+          expect(result).toEqual({
+            data: dataWithId(1),
+            loading: false,
+            networkStatus: NetworkStatus.ready,
+          });
+          expect(client.cache.extract(true)).toEqual({});
+          return observable.setVariables({ id: '2' });
+        } else if (count === 2) {
+          expect(result).toEqual({
+            data: {},
+            loading: true,
+            networkStatus: NetworkStatus.setVariables,
+            partial: true,
+          });
+        } else if (count === 3) {
+          expect(result).toEqual({
+            data: dataWithId(2),
+            loading: false,
+            networkStatus: NetworkStatus.ready,
+          });
+          expect(client.cache.extract(true)).toEqual({});
+          return observable.refetch();
+        } else if (count === 4) {
+          expect(result).toEqual({
+            data: dataWithId(2),
+            loading: true,
+            networkStatus: NetworkStatus.refetch,
+          });
+          expect(client.cache.extract(true)).toEqual({});
+        } else if (count === 5) {
+          expect(result).toEqual({
+            data: dataWithId(2),
+            loading: false,
+            networkStatus: NetworkStatus.ready,
+          });
+          expect(client.cache.extract(true)).toEqual({});
+          return observable.refetch({ id: '3' });
+        } else if (count === 6) {
+          expect(result).toEqual({
+            data: {},
+            loading: true,
+            networkStatus: NetworkStatus.setVariables,
+            partial: true,
+          });
+          expect(client.cache.extract(true)).toEqual({});
+        } else if (count === 7) {
+          expect(result).toEqual({
+            data: dataWithId(3),
+            loading: false,
+            networkStatus: NetworkStatus.ready,
+          });
+          expect(client.cache.extract(true)).toEqual({});
+          resolve();
+        }
+      });
+    });
   });
 });
 


### PR DESCRIPTION
Fixes #7611 & #6998. While we want to force delivery for an incomplete cache result with `loading: true`, we should preserve the `no-cache` fetchPolicy. ~~An additional check has been added to avoid resetting the fetch policy to "cache-and-network" when it's set to "no-cache".~~ Thanks to @benjamn's feedback below, the "`notifyOnNetworkStatusChange` changes the fetch policy" trickery has been removed. The logic behind that is still valid but it's now centralized in `fetchQueryByPolicy`'s `switch` statement. This means fetch policies are now preserved even with `notifyOnNetworkStatusChange` set. 

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
