### PR TITLE
Allow merge:true to merge references with non-normalized objects, and vice-versa.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ TBD
 - The `FetchMoreQueryOptions` type now takes two instead of three type parameters (`<TVariables, TData>`), thanks to using `Partial<TVariables>` instead of `K extends typeof TVariables` and `Pick<TVariables, K>`. <br/>
   [@ArnaudBarre](https://github.com/ArnaudBarre) in [#7476](https://github.com/apollographql/apollo-client/pull/7476)
 
+- Allow `merge: true` field policy to merge `Reference` objects with non-normalized objects, and vice-versa. <br/>
+  [@benjamn](https://github.com/benjamn) in [#7778](https://github.com/apollographql/apollo-client/pull/7778)
+
 ### Documentation
 TBD
 

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -904,6 +904,12 @@ function makeMergeObjectsFunction(
       }
 
       if (storeValueIsStoreObject(existing) &&
+          isReference(incoming)) {
+        store.merge(existing, incoming.__ref);
+        return incoming;
+      }
+
+      if (storeValueIsStoreObject(existing) &&
           storeValueIsStoreObject(incoming)) {
         return { ...existing, ...incoming };
       }

--- a/src/cache/inmemory/types.ts
+++ b/src/cache/inmemory/types.ts
@@ -33,7 +33,13 @@ export declare type IdGetter = (
 export interface NormalizedCache {
   has(dataId: string): boolean;
   get(dataId: string, fieldName: string): StoreValue;
-  merge(dataId: string, incoming: StoreObject): void;
+
+  // The store.merge method allows either argument to be a string ID, but
+  // the other argument has to be a StoreObject. Either way, newer fields
+  // always take precedence over older fields.
+  merge(olderId: string, newerObject: StoreObject): void;
+  merge(olderObject: StoreObject, newerId: string): void;
+
   modify(dataId: string, fields: Modifiers | Modifier<any>): boolean;
   delete(dataId: string, fieldName?: string): boolean;
   clear(): void;


### PR DESCRIPTION
Previously, you could allow `InMemoryCache` to merge non-normalized data using the `merge: true` configuration (see #6714 and #7070), but the merged objects had to be consistently non-normalized, since attempting to merge a normalized `Reference` with a non-normalized object would give preference to the reference, ignoring the object.

This PR fixes #7642 in both directions:
* merging an incoming non-normalized object with an existing `Reference` now updates the normalized data behind the reference, leaving the field holding the `Reference`, and
* merging an incoming `Reference` with an existing non-normalized object updates the normalized data behind the reference (as above), but, for any fields that overlap, the normalized field data takes precedence over the non-normalized field data.

In both directions, the new behavior matches what would happen if the normalized `Reference` was a non-normalized object instead.