### PR TITLE
Fix typo in `useLazyQuery` API - React section

### DIFF
--- a/docs/source/api/react/hooks.mdx
+++ b/docs/source/api/react/hooks.mdx
@@ -172,7 +172,7 @@ function useLazyQuery<TData = any, TVariables = OperationVariables>(
 
 | Param            | Type                                                  | Description                                                                                                                     |
 | ---------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| Execute function | options?: QueryLazyOptions&lt;TVariables&gt;) => void | Function that can be triggered to execute the suspended query. After being called, `useLazyQuery` behaves just like `useQuery`. |
+| Execute function | (options?: QueryLazyOptions&lt;TVariables&gt;) => void | Function that can be triggered to execute the suspended query. After being called, `useLazyQuery` behaves just like `useQuery`. |
 
 **Result object**
 


### PR DESCRIPTION
## Description

Not 100% sure this is considered a typo, but the fact that there was no opening parenthesis bugged me for a couple of seconds.

### Checklist:

- [ ] <s>If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)</s>
- [ ] <s>Make sure all of the significant new logic is covered by tests</s>

Thank you Apollo team for the amazing work!

