### PR TITLE
docs: make error policy 'none' description clearer

### DIFF
--- a/docs/source/data/error-handling.mdx
+++ b/docs/source/data/error-handling.mdx
@@ -95,7 +95,7 @@ Apollo Client supports the following error policies for an operation:
 
 | Policy | Description |
 |--------|-------------|
-| `none` | `graphQLErrors` are treated the same as a `networkError`, meaning response `data` is ignored. |
+| `none` | If the response has any GraphQL error, they are returned on `error.graphQLErrors` and the response `data` is set to `undefined` even if the server returns `data` in its response. This means network errors and GraphQL errors result in a similar response shape. This is the default error policy. |
 | `ignore` | `graphQLErrors` are ignored (`error.graphQLErrors`  is _not_ populated), and any returned `data` is cached and rendered as if no errors occurred. |
 | `all` | Both `data` and `error.graphQLErrors` are populated, enabling you to render both partial results and error information. |
 

--- a/docs/source/data/error-handling.mdx
+++ b/docs/source/data/error-handling.mdx
@@ -95,7 +95,7 @@ Apollo Client supports the following error policies for an operation:
 
 | Policy | Description |
 |--------|-------------|
-| `none` | If the response has any GraphQL error, they are returned on `error.graphQLErrors` and the response `data` is set to `undefined` even if the server returns `data` in its response. This means network errors and GraphQL errors result in a similar response shape. This is the default error policy. |
+| `none` | If the response includes GraphQL errors, they are returned on `error.graphQLErrors` and the response `data` is set to `undefined` even if the server returns `data` in its response. This means network errors and GraphQL errors result in a similar response shape. This is the default error policy. |
 | `ignore` | `graphQLErrors` are ignored (`error.graphQLErrors`  is _not_ populated), and any returned `data` is cached and rendered as if no errors occurred. |
 | `all` | Both `data` and `error.graphQLErrors` are populated, enabling you to render both partial results and error information. |
 


### PR DESCRIPTION
I was a bit confused by the text here because it sounded like it was saying that GraphQL errors are treated literally the same as network errors (ie, they would actually show up on `error.networkError` somehow). The description above the table was more explicit, but it didn't actually say what the default policy was, so I wasn't sure that the clearer description actually described `none`.
