### PR TITLE
Remove reference to `setTypeDefs` in client side schema docs

### DIFF
--- a/docs/source/local-state/client-side-schema.mdx
+++ b/docs/source/local-state/client-side-schema.mdx
@@ -3,7 +3,7 @@ title: Client-side schema
 description: Configure a client-side schema with Apollo Client
 ---
 
-You can optionally set a client-side schema to be used with Apollo Client, through either the `ApolloClient` constructor `typeDefs` parameter, or the local state API `setTypeDefs` method. Your schema should be written in [Schema Definition Language](https://www.apollographql.com/docs/graphql-tools/generate-schema#schema-language). This schema is not used for validation like it is on the server because the `graphql-js` modules for schema validation would dramatically increase your bundle size. Instead, your client-side schema is used for introspection in [Apollo Client Devtools](https://github.com/apollographql/apollo-client-devtools), where you can explore your schema in GraphiQL.
+You can optionally set a client-side schema to be used with Apollo Client, through the `ApolloClient` constructor `typeDefs` parameter. Your schema should be written in [Schema Definition Language](https://www.apollographql.com/docs/graphql-tools/generate-schema#schema-language). This schema is not used for validation like it is on the server because the `graphql-js` modules for schema validation would dramatically increase your bundle size. Instead, your client-side schema is used for introspection in [Apollo Client Devtools](https://github.com/apollographql/apollo-client-devtools), where you can explore your schema in GraphiQL.
 
 The following demonstrates how to configure a client-side schema through the `ApolloClient` constructor:
 


### PR DESCRIPTION
 setTypeDefs was removed in commit d3931b8 on Feb 1, 2019 with the following explanation:

`We're going to avoid getters/setters for typeDefs for now,
and instead recommend typeDefs are set via the ApolloClient
constructor. We were originally exposing getters/setters for
integrations like Apollo Client Devtools, but we'll adjust
devtools to access the typeDefs in a different way. We will
likely want to revisit this decision in the future, to
accommodate the possibility that people want to add to their
local schema at different points in their application, but
we'll cross that bridge when we get there. For now keeping the
changes to the public ApolloClient API minimal, is the goal.
`
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

