### PR TITLE
add public method to retrieve all current observable queries

### DIFF
--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -2442,6 +2442,18 @@ describe('client', () => {
     expect(spy).toHaveBeenCalledWith(options);
   });
 
+  it('has a getObservableQueries method which calls QueryManager', async () => {
+    const client = new ApolloClient({
+      link: ApolloLink.empty(),
+      cache: new InMemoryCache(),
+    });
+
+    // @ts-ignore
+    const spy = jest.spyOn(client.queryManager, 'getObservableQueries');
+    await client.getObservableQueries();
+    expect(spy).toHaveBeenCalled();
+  });
+
   itAsync('should propagate errors from network interface to observers', (resolve, reject) => {
     const link = ApolloLink.from([
       () =>

--- a/src/__tests__/refetchQueries.ts
+++ b/src/__tests__/refetchQueries.ts
@@ -50,8 +50,13 @@ describe("client.refetchQueries", () => {
         operation.operationName.split("").forEach(letter => {
           data[letter.toLowerCase()] = letter.toUpperCase();
         });
-        observer.next({ data });
-        observer.complete();
+        function finish() {
+          observer.next({ data });
+          observer.complete();
+        }
+        if (typeof operation.variables.delay === "number") {
+          setTimeout(finish, operation.variables.delay);
+        } else finish();
       })),
     });
   }
@@ -513,6 +518,104 @@ describe("client.refetchQueries", () => {
     ]);
 
     unsubscribe();
+    resolve();
+  });
+
+  itAsync('should not include unwatched single queries', async (resolve, reject) => {
+    const client = makeClient();
+    const [
+      aObs,
+      bObs,
+      abObs,
+    ] = await setup(client);
+
+    const delayedQuery = gql`query DELAYED { d e l a y e d }`;
+
+    client.query({
+      query: delayedQuery,
+      variables: {
+        // Delay this query by 10 seconds so it stays in-flight.
+        delay: 10000,
+      },
+    }).catch(reject);
+
+    const queries = client["queryManager"]["queries"];
+    expect(queries.size).toBe(4);
+
+    queries.forEach((queryInfo, queryId) => {
+      if (
+        queryId === "1" ||
+        queryId === "2" ||
+        queryId === "3"
+      ) {
+        expect(queryInfo.observableQuery).toBeInstanceOf(ObservableQuery);
+      } else if (queryId === "4") {
+        // One-off client.query-style queries never get an ObservableQuery, so
+        // they should not be included by include: "active".
+        expect(queryInfo.observableQuery).toBe(null);
+        expect(queryInfo.document).toBe(delayedQuery);
+      }
+    });
+
+    const activeResults = await client.refetchQueries({
+      include: "active",
+
+      onQueryUpdated(obs, diff) {
+        if (obs === aObs) {
+          expect(diff.result).toEqual({ a: "A" });
+        } else if (obs === bObs) {
+          expect(diff.result).toEqual({ b: "B" });
+        } else if (obs === abObs) {
+          expect(diff.result).toEqual({ a: "A", b: "B" });
+        } else {
+          reject(`unexpected ObservableQuery ${
+            obs.queryId
+          } with name ${obs.queryName}`);
+        }
+        return Promise.resolve(diff.result);
+      },
+    });
+
+    sortObjects(activeResults);
+
+    expect(activeResults).toEqual([
+      { a: "A" },
+      { a: "A", b: "B" },
+      { b: "B" },
+    ]);
+
+    const allResults = await client.refetchQueries({
+      include: "all",
+
+      onQueryUpdated(obs, diff) {
+        if (obs === aObs) {
+          expect(diff.result).toEqual({ a: "A" });
+        } else if (obs === bObs) {
+          expect(diff.result).toEqual({ b: "B" });
+        } else if (obs === abObs) {
+          expect(diff.result).toEqual({ a: "A", b: "B" });
+        } else {
+          reject(`unexpected ObservableQuery ${
+            obs.queryId
+          } with name ${obs.queryName}`);
+        }
+        return Promise.resolve(diff.result);
+      },
+    });
+
+    sortObjects(allResults);
+
+    expect(allResults).toEqual([
+      { a: "A" },
+      { a: "A", b: "B" },
+      { b: "B" },
+    ]);
+
+    unsubscribe();
+    client.stop();
+
+    expect(queries.size).toBe(0);
+
     resolve();
   });
 

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -18,7 +18,7 @@ import {
   RefetchQueriesOptions,
   RefetchQueriesResult,
   InternalRefetchQueriesResult,
-  RefetchQueryDescription,
+  RefetchQueriesInclude,
 } from './types';
 
 import {
@@ -566,17 +566,16 @@ export class ApolloClient<TCacheShape> implements DataProxy {
   }
 
   /**
-   * Get all currently active ObservableQuery objects, in a Map keyed by query
-   * ID strings. An "active" query is one that has observers and a fetchPolicy
-   * other than "standby" or "cache-only". You can include all ObservableQuery
-   * objects (including the inactive ones) by passing "all" instead of "active",
-   * or you can include just a subset of active queries by passing an array of
-   * query names or DocumentNode objects. This method is used internally by
-   * `client.refetchQueries` to handle its `include` option.
+   * Get all currently active `ObservableQuery` objects, in a `Map` keyed by
+   * query ID strings. An "active" query is one that has observers and a
+   * `fetchPolicy` other than "standby" or "cache-only". You can include all
+   * `ObservableQuery` objects (including the inactive ones) by passing "all"
+   * instead of "active", or you can include just a subset of active queries by
+   * passing an array of query names or DocumentNode objects.
    */
   public getObservableQueries(
-    include: RefetchQueryDescription = "active",
-  ) {
+    include: RefetchQueriesInclude = "active",
+  ): Map<string, ObservableQuery<any>> {
     return this.queryManager.getObservableQueries(include);
   }
 

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -18,6 +18,7 @@ import {
   RefetchQueriesOptions,
   RefetchQueriesResult,
   InternalRefetchQueriesResult,
+  RefetchQueryDescription,
 } from './types';
 
 import {
@@ -565,6 +566,21 @@ export class ApolloClient<TCacheShape> implements DataProxy {
   }
 
   /**
+   * Get all currently active ObservableQuery objects, in a Map keyed by query
+   * ID strings. An "active" query is one that has observers and a fetchPolicy
+   * other than "standby" or "cache-only". You can include all ObservableQuery
+   * objects (including the inactive ones) by passing "all" instead of "active",
+   * or you can include just a subset of active queries by passing an array of
+   * query names or DocumentNode objects. This method is used internally by
+   * `client.refetchQueries` to handle its `include` option.
+   */
+  public getObservableQueries(
+    include: RefetchQueryDescription = "active",
+  ) {
+    return this.queryManager.getObservableQueries(include);
+  }
+
+  /**
    * Exposes the cache's complete state, in a serializable format for later restoration.
    */
   public extract(optimistic?: boolean): TCacheShape {
@@ -601,14 +617,6 @@ export class ApolloClient<TCacheShape> implements DataProxy {
    */
   public getResolvers() {
     return this.localState.getResolvers();
-  }
-
-  /**
-   * Get all observable queries which have current observers (e.g.
-   * they're mounted).
-   */
-  public getObservableQueries() {
-    return this.queryManager.getObservableQueries();
   }
 
   /**

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -604,6 +604,14 @@ export class ApolloClient<TCacheShape> implements DataProxy {
   }
 
   /**
+   * Get all observable queries which have current observers (e.g.
+   * they're mounted).
+   */
+  public getObservableQueries() {
+    return this.queryManager.getObservableQueries();
+  }
+
+  /**
    * Set a custom local state fragment matcher.
    */
   public setLocalStateFragmentMatcher(fragmentMatcher: FragmentMatcher) {

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -762,9 +762,7 @@ export class QueryManager<TStore> {
           options: { fetchPolicy },
         } = oq;
 
-        if (fetchPolicy === "cache-only" ||
-            fetchPolicy === "standby" ||
-            !oq.hasObservers()) {
+        if (fetchPolicy === "standby" || !oq.hasObservers()) {
           // Skip inactive queries unless include === "all".
           return;
         }
@@ -826,8 +824,13 @@ export class QueryManager<TStore> {
     this.getObservableQueries(
       includeStandby ? "all" : "active"
     ).forEach((observableQuery, queryId) => {
+      const { fetchPolicy } = observableQuery.options;
       observableQuery.resetLastResults();
-      observableQueryPromises.push(observableQuery.refetch());
+      if (includeStandby ||
+          (fetchPolicy !== "standby" &&
+           fetchPolicy !== "cache-only")) {
+        observableQueryPromises.push(observableQuery.refetch());
+      }
       this.getQuery(queryId).setDiff(null);
     });
 

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -782,8 +782,9 @@ export class QueryManager<TStore> {
     if (legacyQueryOptions.size) {
       legacyQueryOptions.forEach((options: QueryOptions) => {
         // We will be issuing a fresh network request for this query, so we
-        // pre-allocate a new query ID here.
-        const queryId = this.generateQueryId();
+        // pre-allocate a new query ID here, using a special prefix to enable
+        // cleaning up these temporary queries later, after fetching.
+        const queryId = makeUniqueId("legacyOneTimeQuery");
         const queryInfo = this.getQuery(queryId).init({
           document: options.query,
           variables: options.variables,
@@ -1309,6 +1310,10 @@ export class QueryManager<TStore> {
 
         if (result !== false) {
           results.set(oq, result!);
+        }
+
+        if (queryId.indexOf("legacyOneTimeQuery") >= 0) {
+          this.stopQueryNoBroadcast(queryId);
         }
       });
     }

--- a/src/core/__tests__/QueryManager/index.ts
+++ b/src/core/__tests__/QueryManager/index.ts
@@ -4774,8 +4774,7 @@ describe('QueryManager', () => {
         result => {
           expect(stripSymbols(result.data)).toEqual(secondReqData);
           expect(consoleWarnSpy).toHaveBeenLastCalledWith(
-            'Unknown query name "fakeQuery" passed to refetchQueries method ' +
-            "in options.include array"
+            'Unknown query named "fakeQuery" requested in refetchQueries options.include array'
           );
         },
       ).then(resolve, reject);
@@ -4843,8 +4842,7 @@ describe('QueryManager', () => {
         });
       }).then(() => {
         expect(consoleWarnSpy).toHaveBeenLastCalledWith(
-          'Unknown query name "getAuthors" passed to refetchQueries method ' +
-          "in options.include array"
+          'Unknown query named "getAuthors" requested in refetchQueries options.include array'
         );
       }).then(resolve, reject);
     });

--- a/src/core/__tests__/QueryManager/index.ts
+++ b/src/core/__tests__/QueryManager/index.ts
@@ -4916,7 +4916,14 @@ describe('QueryManager', () => {
         } else if (count === 2) {
           expect(result.data).toEqual(secondReqData);
           expect(observable.getCurrentResult().data).toEqual(secondReqData);
-          setTimeout(resolve, 10);
+
+          return new Promise(res => setTimeout(res, 10)).then(() => {
+            // Make sure the QueryManager cleans up legacy one-time queries like
+            // the one we requested above using refetchQueries.
+            queryManager["queries"].forEach((queryInfo, queryId) => {
+              expect(queryId).not.toContain("legacyOneTimeQuery");
+            });
+          }).then(resolve, reject);
         } else {
           reject("too many results");
         }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -7,6 +7,7 @@ import { QueryInfo } from './QueryInfo';
 import { NetworkStatus } from './networkStatus';
 import { Resolver } from './LocalState';
 import { ObservableQuery } from './ObservableQuery';
+import { QueryOptions } from './watchQueryOptions';
 import { Cache } from '../cache';
 import { IsStrictlyAny } from '../utilities';
 
@@ -22,8 +23,18 @@ export type OnQueryUpdated<TResult> = (
   lastDiff: Cache.DiffResult<any> | undefined,
 ) => boolean | TResult;
 
-export type RefetchQueryDescriptor = string | DocumentNode | PureQueryOptions;
-export type RefetchQueryDescription = RefetchQueryDescriptor[] | "all" | "active";
+export type RefetchQueryDescriptor = string | DocumentNode;
+export type InternalRefetchQueryDescriptor = RefetchQueryDescriptor | QueryOptions;
+
+type RefetchQueriesIncludeShorthand = "all" | "active";
+
+export type RefetchQueriesInclude =
+  | RefetchQueryDescriptor[]
+  | RefetchQueriesIncludeShorthand;
+
+export type InternalRefetchQueriesInclude =
+  | InternalRefetchQueryDescriptor[]
+  | RefetchQueriesIncludeShorthand;
 
 // Used by ApolloClient["refetchQueries"]
 // TODO Improve documentation comments for this public type.
@@ -32,11 +43,11 @@ export interface RefetchQueriesOptions<
   TResult,
 > {
   updateCache?: (cache: TCache) => void;
-  // Although you can pass PureQueryOptions objects in addition to strings in
-  // the refetchQueries array for a mutation, the client.refetchQueries method
-  // deliberately discourages passing PureQueryOptions, by restricting the
-  // public type of the options.include array to string[] (just query names).
-  include?: Exclude<RefetchQueryDescriptor, PureQueryOptions>[];
+  // The client.refetchQueries method discourages passing QueryOptions, by
+  // restricting the public type of options.include to exclude QueryOptions as
+  // an available array element type (see InternalRefetchQueriesInclude for a
+  // version of RefetchQueriesInclude that allows legacy QueryOptions objects).
+  include?: RefetchQueriesInclude;
   optimistic?: boolean;
   // If no onQueryUpdated function is provided, any queries affected by the
   // updateCache function or included in the options.include array will be
@@ -93,9 +104,10 @@ export interface InternalRefetchQueriesOptions<
   TCache extends ApolloCache<any>,
   TResult,
 > extends Omit<RefetchQueriesOptions<TCache, TResult>, "include"> {
-  // Just like the refetchQueries array for a mutation, allowing both strings
-  // and PureQueryOptions objects.
-  include?: RefetchQueryDescription;
+  // Just like the refetchQueries option for a mutation, an array of strings,
+  // DocumentNode objects, and/or QueryOptions objects, or one of the shorthand
+  // strings "all" or "active", to select every (active) query.
+  include?: InternalRefetchQueriesInclude;
   // This part of the API is a (useful) implementation detail, but need not be
   // exposed in the public client.refetchQueries API (above).
   removeOptimistic?: string;
@@ -108,13 +120,10 @@ export type InternalRefetchQueriesMap<TResult> =
   Map<ObservableQuery<any>,
       InternalRefetchQueriesResult<TResult>>;
 
-export type OperationVariables = Record<string, any>;
+// TODO Remove this unnecessary type in Apollo Client 4.
+export type { QueryOptions as PureQueryOptions };
 
-export type PureQueryOptions = {
-  query: DocumentNode;
-  variables?: { [key: string]: any };
-  context?: any;
-};
+export type OperationVariables = Record<string, any>;
 
 export type ApolloQueryResult<T> = {
   data: T;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -23,7 +23,7 @@ export type OnQueryUpdated<TResult> = (
 ) => boolean | TResult;
 
 export type RefetchQueryDescriptor = string | DocumentNode | PureQueryOptions;
-export type RefetchQueryDescription = RefetchQueryDescriptor[];
+export type RefetchQueryDescription = RefetchQueryDescriptor[] | "all" | "active";
 
 // Used by ApolloClient["refetchQueries"]
 // TODO Improve documentation comments for this public type.

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -8,7 +8,7 @@ import {
   OperationVariables,
   MutationUpdaterFunction,
   OnQueryUpdated,
-  RefetchQueryDescription,
+  InternalRefetchQueriesInclude,
 } from './types';
 import { ApolloCache } from '../cache';
 
@@ -221,8 +221,8 @@ export interface MutationBaseOptions<
    * once these queries return.
    */
   refetchQueries?:
-    | ((result: FetchResult<TData>) => RefetchQueryDescription)
-    | RefetchQueryDescription;
+    | ((result: FetchResult<TData>) => InternalRefetchQueriesInclude)
+    | InternalRefetchQueriesInclude;
 
   /**
    * By default, `refetchQueries` does not wait for the refetched queries to

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -17,7 +17,7 @@ import {
   NetworkStatus,
   ObservableQuery,
   OperationVariables,
-  PureQueryOptions,
+  InternalRefetchQueriesInclude,
   WatchQueryOptions,
 } from '../../core';
 
@@ -137,7 +137,7 @@ export type QueryTuple<TData, TVariables> = [
 
 export type RefetchQueriesFunction = (
   ...args: any[]
-) => Array<string | PureQueryOptions>;
+) => InternalRefetchQueriesInclude;
 
 export interface BaseMutationOptions<
   TData,


### PR DESCRIPTION
### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [X] Make sure all of the significant new logic is covered by tests (covered by other tests that call this method implicitly).

This feature is to help create a workaround for this comment:

https://github.com/apollographql/apollo-feature-requests/issues/272#issuecomment-794296626

By exposing the current observable queries, consumers can look at all their "refetchQueries" for a mutation, and if any of them aren't in the result of "getObservableQueries()", they can figure out how to ensure those queries are re-fetched on subsequent mounts.

This logic was already being done by query manager for its own internal handling of "refetchQueries" logic, so we are just exposing a small piece of that here.
