### PR TITLE
docs: Fix 'get started' docs

### DIFF
--- a/docs/source/get-started.mdx
+++ b/docs/source/get-started.mdx
@@ -74,8 +74,10 @@ import React from 'react';
 import { render } from 'react-dom';
 
 import { ApolloProvider } from '@apollo/client';
+import { useApolloClient } from "@apollo/react-hooks";
 
 function App() {
+  const client = useApolloClient();
   return (
     <ApolloProvider client={client}>
       <div>

--- a/docs/source/get-started.mdx
+++ b/docs/source/get-started.mdx
@@ -72,21 +72,24 @@ In `index.js`, let's wrap our React app with an `ApolloProvider`. We suggest put
 ```jsx
 import React from 'react';
 import { render } from 'react-dom';
+import { ApolloProvider } from '@apollo/client/react';
 
-import { ApolloProvider, useApolloClient } from '@apollo/client/react';
+const client = new ApolloClient({ uri, cache });
 
 function App() {
-  const client = useApolloClient();
   return (
-    <ApolloProvider client={client}>
-      <div>
-        <h2>My first Apollo app 🚀</h2>
-      </div>
-    </ApolloProvider>
+    <div>
+      <h2>My first Apollo app 🚀</h2>
+    </div>
   );
 }
 
-render(<App />, document.getElementById('root'));
+render(
+  <ApolloProvider client={client}>
+    <App />
+  </ApolloProvider>,
+  document.getElementById('root'),
+);
 ```
 
 ## Request data

--- a/docs/source/get-started.mdx
+++ b/docs/source/get-started.mdx
@@ -73,8 +73,7 @@ In `index.js`, let's wrap our React app with an `ApolloProvider`. We suggest put
 import React from 'react';
 import { render } from 'react-dom';
 
-import { ApolloProvider } from '@apollo/client';
-import { useApolloClient } from "@apollo/react-hooks";
+import { ApolloProvider, useApolloClient } from '@apollo/client/react';
 
 function App() {
   const client = useApolloClient();


### PR DESCRIPTION
I've noticed, that `<ApolloProvider` has _client_ prop, but it is not defined anywhere. So, hope I did it right.

![image](https://user-images.githubusercontent.com/6331352/110692799-6cf38e80-81ef-11eb-8d24-b273c3f36ebc.png)
![image](https://user-images.githubusercontent.com/6331352/110693136-c5c32700-81ef-11eb-956b-0aaa65089ee5.png)