### PR TITLE
Support options.reobserveQuery callback for mutations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ TBD
   ```
   [@benjamn](https://github.com/benjamn) in [#7810](https://github.com/apollographql/apollo-client/pull/7810)
 
+- Mutations now accept an optional callback function called `reobserveQuery`, which will be passed the `ObservableQuery` and `Cache.DiffResult` objects for any queries invalidated by cache writes performed by the mutation's final `update` function. Using `reobserveQuery`, you can override the default `FetchPolicy` of the query, by (for example) calling `ObservableQuery` methods like `refetch` to force a network request. This automatic detection of invalidated queries provides an alternative to manually enumerating queries using the `refetchQueries` mutation option. Also, if you return a `Promise` from `reobserveQuery`, the mutation will automatically await that `Promise`, rendering the `awaitRefetchQueries` option unnecessary. <br/>
+  [@benjamn](https://github.com/benjamn) in [#7827](https://github.com/apollographql/apollo-client/pull/7827)
+
 - Support `client.refetchQueries` as an imperative way to refetch queries, without having to pass `options.refetchQueries` to `client.mutate`. <br/>
   [@dannycochran](https://github.com/dannycochran) in [#7431](https://github.com/apollographql/apollo-client/pull/7431)
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     {
       "name": "apollo-client",
       "path": "./dist/apollo-client.cjs.min.js",
-      "maxSize": "26.4 kB"
+      "maxSize": "26.5 kB"
     }
   ],
   "peerDependencies": {

--- a/src/cache/core/types/Cache.ts
+++ b/src/cache/core/types/Cache.ts
@@ -26,7 +26,10 @@ export namespace Cache {
     // declaring the returnPartialData option.
   }
 
-  export interface WatchOptions extends ReadOptions {
+  export interface WatchOptions<
+    Watcher extends object = Record<string, any>
+  > extends ReadOptions {
+    watcher?: Watcher;
     immediate?: boolean;
     callback: WatchCallback;
     lastDiff?: DiffResult<any>;

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -261,7 +261,7 @@ export class QueryInfo {
   // updateWatch method.
   private cancel() {}
 
-  private lastWatch?: Cache.WatchOptions;
+  private lastWatch?: Cache.WatchOptions<QueryInfo>;
 
   private updateWatch(variables = this.variables) {
     const oq = this.observableQuery;
@@ -276,6 +276,7 @@ export class QueryInfo {
         query: this.document!,
         variables,
         optimistic: true,
+        watcher: this,
         callback: diff => this.setDiff(diff),
       });
     }

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -35,6 +35,7 @@ import { NetworkStatus, isNetworkRequestInFlight } from './networkStatus';
 import {
   ApolloQueryResult,
   OperationVariables,
+  ReobserveQueryCallback,
 } from './types';
 import { LocalState } from './LocalState';
 
@@ -135,6 +136,7 @@ export class QueryManager<TStore> {
     refetchQueries = [],
     awaitRefetchQueries = false,
     update: updateWithProxyFn,
+    reobserveQuery,
     errorPolicy = 'none',
     fetchPolicy,
     context = {},
@@ -218,6 +220,7 @@ export class QueryManager<TStore> {
                 errorPolicy,
                 updateQueries,
                 update: updateWithProxyFn,
+                reobserveQuery,
               });
             } catch (e) {
               error = new ApolloError({
@@ -301,6 +304,7 @@ export class QueryManager<TStore> {
         cache: ApolloCache<TStore>,
         result: FetchResult<TData>,
       ) => void;
+      reobserveQuery?: ReobserveQueryCallback;
     },
     cache = this.cache,
   ) {
@@ -362,8 +366,20 @@ export class QueryManager<TStore> {
             update(c, mutation.result);
           }
         },
+
         // Write the final mutation.result to the root layer of the cache.
         optimistic: false,
+
+        onDirty(watch, diff) {
+          if (mutation.reobserveQuery) {
+            // TODO Get ObservableQuery from watch, somehow.
+            // TODO Call mutation.reobserveQuery with that ObservableQuery.
+            // TODO Store results in an array for the mutation to await.
+
+            // Skip the normal broadcast of this result.
+            return false;
+          }
+        },
       });
     }
   }

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -186,23 +186,23 @@ export class QueryManager<TStore> {
 
     return new Promise((resolve, reject) => {
       let storeResult: FetchResult<T> | null;
-      let error: ApolloError;
 
-      self.getObservableFromLink(
-        mutation,
-        {
-          ...context,
-          optimisticResponse,
-        },
-        variables,
-        false,
-      ).subscribe({
-        next(result: FetchResult<T>) {
+      return asyncMap(
+        self.getObservableFromLink(
+          mutation,
+          {
+            ...context,
+            optimisticResponse,
+          },
+          variables,
+          false,
+        ),
+
+        (result: FetchResult<T>) => {
           if (graphQLResultHasError(result) && errorPolicy === 'none') {
-            error = new ApolloError({
+            throw new ApolloError({
               graphQLErrors: result.errors,
             });
-            return;
           }
 
           if (mutationStoreValue) {
@@ -210,9 +210,15 @@ export class QueryManager<TStore> {
             mutationStoreValue.error = null;
           }
 
+          storeResult = result;
+
           if (fetchPolicy !== 'no-cache') {
             try {
-              self.markMutationResult<T>({
+              // Returning the result of markMutationResult here makes the
+              // mutation await any Promise that markMutationResult returns,
+              // since we are returning this Promise from the asyncMap mapping
+              // function.
+              return self.markMutationResult<T>({
                 mutationId,
                 result,
                 document: mutation,
@@ -223,48 +229,41 @@ export class QueryManager<TStore> {
                 reobserveQuery,
               });
             } catch (e) {
-              error = new ApolloError({
+              // Likewise, throwing an error from the asyncMap mapping function
+              // will result in calling the subscribed error handler function.
+              throw new ApolloError({
                 networkError: e,
               });
-              return;
             }
           }
-
-          storeResult = result;
         },
 
+      ).subscribe({
         error(err: Error) {
           if (mutationStoreValue) {
             mutationStoreValue.loading = false;
             mutationStoreValue.error = err;
           }
+
           if (optimisticResponse) {
             self.cache.removeOptimistic(mutationId);
           }
+
           self.broadcastQueries();
+
           reject(
-            new ApolloError({
+            err instanceof ApolloError ? err : new ApolloError({
               networkError: err,
             }),
           );
         },
 
         complete() {
-          if (error && mutationStoreValue) {
-            mutationStoreValue.loading = false;
-            mutationStoreValue.error = error;
-          }
-
           if (optimisticResponse) {
             self.cache.removeOptimistic(mutationId);
           }
 
           self.broadcastQueries();
-
-          if (error) {
-            reject(error);
-            return;
-          }
 
           // allow for conditional refetches
           // XXX do we want to make this the only API one day?
@@ -307,7 +306,7 @@ export class QueryManager<TStore> {
       reobserveQuery?: ReobserveQueryCallback;
     },
     cache = this.cache,
-  ) {
+  ): Promise<void> {
     if (shouldWriteResult(mutation.result, mutation.errorPolicy)) {
       const cacheWrites: Cache.WriteOptions[] = [{
         result: mutation.result.data,
@@ -355,7 +354,7 @@ export class QueryManager<TStore> {
         });
       }
 
-      const reobserveResults = [];
+      const reobserveResults: any[] = [];
 
       cache.batch({
         transaction(c) {
@@ -383,7 +382,11 @@ export class QueryManager<TStore> {
           }
         }),
       });
+
+      return Promise.all(reobserveResults).then(() => void 0);
     }
+
+    return Promise.resolve();
   }
 
   public markMutationOptimistic<TData>(

--- a/src/core/__tests__/QueryManager/index.ts
+++ b/src/core/__tests__/QueryManager/index.ts
@@ -5168,6 +5168,207 @@ describe('QueryManager', () => {
     });
   });
 
+  describe('reobserveQuery', () => {
+    const mutation = gql`
+      mutation changeAuthorName {
+        changeAuthorName(newName: "Jack Smith") {
+          firstName
+          lastName
+        }
+      }
+    `;
+
+    const mutationData = {
+      changeAuthorName: {
+        firstName: 'Jack',
+        lastName: 'Smith',
+      },
+    };
+
+    const query = gql`
+      query getAuthors($id: ID!) {
+        author(id: $id) {
+          firstName
+          lastName
+        }
+      }
+    `;
+
+    const data = {
+      author: {
+        firstName: 'John',
+        lastName: 'Smith',
+      },
+    };
+
+    const secondReqData = {
+      author: {
+        firstName: 'Jane',
+        lastName: 'Johnson',
+      },
+    };
+
+    const variables = { id: '1234' };
+
+    function makeQueryManager(reject: (reason?: any) => void) {
+      return mockQueryManager(
+        reject,
+        {
+          request: { query, variables },
+          result: { data },
+        },
+        {
+          request: { query, variables },
+          result: { data: secondReqData },
+        },
+        {
+          request: { query: mutation },
+          result: { data: mutationData },
+        },
+      );
+    }
+
+    itAsync('should refetch the right query when a result is successfully returned', (resolve, reject) => {
+      const queryManager = makeQueryManager(reject);
+
+      const observable = queryManager.watchQuery<any>({
+        query,
+        variables,
+        notifyOnNetworkStatusChange: false,
+      });
+
+      return observableToPromise(
+        { observable },
+        result => {
+          expect(stripSymbols(result.data)).toEqual(data);
+
+          queryManager.mutate({
+            mutation,
+
+            update(cache) {
+              cache.modify({
+                fields: {
+                  author(_, { INVALIDATE }) {
+                    return INVALIDATE;
+                  },
+                },
+              });
+            },
+
+            reobserveQuery(obsQuery) {
+              expect(obsQuery.options.query).toBe(query);
+              return obsQuery.refetch();
+            },
+          });
+        },
+
+        result => {
+          expect(stripSymbols(observable.getCurrentResult().data)).toEqual(
+            secondReqData,
+          );
+          expect(stripSymbols(result.data)).toEqual(secondReqData);
+        },
+      ).then(resolve, reject);
+    });
+
+    itAsync('should refetch using the original query context (if any)', (resolve, reject) => {
+      const queryManager = makeQueryManager(reject);
+
+      const headers = {
+        someHeader: 'some value',
+      };
+
+      const observable = queryManager.watchQuery<any>({
+        query,
+        variables,
+        context: {
+          headers,
+        },
+        notifyOnNetworkStatusChange: false,
+      });
+
+      return observableToPromise(
+        { observable },
+        result => {
+          expect(result.data).toEqual(data);
+
+          queryManager.mutate({
+            mutation,
+
+            update(cache) {
+              cache.modify({
+                fields: {
+                  author(_, { INVALIDATE }) {
+                    return INVALIDATE;
+                  },
+                },
+              });
+            },
+
+            reobserveQuery(obsQuery) {
+              expect(obsQuery.options.query).toBe(query);
+              return obsQuery.refetch();
+            },
+          });
+        },
+
+        result => {
+          expect(result.data).toEqual(secondReqData);
+          const context = (queryManager.link as MockApolloLink).operation!.getContext();
+          expect(context.headers).not.toBeUndefined();
+          expect(context.headers.someHeader).toEqual(headers.someHeader);
+        },
+      ).then(resolve, reject);
+    });
+
+    itAsync('should refetch using the specified context, if provided', (resolve, reject) => {
+      const queryManager = makeQueryManager(reject);
+
+      const observable = queryManager.watchQuery<any>({
+        query,
+        variables,
+        notifyOnNetworkStatusChange: false,
+      });
+
+      const headers = {
+        someHeader: 'some value',
+      };
+
+      return observableToPromise(
+        { observable },
+        result => {
+          expect(result.data).toEqual(data);
+
+          queryManager.mutate({
+            mutation,
+
+            update(cache) {
+              cache.evict({ fieldName: "author" });
+            },
+
+            reobserveQuery(obsQuery) {
+              expect(obsQuery.options.query).toBe(query);
+              return obsQuery.reobserve({
+                fetchPolicy: "network-only",
+                context: {
+                  ...obsQuery.options.context,
+                  headers,
+                },
+              });
+            },
+          });
+        },
+
+        result => {
+          expect(result.data).toEqual(secondReqData);
+          const context = (queryManager.link as MockApolloLink).operation!.getContext();
+          expect(context.headers).not.toBeUndefined();
+          expect(context.headers.someHeader).toEqual(headers.someHeader);
+        },
+      ).then(resolve, reject);
+    });
+  });
+
   describe('awaitRefetchQueries', () => {
     const awaitRefetchTest =
     ({ awaitRefetchQueries, testQueryError = false }: MutationBaseOptions & { testQueryError?: boolean }) =>

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -5,10 +5,17 @@ import { ApolloError } from '../errors';
 import { QueryInfo } from './QueryInfo';
 import { NetworkStatus } from './networkStatus';
 import { Resolver } from './LocalState';
+import { ObservableQuery } from './ObservableQuery';
+import { Cache } from '../cache';
 
 export { TypedDocumentNode } from '@graphql-typed-document-node/core';
 
 export type QueryListener = (queryInfo: QueryInfo) => void;
+
+export type ReobserveQueryCallback = (
+  observableQuery: ObservableQuery,
+  diff: Cache.DiffResult<any>,
+) => void | Promise<any>;
 
 export type OperationVariables = Record<string, any>;
 

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -3,7 +3,7 @@ import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 
 import { ApolloCache } from '../cache';
 import { FetchResult } from '../link/core';
-import { MutationQueryReducersMap } from './types';
+import { MutationQueryReducersMap, ReobserveQueryCallback } from './types';
 import { PureQueryOptions, OperationVariables } from './types';
 
 /**
@@ -240,6 +240,12 @@ export interface MutationBaseOptions<
    * `client.mutate` instead.
    */
   update?: MutationUpdaterFn<T>;
+
+  /**
+   * A function that will be called for each ObservableQuery affected by
+   * this mutation, after the mutation has completed.
+   */
+  reobserveQuery?: ReobserveQueryCallback;
 
   /**
    * Specifies the {@link ErrorPolicy} to be used for this operation

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -4,9 +4,9 @@ import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 
 import { Observable } from '../../utilities';
 import { FetchResult } from '../../link/core';
-import { ApolloClient, WatchQueryOptions } from '../../core';
 import { ApolloError } from '../../errors';
 import {
+  ApolloClient,
   ApolloQueryResult,
   ErrorPolicy,
   FetchMoreOptions,
@@ -17,7 +17,9 @@ import {
   ObservableQuery,
   OperationVariables,
   PureQueryOptions,
+  ReobserveQueryCallback,
   WatchQueryFetchPolicy,
+  WatchQueryOptions,
 } from '../../core';
 
 /* Common types */
@@ -148,6 +150,7 @@ export interface BaseMutationOptions<
   awaitRefetchQueries?: boolean;
   errorPolicy?: ErrorPolicy;
   update?: MutationUpdaterFn<TData>;
+  reobserveQuery?: ReobserveQueryCallback;
   client?: ApolloClient<object>;
   notifyOnNetworkStatusChange?: boolean;
   context?: Context;
@@ -166,6 +169,7 @@ export interface MutationFunctionOptions<
   refetchQueries?: Array<string | PureQueryOptions> | RefetchQueriesFunction;
   awaitRefetchQueries?: boolean;
   update?: MutationUpdaterFn<TData>;
+  reobserveQuery?: ReobserveQueryCallback;
   context?: Context;
   fetchPolicy?: WatchQueryFetchPolicy;
 }


### PR DESCRIPTION
Building on #7819, this PR implements the `reobserveQuery` option I described in https://github.com/apollographql/apollo-client/issues/7060#issuecomment-698026089, which allows mutations to override the refetching logic for any watched queries invalidated by the mutation `update` function.

The word "invalidated" is important here, since it means `reobserveQuery` will fire for any queries affected by cache writes, even if the result of the query does not end up changing. This is why it was previously difficult to make use of the `INVALIDATE` sentinel object added in #6991, as reported in #7060. Using `cache.modify` and `INVALIDATE` in the mutation `update` function should work smoothly with `reobserveQuery`, hopefully resolving #7060.

Similar functionality is achievable using just `cache.batch` and `onDirty`, so `reobserveQuery`-style behavior does not absolutely require a mutation, but `reobserveQuery` should greatly reduce the need for manual query enumeration after mutations, a la [`refetchQueries`](https://www.apollographql.com/blog/when-to-use-refetch-queries-in-apollo-client/). Also, since you can simply return a `Promise` from `reobserveQuery` to make the mutation await async work, the need to use `awaitRefetchQueries` should be (mostly) eliminated.

As foretold in #7819, this PR continues (finishes? 🤞) the implementation of the following item from the [Apollo Client v3.4 `ROADMAP.md` section](https://github.com/apollographql/apollo-client/blob/main/ROADMAP.md#34):

* A new API for reobserving/refetching queries after a mutation, eliminating the need for `updateQueries`, `refetchQueries`, and `awaitRefetchQueries` in a lot of cases.