### PR TITLE
Remove  `children` type override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Maintain serial ordering of `asyncMap` mapping function calls, and prevent potential unhandled `Promise` rejection errors. <br/>
   [@benjamn](https://github.com/benjamn) in [#7818](https://github.com/apollographql/apollo-client/pull/7818)
 
+- Remove `children` type override in MockedProviderProps <br />
+  [@kevinperaza](https://github.com/kevinperaza) in [#7833](https://github.com/apollographql/apollo-client/pull/7833)
+
 ## Apollo Client 3.3.11
 
 ### Bug fixes

--- a/src/utilities/testing/mocking/MockedProvider.tsx
+++ b/src/utilities/testing/mocking/MockedProvider.tsx
@@ -15,7 +15,7 @@ export interface MockedProviderProps<TSerializedCache = {}> {
   cache?: ApolloCache<TSerializedCache>;
   resolvers?: Resolvers;
   childProps?: object;
-  children?: React.ReactElement;
+  children?: any;
   link?: ApolloLink;
 }
 
@@ -57,7 +57,7 @@ export class MockedProvider extends React.Component<
 
   public render() {
     const { children, childProps } = this.props;
-    return children ? (
+    return React.isValidElement(children) ? (
       <ApolloProvider client={this.state.client}>
         {React.cloneElement(React.Children.only(children), { ...childProps })}
       </ApolloProvider>


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

Remove  `children` type override and add `React.isValidElement` to properly cast `React.ReactNode` to `React.ReactElement`

Fixes: https://github.com/apollographql/apollo-client/issues/7825

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
