### PR TITLE
Bump to the latest version of ts-invariant

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11206,9 +11206,9 @@
       }
     },
     "ts-invariant": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.6.1.tgz",
-      "integrity": "sha512-QQgN33g8E8yrdDuH29HASveLtbzMnRRgWh0i/JNTW4+zcLsdIOnfsgEDi/NKx4UckQyuMFt9Ujm6TWLWQ58Kvg==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.6.2.tgz",
+      "integrity": "sha512-hsVurayufl1gXg8CHtgZkB7X0KtA3TrI3xcJ9xkRr8FeJHnM/TIEQkgBq9XkpduyBWWUdlRIR9xWf4Lxq3LJTg==",
       "requires": {
         "@types/ungap__global-this": "^0.3.1",
         "@ungap/global-this": "^0.4.2",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "optimism": "^0.14.0",
     "prop-types": "^15.7.2",
     "symbol-observable": "^2.0.0",
-    "ts-invariant": "^0.6.1",
+    "ts-invariant": "^0.6.2",
     "tslib": "^1.10.0",
     "zen-observable": "^0.8.14"
   },


### PR DESCRIPTION
To bring in the changes outlined in https://github.com/apollographql/invariant-packages/pull/91 (I don't think we need to mention this in the `CHANGELOG` but let me know otherwise).

Closes #7845.