### PR TITLE
Add arg type to RefetchQueriesFunction

### DIFF
--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -142,8 +142,8 @@ export type QueryTuple<TData, TVariables> = [
 
 /* Mutation types */
 
-export type RefetchQueriesFunction = (
-  ...args: any[]
+export type RefetchQueriesFunction<TData> = (
+  result: FetchResult<TData>
 ) => Array<string | PureQueryOptions>;
 
 export interface BaseMutationOptions<
@@ -152,7 +152,7 @@ export interface BaseMutationOptions<
 > {
   variables?: TVariables;
   optimisticResponse?: TData | ((vars: TVariables) => TData);
-  refetchQueries?: Array<string | PureQueryOptions> | RefetchQueriesFunction;
+  refetchQueries?: Array<string | PureQueryOptions> | RefetchQueriesFunction<TData>;
   awaitRefetchQueries?: boolean;
   errorPolicy?: ErrorPolicy;
   update?: MutationUpdaterFn<TData>;
@@ -171,7 +171,7 @@ export interface MutationFunctionOptions<
 > {
   variables?: TVariables;
   optimisticResponse?: TData | ((vars: TVariables) => TData);
-  refetchQueries?: Array<string | PureQueryOptions> | RefetchQueriesFunction;
+  refetchQueries?: Array<string | PureQueryOptions> | RefetchQueriesFunction<TData>;
   awaitRefetchQueries?: boolean;
   update?: MutationUpdaterFn<TData>;
   context?: Context;


### PR DESCRIPTION
RefetchQueriesFunction has a FetchResult type on the [documentation](https://www.apollographql.com/docs/react/data/mutations/#usemutation-api), but the type is `any` on the code right now.

This PR add the type to `RefetchQueriesFunction` according to the documentation and the [source code](https://github.com/apollographql/apollo-client/blob/main/src/core/watchQueryOptions.ts#L201).

If the type is wrong or there is something I need to change, just let me know and I'll try to update it.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
