### PR TITLE
Prevent skipped/observerless `ObservableQuery`s from being refetched by `refetchQueries`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Remove unnecessary TypeScript global `Observable<T>["@@observable"]` method declaration. <br/>
   [@benjamn](https://github.com/benjamn) in [#7888](https://github.com/apollographql/apollo-client/pull/7888)
 
+- Prevent skipped/observerless `ObservableQuery`s from being refetched by `refetchQueries`. <br/>
+  [@dannycochran](https://github.com/dannycochran) in [#7877](https://github.com/apollographql/apollo-client/pull/7877)
+
 ## Apollo Client 3.3.12
 
 ### Bug fixes

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -272,6 +272,7 @@ export class QueryManager<TStore> {
               if (typeof refetchQuery === 'string') {
                 self.queries.forEach(({ observableQuery }) => {
                   if (observableQuery &&
+                      observableQuery.hasObservers() &&
                       observableQuery.queryName === refetchQuery) {
                     refetchQueryPromises.push(observableQuery.refetch());
                   }


### PR DESCRIPTION
Similar to the effort in https://github.com/apollographql/apollo-client/pull/7146, but this also applies that logic when refetching queries following a mutation.
