### PR TITLE
squash some console warnings in tests

### DIFF
--- a/src/__tests__/fetchMore.ts
+++ b/src/__tests__/fetchMore.ts
@@ -131,6 +131,52 @@ describe('updateQuery on a query with required and optional variables', () => {
   });
 });
 
+// TODO: Delete this test after removal of updateQuery from fetchMore.
+// This test squashes deprecation notice errors when the suite is run, but not
+// when individual tests are run.
+describe('updateQuery with fetchMore deprecation notice', () => {
+  const query = gql`
+    query thing {
+      entry
+    }
+  `;
+
+  const result = {
+    data: {
+      __typename: 'Query',
+      entry: 1,
+    },
+  };
+
+  const result1 = cloneDeep(result);
+  itAsync('fetchMore warns exactly once', (resolve, reject) => {
+    const spy = jest.spyOn(console, "warn").mockImplementation();
+    const link = mockSingleLink({
+      request: { query },
+      result,
+    }, {
+      request: { query },
+      result: result1,
+    }).setOnError(reject);
+
+    const client = new ApolloClient({
+      link,
+      cache: new InMemoryCache(),
+    });
+
+    const observable = client.watchQuery({query});
+    return observable.fetchMore({updateQuery: (prev) => prev}).then(() => {
+      expect(spy).toHaveBeenCalledTimes(1);
+    }).then(() => {
+      return observable.fetchMore({updateQuery: (prev) => prev});
+    }).then(() => {
+      expect(spy).toHaveBeenCalledTimes(1);
+    }).finally(() => {
+      spy.mockRestore();
+    }).then(resolve, reject);
+  });
+});
+
 describe('fetchMore on an observable query', () => {
   const query = gql`
     query Comment($repoName: String!, $start: Int!, $limit: Int!) {

--- a/src/core/__tests__/QueryManager/index.ts
+++ b/src/core/__tests__/QueryManager/index.ts
@@ -1352,6 +1352,7 @@ describe('QueryManager', () => {
   });
 
   itAsync('supports cache-only fetchPolicy fetching only cached data', (resolve, reject) => {
+    const spy = jest.spyOn(console, "warn").mockImplementation();
     const primeQuery = gql`
       query primeQuery {
         luke: people_one(id: 1) {
@@ -1396,9 +1397,13 @@ describe('QueryManager', () => {
         return handle.result().then(result => {
           expect(result.data['luke'].name).toBe('Luke Skywalker');
           expect(result.data).not.toHaveProperty('vader');
+          expect(spy).toHaveBeenCalledTimes(1);
         });
       })
-      .then(resolve, reject);
+      .finally(() => {
+        spy.mockRestore();
+      })
+      .then(resolve, reject)
   });
 
   itAsync('runs a mutation', (resolve, reject) => {
@@ -5410,21 +5415,16 @@ describe('QueryManager', () => {
   });
 
   describe('missing cache field warnings', () => {
-    const originalWarn = console.warn;
-    let warnCount = 0;
     let verbosity: ReturnType<typeof setVerbosity>;
-
+    let spy: any;
     beforeEach(() => {
-      warnCount = 0;
       verbosity = setVerbosity("warn");
-      console.warn = (...args: any[]) => {
-        warnCount += 1;
-      };
+      spy = jest.spyOn(console, "warn").mockImplementation();
     });
 
     afterEach(() => {
-      console.warn = originalWarn;
       setVerbosity(verbosity);
+      spy.mockRestore();
     });
 
     function validateWarnings(
@@ -5499,7 +5499,7 @@ describe('QueryManager', () => {
               networkStatus: NetworkStatus.ready,
               partial: true,
             });
-            expect(warnCount).toBe(expectedWarnCount);
+            expect(spy).toHaveBeenCalledTimes(expectedWarnCount);
           },
         ).then(resolve, reject)
       });

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -1113,6 +1113,26 @@ describe('useQuery Hook', () => {
   });
 
   describe('Pagination', () => {
+    // Because fetchMore with updateQuery is deprecated, this setup/teardown
+    // code is used to squash deprecation notices.
+    // TODO: delete me after fetchMore with updateQuery is removed.
+    let spy: any;
+    let warned = false;
+    beforeEach(() => {
+      if (!warned) {
+        spy = jest.spyOn(console, "warn").mockImplementation(() => {
+          warned = true;
+        });
+      }
+    });
+
+    afterEach(() => {
+      if (spy) {
+        spy.mockRestore();
+        spy = undefined;
+      }
+    });
+
     describe('should render fetchMore-updated results with proper loading status, when `notifyOnNetworkStatusChange` is true', () => {
       const carQuery: DocumentNode = gql`
         query cars($limit: Int) {
@@ -1221,6 +1241,11 @@ describe('useQuery Hook', () => {
 
         return wait(() => {
           expect(renderCount).toBe(4);
+          // TODO: delete me after fetchMore with updateQuery is removed.
+          if (spy) {
+            expect(spy).toHaveBeenCalledTimes(1);
+            spy.mockRestore();
+          }
         }).then(resolve, reject);
       });
 
@@ -1288,6 +1313,11 @@ describe('useQuery Hook', () => {
 
         return wait(() => {
           expect(renderCount).toBe(4);
+          // TODO: delete me after fetchMore with updateQuery is removed.
+          if (spy) {
+            expect(spy).toHaveBeenCalledTimes(1);
+            spy.mockRestore();
+          }
         }).then(resolve, reject);
       });
     });


### PR DESCRIPTION
👋 Just getting my feet wet by squashing a couple warnings which were emitted when running tests. I started to look into squashing the React warnings as well, but it looks like that is a little bit more involved and there seems to be multiple efforts to do this already (https://github.com/apollographql/apollo-client/pull/7745). Happy to be joining Apollo! No pressure to merge.