### PR TITLE
Update homepage link to react docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "bugs": {
     "url": "https://github.com/apollographql/apollo-client/issues"
   },
-  "homepage": "https://www.apollographql.com",
+  "homepage": "https://www.apollographql.com/docs/react/",
   "scripts": {
     "prebuild": "npm run clean",
     "build": "tsc",


### PR DESCRIPTION
Currently, the homepage link takes devs to `apollographql.com`. This PR changes the homepage link to the docs.
