### PR TITLE
Simplify EntityStore CacheGroup logic to improve InMemoryCache result caching.

### DIFF
--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -2199,7 +2199,8 @@ describe('client', () => {
     {
       const { data, optimisticData } = client.cache as any;
       expect(optimisticData).not.toBe(data);
-      expect(optimisticData.parent).toBe(data);
+      expect(optimisticData.parent).toBe(data.stump);
+      expect(optimisticData.parent.parent).toBe(data);
     }
 
     mutatePromise
@@ -2208,7 +2209,7 @@ describe('client', () => {
       })
       .catch((_: ApolloError) => {
         const { data, optimisticData } = client.cache as any;
-        expect(optimisticData).toBe(data);
+        expect(optimisticData).toBe(data.stump);
         resolve();
       });
   });

--- a/src/cache/core/types/Cache.ts
+++ b/src/cache/core/types/Cache.ts
@@ -28,6 +28,7 @@ export namespace Cache {
   export interface WatchOptions extends ReadOptions {
     immediate?: boolean;
     callback: WatchCallback;
+    lastDiff?: DiffResult<any>;
   }
 
   export interface EvictOptions {

--- a/src/cache/inmemory/__tests__/cache.ts
+++ b/src/cache/inmemory/__tests__/cache.ts
@@ -1492,22 +1492,11 @@ describe('Cache', () => {
       expect(dirtied.has(abInfo.watch)).toBe(true);
       expect(dirtied.has(bInfo.watch)).toBe(false);
 
-      expect(last(aInfo.diffs)).toEqual({
-        complete: true,
-        result: {
-          a: "ay",
-        },
-      });
-
-      expect(last(abInfo.diffs)).toEqual({
-        complete: true,
-        result: {
-          a: "ay",
-          b: "bee",
-        },
-      });
-
-      expect(bInfo.diffs.length).toBe(0);
+      // No new diffs should have been generated, since we only invalidated
+      // fields using cache.modify, and did not change any field values.
+      expect(aInfo.diffs).toEqual([]);
+      expect(abInfo.diffs).toEqual([]);
+      expect(bInfo.diffs).toEqual([]);
 
       aInfo.cancel();
       abInfo.cancel();
@@ -1686,7 +1675,6 @@ describe("InMemoryCache#broadcastWatches", function () {
     expect(receivedCallbackResults).toEqual([
       received1,
       // New results:
-      received1,
       received2,
     ]);
 
@@ -1715,7 +1703,6 @@ describe("InMemoryCache#broadcastWatches", function () {
 
     expect(receivedCallbackResults).toEqual([
       received1,
-      received1,
       received2,
       // New results:
       received3,
@@ -1735,15 +1722,11 @@ describe("InMemoryCache#broadcastWatches", function () {
 
     expect(receivedCallbackResults).toEqual([
       received1,
-      received1,
       received2,
       received3,
       received4,
       // New results:
-      received1,
       received2AllCaps,
-      received3,
-      received4,
     ]);
   });
 });

--- a/src/cache/inmemory/__tests__/readFromStore.ts
+++ b/src/cache/inmemory/__tests__/readFromStore.ts
@@ -1419,10 +1419,10 @@ describe('reading from the store', () => {
 
     const diffs: Cache.DiffResult<any>[] = [];
 
-    function watch() {
+    function watch(immediate = true) {
       return cache.watch({
         query: rulerQuery,
-        immediate: true,
+        immediate,
         optimistic: true,
         callback(diff) {
           diffs.push(diff);
@@ -1764,14 +1764,10 @@ describe('reading from the store', () => {
       diffWithZeusAsRuler,
     ]);
 
-    // Rewatch the rulerQuery, which will populate the same diffs array
-    // that we were using before.
-    const cancel2 = watch();
-
-    const diffWithApolloAsRuler = {
-      complete: true,
-      result: apolloRulerResult,
-    };
+    // Rewatch the rulerQuery, but avoid delivering an immediate initial
+    // result (by passing false), so that we can use cache.modify to
+    // trigger the delivery of diffWithApolloAsRuler below.
+    const cancel2 = watch(false);
 
     expect(diffs).toEqual([
       initialDiff,
@@ -1779,7 +1775,6 @@ describe('reading from the store', () => {
       diffWithoutDevouredSons,
       diffWithChildrenOfZeus,
       diffWithZeusAsRuler,
-      diffWithApolloAsRuler,
     ]);
 
     cache.modify({
@@ -1797,6 +1792,11 @@ describe('reading from the store', () => {
 
     cancel2();
 
+    const diffWithApolloAsRuler = {
+      complete: true,
+      result: apolloRulerResult,
+    };
+
     // The cache.modify call should have triggered another diff, since we
     // overwrote the ROOT_QUERY.ruler field with a valid Reference to the
     // Apollo entity object.
@@ -1806,7 +1806,6 @@ describe('reading from the store', () => {
       diffWithoutDevouredSons,
       diffWithChildrenOfZeus,
       diffWithZeusAsRuler,
-      diffWithApolloAsRuler,
       diffWithApolloAsRuler,
     ]);
 

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -518,7 +518,10 @@ export type FieldValueGetter = EntityStore["getFieldValue"];
 class CacheGroup {
   private d: OptimisticDependencyFunction<string> | null = null;
 
-  constructor(public readonly caching: boolean) {
+  constructor(
+    public readonly caching: boolean,
+    private parent: CacheGroup | null = null,
+  ) {
     this.d = caching ? dep<string>() : null;
   }
 
@@ -533,6 +536,9 @@ class CacheGroup {
         // short fieldName, so the field can be invalidated using either
         // level of specificity.
         this.d(makeDepKey(dataId, fieldName));
+      }
+      if (this.parent) {
+        this.parent.depend(dataId, storeFieldName);
       }
     }
   }
@@ -674,7 +680,7 @@ class Stump extends Layer {
       "EntityStore.Stump",
       root,
       () => {},
-      new CacheGroup(root.group.caching),
+      new CacheGroup(root.group.caching, root.group),
     );
   }
 

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -341,6 +341,17 @@ export abstract class EntityStore implements NormalizedCache {
     }
   }
 
+  // Remove every Layer, leaving behind only the Root and the Stump.
+  public prune(): EntityStore {
+    if (this instanceof Layer) {
+      const parent = this.removeLayer(this.id);
+      if (parent !== this) {
+        return parent.prune();
+      }
+    }
+    return this;
+  }
+
   public abstract getStorage(
     idOrObj: string | StoreObject,
     ...storeFieldNames: (string | number)[]
@@ -547,13 +558,6 @@ function makeDepKey(dataId: string, storeFieldName: string) {
 export namespace EntityStore {
   // Refer to this class as EntityStore.Root outside this namespace.
   export class Root extends EntityStore {
-    // Although each Root instance gets its own unique CacheGroup object,
-    // any Layer instances created by calling addLayer need to share a
-    // single distinct CacheGroup object. Since this shared object must
-    // outlast the Layer instances themselves, it needs to be created and
-    // owned by the Root instance.
-    private sharedLayerGroup: CacheGroup;
-
     constructor({
       policies,
       resultCaching = true,
@@ -564,16 +568,19 @@ export namespace EntityStore {
       seed?: NormalizedCacheObject;
     }) {
       super(policies, new CacheGroup(resultCaching));
-      this.sharedLayerGroup = new CacheGroup(resultCaching);
       if (seed) this.replace(seed);
     }
+
+    public readonly stump = new Stump(this);
 
     public addLayer(
       layerId: string,
       replay: (layer: EntityStore) => any,
     ): Layer {
-      // The replay function will be called in the Layer constructor.
-      return new Layer(layerId, this, replay, this.sharedLayerGroup);
+      // Adding an optimistic Layer on top of the Root actually adds the Layer
+      // on top of the Stump, so the Stump always comes between the Root and
+      // any Layer objects that we've added.
+      return this.stump.addLayer(layerId, replay);
     }
 
     public removeLayer(): Root {
@@ -654,6 +661,35 @@ class Layer extends EntityStore {
     let p: EntityStore = this.parent;
     while ((p as Layer).parent) p = (p as Layer).parent;
     return p.getStorage.apply(p, arguments);
+  }
+}
+
+// Represents a Layer permanently installed just above the Root, which allows
+// reading optimistically (and registering optimistic dependencies) even when
+// no optimistic layers are currently active. The stump.group CacheGroup object
+// is shared by any/all Layer objects added on top of the Stump.
+class Stump extends Layer {
+  constructor(root: EntityStore.Root) {
+    super(
+      "EntityStore.Stump",
+      root,
+      () => {},
+      new CacheGroup(root.group.caching),
+    );
+  }
+
+  public removeLayer() {
+    // Never remove the Stump layer.
+    return this;
+  }
+
+  public merge() {
+    // We never want to write any data into the Stump, so we forward any merge
+    // calls to the Root instead. Another option here would be to throw an
+    // exception, but the toReference(object, true) function can sometimes
+    // trigger Stump writes (which used to be Root writes, before the Stump
+    // concept was introduced).
+    return this.parent.merge.apply(this.parent, arguments);
   }
 }
 

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -446,6 +446,8 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
       }
     }
 
-    c.callback(diff);
+    if (!c.lastDiff || c.lastDiff.result !== diff.result) {
+      c.callback(c.lastDiff = diff);
+    }
   }
 }

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -83,7 +83,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     // Passing { resultCaching: false } in the InMemoryCache constructor options
     // will completely disable dependency tracking, which will improve memory
     // usage but worsen the performance of repeated reads.
-    this.data = new EntityStore.Root({
+    const rootStore = this.data = new EntityStore.Root({
       policies: this.policies,
       resultCaching: this.config.resultCaching,
     });
@@ -91,9 +91,9 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     // When no optimistic writes are currently active, cache.optimisticData ===
     // cache.data, so there are no additional layers on top of the actual data.
     // When an optimistic update happens, this.optimisticData will become a
-    // linked list of OptimisticCacheLayer objects that terminates with the
+    // linked list of EntityStore Layer objects that terminates with the
     // original this.data cache object.
-    this.optimisticData = this.data;
+    this.optimisticData = rootStore.stump;
 
     this.storeWriter = new StoreWriter(
       this,
@@ -293,8 +293,8 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
   }
 
   public reset(): Promise<void> {
+    this.optimisticData = this.optimisticData.prune();
     this.data.clear();
-    this.optimisticData = this.data;
     this.broadcastWatches();
     return Promise.resolve();
   }

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -2,7 +2,7 @@
 import './fixPolyfills';
 
 import { DocumentNode } from 'graphql';
-import { dep, wrap } from 'optimism';
+import { wrap } from 'optimism';
 
 import { ApolloCache, BatchOptions } from '../core/cache';
 import { Cache } from '../core/types/Cache';
@@ -225,7 +225,6 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
       if (this.watches.delete(watch) && !this.watches.size) {
         forgetCache(this);
       }
-      this.watchDep.dirty(watch);
       // Remove this watch from the LRU cache managed by the
       // maybeBroadcastWatch OptimisticWrapperFunction, to prevent memory
       // leaks involving the closure of watch.callback.
@@ -417,8 +416,6 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     }
   });
 
-  private watchDep = dep<Cache.WatchOptions>();
-
   // This method is wrapped by maybeBroadcastWatch, which is called by
   // broadcastWatches, so that we compute and broadcast results only when
   // the data that would be broadcast might have changed. It would be
@@ -429,23 +426,6 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     c: Cache.WatchOptions,
     options?: BroadcastOptions,
   ) {
-    // First, invalidate any other maybeBroadcastWatch wrapper functions
-    // currently depending on this Cache.WatchOptions object (including
-    // the one currently calling broadcastWatch), so they will be included
-    // in the next broadcast, even if the result they receive is the same
-    // as the previous result they received. This is important because we
-    // are about to deliver a different result to c.callback, so any
-    // previous results should have a chance to be redelivered.
-    this.watchDep.dirty(c);
-
-    // Next, re-depend on this.watchDep for just this invocation of
-    // maybeBroadcastWatch (this is a no-op if broadcastWatch was not
-    // called by maybeBroadcastWatch). This allows only the most recent
-    // maybeBroadcastWatch invocation for this watcher to remain cached,
-    // enabling re-broadcast of previous results even if they have not
-    // changed since they were previously delivered.
-    this.watchDep(c);
-
     const diff = this.diff<any>({
       query: c.query,
       variables: c.variables,


### PR DESCRIPTION
I'll be the first person to admit I don't love the complexity added by the `CacheGroup` concept I introduced in #5648, but it remains useful for separating result caching (#3394) dependencies into two distinct groups: optimistic and non-optimistic.

This separation is important because it allows cache readers who only care about non-optimistic data to continue to benefit from `InMemoryCache` result caching even while optimistic cache updates are taking place, because the optimistic dependencies that get invalidated by optimistic cache writes are tracked in a separate `CacheGroup` from the group used to track the non-optimistic dependencies registered by non-optimistic reads.

In the process of writing tests for #7827, I realized this `CacheGroup` story had a missing piece (or two):

During optimistic cache reads (where the reader indicates they can accept optimistic data, by passing `optimistic: true`), optimistic dependencies were getting registered only when there were any active optimistic `Layer` objects (that is, only during mutations with optimistic responses). When no optimistic updates were in progress (that is, most of the time), an optimistic cache read would register exactly the same (non-optimistic) dependencies as a non-optimistic read, so future optimistic updates would be mistakenly prevented from invalidating the cached results of those optimistic reads.

By adding a permanent `Stump` layer between the `Root` store and any additional `Layer` objects, we can ensure that optimistic reads always register optimistic dependencies, because those reads now always read _through_ the `Stump` layer (which owns the `CacheGroup` shared by all `Layer` objects), even when there are no active `Layer`s currently on top of the `Stump`. Likewise, non-optimistic reads always read directly from the `Root` layer, ignoring the `Stump`.

This insight may not simplify the `CacheGroup` logic much, but it means optimistic cache reads will consistently register optimistic dependencies (by reading through the `Stump`), rather than registering them only sometimes (depending on whether optimistic updates are currently in progress, a dangerously dynamic condition).

More importantly, since optimistic cache watchers no longer switch their `CacheGroup` when optimistic updates start or stop happening, optimistic result objects previously read from the cache (when there were no optimistic updates happening) can be immediately reused as optimistic results while optimistic updates are in progress, as long as none of the fields involved have been invalidated. This improvement should resolve the concerns raised by @stephenh in https://github.com/apollographql/apollo-client/issues/4141#issuecomment-749552928.

In addition to introducing the concept of a `Stump`, I noticed a few more opportunities for related improvements. For more details, please read the commit messages.