### PR TITLE
Remove global Observable<T>["@@observable"] method declaration.

### DIFF
--- a/src/utilities/observables/Observable.ts
+++ b/src/utilities/observables/Observable.ts
@@ -8,15 +8,13 @@ export type ObservableSubscription = ZenObservable.Subscription;
 export type Observer<T> = ZenObservable.Observer<T>;
 export type Subscriber<T> = ZenObservable.Subscriber<T>;
 
-// Use global module augmentation to add RxJS interop functionality. By
-// using this approach (instead of subclassing `Observable` and adding an
-// ['@@observable']() method), we ensure the exported `Observable` retains all
-// existing type declarations from `@types/zen-observable` (which is important
-// for projects like `apollo-link`).
-declare global {
-  interface Observable<T> {
-    ['@@observable'](): Observable<T>;
-  }
+// The zen-observable package defines Observable.prototype[Symbol.observable]
+// when Symbol is supported, but RxJS interop depends on also setting this fake
+// '@@observable' string as a polyfill for Symbol.observable.
+const { prototype } = Observable;
+const fakeObsSymbol = '@@observable' as keyof typeof prototype;
+if (!prototype[fakeObsSymbol]) {
+  prototype[fakeObsSymbol] = function () { return this; };
 }
-(Observable.prototype as any)['@@observable'] = function () { return this; };
+
 export { Observable };


### PR DESCRIPTION
Should fix #7839.

I find it surprising that setting `Observable.prototype['@@observable']` is necessary in addition to setting `Observable.prototype[Symbol.observable]` (which `zen-observable` already [does](https://github.com/zenparsing/zen-observable/blob/328fb66a99242900c0fd4a330e9ff66ecfa3a887/src/Observable.js#L3-L12)), but if you comment out
```ts
  prototype[fakeObsSymbol] = function () { return this; };
```
and run our test suite, you will see failures:
```
 FAIL  core/__tests__/QueryManager/index.ts (20.796 s)
  ● QueryManager › supports interoperability with other Observable implementations like RxJS

    TypeError: You provided an invalid object where a stream was expected. You can provide an Observable, Promise, Array, or Iterable.

      577 |     });
      578 | 
    > 579 |     const observable = from(handle as any);
          |                        ^
      580 | 
      581 |     observable.pipe(map(result => assign({ fromRx: true }, result))).subscribe({
      582 |       next: wrap(reject, newResult => {

      at Object.<anonymous>.exports.subscribeTo (../node_modules/rxjs/src/internal/util/subscribeTo.ts:27:11)
      at Object.from (../node_modules/rxjs/src/internal/observable/from.ts:114:30)
      at Object.<anonymous> (core/__tests__/QueryManager/index.ts:579:24)
      at utilities/testing/itAsync.ts:11:37
      at Object.<anonymous> (utilities/testing/itAsync.ts:10:12)
```