### PR TITLE
Allow keyFields and keyArgs functions to return false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Apollo Client 3.3.14 (not yet released)
+
+### Improvements
+
+- Adjust TypeScript types to allow `keyFields` and `keyArgs` functions to return `false`. <br/>
+  [@CarsonF](https://github.com/CarsonF) and [@benjamn](https://github.com/benjamn) in [#7900](https://github.com/apollographql/apollo-client/pull/7900)
+
 ## Apollo Client 3.3.13
 
 ### Improvements

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -63,7 +63,7 @@ type KeyFieldsContext = {
 export type KeyFieldsFunction = (
   object: Readonly<StoreObject>,
   context: KeyFieldsContext,
-) => KeySpecifier | ReturnType<IdGetter>;
+) => KeySpecifier | false | ReturnType<IdGetter>;
 
 // TODO Should TypePolicy be a generic type, with a TObject or TEntity
 // type parameter?
@@ -103,7 +103,7 @@ export type KeyArgsFunction = (
     field: FieldNode | null;
     variables?: Record<string, any>;
   },
-) => KeySpecifier | ReturnType<IdGetter>;
+) => KeySpecifier | false | ReturnType<IdGetter>;
 
 export type FieldPolicy<
   // The internal representation used to store the field's data in the

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -65,6 +65,8 @@ export type KeyFieldsFunction = (
   context: KeyFieldsContext,
 ) => KeySpecifier | false | ReturnType<IdGetter>;
 
+type KeyFieldsResult = Exclude<ReturnType<KeyFieldsFunction>, KeySpecifier>;
+
 // TODO Should TypePolicy be a generic type, with a TObject or TEntity
 // type parameter?
 export type TypePolicy = {
@@ -104,6 +106,8 @@ export type KeyArgsFunction = (
     variables?: Record<string, any>;
   },
 ) => KeySpecifier | false | ReturnType<IdGetter>;
+
+type KeyArgsResult = Exclude<ReturnType<KeyArgsFunction>, KeySpecifier>;
 
 export type FieldPolicy<
   // The internal representation used to store the field's data in the
@@ -337,7 +341,7 @@ export class Policies {
       fragmentMap,
     };
 
-    let id: string | undefined;
+    let id: KeyFieldsResult;
 
     const policy = typename && this.getTypePolicy(typename);
     let keyFn = policy && policy.keyFn || this.config.dataIdFromObject;
@@ -351,8 +355,7 @@ export class Policies {
       }
     }
 
-    id = id && String(id);
-
+    id = id ? String(id) : void 0;
     return context.keyObject ? [id, context.keyObject] : [id];
   }
 
@@ -674,7 +677,7 @@ export class Policies {
   public getStoreFieldName(fieldSpec: FieldSpecifier): string {
     const { typename, fieldName } = fieldSpec;
     const policy = this.getFieldPolicy(typename, fieldName, false);
-    let storeFieldName: string | undefined;
+    let storeFieldName: KeyArgsResult;
 
     let keyFn = policy && policy.keyFn;
     if (keyFn && typename) {
@@ -702,6 +705,12 @@ export class Policies {
       storeFieldName = fieldSpec.field
         ? storeKeyNameFromField(fieldSpec.field, fieldSpec.variables)
         : getStoreKeyName(fieldName, argsFromFieldSpecifier(fieldSpec));
+    }
+
+    // Returning false from a keyArgs function is like configuring
+    // keyArgs: false, but more dynamic.
+    if (storeFieldName === false) {
+      return fieldName;
     }
 
     // Make sure custom field names start with the actual field.name.value

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -85,7 +85,7 @@ export class StoreWriter {
 
     variables = {
       ...getDefaultValues(operationDefinition),
-      ...variables,
+      ...variables!,
     };
 
     const ref = this.processSelectionSet({
@@ -178,7 +178,7 @@ export class StoreWriter {
     // If typename was not passed in, infer it. Note that typename is
     // always passed in for tricky-to-infer cases such as "Query" for
     // ROOT_QUERY.
-    const typename =
+    const typename: string | undefined =
       (dataId && policies.rootTypenamesById[dataId]) ||
       getTypenameFromResult(result, selectionSet, context.fragmentMap) ||
       (dataId && context.store.get(dataId, "__typename") as string);


### PR DESCRIPTION
Previously the function was not allowed to return false even though false is supported
