### PR TITLE
Provide variables and context to update function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ TBD
 - Allow `merge: true` field policy to merge `Reference` objects with non-normalized objects, and vice-versa. <br/>
   [@benjamn](https://github.com/benjamn) in [#7778](https://github.com/apollographql/apollo-client/pull/7778)
 
+- Pass `variables` and `context` to a mutation's `update` function <br/>
+  [@jcreighton](https://github.com/jcreighton) in [#7902](https://github.com/apollographql/apollo-client/pull/7902)
 ### Documentation
 TBD
 

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -29,11 +29,12 @@ import {
   LocalState,
   FragmentMatcher,
 } from './LocalState';
+import { Context } from 'vm';
 
 export interface DefaultOptions {
   watchQuery?: Partial<WatchQueryOptions<any, any>>;
   query?: Partial<QueryOptions<any, any>>;
-  mutate?: Partial<MutationOptions<any, any>>;
+  mutate?: Partial<MutationOptions<any, any, any>>;
 }
 
 let hasSuggestedDevtools = false;
@@ -57,13 +58,13 @@ export type ApolloClientOptions<TCacheShape> = {
   version?: string;
 };
 
-type OptionsUnion<TData, TVariables> =
+type OptionsUnion<TData, TVariables, TContext> =
   | WatchQueryOptions<TVariables, TData>
   | QueryOptions<TVariables, TData>
-  | MutationOptions<TData, TVariables>;
+  | MutationOptions<TData, TVariables, TContext>;
 
 export function mergeOptions<
-  TOptions extends OptionsUnion<any, any>
+  TOptions extends OptionsUnion<any, any, any>
 >(
   defaults: Partial<TOptions>,
   options: TOptions,
@@ -348,13 +349,13 @@ export class ApolloClient<TCacheShape> implements DataProxy {
    *
    * It takes options as an object with the following keys and values:
    */
-  public mutate<T = any, TVariables = OperationVariables>(
-    options: MutationOptions<T, TVariables>,
+  public mutate<T = any, TVariables = OperationVariables, TContext = Context>(
+    options: MutationOptions<T, TVariables, TContext>,
   ): Promise<FetchResult<T>> {
     if (this.defaultOptions.mutate) {
       options = mergeOptions(this.defaultOptions.mutate, options);
     }
-    return this.queryManager.mutate<T>(options);
+    return this.queryManager.mutate<T, TVariables, TContext>(options);
   }
 
   /**

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -12,9 +12,9 @@ import { ObservableQuery } from './ObservableQuery';
 
 import {
   ApolloQueryResult,
+  Context,
   OperationVariables,
   Resolvers,
-  Context,
 } from './types';
 
 import {

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -12,7 +12,7 @@ import { ObservableQuery } from './ObservableQuery';
 
 import {
   ApolloQueryResult,
-  Context,
+  DefaultContext,
   OperationVariables,
   Resolvers,
 } from './types';
@@ -349,7 +349,7 @@ export class ApolloClient<TCacheShape> implements DataProxy {
    *
    * It takes options as an object with the following keys and values:
    */
-  public mutate<T = any, TVariables = OperationVariables, TContext = Context>(
+  public mutate<T = any, TVariables = OperationVariables, TContext = DefaultContext>(
     options: MutationOptions<T, TVariables, TContext>,
   ): Promise<FetchResult<T>> {
     if (this.defaultOptions.mutate) {

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -349,13 +349,18 @@ export class ApolloClient<TCacheShape> implements DataProxy {
    *
    * It takes options as an object with the following keys and values:
    */
-  public mutate<T = any, TVariables = OperationVariables, TContext = DefaultContext>(
-    options: MutationOptions<T, TVariables, TContext>,
-  ): Promise<FetchResult<T>> {
+  public mutate<
+    TData = any,
+    TVariables = OperationVariables,
+    TContext = DefaultContext,
+    TCache extends ApolloCache<any> = ApolloCache<any>
+  >(
+    options: MutationOptions<TData, TVariables, TContext>,
+  ): Promise<FetchResult<TData>> {
     if (this.defaultOptions.mutate) {
       options = mergeOptions(this.defaultOptions.mutate, options);
     }
-    return this.queryManager.mutate<T, TVariables, TContext>(options);
+    return this.queryManager.mutate<TData, TVariables, TContext, TCache>(options);
   }
 
   /**

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -14,6 +14,7 @@ import {
   ApolloQueryResult,
   OperationVariables,
   Resolvers,
+  Context,
 } from './types';
 
 import {
@@ -29,7 +30,6 @@ import {
   LocalState,
   FragmentMatcher,
 } from './LocalState';
-import { Context } from 'vm';
 
 export interface DefaultOptions {
   watchQuery?: Partial<WatchQueryOptions<any, any>>;

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -36,6 +36,7 @@ import {
   ApolloQueryResult,
   OperationVariables,
   MutationUpdaterFunction,
+  ReobserveQueryCallback,
 } from './types';
 import { LocalState } from './LocalState';
 
@@ -217,7 +218,11 @@ export class QueryManager<TStore> {
 
           if (fetchPolicy !== 'no-cache') {
             try {
-              self.markMutationResult<T, TVariables, TContext>({
+            // Returning the result of markMutationResult here makes the
+            // mutation await any Promise that markMutationResult returns,
+            // since we are returning this Promise from the asyncMap mapping
+            // function.
+              return self.markMutationResult<T, TVariables, TContext>({
                 mutationId,
                 result,
                 document: mutation,
@@ -299,8 +304,9 @@ export class QueryManager<TStore> {
       variables?: TVariables;
       errorPolicy: ErrorPolicy;
       context?: TContext;
-      updateQueries: UpdateQueries<TData>,
-      update?: MutationUpdaterFunction<TData, TVariables, TContext>,
+      updateQueries: UpdateQueries<TData>;
+      update?: MutationUpdaterFunction<TData, TVariables, TContext>;
+      reobserveQuery?: ReobserveQueryCallback;
     },
     cache = this.cache,
   ): Promise<void> {
@@ -361,24 +367,29 @@ export class QueryManager<TStore> {
           // a write action.
           const { update } = mutation;
           if (update) {
-            update(c, mutation.result);
+            update(c as any, mutation.result, {
+              context: mutation.context,
+              variables: mutation.variables,
+            });
           }
         },
 
         // Write the final mutation.result to the root layer of the cache.
         optimistic: false,
 
-        // If the mutation has some writes associated with it then we need to
-        // apply those writes to the store by running this reducer again with a
-        // write action.
-        const { update } = mutation;
-        if (update) {
-          update(c as any, mutation.result, {
-            context: mutation.context,
-            variables: mutation.variables,
-          });
-        }
-      }, /* non-optimistic transaction: */ null);
+        onDirty: mutation.reobserveQuery && ((watch, diff) => {
+          if (watch.watcher instanceof QueryInfo) {
+            const oq = watch.watcher.observableQuery;
+            if (oq) {
+              reobserveResults.push(mutation.reobserveQuery!(oq, diff));
+              // Prevent the normal cache broadcast of this result.
+              return false;
+            }
+          }
+        }),
+      });
+
+      return Promise.all(reobserveResults).then(() => void 0);
     }
 
     return Promise.resolve();

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -56,6 +56,10 @@ interface MutationStoreValue {
 }
 
 type MutationResult<TData> = Omit<FetchResult<TData>, 'context'>;
+interface MutationResultOptions {
+  context?: Record<string, any>,
+  variables?: OperationVariables,
+}
 
 export class QueryManager<TStore> {
   public cache: ApolloCache<TStore>;
@@ -141,7 +145,7 @@ export class QueryManager<TStore> {
     reobserveQuery,
     errorPolicy = 'none',
     fetchPolicy,
-    context = {},
+    context,
   }: MutationOptions): Promise<FetchResult<T>> {
     invariant(
       mutation,
@@ -307,10 +311,7 @@ export class QueryManager<TStore> {
       update?: (
         cache: ApolloCache<TStore>,
         result: MutationResult<TData>,
-        options: {
-          context?: Record<string, any>,
-          variables?: OperationVariables,
-        },
+        options: MutationResultOptions,
       ) => void;
       reobserveQuery?: ReobserveQueryCallback;
     },
@@ -407,7 +408,8 @@ export class QueryManager<TStore> {
       updateQueries: MutationOptions<TData>["updateQueries"],
       update?: (
         cache: ApolloCache<TStore>,
-        result: MutationResult<TData>
+        result: MutationResult<TData>,
+        options: MutationResultOptions,
       ) => void;
     },
   ) {

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -223,10 +223,10 @@ export class QueryManager<TStore> {
 
           if (fetchPolicy !== 'no-cache') {
             try {
-            // Returning the result of markMutationResult here makes the
-            // mutation await any Promise that markMutationResult returns,
-            // since we are returning this Promise from the asyncMap mapping
-            // function.
+              // Returning the result of markMutationResult here makes the
+              // mutation await any Promise that markMutationResult returns,
+              // since we are returning this Promise from the asyncMap mapping
+              // function.
               return self.markMutationResult<TData, TVariables, TContext, TCache>({
                 mutationId,
                 result,

--- a/src/core/__tests__/QueryManager/index.ts
+++ b/src/core/__tests__/QueryManager/index.ts
@@ -5381,7 +5381,7 @@ describe('QueryManager', () => {
 
   describe('awaitRefetchQueries', () => {
     const awaitRefetchTest =
-    ({ awaitRefetchQueries, testQueryError = false }: MutationBaseOptions & { testQueryError?: boolean }) =>
+    ({ awaitRefetchQueries, testQueryError = false }: MutationBaseOptions<any, any, any> & { testQueryError?: boolean }) =>
     new Promise((resolve, reject) => {
       const query = gql`
         query getAuthors($id: ID!) {
@@ -5455,7 +5455,7 @@ describe('QueryManager', () => {
         { observable },
         result => {
           expect(stripSymbols(result.data)).toEqual(queryData);
-          const mutateOptions: MutationOptions = {
+          const mutateOptions: MutationOptions<any, any, any> = {
             mutation,
             refetchQueries: ['getAuthors'],
           };

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -21,7 +21,6 @@ export {
   ErrorPolicy,
   FetchMoreQueryOptions,
   SubscribeToMoreOptions,
-  MutationUpdaterFn,
 } from './watchQueryOptions';
 export { NetworkStatus } from './networkStatus';
 export * from './types';

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,5 +1,6 @@
 import { DocumentNode, GraphQLError } from 'graphql';
 
+import { ApolloCache } from '../cache';
 import { FetchResult } from '../link/core';
 import { ApolloError } from '../errors';
 import { QueryInfo } from './QueryInfo';
@@ -9,6 +10,8 @@ import { ObservableQuery } from './ObservableQuery';
 import { Cache } from '../cache';
 
 export { TypedDocumentNode } from '@graphql-typed-document-node/core';
+
+export type Context = Record<string, any>;
 
 export type QueryListener = (queryInfo: QueryInfo) => void;
 
@@ -51,6 +54,14 @@ export type MutationQueryReducersMap<T = { [key: string]: any }> = {
   [queryName: string]: MutationQueryReducer<T>;
 };
 
+export type MutationUpdaterFunction<T extends Record<string, any>, TVariables, TContext> = (
+  cache: ApolloCache<T>,
+  result: Omit<FetchResult<T>, 'context'>,
+  options: {
+    context?: TContext,
+    variables?: TVariables,
+  },
+) => void;
 export interface Resolvers {
   [key: string]: {
     [ field: string ]: Resolver;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -54,7 +54,7 @@ export type MutationQueryReducersMap<T = { [key: string]: any }> = {
   [queryName: string]: MutationQueryReducer<T>;
 };
 
-export type MutationUpdaterFunction<T extends Record<string, any>, TVariables, TContext> = (
+export type MutationUpdaterFunction<T, TVariables, TContext> = (
   cache: ApolloCache<T>,
   result: Omit<FetchResult<T>, 'context'>,
   options: {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -54,9 +54,14 @@ export type MutationQueryReducersMap<T = { [key: string]: any }> = {
   [queryName: string]: MutationQueryReducer<T>;
 };
 
-export type MutationUpdaterFunction<T, TVariables, TContext> = (
-  cache: ApolloCache<T>,
-  result: Omit<FetchResult<T>, 'context'>,
+export type MutationUpdaterFunction<
+  TData,
+  TVariables,
+  TContext,
+  TCache extends ApolloCache<any>
+> = (
+  cache: TCache,
+  result: Omit<FetchResult<TData>, 'context'>,
   options: {
     context?: TContext,
     variables?: TVariables,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -11,7 +11,7 @@ import { Cache } from '../cache';
 
 export { TypedDocumentNode } from '@graphql-typed-document-node/core';
 
-export type Context = Record<string, any>;
+export type DefaultContext = Record<string, any>;
 
 export type QueryListener = (queryInfo: QueryInfo) => void;
 

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -3,7 +3,7 @@ import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 
 import { FetchResult } from '../link/core';
 import {
-  Context,
+  DefaultContext,
   MutationQueryReducersMap,
   PureQueryOptions,
   OperationVariables,
@@ -149,7 +149,7 @@ export type SubscribeToMoreOptions<
   variables?: TSubscriptionVariables;
   updateQuery?: UpdateQueryFn<TData, TSubscriptionVariables, TSubscriptionData>;
   onError?: (error: Error) => void;
-  context?: Record<string, any>;
+  context?: DefaultContext;
 };
 
 export interface SubscriptionOptions<TVariables = OperationVariables, TData = any> {
@@ -178,15 +178,15 @@ export interface SubscriptionOptions<TVariables = OperationVariables, TData = an
   /**
    * Context object to be passed through the link execution chain.
    */
-  context?: Record<string, any>;
+  context?: DefaultContext;
 }
 
 export type RefetchQueryDescription = Array<string | PureQueryOptions>;
 
 export interface MutationBaseOptions<
-  T,
-  TVariables,
-  TContext,
+  T = any,
+  TVariables = OperationVariables,
+  TContext = DefaultContext,
 > {
   /**
    * An object that represents the result of this mutation that will be
@@ -267,8 +267,8 @@ export interface MutationBaseOptions<
 
 export interface MutationOptions<
   T = any,
-  TVariables extends OperationVariables = OperationVariables,
-  TContext extends Context = Context,
+  TVariables = OperationVariables,
+  TContext = DefaultContext,
 > extends MutationBaseOptions<T, TVariables, TContext> {
   /**
    * A GraphQL document, often created with `gql` from the `graphql-tag`

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -8,6 +8,7 @@ import {
   PureQueryOptions,
   OperationVariables,
   MutationUpdaterFunction,
+  ReobserveQueryCallback,
 } from './types';
 
 /**
@@ -265,9 +266,9 @@ export interface MutationBaseOptions<
 }
 
 export interface MutationOptions<
-  T,
-  TVariables extends OperationVariables,
-  TContext extends Context,
+  T = any,
+  TVariables extends OperationVariables = OperationVariables,
+  TContext extends Context = Context,
 > extends MutationBaseOptions<T, TVariables, TContext> {
   /**
    * A GraphQL document, often created with `gql` from the `graphql-tag`

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -294,4 +294,5 @@ export interface MutationOptions<
 export type MutationUpdaterFn<T = { [key: string]: any }> = (
   cache: ApolloCache<T>,
   mutationResult: FetchResult<T>,
+  options?: any,
 ) => void;

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -10,6 +10,7 @@ import {
   MutationUpdaterFunction,
   ReobserveQueryCallback,
 } from './types';
+import { ApolloCache } from '../cache';
 
 /**
  * fetchPolicy determines where the client may return a result from. The options are:
@@ -184,9 +185,10 @@ export interface SubscriptionOptions<TVariables = OperationVariables, TData = an
 export type RefetchQueryDescription = Array<string | PureQueryOptions>;
 
 export interface MutationBaseOptions<
-  T = any,
+  TData = any,
   TVariables = OperationVariables,
   TContext = DefaultContext,
+  TCache extends ApolloCache<any> = ApolloCache<any>,
 > {
   /**
    * An object that represents the result of this mutation that will be
@@ -195,7 +197,7 @@ export interface MutationBaseOptions<
    * the result of a mutation immediately, and update the UI later if any errors
    * appear.
    */
-  optimisticResponse?: T | ((vars: TVariables) => T);
+  optimisticResponse?: TData | ((vars: TVariables) => TData);
 
   /**
    * A {@link MutationQueryReducersMap}, which is map from query names to
@@ -203,7 +205,7 @@ export interface MutationBaseOptions<
    * results of the mutation into the results of queries that are currently
    * being watched by your application.
    */
-  updateQueries?: MutationQueryReducersMap<T>;
+  updateQueries?: MutationQueryReducersMap<TData>;
 
   /**
    * A list of query names which will be refetched once this mutation has
@@ -214,7 +216,7 @@ export interface MutationBaseOptions<
    * once these queries return.
    */
   refetchQueries?:
-    | ((result: FetchResult<T>) => RefetchQueryDescription)
+    | ((result: FetchResult<TData>) => RefetchQueryDescription)
     | RefetchQueryDescription;
 
   /**
@@ -245,7 +247,7 @@ export interface MutationBaseOptions<
    * and you don't need to update the store, use the Promise returned from
    * `client.mutate` instead.
    */
-  update?: MutationUpdaterFunction<T, TVariables, TContext>;
+  update?: MutationUpdaterFunction<TData, TVariables, TContext, TCache>;
 
   /**
    * A function that will be called for each ObservableQuery affected by
@@ -266,15 +268,16 @@ export interface MutationBaseOptions<
 }
 
 export interface MutationOptions<
-  T = any,
+  TData = any,
   TVariables = OperationVariables,
   TContext = DefaultContext,
-> extends MutationBaseOptions<T, TVariables, TContext> {
+  TCache extends ApolloCache<any> = ApolloCache<any>,
+> extends MutationBaseOptions<TData, TVariables, TContext, TCache> {
   /**
    * A GraphQL document, often created with `gql` from the `graphql-tag`
    * package, that contains a single mutation inside of it.
    */
-  mutation: DocumentNode | TypedDocumentNode<T, TVariables>;
+  mutation: DocumentNode | TypedDocumentNode<TData, TVariables>;
 
   /**
    * The context to be passed to the link execution chain. This context will

--- a/src/react/components/types.ts
+++ b/src/react/components/types.ts
@@ -1,7 +1,7 @@
 import { DocumentNode } from 'graphql';
 import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 
-import { OperationVariables, DefaultContext } from '../../core';
+import { OperationVariables, DefaultContext, ApolloCache } from '../../core';
 import {
   QueryFunctionOptions,
   QueryResult,
@@ -24,7 +24,8 @@ export interface MutationComponentOptions<
   TData = any,
   TVariables = OperationVariables,
   TContext = DefaultContext,
-> extends BaseMutationOptions<TData, TVariables, TContext> {
+  TCache extends ApolloCache<any> = ApolloCache<any>
+> extends BaseMutationOptions<TData, TVariables, TContext, TCache> {
   mutation: DocumentNode | TypedDocumentNode<TData, TVariables>;
   children: (
     mutateFunction: MutationFunction<TData, TVariables, TContext>,

--- a/src/react/components/types.ts
+++ b/src/react/components/types.ts
@@ -1,7 +1,7 @@
 import { DocumentNode } from 'graphql';
 import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 
-import { OperationVariables } from '../../core';
+import { OperationVariables, Context } from '../../core';
 import {
   QueryFunctionOptions,
   QueryResult,
@@ -22,11 +22,12 @@ export interface QueryComponentOptions<
 
 export interface MutationComponentOptions<
   TData = any,
-  TVariables = OperationVariables
-> extends BaseMutationOptions<TData, TVariables> {
+  TVariables = OperationVariables,
+  TContext = Context,
+> extends BaseMutationOptions<TData, TVariables, TContext> {
   mutation: DocumentNode | TypedDocumentNode<TData, TVariables>;
   children: (
-    mutateFunction: MutationFunction<TData, TVariables>,
+    mutateFunction: MutationFunction<TData, TVariables, TContext>,
     result: MutationResult<TData>
   ) => JSX.Element | null;
 }

--- a/src/react/components/types.ts
+++ b/src/react/components/types.ts
@@ -1,7 +1,7 @@
 import { DocumentNode } from 'graphql';
 import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 
-import { OperationVariables, Context } from '../../core';
+import { OperationVariables, DefaultContext } from '../../core';
 import {
   QueryFunctionOptions,
   QueryResult,
@@ -23,7 +23,7 @@ export interface QueryComponentOptions<
 export interface MutationComponentOptions<
   TData = any,
   TVariables = OperationVariables,
-  TContext = Context,
+  TContext = DefaultContext,
 > extends BaseMutationOptions<TData, TVariables, TContext> {
   mutation: DocumentNode | TypedDocumentNode<TData, TVariables>;
   children: (

--- a/src/react/hoc/__tests__/mutations/queries.test.tsx
+++ b/src/react/hoc/__tests__/mutations/queries.test.tsx
@@ -3,7 +3,7 @@ import { render, wait } from '@testing-library/react';
 import gql from 'graphql-tag';
 import { DocumentNode } from 'graphql';
 
-import { ApolloClient, MutationUpdaterFunction } from '../../../../core';
+import { ApolloClient, MutationUpdaterFunction, ApolloCache } from '../../../../core';
 import { ApolloProvider } from '../../../context';
 import { InMemoryCache as Cache } from '../../../../cache';
 import {
@@ -134,7 +134,8 @@ describe('graphql(mutation) query integration', () => {
     const update: MutationUpdaterFunction<
       MutationData,
       Record<string, any>,
-      Record<string, any>
+      Record<string, any>,
+      ApolloCache<any>
     > = (proxy, result) => {
       const data = JSON.parse(
         JSON.stringify(proxy.readQuery<QueryData>({ query }))

--- a/src/react/hoc/__tests__/mutations/queries.test.tsx
+++ b/src/react/hoc/__tests__/mutations/queries.test.tsx
@@ -3,7 +3,7 @@ import { render, wait } from '@testing-library/react';
 import gql from 'graphql-tag';
 import { DocumentNode } from 'graphql';
 
-import { ApolloClient, MutationUpdaterFn } from '../../../../core';
+import { ApolloClient, MutationUpdaterFunction } from '../../../../core';
 import { ApolloProvider } from '../../../context';
 import { InMemoryCache as Cache } from '../../../../cache';
 import {
@@ -131,7 +131,11 @@ describe('graphql(mutation) query integration', () => {
       };
     }
 
-    const update: MutationUpdaterFn = (proxy, result) => {
+    const update: MutationUpdaterFunction<
+      MutationData,
+      Record<string, any>,
+      Record<string, any>
+    > = (proxy, result) => {
       const data = JSON.parse(
         JSON.stringify(proxy.readQuery<QueryData>({ query }))
       );

--- a/src/react/hoc/__tests__/mutations/recycled-queries.test.tsx
+++ b/src/react/hoc/__tests__/mutations/recycled-queries.test.tsx
@@ -3,7 +3,7 @@ import { render, wait } from '@testing-library/react';
 import gql from 'graphql-tag';
 import { DocumentNode } from 'graphql';
 
-import { ApolloClient, MutationUpdaterFn } from '../../../../core';
+import { ApolloClient, MutationUpdaterFunction } from '../../../../core';
 import { ApolloProvider } from '../../../context';
 import { InMemoryCache as Cache } from '../../../../cache';
 import { MutationFunction } from '../../../types/types';
@@ -74,7 +74,11 @@ describe('graphql(mutation) update queries', () => {
     type MutationData = typeof mutationData;
 
     let todoUpdateQueryCount = 0;
-    const update: MutationUpdaterFn = (proxy, result) => {
+    const update: MutationUpdaterFunction<
+      MutationData,
+      Record<string, any>,
+      Record<string, any>
+    > = (proxy, result) => {
       todoUpdateQueryCount++;
       const data = JSON.parse(
         JSON.stringify(

--- a/src/react/hoc/__tests__/mutations/recycled-queries.test.tsx
+++ b/src/react/hoc/__tests__/mutations/recycled-queries.test.tsx
@@ -3,7 +3,7 @@ import { render, wait } from '@testing-library/react';
 import gql from 'graphql-tag';
 import { DocumentNode } from 'graphql';
 
-import { ApolloClient, MutationUpdaterFunction } from '../../../../core';
+import { ApolloCache, ApolloClient, MutationUpdaterFunction } from '../../../../core';
 import { ApolloProvider } from '../../../context';
 import { InMemoryCache as Cache } from '../../../../cache';
 import { MutationFunction } from '../../../types/types';
@@ -77,7 +77,8 @@ describe('graphql(mutation) update queries', () => {
     const update: MutationUpdaterFunction<
       MutationData,
       Record<string, any>,
-      Record<string, any>
+      Record<string, any>,
+      ApolloCache<any>
     > = (proxy, result) => {
       todoUpdateQueryCount++;
       const data = JSON.parse(

--- a/src/react/hoc/mutation-hoc.tsx
+++ b/src/react/hoc/mutation-hoc.tsx
@@ -18,6 +18,7 @@ import {
   GraphQLBase
 } from './hoc-utils';
 import { OperationOption, OptionProps, MutateProps } from './types';
+import { ApolloCache } from '../../core';
 
 export function withMutation<
   TProps extends TGraphQLVariables | {} = {},
@@ -25,6 +26,7 @@ export function withMutation<
   TGraphQLVariables = {},
   TChildProps = MutateProps<TData, TGraphQLVariables>,
   TContext = DefaultContext,
+  TCache extends ApolloCache<any> = ApolloCache<any>,
 >(
   document: DocumentNode,
   operationOptions: OperationOption<
@@ -43,9 +45,9 @@ export function withMutation<
     alias = 'Apollo'
   } = operationOptions;
 
-  let mapPropsToOptions = options as (props: any) => BaseMutationOptions<TData, TGraphQLVariables, TContext>;
+  let mapPropsToOptions = options as (props: any) => BaseMutationOptions<TData, TGraphQLVariables, TContext, TCache>;
   if (typeof mapPropsToOptions !== 'function')
-    mapPropsToOptions = () => options as BaseMutationOptions<TData, TGraphQLVariables, TContext>;
+    mapPropsToOptions = () => options as BaseMutationOptions<TData, TGraphQLVariables, TContext, TCache>;
 
   return (
     WrappedComponent: React.ComponentType<TProps & TChildProps>
@@ -56,7 +58,7 @@ export function withMutation<
       static WrappedComponent = WrappedComponent;
       render() {
         let props = this.props as TProps;
-        const opts = mapPropsToOptions(props) as BaseMutationOptions<TData, TGraphQLVariables, TContext>;
+        const opts = mapPropsToOptions(props) as BaseMutationOptions<TData, TGraphQLVariables, TContext, TCache>;
 
         if (operationOptions.withRef) {
           this.withRef = true;

--- a/src/react/hoc/mutation-hoc.tsx
+++ b/src/react/hoc/mutation-hoc.tsx
@@ -3,7 +3,7 @@ import { DocumentNode } from 'graphql';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 
 import { parser } from '../parser';
-import { Context } from '../../core/types';
+import { DefaultContext } from '../../core/types';
 import {
   BaseMutationOptions,
   MutationFunction,
@@ -24,7 +24,7 @@ export function withMutation<
   TData extends Record<string, any> = {},
   TGraphQLVariables = {},
   TChildProps = MutateProps<TData, TGraphQLVariables>,
-  TContext = Context,
+  TContext = DefaultContext,
 >(
   document: DocumentNode,
   operationOptions: OperationOption<

--- a/src/react/hoc/types.ts
+++ b/src/react/hoc/types.ts
@@ -1,4 +1,4 @@
-import { ApolloClient } from '../../core';
+import { ApolloCache, ApolloClient } from '../../core';
 import { ApolloError } from '../../errors';
 import {
   ApolloQueryResult,
@@ -92,15 +92,16 @@ export interface OperationOption<
   TGraphQLVariables = OperationVariables,
   TChildProps = ChildProps<TProps, TData, TGraphQLVariables>,
   TContext = DefaultContext,
+  TCache extends ApolloCache<any> = ApolloCache<any>,
 > {
   options?:
     | BaseQueryOptions<TGraphQLVariables>
-    | BaseMutationOptions<TData, TGraphQLVariables, TContext>
+    | BaseMutationOptions<TData, TGraphQLVariables, TContext, TCache>
     | ((
         props: TProps
       ) =>
         | BaseQueryOptions<TGraphQLVariables>
-        | BaseMutationOptions<TData, TGraphQLVariables, TContext>
+        | BaseMutationOptions<TData, TGraphQLVariables, TContext, TCache>
       );
   props?: (
     props: OptionProps<TProps, TData, TGraphQLVariables>,

--- a/src/react/hoc/types.ts
+++ b/src/react/hoc/types.ts
@@ -7,7 +7,7 @@ import {
   UpdateQueryOptions,
   FetchMoreQueryOptions,
   SubscribeToMoreOptions,
-  Context,
+  DefaultContext,
 } from '../../core';
 import {
   MutationFunction,
@@ -91,7 +91,7 @@ export interface OperationOption<
   TData,
   TGraphQLVariables = OperationVariables,
   TChildProps = ChildProps<TProps, TData, TGraphQLVariables>,
-  TContext = Context,
+  TContext = DefaultContext,
 > {
   options?:
     | BaseQueryOptions<TGraphQLVariables>

--- a/src/react/hoc/types.ts
+++ b/src/react/hoc/types.ts
@@ -7,6 +7,7 @@ import {
   UpdateQueryOptions,
   FetchMoreQueryOptions,
   SubscribeToMoreOptions,
+  Context,
 } from '../../core';
 import {
   MutationFunction,
@@ -89,16 +90,17 @@ export interface OperationOption<
   TProps,
   TData,
   TGraphQLVariables = OperationVariables,
-  TChildProps = ChildProps<TProps, TData, TGraphQLVariables>
+  TChildProps = ChildProps<TProps, TData, TGraphQLVariables>,
+  TContext = Context,
 > {
   options?:
     | BaseQueryOptions<TGraphQLVariables>
-    | BaseMutationOptions<TData, TGraphQLVariables>
+    | BaseMutationOptions<TData, TGraphQLVariables, TContext>
     | ((
         props: TProps
       ) =>
         | BaseQueryOptions<TGraphQLVariables>
-        | BaseMutationOptions<TData, TGraphQLVariables>
+        | BaseMutationOptions<TData, TGraphQLVariables, TContext>
       );
   props?: (
     props: OptionProps<TProps, TData, TGraphQLVariables>,

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -512,6 +512,48 @@ describe('useMutation Hook', () => {
         </MockedProvider>
       );
     });
+
+    describe('If context is not provided', () => {
+      itAsync('should be undefined', async (resolve, reject) => {
+        const variables = {
+          description: 'Get milk!'
+        };
+
+        const mocks = [
+          {
+            request: {
+              query: CREATE_TODO_MUTATION,
+              variables
+            },
+            result: { data: CREATE_TODO_RESULT }
+          }
+        ];
+
+        const Component = () => {
+          const [createTodo] = useMutation(
+            CREATE_TODO_MUTATION,
+            {
+              update(_, __, options) {
+                expect(options.context).toBeUndefined();
+                resolve();
+              }
+            }
+          );
+
+          useEffect(() => {
+            createTodo({ variables });
+          }, []);
+
+          return null;
+        };
+
+        render(
+          <MockedProvider mocks={mocks}>
+            <Component />
+          </MockedProvider>
+        );
+      });
+    });
   });
 
   describe('Optimistic response', () => {

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -488,7 +488,7 @@ describe('useMutation Hook', () => {
       ];
 
       const Component = () => {
-        const [createTodo] = useMutation(
+        const [createTodo] = useMutation<Todo, { description: string }, { id: number }>(
           CREATE_TODO_MUTATION,
           {
             context,

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -428,6 +428,92 @@ describe('useMutation Hook', () => {
     });
   });
 
+  describe('Update function', () => {
+
+    itAsync('should be called with the provided variables', async (resolve, reject) => {
+      const variables = {
+        description: 'Get milk!'
+      };
+
+      const mocks = [
+        {
+          request: {
+            query: CREATE_TODO_MUTATION,
+            variables
+          },
+          result: { data: CREATE_TODO_RESULT }
+        }
+      ];
+
+      const Component = () => {
+        const [createTodo] = useMutation(
+          CREATE_TODO_MUTATION,
+          {
+            update(_, __, options) {
+              expect(options.variables).toEqual(variables);
+              resolve();
+            }
+          }
+        );
+
+        useEffect(() => {
+          createTodo({ variables });
+        }, []);
+
+        return null;
+      };
+
+      render(
+        <MockedProvider mocks={mocks}>
+          <Component />
+        </MockedProvider>
+      );
+    });
+
+    itAsync('should be called with the provided context', async (resolve, reject) => {
+      const context = { id: 3 };
+
+      const variables = {
+        description: 'Get milk!'
+      };
+
+      const mocks = [
+        {
+          request: {
+            query: CREATE_TODO_MUTATION,
+            variables
+          },
+          result: { data: CREATE_TODO_RESULT }
+        }
+      ];
+
+      const Component = () => {
+        const [createTodo] = useMutation(
+          CREATE_TODO_MUTATION,
+          {
+            context,
+            update(_, __, options) {
+              expect(options.context).toEqual(context);
+              resolve();
+            }
+          }
+        );
+
+        useEffect(() => {
+          createTodo({ variables });
+        }, []);
+
+        return null;
+      };
+
+      render(
+        <MockedProvider mocks={mocks}>
+          <Component />
+        </MockedProvider>
+      );
+    });
+  });
+
   describe('Optimistic response', () => {
     itAsync('should support optimistic response handling', async (resolve, reject) => {
       const optimisticResponse = {

--- a/src/react/hooks/useMutation.ts
+++ b/src/react/hooks/useMutation.ts
@@ -4,21 +4,25 @@ import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 
 import { MutationHookOptions, MutationTuple } from '../types/types';
 import { MutationData } from '../data';
-import { OperationVariables } from '../../core';
+import { Context, OperationVariables } from '../../core';
 import { getApolloContext } from '../context';
 
-export function useMutation<TData = any, TVariables = OperationVariables>(
+export function useMutation<
+  TData = any,
+  TVariables extends OperationVariables = OperationVariables,
+  TContext extends Context = Context
+>(
   mutation: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  options?: MutationHookOptions<TData, TVariables>
-): MutationTuple<TData, TVariables> {
+  options?: MutationHookOptions<TData, TVariables, TContext>
+): MutationTuple<TData, TVariables, TContext> {
   const context = useContext(getApolloContext());
   const [result, setResult] = useState({ called: false, loading: false });
   const updatedOptions = options ? { ...options, mutation } : { mutation };
 
-  const mutationDataRef = useRef<MutationData<TData, TVariables>>();
+  const mutationDataRef = useRef<MutationData<TData, TVariables, TContext>>();
   function getMutationDataRef() {
     if (!mutationDataRef.current) {
-      mutationDataRef.current = new MutationData<TData, TVariables>({
+      mutationDataRef.current = new MutationData<TData, TVariables, TContext>({
         options: updatedOptions,
         context,
         result,

--- a/src/react/hooks/useMutation.ts
+++ b/src/react/hooks/useMutation.ts
@@ -4,13 +4,13 @@ import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 
 import { MutationHookOptions, MutationTuple } from '../types/types';
 import { MutationData } from '../data';
-import { Context, OperationVariables } from '../../core';
+import { DefaultContext, OperationVariables } from '../../core';
 import { getApolloContext } from '../context';
 
 export function useMutation<
   TData = any,
-  TVariables extends OperationVariables = OperationVariables,
-  TContext extends Context = Context
+  TVariables = OperationVariables,
+  TContext = DefaultContext
 >(
   mutation: DocumentNode | TypedDocumentNode<TData, TVariables>,
   options?: MutationHookOptions<TData, TVariables, TContext>

--- a/src/react/hooks/useMutation.ts
+++ b/src/react/hooks/useMutation.ts
@@ -4,17 +4,18 @@ import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 
 import { MutationHookOptions, MutationTuple } from '../types/types';
 import { MutationData } from '../data';
-import { DefaultContext, OperationVariables } from '../../core';
+import { ApolloCache, DefaultContext, OperationVariables } from '../../core';
 import { getApolloContext } from '../context';
 
 export function useMutation<
   TData = any,
   TVariables = OperationVariables,
-  TContext = DefaultContext
+  TContext = DefaultContext,
+  TCache extends ApolloCache<any> = ApolloCache<any>,
 >(
   mutation: DocumentNode | TypedDocumentNode<TData, TVariables>,
   options?: MutationHookOptions<TData, TVariables, TContext>
-): MutationTuple<TData, TVariables, TContext> {
+): MutationTuple<TData, TVariables, TContext, TCache> {
   const context = useContext(getApolloContext());
   const [result, setResult] = useState({ called: false, loading: false });
   const updatedOptions = options ? { ...options, mutation } : { mutation };

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -8,7 +8,7 @@ import { ApolloError } from '../../errors';
 import {
   ApolloClient,
   ApolloQueryResult,
-  Context,
+  DefaultContext,
   ErrorPolicy,
   FetchMoreOptions,
   FetchMoreQueryOptions,
@@ -25,6 +25,8 @@ import {
 
 /* Common types */
 
+export type { DefaultContext as Context } from "../../core";
+
 export type CommonOptions<TOptions> = TOptions & {
   client?: ApolloClient<object>;
 };
@@ -35,7 +37,7 @@ export interface BaseQueryOptions<TVariables = OperationVariables>
 extends Omit<WatchQueryOptions<TVariables>, "query"> {
   ssr?: boolean;
   client?: ApolloClient<any>;
-  context?: Context;
+  context?: DefaultContext;
 }
 
 export interface QueryFunctionOptions<
@@ -101,7 +103,7 @@ export interface LazyQueryHookOptions<
 
 export interface QueryLazyOptions<TVariables> {
   variables?: TVariables;
-  context?: Context;
+  context?: DefaultContext;
 }
 
 type UnexecutedLazyFields = {
@@ -142,7 +144,7 @@ export type RefetchQueriesFunction = (
 export interface BaseMutationOptions<
   TData,
   TVariables extends OperationVariables,
-  TContext extends Context,
+  TContext extends DefaultContext,
 > {
   variables?: TVariables;
   optimisticResponse?: TData | ((vars: TVariables) => TData);
@@ -186,7 +188,7 @@ export interface MutationResult<TData = any> {
 export declare type MutationFunction<
   TData,
   TVariables = OperationVariables,
-  TContext = Context,
+  TContext = DefaultContext,
 > = (
   options?: MutationFunctionOptions<TData, TVariables, TContext>
 ) => Promise<FetchResult<TData>>;
@@ -194,7 +196,7 @@ export declare type MutationFunction<
 export interface MutationHookOptions<
   TData = any,
   TVariables = OperationVariables,
-  TContext = Context,
+  TContext = DefaultContext,
 > extends BaseMutationOptions<TData, TVariables, TContext> {
   mutation?: DocumentNode | TypedDocumentNode<TData, TVariables>;
 }
@@ -202,7 +204,7 @@ export interface MutationHookOptions<
 export interface MutationDataOptions<
   TData,
   TVariables extends OperationVariables,
-  TContext extends Context
+  TContext extends DefaultContext
 >
   extends BaseMutationOptions<TData, TVariables, TContext> {
   mutation: DocumentNode | TypedDocumentNode<TData, TVariables>;
@@ -233,7 +235,7 @@ export interface BaseSubscriptionOptions<
     | ((options: BaseSubscriptionOptions<TData, TVariables>) => boolean);
   client?: ApolloClient<object>;
   skip?: boolean;
-  context?: Context;
+  context?: DefaultContext;
   onSubscriptionData?: (options: OnSubscriptionDataOptions<TData>) => any;
   onSubscriptionComplete?: () => void;
 }

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -6,6 +6,7 @@ import { Observable } from '../../utilities';
 import { FetchResult } from '../../link/core';
 import { ApolloError } from '../../errors';
 import {
+  ApolloCache,
   ApolloClient,
   ApolloQueryResult,
   DefaultContext,
@@ -145,13 +146,14 @@ export interface BaseMutationOptions<
   TData,
   TVariables extends OperationVariables,
   TContext extends DefaultContext,
+  TCache extends ApolloCache<any>,
 > {
   variables?: TVariables;
   optimisticResponse?: TData | ((vars: TVariables) => TData);
   refetchQueries?: Array<string | PureQueryOptions> | RefetchQueriesFunction;
   awaitRefetchQueries?: boolean;
   errorPolicy?: ErrorPolicy;
-  update?: MutationUpdaterFunction<TData, TVariables, TContext>;
+  update?: MutationUpdaterFunction<TData, TVariables, TContext, TCache>;
   reobserveQuery?: ReobserveQueryCallback;
   client?: ApolloClient<object>;
   notifyOnNetworkStatusChange?: boolean;
@@ -166,12 +168,13 @@ export interface MutationFunctionOptions<
   TData,
   TVariables,
   TContext,
+  TCache extends ApolloCache<any>,
 > {
   variables?: TVariables;
   optimisticResponse?: TData | ((vars: TVariables) => TData);
   refetchQueries?: Array<string | PureQueryOptions> | RefetchQueriesFunction;
   awaitRefetchQueries?: boolean;
-  update?: MutationUpdaterFunction<TData, TVariables, TContext>;
+  update?: MutationUpdaterFunction<TData, TVariables, TContext, TCache>;
   reobserveQuery?: ReobserveQueryCallback;
   context?: TContext;
   fetchPolicy?: WatchQueryFetchPolicy;
@@ -189,30 +192,33 @@ export declare type MutationFunction<
   TData,
   TVariables = OperationVariables,
   TContext = DefaultContext,
+  TCache extends ApolloCache<any> = ApolloCache<any>,
 > = (
-  options?: MutationFunctionOptions<TData, TVariables, TContext>
+  options?: MutationFunctionOptions<TData, TVariables, TContext, TCache>
 ) => Promise<FetchResult<TData>>;
 
 export interface MutationHookOptions<
   TData = any,
   TVariables = OperationVariables,
   TContext = DefaultContext,
-> extends BaseMutationOptions<TData, TVariables, TContext> {
+  TCache extends ApolloCache<any> = ApolloCache<any>,
+> extends BaseMutationOptions<TData, TVariables, TContext, TCache> {
   mutation?: DocumentNode | TypedDocumentNode<TData, TVariables>;
 }
 
 export interface MutationDataOptions<
   TData,
   TVariables extends OperationVariables,
-  TContext extends DefaultContext
+  TContext extends DefaultContext,
+  TCache extends ApolloCache<any>,
 >
-  extends BaseMutationOptions<TData, TVariables, TContext> {
+  extends BaseMutationOptions<TData, TVariables, TContext, TCache> {
   mutation: DocumentNode | TypedDocumentNode<TData, TVariables>;
 }
 
-export type MutationTuple<TData, TVariables, TContext> = [
+export type MutationTuple<TData, TVariables, TContext, TCache extends ApolloCache<any>> = [
   (
-    options?: MutationFunctionOptions<TData, TVariables, TContext>
+    options?: MutationFunctionOptions<TData, TVariables, TContext, TCache>
   ) => Promise<FetchResult<TData>>,
   MutationResult<TData>
 ];

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -189,7 +189,7 @@ export interface MutationResult<TData = any> {
 }
 
 export declare type MutationFunction<
-  TData,
+  TData = any,
   TVariables = OperationVariables,
   TContext = DefaultContext,
   TCache extends ApolloCache<any> = ApolloCache<any>,

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -6,13 +6,13 @@ import { Observable } from '../../utilities';
 import { FetchResult } from '../../link/core';
 import { ApolloError } from '../../errors';
 import {
-  ApolloClient,
+  Context,
   ApolloQueryResult,
   ErrorPolicy,
   FetchMoreOptions,
   FetchMoreQueryOptions,
   FetchPolicy,
-  MutationUpdaterFn,
+  MutationUpdaterFunction,
   NetworkStatus,
   ObservableQuery,
   OperationVariables,
@@ -23,8 +23,6 @@ import {
 } from '../../core';
 
 /* Common types */
-
-export type Context = Record<string, any>;
 
 export type CommonOptions<TOptions> = TOptions & {
   client?: ApolloClient<object>;
@@ -141,19 +139,19 @@ export type RefetchQueriesFunction = (
 ) => Array<string | PureQueryOptions>;
 
 export interface BaseMutationOptions<
-  TData = any,
-  TVariables = OperationVariables
+  TData,
+  TVariables extends OperationVariables,
+  TContext extends Context,
 > {
   variables?: TVariables;
   optimisticResponse?: TData | ((vars: TVariables) => TData);
   refetchQueries?: Array<string | PureQueryOptions> | RefetchQueriesFunction;
   awaitRefetchQueries?: boolean;
   errorPolicy?: ErrorPolicy;
-  update?: MutationUpdaterFn<TData>;
-  reobserveQuery?: ReobserveQueryCallback;
+  update?: MutationUpdaterFunction<TData, TVariables, TContext>;
   client?: ApolloClient<object>;
   notifyOnNetworkStatusChange?: boolean;
-  context?: Context;
+  context?: TContext;
   onCompleted?: (data: TData) => void;
   onError?: (error: ApolloError) => void;
   fetchPolicy?: Extract<WatchQueryFetchPolicy, 'no-cache'>;
@@ -161,16 +159,16 @@ export interface BaseMutationOptions<
 }
 
 export interface MutationFunctionOptions<
-  TData = any,
-  TVariables = OperationVariables
+  TData,
+  TVariables,
+  TContext,
 > {
   variables?: TVariables;
   optimisticResponse?: TData | ((vars: TVariables) => TData);
   refetchQueries?: Array<string | PureQueryOptions> | RefetchQueriesFunction;
   awaitRefetchQueries?: boolean;
-  update?: MutationUpdaterFn<TData>;
-  reobserveQuery?: ReobserveQueryCallback;
-  context?: Context;
+  update?: MutationUpdaterFunction<TData, TVariables, TContext>;
+  context?: TContext;
   fetchPolicy?: WatchQueryFetchPolicy;
 }
 
@@ -183,27 +181,33 @@ export interface MutationResult<TData = any> {
 }
 
 export declare type MutationFunction<
-  TData = any,
-  TVariables = OperationVariables
+  TData,
+  TVariables = OperationVariables,
+  TContext = Context,
 > = (
-  options?: MutationFunctionOptions<TData, TVariables>
+  options?: MutationFunctionOptions<TData, TVariables, TContext>
 ) => Promise<FetchResult<TData>>;
 
 export interface MutationHookOptions<
   TData = any,
-  TVariables = OperationVariables
-> extends BaseMutationOptions<TData, TVariables> {
+  TVariables = OperationVariables,
+  TContext = Context,
+> extends BaseMutationOptions<TData, TVariables, TContext> {
   mutation?: DocumentNode | TypedDocumentNode<TData, TVariables>;
 }
 
-export interface MutationDataOptions<TData = any, TVariables = OperationVariables>
-  extends BaseMutationOptions<TData, TVariables> {
+export interface MutationDataOptions<
+  TData,
+  TVariables extends OperationVariables,
+  TContext extends Context
+>
+  extends BaseMutationOptions<TData, TVariables, TContext> {
   mutation: DocumentNode | TypedDocumentNode<TData, TVariables>;
 }
 
-export type MutationTuple<TData, TVariables> = [
+export type MutationTuple<TData, TVariables, TContext> = [
   (
-    options?: MutationFunctionOptions<TData, TVariables>
+    options?: MutationFunctionOptions<TData, TVariables, TContext>
   ) => Promise<FetchResult<TData>>,
   MutationResult<TData>
 ];

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -6,8 +6,9 @@ import { Observable } from '../../utilities';
 import { FetchResult } from '../../link/core';
 import { ApolloError } from '../../errors';
 import {
-  Context,
+  ApolloClient,
   ApolloQueryResult,
+  Context,
   ErrorPolicy,
   FetchMoreOptions,
   FetchMoreQueryOptions,
@@ -149,6 +150,7 @@ export interface BaseMutationOptions<
   awaitRefetchQueries?: boolean;
   errorPolicy?: ErrorPolicy;
   update?: MutationUpdaterFunction<TData, TVariables, TContext>;
+  reobserveQuery?: ReobserveQueryCallback;
   client?: ApolloClient<object>;
   notifyOnNetworkStatusChange?: boolean;
   context?: TContext;
@@ -168,6 +170,7 @@ export interface MutationFunctionOptions<
   refetchQueries?: Array<string | PureQueryOptions> | RefetchQueriesFunction;
   awaitRefetchQueries?: boolean;
   update?: MutationUpdaterFunction<TData, TVariables, TContext>;
+  reobserveQuery?: ReobserveQueryCallback;
   context?: TContext;
   fetchPolicy?: WatchQueryFetchPolicy;
 }


### PR DESCRIPTION
This PR implements an enhancement discussed in #7843. A mutation's `update` function now receives an optional third argument with the context and variables provided to the original function.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
