### PR TITLE
Broadcast watches before transaction when onDirty provided.

### DIFF
--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -322,6 +322,16 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
       }
     };
 
+    if (options.onDirty) {
+      // If an options.onDirty callback is provided, we want to call it with
+      // only the Cache.WatchOptions objects affected by options.transaction,
+      // so we broadcast watches first, to clear any pending watches waiting
+      // to be broadcast.
+      const { onDirty, ...rest } = options;
+      // Note that rest is just like options, except with onDirty removed.
+      this.broadcastWatches(rest);
+    }
+
     if (typeof optimistic === 'string') {
       // Note that there can be multiple layers with the same optimistic ID.
       // When removeOptimistic(id) is called for that id, all matching layers


### PR DESCRIPTION
When an `options.onDirty` callback is provided to `cache.batch` (#7819), we want to call `onDirty` with only the `Cache.WatchOptions` objects that were directly affected by `options.transaction`, so it's important to broadcast watches _before_ the transaction, to flush out any pending watches waiting to be broadcast.

See provided tests for an example where this matters.