### PR TITLE
Cancel the pending notify timeout when stopping a query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - Prevent `RenderPromises` memory leak by calling `renderPromises.clear()` after `getMarkupFromTree` finishes. <br/>
   [@benjamn](https://github.com/benjamn) in [#7943](https://github.com/apollographql/apollo-client/pull/7943)
 
+- Cancel pending notify timeout when stopping a `QueryInfo` object. <br/>
+  [@hollandThomas](https://github.com/hollandThomas) in [#7935](https://github.com/apollographql/apollo-client/pull/7935)
+
 ## Apollo Client 3.3.13
 
 ### Improvements

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -234,6 +234,9 @@ export class QueryInfo {
     if (!this.stopped) {
       this.stopped = true;
 
+      // Cancel the pending notify timeout
+      this.reset();
+      
       this.cancel();
       // Revert back to the no-op version of cancel inherited from
       // QueryInfo.prototype.


### PR DESCRIPTION
The original `stop` method does not clear the pending `notifyTimeout`. When a query is stopped in the same tick and right after a cache update sets the `notifyTimeout`, the query is not removed correctly, as the `notifyTimeout` callback will recreate the `QueryInfo`. This might lead to undesired behavior, as queries are executed that should have been stopped already.

I could not find a suitable test to extend / was unsure how to add a new test for this.

Might be related to https://github.com/apollographql/apollo-client/issues/6888

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
