### PR TITLE
Handle nullable connections in relayStylePagination

### DIFF
--- a/src/utilities/policies/__tests__/relayStylePagination.test.ts
+++ b/src/utilities/policies/__tests__/relayStylePagination.test.ts
@@ -96,6 +96,58 @@ describe('relayStylePagination', () => {
       });
     });
 
+    it('should merge incoming null with null', () => {
+      const existingEdges = [
+        { cursor: 'alpha', node: makeReference("fakeAlpha") },
+      ];
+      const result = merge(
+        {
+          edges: existingEdges,
+          pageInfo: {
+            hasPreviousPage: false,
+            hasNextPage: true,
+            startCursor: 'alpha',
+            endCursor: 'alpha'
+          },
+        }, null,
+        {
+          ...options,
+          args: {
+            after: 'alpha',
+          },
+        },
+      );
+
+      expect(result).toBeNull();
+    })
+
+    it('should replace existing null with incoming', () => {
+      const incomingEdges = [
+        { cursor: 'alpha', node: makeReference("fakeAlpha") },
+      ];
+      const incoming = {
+        edges: incomingEdges,
+        pageInfo: {
+          hasPreviousPage: false,
+          hasNextPage: true,
+          startCursor: 'alpha',
+          endCursor: 'alpha'
+        },
+      };
+      const result = merge(
+        null,
+        incoming,
+        {
+          ...options,
+          args: {
+            after: 'alpha',
+          },
+        },
+      );
+
+      expect(result).toEqual(incoming);
+    })
+
     it('should maintain extra PageInfo properties', () => {
       const existingEdges = [
         { cursor: 'alpha', node: makeReference("fakeAlpha") },

--- a/src/utilities/policies/pagination.ts
+++ b/src/utilities/policies/pagination.ts
@@ -80,9 +80,9 @@ export type TIncomingRelay<TNode> = {
 };
 
 export type RelayFieldPolicy<TNode> = FieldPolicy<
-  TExistingRelay<TNode>,
-  TIncomingRelay<TNode>,
-  TIncomingRelay<TNode>
+  TExistingRelay<TNode> | null,
+  TIncomingRelay<TNode> | null,
+  TIncomingRelay<TNode> | null
 >;
 
 // As proof of the flexibility of field policies, this function generates
@@ -95,7 +95,8 @@ export function relayStylePagination<TNode = Reference>(
     keyArgs,
 
     read(existing, { canRead, readField }) {
-      if (!existing) return;
+      if (existing === undefined) return undefined;
+      if (existing === null) return null;
 
       const edges: TRelayEdge<TNode>[] = [];
       let startCursor = "";
@@ -127,6 +128,12 @@ export function relayStylePagination<TNode = Reference>(
     },
 
     merge(existing = makeEmptyData(), incoming, { args, isReference, readField }) {
+      if (incoming === null) {
+        return null
+      }
+      if (existing === null) {
+        existing = makeEmptyData()
+      }
       const incomingEdges = incoming.edges ? incoming.edges.map(edge => {
         if (isReference(edge = { ...edge })) {
           // In case edge is a Reference, we read out its cursor field and


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

This handles my edge case in https://github.com/apollographql/apollo-client/issues/7822#issuecomment-812766980 where a nullable connection with a field policy set to `relayStylePagination` would throw an error whenever a null existing/incoming node was handled. The fix is pretty bone-headed, so if there's a better way to go about fixing this please let me know!

### Checklist:

- [X] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [X] Make sure all of the significant new logic is covered by tests
