### PR TITLE
only increment lastRequestId when using links to get results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## Apollo Client 3.4.0 (not yet released)
 
 ### Bug fixes
-TBD
+
+- Increment `queryInfo.lastRequestId` only when making a network request through the `ApolloLink` chain, rather than every time `fetchQueryByPolicy` is called. <br/>
+  [@dannycochran](https://github.com/dannycochran) in [#7956](https://github.com/apollographql/apollo-client/pull/7956)
 
 ### Potentially breaking changes
 

--- a/src/core/__tests__/QueryManager/index.ts
+++ b/src/core/__tests__/QueryManager/index.ts
@@ -37,6 +37,7 @@ import subscribeAndCount from '../../../utilities/testing/subscribeAndCount';
 import { stripSymbols } from '../../../utilities/testing/stripSymbols';
 import { itAsync } from '../../../utilities/testing/itAsync';
 import { ApolloClient } from '../../../core'
+import { mockFetchQuery } from '../ObservableQuery';
 
 interface MockedMutation {
   reject: (reason: any) => any;
@@ -2721,6 +2722,64 @@ describe('QueryManager', () => {
       }),
     ]).then(resolve, reject);
   });
+
+
+  itAsync('only increments "queryInfo.lastRequestId" when fetching data from network', (resolve, reject) => {
+    const query = gql`
+      query query($id: ID!) {
+        people_one(id: $id) {
+          name
+        }
+      }
+    `;
+    const variables = { id: 1 };
+    const dataOne = {
+      people_one: {
+        name: 'Luke Skywalker',
+      },
+    };
+    const mockedResponses = [
+      {
+        request: { query, variables },
+        result: { data: dataOne },
+      },
+    ];
+
+    const queryManager = mockQueryManager(reject, ...mockedResponses);
+    const queryOptions: WatchQueryOptions<any> = {
+      query,
+      variables,
+      fetchPolicy: 'cache-and-network',
+    };
+    const observable = queryManager.watchQuery(queryOptions);
+
+    const mocks = mockFetchQuery(queryManager);
+    const queryId = '1';
+    const getQuery: QueryManager<any>["getQuery"] =
+      (queryManager as any).getQuery.bind(queryManager);
+
+    subscribeAndCount(reject, observable, async (handleCount) => {
+      const query = getQuery(queryId);
+      const fqbpCalls = mocks.fetchQueryByPolicy.mock.calls;
+      expect(query.lastRequestId).toEqual(1);
+      expect(fqbpCalls.length).toBe(1);
+
+      // Simulate updating the options of the query, which will trigger
+      // fetchQueryByPolicy, but it should just read from cache and not
+      // update "queryInfo.lastRequestId". For more information, see
+      // https://github.com/apollographql/apollo-client/pull/7956#issue-610298427
+      await observable.setOptions({
+        ...queryOptions,
+        fetchPolicy: 'cache-first',
+      });
+
+      // "fetchQueryByPolicy" was called, but "lastRequestId" does not update
+      // since it was able to read from cache.
+      expect(query.lastRequestId).toEqual(1);
+      expect(fqbpCalls.length).toBe(2);
+      resolve();
+    });
+  })
 
   describe('polling queries', () => {
     itAsync('allows you to poll queries', (resolve, reject) => {


### PR DESCRIPTION
`fetchQueryByPolicy` currently always increments `queryInfo.lastRequestId`, even when a new request is not necessary and results are instead read directly from cache.

An example way to trigger this bug:

```
git clone https://github.com/dannycochran/usequery/tree/refetchPolicy
cd usequery
npm install
npm run start
```

Then, try deleting an item. You’ll notice in the network tab the mutation fires successfully and so does the refetch query with the correct results of one less bid item. However, the Apollo cache doesn’t update so 4 items will remain. Subsequent deletes / adds work just fine.

The cache is not updating because we are updating `fetchPolicy` manually from our useQuery invocation, which triggers `fetchQueryByPolicy`, but the result ends up just reading from cache. However, since it also updates the `lastRequestid`, the conditions to write the result to cache are no longer satisfied: `lastRequestId` is not greater than `queryInfo.lastRequestId`, so the cache does not get updated after refetch: https://github.com/apollographql/apollo-client/blob/main/src/core/QueryManager.ts#L869
