### PR TITLE
Change default refetchWritePolicy to "overwrite" rather than "merge".

### DIFF
--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1107,7 +1107,7 @@ export class QueryManager<TStore> {
       ( // Watched queries must opt into overwriting existing data on refetch,
         // by passing refetchWritePolicy: "overwrite" in their WatchQueryOptions.
         networkStatus === NetworkStatus.refetch &&
-        refetchWritePolicy === "overwrite"
+        refetchWritePolicy !== "merge"
       ) ? CacheWriteBehavior.OVERWRITE
         : CacheWriteBehavior.MERGE;
 

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -1830,9 +1830,7 @@ describe('useQuery Hook', () => {
       }).then(resolve, reject);
     });
 
-    // TODO The default refetchWritePolicy probably should change to "overwrite"
-    // when we release the next major version of Apollo Client (v4).
-    itAsync('should assume default refetchWritePolicy value is "merge"', (resolve, reject) => {
+    itAsync('should assume default refetchWritePolicy value is "overwrite"', (resolve, reject) => {
       const mergeParams: [any, any][] = [];
       const cache = new InMemoryCache({
         typePolicies: {
@@ -1893,7 +1891,7 @@ describe('useQuery Hook', () => {
                   loading: false,
                   networkStatus: NetworkStatus.ready,
                   data: {
-                    primes: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29],
+                    primes: [13, 17, 19, 23, 29],
                   },
                 });
               });
@@ -1914,13 +1912,13 @@ describe('useQuery Hook', () => {
             expect(loading).toBe(false);
             expect(error).toBeUndefined();
             expect(data).toEqual({
-              // Thanks to refetchWritePolicy: "merge".
-              primes: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29],
+              primes: [13, 17, 19, 23, 29],
             });
             expect(mergeParams).toEqual([
               [void 0, [2, 3, 5, 7, 11]],
-              // This indicates concatenation happened.
-              [[2, 3, 5, 7, 11], [13, 17, 19, 23, 29]],
+              // Without refetchWritePolicy: "overwrite", this array will be
+              // all 10 primes (2 through 29) together.
+              [void 0, [13, 17, 19, 23, 29]],
             ]);
             break;
           default:


### PR DESCRIPTION
After discussions with @Akryum in PR #7810 and with the client team, I/we believe the benefit of restoring the Apollo Client 2.x `refetch` behavior (that is, refetching overwrites existing field data), for the specific case of custom `merge` functions (see https://github.com/apollographql/apollo-client/issues/7491#issuecomment-772115227), outweighs the risk of breaking applications that somehow depend on custom `merge` functions combining refetched data with existing data, especially since those applications can easily recover the previous AC3 behavior by passing `refetchWritePolicy: "merge"` on a per-query basis, or as a client-wide default using `defaultOptions.watchQuery`:
```ts
new ApolloClient({
  defaultOptions: {
    watchQuery: {
      // We recommend "overwrite" instead of "merge", but here's how
      // you can restore the "merge" behavior by default for all queries.
      refetchWritePolicy: "merge",
    },
  },
})
```
Though this change to the default `refetchWritePolicy` behavior could be construed as a breaking change, it affects only the behavior of custom `merge` functions, since fields without `merge` functions are always overwritten.

If we do not make `refetchWritePolicy: "overwrite"` the default, I believe many applications that could benefit from this bug fix will never be updated to take advantage of the `refetchWritePolicy` option, and so this bug will effectively remain unfixed for those applications.