### PR TITLE
update docs on partialRefetch

### DIFF
--- a/docs/shared/query-options.mdx
+++ b/docs/shared/query-options.mdx
@@ -13,6 +13,6 @@
 | `onCompleted` | (data: TData &#124; {}) => void | A callback executed once your query successfully completes. |
 | `onError` | (error: ApolloError) => void | A callback executed in the event of an error. |
 | `context` | Record&lt;string, any&gt; | Shared context between your component and your network interface (Apollo Link). |
-| `partialRefetch` | boolean | If `true`, perform a query `refetch` if the query result is marked as being partial, and the returned data is reset to an empty Object by the Apollo Client `QueryManager` (due to a cache miss). The default value is `false` for backwards-compatibility's sake, but should be changed to true for most use-cases. |
 | `client` | ApolloClient | An `ApolloClient` instance. By default `useQuery` / `Query` uses the client passed down via context, but a different client can be passed in. |
 | `returnPartialData` | boolean | Opt into receiving partial results from the cache for queries that are not fully satisfied by the cache. false by default. |
+| `partialRefetch` (deprecated) | boolean | If `true`, causes a query `refetch` if the query result is detected as partial. By default, it is set to `false` instead. Setting this option is unnecessary in Apollo 3.0 thanks to a more consistent application of fetch policies. It may be removed in future versions. |


### PR DESCRIPTION
Let me know if y’all have thoughts on the wording or the deprecation.

Related: https://github.com/apollographql/apollo-client/issues/7967

Rendered: 
<img width="737" alt="Screen Shot 2021-04-09 at 6 38 49 PM" src="https://user-images.githubusercontent.com/2996754/114247341-dd164100-9962-11eb-8e77-7fb81ef1a066.png">
