### PR TITLE
Backport PR #7956 from release-3.4 to main branch.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Apollo Client 3.3.15 (not yet released)
+
+### Bug fixes
+
+- Increment `queryInfo.lastRequestId` only when making a network request through the `ApolloLink` chain, rather than every time `fetchQueryByPolicy` is called. <br/>
+  [@dannycochran](https://github.com/dannycochran) in [#7956](https://github.com/apollographql/apollo-client/pull/7956)
+
 ## Apollo Client 3.3.14
 
 ### Improvements

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -854,7 +854,7 @@ export class QueryManager<TStore> {
       | "fetchPolicy"
       | "errorPolicy">,
   ): Observable<ApolloQueryResult<TData>> {
-    const { lastRequestId } = queryInfo;
+    const requestId = queryInfo.lastRequestId = this.generateRequestId();
 
     return asyncMap(
       this.getObservableFromLink(
@@ -866,7 +866,9 @@ export class QueryManager<TStore> {
       result => {
         const hasErrors = isNonEmptyArray(result.errors);
 
-        if (lastRequestId >= queryInfo.lastRequestId) {
+        // If we interrupted this request by calling getResultsFromLink again
+        // with the same QueryInfo object, we ignore the old results.
+        if (requestId >= queryInfo.lastRequestId) {
           if (hasErrors && options.errorPolicy === "none") {
             // Throwing here effectively calls observer.error.
             throw queryInfo.markError(new ApolloError({
@@ -895,7 +897,8 @@ export class QueryManager<TStore> {
           ? networkError
           : new ApolloError({ networkError });
 
-        if (lastRequestId >= queryInfo.lastRequestId) {
+        // Avoid storing errors from older interrupted queries.
+        if (requestId >= queryInfo.lastRequestId) {
           queryInfo.markError(error);
         }
 
@@ -1044,7 +1047,6 @@ export class QueryManager<TStore> {
     queryInfo.init({
       document: query,
       variables,
-      lastRequestId: this.generateRequestId(),
       networkStatus,
     });
 


### PR DESCRIPTION
PR #7956 by @dannycochran originally landed on the `release-3.4` branch (so we could test it in a beta release), but the changes are worthwhile and backwards compatible for the `@apollo/client@3.3.x` release line as well, which is currently published from the `main` branch.