### PR TITLE
Check structural equality in QueryInfo#setDiff, again.

### DIFF
--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -197,7 +197,8 @@ export class QueryInfo {
     const oldDiff = this.lastDiff && this.lastDiff.diff;
     this.updateLastDiff(diff);
     if (!this.dirty &&
-        (diff && diff.result) !== (oldDiff && oldDiff.result)) {
+        !equal(oldDiff && oldDiff.result,
+               diff && diff.result)) {
       this.dirty = true;
       if (!this.notifyTimeout) {
         this.notifyTimeout = setTimeout(() => this.notify(), 0);

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -1,5 +1,6 @@
 import gql from 'graphql-tag';
 import { GraphQLError } from 'graphql';
+import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 
 import { ApolloClient, NetworkStatus } from '../../core';
 import { ObservableQuery } from '../ObservableQuery';
@@ -39,7 +40,11 @@ export const mockFetchQuery = (queryManager: QueryManager<any>) => {
 
 describe('ObservableQuery', () => {
   // Standard data for all these tests
-  const query = gql`
+  const query: TypedDocumentNode<{
+    people_one: {
+      name: string;
+    };
+  }> = gql`
     query query($id: ID!) {
       people_one(id: $id) {
         name

--- a/src/utilities/testing/subscribeAndCount.ts
+++ b/src/utilities/testing/subscribeAndCount.ts
@@ -1,12 +1,15 @@
 import { ObservableQuery } from '../../core/ObservableQuery';
-import { ApolloQueryResult } from '../../core/types';
+import { ApolloQueryResult, OperationVariables } from '../../core/types';
 import { ObservableSubscription } from '../../utilities/observables/Observable';
 import { asyncMap } from '../../utilities/observables/asyncMap';
 
-export default function subscribeAndCount(
+export default function subscribeAndCount<
+  TData,
+  TVariables = OperationVariables,
+>(
   reject: (reason: any) => any,
-  observable: ObservableQuery<any>,
-  cb: (handleCount: number, result: ApolloQueryResult<any>) => any,
+  observable: ObservableQuery<TData, TVariables>,
+  cb: (handleCount: number, result: ApolloQueryResult<TData>) => any,
 ): ObservableSubscription {
   // Use a Promise queue to prevent callbacks from being run out of order.
   let queue = Promise.resolve();
@@ -14,7 +17,7 @@ export default function subscribeAndCount(
 
   const subscription = asyncMap(
     observable,
-    (result: ApolloQueryResult<any>) => {
+    (result: ApolloQueryResult<TData>) => {
       // All previous asynchronous callbacks must complete before cb can
       // be invoked with this result.
       return queue = queue.then(() => {


### PR DESCRIPTION
Revisiting PR #6891, which was reverted by commit c2ef68f9561b807df808a08a384032f574818c11.

With the introduction of canonical cache results (#7439), the strict equality check in `setDiff` is about to become mostly synonymous with deep equality checking (but much faster to check), so we need to deal with the consequences of #6891 one way or another.

As evidence that this change now (after #7439) has no observable impact, notice that we were able to switch back to using `!equal(a, b)` without needing to fix/update any failing tests, compared to the handful of tests that needed updating in #6891.

However, by switching to deep equality checking, we allow ourselves the option to experiment with disabling (or periodically clearing) the `ObjectCanon`, which would presumably lead to broadcasting more `!==` (but deeply equal) results to `cache.watch` watchers.

With deep equality checking in `setDiff`, those `!==` results will get past the `setDiff` filter in the same cases canonical objects would, so there will be less of a discrepancy in client behavior with/without canonization enabled.