### PR TITLE
Improve standalone client.refetchQueries method to support automatic detection of queries needing to be refetched.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,11 +34,14 @@
 - `InMemoryCache` supports a new method called `batch`, which is similar to `performTransaction` but takes named options rather than positional parameters. One of these named options is an `onDirty(watch, diff)` callback, which can be used to determine which watched queries were invalidated by the `batch` operation. <br/>
   [@benjamn](https://github.com/benjamn) in [#7819](https://github.com/apollographql/apollo-client/pull/7819)
 
-- Mutations now accept an optional callback function called `reobserveQuery`, which will be passed the `ObservableQuery` and `Cache.DiffResult` objects for any queries invalidated by cache writes performed by the mutation's final `update` function. Using `reobserveQuery`, you can override the default `FetchPolicy` of the query, by (for example) calling `ObservableQuery` methods like `refetch` to force a network request. This automatic detection of invalidated queries provides an alternative to manually enumerating queries using the `refetchQueries` mutation option. Also, if you return a `Promise` from `reobserveQuery`, the mutation will automatically await that `Promise`, rendering the `awaitRefetchQueries` option unnecessary. <br/>
+- Mutations now accept an optional callback function called `onQueryUpdated`, which will be passed the `ObservableQuery` and `Cache.DiffResult` objects for any queries invalidated by cache writes performed by the mutation's final `update` function. Using `onQueryUpdated`, you can override the default `FetchPolicy` of the query, by (for example) calling `ObservableQuery` methods like `refetch` to force a network request. This automatic detection of invalidated queries provides an alternative to manually enumerating queries using the `refetchQueries` mutation option. Also, if you return a `Promise` from `onQueryUpdated`, the mutation will automatically await that `Promise`, rendering the `awaitRefetchQueries` option unnecessary. <br/>
   [@benjamn](https://github.com/benjamn) in [#7827](https://github.com/apollographql/apollo-client/pull/7827)
 
 - Support `client.refetchQueries` as an imperative way to refetch queries, without having to pass `options.refetchQueries` to `client.mutate`. <br/>
   [@dannycochran](https://github.com/dannycochran) in [#7431](https://github.com/apollographql/apollo-client/pull/7431)
+
+- Improve standalone `client.refetchQueries` method to support automatic detection of queries needing to be refetched. <br/>
+  [@benjamn](https://github.com/benjamn) in [#8000](https://github.com/apollographql/apollo-client/pull/8000)
 
 - When `@apollo/client` is imported as CommonJS (for example, in Node.js), the global `process` variable is now shadowed with a stripped-down object that includes only `process.env.NODE_ENV` (since that's all Apollo Client needs), eliminating the significant performance penalty of repeatedly accessing `process.env` at runtime. <br/>
   [@benjamn](https://github.com/benjamn) in [#7627](https://github.com/apollographql/apollo-client/pull/7627)

--- a/src/__tests__/__snapshots__/exports.ts.snap
+++ b/src/__tests__/__snapshots__/exports.ts.snap
@@ -347,6 +347,7 @@ Array [
   "graphQLResultHasError",
   "hasClientExports",
   "hasDirectives",
+  "isDocumentNode",
   "isField",
   "isInlineFragment",
   "isNonEmptyArray",

--- a/src/__tests__/__snapshots__/exports.ts.snap
+++ b/src/__tests__/__snapshots__/exports.ts.snap
@@ -353,6 +353,7 @@ Array [
   "isReference",
   "iterateObserversSafely",
   "makeReference",
+  "makeUniqueId",
   "maybeDeepFreeze",
   "mergeDeep",
   "mergeDeepArray",

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -2428,18 +2428,18 @@ describe('client', () => {
   });
 
   it('has a refetchQueries method which calls QueryManager', async () => {
-    // TODO(dannycochran)
     const client = new ApolloClient({
       link: ApolloLink.empty(),
       cache: new InMemoryCache(),
     });
 
-    // @ts-ignore
-    const spy = jest.spyOn(client.queryManager, 'refetchQueries');
-    await client.refetchQueries({
-      include: ['Author1'],
-    });
-    expect(spy).toHaveBeenCalled();
+    const spy = jest.spyOn(client['queryManager'], 'refetchQueries');
+    spy.mockImplementation(() => new Map);
+
+    const options = { include: ['Author1'] };
+    await client.refetchQueries(options);
+
+    expect(spy).toHaveBeenCalledWith(options);
   });
 
   itAsync('should propagate errors from network interface to observers', (resolve, reject) => {

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -2436,7 +2436,9 @@ describe('client', () => {
 
     // @ts-ignore
     const spy = jest.spyOn(client.queryManager, 'refetchQueries');
-    await client.refetchQueries(['Author1']);
+    await client.refetchQueries({
+      include: ['Author1'],
+    });
     expect(spy).toHaveBeenCalled();
   });
 

--- a/src/__tests__/refetchQueries.ts
+++ b/src/__tests__/refetchQueries.ts
@@ -500,6 +500,7 @@ describe("client.refetchQueries", () => {
   });
 
   it("can refetch no-cache queries", () => {
-    // TODO
+    // TODO The options.updateCache function won't work for these queries, but
+    // the options.include array should work, at least.
   });
 });

--- a/src/__tests__/refetchQueries.ts
+++ b/src/__tests__/refetchQueries.ts
@@ -1,0 +1,256 @@
+import { Subscription } from "zen-observable-ts";
+
+import { itAsync } from '../utilities/testing/itAsync';
+import {
+  ApolloClient,
+  ApolloLink,
+  InMemoryCache,
+  gql,
+  Observable,
+  TypedDocumentNode,
+  ObservableQuery,
+} from "../core";
+
+describe("client.refetchQueries", () => {
+  itAsync("is public and callable", (resolve, reject) => {
+    const client = new ApolloClient({
+      cache: new InMemoryCache,
+    });
+    expect(typeof client.refetchQueries).toBe("function");
+
+    const result = client.refetchQueries({
+      updateCache(cache) {
+        expect(cache).toBe(client.cache);
+        expect(cache.extract()).toEqual({});
+      },
+      onQueryUpdated(obsQuery, diff) {
+        reject("should not have called onQueryUpdated");
+        return false;
+      },
+    });
+
+    expect(result.queries).toEqual([]);
+    expect(result.results).toEqual([]);
+
+    result.then(resolve, reject);
+  });
+
+  const aQuery: TypedDocumentNode<{ a: string }> = gql`query A { a }`;
+  const bQuery: TypedDocumentNode<{ b: string }> = gql`query B { b }`;
+  const abQuery: TypedDocumentNode<{
+    a: string;
+    b: string;
+  }> = gql`query AB { a b }`;
+
+  function makeClient() {
+    return new ApolloClient({
+      cache: new InMemoryCache,
+      link: new ApolloLink(operation => new Observable(observer => {
+        const data: Record<string, string> = {};
+        operation.operationName.split("").forEach(letter => {
+          data[letter.toLowerCase()] = letter.toUpperCase();
+        });
+        observer.next({ data });
+        observer.complete();
+      })),
+    });
+  }
+
+  const subs: Subscription[] = [];
+  function unsubscribe() {
+    subs.splice(0).forEach(sub => sub.unsubscribe());
+  }
+
+  function setup(client = makeClient()) {
+    function watch<T>(query: TypedDocumentNode<T>) {
+      const obsQuery = client.watchQuery({ query });
+      return new Promise<ObservableQuery<T>>((resolve, reject) => {
+        subs.push(obsQuery.subscribe({
+          error: reject,
+          next(result) {
+            expect(result.loading).toBe(false);
+            resolve(obsQuery);
+          },
+        }));
+      });
+    }
+
+    return Promise.all([
+      watch(aQuery),
+      watch(bQuery),
+      watch(abQuery),
+    ]);
+  }
+
+  // Not a great way to sort objects, but it will give us stable orderings in
+  // these specific tests (especially since the keys are all "a" and/or "b").
+  function sortObjects<T extends object[]>(array: T) {
+    array.sort((a, b) => {
+      const aKey = Object.keys(a).join(",");
+      const bKey = Object.keys(b).join(",");
+      if (aKey < bKey) return -1;
+      if (bKey < aKey) return 1;
+      return 0;
+    });
+  }
+
+  itAsync("includes watched queries affected by updateCache", async (resolve, reject) => {
+    const client = makeClient();
+    const [
+      aObs,
+      bObs,
+      abObs,
+    ] = await setup(client);
+
+    const ayyResults = await client.refetchQueries({
+      updateCache(cache) {
+        cache.writeQuery({
+          query: aQuery,
+          data: {
+            a: "Ayy",
+          },
+        });
+      },
+
+      onQueryUpdated(obs, diff) {
+        if (obs === aObs) {
+          expect(diff.result).toEqual({ a: "Ayy" });
+        } else if (obs === bObs) {
+          reject("bQuery should not have been updated");
+        } else if (obs === abObs) {
+          expect(diff.result).toEqual({ a: "Ayy", b: "B" });
+        } else {
+          reject("unexpected ObservableQuery");
+        }
+        return Promise.resolve(diff.result);
+      },
+    });
+
+    sortObjects(ayyResults);
+
+    expect(ayyResults).toEqual([
+      { a: "Ayy" },
+      { a: "Ayy", b: "B" },
+      // Note that no bQuery result is included here.
+    ]);
+
+    const beeResults = await client.refetchQueries({
+      updateCache(cache) {
+        cache.writeQuery({
+          query: bQuery,
+          data: {
+            b: "Bee",
+          },
+        });
+      },
+
+      onQueryUpdated(obs, diff) {
+        if (obs === aObs) {
+          reject("aQuery should not have been updated");
+        } else if (obs === bObs) {
+          expect(diff.result).toEqual({ b: "Bee" });
+        } else if (obs === abObs) {
+          expect(diff.result).toEqual({ a: "Ayy", b: "Bee" });
+        } else {
+          reject("unexpected ObservableQuery");
+        }
+        return diff.result;
+      },
+    });
+
+    sortObjects(beeResults);
+
+    expect(beeResults).toEqual([
+      // Note that no aQuery result is included here.
+      { a: "Ayy", b: "Bee" },
+      { b: "Bee" },
+    ]);
+
+    unsubscribe();
+    resolve();
+  });
+
+  itAsync("includes watched queries named in options.include", async (resolve, reject) => {
+    const client = makeClient();
+    const [
+      aObs,
+      bObs,
+      abObs,
+    ] = await setup(client);
+
+    const ayyResults = await client.refetchQueries({
+      updateCache(cache) {
+        cache.writeQuery({
+          query: aQuery,
+          data: {
+            a: "Ayy",
+          },
+        });
+      },
+
+      // This is the options.include array mentioned in the test description.
+      include: ["B"],
+
+      onQueryUpdated(obs, diff) {
+        if (obs === aObs) {
+          expect(diff.result).toEqual({ a: "Ayy" });
+        } else if (obs === bObs) {
+          expect(diff.result).toEqual({ b: "B" });
+        } else if (obs === abObs) {
+          expect(diff.result).toEqual({ a: "Ayy", b: "B" });
+        } else {
+          reject("unexpected ObservableQuery");
+        }
+        return Promise.resolve(diff.result);
+      },
+    });
+
+    sortObjects(ayyResults);
+
+    expect(ayyResults).toEqual([
+      { a: "Ayy" },
+      { a: "Ayy", b: "B" },
+      // Included this time!
+      { b: "B" },
+    ]);
+
+    const beeResults = await client.refetchQueries({
+      updateCache(cache) {
+        cache.writeQuery({
+          query: bQuery,
+          data: {
+            b: "Bee",
+          },
+        });
+      },
+
+      // The "A" here causes aObs to be included, but the "AB" should be
+      // redundant because that query is already included.
+      include: ["A", "AB"],
+
+      onQueryUpdated(obs, diff) {
+        if (obs === aObs) {
+          expect(diff.result).toEqual({ a: "Ayy" });
+        } else if (obs === bObs) {
+          expect(diff.result).toEqual({ b: "Bee" });
+        } else if (obs === abObs) {
+          expect(diff.result).toEqual({ a: "Ayy", b: "Bee" });
+        } else {
+          reject("unexpected ObservableQuery");
+        }
+        return diff.result;
+      },
+    });
+
+    sortObjects(beeResults);
+
+    expect(beeResults).toEqual([
+      { a: "Ayy" }, // Included this time!
+      { a: "Ayy", b: "Bee" },
+      { b: "Bee" },
+    ]);
+
+    unsubscribe();
+    resolve();
+  });
+});

--- a/src/__tests__/refetchQueries.ts
+++ b/src/__tests__/refetchQueries.ts
@@ -298,4 +298,20 @@ describe("client.refetchQueries", () => {
     unsubscribe();
     resolve();
   });
+
+  it("can run updateQuery function against optimistic cache layer", () => {
+    // TODO
+  });
+
+  it("can return true from onQueryUpdated to choose default refetching behavior", () => {
+    // TODO
+  });
+
+  it("can return false from onQueryUpdated to skip the updated query", () => {
+    // TODO
+  });
+
+  it("can refetch no-cache queries", () => {
+    // TODO
+  });
 });

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -23,6 +23,8 @@ export type BatchOptions<C extends ApolloCache<any>> = {
   // the same as passing null.
   optimistic: string | boolean;
 
+  removeOptimistic?: string;
+
   // If you want to find out which watched queries were invalidated during
   // this batch operation, pass this optional callback function. Returning
   // false from the callback will prevent broadcasting this result.

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -31,7 +31,8 @@ export type BatchOptions<C extends ApolloCache<any>> = {
   onWatchUpdated?: (
     this: C,
     watch: Cache.WatchOptions,
-    diff: Cache.DiffResult<any>,
+    newDiff: Cache.DiffResult<any>,
+    oldDiff?: Cache.DiffResult<any>,
   ) => any;
 };
 

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -26,7 +26,7 @@ export type BatchOptions<C extends ApolloCache<any>> = {
   // If you want to find out which watched queries were invalidated during
   // this batch operation, pass this optional callback function. Returning
   // false from the callback will prevent broadcasting this result.
-  onDirty?: (
+  onWatchUpdated?: (
     this: C,
     watch: Cache.WatchOptions,
     diff: Cache.DiffResult<any>,

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -11,31 +11,6 @@ import { Cache } from './types/Cache';
 
 export type Transaction<T> = (c: ApolloCache<T>) => void;
 
-export type BatchOptions<C extends ApolloCache<any>> = {
-  // Same as the first parameter of performTransaction, except the cache
-  // argument will have the subclass type rather than ApolloCache.
-  transaction(cache: C): void;
-
-  // Passing a string for this option creates a new optimistic layer with
-  // that string as its layer.id, just like passing a string for the
-  // optimisticId parameter of performTransaction. Passing true is the
-  // same as passing undefined to performTransaction, and passing false is
-  // the same as passing null.
-  optimistic: string | boolean;
-
-  removeOptimistic?: string;
-
-  // If you want to find out which watched queries were invalidated during
-  // this batch operation, pass this optional callback function. Returning
-  // false from the callback will prevent broadcasting this result.
-  onWatchUpdated?: (
-    this: C,
-    watch: Cache.WatchOptions,
-    newDiff: Cache.DiffResult<any>,
-    oldDiff?: Cache.DiffResult<any>,
-  ) => any;
-};
-
 export abstract class ApolloCache<TSerialized> implements DataProxy {
   // required to implement
   // core API
@@ -84,7 +59,7 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
   // provide a default batch implementation that's just another way of calling
   // performTransaction. Subclasses of ApolloCache (such as InMemoryCache) can
   // override the batch method to do more interesting things with its options.
-  public batch(options: BatchOptions<this>) {
+  public batch(options: Cache.BatchOptions<this>) {
     const optimisticId =
       typeof options.optimistic === "string" ? options.optimistic :
       options.optimistic === false ? null : void 0;

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -63,7 +63,7 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
     const optimisticId =
       typeof options.optimistic === "string" ? options.optimistic :
       options.optimistic === false ? null : void 0;
-    this.performTransaction(options.transaction, optimisticId);
+    this.performTransaction(options.update, optimisticId);
   }
 
   public abstract performTransaction(

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -32,7 +32,7 @@ export type BatchOptions<C extends ApolloCache<any>> = {
     this: C,
     watch: Cache.WatchOptions,
     diff: Cache.DiffResult<any>,
-  ) => void | false;
+  ) => any;
 };
 
 export abstract class ApolloCache<TSerialized> implements DataProxy {

--- a/src/cache/core/types/Cache.ts
+++ b/src/cache/core/types/Cache.ts
@@ -2,7 +2,10 @@ import { DataProxy } from './DataProxy';
 import { Modifier, Modifiers } from './common';
 
 export namespace Cache {
-  export type WatchCallback = (diff: Cache.DiffResult<any>) => void;
+  export type WatchCallback = (
+    newDiff: Cache.DiffResult<any>,
+    oldDiff?: Cache.DiffResult<any>,
+  ) => void;
 
   export interface ReadOptions<TVariables = any, TData = any>
     extends DataProxy.Query<TVariables, TData> {

--- a/src/cache/core/types/Cache.ts
+++ b/src/cache/core/types/Cache.ts
@@ -4,8 +4,8 @@ import { ApolloCache } from '../cache';
 
 export namespace Cache {
   export type WatchCallback = (
-    newDiff: Cache.DiffResult<any>,
-    oldDiff?: Cache.DiffResult<any>,
+    diff: Cache.DiffResult<any>,
+    lastDiff?: Cache.DiffResult<any>,
   ) => void;
 
   export interface ReadOptions<TVariables = any, TData = any>

--- a/src/cache/core/types/Cache.ts
+++ b/src/cache/core/types/Cache.ts
@@ -62,7 +62,7 @@ export namespace Cache {
     // Passing a string for this option creates a new optimistic layer, with the
     // given string as its layer.id, just like passing a string for the
     // optimisticId parameter of performTransaction. Passing true is the same as
-    // passing undefined to performTransaction (runing the batch operation
+    // passing undefined to performTransaction (running the batch operation
     // against the current top layer of the cache), and passing false is the
     // same as passing null (running the operation against root/non-optimistic
     // cache data).

--- a/src/cache/core/types/Cache.ts
+++ b/src/cache/core/types/Cache.ts
@@ -1,5 +1,6 @@
 import { DataProxy } from './DataProxy';
 import { Modifier, Modifiers } from './common';
+import { ApolloCache } from '../cache';
 
 export namespace Cache {
   export type WatchCallback = (
@@ -51,6 +52,39 @@ export namespace Cache {
     fields: Modifiers | Modifier<any>;
     optimistic?: boolean;
     broadcast?: boolean;
+  }
+
+  export interface BatchOptions<C extends ApolloCache<any>> {
+    // Same as the first parameter of performTransaction, except the cache
+    // argument will have the subclass type rather than ApolloCache.
+    transaction(cache: C): void;
+
+    // Passing a string for this option creates a new optimistic layer, with the
+    // given string as its layer.id, just like passing a string for the
+    // optimisticId parameter of performTransaction. Passing true is the same as
+    // passing undefined to performTransaction (runing the batch operation
+    // against the current top layer of the cache), and passing false is the
+    // same as passing null (running the operation against root/non-optimistic
+    // cache data).
+    optimistic: string | boolean;
+
+    // If you specify the ID of an optimistic layer using this option, that
+    // layer will be removed as part of the batch transaction, triggering at
+    // most one broadcast for both the transaction and the removal of the layer.
+    // Note: this option is needed because calling cache.removeOptimistic during
+    // the transaction function may not be not safe, since any modifications to
+    // cache layers may be discarded after the transaction finishes.
+    removeOptimistic?: string;
+
+    // If you want to find out which watched queries were invalidated during
+    // this batch operation, pass this optional callback function. Returning
+    // false from the callback will prevent broadcasting this result.
+    onWatchUpdated?: (
+      this: C,
+      watch: Cache.WatchOptions,
+      diff: Cache.DiffResult<any>,
+      lastDiff: Cache.DiffResult<any> | undefined,
+    ) => any;
   }
 
   export import DiffResult = DataProxy.DiffResult;

--- a/src/cache/core/types/Cache.ts
+++ b/src/cache/core/types/Cache.ts
@@ -57,7 +57,7 @@ export namespace Cache {
   export interface BatchOptions<C extends ApolloCache<any>> {
     // Same as the first parameter of performTransaction, except the cache
     // argument will have the subclass type rather than ApolloCache.
-    transaction(cache: C): void;
+    update(cache: C): void;
 
     // Passing a string for this option creates a new optimistic layer, with the
     // given string as its layer.id, just like passing a string for the

--- a/src/cache/inmemory/__tests__/cache.ts
+++ b/src/cache/inmemory/__tests__/cache.ts
@@ -1362,7 +1362,7 @@ describe('Cache', () => {
       const dirtied = new Map<Cache.WatchOptions, Cache.DiffResult<any>>();
 
       cache.batch({
-        transaction(cache) {
+        update(cache) {
           cache.writeQuery({
             query: aQuery,
             data: {
@@ -1403,7 +1403,7 @@ describe('Cache', () => {
       dirtied.clear();
 
       cache.batch({
-        transaction(cache) {
+        update(cache) {
           cache.writeQuery({
             query: bQuery,
             data: {
@@ -1474,7 +1474,7 @@ describe('Cache', () => {
       const dirtied = new Map<Cache.WatchOptions, Cache.DiffResult<any>>();
 
       cache.batch({
-        transaction(cache) {
+        update(cache) {
           cache.modify({
             fields: {
               a(value, { INVALIDATE }) {
@@ -1548,7 +1548,7 @@ describe('Cache', () => {
       const dirtied = new Map<Cache.WatchOptions, Cache.DiffResult<any>>();
 
       cache.batch({
-        transaction(cache) {
+        update(cache) {
           cache.modify({
             fields: {
               a(value) {
@@ -1571,7 +1571,7 @@ describe('Cache', () => {
 
       expect(aInfo.diffs).toEqual([
         // This diff resulted from the cache.modify call in the cache.batch
-        // transaction function.
+        // update function.
         {
           complete: true,
           result: {
@@ -1582,7 +1582,7 @@ describe('Cache', () => {
 
       expect(abInfo.diffs).toEqual([
         // This diff resulted from the cache.modify call in the cache.batch
-        // transaction function.
+        // update function.
         {
           complete: true,
           result: {

--- a/src/cache/inmemory/__tests__/cache.ts
+++ b/src/cache/inmemory/__tests__/cache.ts
@@ -1348,7 +1348,7 @@ describe('Cache', () => {
       return { diffs, watch: options, cancel };
     }
 
-    it('calls onDirty for each invalidated watch', () => {
+    it('calls onWatchUpdated for each invalidated watch', () => {
       const cache = new InMemoryCache;
 
       const aQuery = gql`query { a }`;
@@ -1371,7 +1371,7 @@ describe('Cache', () => {
           });
         },
         optimistic: true,
-        onDirty(w, diff) {
+        onWatchUpdated(w, diff) {
           dirtied.set(w, diff);
         },
       });
@@ -1412,7 +1412,7 @@ describe('Cache', () => {
           });
         },
         optimistic: true,
-        onDirty(w, diff) {
+        onWatchUpdated(w, diff) {
           dirtied.set(w, diff);
         },
       });
@@ -1485,7 +1485,7 @@ describe('Cache', () => {
           });
         },
         optimistic: true,
-        onDirty(w, diff) {
+        onWatchUpdated(w, diff) {
           dirtied.set(w, diff);
         },
       });
@@ -1506,7 +1506,7 @@ describe('Cache', () => {
       bInfo.cancel();
     });
 
-    it('does not pass previously invalidated queries to onDirty', () => {
+    it('does not pass previously invalidated queries to onWatchUpdated', () => {
       const cache = new InMemoryCache;
 
       const aQuery = gql`query { a }`;
@@ -1527,13 +1527,13 @@ describe('Cache', () => {
 
       cache.writeQuery({
         query: bQuery,
-        // Writing this data with broadcast:false queues this update for the
-        // next broadcast, whenever it happens. If that next broadcast is the
-        // one triggered by cache.batch, the bQuery broadcast could be
-        // accidentally intercepted by onDirty, even though the transaction
-        // does not touch the Query.b field. To solve this problem, the batch
-        // method calls cache.broadcastWatches() before the transaction, when
-        // options.onDirty is provided.
+        // Writing this data with broadcast:false queues this update for
+        // the next broadcast, whenever it happens. If that next broadcast
+        // is the one triggered by cache.batch, the bQuery broadcast could
+        // be accidentally intercepted by onWatchUpdated, even though the
+        // transaction does not touch the Query.b field. To solve this
+        // problem, the batch method calls cache.broadcastWatches() before
+        // the transaction, when options.onWatchUpdated is provided.
         broadcast: false,
         data: {
           b: "beeeee",
@@ -1559,7 +1559,7 @@ describe('Cache', () => {
           });
         },
         optimistic: true,
-        onDirty(watch, diff) {
+        onWatchUpdated(watch, diff) {
           dirtied.set(watch, diff);
         },
       });

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -342,6 +342,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     const {
       transaction,
       optimistic = true,
+      removeOptimistic,
     } = options;
 
     const perform = (layer?: EntityStore) => {
@@ -398,6 +399,10 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
       // Otherwise, leave this.data and this.optimisticData unchanged and
       // run the transaction with broadcast batching.
       perform();
+    }
+
+    if (typeof removeOptimistic === "string") {
+      this.optimisticData = this.optimisticData.removeLayer(removeOptimistic);
     }
 
     // Note: if this.txCount > 0, then alreadyDirty.size === 0, so this code

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -477,6 +477,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     c: Cache.WatchOptions,
     options?: BroadcastOptions,
   ) {
+    const { lastDiff } = c;
     const diff = this.diff<any>({
       query: c.query,
       variables: c.variables,
@@ -490,15 +491,15 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
       }
 
       if (options.onWatchUpdated &&
-          options.onWatchUpdated.call(this, c, diff) === false) {
+          options.onWatchUpdated.call(this, c, diff, lastDiff) === false) {
         // Returning false from the onWatchUpdated callback will prevent
         // calling c.callback(diff) for this watcher.
         return;
       }
     }
 
-    if (!c.lastDiff || c.lastDiff.result !== diff.result) {
-      c.callback(c.lastDiff = diff);
+    if (!lastDiff || lastDiff.result !== diff.result) {
+      c.callback(c.lastDiff = diff, lastDiff);
     }
   }
 }

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -5,7 +5,7 @@ import { DocumentNode } from 'graphql';
 import { OptimisticWrapperFunction, wrap } from 'optimism';
 import { equal } from '@wry/equality';
 
-import { ApolloCache, BatchOptions } from '../core/cache';
+import { ApolloCache } from '../core/cache';
 import { Cache } from '../core/types/Cache';
 import { MissingFieldError } from '../core/types/common';
 import {
@@ -39,7 +39,7 @@ export interface InMemoryCacheConfig extends ApolloReducerConfig {
 }
 
 type BroadcastOptions = Pick<
-  BatchOptions<InMemoryCache>,
+  Cache.BatchOptions<InMemoryCache>,
   | "optimistic"
   | "onWatchUpdated"
 >
@@ -339,7 +339,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
 
   private txCount = 0;
 
-  public batch(options: BatchOptions<InMemoryCache>) {
+  public batch(options: Cache.BatchOptions<InMemoryCache>) {
     const {
       transaction,
       optimistic = true,

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -3,6 +3,7 @@ import './fixPolyfills';
 
 import { DocumentNode } from 'graphql';
 import { OptimisticWrapperFunction, wrap } from 'optimism';
+import { equal } from '@wry/equality';
 
 import { ApolloCache, BatchOptions } from '../core/cache';
 import { Cache } from '../core/types/Cache';
@@ -498,7 +499,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
       }
     }
 
-    if (!lastDiff || lastDiff.result !== diff.result) {
+    if (!lastDiff || !equal(lastDiff.result, diff.result)) {
       c.callback(c.lastDiff = diff, lastDiff);
     }
   }

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -344,6 +344,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
       transaction,
       optimistic = true,
       removeOptimistic,
+      onWatchUpdated,
     } = options;
 
     const perform = (layer?: EntityStore) => {
@@ -361,7 +362,6 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
       }
     };
 
-    const { onWatchUpdated } = options;
     const alreadyDirty = new Set<Cache.WatchOptions>();
 
     if (onWatchUpdated && !this.txCount) {

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -535,25 +535,25 @@ export class ApolloClient<TCacheShape> implements DataProxy {
    * active queries.
    * Takes optional parameter `includeStandby` which will include queries in standby-mode when refetching.
    */
-  public refetchQueries<TData>(
-    options: PublicRefetchQueriesOptions<TData, ApolloCache<TCacheShape>>,
-  ): Promise<{
+  public refetchQueries<
+    TData,
+    TCache extends ApolloCache<any> = ApolloCache<TCacheShape>,
+  >(
+    options: PublicRefetchQueriesOptions<TData, TCache>,
+  ): {
     queries: ObservableQuery<any>[];
-    results: ApolloQueryResult<TData>[];
-   }> {
+    updates: any[];
+  } {
     const map = this.queryManager.refetchQueries(options);
     const queries: ObservableQuery<any>[] = [];
-    const results: any[] = [];
+    const updates: any[] = [];
 
     map.forEach((result, obsQuery) => {
       queries.push(obsQuery);
-      results.push(result);
+      updates.push(result);
     });
 
-    return Promise.all(results).then(results => ({
-      queries,
-      results,
-    }));
+    return { queries, updates };
   }
 
   /**

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -17,6 +17,7 @@ import {
   Resolvers,
   RefetchQueriesOptions,
   RefetchQueriesResult,
+  InternalRefetchQueriesResult,
 } from './types';
 
 import {
@@ -544,18 +545,22 @@ export class ApolloClient<TCacheShape> implements DataProxy {
   ): RefetchQueriesResult<TResult> {
     const map = this.queryManager.refetchQueries(options);
     const queries: ObservableQuery<any>[] = [];
-    const results: TResult[] = [];
+    const results: InternalRefetchQueriesResult<TResult>[] = [];
 
-    map.forEach((update, obsQuery) => {
+    map.forEach((result, obsQuery) => {
       queries.push(obsQuery);
-      results.push(update);
+      results.push(result);
     });
 
-    const result = Promise.all(results) as RefetchQueriesResult<TResult>;
+    const result = Promise.all<TResult>(
+      results as TResult[]
+    ) as RefetchQueriesResult<TResult>;
+
     // In case you need the raw results immediately, without awaiting
     // Promise.all(results):
     result.queries = queries;
     result.results = results;
+
     return result;
   }
 

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -538,7 +538,7 @@ export class ApolloClient<TCacheShape> implements DataProxy {
    */
   public refetchQueries<
     TCache extends ApolloCache<any> = ApolloCache<TCacheShape>,
-    TResult = any,
+    TResult = Promise<ApolloQueryResult<any>>,
   >(
     options: RefetchQueriesOptions<TCache, TResult>,
   ): PromiseLike<PromiseResult<TResult>[]> & {

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -23,7 +23,7 @@ import {
   MutationOptions,
   SubscriptionOptions,
   WatchQueryFetchPolicy,
-  PublicRefetchQueriesOptions,
+  RefetchQueriesOptions,
 } from './watchQueryOptions';
 
 import {
@@ -539,7 +539,7 @@ export class ApolloClient<TCacheShape> implements DataProxy {
     TData,
     TCache extends ApolloCache<any> = ApolloCache<TCacheShape>,
   >(
-    options: PublicRefetchQueriesOptions<TData, TCache>,
+    options: RefetchQueriesOptions<TData, TCache>,
   ): {
     queries: ObservableQuery<any>[];
     updates: any[];

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -16,6 +16,7 @@ import {
   OperationVariables,
   PromiseResult,
   Resolvers,
+  RefetchQueriesOptions,
 } from './types';
 
 import {
@@ -24,7 +25,6 @@ import {
   MutationOptions,
   SubscriptionOptions,
   WatchQueryFetchPolicy,
-  RefetchQueriesOptions,
 } from './watchQueryOptions';
 
 import {

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -14,6 +14,7 @@ import {
   ApolloQueryResult,
   DefaultContext,
   OperationVariables,
+  PromiseResult,
   Resolvers,
 } from './types';
 
@@ -536,13 +537,13 @@ export class ApolloClient<TCacheShape> implements DataProxy {
    * Takes optional parameter `includeStandby` which will include queries in standby-mode when refetching.
    */
   public refetchQueries<
-    TData,
     TCache extends ApolloCache<any> = ApolloCache<TCacheShape>,
+    TResult = any,
   >(
-    options: RefetchQueriesOptions<TData, TCache>,
-  ): PromiseLike<ApolloQueryResult<any>[]> & {
+    options: RefetchQueriesOptions<TCache, TResult>,
+  ): PromiseLike<PromiseResult<TResult>[]> & {
     queries: ObservableQuery<any>[];
-    results: any[];
+    results: TResult[];
   } {
     const map = this.queryManager.refetchQueries(options);
     const queries: ObservableQuery<any>[] = [];

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -382,7 +382,7 @@ export class QueryManager<TStore> {
         // Write the final mutation.result to the root layer of the cache.
         optimistic: false,
 
-        onDirty: mutation.reobserveQuery && ((watch, diff) => {
+        onWatchUpdated: mutation.reobserveQuery && ((watch, diff) => {
           if (watch.watcher instanceof QueryInfo) {
             const oq = watch.watcher.observableQuery;
             if (oq) {

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1160,11 +1160,14 @@ export class QueryManager<TStore> {
         }
 
         if (oq && fallback) {
+          let result: boolean | TResult | undefined;
           // If onQueryUpdated is provided, we want to use it for all included
           // queries, even the PureQueryOptions ones. Otherwise, we call the
           // fallback function defined above.
-          let result = onQueryUpdated &&
-            onQueryUpdated(oq, queryInfo.getDiff(), diff);
+          if (onQueryUpdated) {
+            queryInfo.reset(); // Force queryInfo.getDiff() to read from cache.
+            result = onQueryUpdated(oq, queryInfo.getDiff(), diff);
+          }
           if (!onQueryUpdated || result === true) {
             result = fallback();
           }

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -232,6 +232,7 @@ export class QueryManager<TStore> {
                 result,
                 document: mutation,
                 variables,
+                removeOptimistic: !!optimisticResponse,
                 errorPolicy,
                 context,
                 updateQueries,
@@ -311,6 +312,7 @@ export class QueryManager<TStore> {
       context?: TContext;
       updateQueries: UpdateQueries<TData>;
       update?: MutationUpdaterFunction<TData, TVariables, TContext, TCache>;
+      removeOptimistic: boolean;
       onQueryUpdated?: OnQueryUpdated;
     },
     cache = this.cache,
@@ -382,6 +384,10 @@ export class QueryManager<TStore> {
         // Write the final mutation.result to the root layer of the cache.
         optimistic: false,
 
+        removeOptimistic: mutation.removeOptimistic
+          ? mutation.mutationId
+          : void 0,
+
         onWatchUpdated: mutation.onQueryUpdated && ((watch, diff) => {
           if (watch.watcher instanceof QueryInfo) {
             const oq = watch.watcher.observableQuery;
@@ -420,6 +426,7 @@ export class QueryManager<TStore> {
       try {
         this.markMutationResult<TData, TVariables, TContext, TCache>({
           ...mutation,
+          removeOptimistic: false,
           result: { data },
         }, cache);
       } catch (error) {

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1141,20 +1141,21 @@ export class QueryManager<TStore> {
           results.set(oq, result);
 
         } else if (typeof queryNameOrOptions === "object") {
-          const fetchPromise = this.fetchQuery(queryId, {
+          const options: WatchQueryOptions = {
             query: queryNameOrOptions.query,
             variables: queryNameOrOptions.variables,
             fetchPolicy: "network-only",
             context: queryNameOrOptions.context,
-          });
+          };
 
-          oq = queryInfo.observableQuery;
-          if (oq) {
-            results.set(oq, fetchPromise);
-          } else {
-            throw new InvariantError(JSON.stringify(queryInfo, null, 2));
-          }
+          queryInfo.setObservableQuery(oq = new ObservableQuery({
+            queryManager: this,
+            queryInfo,
+            options,
+          }));
 
+          const fetchPromise = this.fetchQuery(queryId, options);
+          results.set(oq, fetchPromise);
           const stop = () => this.stopQuery(queryId);
           fetchPromise.then(stop, stop);
         }

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -29,7 +29,7 @@ import {
   WatchQueryFetchPolicy,
   ErrorPolicy,
   RefetchQueryDescription,
-  PrivateRefetchQueriesOptions,
+  InternalRefetchQueriesOptions,
 } from './watchQueryOptions';
 import { ObservableQuery } from './ObservableQuery';
 import { NetworkStatus, isNetworkRequestInFlight } from './networkStatus';
@@ -1041,7 +1041,7 @@ export class QueryManager<TStore> {
     optimistic = false,
     removeOptimistic = optimistic ? makeUniqueId("refetchQueries") : void 0,
     onQueryUpdated,
-  }: PrivateRefetchQueriesOptions<TData, ApolloCache<TStore>>) {
+  }: InternalRefetchQueriesOptions<TData, ApolloCache<TStore>>) {
     const includedQueriesById = new Map<string, RefetchQueryDescription[number]>();
     const results = new Map<ObservableQuery<any>, any>();
 

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -272,10 +272,6 @@ export class QueryManager<TStore> {
 
       ).subscribe({
         next(storeResult) {
-          if (optimisticResponse) {
-            self.cache.removeOptimistic(mutationId);
-          }
-
           self.broadcastQueries();
 
           // At the moment, a mutation can have only one result, so we can
@@ -1158,6 +1154,17 @@ export class QueryManager<TStore> {
           fetchPromise.then(stop, stop);
         }
       });
+    }
+
+    if (removeOptimistic) {
+      // In case no updateCache callback was provided (so cache.batch was not
+      // called above, and thus did not already remove the optimistic layer),
+      // remove it here. Since this is a no-op when the layer has already been
+      // removed, we do it even if we called cache.batch above, since it's
+      // possible this.cache is an instance of some ApolloCache subclass other
+      // than InMemoryCache, and does not fully support the removeOptimistic
+      // option for cache.batch.
+      this.cache.removeOptimistic(removeOptimistic);
     }
 
     return results;

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1044,7 +1044,8 @@ export class QueryManager<TStore> {
     optimistic = false,
     removeOptimistic = optimistic ? makeUniqueId("refetchQueries") : void 0,
     onQueryUpdated,
-  }: InternalRefetchQueriesOptions<ApolloCache<TStore>, TResult>) {
+  }: InternalRefetchQueriesOptions<ApolloCache<TStore>, TResult>
+  ): Map<ObservableQuery<any>, TResult> {
     const includedQueriesById = new Map<string, {
       desc: RefetchQueryDescriptor;
       diff: Cache.DiffResult<any> | undefined;
@@ -1063,7 +1064,7 @@ export class QueryManager<TStore> {
       });
     }
 
-    const results = new Map<ObservableQuery<any>, any>();
+    const results = new Map<ObservableQuery<any>, TResult>();
     function maybeAddResult(oq: ObservableQuery<any>, result: any): boolean {
       // The onQueryUpdated function can return false to ignore this query and
       // skip its normal broadcast, or true to allow the usual broadcast to

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1160,15 +1160,15 @@ export class QueryManager<TStore> {
         }
 
         if (oq && fallback) {
-          maybeAddResult(
-            oq,
-            // If onQueryUpdated is provided, we want to use it for all included
-            // queries, even the PureQueryOptions ones. Otherwise, we call the
-            // fallback function defined above.
-            onQueryUpdated
-              ? onQueryUpdated(oq, queryInfo.getDiff(), diff)
-              : fallback(),
-          );
+          // If onQueryUpdated is provided, we want to use it for all included
+          // queries, even the PureQueryOptions ones. Otherwise, we call the
+          // fallback function defined above.
+          let result = onQueryUpdated &&
+            onQueryUpdated(oq, queryInfo.getDiff(), diff);
+          if (!onQueryUpdated || result === true) {
+            result = fallback();
+          }
+          maybeAddResult(oq, result);
         }
       });
     }

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -36,7 +36,7 @@ import {
   ApolloQueryResult,
   OperationVariables,
   MutationUpdaterFunction,
-  ReobserveQueryCallback,
+  OnQueryUpdated,
 } from './types';
 import { LocalState } from './LocalState';
 
@@ -139,7 +139,7 @@ export class QueryManager<TStore> {
     refetchQueries = [],
     awaitRefetchQueries = false,
     update: updateWithProxyFn,
-    reobserveQuery,
+    onQueryUpdated,
     errorPolicy = 'none',
     fetchPolicy,
     context,
@@ -236,7 +236,7 @@ export class QueryManager<TStore> {
                 context,
                 updateQueries,
                 update: updateWithProxyFn,
-                reobserveQuery,
+                onQueryUpdated,
               });
             } catch (e) {
               // Likewise, throwing an error from the asyncMap mapping function
@@ -311,7 +311,7 @@ export class QueryManager<TStore> {
       context?: TContext;
       updateQueries: UpdateQueries<TData>;
       update?: MutationUpdaterFunction<TData, TVariables, TContext, TCache>;
-      reobserveQuery?: ReobserveQueryCallback;
+      onQueryUpdated?: OnQueryUpdated;
     },
     cache = this.cache,
   ): Promise<void> {
@@ -382,11 +382,11 @@ export class QueryManager<TStore> {
         // Write the final mutation.result to the root layer of the cache.
         optimistic: false,
 
-        onWatchUpdated: mutation.reobserveQuery && ((watch, diff) => {
+        onWatchUpdated: mutation.onQueryUpdated && ((watch, diff) => {
           if (watch.watcher instanceof QueryInfo) {
             const oq = watch.watcher.observableQuery;
             if (oq) {
-              reobserveResults.push(mutation.reobserveQuery!(oq, diff));
+              reobserveResults.push(mutation.onQueryUpdated!(oq, diff));
               // Prevent the normal cache broadcast of this result.
               return false;
             }

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -28,9 +28,6 @@ import {
   MutationOptions,
   WatchQueryFetchPolicy,
   ErrorPolicy,
-  RefetchQueryDescription,
-  InternalRefetchQueriesOptions,
-  RefetchQueryDescriptor,
 } from './watchQueryOptions';
 import { ObservableQuery } from './ObservableQuery';
 import { NetworkStatus, isNetworkRequestInFlight } from './networkStatus';
@@ -39,6 +36,9 @@ import {
   OperationVariables,
   MutationUpdaterFunction,
   OnQueryUpdated,
+  RefetchQueryDescription,
+  InternalRefetchQueriesOptions,
+  RefetchQueryDescriptor,
 } from './types';
 import { LocalState } from './LocalState';
 

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1137,14 +1137,14 @@ export class QueryManager<TStore> {
         // temporary optimistic layer, in case that ever matters.
         removeOptimistic,
 
-        onWatchUpdated: onQueryUpdated && function (watch, newDiff, oldDiff) {
+        onWatchUpdated: onQueryUpdated && function (watch, diff, lastDiff) {
           const oq =
             watch.watcher instanceof QueryInfo &&
             watch.watcher.observableQuery;
 
           if (oq) {
             includedQueriesById.delete(oq.queryId);
-            return maybeAddResult(oq, onQueryUpdated(oq, newDiff, oldDiff));
+            return maybeAddResult(oq, onQueryUpdated(oq, diff, lastDiff));
           }
         },
       });

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1039,7 +1039,7 @@ export class QueryManager<TStore> {
     updateCache,
     include,
     optimistic = false,
-    removeOptimistic = optimistic ? "TODO" : void 0,
+    removeOptimistic = optimistic ? makeUniqueId("refetchQueries") : void 0,
     onQueryUpdated,
   }: PrivateRefetchQueriesOptions<TData, ApolloCache<TStore>>) {
     const includedQueriesById = new Map<string, RefetchQueryDescription[number]>();
@@ -1366,4 +1366,11 @@ export class QueryManager<TStore> {
       clientAwareness: this.clientAwareness,
     };
   }
+}
+
+const prefixCounts: Record<string, number> = Object.create(null);
+function makeUniqueId(prefix: string) {
+  const count = prefixCounts[prefix] || 1;
+  prefixCounts[prefix] = count + 1;
+  return `${prefix}:${count}:${Math.random().toString(36).slice(2)}`;
 }

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -29,7 +29,7 @@ import {
   WatchQueryFetchPolicy,
   ErrorPolicy,
   RefetchQueryDescription,
-  RefetchQueriesOptions,
+  PrivateRefetchQueriesOptions,
 } from './watchQueryOptions';
 import { ObservableQuery } from './ObservableQuery';
 import { NetworkStatus, isNetworkRequestInFlight } from './networkStatus';
@@ -132,7 +132,12 @@ export class QueryManager<TStore> {
     this.fetchCancelFns.clear();
   }
 
-  public async mutate<TData, TVariables, TContext, TCache extends ApolloCache<any>>({
+  public async mutate<
+    TData,
+    TVariables,
+    TContext,
+    TCache extends ApolloCache<any>
+  >({
     mutation,
     variables,
     optimisticResponse,
@@ -324,7 +329,7 @@ export class QueryManager<TStore> {
       update?: MutationUpdaterFunction<TData, TVariables, TContext, TCache>;
       refetchQueries?: RefetchQueryDescription;
       removeOptimistic?: string;
-      onQueryUpdated?: OnQueryUpdated;
+      onQueryUpdated?: OnQueryUpdated<TData>;
     },
     cache = this.cache,
   ): Promise<void> {
@@ -1030,13 +1035,13 @@ export class QueryManager<TStore> {
     return concast;
   }
 
-  public refetchQueries({
+  public refetchQueries<TData>({
     updateCache,
     include,
     optimistic = false,
     removeOptimistic = optimistic ? "TODO" : void 0,
     onQueryUpdated,
-  }: RefetchQueriesOptions<ApolloCache<TStore>>) {
+  }: PrivateRefetchQueriesOptions<TData, ApolloCache<TStore>>) {
     const includedQueriesById = new Map<string, RefetchQueryDescription[number]>();
     const results = new Map<ObservableQuery<any>, any>();
 

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1137,14 +1137,14 @@ export class QueryManager<TStore> {
         // temporary optimistic layer, in case that ever matters.
         removeOptimistic,
 
-        onWatchUpdated: onQueryUpdated && function (watch, diff) {
+        onWatchUpdated: onQueryUpdated && function (watch, newDiff, oldDiff) {
           const oq =
             watch.watcher instanceof QueryInfo &&
             watch.watcher.observableQuery;
 
           if (oq) {
             includedQueriesById.delete(oq.queryId);
-            return maybeAddResult(oq, onQueryUpdated(oq, diff));
+            return maybeAddResult(oq, onQueryUpdated(oq, newDiff, oldDiff));
           }
         },
       });

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -230,13 +230,15 @@ export class QueryManager<TStore> {
           }
 
           if (fetchPolicy === 'no-cache') {
-            const refetchResults = this.refetchQueries({
+            const results: any[] = [];
+
+            this.refetchQueries({
               include: refetchQueries,
               onQueryUpdated,
-            });
+            }).forEach(result => results.push(result));
 
             return Promise.all(
-              awaitRefetchQueries ? refetchResults.values() : [],
+              awaitRefetchQueries ? results : [],
             ).then(() => storeResult);
           }
 
@@ -373,7 +375,9 @@ export class QueryManager<TStore> {
         });
       }
 
-      const results = this.refetchQueries({
+      const results: any[] = [];
+
+      this.refetchQueries({
         updateCache(cache: TCache) {
           cacheWrites.forEach(write => cache.write(write));
 
@@ -401,9 +405,10 @@ export class QueryManager<TStore> {
         // Let the caller of client.mutate optionally determine the refetching
         // behavior for watched queries after the mutation.update function runs.
         onQueryUpdated: mutation.onQueryUpdated,
-      });
 
-      return Promise.all(results.values()).then(() => void 0);
+      }).forEach(result => results.push(result));
+
+      return Promise.all(results).then(() => void 0);
     }
 
     return Promise.resolve();

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -330,7 +330,7 @@ export class QueryManager<TStore> {
       update?: MutationUpdaterFunction<TData, TVariables, TContext, TCache>;
       refetchQueries?: RefetchQueryDescription;
       removeOptimistic?: string;
-      onQueryUpdated?: OnQueryUpdated<TData>;
+      onQueryUpdated?: OnQueryUpdated<any>;
     },
     cache = this.cache,
   ): Promise<void> {
@@ -1036,13 +1036,13 @@ export class QueryManager<TStore> {
     return concast;
   }
 
-  public refetchQueries<TData>({
+  public refetchQueries<TResult>({
     updateCache,
     include,
     optimistic = false,
     removeOptimistic = optimistic ? makeUniqueId("refetchQueries") : void 0,
     onQueryUpdated,
-  }: InternalRefetchQueriesOptions<TData, ApolloCache<TStore>>) {
+  }: InternalRefetchQueriesOptions<ApolloCache<TStore>, TResult>) {
     const includedQueriesById = new Map<string, {
       desc: RefetchQueryDescriptor;
       diff: Cache.DiffResult<any> | undefined;
@@ -1140,7 +1140,7 @@ export class QueryManager<TStore> {
       includedQueriesById.forEach(({ desc, diff }, queryId) => {
         const queryInfo = this.getQuery(queryId);
         let oq = queryInfo.observableQuery;
-        let fallback: undefined | (() => Promise<ApolloQueryResult<any>>);
+        let fallback: undefined | (() => any);
 
         if (typeof desc === "string") {
           fallback = () => oq!.refetch();

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1095,11 +1095,11 @@ export class QueryManager<TStore> {
 
     if (updateCache) {
       this.cache.batch({
-        transaction: updateCache,
+        update: updateCache,
 
         // Since you can perform any combination of cache reads and/or writes in
-        // the cache.batch transaction function, its optimistic option can be
-        // either a boolean or a string, representing three distinct modes of
+        // the cache.batch update function, its optimistic option can be either
+        // a boolean or a string, representing three distinct modes of
         // operation:
         //
         // * false: read/write only the root layer
@@ -1110,7 +1110,7 @@ export class QueryManager<TStore> {
         // temporarily created within cache.batch with that string as its ID. If
         // we then pass that same string as the removeOptimistic option, we can
         // make cache.batch immediately remove the optimistic layer after
-        // running the transaction, triggering only one broadcast.
+        // running the updateCache function, triggering only one broadcast.
         //
         // However, the refetchQueries method accepts only true or false for its
         // optimistic option (not string). We interpret true to mean a temporary

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -19,6 +19,7 @@ import {
   isNonEmptyArray,
   Concast,
   ConcastSourcesIterable,
+  makeUniqueId,
 } from '../utilities';
 import { ApolloError, isApolloError } from '../errors';
 import {
@@ -1413,11 +1414,4 @@ function getQueryIdsForQueryDescriptor<TStore>(
     } passed to refetchQueries method in options.include array`);
   }
   return queryIds;
-}
-
-const prefixCounts: Record<string, number> = Object.create(null);
-function makeUniqueId(prefix: string) {
-  const count = prefixCounts[prefix] || 1;
-  prefixCounts[prefix] = count + 1;
-  return `${prefix}:${count}:${Math.random().toString(36).slice(2)}`;
 }

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -1957,7 +1957,7 @@ describe('ObservableQuery', () => {
 
         cache.batch({
           optimistic: true,
-          transaction(cache) {
+          update(cache) {
             cache.modify({
               fields: {
                 people_one(value, { INVALIDATE }) {

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -1953,7 +1953,7 @@ describe('ObservableQuery', () => {
         });
 
         let invalidateCount = 0;
-        let onDirtyCount = 0;
+        let onWatchUpdatedCount = 0;
 
         cache.batch({
           optimistic: true,
@@ -1969,7 +1969,7 @@ describe('ObservableQuery', () => {
             });
           },
           // Verify that the cache.modify operation did trigger a cache broadcast.
-          onDirty(watch, diff) {
+          onWatchUpdated(watch, diff) {
             expect(watch.watcher).toBe(queryInfo);
             expect(diff).toEqual({
               complete: true,
@@ -1979,7 +1979,7 @@ describe('ObservableQuery', () => {
                 },
               },
             });
-            ++onDirtyCount;
+            ++onWatchUpdatedCount;
           },
         });
 
@@ -1987,7 +1987,7 @@ describe('ObservableQuery', () => {
           expect(setDiffSpy).toHaveBeenCalledTimes(1);
           expect(notifySpy).not.toHaveBeenCalled();
           expect(invalidateCount).toBe(1);
-          expect(onDirtyCount).toBe(1);
+          expect(onWatchUpdatedCount).toBe(1);
           queryManager.stop();
         }).then(resolve, reject);
       } else {

--- a/src/core/__tests__/QueryManager/index.ts
+++ b/src/core/__tests__/QueryManager/index.ts
@@ -4382,7 +4382,9 @@ describe('QueryManager', () => {
         observable.subscribe({ next: () => null });
         observable2.subscribe({ next: () => null });
 
-        return Promise.all(queryManager.refetchQueries(['GetAuthor', 'GetAuthor2'])).then(() => {
+        return Promise.all(queryManager.refetchQueries({
+          include: ['GetAuthor', 'GetAuthor2'],
+        })).then(() => {
           const result = getCurrentQueryResult(observable);
           expect(result.partial).toBe(false);
           expect(stripSymbols(result.data)).toEqual(dataChanged);

--- a/src/core/__tests__/QueryManager/index.ts
+++ b/src/core/__tests__/QueryManager/index.ts
@@ -5227,7 +5227,7 @@ describe('QueryManager', () => {
     });
   });
 
-  describe('reobserveQuery', () => {
+  describe('onQueryUpdated', () => {
     const mutation = gql`
       mutation changeAuthorName {
         changeAuthorName(newName: "Jack Smith") {
@@ -5316,7 +5316,7 @@ describe('QueryManager', () => {
               });
             },
 
-            reobserveQuery(obsQuery) {
+            onQueryUpdated(obsQuery) {
               expect(obsQuery.options.query).toBe(query);
               return obsQuery.refetch().then(async () => {
                 // Wait a bit to make sure the mutation really awaited the
@@ -5374,7 +5374,7 @@ describe('QueryManager', () => {
               });
             },
 
-            reobserveQuery(obsQuery) {
+            onQueryUpdated(obsQuery) {
               expect(obsQuery.options.query).toBe(query);
               return obsQuery.refetch();
             },
@@ -5415,7 +5415,7 @@ describe('QueryManager', () => {
               cache.evict({ fieldName: "author" });
             },
 
-            reobserveQuery(obsQuery) {
+            onQueryUpdated(obsQuery) {
               expect(obsQuery.options.query).toBe(query);
               return obsQuery.reobserve({
                 fetchPolicy: "network-only",

--- a/src/core/__tests__/QueryManager/index.ts
+++ b/src/core/__tests__/QueryManager/index.ts
@@ -5320,11 +5320,12 @@ describe('QueryManager', () => {
 
             onQueryUpdated(obsQuery) {
               expect(obsQuery.options.query).toBe(query);
-              return obsQuery.refetch().then(async () => {
+              return obsQuery.refetch().then(async (result) => {
                 // Wait a bit to make sure the mutation really awaited the
                 // refetching of the query.
                 await new Promise(resolve => setTimeout(resolve, 100));
                 finishedRefetch = true;
+                return result;
               });
             },
           }).then(() => {

--- a/src/core/__tests__/QueryManager/index.ts
+++ b/src/core/__tests__/QueryManager/index.ts
@@ -4382,9 +4382,12 @@ describe('QueryManager', () => {
         observable.subscribe({ next: () => null });
         observable2.subscribe({ next: () => null });
 
-        return Promise.all(queryManager.refetchQueries({
+        const results: any[] = [];
+        queryManager.refetchQueries({
           include: ['GetAuthor', 'GetAuthor2'],
-        })).then(() => {
+        }).forEach(result => results.push(result));
+
+        return Promise.all(results).then(() => {
           const result = getCurrentQueryResult(observable);
           expect(result.partial).toBe(false);
           expect(stripSymbols(result.data)).toEqual(dataChanged);

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -24,6 +24,43 @@ export type OnQueryUpdated<TResult> = (
 export type PromiseResult<T> =
   T extends PromiseLike<infer U> ? U : T;
 
+export type RefetchQueryDescriptor = string | PureQueryOptions;
+export type RefetchQueryDescription = RefetchQueryDescriptor[];
+
+// Used by ApolloClient["refetchQueries"]
+// TODO Improve documentation comments for this public type.
+export interface RefetchQueriesOptions<
+  TCache extends ApolloCache<any>,
+  TResult,
+> {
+  updateCache?: (cache: TCache) => void;
+  // Although you can pass PureQueryOptions objects in addition to strings in
+  // the refetchQueries array for a mutation, the client.refetchQueries method
+  // deliberately discourages passing PureQueryOptions, by restricting the
+  // public type of the options.include array to string[] (just query names).
+  include?: string[];
+  optimistic?: boolean;
+  // If no onQueryUpdated function is provided, any queries affected by the
+  // updateCache function or included in the options.include array will be
+  // refetched by default. Passing null instead of undefined disables this
+  // default refetching behavior for affected queries, though included queries
+  // will still be refetched.
+  onQueryUpdated?: OnQueryUpdated<TResult> | null;
+}
+
+// Used by QueryManager["refetchQueries"]
+export interface InternalRefetchQueriesOptions<
+  TCache extends ApolloCache<any>,
+  TResult,
+> extends Omit<RefetchQueriesOptions<TCache, TResult>, "include"> {
+  // Just like the refetchQueries array for a mutation, allowing both strings
+  // and PureQueryOptions objects.
+  include?: RefetchQueryDescription;
+  // This part of the API is a (useful) implementation detail, but need not be
+  // exposed in the public client.refetchQueries API (above).
+  removeOptimistic?: string;
+}
+
 export type OperationVariables = Record<string, any>;
 
 export type PureQueryOptions = {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -22,7 +22,7 @@ export type OnQueryUpdated<TResult> = (
   lastDiff: Cache.DiffResult<any> | undefined,
 ) => boolean | TResult;
 
-export type RefetchQueryDescriptor = string | PureQueryOptions;
+export type RefetchQueryDescriptor = string | DocumentNode | PureQueryOptions;
 export type RefetchQueryDescription = RefetchQueryDescriptor[];
 
 // Used by ApolloClient["refetchQueries"]
@@ -36,7 +36,7 @@ export interface RefetchQueriesOptions<
   // the refetchQueries array for a mutation, the client.refetchQueries method
   // deliberately discourages passing PureQueryOptions, by restricting the
   // public type of the options.include array to string[] (just query names).
-  include?: string[];
+  include?: Exclude<RefetchQueryDescriptor, PureQueryOptions>[];
   optimistic?: boolean;
   // If no onQueryUpdated function is provided, any queries affected by the
   // updateCache function or included in the options.include array will be

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -85,7 +85,7 @@ extends Promise<RefetchQueriesPromiseResults<TResult>> {
   queries: ObservableQuery<any>[];
   // These are the raw TResult values returned by any onQueryUpdated functions
   // that were invoked by client.refetchQueries.
-  results: TResult[];
+  results: InternalRefetchQueriesResult<TResult>[];
 }
 
 // Used by QueryManager["refetchQueries"]
@@ -100,6 +100,13 @@ export interface InternalRefetchQueriesOptions<
   // exposed in the public client.refetchQueries API (above).
   removeOptimistic?: string;
 }
+
+export type InternalRefetchQueriesResult<TResult> =
+  TResult | Promise<ApolloQueryResult<any>>;
+
+export type InternalRefetchQueriesMap<TResult> =
+  Map<ObservableQuery<any>,
+      InternalRefetchQueriesResult<TResult>>;
 
 export type OperationVariables = Record<string, any>;
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -73,20 +73,20 @@ export type RefetchQueriesPromiseResults<TResult> =
   // to client.refetchQueries.
   TResult[];
 
-export type RefetchQueriesResult<TResult> =
-  // The result of client.refetchQueries is thenable/awaitable, if you just want
-  // an array of fully resolved results, but you can also access the raw results
-  // immediately by examining the additional { queries, results } properties of
-  // the RefetchQueriesResult<TResult> object.
-  Promise<RefetchQueriesPromiseResults<TResult>> & {
-    // An array of ObservableQuery objects corresponding 1:1 to TResult values
-    // in the results arrays (both the TResult[] array below, and the results
-    // array resolved by the Promise above).
-    queries: ObservableQuery<any>[];
-    // These are the raw TResult values returned by any onQueryUpdated functions
-    // that were invoked by client.refetchQueries.
-    results: TResult[];
-  };
+// The result of client.refetchQueries is thenable/awaitable, if you just want
+// an array of fully resolved results, but you can also access the raw results
+// immediately by examining the additional { queries, results } properties of
+// the RefetchQueriesResult<TResult> object.
+export interface RefetchQueriesResult<TResult>
+extends Promise<RefetchQueriesPromiseResults<TResult>> {
+  // An array of ObservableQuery objects corresponding 1:1 to TResult values
+  // in the results arrays (both the TResult[] array below, and the results
+  // array resolved by the Promise above).
+  queries: ObservableQuery<any>[];
+  // These are the raw TResult values returned by any onQueryUpdated functions
+  // that were invoked by client.refetchQueries.
+  results: TResult[];
+}
 
 // Used by QueryManager["refetchQueries"]
 export interface InternalRefetchQueriesOptions<

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -15,11 +15,14 @@ export type DefaultContext = Record<string, any>;
 
 export type QueryListener = (queryInfo: QueryInfo) => void;
 
-export type OnQueryUpdated<TData> = (
-  observableQuery: ObservableQuery,
-  diff: Cache.DiffResult<TData>,
-  lastDiff: Cache.DiffResult<TData> | undefined,
-) => boolean | Promise<ApolloQueryResult<TData>>;
+export type OnQueryUpdated<TResult> = (
+  observableQuery: ObservableQuery<any>,
+  diff: Cache.DiffResult<any>,
+  lastDiff: Cache.DiffResult<any> | undefined,
+) => boolean | TResult;
+
+export type PromiseResult<T> =
+  T extends PromiseLike<infer U> ? U : T;
 
 export type OperationVariables = Record<string, any>;
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -15,7 +15,7 @@ export type DefaultContext = Record<string, any>;
 
 export type QueryListener = (queryInfo: QueryInfo) => void;
 
-export type ReobserveQueryCallback = (
+export type OnQueryUpdated = (
   observableQuery: ObservableQuery,
   diff: Cache.DiffResult<any>,
 ) => void | Promise<any>;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -18,7 +18,7 @@ export type QueryListener = (queryInfo: QueryInfo) => void;
 export type OnQueryUpdated<TData> = (
   observableQuery: ObservableQuery,
   diff: Cache.DiffResult<TData>,
-  lastDiff?: Cache.DiffResult<TData>,
+  lastDiff: Cache.DiffResult<TData> | undefined,
 ) => boolean | Promise<ApolloQueryResult<TData>>;
 
 export type OperationVariables = Record<string, any>;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -8,6 +8,7 @@ import { NetworkStatus } from './networkStatus';
 import { Resolver } from './LocalState';
 import { ObservableQuery } from './ObservableQuery';
 import { Cache } from '../cache';
+import { IsStrictlyAny } from '../utilities';
 
 export { TypedDocumentNode } from '@graphql-typed-document-node/core';
 
@@ -20,9 +21,6 @@ export type OnQueryUpdated<TResult> = (
   diff: Cache.DiffResult<any>,
   lastDiff: Cache.DiffResult<any> | undefined,
 ) => boolean | TResult;
-
-export type PromiseResult<T> =
-  T extends PromiseLike<infer U> ? U : T;
 
 export type RefetchQueryDescriptor = string | PureQueryOptions;
 export type RefetchQueryDescription = RefetchQueryDescriptor[];
@@ -47,6 +45,48 @@ export interface RefetchQueriesOptions<
   // will still be refetched.
   onQueryUpdated?: OnQueryUpdated<TResult> | null;
 }
+
+// The client.refetchQueries method returns a thenable (PromiseLike) object
+// whose result is an array of Promise.resolve'd TResult values, where TResult
+// is whatever type the (optional) onQueryUpdated function returns. When no
+// onQueryUpdated function is given, TResult defaults to ApolloQueryResult<any>
+// (thanks to default type parameters for client.refetchQueries).
+export type RefetchQueriesPromiseResults<TResult> =
+  // If onQueryUpdated returns any, all bets are off, so the results array must
+  // be a generic any[] array, which is much less confusing than the union type
+  // we get if we don't check for any. I hoped `any extends TResult` would do
+  // the trick here, instead of IsStrictlyAny, but you can see for yourself what
+  // fails in the refetchQueries tests if you try making that simplification.
+  IsStrictlyAny<TResult> extends true ? any[] :
+  // If the onQueryUpdated function passed to client.refetchQueries returns true
+  // or false, that means either to refetch the query (true) or to skip the
+  // query (false). Since refetching produces an ApolloQueryResult<any>, and
+  // skipping produces nothing, the fully-resolved array of all results produced
+  // will be an ApolloQueryResult<any>[], when TResult extends boolean.
+  TResult extends boolean ? ApolloQueryResult<any>[] :
+  // If onQueryUpdated returns a PromiseLike<U>, that thenable will be passed as
+  // an array element to Promise.all, so we infer/unwrap the array type U here.
+  TResult extends PromiseLike<infer U> ? U[] :
+  // All other onQueryUpdated results end up in the final Promise.all array as
+  // themselves, with their original TResult type. Note that TResult will
+  // default to ApolloQueryResult<any> if no onQueryUpdated function is passed
+  // to client.refetchQueries.
+  TResult[];
+
+export type RefetchQueriesResult<TResult> =
+  // The result of client.refetchQueries is thenable/awaitable, if you just want
+  // an array of fully resolved results, but you can also access the raw results
+  // immediately by examining the additional { queries, results } properties of
+  // the RefetchQueriesResult<TResult> object.
+  Promise<RefetchQueriesPromiseResults<TResult>> & {
+    // An array of ObservableQuery objects corresponding 1:1 to TResult values
+    // in the results arrays (both the TResult[] array below, and the results
+    // array resolved by the Promise above).
+    queries: ObservableQuery<any>[];
+    // These are the raw TResult values returned by any onQueryUpdated functions
+    // that were invoked by client.refetchQueries.
+    results: TResult[];
+  };
 
 // Used by QueryManager["refetchQueries"]
 export interface InternalRefetchQueriesOptions<

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -17,7 +17,8 @@ export type QueryListener = (queryInfo: QueryInfo) => void;
 
 export type OnQueryUpdated<TData> = (
   observableQuery: ObservableQuery,
-  diff: Cache.DiffResult<TData>,
+  newDiff: Cache.DiffResult<TData>,
+  oldDiff?: Cache.DiffResult<TData>,
 ) => boolean | Promise<ApolloQueryResult<TData>>;
 
 export type OperationVariables = Record<string, any>;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -15,10 +15,10 @@ export type DefaultContext = Record<string, any>;
 
 export type QueryListener = (queryInfo: QueryInfo) => void;
 
-export type OnQueryUpdated = (
+export type OnQueryUpdated<TData> = (
   observableQuery: ObservableQuery,
-  diff: Cache.DiffResult<any>,
-) => void | Promise<any>;
+  diff: Cache.DiffResult<TData>,
+) => void | Promise<ApolloQueryResult<TData>>;
 
 export type OperationVariables = Record<string, any>;
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -18,7 +18,7 @@ export type QueryListener = (queryInfo: QueryInfo) => void;
 export type OnQueryUpdated<TData> = (
   observableQuery: ObservableQuery,
   diff: Cache.DiffResult<TData>,
-) => void | Promise<ApolloQueryResult<TData>>;
+) => boolean | Promise<ApolloQueryResult<TData>>;
 
 export type OperationVariables = Record<string, any>;
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -17,8 +17,8 @@ export type QueryListener = (queryInfo: QueryInfo) => void;
 
 export type OnQueryUpdated<TData> = (
   observableQuery: ObservableQuery,
-  newDiff: Cache.DiffResult<TData>,
-  oldDiff?: Cache.DiffResult<TData>,
+  diff: Cache.DiffResult<TData>,
+  lastDiff?: Cache.DiffResult<TData>,
 ) => boolean | Promise<ApolloQueryResult<TData>>;
 
 export type OperationVariables = Record<string, any>;

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -191,6 +191,14 @@ export interface SubscriptionOptions<TVariables = OperationVariables, TData = an
 
 export type RefetchQueryDescription = Array<string | PureQueryOptions>;
 
+export type RefetchQueriesOptions<Cache extends ApolloCache<any>> = {
+  updateCache?: (cache: Cache) => void;
+  include?: RefetchQueryDescription;
+  optimistic?: boolean;
+  removeOptimistic?: string;
+  onQueryUpdated?: OnQueryUpdated;
+};
+
 export interface MutationBaseOptions<
   TData = any,
   TVariables = OperationVariables,

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -5,10 +5,10 @@ import { FetchResult } from '../link/core';
 import {
   DefaultContext,
   MutationQueryReducersMap,
-  PureQueryOptions,
   OperationVariables,
   MutationUpdaterFunction,
   OnQueryUpdated,
+  RefetchQueryDescription,
 } from './types';
 import { ApolloCache } from '../cache';
 
@@ -187,43 +187,6 @@ export interface SubscriptionOptions<TVariables = OperationVariables, TData = an
    * Context object to be passed through the link execution chain.
    */
   context?: DefaultContext;
-}
-
-export type RefetchQueryDescriptor = string | PureQueryOptions;
-export type RefetchQueryDescription = RefetchQueryDescriptor[];
-
-// Used by ApolloClient["refetchQueries"]
-// TODO Improve documentation comments for this public type.
-export interface RefetchQueriesOptions<
-  TCache extends ApolloCache<any>,
-  TResult,
-> {
-  updateCache?: (cache: TCache) => void;
-  // Although you can pass PureQueryOptions objects in addition to strings in
-  // the refetchQueries array for a mutation, the client.refetchQueries method
-  // deliberately discourages passing PureQueryOptions, by restricting the
-  // public type of the options.include array to string[] (just query names).
-  include?: string[];
-  optimistic?: boolean;
-  // If no onQueryUpdated function is provided, any queries affected by the
-  // updateCache function or included in the options.include array will be
-  // refetched by default. Passing null instead of undefined disables this
-  // default refetching behavior for affected queries, though included queries
-  // will still be refetched.
-  onQueryUpdated?: OnQueryUpdated<TResult> | null;
-}
-
-// Used by QueryManager["refetchQueries"]
-export interface InternalRefetchQueriesOptions<
-  TCache extends ApolloCache<any>,
-  TResult,
-> extends Omit<RefetchQueriesOptions<TCache, TResult>, "include"> {
-  // Just like the refetchQueries array for a mutation, allowing both strings
-  // and PureQueryOptions objects.
-  include?: RefetchQueryDescription;
-  // This part of the API is a (useful) implementation detail, but need not be
-  // exposed in the public client.refetchQueries API (above).
-  removeOptimistic?: string;
 }
 
 export interface MutationBaseOptions<

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -205,7 +205,12 @@ export interface RefetchQueriesOptions<
   // public type of the options.include array to string[] (just query names).
   include?: string[];
   optimistic?: boolean;
-  onQueryUpdated?: OnQueryUpdated<TResult>;
+  // If no onQueryUpdated function is provided, any queries affected by the
+  // updateCache function or included in the options.include array will be
+  // refetched by default. Passing null instead of undefined disables this
+  // default refetching behavior for affected queries, though included queries
+  // will still be refetched.
+  onQueryUpdated?: OnQueryUpdated<TResult> | null;
 }
 
 // Used by QueryManager["refetchQueries"]

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -195,8 +195,8 @@ export type RefetchQueryDescription = RefetchQueryDescriptor[];
 // Used by ApolloClient["refetchQueries"]
 // TODO Improve documentation comments for this public type.
 export interface RefetchQueriesOptions<
-  TData,
   TCache extends ApolloCache<any>,
+  TResult,
 > {
   updateCache?: (cache: TCache) => void;
   // Although you can pass PureQueryOptions objects in addition to strings in
@@ -205,14 +205,14 @@ export interface RefetchQueriesOptions<
   // public type of the options.include array to string[] (just query names).
   include?: string[];
   optimistic?: boolean;
-  onQueryUpdated?: OnQueryUpdated<TData>;
+  onQueryUpdated?: OnQueryUpdated<TResult>;
 }
 
 // Used by QueryManager["refetchQueries"]
 export interface InternalRefetchQueriesOptions<
-  TData,
   TCache extends ApolloCache<any>,
-> extends Omit<RefetchQueriesOptions<TData, TCache>, "include"> {
+  TResult,
+> extends Omit<RefetchQueriesOptions<TCache, TResult>, "include"> {
   // Just like the refetchQueries array for a mutation, allowing both strings
   // and PureQueryOptions objects.
   include?: RefetchQueryDescription;
@@ -290,7 +290,7 @@ export interface MutationBaseOptions<
    * A function that will be called for each ObservableQuery affected by
    * this mutation, after the mutation has completed.
    */
-  onQueryUpdated?: OnQueryUpdated<TData>;
+  onQueryUpdated?: OnQueryUpdated<any>;
 
   /**
    * Specifies the {@link ErrorPolicy} to be used for this operation

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -189,7 +189,8 @@ export interface SubscriptionOptions<TVariables = OperationVariables, TData = an
   context?: DefaultContext;
 }
 
-export type RefetchQueryDescription = Array<string | PureQueryOptions>;
+export type RefetchQueryDescriptor = string | PureQueryOptions;
+export type RefetchQueryDescription = RefetchQueryDescriptor[];
 
 // Used by ApolloClient["refetchQueries"]
 // TODO Improve documentation comments for this public type.

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -191,13 +191,31 @@ export interface SubscriptionOptions<TVariables = OperationVariables, TData = an
 
 export type RefetchQueryDescription = Array<string | PureQueryOptions>;
 
-export type RefetchQueriesOptions<Cache extends ApolloCache<any>> = {
-  updateCache?: (cache: Cache) => void;
-  include?: RefetchQueryDescription;
+export interface PublicRefetchQueriesOptions<
+  TData,
+  TCache extends ApolloCache<any>,
+> {
+  updateCache?: (cache: TCache) => void;
+  // Although you can pass PureQueryOptions objects in addition to strings in
+  // the refetchQueries array for a mutation, the client.refetchQueries method
+  // deliberately discourages passing PureQueryOptions, by restricting the
+  // public type of the options.include array to string[] (just query names).
+  include?: string[];
   optimistic?: boolean;
+  onQueryUpdated?: OnQueryUpdated<TData>;
+}
+
+export interface PrivateRefetchQueriesOptions<
+  TData,
+  TCache extends ApolloCache<any>,
+> extends Omit<PublicRefetchQueriesOptions<TData, TCache>, "include"> {
+  // Just like the refetchQueries array for a mutation, allowing both strings
+  // and PureQueryOptions objects.
+  include?: RefetchQueryDescription;
+  // This part of the API is a (useful) implementation detail, but need not be
+  // exposed in the public client.refetchQueries API (above).
   removeOptimistic?: string;
-  onQueryUpdated?: OnQueryUpdated;
-};
+}
 
 export interface MutationBaseOptions<
   TData = any,
@@ -268,7 +286,7 @@ export interface MutationBaseOptions<
    * A function that will be called for each ObservableQuery affected by
    * this mutation, after the mutation has completed.
    */
-  onQueryUpdated?: OnQueryUpdated;
+  onQueryUpdated?: OnQueryUpdated<TData>;
 
   /**
    * Specifies the {@link ErrorPolicy} to be used for this operation

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -191,7 +191,9 @@ export interface SubscriptionOptions<TVariables = OperationVariables, TData = an
 
 export type RefetchQueryDescription = Array<string | PureQueryOptions>;
 
-export interface PublicRefetchQueriesOptions<
+// Used by ApolloClient["refetchQueries"]
+// TODO Improve documentation comments for this public type.
+export interface RefetchQueriesOptions<
   TData,
   TCache extends ApolloCache<any>,
 > {
@@ -205,10 +207,11 @@ export interface PublicRefetchQueriesOptions<
   onQueryUpdated?: OnQueryUpdated<TData>;
 }
 
-export interface PrivateRefetchQueriesOptions<
+// Used by QueryManager["refetchQueries"]
+export interface InternalRefetchQueriesOptions<
   TData,
   TCache extends ApolloCache<any>,
-> extends Omit<PublicRefetchQueriesOptions<TData, TCache>, "include"> {
+> extends Omit<RefetchQueriesOptions<TData, TCache>, "include"> {
   // Just like the refetchQueries array for a mutation, allowing both strings
   // and PureQueryOptions objects.
   include?: RefetchQueryDescription;

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -8,7 +8,7 @@ import {
   PureQueryOptions,
   OperationVariables,
   MutationUpdaterFunction,
-  ReobserveQueryCallback,
+  OnQueryUpdated,
 } from './types';
 import { ApolloCache } from '../cache';
 
@@ -260,7 +260,7 @@ export interface MutationBaseOptions<
    * A function that will be called for each ObservableQuery affected by
    * this mutation, after the mutation has completed.
    */
-  reobserveQuery?: ReobserveQueryCallback;
+  onQueryUpdated?: OnQueryUpdated;
 
   /**
    * Specifies the {@link ErrorPolicy} to be used for this operation

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -747,7 +747,7 @@ describe('useMutation Hook', () => {
   });
 
   describe('refetching queries', () => {
-    itAsync('can pass reobserveQuery to useMutation', (resolve, reject) => {
+    itAsync('can pass onQueryUpdated to useMutation', (resolve, reject) => {
       interface TData {
         todoCount: number;
       }
@@ -791,17 +791,17 @@ describe('useMutation Hook', () => {
         }).setOnError(reject),
       });
 
-      // The goal of this test is to make sure reobserveQuery gets called as
+      // The goal of this test is to make sure onQueryUpdated gets called as
       // part of the createTodo mutation, so we use this reobservePromise to
-      // await the calling of reobserveQuery.
-      interface ReobserveResults {
+      // await the calling of onQueryUpdated.
+      interface OnQueryUpdatedResults {
         obsQuery: ObservableQuery;
         diff: Cache.DiffResult<TData>;
         result: ApolloQueryResult<TData>;
       }
-      let reobserveResolve: (results: ReobserveResults) => any;
-      const reobservePromise = new Promise<ReobserveResults>(resolve => {
-        reobserveResolve = resolve;
+      let resolveOnUpdate: (results: OnQueryUpdatedResults) => any;
+      const onUpdatePromise = new Promise<OnQueryUpdatedResults>(resolve => {
+        resolveOnUpdate = resolve;
       });
       let finishedReobserving = false;
 
@@ -838,10 +838,10 @@ describe('useMutation Hook', () => {
             act(() => {
               createTodo({
                 variables,
-                reobserveQuery(obsQuery, diff) {
+                onQueryUpdated(obsQuery, diff) {
                   return obsQuery.reobserve().then(result => {
                     finishedReobserving = true;
-                    reobserveResolve({ obsQuery, diff, result });
+                    resolveOnUpdate({ obsQuery, diff, result });
                   });
                 },
               });
@@ -888,7 +888,7 @@ describe('useMutation Hook', () => {
         </ApolloProvider>
       );
 
-      return reobservePromise.then(results => {
+      return onUpdatePromise.then(results => {
         expect(finishedReobserving).toBe(true);
 
         expect(results.diff).toEqual({

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -842,6 +842,7 @@ describe('useMutation Hook', () => {
                   return obsQuery.reobserve().then(result => {
                     finishedReobserving = true;
                     resolveOnUpdate({ obsQuery, diff, result });
+                    return result;
                   });
                 },
               });

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -19,7 +19,7 @@ import {
   ObservableQuery,
   OperationVariables,
   PureQueryOptions,
-  ReobserveQueryCallback,
+  OnQueryUpdated,
   WatchQueryFetchPolicy,
   WatchQueryOptions,
 } from '../../core';
@@ -154,7 +154,7 @@ export interface BaseMutationOptions<
   awaitRefetchQueries?: boolean;
   errorPolicy?: ErrorPolicy;
   update?: MutationUpdaterFunction<TData, TVariables, TContext, TCache>;
-  reobserveQuery?: ReobserveQueryCallback;
+  onQueryUpdated?: OnQueryUpdated;
   client?: ApolloClient<object>;
   notifyOnNetworkStatusChange?: boolean;
   context?: TContext;
@@ -175,7 +175,7 @@ export interface MutationFunctionOptions<
   refetchQueries?: Array<string | PureQueryOptions> | RefetchQueriesFunction;
   awaitRefetchQueries?: boolean;
   update?: MutationUpdaterFunction<TData, TVariables, TContext, TCache>;
-  reobserveQuery?: ReobserveQueryCallback;
+  onQueryUpdated?: OnQueryUpdated;
   context?: TContext;
   fetchPolicy?: WatchQueryFetchPolicy;
 }

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -154,7 +154,11 @@ export interface BaseMutationOptions<
   awaitRefetchQueries?: boolean;
   errorPolicy?: ErrorPolicy;
   update?: MutationUpdaterFunction<TData, TVariables, TContext, TCache>;
-  onQueryUpdated?: OnQueryUpdated;
+  // Use OnQueryUpdated<any> instead of OnQueryUpdated<TData> here because TData
+  // is the shape of the mutation result, but onQueryUpdated gets called with
+  // results from any queries affected by the mutation update function, which
+  // probably do not have the same shape as the mutation result.
+  onQueryUpdated?: OnQueryUpdated<any>;
   client?: ApolloClient<object>;
   notifyOnNetworkStatusChange?: boolean;
   context?: TContext;
@@ -175,7 +179,11 @@ export interface MutationFunctionOptions<
   refetchQueries?: Array<string | PureQueryOptions> | RefetchQueriesFunction;
   awaitRefetchQueries?: boolean;
   update?: MutationUpdaterFunction<TData, TVariables, TContext, TCache>;
-  onQueryUpdated?: OnQueryUpdated;
+  // Use OnQueryUpdated<any> instead of OnQueryUpdated<TData> here because TData
+  // is the shape of the mutation result, but onQueryUpdated gets called with
+  // results from any queries affected by the mutation update function, which
+  // probably do not have the same shape as the mutation result.
+  onQueryUpdated?: OnQueryUpdated<any>;
   context?: TContext;
   fetchPolicy?: WatchQueryFetchPolicy;
 }

--- a/src/utilities/common/makeUniqueId.ts
+++ b/src/utilities/common/makeUniqueId.ts
@@ -1,0 +1,9 @@
+const prefixCounts = new Map<string, number>();
+
+// These IDs won't be globally unique, but they will be unique within this
+// process, thanks to the counter, and unguessable thanks to the random suffix.
+export function makeUniqueId(prefix: string) {
+  const count = prefixCounts.get(prefix) || 1;
+  prefixCounts.set(prefix, count + 1);
+  return `${prefix}:${count}:${Math.random().toString(36).slice(2)}`;
+}

--- a/src/utilities/graphql/storeUtils.ts
+++ b/src/utilities/graphql/storeUtils.ts
@@ -15,6 +15,7 @@ import {
   SelectionNode,
   NameNode,
   SelectionSetNode,
+  DocumentNode,
 } from 'graphql';
 
 import { InvariantError } from 'ts-invariant';
@@ -46,6 +47,15 @@ export type StoreValue =
 export interface StoreObject {
   __typename?: string;
   [storeFieldName: string]: StoreValue;
+}
+
+export function isDocumentNode(value: any): value is DocumentNode {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    (value as DocumentNode).kind === "Document" &&
+    Array.isArray((value as DocumentNode).definitions)
+  );
 }
 
 function isStringValue(value: ValueNode): value is StringValueNode {

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -86,3 +86,5 @@ export * from './common/arrays';
 export * from './common/errorHandling';
 export * from './common/canUse';
 export * from './common/compact';
+
+export * from './types/IsStrictlyAny';

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -33,6 +33,7 @@ export {
   Directives,
   VariableValue,
   makeReference,
+  isDocumentNode,
   isReference,
   isField,
   isInlineFragment,

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -86,5 +86,6 @@ export * from './common/arrays';
 export * from './common/errorHandling';
 export * from './common/canUse';
 export * from './common/compact';
+export * from './common/makeUniqueId';
 
 export * from './types/IsStrictlyAny';

--- a/src/utilities/types/IsStrictlyAny.ts
+++ b/src/utilities/types/IsStrictlyAny.ts
@@ -1,17 +1,17 @@
-// If (and only if) T is any, the union 'a' | 'b' is returned here, representing
-// both branches of this conditional type. Only UnionForAny<any> produces this
-// union type; all other inputs produce the 'b' literal type.
-type UnionForAny<T> = T extends never ? 'a' : 'b';
+// Returns true if T is any, or false for any other type.
+// Inspired by https://stackoverflow.com/a/61625296/128454.
+export type IsStrictlyAny<T> =
+  UnionToIntersection<UnionForAny<T>> extends never ? true : false;
 
-// If that 'A' | 'B' union is then passed to UnionToIntersection, the result
-// should be 'A' & 'B', which TypeScript simplifies to the never type, since the
-// literal string types 'A' and 'B' are incompatible. More explanation of this
-// helper type: https://stackoverflow.com/a/50375286/62076
+// If (and only if) T is any, the union 'a' | 1 is returned here, representing
+// both branches of this conditional type. Only UnionForAny<any> produces this
+// union type; all other inputs produce the 1 literal type.
+type UnionForAny<T> = T extends never ? 'a' : 1;
+
+// If that 'a' | 1 union is then passed to UnionToIntersection, the result
+// should be 'a' & 1, which TypeScript simplifies to the never type, since the
+// literal type 'a' and the literal type 1 are incompatible. More explanation of
+// this helper type: https://stackoverflow.com/a/50375286/62076.
 type UnionToIntersection<U> =
   (U extends any ? (k: U) => void : never) extends
     ((k: infer I) => void) ? I : never
-
-// Returns true if T is any, or false for any other type.
-// From https://stackoverflow.com/a/61625296/128454
-export type IsStrictlyAny<T> =
-  UnionToIntersection<UnionForAny<T>> extends never ? true : false;

--- a/src/utilities/types/IsStrictlyAny.ts
+++ b/src/utilities/types/IsStrictlyAny.ts
@@ -1,0 +1,17 @@
+// If (and only if) T is any, the union 'a' | 'b' is returned here, representing
+// both branches of this conditional type. Only UnionForAny<any> produces this
+// union type; all other inputs produce the 'b' literal type.
+type UnionForAny<T> = T extends never ? 'a' : 'b';
+
+// If that 'A' | 'B' union is then passed to UnionToIntersection, the result
+// should be 'A' & 'B', which TypeScript simplifies to the never type, since the
+// literal string types 'A' and 'B' are incompatible. More explanation of this
+// helper type: https://stackoverflow.com/a/50375286/62076
+type UnionToIntersection<U> =
+  (U extends any ? (k: U) => void : never) extends
+    ((k: infer I) => void) ? I : never
+
+// Returns true if T is any, or false for any other type.
+// From https://stackoverflow.com/a/61625296/128454
+export type IsStrictlyAny<T> =
+  UnionToIntersection<UnionForAny<T>> extends never ? true : false;


### PR DESCRIPTION
As promised in https://github.com/apollographql/apollo-client/issues/7878#issuecomment-805320556 and https://github.com/apollographql/apollo-client/pull/7827#issuecomment-805321246, this PR turns the `client.refetchQueries` method into a one-stop solution for refetching queries (without having to perform a mutation), tying together several previous ways of triggering refetches into a single, flexible API.

This is the last major piece of new functionality that we plan to add to Apollo Client v3.4, and is intended to complement similar functionality added to mutations (`options.onQueryUpdated`, previously called `options.reobserveQuery`) in #7827, and builds on the `cache.batch` primitive added to `InMemoryCache` in #7819. If this PR is merged, it should conclude the implementation of the following item from the [Apollo Client v3.4 `ROADMAP.md` section](https://github.com/apollographql/apollo-client/blob/main/ROADMAP.md#34):

* A new API for reobserving/refetching queries after a mutation, eliminating the need for `updateQueries`, `refetchQueries`, and `awaitRefetchQueries` in a lot of cases.

Since the API has changed since I last sketched it out, here's an overview of the current functionality:
```ts
const { queries, results } = client.refetchQueries({
  updateCache(cache) {
    // Trigger query updates by updating the client.cache in any way you like.
    // To pick just one possible example:
    cache.evict({
      id: cache.identify(...),
      fieldName,
    });
  },

  // Make sure these queries are included even if they were not affected by the
  // updateCache function (or the updateCache function was not provided). This
  // option is similar to the existing refetchQueries option for mutations.
  include: ["QueryName", "AnotherQueryName"],

  // Optional callback that will be called for every ObservableQuery that was affected
  // by updateCache (or included explicitly by name). If onQueryUpdated is not
  // provided, the affected queries will be refetched by calling obsQuery.refetch().
  onQueryUpdated(obsQuery, diff) {
    if (shouldIgnoreUpdate(obsQuery, diff)) {
      // Returning false causes this query not to be refetched, and omits its result from
      // the client.refetchQueries(...).{queries,updates} arrays.
      return false;
    }
    // Providing an onQueryUpdated function allows dynamically determining whether/how
    // each query should be refetched. Anything you return here will end up in the
    // client.refetchQueries(...).updates array.
    return obsQuery.refetch();
  },

  // Passing optimistic: false (the default) causes the updateCache function to run
  // against the root (non-optimistic) cache layer. Passing optimistic: true causes
  // updateCache to run in a temporary optimistic cache layer that client.refetchQueries
  // removes before returning, which can be useful when you want to use updateCache
  // to trigger some refetches but you don't want to modify cache data permanently.
  optimistic: true,
});
```
All of these options (`updateCache`, `include`, `onQueryUpdated`, and `optimistic`) are optional, but you have to pass either `updateCache` or `include` to get any queries to be refetched by `client.refetchQueries`.

This PR is a work-in-progress because this still needs more tests and documentation, but I wanted to share my progress so far, so folks can share their thoughts on this new `client.refetchQueries` API.