### PR TITLE
Prevent `undefined` mutation result in useMutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - During server-side rendering, allow initial `useQuery` calls to return final `{ loading: false, data }` results when the cache already contains the necessary data. <br/>
   [@benjamn](https://github.com/benjamn) in [#7983](https://github.com/apollographql/apollo-client/pull/7983)
 
+- Prevent `undefined` mutation result in useMutation <br/>
+  [@jcreighton](https://github.com/jcreighton) in [#8018](https://github.com/apollographql/apollo-client/pull/8018)
+
 ## Apollo Client 3.3.14
 
 ### Improvements

--- a/src/react/data/MutationData.ts
+++ b/src/react/data/MutationData.ts
@@ -71,9 +71,6 @@ export class MutationData<
     return this.mutate(mutationFunctionOptions)
       .then((response: FetchResult<TData>) => {
         this.onMutationCompleted(response, mutationId);
-        if (response.errors) {
-
-        }
         return response;
       })
       .catch((error: ApolloError) => {

--- a/src/react/data/MutationData.ts
+++ b/src/react/data/MutationData.ts
@@ -71,11 +71,23 @@ export class MutationData<
     return this.mutate(mutationFunctionOptions)
       .then((response: FetchResult<TData>) => {
         this.onMutationCompleted(response, mutationId);
+        if (response.errors) {
+
+        }
         return response;
       })
       .catch((error: ApolloError) => {
+        const { onError } = this.getOptions();
         this.onMutationError(error, mutationId);
-        if (!this.getOptions().onError) throw error;
+        if (onError) {
+          onError(error);
+          return {
+            data: undefined,
+            errors: error,
+          };
+        } else {
+          throw error;
+        }
       });
   };
 
@@ -128,8 +140,6 @@ export class MutationData<
   }
 
   private onMutationError(error: ApolloError, mutationId: number) {
-    const { onError } = this.getOptions();
-
     if (this.isMostRecentMutation(mutationId)) {
       this.updateResult({
         loading: false,
@@ -137,10 +147,6 @@ export class MutationData<
         data: undefined,
         called: true
       });
-    }
-
-    if (onError) {
-      onError(error);
     }
   }
 
@@ -152,13 +158,14 @@ export class MutationData<
     return this.mostRecentMutationId === mutationId;
   }
 
-  private updateResult(result: MutationResultWithoutClient<TData>) {
+  private updateResult(result: MutationResultWithoutClient<TData>): MutationResultWithoutClient<TData> | undefined {
     if (
       this.isMounted &&
       (!this.previousResult || !equal(this.previousResult, result))
     ) {
       this.setResult(result);
       this.previousResult = result;
+      return result;
     }
   }
 }

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -252,6 +252,58 @@ describe('useMutation Hook', () => {
     });
 
     describe('mutate function upon error', () => {
+      itAsync('resolves with the resulting data and errors', async (resolve, reject) => {
+        const variables = {
+          description: 'Get milk!'
+        };
+
+        const mocks = [
+          {
+            request: {
+              query: CREATE_TODO_MUTATION,
+              variables
+            },
+            result: {
+              data: CREATE_TODO_RESULT,
+              errors: [new GraphQLError(CREATE_TODO_ERROR)],
+            },
+          }
+        ];
+
+        let fetchResult: any;
+        const Component = () => {
+          const [createTodo] = useMutation<{ createTodo: Todo }>(
+            CREATE_TODO_MUTATION,
+            {
+              onError: error => {
+                expect(error.message).toEqual(CREATE_TODO_ERROR);
+              }
+            }
+          );
+
+          async function runMutation() {
+            fetchResult = await createTodo({ variables });
+          }
+
+          useEffect(() => {
+            runMutation();
+          }, []);
+
+          return null;
+        };
+
+        render(
+          <MockedProvider mocks={mocks}>
+            <Component />
+          </MockedProvider>
+        );
+
+        await wait(() => {
+          expect(fetchResult.data).toEqual(undefined);
+          expect(fetchResult.errors.message).toEqual(CREATE_TODO_ERROR);
+        }).then(resolve, reject);
+      });
+
       it(`should reject when errorPolicy is 'none'`, async () => {
         const variables = {
           description: 'Get milk!'


### PR DESCRIPTION
Fixes #7754. When an `onError` handler is provided, the mutation promise returned `undefined` when it should return a result. We now return a result with `data` and `errors`.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
