### PR TITLE
Fixes #8012 where a race condition with useEffect was causing stale renders of values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Apollo Client 3.3.16 (to be released)
+
+### Bug fixes
+- Prevent `undefined` mutation result in useMutation <br/>
+  [@jcreighton](https://github.com/jcreighton) in [#8018](https://github.com/apollographql/apollo-client/pull/8018)
+
+- Fix `useReactiveVar` not rerendering for successive synchronous calls. <br/>
+  [@brainkim](https://github.com/brainkim) in [#8022](https://github.com/apollographql/apollo-client/pull/8022)
+
 ## Apollo Client 3.3.15
 
 ### Bug fixes
@@ -7,9 +16,6 @@
 
 - During server-side rendering, allow initial `useQuery` calls to return final `{ loading: false, data }` results when the cache already contains the necessary data. <br/>
   [@benjamn](https://github.com/benjamn) in [#7983](https://github.com/apollographql/apollo-client/pull/7983)
-
-- Prevent `undefined` mutation result in useMutation <br/>
-  [@jcreighton](https://github.com/jcreighton) in [#8018](https://github.com/apollographql/apollo-client/pull/8018)
 
 ## Apollo Client 3.3.14
 

--- a/src/react/hooks/__tests__/useReactiveVar.test.tsx
+++ b/src/react/hooks/__tests__/useReactiveVar.test.tsx
@@ -236,5 +236,34 @@ describe("useReactiveVar Hook", () => {
 
       resolve();
     });
+
+    itAsync("works with multiple synchronous calls", async (resolve, reject) => {
+      const counterVar = makeVar(0);
+      function Component() {
+        const count = useReactiveVar(counterVar);
+
+        return (<div>{count}</div>);
+      }
+
+      const { getAllByText } = render(<Component />);
+      Promise.resolve().then(() => {
+        counterVar(1);
+        counterVar(2);
+        counterVar(3);
+        counterVar(4);
+        counterVar(5);
+        counterVar(6);
+        counterVar(7);
+        counterVar(8);
+        counterVar(9);
+        counterVar(10);
+      });
+
+      await wait(() => {
+        expect(getAllByText("10")).toHaveLength(1);
+      });
+
+      resolve();
+    });
   });
 });

--- a/src/react/hooks/__tests__/useReactiveVar.test.tsx
+++ b/src/react/hooks/__tests__/useReactiveVar.test.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { StrictMode, useEffect } from "react";
 import { render, wait, act } from "@testing-library/react";
 
 import { itAsync } from "../../../testing";
@@ -232,6 +232,40 @@ describe("useReactiveVar Hook", () => {
 
       await wait(() => {
         expect(getAllByText("1")).toHaveLength(2);
+      });
+
+      resolve();
+    });
+
+    itAsync("works with strict mode", async (resolve, reject) => {
+      const counterVar = makeVar(0);
+      const mock = jest.fn();
+
+      function Component() {
+        const count = useReactiveVar(counterVar);
+        useEffect(() => {
+          mock(count);
+        }, [count]);
+
+        useEffect(() => {
+          Promise.resolve().then(() => {
+            counterVar(counterVar() + 1);
+          });
+        }, []);
+
+        return (
+          <div />
+        );
+      }
+
+      render(
+        <StrictMode>
+          <Component />
+        </StrictMode>
+      );
+
+      await wait(() => {
+        expect(mock).toHaveBeenCalledWith(1);
       });
 
       resolve();

--- a/src/react/hooks/useReactiveVar.ts
+++ b/src/react/hooks/useReactiveVar.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useLayoutEffect } from 'react';
 import { ReactiveVar } from '../../core';
 
 export function useReactiveVar<T>(rv: ReactiveVar<T>): T {
@@ -9,7 +9,7 @@ export function useReactiveVar<T>(rv: ReactiveVar<T>): T {
   // We subscribe to variable updates on initial mount and when the value has
   // changed. This avoids a subtle bug in React.StrictMode where multiple listeners
   // are added, leading to inconsistent updates.
-  useEffect(() => rv.onNextChange(setValue), [value]);
+  useLayoutEffect(() => rv.onNextChange(setValue), [value]);
   // Once the component is unmounted, ignore future updates. Note that the
   // above useEffect function returns a mute function without calling it,
   // allowing it to be called when the component unmounts. This is
@@ -24,9 +24,7 @@ export function useReactiveVar<T>(rv: ReactiveVar<T>): T {
   // a useEffect higher in the component tree changing a variable's value
   // before the above useEffect can set the onNextChange handler. Note that React
   // will not schedule an update if setState is called with the same value as before.
-  useEffect(() => {
-    setValue(rv())
-  }, []);
+  useEffect(() => setValue(rv()), []);
 
   return value;
 }


### PR DESCRIPTION
Fixes
#6699 (maybe)
#7694 
#7896
#8012


A race condition with useEffect was causing stale renders of values when reactivevars were called multiple times synchronously.