### PR TITLE
support "debounce" for the batch link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 ## Apollo Client 3.3.16 (to be released)
 
 ### Bug fixes
-- Prevent `undefined` mutation result in useMutation <br/>
+
+- Prevent `undefined` mutation result in `useMutation`. <br/>
   [@jcreighton](https://github.com/jcreighton) in [#8018](https://github.com/apollographql/apollo-client/pull/8018)
 
 - Fix `useReactiveVar` not rerendering for successive synchronous calls. <br/>
   [@brainkim](https://github.com/brainkim) in [#8022](https://github.com/apollographql/apollo-client/pull/8022)
+
+- Support `batchDebounce` option for `BatchLink` and `BatchHttpLink`. <br/>
+  [@dannycochran](https://github.com/dannycochran) in [#8024](https://github.com/apollographql/apollo-client/pull/8024)
 
 ## Apollo Client 3.3.15
 

--- a/src/link/batch-http/batchHttpLink.ts
+++ b/src/link/batch-http/batchHttpLink.ts
@@ -16,7 +16,7 @@ import { BatchLink } from '../batch';
 export namespace BatchHttpLink {
   export type Options = Pick<
     BatchLink.Options,
-    'batchMax' | 'debounce' | 'batchInterval' | 'batchKey'
+    'batchMax' | 'batchDebounce' | 'batchInterval' | 'batchKey'
   > & HttpOptions;
 }
 
@@ -25,7 +25,7 @@ export namespace BatchHttpLink {
  * context can include the headers property, which will be passed to the fetch function
  */
 export class BatchHttpLink extends ApolloLink {
-  private debounce?: boolean;
+  private batchDebounce?: boolean;
   private batchInterval: number;
   private batchMax: number;
   private batcher: ApolloLink;
@@ -39,7 +39,7 @@ export class BatchHttpLink extends ApolloLink {
       fetch: fetcher,
       includeExtensions,
       batchInterval,
-      debounce,
+      batchDebounce,
       batchMax,
       batchKey,
       ...requestOptions
@@ -62,7 +62,7 @@ export class BatchHttpLink extends ApolloLink {
       headers: requestOptions.headers,
     };
 
-    this.debounce = debounce;
+    this.batchDebounce = batchDebounce;
     this.batchInterval = batchInterval || 10;
     this.batchMax = batchMax || 10;
 
@@ -206,7 +206,7 @@ export class BatchHttpLink extends ApolloLink {
       });
 
     this.batcher = new BatchLink({
-      debounce: this.debounce,
+      batchDebounce: this.batchDebounce,
       batchInterval: this.batchInterval,
       batchMax: this.batchMax,
       batchKey,

--- a/src/link/batch-http/batchHttpLink.ts
+++ b/src/link/batch-http/batchHttpLink.ts
@@ -14,26 +14,10 @@ import {
 import { BatchLink } from '../batch';
 
 export namespace BatchHttpLink {
-  export interface Options extends HttpOptions {
-    /**
-     * The maximum number of operations to include in one fetch.
-     *
-     * Defaults to 10.
-     */
-    batchMax?: number;
-
-    /**
-     * The interval at which to batch, in milliseconds.
-     *
-     * Defaults to 10.
-     */
-    batchInterval?: number;
-
-    /**
-     * Sets the key for an Operation, which specifies the batch an operation is included in
-     */
-    batchKey?: (operation: Operation) => string;
-  }
+  export type Options = Pick<
+    BatchLink.Options,
+    'batchMax' | 'debounce' | 'batchInterval' | 'batchKey'
+  > & HttpOptions;
 }
 
 /**
@@ -41,6 +25,7 @@ export namespace BatchHttpLink {
  * context can include the headers property, which will be passed to the fetch function
  */
 export class BatchHttpLink extends ApolloLink {
+  private debounce?: boolean;
   private batchInterval: number;
   private batchMax: number;
   private batcher: ApolloLink;
@@ -54,6 +39,7 @@ export class BatchHttpLink extends ApolloLink {
       fetch: fetcher,
       includeExtensions,
       batchInterval,
+      debounce,
       batchMax,
       batchKey,
       ...requestOptions
@@ -76,6 +62,7 @@ export class BatchHttpLink extends ApolloLink {
       headers: requestOptions.headers,
     };
 
+    this.debounce = debounce;
     this.batchInterval = batchInterval || 10;
     this.batchMax = batchMax || 10;
 
@@ -219,6 +206,7 @@ export class BatchHttpLink extends ApolloLink {
       });
 
     this.batcher = new BatchLink({
+      debounce: this.debounce,
       batchInterval: this.batchInterval,
       batchMax: this.batchMax,
       batchKey,

--- a/src/link/batch/__tests__/batchLink.ts
+++ b/src/link/batch/__tests__/batchLink.ts
@@ -332,7 +332,7 @@ describe('OperationBatcher', () => {
       jest.useFakeTimers();
       const batchInterval = 10;
       const myBatcher = new OperationBatcher({
-        debounce: true,
+        batchDebounce: true,
         batchInterval,
         batchHandler,
       });

--- a/src/link/batch/__tests__/batchLink.ts
+++ b/src/link/batch/__tests__/batchLink.ts
@@ -132,6 +132,8 @@ function createMockBatchHandler(...mockedResponses: MockedResponse[]) {
 }
 
 describe('OperationBatcher', () => {
+  afterEach(() => jest.useRealTimers());
+
   it('should construct', () => {
     expect(() => {
       const querySched = new OperationBatcher({
@@ -324,6 +326,43 @@ describe('OperationBatcher', () => {
         }),
       );
       myBatcher.consumeQueue();
+    });
+
+    it('should be able to debounce requests', done => {
+      jest.useFakeTimers();
+      const batchInterval = 10;
+      const myBatcher = new OperationBatcher({
+        debounce: true,
+        batchInterval,
+        batchHandler,
+      });
+
+      // 1. Queue up 3 requests
+      myBatcher.enqueueRequest({ operation }).subscribe({});
+      myBatcher.enqueueRequest({ operation }).subscribe({});
+      myBatcher.enqueueRequest({ operation }).subscribe({});
+      expect(myBatcher.queuedRequests.get('')!.length).toEqual(3);
+
+      // 2. Run the timer halfway.
+      jest.runTimersToTime(batchInterval / 2);
+      expect(myBatcher.queuedRequests.get('')!.length).toEqual(3);
+
+      // 3. Queue a 4th request, causing the timer to reset.
+      myBatcher.enqueueRequest({ operation }).subscribe({});
+      expect(myBatcher.queuedRequests.get('')!.length).toEqual(4);
+
+      // 4. Run the timer to batchInterval + 1, at this point, if debounce were
+      // not set, the original 3 requests would have fired, but we expect
+      // instead that the queries will instead fire at
+      // (batchInterval + batchInterval / 2).
+      jest.runTimersToTime(batchInterval / 2 + 1);
+      expect(myBatcher.queuedRequests.get('')!.length).toEqual(4);
+
+      // 5. Finally, run the timer to (batchInterval + batchInterval / 2) +1,
+      // and expect the queue to be empty.
+      jest.runTimersToTime(batchInterval / 2);
+      expect(myBatcher.queuedRequests.size).toEqual(0);
+      done();
     });
   });
 

--- a/src/link/batch/batchLink.ts
+++ b/src/link/batch/batchLink.ts
@@ -15,10 +15,10 @@ export namespace BatchLink {
 
     /**
      * "batchInterval" is a throttling behavior by default, if you instead wish
-     * to debounce outbound requests, set "debounce" to true. More useful
+     * to debounce outbound requests, set "batchDebounce" to true. More useful
      * for mutations than queries.
      */
-    debounce?: boolean;
+    batchDebounce?: boolean;
 
     /**
      * The maximum number of operations to include in one fetch.
@@ -46,7 +46,7 @@ export class BatchLink extends ApolloLink {
     super();
 
     const {
-      debounce,
+      batchDebounce,
       batchInterval = 10,
       batchMax = 0,
       batchHandler = () => null,
@@ -54,7 +54,7 @@ export class BatchLink extends ApolloLink {
     } = fetchParams || {};
 
     this.batcher = new OperationBatcher({
-      debounce,
+      batchDebounce,
       batchInterval,
       batchMax,
       batchHandler,

--- a/src/link/batch/batchLink.ts
+++ b/src/link/batch/batchLink.ts
@@ -3,6 +3,7 @@ import { Observable } from '../../utilities';
 import { OperationBatcher, BatchHandler } from './batching';
 export { OperationBatcher, BatchableRequest, BatchHandler } from './batching';
 
+
 export namespace BatchLink {
   export interface Options {
     /**
@@ -11,6 +12,13 @@ export namespace BatchLink {
      * Defaults to 10.
      */
     batchInterval?: number;
+
+    /**
+     * "batchInterval" is a throttling behavior by default, if you instead wish
+     * to debounce outbound requests, set "debounce" to true. More useful
+     * for mutations than queries.
+     */
+    debounce?: boolean;
 
     /**
      * The maximum number of operations to include in one fetch.
@@ -38,6 +46,7 @@ export class BatchLink extends ApolloLink {
     super();
 
     const {
+      debounce,
       batchInterval = 10,
       batchMax = 0,
       batchHandler = () => null,
@@ -45,6 +54,7 @@ export class BatchLink extends ApolloLink {
     } = fetchParams || {};
 
     this.batcher = new OperationBatcher({
+      debounce,
       batchInterval,
       batchMax,
       batchHandler,

--- a/src/link/batch/batching.ts
+++ b/src/link/batch/batching.ts
@@ -27,6 +27,8 @@ export class OperationBatcher {
   // Public only for testing
   public queuedRequests: Map<string, BatchableRequest[]>;
 
+  private scheduledBatchTimer?: number;
+  private debounce?: boolean;
   private batchInterval?: number;
   private batchMax: number;
 
@@ -35,17 +37,20 @@ export class OperationBatcher {
   private batchKey: (operation: Operation) => string;
 
   constructor({
+    debounce,
     batchInterval,
     batchMax,
     batchHandler,
     batchKey,
   }: {
+    debounce?: boolean;
     batchInterval?: number;
     batchMax?: number;
     batchHandler: BatchHandler;
     batchKey?: (operation: Operation) => string;
   }) {
     this.queuedRequests = new Map();
+    this.debounce = debounce;
     this.batchInterval = batchInterval;
     this.batchMax = batchMax || 0;
     this.batchHandler = batchHandler;
@@ -85,6 +90,9 @@ export class OperationBatcher {
 
         // The first enqueued request triggers the queue consumption after `batchInterval` milliseconds.
         if (this.queuedRequests.get(key)!.length === 1) {
+          this.scheduleQueueConsumption(key);
+        } else if (this.debounce) {
+          clearTimeout(this.scheduledBatchTimer);
           this.scheduleQueueConsumption(key);
         }
 
@@ -183,13 +191,13 @@ export class OperationBatcher {
 
   private scheduleQueueConsumption(key?: string): void {
     const requestKey = key || '';
-    setTimeout(() => {
+    this.scheduledBatchTimer = (setTimeout(() => {
       if (
         this.queuedRequests.get(requestKey) &&
         this.queuedRequests.get(requestKey)!.length
       ) {
         this.consumeQueue(requestKey);
       }
-    }, this.batchInterval);
+    }, this.batchInterval) as unknown as number);
   }
 }

--- a/src/link/batch/batching.ts
+++ b/src/link/batch/batching.ts
@@ -27,8 +27,8 @@ export class OperationBatcher {
   // Public only for testing
   public queuedRequests: Map<string, BatchableRequest[]>;
 
-  private scheduledBatchTimer?: number;
-  private debounce?: boolean;
+  private scheduledBatchTimer: ReturnType<typeof setTimeout>;
+  private batchDebounce?: boolean;
   private batchInterval?: number;
   private batchMax: number;
 
@@ -37,20 +37,20 @@ export class OperationBatcher {
   private batchKey: (operation: Operation) => string;
 
   constructor({
-    debounce,
+    batchDebounce,
     batchInterval,
     batchMax,
     batchHandler,
     batchKey,
   }: {
-    debounce?: boolean;
+    batchDebounce?: boolean;
     batchInterval?: number;
     batchMax?: number;
     batchHandler: BatchHandler;
     batchKey?: (operation: Operation) => string;
   }) {
     this.queuedRequests = new Map();
-    this.debounce = debounce;
+    this.batchDebounce = batchDebounce;
     this.batchInterval = batchInterval;
     this.batchMax = batchMax || 0;
     this.batchHandler = batchHandler;
@@ -91,7 +91,7 @@ export class OperationBatcher {
         // The first enqueued request triggers the queue consumption after `batchInterval` milliseconds.
         if (this.queuedRequests.get(key)!.length === 1) {
           this.scheduleQueueConsumption(key);
-        } else if (this.debounce) {
+        } else if (this.batchDebounce) {
           clearTimeout(this.scheduledBatchTimer);
           this.scheduleQueueConsumption(key);
         }
@@ -198,6 +198,6 @@ export class OperationBatcher {
       ) {
         this.consumeQueue(requestKey);
       }
-    }, this.batchInterval) as unknown as number);
+    }, this.batchInterval));
   }
 }


### PR DESCRIPTION
### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests

### Motivation:

By default, `@apollo/client/link/batch-http` throttles requests using `batchInterval`. E.g. the queue of batched requests will fire every `batchInterval` milliseconds.

It may be desirable to instead debounce those requests so every new inbound request resets the timer. For instance, many mutations which are firing frequently from editing a table.

This PR introduces a simple `debounce` boolean to the http-batch-link and batch-link.
