### PR TITLE
Extend main README with a "Who is Apollo?" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The Apollo Client API reference can be found at: <br/>
 - [@jcreighton](https://github.com/jcreighton) (Apollo)
 - [@brainkim](https://github.com/brainkim) (Apollo)
 
-### Who is Apollo?
+## Who is Apollo?
 
 [Apollo Graph Inc.](https://apollographql.com/) is the company behind the industry's leading tools for building applications with GraphQL:
 

--- a/README.md
+++ b/README.md
@@ -21,3 +21,15 @@ The Apollo Client API reference can be found at: <br/>
 - [@benjamn](https://github.com/benjamn) (Apollo)
 - [@hwillson](https://github.com/hwillson) (Apollo)
 - [@jcreighton](https://github.com/jcreighton) (Apollo)
+- [@brainkim](https://github.com/brainkim) (Apollo)
+
+### Who is Apollo?
+
+[Apollo Graph Inc.](https://apollographql.com/) is the company behind the industry's leading tools for building applications with GraphQL:
+
+- [Apollo Client](https://www.apollographql.com/apollo-client/) – most popular GraphQL client for the web. Apollo also builds and maintains [apollo-ios](https://github.com/apollographql/apollo-ios) and [apollo-android](https://github.com/apollographql/apollo-android).
+- [Apollo Server](https://www.apollographql.com/docs/apollo-server/) – build a production-ready JavaScript GraphQL server in a schema-first way.
+- [Apollo Studio](https://www.apollographql.com/studio/develop/) – a turnkey portal for your GraphQL developers with the most feature-rich GraphQL IDE available, the [Apollo Explorer](https://www.apollographql.com/docs/studio/explorer/), and intelligent schema search and documentation.
+- [Apollo Federation](https://www.apollographql.com/apollo-federation) – create and manage a single data graph comprised of subgraphs that can be controlled and managed with independent lifecycles.
+
+We are fully committed to pushing the frontier of graph development forward across our developer tools in open source frameworks, hosted software tooling, developer extensions, and more.


### PR DESCRIPTION
We're planning to add a "Who is Apollo" section to most of our project READMEs, so this is the first of  few similar commits across our different projects.