### PR TITLE
add resultCacheMaxSize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@
 - Pass `variables` and `context` to a mutation's `update` function <br/>
   [@jcreighton](https://github.com/jcreighton) in [#7902](https://github.com/apollographql/apollo-client/pull/7902)
 
+- A `resultCacheMaxSize` option may be passed to the `InMemoryCache` constructor to limit the number of result objects that will be retained in memory (to speed up repeated reads), and calling `cache.reset()` now releases all such memory. <br/>
+  [@SofianHn](https://github.com/SofianHn) in [#8701](https://github.com/apollographql/apollo-client/pull/8701)
+
 ### Documentation
 TBD
 

--- a/src/cache/inmemory/__mocks__/optimism.ts
+++ b/src/cache/inmemory/__mocks__/optimism.ts
@@ -1,0 +1,5 @@
+const optimism = jest.requireActual('optimism');
+module.exports = {
+  ...optimism,
+  wrap: jest.fn(optimism.wrap),
+};

--- a/src/cache/inmemory/__tests__/cache.ts
+++ b/src/cache/inmemory/__tests__/cache.ts
@@ -1737,35 +1737,33 @@ describe('Cache', () => {
 });
 
 describe('resultCacheMaxSize', () => {
-    let wrapSpy: jest.Mock = wrap as jest.Mock;
-    beforeEach(() => {
-      wrapSpy.mockClear();
-    });
+  let wrapSpy: jest.Mock = wrap as jest.Mock;
+  beforeEach(() => {
+    wrapSpy.mockClear();
+  });
 
-    it("does not set max size on caches if resultCacheMaxSize is not configured", () => {
-      new InMemoryCache();
-      expect(wrapSpy).toHaveBeenCalled();
-      /*
-       * The first wrap call is for getFragmentQueryDocument which intentionally
-       * does not have a max set since it's not expected to grow.
-       */
-      wrapSpy.mock.calls.splice(1).forEach(([, { max }]) => {
-        expect(max).toBeUndefined();
-      })
-    });
+  it("does not set max size on caches if resultCacheMaxSize is not configured", () => {
+    new InMemoryCache();
+    expect(wrapSpy).toHaveBeenCalled();
 
-    it("configures max size on caches when resultCacheMaxSize is set", () => {
-      const resultCacheMaxSize = 12345;
-      new InMemoryCache({ resultCacheMaxSize });
-      expect(wrapSpy).toHaveBeenCalled();
-      /*
-       * The first wrap call is for getFragmentQueryDocument which intentionally
-       * does not have a max set since it's not expected to grow.
-       */
-      wrapSpy.mock.calls.splice(1).forEach(([, { max }]) => {
-        expect(max).toBe(resultCacheMaxSize);
-      })
-    });
+    // The first wrap call is for getFragmentQueryDocument which intentionally
+    // does not have a max set since it's not expected to grow.
+    wrapSpy.mock.calls.splice(1).forEach(([, { max }]) => {
+      expect(max).toBeUndefined();
+    })
+  });
+
+  it("configures max size on caches when resultCacheMaxSize is set", () => {
+    const resultCacheMaxSize = 12345;
+    new InMemoryCache({ resultCacheMaxSize });
+    expect(wrapSpy).toHaveBeenCalled();
+
+    // The first wrap call is for getFragmentQueryDocument which intentionally
+    // does not have a max set since it's not expected to grow.
+    wrapSpy.mock.calls.splice(1).forEach(([, { max }]) => {
+      expect(max).toBe(resultCacheMaxSize);
+    })
+  });
 });
 
 describe("InMemoryCache#broadcastWatches", function () {

--- a/src/cache/inmemory/__tests__/cache.ts
+++ b/src/cache/inmemory/__tests__/cache.ts
@@ -6,6 +6,9 @@ import { makeReference, Reference, makeVar, TypedDocumentNode, isReference, Docu
 import { Cache } from '../../../cache';
 import { InMemoryCache, InMemoryCacheConfig } from '../inMemoryCache';
 
+jest.mock('optimism');
+import { wrap } from 'optimism';
+
 disableFragmentWarnings();
 
 describe('Cache', () => {
@@ -1731,6 +1734,38 @@ describe('Cache', () => {
       expect(numBroadcasts).toEqual(1);
     });
   });
+});
+
+describe('resultCacheMaxSize', () => {
+    let wrapSpy: jest.Mock = wrap as jest.Mock;
+    beforeEach(() => {
+      wrapSpy.mockClear();
+    });
+
+    it("does not set max size on caches if resultCacheMaxSize is not configured", () => {
+      new InMemoryCache();
+      expect(wrapSpy).toHaveBeenCalled();
+      /*
+       * The first wrap call is for getFragmentQueryDocument which intentionally
+       * does not have a max set since it's not expected to grow.
+       */
+      wrapSpy.mock.calls.splice(1).forEach(([, { max }]) => {
+        expect(max).toBeUndefined();
+      })
+    });
+
+    it("configures max size on caches when resultCacheMaxSize is set", () => {
+      const resultCacheMaxSize = 12345;
+      new InMemoryCache({ resultCacheMaxSize });
+      expect(wrapSpy).toHaveBeenCalled();
+      /*
+       * The first wrap call is for getFragmentQueryDocument which intentionally
+       * does not have a max set since it's not expected to grow.
+       */
+      wrapSpy.mock.calls.splice(1).forEach(([, { max }]) => {
+        expect(max).toBe(resultCacheMaxSize);
+      })
+    });
 });
 
 describe("InMemoryCache#broadcastWatches", function () {

--- a/src/cache/inmemory/__tests__/readFromStore.ts
+++ b/src/cache/inmemory/__tests__/readFromStore.ts
@@ -19,6 +19,37 @@ import {
   TypedDocumentNode,
 } from '../../../core';
 
+jest.mock('optimism');
+import { wrap } from 'optimism';
+
+describe('resultCacheMaxSize', () => {
+  const cache = new InMemoryCache();
+  let wrapSpy: jest.Mock = wrap as jest.Mock;
+  beforeEach(() => {
+    wrapSpy.mockClear();
+  });
+
+  it("does not set max size on caches if resultCacheMaxSize is not configured", () => {
+    new StoreReader({ cache });
+    expect(wrapSpy).toHaveBeenCalled();
+
+    wrapSpy.mock.calls.forEach(([, { max }]) => {
+      expect(max).toBeUndefined();
+    })
+  });
+
+  it("configures max size on caches when resultCacheMaxSize is set", () => {
+    const resultCacheMaxSize = 12345;
+    new StoreReader({ cache, resultCacheMaxSize });
+    expect(wrapSpy).toHaveBeenCalled();
+
+    wrapSpy.mock.calls.forEach(([, { max }]) => {
+      expect(max).toBe(resultCacheMaxSize);
+    })
+  });
+});
+
+
 describe('reading from the store', () => {
   const reader = new StoreReader({
     cache: new InMemoryCache(),

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -341,17 +341,6 @@ export abstract class EntityStore implements NormalizedCache {
     }
   }
 
-  // Remove every Layer, leaving behind only the Root and the Stump.
-  public prune(): EntityStore {
-    if (this instanceof Layer) {
-      const parent = this.removeLayer(this.id);
-      if (parent !== this) {
-        return parent.prune();
-      }
-    }
-    return this;
-  }
-
   public abstract getStorage(
     idOrObj: string | StoreObject,
     ...storeFieldNames: (string | number)[]

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -85,6 +85,10 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
       typePolicies: this.config.typePolicies,
     });
 
+    this.init();
+  }
+
+  private init() {
     // Passing { resultCaching: false } in the InMemoryCache constructor options
     // will completely disable dependency tracking, which will improve memory
     // usage but worsen the performance of repeated reads.
@@ -320,8 +324,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
   }
 
   public reset(): Promise<void> {
-    this.optimisticData = this.optimisticData.prune();
-    this.data.clear();
+    this.init();
     this.broadcastWatches();
     return Promise.resolve();
   }

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -2,7 +2,7 @@
 import './fixPolyfills';
 
 import { DocumentNode } from 'graphql';
-import { wrap } from 'optimism';
+import { OptimisticWrapperFunction, wrap } from 'optimism';
 
 import { ApolloCache, BatchOptions } from '../core/cache';
 import { Cache } from '../core/types/Cache';
@@ -33,6 +33,7 @@ export interface InMemoryCacheConfig extends ApolloReducerConfig {
   resultCaching?: boolean;
   possibleTypes?: PossibleTypesMap;
   typePolicies?: TypePolicies;
+  resultCacheMaxSize?: number;
 }
 
 type BroadcastOptions = Pick<
@@ -59,6 +60,11 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
   private typenameDocumentCache = new Map<DocumentNode, DocumentNode>();
   private storeReader: StoreReader;
   private storeWriter: StoreWriter;
+
+  private maybeBroadcastWatch: OptimisticWrapperFunction<
+    [Cache.WatchOptions, BroadcastOptions?],
+    any,
+    [Cache.WatchOptions]>;
 
   // Dynamically imported code can augment existing typePolicies or
   // possibleTypes by calling cache.policies.addTypePolicies or
@@ -99,8 +105,37 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
       this.storeReader = new StoreReader({
         cache: this,
         addTypename: this.addTypename,
+        resultCacheMaxSize: this.config.resultCacheMaxSize,
       }),
     );
+
+    this.maybeBroadcastWatch = wrap((
+      c: Cache.WatchOptions,
+      options?: BroadcastOptions,
+    ) => {
+      return this.broadcastWatch(c, options);
+    }, {
+      max: this.config.resultCacheMaxSize,
+      makeCacheKey: (c: Cache.WatchOptions) => {
+        // Return a cache key (thus enabling result caching) only if we're
+        // currently using a data store that can track cache dependencies.
+        const store = c.optimistic ? this.optimisticData : this.data;
+        if (supportsResultCaching(store)) {
+          const { optimistic, rootId, variables } = c;
+          return store.makeCacheKey(
+            c.query,
+            // Different watches can have the same query, optimistic
+            // status, rootId, and variables, but if their callbacks are
+            // different, the (identical) result needs to be delivered to
+            // each distinct callback. The easiest way to achieve that
+            // separation is to include c.callback in the cache key for
+            // maybeBroadcastWatch calls. See issue #5733.
+            c.callback,
+            JSON.stringify({ optimistic, rootId, variables }),
+          );
+        }
+      }
+    });
   }
 
   public restore(data: NormalizedCacheObject): this {
@@ -422,33 +457,6 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
       this.watches.forEach(c => this.maybeBroadcastWatch(c, options));
     }
   }
-
-  private maybeBroadcastWatch = wrap((
-    c: Cache.WatchOptions,
-    options?: BroadcastOptions,
-  ) => {
-    return this.broadcastWatch(c, options);
-  }, {
-    makeCacheKey: (c: Cache.WatchOptions) => {
-      // Return a cache key (thus enabling result caching) only if we're
-      // currently using a data store that can track cache dependencies.
-      const store = c.optimistic ? this.optimisticData : this.data;
-      if (supportsResultCaching(store)) {
-        const { optimistic, rootId, variables } = c;
-        return store.makeCacheKey(
-          c.query,
-          // Different watches can have the same query, optimistic
-          // status, rootId, and variables, but if their callbacks are
-          // different, the (identical) result needs to be delivered to
-          // each distinct callback. The easiest way to achieve that
-          // separation is to include c.callback in the cache key for
-          // maybeBroadcastWatch calls. See issue #5733.
-          c.callback,
-          JSON.stringify({ optimistic, rootId, variables }),
-        );
-      }
-    }
-  });
 
   // This method is wrapped by maybeBroadcastWatch, which is called by
   // broadcastWatches, so that we compute and broadcast results only when


### PR DESCRIPTION
Per the conversation in https://github.com/apollographql/apollo-feature-requests/issues/289, this PR is proposing two changes:
1. Add `resultCachMaxSize` config
This will allow customizing the max size of caches used for `resultCaching`.
`const cache = new InMemoryCache({ resultCachMaxSize: 5000 });`

2. Add automatic clean up for the caches in `executeSelectionSet` and in `executeSubSelectedArray` upon eviction of related entries.
