### PR TITLE
use an “isomorphic” effect to squelch server warnings

### DIFF
--- a/src/react/hooks/useReactiveVar.ts
+++ b/src/react/hooks/useReactiveVar.ts
@@ -1,5 +1,12 @@
-import { useState, useEffect, useLayoutEffect } from 'react';
+import { useEffect, useLayoutEffect, useState } from 'react';
 import { ReactiveVar } from '../../core';
+
+
+const isBrowser = typeof window !== 'undefined' &&
+  typeof window.document !== 'undefined' &&
+  typeof window.document.createElement !== 'undefined';
+
+const useIsomorphicEffect = isBrowser ? useLayoutEffect : useEffect;
 
 export function useReactiveVar<T>(rv: ReactiveVar<T>): T {
   const value = rv();
@@ -9,7 +16,7 @@ export function useReactiveVar<T>(rv: ReactiveVar<T>): T {
   // We subscribe to variable updates on initial mount and when the value has
   // changed. This avoids a subtle bug in React.StrictMode where multiple listeners
   // are added, leading to inconsistent updates.
-  useLayoutEffect(() => rv.onNextChange(setValue), [value]);
+  useIsomorphicEffect(() => rv.onNextChange(setValue), [value]);
   // Once the component is unmounted, ignore future updates. Note that the
   // above useEffect function returns a mute function without calling it,
   // allowing it to be called when the component unmounts. This is

--- a/src/react/ssr/__tests__/useLazyQuery.test.tsx
+++ b/src/react/ssr/__tests__/useLazyQuery.test.tsx
@@ -1,3 +1,4 @@
+/** @jest-environment node */
 import React from 'react';
 import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';

--- a/src/react/ssr/__tests__/useReactiveVar.test.tsx
+++ b/src/react/ssr/__tests__/useReactiveVar.test.tsx
@@ -1,0 +1,26 @@
+/** @jest-environment node */
+import React from 'react';
+import { makeVar } from '../../../core';
+import { useReactiveVar } from '../../hooks';
+import { itAsync } from "../../../testing";
+import { renderToStringWithData } from '../';
+
+describe('useReactiveVar Hook SSR', () => {
+  itAsync("does not cause warnings", (resolve, reject) => {
+    const mock = jest.spyOn(console, 'error');
+    const counterVar = makeVar(0);
+    function Component() {
+      const count = useReactiveVar(counterVar);
+      counterVar(1);
+      counterVar(2);
+      return <div>{count}</div>;
+    }
+
+    renderToStringWithData(<Component />).then((value) => {
+      expect(value).toEqual('<div>0</div>');
+      expect(mock).toHaveBeenCalledTimes(0);
+    }).finally(() => {
+      mock.mockRestore();
+    }).then(resolve, reject);
+  });
+});


### PR DESCRIPTION
Fixes #8124. Is this all we have to do? They mentioned hydration mismatches but that they’re not sure if it’s because of the new changes.