### PR TITLE
Recheck `rv()` against previous `value` in `useEffect` callback in `useReactiveVar`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Apollo Client 3.3.17 (not yet released)
+
+### Bug fixes
+
+- Prevent warnings about `useLayoutEffect` when using `useReactiveVar` during React server rendering. <br/>
+  [@brainkim](https://github.com/brainkim) in [#8126](https://github.com/apollographql/apollo-client/pull/8126)
+
+- Make `useReactiveVar(rv)` recheck the latest `rv()` value in its `useEffect` callback, and immediately update state if the value has already changed, rather than calling `rv.onNextChange(setValue)` to listen for future changes. <br/>
+  [@benjamn](https://github.com/benjamn) in [#8135](https://github.com/apollographql/apollo-client/pull/8135)
+
 ## Apollo Client 3.3.16
 
 ### Bug fixes

--- a/src/react/hooks/useReactiveVar.ts
+++ b/src/react/hooks/useReactiveVar.ts
@@ -1,7 +1,6 @@
 import { useEffect, useLayoutEffect, useState } from 'react';
 import { ReactiveVar } from '../../core';
 
-
 const isBrowser = typeof window !== 'undefined' &&
   typeof window.document !== 'undefined' &&
   typeof window.document.createElement !== 'undefined';
@@ -10,21 +9,24 @@ const useIsomorphicEffect = isBrowser ? useLayoutEffect : useEffect;
 
 export function useReactiveVar<T>(rv: ReactiveVar<T>): T {
   const value = rv();
+
   // We don't actually care what useState thinks the value of the variable
   // is, so we take only the update function from the returned array.
   const [, setValue] = useState(value);
+
   // We subscribe to variable updates on initial mount and when the value has
   // changed. This avoids a subtle bug in React.StrictMode where multiple listeners
   // are added, leading to inconsistent updates.
-  useIsomorphicEffect(() => rv.onNextChange(setValue), [value]);
-  // Once the component is unmounted, ignore future updates. Note that the
-  // above useEffect function returns a mute function without calling it,
-  // allowing it to be called when the component unmounts. This is
-  // equivalent to the following, but shorter:
-  // useEffect(() => {
-  //   const mute = rv.onNextChange(setValue);
-  //   return () => mute();
-  // }, [value])
+  useIsomorphicEffect(() => {
+    const probablySameValue = rv();
+    if (value !== probablySameValue) {
+      // If the value of rv has already changed, we don't need to listen for the
+      // next change, because we can report this change immediately.
+      setValue(probablySameValue);
+    } else {
+      return rv.onNextChange(setValue);
+    }
+  }, [value]);
 
   // We check the variable's value in this useEffect and schedule an update if
   // the value has changed. This check occurs once, on the initial render, to avoid

--- a/src/react/hooks/useReactiveVar.ts
+++ b/src/react/hooks/useReactiveVar.ts
@@ -1,11 +1,5 @@
-import { useEffect, useLayoutEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ReactiveVar } from '../../core';
-
-const isBrowser = typeof window !== 'undefined' &&
-  typeof window.document !== 'undefined' &&
-  typeof window.document.createElement !== 'undefined';
-
-const useIsomorphicEffect = isBrowser ? useLayoutEffect : useEffect;
 
 export function useReactiveVar<T>(rv: ReactiveVar<T>): T {
   const value = rv();
@@ -17,7 +11,7 @@ export function useReactiveVar<T>(rv: ReactiveVar<T>): T {
   // We subscribe to variable updates on initial mount and when the value has
   // changed. This avoids a subtle bug in React.StrictMode where multiple listeners
   // are added, leading to inconsistent updates.
-  useIsomorphicEffect(() => {
+  useEffect(() => {
     const probablySameValue = rv();
     if (value !== probablySameValue) {
       // If the value of rv has already changed, we don't need to listen for the
@@ -27,13 +21,6 @@ export function useReactiveVar<T>(rv: ReactiveVar<T>): T {
       return rv.onNextChange(setValue);
     }
   }, [value]);
-
-  // We check the variable's value in this useEffect and schedule an update if
-  // the value has changed. This check occurs once, on the initial render, to avoid
-  // a useEffect higher in the component tree changing a variable's value
-  // before the above useEffect can set the onNextChange handler. Note that React
-  // will not schedule an update if setState is called with the same value as before.
-  useEffect(() => setValue(rv()), []);
 
   return value;
 }


### PR DESCRIPTION
While rereading the code @jcreighton added in #7652, I remembered it's safe to access a reactive variable `rv` by calling `rv()` in a `useEffect` callback (without going through `useReactiveVar`).

Taking advantage of this insight, we should be able to compare the latest variable value to the previous `value` _before_ deciding whether to call `rv.onNextChange(setValue)` in the effect callback function, if/when that callback fires. If the values already disagree, we can skip listening and just call `setValue` right away.

In React `<StrictMode>`, there will be two initial `rv()` values generated prior to the `useIsomorphicEffect` callback (which may never fire), but those values should always be the same, unless the reactive variable somehow gets updated in between the double renders. I don't think that's possible, since React invokes those renders [synchronously, one after the other](https://github.com/facebook/react/blob/0e100ed00fb52cfd107db1d1081ef18fe4b9167f/packages/react-reconciler/src/ReactUpdateQueue.new.js#L391-L399).

The key difference between this approach and calling `rv.onNextChange` synchronously in `render` is that (in this new approach) we can safely ignore the extra `value` without doing anything to clean up its resources, whereas calling `rv.onNextChange` in `render` made us additionally responsible for calling the extra `cancel` function returned by the extra `rv.onNextChange` call, which was not easy/possible.

If I'm on the right track here, then we finally have a way to "listen" for reactive variable changes that happen before the effect callback fires, even if that callback is noticeably delayed.