### PR TITLE
fix: remove this.link which results in mutating link chain

### DIFF
--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -566,6 +566,6 @@ export class ApolloClient<TCacheShape> implements DataProxy {
    * Define a new ApolloLink (or link chain) that Apollo Client will use.
    */
   public setLink(newLink: ApolloLink) {
-    this.link = this.queryManager.link = newLink;
+    this.queryManager.link = newLink;
   }
 }


### PR DESCRIPTION
Fixes issue described here https://github.com/apollographql/apollo-client/issues/8182.

Due to single instance of apolloClient in SPA, `this.link` keeps on adding/preserving new/old apollo-links, which all runs on graphQL request/response. 

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
