### PR TITLE
Mark all generated package.json files as "sideEffects": false.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Apollo Client 3.3.18 (not yet released)
+
+### Bug fixes
+
+- Add `"sideEffects": false` to all generated/published `package.json` files, to improve dead code elimination for nested entry points like `@apollo/client/cache`. <br/>
+  [@benjamn](https://github.com/benjamn) in [#8213](https://github.com/apollographql/apollo-client/pull/8213)
+
 ## Apollo Client 3.3.17
 
 ### Bug fixes

--- a/config/prepareDist.js
+++ b/config/prepareDist.js
@@ -71,6 +71,7 @@ entryPoints.forEach(function buildPackageJson({
       main: `${bundleName}.cjs.js`,
       module: 'index.js',
       types: 'index.d.ts',
+      sideEffects: false,
     }, null, 2) + "\n",
   );
 });

--- a/package.json
+++ b/package.json
@@ -16,9 +16,7 @@
   "main": "./dist/main.cjs.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "sideEffects": [
-    "./dist/cache/inmemory/fixPolyfills.native.js"
-  ],
+  "sideEffects": false,
   "react-native": {
     "./dist/cache/inmemory/fixPolyfills.js": "./dist/cache/inmemory/fixPolyfills.native.js"
   },


### PR DESCRIPTION
Should fix #8168 and #5686.

The only side-effectful file we previously advertised was the [`fixPolyfills.native.js`](https://github.com/apollographql/apollo-client/blob/main/src/cache/inmemory/fixPolyfills.native.ts) module within `@apollo/client/cache`, but that file should be used only in React Native, whose Metro bundler does not perform tree-shaking or dead code elimination, which means we never really needed to defend that file from tree-shaking in the first place. In other words, I believe we can get away with putting `"sideEffects": false` in _all_ of our `package.json` files, for simplicity (as correctly conjectured by @nwalters512 in #8168).

Background explanation of the `"sideEffects": false` convention: https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free