### PR TITLE
Correcting typo in example

### DIFF
--- a/docs/source/data/fragments.md
+++ b/docs/source/data/fragments.md
@@ -150,7 +150,7 @@ FeedEntry.fragments = {
 };
 ```
 
-There's nothing special about the naming of `VoteButtons.fragments.entry` or `RepoInfo.fragments.entry`. Any naming convention works as long as you can retrieve a component's fragments given the component.
+There's nothing special about the naming of `VoteButtons.fragments.entry` or `EntryInfo.fragments.entry`. Any naming convention works as long as you can retrieve a component's fragments given the component.
 
 ### Importing fragments when using Webpack
 


### PR DESCRIPTION
There is no RepoInfo.fragments.entry in the above example, I think it is referring to EntryInfo.fragments.entry

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
