### PR TITLE
Re-export graphql-tag exports directly, without destructuring.

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -103,11 +103,10 @@ setVerbosity("log");
 // workaround of pulling the extra properties off the `gql` function,
 // then re-exporting them separately, helps keeps bundlers happy without any
 // additional config changes.
-import gql from 'graphql-tag';
-export const {
+export {
+  default as gql,
   resetCaches,
   disableFragmentWarnings,
   enableExperimentalFragmentVariables,
-  disableExperimentalFragmentVariables
-} = gql;
-export { gql };
+  disableExperimentalFragmentVariables,
+} from 'graphql-tag';


### PR DESCRIPTION
Seems to fix #8217, judging from the provided reproduction. Presumably this is because using ECMAScript `export...from` syntax means we don't have to import anything into the scope of the `index.ts` module, which makes the whole situation easier for the tree-shaker to reason about.