### PR TITLE
Remove dependency on `fast-json-stable-stringify`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6654,7 +6654,8 @@
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "@wry/context": "^0.6.0",
     "@wry/equality": "^0.4.0",
     "@wry/trie": "^0.3.0",
-    "fast-json-stable-stringify": "^2.0.0",
     "graphql-tag": "^2.12.3",
     "hoist-non-react-statics": "^3.3.2",
     "optimism": "^0.16.1",

--- a/src/__tests__/__snapshots__/exports.ts.snap
+++ b/src/__tests__/__snapshots__/exports.ts.snap
@@ -68,6 +68,7 @@ Array [
   "MissingFieldError",
   "Policies",
   "cacheSlot",
+  "canonicalStringify",
   "defaultDataIdFromObject",
   "fieldNameFromStoreName",
   "isReference",

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -38,4 +38,8 @@ export {
   Policies,
 } from './inmemory/policies';
 
+export {
+  canonicalStringify,
+} from './inmemory/object-canon';
+
 export * from './inmemory/types';

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -28,7 +28,7 @@ import {
   TypePolicies,
 } from './policies';
 import { hasOwn } from './helpers';
-import { resetStringifyCanon } from './object-canon';
+import { canonicalStringify } from './object-canon';
 
 export interface InMemoryCacheConfig extends ApolloReducerConfig {
   resultCaching?: boolean;
@@ -263,7 +263,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
 
   // Request garbage collection of unreachable normalized entities.
   public gc() {
-    resetStringifyCanon();
+    canonicalStringify.reset();
     return this.optimisticData.gc();
   }
 
@@ -324,7 +324,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
   public reset(): Promise<void> {
     this.init();
     this.broadcastWatches();
-    resetStringifyCanon();
+    canonicalStringify.reset();
     return Promise.resolve();
   }
 

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -28,6 +28,7 @@ import {
   TypePolicies,
 } from './policies';
 import { hasOwn } from './helpers';
+import { resetStringifyCanon } from './object-canon';
 
 export interface InMemoryCacheConfig extends ApolloReducerConfig {
   resultCaching?: boolean;
@@ -262,6 +263,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
 
   // Request garbage collection of unreachable normalized entities.
   public gc() {
+    resetStringifyCanon();
     return this.optimisticData.gc();
   }
 
@@ -322,6 +324,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
   public reset(): Promise<void> {
     this.init();
     this.broadcastWatches();
+    resetStringifyCanon();
     return Promise.resolve();
   }
 

--- a/src/cache/inmemory/object-canon.ts
+++ b/src/cache/inmemory/object-canon.ts
@@ -194,7 +194,10 @@ type SortedKeysInfo = {
   json: string;
 };
 
-const stringifyCanon = new ObjectCanon;
+let stringifyCanon = new ObjectCanon;
+export function resetStringifyCanon() {
+  stringifyCanon = new ObjectCanon;
+}
 const stringifyCache = new WeakMap<object, string>();
 
 // Since the keys of canonical objects are always created in lexicographically

--- a/src/cache/inmemory/object-canon.ts
+++ b/src/cache/inmemory/object-canon.ts
@@ -194,16 +194,10 @@ type SortedKeysInfo = {
   json: string;
 };
 
-let stringifyCanon = new ObjectCanon;
-export function resetStringifyCanon() {
-  stringifyCanon = new ObjectCanon;
-}
-const stringifyCache = new WeakMap<object, string>();
-
 // Since the keys of canonical objects are always created in lexicographically
 // sorted order, we can use the ObjectCanon to implement a fast and stable
 // version of JSON.stringify, which automatically sorts object keys.
-export function canonicalStringify(value: any): string {
+export const canonicalStringify = Object.assign(function (value: any): string {
   if (isObjectOrArray(value)) {
     const canonical = stringifyCanon.admit(value);
     let json = stringifyCache.get(canonical);
@@ -216,4 +210,14 @@ export function canonicalStringify(value: any): string {
     return json;
   }
   return JSON.stringify(value);
-}
+}, {
+  reset() {
+    stringifyCanon = new ObjectCanon;
+  },
+});
+
+// Can be reset by calling canonicalStringify.reset().
+let stringifyCanon = new ObjectCanon;
+
+// Needs no resetting, thanks to weakness.
+const stringifyCache = new WeakMap<object, string>();

--- a/src/cache/inmemory/object-canon.ts
+++ b/src/cache/inmemory/object-canon.ts
@@ -2,7 +2,7 @@ import { Trie } from "@wry/trie";
 import { canUseWeakMap } from "../../utilities";
 import { objToStr } from "./helpers";
 
-function isObjectOrArray(value: any): boolean {
+function isObjectOrArray(value: any): value is object {
   return !!value && typeof value === "object";
 }
 
@@ -109,7 +109,7 @@ export class ObjectCanon {
       switch (objToStr.call(value)) {
         case "[object Array]": {
           if (this.known.has(value)) return value;
-          const array: any[] = value.map(this.admit, this);
+          const array: any[] = (value as any[]).map(this.admit, this);
           // Arrays are looked up in the Trie using their recursively
           // canonicalized elements, and the known version of the array is
           // preserved as node.array.
@@ -134,7 +134,7 @@ export class ObjectCanon {
           array.push(keys.json);
           const firstValueIndex = array.length;
           keys.sorted.forEach(key => {
-            array.push(this.admit(value[key]));
+            array.push(this.admit((value as any)[key]));
           });
           // Objects are looked up in the Trie by their prototype (which
           // is *not* recursively canonicalized), followed by a JSON
@@ -193,3 +193,24 @@ type SortedKeysInfo = {
   sorted: string[];
   json: string;
 };
+
+const stringifyCanon = new ObjectCanon;
+const stringifyCache = new WeakMap<object, string>();
+
+// Since the keys of canonical objects are always created in lexicographically
+// sorted order, we can use the ObjectCanon to implement a fast and stable
+// version of JSON.stringify, which automatically sorts object keys.
+export function canonicalStringify(value: any): string {
+  if (isObjectOrArray(value)) {
+    const canonical = stringifyCanon.admit(value);
+    let json = stringifyCache.get(canonical);
+    if (json === void 0) {
+      stringifyCache.set(
+        canonical,
+        json = JSON.stringify(canonical),
+      );
+    }
+    return json;
+  }
+  return JSON.stringify(value);
+}

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -48,6 +48,12 @@ import {
 } from '../core/types/common';
 import { WriteContext } from './writeToStore';
 
+// Upgrade to a faster version of the default stable JSON.stringify function
+// used by getStoreKeyName. This function is used when computing storeFieldName
+// strings (when no keyArgs has been configured for a field).
+import { canonicalStringify } from './object-canon';
+getStoreKeyName.setStringify(canonicalStringify);
+
 export type TypePolicies = {
   [__typename: string]: TypePolicy;
 }

--- a/src/utilities/graphql/storeUtils.ts
+++ b/src/utilities/graphql/storeUtils.ts
@@ -250,7 +250,7 @@ function stringifyReplacer(_key: string, value: any): any {
     value = Object.keys(value).sort().reduce((copy, key) => {
       copy[key] = value[key];
       return copy;
-    }, Object.create(Object.getPrototypeOf(value)));
+    }, {} as Record<string, any>);
   }
   return value;
 }

--- a/src/utilities/graphql/storeUtils.ts
+++ b/src/utilities/graphql/storeUtils.ts
@@ -176,7 +176,7 @@ const KNOWN_DIRECTIVES: string[] = [
   'export',
 ];
 
-export function getStoreKeyName(
+export const getStoreKeyName = Object.assign(function (
   fieldName: string,
   args?: Record<string, any> | null,
   directives?: Directives,
@@ -231,16 +231,16 @@ export function getStoreKeyName(
   }
 
   return completeFieldName;
-}
-
-export namespace getStoreKeyName {
-  export function setStringify(s: typeof stringify) {
+}, {
+  setStringify(s: typeof stringify) {
     const previous = stringify;
     stringify = s;
     return previous;
-  }
-}
+  },
+});
 
+// Default stable JSON.stringify implementation. Can be updated/replaced with
+// something better by calling getStoreKeyName.setStringify.
 let stringify = function defaultStringify(value: any): string {
   return JSON.stringify(value, stringifyReplacer);
 };

--- a/src/utilities/graphql/storeUtils.ts
+++ b/src/utilities/graphql/storeUtils.ts
@@ -180,7 +180,6 @@ export function getStoreKeyName(
   fieldName: string,
   args?: Record<string, any> | null,
   directives?: Directives,
-  stringify: (value: any) => string = JSON.stringify,
 ): string {
   if (
     args &&
@@ -232,6 +231,28 @@ export function getStoreKeyName(
   }
 
   return completeFieldName;
+}
+
+export namespace getStoreKeyName {
+  export function setStringify(s: typeof stringify) {
+    const previous = stringify;
+    stringify = s;
+    return previous;
+  }
+}
+
+let stringify = function defaultStringify(value: any): string {
+  return JSON.stringify(value, stringifyReplacer);
+};
+
+function stringifyReplacer(_key: string, value: any): any {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    value = Object.keys(value).sort().reduce((copy, key) => {
+      copy[key] = value[key];
+      return copy;
+    }, Object.create(Object.getPrototypeOf(value)));
+  }
+  return value;
 }
 
 export function argumentsObjectFromField(

--- a/src/utilities/graphql/storeUtils.ts
+++ b/src/utilities/graphql/storeUtils.ts
@@ -17,7 +17,6 @@ import {
   SelectionSetNode,
 } from 'graphql';
 
-import stringify from 'fast-json-stable-stringify';
 import { InvariantError } from 'ts-invariant';
 import { FragmentMap, getFragmentFromSelection } from './fragments';
 
@@ -181,6 +180,7 @@ export function getStoreKeyName(
   fieldName: string,
   args?: Record<string, any> | null,
   directives?: Directives,
+  stringify: (value: any) => string = JSON.stringify,
 ): string {
   if (
     args &&
@@ -202,7 +202,7 @@ export function getStoreKeyName(
         filteredArgs[key] = args[key];
       });
 
-      return `${directives['connection']['key']}(${JSON.stringify(
+      return `${directives['connection']['key']}(${stringify(
         filteredArgs,
       )})`;
     } else {
@@ -224,7 +224,7 @@ export function getStoreKeyName(
     Object.keys(directives).forEach(key => {
       if (KNOWN_DIRECTIVES.indexOf(key) !== -1) return;
       if (directives[key] && Object.keys(directives[key]).length) {
-        completeFieldName += `@${key}(${JSON.stringify(directives[key])})`;
+        completeFieldName += `@${key}(${stringify(directives[key])})`;
       } else {
         completeFieldName += `@${key}`;
       }


### PR DESCRIPTION
Fixes #8185, though I would say this removal is more for ESM-friendliness than for performance, as I explain below.

> Note: I am expecting tests to fail for the first commit, demonstrating the importance of using a stable serialization strategy for field arguments.

Although `fast-json-stable-stringify` has done its job well, it only provides a `"main"` field in its `package.json` file, pointing to a CommonJS entry point, and does not appear to export any ECMAScript modules.

Thanks to our conversion/abandonment of `fast-json-stable-stringify` and other CommonJS-only npm dependencies (`zen-observable` in #5961 and `graphql-tag` in #6074), it should now (after this PR is merged) be possible to load `@apollo/client/core` from an ESM-aware CDN like jsdelivr.net or jspm.io:
```html
<script type=module
        src="https://cdn.jsdelivr.net/npm/@apollo/client@beta/core/+esm">
</script>
```
If you put that script tag in an HTML file, or inject it into the DOM of any webpage, you will currently see this error:
```
Uncaught SyntaxError: The requested module '/npm/fast-json-stable-stringify@2.1.0/+esm' does not provide an export named 'default'
```
This list of errors used to be longer, but thankfully the only package left is `fast-json-stable-stringify`!

Note that we're loading `@apollo/client/core@beta` here, not `@apollo/client@beta`. The reason `@apollo/client` itself is not yet ESM-ready is that `react` and `react-dom` are unfortunately also CommonJS-only dependencies, and `@apollo/client` currently/regrettably re-exports utilities from `@apollo/client/react`. See #5541 for background on why this somewhat awkward package structure was originally necessary.

If importing from `@apollo/client/core` is a burden or feels weird, please know that we are planning to make `@apollo/client` synonymous with `@apollo/client/core` in Apollo Client 4.0 (see #8190), along with making `@apollo/client/react` synonymous with the v3 API of `@apollo/client`. While we think React developers will have an easy time accommodating these changes (just find/replace `@apollo/client` with `@apollo/client/react`), it's clearly a major breaking change, so it will have to wait until AC4.