### PR TITLE
Various improvements to ROOT_MUTATION caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
 
 ### Potentially breaking changes
 
+- To avoid retaining sensitive information from mutation root field arguments, Apollo Client v3.4 automatically clears any `ROOT_MUTATION` fields from the cache after each mutation finishes. If you need this information to remain in the cache, you can prevent the removal by passing the `keepRootFields: true` option to `client.mutate`. `ROOT_MUTATION` result data are also passed to the mutation `update` function, so we recommend obtaining the results that way, rather than using `keepRootFields: true`, if possible. <br/>
+  [@benjamn](https://github.com/benjamn) in [#8280](https://github.com/apollographql/apollo-client/pull/8280)
+
 - Internally, Apollo Client now uses namespace syntax (e.g. `import * as React from "react"`) for imports whose types are re-exported (and thus may appear in `.d.ts` files). This change should remove any need to configure `esModuleInterop` or `allowSyntheticDefaultImports` in `tsconfig.json`, but might require updating bundler configurations that specify named exports of the `react` and `prop-types` packages, to include exports like `createContext` and `createElement` ([example](https://github.com/apollographql/apollo-client/commit/16b08e1af9ba9934041298496e167aafb128c15d)). <br/>
   [@devrelm](https://github.com/devrelm) in [#7742](https://github.com/apollographql/apollo-client/pull/7742)
 

--- a/src/__tests__/__snapshots__/mutationResults.ts.snap
+++ b/src/__tests__/__snapshots__/mutationResults.ts.snap
@@ -8,6 +8,9 @@ Object {
     "__typename": "Person",
     "name": "Jenn Creighton",
   },
+  "ROOT_MUTATION": Object {
+    "__typename": "Mutation",
+  },
 }
 `;
 
@@ -20,6 +23,9 @@ Object {
   "Person:{\\"name\\":\\"Jenn Creighton\\"}": Object {
     "__typename": "Person",
     "name": "Jenn Creighton",
+  },
+  "ROOT_MUTATION": Object {
+    "__typename": "Mutation",
   },
 }
 `;

--- a/src/__tests__/__snapshots__/mutationResults.ts.snap
+++ b/src/__tests__/__snapshots__/mutationResults.ts.snap
@@ -8,12 +8,6 @@ Object {
     "__typename": "Person",
     "name": "Jenn Creighton",
   },
-  "ROOT_MUTATION": Object {
-    "__typename": "Mutation",
-    "newPerson({\\"name\\":\\"Jenn Creighton\\"})": Object {
-      "__ref": "Person:{\\"name\\":\\"Jenn Creighton\\"}",
-    },
-  },
 }
 `;
 
@@ -26,15 +20,6 @@ Object {
   "Person:{\\"name\\":\\"Jenn Creighton\\"}": Object {
     "__typename": "Person",
     "name": "Jenn Creighton",
-  },
-  "ROOT_MUTATION": Object {
-    "__typename": "Mutation",
-    "newPerson({\\"name\\":\\"Ellen Shapiro\\"})": Object {
-      "__ref": "Person:{\\"name\\":\\"Ellen Shapiro\\"}",
-    },
-    "newPerson({\\"name\\":\\"Jenn Creighton\\"})": Object {
-      "__ref": "Person:{\\"name\\":\\"Jenn Creighton\\"}",
-    },
   },
 }
 `;

--- a/src/__tests__/mutationResults.ts
+++ b/src/__tests__/mutationResults.ts
@@ -582,9 +582,15 @@ describe('mutation results', () => {
         expect(time.getTime()).toBe(startTime);
         expect(timeReadCount).toBe(1);
         expect(timeMergeCount).toBe(1);
-        // The ROOT_MUTATION object exists only briefly, for the duration of the
-        // mutation update, and is removed after the mutation write is finished.
-        expect(client.cache.extract()).toEqual({});
+
+        // The contents of the ROOT_MUTATION object exist only briefly, for the
+        // duration of the mutation update, and are removed after the mutation
+        // write is finished.
+        expect(client.cache.extract()).toEqual({
+          ROOT_MUTATION: {
+            __typename: "Mutation",
+          },
+        });
       });
     });
 
@@ -1095,7 +1101,11 @@ describe('mutation results', () => {
         mutation,
       }),
     ]).then(results => {
-      expect(client.cache.extract()).toEqual({});
+      expect(client.cache.extract()).toEqual({
+        ROOT_MUTATION: {
+          __typename: "Mutation",
+        },
+      });
       expect(results).toEqual([
         { data: { result: "hello" }},
         { data: { result: "world" }},
@@ -1168,7 +1178,11 @@ describe('mutation results', () => {
         variables: { c: 3 },
       }),
     ]).then(results => {
-      expect(client.cache.extract()).toEqual({});
+      expect(client.cache.extract()).toEqual({
+        ROOT_MUTATION: {
+          __typename: "Mutation",
+        },
+      });
       expect(results).toEqual([
         { data: { result: 'hello' }},
         { data: { result: 'world' }},
@@ -1241,7 +1255,11 @@ describe('mutation results', () => {
         variables: { a: null, b: null, c: null },
       }),
     ]).then(results => {
-      expect(client.cache.extract()).toEqual({});
+      expect(client.cache.extract()).toEqual({
+        ROOT_MUTATION: {
+          __typename: "Mutation",
+        },
+      });
       expect(results).toEqual([
         { data: { result: 'hello' }},
         { data: { result: 'world' }},

--- a/src/__tests__/mutationResults.ts
+++ b/src/__tests__/mutationResults.ts
@@ -934,20 +934,15 @@ describe('mutation results', () => {
       client.mutate({
         mutation,
       }),
-    ])
-      .then(() => {
-        expect((client.cache as InMemoryCache).extract()).toEqual({
-          ROOT_MUTATION: {
-            __typename: 'Mutation',
-            'result({"a":1,"b":2})': 'hello',
-            'result({"a":1,"c":3})': 'world',
-            'result({"b":2,"c":3})': 'goodbye',
-            'result({})': 'moon',
-          },
-        });
-        resolve();
-      })
-      .catch(reject);
+    ]).then(results => {
+      expect(client.cache.extract()).toEqual({});
+      expect(results).toEqual([
+        { data: { result: "hello" }},
+        { data: { result: "world" }},
+        { data: { result: "goodbye" }},
+        { data: { result: "moon" }},
+      ]);
+    }).then(resolve, reject);
   });
 
   itAsync('allows mutations with default values', (resolve, reject) => {
@@ -1012,19 +1007,14 @@ describe('mutation results', () => {
         mutation,
         variables: { c: 3 },
       }),
-    ])
-      .then(() => {
-        expect((client.cache as InMemoryCache).extract()).toEqual({
-          ROOT_MUTATION: {
-            __typename: 'Mutation',
-            'result({"a":1,"b":"water"})': 'hello',
-            'result({"a":2,"b":"cheese","c":3})': 'world',
-            'result({"a":1,"b":"cheese","c":3})': 'goodbye',
-          },
-        });
-        resolve();
-      })
-      .catch(reject);
+    ]).then(results => {
+      expect(client.cache.extract()).toEqual({});
+      expect(results).toEqual([
+        { data: { result: 'hello' }},
+        { data: { result: 'world' }},
+        { data: { result: 'goodbye' }},
+      ]);
+    }).then(resolve, reject);
   });
 
   itAsync('will pass null to the network interface when provided', (resolve, reject) => {
@@ -1090,19 +1080,14 @@ describe('mutation results', () => {
         mutation,
         variables: { a: null, b: null, c: null },
       }),
-    ])
-      .then(() => {
-        expect((client.cache as InMemoryCache).extract()).toEqual({
-          ROOT_MUTATION: {
-            __typename: 'Mutation',
-            'result({"a":1,"b":2,"c":null})': 'hello',
-            'result({"a":1,"b":null,"c":3})': 'world',
-            'result({"a":null,"b":null,"c":null})': 'moon',
-          },
-        });
-        resolve();
-      })
-      .catch(reject);
+    ]).then(results => {
+      expect(client.cache.extract()).toEqual({});
+      expect(results).toEqual([
+        { data: { result: 'hello' }},
+        { data: { result: 'world' }},
+        { data: { result: 'moon' }},
+      ]);
+    }).then(resolve, reject);
   });
 
   describe('store transaction updater', () => {

--- a/src/__tests__/optimistic.ts
+++ b/src/__tests__/optimistic.ts
@@ -2049,6 +2049,9 @@ describe('optimistic mutation results', () => {
               mutationItem,
             ],
           },
+          ROOT_MUTATION: {
+            __typename: "Mutation",
+          },
         });
 
         // Now that the mutation is finished, reading optimistically from
@@ -2080,6 +2083,9 @@ describe('optimistic mutation results', () => {
               manualItem2,
             ],
           },
+          ROOT_MUTATION: {
+            __typename: "Mutation",
+          },
         });
 
         cache.removeOptimistic("manual");
@@ -2092,6 +2098,9 @@ describe('optimistic mutation results', () => {
             items: [
               mutationItem,
             ],
+          },
+          ROOT_MUTATION: {
+            __typename: "Mutation",
           },
         });
 

--- a/src/__tests__/optimistic.ts
+++ b/src/__tests__/optimistic.ts
@@ -2049,9 +2049,6 @@ describe('optimistic mutation results', () => {
               mutationItem,
             ],
           },
-          ROOT_MUTATION: {
-            __typename: "Mutation",
-          },
         });
 
         // Now that the mutation is finished, reading optimistically from
@@ -2083,9 +2080,6 @@ describe('optimistic mutation results', () => {
               manualItem2,
             ],
           },
-          ROOT_MUTATION: {
-            __typename: "Mutation",
-          },
         });
 
         cache.removeOptimistic("manual");
@@ -2098,9 +2092,6 @@ describe('optimistic mutation results', () => {
             items: [
               mutationItem,
             ],
-          },
-          ROOT_MUTATION: {
-            __typename: "Mutation",
           },
         });
 

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -401,6 +401,17 @@ export class QueryManager<TStore> {
               variables: mutation.variables,
             });
           }
+
+          // TODO Do this with cache.evict({ id: 'ROOT_MUTATION' }) but make it
+          // shallow to allow rolling back optimistic evictions.
+          if (!skipCache) {
+            cache.modify({
+              id: 'ROOT_MUTATION',
+              fields(_fieldValue, { DELETE }) {
+                return DELETE;
+              },
+            });
+          }
         },
 
         include: mutation.refetchQueries,

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -434,8 +434,8 @@ export class QueryManager<TStore> {
           if (!skipCache) {
             cache.modify({
               id: 'ROOT_MUTATION',
-              fields(_fieldValue, { DELETE }) {
-                return DELETE;
+              fields(value, { fieldName, DELETE }) {
+                return fieldName === "__typename" ? value : DELETE;
               },
             });
           }

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -163,6 +163,7 @@ export class QueryManager<TStore> {
     onQueryUpdated,
     errorPolicy = 'none',
     fetchPolicy,
+    keepRootFields,
     context,
   }: MutationOptions<TData, TVariables, TContext>): Promise<FetchResult<TData>> {
     invariant(
@@ -208,6 +209,7 @@ export class QueryManager<TStore> {
         context,
         updateQueries,
         update: updateWithProxyFn,
+        keepRootFields,
       });
     }
 
@@ -269,6 +271,7 @@ export class QueryManager<TStore> {
             refetchQueries,
             removeOptimistic: optimisticResponse ? mutationId : void 0,
             onQueryUpdated,
+            keepRootFields,
           });
         },
 
@@ -327,6 +330,7 @@ export class QueryManager<TStore> {
       refetchQueries?: RefetchQueryDescription;
       removeOptimistic?: string;
       onQueryUpdated?: OnQueryUpdated<any>;
+      keepRootFields?: boolean;
     },
     cache = this.cache,
   ): Promise<FetchResult<TData>> {
@@ -431,7 +435,7 @@ export class QueryManager<TStore> {
 
           // TODO Do this with cache.evict({ id: 'ROOT_MUTATION' }) but make it
           // shallow to allow rolling back optimistic evictions.
-          if (!skipCache) {
+          if (!skipCache && !mutation.keepRootFields) {
             cache.modify({
               id: 'ROOT_MUTATION',
               fields(value, { fieldName, DELETE }) {
@@ -480,6 +484,7 @@ export class QueryManager<TStore> {
       context?: TContext;
       updateQueries: UpdateQueries<TData>,
       update?: MutationUpdaterFunction<TData, TVariables, TContext, TCache>;
+      keepRootFields?: boolean,
     },
   ) {
     const data = typeof optimisticResponse === "function"

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -303,4 +303,15 @@ export interface MutationOptions<
    * behavior.
    */
   fetchPolicy?: Extract<FetchPolicy, 'no-cache'>;
+
+  /**
+   * To avoid retaining sensitive information from mutation root field
+   * arguments, Apollo Client v3.4+ automatically clears any `ROOT_MUTATION`
+   * fields from the cache after each mutation finishes. If you need this
+   * information to remain in the cache, you can prevent the removal by passing
+   * `keepRootFields: true` to the mutation. `ROOT_MUTATION` result data are
+   * also passed to the mutation `update` function, so we recommend obtaining
+   * the results that way, rather than using this option, if possible.
+   */
+  keepRootFields?: boolean;
 }

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -270,6 +270,18 @@ export interface MutationBaseOptions<
    * GraphQL document to that variable's value.
    */
   variables?: TVariables;
+
+  /**
+   * The context to be passed to the link execution chain. This context will
+   * only be used with this mutation. It will not be used with
+   * `refetchQueries`. Refetched queries use the context they were
+   * initialized with (since the intitial context is stored as part of the
+   * `ObservableQuery` instance). If a specific context is needed when
+   * refetching queries, make sure it is configured (via the
+   * [query `context` option](https://www.apollographql.com/docs/react/api/apollo-client#ApolloClient.query))
+   * when the query is first initialized/run.
+   */
+   context?: TContext;
 }
 
 export interface MutationOptions<
@@ -283,18 +295,6 @@ export interface MutationOptions<
    * package, that contains a single mutation inside of it.
    */
   mutation: DocumentNode | TypedDocumentNode<TData, TVariables>;
-
-  /**
-   * The context to be passed to the link execution chain. This context will
-   * only be used with the mutation. It will not be used with
-   * `refetchQueries`. Refetched queries use the context they were
-   * initialized with (since the intitial context is stored as part of the
-   * `ObservableQuery` instance). If a specific context is needed when
-   * refetching queries, make sure it is configured (via the
-   * [`query` `context` option](https://www.apollographql.com/docs/react/api/apollo-client#ApolloClient.query))
-   * when the query is first initialized/run.
-   */
-  context?: TContext;
 
   /**
    * Specifies the {@link FetchPolicy} to be used for this query. Mutations only

--- a/src/react/components/Mutation.tsx
+++ b/src/react/components/Mutation.tsx
@@ -30,5 +30,5 @@ Mutation.propTypes = {
   children: PropTypes.func.isRequired,
   onCompleted: PropTypes.func,
   onError: PropTypes.func,
-  fetchPolicy: PropTypes.string
-};
+  fetchPolicy: PropTypes.string,
+} as Mutation<any, any>["propTypes"];

--- a/src/react/components/Query.tsx
+++ b/src/react/components/Query.tsx
@@ -29,4 +29,4 @@ Query.propTypes = {
   ssr: PropTypes.bool,
   partialRefetch: PropTypes.bool,
   returnPartialData: PropTypes.bool
-};
+} as Query<any, any>["propTypes"];

--- a/src/react/components/Subscription.tsx
+++ b/src/react/components/Subscription.tsx
@@ -22,4 +22,4 @@ Subscription.propTypes = {
   onSubscriptionData: PropTypes.func,
   onSubscriptionComplete: PropTypes.func,
   shouldResubscribe: PropTypes.oneOfType([PropTypes.func, PropTypes.bool])
-};
+} as Subscription<any, any>["propTypes"];

--- a/src/react/hoc/__tests__/mutations/queries.test.tsx
+++ b/src/react/hoc/__tests__/mutations/queries.test.tsx
@@ -175,11 +175,6 @@ describe('graphql(mutation) query integration', () => {
           this.props.mutate!().then(result => {
             expect(stripSymbols(result && result.data)).toEqual(mutationData);
           });
-
-          const dataInStore = cache.extract(true);
-          expect(stripSymbols(dataInStore.ROOT_MUTATION!.createTodo)).toEqual(
-            optimisticResponse.createTodo
-          );
           return null;
         }
 

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -10,17 +10,14 @@ import {
   ApolloClient,
   ApolloQueryResult,
   DefaultContext,
-  ErrorPolicy,
   FetchMoreOptions,
   FetchMoreQueryOptions,
   FetchPolicy,
-  MutationUpdaterFunction,
+  MutationOptions,
   NetworkStatus,
   ObservableQuery,
   OperationVariables,
   PureQueryOptions,
-  OnQueryUpdated,
-  WatchQueryFetchPolicy,
   WatchQueryOptions,
 } from '../../core';
 
@@ -147,24 +144,14 @@ export interface BaseMutationOptions<
   TVariables extends OperationVariables,
   TContext extends DefaultContext,
   TCache extends ApolloCache<any>,
+> extends Omit<
+  MutationOptions<TData, TVariables, TContext, TCache>,
+  | "mutation"
 > {
-  variables?: TVariables;
-  optimisticResponse?: TData | ((vars: TVariables) => TData);
-  refetchQueries?: Array<string | PureQueryOptions> | RefetchQueriesFunction;
-  awaitRefetchQueries?: boolean;
-  errorPolicy?: ErrorPolicy;
-  update?: MutationUpdaterFunction<TData, TVariables, TContext, TCache>;
-  // Use OnQueryUpdated<any> instead of OnQueryUpdated<TData> here because TData
-  // is the shape of the mutation result, but onQueryUpdated gets called with
-  // results from any queries affected by the mutation update function, which
-  // probably do not have the same shape as the mutation result.
-  onQueryUpdated?: OnQueryUpdated<any>;
   client?: ApolloClient<object>;
   notifyOnNetworkStatusChange?: boolean;
-  context?: TContext;
   onCompleted?: (data: TData) => void;
   onError?: (error: ApolloError) => void;
-  fetchPolicy?: Extract<WatchQueryFetchPolicy, 'no-cache'>;
   ignoreResults?: boolean;
 }
 
@@ -173,19 +160,8 @@ export interface MutationFunctionOptions<
   TVariables,
   TContext,
   TCache extends ApolloCache<any>,
-> {
-  variables?: TVariables;
-  optimisticResponse?: TData | ((vars: TVariables) => TData);
-  refetchQueries?: Array<string | PureQueryOptions> | RefetchQueriesFunction;
-  awaitRefetchQueries?: boolean;
-  update?: MutationUpdaterFunction<TData, TVariables, TContext, TCache>;
-  // Use OnQueryUpdated<any> instead of OnQueryUpdated<TData> here because TData
-  // is the shape of the mutation result, but onQueryUpdated gets called with
-  // results from any queries affected by the mutation update function, which
-  // probably do not have the same shape as the mutation result.
-  onQueryUpdated?: OnQueryUpdated<any>;
-  context?: TContext;
-  fetchPolicy?: WatchQueryFetchPolicy;
+> extends BaseMutationOptions<TData, TVariables, TContext, TCache> {
+  mutation?: DocumentNode | TypedDocumentNode<TData, TVariables>;
 }
 
 export interface MutationResult<TData = any> {
@@ -219,8 +195,7 @@ export interface MutationDataOptions<
   TVariables extends OperationVariables,
   TContext extends DefaultContext,
   TCache extends ApolloCache<any>,
->
-  extends BaseMutationOptions<TData, TVariables, TContext, TCache> {
+> extends BaseMutationOptions<TData, TVariables, TContext, TCache> {
   mutation: DocumentNode | TypedDocumentNode<TData, TVariables>;
 }
 


### PR DESCRIPTION
Fixes #7665 by allowing [field policy `read` functions](https://www.apollographql.com/docs/react/caching/cache-field-behavior/#the-read-function) to run for fields within mutation results, making it easier for mutation result data to use custom scalar types (to borrow @stephenh's use case from #7665).

In order to keep each `ROOT_MUTATION` write isolated from others that might be happening at the same time, this PR also removes the temporary `ROOT_MUTATION` object from the cache immediately after the `update` function runs, so information like arguments passed to mutation root fields will not be retained in the cache longer than need be, thereby resolving #3592. To be clear, the Apollo Client team does not believe the previous behavior of leaving `ROOT_MUTATION` in the cache created any meaningful opportunities for attackers to read cached data, but we believe in [defense in depth](https://en.wikipedia.org/wiki/Defense_in_depth_(computing)) and agree with the principles articulated by @danilobuerger in https://github.com/apollographql/apollo-client/issues/3592#issuecomment-398278906.

The removal/impermanence of `ROOT_MUTATION` could be a disruptive change for anyone who depends on reading `ROOT_MUTATION` data from the cache after the mutation has finished, but that's not encouraged or well supported right now, so we think/hope the potential disruption is justified in order to achieve better security by default. We can revisit this before Apollo Client v3.4 is released, if anyone reports problems.