### PR TITLE
Re-export the MockedResponse ResultFunction type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
   })
   ```
   [@benjamn](https://github.com/benjamn) in [#7810](https://github.com/apollographql/apollo-client/pull/7810)
+- Make sure the `MockedResponse` `ResultFunction` type is re-exported.  <br/>
+  [@hwillson](https://github.com/hwillson) in [#8315](https://github.com/apollographql/apollo-client/pull/8315)
 
 ### Potentially breaking changes
 

--- a/src/utilities/testing/index.ts
+++ b/src/utilities/testing/index.ts
@@ -1,5 +1,10 @@
 export { MockedProvider, MockedProviderProps } from './mocking/MockedProvider';
-export { MockLink, mockSingleLink, MockedResponse } from './mocking/mockLink';
+export {
+  MockLink,
+  mockSingleLink,
+  MockedResponse,
+  ResultFunction
+} from './mocking/mockLink';
 export {
   MockSubscriptionLink,
   mockObservableLink


### PR DESCRIPTION
This addresses a regression that happened when AC 3 was launched.

Fixes #6540