### PR TITLE
Update rollup to version 2.50.5

### DIFF
--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -7,15 +7,41 @@ const entryPoints = require('./entryPoints');
 
 const distDir = './dist';
 
-function isExternal(id) {
-  return !(id.startsWith("./") || id.startsWith("../"));
+function isExternal(id, parentId, entryPointsAreExternal = true) {
+  // Rollup v2.26.8 started passing absolute id strings to this function, thanks
+  // apparently to https://github.com/rollup/rollup/pull/3753, so we relativize
+  // the id again in those cases.
+  if (path.posix.isAbsolute(id)) {
+    id = path.posix.relative(
+      path.posix.dirname(parentId),
+      id,
+    );
+    if (!id.startsWith(".")) {
+      id = "./" + id;
+    }
+  }
+
+  const isRelative =
+    id.startsWith("./") ||
+    id.startsWith("../");
+
+  if (!isRelative) {
+    return true;
+  }
+
+  if (entryPointsAreExternal &&
+      entryPoints.check(id, parentId)) {
+    return true;
+  }
+
+  return false;
 }
 
 function prepareCJS(input, output) {
   return {
     input,
-    external(id) {
-      return isExternal(id);
+    external(id, parentId) {
+      return isExternal(id, parentId, false);
     },
     output: {
       file: output,
@@ -62,7 +88,7 @@ function prepareBundle({
   return {
     input: `${dir}/index.js`,
     external(id, parentId) {
-      return isExternal(id) || entryPoints.check(id, parentId);
+      return isExternal(id, parentId, true);
     },
     output: {
       file: `${dir}/${bundleName}.cjs.js`,

--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -95,6 +95,7 @@ function prepareBundle({
       format: 'cjs',
       sourcemap: true,
       exports: 'named',
+      interop: 'esModule',
       externalLiveBindings: false,
       // In Node.js, where these CommonJS bundles are most commonly used,
       // the expression process.env.NODE_ENV can be very expensive to

--- a/package-lock.json
+++ b/package-lock.json
@@ -1672,12 +1672,6 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
-    "@types/estree": {
-      "version": "0.0.42",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.42.tgz",
-      "integrity": "sha512-K1DPVvnBCPxzD+G51/cxVIoc2X8uUVl1zpJeE6iKcgHMj4+tbat5Xu4TjV7v2QSDbIeAfLi2hIk+u2+s0MlpUQ==",
-      "dev": true
-    },
     "@types/fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -8173,21 +8167,20 @@
       }
     },
     "rollup": {
-      "version": "1.31.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.31.1.tgz",
-      "integrity": "sha512-2JREN1YdrS/kpPzEd33ZjtuNbOuBC3ePfuZBdKEybvqcEcszW1ckyVqzcEiEe0nE8sqHK+pbJg+PsAgRJ8+1dg==",
+      "version": "2.50.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.50.5.tgz",
+      "integrity": "sha512-Ztz4NurU2LbS3Jn5rlhnYv35z6pkjBUmYKr94fOBIKINKRO6kug9NTFHArT7jqwMP2kqEZ39jJuEtkk91NBltQ==",
       "dev": true,
       "requires": {
-        "@types/estree": "*",
-        "@types/node": "*",
-        "acorn": "^7.1.0"
+        "fsevents": "~2.3.1"
       },
       "dependencies": {
-        "acorn": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-          "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
-          "dev": true
+        "fsevents": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "recompose": "0.30.0",
     "resolve": "1.20.0",
     "rimraf": "3.0.2",
-    "rollup": "1.31.1",
+    "rollup": "2.50.5",
     "rollup-plugin-terser": "7.0.2",
     "rxjs": "6.6.7",
     "subscriptions-transport-ws": "0.9.18",

--- a/src/__tests__/__snapshots__/exports.ts.snap
+++ b/src/__tests__/__snapshots__/exports.ts.snap
@@ -351,6 +351,7 @@ Array [
   "isField",
   "isInlineFragment",
   "isNonEmptyArray",
+  "isNonNullObject",
   "isReference",
   "iterateObserversSafely",
   "makeReference",

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -12,6 +12,7 @@ import {
   DeepMerger,
   maybeDeepFreeze,
   canUseWeakMap,
+  isNonNullObject,
 } from '../../utilities';
 import { NormalizedCache, NormalizedCacheObject } from './types';
 import { hasOwn, fieldNameFromStoreName } from './helpers';
@@ -419,15 +420,14 @@ export abstract class EntityStore implements NormalizedCache {
       const workSet = new Set([this.data[dataId]]);
       // Within the store, only arrays and objects can contain child entity
       // references, so we can prune the traversal using this predicate:
-      const canTraverse = (obj: any) => obj !== null && typeof obj === 'object';
       workSet.forEach(obj => {
         if (isReference(obj)) {
           found[obj.__ref] = true;
-        } else if (canTraverse(obj)) {
+        } else if (isNonNullObject(obj)) {
           Object.values(obj!)
             // No need to add primitive values to the workSet, since they cannot
             // contain reference objects.
-            .filter(canTraverse)
+            .filter(isNonNullObject)
             .forEach(workSet.add, workSet);
         }
       });

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -1,5 +1,5 @@
 import { dep, OptimisticDependencyFunction } from 'optimism';
-import invariant from 'ts-invariant';
+import { invariant } from 'ts-invariant';
 import { equal } from '@wry/equality';
 import { Trie } from '@wry/trie';
 

--- a/src/cache/inmemory/helpers.ts
+++ b/src/cache/inmemory/helpers.ts
@@ -10,6 +10,7 @@ import {
   DeepMerger,
   resultKeyNameFromField,
   shouldInclude,
+  isNonNullObject,
 } from '../../utilities';
 
 export const {
@@ -37,7 +38,7 @@ export function selectionSetMatchesResult(
   result: Record<string, any>,
   variables?: Record<string, any>,
 ): boolean {
-  if (result && typeof result === "object") {
+  if (isNonNullObject(result)) {
     return Array.isArray(result)
       ? result.every(item => selectionSetMatchesResult(selectionSet, item, variables))
       : selectionSet.selections.every(field => {
@@ -61,8 +62,7 @@ export function selectionSetMatchesResult(
 export function storeValueIsStoreObject(
   value: StoreValue,
 ): value is StoreObject {
-  return value !== null &&
-    typeof value === "object" &&
+  return isNonNullObject(value) &&
     !isReference(value) &&
     !Array.isArray(value);
 }

--- a/src/cache/inmemory/object-canon.ts
+++ b/src/cache/inmemory/object-canon.ts
@@ -1,9 +1,8 @@
 import { Trie } from "@wry/trie";
-import { canUseWeakMap } from "../../utilities";
-
-function isObjectOrArray(value: any): value is object {
-  return !!value && typeof value === "object";
-}
+import {
+  canUseWeakMap,
+  isNonNullObject as isObjectOrArray,
+} from "../../utilities";
 
 function shallowCopy<T>(value: T): T {
   if (isObjectOrArray(value)) {

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -22,6 +22,7 @@ import {
   getStoreKeyName,
   canUseWeakMap,
   compact,
+  isNonNullObject,
 } from '../../utilities';
 import {
   IdGetter,
@@ -911,8 +912,8 @@ function makeMergeObjectsFunction(
     // custom merge function can easily have the any type, so the type
     // system cannot always enforce the StoreObject | Reference parameter
     // types of options.mergeObjects.
-    if (existing && typeof existing === "object" &&
-        incoming && typeof incoming === "object") {
+    if (isNonNullObject(existing) &&
+        isNonNullObject(incoming)) {
       const eType = store.getFieldValue(existing, "__typename");
       const iType = store.getFieldValue(incoming, "__typename");
       const typesDiffer = eType && iType && eType !== iType;

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -24,6 +24,7 @@ import {
   mergeDeepArray,
   getFragmentFromSelection,
   maybeDeepFreeze,
+  isNonNullObject,
 } from '../../utilities';
 import { Cache } from '../core/types/Cache';
 import {
@@ -500,7 +501,7 @@ function assertSelectionSetForIdValue(
   if (!field.selectionSet) {
     const workSet = new Set([fieldValue]);
     workSet.forEach(value => {
-      if (value && typeof value === "object") {
+      if (isNonNullObject(value)) {
         invariant(
           !isReference(value),
           `Missing selection set for object of type ${

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -21,6 +21,7 @@ import {
   ConcastSourcesIterable,
   makeUniqueId,
   isDocumentNode,
+  isNonNullObject,
 } from '../utilities';
 import { ApolloError, isApolloError } from '../errors';
 import {
@@ -1223,7 +1224,7 @@ export class QueryManager<TStore> {
 
         if (typeof desc === "string" || isDocumentNode(desc)) {
           fallback = () => oq!.refetch();
-        } else if (desc && typeof desc === "object") {
+        } else if (isNonNullObject(desc)) {
           const options = {
             ...desc,
             fetchPolicy: "network-only",

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -103,7 +103,7 @@ setVerbosity("log");
 // then re-exporting them separately, helps keeps bundlers happy without any
 // additional config changes.
 export {
-  default as gql,
+  gql,
   resetCaches,
   disableFragmentWarnings,
   enableExperimentalFragmentVariables,

--- a/src/utilities/common/maybeDeepFreeze.ts
+++ b/src/utilities/common/maybeDeepFreeze.ts
@@ -1,16 +1,13 @@
 import { isDevelopment, isTest } from './environment';
-
-function isObject(value: any) {
-  return value !== null && typeof value === "object";
-}
+import { isNonNullObject } from './objects';
 
 function deepFreeze(value: any) {
   const workSet = new Set([value]);
   workSet.forEach(obj => {
-    if (isObject(obj)) {
+    if (isNonNullObject(obj)) {
       if (!Object.isFrozen(obj)) Object.freeze(obj);
       Object.getOwnPropertyNames(obj).forEach(name => {
-        if (isObject(obj[name])) workSet.add(obj[name]);
+        if (isNonNullObject(obj[name])) workSet.add(obj[name]);
       });
     }
   });

--- a/src/utilities/common/mergeDeep.ts
+++ b/src/utilities/common/mergeDeep.ts
@@ -1,3 +1,5 @@
+import { isNonNullObject } from "./objects";
+
 const { hasOwnProperty } = Object.prototype;
 
 // These mergeDeep and mergeDeepArray utilities merge any number of objects
@@ -46,10 +48,6 @@ export function mergeDeepArray<T>(sources: T[]): T {
   return target;
 }
 
-function isObject(obj: any): obj is Record<string | number, any> {
-  return obj !== null && typeof obj === 'object';
-}
-
 export type ReconcilerFunction<TContextArgs extends any[]> = (
   this: DeepMerger<TContextArgs>,
   target: Record<string | number, any>,
@@ -69,7 +67,7 @@ export class DeepMerger<TContextArgs extends any[]> {
   ) {}
 
   public merge(target: any, source: any, ...context: TContextArgs): any {
-    if (isObject(source) && isObject(target)) {
+    if (isNonNullObject(source) && isNonNullObject(target)) {
       Object.keys(source).forEach(sourceKey => {
         if (hasOwnProperty.call(target, sourceKey)) {
           const targetValue = target[sourceKey];
@@ -97,12 +95,12 @@ export class DeepMerger<TContextArgs extends any[]> {
     return source;
   }
 
-  public isObject = isObject;
+  public isObject = isNonNullObject;
 
   private pastCopies = new Set<any>();
 
   public shallowCopyForMerge<T>(value: T): T {
-    if (isObject(value) && !this.pastCopies.has(value)) {
+    if (isNonNullObject(value) && !this.pastCopies.has(value)) {
       if (Array.isArray(value)) {
         value = (value as any).slice(0);
       } else {

--- a/src/utilities/common/objects.ts
+++ b/src/utilities/common/objects.ts
@@ -1,0 +1,3 @@
+export function isNonNullObject(obj: any): obj is Record<string | number, any> {
+  return obj !== null && typeof obj === 'object';
+}

--- a/src/utilities/graphql/storeUtils.ts
+++ b/src/utilities/graphql/storeUtils.ts
@@ -19,6 +19,7 @@ import {
 } from 'graphql';
 
 import { InvariantError } from 'ts-invariant';
+import { isNonNullObject } from '../common/objects';
 import { FragmentMap, getFragmentFromSelection } from './fragments';
 
 export interface Reference {
@@ -51,8 +52,7 @@ export interface StoreObject {
 
 export function isDocumentNode(value: any): value is DocumentNode {
   return (
-    value !== null &&
-    typeof value === "object" &&
+    isNonNullObject(value) &&
     (value as DocumentNode).kind === "Document" &&
     Array.isArray((value as DocumentNode).definitions)
   );
@@ -256,7 +256,7 @@ let stringify = function defaultStringify(value: any): string {
 };
 
 function stringifyReplacer(_key: string, value: any): any {
-  if (value && typeof value === "object" && !Array.isArray(value)) {
+  if (isNonNullObject(value) && !Array.isArray(value)) {
     value = Object.keys(value).sort().reduce((copy, key) => {
       copy[key] = value[key];
       return copy;

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -84,6 +84,7 @@ export * from './observables/asyncMap';
 export * from './observables/Concast';
 export * from './observables/subclassing';
 export * from './common/arrays';
+export * from './common/objects';
 export * from './common/errorHandling';
 export * from './common/canUse';
 export * from './common/compact';


### PR DESCRIPTION
It appears our closing of this old [@renovate PR to update Rollup to v2](https://github.com/apollographql/apollo-client/pull/6033) caused @renovate to stop opening PRs to update Rollup to any v2.x.y version, so our version of Rollup has been out of date since then.

Though obviously not ideal, this major version lag hasn't been a problem for us because Rollup v1 still works very well, and we use it only to generate CommonJS bundles, which is a relatively stable build target (CommonJS hasn't changed much lately). We rely on other tools like `tsc` for critical stuff like TypeScript compilation, and we have numerous ways to verify the output of our build system. With that said, Rollup v2 has some great new features that I'm looking forward to trying, such as `output.inlineDynamicImports`!

To verify these changes, I compared the output of the build system before and after this upgrade (taking f76ec87b83e51c2a3375ab0f4412b65ff37da599 and 2ae6ddd68b3d7bb61f878060b6127903a6764e9c as given/prior):
```diff
diff --git a/@apollo/client/apollo-client.cjs.js b/@apollo/client/apollo-client.cjs.js
index 65e3dc0..16a05c0 100644
--- a/@apollo/client/apollo-client.cjs.js
+++ b/@apollo/client/apollo-client.cjs.js
@@ -4,13 +4,13 @@ Object.defineProperty(exports, '__esModule', { value: true });
 
 var tslib = require('tslib');
 var tsInvariant = require('ts-invariant');
-var graphql = require('graphql');
+var equality = require('@wry/equality');
 var zenObservableTs = require('zen-observable-ts');
 require('symbol-observable');
-var equality = require('@wry/equality');
+var graphql = require('graphql');
 var optimism = require('optimism');
-var trie = require('@wry/trie');
 var context = require('@wry/context');
+var trie = require('@wry/trie');
 var graphqlTag = require('graphql-tag');
 
 function shouldInclude(_a, variables) {
@@ -681,7 +681,7 @@ function isNonNullObject(obj) {
     return obj !== null && typeof obj === 'object';
 }
 
-var hasOwnProperty = Object.prototype.hasOwnProperty;
+var hasOwnProperty$2 = Object.prototype.hasOwnProperty;
 function mergeDeep() {
     var sources = [];
     for (var _i = 0; _i < arguments.length; _i++) {
@@ -718,7 +718,7 @@ var DeepMerger = (function () {
         }
         if (isNonNullObject(source) && isNonNullObject(target)) {
             Object.keys(source).forEach(function (sourceKey) {
-                if (hasOwnProperty.call(target, sourceKey)) {
+                if (hasOwnProperty$2.call(target, sourceKey)) {
                     var targetValue = target[sourceKey];
                     if (source[sourceKey] !== targetValue) {
                         var result = _this.reconciler.apply(_this, tslib.__spreadArrays([target, source, sourceKey], context));
@@ -1588,6 +1588,7 @@ var ApolloCache = (function () {
     return ApolloCache;
 }());
 
+exports.Cache = void 0;
 (function (Cache) {
 })(exports.Cache || (exports.Cache = {}));
 
@@ -3548,6 +3549,7 @@ var ApolloError = (function (_super) {
     return ApolloError;
 }(Error));
 
+exports.NetworkStatus = void 0;
 (function (NetworkStatus) {
     NetworkStatus[NetworkStatus["loading"] = 1] = "loading";
     NetworkStatus[NetworkStatus["setVariables"] = 2] = "setVariables";
@@ -4519,7 +4521,7 @@ function shouldWriteResult(result, errorPolicy) {
     return writeWithErrors;
 }
 
-var hasOwnProperty$2 = Object.prototype.hasOwnProperty;
+var hasOwnProperty = Object.prototype.hasOwnProperty;
 var QueryManager = (function () {
     function QueryManager(_a) {
         var cache = _a.cache, link = _a.link, _b = _a.queryDeduplication, queryDeduplication = _b === void 0 ? false : _b, onBroadcast = _a.onBroadcast, _c = _a.ssrMode, ssrMode = _c === void 0 ? false : _c, _d = _a.clientAwareness, clientAwareness = _d === void 0 ? {} : _d, localState = _a.localState, assumeImmutableResults = _a.assumeImmutableResults;
@@ -4670,7 +4672,7 @@ var QueryManager = (function () {
                 this.queries.forEach(function (_a, queryId) {
                     var observableQuery = _a.observableQuery;
                     var queryName = observableQuery && observableQuery.queryName;
-                    if (!queryName || !hasOwnProperty$2.call(updateQueries_1, queryName)) {
+                    if (!queryName || !hasOwnProperty.call(updateQueries_1, queryName)) {
                         return;
                     }
                     var updater = updateQueries_1[queryName];
```
All of these changes seem harmless/fine/good to me!