### PR TITLE
Deep merge toBeAdded type policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Apollo Client 3.3.20 (not yet released)
+
+### Bug fixes
+
+- Fix policy merging bug when calling `cache.policies.addTypePolicies` multiple times for the same type policy. <br/>
+  [@Banou26](https://github.com/Banou26) in [#8361](https://github.com/apollographql/apollo-client/pull/8361)
+
 ## Apollo Client 3.3.19
 
 ### Bug fixes

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -318,6 +318,29 @@ describe("type policies", function () {
     })).toBe("MotionPicture::3993d4118143");
   });
 
+  it.only("does not remove previous typePolicies", function () {
+    const cache = new InMemoryCache({
+      typePolicies: {
+        Query: {
+          fields: {
+            foo: () => 'foo'
+          }
+        },
+      },
+    });
+
+    cache.policies.addTypePolicies({
+      Query: {
+        fields: {
+          bar: () => 'bar'
+        }
+      },
+    });
+
+    expect(cache.readQuery({ query: gql` { foo } ` })).toEqual({foo: "foo"});
+    expect(cache.readQuery({ query: gql` { bar } ` })).toEqual({bar: "bar"});
+  });
+
   it("support inheritance", function () {
     const cache = new InMemoryCache({
       possibleTypes: {

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -318,7 +318,7 @@ describe("type policies", function () {
     })).toBe("MotionPicture::3993d4118143");
   });
 
-  it.only("does not remove previous typePolicies", function () {
+  it("does not remove previous typePolicies", function () {
     const cache = new InMemoryCache({
       typePolicies: {
         Query: {

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -21,7 +21,7 @@ import {
   isReference,
   getStoreKeyName,
   canUseWeakMap,
-  compact,
+  mergeDeep,
 } from '../../utilities';
 import { IdGetter, ReadMergeModifyContext, MergeInfo } from "./types";
 import {
@@ -545,7 +545,7 @@ export class Policies {
 
     const inbox = this.toBeAdded[typename];
     if (inbox && inbox.length) {
-      this.updateTypePolicy(typename, compact(...inbox.splice(0)));
+      this.updateTypePolicy(typename, mergeDeep(...inbox.splice(0)));
     }
 
     return this.typePolicies[typename];

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -21,7 +21,6 @@ import {
   isReference,
   getStoreKeyName,
   canUseWeakMap,
-  mergeDeep,
 } from '../../utilities';
 import { IdGetter, ReadMergeModifyContext, MergeInfo } from "./types";
 import {
@@ -545,7 +544,11 @@ export class Policies {
 
     const inbox = this.toBeAdded[typename];
     if (inbox && inbox.length) {
-      this.updateTypePolicy(typename, mergeDeep(...inbox.splice(0)));
+      // Merge the pending policies into this.typePolicies, in the order they
+      // were originally passed to addTypePolicy.
+      inbox.splice(0).forEach(policy => {
+        this.updateTypePolicy(typename, policy);
+      });
     }
 
     return this.typePolicies[typename];


### PR DESCRIPTION
Fix https://github.com/apollographql/apollo-client/issues/7535

This PR deep-merge `toBeAdded` typePolicies instead of shallowly merging them

cc @brainkim 
