### PR TITLE
Merge incoming fragment fields before running `merge` functions and updating the `EntityStore`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@
 - Fix polling when used with `skip`. <br/>
   [@brainkim](https://github.com/brainkim) in [#8346](https://github.com/apollographql/apollo-client/pull/8346)
 
+- `InMemoryCache` now coalesces `EntityStore` updates to guarantee only one `store.merge(id, fields)` call per `id` per cache write. <br/>
+  [@benjamn](https://github.com/benjamn) in [#8372](https://github.com/apollographql/apollo-client/pull/8372)
+
 ### Potentially breaking changes
 
 - To avoid retaining sensitive information from mutation root field arguments, Apollo Client v3.4 automatically clears any `ROOT_MUTATION` fields from the cache after each mutation finishes. If you need this information to remain in the cache, you can prevent the removal by passing the `keepRootFields: true` option to `client.mutate`. `ROOT_MUTATION` result data are also passed to the mutation `update` function, so we recommend obtaining the results that way, rather than using `keepRootFields: true`, if possible. <br/>

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     {
       "name": "apollo-client",
       "path": "./dist/apollo-client.cjs.min.js",
-      "maxSize": "24.3 kB"
+      "maxSize": "24.5 kB"
     }
   ],
   "peerDependencies": {

--- a/src/cache/inmemory/__tests__/__snapshots__/writeToStore.ts.snap
+++ b/src/cache/inmemory/__tests__/__snapshots__/writeToStore.ts.snap
@@ -69,6 +69,35 @@ Object {
 }
 `;
 
+exports[`writing to the store should respect id fields added by fragments 1`] = `
+Object {
+  "AType:a-id": Object {
+    "__typename": "AType",
+    "b": Array [
+      Object {
+        "__ref": "BType:b-id",
+      },
+    ],
+    "id": "a-id",
+  },
+  "BType:b-id": Object {
+    "__typename": "BType",
+    "c": Object {
+      "__typename": "CType",
+      "title": "Your experience",
+      "titleSize": null,
+    },
+    "id": "b-id",
+  },
+  "ROOT_QUERY": Object {
+    "__typename": "Query",
+    "a": Object {
+      "__ref": "AType:a-id",
+    },
+  },
+}
+`;
+
 exports[`writing to the store user objects should be able to have { __typename: "Mutation" } 1`] = `
 Object {
   "Gene:{\\"id\\":\\"SLC45A2\\"}": Object {

--- a/src/cache/inmemory/__tests__/__snapshots__/writeToStore.ts.snap
+++ b/src/cache/inmemory/__tests__/__snapshots__/writeToStore.ts.snap
@@ -34,6 +34,41 @@ Object {
 }
 `;
 
+exports[`writing to the store correctly merges fragment fields along multiple paths 1`] = `
+Object {
+  "Item:0f47f85d-8081-466e-9121-c94069a77c3e": Object {
+    "__typename": "Item",
+    "id": "0f47f85d-8081-466e-9121-c94069a77c3e",
+    "value": Object {
+      "__typename": "Container",
+      "value": Object {
+        "__typename": "Value",
+        "item": Object {
+          "__ref": "Item:6dc3530b-6731-435e-b12a-0089d0ae05ac",
+        },
+      },
+    },
+  },
+  "Item:6dc3530b-6731-435e-b12a-0089d0ae05ac": Object {
+    "__typename": "Item",
+    "id": "6dc3530b-6731-435e-b12a-0089d0ae05ac",
+    "value": Object {
+      "__typename": "Container",
+      "text": "Hello World",
+      "value": Object {
+        "__typename": "Value",
+      },
+    },
+  },
+  "ROOT_QUERY": Object {
+    "__typename": "Query",
+    "item({\\"id\\":\\"123\\"})": Object {
+      "__ref": "Item:0f47f85d-8081-466e-9121-c94069a77c3e",
+    },
+  },
+}
+`;
+
 exports[`writing to the store user objects should be able to have { __typename: "Mutation" } 1`] = `
 Object {
   "Gene:{\\"id\\":\\"SLC45A2\\"}": Object {

--- a/src/cache/inmemory/__tests__/writeToStore.ts
+++ b/src/cache/inmemory/__tests__/writeToStore.ts
@@ -1484,6 +1484,63 @@ describe('writing to the store', () => {
     expect(cache.extract()).toMatchSnapshot();
   });
 
+  it('should respect id fields added by fragments', () => {
+    const query = gql`
+      query ABCQuery {
+        __typename
+        a {
+          __typename
+          id
+          ...SharedFragment
+          b {
+            __typename
+            c {
+              __typename
+              title
+              titleSize
+            }
+          }
+        }
+      }
+      fragment SharedFragment on AShared {
+        __typename
+        b {
+          __typename
+          id
+          c {
+            __typename
+          }
+        }
+      }
+    `;
+
+    const data = {
+      __typename: "Query",
+      a: {
+        __typename: "AType",
+        id: "a-id",
+        b: [{
+          __typename: "BType",
+          id: "b-id",
+          c: {
+            __typename: "CType",
+            title: "Your experience",
+            titleSize: null
+          },
+        }],
+      },
+    };
+
+    const cache = new InMemoryCache({
+      possibleTypes: { AShared: ["AType"] }
+    });
+
+    cache.writeQuery({ query, data });
+    expect(cache.readQuery({ query })).toEqual(data);
+
+    expect(cache.extract()).toMatchSnapshot();
+  });
+
   it('should allow a union of objects of a different type, when overwriting a generated id with a real id', () => {
     const dataWithPlaceholder = {
       author: {

--- a/src/cache/inmemory/__tests__/writeToStore.ts
+++ b/src/cache/inmemory/__tests__/writeToStore.ts
@@ -1402,6 +1402,88 @@ describe('writing to the store', () => {
     });
   });
 
+  it('correctly merges fragment fields along multiple paths', () => {
+    const cache = new InMemoryCache({
+      typePolicies: {
+        Container: {
+          // Uncommenting this line fixes the test, but should not be necessary,
+          // since the Container response object in question has the same
+          // identity along both paths.
+          // merge: true,
+        },
+      },
+    });
+
+    const query = gql`
+      query Query {
+        item(id: "123") {
+          id
+          value {
+            ...ContainerFragment
+          }
+        }
+      }
+
+      fragment ContainerFragment on Container {
+        value {
+          ...ValueFragment
+          item {
+            id
+            value {
+              text
+            }
+          }
+        }
+      }
+
+      fragment ValueFragment on Value {
+        item {
+          ...ItemFragment
+        }
+      }
+
+      fragment ItemFragment on Item {
+        value {
+          value {
+            __typename
+          }
+        }
+      }
+    `;
+
+    const data = {
+      item: {
+        __typename: "Item",
+        id: "0f47f85d-8081-466e-9121-c94069a77c3e",
+        value: {
+          __typename: "Container",
+          value: {
+            __typename: "Value",
+            item: {
+              __typename: "Item",
+              id: "6dc3530b-6731-435e-b12a-0089d0ae05ac",
+              value: {
+                __typename: "Container",
+                text: "Hello World",
+                value: {
+                  __typename: "Value"
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    cache.writeQuery({
+      query,
+      data,
+    });
+
+    expect(cache.readQuery({ query })).toEqual(data);
+    expect(cache.extract()).toMatchSnapshot();
+  });
+
   it('should allow a union of objects of a different type, when overwriting a generated id with a real id', () => {
     const dataWithPlaceholder = {
       author: {


### PR DESCRIPTION
Fixes #8370 by postponing all `context.store.merge` updates until after all `processSelectionSet` work is done, performing the store updates at the end of `StoreWriter#writeToStore`, whereas previously those updates happened at the end of each `StoreWriter#processSelectionSet` call.

The postponement of store updates gives the `StoreWriter` a chance to merge together multiple partial objects representing the same logical object (possibly matched by different fragments along different query paths), before running `merge` functions with `applyMerges`.

Previously, those partial objects would be merged separately into `context.store`, so later objects might replace earlier objects in cases where the objects are unidentifiable/non-normalized, and there was no `merge` function (or `merge: true` shorthand) to force the objects to merge.

Of course, you could configure `merge: true` to explicitly permit merging unidentified objects with a given `__typename`. Configuring `merge: true` for the `Container` type seems to fixes the reproduction in #8370. But this explicit configuration should not be necessary when we know the objects in question represent the same logical object, because they were derived from the same incoming result object (same ID, not necessarily `===` objects).

In other words, this PR should wipe out a whole class of situations where we used to show `Cache data may be lost...` warnings, since we can now safely merge the fields of unidentifiable objects that share the same original result object, without requiring an explicit `merge: true` configuration to permit that mixing of fields.