### PR TITLE
Add `updateQuery` and `updateFragment` methods to `ApolloCache`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Apollo Client 3.5.0 (not yet released)
 
+### Improvements
+
+- Add `updateQuery` and `updateFragment` methods to `ApolloCache`, simplifying common `readQuery`/`writeQuery` cache update patterns. <br/>
+  [@wassim-k](https://github.com/wassim-k) in [#8382](https://github.com/apollographql/apollo-client/pull/8382)
+
 ### React Refactoring
 
 #### Bug Fixes (due to [@brainkim](https://github.com/brainkim) in [#8596](https://github.com/apollographql/apollo-client/pull/8596)):

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     {
       "name": "apollo-client",
       "path": "./temp/bundlesize.min.cjs",
-      "maxSize": "24.7 kB"
+      "maxSize": "24.75 kB"
     }
   ],
   "engines": {

--- a/src/cache/core/__tests__/cache.ts
+++ b/src/cache/core/__tests__/cache.ts
@@ -1,5 +1,5 @@
 import gql from 'graphql-tag';
-import { ApolloCache  } from '../cache';
+import { ApolloCache } from '../cache';
 import { Cache, DataProxy } from '../..';
 import { Reference } from '../../../utilities/graphql/storeUtils';
 
@@ -73,7 +73,7 @@ describe('abstract cache', () => {
       const test = new TestCache();
       test.read = jest.fn();
 
-      test.readQuery({query});
+      test.readQuery({ query });
       expect(test.read).toBeCalled();
     });
 
@@ -81,8 +81,8 @@ describe('abstract cache', () => {
       const test = new TestCache();
       test.read = ({ optimistic }) => optimistic as any;
 
-      expect(test.readQuery({query})).toBe(false);
-      expect(test.readQuery({query}, true)).toBe(true);
+      expect(test.readQuery({ query })).toBe(false);
+      expect(test.readQuery({ query }, true)).toBe(true);
     });
   });
 
@@ -149,6 +149,161 @@ describe('abstract cache', () => {
 
       test.writeFragment(fragment);
       expect(test.write).toBeCalled();
+    });
+  });
+
+  describe('modifyQuery', () => {
+    it('runs the readQuery & writeQuery methods', () => {
+      const test = new TestCache();
+      test.readQuery = jest.fn();
+      test.writeQuery = jest.fn();
+
+      test.modifyQuery({ query }, data => 'foo');
+
+      expect(test.readQuery).toBeCalled();
+      expect(test.writeQuery).toBeCalled();
+    });
+
+    it('does not call writeQuery method if data is null', () => {
+      const test = new TestCache();
+      test.readQuery = jest.fn();
+      test.writeQuery = jest.fn();
+
+      test.modifyQuery({ query }, data => null);
+
+      expect(test.readQuery).toBeCalled();
+      expect(test.writeQuery).not.toBeCalled();
+    });
+
+    it('does not call writeQuery method if data is undefined', () => {
+      const test = new TestCache();
+      test.readQuery = jest.fn();
+      test.writeQuery = jest.fn();
+
+      test.modifyQuery({ query }, data => { return; });
+
+      expect(test.readQuery).toBeCalled();
+      expect(test.writeQuery).not.toBeCalled();
+    });
+
+    it('calls the readQuery & writeQuery methods with the options object', () => {
+      const test = new TestCache();
+      const options: Cache.ModifyQueryOptions<string, any> = { query, broadcast: true, variables: { test: 1 }, optimistic: true, returnPartialData: true };
+      test.readQuery = jest.fn();
+      test.writeQuery = jest.fn();
+
+      test.modifyQuery(options, data => 'foo');
+
+      expect(test.readQuery).toBeCalledWith(
+        expect.objectContaining(options)
+      );
+
+      expect(test.writeQuery).toBeCalledWith(
+        expect.objectContaining({ ...options, data: 'foo' })
+      );
+    });
+
+    it('returns current value in memory if no update was made', () => {
+      const test = new TestCache();
+      test.readQuery = jest.fn().mockReturnValue('foo');
+      expect(test.modifyQuery({ query }, data => null)).toBe('foo');
+    });
+
+    it('returns the updated value in memory if an update was made', () => {
+      const test = new TestCache();
+      let currentValue = 'foo';
+      test.readQuery = jest.fn().mockImplementation(() => currentValue);
+      test.writeQuery = jest.fn().mockImplementation(({ data }) => currentValue = data);
+      expect(test.modifyQuery({ query }, data => 'bar')).toBe('bar');
+    });
+
+    it('calls modify function with the current value in memory', () => {
+      const test = new TestCache();
+      test.readQuery = jest.fn().mockReturnValue('foo');
+      test.modifyQuery({ query }, data => {
+        expect(data).toBe('foo');
+      });
+    });
+  });
+
+  describe('modifyFragment', () => {
+    const fragmentId = 'frag';
+    const fragment = gql`
+      fragment a on b {
+        name
+      }
+    `;
+
+    it('runs the readFragment & writeFragment methods', () => {
+      const test = new TestCache();
+      test.readFragment = jest.fn();
+      test.writeFragment = jest.fn();
+
+      test.modifyFragment({ id: fragmentId, fragment }, data => 'foo');
+
+      expect(test.readFragment).toBeCalled();
+      expect(test.writeFragment).toBeCalled();
+    });
+
+    it('does not call writeFragment method if data is null', () => {
+      const test = new TestCache();
+      test.readFragment = jest.fn();
+      test.writeFragment = jest.fn();
+
+      test.modifyFragment({ id: fragmentId, fragment }, data => null);
+
+      expect(test.readFragment).toBeCalled();
+      expect(test.writeFragment).not.toBeCalled();
+    });
+
+    it('does not call writeFragment method if data is undefined', () => {
+      const test = new TestCache();
+      test.readFragment = jest.fn();
+      test.writeFragment = jest.fn();
+
+      test.modifyFragment({ id: fragmentId, fragment }, data => { return; });
+
+      expect(test.readFragment).toBeCalled();
+      expect(test.writeFragment).not.toBeCalled();
+    });
+
+    it('calls the readFragment & writeFragment methods with the options object', () => {
+      const test = new TestCache();
+      const options: Cache.ModifyFragmentOptions<string, any> = { id: fragmentId, fragment, fragmentName: 'a', broadcast: true, variables: { test: 1 }, optimistic: true, returnPartialData: true };
+      test.readFragment = jest.fn();
+      test.writeFragment = jest.fn();
+
+      test.modifyFragment(options, data => 'foo');
+
+      expect(test.readFragment).toBeCalledWith(
+        expect.objectContaining(options)
+      );
+
+      expect(test.writeFragment).toBeCalledWith(
+        expect.objectContaining({ ...options, data: 'foo' })
+      );
+    });
+
+    it('returns current value in memory if no update was made', () => {
+      const test = new TestCache();
+      test.readFragment = jest.fn().mockReturnValue('foo');
+      expect(test.modifyFragment({ id: fragmentId, fragment }, data => { return; })).toBe('foo');
+    });
+
+    it('returns the updated value in memory if an update was made', () => {
+      const test = new TestCache();
+      let currentValue = 'foo';
+      test.readFragment = jest.fn().mockImplementation(() => currentValue);
+      test.writeFragment = jest.fn().mockImplementation(({ data }) => currentValue = data);
+      expect(test.modifyFragment({ id: fragmentId, fragment }, data => 'bar')).toBe('bar');
+    });
+
+    it('calls modify function with the current value in memory', () => {
+      const test = new TestCache();
+      test.readFragment = jest.fn().mockReturnValue('foo');
+      test.modifyFragment({ id: fragmentId, fragment }, data => {
+        expect(data).toBe('foo');
+      });
     });
   });
 });

--- a/src/cache/core/__tests__/cache.ts
+++ b/src/cache/core/__tests__/cache.ts
@@ -152,13 +152,13 @@ describe('abstract cache', () => {
     });
   });
 
-  describe('modifyQuery', () => {
+  describe('updateQuery', () => {
     it('runs the readQuery & writeQuery methods', () => {
       const test = new TestCache();
       test.readQuery = jest.fn();
       test.writeQuery = jest.fn();
 
-      test.modifyQuery({ query }, data => 'foo');
+      test.updateQuery({ query }, data => 'foo');
 
       expect(test.readQuery).toBeCalled();
       expect(test.writeQuery).toBeCalled();
@@ -169,7 +169,7 @@ describe('abstract cache', () => {
       test.readQuery = jest.fn();
       test.writeQuery = jest.fn();
 
-      test.modifyQuery({ query }, data => null);
+      test.updateQuery({ query }, data => null);
 
       expect(test.readQuery).toBeCalled();
       expect(test.writeQuery).not.toBeCalled();
@@ -180,7 +180,7 @@ describe('abstract cache', () => {
       test.readQuery = jest.fn();
       test.writeQuery = jest.fn();
 
-      test.modifyQuery({ query }, data => { return; });
+      test.updateQuery({ query }, data => { return; });
 
       expect(test.readQuery).toBeCalled();
       expect(test.writeQuery).not.toBeCalled();
@@ -188,11 +188,11 @@ describe('abstract cache', () => {
 
     it('calls the readQuery & writeQuery methods with the options object', () => {
       const test = new TestCache();
-      const options: Cache.ModifyQueryOptions<string, any> = { query, broadcast: true, variables: { test: 1 }, optimistic: true, returnPartialData: true };
+      const options: Cache.UpdateQueryOptions<string, any> = { query, broadcast: true, variables: { test: 1 }, optimistic: true, returnPartialData: true };
       test.readQuery = jest.fn();
       test.writeQuery = jest.fn();
 
-      test.modifyQuery(options, data => 'foo');
+      test.updateQuery(options, data => 'foo');
 
       expect(test.readQuery).toBeCalledWith(
         expect.objectContaining(options)
@@ -206,7 +206,7 @@ describe('abstract cache', () => {
     it('returns current value in memory if no update was made', () => {
       const test = new TestCache();
       test.readQuery = jest.fn().mockReturnValue('foo');
-      expect(test.modifyQuery({ query }, data => null)).toBe('foo');
+      expect(test.updateQuery({ query }, data => null)).toBe('foo');
     });
 
     it('returns the updated value in memory if an update was made', () => {
@@ -214,19 +214,19 @@ describe('abstract cache', () => {
       let currentValue = 'foo';
       test.readQuery = jest.fn().mockImplementation(() => currentValue);
       test.writeQuery = jest.fn().mockImplementation(({ data }) => currentValue = data);
-      expect(test.modifyQuery({ query }, data => 'bar')).toBe('bar');
+      expect(test.updateQuery({ query }, data => 'bar')).toBe('bar');
     });
 
-    it('calls modify function with the current value in memory', () => {
+    it('calls update function with the current value in memory', () => {
       const test = new TestCache();
       test.readQuery = jest.fn().mockReturnValue('foo');
-      test.modifyQuery({ query }, data => {
+      test.updateQuery({ query }, data => {
         expect(data).toBe('foo');
       });
     });
   });
 
-  describe('modifyFragment', () => {
+  describe('updateFragment', () => {
     const fragmentId = 'frag';
     const fragment = gql`
       fragment a on b {
@@ -239,7 +239,7 @@ describe('abstract cache', () => {
       test.readFragment = jest.fn();
       test.writeFragment = jest.fn();
 
-      test.modifyFragment({ id: fragmentId, fragment }, data => 'foo');
+      test.updateFragment({ id: fragmentId, fragment }, data => 'foo');
 
       expect(test.readFragment).toBeCalled();
       expect(test.writeFragment).toBeCalled();
@@ -250,7 +250,7 @@ describe('abstract cache', () => {
       test.readFragment = jest.fn();
       test.writeFragment = jest.fn();
 
-      test.modifyFragment({ id: fragmentId, fragment }, data => null);
+      test.updateFragment({ id: fragmentId, fragment }, data => null);
 
       expect(test.readFragment).toBeCalled();
       expect(test.writeFragment).not.toBeCalled();
@@ -261,7 +261,7 @@ describe('abstract cache', () => {
       test.readFragment = jest.fn();
       test.writeFragment = jest.fn();
 
-      test.modifyFragment({ id: fragmentId, fragment }, data => { return; });
+      test.updateFragment({ id: fragmentId, fragment }, data => { return; });
 
       expect(test.readFragment).toBeCalled();
       expect(test.writeFragment).not.toBeCalled();
@@ -269,11 +269,11 @@ describe('abstract cache', () => {
 
     it('calls the readFragment & writeFragment methods with the options object', () => {
       const test = new TestCache();
-      const options: Cache.ModifyFragmentOptions<string, any> = { id: fragmentId, fragment, fragmentName: 'a', broadcast: true, variables: { test: 1 }, optimistic: true, returnPartialData: true };
+      const options: Cache.UpdateFragmentOptions<string, any> = { id: fragmentId, fragment, fragmentName: 'a', broadcast: true, variables: { test: 1 }, optimistic: true, returnPartialData: true };
       test.readFragment = jest.fn();
       test.writeFragment = jest.fn();
 
-      test.modifyFragment(options, data => 'foo');
+      test.updateFragment(options, data => 'foo');
 
       expect(test.readFragment).toBeCalledWith(
         expect.objectContaining(options)
@@ -287,7 +287,7 @@ describe('abstract cache', () => {
     it('returns current value in memory if no update was made', () => {
       const test = new TestCache();
       test.readFragment = jest.fn().mockReturnValue('foo');
-      expect(test.modifyFragment({ id: fragmentId, fragment }, data => { return; })).toBe('foo');
+      expect(test.updateFragment({ id: fragmentId, fragment }, data => { return; })).toBe('foo');
     });
 
     it('returns the updated value in memory if an update was made', () => {
@@ -295,13 +295,13 @@ describe('abstract cache', () => {
       let currentValue = 'foo';
       test.readFragment = jest.fn().mockImplementation(() => currentValue);
       test.writeFragment = jest.fn().mockImplementation(({ data }) => currentValue = data);
-      expect(test.modifyFragment({ id: fragmentId, fragment }, data => 'bar')).toBe('bar');
+      expect(test.updateFragment({ id: fragmentId, fragment }, data => 'bar')).toBe('bar');
     });
 
-    it('calls modify function with the current value in memory', () => {
+    it('calls update function with the current value in memory', () => {
       const test = new TestCache();
       test.readFragment = jest.fn().mockReturnValue('foo');
-      test.modifyFragment({ id: fragmentId, fragment }, data => {
+      test.updateFragment({ id: fragmentId, fragment }, data => {
         expect(data).toBe('foo');
       });
     });

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -167,24 +167,24 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
     }));
   }
 
-  public modifyQuery<TData = any, TVariables = any>(
-    options: Cache.ModifyQueryOptions<TData, TVariables>,
-    modifyFn: (data: TData | null) => TData | null | void
+  public updateQuery<TData = any, TVariables = any>(
+    options: Cache.UpdateQueryOptions<TData, TVariables>,
+    update: (data: TData | null) => TData | null | void,
   ): TData | null {
     const value = this.readQuery<TData, TVariables>(options);
-    const data = modifyFn(value);
-    if (data === undefined || data === null) return value;
+    const data = update(value);
+    if (data === void 0 || data === null) return value;
     this.writeQuery<TData, TVariables>({ ...options, data });
     return data;
   }
 
-  public modifyFragment<TData = any, TVariables = any>(
-    options: Cache.ModifyFragmentOptions<TData, TVariables>,
-    modifyFn: (data: TData | null) => TData | null | void
+  public updateFragment<TData = any, TVariables = any>(
+    options: Cache.UpdateFragmentOptions<TData, TVariables>,
+    update: (data: TData | null) => TData | null | void,
   ): TData | null {
     const value = this.readFragment<TData, TVariables>(options);
-    const data = modifyFn(value);
-    if (data === undefined || data === null) return value;
+    const data = update(value);
+    if (data === void 0 || data === null) return value;
     this.writeFragment<TData, TVariables>({ ...options, data });
     return data;
   }

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -166,4 +166,26 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
       result: data,
     }));
   }
+
+  public modifyQuery<TData = any, TVariables = any>(
+    options: Cache.ModifyQueryOptions<TData, TVariables>,
+    modifyFn: (data: TData | null) => TData | null | void
+  ): TData | null {
+    const value = this.readQuery<TData, TVariables>(options);
+    const data = modifyFn(value);
+    if (data === undefined || data === null) return value;
+    this.writeQuery<TData, TVariables>({ ...options, data });
+    return data;
+  }
+
+  public modifyFragment<TData = any, TVariables = any>(
+    options: Cache.ModifyFragmentOptions<TData, TVariables>,
+    modifyFn: (data: TData | null) => TData | null | void
+  ): TData | null {
+    const value = this.readFragment<TData, TVariables>(options);
+    const data = modifyFn(value);
+    if (data === undefined || data === null) return value;
+    this.writeFragment<TData, TVariables>({ ...options, data });
+    return data;
+  }
 }

--- a/src/cache/core/types/Cache.ts
+++ b/src/cache/core/types/Cache.ts
@@ -92,7 +92,7 @@ export namespace Cache {
   export import ReadFragmentOptions = DataProxy.ReadFragmentOptions;
   export import WriteQueryOptions = DataProxy.WriteQueryOptions;
   export import WriteFragmentOptions = DataProxy.WriteFragmentOptions;
-  export import ModifyQueryOptions = DataProxy.ModifyQueryOptions;
-  export import ModifyFragmentOptions = DataProxy.ModifyFragmentOptions;
+  export import UpdateQueryOptions = DataProxy.UpdateQueryOptions;
+  export import UpdateFragmentOptions = DataProxy.UpdateFragmentOptions;
   export import Fragment = DataProxy.Fragment;
 }

--- a/src/cache/core/types/Cache.ts
+++ b/src/cache/core/types/Cache.ts
@@ -92,5 +92,7 @@ export namespace Cache {
   export import ReadFragmentOptions = DataProxy.ReadFragmentOptions;
   export import WriteQueryOptions = DataProxy.WriteQueryOptions;
   export import WriteFragmentOptions = DataProxy.WriteFragmentOptions;
+  export import ModifyQueryOptions = DataProxy.ModifyQueryOptions;
+  export import ModifyFragmentOptions = DataProxy.ModifyFragmentOptions;
   export import Fragment = DataProxy.Fragment;
 }

--- a/src/cache/core/types/DataProxy.ts
+++ b/src/cache/core/types/DataProxy.ts
@@ -118,6 +118,12 @@ export namespace DataProxy {
   export interface WriteFragmentOptions<TData, TVariables>
     extends Fragment<TVariables, TData>, WriteOptions<TData> {}
 
+  export interface ModifyQueryOptions<TData, TVariables>
+    extends Omit<ReadQueryOptions<TData, TVariables> & WriteQueryOptions<TData, TVariables>, 'data'> {}
+
+  export interface ModifyFragmentOptions<TData, TVariables>
+    extends Omit<ReadFragmentOptions<TData, TVariables> & WriteFragmentOptions<TData, TVariables>, 'data'> {}
+
   export type DiffResult<T> = {
     result?: T;
     complete?: boolean;

--- a/src/cache/core/types/DataProxy.ts
+++ b/src/cache/core/types/DataProxy.ts
@@ -118,11 +118,17 @@ export namespace DataProxy {
   export interface WriteFragmentOptions<TData, TVariables>
     extends Fragment<TVariables, TData>, WriteOptions<TData> {}
 
-  export interface ModifyQueryOptions<TData, TVariables>
-    extends Omit<ReadQueryOptions<TData, TVariables> & WriteQueryOptions<TData, TVariables>, 'data'> {}
+  export interface UpdateQueryOptions<TData, TVariables>
+    extends Omit<(
+      ReadQueryOptions<TData, TVariables> &
+      WriteQueryOptions<TData, TVariables>
+    ), 'data'> {}
 
-  export interface ModifyFragmentOptions<TData, TVariables>
-    extends Omit<ReadFragmentOptions<TData, TVariables> & WriteFragmentOptions<TData, TVariables>, 'data'> {}
+  export interface UpdateFragmentOptions<TData, TVariables>
+    extends Omit<(
+      ReadFragmentOptions<TData, TVariables> &
+      WriteFragmentOptions<TData, TVariables>
+    ), 'data'> {}
 
   export type DiffResult<T> = {
     result?: T;


### PR DESCRIPTION
### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests

Hi,

We love apollo client in our company and use it for all of our state management needs in our project.
With the help of graphql-code-generator, we're able to write 100% type-safe state management code, whether it's from server or client only schema and we quite like using the schema as the layer of abstraction for our state's structure.
This PR is about two helper methods we've been using for quite some time, they're just a more concise way to do common operations, like reading from state, modifying it then writing it back, I hope you find it useful for other users too.

From the example in the docs, this PR allows rewriting this logic:
```typescript
const data = client.readQuery({ query });

client.writeQuery({
  query,
  data: {
    todos: [...data.todos, myNewTodo],
  },
});
```

Into:
```typescript
client.modifyQuery({ query }, data => ({ todos: [...data.todos, myNewTodo] }));
```

Please let me know if you have any questions or suggestions.