### PR TITLE
Fix useBaseQuery do not called cleanup in SSR

### DIFF
--- a/src/react/hooks/utils/useBaseQuery.ts
+++ b/src/react/hooks/utils/useBaseQuery.ts
@@ -70,6 +70,10 @@ export function useBaseQuery<TData = any, TVariables = OperationVariables>(
     ? (result as QueryTuple<TData, TVariables>)[1]
     : (result as QueryResult<TData, TVariables>);
 
+  if (typeof window === 'undefined') {
+    queryData.cleanup();
+  }
+
   useEffect(() => {
     return () => queryData.cleanup();
   }, []);

--- a/src/react/hooks/utils/useBaseQuery.ts
+++ b/src/react/hooks/utils/useBaseQuery.ts
@@ -70,7 +70,7 @@ export function useBaseQuery<TData = any, TVariables = OperationVariables>(
     ? (result as QueryTuple<TData, TVariables>)[1]
     : (result as QueryResult<TData, TVariables>);
 
-  if (typeof window === 'undefined') {
+  if (!lazy && typeof window === 'undefined') {
     queryData.cleanup();
   }
 


### PR DESCRIPTION
This PR fix memory leak when we use `useQuery` hook inside ReactDOM.hydrate

Related Issue:
* https://github.com/apollographql/apollo-client/issues/7942

### Checklist:
- [ ] After hydrating a component with useQuery, check that ApolloClient instance is unassigned when inspecting the next.js server
