### PR TITLE
Update typescript to v4.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@
 - Respect `no-cache` fetch policy (by not reading any `data` from the cache) for `loading: true` results triggered by `notifyOnNetworkStatusChange: true`. <br />
   [@jcreighton](https://github.com/jcreighton) in [#7761](https://github.com/apollographql/apollo-client/pull/7761)
 
+- The TypeScript return types of the `getLastResult` and `getLastError` methods of `ObservableQuery` now correctly include the possibility of returning `undefined`. If you happen to be calling either of these methods directly, you may need to adjust how the calling code handles the methods' possibly-`undefined` results. <br/>
+  [@benjamn](https://github.com/benjamn) in [#8394](https://github.com/apollographql/apollo-client/pull/8394)
+
 ### Improvements
 
 - `InMemoryCache` now _guarantees_ that any two result objects returned by the cache (from `readQuery`, `readFragment`, etc.) will be referentially equal (`===`) if they are deeply equal. Previously, `===` equality was often achievable for results for the same query, on a best-effort basis. Now, equivalent result objects will be automatically shared among the result trees of completely different queries. This guarantee is important for taking full advantage of optimistic updates that correctly guess the final data, and for "pure" UI components that can skip re-rendering when their input data are unchanged. <br/>

--- a/config/helpers.ts
+++ b/config/helpers.ts
@@ -11,7 +11,7 @@ export function eachFile(dir: string, callback: (
 ) => any) {
   const promises: Promise<any>[] = [];
 
-  return new Promise((resolve, reject) => {
+  return new Promise<void>((resolve, reject) => {
     glob(`${dir}/**/*.js`, (error, files) => {
       if (error) return reject(error);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9216,9 +9216,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.9",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
-      "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.3.tgz",
+      "integrity": "sha512-rUvLW0WtF7PF2b9yenwWUi9Da9euvDRhmH7BLyBG4DCFfOJ850LGNknmRpp8Z8kXNUPObdZQEfKOiHtXuQHHKA==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "terser": "5.7.0",
     "ts-jest": "26.5.6",
     "ts-node": "10.0.0",
-    "typescript": "3.9.9",
+    "typescript": "^4.3.3",
     "wait-for-observables": "1.0.3"
   },
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "terser": "5.7.0",
     "ts-jest": "26.5.6",
     "ts-node": "10.0.0",
-    "typescript": "^4.3.3",
+    "typescript": "4.3.3",
     "wait-for-observables": "1.0.3"
   },
   "publishConfig": {

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -2582,8 +2582,9 @@ describe('client', () => {
         const lastError = observable.getLastError();
         const lastResult = observable.getLastResult();
 
-        expect(lastResult.loading).toBeFalsy();
-        expect(lastResult.networkStatus).toBe(8);
+        expect(lastResult).toBeTruthy();
+        expect(lastResult!.loading).toBe(false);
+        expect(lastResult!.networkStatus).toBe(8);
 
         observable.resetLastResults();
         subscription = observable.subscribe(observerOptions);

--- a/src/__tests__/graphqlSubscriptions.ts
+++ b/src/__tests__/graphqlSubscriptions.ts
@@ -190,7 +190,7 @@ describe('GraphQL Subscriptions', () => {
     const promises = [];
     for (let i = 0; i < 2; i += 1) {
       promises.push(
-        new Promise((resolve, reject) => {
+        new Promise<void>((resolve, reject) => {
           obs.subscribe({
             next(result) {
               fail('Should have hit the error block');
@@ -234,7 +234,7 @@ describe('GraphQL Subscriptions', () => {
       cache: new InMemoryCache({ addTypename: false }),
     });
 
-    return new Promise(resolve => {
+    return new Promise<void>(resolve => {
       client.subscribe(defaultOptions).subscribe({
         complete() {
           resolve();

--- a/src/__tests__/local-state/resolvers.ts
+++ b/src/__tests__/local-state/resolvers.ts
@@ -447,7 +447,7 @@ describe('Basic resolver capabilities', () => {
     });
 
     function check(result: ApolloQueryResult<any>) {
-      return new Promise(resolve => {
+      return new Promise<void>(resolve => {
         expect(result.data.developer.id).toBe(developerId);
         expect(result.data.developer.handle).toBe('@benjamn');
         expect(result.data.developer.tickets.length).toBe(ticketsPerDev);

--- a/src/cache/inmemory/__tests__/readFromStore.ts
+++ b/src/cache/inmemory/__tests__/readFromStore.ts
@@ -1710,7 +1710,7 @@ describe('reading from the store', () => {
       ...snapshotAfterGC,
       __META: zeusMeta,
     };
-    delete snapshotWithoutAres["Deity:{\"name\":\"Ares\"}"];
+    delete (snapshotWithoutAres as any)["Deity:{\"name\":\"Ares\"}"];
     expect(cache.extract()).toEqual(snapshotWithoutAres);
     // Ares already removed, so no new garbage to collect.
     expect(cache.gc()).toEqual([]);

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -61,9 +61,9 @@ export class ObservableQuery<
   private observers = new Set<Observer<ApolloQueryResult<TData>>>();
   private subscriptions = new Set<ObservableSubscription>();
 
-  private lastResult: ApolloQueryResult<TData>;
-  private lastResultSnapshot: ApolloQueryResult<TData>;
-  private lastError: ApolloError;
+  private lastResult: ApolloQueryResult<TData> | undefined;
+  private lastResultSnapshot: ApolloQueryResult<TData> | undefined;
+  private lastError: ApolloError | undefined;
   private queryInfo: QueryInfo;
 
   constructor({
@@ -134,11 +134,11 @@ export class ObservableQuery<
       (lastResult && lastResult.networkStatus) ||
       NetworkStatus.ready;
 
-    const result: ApolloQueryResult<TData> = {
+    const result = {
       ...lastResult,
       loading: isNetworkRequestInFlight(networkStatus),
       networkStatus,
-    };
+    } as ApolloQueryResult<TData>;
 
     if (this.isTornDown) {
       return result;
@@ -208,11 +208,11 @@ export class ObservableQuery<
 
   // Returns the last result that observer.next was called with. This is not the same as
   // getCurrentResult! If you're not sure which you need, then you probably need getCurrentResult.
-  public getLastResult(): ApolloQueryResult<TData> {
+  public getLastResult(): ApolloQueryResult<TData> | undefined {
     return this.lastResult;
   }
 
-  public getLastError(): ApolloError {
+  public getLastError(): ApolloError | undefined {
     return this.lastError;
   }
 
@@ -623,7 +623,7 @@ once, rather than every time you call fetchMore.`);
         errors: error.graphQLErrors,
         networkStatus: NetworkStatus.error,
         loading: false,
-      });
+      } as ApolloQueryResult<TData>);
 
       iterateObserversSafely(this.observers, 'error', this.lastError = error);
     },

--- a/src/core/__tests__/QueryManager/index.ts
+++ b/src/core/__tests__/QueryManager/index.ts
@@ -5440,7 +5440,7 @@ describe('QueryManager', () => {
   describe('awaitRefetchQueries', () => {
     const awaitRefetchTest =
     ({ awaitRefetchQueries, testQueryError = false }: MutationBaseOptions<any, any, any> & { testQueryError?: boolean }) =>
-    new Promise((resolve, reject) => {
+    new Promise<void>((resolve, reject) => {
       const query = gql`
         query getAuthors($id: ID!) {
           author(id: $id) {
@@ -5540,7 +5540,7 @@ describe('QueryManager', () => {
           expect(stripSymbols(result.data)).toEqual(secondReqData);
         },
       )
-      .then(resolve)
+      .then(() => resolve())
       .catch(error => {
         const isRefetchError = awaitRefetchQueries && testQueryError &&
           error.message.includes(refetchError?.message);

--- a/src/link/http/__tests__/HttpLink.ts
+++ b/src/link/http/__tests__/HttpLink.ts
@@ -11,6 +11,7 @@ import { ClientParseError } from '../serializeFetchParameter';
 import { ServerParseError } from '../parseAndCheckHttpResponse';
 import { ServerError } from '../../..';
 import DoneCallback = jest.DoneCallback;
+import { voidFetchDuringEachTest } from './helpers';
 
 const sampleQuery = gql`
   query SampleQuery {
@@ -907,15 +908,7 @@ describe('HttpLink', () => {
   });
 
   describe('Dev warnings', () => {
-    let oldFetch: WindowOrWorkerGlobalScope['fetch'];;
-    beforeEach(() => {
-      oldFetch = window.fetch;
-      delete window.fetch;
-    });
-
-    afterEach(() => {
-      window.fetch = oldFetch;
-    });
+    voidFetchDuringEachTest();
 
     it('warns if fetch is undeclared', done => {
       try {

--- a/src/link/http/__tests__/checkFetcher.ts
+++ b/src/link/http/__tests__/checkFetcher.ts
@@ -1,15 +1,8 @@
 import { checkFetcher } from '../checkFetcher';
+import { voidFetchDuringEachTest } from './helpers';
 
 describe('checkFetcher', () => {
-  let oldFetch: WindowOrWorkerGlobalScope['fetch'];
-  beforeEach(() => {
-    oldFetch = window.fetch;
-    delete window.fetch;
-  });
-
-  afterEach(() => {
-    window.fetch = oldFetch;
-  });
+  voidFetchDuringEachTest();
 
   it('throws if no fetch is present', () => {
     expect(() => checkFetcher(undefined)).toThrow(

--- a/src/link/http/__tests__/helpers.ts
+++ b/src/link/http/__tests__/helpers.ts
@@ -1,0 +1,29 @@
+export function voidFetchDuringEachTest() {
+  let fetchDesc = Object.getOwnPropertyDescriptor(window, "fetch");
+
+  beforeEach(() => {
+    fetchDesc = fetchDesc || Object.getOwnPropertyDescriptor(window, "fetch");
+    if (fetchDesc?.configurable) {
+      delete (window as any).fetch;
+    }
+  });
+
+  afterEach(() => {
+    if (fetchDesc?.configurable) {
+      Object.defineProperty(window, "fetch", fetchDesc);
+    }
+  });
+}
+
+describe("voidFetchDuringEachTest", () => {
+  voidFetchDuringEachTest();
+
+  it("hides the global.fetch function", () => {
+    expect(window.fetch).toBe(void 0);
+    expect(() => fetch).toThrowError(ReferenceError);
+  });
+
+  it("globalThis === window", () => {
+    expect(globalThis).toBe(window);
+  });
+});

--- a/src/link/retry/__tests__/retryLink.ts
+++ b/src/link/retry/__tests__/retryLink.ts
@@ -67,7 +67,7 @@ describe('RetryLink', () => {
     const firstTry = fromError(standardError);
     // Hold the test hostage until we're hit
     let secondTry;
-    const untilSecondTry = new Promise(resolve => {
+    const untilSecondTry = new Promise<void>(resolve => {
       secondTry = {
         subscribe(observer: any) {
           resolve(); // Release hold on test.

--- a/src/react/components/Query.tsx
+++ b/src/react/components/Query.tsx
@@ -9,7 +9,7 @@ export function Query<TData = any, TVariables = OperationVariables>(
 ) {
   const { children, query, ...options } = props;
   const result = useQuery(query, options);
-  return children && result ? children(result) : null;
+  return result ? children(result) : null;
 }
 
 export interface Query<TData, TVariables> {

--- a/src/react/hoc/__tests__/queries/errors.test.tsx
+++ b/src/react/hoc/__tests__/queries/errors.test.tsx
@@ -252,7 +252,7 @@ describe('[queries] errors', () => {
   });
 
   it('will not log a warning when there is an error that is not caught in the render method when using query', () =>
-    new Promise((resolve, reject) => {
+    new Promise<void>((resolve, reject) => {
       const query: DocumentNode = gql`
         query people {
           allPeople(first: 1) {


### PR DESCRIPTION
Closes #6886.

As of this writing, `@apollo/client@beta` should support [`typescript@3.7`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html) and later, by avoiding any type system features in `.d.ts` files that are not understood by TS 3.7.

Until this PR, we have been using `typescript@3.9.9` to build `@apollo/client` and run its tests, ensuring compatibility with that version of TypeScript (v3.9.9), at the very least.

Despite the upgrade to v4.3.3 in this PR, we intend to continue supporting older v3.x versions of `typescript`, unless there is a compelling reason to use recently added syntax in externally visible type declarations. One such compelling feature: TypeScript v3.8 would be required to support [type-only `import type { ... } from ...` declarations](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html).