### PR TITLE
Fix `WeakSet` feature detection in `ObjectCanon`

### DIFF
--- a/src/__tests__/__snapshots__/exports.ts.snap
+++ b/src/__tests__/__snapshots__/exports.ts.snap
@@ -328,6 +328,7 @@ Array [
   "asyncMap",
   "buildQueryFromSelectionSet",
   "canUseWeakMap",
+  "canUseWeakSet",
   "checkDocument",
   "cloneDeep",
   "compact",

--- a/src/cache/inmemory/object-canon.ts
+++ b/src/cache/inmemory/object-canon.ts
@@ -1,6 +1,7 @@
 import { Trie } from "@wry/trie";
 import {
   canUseWeakMap,
+  canUseWeakSet,
   isNonNullObject as isObjectOrArray,
 } from "../../utilities";
 
@@ -71,7 +72,7 @@ function shallowCopy<T>(value: T): T {
 export class ObjectCanon {
   // Set of all canonical objects this ObjectCanon has admitted, allowing
   // canon.admit to return previously-canonicalized objects immediately.
-  private known = new (canUseWeakMap ? WeakSet : Set)<object>();
+  private known = new (canUseWeakSet ? WeakSet : Set)<object>();
 
   // Efficient storage/lookup structure for canonical objects.
   private pool = new Trie<{

--- a/src/utilities/common/canUse.ts
+++ b/src/utilities/common/canUse.ts
@@ -2,3 +2,5 @@ export const canUseWeakMap = typeof WeakMap === 'function' && !(
   typeof navigator === 'object' &&
   navigator.product === 'ReactNative'
 );
+
+export const canUseWeakSet = typeof WeakSet === 'function';


### PR DESCRIPTION
I noticed that `canUseWeakMap` is being used for `WeakSet` feature detection. We still support IE11 (😭) and in that environment `canUseWeakMap` is `true` but `WeakSet` is [not supported](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakSet#browser_compatibility). Thanks!

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
