### PR TITLE
Fix typo for the "Subscriptions" chapter

### DIFF
--- a/docs/source/data/subscriptions.mdx
+++ b/docs/source/data/subscriptions.mdx
@@ -253,7 +253,7 @@ Next, we modify our `CommentsPageWithData` function to add a `subscribeToNewComm
 ```jsx{10-25}
 function CommentsPageWithData({ params }) {
   const { subscribeToMore, ...result } = useQuery(
-    COMMENT_QUERY,
+    COMMENTS_QUERY,
     { variables: { postID: params.postID } }
   );
 


### PR DESCRIPTION
Replace `COMMENT_QUERY` with `COMMENTS_QUERY` for the "Subscribing to
updates for a query" section.