### PR TITLE
Fix backwards-incompatible changes to types

### DIFF
--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -142,8 +142,8 @@ export type RefetchQueriesFunction = (
 export interface BaseMutationOptions<
   TData,
   TVariables extends OperationVariables,
-  TContext extends DefaultContext,
-  TCache extends ApolloCache<any>,
+  TContext extends DefaultContext = DefaultContext,
+  TCache extends ApolloCache<any> = ApolloCache<any>
 > extends Omit<
   MutationOptions<TData, TVariables, TContext, TCache>,
   | "mutation"


### PR DESCRIPTION
Fixes https://github.com/apollographql/apollo-client/issues/8407

I’m leaving this open so I can do a quick comparison of the old and new types to see if other things have changed in a backwards-incompatible way.