### PR TITLE
Align NetworkError and GraphQLErrors types

### DIFF
--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -37,9 +37,13 @@ const generateErrorMessage = (err: ApolloError) => {
   return message;
 };
 
+export type GraphQLErrors = ReadonlyArray<GraphQLError>;
+
+export type NetworkError = Error | ServerParseError | ServerError | null;
+
 export class ApolloError extends Error {
   public message: string;
-  public graphQLErrors: ReadonlyArray<GraphQLError>;
+  public graphQLErrors: GraphQLErrors;
   public clientErrors: ReadonlyArray<Error>;
   public networkError: Error | ServerParseError | ServerError | null;
 

--- a/src/link/error/index.ts
+++ b/src/link/error/index.ts
@@ -1,14 +1,12 @@
-import { GraphQLError, ExecutionResult } from 'graphql';
+import { ExecutionResult } from 'graphql';
 
-import { ApolloLink, Operation, FetchResult, NextLink } from '../core';
+import { NetworkError, GraphQLErrors } from '../../errors';
 import { Observable } from '../../utilities';
-
-import { ServerError } from '../utils';
-import { ServerParseError } from '../http';
+import { ApolloLink, Operation, FetchResult, NextLink } from '../core';
 
 export interface ErrorResponse {
-  graphQLErrors?: ReadonlyArray<GraphQLError>;
-  networkError?: Error | ServerError | ServerParseError;
+  graphQLErrors?: GraphQLErrors;
+  networkError?: NetworkError;
   response?: ExecutionResult;
   operation: Operation;
   forward: NextLink;


### PR DESCRIPTION
The problem:

Application-wide networkError error handler fails with error:

```
TS2322: Type 'Error | ServerParseError | ServerError | null' is not assignable to type 'Error | ServerParseError | ServerError | undefined'.   Type 'null' is not assignable to type 'Error | ServerParseError | ServerError | undefined'. 
```

Seems to be due to:

`ApolloError` networkError have `Error | ServerParseError | ServerError | null` type:

```ts
export declare class ApolloError extends Error {
    message: string;
    graphQLErrors: ReadonlyArray<GraphQLError>;
    networkError: Error | ServerParseError | ServerError | null;
```

But the same networkError in ErrorResponse have `Error | ServerError | ServerParseError` type:

```ts
export interface ErrorResponse {
    graphQLErrors?: ReadonlyArray<GraphQLError>;
    networkError?: Error | ServerError | ServerParseError;
```

The difference is in `null`. To keep backward compatibility as much as possible, I am adding `null` to Link `ErrorResponse` interface.

The next step may be to remove `null` and make it optional.