### PR TITLE
Squash remaining "not wrapped in act(...)" error messages in React-related tests

### DIFF
--- a/src/react/components/__tests__/client/Mutation.test.tsx
+++ b/src/react/components/__tests__/client/Mutation.test.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import gql from 'graphql-tag';
 import { ExecutionResult, GraphQLError } from 'graphql';
-import { render, cleanup, fireEvent, wait } from '@testing-library/react';
+import { render, cleanup, fireEvent, wait, act } from '@testing-library/react';
 
 import { ApolloClient } from '../../../../core';
 import { ApolloError } from '../../../../errors';
@@ -1305,7 +1305,7 @@ describe('General Mutation testing', () => {
         <Mutation client={client2} mutation={mutation}>
           {(createTodo: any, result: any) => {
             if (!result.called) {
-              setTimeout(() => {
+              act(() => {
                 createTodo();
               });
             }
@@ -1322,6 +1322,10 @@ describe('General Mutation testing', () => {
         </Mutation>
       </ApolloProvider>
     );
+
+    return wait(() => {
+      expect(count).toBe(3);
+    });
   });
 
   it('errors if a query is passed instead of a mutation', () => {

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -768,8 +768,7 @@ describe('useMutation Hook', () => {
   });
 
   describe('Update function', () => {
-
-    itAsync('should be called with the provided variables', async (resolve, reject) => {
+    itAsync('should be called with the provided variables', (resolve, reject) => {
       const variables = {
         description: 'Get milk!'
       };
@@ -784,13 +783,14 @@ describe('useMutation Hook', () => {
         }
       ];
 
+      let variablesMatched = false;
       const Component = () => {
         const [createTodo] = useMutation(
           CREATE_TODO_MUTATION,
           {
             update(_, __, options) {
               expect(options.variables).toEqual(variables);
-              resolve();
+              variablesMatched = true;
             }
           }
         );
@@ -807,9 +807,13 @@ describe('useMutation Hook', () => {
           <Component />
         </MockedProvider>
       );
+
+      return wait(() => {
+        expect(variablesMatched).toBe(true);
+      }).then(resolve, reject);
     });
 
-    itAsync('should be called with the provided context', async (resolve, reject) => {
+    itAsync('should be called with the provided context', (resolve, reject) => {
       const context = { id: 3 };
 
       const variables = {
@@ -826,6 +830,7 @@ describe('useMutation Hook', () => {
         }
       ];
 
+      let foundContext = false;
       const Component = () => {
         const [createTodo] = useMutation<Todo, { description: string }, { id: number }>(
           CREATE_TODO_MUTATION,
@@ -833,7 +838,7 @@ describe('useMutation Hook', () => {
             context,
             update(_, __, options) {
               expect(options.context).toEqual(context);
-              resolve();
+              foundContext = true;
             }
           }
         );
@@ -850,10 +855,14 @@ describe('useMutation Hook', () => {
           <Component />
         </MockedProvider>
       );
+
+      return wait(() => {
+        expect(foundContext).toBe(true);
+      }).then(resolve, reject);
     });
 
     describe('If context is not provided', () => {
-      itAsync('should be undefined', async (resolve, reject) => {
+      itAsync('should be undefined', (resolve, reject) => {
         const variables = {
           description: 'Get milk!'
         };
@@ -868,13 +877,14 @@ describe('useMutation Hook', () => {
           }
         ];
 
+        let checkedContext = false;
         const Component = () => {
           const [createTodo] = useMutation(
             CREATE_TODO_MUTATION,
             {
               update(_, __, options) {
                 expect(options.context).toBeUndefined();
-                resolve();
+                checkedContext = true;
               }
             }
           );
@@ -891,6 +901,10 @@ describe('useMutation Hook', () => {
             <Component />
           </MockedProvider>
         );
+
+        return wait(() => {
+          expect(checkedContext).toBe(true);
+        }).then(resolve, reject);
       });
     });
   });
@@ -1176,8 +1190,9 @@ describe('useMutation Hook', () => {
         </ApolloProvider>
       );
 
-      return onUpdatePromise.then(results => {
+      return wait(() => onUpdatePromise.then(results => {
         expect(finishedReobserving).toBe(true);
+        expect(renderCount).toBe(4);
 
         expect(results.diff).toEqual({
           complete: true,
@@ -1193,11 +1208,7 @@ describe('useMutation Hook', () => {
             todoCount: 1,
           },
         });
-
-        return wait(() => {
-          expect(renderCount).toBe(4);
-        }).then(resolve, reject);
-      });
+      })).then(resolve, reject);
     });
   });
 });


### PR DESCRIPTION
Building on #7745, this PR means that `npm test` no longer spits out any red error text:

<img width="468" alt="Screen Shot 2021-06-24 at 2 19 35 PM" src="https://user-images.githubusercontent.com/5750/123313179-3cfa9d80-d4f7-11eb-88d6-7593e9688ee0.png">