### PR TITLE
Normalize user-provided HttpLink headers by lower-casing their names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 - Prefer `existing.pageInfo.startCursor` and `endCursor` (if defined) in `read` function of `relayStylePagination` policies. <br/>
   [@benjamn](https://github.com/benjamn) in [#8438](https://github.com/apollographql/apollo-client/pull/8438)
 
+### Improvements
+
+- Normalize user-provided `HttpLink` headers by lower-casing their names. <br/>
+  [@benjamn](https://github.com/benjamn) in [#8449](https://github.com/apollographql/apollo-client/pull/8449)
+
 ## Apollo Client 3.3.20
 
 ### Bug fixes

--- a/src/link/http/__tests__/selectHttpOptionsAndBody.ts
+++ b/src/link/http/__tests__/selectHttpOptionsAndBody.ts
@@ -88,4 +88,29 @@ describe('selectHttpOptionsAndBody', () => {
     expect(options.opt).toEqual('hi');
     expect(options.method).toEqual('POST'); //from default
   });
+
+  it('normalizes HTTP header names to lower case', () => {
+    const headers = {
+      accept: 'application/json',
+      Accept: 'application/octet-stream',
+      'content-type': 'application/graphql',
+      'Content-Type': 'application/javascript',
+      'CONTENT-type': 'application/json',
+    };
+
+    const config = { headers };
+    const { options, body } = selectHttpOptionsAndBody(
+      createOperation({}, { query }),
+      fallbackHttpConfig,
+      config,
+    );
+
+    expect(body).toHaveProperty('query');
+    expect(body).not.toHaveProperty('extensions');
+
+    expect(options.headers).toEqual({
+      accept: 'application/octet-stream',
+      'content-type': 'application/json',
+    });
+  });
 });

--- a/src/link/http/selectHttpOptionsAndBody.ts
+++ b/src/link/http/selectHttpOptionsAndBody.ts
@@ -122,7 +122,7 @@ export const selectHttpOptionsAndBody = (
       ...config.options,
       headers: {
         ...options.headers,
-        ...config.headers,
+        ...headersToLowerCase(config.headers),
       },
     };
     if (config.credentials) options.credentials = config.credentials;
@@ -147,3 +147,16 @@ export const selectHttpOptionsAndBody = (
     body,
   };
 };
+
+function headersToLowerCase(
+  headers: Record<string, string> | undefined
+): typeof headers {
+  if (headers) {
+    const normalized = Object.create(null);
+    Object.keys(headers).forEach(name => {
+      normalized[name.toLowerCase()] = headers[name];
+    });
+    return normalized;
+  }
+  return headers;
+}

--- a/src/link/http/selectHttpOptionsAndBody.ts
+++ b/src/link/http/selectHttpOptionsAndBody.ts
@@ -153,7 +153,7 @@ function headersToLowerCase(
 ): typeof headers {
   if (headers) {
     const normalized = Object.create(null);
-    Object.keys(headers).forEach(name => {
+    Object.keys(Object(headers)).forEach(name => {
       normalized[name.toLowerCase()] = headers[name];
     });
     return normalized;


### PR DESCRIPTION
Should fix #8447, by preferring the _last_ (according to `Object.keys(headers)`) header among multiple headers whose names are case-insensitively equivalent.

I'm a little worried this could be a user-visible change in some (HTTP-specification-violating) situations. If so, we can easily retarget this PR to the `release-3.4` branch, and make a clear note of it in `CHANGELOG.md`.