### PR TITLE
Suppress `Missing cache result fields...` warnings unless `setLogVerbosity("debug")` configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,9 @@
 - The `InMemoryCache` version of the `cache.gc` method now supports additional options for removing non-essential (recomputable) result caching data. <br/>
   [@benjamn](https://github.com/benjamn) in [#8421](https://github.com/apollographql/apollo-client/pull/8421)
 
+- Suppress noisy `Missing cache result fields...` warnings by default unless `setLogVerbosity("debug")` called. <br/>
+  [@benjamn](https://github.com/benjamn) in [#8489](https://github.com/apollographql/apollo-client/pull/8489)
+
 ### Documentation
 TBD
 

--- a/config/processInvariants.ts
+++ b/config/processInvariants.ts
@@ -90,7 +90,7 @@ function transform(code: string, file: string) {
 
       if (node.callee.type === "MemberExpression" &&
           isIdWithName(node.callee.object, "invariant") &&
-          isIdWithName(node.callee.property, "log", "warn", "error")) {
+          isIdWithName(node.callee.property, "debug", "log", "warn", "error")) {
         if (isDEVLogicalAnd(path.parent.node)) {
           return;
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9075,18 +9075,11 @@
       }
     },
     "ts-invariant": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.8.2.tgz",
-      "integrity": "sha512-VI1ZSMW8soizP5dU8DsMbj/TncHf7bIUqavuE7FTeYeQat454HHurJ8wbfCnVWcDOMkyiBUWOW2ytew3xUxlRw==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.9.0.tgz",
+      "integrity": "sha512-+JqhKqywk+ue5JjAC6eTWe57mOIxYXypMUkBDStkAzvnlfkDJ1KGyeMuNRMwOt6GXzHSC1UT9JecowpZDmgXqA==",
       "requires": {
         "tslib": "^2.1.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
-        }
       }
     },
     "ts-jest": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "optimism": "^0.16.1",
     "prop-types": "^15.7.2",
     "symbol-observable": "^4.0.0",
-    "ts-invariant": "^0.8.2",
+    "ts-invariant": "^0.9.0",
     "tslib": "^2.1.0",
     "zen-observable-ts": "^1.1.0"
   },

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1349,7 +1349,7 @@ export class QueryManager<TStore> {
           isNonEmptyArray(diff.missing) &&
           !equal(data, {}) &&
           !returnPartialData) {
-        invariant.warn(`Missing cache result fields: ${
+        invariant.debug(`Missing cache result fields: ${
           diff.missing.map(m => m.path.join('.')).join(', ')
         }`, diff.missing);
       }

--- a/src/core/__tests__/QueryManager/index.ts
+++ b/src/core/__tests__/QueryManager/index.ts
@@ -1350,7 +1350,6 @@ describe('QueryManager', () => {
   });
 
   itAsync('supports cache-only fetchPolicy fetching only cached data', (resolve, reject) => {
-    const spy = jest.spyOn(console, "warn").mockImplementation();
     const primeQuery = gql`
       query primeQuery {
         luke: people_one(id: 1) {
@@ -1395,13 +1394,9 @@ describe('QueryManager', () => {
         return handle.result().then(result => {
           expect(result.data['luke'].name).toBe('Luke Skywalker');
           expect(result.data).not.toHaveProperty('vader');
-          expect(spy).toHaveBeenCalledTimes(1);
         });
       })
-      .finally(() => {
-        spy.mockRestore();
-      })
-      .then(resolve, reject)
+      .then(resolve, reject);
   });
 
   itAsync('runs a mutation', (resolve, reject) => {
@@ -5785,8 +5780,8 @@ describe('QueryManager', () => {
     let verbosity: ReturnType<typeof setVerbosity>;
     let spy: any;
     beforeEach(() => {
-      verbosity = setVerbosity("warn");
-      spy = jest.spyOn(console, "warn").mockImplementation();
+      verbosity = setVerbosity("debug");
+      spy = jest.spyOn(console, "debug").mockImplementation();
     });
 
     afterEach(() => {


### PR DESCRIPTION
Implementing the plan I described in https://github.com/apollographql/apollo-client/issues/8442#issuecomment-878418870, building on https://github.com/apollographql/invariant-packages/pull/155.

Here's where [`setLogVerbosity("log")`](https://github.com/apollographql/apollo-client/blob/5b76276e9dfa1d19ee91d043ceb76b5a1d0dbe87/src/core/index.ts#L86-L92) is called by default. Note that all `invariant.*` log messages (of any level) are always hidden in production, so the `setLogVerbosity` configuration matters only in development.