### PR TITLE
Note that mutate/useMutation with @client is not supported in AC3

### DIFF
--- a/docs/source/local-state/managing-state-with-field-policies.mdx
+++ b/docs/source/local-state/managing-state-with-field-policies.mdx
@@ -97,6 +97,8 @@ You can use Apollo Client to query local state, regardless of how you _store_ th
 * [Reactive variables](#storing-local-state-in-reactive-variables)
 * [The Apollo Client cache itself](#storing-local-state-in-the-cache)
 
+> **Note:** Apollo Client >= 3 no longer recommends the [local resolver](/local-state/local-resolvers) approach of using `client.mutate` / `useMutation` combined with an `@client` mutation operation, to [update local state](/local-state/local-resolvers/#local-resolvers). If you want to update local state, we recommend using [`writeQuery`](/caching/cache-interaction/#writequery), [`writeFragment`](/caching/cache-interaction/#writefragment), or [reactive variables](/local-state/reactive-variables/).
+
 ### Storing local state in reactive variables
 
 Apollo Client [reactive variables](./reactive-variables) are great for representing local state:


### PR DESCRIPTION
This has been a pretty large source of confusion when people move from local resolvers to field policies. We'll probably want to expand on this much further, and show people how to switch from using `mutate` / `useMutation` with `@client` to equivalent `writeQuery` / `writeFragment` / reactive variable functionality, but this quick note will hopefully serve as a start to help clarify things.