### PR TITLE
Multiple (3) lines of defense against merging `{ __ref }` objects into normalized `StoreObject` entities

### DIFF
--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -102,6 +102,10 @@ export abstract class EntityStore implements NormalizedCache {
   ): void {
     let dataId: string | undefined;
 
+    // Convert unexpected references to ID strings.
+    if (isReference(older)) older = older.__ref;
+    if (isReference(newer)) newer = newer.__ref;
+
     const existing: StoreObject | undefined =
       typeof older === "string"
         ? this.lookup(dataId = older)

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -927,12 +927,19 @@ function makeMergeObjectsFunction(
 
       if (isReference(existing) &&
           storeValueIsStoreObject(incoming)) {
+        // Update the normalized EntityStore for the entity identified by
+        // existing.__ref, preferring/overwriting any fields contributed by the
+        // newer incoming StoreObject.
         store.merge(existing.__ref, incoming);
         return existing;
       }
 
       if (storeValueIsStoreObject(existing) &&
           isReference(incoming)) {
+        // Update the normalized EntityStore for the entity identified by
+        // incoming.__ref, taking fields from the older existing object only if
+        // those fields are not already present in the newer StoreObject
+        // identified by incoming.__ref.
         store.merge(existing, incoming.__ref);
         return incoming;
       }


### PR DESCRIPTION
PR #7778 (first released in `@apollo/client@3.4.0-beta.12`) allowed [`merge: true`](https://github.com/apollographql/apollo-client/pull/6714) to combine `Reference` objects (which refer to normalized `StoreObject` entities by ID) with non-normalized `StoreObject` objects.

When these mixed `Reference`/`StoreObject` merges happen (e.g. in the `mergeObjects` function), the `StoreWriter#applyMerges` method returns a `Reference` rather than a `StoreObject`, which was a new possibility not adequately handled by the calling code in PR #7778. In particular, `applyMerges` returning a `Reference` could result in calling `store.merge(dataId, fields)` when `isReference(fields)`, allowing `__ref` properties to end up as fields in the normalized `StoreObject`. These stray `__ref` properties could later confuse the `EntityStore` garbage collector into not traversing the other properties of the `StoreObject` (because the object appears to be a `Reference`), potentially misidentifying any unreached references as unreachable, and thus inappropriately deleting them from the store.

This PR solves these problems in three independent ways:
1. When `StoreWriter#applyMerges` returns a `Reference`, we now assume its fields have already been updated in the store, and avoid merging the `Reference` object using `store.merge(dataId, fields)`.
2. Fix `EntityStore#findChildRefIds` to continue traversing other properties of objects that appear to have `__ref` properties, just in case there has been an accidental merge.
3. Tolerate surprise `Reference` arguments in `EntityStore#merge` by converting them to their string IDs, which are well-handled by the `merge` method already. This shouldn't happen now thanks to 1, but provides a foolproof backup plan.