### PR TITLE
Delay initializing `stringifyCanon` until `canonicalStringify` used.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Apollo Client 3.4.1
+
+### Bug Fixes
+
+- Initialize `stringifyCanon` lazily, when `canonicalStringify` is first called, fixing `Uncaught ReferenceError: __DEV__ is not defined` errors due to usage of `__DEV__` before declaration. <br/>
+  [@benjamn](https://github.com/benjamn) in [#8557](https://github.com/apollographql/apollo-client/pull/8557)
+
 ## Apollo Client 3.4.0
 
 ### New documentation

--- a/src/cache/inmemory/object-canon.ts
+++ b/src/cache/inmemory/object-canon.ts
@@ -200,6 +200,9 @@ type SortedKeysInfo = {
 // version of JSON.stringify, which automatically sorts object keys.
 export const canonicalStringify = Object.assign(function (value: any): string {
   if (isObjectOrArray(value)) {
+    if (stringifyCanon === void 0) {
+      resetCanonicalStringify();
+    }
     const canonical = stringifyCanon.admit(value);
     let json = stringifyCache.get(canonical);
     if (json === void 0) {
@@ -212,13 +215,14 @@ export const canonicalStringify = Object.assign(function (value: any): string {
   }
   return JSON.stringify(value);
 }, {
-  reset() {
-    stringifyCanon = new ObjectCanon;
-  },
+  reset: resetCanonicalStringify,
 });
 
 // Can be reset by calling canonicalStringify.reset().
-let stringifyCanon = new ObjectCanon;
+let stringifyCanon: ObjectCanon;
+let stringifyCache: WeakMap<object, string>;
 
-// Needs no resetting, thanks to weakness.
-const stringifyCache = new WeakMap<object, string>();
+function resetCanonicalStringify() {
+  stringifyCanon = new ObjectCanon;
+  stringifyCache = new (canUseWeakMap ? WeakMap : Map)();
+}


### PR DESCRIPTION
May help with #8557, because initializing `let stringifyCanon = new ObjectCanon` in module scope led to evaluating the `__DEV__` global variable before it had been polyfilled (that's my current theory, at least).

Background reading:
  * `__DEV__`: #8347
  * `canonicalStringify`: #8222