### PR TITLE
Use more default type parameters for mutation-related types in `react/types/types.ts`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Apollo Client 3.4.2
+
+### Bug Fixes
+
+- Use more default type parameters for mutation-related types in `react/types/types.ts`, to provide smoother backwards compatibility for code using those types explicitly. <br/>
+  [@benjamn](https://github.com/benjamn) in [#8573](https://github.com/apollographql/apollo-client/pull/8573)
+
 ## Apollo Client 3.4.1
 
 ### Bug Fixes

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -140,9 +140,9 @@ export type RefetchQueriesFunction = (
 ) => InternalRefetchQueriesInclude;
 
 export interface BaseMutationOptions<
-  TData,
-  TVariables extends OperationVariables,
-  TContext extends DefaultContext = DefaultContext,
+  TData = any,
+  TVariables = OperationVariables,
+  TContext = DefaultContext,
   TCache extends ApolloCache<any> = ApolloCache<any>
 > extends Omit<
   MutationOptions<TData, TVariables, TContext, TCache>,
@@ -156,10 +156,10 @@ export interface BaseMutationOptions<
 }
 
 export interface MutationFunctionOptions<
-  TData,
-  TVariables,
-  TContext,
-  TCache extends ApolloCache<any>,
+  TData = any,
+  TVariables = OperationVariables,
+  TContext = DefaultContext,
+  TCache extends ApolloCache<any> = ApolloCache<any>,
 > extends BaseMutationOptions<TData, TVariables, TContext, TCache> {
   mutation?: DocumentNode | TypedDocumentNode<TData, TVariables>;
 }
@@ -191,19 +191,24 @@ export interface MutationHookOptions<
 }
 
 export interface MutationDataOptions<
-  TData,
-  TVariables extends OperationVariables,
-  TContext extends DefaultContext,
-  TCache extends ApolloCache<any>,
+  TData = any,
+  TVariables = OperationVariables,
+  TContext = DefaultContext,
+  TCache extends ApolloCache<any> = ApolloCache<any>,
 > extends BaseMutationOptions<TData, TVariables, TContext, TCache> {
   mutation: DocumentNode | TypedDocumentNode<TData, TVariables>;
 }
 
-export type MutationTuple<TData, TVariables, TContext, TCache extends ApolloCache<any>> = [
+export type MutationTuple<
+  TData,
+  TVariables,
+  TContext = DefaultContext,
+  TCache extends ApolloCache<any> = ApolloCache<any>,
+> = [
   (
     options?: MutationFunctionOptions<TData, TVariables, TContext, TCache>
   ) => Promise<FetchResult<TData>>,
-  MutationResult<TData>
+  MutationResult<TData>,
 ];
 
 /* Subscription types */


### PR DESCRIPTION
Commit 3f2eee7e8d6a4874120b6c84707b565ebcdaa349 in #7902 added a number of new type parameters to existing types, without always providing a default.

Should alleviate #8572.