### PR TITLE
Remove `"engines"` section from `dist/package.json` before publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Apollo Client 3.4.4
+
+### Bug Fixes
+
+- Revert accidental addition of `engines.npm` section to published version of `@apollo/client/package.json`. <br/>
+  [@benjamn](https://github.com/benjamn) in [#8578](https://github.com/apollographql/apollo-client/pull/8578)
+
 ## Apollo Client 3.4.3
 
 ### Bug Fixes

--- a/config/prepareDist.js
+++ b/config/prepareDist.js
@@ -31,6 +31,7 @@ packageJson.private = false;
 // Remove package.json items that we don't need to publish
 delete packageJson.scripts;
 delete packageJson.bundlesize;
+delete packageJson.engines;
 
 // The root package.json points to the CJS/ESM source in "dist", to support
 // on-going package development (e.g. running tests, supporting npm link, etc.).


### PR DESCRIPTION
We currently define only `engines.npm` in the root `package.json` file (as of 68d9cabab976a4ca659e161ec52ea1700aab8496 or `@apollo/client@3.4.2`), so that's all that's being hidden when we `delete packageJson.engines` here.

We can carve out exceptions for other `engines` constraints in the future if we need to, but for now we don't need any of them, so we can just delete the whole `engines` section.

Should fix #8577, if my theory in https://github.com/apollographql/apollo-client/issues/8577#issuecomment-891949871 is correct.