### PR TITLE
Fix double registration bug for mutation `refetchQueries` specified using legacy one-time `refetchQueries: [{ query, variables }]` style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Apollo Client 3.4.5
+
+### Bug Fixes
+
+- Fix double registration bug for mutation `refetchQueries` specified using legacy one-time `refetchQueries: [{ query, variables }]` style. Though the bug is fixed, we recommend using `refetchQueries: [query]` instead (when possible) to refetch an existing query using its `DocumentNode`, rather than creating, executing, and then deleting a new query, as the legacy `{ query, variables }` style unfortunately does. <br/>
+  [@benjamn](https://github.com/benjamn) in [#8586](https://github.com/apollographql/apollo-client/pull/8586)
+
 ## Apollo Client 3.4.4
 
 ### Bug Fixes

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -129,7 +129,7 @@ export class ObservableQuery<
 
     // query information
     this.options = options;
-    this.queryId = queryManager.generateQueryId();
+    this.queryId = queryInfo.queryId || queryManager.generateQueryId();
 
     const opDef = getOperationDefinition(options.query);
     this.queryName = opDef && opDef.name && opDef.name.value;

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -17,6 +17,7 @@ import {
   isNetworkRequestInFlight,
 } from './networkStatus';
 import { ApolloError } from '../errors';
+import { QueryManager } from './QueryManager';
 
 export type QueryStoreValue = Pick<QueryInfo,
   | "variables"
@@ -85,7 +86,14 @@ export class QueryInfo {
   graphQLErrors?: ReadonlyArray<GraphQLError>;
   stopped = false;
 
-  constructor(private cache: ApolloCache<any>) {
+  private cache: ApolloCache<any>;
+
+  constructor(
+    queryManager: QueryManager<any>,
+    public readonly queryId = queryManager.generateQueryId(),
+  ) {
+    const cache = this.cache = queryManager.cache;
+
     // Track how often cache.evict is called, since we want eviction to
     // override the feud-stopping logic in the markResult method, by
     // causing shouldWrite to return true. Wrapping the cache.evict method

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -619,7 +619,7 @@ export class QueryManager<TStore> {
       options.notifyOnNetworkStatusChange = false;
     }
 
-    const queryInfo = new QueryInfo(this.cache);
+    const queryInfo = new QueryInfo(this);
     const observable = new ObservableQuery<T, TVariables>({
       queryManager: this,
       queryInfo,
@@ -1470,7 +1470,7 @@ export class QueryManager<TStore> {
 
   private getQuery(queryId: string): QueryInfo {
     if (queryId && !this.queries.has(queryId)) {
-      this.queries.set(queryId, new QueryInfo(this.cache));
+      this.queries.set(queryId, new QueryInfo(this, queryId));
     }
     return this.queries.get(queryId)!;
   }

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -799,6 +799,7 @@ export class QueryManager<TStore> {
             fetchPolicy: "network-only",
           },
         });
+        invariant(oq.queryId === queryId);
         queryInfo.setObservableQuery(oq);
         queries.set(queryId, oq);
       });


### PR DESCRIPTION
The `invariant` in the first commit is expected to fail, and serves as a minimal regression test for issue #8586.

This refactoring ensures `observableQuery.queryId` ends up the same as `observableQuery.queryInfo.queryId`, which is relevant in cases when we choose a specific query ID string before creating the `QueryInfo` and `ObservableQuery` objects.

Ensuring that `queryInfo.queryId === queryInfo.observableQuery.queryId` (another way of saying the same thing) also fixes the `invariant` failures I deliberately introduced in the first commit.

This inconsistency between IDs was the cause of issue #8586, a double registration bug for mutation `refetchQueries` specified using the legacy one-time `refetchQueries: [{ query, variables }]` style.

Another (recommended) way to work around that problem would be to specify `refetchQueries: [query]` instead, to select the existing query by its `DocumentNode` rather than creating and deleting a new one-time legacy query.