### PR TITLE
Fix useQuery stalling when observable queries change due to query changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Fix double registration bug for mutation `refetchQueries` specified using legacy one-time `refetchQueries: [{ query, variables }]` style. Though the bug is fixed, we recommend using `refetchQueries: [query]` instead (when possible) to refetch an existing query using its `DocumentNode`, rather than creating, executing, and then deleting a new query, as the legacy `{ query, variables }` style unfortunately does. <br/>
   [@benjamn](https://github.com/benjamn) in [#8586](https://github.com/apollographql/apollo-client/pull/8586)
+- Fix `useQuery`/`useLazyQuery` stalling when clients or queries change. <br/>
+  [@brainkim](https://github.com/brainkim) in [#8589](https://github.com/apollographql/apollo-client/pull/8589)
 
 ## Apollo Client 3.4.4
 

--- a/src/react/data/QueryData.ts
+++ b/src/react/data/QueryData.ts
@@ -35,7 +35,7 @@ export class QueryData<TData, TVariables> extends OperationData<
   QueryDataOptions<TData, TVariables>
 > {
   public onNewData: () => void;
-  private currentObservable?: ObservableQuery<TData, TVariables>;
+  public currentObservable?: ObservableQuery<TData, TVariables>;
   private currentSubscription?: ObservableSubscription;
   private runLazy: boolean = false;
   private lazyOptions?: QueryLazyOptions<TVariables>;

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -437,12 +437,11 @@ describe('useQuery Hook', () => {
         {
           request: { query: query1 },
           result: { data: allPeopleData },
-          delay: 10,
         },
         {
           request: { query: query2 },
           result: { data: allThingsData },
-          delay: 10,
+          delay: 50,
         },
       );
 
@@ -467,6 +466,12 @@ describe('useQuery Hook', () => {
 
       expect(result.current[0].loading).toBe(true);
       expect(result.current[0].data).toBe(undefined);
+      expect(result.current[1].loading).toBe(true);
+      expect(result.current[1].data).toBe(undefined);
+
+      await waitForNextUpdate();
+      expect(result.current[0].loading).toBe(false);
+      expect(result.current[0].data).toEqual(allPeopleData);
       expect(result.current[1].loading).toBe(true);
       expect(result.current[1].data).toBe(undefined);
 

--- a/src/react/hooks/utils/useBaseQuery.ts
+++ b/src/react/hooks/utils/useBaseQuery.ts
@@ -90,6 +90,7 @@ export function useBaseQuery<TData = any, TVariables = OperationVariables>(
     queryResult.networkStatus,
     queryResult.error,
     queryResult.data,
+    queryData.currentObservable,
   ]);
 
   return result;


### PR DESCRIPTION
Fixes situations where the observable query changes and we don’t subscribe to the new one. All this code is in the process of being heavily refactored (I’m currently chasing down QueryData in a track suit with a machete), so this is a band-aid.

Potentially fixes:
- https://github.com/apollographql/apollo-client/issues/8584
- https://github.com/apollographql/apollo-client/issues/8582
- https://github.com/apollographql/apollo-client/issues/8575