### PR TITLE
Clarify mutation `fetchPolicy` options using `MutationFetchPolicy` union type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Reevaluate `window.fetch` each time `HttpLink` uses it, if not configured using `options.fetch`. This change enables a variety of strategies for instrumenting `window.fetch`, without requiring those strategies to run before `@apollo/client/link/http` is first imported. <br/>
   [@benjamn](https://github.com/benjamn) in [#8603](https://github.com/apollographql/apollo-client/pull/8603)
 
+- Clarify mutation `fetchPolicy` options (`"network-only"` or `"no-cache"`) using `MutationFetchPolicy` union type. <br/>
+  [@benjamn](https://github.com/benjamn) in [#8602](https://github.com/apollographql/apollo-client/pull/8602)
+
 ### Bug Fixes
 
 - Restore full `@apollo/client/apollo-client.cjs.js` CommonJS bundle for older bundlers.

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -31,6 +31,7 @@ import {
   MutationOptions,
   WatchQueryFetchPolicy,
   ErrorPolicy,
+  MutationFetchPolicy,
 } from './watchQueryOptions';
 import { ObservableQuery, applyNextFetchPolicy, logMissingFieldErrors } from './ObservableQuery';
 import { NetworkStatus, isNetworkRequestInFlight } from './networkStatus';
@@ -162,7 +163,7 @@ export class QueryManager<TStore> {
     update: updateWithProxyFn,
     onQueryUpdated,
     errorPolicy = 'none',
-    fetchPolicy,
+    fetchPolicy = 'network-only',
     keepRootFields,
     context,
   }: MutationOptions<TData, TVariables, TContext>): Promise<FetchResult<TData>> {
@@ -172,8 +173,9 @@ export class QueryManager<TStore> {
     );
 
     invariant(
-      !fetchPolicy || fetchPolicy === 'no-cache',
-      "Mutations only support a 'no-cache' fetchPolicy. If you don't want to disable the cache, remove your fetchPolicy setting to proceed with the default mutation behavior."
+      fetchPolicy === 'network-only' ||
+      fetchPolicy === 'no-cache',
+      "Mutations support only 'network-only' or 'no-cache' fetchPolicy strings. The default `network-only` behavior automatically writes mutation results to the cache. Passing `no-cache` skips the cache write."
     );
 
     const mutationId = this.generateMutationId();
@@ -321,7 +323,7 @@ export class QueryManager<TStore> {
       result: FetchResult<TData>;
       document: DocumentNode;
       variables?: TVariables;
-      fetchPolicy?: "no-cache";
+      fetchPolicy?: MutationFetchPolicy;
       errorPolicy: ErrorPolicy;
       context?: TContext;
       updateQueries: UpdateQueries<TData>;
@@ -479,7 +481,7 @@ export class QueryManager<TStore> {
       mutationId: string;
       document: DocumentNode;
       variables?: TVariables;
-      fetchPolicy?: "no-cache";
+      fetchPolicy?: MutationFetchPolicy;
       errorPolicy: ErrorPolicy;
       context?: TContext;
       updateQueries: UpdateQueries<TData>,

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -30,6 +30,12 @@ export type FetchPolicy =
 
 export type WatchQueryFetchPolicy = FetchPolicy | 'cache-and-network';
 
+export type MutationFetchPolicy = Extract<
+  FetchPolicy,
+  | 'network-only' // default behavior (mutation results written to cache)
+  | 'no-cache'     // alternate behavior (results not written to cache)
+>;
+
 export type RefetchWritePolicy = "merge" | "overwrite";
 
 /**
@@ -297,12 +303,11 @@ export interface MutationOptions<
   mutation: DocumentNode | TypedDocumentNode<TData, TVariables>;
 
   /**
-   * Specifies the {@link FetchPolicy} to be used for this query. Mutations only
-   * support a 'no-cache' fetchPolicy. If you don't want to disable the cache,
-   * remove your fetchPolicy setting to proceed with the default mutation
-   * behavior.
+   * Specifies the {@link MutationFetchPolicy} to be used for this query.
+   * Mutations support only 'network-only' and 'no-cache' fetchPolicy strings.
+   * If fetchPolicy is not provided, it defaults to 'network-only'.
    */
-  fetchPolicy?: Extract<FetchPolicy, 'no-cache'>;
+  fetchPolicy?: MutationFetchPolicy;
 
   /**
    * To avoid retaining sensitive information from mutation root field


### PR DESCRIPTION
These are the changes I was suggesting in my comments on PR #8595:
* https://github.com/apollographql/apollo-client/pull/8595#pullrequestreview-724460852

I believe this addition of `MutationFetchPolicy` is a backwards-compatible change, since it amounts to replacing a type that could only be `"no-cache" | undefined` with a strictly additive superset: `"network-only" | "no-cache" | undefined`.

I don't expect anyone to want/need to pass `fetchPolicy: "network-only"` explicitly, but I think it makes sense to be explicit about the default mutation `fetchPolicy` behavior, and its relationship to the `"no-cache"` alternative.