### PR TITLE
Restore `@apollo/client/apollo-client.cjs.js` CommonJS bundle for older bundlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 - Reevaluate `window.fetch` each time `HttpLink` uses it, if not configured using `options.fetch`. This change enables a variety of strategies for instrumenting `window.fetch`, without requiring those strategies to run before `@apollo/client/link/http` is first imported. <br/>
   [@benjamn](https://github.com/benjamn) in [#8603](https://github.com/apollographql/apollo-client/pull/8603)
 
+### Bug Fixes
+
+- Restore full `@apollo/client/apollo-client.cjs.js` CommonJS bundle for older bundlers.
+
+  > Note that Node.js and CommonJS bundlers typically use the bundles specified by `"main"` fields in our generated `package.json` files, which are all independent and non-overlapping CommonJS modules. However, `apollo-client.cjs.js` is just one big bundle, so mixing imports of `apollo-client.cjs.js` with the other CommonJS bundles is discouraged, as it could trigger the [dual package hazard](https://nodejs.org/api/packages.html#packages_dual_commonjs_es_module_packages). In other words, please don't start using `apollo-client.cjs.js` if you're not already. <br/>
+
+  [@benjamn](https://github.com/benjamn) in [#8592](https://github.com/apollographql/apollo-client/pull/8592)
+
 ## Apollo Client 3.4.5
 
 ### Bug Fixes

--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -124,11 +124,19 @@ export default [
   ...entryPoints.map(prepareBundle),
   // Convert the ESM entry point to a single CJS bundle.
   prepareCJS(
-    './dist/core/index.js',
+    './dist/index.js',
     './dist/apollo-client.cjs.js',
   ),
-  // Minify that single CJS bundle.
+  // The bundlesize check configured in package.json reflects the total size of
+  // @apollo/client/core (note the /core), rather than @apollo/client, which
+  // currently includes React-related exports that may not be used by all
+  // consumers. We are planning to confine those React exports to
+  // @apollo/client/react in AC4 (see issue #8190).
+  prepareCJS(
+    './dist/core/index.js',
+    './dist/apollo-core.cjs.js',
+  ),
   prepareCJSMinified(
-    './dist/apollo-client.cjs.js',
+    './dist/apollo-core.cjs.js',
   ),
 ];

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "bundlesize": [
     {
       "name": "apollo-client",
-      "path": "./dist/apollo-client.cjs.min.js",
+      "path": "./dist/apollo-core.cjs.min.js",
       "maxSize": "24.6 kB"
     }
   ],

--- a/scripts/memory/tests.js
+++ b/scripts/memory/tests.js
@@ -46,6 +46,30 @@ function makeRegistry(callback, reject) {
   return registry;
 }
 
+// This is not technically a memory-related test, but it depends on the build
+// artifacts generated in the ../../dist directory by `npm run build`, which is
+// an assumption shared by the other tests in this file.
+describe("@apollo/client/apollo-client.cjs.js", () => {
+  it("can be imported as a single CommonJS bundle (issue #8592)", () => {
+    const bundle = require("@apollo/client/apollo-client.cjs.js");
+
+    // Very basic test that requiring the bundle worked.
+    assert.strictEqual(typeof bundle.ApolloClient, "function");
+    assert.strictEqual(typeof bundle.InMemoryCache, "function");
+
+    // TODO This will change in AC4 when we move all React exports to the
+    // @apollo/client/react entry point (see issue #8190).
+    assert.strictEqual(typeof bundle.ApolloProvider, "function");
+
+    // The CommonJS bundles referred to by the "main" fields in the various
+    // package.json files that we generate during `npm run build` are all
+    // independent, non-overlapping bundles, but apollo-client.cjs.js is its own
+    // bundle, so importing it duplicates everything.
+    assert.notStrictEqual(bundle.ApolloClient, ApolloClient);
+    assert.notStrictEqual(bundle.InMemoryCache, InMemoryCache);
+  });
+});
+
 describe("garbage collection", () => {
   itAsync("should collect client.cache after client.stop()", (resolve, reject) => {
     const expectedKeys = new Set([


### PR DESCRIPTION
Should resolve issue #8592.