### PR TITLE
Fix accidental reuse of recycled `MergeTree` objects in `StoreWriter` class used by `InMemoryCache`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Apollo Client 3.4.7 (not yet released)
+
+### Bug Fixes
+
+- Fix accidental reuse of recycled `MergeTree` objects in `StoreWriter` class used by `InMemoryCache`. <br/>
+  [@benjamn](https://github.com/benjamn) in [#8618](https://github.com/apollographql/apollo-client/pull/8618)
+
 ## Apollo Client 3.4.6
 
 ### Improvements


### PR DESCRIPTION
The regression test is expected to fail, as I merely copy/pasted/tweaked the code provided by @Grmiade in  #8600.

This PR fixes a bug I introduced in #8372 in `@apollo/client@3.4.0-rc.7`. In #8372, I introduced code that saved a reference to the current `MergeTree` object in `context.incomingById`, but I did so without thinking carefully about [the recycling system we use for `MergeTree` objects](https://github.com/apollographql/apollo-client/pull/7070#discussion_r494646474), which allows _empty_ `MergeTree` objects to be reused for other unrelated parts of the result tree. In some situations, this reuse can lead to the original field seeming to have a `merge` function, just because some future user of the recycled `MergeTree` populates it with unrelated information by the time it gets consumed in `StoreWriter#applyMerges`. This PR solves that problem by never retaining references to empty `MergeTree` objects, using `undefined` to represent them instead.

Of course, this bug does give me some misgivings about the complexity of recycling these `MergeTree` objects, but that system still seems worthwhile because relatively few fields have `merge` functions associated with them, so the vast majority of `MergeTree` objects that we create in `processSelectionSet` and `processFieldValue` will be empty. It would be a shame to release all those empty objects for the JavaScript GC to reclaim, when they can be pooled and reused instead.