### PR TITLE
Avoid voiding `result.data` in `ObservableQuery#getCurrentResult` when `!diff.complete`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Fix error thrown by nested `keyFields: ["a", ["b", "c"], "d"]` type policies when writing results into the cache where any of the key fields (`.a`, `.a.b`, `.a.c`, or `.d`) have been renamed by query field alias syntax. <br/>
   [@benjamn](https://github.com/benjamn) in [#8643](https://github.com/apollographql/apollo-client/pull/8643)
 
+- Fix regression from PR [#8422](https://github.com/apollographql/apollo-client/pull/8422) (first released in `@apollo/client@3.4.0-rc.15`) that caused `result.data` to be set to undefined in some cases after `ObservableQuery#getCurrentResult` reads an incomplete result from the cache. <br/>
+  [@benjamn](https://github.com/benjamn) in [#8642](https://github.com/apollographql/apollo-client/pull/8642)
+
 ## Apollo Client 3.4.7
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     {
       "name": "apollo-client",
       "path": "./dist/apollo-core.cjs.min.js",
-      "maxSize": "24.6 kB"
+      "maxSize": "24.7 kB"
     }
   ],
   "engines": {

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -2590,15 +2590,16 @@ describe('client', () => {
         subscription.unsubscribe();
 
         const lastError = observable.getLastError();
-        const lastResult = observable.getLastResult();
+        expect(lastError).toBeInstanceOf(ApolloError);
+        expect(lastError!.networkError).toEqual(error);
 
+        const lastResult = observable.getLastResult();
         expect(lastResult).toBeTruthy();
         expect(lastResult!.loading).toBe(false);
         expect(lastResult!.networkStatus).toBe(8);
 
         observable.resetLastResults();
         subscription = observable.subscribe(observerOptions);
-        Object.assign(observable, { lastError, lastResult });
 
         // The error arrived, run a refetch to get the third result
         // which should now contain valid data.

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -183,7 +183,8 @@ export class ObservableQuery<
   }
 
   public getCurrentResult(saveAsLastResult = true): ApolloQueryResult<TData> {
-    const lastResult = this.getLastResult();
+    // Use the last result as long as the variables match this.variables.
+    const lastResult = this.getLastResult(true);
 
     const networkStatus =
       this.queryInfo.networkStatus ||

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -202,10 +202,12 @@ export class ObservableQuery<
     if (!this.queryManager.transform(this.options.query).hasForcedResolvers) {
       const diff = this.queryInfo.getDiff();
 
-      result.data = (
-        diff.complete ||
-        this.options.returnPartialData
-      ) ? diff.result : void 0;
+      if (diff.complete || this.options.returnPartialData) {
+        result.data = diff.result;
+      }
+      if (equal(result.data, {})) {
+        result.data = void 0 as any;
+      }
 
       if (diff.complete) {
         // If the diff is complete, and we're using a FetchPolicy that

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -267,8 +267,6 @@ export class ObservableQuery<
     }
   }
 
-  // Returns the last result that observer.next was called with. This is not the same as
-  // getCurrentResult! If you're not sure which you need, then you probably need getCurrentResult.
   public getLastResult(variablesMustMatch?: boolean): ApolloQueryResult<TData> | undefined {
     return this.getLast("result", variablesMustMatch);
   }

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -624,7 +624,7 @@ once, rather than every time you call fetchMore.`);
       result: this.queryManager.assumeImmutableResults
         ? newResult
         : cloneDeep(newResult),
-      variables: variables && { ...variables },
+      variables,
     };
     if (!isNonEmptyArray(newResult.errors)) {
       delete this.last.error;
@@ -678,13 +678,14 @@ once, rather than every time you call fetchMore.`);
       }
     }
 
+    const variables = options.variables && { ...options.variables };
     const concast = this.fetch(options, newNetworkStatus);
     const observer: Observer<ApolloQueryResult<TData>> = {
       next: result => {
-        this.reportResult(result, options.variables);
+        this.reportResult(result, variables);
       },
       error: error => {
-        this.reportError(error, options.variables);
+        this.reportError(error, variables);
       },
     };
 

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -798,7 +798,7 @@ describe('ObservableQuery', () => {
           expect(result.errors).toEqual([error]);
           expect(observable.getCurrentResult().errors).toEqual([error]);
           observable.setVariables(differentVariables);
-          expect(observable.getCurrentResult().errors).toEqual([error]);
+          expect(observable.getCurrentResult().errors).toBeUndefined();
         } else if (handleCount === 2) {
           expect(result.data).toEqual(dataTwo);
           expect(observable.getCurrentResult().data).toEqual(

--- a/src/react/data/QueryData.ts
+++ b/src/react/data/QueryData.ts
@@ -323,14 +323,13 @@ export class QueryData<TData, TVariables> extends OperationData<
     // has a chance to stay open).
     const { currentObservable } = this;
     if (currentObservable) {
-      const lastError = currentObservable.getLastError();
-      const lastResult = currentObservable.getLastResult();
-      currentObservable.resetLastResults();
-      this.startQuerySubscription();
-      Object.assign(currentObservable, {
-        lastError,
-        lastResult
-      });
+      const last = currentObservable["last"];
+      try {
+        currentObservable.resetLastResults();
+        this.startQuerySubscription();
+      } finally {
+        currentObservable["last"] = last;
+      }
     }
   }
 

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -18,7 +18,6 @@ import { ApolloLink } from '../../../link/core';
 import { itAsync, MockLink, MockedProvider, mockSingleLink } from '../../../testing';
 import { useQuery } from '../useQuery';
 import { useMutation } from '../useMutation';
-import { invariant } from 'ts-invariant';
 
 describe('useQuery Hook', () => {
   describe('General use', () => {
@@ -2438,7 +2437,6 @@ describe('useQuery Hook', () => {
   describe('Missing Fields', () => {
     it('should log debug messages about MissingFieldErrors from the cache', async () => {
       const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-      const debugSpy = jest.spyOn(invariant, 'debug').mockImplementation(() => {});
 
       const carQuery: DocumentNode = gql`
         query cars($id: Int) {
@@ -2488,15 +2486,8 @@ describe('useQuery Hook', () => {
       expect(result.current.error).toBe(undefined);
       await waitForNextUpdate();
       expect(result.current.loading).toBe(false);
-      expect(result.current.data).toBe(undefined);
-
+      expect(result.current.data).toEqual(carData);
       expect(result.current.error).toBeUndefined();
-      expect(debugSpy).toHaveBeenCalledTimes(1);
-      expect(debugSpy).toHaveBeenLastCalledWith(
-        "Missing cache result fields: cars.0.vin",
-        [new Error("Can't find field 'vin' on Car:1 object")]
-      );
-      debugSpy.mockRestore();
 
       expect(errorSpy).toHaveBeenCalledTimes(1);
       expect(errorSpy).toHaveBeenLastCalledWith(


### PR DESCRIPTION
PR #8422 (released in `@apollo/client@3.4.0-rc.15`) attempted to solve issue #7978 (reported by @dylanwulf) by relying on `queryInfo.getDiff()` to obtain results appropriate for the current `variables`, rather than blindly relying on the `lastResult` stored by the `ObservableQuery` (which may have been obtained using different `variables`).

While this solution appeared to resolve #7978, it introduced a new bug (reported in #8620 by @maxsalven) because the following code now runs unconditionally:
https://github.com/apollographql/apollo-client/blob/bd03ff048ecaf4ddc7aeb2906bf0bdfb2eb695d8/src/core/ObservableQuery.ts#L205-L208
Whenever `!(diff.complete || this.options.returnPartialData)`, this code clobbers `result.data` with `void 0`, even though `result.data` might provide useful information. In the case of #8620, that clobbered information is the missing network result for the A query.

Ideally, we should leave `result.data` unmodified except when `diff.result` is used, as follows:
https://github.com/apollographql/apollo-client/blob/1b1f08576fec9d282034bb950db075be9e3a2a6e/src/core/ObservableQuery.ts#L205-L207

This change helps with issue #8620, but introduces some new test failures, because some of the `result.data` objects that are now delivered (instead of `void 0`) were obtained using different/stale `variables` than the current `this.options.variables`. In other words, these test failures can be prevented if we finish fixing #7978, because the previous result will be appropriately ignored by `getCurrentResult` when the `variables` have changed.

The rest of the commits in this PR fix those tests by tracking a snapshot of the original `variables` associated with the last result, so the `getCurrentResult` method can avoid using `this.last.result` if `this.last.variables` no longer match `this.options.variables`.

I also considered reverting PR #8422 and building back up to a better solution for #7978, but #8422 wasn't all bad, and I was able to make everything work more easily and cleanly with the current approach.