### PR TITLE
Fix error thrown by nested `keyFields: ["a", ["b", "c"], "d"]` syntax when some of the fields are aliased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Apollo Client 3.4.8 (not yet released)
+
+### Bug Fixes
+
+- Fix error thrown by nested `keyFields: ["a", ["b", "c"], "d"]` type policies when writing results into the cache where any of the key fields (`.a`, `.a.b`, `.a.c`, or `.d`) have been renamed by query field alias syntax. <br/>
+  [@benjamn](https://github.com/benjamn) in [#8643](https://github.com/apollographql/apollo-client/pull/8643)
+
 ## Apollo Client 3.4.7
 
 ### Bug Fixes

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -143,7 +143,7 @@ describe("type policies", function () {
         book {
           title
           writer: author {
-            name
+            alias: name
           }
         }
       }
@@ -152,7 +152,9 @@ describe("type policies", function () {
     const { author, ...rest } = theInformationBookData;
     const aliasBookData = {
       ...rest,
-      writer: author,
+      writer: {
+        alias: author.name,
+      },
     };
 
     cache.writeQuery({
@@ -172,8 +174,9 @@ describe("type policies", function () {
       'Book:{"title":"The Information","author":{"name":"James Gleick"}}': {
         __typename: "Book",
         title: "The Information",
-        // Note that "author" is stored internally, since it's the real name of
-        // the field, despite the "writer: author" alias.
+        // Note that "author" and "name" are stored internally, since they are
+        // the true names of their fields (according to the schema), despite the
+        // writer:author and alias:name aliases.
         author: {
           name: "James Gleick"
         },


### PR DESCRIPTION
Following @habovh's steps from #8639, expecting failure for the first commit.

I'll push more commits to fix the problem soon.