### PR TITLE
Reimplement `ObservableQuery#result` by calling `this.reobserve()`

### DIFF
--- a/src/__tests__/optimistic.ts
+++ b/src/__tests__/optimistic.ts
@@ -1025,7 +1025,6 @@ describe('optimistic mutation results', () => {
     };
 
     itAsync('will insert a single itemAsync to the beginning', async (resolve, reject) => {
-      expect.assertions(7);
       let subscriptionHandle: Subscription;
       const client = await setup(reject, {
         request: { query: mutation },


### PR DESCRIPTION
There were a number of questionable choices in this code before, and thankfully none of that matters now.