### PR TITLE
Remove root redirect and build deploy previews at /

### DIFF
--- a/docs/static/_redirects
+++ b/docs/static/_redirects
@@ -1,5 +1,3 @@
-/ /docs/react/
-
 # Redirect all 3.0 beta docs to root
 /docs/react/v3.0-beta/* /docs/react/:splat
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,3 +4,5 @@
   command = "npm run types && gatsby build --prefix-paths && mkdir -p docs/react && mv public/* docs/react && mv docs public/ && mv public/docs/react/_redirects public"
 [build.environment]
   NPM_VERSION = "6"
+[context.deploy-preview]
+  command = "gatsby build"


### PR DESCRIPTION
This branch removes the root-level redirect in the docs and forces deploy previews to be deployed at the root to account for this change.