### PR TITLE
Use `setTimeout` instead of `Promise.resolve().then(...)` to delay `Concast` cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Apollo Client 3.4.9 (not yet released)
+
+### Bug Fixes
+
+- Fix unhandled `Promise` rejection warnings/errors whose message is `Observable cancelled prematurely`. <br/>
+  [@benjamn](https://github.com/benjamn) in [#8676](https://github.com/apollographql/apollo-client/pull/8676)
+
 ## Apollo Client 3.4.8
 
 ### Bug Fixes

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1128,7 +1128,7 @@ export class QueryManager<TStore> {
     // in case concast creation synchronously cancels the request.
     this.fetchCancelFns.set(queryId, reason => {
       // This delay ensures the concast variable has been initialized.
-      setTimeout(() => concast.cancel(reason), 10);
+      setTimeout(() => concast.cancel(reason));
     });
 
     // A Concast<T> can be created either from an Iterable<Observable<T>>

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1127,9 +1127,8 @@ export class QueryManager<TStore> {
     // This cancel function needs to be set before the concast is created,
     // in case concast creation synchronously cancels the request.
     this.fetchCancelFns.set(queryId, reason => {
-      // Delaying the cancellation using a Promise ensures that the
-      // concast variable has been initialized.
-      Promise.resolve().then(() => concast.cancel(reason));
+      // This delay ensures the concast variable has been initialized.
+      setTimeout(() => concast.cancel(reason), 10);
     });
 
     // A Concast<T> can be created either from an Iterable<Observable<T>>

--- a/src/utilities/observables/Concast.ts
+++ b/src/utilities/observables/Concast.ts
@@ -178,7 +178,7 @@ export class Concast<T> extends Observable<T> {
         // Delay unsubscribing from the underlying subscription slightly,
         // so that immediately subscribing another observer can keep the
         // subscription active.
-        if (sub) setTimeout(() => sub.unsubscribe(), 10);
+        if (sub) setTimeout(() => sub.unsubscribe());
         this.sub = null;
         this.latest = ["error", error];
         this.reject(error);

--- a/src/utilities/observables/Concast.ts
+++ b/src/utilities/observables/Concast.ts
@@ -178,7 +178,7 @@ export class Concast<T> extends Observable<T> {
         // Delay unsubscribing from the underlying subscription slightly,
         // so that immediately subscribing another observer can keep the
         // subscription active.
-        if (sub) Promise.resolve().then(() => sub.unsubscribe());
+        if (sub) setTimeout(() => sub.unsubscribe(), 10);
         this.sub = null;
         this.latest = ["error", error];
         this.reject(error);


### PR DESCRIPTION
Inspired by @cornedor's comment https://github.com/apollographql/apollo-client/issues/7608#issuecomment-882418482.

Should help with some instances of issue #7608, specifically those with global unhandled promise rejection errors.

I don't know if this is the full solution, but I believe it is helpful and safe to introduce a delay before unsubscribing from the underlying observable, giving other `Concast` subscribers a chance to subscribe, thereby saving the `Concast` from needing to be cancelled, while still quickly unsubscribing if there are no new subscribers within 10ms.