### PR TITLE
Allow `@directive` and `$variable` strings in field policy `key: ["arg", "@dir", "$var"]` arrays

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     {
       "name": "apollo-client",
       "path": "./temp/bundlesize.min.cjs",
-      "maxSize": "24.7 kB"
+      "maxSize": "24.85 kB"
     }
   ],
   "engines": {

--- a/src/cache/inmemory/__tests__/__snapshots__/policies.ts.snap
+++ b/src/cache/inmemory/__tests__/__snapshots__/policies.ts.snap
@@ -77,6 +77,24 @@ exports[`type policies complains about missing key fields 1`] = `
 }
 `;
 
+exports[`type policies field policies assumes key:false when read and merge function present 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "Missing field 'a' while writing result {
+  \\"__typename\\": \\"TypeA\\"
+}",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
 exports[`type policies field policies assumes keyArgs:false when read and merge function present 1`] = `
 [MockFunction] {
   "calls": Array [
@@ -885,7 +903,7 @@ Object {
 }
 `;
 
-exports[`type policies field policies can include optional arguments in keyArgs 1`] = `
+exports[`type policies field policies can include optional arguments in field key policy 1`] = `
 Object {
   "Author:{\\"name\\":\\"Nadia Eghbal\\"}": Object {
     "__typename": "Author",
@@ -907,7 +925,7 @@ Object {
 }
 `;
 
-exports[`type policies field policies can include optional arguments in keyArgs 2`] = `
+exports[`type policies field policies can include optional arguments in field key policy 2`] = `
 Object {
   "Author:{\\"name\\":\\"Nadia Eghbal\\"}": Object {
     "__typename": "Author",
@@ -936,7 +954,7 @@ Object {
 }
 `;
 
-exports[`type policies field policies can include optional arguments in keyArgs 3`] = `
+exports[`type policies field policies can include optional arguments in field key policy 3`] = `
 Object {
   "Author:{\\"name\\":\\"Nadia Eghbal\\"}": Object {
     "__typename": "Author",
@@ -972,7 +990,7 @@ Object {
 }
 `;
 
-exports[`type policies field policies can include optional arguments in keyArgs 4`] = `
+exports[`type policies field policies can include optional arguments in field key policy 4`] = `
 Object {
   "Author:{\\"name\\":\\"Nadia Eghbal\\"}": Object {
     "__typename": "Author",
@@ -1015,7 +1033,7 @@ Object {
 }
 `;
 
-exports[`type policies field policies can include optional arguments in keyArgs 5`] = `
+exports[`type policies field policies can include optional arguments in field key policy 5`] = `
 Object {
   "Author:{\\"name\\":\\"Nadia Eghbal\\"}": Object {
     "__typename": "Author",
@@ -1065,7 +1083,7 @@ Object {
 }
 `;
 
-exports[`type policies field policies can include optional arguments in keyArgs 6`] = `
+exports[`type policies field policies can include optional arguments in field key policy 6`] = `
 Object {
   "Author:{\\"name\\":\\"Nadia Eghbal\\"}": Object {
     "__typename": "Author",
@@ -1122,7 +1140,7 @@ Object {
 }
 `;
 
-exports[`type policies field policies can include optional arguments in keyArgs 7`] = `
+exports[`type policies field policies can include optional arguments in field key policy 7`] = `
 Object {
   "Author:{\\"name\\":\\"Nadia Eghbal\\"}": Object {
     "__typename": "Author",
@@ -1186,7 +1204,379 @@ Object {
 }
 `;
 
-exports[`type policies field policies can include optional arguments in keyArgs 8`] = `
+exports[`type policies field policies can include optional arguments in field key policy 8`] = `
+Object {
+  "Author:{\\"name\\":\\"Nadia Eghbal\\"}": Object {
+    "__typename": "Author",
+    "name": "Nadia Eghbal",
+    "writings": Array [
+      Object {
+        "__typename": "Book",
+        "isbn": "0578675862",
+        "title": "Working in Public: The Making and Maintenance of Open Source Software",
+      },
+    ],
+    "writings:{\\"a\\":1,\\"b\\":2,\\"type\\":\\"Book\\"}": Array [
+      Object {
+        "__typename": "Book",
+        "isbn": "0578675862",
+        "title": "Working in Public: The Making and Maintenance of Open Source Software",
+      },
+    ],
+    "writings:{\\"a\\":1,\\"b\\":2}": Array [
+      Object {
+        "__typename": "Book",
+        "isbn": "0578675862",
+        "title": "Working in Public: The Making and Maintenance of Open Source Software",
+      },
+    ],
+    "writings:{\\"a\\":3}": Array [
+      Object {
+        "__typename": "Book",
+        "isbn": "0578675862",
+        "title": "Working in Public: The Making and Maintenance of Open Source Software",
+      },
+    ],
+    "writings:{\\"b\\":2}": Array [
+      Object {
+        "__typename": "Book",
+        "isbn": "0578675862",
+        "title": "Working in Public: The Making and Maintenance of Open Source Software",
+      },
+    ],
+    "writings:{\\"b\\":4}": Array [
+      Object {
+        "__typename": "Book",
+        "isbn": "0578675862",
+        "title": "Working in Public: The Making and Maintenance of Open Source Software",
+      },
+    ],
+    "writings:{\\"type\\":\\"Book\\"}": Array [
+      Object {
+        "__typename": "Book",
+        "isbn": "0578675862",
+        "title": "Working in Public: The Making and Maintenance of Open Source Software",
+      },
+    ],
+    "writings:{}": Array [
+      Object {
+        "__typename": "Book",
+        "isbn": "0578675862",
+        "title": "Working in Public: The Making and Maintenance of Open Source Software",
+      },
+    ],
+  },
+  "ROOT_QUERY": Object {
+    "__typename": "Query",
+    "author": Object {
+      "__ref": "Author:{\\"name\\":\\"Nadia Eghbal\\"}",
+    },
+  },
+}
+`;
+
+exports[`type policies field policies can include optional arguments in field keyArgs policy 1`] = `
+Object {
+  "Author:{\\"name\\":\\"Nadia Eghbal\\"}": Object {
+    "__typename": "Author",
+    "name": "Nadia Eghbal",
+    "writings:{\\"type\\":\\"Book\\"}": Array [
+      Object {
+        "__typename": "Book",
+        "isbn": "0578675862",
+        "title": "Working in Public: The Making and Maintenance of Open Source Software",
+      },
+    ],
+  },
+  "ROOT_QUERY": Object {
+    "__typename": "Query",
+    "author": Object {
+      "__ref": "Author:{\\"name\\":\\"Nadia Eghbal\\"}",
+    },
+  },
+}
+`;
+
+exports[`type policies field policies can include optional arguments in field keyArgs policy 2`] = `
+Object {
+  "Author:{\\"name\\":\\"Nadia Eghbal\\"}": Object {
+    "__typename": "Author",
+    "name": "Nadia Eghbal",
+    "writings:{\\"a\\":1,\\"b\\":2,\\"type\\":\\"Book\\"}": Array [
+      Object {
+        "__typename": "Book",
+        "isbn": "0578675862",
+        "title": "Working in Public: The Making and Maintenance of Open Source Software",
+      },
+    ],
+    "writings:{\\"type\\":\\"Book\\"}": Array [
+      Object {
+        "__typename": "Book",
+        "isbn": "0578675862",
+        "title": "Working in Public: The Making and Maintenance of Open Source Software",
+      },
+    ],
+  },
+  "ROOT_QUERY": Object {
+    "__typename": "Query",
+    "author": Object {
+      "__ref": "Author:{\\"name\\":\\"Nadia Eghbal\\"}",
+    },
+  },
+}
+`;
+
+exports[`type policies field policies can include optional arguments in field keyArgs policy 3`] = `
+Object {
+  "Author:{\\"name\\":\\"Nadia Eghbal\\"}": Object {
+    "__typename": "Author",
+    "name": "Nadia Eghbal",
+    "writings:{\\"a\\":1,\\"b\\":2,\\"type\\":\\"Book\\"}": Array [
+      Object {
+        "__typename": "Book",
+        "isbn": "0578675862",
+        "title": "Working in Public: The Making and Maintenance of Open Source Software",
+      },
+    ],
+    "writings:{\\"a\\":1,\\"b\\":2}": Array [
+      Object {
+        "__typename": "Book",
+        "isbn": "0578675862",
+        "title": "Working in Public: The Making and Maintenance of Open Source Software",
+      },
+    ],
+    "writings:{\\"type\\":\\"Book\\"}": Array [
+      Object {
+        "__typename": "Book",
+        "isbn": "0578675862",
+        "title": "Working in Public: The Making and Maintenance of Open Source Software",
+      },
+    ],
+  },
+  "ROOT_QUERY": Object {
+    "__typename": "Query",
+    "author": Object {
+      "__ref": "Author:{\\"name\\":\\"Nadia Eghbal\\"}",
+    },
+  },
+}
+`;
+
+exports[`type policies field policies can include optional arguments in field keyArgs policy 4`] = `
+Object {
+  "Author:{\\"name\\":\\"Nadia Eghbal\\"}": Object {
+    "__typename": "Author",
+    "name": "Nadia Eghbal",
+    "writings:{\\"a\\":1,\\"b\\":2,\\"type\\":\\"Book\\"}": Array [
+      Object {
+        "__typename": "Book",
+        "isbn": "0578675862",
+        "title": "Working in Public: The Making and Maintenance of Open Source Software",
+      },
+    ],
+    "writings:{\\"a\\":1,\\"b\\":2}": Array [
+      Object {
+        "__typename": "Book",
+        "isbn": "0578675862",
+        "title": "Working in Public: The Making and Maintenance of Open Source Software",
+      },
+    ],
+    "writings:{\\"b\\":2}": Array [
+      Object {
+        "__typename": "Book",
+        "isbn": "0578675862",
+        "title": "Working in Public: The Making and Maintenance of Open Source Software",
+      },
+    ],
+    "writings:{\\"type\\":\\"Book\\"}": Array [
+      Object {
+        "__typename": "Book",
+        "isbn": "0578675862",
+        "title": "Working in Public: The Making and Maintenance of Open Source Software",
+      },
+    ],
+  },
+  "ROOT_QUERY": Object {
+    "__typename": "Query",
+    "author": Object {
+      "__ref": "Author:{\\"name\\":\\"Nadia Eghbal\\"}",
+    },
+  },
+}
+`;
+
+exports[`type policies field policies can include optional arguments in field keyArgs policy 5`] = `
+Object {
+  "Author:{\\"name\\":\\"Nadia Eghbal\\"}": Object {
+    "__typename": "Author",
+    "name": "Nadia Eghbal",
+    "writings:{\\"a\\":1,\\"b\\":2,\\"type\\":\\"Book\\"}": Array [
+      Object {
+        "__typename": "Book",
+        "isbn": "0578675862",
+        "title": "Working in Public: The Making and Maintenance of Open Source Software",
+      },
+    ],
+    "writings:{\\"a\\":1,\\"b\\":2}": Array [
+      Object {
+        "__typename": "Book",
+        "isbn": "0578675862",
+        "title": "Working in Public: The Making and Maintenance of Open Source Software",
+      },
+    ],
+    "writings:{\\"a\\":3}": Array [
+      Object {
+        "__typename": "Book",
+        "isbn": "0578675862",
+        "title": "Working in Public: The Making and Maintenance of Open Source Software",
+      },
+    ],
+    "writings:{\\"b\\":2}": Array [
+      Object {
+        "__typename": "Book",
+        "isbn": "0578675862",
+        "title": "Working in Public: The Making and Maintenance of Open Source Software",
+      },
+    ],
+    "writings:{\\"type\\":\\"Book\\"}": Array [
+      Object {
+        "__typename": "Book",
+        "isbn": "0578675862",
+        "title": "Working in Public: The Making and Maintenance of Open Source Software",
+      },
+    ],
+  },
+  "ROOT_QUERY": Object {
+    "__typename": "Query",
+    "author": Object {
+      "__ref": "Author:{\\"name\\":\\"Nadia Eghbal\\"}",
+    },
+  },
+}
+`;
+
+exports[`type policies field policies can include optional arguments in field keyArgs policy 6`] = `
+Object {
+  "Author:{\\"name\\":\\"Nadia Eghbal\\"}": Object {
+    "__typename": "Author",
+    "name": "Nadia Eghbal",
+    "writings:{\\"a\\":1,\\"b\\":2,\\"type\\":\\"Book\\"}": Array [
+      Object {
+        "__typename": "Book",
+        "isbn": "0578675862",
+        "title": "Working in Public: The Making and Maintenance of Open Source Software",
+      },
+    ],
+    "writings:{\\"a\\":1,\\"b\\":2}": Array [
+      Object {
+        "__typename": "Book",
+        "isbn": "0578675862",
+        "title": "Working in Public: The Making and Maintenance of Open Source Software",
+      },
+    ],
+    "writings:{\\"a\\":3}": Array [
+      Object {
+        "__typename": "Book",
+        "isbn": "0578675862",
+        "title": "Working in Public: The Making and Maintenance of Open Source Software",
+      },
+    ],
+    "writings:{\\"b\\":2}": Array [
+      Object {
+        "__typename": "Book",
+        "isbn": "0578675862",
+        "title": "Working in Public: The Making and Maintenance of Open Source Software",
+      },
+    ],
+    "writings:{\\"type\\":\\"Book\\"}": Array [
+      Object {
+        "__typename": "Book",
+        "isbn": "0578675862",
+        "title": "Working in Public: The Making and Maintenance of Open Source Software",
+      },
+    ],
+    "writings:{}": Array [
+      Object {
+        "__typename": "Book",
+        "isbn": "0578675862",
+        "title": "Working in Public: The Making and Maintenance of Open Source Software",
+      },
+    ],
+  },
+  "ROOT_QUERY": Object {
+    "__typename": "Query",
+    "author": Object {
+      "__ref": "Author:{\\"name\\":\\"Nadia Eghbal\\"}",
+    },
+  },
+}
+`;
+
+exports[`type policies field policies can include optional arguments in field keyArgs policy 7`] = `
+Object {
+  "Author:{\\"name\\":\\"Nadia Eghbal\\"}": Object {
+    "__typename": "Author",
+    "name": "Nadia Eghbal",
+    "writings:{\\"a\\":1,\\"b\\":2,\\"type\\":\\"Book\\"}": Array [
+      Object {
+        "__typename": "Book",
+        "isbn": "0578675862",
+        "title": "Working in Public: The Making and Maintenance of Open Source Software",
+      },
+    ],
+    "writings:{\\"a\\":1,\\"b\\":2}": Array [
+      Object {
+        "__typename": "Book",
+        "isbn": "0578675862",
+        "title": "Working in Public: The Making and Maintenance of Open Source Software",
+      },
+    ],
+    "writings:{\\"a\\":3}": Array [
+      Object {
+        "__typename": "Book",
+        "isbn": "0578675862",
+        "title": "Working in Public: The Making and Maintenance of Open Source Software",
+      },
+    ],
+    "writings:{\\"b\\":2}": Array [
+      Object {
+        "__typename": "Book",
+        "isbn": "0578675862",
+        "title": "Working in Public: The Making and Maintenance of Open Source Software",
+      },
+    ],
+    "writings:{\\"b\\":4}": Array [
+      Object {
+        "__typename": "Book",
+        "isbn": "0578675862",
+        "title": "Working in Public: The Making and Maintenance of Open Source Software",
+      },
+    ],
+    "writings:{\\"type\\":\\"Book\\"}": Array [
+      Object {
+        "__typename": "Book",
+        "isbn": "0578675862",
+        "title": "Working in Public: The Making and Maintenance of Open Source Software",
+      },
+    ],
+    "writings:{}": Array [
+      Object {
+        "__typename": "Book",
+        "isbn": "0578675862",
+        "title": "Working in Public: The Making and Maintenance of Open Source Software",
+      },
+    ],
+  },
+  "ROOT_QUERY": Object {
+    "__typename": "Query",
+    "author": Object {
+      "__ref": "Author:{\\"name\\":\\"Nadia Eghbal\\"}",
+    },
+  },
+}
+`;
+
+exports[`type policies field policies can include optional arguments in field keyArgs policy 8`] = `
 Object {
   "Author:{\\"name\\":\\"Nadia Eghbal\\"}": Object {
     "__typename": "Author",

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -159,7 +159,7 @@ export abstract class EntityStore implements NormalizedCache {
             // share the same short fieldName, regardless of arguments.
             const fieldName = fieldNameFromStoreName(storeFieldName);
             if (fieldName !== storeFieldName &&
-                !this.policies.hasKeyArgs(merged.__typename, fieldName)) {
+                !this.policies.hasFieldKeyConfig(merged.__typename, fieldName)) {
               fieldsToDirty[fieldName] = 1;
             }
 


### PR DESCRIPTION
This PR provides a much better solution than the three I proposed in https://github.com/apollographql/apollo-client/issues/8659#issuecomment-901479599 to the problem of including more than just arguments in the [`keyArgs: [...]`](https://www.apollographql.com/docs/react/pagination/key-args/) array notation in [field policies](https://www.apollographql.com/docs/react/caching/cache-field-behavior/).

While nothing is changing in the way existing `keyArgs: [...]` configurations work, this PR will allow you to refer to directives like the `@connection` directive, or query variables, in the same array where you usually specify your `keyArgs`:
```ts
new InMemoryCache({
  typePolicies: {
    Query: {
      fields: {
        feed: {
          keyArgs: ["type", "@connection", ["key"], "$var"],
        },
      },
    },
  },
})
```
Information about directives is included by default in the field key if you _don't_ provide a `keyArgs: [...]` configuration, but is lost when switching to `keyArgs: [...]`, which can be surprising. You can alternatively provide a `keyArgs(args, context) {...}` _function_ to return any key you like, taking `context.field.directives` into account, but that's a lot more involved and error-prone.

This cache configuration allows queries to use `@connection(key: ...)` to provide additional identifying information for the `Query.feed` field, which is especially useful when more than one `Query.feed` query is using the same arguments for that field, but you want to keep the query results separate in the cache:
```graphql
query FeedQuery($feedType: String) {
  feed(type: $feedType) @connection(key: "main feed") {
    id
    author { name }
    text
  }
}
```
Within the cache, you'll now see field keys like the following:
```ts
expect(cache.extract()).toEqual({
  ROOT_QUERY: {
    __typename: "Query",
    'feed:{"type":"public","@connection":{"key":"main feed"}}': { __typename, id, author, text },
  },
})
```
While the `@connection` directive is a common and widely recommended way to solve this problem, I'm proud to say this implementation does not hard-code support for the `@connection` directive. You can name the directive anything you want, and it will serve the same purpose, from the perspective of field identity.

The `$var` syntax seems useful when you want the field's storage key to depend on a variable that's not otherwise passed to that field, perhaps because your server expects the variable to be passed as an argument to a different field than the one you're trying to configure.

Both `@directive` and `$variable` notations are unambiguous with actual arguments (and with each other), because field argument names can only start with an alphabetical letter or an underscore, according to the spec [here](https://spec.graphql.org/draft/#sec-Language.Arguments) and [here](https://spec.graphql.org/draft/#Name).

The same tolerance/optionality we introduced for `keyArgs` in #7109 applies to directives and variables, too: when there's no `@connection` directive on the `Query.feed` field in the query, or no `$var` variable provided by the query, those details will simply be omitted from the field key, rather than triggering an exception. Note: `keyFields: [...]` still throws an exception for missing primary keys.

One immediate aesthetic problem with this approach is that the `keyArgs` configuration may seem misnamed, since it's handling more than just field arguments. If that bothers you like it bothers me, I introduced a more general field `key` configuration that's synonymous in every way with `keyArgs` (except that `key` takes precedence if both are provided). I think this new name is the "right" name, since the goal of this configuration is to come up with a uniquely identifying storage key for the field, not necessarily limited to the provided arguments. This insight allows us to avoid introducing new configurations like `keyDirectives` or `keyVariables` to accompany `keyArgs`, as I suggested yesterday in https://github.com/apollographql/apollo-client/issues/8659#issuecomment-901479599.

We may deprecate and remove `keyArgs` in the (distant, post-AC4) future, in favor of this new `key` property, but there's a lot of content out there that talks about `keyArgs`, and I see no reason to force people to migrate existing code, in this case.