### PR TITLE
Improve `keyFields` error behavior when primary key fields are missing

### DIFF
--- a/src/cache/inmemory/__tests__/entityStore.ts
+++ b/src/cache/inmemory/__tests__/entityStore.ts
@@ -1772,9 +1772,19 @@ describe('EntityStore', () => {
       c: 3,
     })).toBe('ABCs:{"b":2,"a":1,"c":3}');
 
-    expect(() => cache.identify(ABCs)).toThrowError(
-      "Missing field 'b' while computing key fields",
-    );
+    { // TODO Extact this to a helper function.
+      const consoleWarnSpy = jest.spyOn(console, "warn");
+      consoleWarnSpy.mockImplementation(() => {});
+      try {
+        expect(cache.identify(ABCs)).toBeUndefined();
+        expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+          new Error("Missing field 'b' while computing key fields")
+        );
+      } finally {
+        consoleWarnSpy.mockRestore();
+      }
+    }
 
     expect(cache.readFragment({
       id: cache.identify({

--- a/src/cache/inmemory/__tests__/entityStore.ts
+++ b/src/cache/inmemory/__tests__/entityStore.ts
@@ -1779,7 +1779,9 @@ describe('EntityStore', () => {
         expect(cache.identify(ABCs)).toBeUndefined();
         expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
         expect(consoleWarnSpy).toHaveBeenCalledWith(
-          new Error("Missing field 'b' while computing key fields")
+          new Error(`Missing field 'b' while extracting keyFields from ${
+            JSON.stringify(ABCs)
+          }`),
         );
       } finally {
         consoleWarnSpy.mockRestore();

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -346,7 +346,11 @@ describe("type policies", function () {
           book: theInformationBookData,
         },
       });
-    }).toThrowError("Missing field 'year' while computing key fields");
+    }).toThrowError(
+      `Missing field 'year' while extracting keyFields from ${JSON.stringify(
+        theInformationBookData
+      )}`,
+    );
   });
 
   it("does not clobber previous keyFields with undefined", function () {

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -4,6 +4,7 @@ import './fixPolyfills';
 import { DocumentNode } from 'graphql';
 import { OptimisticWrapperFunction, wrap } from 'optimism';
 import { equal } from '@wry/equality';
+import { invariant } from 'ts-invariant';
 
 import { ApolloCache } from '../core/cache';
 import { Cache } from '../core/types/Cache';
@@ -334,8 +335,12 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
   // sure that none of the primary key fields have been renamed by aliasing.
   // If you pass a Reference object, its __ref ID string will be returned.
   public identify(object: StoreObject | Reference): string | undefined {
-    return isReference(object) ? object.__ref :
-      this.policies.identify(object)[0];
+    if (isReference(object)) return object.__ref;
+    try {
+      return this.policies.identify(object)[0];
+    } catch (e) {
+      invariant.warn(e);
+    }
   }
 
   public evict(options: Cache.EvictOptions): boolean {

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -1118,7 +1118,9 @@ function computeKeyFieldsObject(
       const responseKey = aliases && aliases[s] || s;
       invariant(
         hasOwn.call(response, responseKey),
-        `Missing field '${responseKey}' while computing key fields`,
+        `Missing field '${responseKey}' while extracting keyFields from ${
+          JSON.stringify(response)
+        }`,
       );
       keyObj[lastActualKey = s] = response[lastResponseKey = responseKey];
     }


### PR DESCRIPTION
Building on #8678 (only because it touches the same code), this PR seeks to improve the way `computeKeyFieldsObject` behaves when it fails, in two ways:
* The `cache.identify` method (which ultimately calls `computeKeyFieldsObject` when `keyFields` is configured) will no longer throw under any circumstances, instead returning undefined to indicate failure (as usual).
* The error message thrown when `computeKeyFieldsObject` fails will now include the object that was missing the desired field, making it much easier to tell why the error happened (as suggested by @jorbuedo in https://github.com/apollographql/apollo-client/issues/6673#issuecomment-902031088).

This may not be a full solution to #6673, but I'm sure it will help.