### PR TITLE
Enforce that `__DEV__` is polyfilled in every entry point that uses it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Fix unhandled `Promise` rejection warnings/errors whose message is `Observable cancelled prematurely`. <br/>
   [@benjamn](https://github.com/benjamn) in [#8676](https://github.com/apollographql/apollo-client/pull/8676)
 
+- Enforce that `__DEV__` is polyfilled by every `@apollo/client/*` entry point that uses it. This build step considers not only explicit `__DEV__` usage but also `__DEV__` references injected near `invariant(...)` and `new InvariantError(...)` expressions. <br/>
+  [@benjamn](https://github.com/benjamn) in [#8689](https://github.com/apollographql/apollo-client/pull/8689)
+
 ## Apollo Client 3.4.8
 
 ### Bug Fixes

--- a/config/checkDEV.ts
+++ b/config/checkDEV.ts
@@ -1,0 +1,54 @@
+import * as path from "path";
+import { readFileSync, promises as fs } from "fs";
+import { eachFile, distDir } from "./helpers";
+
+const entryPoints = require("./entryPoints.js");
+
+const filesWithDEV = new Set<string>();
+
+eachFile(distDir, async file => {
+  const source = await fs.readFile(file, "utf8");
+  if (/\b__DEV__\b/.test(source)) {
+    filesWithDEV.add(file);
+  }
+}).then(() => {
+  const filesByEntryPoint = new Map<string, {
+    indexPath: string;
+    source: string;
+    files: Set<string>;
+  }>();
+
+  entryPoints.forEach(({ dirs }: { dirs: string[] }) => {
+    const relIndexPath = path.join(...dirs, "index.js");
+    const absIndexPath = path.join(distDir, relIndexPath);
+    filesByEntryPoint.set(dirs.join("/"), {
+      indexPath: relIndexPath,
+      source: readFileSync(absIndexPath, "utf8"),
+      files: new Set<string>(),
+    });
+  });
+
+  filesWithDEV.forEach(file => {
+    const entryPointDir = entryPoints.getEntryPointDirectory(file);
+    const info = filesByEntryPoint.get(entryPointDir);
+    const absEntryPointDir = path.join(distDir, entryPointDir);
+    const relPath = "./" + path.relative(absEntryPointDir, file);
+    if (info) {
+      info.files.add(relPath);
+    }
+  });
+
+  filesByEntryPoint.forEach(({ indexPath, source, files }, entryPointDir) => {
+    if (!files.size || source.indexOf("checkDEV()") >= 0) {
+      return;
+    }
+    const entryPointId = `@apollo/client/${entryPointDir}`;
+    throw new Error(`Entry point ${
+      entryPointId
+    }/index.js does not call checkDEV(), but ${
+      entryPointId
+    } contains the following files that use __DEV__: ${
+      Array.from(files).join(", ")
+    }`);
+  });
+});

--- a/config/entryPoints.js
+++ b/config/entryPoints.js
@@ -92,6 +92,12 @@ function partsAfterDist(id) {
   }
 }
 
+exports.getEntryPointDirectory = function (file) {
+  const parts = partsAfterDist(file) || file.split(path.sep);
+  const len = lengthOfLongestEntryPoint(parts);
+  if (len >= 0) return parts.slice(0, len).join(path.sep);
+};
+
 function lengthOfLongestEntryPoint(parts) {
   let node = lookupTrie;
   let longest = -1;

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "prebuild": "npm run clean",
     "build": "tsc",
-    "postbuild": "npm run update-version && npm run invariants && npm run sourcemaps && npm run rollup && npm run prepdist && npm run resolve && npm run verify-version",
+    "postbuild": "npm run update-version && npm run invariants && npm run sourcemaps && npm run rollup && npm run prepdist && npm run resolve && npm run check-DEV && npm run verify-version",
     "update-version": "node config/version.js update",
     "verify-version": "node config/version.js verify",
     "invariants": "ts-node-script config/processInvariants.ts",
@@ -39,6 +39,7 @@
     "rollup": "rollup -c ./config/rollup.config.js",
     "prepdist": "node ./config/prepareDist.js",
     "resolve": "ts-node-script config/resolveModuleIds.ts",
+    "check-DEV": "ts-node-script config/checkDEV.ts",
     "clean": "rimraf -r dist coverage lib",
     "test": "jest --config ./config/jest.config.js",
     "test:debug": "BABEL_ENV=server node --inspect-brk node_modules/.bin/jest --config ./config/jest.config.js --runInBand",

--- a/src/__tests__/__snapshots__/exports.ts.snap
+++ b/src/__tests__/__snapshots__/exports.ts.snap
@@ -331,6 +331,7 @@ Array [
   "buildQueryFromSelectionSet",
   "canUseWeakMap",
   "canUseWeakSet",
+  "checkDEV",
   "checkDocument",
   "cloneDeep",
   "compact",

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -1,6 +1,5 @@
-import { invariant } from "ts-invariant";
-import { DEV } from "../utilities";
-invariant("boolean" === typeof DEV, DEV);
+import { checkDEV } from "../utilities";
+checkDEV();
 
 export { Transaction, ApolloCache } from './core/cache';
 export { Cache } from './core/types/Cache';

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,6 +1,7 @@
 /* Core */
 
-import { DEV } from "../utilities";
+import { DEV, checkDEV } from "../utilities";
+checkDEV();
 
 export {
   ApolloClient,

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,6 +1,5 @@
-import { invariant } from "ts-invariant";
-import { DEV } from "../utilities";
-invariant("boolean" === typeof DEV, DEV);
+import { checkDEV } from "../utilities";
+checkDEV();
 
 import { GraphQLError } from 'graphql';
 

--- a/src/link/core/index.ts
+++ b/src/link/core/index.ts
@@ -1,6 +1,5 @@
-import { invariant } from "ts-invariant";
-import { DEV } from "../../utilities";
-invariant("boolean" === typeof DEV, DEV);
+import { checkDEV } from "../../utilities";
+checkDEV();
 
 export { empty } from './empty';
 export { from } from './from';

--- a/src/link/http/index.ts
+++ b/src/link/http/index.ts
@@ -1,3 +1,8 @@
+import { invariant } from "ts-invariant";
+import { DEV } from "../../utilities";
+// Since createHttpLink uses __DEV__, we must be sure to polyfill it.
+invariant("boolean" === typeof DEV, DEV);
+
 export {
   parseAndCheckHttpResponse,
   ServerParseError

--- a/src/link/http/index.ts
+++ b/src/link/http/index.ts
@@ -1,7 +1,5 @@
-import { invariant } from "ts-invariant";
-import { DEV } from "../../utilities";
-// Since createHttpLink uses __DEV__, we must be sure to polyfill it.
-invariant("boolean" === typeof DEV, DEV);
+import { checkDEV } from "../../utilities";
+checkDEV();
 
 export {
   parseAndCheckHttpResponse,

--- a/src/link/persisted-queries/index.ts
+++ b/src/link/persisted-queries/index.ts
@@ -1,3 +1,6 @@
+import { checkDEV } from "../../utilities";
+checkDEV();
+
 import { print } from 'graphql';
 import {
   DocumentNode,

--- a/src/link/utils/index.ts
+++ b/src/link/utils/index.ts
@@ -1,3 +1,6 @@
+import { checkDEV } from "../../utilities";
+checkDEV();
+
 export { fromError } from './fromError';
 export { toPromise } from './toPromise';
 export { fromPromise } from './fromPromise';

--- a/src/react/context/index.ts
+++ b/src/react/context/index.ts
@@ -1,3 +1,6 @@
+import { checkDEV } from "../../utilities";
+checkDEV();
+
 export * from './ApolloConsumer';
 export * from './ApolloContext';
 export * from './ApolloProvider';

--- a/src/react/data/index.ts
+++ b/src/react/data/index.ts
@@ -1,3 +1,6 @@
+import { checkDEV } from "../../utilities";
+checkDEV();
+
 export { SubscriptionData } from './SubscriptionData';
 export { OperationData } from './OperationData';
 export { MutationData } from './MutationData';

--- a/src/react/hoc/index.ts
+++ b/src/react/hoc/index.ts
@@ -1,3 +1,6 @@
+import { checkDEV } from "../../utilities";
+checkDEV();
+
 export { graphql } from './graphql';
 
 export { withQuery } from './query-hoc';

--- a/src/react/hooks/index.ts
+++ b/src/react/hooks/index.ts
@@ -1,3 +1,6 @@
+import { checkDEV } from "../../utilities";
+checkDEV();
+
 export * from './useApolloClient';
 export * from './useLazyQuery';
 export * from './useMutation';

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -1,6 +1,5 @@
-import { invariant } from "ts-invariant";
-import { DEV } from "../utilities";
-invariant("boolean" === typeof DEV, DEV);
+import { checkDEV } from "../utilities";
+checkDEV();
 
 export {
   ApolloProvider,

--- a/src/react/parser/index.ts
+++ b/src/react/parser/index.ts
@@ -1,3 +1,6 @@
+import { checkDEV } from "../../utilities";
+checkDEV();
+
 import {
   DocumentNode,
   DefinitionNode,

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -1,4 +1,4 @@
-import { invariant } from "ts-invariant";
-import { DEV } from "../utilities";
-invariant("boolean" === typeof DEV, DEV);
+import { checkDEV } from "../utilities";
+checkDEV();
+
 export * from '../utilities/testing';

--- a/src/utilities/globals/index.ts
+++ b/src/utilities/globals/index.ts
@@ -1,7 +1,12 @@
+import { invariant } from "ts-invariant";
+
 // Just in case the graphql package switches from process.env.NODE_ENV to
 // __DEV__, make sure __DEV__ is polyfilled before importing graphql.
 import DEV from "./DEV";
 export { DEV }
+export function checkDEV() {
+  invariant("boolean" === typeof DEV, DEV);
+}
 
 // Import graphql/jsutils/instanceOf safely, working around its unchecked usage
 // of process.env.NODE_ENV and https://github.com/graphql/graphql-js/pull/2894.

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,7 +1,6 @@
-import { invariant } from "ts-invariant";
-import { DEV } from "./globals";
-invariant("boolean" === typeof DEV, DEV);
-export { DEV }
+import { DEV, checkDEV } from "./globals";
+export { DEV, checkDEV }
+checkDEV();
 
 export {
   DirectiveInfo,


### PR DESCRIPTION
This PR started out as a quick fix for #8674, but in the process I realized the best way to prevent `ReferenceError`s for `__DEV__` once and for all is to write a build step that examines compiled `dist/` code for usage of `__DEV__`, and enforces that the corresponding entry point `index.js` file imports and calls `checkDEV()`.

To test these changes using a published version of `@apollo/client`, I merged this PR branch into `release-3.5` and published `@apollo/client@3.5.0-beta.7` with this PR included. From my testing, this version works as before with ESM-aware CDNs like [esm.run](https://esm.run). In particular, the following code works in a browser console:
```js
await import("https://esm.run/@apollo/client@3.5.0-beta.7/core")
```
See #8266 for more background on why this matters here.

Related issues and PRs:
* #8347
* #8393
* #8558
* #8557