### PR TITLE
Update `zen-observable-ts` to eliminate transitive dependency on `@types/zen-observable`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
 - Calling `refetch` on a skipped query will have no effect (issue [#8270](https://github.com/apollographql/apollo-client/issues/8270)).
 - Prevent `onError` and `onCompleted` functions from firing continuously, and improving their polling behavior.
 
+### Other Bugs Fixed
+
+- Update `zen-observable-ts` to eliminate transitive dependency on `@types/zen-observable`. <br/>
+  [@benjamn](https://github.com/benjamn) in [#8695](https://github.com/apollographql/apollo-client/pull/8695)
+
 ## Apollo Client 3.4.9 (not yet released)
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "symbol-observable": "^4.0.0",
         "ts-invariant": "^0.9.0",
         "tslib": "^2.3.0",
-        "zen-observable-ts": "^1.1.0"
+        "zen-observable-ts": "^1.2.0"
       },
       "devDependencies": {
         "@babel/parser": "7.15.3",
@@ -2428,11 +2428,6 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
       "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
       "dev": true
-    },
-    "node_modules/@types/zen-observable": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.3.tgz",
-      "integrity": "sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw=="
     },
     "node_modules/@wry/context": {
       "version": "0.6.0",
@@ -12055,11 +12050,10 @@
       "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
     },
     "node_modules/zen-observable-ts": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.1.0.tgz",
-      "integrity": "sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.0.tgz",
+      "integrity": "sha512-3IklmJSChXaqAD2gPz6yKHThAnZL46D51x5EPpN/MHuPjrepVdSg3qI7f5fh1RT8Y+K46Owo9fpVuJiuJXLMMA==",
       "dependencies": {
-        "@types/zen-observable": "0.8.3",
         "zen-observable": "0.8.15"
       }
     }
@@ -14042,11 +14036,6 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
       "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
       "dev": true
-    },
-    "@types/zen-observable": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.3.tgz",
-      "integrity": "sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw=="
     },
     "@wry/context": {
       "version": "0.6.0",
@@ -21702,11 +21691,10 @@
       "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
     },
     "zen-observable-ts": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.1.0.tgz",
-      "integrity": "sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.0.tgz",
+      "integrity": "sha512-3IklmJSChXaqAD2gPz6yKHThAnZL46D51x5EPpN/MHuPjrepVdSg3qI7f5fh1RT8Y+K46Owo9fpVuJiuJXLMMA==",
       "requires": {
-        "@types/zen-observable": "0.8.3",
         "zen-observable": "0.8.15"
       }
     }

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "symbol-observable": "^4.0.0",
     "ts-invariant": "^0.9.0",
     "tslib": "^2.3.0",
-    "zen-observable-ts": "^1.1.0"
+    "zen-observable-ts": "^1.2.0"
   },
   "devDependencies": {
     "@babel/parser": "7.15.3",

--- a/src/core/__tests__/QueryManager/links.ts
+++ b/src/core/__tests__/QueryManager/links.ts
@@ -1,7 +1,7 @@
 // externals
 import gql from 'graphql-tag';
 
-import { Observable } from '../../../utilities/observables/Observable';
+import { Observable, ObservableSubscription } from '../../../utilities/observables/Observable';
 import { ApolloLink } from '../../../link/core';
 import { InMemoryCache } from '../../../cache/inmemory/inMemoryCache';
 
@@ -104,7 +104,7 @@ describe('Link interactions', () => {
     });
 
     let count = 0;
-    let four: ZenObservable.Subscription;
+    let four: ObservableSubscription;
     // first watch
     const one = observable.subscribe(result => count++);
     // second watch
@@ -175,7 +175,7 @@ describe('Link interactions', () => {
     });
 
     let count = 0;
-    let four: ZenObservable.Subscription;
+    let four: ObservableSubscription;
     // first watch
     const one = observable.subscribe(result => count++);
     // second watch

--- a/src/core/__tests__/QueryManager/recycler.ts
+++ b/src/core/__tests__/QueryManager/recycler.ts
@@ -14,6 +14,7 @@ import {
 // core
 import { QueryManager } from '../../QueryManager';
 import { ObservableQuery } from '../../ObservableQuery';
+import { ObservableSubscription } from '../../../utilities';
 
 describe('Subscription lifecycles', () => {
   it('cleans up and reuses data like QueryRecycler wants', done => {
@@ -48,7 +49,10 @@ describe('Subscription lifecycles', () => {
       fetchPolicy: 'cache-and-network',
     });
 
-    const observableQueries: { observableQuery: ObservableQuery, subscription: ZenObservable.Subscription; }[] = [];
+    const observableQueries: Array<{
+      observableQuery: ObservableQuery;
+      subscription: ObservableSubscription;
+    }> = [];
 
     const resubscribe = () => {
       const { observableQuery, subscription } = observableQueries.pop()!;

--- a/src/link/context/index.ts
+++ b/src/link/context/index.ts
@@ -1,5 +1,5 @@
 import { ApolloLink, Operation, GraphQLRequest, NextLink } from '../core';
-import { Observable } from '../../utilities';
+import { Observable, ObservableSubscription } from '../../utilities';
 
 export type ContextSetter = (
   operation: GraphQLRequest,
@@ -11,7 +11,7 @@ export function setContext(setter: ContextSetter): ApolloLink {
     const { ...request } = operation;
 
     return new Observable(observer => {
-      let handle: ZenObservable.Subscription;
+      let handle: ObservableSubscription;
       let closed = false;
       Promise.resolve(request)
         .then(req => setter(req, operation.getContext()))

--- a/src/link/core/ApolloLink.ts
+++ b/src/link/core/ApolloLink.ts
@@ -1,6 +1,6 @@
 import { InvariantError, invariant } from 'ts-invariant';
 
-import { Observable } from '../../utilities';
+import { Observable, Observer } from '../../utilities';
 import {
   NextLink,
   Operation,
@@ -143,7 +143,7 @@ export class ApolloLink {
 
   protected onError(
     error: any,
-    observer?: ZenObservable.Observer<FetchResult>,
+    observer?: Observer<FetchResult>,
   ): false | void {
     if (observer && observer.error) {
       observer.error(error);

--- a/src/link/http/__tests__/HttpLink.ts
+++ b/src/link/http/__tests__/HttpLink.ts
@@ -2,7 +2,7 @@ import gql from 'graphql-tag';
 import fetchMock from 'fetch-mock';
 import { print } from 'graphql';
 
-import { Observable } from '../../../utilities/observables/Observable';
+import { Observable, Observer, ObservableSubscription } from '../../../utilities/observables/Observable';
 import { ApolloLink } from '../../core/ApolloLink';
 import { execute } from '../../core/execute';
 import { HttpLink } from '../HttpLink';
@@ -53,8 +53,8 @@ describe('HttpLink', () => {
     const data = { data: { hello: 'world' } };
     const data2 = { data: { hello: 'everyone' } };
     const mockError = { throws: new TypeError('mock me') };
-    let subscriber: ZenObservable.Observer<any>;
-    const subscriptions = new Set<ZenObservable.Subscription>();
+    let subscriber: Observer<any>;
+    const subscriptions = new Set<ObservableSubscription>();
 
     beforeEach(() => {
       fetchMock.restore();

--- a/src/link/persisted-queries/index.ts
+++ b/src/link/persisted-queries/index.ts
@@ -10,7 +10,12 @@ import {
 import { invariant } from 'ts-invariant';
 
 import { ApolloLink, Operation } from '../core';
-import { Observable, Observer, compact } from '../../utilities';
+import {
+  Observable,
+  Observer,
+  ObservableSubscription,
+  compact,
+} from '../../utilities';
 
 export const VERSION = 1;
 
@@ -147,7 +152,7 @@ export const createPersistedQueryLink = (
     const { query } = operation;
 
     return new Observable((observer: Observer<ExecutionResult>) => {
-      let subscription: ZenObservable.Subscription;
+      let subscription: ObservableSubscription;
       let retried = false;
       let originalFetchOptions: any;
       let setFetchOptions = false;

--- a/src/link/retry/retryLink.ts
+++ b/src/link/retry/retryLink.ts
@@ -1,5 +1,5 @@
 import { ApolloLink, Operation, FetchResult, NextLink } from '../core';
-import { Observable } from '../../utilities';
+import { Observable, Observer, ObservableSubscription } from '../../utilities';
 import {
   DelayFunction,
   DelayFunctionOptions,
@@ -34,8 +34,8 @@ class RetryableOperation<TValue = any> {
   private error: any;
   private complete = false;
   private canceled = false;
-  private observers: (ZenObservable.Observer<TValue> | null)[] = [];
-  private currentSubscription: ZenObservable.Subscription | null = null;
+  private observers: (Observer<TValue> | null)[] = [];
+  private currentSubscription: ObservableSubscription | null = null;
   private timerId: number | undefined;
 
   constructor(
@@ -51,7 +51,7 @@ class RetryableOperation<TValue = any> {
    * If the operation has previously emitted other events, they will be
    * immediately triggered for the observer.
    */
-  public subscribe(observer: ZenObservable.Observer<TValue>) {
+  public subscribe(observer: Observer<TValue>) {
     if (this.canceled) {
       throw new Error(
         `Subscribing to a retryable link that was canceled is not supported`,
@@ -77,7 +77,7 @@ class RetryableOperation<TValue = any> {
    * If no observers remain, the operation will stop retrying, and unsubscribe
    * from its downstream link.
    */
-  public unsubscribe(observer: ZenObservable.Observer<TValue>) {
+  public unsubscribe(observer: Observer<TValue>) {
     const index = this.observers.indexOf(observer);
     if (index < 0) {
       throw new Error(

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -2,7 +2,7 @@ import { ReactNode } from 'react';
 import { DocumentNode } from 'graphql';
 import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 
-import { Observable } from '../../utilities';
+import { Observable, ObservableSubscription } from '../../utilities';
 import { FetchResult } from '../../link/core';
 import { ApolloError } from '../../errors';
 import {
@@ -239,5 +239,5 @@ export interface SubscriptionDataOptions<
 
 export interface SubscriptionCurrentObservable {
   query?: Observable<any>;
-  subscription?: ZenObservable.Subscription;
+  subscription?: ObservableSubscription;
 }


### PR DESCRIPTION
This update includes https://github.com/apollographql/zen-observable-ts/pull/152, and should fix issue #8688 because Apollo Client no longer generates code in `dist/**/*.d.ts` files with type references to the `@types/zen-observable` package:
```ts
/// <reference types="zen-observable" />
```
With these references gone, consumers of `zen-observable-ts` should not need to add `@types/zen-observable` as a dependency. In fact, the `@types/zen-observable` package is no longer involved at all. Thus, #8688 should be fixed.

Since this could be a disruptive type-level change for anyone who was previously depending on the global declaration of the `ZenObservable` namespace, I'm targeting the `release-3.5` branch so we can test before releasing.