### PR TITLE
Use `cache.batch` within `cache.updateQuery` and `cache.updateFragment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@
 - A new nested entry point called `@apollo/client/testing/core` has been created. Importing from this entry point instead of `@apollo/client/testing` excludes any React-related dependencies. <br/>
   [@wassim-k](https://github.com/wassim-k) in [#8687](https://github.com/apollographql/apollo-client/pull/8687)
 
+- Make `cache.batch` return the result of calling the `options.update` function. <br/>
+  [@benjamn](https://github.com/benjamn) in [#8696](https://github.com/apollographql/apollo-client/pull/8696)
+
 ### React Refactoring
 
 #### Bug Fixes (due to [@brainkim](https://github.com/brainkim) in [#8596](https://github.com/apollographql/apollo-client/pull/8596)):

--- a/src/cache/core/__tests__/cache.ts
+++ b/src/cache/core/__tests__/cache.ts
@@ -21,6 +21,7 @@ class TestCache extends ApolloCache<unknown> {
   }
 
   public performTransaction(transaction: <TSerialized>(c: ApolloCache<TSerialized>) => void): void {
+    transaction(this);
   }
 
   public read<T, TVariables = any>(query: Cache.ReadOptions<TVariables>): T | null {

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -176,21 +176,29 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
     options: Cache.UpdateQueryOptions<TData, TVariables>,
     update: (data: TData | null) => TData | null | void,
   ): TData | null {
-    const value = this.readQuery<TData, TVariables>(options);
-    const data = update(value);
-    if (data === void 0 || data === null) return value;
-    this.writeQuery<TData, TVariables>({ ...options, data });
-    return data;
+    return this.batch({
+      update(cache) {
+        const value = cache.readQuery<TData, TVariables>(options);
+        const data = update(value);
+        if (data === void 0 || data === null) return value;
+        cache.writeQuery<TData, TVariables>({ ...options, data });
+        return data;
+      },
+    });
   }
 
   public updateFragment<TData = any, TVariables = any>(
     options: Cache.UpdateFragmentOptions<TData, TVariables>,
     update: (data: TData | null) => TData | null | void,
   ): TData | null {
-    const value = this.readFragment<TData, TVariables>(options);
-    const data = update(value);
-    if (data === void 0 || data === null) return value;
-    this.writeFragment<TData, TVariables>({ ...options, data });
-    return data;
+    return this.batch({
+      update(cache) {
+        const value = cache.readFragment<TData, TVariables>(options);
+        const data = update(value);
+        if (data === void 0 || data === null) return value;
+        cache.writeFragment<TData, TVariables>({ ...options, data });
+        return data;
+      },
+    });
   }
 }

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -59,11 +59,16 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
   // provide a default batch implementation that's just another way of calling
   // performTransaction. Subclasses of ApolloCache (such as InMemoryCache) can
   // override the batch method to do more interesting things with its options.
-  public batch(options: Cache.BatchOptions<this>) {
+  public batch<U>(options: Cache.BatchOptions<this, U>): U {
     const optimisticId =
       typeof options.optimistic === "string" ? options.optimistic :
       options.optimistic === false ? null : void 0;
-    this.performTransaction(options.update, optimisticId);
+    let updateResult: U;
+    this.performTransaction(
+      () => updateResult = options.update(this),
+      optimisticId,
+    );
+    return updateResult!;
   }
 
   public abstract performTransaction(

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -14,14 +14,16 @@ export type Transaction<T> = (c: ApolloCache<T>) => void;
 export abstract class ApolloCache<TSerialized> implements DataProxy {
   // required to implement
   // core API
-  public abstract read<T, TVariables = any>(
-    query: Cache.ReadOptions<TVariables, T>,
-  ): T | null;
-  public abstract write<TResult = any, TVariables = any>(
-    write: Cache.WriteOptions<TResult, TVariables>,
+  public abstract read<TData = any, TVariables = any>(
+    query: Cache.ReadOptions<TVariables, TData>,
+  ): TData | null;
+  public abstract write<TData = any, TVariables = any>(
+    write: Cache.WriteOptions<TData, TVariables>,
   ): Reference | undefined;
   public abstract diff<T>(query: Cache.DiffOptions): Cache.DiffResult<T>;
-  public abstract watch(watch: Cache.WatchOptions): () => void;
+  public abstract watch<TData = any, TVariables = any>(
+    watch: Cache.WatchOptions<TData, TVariables>,
+  ): () => void;
   public abstract reset(): Promise<void>;
 
   // Remove whole objects from the cache by passing just options.id, or

--- a/src/cache/core/types/Cache.ts
+++ b/src/cache/core/types/Cache.ts
@@ -3,9 +3,9 @@ import { Modifier, Modifiers } from './common';
 import { ApolloCache } from '../cache';
 
 export namespace Cache {
-  export type WatchCallback = (
-    diff: Cache.DiffResult<any>,
-    lastDiff?: Cache.DiffResult<any>,
+  export type WatchCallback<TData = any> = (
+    diff: Cache.DiffResult<TData>,
+    lastDiff?: Cache.DiffResult<TData>,
   ) => void;
 
   export interface ReadOptions<TVariables = any, TData = any>
@@ -25,19 +25,23 @@ export namespace Cache {
     result: TResult;
   }
 
-  export interface DiffOptions extends ReadOptions {
+  export interface DiffOptions<
+    TData = any,
+    TVariables = any,
+  > extends ReadOptions<TVariables, TData> {
     // The DiffOptions interface is currently just an alias for
     // ReadOptions, though DiffOptions used to be responsible for
     // declaring the returnPartialData option.
   }
 
   export interface WatchOptions<
-    Watcher extends object = Record<string, any>
-  > extends ReadOptions {
-    watcher?: Watcher;
+    TData = any,
+    TVariables = any,
+  > extends ReadOptions<TVariables, TData> {
+    watcher?: object;
     immediate?: boolean;
-    callback: WatchCallback;
-    lastDiff?: DiffResult<any>;
+    callback: WatchCallback<TData>;
+    lastDiff?: DiffResult<TData>;
   }
 
   export interface EvictOptions {

--- a/src/cache/core/types/Cache.ts
+++ b/src/cache/core/types/Cache.ts
@@ -54,10 +54,10 @@ export namespace Cache {
     broadcast?: boolean;
   }
 
-  export interface BatchOptions<C extends ApolloCache<any>> {
+  export interface BatchOptions<C extends ApolloCache<any>, U = void> {
     // Same as the first parameter of performTransaction, except the cache
     // argument will have the subclass type rather than ApolloCache.
-    update(cache: C): void;
+    update(cache: C): U;
 
     // Passing a string for this option creates a new optimistic layer, with the
     // given string as its layer.id, just like passing a string for the
@@ -66,7 +66,7 @@ export namespace Cache {
     // against the current top layer of the cache), and passing false is the
     // same as passing null (running the operation against root/non-optimistic
     // cache data).
-    optimistic: string | boolean;
+    optimistic?: string | boolean;
 
     // If you specify the ID of an optimistic layer using this option, that
     // layer will be removed as part of the batch transaction, triggering at

--- a/src/cache/core/types/Cache.ts
+++ b/src/cache/core/types/Cache.ts
@@ -58,10 +58,13 @@ export namespace Cache {
     broadcast?: boolean;
   }
 
-  export interface BatchOptions<C extends ApolloCache<any>, U = void> {
+  export interface BatchOptions<
+    TCache extends ApolloCache<any>,
+    TUpdateResult = void,
+  > {
     // Same as the first parameter of performTransaction, except the cache
     // argument will have the subclass type rather than ApolloCache.
-    update(cache: C): U;
+    update(cache: TCache): TUpdateResult;
 
     // Passing a string for this option creates a new optimistic layer, with the
     // given string as its layer.id, just like passing a string for the
@@ -84,7 +87,7 @@ export namespace Cache {
     // this batch operation, pass this optional callback function. Returning
     // false from the callback will prevent broadcasting this result.
     onWatchUpdated?: (
-      this: C,
+      this: TCache,
       watch: Cache.WatchOptions,
       diff: Cache.DiffResult<any>,
       lastDiff: Cache.DiffResult<any> | undefined,

--- a/src/cache/inmemory/__tests__/cache.ts
+++ b/src/cache/inmemory/__tests__/cache.ts
@@ -1377,7 +1377,7 @@ describe('Cache', () => {
 
       const dirtied = new Map<Cache.WatchOptions, Cache.DiffResult<any>>();
 
-      cache.batch({
+      const aUpdateResult = cache.batch({
         update(cache) {
           cache.writeQuery({
             query: aQuery,
@@ -1385,12 +1385,14 @@ describe('Cache', () => {
               a: "ay",
             },
           });
+          return "aQuery updated";
         },
         optimistic: true,
         onWatchUpdated(w, diff) {
           dirtied.set(w, diff);
         },
       });
+      expect(aUpdateResult).toBe("aQuery updated");
 
       expect(dirtied.size).toBe(2);
       expect(dirtied.has(aInfo.watch)).toBe(true);
@@ -1418,7 +1420,7 @@ describe('Cache', () => {
 
       dirtied.clear();
 
-      cache.batch({
+      const bUpdateResult = cache.batch({
         update(cache) {
           cache.writeQuery({
             query: bQuery,
@@ -1426,12 +1428,14 @@ describe('Cache', () => {
               b: "bee",
             },
           });
+          // Not returning anything, so beUpdateResult will be undefined.
         },
         optimistic: true,
         onWatchUpdated(w, diff) {
           dirtied.set(w, diff);
         },
       });
+      expect(bUpdateResult).toBeUndefined();
 
       expect(dirtied.size).toBe(2);
       expect(dirtied.has(aInfo.watch)).toBe(false);
@@ -1653,6 +1657,98 @@ describe('Cache', () => {
       aInfo.cancel();
       abInfo.cancel();
       bInfo.cancel();
+    });
+
+    it("returns options.update result for optimistic and non-optimistic batches", () => {
+      const cache = new InMemoryCache;
+      const expected = Symbol.for("expected");
+
+      expect(cache.batch({
+        optimistic: false,
+        update(c) {
+          c.writeQuery({
+            query: gql`query { value }`,
+            data: { value: 12345 },
+          });
+          return expected;
+        },
+      })).toBe(expected);
+
+      expect(cache.batch({
+        optimistic: false,
+        update(c) {
+          c.reset();
+          return expected;
+        },
+      })).toBe(expected);
+
+      expect(cache.batch({
+        optimistic: false,
+        update(c) {
+          c.writeQuery({
+            query: gql`query { optimistic }`,
+            data: { optimistic: false },
+          });
+          return expected;
+        },
+        onWatchUpdated() {
+          throw new Error("onWatchUpdated should not have been called");
+        },
+      })).toBe(expected);
+
+      expect(cache.batch({
+        optimistic: true,
+        update(c) {
+          return expected;
+        },
+      })).toBe(expected);
+
+      expect(cache.batch({
+        optimistic: true,
+        update(c) {
+          c.writeQuery({
+            query: gql`query { optimistic }`,
+            data: { optimistic: true },
+          });
+          return expected;
+        },
+        onWatchUpdated() {
+          throw new Error("onWatchUpdated should not have been called");
+        },
+      })).toBe(expected);
+
+      expect(cache.batch({
+        // The optimistic option defaults to true.
+        // optimistic: true,
+        update(c) {
+          return expected;
+        },
+      })).toBe(expected);
+
+      expect(cache.batch({
+        optimistic: "some optimistic ID",
+        update(c) {
+          expect(c.readQuery({
+            query: gql`query { __typename }`,
+          })).toEqual({ __typename: "Query" });
+          return expected;
+        },
+      })).toBe(expected);
+
+      const optimisticId = "some optimistic ID";
+      expect(cache.batch({
+        optimistic: optimisticId,
+        update(c) {
+          c.writeQuery({
+            query: gql`query { optimistic }`,
+            data: { optimistic: optimisticId },
+          });
+          return expected;
+        },
+        onWatchUpdated() {
+          throw new Error("onWatchUpdated should not have been called");
+        },
+      })).toBe(expected);
     });
   });
 

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -384,7 +384,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
 
   private txCount = 0;
 
-  public batch(options: Cache.BatchOptions<InMemoryCache>) {
+  public batch<U>(options: Cache.BatchOptions<InMemoryCache, U>): U {
     const {
       update,
       optimistic = true,
@@ -392,14 +392,15 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
       onWatchUpdated,
     } = options;
 
-    const perform = (layer?: EntityStore) => {
+    let updateResult: U;
+    const perform = (layer?: EntityStore): U => {
       const { data, optimisticData } = this;
       ++this.txCount;
       if (layer) {
         this.data = this.optimisticData = layer;
       }
       try {
-        update(this);
+        return updateResult = update(this);
       } finally {
         --this.txCount;
         this.data = data;
@@ -478,6 +479,8 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
       // options.onWatchUpdated.
       this.broadcastWatches(options);
     }
+
+    return updateResult!;
   }
 
   public performTransaction(

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -247,7 +247,9 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     }
   }
 
-  public diff<T>(options: Cache.DiffOptions): Cache.DiffResult<T> {
+  public diff<TData, TVariables = any>(
+    options: Cache.DiffOptions<TData, TVariables>,
+  ): Cache.DiffResult<TData> {
     return this.storeReader.diffQueryAgainstStore({
       ...options,
       store: options.optimistic ? this.optimisticData : this.data,
@@ -256,7 +258,9 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     });
   }
 
-  public watch(watch: Cache.WatchOptions): () => void {
+  public watch<TData = any, TVariables = any>(
+    watch: Cache.WatchOptions<TData, TVariables>,
+  ): () => void {
     if (!this.watches.size) {
       // In case we previously called forgetCache(this) because
       // this.watches became empty (see below), reattach this cache to any

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -388,7 +388,9 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
 
   private txCount = 0;
 
-  public batch<U>(options: Cache.BatchOptions<InMemoryCache, U>): U {
+  public batch<TUpdateResult>(
+    options: Cache.BatchOptions<InMemoryCache, TUpdateResult>,
+  ): TUpdateResult {
     const {
       update,
       optimistic = true,
@@ -396,8 +398,8 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
       onWatchUpdated,
     } = options;
 
-    let updateResult: U;
-    const perform = (layer?: EntityStore): U => {
+    let updateResult: TUpdateResult;
+    const perform = (layer?: EntityStore): TUpdateResult => {
       const { data, optimisticData } = this;
       ++this.txCount;
       if (layer) {

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -296,7 +296,7 @@ export class QueryInfo {
   // updateWatch method.
   private cancel() {}
 
-  private lastWatch?: Cache.WatchOptions<QueryInfo>;
+  private lastWatch?: Cache.WatchOptions;
 
   private updateWatch(variables = this.variables) {
     const oq = this.observableQuery;
@@ -304,7 +304,7 @@ export class QueryInfo {
       return;
     }
 
-    const watchOptions: Cache.WatchOptions<QueryInfo> = {
+    const watchOptions: Cache.WatchOptions = {
       // Although this.getDiffOptions returns Cache.DiffOptions instead of
       // Cache.WatchOptions, all the overlapping options should be the same, so
       // we can reuse getDiffOptions here, for consistency.


### PR DESCRIPTION
Since `cache.updateQuery` and `cache.updateFragment` (#8382) run user-provided code (the `update` function), there could end up being multiple cache write operations within a single update, which would trigger `broadcastWatches` separately, unless we apply batching.

Fortunately, the `ApolloCache` class already has a tool for `broadcastWatches` batching: `cache.batch` (introduced by #7819 in AC3.4). However, the exercise of using `cache.batch` for this purpose led me a useful improvement for that API, which I describe below.

The `cache.batch` API followed its predecessor `cache.performTransaction(cache => ...)` in _not_ returning the result of the transaction function (the `options.update` function for `cache.batch`), which makes the following code harder to write:
```js
// This is what I want to write
return this.batch({
  update(cache) {
    // ...
    return data;
  },
});

// This is awkward
let result;
this.batch({
  update(cache) {
    // ...
    result = data;
  },
});
return result;
```

Since the `options.update` function is required in [`Cache.BatchOptions`](https://github.com/apollographql/apollo-client/blob/make-cache.batch-return-options.update-result/src/cache/core/types/Cache.ts#L57-L60), and `cache.batch` always calls it once (synchronously) before returning, I think it makes sense for `cache.batch({ update(cache) { ... }})` to return whatever `options.update` returns, enabling the shorter style of code above.

With these improvements to `cache.batch`, the changes within `cache.updateQuery` and `cache.updateFragment` are shorter/cleaner than they otherwise would have been.