### PR TITLE
Suppress `StoreWriter` errors for missing fields with `read` functions

### DIFF
--- a/src/cache/inmemory/__tests__/__snapshots__/policies.ts.snap
+++ b/src/cache/inmemory/__tests__/__snapshots__/policies.ts.snap
@@ -77,24 +77,6 @@ exports[`type policies complains about missing key fields 1`] = `
 }
 `;
 
-exports[`type policies field policies assumes keyArgs:false when read and merge function present 1`] = `
-[MockFunction] {
-  "calls": Array [
-    Array [
-      "Missing field 'a' while writing result {
-  \\"__typename\\": \\"TypeA\\"
-}",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "type": "return",
-      "value": undefined,
-    },
-  ],
-}
-`;
-
 exports[`type policies field policies can handle Relay-style pagination 1`] = `
 Object {
   "Artist:{\\"href\\":\\"/artist/jean-michel-basquiat\\"}": Object {
@@ -1254,45 +1236,6 @@ Object {
       "__ref": "Author:{\\"name\\":\\"Nadia Eghbal\\"}",
     },
   },
-}
-`;
-
-exports[`type policies field policies read and merge can cooperate through options.storage 1`] = `
-[MockFunction] {
-  "calls": Array [
-    Array [
-      "Missing field 'result' while writing result {
-  \\"__typename\\": \\"Job\\",
-  \\"name\\": \\"Job #1\\"
-}",
-    ],
-    Array [
-      "Missing field 'result' while writing result {
-  \\"__typename\\": \\"Job\\",
-  \\"name\\": \\"Job #2\\"
-}",
-    ],
-    Array [
-      "Missing field 'result' while writing result {
-  \\"__typename\\": \\"Job\\",
-  \\"name\\": \\"Job #3\\"
-}",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "type": "return",
-      "value": undefined,
-    },
-    Object {
-      "type": "return",
-      "value": undefined,
-    },
-    Object {
-      "type": "return",
-      "value": undefined,
-    },
-  ],
 }
 `;
 

--- a/src/cache/inmemory/__tests__/__snapshots__/readFromStore.ts.snap
+++ b/src/cache/inmemory/__tests__/__snapshots__/readFromStore.ts.snap
@@ -1,24 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`reading from the store propagates eviction signals to parent queries 1`] = `
-[MockFunction] {
-  "calls": Array [
-    Array [
-      "Missing field 'children' while writing result {
-  \\"__typename\\": \\"Deity\\",
-  \\"name\\": \\"Zeus\\"
-}",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "type": "return",
-      "value": undefined,
-    },
-  ],
-}
-`;
-
 exports[`reading from the store returns === results for different queries 1`] = `
 Object {
   "ROOT_QUERY": Object {

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -645,7 +645,7 @@ describe("type policies", function () {
       expect(result).toEqual(data);
     });
 
-    withErrorSpy(it, `assumes keyArgs:false when read and merge function present`, function () {
+    it("assumes keyArgs:false when read and merge function present", function () {
       const cache = new InMemoryCache({
         typePolicies: {
           TypeA: {
@@ -1554,7 +1554,7 @@ describe("type policies", function () {
       expect(cache.extract(true)).toEqual(expectedExtraction);
     });
 
-    withErrorSpy(it, "read and merge can cooperate through options.storage", function () {
+    it("read and merge can cooperate through options.storage", function () {
       const cache = new InMemoryCache({
         typePolicies: {
           Query: {

--- a/src/cache/inmemory/__tests__/readFromStore.ts
+++ b/src/cache/inmemory/__tests__/readFromStore.ts
@@ -20,7 +20,6 @@ import {
 
 jest.mock('optimism');
 import { wrap } from 'optimism';
-import { withErrorSpy } from '../../../testing';
 
 describe('resultCacheMaxSize', () => {
   const cache = new InMemoryCache();
@@ -1375,7 +1374,7 @@ describe('reading from the store', () => {
     });
   });
 
-  withErrorSpy(it, "propagates eviction signals to parent queries", () => {
+  it("propagates eviction signals to parent queries", () => {
     const cache = new InMemoryCache({
       typePolicies: {
         Deity: {

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -783,6 +783,14 @@ export class Policies {
     return existing;
   }
 
+  public getReadFunction(
+    typename: string | undefined,
+    fieldName: string,
+  ): FieldReadFunction | undefined {
+    const policy = this.getFieldPolicy(typename, fieldName, false);
+    return policy && policy.read;
+  }
+
   public getMergeFunction(
     parentTypename: string | undefined,
     fieldName: string,

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -320,8 +320,13 @@ export class StoreWriter {
           });
 
         } else if (
+          __DEV__ &&
           !context.clientOnly &&
-          !addTypenameToDocument.added(selection)
+          !addTypenameToDocument.added(selection) &&
+          // If the field has a read function, it may be a synthetic field or
+          // provide a default value, so its absence from the written data
+          // should not be cause for alarm.
+          !policies.getReadFunction(typename, selection.name.value)
         ) {
           invariant.error(`Missing field '${
             resultKeyNameFromField(selection)


### PR DESCRIPTION
PR #8416 converted these missing field errors from thrown exceptions to `invariant.error` log messages, so the whole write no longer fails when one field is missing. Uninhibited by the drawbacks of throwing, PR #8416 also allowed these errors to be logged in many more (legitimate) cases than before.

To reduce console noise, we should consider hiding errors that are not urgent. One case of non-urgency is when the field in question has a `read` function in its field policy, which means the field could have a default or synthetic/computed value, so it's not necessarily a mistake to omit the field from the written data. Errors for fields with(in) `@client` directives are hidden as well (that's what `context.clientOnly` means), and this seems like a similar situation.