### PR TITLE
Improve handling of falsy `existing` and/or `incoming` parameters in `relayStylePagination`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Apollo Client 3.4.12 (not yet released)
+
+### Bug Fixes
+
+- Improve handling of falsy `existing` and/or `incoming` parameters in `relayStylePagination` field policy helper function. <br/>
+  [@bubba](https://github.com/bubba) and [@benjamn](https://github.com/benjamn) in [#8733](https://github.com/apollographql/apollo-client/pull/8733)
+
 ## Apollo Client 3.4.11
 
 ### Bug Fixes

--- a/src/utilities/policies/__tests__/relayStylePagination.test.ts
+++ b/src/utilities/policies/__tests__/relayStylePagination.test.ts
@@ -203,6 +203,58 @@ describe('relayStylePagination', () => {
       });
     });
 
+    it('should merge incoming null with null', () => {
+      const existingEdges = [
+        { cursor: 'alpha', node: makeReference("fakeAlpha") },
+      ];
+      const result = merge(
+        {
+          edges: existingEdges,
+          pageInfo: {
+            hasPreviousPage: false,
+            hasNextPage: true,
+            startCursor: 'alpha',
+            endCursor: 'alpha'
+          },
+        }, null,
+        {
+          ...options,
+          args: {
+            after: 'alpha',
+          },
+        },
+      );
+
+      expect(result).toBeNull();
+    })
+
+    it('should replace existing null with incoming', () => {
+      const incomingEdges = [
+        { cursor: 'alpha', node: makeReference("fakeAlpha") },
+      ];
+      const incoming = {
+        edges: incomingEdges,
+        pageInfo: {
+          hasPreviousPage: false,
+          hasNextPage: true,
+          startCursor: 'alpha',
+          endCursor: 'alpha'
+        },
+      };
+      const result = merge(
+        null,
+        incoming,
+        {
+          ...options,
+          args: {
+            after: 'alpha',
+          },
+        },
+      );
+
+      expect(result).toEqual(incoming);
+    })
+
     it('should maintain extra PageInfo properties', () => {
       const existingEdges = [
         { cursor: 'alpha', node: makeReference("fakeAlpha") },

--- a/src/utilities/policies/__tests__/relayStylePagination.test.ts
+++ b/src/utilities/policies/__tests__/relayStylePagination.test.ts
@@ -203,29 +203,37 @@ describe('relayStylePagination', () => {
       });
     });
 
-    it('should merge incoming null with null', () => {
+    it('should preserve existing if incoming is null', () => {
       const existingEdges = [
         { cursor: 'alpha', node: makeReference("fakeAlpha") },
       ];
-      const result = merge(
-        {
-          edges: existingEdges,
-          pageInfo: {
-            hasPreviousPage: false,
-            hasNextPage: true,
-            startCursor: 'alpha',
-            endCursor: 'alpha'
-          },
-        }, null,
-        {
-          ...options,
-          args: {
-            after: 'alpha',
-          },
+
+      const fakeExisting = {
+        edges: existingEdges,
+        pageInfo: {
+          hasPreviousPage: false,
+          hasNextPage: true,
+          startCursor: 'alpha',
+          endCursor: 'alpha'
         },
+      };
+
+      const fakeIncoming = null;
+
+      const fakeOptions = {
+        ...options,
+        args: {
+          after: 'alpha',
+        },
+      };
+
+      const result = merge(
+        fakeExisting,
+        fakeIncoming,
+        fakeOptions,
       );
 
-      expect(result).toBeNull();
+      expect(result).toEqual(fakeExisting);
     })
 
     it('should replace existing null with incoming', () => {

--- a/src/utilities/policies/pagination.ts
+++ b/src/utilities/policies/pagination.ts
@@ -80,9 +80,9 @@ export type TIncomingRelay<TNode> = {
 };
 
 export type RelayFieldPolicy<TNode> = FieldPolicy<
-  TExistingRelay<TNode>,
-  TIncomingRelay<TNode>,
-  TIncomingRelay<TNode>
+  TExistingRelay<TNode> | null,
+  TIncomingRelay<TNode> | null,
+  TIncomingRelay<TNode> | null
 >;
 
 // As proof of the flexibility of field policies, this function generates
@@ -95,7 +95,8 @@ export function relayStylePagination<TNode = Reference>(
     keyArgs,
 
     read(existing, { canRead, readField }) {
-      if (!existing) return;
+      if (existing === undefined) return undefined;
+      if (existing === null) return null;
 
       const edges: TRelayEdge<TNode>[] = [];
       let firstEdgeCursor = "";
@@ -134,6 +135,12 @@ export function relayStylePagination<TNode = Reference>(
     },
 
     merge(existing = makeEmptyData(), incoming, { args, isReference, readField }) {
+      if (incoming === null) {
+        return null
+      }
+      if (existing === null) {
+        existing = makeEmptyData()
+      }
       const incomingEdges = incoming.edges ? incoming.edges.map(edge => {
         if (isReference(edge = { ...edge })) {
           // In case edge is a Reference, we read out its cursor field and

--- a/src/utilities/policies/pagination.ts
+++ b/src/utilities/policies/pagination.ts
@@ -95,8 +95,7 @@ export function relayStylePagination<TNode = Reference>(
     keyArgs,
 
     read(existing, { canRead, readField }) {
-      if (existing === undefined) return undefined;
-      if (existing === null) return null;
+      if (!existing) return existing;
 
       const edges: TRelayEdge<TNode>[] = [];
       let firstEdgeCursor = "";
@@ -134,13 +133,15 @@ export function relayStylePagination<TNode = Reference>(
       };
     },
 
-    merge(existing = makeEmptyData(), incoming, { args, isReference, readField }) {
-      if (incoming === null) {
-        return null
+    merge(existing, incoming, { args, isReference, readField }) {
+      if (!existing) {
+        existing = makeEmptyData();
       }
-      if (existing === null) {
-        existing = makeEmptyData()
+
+      if (!incoming) {
+        return existing;
       }
+
       const incomingEdges = incoming.edges ? incoming.edges.map(edge => {
         if (isReference(edge = { ...edge })) {
           // In case edge is a Reference, we read out its cursor field and


### PR DESCRIPTION
Building on #7949 by @bubba, and hopefully fixing #7822.