### PR TITLE
Report single `MissingTree` instead of large `MissingFieldError[]` array for incomplete cache reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
   ```
   [@benjamn](https://github.com/benjamn) in [#8678](https://github.com/apollographql/apollo-client/pull/8678)
 
+- Report single `MissingFieldError` instead of a potentially very large `MissingFieldError[]` array for incomplete cache reads, improving performance and memory usage. <br/>
+  [@benjamn](https://github.com/benjamn) in [#8734](https://github.com/apollographql/apollo-client/pull/8734)
+
 - Ensure `cache.identify` never throws when primary key fields are missing, and include the source object in the error message when `keyFields` processing fails. <br/>
   [@benjamn](https://github.com/benjamn) in [#8679](https://github.com/apollographql/apollo-client/pull/8679)
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     {
       "name": "apollo-client",
       "path": "./dist/apollo-client.min.cjs",
-      "maxSize": "27.7 kB"
+      "maxSize": "27.8 kB"
     }
   ],
   "engines": {

--- a/src/cache/core/types/common.ts
+++ b/src/cache/core/types/common.ts
@@ -1,4 +1,4 @@
-import { FieldNode } from 'graphql';
+import { DocumentNode, FieldNode } from 'graphql';
 
 import {
   Reference,
@@ -18,18 +18,17 @@ import { StorageType } from '../../inmemory/policies';
 // Readonly<any>, somewhat surprisingly.
 export type SafeReadonly<T> = T extends object ? Readonly<T> : T;
 
-export class MissingFieldError extends Error {
+export type MissingTree = string | {
+  readonly [key: string]: MissingTree;
+};
+
+export class MissingFieldError {
   constructor(
     public readonly message: string,
-    public readonly path: (string | number)[],
-    public readonly query: import('graphql').DocumentNode,
+    public readonly path: MissingTree | Array<string | number>,
+    public readonly query: DocumentNode,
     public readonly variables?: Record<string, any>,
-  ) {
-    super(message);
-    // We're not using `Object.setPrototypeOf` here as it isn't fully
-    // supported on Android (see issue #3236).
-    (this as any).__proto__ = MissingFieldError.prototype;
-  }
+  ) {}
 }
 
 export interface FieldSpecifier {

--- a/src/cache/inmemory/__tests__/entityStore.ts
+++ b/src/cache/inmemory/__tests__/entityStore.ts
@@ -1322,14 +1322,13 @@ describe('EntityStore', () => {
       },
       missing: [
         new MissingFieldError(
-          'Can\'t find field \'hobby\' on Author:{"name":"Ted Chiang"} object',
-          ["authorOfBook", "hobby"],
-          expect.anything(), // query
-          expect.anything(), // variables
-        ),
-        new MissingFieldError(
-          'Can\'t find field \'publisherOfBook\' on ROOT_QUERY object',
-          ["publisherOfBook"],
+          "Can't find field 'hobby' on Author:{\"name\":\"Ted Chiang\"} object",
+          {
+            publisherOfBook: "Can't find field 'publisherOfBook' on ROOT_QUERY object",
+            authorOfBook: {
+              hobby: "Can't find field 'hobby' on Author:{\"name\":\"Ted Chiang\"} object",
+            },
+          },
           expect.anything(), // query
           expect.anything(), // variables
         ),
@@ -1934,7 +1933,11 @@ describe('EntityStore', () => {
     const missing = [
       new MissingFieldError(
         "Dangling reference to missing Author:2 object",
-        ["book", "author"],
+        {
+          book: {
+            author: "Dangling reference to missing Author:2 object",
+          },
+        },
         expect.anything(), // query
         expect.anything(), // variables
       ),
@@ -2203,7 +2206,11 @@ describe('EntityStore', () => {
       missing: [
         new MissingFieldError(
           'Can\'t find field \'title\' on Book:{"isbn":"031648637X"} object',
-          ["book", "title"],
+          {
+            book: {
+              title: 'Can\'t find field \'title\' on Book:{"isbn":"031648637X"} object',
+            },
+          },
           expect.anything(), // query
           expect.anything(), // variables
         ),

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -1646,15 +1646,6 @@ describe("type policies", function () {
 
       expect(cache.extract()).toEqual(snapshot1);
 
-      function makeMissingError(jobNumber: number) {
-        return new MissingFieldError(
-          `Can't find field 'result' on Job:{"name":"Job #${jobNumber}"} object`,
-          ["jobs", jobNumber - 1, "result"],
-          expect.anything(), // query
-          expect.anything(), // variables
-        );
-      }
-
       expect(cache.diff({
         query,
         optimistic: false,
@@ -1674,9 +1665,24 @@ describe("type policies", function () {
         },
         complete: false,
         missing: [
-          makeMissingError(1),
-          makeMissingError(2),
-          makeMissingError(3),
+          new MissingFieldError(
+            `Can't find field 'result' on Job:{"name":"Job #${1}"} object`,
+            {
+              jobs: {
+                0: {
+                  result: "Can't find field 'result' on Job:{\"name\":\"Job #1\"} object",
+                },
+                1: {
+                  result: "Can't find field 'result' on Job:{\"name\":\"Job #2\"} object",
+                },
+                2: {
+                  result: "Can't find field 'result' on Job:{\"name\":\"Job #3\"} object",
+                },
+              },
+            },
+            expect.anything(), // query
+            expect.anything(), // variables
+          ),
         ],
       });
 
@@ -1732,8 +1738,21 @@ describe("type policies", function () {
         },
         complete: false,
         missing: [
-          makeMissingError(1),
-          makeMissingError(3),
+          new MissingFieldError(
+            `Can't find field 'result' on Job:{"name":"Job #${1}"} object`,
+            {
+              jobs: {
+                0: {
+                  result: "Can't find field 'result' on Job:{\"name\":\"Job #1\"} object",
+                },
+                2: {
+                  result: "Can't find field 'result' on Job:{\"name\":\"Job #3\"} object",
+                },
+              },
+            },
+            expect.anything(), // query
+            expect.anything(), // variables
+          ),
         ],
       });
 
@@ -1796,8 +1815,21 @@ describe("type policies", function () {
         },
         complete: false,
         missing: [
-          makeMissingError(1),
-          makeMissingError(3),
+          new MissingFieldError(
+            `Can't find field 'result' on Job:{"name":"Job #${1}"} object`,
+            {
+              jobs: {
+                0: {
+                  result: "Can't find field 'result' on Job:{\"name\":\"Job #1\"} object",
+                },
+                2: {
+                  result: "Can't find field 'result' on Job:{\"name\":\"Job #3\"} object",
+                },
+              },
+            },
+            expect.anything(), // query
+            expect.anything(), // variables
+          ),
         ],
       });
 

--- a/src/cache/inmemory/__tests__/readFromStore.ts
+++ b/src/cache/inmemory/__tests__/readFromStore.ts
@@ -723,18 +723,21 @@ describe('reading from the store', () => {
 
     expect(missing).toEqual([
       new MissingFieldError(
-        `Can't find field 'missing' on object {
-  "present": "here"
-}`,
-        ["normal", "missing"],
-        query,
-        {}, // variables
-      ),
-      new MissingFieldError(
-        `Can't find field 'missing' on object {
-  "present": "also here"
-}`,
-        ["clientOnly", "missing"],
+        `Can't find field 'missing' on object ${JSON.stringify({
+          present: "also here",
+        }, null, 2)}`,
+        {
+          normal: {
+            missing: `Can't find field 'missing' on object ${
+              JSON.stringify({ present: "here" }, null, 2)
+            }`,
+          },
+          clientOnly: {
+            missing: `Can't find field 'missing' on object ${
+              JSON.stringify({ present: "also here" }, null, 2)
+            }`,
+          },
+        },
         query,
         {}, // variables
       ),
@@ -1289,8 +1292,19 @@ describe('reading from the store', () => {
     expect(diffChickens()).toEqual({
       complete: false,
       missing: [
-        expect.anything(),
-        expect.anything(),
+        new MissingFieldError(
+          "Can't find field 'id' on object {}",
+          {
+            chickens: {
+              1: {
+                id: "Can't find field 'id' on object {}",
+                inCoop: "Can't find field 'inCoop' on object {}",
+              },
+            },
+          },
+          expect.anything(), // query
+          expect.anything(), // variables
+        ),
       ],
       result: {
         chickens: [

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -244,6 +244,12 @@ export class StoreReader {
         canonizeResults,
         fragmentMap: createFragmentMap(getFragmentDefinitions(query)),
         merge(a, b) {
+          // We use the same DeepMerger instance throughout the read, so any
+          // merged objects created during this read can be updated later in the
+          // read using in-place/destructive property assignments. Once the read
+          // is finished, these objects will be frozen, but in the meantime it's
+          // good for performance and memory usage if we avoid allocating a new
+          // object for every merged property.
           return merger.merge(a, b);
         },
       },

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -1,4 +1,4 @@
-import { invariant, InvariantError } from '../../utilities/globals';
+import { invariant } from '../../utilities/globals';
 
 import {
   DocumentNode,
@@ -22,7 +22,7 @@ import {
   getFragmentDefinitions,
   getMainDefinition,
   getQueryDefinition,
-  mergeDeepArray,
+  DeepMerger,
   getFragmentFromSelection,
   maybeDeepFreeze,
   isNonNullObject,
@@ -38,7 +38,7 @@ import { maybeDependOnExistenceOfEntity, supportsResultCaching } from './entityS
 import { getTypenameFromStoreObject } from './helpers';
 import { Policies } from './policies';
 import { InMemoryCache } from './inMemoryCache';
-import { MissingFieldError } from '../core/types/common';
+import { MissingFieldError, MissingTree } from '../core/types/common';
 import { canonicalStringify, ObjectCanon } from './object-canon';
 
 export type VariableMap = { [name: string]: any };
@@ -48,25 +48,14 @@ interface ReadContext extends ReadMergeModifyContext {
   policies: Policies;
   canonizeResults: boolean;
   fragmentMap: FragmentMap;
-  path: (string | number)[];
+  // General-purpose deep-merge function for use during reads.
+  merge<T>(existing: T, incoming: T): T;
 };
 
 export type ExecResult<R = any> = {
   result: R;
-  missing?: MissingFieldError[];
+  missing?: MissingTree;
 };
-
-function missingFromInvariant(
-  err: InvariantError,
-  context: ReadContext,
-) {
-  return new MissingFieldError(
-    err.message,
-    context.path.slice(),
-    context.query,
-    context.variables,
-  );
-}
 
 type ExecSelectionSetOptions = {
   selectionSet: SelectionSetNode;
@@ -241,6 +230,7 @@ export class StoreReader {
     };
 
     const rootRef = makeReference(rootId);
+    const merger = new DeepMerger;
     const execResult = this.executeSelectionSet({
       selectionSet: getMainDefinition(query).selectionSet,
       objectOrReference: rootRef,
@@ -253,20 +243,33 @@ export class StoreReader {
         varString: canonicalStringify(variables),
         canonizeResults,
         fragmentMap: createFragmentMap(getFragmentDefinitions(query)),
-        path: [],
+        merge(a, b) {
+          return merger.merge(a, b);
+        },
       },
     });
 
-    const hasMissingFields =
-      execResult.missing && execResult.missing.length > 0;
-    if (hasMissingFields && !returnPartialData) {
-      throw execResult.missing![0];
+    let missing: MissingFieldError[] | undefined;
+    if (execResult.missing) {
+      // For backwards compatibility we still report an array of
+      // MissingFieldError objects, even though there will only ever be at most
+      // one of them, now that all missing field error messages are grouped
+      // together in the execResult.missing tree.
+      missing = [new MissingFieldError(
+        firstMissing(execResult.missing)!,
+        execResult.missing,
+        query,
+        variables,
+      )];
+      if (!returnPartialData) {
+        throw missing[0];
+      }
     }
 
     return {
       result: execResult.result,
-      missing: execResult.missing,
-      complete: !hasMissingFields,
+      complete: !missing,
+      missing,
     };
   }
 
@@ -306,19 +309,15 @@ export class StoreReader {
         !context.store.has(objectOrReference.__ref)) {
       return {
         result: this.canon.empty,
-        missing: [missingFromInvariant(
-          new InvariantError(
-            `Dangling reference to missing ${objectOrReference.__ref} object`
-          ),
-          context,
-        )],
+        missing: `Dangling reference to missing ${objectOrReference.__ref} object`,
       };
     }
 
     const { variables, policies, store } = context;
-    const objectsToMerge: { [key: string]: any }[] = [];
-    const finalResult: ExecResult = { result: null };
     const typename = store.getFieldValue<string>(objectOrReference, "__typename");
+
+    let result: any = {};
+    let missing: MissingTree | undefined;
 
     if (this.config.addTypename &&
         typeof typename === "string" &&
@@ -326,15 +325,13 @@ export class StoreReader {
       // Ensure we always include a default value for the __typename
       // field, if we have one, and this.config.addTypename is true. Note
       // that this field can be overridden by other merged objects.
-      objectsToMerge.push({ __typename: typename });
+      result = { __typename: typename };
     }
 
-    function getMissing() {
-      return finalResult.missing || (finalResult.missing = []);
-    }
-
-    function handleMissing<T>(result: ExecResult<T>): T {
-      if (result.missing) getMissing().push(...result.missing);
+    function handleMissing<T>(result: ExecResult<T>, resultName: string): T {
+      if (result.missing) {
+        missing = context.merge(missing, { [resultName]: result.missing });
+      }
       return result.result;
     }
 
@@ -354,22 +351,18 @@ export class StoreReader {
         }, context);
 
         const resultName = resultKeyNameFromField(selection);
-        context.path.push(resultName);
 
         if (fieldValue === void 0) {
           if (!addTypenameToDocument.added(selection)) {
-            getMissing().push(
-              missingFromInvariant(
-                new InvariantError(`Can't find field '${
-                  selection.name.value
-                }' on ${
-                  isReference(objectOrReference)
-                    ? objectOrReference.__ref + " object"
-                    : "object " + JSON.stringify(objectOrReference, null, 2)
-                }`),
-                context,
-              ),
-            );
+            missing = context.merge(missing, {
+              [resultName]: `Can't find field '${
+                selection.name.value
+              }' on ${
+                isReference(objectOrReference)
+                  ? objectOrReference.__ref + " object"
+                  : "object " + JSON.stringify(objectOrReference, null, 2)
+              }`
+            });
           }
 
         } else if (Array.isArray(fieldValue)) {
@@ -378,7 +371,7 @@ export class StoreReader {
             array: fieldValue,
             enclosingRef,
             context,
-          }));
+          }), resultName);
 
         } else if (!selection.selectionSet) {
           // If the field does not have a selection set, then we handle it
@@ -398,14 +391,12 @@ export class StoreReader {
             objectOrReference: fieldValue as StoreObject | Reference,
             enclosingRef: isReference(fieldValue) ? fieldValue : enclosingRef,
             context,
-          }));
+          }), resultName);
         }
 
         if (fieldValue !== void 0) {
-          objectsToMerge.push({ [resultName]: fieldValue });
+          result = context.merge(result, { [resultName]: fieldValue });
         }
-
-        invariant(context.path.pop() === resultName);
 
       } else {
         const fragment = getFragmentFromSelection(
@@ -419,20 +410,20 @@ export class StoreReader {
       }
     });
 
-    // Perform a single merge at the end so that we can avoid making more
-    // defensive shallow copies than necessary.
-    const merged = mergeDeepArray(objectsToMerge);
-    finalResult.result = context.canonizeResults
-      ? this.canon.admit(merged)
+    const finalResult: ExecResult = { result, missing };
+    const frozen = context.canonizeResults
+      ? this.canon.admit(finalResult)
       // Since this.canon is normally responsible for freezing results (only in
       // development), freeze them manually if canonization is disabled.
-      : maybeDeepFreeze(merged);
+      : maybeDeepFreeze(finalResult);
 
     // Store this result with its selection set so that we can quickly
     // recognize it again in the StoreReader#isFresh method.
-    this.knownResults.set(finalResult.result, selectionSet);
+    if (frozen.result) {
+      this.knownResults.set(frozen.result, selectionSet);
+    }
 
-    return finalResult;
+    return frozen;
   }
 
   // Uncached version of executeSubSelectedArray.
@@ -442,16 +433,12 @@ export class StoreReader {
     enclosingRef,
     context,
   }: ExecSubSelectedArrayOptions): ExecResult {
-    let missing: MissingFieldError[] | undefined;
+    let missing: MissingTree | undefined;
 
     function handleMissing<T>(childResult: ExecResult<T>, i: number): T {
       if (childResult.missing) {
-        missing = missing || [];
-        missing.push(...childResult.missing);
+        missing = context.merge(missing, { [i]: childResult.missing });
       }
-
-      invariant(context.path.pop() === i);
-
       return childResult.result;
     }
 
@@ -464,8 +451,6 @@ export class StoreReader {
       if (item === null) {
         return null;
       }
-
-      context.path.push(i);
 
       // This is a nested array, recurse
       if (Array.isArray(item)) {
@@ -491,8 +476,6 @@ export class StoreReader {
         assertSelectionSetForIdValue(context.store, field, item);
       }
 
-      invariant(context.path.pop() === i);
-
       return item;
     });
 
@@ -500,6 +483,17 @@ export class StoreReader {
       result: context.canonizeResults ? this.canon.admit(array) : array,
       missing,
     };
+  }
+}
+
+function firstMissing(tree: MissingTree): string | undefined {
+  try {
+    JSON.stringify(tree, (_, value) => {
+      if (typeof value === "string") throw value;
+      return value;
+    });
+  } catch (result) {
+    return result;
   }
 }
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -27,6 +27,7 @@ import {
 } from './watchQueryOptions';
 import { QueryInfo } from './QueryInfo';
 import { MissingFieldError } from '../cache';
+import { MissingTree } from '../cache/core/types/common';
 
 const {
   assign,
@@ -816,11 +817,11 @@ function defaultSubscriptionObserverErrorCallback(error: ApolloError) {
 }
 
 export function logMissingFieldErrors(
-  missing: MissingFieldError[] | undefined,
+  missing: MissingFieldError[] | MissingTree | undefined,
 ) {
-  if (__DEV__ && isNonEmptyArray(missing)) {
+  if (__DEV__ && missing) {
     invariant.debug(`Missing cache result fields: ${
-      missing.map(m => m.path.join('.')).join(', ')
+      JSON.stringify(missing)
     }`, missing);
   }
 }


### PR DESCRIPTION
In the (somewhat pathological but also entirely plausible) example in #8707, more than 60% of cache read time is spent creating `MissingFieldError` objects, in part because an unnecessary `InvariantError` is created and then used only for its `message`; in part because the `MissingFieldError` class inherits from `Error`, which makes `super(message)` initialization expensive; but also (in large part) because there are just so many error objects (tens of thousands).

This pull request needs more work to minimize breaking changes for anyone using the `MissingFieldError` type directly, but it offers an extremely appealing solution to the performance problems enumerated above: **What if we reported only one, combined `MissingFieldError` per cache read?**

On a personal note, I'm leaving for a weeklong vacation today, so I don't need this reviewed any time soon. 🏝