### PR TITLE
Export PersistedQueryLink namespace

### DIFF
--- a/src/__tests__/__snapshots__/exports.ts.snap
+++ b/src/__tests__/__snapshots__/exports.ts.snap
@@ -186,6 +186,7 @@ Array [
 
 exports[`exports of public entry points @apollo/client/link/persisted-queries 1`] = `
 Array [
+  "PersistedQueryLink",
   "VERSION",
   "createPersistedQueryLink",
 ]

--- a/src/link/persisted-queries/index.ts
+++ b/src/link/persisted-queries/index.ts
@@ -22,7 +22,7 @@ export interface ErrorResponse {
 type SHA256Function = (...args: any[]) => string | PromiseLike<string>;
 type GenerateHashFunction = (document: DocumentNode) => string | PromiseLike<string>;
 
-namespace PersistedQueryLink {
+export namespace PersistedQueryLink {
   interface BaseOptions {
     disable?: (error: ErrorResponse) => boolean;
     useGETForHashedQueries?: boolean;


### PR DESCRIPTION
Exported PersistedQueryLink namespace so `Options` can be imported and used.

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
