### PR TITLE
Guide tree-shaking by calling `checkDEV()` in `utilities/globals/index.ts`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Apollo Client 3.4.11 (not yet released)
+
+### Bug Fixes
+
+- Fix [Vite](https://vitejs.dev) tree-shaking by calling the `checkDEV()` function (at least once) in the module that exports it, `@apollo/client/utilities/globals/index.ts`. <br/>
+  [@benjamn](https://github.com/benjamn) in [#8767](https://github.com/apollographql/apollo-client/pull/8767)
+
 ## Apollo Client 3.4.10
 
 ### Improvements

--- a/src/utilities/globals/index.ts
+++ b/src/utilities/globals/index.ts
@@ -19,3 +19,7 @@ removeTemporaryGlobals();
 export { maybe } from "./maybe";
 export { default as global } from "./global";
 export { invariant, InvariantError }
+
+// Ensure __DEV__ was properly initialized, and prevent tree-shaking bundlers
+// from mistakenly pruning the ./DEV module (see issue #8674).
+checkDEV();


### PR DESCRIPTION
Actually using `checkDEV` by calling it (instead of just re-exporting it) appears to fix the reproduction provided in this comment by @lauraseidler: https://github.com/apollographql/apollo-client/issues/8674#issuecomment-911417247

I would have thought the `"sideEffects": true` configuration in `@apollo/client/utilities/globals/package.json` would be enough to keep the modules in `@apollo/client/utilities/globals/*` from being tree-shaken, but apparently Vite is clever enough to second-guess that guidance when it comes to uncalled function declarations like `checkDEV`.

Thankfully, we can get away with calling `checkDEV()` just this once, in the module that declares/exports it.