### PR TITLE
To avoid errors like "Cannot add property key, object is not extensible"

### DIFF
--- a/docs/source/caching/cache-interaction.md
+++ b/docs/source/caching/cache-interaction.md
@@ -279,10 +279,24 @@ const CommentsPageWithMutations = () => (
             variables: { repoFullName, commentContent },
             update: (store, { data: { submitComment } }) => {
               // Read the data from our cache for this query.
-              const data = store.readQuery({ query: CommentAppQuery });
+              //You can include (if any) query variables as the second param of readQuery 
+               const data = store.readQuery({ query: CommentAppQuery });
+               //deep copying your data to avoid errors as cache objects are immutabe
+               if(!data){
+                data={}
+              }
+              if(!data.comments){
+                data={
+                  ...data,
+                  comments:[]
+                }
+              }
+              
               // Add our comment from the mutation to the end.
-              data.comments.push(submitComment);
+              data.comments=[...data.comments,submitComment];
+              
               // Write our data back to the cache.
+              //notice: if you have any variables passed to the query while doing readQuery; you might want to pass the same variables here too!
               store.writeQuery({ query: CommentAppQuery, data });
             }
           })


### PR DESCRIPTION
In apollo client 3.0.2 and up if you want to do data.someCacheFieldpush() where data is the result of a readQuery call. It gives an error like mentioned in the title. I think it happens due to apollo cache objects being immutable directly.  I was able to solve the issue by deep copying the data object and its associated fields. Skipping push and using spread operator does not cause the issue at all.
