### PR TITLE
Associate Apollo context with `React.createContext` (instead of using a local `WeakMap`) again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Improve handling of falsy `existing` and/or `incoming` parameters in `relayStylePagination` field policy helper function. <br/>
   [@bubba](https://github.com/bubba) and [@benjamn](https://github.com/benjamn) in [#8733](https://github.com/apollographql/apollo-client/pull/8733)
 
+- Associate Apollo context with `React.createContext` (instead of using a local `WeakMap`) again, so multiple copies of `@apollo/client` (uncommon) can share the same context. <br/>
+  [@benjamn](https://github.com/benjamn) in [#8798](https://github.com/apollographql/apollo-client/pull/8798)
+
 ## Apollo Client 3.4.11
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     {
       "name": "apollo-client",
       "path": "./dist/apollo-client.cjs.min.js",
-      "maxSize": "28.4 kB"
+      "maxSize": "28.5 kB"
     }
   ],
   "engines": {

--- a/src/__tests__/__snapshots__/exports.ts.snap
+++ b/src/__tests__/__snapshots__/exports.ts.snap
@@ -330,6 +330,7 @@ Array [
   "argumentsObjectFromField",
   "asyncMap",
   "buildQueryFromSelectionSet",
+  "canUseSymbol",
   "canUseWeakMap",
   "canUseWeakSet",
   "checkDocument",

--- a/src/react/context/ApolloContext.ts
+++ b/src/react/context/ApolloContext.ts
@@ -1,30 +1,31 @@
 import * as React from 'react';
 import { ApolloClient } from '../../core';
-import { canUseWeakMap } from '../../utilities';
+import { canUseSymbol } from '../../utilities';
+import type { RenderPromises } from '../ssr';
 
 export interface ApolloContextValue {
   client?: ApolloClient<object>;
-  renderPromises?: Record<any, any>;
+  renderPromises?: RenderPromises;
 }
 
 // To make sure Apollo Client doesn't create more than one React context
 // (which can lead to problems like having an Apollo Client instance added
 // in one context, then attempting to retrieve it from another different
 // context), a single Apollo context is created and tracked in global state.
-// We use React.createContext as the key instead of just React to avoid
-// ambiguities between default and namespace React imports.
+const contextKey = canUseSymbol
+  ? Symbol.for('__APOLLO_CONTEXT__')
+  : '__APOLLO_CONTEXT__';
 
-const cache = new (canUseWeakMap ? WeakMap : Map)<
-  typeof React.createContext,
-  React.Context<ApolloContextValue>
->();
-
-export function getApolloContext() {
-  let context = cache.get(React.createContext)!;
+export function getApolloContext(): React.Context<ApolloContextValue> {
+  let context = (React.createContext as any)[contextKey] as React.Context<ApolloContextValue>;
   if (!context) {
-    context = React.createContext<ApolloContextValue>({});
+    Object.defineProperty(React.createContext, contextKey, {
+      value: context = React.createContext<ApolloContextValue>({}),
+      enumerable: false,
+      writable: false,
+      configurable: true,
+    });
     context.displayName = 'ApolloContext';
-    cache.set(React.createContext, context);
   }
   return context;
 }

--- a/src/utilities/common/canUse.ts
+++ b/src/utilities/common/canUse.ts
@@ -4,3 +4,7 @@ export const canUseWeakMap = typeof WeakMap === 'function' && !(
 );
 
 export const canUseWeakSet = typeof WeakSet === 'function';
+
+export const canUseSymbol =
+  typeof Symbol === 'function' &&
+  typeof Symbol.for === 'function';

--- a/src/utilities/observables/subclassing.ts
+++ b/src/utilities/observables/subclassing.ts
@@ -1,4 +1,5 @@
 import { Observable } from "./Observable";
+import { canUseSymbol } from "..";
 
 // Generic implementations of Observable.prototype methods like map and
 // filter need to know how to create a new Observable from an Observable
@@ -17,7 +18,7 @@ export function fixObservableSubclass<
     // can't assign to it with a normal assignment expression.
     Object.defineProperty(subclass, key, { value: Observable });
   }
-  if (typeof Symbol === "function" && Symbol.species) {
+  if (canUseSymbol && Symbol.species) {
     set(Symbol.species);
   }
   // The "@@species" string is used as a fake Symbol.species value in some


### PR DESCRIPTION
Should fix #8790, by allowing multiple copies of `@apollo/client` (uncommon) to share the same `React.createContext[contextKey]` object.

A lot has changed since #7371, but I am not worried about `React.createContext` being undefined, because (in this module, `ApolloContext.ts`), the `React` object is now a namespace object (thanks to `import * as React from 'react'`), and we call `React.createContext` unconditionally within `getApolloContext` already, so `React.createContext` must be defined when `getApolloContext` is called, or this code would be totally broken.

This implementation uses `React.createContext[contextKey]` instead of `React[contextKey]` (as in #7371) because the `React` namespace object is likely frozen/non-extensible, whereas `React.createContext` is an ordinary function object.