### PR TITLE
Pin CircleCI container to `cimg/node:16.8` until 16.9.1 available

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   Filesize:
     docker:
-      - image: circleci/node:16
+      - image: cimg/node:16.8
     steps:
       - checkout
       - restore_cache:
@@ -26,7 +26,7 @@ jobs:
 
   Tests:
     docker:
-      - image: circleci/node:16
+      - image: cimg/node:16.8
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
Upstream Node.js bug https://github.com/nodejs/node/issues/40030 has been fixed in [Node.js v16.9.1](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V16.md#2021-09-10-version-1691-current-richardlau). This bug has recently been causing frequent spurious test failures for Apollo Client. [A](https://app.circleci.com/pipelines/github/apollographql/apollo-client/11547/workflows/4027b7e7-b8bd-4cf1-8927-f08921a4c577/jobs/83124) [few](https://app.circleci.com/pipelines/github/apollographql/apollo-client/11571/workflows/3e78ba11-0e51-4f4f-92dd-e732c53716d2/jobs/83167) [examples](https://app.circleci.com/pipelines/github/apollographql/apollo-client/11536/workflows/55d29d9f-b4a7-4803-80bb-e3891946960d/jobs/83106).

Failure message, for posterity:
```
# Fatal error in , line 0
# Check failed: !holder_map.has_named_interceptor().
```
CircleCI ships docker containers for most Node.js versions, but they haven't shipped a new version for 16.9.1 yet (16.9.0 is the latest). We will switch back to `cimg/node:16` once that gives us a version greater than or equal to 16.9.1.