### PR TITLE
Restore TVariables to useQuery return type

### DIFF
--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -25,7 +25,7 @@ export function useQuery<
 >(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
   options?: QueryHookOptions<TData, TVariables>,
-): QueryResult<TData> {
+): QueryResult<TData, TVariables> {
   const context = useContext(getApolloContext());
   const client = useApolloClient(options?.client);
   verifyDocumentType(query, DocumentType.Query);


### PR DESCRIPTION
### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests

---

## Problem

`useQuery` was clearly rewritten completely from 3.4 to 3.5, but its  signature changed from

```ts
function useQuery<TData = any, TVariables = OperationVariables>(/*...*/): QueryResult<TData, TVariables>;
```

to 

```ts
function useQuery<TData = any, TVariables = OperationVariables>(/*...*/): QueryResult<TData>;
```

This causes the `TVariables` type arg to be thrown away, and then defaulted to `OperationVariables` in `QueryResult`.  This causes assignability issues in TS in some cases. The issue can be demonstrated with a trivial generic hook that wraps a query hook:

```ts
type DumbQuery = { foo: string };
type DumbVariables = { bar: number };
const DumbDocument = gql`
  query Dumb($bar: Int!) {
    dumb(bar: $bar) {
      foo
    }
  }
`;

function useDumbQuery(baseOptions: QueryHookOptions<DumbQuery, DumbVariables>) {
  const options = { ...baseOptions };
  return useQuery<DumbQuery, DumbVariables>(DumbDocument, options);
}

// Trivially wrapping a query hook
const useDumbWrappedQuery = <Q, V>(
  hook: (options: QueryHookOptions<Q, V>) => QueryResult<Q, V>,
  options: QueryHookOptions<Q, V> = {},
) => hook(options);

const Test = () => {
  useDumbWrappedQuery(useDumbQuery);
  /*
  Argument of type '(baseOptions: QueryHookOptions<DumbQuery, DumbVariables>) => QueryResult<DumbQuery, OperationVariables>' is not assignable to parameter of type '(options: QueryHookOptions<DumbQuery, DumbVariables>) => QueryResult<DumbQuery, DumbVariables>'.
  Call signature return types 'QueryResult<DumbQuery, OperationVariables>' and 'QueryResult<DumbQuery, DumbVariables>' are incompatible.
    The types of 'variables' are incompatible between these types.
      Type 'OperationVariables | undefined' is not assignable to type 'DumbVariables | undefined'.
        Type 'OperationVariables' is not assignable to type 'DumbVariables'.
  */

  return null;
};
```

## Notes

- This problem doesn't appear when all of the properties of `TVariables` are optional.
- The "testing" box isn't checked because I don't know if you have any test infrastructure for types, and this is a type-only problem. I didn't look too hard, so if I missed it, let me know.
- `npm run build` and `npm run test` worked fine with this change.

@brainkim  🚎   👀 