### PR TITLE
Ignore TypedArrays when freezing object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Fix internal `canUseSymbol` import within `@apollo/client/utilities` to avoid breaking bundlers/builds. <br/>
   [@benjamn](https://github.com/benjamn) in [#8817](https://github.com/apollographql/apollo-client/pull/8817)
 
+- Tolerate unfreezable objects like `Uint8Array` and `Buffer` in `maybeDeepFreeze`. <br/>
+  [@geekuillaume](https://github.com/geekuillaume) and [@benjamn](https://github.com/benjamn) in [#8813](https://github.com/apollographql/apollo-client/pull/8813)
+
 ## Apollo Client 3.4.12
 
 ### Bug Fixes

--- a/src/utilities/common/__tests__/maybeDeepFeeze.ts
+++ b/src/utilities/common/__tests__/maybeDeepFeeze.ts
@@ -15,8 +15,15 @@ describe('maybeDeepFreeze', () => {
     expect(() => (foo.bar = 1)).toThrow();
   });
 
-  it('should freeze a TypedArray', () => {
-    const foo = {bar: new Uint8Array(1)};
-    maybeDeepFreeze(foo);
-  })
+  it('should avoid freezing Uint8Array', () => {
+    const result = maybeDeepFreeze({ array: new Uint8Array(1) });
+    expect(Object.isFrozen(result)).toBe(true);
+    expect(Object.isFrozen(result.array)).toBe(false);
+  });
+
+  it('should avoid freezing Buffer', () => {
+    const result = maybeDeepFreeze({ oyez: Buffer.from("oyez") });
+    expect(Object.isFrozen(result)).toBe(true);
+    expect(Object.isFrozen(result.oyez)).toBe(false);
+  });
 });

--- a/src/utilities/common/__tests__/maybeDeepFeeze.ts
+++ b/src/utilities/common/__tests__/maybeDeepFeeze.ts
@@ -26,4 +26,16 @@ describe('maybeDeepFreeze', () => {
     expect(Object.isFrozen(result)).toBe(true);
     expect(Object.isFrozen(result.oyez)).toBe(false);
   });
+
+  it('should not freeze child properties of unfreezable objects', () => {
+    const result = maybeDeepFreeze({
+      buffer: Object.assign(Buffer.from("oyez"), {
+        doNotFreeze: { please: "thanks" },
+      }),
+    });
+    expect(Object.isFrozen(result)).toBe(true);
+    expect(Object.isFrozen(result.buffer)).toBe(false);
+    expect(Object.isFrozen(result.buffer.doNotFreeze)).toBe(false);
+    expect(result.buffer.doNotFreeze).toEqual({ please: "thanks" });
+  });
 });

--- a/src/utilities/common/__tests__/maybeDeepFeeze.ts
+++ b/src/utilities/common/__tests__/maybeDeepFeeze.ts
@@ -14,4 +14,9 @@ describe('maybeDeepFreeze', () => {
     maybeDeepFreeze(foo);
     expect(() => (foo.bar = 1)).toThrow();
   });
+
+  it('should freeze a TypedArray', () => {
+    const foo = {bar: new Uint8Array(1)};
+    maybeDeepFreeze(foo);
+  })
 });

--- a/src/utilities/common/maybeDeepFreeze.ts
+++ b/src/utilities/common/maybeDeepFreeze.ts
@@ -5,14 +5,28 @@ function deepFreeze(value: any) {
   const workSet = new Set([value]);
   workSet.forEach(obj => {
     if (isNonNullObject(obj)) {
-      // an array buffer view (like UInt8Array) is not freezable, ignoring it
-      if (!Object.isFrozen(obj) && !ArrayBuffer.isView(obj)) Object.freeze(obj);
+      shallowFreeze(obj);
       Object.getOwnPropertyNames(obj).forEach(name => {
         if (isNonNullObject(obj[name])) workSet.add(obj[name]);
       });
     }
   });
   return value;
+}
+
+function shallowFreeze<T extends object>(obj: T): T {
+  if (__DEV__ && !Object.isFrozen(obj)) {
+    try {
+      Object.freeze(obj);
+    } catch (e) {
+      // Some types like Uint8Array and Node.js's Buffer cannot be frozen, but
+      // they all throw a TypeError when you try, so we re-throw any exceptions
+      // that are not TypeErrors, since that would be unexpected.
+      if (e instanceof TypeError) return obj;
+      throw e;
+    }
+  }
+  return obj;
 }
 
 export function maybeDeepFreeze<T>(obj: T): T {

--- a/src/utilities/common/maybeDeepFreeze.ts
+++ b/src/utilities/common/maybeDeepFreeze.ts
@@ -4,8 +4,7 @@ import { isNonNullObject } from './objects';
 function deepFreeze(value: any) {
   const workSet = new Set([value]);
   workSet.forEach(obj => {
-    if (isNonNullObject(obj)) {
-      shallowFreeze(obj);
+    if (isNonNullObject(obj) && shallowFreeze(obj) === obj) {
       Object.getOwnPropertyNames(obj).forEach(name => {
         if (isNonNullObject(obj[name])) workSet.add(obj[name]);
       });
@@ -14,7 +13,7 @@ function deepFreeze(value: any) {
   return value;
 }
 
-function shallowFreeze<T extends object>(obj: T): T {
+function shallowFreeze<T extends object>(obj: T): T | null {
   if (__DEV__ && !Object.isFrozen(obj)) {
     try {
       Object.freeze(obj);
@@ -22,7 +21,7 @@ function shallowFreeze<T extends object>(obj: T): T {
       // Some types like Uint8Array and Node.js's Buffer cannot be frozen, but
       // they all throw a TypeError when you try, so we re-throw any exceptions
       // that are not TypeErrors, since that would be unexpected.
-      if (e instanceof TypeError) return obj;
+      if (e instanceof TypeError) return null;
       throw e;
     }
   }

--- a/src/utilities/common/maybeDeepFreeze.ts
+++ b/src/utilities/common/maybeDeepFreeze.ts
@@ -5,7 +5,8 @@ function deepFreeze(value: any) {
   const workSet = new Set([value]);
   workSet.forEach(obj => {
     if (isNonNullObject(obj)) {
-      if (!Object.isFrozen(obj)) Object.freeze(obj);
+      // an array buffer view (like UInt8Array) is not freezable, ignoring it
+      if (!Object.isFrozen(obj) && !ArrayBuffer.isView(obj)) Object.freeze(obj);
       Object.getOwnPropertyNames(obj).forEach(name => {
         if (isNonNullObject(obj[name])) workSet.add(obj[name]);
       });


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] Make sure all of the significant new logic is covered by tests

This PR fixes #6813 by ignored TypedArrays when freezing objects.