### PR TITLE
Fix `canUseSymbol` import between internal `src/utilities` modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Fix `componentDidUpate` typo in `withSubscription` higher-order component. <br/>
   [@YarBez](https://github.com/YarBez) in [#7506](https://github.com/apollographql/apollo-client/pull/7506)
 
+- Fix internal `canUseSymbol` import within `@apollo/client/utilities` to avoid breaking bundlers/builds. <br/>
+  [@benjamn](https://github.com/benjamn) in [#8817](https://github.com/apollographql/apollo-client/pull/8817)
+
 ## Apollo Client 3.4.12
 
 ### Bug Fixes

--- a/src/utilities/observables/subclassing.ts
+++ b/src/utilities/observables/subclassing.ts
@@ -1,5 +1,5 @@
 import { Observable } from "./Observable";
-import { canUseSymbol } from "..";
+import { canUseSymbol } from "../common/canUse";
 
 // Generic implementations of Observable.prototype methods like map and
 // filter need to know how to create a new Observable from an Observable


### PR DESCRIPTION
May fix #8809, since this line was added in `@apollo/client@3.4.12`, and seems to be the only change that could explain the appearance of `require('..')` in `@apollo/client/utilities/utilities.cjs.js`, as noticed by @ianhe8x.

Both styles of import _should_ work, but we can be more explicit/precise when the import does not cross entry points.