### PR TITLE
Unpin `circleci/node` container version and update to Node.js v16.9.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   Filesize:
     docker:
-      - image: cimg/node:16.8
+      - image: circleci/node:16.9.1
     steps:
       - checkout
       - restore_cache:
@@ -26,7 +26,7 @@ jobs:
 
   Tests:
     docker:
-      - image: cimg/node:16.8
+      - image: circleci/node:16.9.1
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
As promised in #8800.