### PR TITLE
Disable `InMemoryCache` canonization by default to prevent unexpected memory growth/sharing, with options to reenable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Bug Fixes
 
+- Disable `InMemoryCache` [result object canonization](https://github.com/apollographql/apollo-client/pull/7439) by default, to prevent unexpected memory growth and/or reuse of object references, with multiple ways to reenable it (per-cache, per-query, or a mixture of both). <br/>
+  [@benjamn](https://github.com/benjamn) in [#8822](https://github.com/apollographql/apollo-client/pull/8822)
+
 - Clear `InMemoryCache` `watches` set when `cache.reset()` called. <br/>
   [@benjamn](https://github.com/benjamn) in [#8826](https://github.com/apollographql/apollo-client/pull/8826)
 

--- a/src/cache/core/types/DataProxy.ts
+++ b/src/cache/core/types/DataProxy.ts
@@ -70,7 +70,7 @@ export namespace DataProxy {
     /**
      * Whether to canonize cache results before returning them. Canonization
      * takes some extra time, but it speeds up future deep equality comparisons.
-     * Defaults to true.
+     * Defaults to false.
      */
     canonizeResults?: boolean;
   }
@@ -91,7 +91,7 @@ export namespace DataProxy {
     /**
      * Whether to canonize cache results before returning them. Canonization
      * takes some extra time, but it speeds up future deep equality comparisons.
-     * Defaults to true.
+     * Defaults to false.
      */
     canonizeResults?: boolean;
   }

--- a/src/cache/inmemory/__tests__/cache.ts
+++ b/src/cache/inmemory/__tests__/cache.ts
@@ -2013,6 +2013,7 @@ describe("InMemoryCache#modify", () => {
 
   it("should allow invalidation using details.INVALIDATE", () => {
     const cache = new InMemoryCache({
+      canonizeResults: true,
       typePolicies: {
         Book: {
           keyFields: ["isbn"],
@@ -2946,7 +2947,10 @@ describe("ReactiveVar and makeVar", () => {
   it("should work with resultCaching disabled (unusual)", () => {
     const { cache, nameVar, query } = makeCacheAndVar(false);
 
-    const result1 = cache.readQuery({ query });
+    const result1 = cache.readQuery({
+      query,
+      canonizeResults: true,
+    });
     expect(result1).toEqual({
       onCall: {
         __typename: "Person",
@@ -2954,14 +2958,20 @@ describe("ReactiveVar and makeVar", () => {
       },
     });
 
-    const result2 = cache.readQuery({ query });
+    const result2 = cache.readQuery({
+      query,
+      canonizeResults: true,
+    });
     expect(result2).toEqual(result1);
     expect(result2).toBe(result1);
 
     expect(nameVar()).toBe("Ben");
     expect(nameVar("Hugh")).toBe("Hugh");
 
-    const result3 = cache.readQuery({ query });
+    const result3 = cache.readQuery({
+      query,
+      canonizeResults: true,
+    });
     expect(result3).toEqual({
       onCall: {
         __typename: "Person",

--- a/src/cache/inmemory/__tests__/entityStore.ts
+++ b/src/cache/inmemory/__tests__/entityStore.ts
@@ -170,14 +170,18 @@ describe('EntityStore', () => {
       },
     });
 
-    const resultBeforeGC = cache.readQuery({ query });
+    function read() {
+      return cache.readQuery({ query, canonizeResults: true });
+    }
+
+    const resultBeforeGC = read();
 
     expect(cache.gc().sort()).toEqual([
       'Author:Ray Bradbury',
       'Book:9781451673319',
     ]);
 
-    const resultAfterGC = cache.readQuery({ query });
+    const resultAfterGC = read();
     expect(resultBeforeGC).toBe(resultAfterGC);
 
     expect(cache.extract()).toEqual({
@@ -207,7 +211,7 @@ describe('EntityStore', () => {
       resetResultCache: true,
     })).toEqual([]);
     expect(cache["storeReader"]).not.toBe(originalReader);
-    const resultAfterResetResultCache = cache.readQuery({ query });
+    const resultAfterResetResultCache = read();
     expect(resultAfterResetResultCache).toBe(resultBeforeGC);
     expect(resultAfterResetResultCache).toBe(resultAfterGC);
 
@@ -217,7 +221,7 @@ describe('EntityStore', () => {
       resetResultIdentities: true,
     })).toEqual([]);
 
-    const resultAfterFullGC = cache.readQuery({ query });
+    const resultAfterFullGC = read();
     expect(resultAfterFullGC).toEqual(resultBeforeGC);
     expect(resultAfterFullGC).toEqual(resultAfterGC);
     // These !== relations are triggered by passing resetResultIdentities:true
@@ -225,7 +229,7 @@ describe('EntityStore', () => {
     expect(resultAfterFullGC).not.toBe(resultBeforeGC);
     expect(resultAfterFullGC).not.toBe(resultAfterGC);
     // Result caching immediately begins working again after the intial reset.
-    expect(cache.readQuery({ query })).toBe(resultAfterFullGC);
+    expect(read()).toBe(resultAfterFullGC);
 
     // Go back to the pre-GC snapshot.
     cache.restore(snapshot);
@@ -1049,6 +1053,7 @@ describe('EntityStore', () => {
     `;
 
     const cache = new InMemoryCache({
+      canonizeResults: true,
       typePolicies: {
         Query: {
           fields: {
@@ -2391,6 +2396,7 @@ describe('EntityStore', () => {
     const isbnsWeHaveRead: string[] = [];
 
     const cache = new InMemoryCache({
+      canonizeResults: true,
       typePolicies: {
         Query: {
           fields: {

--- a/src/cache/inmemory/__tests__/optimistic.ts
+++ b/src/cache/inmemory/__tests__/optimistic.ts
@@ -6,6 +6,7 @@ describe('optimistic cache layers', () => {
   it('return === results for repeated reads', () => {
     const cache = new InMemoryCache({
       resultCaching: true,
+      canonizeResults: true,
       dataIdFromObject(value: any) {
         switch (value && value.__typename) {
           case 'Book':
@@ -204,6 +205,7 @@ describe('optimistic cache layers', () => {
   it('dirties appropriate IDs when optimistic layers are removed', () => {
     const cache = new InMemoryCache({
       resultCaching: true,
+      canonizeResults: true,
       dataIdFromObject(value: any) {
         switch (value && value.__typename) {
           case 'Book':

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -4947,6 +4947,7 @@ describe("type policies", function () {
     function readFirstBookResult() {
       return cache.readQuery<{ author: any }>({
         query: firstBookQuery,
+        canonizeResults: true,
       })!;
     }
 

--- a/src/cache/inmemory/__tests__/readFromStore.ts
+++ b/src/cache/inmemory/__tests__/readFromStore.ts
@@ -1377,6 +1377,7 @@ describe('reading from the store', () => {
 
   withErrorSpy(it, "propagates eviction signals to parent queries", () => {
     const cache = new InMemoryCache({
+      canonizeResults: true,
       typePolicies: {
         Deity: {
           keyFields: ["name"],
@@ -1866,7 +1867,9 @@ describe('reading from the store', () => {
   });
 
   it("returns === results for different queries", function () {
-    const cache = new InMemoryCache;
+    const cache = new InMemoryCache({
+      canonizeResults: true,
+    });
 
     const aQuery: TypedDocumentNode<{
       a: string[];

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -13,6 +13,7 @@ import {
   StoreObject,
   Reference,
   isReference,
+  compact,
 } from '../../utilities';
 import {
   ApolloReducerConfig,
@@ -87,7 +88,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
 
   constructor(config: InMemoryCacheConfig = {}) {
     super();
-    this.config = { ...defaultConfig, ...config };
+    this.config = compact(defaultConfig, config);
     this.addTypename = !!this.config.addTypename;
 
     this.policies = new Policies({

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -45,13 +45,21 @@ type BroadcastOptions = Pick<
   | "onWatchUpdated"
 >
 
-const defaultConfig: InMemoryCacheConfig = {
+const defaultConfig = {
   dataIdFromObject: defaultDataIdFromObject,
   addTypename: true,
   resultCaching: true,
+  // Thanks to the shouldCanonizeResults helper, this should be the only line
+  // you have to change to reenable canonization by default in the future.
   canonizeResults: false,
-  typePolicies: {},
 };
+
+export function shouldCanonizeResults(
+  config: Pick<InMemoryCacheConfig, "canonizeResults">,
+): boolean {
+  const value = config.canonizeResults;
+  return value === void 0 ? defaultConfig.canonizeResults : value;
+}
 
 export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
   private data: EntityStore;
@@ -123,7 +131,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
         cache: this,
         addTypename: this.addTypename,
         resultCacheMaxSize: this.config.resultCacheMaxSize,
-        canonizeResults: this.config.canonizeResults,
+        canonizeResults: shouldCanonizeResults(this.config),
         canon: resetResultIdentities
           ? void 0
           : previousReader && previousReader.canon,

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -36,6 +36,7 @@ export interface InMemoryCacheConfig extends ApolloReducerConfig {
   possibleTypes?: PossibleTypesMap;
   typePolicies?: TypePolicies;
   resultCacheMaxSize?: number;
+  canonizeResults?: boolean;
 }
 
 type BroadcastOptions = Pick<
@@ -48,6 +49,7 @@ const defaultConfig: InMemoryCacheConfig = {
   dataIdFromObject: defaultDataIdFromObject,
   addTypename: true,
   resultCaching: true,
+  canonizeResults: false,
   typePolicies: {},
 };
 
@@ -121,6 +123,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
         cache: this,
         addTypename: this.addTypename,
         resultCacheMaxSize: this.config.resultCacheMaxSize,
+        canonizeResults: this.config.canonizeResults,
         canon: resetResultIdentities
           ? void 0
           : previousReader && previousReader.canon,

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -86,6 +86,7 @@ export interface StoreReaderConfig {
   cache: InMemoryCache,
   addTypename?: boolean;
   resultCacheMaxSize?: number;
+  canonizeResults?: boolean;
   canon?: ObjectCanon;
 }
 
@@ -128,6 +129,7 @@ export class StoreReader {
     cache: InMemoryCache,
     addTypename: boolean;
     resultCacheMaxSize?: number;
+    canonizeResults: boolean;
   };
 
   private knownResults = new (
@@ -143,6 +145,7 @@ export class StoreReader {
     this.config = {
       ...config,
       addTypename: config.addTypename !== false,
+      canonizeResults: !!config.canonizeResults,
     };
 
     this.canon = config.canon || new ObjectCanon;
@@ -231,7 +234,7 @@ export class StoreReader {
     rootId = 'ROOT_QUERY',
     variables,
     returnPartialData = true,
-    canonizeResults = false,
+    canonizeResults = this.config.canonizeResults,
   }: DiffQueryAgainstStoreOptions): Cache.DiffResult<T> {
     const policies = this.config.cache.policies;
 

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -231,7 +231,7 @@ export class StoreReader {
     rootId = 'ROOT_QUERY',
     variables,
     returnPartialData = true,
-    canonizeResults = true,
+    canonizeResults = false,
   }: DiffQueryAgainstStoreOptions): Cache.DiffResult<T> {
     const policies = this.config.cache.policies;
 

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -27,6 +27,7 @@ import {
   maybeDeepFreeze,
   isNonNullObject,
   canUseWeakMap,
+  compact,
 } from '../../utilities';
 import { Cache } from '../core/types/Cache';
 import {
@@ -142,11 +143,10 @@ export class StoreReader {
   }
 
   constructor(config: StoreReaderConfig) {
-    this.config = {
-      ...config,
+    this.config = compact(config, {
       addTypename: config.addTypename !== false,
       canonizeResults: shouldCanonizeResults(config),
-    };
+    });
 
     this.canon = config.canon || new ObjectCanon;
 

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -37,7 +37,7 @@ import {
 import { maybeDependOnExistenceOfEntity, supportsResultCaching } from './entityStore';
 import { getTypenameFromStoreObject } from './helpers';
 import { Policies } from './policies';
-import { InMemoryCache } from './inMemoryCache';
+import { shouldCanonizeResults, InMemoryCache } from './inMemoryCache';
 import { MissingFieldError } from '../core/types/common';
 import { canonicalStringify, ObjectCanon } from './object-canon';
 
@@ -145,7 +145,7 @@ export class StoreReader {
     this.config = {
       ...config,
       addTypename: config.addTypename !== false,
-      canonizeResults: !!config.canonizeResults,
+      canonizeResults: shouldCanonizeResults(config),
     };
 
     this.canon = config.canon || new ObjectCanon;

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -192,14 +192,17 @@ export class QueryInfo {
   }
 
   private getDiffOptions(variables = this.variables): Cache.DiffOptions {
-    const oq = this.observableQuery;
-    return {
+    const options: Cache.DiffOptions = {
       query: this.document!,
       variables,
       returnPartialData: true,
       optimistic: true,
-      canonizeResults: !oq || oq.options.canonizeResults !== false,
     };
+    const canonizeResults = this.observableQuery?.options.canonizeResults;
+    if (typeof canonizeResults === "boolean") {
+      options.canonizeResults = canonizeResults;
+    }
+    return options;
   }
 
   setDiff(diff: Cache.DiffResult<any> | null) {

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -192,17 +192,13 @@ export class QueryInfo {
   }
 
   private getDiffOptions(variables = this.variables): Cache.DiffOptions {
-    const options: Cache.DiffOptions = {
+    return {
       query: this.document!,
       variables,
       returnPartialData: true,
       optimistic: true,
+      canonizeResults: this.observableQuery?.options.canonizeResults,
     };
-    const canonizeResults = this.observableQuery?.options.canonizeResults;
-    if (typeof canonizeResults === "boolean") {
-      options.canonizeResults = canonizeResults;
-    }
-    return options;
   }
 
   setDiff(diff: Cache.DiffResult<any> | null) {

--- a/src/core/__tests__/QueryManager/index.ts
+++ b/src/core/__tests__/QueryManager/index.ts
@@ -834,7 +834,7 @@ describe('QueryManager', () => {
   });
 
   itAsync('will return referentially equivalent data if nothing changed in a refetch', (resolve, reject) => {
-    const request = {
+    const request: WatchQueryOptions = {
       query: gql`
         {
           a
@@ -850,6 +850,7 @@ describe('QueryManager', () => {
         }
       `,
       notifyOnNetworkStatusChange: false,
+      canonizeResults: true,
     };
 
     const data1 = {

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -106,7 +106,7 @@ export interface QueryOptions<TVariables = OperationVariables, TData = any> {
   /**
    * Whether to canonize cache results before returning them. Canonization
    * takes some extra time, but it speeds up future deep equality comparisons.
-   * Defaults to true.
+   * Defaults to false.
    */
   canonizeResults?: boolean;
 }

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -3015,6 +3015,7 @@ describe('useQuery Hook', () => {
   describe('canonical cache results', () => {
     it('can be disabled via useQuery options', async () => {
       const cache = new InMemoryCache({
+        canonizeResults: true,
         typePolicies: {
           Result: {
             keyFields: false,


### PR DESCRIPTION
Making `InMemoryCache` result canonization (#7439) _opt-in_ instead of opt-out (as it currently is) should prevent the surprises of shared object references reported in #8717, and fixes the apparent memory leak in #8784, as confirmed using @CollinMonahanLab49's reproduction.

Given that canonization was a headline feature of v3.4, shipping this PR would be something of a retraction, but I believe it's the simplest way to prevent surprise and encourage using canonization (only) where it's actually useful.

Code that benefits from canonization can continue using it! In fact, there are multiple ways to override the new default behavior, with different scopes:
```ts
// This cache will canonize everything by default, unless
// specific reads request canonizeResults:false.
const cache = new InMemoryCache({
  canonizeResults: true,
});

// Override the setting for individual cache reads.
cache.readQuery({ query, canonizeResults: true });
cache.readFragment({ id, fragment, canonizeResults: false });

// Results for this query will be canonized even if canonization
// is disabled elsewhere.
const result = useQuery(query, {
  canonizeResults: true,
});

// This ObservableQuery's results will always be canonized.
const observableQuery = client.watchQuery({
  query,
  canonizeResults: true,
});

// Set the default canonizeResults option for all watchQuery
// calls (including useQuery). Passing canonizeResults:true
// to InMemoryCache may be more reliable than this.
const client = new ApolloClient({
  defaultOptions: {
    watchQuery: {
      canonizeResults: true,
    },
  },
});
```
I had to update a number of tests after changing the default canonization behavior, but I was able to fix every one of them using one of the tricks demonstrated above, which is reassuring.

Though the consequences of canonization (memory usage and poor fit with certain query workloads) all have good explanations, I would rather folks engage with those tradeoffs because they want to optimize specific parts of their application, rather than inheriting the consequences by default (without asking for them).