### PR TITLE
Stop excluding observerless queries from `refetchQueries` selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Clear `InMemoryCache` `watches` set when `cache.reset()` called. <br/>
   [@benjamn](https://github.com/benjamn) in [#8826](https://github.com/apollographql/apollo-client/pull/8826)
 
+- Stop excluding observerless queries from `refetchQueries: [...]` selection. <br/>
+  [@benjamn](https://github.com/benjamn) in [#8825](https://github.com/apollographql/apollo-client/pull/8825)
+
 ## Apollo Client 3.4.13
 
 ### Bug Fixes

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -767,8 +767,10 @@ export class QueryManager<TStore> {
           options: { fetchPolicy },
         } = oq;
 
-        if (fetchPolicy === "standby" || !oq.hasObservers()) {
-          // Skip inactive queries unless include === "all".
+        if (
+          fetchPolicy === "standby" ||
+          (include === "active" && !oq.hasObservers())
+        ) {
           return;
         }
 


### PR DESCRIPTION
The example code I provided in https://github.com/apollographql/apollo-client/issues/5419#issuecomment-908398224 should work even if `QueryIWantToRefresh` currently has no observers:
```ts
client.refetchQueries({
  include: ["QueryIWantToRefresh"],
  // ... other options...
})
```
I suspect the `oq.hasObservers()` check removed by this PR explains at least some instances of issue #5419, but I also believe there's value in refetching observerless queries (at the developer's explicit request), so _future_ subscribers can immediately receive the most recent result or error.

Alternatively, when performing a mutation, this same line of reasoning applies to the `refetchQueries: [...]` option:
```ts
client.mutate({
  // ... other options...
  refetchQueries: ["QueryIWantToRefresh"],
})
```

If you really want to put an `ObservableQuery` out of commission (except when `include: "all"` is used), you can set its `.options.fetchPolicy` to `"standby"`.