### PR TITLE
Clear `InMemoryCache` watches when `cache.reset()` called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Apollo Client 3.4.14 (not yet released)
+
+### Bug Fixes
+
+- Clear `InMemoryCache` `watches` set when `cache.reset()` called. <br/>
+  [@benjamn](https://github.com/benjamn) in [#8826](https://github.com/apollographql/apollo-client/pull/8826)
+
 ## Apollo Client 3.4.13
 
 ### Bug Fixes

--- a/src/cache/inmemory/__tests__/cache.ts
+++ b/src/cache/inmemory/__tests__/cache.ts
@@ -3021,6 +3021,116 @@ describe("ReactiveVar and makeVar", () => {
     expect(spy).toBeCalledWith(cache);
   });
 
+  it("should remove all watchers when cache.reset() called", () => {
+    const { cache, query, nameVar } = makeCacheAndVar(false);
+    const unwatchers: Record<string, Array<() => void>> = Object.create(null);
+    const diffCounts: Record<string, number> = Object.create(null);
+
+    function watch(id: string) {
+      const fns = unwatchers[id] || (unwatchers[id] = []);
+      fns.push(cache.watch({
+        query,
+        optimistic: true,
+        immediate: true,
+        callback() {
+          diffCounts[id] = (diffCounts[id] || 0) + 1;
+        },
+      }));
+    }
+
+    watch("a");
+    watch("b");
+    watch("c");
+    watch("a");
+    watch("d");
+
+    expect(cache["watches"].size).toBe(5);
+    expect(diffCounts).toEqual({
+      a: 2,
+      b: 1,
+      c: 1,
+      d: 1,
+    });
+
+    unwatchers.a.forEach(unwatch => unwatch());
+    unwatchers.a.length = 0;
+    expect(cache["watches"].size).toBe(3);
+
+    nameVar("Hugh");
+    expect(diffCounts).toEqual({
+      a: 2,
+      b: 2,
+      c: 2,
+      d: 2,
+    });
+
+    cache.reset();
+    expect(cache["watches"].size).toBe(0);
+
+    expect(diffCounts).toEqual({
+      a: 2,
+      b: 2,
+      c: 2,
+      d: 2,
+    });
+
+    nameVar("Brian");
+    // No change because cache.reset() called.
+    expect(diffCounts).toEqual({
+      a: 2,
+      b: 2,
+      c: 2,
+      d: 2,
+    });
+
+    cache.writeQuery({
+      query,
+      data: {
+        onCall: {
+          __typename: "Person",
+        },
+      },
+    });
+
+    watch("e");
+    watch("f");
+
+    expect(diffCounts).toEqual({
+      a: 2,
+      b: 2,
+      c: 2,
+      d: 2,
+      e: 1,
+      f: 1,
+    });
+
+    nameVar("Trevor");
+    expect(cache["watches"].size).toBe(2);
+    expect(diffCounts).toEqual({
+      a: 2,
+      b: 2,
+      c: 2,
+      d: 2,
+      e: 2,
+      f: 2,
+    });
+
+    cache.reset();
+    expect(cache["watches"].size).toBe(0);
+
+    nameVar("Danielle");
+    expect(diffCounts).toEqual({
+      a: 2,
+      b: 2,
+      c: 2,
+      d: 2,
+      e: 2,
+      f: 2,
+    });
+
+    expect(cache["watches"].size).toBe(0);
+  });
+
   it("should recall forgotten vars once cache has watches again", () => {
     const { cache, nameVar, query } = makeCacheAndVar(false);
     const spy = jest.spyOn(nameVar, "forgetCache");

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -363,8 +363,15 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
 
   public reset(): Promise<void> {
     this.init();
-    this.broadcastWatches();
+
+    // Similar to what happens in the unsubscribe function returned by
+    // cache.watch, applied to all current watches.
+    this.watches.forEach(watch => this.maybeBroadcastWatch.forget(watch));
+    this.watches.clear();
+    forgetCache(this);
+
     canonicalStringify.reset();
+
     return Promise.resolve();
   }
 


### PR DESCRIPTION
This may help with memory management during SSR (provided `cache.reset()` is called), per my comment https://github.com/apollographql/apollo-client/issues/7942#issuecomment-916450312.

Reusing the same cache between SSR requests is typically not what we recommend, since creating a new client/cache for each request is such an easy and effective way to prevent data from leaking between requests from different users/clients.

However, if you're careful to reset the cache each time, or you have non-SSR reasons for resetting the cache, it seems reasonable to expect the `cache.watches` to be emptied after the reset.