### PR TITLE
Ensure `cache.broadcastWatch` passes all relevant `WatchOptions` to `cache.diff`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 - Prevent optimistic cache evictions from evicting non-optimistic data. <br/>
   [@benjamn](https://github.com/benjamn) in [#8829](https://github.com/apollographql/apollo-client/pull/8829)
 
+- Ensure `cache.broadcastWatch` passes all relevant `WatchOptions` to `cache.diff` as `DiffOptions`. <br/>
+  [@benjamn](https://github.com/benjamn) in [#8832](https://github.com/apollographql/apollo-client/pull/8832)
+
 ## Apollo Client 3.4.13
 
 ### Bug Fixes

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -539,11 +539,14 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     options?: BroadcastOptions,
   ) {
     const { lastDiff } = c;
-    const diff = this.diff<any>({
-      query: c.query,
-      variables: c.variables,
-      optimistic: c.optimistic,
-    });
+
+    // Both WatchOptions and DiffOptions extend ReadOptions, and DiffOptions
+    // currently requires no additional properties, so we can use c (a
+    // WatchOptions object) as DiffOptions, without having to allocate a new
+    // object, and without having to enumerate the relevant properties (query,
+    // variables, etc.) explicitly. There will be some additional properties
+    // (lastDiff, callback, etc.), but cache.diff ignores them.
+    const diff = this.diff<any>(c);
 
     if (options) {
       if (c.optimistic &&


### PR DESCRIPTION
As @aj-foster noticed in #8831, `canonizeResults` (and also `returnPartialData`!) were missing from this `cache.diff` call.

Instead of enumerating the missing properties explicitly, we can take advantage of the overlap between `WatchOptions` and `DiffOptions` to pass _all_ relevant properties through, so this kind of mistake won't happen again.

Fixes #8831.