### PR TITLE
Refactor to avoid import cycle between `inMemoryCache.ts` and `readFromStore.ts`

### DIFF
--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -15,11 +15,13 @@ export {
 } from '../utilities';
 
 export { EntityStore } from './inmemory/entityStore';
-export { fieldNameFromStoreName } from './inmemory/helpers'
+export {
+  fieldNameFromStoreName,
+  defaultDataIdFromObject,
+} from './inmemory/helpers'
 
 export {
   InMemoryCache,
-  InMemoryCacheConfig,
 } from './inmemory/inMemoryCache';
 
 export {
@@ -29,7 +31,6 @@ export {
 } from './inmemory/reactiveVars';
 
 export {
-  defaultDataIdFromObject,
   TypePolicies,
   TypePolicy,
   FieldPolicy,

--- a/src/cache/inmemory/__tests__/cache.ts
+++ b/src/cache/inmemory/__tests__/cache.ts
@@ -3,7 +3,8 @@ import gql, { disableFragmentWarnings } from 'graphql-tag';
 import { cloneDeep } from '../../../utilities/common/cloneDeep';
 import { makeReference, Reference, makeVar, TypedDocumentNode, isReference, DocumentNode } from '../../../core';
 import { Cache } from '../../../cache';
-import { InMemoryCache, InMemoryCacheConfig } from '../inMemoryCache';
+import { InMemoryCache } from '../inMemoryCache';
+import { InMemoryCacheConfig } from '../types';
 
 jest.mock('optimism');
 import { wrap } from 'optimism';

--- a/src/cache/inmemory/__tests__/diffAgainstStore.ts
+++ b/src/cache/inmemory/__tests__/diffAgainstStore.ts
@@ -2,7 +2,7 @@ import gql, { disableFragmentWarnings } from 'graphql-tag';
 
 import { StoreReader } from '../readFromStore';
 import { StoreWriter } from '../writeToStore';
-import { defaultDataIdFromObject } from '../policies';
+import { defaultDataIdFromObject } from '../helpers';
 import { NormalizedCache, Reference } from '../types';
 import { InMemoryCache } from '../inMemoryCache';
 import {

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -37,6 +37,7 @@ import {
   storeValueIsStoreObject,
   selectionSetMatchesResult,
   TypeOrFieldNameRegExp,
+  defaultDataIdFromObject,
 } from './helpers';
 import { cacheSlot } from './reactiveVars';
 import { InMemoryCache } from './inMemoryCache';
@@ -65,7 +66,7 @@ export type TypePolicies = {
 // type KeySpecifier = (string | KeySpecifier)[]
 type KeySpecifier = (string | any[])[];
 
-type KeyFieldsContext = {
+export type KeyFieldsContext = {
   typename?: string;
   selectionSet?: SelectionSetNode;
   fragmentMap?: FragmentMap;
@@ -229,28 +230,6 @@ export type FieldMergeFunction<TExisting = any, TIncoming = TExisting> = (
   incoming: SafeReadonly<TIncoming>,
   options: FieldFunctionOptions,
 ) => SafeReadonly<TExisting>;
-
-export const defaultDataIdFromObject = (
-  { __typename, id, _id }: Readonly<StoreObject>,
-  context?: KeyFieldsContext,
-) => {
-  if (typeof __typename === "string") {
-    if (context) {
-      context.keyObject =
-         id !== void 0 ? {  id } :
-        _id !== void 0 ? { _id } :
-        void 0;
-    }
-    // If there is no object.id, fall back to object._id.
-    if (id === void 0) id = _id;
-    if (id !== void 0) {
-      return `${__typename}:${(
-        typeof id === "number" ||
-        typeof id === "string"
-      ) ? id : JSON.stringify(id)}`;
-    }
-  }
-};
 
 const nullKeyFieldsFn: KeyFieldsFunction = () => void 0;
 const simpleKeyArgsFn: KeyArgsFunction = (_args, context) => context.fieldName;

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -36,9 +36,9 @@ import {
   ReadMergeModifyContext,
 } from './types';
 import { maybeDependOnExistenceOfEntity, supportsResultCaching } from './entityStore';
-import { getTypenameFromStoreObject } from './helpers';
+import { getTypenameFromStoreObject, shouldCanonizeResults } from './helpers';
 import { Policies } from './policies';
-import { shouldCanonizeResults, InMemoryCache } from './inMemoryCache';
+import { InMemoryCache } from './inMemoryCache';
 import { MissingFieldError } from '../core/types/common';
 import { canonicalStringify, ObjectCanon } from './object-canon';
 

--- a/src/cache/inmemory/types.ts
+++ b/src/cache/inmemory/types.ts
@@ -7,13 +7,20 @@ import {
   Reference,
 } from '../../utilities';
 import { FieldValueGetter } from './entityStore';
-import { KeyFieldsFunction, StorageType, FieldMergeFunction } from './policies';
+import {
+  TypePolicies,
+  PossibleTypesMap,
+  KeyFieldsFunction,
+  StorageType,
+  FieldMergeFunction,
+} from './policies';
 import {
   Modifier,
   Modifiers,
   ToReferenceFunction,
   CanReadFunction,
 } from '../core/types/common';
+
 export { StoreObject, StoreValue, Reference }
 
 export interface IdGetterObj extends Object {
@@ -116,6 +123,14 @@ export type ApolloReducerConfig = {
   dataIdFromObject?: KeyFieldsFunction;
   addTypename?: boolean;
 };
+
+export interface InMemoryCacheConfig extends ApolloReducerConfig {
+  resultCaching?: boolean;
+  possibleTypes?: PossibleTypesMap;
+  typePolicies?: TypePolicies;
+  resultCacheMaxSize?: number;
+  canonizeResults?: boolean;
+}
 
 export interface MergeInfo {
   field: FieldNode;

--- a/src/core/__tests__/QueryManager/index.ts
+++ b/src/core/__tests__/QueryManager/index.ts
@@ -8,7 +8,7 @@ import { setVerbosity } from 'ts-invariant';
 
 import { Observable, Observer } from '../../../utilities/observables/Observable';
 import { ApolloLink, GraphQLRequest, FetchResult } from '../../../link/core';
-import { InMemoryCache, InMemoryCacheConfig } from '../../../cache/inmemory/inMemoryCache';
+import { InMemoryCache, InMemoryCacheConfig } from '../../../cache';
 import {
   ApolloReducerConfig,
   NormalizedCacheObject


### PR DESCRIPTION
The `shouldCanonizeResults` helper function introduced in #8822 was defined in `inMemoryCache.ts` but also used in `readFromStore.ts`. Since these two modules already mutually import TypeScript types from each other, the addition of a concrete/value export caused Rollup to begin displaying a warning about the new dependency cycle:
```
dist/cache/index.js → dist/cache/cache.cjs.js...
(!) Circular dependency
dist/cache/inmemory/inMemoryCache.js -> dist/cache/inmemory/readFromStore.js -> dist/cache/inmemory/inMemoryCache.js
created dist/cache/cache.cjs.js in 271ms
```
Dependency cycles in JavaScript are generally harmless and often unavoidable, but we can simplify the work of bundlers like Rollup by eliminating the cycles that are avoidable (as this one is).