### PR TITLE
Require `cache.reset({ discardWatches: true })` to clear `cache.watches`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Apollo Client 3.4.15 (not yet released)
+
+### Bug Fixes
+
+- Require calling `cache.reset({ discardWatches: true })` to make `cache.reset` discard `cache.watches`, restoring behavior broken in v3.4.14 by [#8826](https://github.com/apollographql/apollo-client/pull/8826). <br/>
+  [@benjamn](https://github.com/benjamn) in [#8852](https://github.com/apollographql/apollo-client/pull/8852)
+
 ## Apollo Client 3.4.14
 
 ### Bug Fixes

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -22,7 +22,10 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
   ): Reference | undefined;
   public abstract diff<T>(query: Cache.DiffOptions): Cache.DiffResult<T>;
   public abstract watch(watch: Cache.WatchOptions): () => void;
-  public abstract reset(): Promise<void>;
+
+  // Empty the cache and restart all current watches (unless
+  // options.discardWatches is true).
+  public abstract reset(options?: Cache.ResetOptions): Promise<void>;
 
   // Remove whole objects from the cache by passing just options.id, or
   // specific fields by passing options.field and/or options.args. If no

--- a/src/cache/core/types/Cache.ts
+++ b/src/cache/core/types/Cache.ts
@@ -47,6 +47,12 @@ export namespace Cache {
     broadcast?: boolean;
   }
 
+  // Although you can call cache.reset() without options, its behavior can be
+  // configured by passing a Cache.ResetOptions object.
+  export interface ResetOptions {
+    discardWatches?: boolean;
+  }
+
   export interface ModifyOptions {
     id?: string;
     fields: Modifiers | Modifier<any>;

--- a/src/cache/inmemory/__tests__/cache.ts
+++ b/src/cache/inmemory/__tests__/cache.ts
@@ -3239,7 +3239,7 @@ describe("ReactiveVar and makeVar", () => {
       d: 2,
     });
 
-    cache.reset();
+    cache.reset({ discardWatches: true });
     expect(cache["watches"].size).toBe(0);
 
     expect(diffCounts).toEqual({
@@ -3290,7 +3290,7 @@ describe("ReactiveVar and makeVar", () => {
       f: 2,
     });
 
-    cache.reset();
+    cache.reset({ discardWatches: true });
     expect(cache["watches"].size).toBe(0);
 
     nameVar("Danielle");

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -343,16 +343,26 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     }
   }
 
-  public reset(): Promise<void> {
+  public reset(options?: Cache.ResetOptions): Promise<void> {
     this.init();
 
-    // Similar to what happens in the unsubscribe function returned by
-    // cache.watch, applied to all current watches.
-    this.watches.forEach(watch => this.maybeBroadcastWatch.forget(watch));
-    this.watches.clear();
-    forgetCache(this);
-
     canonicalStringify.reset();
+
+    if (options && options.discardWatches) {
+      // Similar to what happens in the unsubscribe function returned by
+      // cache.watch, applied to all current watches.
+      this.watches.forEach(watch => this.maybeBroadcastWatch.forget(watch));
+      this.watches.clear();
+      forgetCache(this);
+    } else {
+      // Calling this.init() above unblocks all maybeBroadcastWatch caching, so
+      // this.broadcastWatches() triggers a broadcast to every current watcher
+      // (letting them know their data is now missing). This default behavior is
+      // convenient because it means the watches do not have to be manually
+      // reestablished after resetting the cache. To prevent this broadcast and
+      // cancel all watches, pass true for options.discardWatches.
+      this.broadcastWatches();
+    }
 
     return Promise.resolve();
   }


### PR DESCRIPTION
As reported in issue #8851 by @tm1000, PR #8826 (shipped in v3.4.14) was a breaking change for code expecting `cache.watches` to be restarted after `cache.reset()` is called.

This commit establishes a small but extensible `Cache.ResetOptions` API for the `cache.reset` method, which allows the handling of watches to be configured via `options.discardWatches`, which defaults to `false`, thus restoring the behavior of `cache.reset()` from before #8826.

If you need the behavior introduced by #8826, you can now opt (back) into that behavior by calling
```ts
cache.reset({ discardWatches: true })
```