### PR TITLE
Serialize nested `keyFields` objects canonically/stably when computing entity IDs

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     {
       "name": "apollo-client",
       "path": "./dist/apollo-client.min.cjs",
-      "maxSize": "28.0 kB"
+      "maxSize": "28.2 kB"
     }
   ],
   "engines": {

--- a/src/cache/inmemory/__tests__/key-extractor.ts
+++ b/src/cache/inmemory/__tests__/key-extractor.ts
@@ -1,0 +1,123 @@
+import { collectSpecifierPaths, extractKeyPath, getSpecifierPaths } from "../key-extractor";
+import { KeySpecifier } from "../policies";
+
+describe("keyFields and keyArgs extraction", () => {
+  it("getSpecifierPaths should work for various specifiers", () => {
+    function check(specifier: KeySpecifier, expected: string[][]) {
+      const actualPaths = getSpecifierPaths(specifier);
+      expect(actualPaths).toEqual(expected);
+      // Make sure paths lookup is cached.
+      expect(getSpecifierPaths(specifier)).toBe(actualPaths);
+    }
+
+    check([], []);
+    check(["a"], [["a"]]);
+
+    check(["a", "b", "c"], [
+      ["a"],
+      ["b"],
+      ["c"]
+    ]);
+
+    check(["a", ["b", "c"], "d"], [
+      ["a", "b"],
+      ["a", "c"],
+      ["d"],
+    ]);
+
+    check(["a", "b", ["c"], "d"], [
+      ["a"],
+      ["b", "c"],
+      ["d"],
+    ]);
+
+    check(["a", "b", ["c", ["d", ["e", "f"], "g"]]], [
+      ["a"],
+      ["b", "c", "d", "e"],
+      ["b", "c", "d", "f"],
+      ["b", "c", "g"],
+    ]);
+  });
+
+  it("collectSpecifierPaths should work for various specifiers", () => {
+    const object = {
+      a: 123,
+      b: {
+        d: {
+          f: 567,
+          e: 456,
+        },
+        c: 234,
+        g: 678,
+      },
+      h: 789,
+    };
+
+    function collect(specifier: KeySpecifier) {
+      return collectSpecifierPaths(
+        specifier,
+        path => extractKeyPath(object, path, null)
+      );
+    }
+
+    function check(
+      specifier: KeySpecifier,
+      expected: Record<string, any>,
+    ) {
+      const actual = collect(specifier);
+      expect(actual).toEqual(expected);
+      // Not only must actual and expected be equal, but their key orderings
+      // must also be the same.
+      expect(JSON.stringify(actual)).toBe(JSON.stringify(expected));
+    }
+
+    check([], {});
+
+    check(["a", "h"], {
+      a: 123,
+      h: 789,
+    });
+
+
+    check(["h", "a", "bogus"], {
+      h: 789,
+      a: 123,
+    });
+
+    check(["b", ["d", ["e"]]], {
+      b: { d: { e: 456 }}
+    });
+
+    check(["b", ["d", ["e"]], "a"], {
+      b: { d: { e: 456 }},
+      a: 123,
+    });
+
+    check(["b", ["g", "d"], "a"], {
+      b: {
+        g: 678,
+        d: {
+          e: 456,
+          f: 567,
+        },
+      },
+      a: 123,
+    });
+
+    check(["b", "a"], {
+      b: {
+        // Notice that the keys of each nested object are sorted, despite being
+        // out of order in the original object.
+        c: 234,
+        d: {
+          e: 456,
+          f: 567,
+        },
+        g: 678,
+      },
+      // This a key comes after the b key, however, because we requested that
+      // ordering with the ["b", "a"] specifier array.
+      a: 123,
+    });
+  });
+});

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -242,8 +242,8 @@ describe("type policies", function () {
       query {
         book {
           title
-          author {
-            firstName
+          writer: author {
+            first: firstName
             lastName
           }
         }
@@ -255,10 +255,10 @@ describe("type policies", function () {
       data: {
         book: {
           __typename: "Book",
-          author: {
+          writer: {
             // The order of fields shouldn't matter here, since cache
             // identification will stringify them in a stable order.
-            firstName: "Rebecca",
+            first: "Rebecca",
             lastName: "Schwarzlose",
             __typename: "Person",
           },
@@ -273,12 +273,12 @@ describe("type policies", function () {
         book: {
           __typename: "Book",
           title: "The Science of Can and Can't",
-          author: {
+          writer: {
             // The order of fields shouldn't matter here, since cache
             // identification will stringify them in a stable order.
             lastName: "Marletto",
             __typename: "Person",
-            firstName: "Chiarra",
+            first: "Chiarra",
           },
         },
       },

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -224,6 +224,99 @@ describe("type policies", function () {
     checkAuthorName(cache);
   });
 
+  it("serializes nested keyFields objects in stable order", function () {
+    const cache = new InMemoryCache({
+      typePolicies: {
+        Book: {
+          // If you explicitly specify the order of author sub-fields, there
+          // will be no ambiguity about how the author object should be
+          // serialized. However, cache IDs should at least be stably
+          // stringified if the child property names are omitted, as below.
+          // keyFields: ["title", "author", ["firstName", "lastName"]],
+          keyFields: ["title", "author"],
+        },
+      },
+    });
+
+    const query = gql`
+      query {
+        book {
+          title
+          author {
+            firstName
+            lastName
+          }
+        }
+      }
+    `;
+
+    cache.writeQuery({
+      query,
+      data: {
+        book: {
+          __typename: "Book",
+          author: {
+            // The order of fields shouldn't matter here, since cache
+            // identification will stringify them in a stable order.
+            firstName: "Rebecca",
+            lastName: "Schwarzlose",
+            __typename: "Person",
+          },
+          title: "Brainscapes",
+        },
+      },
+    });
+
+    cache.writeQuery({
+      query,
+      data: {
+        book: {
+          __typename: "Book",
+          title: "The Science of Can and Can't",
+          author: {
+            // The order of fields shouldn't matter here, since cache
+            // identification will stringify them in a stable order.
+            lastName: "Marletto",
+            __typename: "Person",
+            firstName: "Chiarra",
+          },
+        },
+      },
+    });
+
+    expect(cache.extract(true)).toEqual({
+      // The order of the author object's __typename, firstName, and lastName
+      // fields has been determined by our keyFields configuration and stable
+      // stringification.
+      'Book:{"title":"Brainscapes","author":{"__typename":"Person","firstName":"Rebecca","lastName":"Schwarzlose"}}': {
+        __typename: "Book",
+        title: "Brainscapes",
+        author: {
+          __typename: "Person",
+          firstName: "Rebecca",
+          lastName: "Schwarzlose",
+        },
+      },
+      // Again, __typename, firstName, and then lastName, despite the different
+      // order of keys in the data we wrote.
+      'Book:{"title":"The Science of Can and Can\'t","author":{"__typename":"Person","firstName":"Chiarra","lastName":"Marletto"}}': {
+        __typename: "Book",
+        title: "The Science of Can and Can't",
+        author: {
+          __typename: "Person",
+          firstName: "Chiarra",
+          lastName: "Marletto",
+        },
+      },
+      ROOT_QUERY: {
+        __typename: "Query",
+        book: {
+          __ref: 'Book:{"title":"The Science of Can and Can\'t","author":{"__typename":"Person","firstName":"Chiarra","lastName":"Marletto"}}',
+        },
+      },
+    });
+  });
+
   it("accepts keyFields functions", function () {
     const cache = new InMemoryCache({
       typePolicies: {

--- a/src/cache/inmemory/key-extractor.ts
+++ b/src/cache/inmemory/key-extractor.ts
@@ -226,12 +226,15 @@ export function extractKeyPath(
     })) {
       return result;
     }
-    invariant(
-      result && hasOwn.call(result, schemaKey),
-      `Missing field '${schemaKey}' while extracting keyFields from ${
-        JSON.stringify(result)
-      }`,
-    );
+    // TODO This should be in the keyFields path extraction function, not here.
+    if (aliasMap) {
+      invariant(
+        result && hasOwn.call(result, schemaKey),
+        `Missing field '${schemaKey}' while extracting keyFields from ${
+          JSON.stringify(result)
+        }`,
+      );
+    }
     aliasMap = resultKeyMap && resultKeyMap[schemaKey];
     return result = result && result[schemaKey];
   }, object);

--- a/src/cache/inmemory/key-extractor.ts
+++ b/src/cache/inmemory/key-extractor.ts
@@ -167,7 +167,7 @@ export class KeyExtractor {
   }
 }
 
-function collectSpecifierPaths(
+export function collectSpecifierPaths(
   specifier: KeySpecifier,
   extractor: (path: string[]) => any,
 ) {
@@ -186,7 +186,7 @@ function collectSpecifierPaths(
   }, Object.create(null));
 }
 
-function getSpecifierPaths(spec: KeySpecifier & {
+export function getSpecifierPaths(spec: KeySpecifier & {
   paths?: string[][];
 }): string[][] {
   if (!spec.paths) {
@@ -210,7 +210,7 @@ function getSpecifierPaths(spec: KeySpecifier & {
   return spec.paths!;
 }
 
-function extractKeyPath(
+export function extractKeyPath(
   object: Record<string, any>,
   path: string[],
   aliasMap: AliasMap | null,

--- a/src/cache/inmemory/key-extractor.ts
+++ b/src/cache/inmemory/key-extractor.ts
@@ -239,18 +239,8 @@ export function extractKeyPath(
   aliasMap: AliasMap | null,
 ): any {
   const extracted = path.reduce((result, schemaKey) => {
-    const resultKeyMap = aliasMap && aliasMap.aliases[schemaKey];
-    if (resultKeyMap && Object.keys(resultKeyMap).some(resultKey => {
-      if (result && hasOwn.call(result, resultKey)) {
-        aliasMap = resultKeyMap[resultKey];
-        result = result[resultKey];
-        return true;
-      }
-    })) {
-      return result;
-    }
-    aliasMap = resultKeyMap && resultKeyMap[schemaKey];
-    return result = result && result[schemaKey];
+    [result, aliasMap] = extractSchemaKey(result, schemaKey, aliasMap);
+    return result;
   }, object);
 
   if (isNonNullObject(extracted) && !Array.isArray(extracted)) {
@@ -272,4 +262,31 @@ export function extractKeyPath(
   }
 
   return extracted;
+}
+
+function extractSchemaKey(
+  object: Record<string, any>,
+  schemaKey: string,
+  aliasMap: AliasMap | null,
+): [any, AliasMap | null] {
+  let key = schemaKey;
+  let nextAliasMap: AliasMap | null = null;
+
+  if (aliasMap) {
+    const resultKeyMap = aliasMap.aliases[key];
+    if (resultKeyMap) {
+      Object.keys(resultKeyMap).some(resultKey => {
+        if (hasOwn.call(object, resultKey)) {
+          key = resultKey;
+          return true;
+        }
+      });
+      nextAliasMap = resultKeyMap[key];
+    }
+  }
+
+  return [
+    object[key],
+    nextAliasMap,
+  ];
 }

--- a/src/cache/inmemory/key-extractor.ts
+++ b/src/cache/inmemory/key-extractor.ts
@@ -1,0 +1,258 @@
+import { invariant } from "../../utilities/globals";
+import { Trie } from "@wry/trie";
+
+import {
+  argumentsObjectFromField,
+  canUseWeakMap,
+  DeepMerger,
+  getFragmentFromSelection,
+  isField,
+  isNonEmptyArray,
+  isNonNullObject,
+  resultKeyNameFromField,
+} from "../../utilities";
+
+import {
+  KeySpecifier,
+  KeyFieldsFunction,
+  KeyFieldsContext,
+  KeyArgsFunction,
+} from "./policies";
+import { hasOwn } from "./helpers";
+
+type AliasMap = {
+  aliases: {
+    // Any given schemaKey (the actual field name, according to the schema) maps
+    // to one or more result field names (typically schemaKey itself, and
+    // possibly additional resultKeys that are !== schemaKey, due to aliases).
+    [schemaKey: string]: {
+      // If the aliased field has a selection set of its own, the AliasMap for
+      // that selection set will be collected here.
+      [resultKey: string]: AliasMap | null;
+    };
+  };
+  // Map from resultKey to schemaKey strings for this selection set.
+  actuals: Record<string, string>;
+};
+
+function makeEmptyAliasMap(): AliasMap {
+  return {
+    aliases: Object.create(null),
+    actuals: Object.create(null),
+  };
+}
+
+export class KeyExtractor {
+  private aliasMapTrie = new Trie<{
+    aliasMap?: AliasMap;
+  }>(canUseWeakMap);
+
+  private getAliasMap(
+    selectionSet: KeyFieldsContext["selectionSet"],
+    fragmentMap: KeyFieldsContext["fragmentMap"],
+  ): AliasMap {
+    if (!selectionSet || !fragmentMap) {
+      return makeEmptyAliasMap();
+    }
+
+    const info = this.aliasMapTrie.lookup(selectionSet, fragmentMap);
+    if (!info.aliasMap) {
+      const aliasMap: AliasMap = info.aliasMap = makeEmptyAliasMap();
+      const workQueue = new Set([selectionSet]);
+      const merger = new DeepMerger;
+      workQueue.forEach(selectionSet => {
+        selectionSet.selections.forEach(selection => {
+          if (isField(selection)) {
+            const schemaKey = selection.name.value;
+            const resultKey = resultKeyNameFromField(selection);
+            const aliases = aliasMap.aliases[schemaKey] ||
+              (aliasMap.aliases[schemaKey] = Object.create(null));
+            // TODO Make sure nulls are merged correctly.
+            aliases[resultKey] = selection.selectionSet ? merger.merge(
+              aliases[resultKey] || Object.create(null),
+              this.getAliasMap(selection.selectionSet, fragmentMap),
+            ) : aliases[resultKey] || null;
+            if (resultKey !== schemaKey) {
+              aliasMap.actuals[resultKey] = schemaKey;
+            }
+          } else {
+            const fragment = getFragmentFromSelection(selection, fragmentMap);
+            if (fragment) {
+              workQueue.add(fragment.selectionSet);
+            }
+          }
+        });
+      });
+    }
+
+    return info.aliasMap!;
+  }
+
+  public keyFieldsFnFromSpecifier(specifier: KeySpecifier): KeyFieldsFunction {
+    return (object, context) => {
+      const aliasMap = this.getAliasMap(
+        context.selectionSet,
+        context.fragmentMap,
+      );
+
+      context.keyObject = collectSpecifierPaths(
+        specifier,
+        schemaKeyPath => extractKeyPath(object, schemaKeyPath, aliasMap),
+      );
+
+      return `${context.typename}:${JSON.stringify(context.keyObject)}`;
+    };
+  }
+
+  public keyArgsFnFromSpecifier(specifier: KeySpecifier): KeyArgsFunction {
+    return (args, { field, variables, fieldName }) => {
+      const collected = collectSpecifierPaths(specifier, keyPath => {
+        const firstKey = keyPath[0];
+        const firstChar = firstKey.charAt(0);
+        if (firstChar === "@") {
+          if (field && isNonEmptyArray(field.directives)) {
+            // TODO Cache this work somehow, a la aliasMap?
+            const directiveName = firstKey.slice(1);
+            // If the directive appears multiple times, only the first
+            // occurrence's arguments will be used. TODO Allow repetition?
+            const d = field.directives.find(d => d.name.value === directiveName);
+            if (d) {
+              // Fortunately argumentsObjectFromField works for DirectiveNode!
+              const directiveArgs = argumentsObjectFromField(d, variables);
+              return directiveArgs ? extractKeyPath(
+                directiveArgs,
+                keyPath.slice(1),
+                null,
+              ) : void 0;
+            }
+          }
+          // If the key started with @ but there was no corresponding
+          // directive, we want to omit this value from the key object, not
+          // fall through to treating @whatever as a normal argument name.
+          return;
+        }
+
+        if (firstChar === "$") {
+          const variableName = firstKey.slice(1);
+          if (variables && hasOwn.call(variables, variableName)) {
+            const variableValue = variables[variableName];
+            return isNonNullObject(variableValue)
+              ? extractKeyPath(variableValue, keyPath.slice(1), null)
+              : variableValue;
+          }
+          // If the key started with $ but there was no corresponding
+          // variable, we want to omit this value from the key object, not
+          // fall through to treating $whatever as a normal argument name.
+          return;
+        }
+
+        if (args) {
+          return extractKeyPath(args, keyPath, null);
+        }
+      });
+
+      const suffix = JSON.stringify(collected);
+
+      // If no arguments were passed to this field, and it didn't have any other
+      // field key contributions from directives or variables, hide the empty
+      // :{} suffix from the field key. However, a field passed no arguments can
+      // still end up with a non-empty :{...} suffix if its key configuration
+      // refers to directives or variables.
+      if (args || suffix !== "{}") {
+        fieldName += ":" + suffix;
+      }
+
+      return fieldName;
+    };
+  }
+}
+
+function collectSpecifierPaths(
+  specifier: KeySpecifier,
+  extractor: (path: string[]) => any,
+) {
+  // For each path specified by specifier, invoke the extractor, and repeatedly
+  // merge the results together, with appropriate ancestor context.
+  const merger = new DeepMerger;
+  return getSpecifierPaths(specifier).reduce((collected, path) => {
+    let result = extractor(path);
+    if (result !== void 0) {
+      for (let i = path.length - 1; i >= 0; --i) {
+        result = { [path[i]]: result };
+      }
+      return merger.merge(collected, result);
+    }
+    return collected;
+  }, Object.create(null));
+}
+
+function getSpecifierPaths(spec: KeySpecifier & {
+  paths?: string[][];
+}): string[][] {
+  if (!spec.paths) {
+    const paths: string[][] = spec.paths = [];
+    const currentPath: string[] = [];
+
+    spec.forEach((s, i) => {
+      if (Array.isArray(s)) {
+        getSpecifierPaths(s).forEach(p => paths.push(currentPath.concat(p)));
+        currentPath.length = 0;
+      } else {
+        currentPath.push(s);
+        if (!Array.isArray(spec[i + 1])) {
+          paths.push(currentPath.slice(0));
+          currentPath.length = 0;
+        }
+      }
+    });
+  }
+
+  return spec.paths!;
+}
+
+function extractKeyPath(
+  object: Record<string, any>,
+  path: string[],
+  aliasMap: AliasMap | null,
+): any {
+  const extracted = path.reduce((result, schemaKey) => {
+    const resultKeyMap = aliasMap && aliasMap.aliases[schemaKey];
+    if (resultKeyMap && Object.keys(resultKeyMap).some(resultKey => {
+      if (result && hasOwn.call(result, resultKey)) {
+        aliasMap = resultKeyMap[resultKey];
+        result = result[resultKey];
+        return true;
+      }
+    })) {
+      return result;
+    }
+    invariant(
+      result && hasOwn.call(result, schemaKey),
+      `Missing field '${schemaKey}' while extracting keyFields from ${
+        JSON.stringify(result)
+      }`,
+    );
+    aliasMap = resultKeyMap && resultKeyMap[schemaKey];
+    return result = result && result[schemaKey];
+  }, object);
+
+  if (isNonNullObject(extracted) && !Array.isArray(extracted)) {
+    const keys = Object.keys(extracted);
+
+    if (aliasMap && aliasMap.actuals) {
+      // Since the keys array will contain result keys rather than store keys,
+      // we need to translate back to store keys before calling handleSpecifier
+      // with the store key array.
+      for (let i = 0, { length } = keys; i < length; ++i) {
+        keys[i] = aliasMap.actuals[keys[i]] || keys[i];
+      }
+    }
+
+    return collectSpecifierPaths(
+      keys.sort(),
+      path => extractKeyPath(extracted, path, aliasMap),
+    );
+  }
+
+  return extracted;
+}

--- a/src/cache/inmemory/object-canon.ts
+++ b/src/cache/inmemory/object-canon.ts
@@ -218,12 +218,6 @@ export const canonicalStringify = Object.assign(function (value: any): string {
   return JSON.stringify(value);
 }, {
   reset: resetCanonicalStringify,
-  canonize<T>(value: T): T {
-    if (stringifyCanon === void 0) {
-      resetCanonicalStringify();
-    }
-    return stringifyCanon.admit(value);
-  },
 });
 
 // Can be reset by calling canonicalStringify.reset().

--- a/src/cache/inmemory/object-canon.ts
+++ b/src/cache/inmemory/object-canon.ts
@@ -218,6 +218,12 @@ export const canonicalStringify = Object.assign(function (value: any): string {
   return JSON.stringify(value);
 }, {
   reset: resetCanonicalStringify,
+  canonize<T>(value: T): T {
+    if (stringifyCanon === void 0) {
+      resetCanonicalStringify();
+    }
+    return stringifyCanon.admit(value);
+  },
 });
 
 // Can be reset by calling canonicalStringify.reset().

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -50,7 +50,7 @@ import { WriteContext } from './writeToStore';
 // used by getStoreKeyName. This function is used when computing storeFieldName
 // strings (when no keyArgs has been configured for a field).
 import { canonicalStringify } from './object-canon';
-import { keyArgsFnFromSpecifier, KeyExtractor } from './key-extractor';
+import { keyArgsFnFromSpecifier, keyFieldsFnFromSpecifier } from './key-extractor';
 
 getStoreKeyName.setStringify(canonicalStringify);
 
@@ -274,8 +274,6 @@ export class Policies {
 
   public readonly usingPossibleTypes = false;
 
-  private keyExtractor = new KeyExtractor;
-
   constructor(private config: {
     cache: InMemoryCache;
     dataIdFromObject?: KeyFieldsFunction;
@@ -335,7 +333,7 @@ export class Policies {
     while (keyFn) {
       const specifierOrId = keyFn(object, context);
       if (Array.isArray(specifierOrId)) {
-        keyFn = this.keyExtractor.keyFieldsFnFromSpecifier(specifierOrId);
+        keyFn = keyFieldsFnFromSpecifier(specifierOrId);
       } else {
         id = specifierOrId;
         break;
@@ -409,7 +407,7 @@ export class Policies {
       keyFields === false ? nullKeyFieldsFn :
       // Pass an array of strings to use those fields to compute a
       // composite ID for objects of this typename.
-      Array.isArray(keyFields) ? this.keyExtractor.keyFieldsFnFromSpecifier(keyFields) :
+      Array.isArray(keyFields) ? keyFieldsFnFromSpecifier(keyFields) :
       // Pass a function to take full control over identification.
       typeof keyFields === "function" ? keyFields :
       // Leave existing.keyFn unchanged if above cases fail.

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -50,7 +50,7 @@ import { WriteContext } from './writeToStore';
 // used by getStoreKeyName. This function is used when computing storeFieldName
 // strings (when no keyArgs has been configured for a field).
 import { canonicalStringify } from './object-canon';
-import { KeyExtractor } from './key-extractor';
+import { keyArgsFnFromSpecifier, KeyExtractor } from './key-extractor';
 
 getStoreKeyName.setStringify(canonicalStringify);
 
@@ -431,7 +431,7 @@ export class Policies {
             keyArgs === false ? simpleKeyArgsFn :
             // Pass an array of strings to use named arguments to
             // compute a composite identity for the field.
-            Array.isArray(keyArgs) ? this.keyExtractor.keyArgsFnFromSpecifier(keyArgs) :
+            Array.isArray(keyArgs) ? keyArgsFnFromSpecifier(keyArgs) :
             // Pass a function to take full control over field identity.
             typeof keyArgs === "function" ? keyArgs :
             // Leave existing.keyFn unchanged if above cases fail.
@@ -682,7 +682,7 @@ export class Policies {
       while (keyFn) {
         const specifierOrString = keyFn(args, context);
         if (Array.isArray(specifierOrString)) {
-          keyFn = this.keyExtractor.keyArgsFnFromSpecifier(specifierOrString);
+          keyFn = keyArgsFnFromSpecifier(specifierOrString);
         } else {
           // If the custom keyFn returns a falsy value, fall back to
           // fieldName instead.

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -1095,7 +1095,15 @@ function computeKeyFieldsObject(
           JSON.stringify(response)
         }`,
       );
-      keyObj[lastActualKey = s] = response[lastResponseKey = responseKey];
+      const child = response[lastResponseKey = responseKey];
+      keyObj[lastActualKey = s] = isNonNullObject(child)
+        // In case there is no nested specifier array to dictate the
+        // stringification ordering of this child object, stringify it
+        // canonically/stably. If there is a nested specifier array, it will be
+        // used to rewrite this child object in the specified order, in the next
+        // forEach iteration.
+        ? canonicalStringify.canonize(child)
+        : child;
     }
   });
 


### PR DESCRIPTION
We're still waiting to hear back about a specific reproduction for #8855, but I thought of an edge case where `keyFields` serialization could depend on the key order of the input objects.