### PR TITLE
Avoid unnecessarily importing `isType` from `graphql` package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
   [@benjamn](https://github.com/benjamn) in [#8862](https://github.com/apollographql/apollo-client/pull/8862)
 
+- Avoid importing `isType` from the `graphql` package internally, to prevent bundlers from including as much as 3.4kB of unnecessary code. <br/>
+  [@benjamn](https://github.com/benjamn) in [#8891](https://github.com/apollographql/apollo-client/pull/8891)
+
 ## Apollo Client 3.4.15
 
 ### Bug Fixes

--- a/src/utilities/globals/fix-graphql.ts
+++ b/src/utilities/globals/fix-graphql.ts
@@ -1,14 +1,14 @@
 // The ordering of these imports is important, because it ensures the temporary
 // process.env.NODE_ENV polyfill is defined globally (if necessary) before we
-// import { isType } from 'graphql'. The instanceOf function that we really care
+// import { Source } from 'graphql'. The instanceOf function that we really care
 // about (the one that uses process.env.NODE_ENV) is not exported from the
-// top-level graphql package, but isType uses instanceOf, and is exported.
+// top-level graphql package, but graphql/language/source uses instanceOf, and
+// has relatively few dependencies, so importing it here should not increase
+// bundle sizes as much as other options.
 import { remove } from 'ts-invariant/process';
-import { isType } from 'graphql';
+import { Source } from 'graphql';
 
 export function removeTemporaryGlobals() {
-  // Calling isType here just to make sure it won't be tree-shaken away,
-  // provided applyFixes is called elsewhere.
-  isType(null);
-  return remove();
+  // Using Source here here just to make sure it won't be tree-shaken away.
+  return typeof Source === "function" ? remove() : remove();
 }


### PR DESCRIPTION
To import `graphql` (and its internal `instanceOf` function) for the first time with `process.env.NODE_ENV` safely polyfilled, PR #8347 selected a somewhat arbitrary export of the `graphql` package that uses `instanceOf`, specifically the `isType` function exported by [`graphql/type/definition`](https://github.com/graphql/graphql-js/blob/0c7165a5d0a7054cac4f2a0898ace19ca9d67f76/src/type/definition.ts#L70-L81).

As revealed by issue #8705, importing `isType` was a bad choice, since it depends on a bunch of other code within the `graphql` package, unnecessarily increasing minified+gzip bundle size by approximately **3.4kB**.

A better choice is the `Source` constructor, which is already imported thanks to other necessary imports, and also imports/uses `instanceOf`.