### PR TITLE
Fix #6557 - Fix slow down on multiple fetchMore

### DIFF
--- a/packages/apollo-client/src/core/ObservableQuery.ts
+++ b/packages/apollo-client/src/core/ObservableQuery.ts
@@ -354,7 +354,7 @@ export class ObservableQuery<
           ...fetchMoreOptions.variables,
         },
       }),
-      fetchPolicy: 'network-only',
+      fetchPolicy: 'no-cache',
     } as WatchQueryOptions;
 
     const qid = this.queryManager.generateQueryId();


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

Having a go at this.

Default fetch policy for fetchMore creates many unreleased cache watches.
The cache is managed in the updateQuery callback anyway, so there should not be a need for network-only in fetchMore.

This seems to fix slowdowns for our use case
