### PR TITLE
Align GraphQLErrors and NetworkError errors. Fix docs

### DIFF
--- a/docs/source/api/link/apollo-link-error.md
+++ b/docs/source/api/link/apollo-link-error.md
@@ -127,12 +127,12 @@ A `networkError` can contain additional fields, such as a GraphQL object in the 
 
 ## Ignoring errors
 
-If you want to conditionally ignore errors, you can set `response.errors = null;` within the error handler:
+If you want to conditionally ignore errors, you can set `response.errors = undefined;` within the error handler:
 
 ```js
 onError(({ response, operation }) => {
-  if (operation.operationName === "IgnoreErrorsQuery") {
-    response.errors = null;
+  if (response && operation.operationName === "IgnoreErrorsQuery") {
+    response.errors = undefined;
   }
 });
 ```

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -1,4 +1,4 @@
-import { DocumentNode, GraphQLError } from 'graphql';
+import { DocumentNode } from 'graphql';
 import { equal } from "@wry/equality";
 
 import { Cache, ApolloCache } from '../cache';
@@ -16,7 +16,7 @@ import {
   NetworkStatus,
   isNetworkRequestInFlight,
 } from './networkStatus';
-import { ApolloError } from '../errors';
+import { ApolloError, GraphQLErrors, NetworkError } from '../errors';
 import { QueryManager } from './QueryManager';
 
 export type QueryStoreValue = Pick<QueryInfo,
@@ -30,7 +30,7 @@ export const enum CacheWriteBehavior {
   FORBID,
   OVERWRITE,
   MERGE,
-};
+}
 
 const destructiveMethodCounts = new (
   canUseWeakMap ? WeakMap : Map
@@ -82,8 +82,8 @@ export class QueryInfo {
   subscriptions = new Set<ObservableSubscription>();
   variables?: Record<string, any>;
   networkStatus?: NetworkStatus;
-  networkError?: Error | null;
-  graphQLErrors?: ReadonlyArray<GraphQLError>;
+  networkError?: NetworkError;
+  graphQLErrors?: GraphQLErrors;
   stopped = false;
 
   private cache: ApolloCache<any>;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,8 +1,8 @@
-import { DocumentNode, GraphQLError } from 'graphql';
+import { DocumentNode } from 'graphql';
 
 import { ApolloCache } from '../cache';
 import { FetchResult } from '../link/core';
-import { ApolloError } from '../errors';
+import { ApolloError, GraphQLErrors } from '../errors';
 import { QueryInfo } from './QueryInfo';
 import { NetworkStatus } from './networkStatus';
 import { Resolver } from './LocalState';
@@ -134,7 +134,7 @@ export type OperationVariables = Record<string, any>;
 
 export type ApolloQueryResult<T> = {
   data: T;
-  errors?: ReadonlyArray<GraphQLError>;
+  errors?: GraphQLErrors;
   error?: ApolloError;
   loading: boolean;
   networkStatus: NetworkStatus;

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -45,7 +45,7 @@ export class ApolloError extends Error {
   public message: string;
   public graphQLErrors: GraphQLErrors;
   public clientErrors: ReadonlyArray<Error>;
-  public networkError: Error | ServerParseError | ServerError | null;
+  public networkError: NetworkError;
 
   // An object that can be used to provide some additional information
   // about an error, e.g. specifying the type of error this is. Used
@@ -62,9 +62,9 @@ export class ApolloError extends Error {
     errorMessage,
     extraInfo,
   }: {
-    graphQLErrors?: ReadonlyArray<GraphQLError>;
+    graphQLErrors?: GraphQLErrors;
     clientErrors?: ReadonlyArray<Error>;
-    networkError?: Error | ServerParseError | ServerError | null;
+    networkError?: NetworkError;
     errorMessage?: string;
     extraInfo?: any;
   }) {

--- a/src/link/core/types.ts
+++ b/src/link/core/types.ts
@@ -28,7 +28,7 @@ export interface FetchResult<
   data?: TData | null;
   extensions?: E;
   context?: C;
-};
+}
 
 export type NextLink = (operation: Operation) => Observable<FetchResult>;
 

--- a/src/link/persisted-queries/index.ts
+++ b/src/link/persisted-queries/index.ts
@@ -1,13 +1,10 @@
 import { invariant } from '../../utilities/globals';
 
 import { print } from 'graphql';
-import {
-  DocumentNode,
-  ExecutionResult,
-  GraphQLError,
-} from 'graphql';
+import { DocumentNode, ExecutionResult } from 'graphql';
 
 import { ApolloLink, Operation } from '../core';
+import { GraphQLErrors, NetworkError } from '../../errors';
 import {
   Observable,
   Observer,
@@ -18,8 +15,8 @@ import {
 export const VERSION = 1;
 
 export interface ErrorResponse {
-  graphQLErrors?: readonly GraphQLError[];
-  networkError?: Error;
+  graphQLErrors?: GraphQLErrors;
+  networkError?: NetworkError;
   response?: ExecutionResult;
   operation: Operation;
 }
@@ -31,17 +28,17 @@ export namespace PersistedQueryLink {
   interface BaseOptions {
     disable?: (error: ErrorResponse) => boolean;
     useGETForHashedQueries?: boolean;
-  };
+  }
 
   interface SHA256Options extends BaseOptions {
     sha256: SHA256Function;
     generateHash?: never;
-  };
+  }
 
   interface GenerateHashOptions extends BaseOptions {
     sha256?: never;
     generateHash: GenerateHashFunction;
-  };
+  }
 
   export type Options = SHA256Options | GenerateHashOptions;
 }
@@ -158,7 +155,7 @@ export const createPersistedQueryLink = (
         {
           response,
           networkError,
-        }: { response?: ExecutionResult; networkError?: Error },
+        }: { response?: ExecutionResult; networkError?: NetworkError },
         cb: () => void,
       ) => {
         if (!retried && ((response && response.errors) || networkError)) {


### PR DESCRIPTION
1. Continue to align error types according to changes in https://github.com/apollographql/apollo-client/pull/8424

2. Try to fix #8896

```
const errorLink = onError(({ response, operation }) => {
  if (operation.operationName === "IgnoreErrorsQuery") {
    response.errors = null;
  }
});
```

The error is:

```
Type 'null' is not assignable to type 'readonly GraphQLError[] | undefined'
```

If we look at `ExecutionResult` types at graphql, `errors` can't be `null`:

![image](https://user-images.githubusercontent.com/988471/138134645-e39ebd47-72e6-4e81-bf67-5d869744c678.png)

https://github.com/graphql/graphql-js/blob/e289e6412ca59cd6298796d61efa19d78eeb945c/src/execution/execute.ts#L127-L134

So I suggest to fix docs to assign `undefined` instead of `null`.

Also we need to check if `response` exists, cause it is optional:

https://github.com/apollographql/apollo-client/blob/cbcf951256b22553bdb065dfa0d32c0a4ca804d3/src/link/error/index.ts#L9-L15

So my suggestion is to check like this:

```
if (response && operation.operationName === "IgnoreErrorsQuery") {
  response.errors = undefined;
}
```

The bad part is that a lot of tests are broken in this rc:

`Test Suites: 93 failed, 18 passed, 111 total`

I could not brake them 🤷‍♂️. So please, verify these changes and merge them on your own risk. Thanks!

