### PR TITLE
Export `Modifier` and `Modifiers`

### DIFF
--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -4,6 +4,8 @@ export { Transaction, ApolloCache } from './core/cache';
 export { Cache } from './core/types/Cache';
 export { DataProxy } from './core/types/DataProxy';
 export {
+  Modifier,
+  Modifiers,
   MissingFieldError,
   ReadFieldOptions
 } from './core/types/common';


### PR DESCRIPTION
Simple export of `Modifers` and `Modifers` so these types can be used externally.