### PR TITLE
Fix for ServerError and ServerParseError occurring at the same time.

### DIFF
--- a/src/link/http/__tests__/HttpLink.ts
+++ b/src/link/http/__tests__/HttpLink.ts
@@ -1202,7 +1202,7 @@ describe('HttpLink', () => {
     const unparsableJson = jest.fn(() => Promise.resolve(body));
     it('throws an error if response is unparsable', done => {
       fetch.mockReturnValueOnce(
-        Promise.resolve({ status: 400, text: unparsableJson }),
+        Promise.resolve({ status: 200, text: unparsableJson }),
       );
       const link = createHttpLink({ uri: 'data', fetch: fetch as any });
 
@@ -1212,7 +1212,7 @@ describe('HttpLink', () => {
         },
         makeCallback(done, (e: ServerParseError) => {
           expect(e.message).toMatch(/JSON/);
-          expect(e.statusCode).toBe(400);
+          expect(e.statusCode).toBe(200);
           expect(e.response).toBeDefined();
           expect(e.bodyText).toBe(body);
         }),

--- a/src/link/http/__tests__/parseAndCheckHttpResponse.ts
+++ b/src/link/http/__tests__/parseAndCheckHttpResponse.ts
@@ -20,7 +20,7 @@ describe('parseAndCheckResponse', () => {
   const operations = [createOperation({}, { query })];
 
   it('throws a parse error with a status code on unparsable response', done => {
-    const status = 400;
+    const status = 200;
     fetchMock.mock('begin:/error', status);
     fetch('error')
       .then(parseAndCheckHttpResponse(operations))

--- a/src/link/http/parseAndCheckHttpResponse.ts
+++ b/src/link/http/parseAndCheckHttpResponse.ts
@@ -15,6 +15,14 @@ export function parseAndCheckHttpResponse(
   return (response: Response) => response
     .text()
     .then(bodyText => {
+      if (response.status >= 300) {
+        // Network error
+        throwServerError(
+          response,
+          bodyText,
+          `Response not successful: Received status code ${response.status}`,
+        );
+      }
       try {
         return JSON.parse(bodyText);
       } catch (err) {
@@ -27,15 +35,6 @@ export function parseAndCheckHttpResponse(
       }
     })
     .then((result: any) => {
-      if (response.status >= 300) {
-        // Network error
-        throwServerError(
-          response,
-          result,
-          `Response not successful: Received status code ${response.status}`,
-        );
-      }
-
       if (
         !Array.isArray(result) &&
         !hasOwnProperty.call(result, 'data') &&

--- a/src/link/http/parseAndCheckHttpResponse.ts
+++ b/src/link/http/parseAndCheckHttpResponse.ts
@@ -17,12 +17,20 @@ export function parseAndCheckHttpResponse(
     .then(bodyText => {
       if (response.status >= 300) {
         // Network error
+        const getResult = () => {
+          try {
+            return JSON.parse(bodyText);
+          } catch (err) {
+            return bodyText
+          }
+        }
         throwServerError(
           response,
-          bodyText,
+          getResult(),
           `Response not successful: Received status code ${response.status}`,
         );
       }
+
       try {
         return JSON.parse(bodyText);
       } catch (err) {


### PR DESCRIPTION
Closes #8945

When `ServerError` and `ServerParseError` are raised at the same time, the response of `ServerError` will be returned.
