### PR TITLE
Correct onCompleted.data type

### DIFF
--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -44,7 +44,7 @@ export interface QueryFunctionOptions<
 > extends BaseQueryOptions<TVariables> {
   displayName?: string;
   skip?: boolean;
-  onCompleted?: (data: TData) => void;
+  onCompleted?: (data: TData | null) => void;
   onError?: (error: ApolloError) => void;
 }
 


### PR DESCRIPTION
Hi,

As mentioned in this issue: https://github.com/apollographql/apollo-client/issues/6966, when using `errorPolicy "all"` it will happen than the `onCompleted` callback to the `useQuery` hook will be called with `data = null`.

The types do not currently reflect this, and I have had several Sentry reports because my code was unsafe and I did not handle it.

I would propose fixing the types to avoid the error.