### PR TITLE
Use type parameters in FetchResult when extending ExecutionResult

### DIFF
--- a/src/link/core/types.ts
+++ b/src/link/core/types.ts
@@ -22,13 +22,11 @@ export interface Operation {
 
 export interface FetchResult<
   TData = { [key: string]: any },
-  C = Record<string, any>,
-  E = Record<string, any>
-> extends ExecutionResult {
-  data?: TData | null;
-  extensions?: E;
-  context?: C;
-};
+  TContext = Record<string, any>,
+  TExtensions = Record<string, any>
+> extends ExecutionResult<TData, TExtensions> {
+  context?: TContext;
+}
 
 export type NextLink = (operation: Operation) => Observable<FetchResult>;
 


### PR DESCRIPTION
The definition of `ExecutionResult` is as follows:

```typescript
export interface ExecutionResult<
  TData = { [key: string]: any },
  TExtensions = { [key: string]: any }
> {
  errors?: ReadonlyArray<GraphQLError>;
  data?: TData | null;
  extensions?: TExtensions;
}
```

So there's no need to redeclare `data` and `extensions` if we pass in the correct type parameters