### PR TITLE
Allow `FieldFunctionOptions` to be passed as Type Argument for `FieldPolicy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Apollo Client 3.4.17 (not yet released)
+
+### Improvements
+
+- Allow `TOptions extends FieldFunctionOptions` to be passed as final (optional) type parameter of `FieldPolicy` type. <br/>
+  [@VictorGaiva](https://github.com/VictorGaiva) in [#9000](https://github.com/apollographql/apollo-client/pull/9000)
+
 ## Apollo Client 3.4.16
 
 ### Improvements

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -137,10 +137,13 @@ export type FieldPolicy<
   // The type that the read function actually returns, using TExisting
   // data and options.args as input. Usually the same as TIncoming.
   TReadResult = TIncoming,
+  // Allows FieldFunctionOptions definition to be overwritten by the
+  // developer
+  TOptions extends FieldFunctionOptions = FieldFunctionOptions
 > = {
   keyArgs?: KeySpecifier | KeyArgsFunction | false;
-  read?: FieldReadFunction<TExisting, TReadResult>;
-  merge?: FieldMergeFunction<TExisting, TIncoming> | boolean;
+  read?: FieldReadFunction<TExisting, TReadResult, TOptions>;
+  merge?: FieldMergeFunction<TExisting, TIncoming, TOptions> | boolean;
 };
 
 export type StorageType = Record<string, any>;
@@ -210,7 +213,11 @@ type MergeObjectsFunction = <T extends StoreObject | Reference>(
   incoming: T,
 ) => T;
 
-export type FieldReadFunction<TExisting = any, TReadResult = TExisting> = (
+export type FieldReadFunction<
+  TExisting = any,
+  TReadResult = TExisting,
+  TOptions extends FieldFunctionOptions = FieldFunctionOptions
+> = (
   // When reading a field, one often needs to know about any existing
   // value stored for that field. If the field is read before any value
   // has been written to the cache, this existing parameter will be
@@ -220,15 +227,21 @@ export type FieldReadFunction<TExisting = any, TReadResult = TExisting> = (
   // developer to annotate it with a type, without also having to provide
   // a whole new type for the options object.
   existing: SafeReadonly<TExisting> | undefined,
-  options: FieldFunctionOptions,
+  options: TOptions,
 ) => TReadResult | undefined;
 
-export type FieldMergeFunction<TExisting = any, TIncoming = TExisting> = (
+export type FieldMergeFunction<
+  TExisting = any,
+  TIncoming = TExisting,
+  // Passing the whole FieldFunctionOptions makes the current definition
+  // independent from its implementation
+  TOptions extends FieldFunctionOptions = FieldFunctionOptions
+> = (
   existing: SafeReadonly<TExisting> | undefined,
   // The incoming parameter needs to be positional as well, for the same
   // reasons discussed in FieldReadFunction above.
   incoming: SafeReadonly<TIncoming>,
-  options: FieldFunctionOptions,
+  options: TOptions,
 ) => SafeReadonly<TExisting>;
 
 const nullKeyFieldsFn: KeyFieldsFunction = () => void 0;


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests

### Description
Allows `FieldFunctionOptions` definition to be passed down to `FieldPolicy`, `FieldReadFunction` and `FieldMergeFunction` so it can be manually defined by the developer.

### Use case
Would allow `apollo-client-helpers` plugin to specify TArgs for each `FieldPolicy`, [currently defined as `any`](https://github.com/VictorGaiva/graphql-code-generator/blob/816e93c05e5ea54cb7e5b57a84f1f9ee06912aad/packages/plugins/typescript/apollo-client-helpers/src/index.ts#L43).

