### PR TITLE
chore: Ensure only current file is run with VSCode debugger

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
       "name": "Jest Current File",
       "program": "${workspaceFolder}/node_modules/.bin/jest",
       "args": [
-        "${fileBasenameNoExtension}",
+        "${relativeFile}",
         "--config",
         "./config/jest.config.js"
       ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 - Avoid rewriting non-relative imported module specifiers in `config/rewriteModuleIds.ts` script, thereby allowing bundlers to resolve those imports as they see fit. <br/>
   [@benjamn](https://github.com/benjamn) in [#9073](https://github.com/apollographql/apollo-client/pull/9073)
 
+- Ensure only current file is matched when running VSCode debugger. <br/>
+  [@eps1lon](https://github.com/eps1lon) in [#9050](https://github.com/apollographql/apollo-client/pull/9050)
+
 ## Apollo Client 3.5.2 (2021-11-10)
 
 - Fix useMutation execute function returning non-identical execution functions when passing similar options. <br/>


### PR DESCRIPTION
Without this change having open e.g. `src/react/hoc/__tests__/mutations/queries.test.tsx` running "Jest Current File" from VSCode's "Run and Debug" would result in `/usr/bin/node ./node_modules/.bin/jest queries.test --config ./config/jest.config.js`. However, this would match multiple files (here `src/react/hoc/__tests__/mutations/recycled-queries.test.tsx` and `src/react/hoc/__tests__/mutations/queries.test.tsx`.

With this change we ensure that only a single file is run.

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
