### PR TITLE
Use CircleCI to enforce `"lockfileVersion": 2" in `package-lock.json`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ jobs:
       - image: circleci/node:16.13.0
     steps:
       - checkout
+      - run: npm run ci:precheck
       - restore_cache:
           keys:
             # When lock file changes, use increasingly general patterns to
@@ -29,6 +30,7 @@ jobs:
       - image: circleci/node:16.13.0
     steps:
       - checkout
+      - run: npm run ci:precheck
       - restore_cache:
           keys:
             # When lock file changes, use increasingly general patterns to

--- a/config/precheck.js
+++ b/config/precheck.js
@@ -1,0 +1,21 @@
+const {
+  lockfileVersion,
+} = require("../package-lock.json");
+
+const expectedVersion = 2;
+
+if (typeof lockfileVersion !== "number" ||
+    lockfileVersion < expectedVersion) {
+  throw new Error(
+    `Old lockfileVersion (${
+      lockfileVersion
+    }) found in package-lock.json (expected ${
+      expectedVersion
+    } or later)`
+  );
+}
+
+console.log("ok", {
+  lockfileVersion,
+  expectedVersion,
+});

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "prepdist": "node ./config/prepareDist.js",
     "resolve": "ts-node-script config/resolveModuleIds.ts",
     "clean": "rimraf -r dist coverage lib temp",
+    "ci:precheck": "node config/precheck.js",
     "test": "jest --config ./config/jest.config.js",
     "test:debug": "BABEL_ENV=server node --inspect-brk node_modules/.bin/jest --config ./config/jest.config.js --runInBand --testTimeout 99999",
     "test:ci": "npm run test:coverage && npm run test:memory",


### PR DESCRIPTION
This should prevent @renovate-bot or @dependabot from merging any dependency PRs that revert `lockfileVersion` to v1, as #9054 did most recently, undoing my commit cf9287321b0bb0b71d9b7226a01ba7514578db88 of just five days ago. You can find several more instances of this flip-flopping in the history of the `main` branch.

For background, the Apollo Client repository (this repository) prefers `"lockfileVersion": 2` (and thus `npm` v7 or v8, not v6) because we can't (and don't want to) prevent contributors from using their existing `npm` v7 (default with Node.js 16) or v8 installations when developing Apollo Client, and it's pretty annoying for `package-lock.json` to be substantially rewritten every time you run `npm install`.