### PR TITLE
Revert `normalizeNonRelativeId` changes in `config/resolveModuleIds.ts`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Apollo Client 3.5.3 (not yet released)
+
+- Avoid rewriting non-relative imported module specifiers in `config/rewriteModuleIds.ts` script, thereby allowing bundlers to resolve those imports as they see fit. <br/>
+  [@benjamn](https://github.com/benjamn) in [#9073](https://github.com/apollographql/apollo-client/pull/9073)
+
 ## Apollo Client 3.5.2 (2021-11-10)
 
 - Fix useMutation execute function returning non-identical execution functions when passing similar options. <br/>

--- a/config/resolveModuleIds.ts
+++ b/config/resolveModuleIds.ts
@@ -83,37 +83,14 @@ class Transformer {
   }
 
   normalizeSourceString(file: string, source?: Node | null) {
-    if (source && n.StringLiteral.check(source)) {
+    if (source && n.StringLiteral.check(source) && this.isRelative(source.value)) {
       try {
-        source.value = this.isRelative(source.value)
-          ? this.normalizeId(source.value, file)
-          : this.normalizeNonRelativeId(source.value, file);
+        source.value = this.normalizeId(source.value, file);
       } catch (error) {
         console.error(`Failed to resolve ${source.value} in ${file} with error ${error}`);
         process.exit(1);
       }
     }
-  }
-
-  normalizeNonRelativeId(id: string, file: string) {
-    const normal = this.normalizeId(id, file);
-    const normalParts = normal.split("/");
-    const sourceParts = id.split("/");
-    const nodeModulesIndex = normalParts.lastIndexOf("node_modules");
-    if (
-      nodeModulesIndex >= 0 &&
-      normalParts[nodeModulesIndex + 1] === sourceParts[0]
-    ) {
-      const bareModuleIdentifier =
-        normalParts.slice(nodeModulesIndex + 1).join("/");
-      if (normal === this.normalizeId(bareModuleIdentifier, file)) {
-        return bareModuleIdentifier;
-      }
-      console.error(`Leaving ${id} import in ${file} unchanged because ${
-        bareModuleIdentifier
-      } does not resolve to the same module`);
-    }
-    return id;
   }
 
   normalizeId(id: string, file: string) {


### PR DESCRIPTION
This reverts commit 60e18e95b366c845501fc30f5e607ab5bf9d2035 from PR #8396.

In theory, commit 60e18e95b366c845501fc30f5e607ab5bf9d2035 should have made it easier to consume `@apollo/client` ESM modules in a browser environment, by rewriting non-relative imported module identifiers like
```js
import { useState } from "react"
```
to
```js
import { useState } from "react/index.js"
```
effectively bypassing `react/package.json` and its `"main"` field (which is not understood by browsers). Of course, the `react` package doesn't actually export ESM modules, and therefore can't be used natively in the browser anyway, so the rewriting doesn't help in this case.

Not helping would be one thing, but unfortunately this change introduces more problems for bundlers that expect to find a `package.json` file when importing non-relative dependencies. For example, webpack complains that `react/index.js` does not export functions such as `useState` (a fair criticism, since `react/index.js` is a CommonJS module).

Reviewing the commit message from 60e18e95b366c845501fc30f5e607ab5bf9d2035, the only third-party package it names as benefitting from this extra resolution step is `ts-invariant/process`, which is a package we control and therefore can fix if necessary. My plan is to merge this PR into `release-3.6` so we can do some additional testing of beta releases before backporting this change to v3.5.x (the `main` branch).

Here's a diff of `import` changes generated as a result of this PR, all of which seem reasonable to me: https://gist.github.com/benjamn/31c6ca0d61ca12bd42f08d3c6e6ef42b