### PR TITLE
accept onError and onCompleted in the useMutation execution function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Apollo Client 3.5.4 (unreleased)
+
+- Restore the ability to pass `onError()` and `onCompleted()` to the mutation execution function. <br/> [@brainkim](https://github.com/brainkim) in [#9076](https://github.com/apollographql/apollo-client/pull/9076)
+
 ## Apollo Client 3.5.3 (2021-11-17)
 
 - Avoid rewriting non-relative imported module specifiers in `config/rewriteModuleIds.ts` script, thereby allowing bundlers to resolve those imports as they see fit. <br/>

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     {
       "name": "apollo-client",
       "path": "./dist/apollo-client.min.cjs",
-      "maxSize": "28.5kB"
+      "maxSize": "28.6kB"
     }
   ],
   "engines": {

--- a/src/react/hooks/useMutation.ts
+++ b/src/react/hooks/useMutation.ts
@@ -92,7 +92,7 @@ export function useMutation<
 
         if (
           mutationId === ref.current.mutationId &&
-          !baseOptions.ignoreResults
+          !clientOptions.ignoreResults
         ) {
           const result = {
             called: true,
@@ -108,6 +108,7 @@ export function useMutation<
         }
 
         baseOptions.onCompleted?.(response.data!);
+        executeOptions.onCompleted?.(response.data!);
         return response;
       }).catch((error) => {
         if (
@@ -127,8 +128,9 @@ export function useMutation<
           }
         }
 
-        if (baseOptions.onError) {
-          baseOptions.onError(error);
+        if (baseOptions.onError || clientOptions.onError) {
+          baseOptions.onError?.(error);
+          executeOptions.onError?.(error);
           // TODO(brian): why are we returning this here???
           return { data: void 0, errors: error };
         }
@@ -147,7 +149,6 @@ export function useMutation<
   useEffect(() => () => {
     ref.current.isMounted = false;
   }, []);
-
 
   return [execute, { reset, ...result }];
 }


### PR DESCRIPTION
“Fixes” https://github.com/apollographql/apollo-client/issues/8793

Let me know if you want less snarky unit test names