### PR TITLE
Resolve `ts-invariant/process` module identifier again in `config/resolveModuleIds.ts`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 - Restore the ability to pass `onError()` and `onCompleted()` to the mutation execution function. <br/> [@brainkim](https://github.com/brainkim) in [#9076](https://github.com/apollographql/apollo-client/pull/9076)
 
+- Work around webpack 5 errors of the form
+  ```
+  The request 'ts-invariant/process' failed to resolve only because it was resolved as fully specified
+  ```
+  by ensuring
+  ```js
+  import { remove } from 'ts-invariant/process'
+  ```
+  is internally written to
+  ```js
+  import { remove } from 'ts-invariant/process/index.js'
+  ```
+  in the ECMAScript module `@apollo/client/utilities/globals/fix-graphql.js`. <br/>
+  [@benjamn](https://github.com/benjamn) in [#9083](https://github.com/apollographql/apollo-client/pull/9083)
+
 ## Apollo Client 3.5.3 (2021-11-17)
 
 - Avoid rewriting non-relative imported module specifiers in `config/rewriteModuleIds.ts` script, thereby allowing bundlers to resolve those imports as they see fit. <br/>


### PR DESCRIPTION
From `@apollo/client@3.5.0` until my recent PR #9073 (v3.5.3), non-relative imported module identifiers like `ts-invariant/process` were rewritten during the build process (during `npm run resolve`) to include a specific module with a file extension (not a directory), producing in this example `ts-invariant/process/index.js`.

That rewriting was the wrong choice in general (for example, it would rewrite `graphql` to `graphql/index.mjs`), so PR #9073 disabled the rewriting for all non-relative imports.

However, the specific replacement of `ts-invariant/process` with `ts-invariant/process/index.js` is still useful to prevent the strange webpack 5-specific error
```
The request 'ts-invariant/process' failed to resolve only because it was resolved as fully specified
```
which apparently happens because the [`resolve.fullySpecified`](https://webpack.js.org/configuration/module/#resolvefullyspecified) option is `true` by default now. App developers could configure `resolve.fullySpecified` explicitly `false`, but we (the Apollo Client team) prefer a general workaround.

In other words, this PR refines the changes from #9073 to reenable one specific non-relative module rewriting (the same module mentioned in the commit message 60e18e95b366c845501fc30f5e607ab5bf9d2035, `ts-invariant/process`).