### PR TITLE
Provide React Native `.cjs` workaround in `CHANGELOG.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,16 @@
 
 - [Relevant if you use Apollo Client with React Native] Since Apollo Client v3.5.0, CommonJS bundles provided by `@apollo/client` use a `.cjs` file extension rather than `.cjs.js`, so Node.js won't interpret them as ECMAScript modules. While this change should be an implementation detail, it may cause problems for the [Metro bundler](https://facebook.github.io/metro/) used by React Native, whose [`resolver.sourceExts`](https://facebook.github.io/metro/docs/configuration#sourceexts) configuration does not include the `cjs` extension by default.
 
-  Until [this issue](https://github.com/facebook/metro/issues/535) is resolved, you can configure Metro to understand the `.cjs` file extension by creating a `metro.config.js` file in the root of your React Native project:
+  As a workaround until [this issue](https://github.com/facebook/metro/issues/535) is resolved, you can configure Metro to understand the `.cjs` file extension by creating a `metro.config.js` file in the root of your React Native project:
   ```js
-  const defaultSourceExts =
-    require("metro-config/src/defaults/defaults").sourceExts;
-
+  const { getDefaultConfig } = require("metro-config");
+  const { resolver: defaultResolver } = getDefaultConfig.getDefaultValues();
   exports.resolver = {
-    sourceExts: [...defaultSourceExts, "cjs"],
+    ...defaultResolver,
+    sourceExts: [
+      ...defaultResolver.sourceExts,
+      "cjs",
+    ],
   };
   ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 ## Apollo Client 3.5.4 (unreleased)
 
+### Notices
+
+- [Relevant if you use Apollo Client with React Native] Since Apollo Client v3.5.0, CommonJS bundles provided by `@apollo/client` use a `.cjs` file extension rather than `.cjs.js`, so Node.js won't interpret them as ECMAScript modules. While this change should be an implementation detail, it may cause problems for the [Metro bundler](https://facebook.github.io/metro/) used by React Native, whose [`resolver.sourceExts`](https://facebook.github.io/metro/docs/configuration#sourceexts) configuration does not include the `cjs` extension by default.
+
+  Until [this issue](https://github.com/facebook/metro/issues/535) is resolved, you can configure Metro to understand the `.cjs` file extension by creating a `metro.config.js` file in the root of your React Native project:
+  ```js
+  const defaultSourceExts =
+    require("metro-config/src/defaults/defaults").sourceExts;
+
+  exports.resolver = {
+    sourceExts: [...defaultSourceExts, "cjs"],
+  };
+  ```
+
+### Improvements
+
 - Restore the ability to pass `onError()` and `onCompleted()` to the mutation execution function. <br/> [@brainkim](https://github.com/brainkim) in [#9076](https://github.com/apollographql/apollo-client/pull/9076)
 
 - Work around webpack 5 errors of the form


### PR DESCRIPTION
In #8396 (first released in `@apollo/client@3.5.0-beta.0`), we adopted the Node.js [recommendation](https://nodejs.org/api/packages.html#determining-module-system) to specify `"type": "module"` in `package.json`, so all `.js` modules within the `@apollo/client` package will be interpreted (correctly) as ECMAScript modules. Since we also provide various CommonJS bundles for consumption by Node.js and older bundlers, those CommonJS bundles now have a `.cjs` file extension, rather than `.cjs.js`, so Node.js won't misinterpret them as ECMAScript modules.

Unfortunately, as I was first made aware by @SimenB in https://github.com/apollographql/zen-observable-ts/pull/156#issuecomment-931102197, switching to a `.cjs` file extension for CommonJS bundles can cause problems for React Native's Metro bundler. This PR updates our `CHANGELOG.md` to provide guidance on a workaround until https://github.com/facebook/metro/issues/535 is resolved. I wish we could solve this problem unilaterally, but it seems like the React Native / Metro maintainers will have to take action here.