### PR TITLE
Undo breaking change to `selectHttpOptionsBody` signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Apollo Client 3.5.5 (unreleased)
+
+### Bug Fixes
+
+- Remove `printer: Printer` positional parameter from publicly-exported `selectHttpOptionsAndBody` function, whose addition in [#8699](https://github.com/apollographql/apollo-client/pull/8699) was a breaking change (starting in Apollo Client 3.5.0) for direct consumers of `selectHttpOptionsAndBody`. <br/>
+  [@benjamn](https://github.com/benjamn) in [#9103](https://github.com/apollographql/apollo-client/pull/9103)
+
 ## Apollo Client 3.5.4 (2021-11-19)
 
 ### Notices

--- a/src/__tests__/__snapshots__/exports.ts.snap
+++ b/src/__tests__/__snapshots__/exports.ts.snap
@@ -46,6 +46,7 @@ Array [
   "resetCaches",
   "rewriteURIForGET",
   "selectHttpOptionsAndBody",
+  "selectHttpOptionsAndBodyInternal",
   "selectURI",
   "serializeFetchParameter",
   "setLogVerbosity",
@@ -118,6 +119,7 @@ Array [
   "resetCaches",
   "rewriteURIForGET",
   "selectHttpOptionsAndBody",
+  "selectHttpOptionsAndBodyInternal",
   "selectURI",
   "serializeFetchParameter",
   "setLogVerbosity",
@@ -182,6 +184,7 @@ Array [
   "parseAndCheckHttpResponse",
   "rewriteURIForGET",
   "selectHttpOptionsAndBody",
+  "selectHttpOptionsAndBodyInternal",
   "selectURI",
   "serializeFetchParameter",
 ]

--- a/src/link/batch-http/batchHttpLink.ts
+++ b/src/link/batch-http/batchHttpLink.ts
@@ -6,7 +6,7 @@ import {
   selectURI,
   parseAndCheckHttpResponse,
   checkFetcher,
-  selectHttpOptionsAndBody,
+  selectHttpOptionsAndBodyInternal,
   defaultPrinter,
   fallbackHttpConfig,
   HttpOptions,
@@ -96,7 +96,7 @@ export class BatchHttpLink extends ApolloLink {
 
       //uses fallback, link, and then context to build options
       const optsAndBody = operations.map(operation =>
-        selectHttpOptionsAndBody(
+        selectHttpOptionsAndBodyInternal(
           operation,
           print,
           fallbackHttpConfig,

--- a/src/link/http/__tests__/selectHttpOptionsAndBody.ts
+++ b/src/link/http/__tests__/selectHttpOptionsAndBody.ts
@@ -4,7 +4,7 @@ import { ASTNode, print, stripIgnoredCharacters } from 'graphql';
 import { createOperation } from '../../utils/createOperation';
 import {
   selectHttpOptionsAndBody,
-  defaultPrinter,
+  selectHttpOptionsAndBodyInternal,
   fallbackHttpConfig,
 } from '../selectHttpOptionsAndBody';
 
@@ -20,7 +20,6 @@ describe('selectHttpOptionsAndBody', () => {
   it('includeQuery allows the query to be ignored', () => {
     const { body } = selectHttpOptionsAndBody(
       createOperation({}, { query }),
-      defaultPrinter,
       { http: { includeQuery: false } },
     );
     expect(body).not.toHaveProperty('query');
@@ -30,7 +29,6 @@ describe('selectHttpOptionsAndBody', () => {
     const extensions = { yo: 'what up' };
     const { body } = selectHttpOptionsAndBody(
       createOperation({}, { query, extensions }),
-      defaultPrinter,
       { http: { includeExtensions: true } },
     );
     expect(body).toHaveProperty('extensions');
@@ -50,7 +48,6 @@ describe('selectHttpOptionsAndBody', () => {
     const extensions = { yo: 'what up' };
     const { options, body } = selectHttpOptionsAndBody(
       createOperation({}, { query, extensions }),
-      defaultPrinter,
       fallbackHttpConfig,
     );
 
@@ -81,7 +78,6 @@ describe('selectHttpOptionsAndBody', () => {
 
     const { options, body } = selectHttpOptionsAndBody(
       createOperation({}, { query, extensions }),
-      defaultPrinter,
       fallbackHttpConfig,
       config,
     );
@@ -107,7 +103,6 @@ describe('selectHttpOptionsAndBody', () => {
     const config = { headers };
     const { options, body } = selectHttpOptionsAndBody(
       createOperation({}, { query }),
-      defaultPrinter,
       fallbackHttpConfig,
       config,
     );
@@ -122,18 +117,16 @@ describe('selectHttpOptionsAndBody', () => {
   });
 
   it('applies custom printer function when provided', () => {
-
     const customPrinter = (ast: ASTNode, originalPrint: typeof print) => {
       return stripIgnoredCharacters(originalPrint(ast));
     };
 
-    const { body } = selectHttpOptionsAndBody(
+    const { body } = selectHttpOptionsAndBodyInternal(
       createOperation({}, { query }),
       customPrinter,
       fallbackHttpConfig,
     );
 
     expect(body.query).toBe('query SampleQuery{stub{id}}');
-
   });
 });

--- a/src/link/http/createHttpLink.ts
+++ b/src/link/http/createHttpLink.ts
@@ -9,7 +9,7 @@ import { selectURI } from './selectURI';
 import { parseAndCheckHttpResponse } from './parseAndCheckHttpResponse';
 import { checkFetcher } from './checkFetcher';
 import {
-  selectHttpOptionsAndBody,
+  selectHttpOptionsAndBodyInternal,
   defaultPrinter,
   fallbackHttpConfig,
   HttpOptions
@@ -82,7 +82,7 @@ export const createHttpLink = (linkOptions: HttpOptions = {}) => {
     };
 
     //uses fallback, link, and then context to build options
-    const { options, body } = selectHttpOptionsAndBody(
+    const { options, body } = selectHttpOptionsAndBodyInternal(
       operation,
       print,
       fallbackHttpConfig,

--- a/src/link/http/index.ts
+++ b/src/link/http/index.ts
@@ -13,6 +13,7 @@ export {
   fallbackHttpConfig,
   defaultPrinter,
   selectHttpOptionsAndBody,
+  selectHttpOptionsAndBodyInternal, // needed by ../batch-http but not public
   UriFunction
 } from './selectHttpOptionsAndBody';
 export { checkFetcher } from './checkFetcher';

--- a/src/link/http/selectHttpOptionsAndBody.ts
+++ b/src/link/http/selectHttpOptionsAndBody.ts
@@ -111,12 +111,25 @@ export const fallbackHttpConfig = {
 
 export const defaultPrinter: Printer = (ast, printer) => printer(ast);
 
-export const selectHttpOptionsAndBody = (
+export function selectHttpOptionsAndBody(
+  operation: Operation,
+  fallbackConfig: HttpConfig,
+  ...configs: Array<HttpConfig>
+) {
+  return selectHttpOptionsAndBodyInternal(
+    operation,
+    defaultPrinter,
+    fallbackConfig,
+    ...configs,
+  );
+}
+
+export function selectHttpOptionsAndBodyInternal(
   operation: Operation,
   printer: Printer,
   fallbackConfig: HttpConfig,
   ...configs: Array<HttpConfig>
-) => {
+) {
   let options: HttpConfig & Record<string, any> = {
     ...fallbackConfig.options,
     headers: fallbackConfig.headers,

--- a/src/link/http/selectHttpOptionsAndBody.ts
+++ b/src/link/http/selectHttpOptionsAndBody.ts
@@ -116,10 +116,10 @@ export function selectHttpOptionsAndBody(
   fallbackConfig: HttpConfig,
   ...configs: Array<HttpConfig>
 ) {
+  configs.unshift(fallbackConfig);
   return selectHttpOptionsAndBodyInternal(
     operation,
     defaultPrinter,
-    fallbackConfig,
     ...configs,
   );
 }
@@ -127,20 +127,11 @@ export function selectHttpOptionsAndBody(
 export function selectHttpOptionsAndBodyInternal(
   operation: Operation,
   printer: Printer,
-  fallbackConfig: HttpConfig,
-  ...configs: Array<HttpConfig>
+  ...configs: HttpConfig[]
 ) {
-  let options: HttpConfig & Record<string, any> = {
-    ...fallbackConfig.options,
-    headers: fallbackConfig.headers,
-    credentials: fallbackConfig.credentials,
-  };
-  let http: HttpQueryOptions = fallbackConfig.http || {};
+  let options = {} as HttpConfig & Record<string, any>;
+  let http = {} as HttpQueryOptions;
 
-  /*
-   * use the rest of the configs to populate the options
-   * configs later in the list will overwrite earlier fields
-   */
   configs.forEach(config => {
     options = {
       ...options,
@@ -150,7 +141,10 @@ export function selectHttpOptionsAndBodyInternal(
         ...headersToLowerCase(config.headers),
       },
     };
-    if (config.credentials) options.credentials = config.credentials;
+
+    if (config.credentials) {
+      options.credentials = config.credentials;
+    }
 
     http = {
       ...http,


### PR DESCRIPTION
As pointed out by @SimenB in https://github.com/apollographql/apollo-client/pull/8699#discussion_r754123804, adding an additional positional argument (`printer: Printer`) to the publicly-exported `selectHttpOptionsBody` helper function was a breaking change for direct consumers of that function. This PR restores `selectHttpOptionsBody` to its previous signature (defaulting to `defaultPrinter`), using the new `selectHttpOptionsBodyInternal` function for the bulk of the implementation.