### PR TITLE
Prevent npm@6-related Netlify failures on `release-3.6` branch

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,7 @@
     "start": "gatsby develop",
     "build": "gatsby build",
     "serve": "gatsby serve",
-    "types": "typedoc ../src/index.ts --json ./docs/src/gatsby-theme-apollo-docs/docs.json"
+    "types": "cd .. && typedoc --json ./docs/src/gatsby-theme-apollo-docs/docs.json ./src/index.ts"
   },
   "dependencies": {
     "gatsby": "2.32.13",

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,7 @@
     "start": "gatsby develop",
     "build": "gatsby build",
     "serve": "gatsby serve",
-    "types": "cd .. && typedoc --json ./docs/src/gatsby-theme-apollo-docs/docs.json ./src/index.ts"
+    "types": "typedoc ../src/index.ts --json ./docs/src/gatsby-theme-apollo-docs/docs.json"
   },
   "dependencies": {
     "gatsby": "2.32.13",

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,9 +1,12 @@
 [build]
   base    = "docs"
   publish = "docs/public"
-  command = "cd .. && npm i && npm run build && cd docs && npm i && npm run types && gatsby build"
+  # Start with running npm@7 in the root apollo-client directory, but downgrade
+  # back to npm@6 for working in the docs/ directory.
+  command = "cd .. && npm i && cd docs && npm i --global npm@6 npm i && npm run types && gatsby build"
 [build.environment]
-  NPM_VERSION = "6"
+  # Downgraded to 6 after the 'npm i --global npm@6' command runs (above).
+  NPM_VERSION = "7"
 [context.production.environment]
   PREFIX_PATHS = "true"
 [context.branch-deploy.environment]

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   publish = "docs/public"
   # Start with running npm@7 in the root apollo-client directory, but downgrade
   # back to npm@6 for working in the docs/ directory.
-  command = "cd .. && npm i && cd docs && npm i --global npm@6 npm i && npm run types && gatsby build"
+  command = "cd .. && npm i && npm run build && cd docs && npm i --global npm@6 npm i && npm run types && gatsby build"
 [build.environment]
   # Downgraded to 6 after the 'npm i --global npm@6' command runs (above).
   NPM_VERSION = "7"


### PR DESCRIPTION
For the time being, the documentation team is sticking to npm@6 for managing the `docs/` directories of our various projects, which mostly entails sticking with `lockfileVersion:1` in `docs/package-lock.json`, instead of `lockfileVersion:2` (like `./package-lock.json`).

Apollo Client itself welcomes contributors using the latest versions of Node.js and npm, so we've switched to `lockfileVersion:2` in the root `package-lock.json` file, even defending it from reversion with checks like #9068.

However, when Netlify attempts to run npm@6 in the root directory of the `apollo-client` repository, the newer `lockfileVersion:2` in `package-lock.json` causes failures on `npm install` like [this one](https://app.netlify.com/sites/apollo-client-docs/deploys/619d49161cd5b80007973178).

~Reading over PR #9006 where the `cd .. && npm i && npm run build` commands were introduced, it doesn't seem to be absolutely necessary to build Apollo Client itself when building the docs, so~ I propose we fix the Netlify build failures by running `npm i` with appropriate npm versions in each directory during the Netlify build, ~and skip running `npm run build` in the root `apollo-client` directory (unless @hwillson or @brainkim or anyone else can think of a reason that's necessary for building the docs).~