### PR TITLE
Correct the type of `error` in "Inspecting error states"

### DIFF
--- a/docs/source/data/queries.mdx
+++ b/docs/source/data/queries.mdx
@@ -216,7 +216,7 @@ The `networkStatus` property is a `NetworkStatus` enum that represents different
 ## Inspecting error states
 
 You can customize your query error handling by providing the `errorPolicy`
-configuration option to the `useQuery` hook. The default value is `none`, which tells Apollo Client to treat all GraphQL errors as runtime errors. In this case, Apollo Client discards any query response data returned by the server and sets the `error` property in the `useQuery` result object to `true`.
+configuration option to the `useQuery` hook. The default value is `none`, which tells Apollo Client to treat all GraphQL errors as runtime errors. In this case, Apollo Client discards any query response data returned by the server and sets the `error` property in the `useQuery` result object.
 
 If you set `errorPolicy` to `all`, `useQuery` does _not_ discard query response data, allowing you to render partial results.
 


### PR DESCRIPTION
Was brushing up on the basics and noticed that the docs say that if there's an error, the `error` prop returned by `useQuery` is set to `true` which isn't correct I believe. `error` is set, but to an informative object, not a Boolean value.

