### PR TITLE
Fix return of updateQuery's update function

### DIFF
--- a/docs/source/caching/cache-interaction.mdx
+++ b/docs/source/caching/cache-interaction.mdx
@@ -252,9 +252,7 @@ const query = gql`
 
 // Set all todos in the cache as completed
 cache.updateQuery({ query }, (data) => ({
-  data: {
-    todos: data.todos.map((todo) => ({ ...todo, completed: true }))
-  }
+  todos: data.todos.map((todo) => ({ ...todo, completed: true }))
 }));
 ```
 


### PR DESCRIPTION
The type of `updateQuery`'s update function is:
```ts
(data: TData | null) => TData | null | void
```
Which (I think) means that it shouldn't return `{ data: { todos: [...] } }` but just `{ todos: [...] }`.

Basically, the return signature in the `InMemoryClass` API docs is the correct one: https://www.apollographql.com/docs/react/api/cache/InMemoryCache/#updatequery.