### PR TITLE
3.5 hotfixes

### DIFF
--- a/src/react/components/__tests__/client/Query.test.tsx
+++ b/src/react/components/__tests__/client/Query.test.tsx
@@ -68,8 +68,6 @@ describe('Query component', () => {
             if (result.loading) {
               expect(rest).toEqual({
                 called: true,
-                data: undefined,
-                error: undefined,
                 loading: true,
                 networkStatus: 1,
                 previousData: undefined,

--- a/src/react/hoc/__tests__/queries/index.test.tsx
+++ b/src/react/hoc/__tests__/queries/index.test.tsx
@@ -178,8 +178,10 @@ describe('queries', () => {
       expect(data).toBeTruthy();
       switch (count) {
         case 0:
-        case 1:
           expect(data!.variables.someId).toEqual(1);
+          break;
+        case 1:
+          expect(data!.variables.someId).toEqual(2);
           break;
         case 2:
           expect(data!.variables.someId).toEqual(2);

--- a/src/react/hoc/__tests__/queries/lifecycle.test.tsx
+++ b/src/react/hoc/__tests__/queries/lifecycle.test.tsx
@@ -63,7 +63,7 @@ describe('[queries] lifecycle', () => {
                 break;
               case 1:
                 expect(data!.loading).toBe(false);
-                expect(data!.variables).toEqual(variables1);
+                expect(data!.variables).toEqual(variables2);
                 expect(data!.allPeople).toEqual(data1.allPeople);
                 break;
               case 2:
@@ -226,7 +226,7 @@ describe('[queries] lifecycle', () => {
                 break;
               case 1:
                 expect(data!.loading).toBe(false);
-                expect(data!.variables).toEqual({ first: 1 });
+                expect(data!.variables).toEqual({ first: 2 });
                 expect(data!.allPeople).toEqual(data1.allPeople);
                 break;
               case 2:
@@ -323,7 +323,7 @@ describe('[queries] lifecycle', () => {
                 break;
               case 1:
                 expect(data!.loading).toBe(false);
-                expect(data!.variables).toEqual({ first: 1 });
+                expect(data!.variables).toEqual({ first: 2 });
                 expect(data!.allPeople).toEqual(data1.allPeople);
                 break;
               case 2:

--- a/src/react/hoc/__tests__/queries/loading.test.tsx
+++ b/src/react/hoc/__tests__/queries/loading.test.tsx
@@ -208,14 +208,14 @@ describe('[queries] loading', () => {
                 expect(prevProps.data!.error).toBe(undefined);
                 expect(prevProps.data!.networkStatus).toBe(NetworkStatus.ready);
                 expect(this.props.data!.loading).toBe(false);
-                expect(this.props.data!.variables).toEqual(variables1);
+                expect(this.props.data!.variables).toEqual(variables2);
                 expect(this.props.data!.allPeople).toEqual(data1.allPeople);
                 expect(this.props.data!.error).toBe(undefined);
                 expect(prevProps.data!.networkStatus).toBe(NetworkStatus.ready);
                 break;
               case 2:
                 expect(prevProps.data!.loading).toBe(false);
-                expect(prevProps.data!.variables).toEqual(variables1);
+                expect(prevProps.data!.variables).toEqual(variables2);
                 expect(prevProps.data!.allPeople).toEqual(data1.allPeople);
                 expect(prevProps.data!.error).toBe(undefined);
                 expect(this.props.data!.loading).toBe(true);

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -119,42 +119,85 @@ describe('useMutation Hook', () => {
       expect(result.current.data).toEqual(CREATE_TODO_RESULT);
     });
 
-    it('should ensure the mutation callback function has a stable identity', async () => {
-      const variables = {
-        description: 'Get milk!'
+    it('should ensure the mutation callback function has a stable identity no matter what', async () => {
+      const variables1 = {
+        description: 'Get milk',
+      };
+
+      const data1 = {
+        createTodo: {
+          id: 1,
+          description: 'Get milk!',
+          priority: 'High',
+          __typename: 'Todo',
+        }
+      };
+
+      const variables2 = {
+        description: 'Write blog post',
+      };
+
+      const data2 = {
+        createTodo: {
+          id: 1,
+          description: 'Write blog post',
+          priority: 'High',
+          __typename: 'Todo',
+        },
       };
 
       const mocks = [
         {
           request: {
             query: CREATE_TODO_MUTATION,
-            variables
+            variables: variables1,
           },
-          result: { data: CREATE_TODO_RESULT }
-        }
+          result: { data: data1 },
+        },
+        {
+          request: {
+            query: CREATE_TODO_MUTATION,
+            variables: variables2,
+          },
+          result: { data: data2 },
+        },
       ];
 
-      const { result, waitForNextUpdate } = renderHook(
-        () => useMutation(CREATE_TODO_MUTATION, {}),
-        { wrapper: ({ children }) => (
-          <MockedProvider mocks={mocks}>
-            {children}
-          </MockedProvider>
-        )},
+      const { result, rerender, waitForNextUpdate } = renderHook(
+        ({ variables }) => useMutation(CREATE_TODO_MUTATION, { variables }),
+        {
+          wrapper: ({ children }) => (
+            <MockedProvider mocks={mocks}>
+              {children}
+            </MockedProvider>
+          ),
+          initialProps: {
+            variables: variables1,
+          },
+        },
       );
 
       const createTodo = result.current[0];
       expect(result.current[1].loading).toBe(false);
       expect(result.current[1].data).toBe(undefined);
-      act(() => void createTodo({ variables }));
+
+      act(() => void createTodo());
       expect(createTodo).toBe(result.current[0]);
       expect(result.current[1].loading).toBe(true);
       expect(result.current[1].data).toBe(undefined);
 
       await waitForNextUpdate();
-      expect(createTodo).toBe(result.current[0]);
+      expect(result.current[0]).toBe(createTodo);
       expect(result.current[1].loading).toBe(false);
-      expect(result.current[1].data).toEqual(CREATE_TODO_RESULT);
+      expect(result.current[1].data).toEqual(data1);
+
+      rerender({ variables: variables2 });
+      act(() => void createTodo());
+
+      await waitForNextUpdate();
+      expect(result.current[0]).toBe(createTodo);
+      expect(result.current[1].loading).toBe(false);
+      expect(result.current[1].data).toEqual(data2);
     });
 
     it('should resolve mutate function promise with mutation results', async () => {

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -567,6 +567,66 @@ describe('useMutation Hook', () => {
       expect(onError).toHaveBeenCalledTimes(1);
       expect(onError).toHaveBeenCalledWith(errors[0]);
     });
+
+    it('should never allow onCompleted handler to be stale', async () => {
+      const CREATE_TODO_DATA = {
+        createTodo: {
+          id: 1,
+          priority: 'Low',
+          description: 'Get milk!',
+          __typename: 'Todo',
+        },
+      };
+
+      const mocks = [
+        {
+          request: {
+            query: CREATE_TODO_MUTATION,
+            variables: {
+              priority: 'Low',
+              description: 'Get milk.',
+            }
+          },
+          result: {
+            data: CREATE_TODO_DATA,
+          },
+        }
+      ];
+
+      const onCompleted = jest.fn();
+      const { result, rerender } = renderHook(
+        ({ onCompleted }) => {
+          return useMutation<
+            { createTodo: Todo },
+            { priority: string, description: string }
+          >(CREATE_TODO_MUTATION, { onCompleted });
+        },
+        {
+          wrapper: ({ children }) => (
+            <MockedProvider mocks={mocks}>
+              {children}
+            </MockedProvider>
+          ),
+          initialProps: { onCompleted },
+        },
+      );
+
+      const onCompleted1 = jest.fn();
+      rerender({ onCompleted: onCompleted1 });
+      const createTodo = result.current[0];
+      let fetchResult: any;
+      await act(async () => {
+        fetchResult = await createTodo({
+          variables: { priority: 'Low', description: 'Get milk.' },
+        });
+      });
+
+      expect(fetchResult).toEqual({ data: CREATE_TODO_DATA });
+      expect(result.current[1].data).toEqual(CREATE_TODO_DATA);
+      expect(onCompleted).toHaveBeenCalledTimes(0);
+      expect(onCompleted1).toHaveBeenCalledTimes(1);
+      expect(onCompleted1).toHaveBeenCalledWith(CREATE_TODO_DATA);
+    });
   });
 
   describe('ROOT_MUTATION cache data', () => {

--- a/src/react/hooks/useMutation.ts
+++ b/src/react/hooks/useMutation.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { DocumentNode } from 'graphql';
 import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import {
@@ -40,107 +40,98 @@ export function useMutation<
     result,
     mutationId: 0,
     isMounted: true,
-    execute: null as null | MutationTuple<TData, TVariables, TContext, TCache>[0],
     client,
     mutation,
     options,
   });
 
-  const execute = useMemo(() => {
-    if (
-      ref.current.execute != null &&
-      ref.current.client === client &&
-      equal(options, ref.current.options) &&
-      equal(mutation, ref.current.mutation)) {
-      return ref.current.execute;
+  // TODO: Trying to assign these in a useEffect or useLayoutEffect breaks
+  // higher-order components.
+  {
+    Object.assign(ref.current, { client, options, mutation });
+  }
+
+  const execute = useCallback((
+    executeOptions: MutationFunctionOptions<
+      TData,
+      TVariables,
+      TContext,
+      TCache
+    > = {}
+  ) => {
+    const {client, options, mutation} = ref.current;
+    const baseOptions = { ...options, mutation };
+    if (!ref.current.result.loading && !baseOptions.ignoreResults) {
+      setResult(ref.current.result = {
+        loading: true,
+        error: void 0,
+        data: void 0,
+        called: true,
+        client,
+      });
     }
 
-    ref.current.client = client;
-    ref.current.options = options;
-    ref.current.mutation = mutation;
-    ref.current.execute = (
-      executeOptions: MutationFunctionOptions<
-        TData,
-        TVariables,
-        TContext,
-        TCache
-      > = {},
-    ) => {
-      const baseOptions = { ...options, mutation };
-      if (!ref.current.result.loading && !baseOptions.ignoreResults) {
-        setResult(ref.current.result = {
-          loading: true,
-          error: void 0,
+    const mutationId = ++ref.current.mutationId;
+    const clientOptions = mergeOptions(
+      baseOptions,
+      executeOptions as any,
+    );
+
+    return client.mutate(clientOptions).then((response) => {
+      const { data, errors } = response;
+      const error =
+        errors && errors.length > 0
+          ? new ApolloError({ graphQLErrors: errors })
+          : void 0;
+
+      if (
+        mutationId === ref.current.mutationId &&
+        !clientOptions.ignoreResults
+      ) {
+        const result = {
+          called: true,
+          loading: false,
+          data,
+          error,
+          client,
+        };
+
+        if (ref.current.isMounted && !equal(ref.current.result, result)) {
+          setResult(ref.current.result = result);
+        }
+      }
+
+      baseOptions.onCompleted?.(response.data!);
+      executeOptions.onCompleted?.(response.data!);
+      return response;
+    }).catch((error) => {
+      if (
+        mutationId === ref.current.mutationId &&
+        ref.current.isMounted
+      ) {
+        const result = {
+          loading: false,
+          error,
           data: void 0,
           called: true,
           client,
-        });
+        };
+
+        if (!equal(ref.current.result, result)) {
+          setResult(ref.current.result = result);
+        }
       }
 
-      const mutationId = ++ref.current.mutationId;
-      const clientOptions = mergeOptions(
-        baseOptions,
-        executeOptions as any,
-      );
+      if (baseOptions.onError || clientOptions.onError) {
+        baseOptions.onError?.(error);
+        executeOptions.onError?.(error);
+        // TODO(brian): why are we returning this here???
+        return { data: void 0, errors: error };
+      }
 
-      return client.mutate(clientOptions).then((response) =>{
-        const { data, errors } = response;
-        const error =
-          errors && errors.length > 0
-            ? new ApolloError({ graphQLErrors: errors })
-            : void 0;
-
-        if (
-          mutationId === ref.current.mutationId &&
-          !clientOptions.ignoreResults
-        ) {
-          const result = {
-            called: true,
-            loading: false,
-            data,
-            error,
-            client,
-          };
-
-          if (ref.current.isMounted && !equal(ref.current.result, result)) {
-            setResult(ref.current.result = result);
-          }
-        }
-
-        baseOptions.onCompleted?.(response.data!);
-        executeOptions.onCompleted?.(response.data!);
-        return response;
-      }).catch((error) => {
-        if (
-          mutationId === ref.current.mutationId &&
-          ref.current.isMounted
-        ) {
-          const result = {
-            loading: false,
-            error,
-            data: void 0,
-            called: true,
-            client,
-          };
-
-          if (!equal(ref.current.result, result)) {
-            setResult(ref.current.result = result);
-          }
-        }
-
-        if (baseOptions.onError || clientOptions.onError) {
-          baseOptions.onError?.(error);
-          executeOptions.onError?.(error);
-          // TODO(brian): why are we returning this here???
-          return { data: void 0, errors: error };
-        }
-
-        throw error;
-      });
-    };
-
-    return ref.current.execute;
-  }, [client, mutation, options]);
+      throw error;
+    });
+  }, []);
 
   const reset = useCallback(() => {
     setResult({ called: false, loading: false, client });

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -310,7 +310,7 @@ export function useQuery<
 
   return {
     ...obsQueryFields,
-    variables: obsQuery.variables,
+    variables: createWatchQueryOptions(query, options).variables,
     client,
     called: true,
     previousData: ref.current.previousData,
@@ -350,6 +350,10 @@ function createWatchQueryOptions<TData, TVariables>(
     // cache-first is the default policy, but we explicitly assign it here so
     // the cache policies computed based on options can be cleared
     watchQueryOptions.fetchPolicy = 'cache-first';
+  }
+
+  if (!watchQueryOptions.variables) {
+    watchQueryOptions.variables = {} as TVariables;
   }
 
   return { query, ...watchQueryOptions };

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -144,7 +144,7 @@ export function useQuery<
       }
     }
 
-    Object.assign(ref.current, { client, query, options });
+    Object.assign(ref.current, { client, query });
   }, [obsQuery, client, query, options]);
 
   // An effect to subscribe to the current observable query
@@ -255,6 +255,10 @@ export function useQuery<
     ) {
       obsQuery.setOptions(createWatchQueryOptions(query, options)).catch(() => {});
     }
+
+    // We assign options during rendering as a guard to make sure that
+    // callbacks like onCompleted and onError are not stale.
+    Object.assign(ref.current, { options });
   }
 
   if (
@@ -318,6 +322,9 @@ export function useQuery<
   };
 }
 
+/**
+ * A function to massage options before passing them the ObservableQuery.
+ */
 function createWatchQueryOptions<TData, TVariables>(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
   options: QueryHookOptions<TData, TVariables> = {},


### PR DESCRIPTION
Review by commit.

Moves a bunch of logic directly in the render function where side effects shouldn’t be done, but we’re doing it because `useEffect()` is just not to be trusted.

Fixes #9111, #9135