### PR TITLE
Update `recast` AST transform tool to version 0.21.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "lodash": "4.17.21",
         "react": "17.0.2",
         "react-dom": "17.0.2",
-        "recast": "0.20.5",
+        "recast": "0.21.0",
         "resolve": "1.20.0",
         "rimraf": "3.0.2",
         "rollup": "2.60.1",
@@ -1807,9 +1807,9 @@
       }
     },
     "node_modules/ast-types": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.14.2.tgz",
-      "integrity": "sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.15.2.tgz",
+      "integrity": "sha512-c27loCv9QkZinsa5ProX751khO9DJl/AcB5c2KNtA6NRvHKS0PgLfcftz72KVq504vB0Gku5s2kUZzDBvQWvHg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.0.1"
@@ -1817,12 +1817,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/ast-types/node_modules/tslib": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
-      "dev": true
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -5647,12 +5641,12 @@
       }
     },
     "node_modules/recast": {
-      "version": "0.20.5",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.20.5.tgz",
-      "integrity": "sha512-E5qICoPoNL4yU0H0NoBDntNB0Q5oMSNh9usFctYniLBluTthi3RsQVBXIJNbApOlvSwW/RGxIuokPcAc59J5fQ==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.21.0.tgz",
+      "integrity": "sha512-N5AMXswCdYlwSULChM5Xsy0ERoP2Zphjp0X94mxRCgJNEggVIfFwOHnWsUanaS2OQrQ9Wi7Hzyp+v3rzFVhRXQ==",
       "dev": true,
       "dependencies": {
-        "ast-types": "0.14.2",
+        "ast-types": "0.15.2",
         "esprima": "~4.0.0",
         "source-map": "~0.6.1",
         "tslib": "^2.0.1"
@@ -5660,12 +5654,6 @@
       "engines": {
         "node": ">= 4"
       }
-    },
-    "node_modules/recast/node_modules/tslib": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
-      "dev": true
     },
     "node_modules/regenerator-runtime": {
       "version": "0.13.5",
@@ -8416,20 +8404,12 @@
       "dev": true
     },
     "ast-types": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.14.2.tgz",
-      "integrity": "sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.15.2.tgz",
+      "integrity": "sha512-c27loCv9QkZinsa5ProX751khO9DJl/AcB5c2KNtA6NRvHKS0PgLfcftz72KVq504vB0Gku5s2kUZzDBvQWvHg==",
       "dev": true,
       "requires": {
         "tslib": "^2.0.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
-          "dev": true
-        }
       }
     },
     "asynckit": {
@@ -11385,23 +11365,15 @@
       }
     },
     "recast": {
-      "version": "0.20.5",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.20.5.tgz",
-      "integrity": "sha512-E5qICoPoNL4yU0H0NoBDntNB0Q5oMSNh9usFctYniLBluTthi3RsQVBXIJNbApOlvSwW/RGxIuokPcAc59J5fQ==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.21.0.tgz",
+      "integrity": "sha512-N5AMXswCdYlwSULChM5Xsy0ERoP2Zphjp0X94mxRCgJNEggVIfFwOHnWsUanaS2OQrQ9Wi7Hzyp+v3rzFVhRXQ==",
       "dev": true,
       "requires": {
-        "ast-types": "0.14.2",
+        "ast-types": "0.15.2",
         "esprima": "~4.0.0",
         "source-map": "~0.6.1",
         "tslib": "^2.0.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
-          "dev": true
-        }
       }
     },
     "regenerator-runtime": {

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "lodash": "4.17.21",
     "react": "17.0.2",
     "react-dom": "17.0.2",
-    "recast": "0.20.5",
+    "recast": "0.21.0",
     "resolve": "1.20.0",
     "rimraf": "3.0.2",
     "rollup": "2.60.1",


### PR DESCRIPTION
We use [`recast`](https://www.npmjs.com/package/recast) in our build scripts (specifically [`config/processInvariants.ts`](https://github.com/apollographql/apollo-client/blob/main/config/processInvariants.ts), [`config/resolveModuleIds.ts`](https://github.com/apollographql/apollo-client/blob/main/config/resolveModuleIds.ts), and some of our [codemods](https://github.com/apollographql/apollo-client/tree/main/scripts/codemods), to parse and transform JavaScript without altering the formatting of unmodified code.

I'm the author of `recast` and its underlying library [`ast-types`](https://www.npmjs.com/package/recast), and I've recently been updating dependencies and implementing new type definitions and pretty-printer cases for AST node types added to TypeScript/Flow/Babel in the past few months:
- https://github.com/benjamn/ast-types/pull/664
- https://github.com/benjamn/ast-types/pull/665
- https://github.com/benjamn/ast-types/pull/667
- https://github.com/benjamn/ast-types/pull/678
- https://github.com/benjamn/recast/pull/1010

I've published new minor versions of both `ast-types` (0.15.2) and `recast` (0.21.0) to npm, using the `next` tag to allow realistic testing (for example, this PR) while avoiding an immediate flood of Renovate/Dependabot PRs.

Since `recast` is used only for building `@apollo/client`, we can be confident this is a safe change by verifying none of the build output in `dist/` changes after updating to `recast@0.21.0` and rerunning `npm run build` (which I can confirm).