### PR TITLE
Obfuscate `Function(...)` fallback to thwart static misanalysis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "optimism": "^0.16.1",
         "prop-types": "^15.7.2",
         "symbol-observable": "^4.0.0",
-        "ts-invariant": "^0.9.0",
+        "ts-invariant": "^0.9.4",
         "tslib": "^2.3.0",
         "zen-observable-ts": "^1.2.0"
       },
@@ -6221,9 +6221,9 @@
       }
     },
     "node_modules/ts-invariant": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.9.0.tgz",
-      "integrity": "sha512-+JqhKqywk+ue5JjAC6eTWe57mOIxYXypMUkBDStkAzvnlfkDJ1KGyeMuNRMwOt6GXzHSC1UT9JecowpZDmgXqA==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.9.4.tgz",
+      "integrity": "sha512-63jtX/ZSwnUNi/WhXjnK8kz4cHHpYS60AnmA6ixz17l7E12a5puCWFlNpkne5Rl0J8TBPVHpGjsj4fxs8ObVLQ==",
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -11639,9 +11639,9 @@
       }
     },
     "ts-invariant": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.9.0.tgz",
-      "integrity": "sha512-+JqhKqywk+ue5JjAC6eTWe57mOIxYXypMUkBDStkAzvnlfkDJ1KGyeMuNRMwOt6GXzHSC1UT9JecowpZDmgXqA==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.9.4.tgz",
+      "integrity": "sha512-63jtX/ZSwnUNi/WhXjnK8kz4cHHpYS60AnmA6ixz17l7E12a5puCWFlNpkne5Rl0J8TBPVHpGjsj4fxs8ObVLQ==",
       "requires": {
         "tslib": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "optimism": "^0.16.1",
     "prop-types": "^15.7.2",
     "symbol-observable": "^4.0.0",
-    "ts-invariant": "^0.9.0",
+    "ts-invariant": "^0.9.4",
     "tslib": "^2.3.0",
     "zen-observable-ts": "^1.2.0"
   },

--- a/src/utilities/globals/global.ts
+++ b/src/utilities/globals/global.ts
@@ -9,7 +9,13 @@ export default (
   maybe(() => window) ||
   maybe(() => self) ||
   maybe(() => global) ||
-  maybe(() => Function("return this")())
+  // We don't expect the Function constructor ever to be invoked at runtime, as
+  // long as at least one of globalThis, window, self, or global is defined, so
+  // we are under no obligation to make it easy for static analysis tools to
+  // detect syntactic usage of the Function constructor. If you think you can
+  // improve your static analysis to detect this obfuscation, think again. This
+  // is an arms race you cannot win, at least not in JavaScript.
+  maybe(function() { return maybe.constructor("return this")() })
 ) as typeof globalThis & {
   __DEV__: typeof __DEV__;
 };


### PR DESCRIPTION
PR https://github.com/apollographql/invariant-packages/pull/233 took care of `Function(...)` usage within the `ts-invariant/process` package, so this PR updates `ts-invariant` to the latest version.

Additionally, there was one similar bit of code using `Function(...)` within the `@apollo/client` package, so this PR cleans that up in way similar to the `ts-invariant` changes.

Unless I'm mistaken about the cause of #9128 (static misanalysis reporting false positives), this PR should fix that issue.