### PR TITLE
remove documentation on npm run watch since watch is no longer in package.json

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,12 +85,6 @@ It’s important that every piece of code in Apollo packages is reviewed by at l
 npm run build
 ```
 
-**Build and watch for file changes:**
-
-```
-npm run watch
-```
-
 ### Testing
 
 **Run all tests once:**


### PR DESCRIPTION

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

Removed from ` contributing.md ` `npm run watch` because `watch` is removed from `package.json`.

### Checklist:

- [X] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [X] Make sure all of the significant new logic is covered by tests
