### PR TITLE
`readQuery` clarification

### DIFF
--- a/docs/source/caching/cache-interaction.mdx
+++ b/docs/source/caching/cache-interaction.mdx
@@ -45,7 +45,7 @@ const READ_TODO = gql`
 // Fetch the cached to-do item with ID 5
 const { todo } = client.readQuery({
   query: READ_TODO,
-  variables: { // Provide any required variables here
+  variables: { // Provide any required variables here. Note that variables are evaluated using strict equality.
     id: 5,
   },
 });


### PR DESCRIPTION
Clarifies that variables passed to `readQuery` are evaluated using strict equality (no implicit type conversion).
