### PR TITLE
Fix relayStylePagination for existing and incoming without edges properterty

### DIFF
--- a/src/utilities/policies/__tests__/relayStylePagination.test.ts
+++ b/src/utilities/policies/__tests__/relayStylePagination.test.ts
@@ -109,7 +109,20 @@ describe('relayStylePagination', () => {
         hasNextPage: true,
       });
     });
+
+    it("should not return empty edges if none existing", () => {
+      const resultWithTotalCount = policy.read!({
+        totalCount: 10
+      }, fakeReadOptions);
+
+      expect(
+        resultWithTotalCount,
+      ).toEqual({
+        totalCount: 10,
+      });
+    });
   });
+
 
   describe('merge', () => {
     const merge = policy.merge;
@@ -143,7 +156,6 @@ describe('relayStylePagination', () => {
       };
       const result = merge(undefined, incoming, options);
       expect(result).toEqual({
-        edges: [],
         pageInfo: {
           hasPreviousPage: false,
           hasNextPage: true,
@@ -234,6 +246,92 @@ describe('relayStylePagination', () => {
       );
 
       expect(result).toEqual(fakeExisting);
+    })
+
+    describe('when incoming has no edges', () => {
+      it('should not replace existing null with empty edges', () => {
+        const fakeExisting = null;
+
+        const fakeIncoming = {
+          totalCount: 10
+        };
+
+        const fakeOptions = {
+          ...options,
+        };
+
+        const result = merge(
+          fakeExisting,
+          fakeIncoming,
+          fakeOptions,
+        );
+
+        expect(result).toEqual({
+          totalCount: 10
+        });
+      })
+
+      it('should not merge existing with empty edges', () => {
+        const fakeExisting = {
+          totalCount: 10
+        };
+
+        const fakeIncoming = {
+          totalCount: 11
+        };
+
+        const fakeOptions = {
+          ...options,
+          args: {
+            after: 'alpha',
+          },
+        };
+
+        const result = merge(
+          fakeExisting,
+          fakeIncoming,
+          fakeOptions,
+        );
+
+        expect(result).toEqual({
+          totalCount: 11
+        });
+      })
+    })
+
+    describe('when existing has no edges', () => {
+      it('should add incoming edges', () => {
+        const fakeExisting = {
+          totalCount: 10
+        };
+
+        const incomingEdges = [
+          { cursor: 'alpha', node: makeReference("fakeAlpha") },
+        ];
+        const incoming = {
+          edges: incomingEdges,
+          pageInfo: {
+            hasPreviousPage: false,
+            hasNextPage: true,
+            startCursor: 'alpha',
+            endCursor: 'alpha'
+          },
+        };
+        const fakeOptions = {
+          ...options,
+        };
+
+        const result = merge(
+          fakeExisting,
+          incoming,
+          fakeOptions,
+        );
+
+        expect(result).toEqual({
+          ...incoming,
+          totalCount: 10
+        });
+      })
     })
 
     it('should replace existing null with incoming', () => {


### PR DESCRIPTION
This PR is suggested fix for #7944 

The main problem comes from the fact the current implementation assumes that `edges` (and `pageInfo`) will always be present in non-null incoming and existing. This PR debunks this assumption and add some tests of the expected behavior in these cases.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
