### PR TITLE
Prevent HttpLink holding a possibly old reference to fetch.

### DIFF
--- a/.changeset/slow-cycles-tickle.md
+++ b/.changeset/slow-cycles-tickle.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Prevent HttpLink holding a possibly old reference to fetch


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

I encountered this issue while we were trialing a crash event collection platform. This platform (and many others) wrap the global fetch and replace fetch with their own (which typically internally calls the original fetch while also forwarding their handling of bad requests to their own platform)

Nothing from `createHttpLink` was working through this, as this actually stores a reference to the original Fetch currently instead of whichever fetch is currently being used on the scope of the window.

This fix simply calls to the fetch provided by the window, instead of globally storing a reference to the original fetch available at the time the file is evaluated.

We're currently working around this by providing `(...args) => window.fetch(...args)` as the `preferredFetch`.

### Checklist:

- [x] ~~If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)~~
- [x] Make sure all of the significant new logic is covered by tests

There were existing tests around this that are still passing and asserting that fetch is or is not available as expected. 