### PR TITLE
Allow passing  function to `useQuery` for finer-grained `options` control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Add `GraphQLWsLink` in `@apollo/client/link/subscriptions`. This link is similar to the existing `WebSocketLink` in `@apollo/client/link/ws`, but uses the newer [`graphql-ws`](https://www.npmjs.com/package/graphql-ws) package and protocol instead of the older `subscriptions-transport-ws` implementation. This functionality was technically first released in `@apollo/client@3.5.10`, but semantically belongs in the 3.6.0 minor version.
   [@glasser](https://github.com/glasser) in [#9369](https://github.com/apollographql/apollo-client/pull/9369)
 
+- Allow passing function to `useQuery` for finer-grained `options` control. <br/>
+  [@benjamn](https://github.com/benjamn) in [#9223](https://github.com/apollographql/apollo-client/pull/9223)
+
 ### Postponed to v3.7
 
 - Tentatively reimplement `useQuery` and `useLazyQuery` to use the [proposed `useSyncExternalStore` API](https://github.com/reactwg/react-18/discussions/86) from React 18. <br/>

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     {
       "name": "apollo-client",
       "path": "./dist/apollo-client.min.cjs",
-      "maxSize": "28.9kB"
+      "maxSize": "28.95kB"
     }
   ],
   "engines": {

--- a/src/react/hooks/options.ts
+++ b/src/react/hooks/options.ts
@@ -1,0 +1,40 @@
+import { useRef } from "react";
+import equal from "@wry/equality";
+
+import {
+  QueryHookOptions,
+  LazyQueryHookOptions,
+} from "../types/types";
+
+// I would have made this function a method of the InternalState class, but it
+// needs to run before we get the client from useApolloClient in the useQuery
+// function above, just in case the options function returns options.client as
+// an override for the ApolloClient instance provided by React context.
+export function useNormalizedOptions<
+  TOptions extends
+    | QueryHookOptions<any, any>
+    | LazyQueryHookOptions<any, any>
+>(
+  optionsOrFunction?:
+    | TOptions
+    | ((prevOptions: TOptions) => TOptions)
+): TOptions {
+  const optionsRef = useRef<TOptions>();
+  let options: TOptions = optionsRef.current || Object.create(null);
+
+  if (typeof optionsOrFunction === "function") {
+    const newOptions = optionsOrFunction(options);
+    if (newOptions !== options) {
+      Object.assign(options, newOptions, newOptions.variables && {
+        variables: {
+          ...options.variables,
+          ...newOptions.variables,
+        },
+      });
+    }
+  } else if (optionsOrFunction && !equal(optionsOrFunction, options)) {
+    options = optionsOrFunction;
+  }
+
+  return optionsRef.current = options;
+}

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -2,13 +2,15 @@ import { DocumentNode } from 'graphql';
 import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { useCallback, useMemo, useState } from 'react';
 
+import { OperationVariables } from '../../core';
 import {
   LazyQueryHookOptions,
   QueryLazyOptions,
   QueryTuple,
+  LazyQueryHookOptionsFunction,
 } from '../types/types';
 import { useQuery } from './useQuery';
-import { OperationVariables } from '../../core';
+import { useNormalizedOptions } from './options';
 
 // The following methods, when called will execute the query, regardless of
 // whether the useLazyQuery execute function was called before.
@@ -22,8 +24,12 @@ const EAGER_METHODS = [
 
 export function useLazyQuery<TData = any, TVariables = OperationVariables>(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  options?: LazyQueryHookOptions<TData, TVariables>
+  optionsOrFunction?:
+    | LazyQueryHookOptions<TData, TVariables>
+    | LazyQueryHookOptionsFunction<TData, TVariables>
 ): QueryTuple<TData, TVariables> {
+  const options = useNormalizedOptions(optionsOrFunction);
+
   const [execution, setExecution] = useState<{
     called: boolean,
     options?: QueryLazyOptions<TVariables>,

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -93,12 +93,20 @@ export interface QueryHookOptions<TData = any, TVariables = OperationVariables>
   query?: DocumentNode | TypedDocumentNode<TData, TVariables>;
 }
 
+export type QueryHookOptionsFunction<TData, TVariables> = (
+  prevOptions: QueryHookOptions<TData, TVariables>,
+) => QueryHookOptions<TData, TVariables>;
+
 export interface LazyQueryHookOptions<
   TData = any,
   TVariables = OperationVariables
 > extends Omit<QueryFunctionOptions<TData, TVariables>, 'skip'> {
   query?: DocumentNode | TypedDocumentNode<TData, TVariables>;
 }
+
+export type LazyQueryHookOptionsFunction<TData, TVariables> = (
+  prevOptions: LazyQueryHookOptions<TData, TVariables>,
+) => LazyQueryHookOptions<TData, TVariables>;
 
 export interface QueryLazyOptions<TVariables> {
   variables?: TVariables;


### PR DESCRIPTION
A pretty serious limitation of the `useQuery(query, options)` API is that it encourages passing a fresh bag of `options` as the second parameter every time the component (re)renders, potentially overwriting previous options from previous renders, with no way to tell which options should be taken merely as default values and which should override existing options. This ambiguity becomes especially problematic when options like `options.fetchPolicy` are updated elsewhere, but that work is undone the next time `useQuery(query, { fetchPolicy: <original policy> })` is called:
```ts
useQuery(QUERY, {
  // Was this just a default value, or should it become the new fetch policy?
  // With the current useQuery API, there's no safe way to guess!
  fetchPolicy: "cache-and-network",
})
```

A more minor problem with the `useQuery` options API is that it's somewhat wasteful (in time and memory) to recreate a new `options` object on every render, even if it will be safely ignored/discarded. The garbage still has to be collected, so it would be convenient (when it matters) to have a way to avoid recreating options unnecessarily.

This PR introduces the option of passing a _function_ as the second parameter to `useQuery`, which will be immediately invoked with the existing/current options (an empty object on first render), and should return new options (possibly including some unchanged existing options) to be merged with the existing options.

Crucially, this functional style allows taking existing options into account when determining the new options to use, which means it's now possible to (re)use existing options as default values:
```ts
useQuery(QUERY, ({
  fetchPolicy = "cache-and-network",
  notifyOnNetworkStatusChange = true,
}) => ({
  // This option defaults to "cache-and-network" if not previously defined.
  fetchPolicy,

  // This option defaults to true if not previously defined.
  notifyOnNetworkStatusChange,

  // It's probably a good idea to pass fresh onCompleted and/or onError functions,
  // since the callbacks from previous options may have the wrong closure/scope.
  onCompleted() {...},
}))
```
This function defaults to the current `options.fetchPolicy` and `options.notifyOnNetworkStatusChange` to avoid overriding them on subsequent renders, but overrides `onCompleted` unconditionally.

Note that you do not need to worry about capturing/preserving `...rest` properties, as that happens automatically, thanks to merging the returned options with the existing options (mentioned above):
```ts
useQuery(QUERY, ({
  fetchPolicy = "cache-and-network",
  ...otherOptions, // Not necessary!
}) => ({
  fetchPolicy,

  // Not necessary, because returned options will be merged with existing options,
  // so existing options remain unchanged by default.
  ...otherOptions,
}))
```

However, if you really want to take control of things, you can skip this automatic merging by modifying the existing `options` object and returning it `===` as given:
```ts
useQuery(QUERY, existingOptions => {
  if (typeof existingOptions.fetchPolicy === "undefined") {
    existingOptions.fetchPolicy = "network-only";
  }
  // Perform any other modifications to existingOptions before returning it,
  // including deleting properties...
  return existingOptions;
})
```

If you only need to provide default values (a common use case) rather than forcing any options (like `onCompleted`), you could imagine implementing a `defaultOptions` helper function that makes this a bit more ergonomic:
```ts
useQuery(QUERY, defaultOptions({
  fetchPolicy: "cache-and-network",
  notifyOnNetworkStatusChange: true,
}))
```
I'll leave that implementation as an exercise for the reader, since this description is already running a bit long.

This PR is still a draft because I need to write tests and documentation, but I wanted to get it out there for discussion sooner rather than later.