### PR TITLE
fix: onCompleted not updating regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Apollo Client 3.5.7 (unreleased)
+
+### Bug Fixes
+
+- Fix regression that prevented `onError` or `onCompleted` from being called in some cases when using `useQuery`. <br/>
+  [@mmahalwy](https://github.com/mmahalwy) in [#9226](https://github.com/apollographql/apollo-client/pull/9226)
+
 ## Apollo Client 3.5.6 (2021-12-07)
 
 ### Bug Fixes (by [@brainkim](https://github.com/brainkim) in [#9144](https://github.com/apollographql/apollo-client/pull/9144))

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -1545,6 +1545,7 @@ describe('useQuery Hook', () => {
       await waitForNextUpdate();
       expect(result.current.loading).toBe(false);
       expect(result.current.data).toEqual(data1);
+      expect(onCompleted).toHaveBeenLastCalledWith(data1);
 
       rerender({ variables: { first: 2 } });
       expect(result.current.loading).toBe(true);
@@ -1552,10 +1553,12 @@ describe('useQuery Hook', () => {
       await waitForNextUpdate();
       expect(result.current.loading).toBe(false);
       expect(result.current.data).toEqual(data2);
+      expect(onCompleted).toHaveBeenLastCalledWith(data2);
 
       rerender({ variables: { first: 1 } });
       expect(result.current.loading).toBe(false);
       expect(result.current.data).toEqual(data1);
+      expect(onCompleted).toHaveBeenLastCalledWith(data1);
 
       expect(onCompleted).toHaveBeenCalledTimes(3);
     });

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -134,12 +134,10 @@ export function useQuery<
 
       setResult(ref.current.result = nextResult);
       if (!nextResult.loading && options) {
-        if (!result.loading) {
-          if (result.error) {
-            options.onError?.(result.error);
-          } else if (result.data) {
-            options.onCompleted?.(result.data);
-          }
+        if (nextResult.error) {
+          options.onError?.(nextResult.error);
+        } else if (nextResult.data) {
+          options.onCompleted?.(nextResult.data);
         }
       }
     }


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->
Fixes regression caused by:
https://github.com/apollographql/apollo-client/commit/f1a9770b2b6f0e30fb89424eea0306afd4f48216#diff-fb7fa652de6d84c08b87344a06a4d120b664c6e8bf491d16575794c755141477R136-R142

I tested this on 3.4.0 and it works as expected. This broke on 3.5.x. I think it's also related to [this issue](https://github.com/apollographql/apollo-client/issues/9111) but for queries.

I also wrote the tests and confirmed that tests were failing prior to my change. 

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
