### PR TITLE
feat: add conditional pjson exports to support both ESM and CJS through package import

### DIFF
--- a/config/prepareDist.js
+++ b/config/prepareDist.js
@@ -79,6 +79,12 @@ entryPoints.forEach(function buildPackageJson({
       type: "module",
       main: `${bundleName}.cjs`,
       module: 'index.js',
+      exports: {
+        ".": {
+          "require": `./${bundleName}.cjs`,
+          "default": "./index.js"
+        }
+      },
       types: 'index.d.ts',
       sideEffects,
     }, null, 2) + "\n",


### PR DESCRIPTION
A small addition to allow for an "exports" key in the `package.json`. This allows: 
```ts
import {ApolloClient} from "@apollo/client/core";
```
in typescript, which transpiles correctly to ESM and CJS. Currently a full import: 
```ts
import {ApolloClient} from "@apollo/client/core/index.js";
``` 
works when exporting to ESM, but it does not work when used with CJS, because the ESM version is imported directly. 
