### PR TITLE
Batch link can cancel operations that are in queue or in flight

### DIFF
--- a/src/link/batch-http/__tests__/batchHttpLink.ts
+++ b/src/link/batch-http/__tests__/batchHttpLink.ts
@@ -193,7 +193,7 @@ describe('BatchHttpLink', () => {
           },
           batchInterval: 1,
           //if batchKey does not work, then the batch size would be 3
-          batchMax: 3,
+          batchMax: 2,
           batchKey,
         }),
       ]);

--- a/src/link/batch/__tests__/batchLink.ts
+++ b/src/link/batch/__tests__/batchLink.ts
@@ -1,12 +1,16 @@
 import gql from 'graphql-tag';
-import {print} from 'graphql';
+import { print } from 'graphql';
 
-import {ApolloLink} from '../../core/ApolloLink';
-import {execute} from '../../core/execute';
-import {FetchResult, GraphQLRequest, Operation} from '../../core/types';
-import {Observable, ObservableSubscription} from '../../../utilities/observables/Observable';
-import {BatchableRequest, BatchHandler, BatchLink, OperationBatcher,} from '../batchLink';
-import {itAsync} from '../../../testing';
+import { ApolloLink, execute } from '../../core';
+import { Operation, FetchResult, GraphQLRequest } from '../../core/types';
+import { Observable } from '../../../utilities';
+import { itAsync } from '../../../testing';
+import {
+  BatchLink,
+  OperationBatcher,
+  BatchHandler,
+  BatchableRequest,
+} from '../batchLink';
 
 interface MockedResponse {
   request: GraphQLRequest;
@@ -409,6 +413,7 @@ describe('OperationBatcher', () => {
       lastName: 'Ever',
       firstName: 'Greatest',
     };
+
     const batcher = new OperationBatcher({
       batchInterval: 10,
       batchHandler: () =>
@@ -417,17 +422,19 @@ describe('OperationBatcher', () => {
           setTimeout(observer.complete.bind(observer));
         }),
     });
-      const query = gql`
-          query {
-              author {
-                  firstName
-                  lastName
-              }
-          }
-      `;
-    const operation: Operation = createOperation({}, {query});
 
-    batcher.enqueueRequest({operation}).subscribe(() => reject('next should never be called')).unsubscribe();
+    const query = gql`
+      query {
+        author {
+          firstName
+          lastName
+        }
+      }
+    `;
+
+    batcher.enqueueRequest({
+      operation: createOperation({}, { query }),
+    }).subscribe(() => reject('next should never be called')).unsubscribe();
 
     expect(batcher.queuedRequests.get('')).toBeUndefined();
     resolve();
@@ -446,14 +453,14 @@ describe('OperationBatcher', () => {
           setTimeout(observer.complete.bind(observer));
         }),
     });
-      const query = gql`
-          query {
-              author {
-                  firstName
-                  lastName
-              }
-          }
-      `;
+    const query = gql`
+      query {
+        author {
+          firstName
+          lastName
+        }
+      }
+    `;
     const operation: Operation = createOperation({}, {query});
 
     const observable = batcher.enqueueRequest({operation});
@@ -475,8 +482,6 @@ describe('OperationBatcher', () => {
   });
 
   itAsync('should cancel single query in flight when unsubscribing', (resolve, reject) => {
-    let subscription: ObservableSubscription | undefined;
-
     const batcher = new OperationBatcher({
       batchInterval: 10,
       batchHandler: () =>
@@ -487,22 +492,22 @@ describe('OperationBatcher', () => {
           return () => {
             expect(batcher.queuedRequests.get('')).toBeUndefined();
             resolve();
-          }
+          };
         }),
     });
 
     const query = gql`
-        query {
-            author {
-                firstName
-                lastName
-            }
+      query {
+        author {
+          firstName
+          lastName
         }
+      }
     `;
 
-    const operation: Operation = createOperation({}, {query});
-
-    subscription = batcher.enqueueRequest({operation}).subscribe(() => reject('next should never be called'));
+    const subscription = batcher.enqueueRequest({
+      operation: createOperation({}, { query }),
+    }).subscribe(() => reject('next should never be called'));
   });
 
   itAsync('should correctly batch multiple queries', (resolve, reject) => {
@@ -561,7 +566,7 @@ describe('OperationBatcher', () => {
     );
   });
 
-  itAsync('should cancel multiples queries in queue when unsubscribing and let pass still subscribed one', (resolve, reject) => {
+  itAsync('should cancel multiple queries in queue when unsubscribing and let pass still subscribed one', (resolve, reject) => {
     const data2 = {
       lastName: 'Hauser',
       firstName: 'Evans',
@@ -571,19 +576,19 @@ describe('OperationBatcher', () => {
       batchInterval: 10,
       batchHandler: () =>
         new Observable(observer => {
-          observer.next([{data: data2}]);
+          observer.next([{ data: data2 }]);
           setTimeout(observer.complete.bind(observer));
         }),
     });
 
-      const query = gql`
-          query {
-              author {
-                  firstName
-                  lastName
-              }
-          }
-      `;
+    const query = gql`
+      query {
+        author {
+          firstName
+          lastName
+        }
+      }
+    `;
 
     const operation: Operation = createOperation({}, {query});
     const operation2: Operation = createOperation({}, {query});

--- a/src/link/batch/__tests__/batchLink.ts
+++ b/src/link/batch/__tests__/batchLink.ts
@@ -187,9 +187,9 @@ describe('OperationBatcher', () => {
 
     expect(batcher.queuedRequests.get('')).toBeUndefined();
     batcher.enqueueRequest(request).subscribe({});
-    expect(batcher.queuedRequests.get('')!.requests.size).toBe(1);
+    expect(batcher.queuedRequests.get('')!.size).toBe(1);
     batcher.enqueueRequest(request).subscribe({});
-    expect(batcher.queuedRequests.get('')!.requests.size).toBe(2);
+    expect(batcher.queuedRequests.get('')!.size).toBe(2);
   });
 
   describe('request queue', () => {
@@ -303,7 +303,7 @@ describe('OperationBatcher', () => {
       });
 
       try {
-        expect(myBatcher.queuedRequests.get('')!.requests.size).toBe(2);
+        expect(myBatcher.queuedRequests.get('')!.size).toBe(2);
         const observables: (
           | Observable<FetchResult>
           | undefined)[] = myBatcher.consumeQueue()!;
@@ -345,22 +345,22 @@ describe('OperationBatcher', () => {
       myBatcher.enqueueRequest({ operation }).subscribe({});
       myBatcher.enqueueRequest({ operation }).subscribe({});
       myBatcher.enqueueRequest({ operation }).subscribe({});
-      expect(myBatcher.queuedRequests.get('')!.requests.size).toEqual(3);
+      expect(myBatcher.queuedRequests.get('')!.size).toEqual(3);
 
       // 2. Run the timer halfway.
       jest.advanceTimersByTime(batchInterval / 2);
-      expect(myBatcher.queuedRequests.get('')!.requests.size).toEqual(3);
+      expect(myBatcher.queuedRequests.get('')!.size).toEqual(3);
 
       // 3. Queue a 4th request, causing the timer to reset.
       myBatcher.enqueueRequest({ operation }).subscribe({});
-      expect(myBatcher.queuedRequests.get('')!.requests.size).toEqual(4);
+      expect(myBatcher.queuedRequests.get('')!.size).toEqual(4);
 
       // 4. Run the timer to batchInterval + 1, at this point, if debounce were
       // not set, the original 3 requests would have fired, but we expect
       // instead that the queries will instead fire at
       // (batchInterval + batchInterval / 2).
       jest.advanceTimersByTime(batchInterval / 2 + 1);
-      expect(myBatcher.queuedRequests.get('')!.requests.size).toEqual(4);
+      expect(myBatcher.queuedRequests.get('')!.size).toEqual(4);
 
       // 5. Finally, run the timer to (batchInterval + batchInterval / 2) +1,
       // and expect the queue to be empty.
@@ -395,7 +395,7 @@ describe('OperationBatcher', () => {
 
     batcher.enqueueRequest({ operation }).subscribe({});
     try {
-      expect(batcher.queuedRequests.get('')!.requests.size).toBe(1);
+      expect(batcher.queuedRequests.get('')!.size).toBe(1);
     } catch (e) {
       reject(e);
     }
@@ -468,10 +468,10 @@ describe('OperationBatcher', () => {
     const checkQueuedRequests = (
       expectedSubscriberCount: number,
     ) => {
-      const queued = batcher.queuedRequests.get('');
-      expect(queued).not.toBeUndefined();
-      expect(queued!.requests.size).toBe(1);
-      queued!.requests.forEach(request => {
+      const batch = batcher.queuedRequests.get('');
+      expect(batch).not.toBeUndefined();
+      expect(batch!.size).toBe(1);
+      batch!.forEach(request => {
         expect(request.subscribers.size).toBe(expectedSubscriberCount);
       });
     };
@@ -551,7 +551,7 @@ describe('OperationBatcher', () => {
     batcher.enqueueRequest({ operation }).subscribe({});
     batcher.enqueueRequest({ operation: operation2 }).subscribe({});
     try {
-      expect(batcher.queuedRequests.get('')!.requests.size).toBe(2);
+      expect(batcher.queuedRequests.get('')!.size).toBe(2);
     } catch (e) {
       reject(e);
     }
@@ -560,7 +560,7 @@ describe('OperationBatcher', () => {
       // The batch shouldn't be fired yet, so we can add one more request.
       batcher.enqueueRequest({ operation: operation3 }).subscribe({});
       try {
-        expect(batcher.queuedRequests.get('')!.requests.size).toBe(3);
+        expect(batcher.queuedRequests.get('')!.size).toBe(3);
       } catch (e) {
         reject(e);
       }
@@ -613,18 +613,18 @@ describe('OperationBatcher', () => {
       resolve();
     });
 
-    expect(batcher.queuedRequests.get('')!.requests.size).toBe(2);
+    expect(batcher.queuedRequests.get('')!.size).toBe(2);
 
     sub1.unsubscribe();
-    expect(batcher.queuedRequests.get('')!.requests.size).toBe(1);
+    expect(batcher.queuedRequests.get('')!.size).toBe(1);
 
     setTimeout(() => {
       // The batch shouldn't be fired yet, so we can add one more request.
       const sub3 = batcher.enqueueRequest({operation: operation3}).subscribe(() => reject('next should never be called'));
-      expect(batcher.queuedRequests.get('')!.requests.size).toBe(2);
+      expect(batcher.queuedRequests.get('')!.size).toBe(2);
 
       sub3.unsubscribe();
-      expect(batcher.queuedRequests.get('')!.requests.size).toBe(1);
+      expect(batcher.queuedRequests.get('')!.size).toBe(1);
     }, 5);
   });
 

--- a/src/link/batch/batching.ts
+++ b/src/link/batch/batching.ts
@@ -1,4 +1,4 @@
-import { Operation, FetchResult, NextLink } from '../core';
+import { FetchResult, NextLink, Operation } from '../core';
 import { Observable, ObservableSubscription } from '../../utilities';
 
 export type BatchHandler = (
@@ -11,7 +11,7 @@ export interface BatchableRequest {
   forward?: NextLink;
 }
 
-interface QueuedRequest extends BatchableRequest {
+type QueuedRequest = BatchableRequest & {
   observable?: Observable<FetchResult>;
   next: Array<(result: FetchResult) => void>;
   error: Array<(error: Error) => void>;
@@ -145,12 +145,12 @@ export class OperationBatcher {
       return;
     }
 
-    const operations: Operation[] = [];
-    const forwards: (NextLink | undefined)[] = [];
-    const observables: (Observable<FetchResult> | undefined)[] = [];
-    const nexts: Array<(result: FetchResult) => void>[] = [];
-    const errors: Array<(error: Error) => void>[] = [];
-    const completes: Array<() => void>[] = [];
+    const operations: QueuedRequest['operation'][] = [];
+    const forwards: QueuedRequest['forward'][] = [];
+    const observables: QueuedRequest['observable'][] = [];
+    const nexts: QueuedRequest['next'][] = [];
+    const errors: QueuedRequest['error'][] = [];
+    const completes: QueuedRequest['complete'][] = [];
 
     // Even though batch is a Set, it preserves the order of first insertion
     // when iterating (per ECMAScript specification), so these requests will be

--- a/src/link/batch/batching.ts
+++ b/src/link/batch/batching.ts
@@ -167,12 +167,12 @@ export class OperationBatcher {
     const batchedObservable =
       this.batchHandler(operations, forwards) || Observable.of();
 
-    const onError = (error: any) => {
+    const onError = (error: Error) => {
       //each callback list in batch
       errors.forEach(rejecters => {
         if (rejecters) {
           //each subscriber to request
-          rejecters.forEach((e: any) => e(error));
+          rejecters.forEach((e) => e(error));
         }
       });
     };
@@ -196,7 +196,7 @@ export class OperationBatcher {
 
         results.forEach((result, index) => {
           if (nexts[index]) {
-            nexts[index].forEach((next: any) => next(result));
+            nexts[index].forEach((next) => next(result));
           }
         });
       },
@@ -205,7 +205,7 @@ export class OperationBatcher {
         completes.forEach(complete => {
           if (complete) {
             //each subscriber to request
-            complete.forEach((c: any) => c());
+            complete.forEach((c) => c());
           }
         });
       },

--- a/src/link/batch/batching.ts
+++ b/src/link/batch/batching.ts
@@ -9,13 +9,10 @@ export type BatchHandler = (
 export interface BatchableRequest {
   operation: Operation;
   forward?: NextLink;
-  observable?: Observable<FetchResult>;
-  next?: Array<(result: FetchResult) => void>;
-  error?: Array<(error: Error) => void>;
-  complete?: Array<() => void>;
 }
 
 interface QueuedRequest extends BatchableRequest {
+  observable?: Observable<FetchResult>;
   next: Array<(result: FetchResult) => void>;
   error: Array<(error: Error) => void>;
   complete: Array<() => void>;

--- a/src/link/batch/batching.ts
+++ b/src/link/batch/batching.ts
@@ -70,7 +70,7 @@ export class OperationBatcher {
       next: [],
       error: [],
       complete: [],
-      subscribers: new Set,
+      subscribers: new Set(),
     };
 
     const key = this.batchKey(request.operation);
@@ -78,7 +78,7 @@ export class OperationBatcher {
     if (!requestCopy.observable) {
       requestCopy.observable = new Observable<FetchResult>(observer => {
         let batch = this.batchesByKey.get(key)!;
-        if (!batch) this.batchesByKey.set(key, batch = new Set);
+        if (!batch) this.batchesByKey.set(key, batch = new Set());
 
         // These booleans seem to me (@benjamn) like they might always be the
         // same (and thus we could do with only one of them), but I'm not 100%

--- a/src/link/batch/batching.ts
+++ b/src/link/batch/batching.ts
@@ -9,13 +9,13 @@ export type BatchHandler = (
 export interface BatchableRequest {
   operation: Operation;
   forward?: NextLink;
+  observable?: Observable<FetchResult>;
+  next?: Array<(result: FetchResult) => void>;
+  error?: Array<(error: Error) => void>;
+  complete?: Array<() => void>;
 }
 
 interface QueuedRequest extends BatchableRequest {
-  // promise is created when the query fetch request is
-  // added to the queue and is resolved once the result is back
-  // from the server.
-  observable?: Observable<FetchResult>;
   next: Array<(result: FetchResult) => void>;
   error: Array<(error: Error) => void>;
   complete: Array<() => void>;

--- a/src/link/batch/batching.ts
+++ b/src/link/batch/batching.ts
@@ -1,5 +1,5 @@
-import {FetchResult, NextLink, Operation} from '../core';
-import {Observable, ObservableSubscription} from '../../utilities';
+import { Operation, FetchResult, NextLink } from '../core';
+import { Observable, ObservableSubscription } from '../../utilities';
 
 export type BatchHandler = (
   operations: Operation[],
@@ -43,12 +43,12 @@ export class OperationBatcher {
   private batchKey: (operation: Operation) => string;
 
   constructor({
-                batchDebounce,
-                batchInterval,
-                batchMax,
-                batchHandler,
-                batchKey,
-              }: {
+    batchDebounce,
+    batchInterval,
+    batchMax,
+    batchHandler,
+    batchKey,
+  }: {
     batchDebounce?: boolean;
     batchInterval?: number;
     batchMax?: number;

--- a/src/link/batch/batching.ts
+++ b/src/link/batch/batching.ts
@@ -141,9 +141,12 @@ export class OperationBatcher {
     key: string = '',
   ): (Observable<FetchResult> | undefined)[] | undefined {
     const batch = this.batchesByKey.get(key);
-    if (!batch) return;
-
+    // Delete this batch and process it below.
     this.batchesByKey.delete(key);
+    if (!batch || !batch.size) {
+      // No requests to be processed.
+      return;
+    }
 
     const operations: Operation[] = [];
     const forwards: (NextLink | undefined)[] = [];
@@ -216,9 +219,7 @@ export class OperationBatcher {
 
   private scheduleQueueConsumption(key: string): void {
     this.scheduledBatchTimer = setTimeout(() => {
-      if (this.batchesByKey.get(key)?.size) {
-        this.consumeQueue(key);
-      }
+      this.consumeQueue(key);
     }, this.batchInterval);
   }
 }


### PR DESCRIPTION
After an operation has been subscribed to, and so queued, it is possible
to unsubscribe from it, and it will be removed from the queue.

Unsubscribing will not impact the debounce, so other operations, if any, will
not be delayed by an unsubscription.

If a batch of operation is already in flight, and all operations are unsubscribed
then the entire XHR will be cancelled. If only some operations are unsubscribed
the XHR will be left untouched.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
