### PR TITLE
Fix `useSubscription` executes skipped subscription if input changes

### DIFF
--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -135,10 +135,12 @@ describe('useSubscription Hook', () => {
       cache: new Cache({ addTypename: false })
     });
 
+    const onSubscriptionData = jest.fn();
     const { result, unmount, waitForNextUpdate, rerender } = renderHook(
       ({ variables }) => useSubscription(subscription, {
         variables,
-        skip: true
+        skip: true,
+        onSubscriptionData,
       }),
       {
         initialProps: {
@@ -159,10 +161,11 @@ describe('useSubscription Hook', () => {
     expect(result.current.data).toBe(undefined);
 
     rerender({ variables: { foo: 'bar2' }});
-    expect(onSetup).toHaveBeenCalledTimes(0);
-
     await expect(waitForNextUpdate({ timeout: 20 }))
       .rejects.toThrow('Timed out');
+
+    expect(onSetup).toHaveBeenCalledTimes(0);
+    expect(onSubscriptionData).toHaveBeenCalledTimes(0);
     unmount();
   });
 

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -127,19 +127,25 @@ describe('useSubscription Hook', () => {
       }
     `;
 
+    const onSetup = jest.fn();
     const link = new MockSubscriptionLink();
+    link.onSetup(onSetup);
     const client = new ApolloClient({
       link,
       cache: new Cache({ addTypename: false })
     });
 
-    const onSubscriptionData = jest.fn();
-    const { result, unmount, waitForNextUpdate } = renderHook(
-      () => useSubscription(subscription, {
-        onSubscriptionData,
-        skip: true,
+    const { result, unmount, waitForNextUpdate, rerender } = renderHook(
+      ({ variables }) => useSubscription(subscription, {
+        variables,
+        skip: true
       }),
       {
+        initialProps: {
+          variables: {
+            foo: 'bar'
+          }
+        },
         wrapper: ({ children }) => (
           <ApolloProvider client={client}>
             {children}
@@ -151,11 +157,13 @@ describe('useSubscription Hook', () => {
     expect(result.current.loading).toBe(false);
     expect(result.current.error).toBe(undefined);
     expect(result.current.data).toBe(undefined);
+
+    rerender({ variables: { foo: 'bar2' }});
+    expect(onSetup).toHaveBeenCalledTimes(0);
+
     await expect(waitForNextUpdate({ timeout: 20 }))
       .rejects.toThrow('Timed out');
     unmount();
-
-    expect(onSubscriptionData).toHaveBeenCalledTimes(0);
   });
 
   it('should create a subscription after skip has changed from true to a falsy value', async () => {

--- a/src/react/hooks/useSubscription.ts
+++ b/src/react/hooks/useSubscription.ts
@@ -45,14 +45,16 @@ export function useSubscription<TData = any, TVariables = OperationVariables>(
       shouldResubscribe = !!shouldResubscribe(options!);
     }
 
-    if (options?.skip && !options?.skip !== !ref.current.options?.skip) {
-      setResult({
-        loading: false,
-        data: void 0,
-        error: void 0,
-        variables: options?.variables,
-      });
-      setObservable(null);
+    if (options?.skip) {
+      if (!options?.skip !== !ref.current.options?.skip) {
+        setResult({
+          loading: false,
+          data: void 0,
+          error: void 0,
+          variables: options?.variables,
+        });
+        setObservable(null);
+      }
     } else if (
       shouldResubscribe !== false && (
         client !== ref.current.client ||


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests

This bug triggered a regression in our application after updating from Apollo Client 3.3.21 to 3.5.7.

The unit test testing the `skip` flag wasn't actually working correctly. It didn't fail when `skip` was set to `false`.
I've updated it to make sure no subscription is being executed by spying on `onSetup` callback of the link instead of the `onSubscriptionData` one on the hook which isn't called anyway since `simulateResult` isn't called as part of the test. I also extended the test to make sure no subscription is being executed when variables are changing.
The final version of the test was verified to fail on `main` branch.

I wasn't sure if I shall extend the existing test or add a new one. Let me know if a new test case for the update case is preferred.