### PR TITLE
Add apollo-multi-endpoint-link to community links

### DIFF
--- a/docs/source/api/link/community-links.md
+++ b/docs/source/api/link/community-links.md
@@ -24,3 +24,4 @@ Thank you to all the Apollo community members who have contributed custom Apollo
 | [apollo-link-serialize](https://github.com/helfer/apollo-link-serialize) | [@helfer](https://github.com/helfer) | Serializes requests by key to ensure execution order. |
 | [apollo-link-debounce](https://github.com/helfer/apollo-link-debounce) | [@helfer](https://github.com/helfer) | Debounce requests made within an interval. |
 | [apollo-link-segment](https://github.com/hobochild/apollo-link-segment) | [@hobochild](https://github.com/hobochild) | Automatically track apollo operations with [segment](https://segment.com/). |
+| [apollo-multi-endpoint-link](https://github.com/habx/apollo-multi-endpoint-link) | [@habx](https://github.com/habx) | Add directive to redirect requests to right endpoint |


### PR DESCRIPTION
We developped a link that could be useful for people using appolo client, everything is described in the [readme](https://github.com/habx/apollo-multi-endpoint-link#readme)
