### PR TITLE
Change default `Accept` header to `application/json`

### DIFF
--- a/src/link/batch-http/__tests__/batchHttpLink.ts
+++ b/src/link/batch-http/__tests__/batchHttpLink.ts
@@ -513,7 +513,7 @@ describe('SharedHttpTest', () => {
         const headers: any = fetchMock.lastCall()![1]!.headers;
         expect(headers.authorization).toBe('1234');
         expect(headers['content-type']).toBe('application/json');
-        expect(headers.accept).toBe('*/*');
+        expect(headers.accept).toBe('application/json');
       }),
     );
   });
@@ -530,7 +530,7 @@ describe('SharedHttpTest', () => {
         const headers: any = fetchMock.lastCall()![1]!.headers;
         expect(headers.authorization).toBe('1234');
         expect(headers['content-type']).toBe('application/json');
-        expect(headers.accept).toBe('*/*');
+        expect(headers.accept).toBe('application/json');
       }),
     );
   });
@@ -552,7 +552,7 @@ describe('SharedHttpTest', () => {
         const headers: any = fetchMock.lastCall()![1]!.headers;
         expect(headers.authorization).toBe('1234');
         expect(headers['content-type']).toBe('application/json');
-        expect(headers.accept).toBe('*/*');
+        expect(headers.accept).toBe('application/json');
       }),
     );
   });
@@ -573,7 +573,7 @@ describe('SharedHttpTest', () => {
         const headers: any = fetchMock.lastCall()![1]!.headers;
         expect(headers.authorization).toBe('1234');
         expect(headers['content-type']).toBe('application/json');
-        expect(headers.accept).toBe('*/*');
+        expect(headers.accept).toBe('application/json');
       }),
     );
   });

--- a/src/link/http/__tests__/HttpLink.ts
+++ b/src/link/http/__tests__/HttpLink.ts
@@ -617,7 +617,7 @@ describe('HttpLink', () => {
           const headers = fetchMock.lastCall()![1]!.headers as any;
           expect(headers.authorization).toBe('1234');
           expect(headers['content-type']).toBe('application/json');
-          expect(headers.accept).toBe('*/*');
+          expect(headers.accept).toBe('application/json');
         }),
       );
     });
@@ -634,7 +634,7 @@ describe('HttpLink', () => {
           const headers = fetchMock.lastCall()![1]!.headers as any;
           expect(headers.authorization).toBe('1234');
           expect(headers['content-type']).toBe('application/json');
-          expect(headers.accept).toBe('*/*');
+          expect(headers.accept).toBe('application/json');
         }),
       );
     });
@@ -656,7 +656,7 @@ describe('HttpLink', () => {
           const headers = fetchMock.lastCall()![1]!.headers as any;
           expect(headers.authorization).toBe('1234');
           expect(headers['content-type']).toBe('application/json');
-          expect(headers.accept).toBe('*/*');
+          expect(headers.accept).toBe('application/json');
         }),
       );
     });
@@ -677,7 +677,7 @@ describe('HttpLink', () => {
           const headers = fetchMock.lastCall()![1]!.headers as any;
           expect(headers.authorization).toBe('1234');
           expect(headers['content-type']).toBe('application/json');
-          expect(headers.accept).toBe('*/*');
+          expect(headers.accept).toBe('application/json');
         }),
       );
     });

--- a/src/link/http/__tests__/selectHttpOptionsAndBody.ts
+++ b/src/link/http/__tests__/selectHttpOptionsAndBody.ts
@@ -37,7 +37,7 @@ describe('selectHttpOptionsAndBody', () => {
 
   it('the fallbackConfig is used if no other configs are specified', () => {
     const defaultHeaders = {
-      accept: '*/*',
+      accept: 'application/json',
       'content-type': 'application/json',
     };
 

--- a/src/link/http/selectHttpOptionsAndBody.ts
+++ b/src/link/http/selectHttpOptionsAndBody.ts
@@ -95,7 +95,7 @@ const defaultHttpOptions: HttpQueryOptions = {
 
 const defaultHeaders = {
   // headers are case insensitive (https://stackoverflow.com/a/5259004)
-  accept: '*/*',
+  accept: 'application/json',
   'content-type': 'application/json',
 };
 


### PR DESCRIPTION
### What

While the GraphQL spec does not specify JSON as the serialization format, it it by far the most popular.

Therefore, it we can provide a better default `accept` header, especially given we already default to `application/json` for the `content-type` header. Consumers continue to have the ability to override this if necessary.

**This changes the default `accept` header from `*/*` to `application/json`.**

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Why

Setting reasonable defaults can help consumers who might not think to set certain configuration, or who assume it is already being set.

One example of how this particular setting is useful is for consumers using an API behind an authorization reverse proxy (such as [OAuth2-Proxy](https://github.com/oauth2-proxy/oauth2-proxy)) which checks if the request is authorized before forwarding it to the actual GraphQL server. Many such services will check the `Accept` header to determine the appropriate response for an unauthorized request. For example, [OAuth2-Proxy's behaviour](https://oauth2-proxy.github.io/oauth2-proxy/docs/behaviour) is:

> If authentication is required but missing then the user is asked to log in and redirected to the authentication provider (unless it is an Ajax request, i.e. one with Accept: `application/json`, in which case `401 Unauthorized` is returned)

Currently, Apollo-Client uses `accept: */*`, which means that unauthorized requests are routed to the authentication provider instead of resulting in a `401 Unauthorized` response. Apollo-Client then follows the redirect resulting in it trying to handle a `200 OK` response containing an HTML login page, which blows up on `JSON.parse`.

By setting a better default, these cases will result in a far more easily actioned error.

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
