### PR TITLE
Fix duplicate word "ApolloClient" in error message

### DIFF
--- a/src/react/hooks/useApolloClient.ts
+++ b/src/react/hooks/useApolloClient.ts
@@ -11,8 +11,8 @@ export function useApolloClient(
   invariant(
     !!client,
     'Could not find "client" in the context or passed in as an option. ' +
-    'Wrap the root component in an <ApolloProvider>, or pass an ApolloClient' +
-    'ApolloClient instance in via options.',
+    'Wrap the root component in an <ApolloProvider>, or pass an ApolloClient ' +
+    'instance in via options.',
   );
 
   return client;


### PR DESCRIPTION
I noticed this error message says "pass an **ApolloClient ApolloClient** instance in via options". I assume the duplicate "ApolloClient" was not intentional. Thanks!