### PR TITLE
Fix TS type of called in useLazyQuery

### DIFF
--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -105,7 +105,9 @@ export interface QueryLazyOptions<TVariables> {
 }
 
 // TODO: Delete this
-export type LazyQueryResult<TData, TVariables> = QueryResult<TData, TVariables>;
+export interface LazyQueryResult<TData, TVariables> extends Omit<QueryResult<TData, TVariables>, 'called'> {
+  called: boolean
+};
 
 export type QueryTuple<TData, TVariables> = [
   (options?: QueryLazyOptions<TVariables>) => Promise<LazyQueryResult<TData, TVariables>>,


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

This should fix https://github.com/apollographql/apollo-client/issues/9116 and https://github.com/apollographql/apollo-client/issues/9102.

Currently the typescript type of `called` when using `useLazyQuery` is `true` however it should be `boolean`.

