### PR TITLE
Fix partial data appearing in `useQuery()` when `notifyOnNetworkStatusChange` is `true`.

### DIFF
--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -285,9 +285,11 @@ export class ObservableQuery<
     variablesMustMatch?: boolean,
   ) {
     const last = this.last;
-    if (last &&
-        last[key] &&
-        (!variablesMustMatch || equal(last!.variables, this.variables))) {
+    if (
+      last &&
+      last[key] &&
+      (!variablesMustMatch || equal(last.variables, this.variables))
+    ) {
       return last[key];
     }
   }
@@ -761,8 +763,12 @@ once, rather than every time you call fetchMore.`);
     result: ApolloQueryResult<TData>,
     variables: TVariables | undefined,
   ) {
-    if (this.getLastError() || this.isDifferentFromLastResult(result)) {
-      this.updateLastResult(result, variables);
+    const lastError = this.getLastError();
+    if (lastError || this.isDifferentFromLastResult(result)) {
+      if (lastError || !result.partial || this.options.returnPartialData) {
+        this.updateLastResult(result, variables);
+      }
+
       iterateObserversSafely(this.observers, 'next', result);
     }
   }


### PR DESCRIPTION
Fixes #8715, fixes #9169, fixes #9291, fixes #9334 (dupes).

Introduced in #8642.