### PR TITLE
Temporarily revert `useSyncExternalStore` changes (#8785).

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
         "@types/node": "16.11.19",
         "@types/react": "17.0.34",
         "@types/react-dom": "17.0.2",
-        "@types/use-sync-external-store": "^0.0.3",
         "acorn": "8.6.0",
         "bundlesize": "0.18.1",
         "cross-fetch": "3.1.4",
@@ -63,7 +62,6 @@
         "ts-jest": "27.1.2",
         "ts-node": "10.4.0",
         "typescript": "4.5.2",
-        "use-sync-external-store": "1.0.0-rc.0",
         "wait-for-observables": "1.0.3",
         "whatwg-fetch": "3.6.2"
       },
@@ -73,9 +71,8 @@
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0",
         "graphql-ws": "^5.5.5",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0-beta",
-        "subscriptions-transport-ws": "^0.9.0 || ^0.11.0",
-        "use-sync-external-store": "^1.0.0 || ^1.0.0-rc || ^1.0.0-beta"
+        "react": "^16.8.0 || ^17.0.0",
+        "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
       },
       "peerDependenciesMeta": {
         "graphql-ws": {
@@ -85,9 +82,6 @@
           "optional": true
         },
         "subscriptions-transport-ws": {
-          "optional": true
-        },
-        "use-sync-external-store": {
           "optional": true
         }
       }
@@ -1369,12 +1363,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
-      "dev": true
-    },
-    "node_modules/@types/use-sync-external-store": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
-      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -5893,15 +5881,6 @@
         "node": ">= 4.0.0"
       }
     },
-    "node_modules/use-sync-external-store": {
-      "version": "1.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.0.0-rc.0.tgz",
-      "integrity": "sha512-0U9Xlc2QDFzSGMB0DvcJQL0+DIdxDPJC7mnZlYFbl7wrSrPMcs89X5TVkNB6Dzg618m8lZop+U+J6ow3vq9RAQ==",
-      "dev": true,
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0-rc"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -7342,12 +7321,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
-      "dev": true
-    },
-    "@types/use-sync-external-store": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
-      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==",
       "dev": true
     },
     "@types/yargs": {
@@ -10824,13 +10797,6 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
-    },
-    "use-sync-external-store": {
-      "version": "1.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.0.0-rc.0.tgz",
-      "integrity": "sha512-0U9Xlc2QDFzSGMB0DvcJQL0+DIdxDPJC7mnZlYFbl7wrSrPMcs89X5TVkNB6Dzg618m8lZop+U+J6ow3vq9RAQ==",
-      "dev": true,
-      "requires": {}
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -65,9 +65,8 @@
   "peerDependencies": {
     "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0",
     "graphql-ws": "^5.5.5",
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0-beta",
-    "subscriptions-transport-ws": "^0.9.0 || ^0.11.0",
-    "use-sync-external-store": "^1.0.0 || ^1.0.0-rc || ^1.0.0-beta"
+    "react": "^16.8.0 || ^17.0.0",
+    "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
   },
   "peerDependenciesMeta": {
     "graphql-ws": {
@@ -77,9 +76,6 @@
       "optional": true
     },
     "subscriptions-transport-ws": {
-      "optional": true
-    },
-    "use-sync-external-store": {
       "optional": true
     }
   },
@@ -112,7 +108,6 @@
     "@types/node": "16.11.19",
     "@types/react": "17.0.34",
     "@types/react-dom": "17.0.2",
-    "@types/use-sync-external-store": "^0.0.3",
     "acorn": "8.6.0",
     "bundlesize": "0.18.1",
     "cross-fetch": "3.1.4",
@@ -138,7 +133,6 @@
     "ts-jest": "27.1.2",
     "ts-node": "10.4.0",
     "typescript": "4.5.2",
-    "use-sync-external-store": "1.0.0-rc.0",
     "wait-for-observables": "1.0.3",
     "whatwg-fetch": "3.6.2"
   },

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -285,9 +285,11 @@ export class ObservableQuery<
     variablesMustMatch?: boolean,
   ) {
     const last = this.last;
-    if (last &&
-        last[key] &&
-        (!variablesMustMatch || equal(last!.variables, this.variables))) {
+    if (
+      last &&
+      last[key] &&
+      (!variablesMustMatch || equal(last.variables, this.variables))
+    ) {
       return last[key];
     }
   }
@@ -326,7 +328,7 @@ export class ObservableQuery<
     // (no-cache, network-only, or cache-and-network), override it with
     // network-only to force the refetch for this fetchQuery call.
     const { fetchPolicy } = this.options;
-    if (fetchPolicy === 'standby' || fetchPolicy === 'cache-and-network') {
+    if (fetchPolicy === 'cache-and-network') {
       reobserveOptions.fetchPolicy = fetchPolicy;
     } else if (fetchPolicy === 'no-cache') {
       reobserveOptions.fetchPolicy = 'no-cache';
@@ -761,8 +763,12 @@ once, rather than every time you call fetchMore.`);
     result: ApolloQueryResult<TData>,
     variables: TVariables | undefined,
   ) {
-    if (this.getLastError() || this.isDifferentFromLastResult(result)) {
-      this.updateLastResult(result, variables);
+    const lastError = this.getLastError();
+    if (lastError || this.isDifferentFromLastResult(result)) {
+      if (lastError || !result.partial || this.options.returnPartialData) {
+        this.updateLastResult(result, variables);
+      }
+
       iterateObserversSafely(this.observers, 'next', result);
     }
   }

--- a/src/react/components/__tests__/client/Mutation.test.tsx
+++ b/src/react/components/__tests__/client/Mutation.test.tsx
@@ -1021,11 +1021,7 @@ describe('General Mutation testing', () => {
       return (
         <Mutation mutation={mutation} refetchQueries={refetchQueries}>
           {(createTodo: any, resultMutation: any) => (
-            <Query
-              query={query}
-              variables={variables}
-              notifyOnNetworkStatusChange={true}
-            >
+            <Query query={query} variables={variables}>
               {(resultQuery: any) => {
                 try {
                   if (count === 0) {
@@ -1051,16 +1047,13 @@ describe('General Mutation testing', () => {
                     // mutation loading
                     expect(resultMutation.loading).toBe(true);
                   } else if (count === 6) {
-                    // mutation still loading???
-                    expect(resultMutation.loading).toBe(true);
-                  } else if (count === 7) {
-                    expect(resultQuery.loading).toBe(true);
+                    // mutation loaded
                     expect(resultMutation.loading).toBe(false);
-                  } else if (count === 8) {
+                  } else if (count === 7) {
                     // query refetched
-                    expect(resultQuery.data).toEqual(peopleData3);
                     expect(resultQuery.loading).toBe(false);
                     expect(resultMutation.loading).toBe(false);
+                    expect(resultQuery.data).toEqual(peopleData3);
                   }
                   count++;
                 } catch (err) {
@@ -1081,7 +1074,7 @@ describe('General Mutation testing', () => {
     );
 
     waitFor(() => {
-      expect(count).toBe(9);
+      expect(count).toEqual(8);
     }).then(resolve, reject);
   }));
 

--- a/src/react/components/__tests__/client/Query.test.tsx
+++ b/src/react/components/__tests__/client/Query.test.tsx
@@ -1229,11 +1229,7 @@ describe('Query component', () => {
           const { variables } = this.state;
 
           return (
-            <AllPeopleQuery
-              query={query}
-              variables={variables}
-              notifyOnNetworkStatusChange={true}
-            >
+            <AllPeopleQuery query={query} variables={variables}>
               {(result: any) => {
                 try {
                   switch (count) {
@@ -1721,40 +1717,35 @@ describe('Query component', () => {
           <AllPeopleQuery
             query={query}
             variables={variables}
-            notifyOnNetworkStatusChange={true}
             onCompleted={this.onCompleted}
           >
             {({ loading, data }: any) => {
-              try {
-                switch (renderCount) {
-                  case 0:
-                    expect(loading).toBe(true);
-                    break;
-                  case 1:
-                  case 2:
-                    expect(loading).toBe(false);
-                    expect(data).toEqual(data1);
-                    break;
-                  case 3:
-                    expect(loading).toBe(true);
-                    break;
-                  case 4:
-                    expect(loading).toBe(false);
-                    expect(data).toEqual(data2);
-                    setTimeout(() => {
-                      this.setState({ variables: { first: 1 } });
-                    });
-                  case 5:
-                    expect(loading).toBe(false);
-                    expect(data).toEqual(data2);
-                    break;
-                  case 6:
-                    expect(loading).toBe(false);
-                    expect(data).toEqual(data1);
-                    break;
-                }
-              } catch (err) {
-                reject(err);
+              switch (renderCount) {
+                case 0:
+                  expect(loading).toBe(true);
+                  break;
+                case 1:
+                case 2:
+                  expect(loading).toBe(false);
+                  expect(data).toEqual(data1);
+                  break;
+                case 3:
+                  expect(loading).toBe(true);
+                  break;
+                case 4:
+                  expect(loading).toBe(false);
+                  expect(data).toEqual(data2);
+                  setTimeout(() => {
+                    this.setState({ variables: { first: 1 } });
+                  });
+                case 5:
+                  expect(loading).toBe(false);
+                  expect(data).toEqual(data2);
+                  break;
+                case 6:
+                  expect(loading).toBe(false);
+                  expect(data).toEqual(data1);
+                  break;
               }
               renderCount += 1;
               return null;
@@ -1771,7 +1762,6 @@ describe('Query component', () => {
     );
 
     waitFor(() => {
-      expect(renderCount).toBe(7);
       expect(onCompletedCallCount).toBe(3);
     }).then(resolve, reject);
   });

--- a/src/react/components/__tests__/ssr/getDataFromTree.test.tsx
+++ b/src/react/components/__tests__/ssr/getDataFromTree.test.tsx
@@ -1,4 +1,3 @@
-/** @jest-environment node */
 import React from 'react';
 import gql from 'graphql-tag';
 import { DocumentNode } from 'graphql';

--- a/src/react/components/__tests__/ssr/server.test.tsx
+++ b/src/react/components/__tests__/ssr/server.test.tsx
@@ -1,4 +1,3 @@
-/** @jest-environment node */
 import React from 'react';
 import {
   print,

--- a/src/react/hoc/__tests__/queries/errors.test.tsx
+++ b/src/react/hoc/__tests__/queries/errors.test.tsx
@@ -216,10 +216,7 @@ describe('[queries] errors', () => {
       let iteration = 0;
       let done = false;
       const ErrorContainer = withState('var', 'setVar', 1)(
-        graphql<Props, Data, Vars>(
-          query,
-          { options: { notifyOnNetworkStatusChange: true }},
-        )(
+        graphql<Props, Data, Vars>(query)(
           class extends React.Component<ChildProps<Props, Data, Vars>> {
             componentDidUpdate() {
               const { props } = this;
@@ -237,7 +234,7 @@ describe('[queries] errors', () => {
                   );
                 } else if (iteration === 3) {
                   // variables have changed, wee are loading again but also have data
-                  expect(props.data!.loading).toBe(true);
+                  expect(props.data!.loading).toBeTruthy();
                 } else if (iteration === 4) {
                   // the second request had an error!
                   expect(props.data!.error).toBeTruthy();
@@ -259,8 +256,8 @@ describe('[queries] errors', () => {
             render() {
               return null;
             }
-          },
-        ),
+          }
+        )
       );
 
       render(
@@ -473,11 +470,9 @@ describe('[queries] errors', () => {
                   });
                 break;
               case 3:
-                // Second render was added by useSyncExternalStore changes...
-              case 4:
                 expect(props.data!.loading).toBeTruthy();
                 break;
-              case 5:
+              case 4:
                 expect(props.data!.loading).toBeFalsy();
                 expect(props.data!.error).toBeFalsy();
                 expect(props.data!.allPeople).toEqual(
@@ -504,7 +499,7 @@ describe('[queries] errors', () => {
       </ApolloProvider>
     );
 
-    waitFor(() => expect(count).toBe(6)).then(resolve, reject);
+    waitFor(() => expect(count).toBe(5)).then(resolve, reject);
   });
 
   itAsync('does not throw/console.err an error after a component that received a network error is unmounted', (resolve, reject) => {

--- a/src/react/hoc/__tests__/queries/lifecycle.test.tsx
+++ b/src/react/hoc/__tests__/queries/lifecycle.test.tsx
@@ -46,8 +46,7 @@ describe('[queries] lifecycle', () => {
     const Container = graphql<Vars, Data, Vars>(query, {
       options: props => ({
         variables: props,
-        fetchPolicy: count === 0 ? 'cache-and-network' : 'cache-first',
-        notifyOnNetworkStatusChange: true,
+        fetchPolicy: count === 0 ? 'cache-and-network' : 'cache-first'
       })
     })(
       class extends React.Component<ChildProps<Vars, Data, Vars>> {
@@ -210,10 +209,7 @@ describe('[queries] lifecycle', () => {
     });
 
     const Container = graphql<Vars, Data, Vars>(query, {
-      options: props => ({
-        variables: props,
-        notifyOnNetworkStatusChange: true,
-      }),
+      options: props => ({ variables: props })
     })(
       class extends React.Component<ChildProps<Vars, Data, Vars>> {
         componentDidUpdate(prevProps: ChildProps<Vars, Data, Vars>) {
@@ -311,10 +307,7 @@ describe('[queries] lifecycle', () => {
       cache: new Cache({ addTypename: false })
     });
 
-    const Container = graphql<Vars, Data, Vars>(
-      query,
-      { options: { notifyOnNetworkStatusChange: true } },
-    )(
+    const Container = graphql<Vars, Data, Vars>(query)(
       class extends React.Component<ChildProps<Vars, Data, Vars>> {
         componentDidUpdate(prevProps: ChildProps<Vars, Data, Vars>) {
           try {
@@ -801,15 +794,11 @@ describe('[queries] lifecycle', () => {
         }
 
         render() {
-          try {
-            count++;
-            const user = this.props.data!.user;
-            const name = user ? user.name : '';
-            if (count === 3) {
-              expect(name).toBe('Luke Skywalker');
-            }
-          } catch (err) {
-            reject(err);
+          count++;
+          const user = this.props.data!.user;
+          const name = user ? user.name : '';
+          if (count === 2) {
+            expect(name).toBe('Luke Skywalker');
           }
           return null;
         }
@@ -884,30 +873,26 @@ describe('[queries] lifecycle', () => {
       <ApolloProvider client={client}>
         <QueryComponent query={query}>
           {({ loading, data, refetch }: any) => {
-            try {
-              if (!loading) {
-                if (!refetched) {
-                  expect(data.books[0].name).toEqual('ssrfirst');
-                  //setTimeout allows component to mount, which often happens
-                  //when waiting  ideally we should be able to call refetch
-                  //immediately However the subscription needs to start before
-                  //we update the data To get around this issue, we would need
-                  //to start the subscription before we render to the page. In
-                  //practice, this seems like an uncommon use case, since the
-                  //data you get is fresh, so one would wait for an interaction
-                  setTimeout(() => {
-                    refetch().then((refetchResult: any) => {
-                      expect(refetchResult.data.books[0].name).toEqual('first');
-                      done = true;
-                    });
+            if (!loading) {
+              if (!refetched) {
+                expect(data.books[0].name).toEqual('ssrfirst');
+                //setTimeout allows component to mount, which often happens
+                //when waiting  ideally we should be able to call refetch
+                //immediately However the subscription needs to start before
+                //we update the data To get around this issue, we would need
+                //to start the subscription before we render to the page. In
+                //practice, this seems like an uncommon use case, since the
+                //data you get is fresh, so one would wait for an interaction
+                setTimeout(() => {
+                  refetch().then((refetchResult: any) => {
+                    expect(refetchResult.data.books[0].name).toEqual('first');
+                    done = true;
                   });
-                  refetched = true;
-                } else {
-                  expect(data.books[0].name).toEqual('first');
-                }
+                });
+                refetched = true;
+              } else {
+                expect(data.books[0].name).toEqual('first');
               }
-            } catch (err) {
-              reject(err);
             }
             return <p> stub </p>;
           }}

--- a/src/react/hoc/__tests__/queries/loading.test.tsx
+++ b/src/react/hoc/__tests__/queries/loading.test.tsx
@@ -635,10 +635,7 @@ describe('[queries] loading', () => {
 
     const Container = connect(
       graphql<Props, Data, Vars>(query, {
-        options: ({ first }) => ({
-          variables: { first },
-          notifyOnNetworkStatusChange: true,
-        })
+        options: ({ first }) => ({ variables: { first } })
       })(
         class extends React.Component<ChildProps<Props, Data, Vars>> {
           render() {
@@ -757,8 +754,7 @@ describe('[queries] loading', () => {
         graphql<Props, Data, Vars>(query, {
           options: ({ first }) => ({
             variables: { first },
-            fetchPolicy: 'network-only',
-            notifyOnNetworkStatusChange: true,
+            fetchPolicy: 'network-only'
           })
         })(
           class extends React.Component<ChildProps<Props, Data, Vars>> {
@@ -778,6 +774,7 @@ describe('[queries] loading', () => {
                     expect(props.data!.loading).toBeFalsy(); // has initial data
                     expect(props.data!.allPeople).toEqual(data.allPeople);
                     break;
+
                   case 3:
                     expect(props.data!.loading).toBeTruthy(); // on variables change
                     break;

--- a/src/react/hoc/__tests__/queries/observableQuery.test.tsx
+++ b/src/react/hoc/__tests__/queries/observableQuery.test.tsx
@@ -446,9 +446,7 @@ describe('[queries] observableQuery', () => {
             if (count === 2) {
               expect(loading).toBe(false);
               expect(allPeople).toEqual(dataOne.allPeople);
-              setTimeout(() => {
-                refetch();
-              });
+              refetch();
             }
             if (count === 3) {
               expect(loading).toBe(false);

--- a/src/react/hoc/__tests__/queries/skip.test.tsx
+++ b/src/react/hoc/__tests__/queries/skip.test.tsx
@@ -166,8 +166,7 @@ describe('[queries] skip', () => {
       options: ({ person }) => ({
         variables: {
           id: person!.id
-        },
-        notifyOnNetworkStatusChange: true,
+        }
       })
     })(
       class extends React.Component<ChildProps<Props, Data, Vars>> {
@@ -176,13 +175,13 @@ describe('[queries] skip', () => {
             const { props } = this;
             switch (count) {
               case 0:
-                expect(props.data!.loading).toBe(true);
-                break;
               case 1:
-                expect(props.data!.loading).toBe(false);
-                expect(props.data!.allPeople).toEqual(data.allPeople);
+                expect(props.data!.loading).toBeTruthy();
                 break;
               case 2:
+                expect(props.data!.allPeople).toEqual(data.allPeople);
+                break;
+              case 3:
                 expect(renderCount).toBe(3);
                 break;
             }
@@ -219,7 +218,7 @@ describe('[queries] skip', () => {
       </ApolloProvider>
     );
 
-    waitFor(() => expect(count).toBe(2)).then(resolve, reject);
+    waitFor(() => expect(count).toBe(3)).then(resolve, reject);
   });
 
   itAsync("doesn't run options or props when skipped, including option.client", (resolve, reject) => {
@@ -664,21 +663,28 @@ describe('[queries] skip', () => {
               case 3:
                 // This render is triggered after setting skip to true. Now
                 // let's set skip to false to re-trigger the query.
-                expect(this.props.skip).toBe(true);
-                expect(this.props.data).toBeUndefined();
-                expect(ranQuery).toBe(1);
                 setTimeout(() => {
                   this.props.setSkip(false);
                 }, 10);
-                break;
+                // fallthrough
               case 4:
+                expect(this.props.skip).toBe(true);
+                expect(this.props.data).toBeUndefined();
+                expect(ranQuery).toBe(1);
+                break;
+              case 5:
                 expect(this.props.skip).toBe(false);
                 expect(this.props.data!.loading).toBe(true);
                 expect(this.props.data.allPeople).toEqual(data.allPeople);
                 expect(ranQuery).toBe(1);
                 break;
-              case 5:
+              case 6:
                 expect(this.props.skip).toBe(false);
+                expect(this.props.data!.loading).toBe(true);
+                expect(this.props.data.allPeople).toEqual(data.allPeople);
+                expect(ranQuery).toBe(2);
+                break;
+              case 7:
                 expect(this.props.data!.loading).toBe(false);
                 expect(this.props.data.allPeople).toEqual(nextData.allPeople);
                 expect(ranQuery).toBe(2);
@@ -690,13 +696,13 @@ describe('[queries] skip', () => {
                   this.props.data.refetch();
                 }, 10);
                 break;
-              case 6:
+              case 8:
                 expect(this.props.skip).toBe(false);
                 expect(this.props.data!.loading).toBe(true);
                 expect(this.props.data.allPeople).toEqual(nextData.allPeople);
                 expect(ranQuery).toBe(3);
                 break;
-              case 7:
+              case 9:
                 // The next batch of data has loaded.
                 expect(this.props.skip).toBe(false);
                 expect(this.props.data!.loading).toBe(false);
@@ -733,7 +739,7 @@ describe('[queries] skip', () => {
       </ApolloProvider>
     );
 
-    waitFor(() => expect(count).toEqual(7)).then(resolve, reject);
+    waitFor(() => expect(count).toEqual(9)).then(resolve, reject);
   }));
 
   it('removes the injected props if skip becomes true', async () => {

--- a/src/react/hoc/__tests__/ssr/getDataFromTree.test.tsx
+++ b/src/react/hoc/__tests__/ssr/getDataFromTree.test.tsx
@@ -1,4 +1,3 @@
-/** @jest-environment node */
 import React from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom/server';

--- a/src/react/hoc/__tests__/ssr/server.test.tsx
+++ b/src/react/hoc/__tests__/ssr/server.test.tsx
@@ -1,4 +1,3 @@
-/** @jest-environment node */
 import React from 'react';
 import {
   print,

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { GraphQLError } from 'graphql';
 import gql from 'graphql-tag';
 import { renderHook } from '@testing-library/react-hooks';
 
@@ -261,8 +262,9 @@ describe('useLazyQuery Hook', () => {
     expect(result.current[1].data).toEqual({ hello: 'world 1' });
 
     setTimeout(() => execute());
+
     await waitForNextUpdate();
-    expect(result.current[1].loading).toBe(true);
+    expect(result.current[1].loading).toBe(false);
     expect(result.current[1].data).toEqual({ hello: 'world 1' });
 
     await waitForNextUpdate();
@@ -449,6 +451,7 @@ describe('useLazyQuery Hook', () => {
     expect(result.current[1].previousData).toBe(undefined);
 
     setTimeout(() => execute({ variables: { id: 2 }}));
+
     await waitForNextUpdate();
     expect(result.current[1].loading).toBe(true);
     expect(result.current[1].data).toBe(undefined);
@@ -529,8 +532,10 @@ describe('useLazyQuery Hook', () => {
     expect(result.current[1].loading).toBe(false);
     expect(result.current[1].data).toBe(undefined);
     const execute = result.current[0];
-    const mock = jest.fn();
-    setTimeout(() => mock(execute()));
+    let executeResult: any;
+    setTimeout(() => {
+      executeResult = execute();
+    });
 
     await waitForNextUpdate();
     expect(result.current[1].loading).toBe(true);
@@ -538,9 +543,221 @@ describe('useLazyQuery Hook', () => {
     await waitForNextUpdate();
     expect(result.current[1].loading).toBe(false);
     expect(result.current[1].data).toEqual({ hello: 'world' });
+    await expect(executeResult).resolves.toEqual(result.current[1]);
+  });
 
-    expect(mock).toHaveBeenCalledTimes(1);
-    expect(mock.mock.calls[0][0]).toBeInstanceOf(Promise);
-    expect(await mock.mock.calls[0][0]).toEqual(result.current[1]);
+  it('should have matching results from execution function and hook', async () => {
+    const query = gql`
+      query GetCountries($filter: String) {
+        countries(filter: $filter) {
+          code
+          name
+        }
+      }
+    `;
+
+    const mocks = [
+      {
+        request: {
+          query,
+          variables: {
+            filter: "PA",
+          },
+        },
+        result: {
+          data: {
+            countries: {
+              code: "PA",
+              name: "Panama",
+            },
+          },
+        },
+        delay: 20,
+      },
+      {
+        request: {
+          query,
+          variables: {
+            filter: "BA",
+          },
+        },
+        result: {
+          data: {
+            countries: {
+              code: "BA",
+              name: "Bahamas",
+            },
+          },
+        },
+        delay: 20,
+      },
+    ];
+
+    const { result, waitForNextUpdate } = renderHook(
+      () => useLazyQuery(query),
+      {
+        wrapper: ({ children }) => (
+          <MockedProvider mocks={mocks}>
+            {children}
+          </MockedProvider>
+        ),
+      },
+    );
+
+    expect(result.current[1].loading).toBe(false);
+    expect(result.current[1].data).toBe(undefined);
+    const execute = result.current[0];
+    let executeResult: any;
+    setTimeout(() => {
+      executeResult = execute({ variables: { filter: "PA" } });
+    });
+
+    await waitForNextUpdate();
+    expect(result.current[1].loading).toBe(true);
+
+    await waitForNextUpdate();
+    expect(result.current[1].loading).toBe(false);
+    expect(result.current[1].data).toEqual({
+      countries: {
+        code: "PA",
+        name: "Panama",
+      },
+    });
+
+    expect(executeResult).toBeInstanceOf(Promise);
+    expect((await executeResult).data).toEqual({
+      countries: {
+        code: "PA",
+        name: "Panama",
+      },
+    });
+
+    setTimeout(() => {
+      executeResult = execute({ variables: { filter: "BA" } });
+    });
+
+    await waitForNextUpdate();
+    // TODO: Get rid of this render.
+
+    await waitForNextUpdate();
+    expect(result.current[1].loading).toBe(false);
+    expect(result.current[1].data).toEqual({
+      countries: {
+        code: "BA",
+        name: "Bahamas",
+      },
+    });
+
+    expect(executeResult).toBeInstanceOf(Promise);
+    expect((await executeResult).data).toEqual({
+      countries: {
+        code: "BA",
+        name: "Bahamas",
+      },
+    });
+  });
+
+  it('the promise should reject with errors the “way useMutation does”', async () => {
+    const query = gql`{ hello }`;
+    const mocks = [
+      {
+        request: { query },
+        result: {
+          errors: [new GraphQLError('error 1')],
+        },
+        delay: 20,
+      },
+      {
+        request: { query },
+        result: {
+          errors: [new GraphQLError('error 2')],
+        },
+        delay: 20,
+      },
+    ];
+
+    const { result, waitForNextUpdate } = renderHook(
+      () => useLazyQuery(query),
+      {
+        wrapper: ({ children }) => (
+          <MockedProvider mocks={mocks}>
+            {children}
+          </MockedProvider>
+        ),
+      },
+    );
+
+    const execute = result.current[0];
+    let executeResult: any;
+    expect(result.current[1].loading).toBe(false);
+    expect(result.current[1].data).toBe(undefined);
+    setTimeout(() => {
+      executeResult = execute();
+      executeResult.catch(() => {});
+    });
+
+    await waitForNextUpdate();
+    expect(result.current[1].loading).toBe(true);
+    expect(result.current[1].data).toBe(undefined);
+    expect(result.current[1].error).toBe(undefined);
+
+    await waitForNextUpdate();
+    expect(result.current[1].loading).toBe(false);
+    expect(result.current[1].data).toBe(undefined);
+    expect(result.current[1].error).toEqual(new Error('error 1'));
+
+    await expect(executeResult).rejects.toEqual(new Error('error 1'));
+
+    setTimeout(() => {
+      executeResult = execute();
+      executeResult.catch(() => {});
+    });
+
+    await waitForNextUpdate();
+    expect(result.current[1].loading).toBe(false);
+    expect(result.current[1].data).toBe(undefined);
+    expect(result.current[1].error).toEqual(new Error('error 1'));
+
+    await waitForNextUpdate();
+    expect(result.current[1].loading).toBe(false);
+    expect(result.current[1].data).toBe(undefined);
+    expect(result.current[1].error).toEqual(new Error('error 2'));
+
+    await expect(executeResult).rejects.toEqual(new Error('error 2'));
+  });
+
+  it('the promise should not cause an unhandled rejection', async () => {
+    const query = gql`{ hello }`;
+    const mocks = [
+      {
+        request: { query },
+        result: {
+          errors: [new GraphQLError('error 1')],
+        },
+      },
+    ];
+
+    const { result, waitForNextUpdate } = renderHook(
+      () => useLazyQuery(query),
+      {
+        wrapper: ({ children }) => (
+          <MockedProvider mocks={mocks}>
+            {children}
+          </MockedProvider>
+        ),
+      },
+    );
+
+    const execute = result.current[0];
+    expect(result.current[1].loading).toBe(false);
+    expect(result.current[1].data).toBe(undefined);
+    setTimeout(() => {
+      execute();
+    });
+
+    await waitForNextUpdate();
+
+    // Making sure the rejection triggers a test failure.
+    await new Promise((resolve) => setTimeout(resolve, 50));
   });
 });

--- a/src/react/hooks/useApolloClient.ts
+++ b/src/react/hooks/useApolloClient.ts
@@ -11,8 +11,8 @@ export function useApolloClient(
   invariant(
     !!client,
     'Could not find "client" in the context or passed in as an option. ' +
-    'Wrap the root component in an <ApolloProvider>, or pass an ApolloClient' +
-    'ApolloClient instance in via options.',
+    'Wrap the root component in an <ApolloProvider>, or pass an ApolloClient ' +
+    'instance in via options.',
   );
 
   return client;

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -1,10 +1,9 @@
 import { DocumentNode } from 'graphql';
 import { TypedDocumentNode } from '@graphql-typed-document-node/core';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import {
   LazyQueryHookOptions,
-  LazyQueryResult,
   QueryLazyOptions,
   QueryTuple,
 } from '../types/types';
@@ -25,54 +24,21 @@ export function useLazyQuery<TData = any, TVariables = OperationVariables>(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
   options?: LazyQueryHookOptions<TData, TVariables>
 ): QueryTuple<TData, TVariables> {
-  const [execution, setExecution] = useState<
-    {
-      called: boolean,
-      options?: QueryLazyOptions<TVariables>,
-      resolves: Array<(result: LazyQueryResult<TData, TVariables>) => void>,
-    }
-  >({
+  const [execution, setExecution] = useState<{
+    called: boolean,
+    options?: QueryLazyOptions<TVariables>,
+  }>({
     called: false,
-    resolves: [],
   });
-
-  const execute = useCallback<
-    QueryTuple<TData, TVariables>[0]
-  >((executeOptions?: QueryLazyOptions<TVariables>) => {
-    let resolve!: (result: LazyQueryResult<TData, TVariables>) => void;
-    const promise = new Promise<LazyQueryResult<TData, TVariables>>(
-      (resolve1) => (resolve = resolve1),
-    );
-    setExecution((execution) => {
-      if (execution.called) {
-        result && result.refetch(executeOptions?.variables);
-      }
-
-      return {
-        called: true,
-        resolves: [...execution.resolves, resolve],
-        options: executeOptions,
-      };
-    });
-
-    return promise;
-  }, []);
 
   let result = useQuery<TData, TVariables>(query, {
     ...options,
     ...execution.options,
-    // We don’t set skip to execution.called, because we need useQuery to call
-    // addQueryPromise, so that ssr calls waits for execute to be called.
+    // We don’t set skip to execution.called, because some useQuery SSR code
+    // checks skip for some reason.
     fetchPolicy: execution.called ? options?.fetchPolicy : 'standby',
     skip: undefined,
   });
-  useEffect(() => {
-    const { resolves } = execution;
-    if (!result.loading && resolves.length) {
-      setExecution((execution) => ({ ...execution, resolves: [] }));
-      resolves.forEach((resolve) => resolve(result));
-    }
-  }, [result, execution]);
 
   if (!execution.called) {
     result = {
@@ -80,19 +46,50 @@ export function useLazyQuery<TData = any, TVariables = OperationVariables>(
       loading: false,
       data: void 0 as unknown as TData,
       error: void 0,
-      // TODO: fix the type of result
-      called: false as any,
+      called: false,
     };
+  }
 
+  // We use useMemo here to make sure the eager methods have a stable identity.
+  const eagerMethods = useMemo(() => {
+    const eagerMethods: Record<string, any> = {};
     for (const key of EAGER_METHODS) {
       const method = result[key];
-      result[key] = (...args: any) => {
+      eagerMethods[key] = (...args: any) => {
         setExecution((execution) => ({ ...execution, called: true }));
         return (method as any)(...args);
       };
     }
-  }
 
-  // TODO: fix the type of result
-  return [execute, result as LazyQueryResult<TData, TVariables>];
+    return eagerMethods;
+  }, []);
+
+  result.error = result.error || void 0;
+  Object.assign(result, eagerMethods);
+
+  const execute = useCallback<
+    QueryTuple<TData, TVariables>[0]
+  >((executeOptions?: QueryLazyOptions<TVariables>) => {
+    setExecution({ called: true, options: executeOptions });
+    const promise = result.refetch(executeOptions?.variables).then((result1) => {
+      const result2 = {
+        ...result,
+        data: result1.data,
+        error: result1.error,
+        called: true,
+        loading: false,
+      };
+
+      Object.assign(result2, eagerMethods);
+      return result2;
+    });
+
+    // Because the return value of `useLazyQuery` is usually floated, we need
+    // to catch the promise to prevent unhandled rejections.
+    promise.catch(() => {});
+
+    return promise;
+  }, []);
+
+  return [execute, result];
 }

--- a/src/react/hooks/useSubscription.ts
+++ b/src/react/hooks/useSubscription.ts
@@ -45,14 +45,16 @@ export function useSubscription<TData = any, TVariables = OperationVariables>(
       shouldResubscribe = !!shouldResubscribe(options!);
     }
 
-    if (options?.skip && !options?.skip !== !ref.current.options?.skip) {
-      setResult({
-        loading: false,
-        data: void 0,
-        error: void 0,
-        variables: options?.variables,
-      });
-      setObservable(null);
+    if (options?.skip) {
+      if (!options?.skip !== !ref.current.options?.skip) {
+        setResult({
+          loading: false,
+          data: void 0,
+          error: void 0,
+          variables: options?.variables,
+        });
+        setObservable(null);
+      }
     } else if (
       shouldResubscribe !== false && (
         client !== ref.current.client ||

--- a/src/react/ssr/RenderPromises.ts
+++ b/src/react/ssr/RenderPromises.ts
@@ -44,22 +44,21 @@ export class RenderPromises {
   // Registers the server side rendered observable.
   public registerSSRObservable<TData, TVariables>(
     observable: ObservableQuery<any, TVariables>,
-    options: QueryDataOptions<TData, TVariables>
+    props: QueryDataOptions<TData, TVariables>
   ) {
     if (this.stopped) return;
-    this.lookupQueryInfo(options).observable = observable;
+    this.lookupQueryInfo(props).observable = observable;
   }
 
   // Get's the cached observable that matches the SSR Query instances query and variables.
   public getSSRObservable<TData, TVariables>(
-    options: QueryDataOptions<TData, TVariables>
+    props: QueryDataOptions<TData, TVariables>
   ): ObservableQuery<any, TVariables> | null {
-    return this.lookupQueryInfo(options).observable;
+    return this.lookupQueryInfo(props).observable;
   }
 
   public addQueryPromise(
     queryInstance: QueryData,
-    // TODO: This callback is a noop on the useQuery side.
     finish: () => React.ReactNode
   ): React.ReactNode {
     if (!this.stopped) {
@@ -67,14 +66,15 @@ export class RenderPromises {
       if (!info.seen) {
         this.queryPromises.set(
           queryInstance.getOptions(),
-          new Promise(resolve => resolve(queryInstance.fetchData()))
+          new Promise(resolve => {
+            resolve(queryInstance.fetchData());
+          })
         );
         // Render null to abandon this subtree for this rendering, so that we
         // can wait for the data to arrive.
         return null;
       }
     }
-
     return finish();
   }
 

--- a/src/react/ssr/__tests__/useLazyQuery.test.tsx
+++ b/src/react/ssr/__tests__/useLazyQuery.test.tsx
@@ -40,7 +40,7 @@ describe('useLazyQuery Hook SSR', () => {
     const client = new ApolloClient({
       cache: new InMemoryCache(),
       link,
-      ssrMode: true,
+      ssrMode: true
     });
 
     const Component = () => {

--- a/src/react/ssr/__tests__/useQuery.test.tsx
+++ b/src/react/ssr/__tests__/useQuery.test.tsx
@@ -1,4 +1,3 @@
-/** @jest-environment node */
 import React from 'react';
 import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -78,7 +78,7 @@ export interface QueryResult<TData = any, TVariables = OperationVariables>
   error?: ApolloError;
   loading: boolean;
   networkStatus: NetworkStatus;
-  called: true;
+  called: boolean;
 }
 
 export interface QueryDataOptions<TData = any, TVariables = OperationVariables>


### PR DESCRIPTION
We are considering an accelerated release schedule for Apollo Client v3.6, which will include low-risk/additive changes from `release-3.6`, while postponing experimental changes depending on React 18 (which has not been finalized) to the next minor release, v3.7. This PR represents the current `release-3.6` branch with PR #8785 reverted (see below for details). Specifically, this PR reverts commit 7f0d459c7b3b94c5de1561433c006a6efa017007 (#8785) and follow-up commit 5328dae6756fab6f8f27e8855cfb7ad5932ec03c.

If/once this PR looks good (note: we can manually drop any changes we don't like), we can merge it into `release-3.6`, then create a new `release-3.7` branch from `release-3.6`, and cherry-pick the inverse of this commit onto that new branch, effectively recreating the `useSyncExternalStore` work. This refactoring should allow us to continue releasing v3.6 betas without the risk/complexity introduced by `useSyncExternalStore`. We are still committed to implementing that API and fully supporting React 18, with prerelease availability continuing uninterrupted in the v3.7 betas.

Now, because there have been several merges of `main` onto `release-3.6` since those commits, and some of those merges involve `useSyncExternalStore`-related code, I was not able to obtain a good state simply by reverting the commits and manually resolving the conflicts.

Instead, I removed the commits during an interactive Git rebase, using `--rebase-merges` to replay/recreate merge commits (rather than dropping them, as rebase usually does). Once I verified tests were passing after this rebase, I constructed the current commit from the difference between the branches, which should allow us to keep the current history from before the rebase, with this commit achieving the same final state as after the rebase.