### PR TITLE
Release 3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Apollo Client 3.7.0 (not yet released)
+
+### Improvements
+
+- Reimplement `useQuery` and `useLazyQuery` to use the [proposed `useSyncExternalStore` API](https://github.com/reactwg/react-18/discussions/86) from React 18. <br/>
+  [@brainkim](https://github.com/brainkim) in [#8785](https://github.com/apollographql/apollo-client/pull/8785)
+
 ## Apollo Client 3.6.0 (not yet released)
 
 ### Improvements
@@ -7,11 +14,6 @@
 
 - Add `GraphQLWsLink` in `@apollo/client/ws/subscriptions`. This link is similar to the existing `WebSocketLink` in `@apollo/client/link/ws`, but uses the newer [`graphql-ws`](https://www.npmjs.com/package/graphql-ws) package and protocol instead of the older `subscriptions-transport-ws` implementation.
   [@glasser](https://github.com/glasser) in [#9369](https://github.com/apollographql/apollo-client/pull/9369)
-
-### Postponed to v3.7
-
-- Tentatively reimplement `useQuery` and `useLazyQuery` to use the [proposed `useSyncExternalStore` API](https://github.com/reactwg/react-18/discussions/86) from React 18. <br/>
-  [@brainkim](https://github.com/brainkim) in [#8785](https://github.com/apollographql/apollo-client/pull/8785)
 
 ## Apollo Client 3.5.8 (2022-01-24)
 


### PR DESCRIPTION
Like the (still in progress!) [Release 3.6.0 PR](https://github.com/apollographql/apollo-client/pull/9067), this PR will serve to collect significant new features, deprecation warnings, and minor breaking changes that we intend to release in `@apollo/client@3.7.0`.

If you want to test these changes, run
```sh
npm i @apollo/client@3.7.0-beta.n
```
in your application, where the `n` in `-beta.n` comes from the most recent commit message like
```
Bump @apollo/client npm version to 3.7.0-beta.n.
```

Until v3.7.0 is released, we can continue merging smaller changes into `main` or `release-3.6` and releasing them, without worrying about larger changes on the `release-3.7` branch.

Initial list of noteworthy changes in v3.7:
- [ ] Reimplement `useQuery` and `useLazyQuery` to use the [proposed `useSyncExternalStore` API](https://github.com/reactwg/react-18/discussions/86) from React 18.
  [@brainkim](https://github.com/brainkim) in [#8785](https://github.com/apollographql/apollo-client/pull/8785)