### PR TITLE
Restore `useSyncExternalStore` changes from PR #8785.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@types/node": "16.11.21",
         "@types/react": "17.0.34",
         "@types/react-dom": "17.0.2",
+        "@types/use-sync-external-store": "^0.0.3",
         "acorn": "8.6.0",
         "bundlesize": "0.18.1",
         "cross-fetch": "3.1.5",
@@ -62,6 +63,7 @@
         "ts-jest": "27.1.3",
         "ts-node": "10.4.0",
         "typescript": "4.5.2",
+        "use-sync-external-store": "1.0.0-rc.0",
         "wait-for-observables": "1.0.3",
         "whatwg-fetch": "3.6.2"
       },
@@ -71,8 +73,9 @@
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0",
         "graphql-ws": "^5.5.5",
-        "react": "^16.8.0 || ^17.0.0",
-        "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0-beta",
+        "subscriptions-transport-ws": "^0.9.0 || ^0.11.0",
+        "use-sync-external-store": "^1.0.0 || ^1.0.0-rc || ^1.0.0-beta"
       },
       "peerDependenciesMeta": {
         "graphql-ws": {
@@ -82,6 +85,9 @@
           "optional": true
         },
         "subscriptions-transport-ws": {
+          "optional": true
+        },
+        "use-sync-external-store": {
           "optional": true
         }
       }
@@ -1363,6 +1369,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
+      "dev": true
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -5914,6 +5926,15 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.0.0-rc.0.tgz",
+      "integrity": "sha512-0U9Xlc2QDFzSGMB0DvcJQL0+DIdxDPJC7mnZlYFbl7wrSrPMcs89X5TVkNB6Dzg618m8lZop+U+J6ow3vq9RAQ==",
+      "dev": true,
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0-rc"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -7354,6 +7375,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
+      "dev": true
+    },
+    "@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==",
       "dev": true
     },
     "@types/yargs": {
@@ -10857,6 +10884,13 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
+    },
+    "use-sync-external-store": {
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.0.0-rc.0.tgz",
+      "integrity": "sha512-0U9Xlc2QDFzSGMB0DvcJQL0+DIdxDPJC7mnZlYFbl7wrSrPMcs89X5TVkNB6Dzg618m8lZop+U+J6ow3vq9RAQ==",
+      "dev": true,
+      "requires": {}
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -65,8 +65,9 @@
   "peerDependencies": {
     "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0",
     "graphql-ws": "^5.5.5",
-    "react": "^16.8.0 || ^17.0.0",
-    "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0-beta",
+    "subscriptions-transport-ws": "^0.9.0 || ^0.11.0",
+    "use-sync-external-store": "^1.0.0 || ^1.0.0-rc || ^1.0.0-beta"
   },
   "peerDependenciesMeta": {
     "graphql-ws": {
@@ -76,6 +77,9 @@
       "optional": true
     },
     "subscriptions-transport-ws": {
+      "optional": true
+    },
+    "use-sync-external-store": {
       "optional": true
     }
   },
@@ -108,6 +112,7 @@
     "@types/node": "16.11.21",
     "@types/react": "17.0.34",
     "@types/react-dom": "17.0.2",
+    "@types/use-sync-external-store": "^0.0.3",
     "acorn": "8.6.0",
     "bundlesize": "0.18.1",
     "cross-fetch": "3.1.5",
@@ -133,6 +138,7 @@
     "ts-jest": "27.1.3",
     "ts-node": "10.4.0",
     "typescript": "4.5.2",
+    "use-sync-external-store": "1.0.0-rc.0",
     "wait-for-observables": "1.0.3",
     "whatwg-fetch": "3.6.2"
   },

--- a/src/react/components/__tests__/client/Mutation.test.tsx
+++ b/src/react/components/__tests__/client/Mutation.test.tsx
@@ -1021,7 +1021,11 @@ describe('General Mutation testing', () => {
       return (
         <Mutation mutation={mutation} refetchQueries={refetchQueries}>
           {(createTodo: any, resultMutation: any) => (
-            <Query query={query} variables={variables}>
+            <Query
+              query={query}
+              variables={variables}
+              notifyOnNetworkStatusChange={true}
+            >
               {(resultQuery: any) => {
                 try {
                   if (count === 0) {
@@ -1047,13 +1051,16 @@ describe('General Mutation testing', () => {
                     // mutation loading
                     expect(resultMutation.loading).toBe(true);
                   } else if (count === 6) {
-                    // mutation loaded
-                    expect(resultMutation.loading).toBe(false);
+                    // mutation still loading???
+                    expect(resultMutation.loading).toBe(true);
                   } else if (count === 7) {
+                    expect(resultQuery.loading).toBe(true);
+                    expect(resultMutation.loading).toBe(false);
+                  } else if (count === 8) {
                     // query refetched
+                    expect(resultQuery.data).toEqual(peopleData3);
                     expect(resultQuery.loading).toBe(false);
                     expect(resultMutation.loading).toBe(false);
-                    expect(resultQuery.data).toEqual(peopleData3);
                   }
                   count++;
                 } catch (err) {
@@ -1074,7 +1081,7 @@ describe('General Mutation testing', () => {
     );
 
     waitFor(() => {
-      expect(count).toEqual(8);
+      expect(count).toBe(9);
     }).then(resolve, reject);
   }));
 

--- a/src/react/components/__tests__/client/Query.test.tsx
+++ b/src/react/components/__tests__/client/Query.test.tsx
@@ -1229,7 +1229,11 @@ describe('Query component', () => {
           const { variables } = this.state;
 
           return (
-            <AllPeopleQuery query={query} variables={variables}>
+            <AllPeopleQuery
+              query={query}
+              variables={variables}
+              notifyOnNetworkStatusChange={true}
+            >
               {(result: any) => {
                 try {
                   switch (count) {
@@ -1717,35 +1721,40 @@ describe('Query component', () => {
           <AllPeopleQuery
             query={query}
             variables={variables}
+            notifyOnNetworkStatusChange={true}
             onCompleted={this.onCompleted}
           >
             {({ loading, data }: any) => {
-              switch (renderCount) {
-                case 0:
-                  expect(loading).toBe(true);
-                  break;
-                case 1:
-                case 2:
-                  expect(loading).toBe(false);
-                  expect(data).toEqual(data1);
-                  break;
-                case 3:
-                  expect(loading).toBe(true);
-                  break;
-                case 4:
-                  expect(loading).toBe(false);
-                  expect(data).toEqual(data2);
-                  setTimeout(() => {
-                    this.setState({ variables: { first: 1 } });
-                  });
-                case 5:
-                  expect(loading).toBe(false);
-                  expect(data).toEqual(data2);
-                  break;
-                case 6:
-                  expect(loading).toBe(false);
-                  expect(data).toEqual(data1);
-                  break;
+              try {
+                switch (renderCount) {
+                  case 0:
+                    expect(loading).toBe(true);
+                    break;
+                  case 1:
+                  case 2:
+                    expect(loading).toBe(false);
+                    expect(data).toEqual(data1);
+                    break;
+                  case 3:
+                    expect(loading).toBe(true);
+                    break;
+                  case 4:
+                    expect(loading).toBe(false);
+                    expect(data).toEqual(data2);
+                    setTimeout(() => {
+                      this.setState({ variables: { first: 1 } });
+                    });
+                  case 5:
+                    expect(loading).toBe(false);
+                    expect(data).toEqual(data2);
+                    break;
+                  case 6:
+                    expect(loading).toBe(false);
+                    expect(data).toEqual(data1);
+                    break;
+                }
+              } catch (err) {
+                reject(err);
               }
               renderCount += 1;
               return null;
@@ -1762,6 +1771,7 @@ describe('Query component', () => {
     );
 
     waitFor(() => {
+      expect(renderCount).toBe(7);
       expect(onCompletedCallCount).toBe(3);
     }).then(resolve, reject);
   });

--- a/src/react/components/__tests__/ssr/getDataFromTree.test.tsx
+++ b/src/react/components/__tests__/ssr/getDataFromTree.test.tsx
@@ -1,3 +1,4 @@
+/** @jest-environment node */
 import React from 'react';
 import gql from 'graphql-tag';
 import { DocumentNode } from 'graphql';

--- a/src/react/components/__tests__/ssr/server.test.tsx
+++ b/src/react/components/__tests__/ssr/server.test.tsx
@@ -1,3 +1,4 @@
+/** @jest-environment node */
 import React from 'react';
 import {
   print,

--- a/src/react/hoc/__tests__/queries/errors.test.tsx
+++ b/src/react/hoc/__tests__/queries/errors.test.tsx
@@ -216,7 +216,10 @@ describe('[queries] errors', () => {
       let iteration = 0;
       let done = false;
       const ErrorContainer = withState('var', 'setVar', 1)(
-        graphql<Props, Data, Vars>(query)(
+        graphql<Props, Data, Vars>(
+          query,
+          { options: { notifyOnNetworkStatusChange: true }},
+        )(
           class extends React.Component<ChildProps<Props, Data, Vars>> {
             componentDidUpdate() {
               const { props } = this;
@@ -234,7 +237,7 @@ describe('[queries] errors', () => {
                   );
                 } else if (iteration === 3) {
                   // variables have changed, wee are loading again but also have data
-                  expect(props.data!.loading).toBeTruthy();
+                  expect(props.data!.loading).toBe(true);
                 } else if (iteration === 4) {
                   // the second request had an error!
                   expect(props.data!.error).toBeTruthy();
@@ -256,8 +259,8 @@ describe('[queries] errors', () => {
             render() {
               return null;
             }
-          }
-        )
+          },
+        ),
       );
 
       render(
@@ -470,9 +473,11 @@ describe('[queries] errors', () => {
                   });
                 break;
               case 3:
+                // Second render was added by useSyncExternalStore changes...
+              case 4:
                 expect(props.data!.loading).toBeTruthy();
                 break;
-              case 4:
+              case 5:
                 expect(props.data!.loading).toBeFalsy();
                 expect(props.data!.error).toBeFalsy();
                 expect(props.data!.allPeople).toEqual(
@@ -499,7 +504,7 @@ describe('[queries] errors', () => {
       </ApolloProvider>
     );
 
-    waitFor(() => expect(count).toBe(5)).then(resolve, reject);
+    waitFor(() => expect(count).toBe(6)).then(resolve, reject);
   });
 
   itAsync('does not throw/console.err an error after a component that received a network error is unmounted', (resolve, reject) => {

--- a/src/react/hoc/__tests__/queries/loading.test.tsx
+++ b/src/react/hoc/__tests__/queries/loading.test.tsx
@@ -635,7 +635,10 @@ describe('[queries] loading', () => {
 
     const Container = connect(
       graphql<Props, Data, Vars>(query, {
-        options: ({ first }) => ({ variables: { first } })
+        options: ({ first }) => ({
+          variables: { first },
+          notifyOnNetworkStatusChange: true,
+        })
       })(
         class extends React.Component<ChildProps<Props, Data, Vars>> {
           render() {
@@ -754,7 +757,8 @@ describe('[queries] loading', () => {
         graphql<Props, Data, Vars>(query, {
           options: ({ first }) => ({
             variables: { first },
-            fetchPolicy: 'network-only'
+            fetchPolicy: 'network-only',
+            notifyOnNetworkStatusChange: true,
           })
         })(
           class extends React.Component<ChildProps<Props, Data, Vars>> {
@@ -774,7 +778,6 @@ describe('[queries] loading', () => {
                     expect(props.data!.loading).toBeFalsy(); // has initial data
                     expect(props.data!.allPeople).toEqual(data.allPeople);
                     break;
-
                   case 3:
                     expect(props.data!.loading).toBeTruthy(); // on variables change
                     break;

--- a/src/react/hoc/__tests__/queries/observableQuery.test.tsx
+++ b/src/react/hoc/__tests__/queries/observableQuery.test.tsx
@@ -446,7 +446,9 @@ describe('[queries] observableQuery', () => {
             if (count === 2) {
               expect(loading).toBe(false);
               expect(allPeople).toEqual(dataOne.allPeople);
-              refetch();
+              setTimeout(() => {
+                refetch();
+              });
             }
             if (count === 3) {
               expect(loading).toBe(false);

--- a/src/react/hoc/__tests__/queries/skip.test.tsx
+++ b/src/react/hoc/__tests__/queries/skip.test.tsx
@@ -166,7 +166,8 @@ describe('[queries] skip', () => {
       options: ({ person }) => ({
         variables: {
           id: person!.id
-        }
+        },
+        notifyOnNetworkStatusChange: true,
       })
     })(
       class extends React.Component<ChildProps<Props, Data, Vars>> {
@@ -175,13 +176,13 @@ describe('[queries] skip', () => {
             const { props } = this;
             switch (count) {
               case 0:
-              case 1:
-                expect(props.data!.loading).toBeTruthy();
+                expect(props.data!.loading).toBe(true);
                 break;
-              case 2:
+              case 1:
+                expect(props.data!.loading).toBe(false);
                 expect(props.data!.allPeople).toEqual(data.allPeople);
                 break;
-              case 3:
+              case 2:
                 expect(renderCount).toBe(3);
                 break;
             }
@@ -218,7 +219,7 @@ describe('[queries] skip', () => {
       </ApolloProvider>
     );
 
-    waitFor(() => expect(count).toBe(3)).then(resolve, reject);
+    waitFor(() => expect(count).toBe(2)).then(resolve, reject);
   });
 
   itAsync("doesn't run options or props when skipped, including option.client", (resolve, reject) => {
@@ -663,28 +664,21 @@ describe('[queries] skip', () => {
               case 3:
                 // This render is triggered after setting skip to true. Now
                 // let's set skip to false to re-trigger the query.
+                expect(this.props.skip).toBe(true);
+                expect(this.props.data).toBeUndefined();
+                expect(ranQuery).toBe(1);
                 setTimeout(() => {
                   this.props.setSkip(false);
                 }, 10);
-                // fallthrough
+                break;
               case 4:
-                expect(this.props.skip).toBe(true);
-                expect(this.props.data).toBeUndefined();
+                expect(this.props.skip).toBe(false);
+                expect(this.props.data!.loading).toBe(true);
+                expect(this.props.data.allPeople).toEqual(data.allPeople);
                 expect(ranQuery).toBe(1);
                 break;
               case 5:
                 expect(this.props.skip).toBe(false);
-                expect(this.props.data!.loading).toBe(true);
-                expect(this.props.data.allPeople).toEqual(data.allPeople);
-                expect(ranQuery).toBe(1);
-                break;
-              case 6:
-                expect(this.props.skip).toBe(false);
-                expect(this.props.data!.loading).toBe(true);
-                expect(this.props.data.allPeople).toEqual(data.allPeople);
-                expect(ranQuery).toBe(2);
-                break;
-              case 7:
                 expect(this.props.data!.loading).toBe(false);
                 expect(this.props.data.allPeople).toEqual(nextData.allPeople);
                 expect(ranQuery).toBe(2);
@@ -696,13 +690,13 @@ describe('[queries] skip', () => {
                   this.props.data.refetch();
                 }, 10);
                 break;
-              case 8:
+              case 6:
                 expect(this.props.skip).toBe(false);
                 expect(this.props.data!.loading).toBe(true);
                 expect(this.props.data.allPeople).toEqual(nextData.allPeople);
                 expect(ranQuery).toBe(3);
                 break;
-              case 9:
+              case 7:
                 // The next batch of data has loaded.
                 expect(this.props.skip).toBe(false);
                 expect(this.props.data!.loading).toBe(false);
@@ -739,7 +733,7 @@ describe('[queries] skip', () => {
       </ApolloProvider>
     );
 
-    waitFor(() => expect(count).toEqual(9)).then(resolve, reject);
+    waitFor(() => expect(count).toEqual(7)).then(resolve, reject);
   }));
 
   it('removes the injected props if skip becomes true', async () => {

--- a/src/react/hoc/__tests__/ssr/getDataFromTree.test.tsx
+++ b/src/react/hoc/__tests__/ssr/getDataFromTree.test.tsx
@@ -1,3 +1,4 @@
+/** @jest-environment node */
 import React from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom/server';

--- a/src/react/hoc/__tests__/ssr/server.test.tsx
+++ b/src/react/hoc/__tests__/ssr/server.test.tsx
@@ -1,3 +1,4 @@
+/** @jest-environment node */
 import React from 'react';
 import {
   print,

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -264,7 +264,7 @@ describe('useLazyQuery Hook', () => {
     setTimeout(() => execute());
 
     await waitForNextUpdate();
-    expect(result.current[1].loading).toBe(false);
+    expect(result.current[1].loading).toBe(true);
     expect(result.current[1].data).toEqual({ hello: 'world 1' });
 
     await waitForNextUpdate();
@@ -451,7 +451,6 @@ describe('useLazyQuery Hook', () => {
     expect(result.current[1].previousData).toBe(undefined);
 
     setTimeout(() => execute({ variables: { id: 2 }}));
-
     await waitForNextUpdate();
     expect(result.current[1].loading).toBe(true);
     expect(result.current[1].data).toBe(undefined);
@@ -532,10 +531,8 @@ describe('useLazyQuery Hook', () => {
     expect(result.current[1].loading).toBe(false);
     expect(result.current[1].data).toBe(undefined);
     const execute = result.current[0];
-    let executeResult: any;
-    setTimeout(() => {
-      executeResult = execute();
-    });
+    const mock = jest.fn();
+    setTimeout(() => mock(execute()));
 
     await waitForNextUpdate();
     expect(result.current[1].loading).toBe(true);
@@ -543,7 +540,10 @@ describe('useLazyQuery Hook', () => {
     await waitForNextUpdate();
     expect(result.current[1].loading).toBe(false);
     expect(result.current[1].data).toEqual({ hello: 'world' });
-    await expect(executeResult).resolves.toEqual(result.current[1]);
+
+    expect(mock).toHaveBeenCalledTimes(1);
+    expect(mock.mock.calls[0][0]).toBeInstanceOf(Promise);
+    expect(await mock.mock.calls[0][0]).toEqual(result.current[1]);
   });
 
   it('should have matching results from execution function and hook', async () => {

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -1378,7 +1378,6 @@ describe('useMutation Hook', () => {
           optimisticResponse,
           update(cache) {
             const result = cache.readQuery({ query: countQuery });
-
             cache.writeQuery({
               query: countQuery,
               data: {
@@ -1412,13 +1411,7 @@ describe('useMutation Hook', () => {
         });
       });
 
-      expect(result.current.query.loading).toBe(false);
-      expect(result.current.query.data).toEqual({ todoCount: 0 });
-      expect(result.current.mutation[1].loading).toBe(true);
-      expect(result.current.mutation[1].data).toBe(undefined);
       expect(finishedReobserving).toBe(false);
-
-      await waitForNextUpdate();
       expect(result.current.query.loading).toBe(false);
       expect(result.current.query.data).toEqual({ todoCount: 1 });
       expect(result.current.mutation[1].loading).toBe(true);
@@ -1569,7 +1562,7 @@ describe('useMutation Hook', () => {
       expect(result.current.query.data).toEqual(mocks[0].result.data);
 
       await waitForNextUpdate();
-      expect(result.current.query.loading).toBe(false);
+      expect(result.current.query.loading).toBe(true);
       expect(result.current.query.data).toEqual(mocks[0].result.data);
 
       await waitForNextUpdate();

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -158,7 +158,7 @@ describe('useQuery Hook', () => {
       );
 
       const { result, rerender, waitForNextUpdate } = renderHook(
-        ({ id }) => useQuery(query, { variables: { id }}),
+        ({ id }) => useQuery(query, { variables: { id } }),
         { wrapper, initialProps: { id: 1 } },
       );
       expect(result.current.loading).toBe(true);
@@ -210,7 +210,6 @@ describe('useQuery Hook', () => {
       await waitForNextUpdate();
       expect(result.current.loading).toBe(false);
       expect(result.current.data).toEqual({ hello: "world 1" });
-
 
       rerender({ id: 2 });
       expect(result.current.loading).toBe(true);
@@ -1585,6 +1584,7 @@ describe('useQuery Hook', () => {
       expect(result.current.loading).toBe(false);
       expect(result.current.data).toEqual(data1);
       expect(onCompleted).toHaveBeenLastCalledWith(data1);
+      expect(onCompleted).toHaveBeenCalledTimes(1);
 
       rerender({ variables: { first: 2 } });
       expect(result.current.loading).toBe(true);
@@ -1593,12 +1593,13 @@ describe('useQuery Hook', () => {
       expect(result.current.loading).toBe(false);
       expect(result.current.data).toEqual(data2);
       expect(onCompleted).toHaveBeenLastCalledWith(data2);
+      expect(onCompleted).toHaveBeenCalledTimes(2);
 
       rerender({ variables: { first: 1 } });
       expect(result.current.loading).toBe(false);
       expect(result.current.data).toEqual(data1);
-      expect(onCompleted).toHaveBeenLastCalledWith(data1);
 
+      expect(onCompleted).toHaveBeenLastCalledWith(data1);
       expect(onCompleted).toHaveBeenCalledTimes(3);
     });
   });

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -127,27 +127,19 @@ describe('useSubscription Hook', () => {
       }
     `;
 
-    const onSetup = jest.fn();
     const link = new MockSubscriptionLink();
-    link.onSetup(onSetup);
     const client = new ApolloClient({
       link,
       cache: new Cache({ addTypename: false })
     });
 
     const onSubscriptionData = jest.fn();
-    const { result, unmount, waitForNextUpdate, rerender } = renderHook(
-      ({ variables }) => useSubscription(subscription, {
-        variables,
-        skip: true,
+    const { result, unmount, waitForNextUpdate } = renderHook(
+      () => useSubscription(subscription, {
         onSubscriptionData,
+        skip: true,
       }),
       {
-        initialProps: {
-          variables: {
-            foo: 'bar'
-          }
-        },
         wrapper: ({ children }) => (
           <ApolloProvider client={client}>
             {children}
@@ -159,14 +151,11 @@ describe('useSubscription Hook', () => {
     expect(result.current.loading).toBe(false);
     expect(result.current.error).toBe(undefined);
     expect(result.current.data).toBe(undefined);
-
-    rerender({ variables: { foo: 'bar2' }});
     await expect(waitForNextUpdate({ timeout: 20 }))
       .rejects.toThrow('Timed out');
-
-    expect(onSetup).toHaveBeenCalledTimes(0);
-    expect(onSubscriptionData).toHaveBeenCalledTimes(0);
     unmount();
+
+    expect(onSubscriptionData).toHaveBeenCalledTimes(0);
   });
 
   it('should create a subscription after skip has changed from true to a falsy value', async () => {

--- a/src/react/hooks/useApolloClient.ts
+++ b/src/react/hooks/useApolloClient.ts
@@ -11,8 +11,8 @@ export function useApolloClient(
   invariant(
     !!client,
     'Could not find "client" in the context or passed in as an option. ' +
-    'Wrap the root component in an <ApolloProvider>, or pass an ApolloClient ' +
-    'instance in via options.',
+    'Wrap the root component in an <ApolloProvider>, or pass an ApolloClient' +
+    'ApolloClient instance in via options.',
   );
 
   return client;

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -55,7 +55,7 @@ export function useLazyQuery<TData = any, TVariables = OperationVariables>(
     const eagerMethods: Record<string, any> = {};
     for (const key of EAGER_METHODS) {
       const method = result[key];
-      eagerMethods[key] = (...args: any) => {
+      eagerMethods[key] = (...args: any[]) => {
         setExecution((execution) => ({ ...execution, called: true }));
         return (method as any)(...args);
       };
@@ -71,6 +71,7 @@ export function useLazyQuery<TData = any, TVariables = OperationVariables>(
     QueryTuple<TData, TVariables>[0]
   >((executeOptions?: QueryLazyOptions<TVariables>) => {
     setExecution({ called: true, options: executeOptions });
+
     const promise = result.refetch(executeOptions?.variables).then((result1) => {
       const result2 = {
         ...result,

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -1,4 +1,5 @@
 import { useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { useSyncExternalStore } from 'use-sync-external-store/shim';
 import { equal } from '@wry/equality';
 import { OperationVariables, mergeOptions } from '../../core';
 import { getApolloContext } from '../context';
@@ -30,6 +31,15 @@ export function useQuery<
   const client = useApolloClient(options?.client);
   const defaultWatchQueryOptions = client.defaultOptions.watchQuery;
   verifyDocumentType(query, DocumentType.Query);
+
+  const ref = useRef({
+    client,
+    query,
+    options,
+    previousData: void 0,
+    watchQueryOptions: createWatchQueryOptions(query, options, defaultWatchQueryOptions),
+  });
+
   const [obsQuery, setObsQuery] = useState(() => {
     const watchQueryOptions = createWatchQueryOptions(query, options, defaultWatchQueryOptions);
     // See if there is an existing observable that was used to fetch the same
@@ -76,6 +86,7 @@ export function useQuery<
                 sub.unsubscribe();
               },
               complete() {
+                // TODO: Does this branch ever get called before next() and error()?
                 resolve();
               },
             });
@@ -89,142 +100,127 @@ export function useQuery<
     return obsQuery;
   });
 
-  let [result, setResult] = useState(() => {
-    const result = obsQuery.getCurrentResult();
-    if (!result.loading && options) {
-      if (result.error) {
-        options.onError?.(result.error);
-      } else if (result.data) {
-        options.onCompleted?.(result.data);
-      }
-    }
-
-    return result;
-  });
-
-  const ref = useRef({
-    client,
-    query,
-    options,
-    result,
-    previousData: void 0 as TData | undefined,
-    watchQueryOptions: createWatchQueryOptions(query, options, defaultWatchQueryOptions),
-  });
-
   // An effect to recreate the obsQuery whenever the client or query changes.
-  // This effect is also responsible for checking and updating the obsQuery
-  // options whenever they change.
+  // This effect is also responsible for updating the obsQuery options whenever
+  // they change.
   useEffect(() => {
     const watchQueryOptions = createWatchQueryOptions(query, options, defaultWatchQueryOptions);
-    let nextResult: ApolloQueryResult<TData> | undefined;
+
     if (ref.current.client !== client || !equal(ref.current.query, query)) {
       const obsQuery = client.watchQuery(watchQueryOptions);
       setObsQuery(obsQuery);
-      nextResult = obsQuery.getCurrentResult();
     } else if (!equal(ref.current.watchQueryOptions, watchQueryOptions)) {
-      obsQuery.setOptions(watchQueryOptions).catch(() => {});
-      nextResult = obsQuery.getCurrentResult();
-      ref.current.watchQueryOptions = watchQueryOptions;
+      obsQuery.setOptions(watchQueryOptions);
+      // We call setObsQuery to rerender the hook.
+      setObsQuery(obsQuery);
     }
 
-    if (nextResult) {
-      const previousResult = ref.current.result;
-      if (previousResult.data) {
-        ref.current.previousData = previousResult.data;
-      }
-
-      setResult(ref.current.result = nextResult);
-      if (!nextResult.loading && options) {
-        if (nextResult.error) {
-          options.onError?.(nextResult.error);
-        } else if (nextResult.data) {
-          options.onCompleted?.(nextResult.data);
-        }
-      }
-    }
-
-    Object.assign(ref.current, { client, query });
+    Object.assign(ref.current, {
+      client,
+      query,
+      options,
+      watchQueryOptions,
+    });
   }, [obsQuery, client, query, options]);
 
-  // An effect to subscribe to the current observable query
-  useEffect(() => {
-    if (context.renderPromises) {
-      return;
-    }
-
-    let subscription = obsQuery.subscribe(onNext, onError);
-    // We use `getCurrentResult()` instead of the callback argument because
-    // the values differ slightly. Specifically, loading results will have
-    // an empty object for data instead of `undefined` for some reason.
-    function onNext() {
-      const previousResult = ref.current.result;
-      const result = obsQuery.getCurrentResult();
-      // Make sure we're not attempting to re-render similar results
-      if (
-        previousResult &&
-        previousResult.loading === result.loading &&
-        previousResult.networkStatus === result.networkStatus &&
-        equal(previousResult.data, result.data)
-      ) {
-        return;
-      }
-
-      if (previousResult.data) {
-        ref.current.previousData = previousResult.data;
-      }
-
-      setResult(ref.current.result = result);
-      if (!result.loading) {
-        ref.current.options?.onCompleted?.(result.data);
-      }
-    }
-
-    function onError(error: Error) {
-      const last = obsQuery["last"];
-      subscription.unsubscribe();
-      // Unfortunately, if `lastError` is set in the current
-      // `observableQuery` when the subscription is re-created,
-      // the subscription will immediately receive the error, which will
-      // cause it to terminate again. To avoid this, we first clear
-      // the last error/result from the `observableQuery` before re-starting
-      // the subscription, and restore it afterwards (so the subscription
-      // has a chance to stay open).
-      try {
+  const [subscribe, getSnapshot] = useMemo(() => {
+    let previousResult: ApolloQueryResult<TData> | undefined;
+    const subscribe = (forceUpdate: () => void) => {
+      let subscription = obsQuery.subscribe(forceUpdate, onError);
+      function onError(error: Error) {
+        forceUpdate();
+        subscription.unsubscribe();
+        const last = obsQuery["last"];
         obsQuery.resetLastResults();
-        subscription = obsQuery.subscribe(onNext, onError);
-      } finally {
+        obsQuery.subscribe(forceUpdate, onError);
         obsQuery["last"] = last;
+        if (!error.hasOwnProperty('graphQLErrors')) {
+          // The error is not a GraphQL error
+          throw error;
+        }
       }
 
-      if (!error.hasOwnProperty('graphQLErrors')) {
-        // The error is not a GraphQL error
-        throw error;
+      return () => {
+        subscription.unsubscribe();
+      };
+    };
+
+    const getSnapshot = () => {
+      let result = obsQuery.getCurrentResult();
+      if (result.errors && result.errors.length) {
+        // Until a set naming convention for networkError and graphQLErrors is
+        // decided upon, we map errors (graphQLErrors) to the error options.
+        // TODO: Is it possible for both result.error and result.errors to be
+        // defined here?
+        result = {
+          ...result,
+          error:
+            result.error || new ApolloError({ graphQLErrors: result.errors }),
+        };
       }
 
-      const previousResult = ref.current.result;
       if (
-        (previousResult && previousResult.loading) ||
-        !equal(error, previousResult.error)
+        !previousResult ||
+        previousResult.loading !== result.loading ||
+        previousResult.networkStatus !== result.networkStatus ||
+        !equal(previousResult.data, result.data) ||
+        !equal(previousResult.error, result.error)
       ) {
-        setResult(ref.current.result = {
-          data: previousResult.data,
-          error: error as ApolloError,
-          loading: false,
-          networkStatus: NetworkStatus.error,
-        });
-        ref.current.options?.onError?.(error as ApolloError);
+        if (previousResult) {
+          result = {
+            ...result,
+            previousData: previousResult.data || (previousResult as any).previousData,
+          } as ApolloQueryResult<TData>;
+        }
+
+        previousResult = result;
+
+        if (!result.loading) {
+          if (result.data) {
+            ref.current.options?.onCompleted?.(result.data);
+          } else if (result.error) {
+            ref.current.options?.onError?.(result.error);
+          }
+        }
       }
-    }
 
-    return () => subscription.unsubscribe();
-  }, [obsQuery, context.renderPromises, client.disableNetworkFetches]);
+      return previousResult;
+    };
 
+    return [subscribe, getSnapshot];
+  }, [obsQuery]);
+
+  const obsQueryMethods = useMemo(() => ({
+    refetch: obsQuery.refetch.bind(obsQuery),
+    fetchMore: obsQuery.fetchMore.bind(obsQuery),
+    updateQuery: obsQuery.updateQuery.bind(obsQuery),
+    startPolling: obsQuery.startPolling.bind(obsQuery),
+    stopPolling: obsQuery.stopPolling.bind(obsQuery),
+    subscribeToMore: obsQuery.subscribeToMore.bind(obsQuery),
+  }), [obsQuery]);
+
+  let result = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
   let partial: boolean | undefined;
   ({ partial, ...result } = result);
-
-  {
-    // BAD BOY CODE BLOCK WHERE WE PUT SIDE-EFFECTS IN THE RENDER FUNCTION
+  if (options?.skip || options?.fetchPolicy === 'standby') {
+    // When skipping a query (ie. we're not querying for data but still want to
+    // render children), make sure the `data` is cleared out and `loading` is
+    // set to `false` (since we aren't loading anything).
     //
+    // NOTE: We no longer think this is the correct behavior. Skipping should
+    // not automatically set `data` to `undefined`, but instead leave the
+    // previous data in place. In other words, skipping should not mandate that
+    // previously received data is all of a sudden removed. Unfortunately,
+    // changing this is breaking, so we'll have to wait until Apollo Client 4.0
+    // to address this.
+    result = {
+      loading: false,
+      data: void 0 as unknown as TData,
+      error: void 0,
+      networkStatus: NetworkStatus.ready,
+    };
+  } else {
+    // BAD BOY CODE BLOCK WHERE WE PUT SIDE-EFFECTS IN THE RENDER FUNCTION
     // TODO: This code should be removed when the partialRefetch option is
     // removed. I was unable to get this hook to behave reasonably in certain
     // edge cases when this block was put in an effect.
@@ -252,71 +248,22 @@ export function useQuery<
       !options?.skip &&
       result.loading
     ) {
-      obsQuery.setOptions(createWatchQueryOptions(query, options, defaultWatchQueryOptions)).catch(() => {});
+      obsQuery.setOptions(
+        createWatchQueryOptions(query, options, defaultWatchQueryOptions)
+      ).catch(() => {});
     }
 
     // We assign options during rendering as a guard to make sure that
     // callbacks like onCompleted and onError are not stale.
+    // TODO
     Object.assign(ref.current, { options });
   }
 
-  if (
-    (context.renderPromises || client.disableNetworkFetches) &&
-    options?.ssr === false
-  ) {
-    // If SSR has been explicitly disabled, and this function has been called
-    // on the server side, return the default loading state.
-    result = ref.current.result = {
-      loading: true,
-      data: void 0 as unknown as TData,
-      error: void 0,
-      networkStatus: NetworkStatus.loading,
-    };
-  } else if (options?.skip || options?.fetchPolicy === 'standby') {
-    // When skipping a query (ie. we're not querying for data but still want to
-    // render children), make sure the `data` is cleared out and `loading` is
-    // set to `false` (since we aren't loading anything).
-    //
-    // NOTE: We no longer think this is the correct behavior. Skipping should
-    // not automatically set `data` to `undefined`, but instead leave the
-    // previous data in place. In other words, skipping should not mandate that
-    // previously received data is all of a sudden removed. Unfortunately,
-    // changing this is breaking, so we'll have to wait until Apollo Client 4.0
-    // to address this.
-    result = {
-      loading: false,
-      data: void 0 as unknown as TData,
-      error: void 0,
-      networkStatus: NetworkStatus.ready,
-    };
-  }
-
-  if (result.errors && result.errors.length) {
-    // Until a set naming convention for networkError and graphQLErrors is
-    // decided upon, we map errors (graphQLErrors) to the error options.
-    // TODO: Is it possible for both result.error and result.errors to be
-    // defined here?
-    result = {
-      ...result,
-      error: result.error || new ApolloError({ graphQLErrors: result.errors }),
-    };
-  }
-
-  const obsQueryFields = useMemo(() => ({
-    refetch: obsQuery.refetch.bind(obsQuery),
-    fetchMore: obsQuery.fetchMore.bind(obsQuery),
-    updateQuery: obsQuery.updateQuery.bind(obsQuery),
-    startPolling: obsQuery.startPolling.bind(obsQuery),
-    stopPolling: obsQuery.stopPolling.bind(obsQuery),
-    subscribeToMore: obsQuery.subscribeToMore.bind(obsQuery),
-  }), [obsQuery]);
-
   return {
-    ...obsQueryFields,
+    ...obsQueryMethods,
     variables: createWatchQueryOptions(query, options, defaultWatchQueryOptions).variables,
     client,
     called: true,
-    previousData: ref.current.previousData,
     ...result,
   };
 }
@@ -329,9 +276,7 @@ function createWatchQueryOptions<TData, TVariables>(
   options: QueryHookOptions<TData, TVariables> = {},
   defaultOptions?: Partial<WatchQueryOptions<any, any>>
 ): WatchQueryOptions<TVariables, TData> {
-  // TODO: For some reason, we pass context, which is the React Apollo Context,
-  // into observable queries, and test for that.
-  // removing hook specific options
+  // Using destructuring to remove hook specific options.
   const {
     skip,
     ssr,
@@ -340,6 +285,8 @@ function createWatchQueryOptions<TData, TVariables>(
     displayName,
     ...otherOptions
   } = options;
+  // TODO: For some reason, we pass context, which is the React Apollo Context,
+  // into observable queries, and test for that.
 
   let watchQueryOptions = { query, ...otherOptions };
   if (defaultOptions) {

--- a/src/react/hooks/useSubscription.ts
+++ b/src/react/hooks/useSubscription.ts
@@ -45,16 +45,14 @@ export function useSubscription<TData = any, TVariables = OperationVariables>(
       shouldResubscribe = !!shouldResubscribe(options!);
     }
 
-    if (options?.skip) {
-      if (!options?.skip !== !ref.current.options?.skip) {
-        setResult({
-          loading: false,
-          data: void 0,
-          error: void 0,
-          variables: options?.variables,
-        });
-        setObservable(null);
-      }
+    if (options?.skip && !options?.skip !== !ref.current.options?.skip) {
+      setResult({
+        loading: false,
+        data: void 0,
+        error: void 0,
+        variables: options?.variables,
+      });
+      setObservable(null);
     } else if (
       shouldResubscribe !== false && (
         client !== ref.current.client ||

--- a/src/react/ssr/RenderPromises.ts
+++ b/src/react/ssr/RenderPromises.ts
@@ -44,21 +44,22 @@ export class RenderPromises {
   // Registers the server side rendered observable.
   public registerSSRObservable<TData, TVariables>(
     observable: ObservableQuery<any, TVariables>,
-    props: QueryDataOptions<TData, TVariables>
+    options: QueryDataOptions<TData, TVariables>
   ) {
     if (this.stopped) return;
-    this.lookupQueryInfo(props).observable = observable;
+    this.lookupQueryInfo(options).observable = observable;
   }
 
   // Get's the cached observable that matches the SSR Query instances query and variables.
   public getSSRObservable<TData, TVariables>(
-    props: QueryDataOptions<TData, TVariables>
+    options: QueryDataOptions<TData, TVariables>
   ): ObservableQuery<any, TVariables> | null {
-    return this.lookupQueryInfo(props).observable;
+    return this.lookupQueryInfo(options).observable;
   }
 
   public addQueryPromise(
     queryInstance: QueryData,
+    // TODO: This callback is a noop on the useQuery side.
     finish: () => React.ReactNode
   ): React.ReactNode {
     if (!this.stopped) {
@@ -66,15 +67,14 @@ export class RenderPromises {
       if (!info.seen) {
         this.queryPromises.set(
           queryInstance.getOptions(),
-          new Promise(resolve => {
-            resolve(queryInstance.fetchData());
-          })
+          new Promise(resolve => resolve(queryInstance.fetchData()))
         );
         // Render null to abandon this subtree for this rendering, so that we
         // can wait for the data to arrive.
         return null;
       }
     }
+
     return finish();
   }
 

--- a/src/react/ssr/__tests__/useLazyQuery.test.tsx
+++ b/src/react/ssr/__tests__/useLazyQuery.test.tsx
@@ -40,7 +40,7 @@ describe('useLazyQuery Hook SSR', () => {
     const client = new ApolloClient({
       cache: new InMemoryCache(),
       link,
-      ssrMode: true
+      ssrMode: true,
     });
 
     const Component = () => {

--- a/src/react/ssr/__tests__/useQuery.test.tsx
+++ b/src/react/ssr/__tests__/useQuery.test.tsx
@@ -1,3 +1,4 @@
+/** @jest-environment node */
 import React from 'react';
 import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';


### PR DESCRIPTION
This PR reverts commit c6ab36458ae07b7f88d372715f9f427b6284b1c7 on `release-3.7`, as promised in PR #9393, fully restoring @brainkim's `useSyncExternalStore` changes from PR #8785.

There are still two test failures that seem somewhat related to the merge conflicts we were seeing when trying to merge `main` into `release-3.6` before we split out `useSyncExternalStore`. I can keep looking into this tomorrow, but I'm passing it back over to you @brainkim in case you have ideas.

I think we're close!