### PR TITLE
Fix persistedQueries to pull graphqlErrors from networkErrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Apollo Client 3.6.2 (unreleased)
+
+- Consider `networkError.result.errors` in addition to `result.errors` in `PersistedQueryLink`. <br/>
+  [@redaid113](https://github.com/redaid113) and [@benjamn](https://github.com/benjamn) in [#9410](https://github.com/apollographql/apollo-client/pull/9410)
+
 ## Apollo Client 3.6.1 (2022-04-28)
 
 ### Bug Fixes

--- a/src/link/persisted-queries/index.ts
+++ b/src/link/persisted-queries/index.ts
@@ -177,14 +177,28 @@ export const createPersistedQueryLink = (
       ) => {
         if (!retried && ((response && response.errors) || networkError)) {
           retried = true;
+
+          const graphQLErrors: GraphQLError[] = [];
+
+          const responseErrors = response && response.errors;
+          if (isNonEmptyArray(responseErrors)) {
+            graphQLErrors.push(...responseErrors);
+          }
+
           // Network errors can return GraphQL errors on for example a 403
-          const graphQLErrors = response ? response.errors : networkError && networkError.result && networkError.result.errors;
+          const networkErrors =
+            networkError &&
+            networkError.result &&
+            networkError.result.errors as GraphQLError[];
+          if (isNonEmptyArray(networkErrors)) {
+            graphQLErrors.push(...networkErrors);
+          }
 
           const disablePayload = {
             response,
             networkError,
             operation,
-            graphQLErrors,
+            graphQLErrors: isNonEmptyArray(graphQLErrors) ? graphQLErrors : void 0,
           };
 
           // if the server doesn't support persisted queries, don't try anymore


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

This MR fixes an issue with persistedQueries.

Servers can contain graphQLErrors, but was missing in persistedQueries. If a server returned a 400 with a 'PersistedQueryNotFound' error message, it would be treated as a networkError and disable persistedQueries.

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
