### PR TITLE
Refactor `useQuery` using `InternalState` class to simplify reasoning about state

### DIFF
--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -93,7 +93,7 @@ export class ApolloClient<TCacheShape> implements DataProxy {
   public disableNetworkFetches: boolean;
   public version: string;
   public queryDeduplication: boolean;
-  public defaultOptions: DefaultOptions = {};
+  public defaultOptions: DefaultOptions;
   public readonly typeDefs: ApolloClientOptions<TCacheShape>['typeDefs'];
 
   private queryManager: QueryManager<TCacheShape>;
@@ -183,7 +183,7 @@ export class ApolloClient<TCacheShape> implements DataProxy {
     this.cache = cache;
     this.disableNetworkFetches = ssrMode || ssrForceFetchDelay > 0;
     this.queryDeduplication = queryDeduplication;
-    this.defaultOptions = defaultOptions || {};
+    this.defaultOptions = defaultOptions || Object.create(null);
     this.typeDefs = typeDefs;
 
     if (ssrForceFetchDelay) {
@@ -246,6 +246,7 @@ export class ApolloClient<TCacheShape> implements DataProxy {
     this.queryManager = new QueryManager({
       cache: this.cache,
       link: this.link,
+      defaultOptions: this.defaultOptions,
       queryDeduplication,
       ssrMode,
       clientAwareness: {

--- a/src/react/components/__tests__/client/Query.test.tsx
+++ b/src/react/components/__tests__/client/Query.test.tsx
@@ -72,7 +72,6 @@ describe('Query component', () => {
                 networkStatus: 1,
                 previousData: undefined,
                 variables: {},
-                partial: true,
               });
               expect(clientResult).toBe(client);
             } else {

--- a/src/react/components/__tests__/client/Query.test.tsx
+++ b/src/react/components/__tests__/client/Query.test.tsx
@@ -72,6 +72,7 @@ describe('Query component', () => {
                 networkStatus: 1,
                 previousData: undefined,
                 variables: {},
+                partial: true,
               });
               expect(clientResult).toBe(client);
             } else {

--- a/src/react/components/__tests__/client/Query.test.tsx
+++ b/src/react/components/__tests__/client/Query.test.tsx
@@ -1148,28 +1148,26 @@ describe('Query component', () => {
               {(result: any) => {
                 if (result.loading) return null;
                 try {
-                  switch (count) {
-                    case 0:
+                  switch (++count) {
+                    case 1:
                       expect(query).toEqual(query1);
                       expect(result.data).toEqual(data1);
                       setTimeout(() => {
                         this.setState({ query: query2 });
                       });
                       break;
-                    case 1:
-                      expect(query).toEqual(query2);
-                      expect(result.data).toEqual(data1);
-                      break;
                     case 2:
                       expect(query).toEqual(query2);
                       expect(result.data).toEqual(data2);
+                      break;
+                    default:
+                      reject(`Too many renders (${count})`);
                       break;
                   }
                 } catch (error) {
                   reject(error);
                 }
 
-                count++;
                 return null;
               }}
             </Query>
@@ -1183,7 +1181,7 @@ describe('Query component', () => {
         </MockedProvider>
       );
 
-      waitFor(() => expect(count).toBe(3)).then(resolve, reject);
+      waitFor(() => expect(count).toBe(2)).then(resolve, reject);
     });
 
     itAsync('with data while loading', (resolve, reject) => {

--- a/src/react/hoc/__tests__/queries/index.test.tsx
+++ b/src/react/hoc/__tests__/queries/index.test.tsx
@@ -53,7 +53,6 @@ describe('queries', () => {
     const ContainerWithData = graphql<any, Data>(query)(
       ({ data }: DataProps<Data>) => {
         expect(data).toBeTruthy();
-        expect(data.loading).toBeTruthy();
         done = true;
         return null;
       }
@@ -176,19 +175,27 @@ describe('queries', () => {
       options
     )(({ data }: ChildProps<Variables, Data, Variables>) => {
       expect(data).toBeTruthy();
-      switch (count) {
-        case 0:
-          expect(data!.variables.someId).toEqual(1);
-          break;
+      switch (++count) {
         case 1:
-          expect(data!.variables.someId).toEqual(2);
+          expect(data!.loading).toBe(true);
+          expect(data!.variables).toEqual({ someId: 1 });
           break;
         case 2:
-          expect(data!.variables.someId).toEqual(2);
+          expect(data!.loading).toBe(true);
+          expect(data!.variables).toEqual({ someId: 1 });
           break;
+        case 3:
+          expect(data!.loading).toBe(true);
+          expect(data!.variables).toEqual({ someId: 2 });
+          break;
+        case 4:
+          expect(data!.loading).toBe(false);
+          expect(data!.variables).toEqual({ someId: 2 });
+          break;
+        default:
+          reject(`too many renders (${count})`);
       }
 
-      count += 1;
       return null;
     });
 
@@ -204,7 +211,7 @@ describe('queries', () => {
     );
 
     waitFor(() => {
-      expect(count).toBe(3);
+      expect(count).toBe(4);
     }).then(resolve, reject);
   });
 

--- a/src/react/hoc/__tests__/queries/lifecycle.test.tsx
+++ b/src/react/hoc/__tests__/queries/lifecycle.test.tsx
@@ -592,16 +592,16 @@ describe('[queries] lifecycle', () => {
         render() {
           try {
             const { loading, a, b, c } = this.props.data!;
-            switch (count) {
-              case 0:
+            switch (++count) {
+              case 1:
                 expect({ loading, a, b, c }).toEqual({
                   loading: true,
-                  a: undefined,
-                  b: undefined,
-                  c: undefined
+                  a: void 0,
+                  b: void 0,
+                  c: void 0,
                 });
                 break;
-              case 1:
+              case 2:
                 expect({ loading, a, b, c }).toEqual({
                   loading: false,
                   a: 1,
@@ -610,7 +610,7 @@ describe('[queries] lifecycle', () => {
                 });
                 refetchQuery!();
                 break;
-              case 2:
+              case 3:
                 expect({ loading, a, b, c }).toEqual({
                   loading: true,
                   a: 1,
@@ -618,11 +618,6 @@ describe('[queries] lifecycle', () => {
                   c: 3
                 });
                 break;
-              case 3:
-                setTimeout(() => {
-                  switchClient!(client2);
-                });
-                // fallthrough
               case 4:
                 expect({ loading, a, b, c }).toEqual({
                   loading: false,
@@ -630,16 +625,27 @@ describe('[queries] lifecycle', () => {
                   b: 2,
                   c: 3
                 });
+                setTimeout(() => {
+                  switchClient!(client2);
+                });
                 break;
               case 5:
                 expect({ loading, a, b, c }).toEqual({
                   loading: true,
-                  a: undefined,
-                  b: undefined,
-                  c: undefined
+                  a: void 0,
+                  b: void 0,
+                  c: void 0,
                 });
                 break;
               case 6:
+                expect({ loading, a, b, c }).toEqual({
+                  loading: true,
+                  a: void 0,
+                  b: void 0,
+                  c: void 0,
+                });
+                break;
+              case 7:
                 expect({ loading, a, b, c }).toEqual({
                   loading: false,
                   a: 4,
@@ -648,7 +654,7 @@ describe('[queries] lifecycle', () => {
                 });
                 refetchQuery!();
                 break;
-              case 7:
+              case 8:
                 expect({ loading, a, b, c }).toEqual({
                   loading: true,
                   a: 4,
@@ -656,11 +662,6 @@ describe('[queries] lifecycle', () => {
                   c: 6
                 });
                 break;
-              case 8:
-                setTimeout(() => {
-                  switchClient!(client3);
-                });
-                // fallthrough
               case 9:
                 expect({ loading, a, b, c }).toEqual({
                   loading: false,
@@ -668,20 +669,26 @@ describe('[queries] lifecycle', () => {
                   b: 5,
                   c: 6
                 });
+                setTimeout(() => {
+                  switchClient!(client3);
+                });
                 break;
               case 10:
                 expect({ loading, a, b, c }).toEqual({
                   loading: true,
-                  a: undefined,
-                  b: undefined,
-                  c: undefined
+                  a: void 0,
+                  b: void 0,
+                  c: void 0,
                 });
                 break;
               case 11:
-                setTimeout(() => {
-                  switchClient!(client1);
+                expect({ loading, a, b, c }).toEqual({
+                  loading: true,
+                  a: void 0,
+                  b: void 0,
+                  c: void 0,
                 });
-                // fallthrough
+                break;
               case 12:
                 expect({ loading, a, b, c }).toEqual({
                   loading: false,
@@ -689,12 +696,18 @@ describe('[queries] lifecycle', () => {
                   b: 8,
                   c: 9
                 });
+                setTimeout(() => {
+                  switchClient!(client1);
+                });
                 break;
               case 13:
-                setTimeout(() => {
-                  switchClient!(client3);
+                expect({ loading, a, b, c }).toEqual({
+                  loading: false,
+                  a: 1,
+                  b: 2,
+                  c: 3,
                 });
-                // fallthrough
+                break;
               case 14:
                 expect({ loading, a, b, c }).toEqual({
                   loading: false,
@@ -702,8 +715,19 @@ describe('[queries] lifecycle', () => {
                   b: 2,
                   c: 3
                 });
+                setTimeout(() => {
+                  switchClient!(client3);
+                });
                 break;
               case 15:
+                expect({ loading, a, b, c }).toEqual({
+                  loading: false,
+                  a: 7,
+                  b: 8,
+                  c: 9,
+                });
+                break;
+              case 16:
                 expect({ loading, a, b, c }).toEqual({
                   loading: false,
                   a: 7,
@@ -716,7 +740,6 @@ describe('[queries] lifecycle', () => {
             reject(err);
           }
 
-          count++;
           return null;
         }
       }

--- a/src/react/hoc/__tests__/queries/lifecycle.test.tsx
+++ b/src/react/hoc/__tests__/queries/lifecycle.test.tsx
@@ -63,7 +63,7 @@ describe('[queries] lifecycle', () => {
                 break;
               case 1:
                 expect(data!.loading).toBe(false);
-                expect(data!.variables).toEqual(variables2);
+                expect(data!.variables).toEqual(variables1);
                 expect(data!.allPeople).toEqual(data1.allPeople);
                 break;
               case 2:
@@ -226,7 +226,7 @@ describe('[queries] lifecycle', () => {
                 break;
               case 1:
                 expect(data!.loading).toBe(false);
-                expect(data!.variables).toEqual({ first: 2 });
+                expect(data!.variables).toEqual({ first: 1 });
                 expect(data!.allPeople).toEqual(data1.allPeople);
                 break;
               case 2:
@@ -323,7 +323,7 @@ describe('[queries] lifecycle', () => {
                 break;
               case 1:
                 expect(data!.loading).toBe(false);
-                expect(data!.variables).toEqual({ first: 2 });
+                expect(data!.variables).toEqual({ first: 1 });
                 expect(data!.allPeople).toEqual(data1.allPeople);
                 break;
               case 2:

--- a/src/react/hoc/__tests__/queries/loading.test.tsx
+++ b/src/react/hoc/__tests__/queries/loading.test.tsx
@@ -208,14 +208,14 @@ describe('[queries] loading', () => {
                 expect(prevProps.data!.error).toBe(undefined);
                 expect(prevProps.data!.networkStatus).toBe(NetworkStatus.ready);
                 expect(this.props.data!.loading).toBe(false);
-                expect(this.props.data!.variables).toEqual(variables2);
+                expect(this.props.data!.variables).toEqual(variables1);
                 expect(this.props.data!.allPeople).toEqual(data1.allPeople);
                 expect(this.props.data!.error).toBe(undefined);
                 expect(prevProps.data!.networkStatus).toBe(NetworkStatus.ready);
                 break;
               case 2:
                 expect(prevProps.data!.loading).toBe(false);
-                expect(prevProps.data!.variables).toEqual(variables2);
+                expect(prevProps.data!.variables).toEqual(variables1);
                 expect(prevProps.data!.allPeople).toEqual(data1.allPeople);
                 expect(prevProps.data!.error).toBe(undefined);
                 expect(this.props.data!.loading).toBe(true);

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -27,7 +27,7 @@ describe('useQuery Hook', () => {
 
       useEffect(() => {
         /**
-         * Since the return value from useQuery changes on each render,
+         * IF the return value from useQuery changes on each render,
          * this component will re-render in an infinite loop.
          */
          console.log('CURRENT RESULT CHANGED')
@@ -39,6 +39,48 @@ describe('useQuery Hook', () => {
       if (result.loading) return null
 
       return <div>{result.data.hello}{counter}</div>
+    }
+
+    itAsync('should handle a simple query', (resolve, reject) => {
+      const query = gql`{ hello }`;
+      const mocks = [
+        {
+          request: { query },
+          result: { data: { hello: "world" } },
+        },
+      ];
+
+      const { getByText } = render(
+        <MockedProvider mocks={mocks}>
+          <Component query={query} />
+        </MockedProvider>
+      );
+
+      waitFor(() => {
+        expect(getByText('world2')).toBeTruthy();
+      }).then(resolve, reject);
+    });
+  })
+
+  describe('regression test issue #9204 - destructured', () => {
+    const Component = ({ query }: any) => {
+      const [counter, setCounter] = useState(0)
+      const {data, loading} = useQuery(query)
+
+      useEffect(() => {
+        /**
+         * IF the return value from useQuery changes on each render,
+         * this component will re-render in an infinite loop.
+         */
+         console.log('CURRENT RESULT CHANGED')
+        setCounter(p => p + 1)
+      }, [
+        data
+      ])
+
+      if (loading) return null
+
+      return <div>{data.hello}{counter}</div>
     }
 
     itAsync('should handle a simple query', (resolve, reject) => {

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -46,6 +46,21 @@ describe('useQuery Hook', () => {
       expect(result.current.data).toEqual({ hello: "world" });
     });
 
+    it('memo\'s it\'s output', async () => {
+      const query = gql`{ hello }`;
+      const mocks = [ {
+          request: { query },
+          result: { data: { hello: "world" } },
+      } ];
+      const wrapper = ({ children }: any) => <MockedProvider mocks={mocks}>{children}</MockedProvider>;
+      const { result, waitFor, rerender } = renderHook(() => useQuery(query), { wrapper });
+      await waitFor(() => result.current.loading === false);
+      const oldResult = result.current;
+      rerender({ children: null });
+
+      expect(oldResult).toBe(result.current);
+    });
+
     it('should read and write results from the cache', async () => {
       const query = gql`{ hello }`;
       const mocks = [

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -54,7 +54,7 @@ export function useQuery<
         context.renderPromises.addQueryPromise({
           // The only options which seem to actually be used by the
           // RenderPromises class are query and variables.
-          getOptions: () => watchQueryOptions,
+          getOptions: () => obsQuery.options,
           fetchData: () => new Promise<void>((resolve) => {
             const sub = obsQuery.subscribe({
               next(result) {

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -300,15 +300,17 @@ class InternalState<TData, TVariables> {
     if (previousResult && previousResult.data) {
       this.previousData = previousResult.data;
     }
-
     this.result = nextResult;
     this.forceUpdate();
+    this.handleErrorOrCompleted(nextResult);
+  }
 
-    if (!nextResult.loading) {
-      if (nextResult.error) {
-        this.onError(nextResult.error);
-      } else if (nextResult.data) {
-        this.onCompleted(nextResult.data);
+  private handleErrorOrCompleted(result: ApolloQueryResult<TData>) {
+    if (!result.loading) {
+      if (result.error) {
+        this.onError(result.error);
+      } else if (result.data) {
+        this.onCompleted(result.data);
       }
     }
   }
@@ -317,13 +319,7 @@ class InternalState<TData, TVariables> {
     let { result } = this;
     if (!result) {
       result = this.result = this.observable.getCurrentResult();
-      if (!result.loading) {
-        if (result.error) {
-          this.onError(result.error);
-        } else if (result.data) {
-          this.onCompleted(result.data);
-        }
-      }
+      this.handleErrorOrCompleted(result);
     }
 
     if (

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -34,11 +34,13 @@ export function useQuery<
 ): QueryResult<TData, TVariables> {
   const context = useContext(getApolloContext());
   const client = useApolloClient(options?.client);
-  verifyDocumentType(query, DocumentType.Query);
-  const watchQueryOptions = useMemo(
-    () => createWatchQueryOptions(query, options, client.defaultOptions.watchQuery),
-    [query, options, client.defaultOptions.watchQuery],
+
+  const watchQueryOptions = useWatchQueryOptions(
+    client,
+    query,
+    options,
   );
+
   const [obsQuery, setObsQuery] = useState(() => {
     // See if there is an existing observable that was used to fetch the same
     // data and if so, use it instead since it will contain the proper queryId
@@ -319,6 +321,27 @@ export function useQuery<
     called: true,
     previousData: ref.current.previousData,
   });
+}
+
+function useWatchQueryOptions<TData, TVariables>(
+  client: ReturnType<typeof useApolloClient>,
+  query: DocumentNode | TypedDocumentNode<TData, TVariables>,
+  options: QueryHookOptions<TData, TVariables> | undefined,
+) {
+  verifyDocumentType(query, DocumentType.Query);
+
+  const watchQueryOptions = createWatchQueryOptions(
+    query,
+    options,
+    client.defaultOptions.watchQuery,
+  );
+
+  const ref = useRef<WatchQueryOptions<TVariables, TData>>(watchQueryOptions);
+  if (!equal(ref.current, watchQueryOptions)) {
+    ref.current = watchQueryOptions;
+  }
+
+  return ref.current;
 }
 
 /**

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -237,12 +237,10 @@ export function useQuery<
       (!result.data || Object.keys(result.data).length === 0) &&
       obsQuery.options.fetchPolicy !== 'cache-only'
     ) {
-      result = {
-        ...result,
+      Object.assign(result, {
         loading: true,
         networkStatus: NetworkStatus.refetch,
-      };
-
+      });
       obsQuery.refetch();
     }
 
@@ -298,10 +296,9 @@ export function useQuery<
     // decided upon, we map errors (graphQLErrors) to the error options.
     // TODO: Is it possible for both result.error and result.errors to be
     // defined here?
-    result = {
-      ...result,
-      error: result.error || new ApolloError({ graphQLErrors: result.errors }),
-    };
+    if (!result.error) {
+      result.error = new ApolloError({ graphQLErrors: result.errors });
+    }
   }
 
   const obsQueryFields = useMemo(() => ({
@@ -313,15 +310,12 @@ export function useQuery<
     subscribeToMore: obsQuery.subscribeToMore.bind(obsQuery),
   }), [obsQuery]);
 
-  return useMemo(() => ({
-    ...obsQueryFields,
-    variables: watchQueryOptions.variables,
+  return Object.assign(result, obsQueryFields, {
     client,
+    variables: watchQueryOptions.variables,
     called: true,
     previousData: ref.current.previousData,
-    ...result,
-  }), [obsQueryFields, watchQueryOptions.variables, client, ref.current.previousData, result]);
-
+  });
 }
 
 /**

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -193,7 +193,7 @@ class InternalState<TData, TVariables> {
       }
     }
 
-    const ref = useRef({
+    const prevOptionsRef = useRef({
       watchQueryOptions: this.watchQueryOptions,
     });
 
@@ -202,9 +202,14 @@ class InternalState<TData, TVariables> {
     useEffect(() => {
       if (this.renderPromises) {
         // Do nothing during server rendering.
-      } else if (!equal(ref.current.watchQueryOptions, this.watchQueryOptions)) {
+      } else if (
+        // The useOptions method only updates this.watchQueryOptions if new new
+        // watchQueryOptions are not deep-equal to the previous options, so we
+        // only need a reference check (!==) here.
+        this.watchQueryOptions !== prevOptionsRef.current.watchQueryOptions
+      ) {
         obsQuery.setOptions(this.watchQueryOptions).catch(() => {});
-        ref.current.watchQueryOptions = this.watchQueryOptions;
+        prevOptionsRef.current.watchQueryOptions = this.watchQueryOptions;
         this.setResult(obsQuery.getCurrentResult());
       }
     }, [obsQuery, this.watchQueryOptions]);

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -44,17 +44,14 @@ export function useQuery<
 
     if (context.renderPromises) {
       context.renderPromises.registerSSRObservable(obsQuery);
-    }
 
-    if (
-      context.renderPromises &&
-      options?.ssr !== false &&
-      !options?.skip &&
-      obsQuery.getCurrentResult().loading
-    ) {
-      // TODO: This is a legacy API which could probably be cleaned up
-      context.renderPromises.addQueryPromise(
-        {
+      if (
+        options?.ssr !== false &&
+        !options?.skip &&
+        obsQuery.getCurrentResult().loading
+      ) {
+        // TODO: This is a legacy API which could probably be cleaned up
+        context.renderPromises.addQueryPromise({
           // The only options which seem to actually be used by the
           // RenderPromises class are query and variables.
           getOptions: () => watchQueryOptions,
@@ -77,8 +74,8 @@ export function useQuery<
           }),
         },
         // This callback never seemed to do anything
-        () => null,
-      );
+        () => null);
+      }
     }
 
     return obsQuery;

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -165,6 +165,10 @@ class InternalState<TData, TVariables> {
         },
         // This callback never seemed to do anything
         () => null);
+
+        // TODO: This is a hack to make sure useLazyQuery executions update the
+        // obsevable query options for ssr.
+        obsQuery.setOptions(this.watchQueryOptions).catch(() => {});
       }
     }
 
@@ -424,17 +428,6 @@ export function useQuery<
         networkStatus: NetworkStatus.refetch,
       });
       obsQuery.refetch();
-    }
-
-    // TODO: This is a hack to make sure useLazyQuery executions update the
-    // obsevable query options for ssr.
-    if (
-      state.renderPromises &&
-      state.queryHookOptions.ssr !== false &&
-      !state.queryHookOptions.skip &&
-      result.loading
-    ) {
-      obsQuery.setOptions(state.watchQueryOptions).catch(() => {});
     }
   }
 

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -385,16 +385,7 @@ export function useQuery<
     }
   }
 
-  const obsQueryFields = useMemo(() => ({
-    refetch: obsQuery.refetch.bind(obsQuery),
-    fetchMore: obsQuery.fetchMore.bind(obsQuery),
-    updateQuery: obsQuery.updateQuery.bind(obsQuery),
-    startPolling: obsQuery.startPolling.bind(obsQuery),
-    stopPolling: obsQuery.stopPolling.bind(obsQuery),
-    subscribeToMore: obsQuery.subscribeToMore.bind(obsQuery),
-  }), [obsQuery]);
-
-  return Object.assign(result, obsQueryFields, {
+  return Object.assign(result, state.obsQueryFields, {
     client: state.client,
     variables: state.watchQueryOptions.variables,
     called: true,

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -89,8 +89,19 @@ class InternalState<TData, TVariables> {
       options.skip
     ));
 
+    this.onCompleted = options
+      && options.onCompleted
+      || InternalState.prototype.onCompleted;
+
+    this.onError = options
+      && options.onError
+      || InternalState.prototype.onError;
+
     return this;
   }
+
+  public onCompleted(data: TData) {}
+  public onError(error: ApolloError) {}
 
   public observable: ObservableQuery<TData, TVariables>;
   public obsQueryFields: Omit<
@@ -168,11 +179,11 @@ export function useQuery<
   // setResultState directly, unless you know what you're up to.
   let [result, setResultState] = useState(() => {
     const result = obsQuery.getCurrentResult();
-    if (!result.loading && options) {
+    if (!result.loading) {
       if (result.error) {
-        options.onError?.(result.error);
+        state.onError(result.error);
       } else if (result.data) {
-        options.onCompleted?.(result.data);
+        state.onCompleted(result.data);
       }
     }
 
@@ -203,9 +214,9 @@ export function useQuery<
 
     if (!nextResult.loading && options) {
       if (nextResult.error) {
-        options.onError?.(nextResult.error);
+        state.onError(nextResult.error);
       } else if (nextResult.data) {
-        options.onCompleted?.(nextResult.data);
+        state.onCompleted(nextResult.data);
       }
     }
   }

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -144,8 +144,7 @@ export function useQuery<
   });
 
   const ref = useRef({
-    client: state.client,
-    query,
+    state,
     options,
     // The ref.current.{result,previousData} properties are kept in sync with
     // the useState result by the helper function setResult, declared below.
@@ -180,7 +179,7 @@ export function useQuery<
   // options whenever they change.
   useEffect(() => {
     let nextResult: ApolloQueryResult<TData> | undefined;
-    if (ref.current.client !== state.client || !equal(ref.current.query, query)) {
+    if (ref.current.state !== state) {
       const obsQuery = state.client.watchQuery(watchQueryOptions);
       setObsQuery(obsQuery);
       nextResult = obsQuery.getCurrentResult();
@@ -194,8 +193,8 @@ export function useQuery<
       setResult(nextResult);
     }
 
-    Object.assign(ref.current, { client: state.client, query });
-  }, [obsQuery, state.client, query, options]);
+    ref.current.state = state;
+  }, [obsQuery, state, options]);
 
   // An effect to subscribe to the current observable query
   useEffect(() => {

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -38,17 +38,15 @@ export function useQuery<
   options?: QueryHookOptions<TData, TVariables>,
 ): QueryResult<TData, TVariables> {
   return useInternalState(
+    useApolloClient(options && options.client),
     query,
-    options && options.client,
   ).useQuery(options);
 }
 
 function useInternalState<TData, TVariables>(
+  client: ApolloClient<any>,
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  clientOverride?: ApolloClient<any>,
 ) {
-  const client = useApolloClient(clientOverride);
-
   const state = useMemo(
     () => new InternalState(client, query),
     [client, query],

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -19,6 +19,12 @@ import {
 import { DocumentType, verifyDocumentType } from '../parser';
 import { useApolloClient } from './useApolloClient';
 
+const {
+  prototype: {
+    hasOwnProperty,
+  },
+} = Object;
+
 export function useQuery<
   TData = any,
   TVariables = OperationVariables,
@@ -192,7 +198,7 @@ export function useQuery<
         obsQuery["last"] = last;
       }
 
-      if (!error.hasOwnProperty('graphQLErrors')) {
+      if (!hasOwnProperty.call(error, 'graphQLErrors')) {
         // The error is not a GraphQL error
         throw error;
       }
@@ -216,7 +222,10 @@ export function useQuery<
   }, [obsQuery, context.renderPromises, client.disableNetworkFetches]);
 
   const { partial } = result;
-  delete result.partial;
+  if (!partial && hasOwnProperty.call(result, "partial")) {
+    // Hide result.partial if it is defined but falsy.
+    delete result.partial;
+  }
 
   {
     // BAD BOY CODE BLOCK WHERE WE PUT SIDE-EFFECTS IN THE RENDER FUNCTION

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -221,7 +221,8 @@ export function useQuery<
     return () => subscription.unsubscribe();
   }, [obsQuery, context.renderPromises, client.disableNetworkFetches]);
 
-  const partial: boolean | undefined = result.partial;
+  const { partial } = result;
+  delete result.partial;
 
   {
     // BAD BOY CODE BLOCK WHERE WE PUT SIDE-EFFECTS IN THE RENDER FUNCTION

--- a/src/react/ssr/RenderPromises.ts
+++ b/src/react/ssr/RenderPromises.ts
@@ -44,10 +44,9 @@ export class RenderPromises {
   // Registers the server side rendered observable.
   public registerSSRObservable<TData, TVariables>(
     observable: ObservableQuery<any, TVariables>,
-    props: QueryDataOptions<TData, TVariables>
   ) {
     if (this.stopped) return;
-    this.lookupQueryInfo(props).observable = observable;
+    this.lookupQueryInfo(observable.options).observable = observable;
   }
 
   // Get's the cached observable that matches the SSR Query instances query and variables.


### PR DESCRIPTION
This work began as a solution to issue #9204, incorporating the tests contributed by @jamesopti and @FritsvanCampen in #9407 and #9412. It snowballed into a more general refactoring of the `useQuery` hook, somewhat resembling the `InternalState` approach I used for `useBackgroundQuery` in #8783.

I feel like this approach has been productive so far, but before I spend more time on it, I wanted to share what I'm thinking (especially with @brainkim and @hwillson) in this draft PR.

I don't know if reviewing each commit is worthwhile, since some of the earlier commits are undone later, but I tried to do things incrementally, keeping tests passing with each commit, in case that's a helpful narrative.

This PR targets `release-3.6`, which seems appropriate for a refactoring of this size, but I am hopeful we can find a smaller/safer subset of the changes that we could ship in a 3.5.x patch release, so #9204 and related issues can be solved without waiting for v3.6.

Because this PR interacts so much with `useQuery` options handling, I've been holding off on #9223 and #9222 and some other issues until the dust has settled here.