### PR TITLE
Update subscriptions-transport-ws example in subscriptions.mdx

### DIFF
--- a/docs/source/data/subscriptions.mdx
+++ b/docs/source/data/subscriptions.mdx
@@ -335,15 +335,12 @@ import { WebSocketLink } from "@apollo/client/link/ws";
 import { SubscriptionClient } from "subscriptions-transport-ws";
 
 const wsLink = new WebSocketLink(
-  new SubscriptionClient({
-    uri: "ws://localhost:4000/subscriptions",
-    options: {
-      connectionParams: {
-        authToken: user.authToken,
-      },
+  new SubscriptionClient('ws://localhost:4000/subscriptions', {
+    connectionParams: {
+      authToken: user.authToken,
     },
   }),
-});
+);
 ```
 
 More details on `WebSocketLink`'s API can be found in [its API docs](../api/link/apollo-link-ws).


### PR DESCRIPTION
The parameters in the example is wrong according to the documentation of the SubscriptionClient in the subscriptions-transport-ws repo. 

From: https://github.com/apollographql/subscriptions-transport-ws

👉 Constructor(url, options, webSocketImpl) 👈

url: string : url that the client will connect to, starts with ws:// or wss://
options?: Object : optional, object to modify default client behavior
timeout?: number : how long the client should wait in ms for a keep-alive message from the server (default 30000 ms), this parameter is ignored if the server does not send keep-alive messages. This will also be used to calculate the max connection time per connect/reconnect
minTimeout?: number: the minimum amount of time the client should wait for a connection to be made (default 1000 ms)
lazy?: boolean : use to set lazy mode - connects only when first subscription created, and delay the socket initialization
connectionParams?: Object | Function | Promise<Object> : object that will be available as first argument of onConnect (in server side), if passed a function - it will call it and send the return value, if function returns as promise - it will wait until it resolves and send the resolved value.
reconnect?: boolean : automatic reconnect in case of connection error
reconnectionAttempts?: number : how much reconnect attempts
connectionCallback?: (error) => {} : optional, callback that called after the first init message, with the error (if there is one)
inactivityTimeout?: number : how long the client should wait in ms, when there are no active subscriptions, before disconnecting from the server. Set to 0 to disable this behavior. (default 0)
webSocketImpl?: Object - optional, constructor for W3C compliant WebSocket implementation. Use this when your environment does not have a built-in native WebSocket (for example, with NodeJS client)

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
