### PR TITLE
Add onError option to useSubscription hook

### DIFF
--- a/src/react/hooks/useSubscription.ts
+++ b/src/react/hooks/useSubscription.ts
@@ -110,6 +110,7 @@ export function useSubscription<TData = any, TVariables = OperationVariables>(
           error,
           variables: options?.variables,
         });
+        ref.current.options?.onError?.(error);
       },
       complete() {
         ref.current.options?.onSubscriptionComplete?.();

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -211,6 +211,7 @@ export interface BaseSubscriptionOptions<
   skip?: boolean;
   context?: DefaultContext;
   onSubscriptionData?: (options: OnSubscriptionDataOptions<TData>) => any;
+  onError?: (error: ApolloError) => void;
   onSubscriptionComplete?: () => void;
 }
 


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Feature
Adds `onError` option to the `useSubscription` hook, similar to how it is offered on other hooks.

I've added a simple test, but wasn't able to add an error-only result, I had to send `data` as well, I'm not sure why. If there's a better way to do that, I'd love to learn.

### Related issues and feature requests:
- https://github.com/apollographql/apollo-client/issues/8338
- https://github.com/apollographql/apollo-feature-requests/issues/122