### PR TITLE
Avoid full reapplication of `cache-and-network` and `network-only` fetch policies after successful `fetchMore`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
 - Provide additional context to `nextFetchPolicy` functions to assist with `fetchPolicy` transitions. More details can be found in the [`nextFetchPolicy` documentation](https://deploy-preview-9067--apollo-client-docs.netlify.app/data/queries/#nextfetchpolicy). <br/>
   [@benjamn](https://github.com/benjamn) in [#9222](https://github.com/apollographql/apollo-client/pull/9222)
 
+### Potentially disruptive changes
+
+- Calling `fetchMore` for queries using the `cache-and-network` or `network-only` fetch policies should no longer trigger additional network requests when cache results are complete. <br/>
+  [@benjamn](https://github.com/benjamn) in [#9504](https://github.com/apollographql/apollo-client/pull/9504)
+
 ### Postponed to v3.7
 
 - Tentatively reimplement `useQuery` and `useLazyQuery` to use the [proposed `useSyncExternalStore` API](https://github.com/reactwg/react-18/discussions/86) from React 18. <br/>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 - Provide additional context to `nextFetchPolicy` functions to assist with `fetchPolicy` transitions. More details can be found in the [`nextFetchPolicy` documentation](https://deploy-preview-9067--apollo-client-docs.netlify.app/data/queries/#nextfetchpolicy). <br/>
   [@benjamn](https://github.com/benjamn) in [#9222](https://github.com/apollographql/apollo-client/pull/9222)
 
+- Remove nagging deprecation warning about passing an `options.updateQuery` function to `fetchMore`. <br/>
+  [@benjamn](https://github.com/benjamn) in [#9504](https://github.com/apollographql/apollo-client/pull/9504)
+
 ### Potentially disruptive changes
 
 - Calling `fetchMore` for queries using the `cache-and-network` or `network-only` fetch policies should no longer trigger additional network requests when cache results are complete. <br/>

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     {
       "name": "apollo-client",
       "path": "./dist/apollo-client.min.cjs",
-      "maxSize": "29kB"
+      "maxSize": "29.2kB"
     }
   ],
   "engines": {

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -3374,12 +3374,9 @@ describe('@connection', () => {
         } else if (handleCount === 4) {
           expect(result.data).toEqual({ count: "secondary" });
           expect(nextFetchPolicyCallCount).toBe(3);
+          client.cache.evict({ fieldName: "count" });
         } else if (handleCount === 5) {
           expect(result.data).toEqual({ count: 1 });
-          expect(nextFetchPolicyCallCount).toBe(3);
-          client.cache.evict({ fieldName: "count" });
-        } else if (handleCount === 6) {
-          expect(result.data).toEqual({ count: 2 });
           expect(nextFetchPolicyCallCount).toBe(4);
           expect(obs.options.fetchPolicy).toBe("cache-first");
           setTimeout(resolve, 50);

--- a/src/__tests__/fetchMore.ts
+++ b/src/__tests__/fetchMore.ts
@@ -4,7 +4,6 @@ import gql from 'graphql-tag';
 import {
   ApolloClient,
   ApolloLink,
-  ApolloQueryResult,
   NetworkStatus,
   ObservableQuery,
   TypedDocumentNode,
@@ -229,7 +228,7 @@ describe('fetchMore on an observable query', () => {
     }
   `;
   const query2: TypedDocumentNode<
-    TCommentData,
+    TCommentData["entry"],
     Omit<TCommentVars, "repoName">
   > = gql`
     query NewComments($start: Int!, $limit: Int!) {
@@ -363,7 +362,7 @@ describe('fetchMore on an observable query', () => {
               const state = cloneDeep(prev) as any;
               state.entry.comments = [
                 ...state.entry.comments,
-                ...options.fetchMoreResult!.entry.comments,
+                ...options.fetchMoreResult.entry.comments,
               ];
               return state;
             },
@@ -457,7 +456,7 @@ describe('fetchMore on an observable query', () => {
               const state = cloneDeep(prev) as any;
               state.entry.comments = [
                 ...state.entry.comments,
-                ...options.fetchMoreResult!.entry.comments,
+                ...options.fetchMoreResult.entry.comments,
               ];
               return state;
             },
@@ -1265,15 +1264,13 @@ describe('fetchMore on an observable query', () => {
             const state = cloneDeep(prev) as any;
             state.entry.comments = [
               ...state.entry.comments,
-              ...(options.fetchMoreResult as any as TCommentData["entry"]).comments,
+              ...options.fetchMoreResult.comments,
             ];
             return state;
           },
         }).then(fetchMoreResult => {
           expect(fetchMoreResult.loading).toBe(false);
-          expect((
-            fetchMoreResult as any as ApolloQueryResult<TCommentData["entry"]>
-          ).data.comments).toHaveLength(10);
+          expect(fetchMoreResult.data.comments).toHaveLength(10);
         });
 
       } else if (count === 2) {
@@ -1591,7 +1588,7 @@ describe('fetchMore on an observable query with connection', () => {
               const state = cloneDeep(prev) as any;
               state.entry.comments = [
                 ...state.entry.comments,
-                ...(options.fetchMoreResult as TEntryComments).entry.comments,
+                ...options.fetchMoreResult.entry.comments,
               ];
               return state;
             },

--- a/src/__tests__/fetchMore.ts
+++ b/src/__tests__/fetchMore.ts
@@ -153,52 +153,6 @@ describe('updateQuery on a query with required and optional variables', () => {
   });
 });
 
-// TODO: Delete this test after removal of updateQuery from fetchMore.
-// This test squashes deprecation notice errors when the suite is run, but not
-// when individual tests are run.
-describe('updateQuery with fetchMore deprecation notice', () => {
-  const query = gql`
-    query thing {
-      entry
-    }
-  `;
-
-  const result = {
-    data: {
-      __typename: 'Query',
-      entry: 1,
-    },
-  };
-
-  const result1 = cloneDeep(result);
-  itAsync('fetchMore warns exactly once', (resolve, reject) => {
-    const spy = jest.spyOn(console, "warn").mockImplementation();
-    const link = mockSingleLink({
-      request: { query },
-      result,
-    }, {
-      request: { query },
-      result: result1,
-    }).setOnError(reject);
-
-    const client = new ApolloClient({
-      link,
-      cache: new InMemoryCache(),
-    });
-
-    const observable = client.watchQuery({query});
-    return observable.fetchMore({updateQuery: (prev) => prev}).then(() => {
-      expect(spy).toHaveBeenCalledTimes(1);
-    }).then(() => {
-      return observable.fetchMore({updateQuery: (prev) => prev});
-    }).then(() => {
-      expect(spy).toHaveBeenCalledTimes(1);
-    }).finally(() => {
-      spy.mockRestore();
-    }).then(resolve, reject);
-  });
-});
-
 describe('fetchMore on an observable query', () => {
   type TCommentData = {
     entry: {

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -435,10 +435,17 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`);
     once, rather than every time you call fetchMore.`);
               warnedAboutUpdateQuery = true;
             }
-            this.updateQuery(previous => updateQuery(previous, {
+
+            cache.updateQuery({
+              query: this.options.query,
+              variables: this.variables,
+              returnPartialData: true,
+              optimistic: false,
+            }, previous => updateQuery(previous!, {
               fetchMoreResult: fetchMoreResult.data,
               variables: combinedOptions.variables as TFetchVars,
             }));
+
           } else {
             // If we're using a field policy instead of updateQuery, the only
             // thing we need to do is write the new data to the cache using

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -362,10 +362,18 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`);
     return this.reobserve(reobserveOptions, NetworkStatus.refetch);
   }
 
-  public fetchMore(
-    fetchMoreOptions: FetchMoreQueryOptions<TVariables, TData> &
-      FetchMoreOptions<TData, TVariables>,
-  ): Promise<ApolloQueryResult<TData>> {
+  public fetchMore<
+    TFetchData = TData,
+    TFetchVars = TVariables,
+  >(fetchMoreOptions: FetchMoreQueryOptions<TFetchVars, TFetchData> & {
+    updateQuery?: (
+      previousQueryResult: TData,
+      options: {
+        fetchMoreResult: TFetchData;
+        variables: TFetchVars;
+      },
+    ) => TData;
+  }): Promise<ApolloQueryResult<TFetchData>> {
     const combinedOptions = {
       ...(fetchMoreOptions.query ? fetchMoreOptions : {
         ...this.options,
@@ -381,7 +389,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`);
       // fetchMore to provide an updateQuery callback that determines how
       // the data gets written to the cache.
       fetchPolicy: "no-cache",
-    } as WatchQueryOptions;
+    } as WatchQueryOptions<TFetchVars, TFetchData>;
 
     const qid = this.queryManager.generateQueryId();
 
@@ -401,9 +409,6 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`);
       combinedOptions,
       NetworkStatus.fetchMore,
     ).then(fetchMoreResult => {
-      const data = fetchMoreResult.data as TData;
-      const { updateQuery } = fetchMoreOptions;
-
       this.queryManager.removeQuery(qid);
 
       if (queryInfo.networkStatus === NetworkStatus.fetchMore) {
@@ -412,6 +417,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`);
 
       this.queryManager.cache.batch({
         update: cache => {
+          const { updateQuery } = fetchMoreOptions;
           if (updateQuery) {
             if (__DEV__ &&
                 !warnedAboutUpdateQuery) {
@@ -430,8 +436,8 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`);
               warnedAboutUpdateQuery = true;
             }
             this.updateQuery(previous => updateQuery(previous, {
-              fetchMoreResult: data,
-              variables: combinedOptions.variables as TVariables,
+              fetchMoreResult: fetchMoreResult.data,
+              variables: combinedOptions.variables as TFetchVars,
             }));
           } else {
             // If we're using a field policy instead of updateQuery, the only
@@ -443,7 +449,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`);
             cache.writeQuery({
               query: combinedOptions.query,
               variables: combinedOptions.variables,
-              data,
+              data: fetchMoreResult.data,
             });
           }
         },
@@ -453,7 +459,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`);
         },
       });
 
-      return fetchMoreResult as ApolloQueryResult<TData>;
+      return fetchMoreResult as ApolloQueryResult<TFetchData>;
 
     }).finally(() => {
       if (!updatedQuerySet.has(this.options.query)) {

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -52,8 +52,6 @@ export interface UpdateQueryOptions<TVariables> {
   variables?: TVariables;
 }
 
-let warnedAboutUpdateQuery = false;
-
 interface Last<TData, TVariables> {
   result: ApolloQueryResult<TData>;
   variables?: TVariables;
@@ -419,23 +417,6 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`);
         update: cache => {
           const { updateQuery } = fetchMoreOptions;
           if (updateQuery) {
-            if (__DEV__ &&
-                !warnedAboutUpdateQuery) {
-              invariant.warn(
-    `The updateQuery callback for fetchMore is deprecated, and will be removed
-    in the next major version of Apollo Client.
-
-    Please convert updateQuery functions to field policies with appropriate
-    read and merge functions, or use/adapt a helper function (such as
-    concatPagination, offsetLimitPagination, or relayStylePagination) from
-    @apollo/client/utilities.
-
-    The field policy system handles pagination more effectively than a
-    hand-written updateQuery function, and you only need to define the policy
-    once, rather than every time you call fetchMore.`);
-              warnedAboutUpdateQuery = true;
-            }
-
             cache.updateQuery({
               query: this.options.query,
               variables: this.variables,

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -433,6 +433,11 @@ once, rather than every time you call fetchMore.`);
           query: combinedOptions.query,
           variables: combinedOptions.variables,
           data,
+          // TODO Figure out why this breaks tests, since the result should
+          // ultimately be broadcast by this.reobserveCacheFirst in the finally
+          // block below. Alternatively, we rely on the cache broadcast for this
+          // cache.writeQuery, and avoid using reobserveCacheFirst below.
+          broadcast: false,
         });
       }
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -462,7 +462,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`);
       // the cache, we still want fetchMore to deliver its final loading:false
       // result with the unchanged data.
       if (!updatedQuerySet.has(this.options.query)) {
-        this.reobserveCacheFirst();
+        reobserveCacheFirst(this);
       }
     });
   }
@@ -824,43 +824,6 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`);
     );
   }
 
-  // Reobserve with fetchPolicy effectively set to "cache-first", triggering
-  // delivery of any new data from the cache, possibly falling back to the
-  // network if any cache data are missing. This allows _complete_ cache results
-  // to be delivered without also kicking off unnecessary network requests when
-  // this.options.fetchPolicy is "cache-and-network" or "network-only". When
-  // this.options.fetchPolicy is any other policy ("cache-first", "cache-only",
-  // "standby", or "no-cache"), we call this.reobserve() as usual.
-  public reobserveCacheFirst() {
-    const { fetchPolicy, nextFetchPolicy } = this.options;
-
-    if (
-      fetchPolicy === "cache-and-network" ||
-      fetchPolicy === "network-only"
-    ) {
-      return this.reobserve({
-        fetchPolicy: "cache-first",
-        // Use a temporary nextFetchPolicy function that replaces itself with
-        // the previous nextFetchPolicy value and returns the original
-        // fetchPolicy.
-        nextFetchPolicy(...args) {
-          // Replace this nextFetchPolicy function in the options object with
-          // the original this.options.nextFetchPolicy value.
-          this.nextFetchPolicy = nextFetchPolicy;
-          // If the original nextFetchPolicy value was a function, give it a
-          // chance to decide what happens here.
-          if (typeof nextFetchPolicy === "function") {
-            return nextFetchPolicy.apply(this, args);
-          }
-          // Otherwise go back to the original this.options.fetchPolicy.
-          return fetchPolicy!;
-        },
-      });
-    }
-
-    return this.reobserve();
-  }
-
   private reportResult(
     result: ApolloQueryResult<TData>,
     variables: TVariables | undefined,
@@ -919,6 +882,44 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`);
 // Necessary because the ObservableQuery constructor has a different
 // signature than the Observable constructor.
 fixObservableSubclass(ObservableQuery);
+
+// Reobserve with fetchPolicy effectively set to "cache-first", triggering
+// delivery of any new data from the cache, possibly falling back to the network
+// if any cache data are missing. This allows _complete_ cache results to be
+// delivered without also kicking off unnecessary network requests when
+// this.options.fetchPolicy is "cache-and-network" or "network-only". When
+// this.options.fetchPolicy is any other policy ("cache-first", "cache-only",
+// "standby", or "no-cache"), we call this.reobserve() as usual.
+export function reobserveCacheFirst<TData, TVars>(
+  obsQuery: ObservableQuery<TData, TVars>,
+) {
+  const { fetchPolicy, nextFetchPolicy } = obsQuery.options;
+
+  if (
+    fetchPolicy === "cache-and-network" ||
+    fetchPolicy === "network-only"
+  ) {
+    return obsQuery.reobserve({
+      fetchPolicy: "cache-first",
+      // Use a temporary nextFetchPolicy function that replaces itself with the
+      // previous nextFetchPolicy value and returns the original fetchPolicy.
+      nextFetchPolicy(this: WatchQueryOptions<TVars, TData>) {
+        // Replace this nextFetchPolicy function in the options object with the
+        // original this.options.nextFetchPolicy value.
+        this.nextFetchPolicy = nextFetchPolicy;
+        // If the original nextFetchPolicy value was a function, give it a
+        // chance to decide what happens here.
+        if (typeof nextFetchPolicy === "function") {
+          return nextFetchPolicy.apply(this, arguments);
+        }
+        // Otherwise go back to the original this.options.fetchPolicy.
+        return fetchPolicy!;
+      },
+    });
+  }
+
+  return obsQuery.reobserve();
+}
 
 function defaultSubscriptionObserverErrorCallback(error: ApolloError) {
   invariant.error('Unhandled error', error.message, error.stack);

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -238,17 +238,7 @@ export class QueryInfo {
         if (diff.fromOptimisticTransaction) {
           oq["observe"]();
         } else if (diff.complete) {
-          const { fetchPolicy, nextFetchPolicy } = oq.options;
-          oq.reobserve({
-            fetchPolicy: "cache-first",
-            nextFetchPolicy(...args) {
-              this.nextFetchPolicy = nextFetchPolicy;
-              if (typeof nextFetchPolicy === "function") {
-                return nextFetchPolicy.apply(this, args);
-              }
-              return fetchPolicy!;
-            },
-          });
+          oq["reobserveCacheFirst"]();
         } else {
           oq.reobserve();
         }

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -229,18 +229,15 @@ export class QueryInfo {
     if (oq) {
       oq["queryInfo"] = this;
       this.listeners.add(this.oqListener = () => {
-        // If this.diff came from an optimistic transaction, deliver the
-        // current cache data to the ObservableQuery, but don't perform a
-        // full reobservation, since oq.reobserve might make a network
-        // request, and we don't want to trigger network requests for
-        // optimistic updates.
+        // If this.diff came from an optimistic transaction, deliver the current
+        // cache data to the ObservableQuery, but don't perform a reobservation,
+        // since oq.reobserveCacheFirst might make a network request, and we
+        // don't want to trigger network requests for optimistic updates.
         const diff = this.getDiff();
         if (diff.fromOptimisticTransaction) {
           oq["observe"]();
-        } else if (diff.complete) {
-          oq.reobserveCacheFirst();
         } else {
-          oq.reobserve();
+          oq.reobserveCacheFirst();
         }
       });
     } else {

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -238,7 +238,7 @@ export class QueryInfo {
         if (diff.fromOptimisticTransaction) {
           oq["observe"]();
         } else if (diff.complete) {
-          oq["reobserveCacheFirst"]();
+          oq.reobserveCacheFirst();
         } else {
           oq.reobserve();
         }

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -3,7 +3,7 @@ import { equal } from "@wry/equality";
 
 import { Cache, ApolloCache } from '../cache';
 import { WatchQueryOptions, ErrorPolicy } from './watchQueryOptions';
-import { ObservableQuery } from './ObservableQuery';
+import { ObservableQuery, reobserveCacheFirst } from './ObservableQuery';
 import { QueryListener } from './types';
 import { FetchResult } from '../link/core';
 import {
@@ -246,7 +246,7 @@ export class QueryInfo {
           // this method, and are handled by calling oq.reobserve(). If this
           // reobservation is spurious, isDifferentFromLastResult still has a
           // chance to catch it before delivery to ObservableQuery subscribers.
-          oq.reobserveCacheFirst();
+          reobserveCacheFirst(oq);
         }
       });
     } else {

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -927,8 +927,10 @@ export class QueryManager<TStore> {
     // A query created with `QueryManager.query()` could trigger a `QueryManager.fetchRequest`.
     // The same queryId could have two rejection fns for two promises
     this.fetchCancelFns.delete(queryId);
-    this.getQuery(queryId).stop();
-    this.queries.delete(queryId);
+    if (this.queries.has(queryId)) {
+      this.getQuery(queryId).stop();
+      this.queries.delete(queryId);
+    }
   }
 
   public broadcastQueries() {


### PR DESCRIPTION
This PR implements a variation on the idea I sketched in https://github.com/apollographql/apollo-client/issues/6916#issuecomment-901466918, ~without doing too much violence to our existing test suite~. I did end up making a number of adjustments to tests that this PR initially caused to fail, but I'm confident they are nonviolent (that is, they test the same things in a more robust/realistic way).

Previous attempts to solve #6916 stalled in part because the number of test failures felt indicative of potential backwards incompatibility. Now that I've worked through all the failing tests in this PR, I believe they are mostly just fragile/flaky/timing-sensitive tests, though of course it would be great to validate that hope with beta testing.

In short, `fetchMore` should (now) be able to deliver complete cache results to `ObservableQuery` subscribers without triggering additional network requests when using the `cache-and-network` or `network-only` fetch policies, resolving the following related (some long-standing) issues:
* #6916
* #7939
* #9363
* https://github.com/vuejs/apollo/issues/1026
* … and likely more