### PR TITLE
Ease debugging Node.js from within VSCode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,15 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "Attach to Node.js inspector",
+      "port": 9229,
+      "request": "attach",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "type": "pwa-node"
+    },
+    {
       "type": "node",
       "request": "launch",
       "name": "Jest Current File",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "clean": "rimraf -r dist coverage lib temp",
     "ci:precheck": "node config/precheck.js",
     "test": "jest --config ./config/jest.config.js",
-    "test:debug": "BABEL_ENV=server node --inspect-brk node_modules/.bin/jest --config ./config/jest.config.js --runInBand --testTimeout 99999",
+    "test:debug": "node --inspect-brk node_modules/.bin/jest --config ./config/jest.config.js --runInBand --testTimeout 99999",
     "test:ci": "npm run test:coverage && npm run test:memory",
     "test:watch": "jest --config ./config/jest.config.js --watch",
     "test:memory": "cd scripts/memory && npm i && npm test",


### PR DESCRIPTION
The other day my Chrome browser (dev channel, 101.0.4929.5) started crashing spontaneously on startup, which kept me from using the Chrome DevTools to debug Apollo Client tests running in Node.js.

Since I mostly use VSCode for editing these days, I decided to see if I could debug Node.js from entirely within VSCode. This would be appealing not just as a backup for Chrome, but also because it allows setting temporary breakpoints in source files (as well as inspecting local variables and the call stack) without leaving VSCode.

This experiment worked out quite nicely, so this PR shares my VSCode configuration for this repository, for anyone else who wants to try this style of debugging.

Steps:
0. Add some breakpoints to a test you'd like to debug, either using `debugger` statements or VSCode breakpoints (click the red dot at the far left of any line)
1. Within your clone of this repository, run `npm run test:debug`, or `npm run test:debug src/cache/inmemory` to scope which tests are run
2. Switch to the debugging panel of VSCode, choose `Attach to Node.js inspector` from the drop-down menu towards the top, and press the green triangle to start debugging
3. Find the debugger control arrows, and press the leftmost button to continue past the very first statement in the program (likely in `jest.js`)
4. Wait until your test stops at the breakpoints you set!

You can also judge the DX for yourself with this (silent) [screen recording](https://user-images.githubusercontent.com/5750/157909688-34e005f1-6d39-449f-8e17-b2b7d8e115d5.mov).