### PR TITLE
Fix FetchResult type

### DIFF
--- a/src/link/core/types.ts
+++ b/src/link/core/types.ts
@@ -24,7 +24,7 @@ export interface FetchResult<
   TData = Record<string, any>,
   TContext = Record<string, any>,
   TExtensions = Record<string, any>
-> extends ExecutionResult<TData, TExtensions> {
+> extends ExecutionResult<TData> {
   data?: TData | null | undefined;
   extensions?: TExtensions;
   context?: TContext;


### PR DESCRIPTION
ExecutionResult has only one generic parameter. Adding two causes the inheritance to not work.
Causing this issue https://github.com/apollographql/apollo-client/issues/9292

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

Test plan: This fixes types on my project 
