### PR TITLE
Refactor `useLazyQuery` to reuse `useInternalState` and make execution function call `reobserve` instead of `refetch`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 - Remove nagging deprecation warning about passing an `options.updateQuery` function to `fetchMore`. <br/>
   [@benjamn](https://github.com/benjamn) in [#9504](https://github.com/apollographql/apollo-client/pull/9504)
 
+- Fixed bug where the `useLazyQuery` execution function would always use the `refetch` method of `ObservableQuery`, instead of properly reapplying the current `fetchPolicy` using the `reobserve` method. <br/>
+  [@benjamn](https://github.com/benjamn) in [#9564](https://github.com/apollographql/apollo-client/pull/9564)
+
 ### Potentially disruptive changes
 
 - Calling `fetchMore` for queries using the `cache-and-network` or `network-only` fetch policies should no longer trigger additional network requests when cache results are complete. <br/>

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -3321,7 +3321,7 @@ describe('@connection', () => {
               expect(context.reason).toBe("after-fetch");
               expect(context.observable).toBe(obs);
               expect(context.options).toBe(obs.options);
-              expect(context.initialPolicy).toBe("cache-first");
+              expect(context.initialFetchPolicy).toBe("cache-first");
 
               // Usually options.nextFetchPolicy applies only once, but a
               // nextFetchPolicy function can set this.nextFetchPolicy

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -755,6 +755,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`);
 
     // Save the old variables, since Object.assign may modify them below.
     const oldVariables = this.options.variables;
+    const oldFetchPolicy = this.options.fetchPolicy;
 
     const mergedOptions = mergeOptions(this.options, newOptions || {});
     const options = useDisposableConcast
@@ -772,8 +773,8 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`);
       if (
         newOptions &&
         newOptions.variables &&
-        !newOptions.fetchPolicy &&
-        !equal(newOptions.variables, oldVariables)
+        !equal(newOptions.variables, oldVariables) &&
+        (!newOptions.fetchPolicy || newOptions.fetchPolicy === oldFetchPolicy)
       ) {
         this.applyNextFetchPolicy("variables-changed", options);
         if (newNetworkStatus === void 0) {

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -616,7 +616,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`);
     // options.fetchPolicy even if options !== this.options, though that happens
     // most often when the options are temporary, used for only one request and
     // then thrown away, so nextFetchPolicy may not end up mattering.
-    options: WatchQueryOptions<TVariables, TData> = this.options,
+    options: WatchQueryOptions<TVariables, TData>,
   ) {
     if (options.nextFetchPolicy) {
       const { fetchPolicy = "cache-first" } = options;
@@ -775,7 +775,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`);
         !newOptions.fetchPolicy &&
         !equal(newOptions.variables, oldVariables)
       ) {
-        this.applyNextFetchPolicy("variables-changed");
+        this.applyNextFetchPolicy("variables-changed", options);
         if (newNetworkStatus === void 0) {
           newNetworkStatus = NetworkStatus.setVariables;
         }

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1060,11 +1060,12 @@ export class QueryManager<TStore> {
         const aqr: ApolloQueryResult<TData> = {
           data: result.data,
           loading: false,
-          networkStatus: queryInfo.networkStatus || NetworkStatus.ready,
+          networkStatus: NetworkStatus.ready,
         };
 
         if (hasErrors && options.errorPolicy !== "ignore") {
           aqr.errors = result.errors;
+          aqr.networkStatus = NetworkStatus.error;
         }
 
         return aqr;

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -1199,7 +1199,7 @@ describe('ObservableQuery', () => {
       });
 
       expect(observable.options.fetchPolicy).toBe('cache-and-network');
-      expect(observable["initialFetchPolicy"]).toBe('cache-and-network');
+      expect(observable.options.initialFetchPolicy).toBe('cache-and-network');
 
       subscribeAndCount(reject, observable, (handleCount, result) => {
         expect(result.error).toBeUndefined();

--- a/src/core/__tests__/fetchPolicies.ts
+++ b/src/core/__tests__/fetchPolicies.ts
@@ -938,7 +938,8 @@ describe("nextFetchPolicy", () => {
     expect(currentFetchPolicy).toBe(context.options.fetchPolicy);
     switch (context.reason) {
       case "variables-changed":
-        return context.initialPolicy;
+        expect(context.initialFetchPolicy).toBe(context.options.initialFetchPolicy);
+        return context.initialFetchPolicy;
       default:
       case "after-fetch":
         return "cache-first";
@@ -1070,7 +1071,8 @@ describe("nextFetchPolicy", () => {
     expect(currentFetchPolicy).toBe(context.options.fetchPolicy);
     switch (context.reason) {
       case "variables-changed":
-        return context.initialPolicy;
+        expect(context.initialFetchPolicy).toBe(context.options.initialFetchPolicy);
+        return context.initialFetchPolicy;
       default:
       case "after-fetch":
         return "cache-first";

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -121,6 +121,7 @@ export interface WatchQueryOptions<TVariables = OperationVariables, TData = any>
    * Specifies the {@link FetchPolicy} to be used for this query.
    */
   fetchPolicy?: WatchQueryFetchPolicy;
+
   /**
    * Specifies the {@link FetchPolicy} to be used after this query has completed.
    */
@@ -129,6 +130,14 @@ export interface WatchQueryOptions<TVariables = OperationVariables, TData = any>
     currentFetchPolicy: WatchQueryFetchPolicy,
     context: NextFetchPolicyContext<TData, TVariables>,
   ) => WatchQueryFetchPolicy);
+
+  /**
+   * Defaults to the initial value of options.fetchPolicy, but can be explicitly
+   * configured to specify the WatchQueryFetchPolicy to revert back to whenever
+   * variables change (unless nextFetchPolicy intervenes).
+   */
+  initialFetchPolicy?: WatchQueryFetchPolicy;
+
   /**
    * Specifies whether a {@link NetworkStatus.refetch} operation should merge
    * incoming field data with existing data, or overwrite the existing data.
@@ -144,7 +153,7 @@ export interface NextFetchPolicyContext<TData, TVariables> {
     | "variables-changed";
   observable: ObservableQuery<TData, TVariables>;
   options: WatchQueryOptions<TVariables, TData>;
-  initialPolicy: WatchQueryFetchPolicy;
+  initialFetchPolicy: WatchQueryFetchPolicy;
 }
 
 export interface FetchMoreQueryOptions<TVariables, TData = any> {

--- a/src/react/components/__tests__/client/Query.test.tsx
+++ b/src/react/components/__tests__/client/Query.test.tsx
@@ -59,6 +59,7 @@ describe('Query component', () => {
             observable,
             fetchMore,
             refetch,
+            reobserve,
             startPolling,
             stopPolling,
             subscribeToMore,

--- a/src/react/hooks/index.ts
+++ b/src/react/hooks/index.ts
@@ -3,6 +3,6 @@ import '../../utilities/globals';
 export * from './useApolloClient';
 export * from './useLazyQuery';
 export * from './useMutation';
-export * from './useQuery';
+export { useQuery } from './useQuery';
 export * from './useSubscription';
 export * from './useReactiveVar';

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -58,10 +58,13 @@ export function useLazyQuery<TData = any, TVariables = OperationVariables>(
     const eagerMethods: Record<string, any> = {};
     for (const key of EAGER_METHODS) {
       const method = result[key];
-      eagerMethods[key] = (...args: any) => {
-        execOptionsRef.current = execOptionsRef.current || {};
-        internalState.forceUpdate();
-        return (method as any)(...args);
+      eagerMethods[key] = function () {
+        if (!execOptionsRef.current) {
+          execOptionsRef.current = Object.create(null);
+          // Only the first time populating execOptionsRef.current matters here.
+          internalState.forceUpdate();
+        }
+        return method.apply(this, arguments);
       };
     }
 

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -17,6 +17,7 @@ import { isNonEmptyArray } from '../../utilities';
 // whether the useLazyQuery execute function was called before.
 const EAGER_METHODS = [
   'refetch',
+  'reobserve',
   'fetchMore',
   'updateQuery',
   'startPolling',
@@ -76,7 +77,7 @@ export function useLazyQuery<TData = any, TVariables = OperationVariables>(
   const execute = useCallback<
     LazyQueryResultTuple<TData, TVariables>[0]
   >(executeOptions => {
-    const promise = result.observable.reobserve(
+    const promise = result.reobserve(
       execOptionsRef.current = executeOptions ? {
         ...executeOptions,
         fetchPolicy: executeOptions.fetchPolicy || initialFetchPolicy,

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -44,8 +44,6 @@ export function useLazyQuery<TData = any, TVariables = OperationVariables>(
   const useQueryResult = internalState.useQuery({
     ...options,
     ...execOptionsRef.current,
-    // TODO This probably means this.observable.initialFetchPolicy is never set
-    // appropriately.
     skip: !execOptionsRef.current,
   });
 

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -7,7 +7,8 @@ import {
   LazyQueryHookOptions,
   LazyQueryResultTuple,
 } from '../types/types';
-import { useQuery } from './useQuery';
+import { useInternalState } from './useQuery';
+import { useApolloClient } from './useApolloClient';
 
 // The following methods, when called will execute the query, regardless of
 // whether the useLazyQuery execute function was called before.
@@ -23,6 +24,11 @@ export function useLazyQuery<TData = any, TVariables = OperationVariables>(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
   options?: LazyQueryHookOptions<TData, TVariables>
 ): LazyQueryResultTuple<TData, TVariables> {
+  const internalState = useInternalState(
+    useApolloClient(options && options.client),
+    query,
+  );
+
   const [execution, setExecution] = useState<{
     called: boolean,
     options?: Partial<LazyQueryHookOptions<TData, TVariables>>;
@@ -30,7 +36,7 @@ export function useLazyQuery<TData = any, TVariables = OperationVariables>(
     called: false,
   });
 
-  let result = useQuery<TData, TVariables>(query, {
+  let result = internalState.useQuery({
     ...options,
     ...execution.options,
     // We don’t set skip to execution.called, because some useQuery SSR code

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -5,8 +5,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { OperationVariables } from '../../core';
 import {
   LazyQueryHookOptions,
-  QueryLazyOptions,
-  QueryTuple,
+  LazyQueryResultTuple,
 } from '../types/types';
 import { useQuery } from './useQuery';
 
@@ -23,10 +22,10 @@ const EAGER_METHODS = [
 export function useLazyQuery<TData = any, TVariables = OperationVariables>(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
   options?: LazyQueryHookOptions<TData, TVariables>
-): QueryTuple<TData, TVariables> {
+): LazyQueryResultTuple<TData, TVariables> {
   const [execution, setExecution] = useState<{
     called: boolean,
-    options?: QueryLazyOptions<TVariables>,
+    options?: Partial<LazyQueryHookOptions<TData, TVariables>>;
   }>({
     called: false,
   });
@@ -68,8 +67,8 @@ export function useLazyQuery<TData = any, TVariables = OperationVariables>(
   Object.assign(result, eagerMethods);
 
   const execute = useCallback<
-    QueryTuple<TData, TVariables>[0]
-  >((executeOptions?: QueryLazyOptions<TVariables>) => {
+    LazyQueryResultTuple<TData, TVariables>[0]
+  >(executeOptions => {
     setExecution({ called: true, options: executeOptions });
     const promise = result.refetch(executeOptions?.variables).then((result1) => {
       const result2 = {

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -71,18 +71,9 @@ export function useLazyQuery<TData = any, TVariables = OperationVariables>(
     LazyQueryResultTuple<TData, TVariables>[0]
   >(executeOptions => {
     setExecution({ called: true, options: executeOptions });
-    const promise = result.refetch(executeOptions?.variables).then((result1) => {
-      const result2 = {
-        ...result,
-        data: result1.data,
-        error: result1.error,
-        called: true,
-        loading: false,
-      };
-
-      Object.assign(result2, eagerMethods);
-      return result2;
-    });
+    const promise = result.refetch(executeOptions?.variables)
+      .then(apolloQueryResult => internalState.toQueryResult(apolloQueryResult))
+      .then(queryResult => Object.assign(queryResult, eagerMethods));
 
     // Because the return value of `useLazyQuery` is usually floated, we need
     // to catch the promise to prevent unhandled rejections.

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -78,7 +78,15 @@ export function useLazyQuery<TData = any, TVariables = OperationVariables>(
     };
 
     const promise = result.observable.reobserve(executeOptions)
-      .then(apolloQueryResult => internalState.toQueryResult(apolloQueryResult))
+      .then(apolloQueryResult => {
+        return internalState.toQueryResult(
+          // If this.observable.options.fetchPolicy is "standby", the
+          // apolloQueryResult we receive here can be undefined, so we call
+          // getCurrentResult to obtain a stub result. TODO Investigate whether
+          // standby queries could return this stub result in the first place.
+          apolloQueryResult || internalState["getCurrentResult"]()
+        );
+      })
       .then(queryResult => Object.assign(queryResult, eagerMethods));
 
     // Deliver the loading state for this reobservation immediately.

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -85,8 +85,9 @@ export function useLazyQuery<TData = any, TVariables = OperationVariables>(
     ).then(apolloQueryResult => {
       // If this.observable.options.fetchPolicy is "standby", the
       // apolloQueryResult we receive here can be undefined, so we call
-      // getCurrentResult to obtain a stub result. TODO Investigate whether
-      // standby queries could return this stub result in the first place.
+      // getCurrentResult to obtain a stub result.
+      // TODO Investigate whether standby queries could return this stub result
+      // in the first place.
       apolloQueryResult = apolloQueryResult || internalState["getCurrentResult"]();
 
       if (

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -282,6 +282,7 @@ class InternalState<TData, TVariables> {
       return {
         // These methods are available directly from result.observable now.
         refetch: wrap("refetch"),
+        reobserve: wrap("reobserve"),
         fetchMore: wrap("fetchMore"),
         updateQuery: wrap("updateQuery"),
         startPolling: wrap("startPolling"),

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -497,7 +497,7 @@ class InternalState<TData, TVariables> {
     QueryResult<TData, TVariables>
   >();
 
-  private toQueryResult(
+  public toQueryResult(
     result: ApolloQueryResult<TData>,
   ): QueryResult<TData, TVariables> {
     let queryResult = this.toQueryResultCache.get(result);

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -466,7 +466,7 @@ class InternalState<TData, TVariables> {
       };
     } else if (
       this.queryHookOptions.skip ||
-      this.queryHookOptions.fetchPolicy === 'standby'
+      this.watchQueryOptions.fetchPolicy === 'standby'
     ) {
       // When skipping a query (ie. we're not querying for data but still want to
       // render children), make sure the `data` is cleared out and `loading` is

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -220,9 +220,7 @@ class InternalState<TData, TVariables> {
     const watchQueryOptions: WatchQueryOptions<TVariables, TData> =
       Object.assign(merged, { query: this.query });
 
-    if (skip) {
-      watchQueryOptions.fetchPolicy = 'standby';
-    } else if (
+    if (
       this.renderPromises &&
       (
         watchQueryOptions.fetchPolicy === 'network-only' ||
@@ -237,6 +235,24 @@ class InternalState<TData, TVariables> {
       // globalDefaults and defaultOptions), so, if fetchPolicy is still
       // undefined, fall back to the default default (no typo), cache-first.
       watchQueryOptions.fetchPolicy = 'cache-first';
+    }
+
+    if (skip) {
+      const {
+        // The watchQueryOptions.initialFetchPolicy field usually defaults to
+        // watchQueryOptions.fetchPolicy, which has now been properly
+        // defaulted/initialized. However, watchQueryOptions.initialFetchPolicy
+        // can be provided explicitly instead, if more control is desired.
+        initialFetchPolicy = watchQueryOptions.fetchPolicy,
+      } = watchQueryOptions;
+
+      // When skipping, we set watchQueryOptions.fetchPolicy initially to
+      // "standby", but we also need/want to preserve the initial non-standby
+      // fetchPolicy that would have been used if not skipping.
+      Object.assign(watchQueryOptions, {
+        initialFetchPolicy,
+        fetchPolicy: 'standby',
+      });
     }
 
     if (!watchQueryOptions.variables) {

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -79,14 +79,14 @@ class InternalState<TData, TVariables> {
     verifyDocumentType(query, DocumentType.Query);
   }
 
-  public forceUpdate() {
+  forceUpdate() {
     // Replaced (in useInternalState) with a method that triggers an update.
   }
 
   // Methods beginning with use- should be called according to the standard
   // rules of React hooks: only at the top level of the calling function, and
   // without any dynamic conditional logic.
-  public useQuery(options: QueryHookOptions<TData, TVariables>) {
+  useQuery(options: QueryHookOptions<TData, TVariables>) {
     // The renderPromises field gets initialized here in the useQuery method, at
     // the beginning of everything (for a given component rendering, at least),
     // so we can safely use this.renderPromises in other/later InternalState
@@ -498,7 +498,7 @@ class InternalState<TData, TVariables> {
     QueryResult<TData, TVariables>
   >();
 
-  public toQueryResult(
+  toQueryResult(
     result: ApolloQueryResult<TData>,
   ): QueryResult<TData, TVariables> {
     let queryResult = this.toQueryResultCache.get(result);

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -43,7 +43,7 @@ export function useQuery<
   ).useQuery(options);
 }
 
-function useInternalState<TData, TVariables>(
+export function useInternalState<TData, TVariables>(
   client: ApolloClient<any>,
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
 ) {

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -268,28 +268,15 @@ class InternalState<TData, TVariables> {
         || this.observable // Reuse this.observable if possible (and not SSR)
         || this.client.watchQuery(this.watchQueryOptions);
 
-    this.obsQueryFields = useMemo(() => {
-      type OQFieldName = keyof typeof this.obsQueryFields;
-
-      function wrap<M extends OQFieldName>(
-        method: M,
-      ): ObservableQuery<TData, TVariables>[M] {
-        return function () {
-          return obsQuery[method].apply(obsQuery, arguments);
-        };
-      }
-
-      return {
-        // These methods are available directly from result.observable now.
-        refetch: wrap("refetch"),
-        reobserve: wrap("reobserve"),
-        fetchMore: wrap("fetchMore"),
-        updateQuery: wrap("updateQuery"),
-        startPolling: wrap("startPolling"),
-        stopPolling: wrap("stopPolling"),
-        subscribeToMore: wrap("subscribeToMore"),
-      };
-    }, [obsQuery]);
+    this.obsQueryFields = useMemo(() => ({
+      refetch: obsQuery.refetch.bind(obsQuery),
+      reobserve: obsQuery.reobserve.bind(obsQuery),
+      fetchMore: obsQuery.fetchMore.bind(obsQuery),
+      updateQuery: obsQuery.updateQuery.bind(obsQuery),
+      startPolling: obsQuery.startPolling.bind(obsQuery),
+      stopPolling: obsQuery.stopPolling.bind(obsQuery),
+      subscribeToMore: obsQuery.subscribeToMore.bind(obsQuery),
+    }), [obsQuery]);
 
     if (this.renderPromises) {
       this.renderPromises.registerSSRObservable(obsQuery);

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -59,6 +59,7 @@ export type ObservableQueryFields<TData, TVariables> = Pick<
   | 'subscribeToMore'
   | 'updateQuery'
   | 'refetch'
+  | 'reobserve'
   | 'variables'
   | 'fetchMore'
 >;

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -8,10 +8,7 @@ import { ApolloError } from '../../errors';
 import {
   ApolloCache,
   ApolloClient,
-  ApolloQueryResult,
   DefaultContext,
-  FetchMoreOptions,
-  FetchMoreQueryOptions,
   FetchPolicy,
   MutationOptions,
   NetworkStatus,
@@ -63,19 +60,8 @@ export type ObservableQueryFields<TData, TVariables> = Pick<
   | 'updateQuery'
   | 'refetch'
   | 'variables'
-> & {
-  fetchMore: ((
-    fetchMoreOptions: FetchMoreQueryOptions<TVariables, TData> &
-      FetchMoreOptions<TData, TVariables>
-  ) => Promise<ApolloQueryResult<TData>>) &
-    (<TData2, TVariables2>(
-      fetchMoreOptions: { query?: DocumentNode | TypedDocumentNode<TData, TVariables> } & FetchMoreQueryOptions<
-        TVariables2,
-        TData
-      > &
-        FetchMoreOptions<TData2, TVariables2>
-    ) => Promise<ApolloQueryResult<TData2>>);
-};
+  | 'fetchMore'
+>;
 
 export interface QueryResult<TData = any, TVariables = OperationVariables>
   extends ObservableQueryFields<TData, TVariables> {

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -103,21 +103,28 @@ export interface QueryHookOptions<TData = any, TVariables = OperationVariables>
 export interface LazyQueryHookOptions<
   TData = any,
   TVariables = OperationVariables
-> extends Omit<QueryFunctionOptions<TData, TVariables>, 'skip'> {
-  query?: DocumentNode | TypedDocumentNode<TData, TVariables>;
-}
+> extends Omit<QueryHookOptions<TData, TVariables>, 'skip'> {}
 
+/**
+ * @deprecated TODO Delete this unused interface.
+ */
 export interface QueryLazyOptions<TVariables> {
   variables?: TVariables;
   context?: DefaultContext;
 }
 
-// TODO: Delete this
+/**
+ * @deprecated TODO Delete this unused type alias.
+ */
 export type LazyQueryResult<TData, TVariables> = QueryResult<TData, TVariables>;
 
-export type QueryTuple<TData, TVariables> = [
-  (options?: QueryLazyOptions<TVariables>) => Promise<LazyQueryResult<TData, TVariables>>,
-  LazyQueryResult<TData, TVariables>
+export type LazyQueryExecFunction<TData, TVariables> = (
+  options?: Partial<LazyQueryHookOptions<TData, TVariables>>,
+) => Promise<QueryResult<TData, TVariables>>;
+
+export type LazyQueryResultTuple<TData, TVariables> = [
+  LazyQueryExecFunction<TData, TVariables>,
+  QueryResult<TData, TVariables>,
 ];
 
 /* Mutation types */

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -105,6 +105,12 @@ export interface QueryLazyOptions<TVariables> {
  */
 export type LazyQueryResult<TData, TVariables> = QueryResult<TData, TVariables>;
 
+/**
+ * @deprecated TODO Delete this unused type alias.
+ */
+export type QueryTuple<TData, TVariables> =
+  LazyQueryResultTuple<TData, TVariables>;
+
 export type LazyQueryExecFunction<TData, TVariables> = (
   options?: Partial<LazyQueryHookOptions<TData, TVariables>>,
 ) => Promise<QueryResult<TData, TVariables>>;


### PR DESCRIPTION
Building on #9563 and taking inspiration from #9459, this refactoring allows `useLazyQuery` to use the same `InternalState` machinery as `useQuery` (introduced in #9459), and fixes issue #9375 by making the execution function call `reobserve` (which respects the current `fetchPolicy`) instead of `refetch` (which always triggers a network request).