### PR TITLE
Let `addTypenameToDocument` take any `ASTNode` (including `DocumentNode`, as before)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
 - Fixed bug where the `useLazyQuery` execution function would always use the `refetch` method of `ObservableQuery`, instead of properly reapplying the current `fetchPolicy` using the `reobserve` method. <br/>
   [@benjamn](https://github.com/benjamn) in [#9564](https://github.com/apollographql/apollo-client/pull/9564)
 
+- Let `addTypenameToDocument` take any `ASTNode` (including `DocumentNode`, as before). <br/>
+  [@benjamn](https://github.com/benjamn) in [#9595](https://github.com/apollographql/apollo-client/pull/9595)
+
 ### Potentially disruptive changes
 
 - Calling `fetchMore` for queries using the `cache-and-network` or `network-only` fetch policies should no longer trigger additional network requests when cache results are complete. <br/>

--- a/src/utilities/graphql/transform.ts
+++ b/src/utilities/graphql/transform.ts
@@ -13,6 +13,7 @@ import {
   VariableDefinitionNode,
   VariableNode,
   visit,
+  ASTNode,
 } from 'graphql';
 
 // TODO(brian): A hack until this issue is resolved (https://github.com/graphql/graphql-js/issues/3356)
@@ -213,10 +214,12 @@ export function removeDirectivesFromDocument(
   return modifiedDoc;
 }
 
-export const addTypenameToDocument = Object.assign(function (
-  doc: DocumentNode
-): DocumentNode {
-  return visit(checkDocument(doc), {
+export const addTypenameToDocument = Object.assign(function <
+  TNode extends ASTNode
+>(
+  doc: TNode
+): TNode {
+  return visit(doc, {
     SelectionSet: {
       enter(node, _key, parent) {
         // Don't add __typename to OperationDefinitions.


### PR DESCRIPTION
As requested by @AnthonyMDev.