### PR TITLE
Fix extra `useQuery` result frames

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     {
       "name": "apollo-client",
       "path": "./dist/apollo-client.min.cjs",
-      "maxSize": "29.3kB"
+      "maxSize": "29.4kB"
     }
   ],
   "engines": {

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -655,6 +655,8 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`);
     options: WatchQueryOptions<TVariables, TData>,
     newNetworkStatus?: NetworkStatus,
   ): Concast<ApolloQueryResult<TData>> {
+    // TODO Make sure we update the networkStatus (and infer fetchVariables)
+    // before actually committing to the fetch.
     this.queryManager.setObservableQuery(this);
     return this.queryManager.fetchQueryObservable(
       this.queryId,

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1333,6 +1333,7 @@ export class QueryManager<TStore> {
       returnPartialData,
       context,
       notifyOnNetworkStatusChange,
+      fetchBlockingPromise,
     }: WatchQueryOptions<TVars, TData>,
     // The initial networkStatus for this fetch, most often
     // NetworkStatus.loading, but also possibly fetchMore, poll, refetch,
@@ -1390,13 +1391,25 @@ export class QueryManager<TStore> {
       ) ? CacheWriteBehavior.OVERWRITE
         : CacheWriteBehavior.MERGE;
 
-    const resultsFromLink = () =>
-      this.getResultsFromLink<TData, TVars>(queryInfo, cacheWriteBehavior, {
-        variables,
-        context,
-        fetchPolicy,
-        errorPolicy,
-      });
+    const resultsFromLink = () => {
+      const get = () => this.getResultsFromLink<TData, TVars>(
+        queryInfo,
+        cacheWriteBehavior,
+        {
+          variables,
+          context,
+          fetchPolicy,
+          errorPolicy,
+        },
+      );
+
+      // If we have a fetchBlockingPromise, wait for it to be resolved before
+      // allowing any network requests, and only proceed if fetchBlockingPromise
+      // resolves to true. If it resolves to false, the request is discarded.
+      return fetchBlockingPromise ? fetchBlockingPromise.then(
+        ok => ok ? get() : Observable.of<ApolloQueryResult<TData>>()
+      ) : get();
+    }
 
     const shouldNotify =
       notifyOnNetworkStatusChange &&

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -2421,4 +2421,188 @@ describe('ObservableQuery', () => {
       error: reject,
     });
   });
+
+  describe("options.fetchBlockingPromise", () => {
+    itAsync("should not block future refetches", (resolve, reject) => {
+      const query: TypedDocumentNode<{
+        linkCount: number;
+      }> = gql`query Counter { linkCount }`;
+
+      let linkCount = 0;
+      const client = new ApolloClient({
+        cache: new InMemoryCache(),
+        link: new ApolloLink(request => new Observable(observer => {
+          if (request.operationName === "Counter") {
+            observer.next({
+              data: {
+                linkCount: ++linkCount,
+              },
+            });
+            observer.complete();
+          }
+        })),
+      });
+
+      let resolved = false;
+      const observable = client.watchQuery({
+        query,
+        notifyOnNetworkStatusChange: true,
+        fetchBlockingPromise: new Promise(resolve => {
+          setTimeout(() => {
+            resolved = true;
+            resolve(true);
+          }, 100);
+        }),
+      });
+
+      subscribeAndCount(reject, observable, (count, result) => {
+        if (count === 1) {
+          expect(resolved).toBe(true);
+          expect(result.loading).toBe(false);
+          expect(result.data).toEqual({
+            linkCount: 1,
+          });
+
+          client.cache.writeQuery({
+            query,
+            data: {
+              linkCount: 1234,
+            },
+          });
+
+        } else if (count === 2) {
+          expect(resolved).toBe(true);
+          expect(result.loading).toBe(false);
+          expect(result.data).toEqual({
+            linkCount: 1234,
+          });
+
+          // Make sure refetching is not blocked by the fetchBlockingPromise.
+          return observable.refetch();
+
+        } else if (count === 3) {
+          expect(resolved).toBe(true);
+          expect(result.loading).toBe(true);
+          expect(result.networkStatus).toBe(NetworkStatus.refetch);
+          expect(result.data).toEqual({
+            linkCount: 1234,
+          });
+
+        } else if (count === 4) {
+          expect(resolved).toBe(true);
+          expect(result.loading).toBe(false);
+          expect(result.networkStatus).toBe(NetworkStatus.ready);
+          expect(result.data).toEqual({
+            linkCount: 2,
+          });
+
+          const { fetchBlockingPromise } = observable.options;
+          expect(fetchBlockingPromise).toBeInstanceOf(Promise);
+          return fetchBlockingPromise!.then(ok => {
+            expect(ok).toBe(true);
+            setTimeout(resolve, 20);
+          });
+
+        } else {
+          reject(`Too many results (${count}, ${JSON.stringify(result)})`);
+        }
+      });
+    });
+
+    itAsync("should behave reasonably when rejected", (resolve, reject) => {
+      const query: TypedDocumentNode<{
+        linkCount: number;
+      }> = gql`query Counter { linkCount }`;
+
+      let linkCount = 0;
+      const client = new ApolloClient({
+        cache: new InMemoryCache(),
+        link: new ApolloLink(request => new Observable(observer => {
+          if (request.operationName === "Counter") {
+            observer.next({
+              data: {
+                linkCount: ++linkCount,
+              },
+            });
+            observer.complete();
+          }
+        })),
+      });
+
+      let rejected = false;
+      const observable = client.watchQuery({
+        query,
+        notifyOnNetworkStatusChange: true,
+        fetchBlockingPromise: new Promise((_, reject) => {
+          setTimeout(() => {
+            rejected = true;
+            reject(new Error("expected"));
+          }, 100);
+        }),
+      });
+
+      subscribeAndCount(reject, observable, (count, result) => {
+        if (count === 1) {
+          expect(rejected).toBe(true);
+          expect(result.loading).toBe(false);
+          expect(result.error!.message).toBe("expected");
+
+          client.cache.writeQuery({
+            query,
+            data: {
+              linkCount: 1234,
+            },
+          });
+
+        } else if (count === 2) {
+          expect(rejected).toBe(true);
+          expect(result.loading).toBe(false);
+          expect(result.networkStatus).toBe(NetworkStatus.ready);
+          expect(result.error).toBeUndefined();
+          expect(result.data).toEqual({
+            linkCount: 1234,
+          });
+
+          // Make sure refetching is not blocked by the fetchBlockingPromise.
+          return observable.refetch().then(result => {
+            expect(rejected).toBe(true);
+            expect(result.loading).toBe(false);
+            expect(result.networkStatus).toBe(NetworkStatus.error);
+            expect(result.error).toBeInstanceOf(ApolloError);
+            expect(result.error!.message).toBe("expected");
+            expect(result.data).toEqual({
+              linkCount: 1234,
+            });
+          });
+
+        } else if (count === 3) {
+          expect(rejected).toBe(true);
+          expect(result.loading).toBe(true);
+          expect(result.networkStatus).toBe(NetworkStatus.refetch);
+          expect(result.error).toBeUndefined();
+          expect(result.data).toEqual({
+            linkCount: 1234,
+          });
+
+        } else if (count === 4) {
+          expect(rejected).toBe(true);
+          expect(result.loading).toBe(false);
+          expect(result.networkStatus).toBe(NetworkStatus.error);
+          expect(result.error!.message).toBe("expected");
+
+          const { fetchBlockingPromise } = observable.options;
+          expect(fetchBlockingPromise).toBeInstanceOf(Promise);
+          return fetchBlockingPromise!.then(() => {
+            throw new Error("fetchBlockingPromise should be rejected");
+          }).catch(error => {
+            expect(error.message).toBe("expected");
+            setTimeout(resolve, 20);
+          });
+
+        } else {
+          reject(`Too many results (${count}, ${JSON.stringify(result)})`);
+        }
+      });
+    });
+  });
 });

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -145,6 +145,14 @@ export interface WatchQueryOptions<TVariables = OperationVariables, TData = any>
    * behavior, for backwards compatibility with Apollo Client 3.x.
    */
   refetchWritePolicy?: RefetchWritePolicy;
+
+  /**
+   * If provided, stalls any network activity for this request until the Promise
+   * has resolved. If the Promise resolves to true, the network request will
+   * proceed. If the Promise resolves to false, the network request will be
+   * silently discarded.
+   */
+  fetchBlockingPromise?: Promise<boolean>;
 }
 
 export interface NextFetchPolicyContext<TData, TVariables> {

--- a/src/react/components/__tests__/client/Mutation.test.tsx
+++ b/src/react/components/__tests__/client/Mutation.test.tsx
@@ -1027,33 +1027,32 @@ describe('General Mutation testing', () => {
                   if (count === 0) {
                     // "first: 1" loading
                     expect(resultQuery.loading).toBe(true);
+                    expect(resultQuery.data).toBeUndefined();
                   } else if (count === 1) {
                     // "first: 1" loaded
                     expect(resultQuery.loading).toBe(false);
                     expect(resultQuery.data).toEqual(peopleData1);
                     setTimeout(() => setVariables({ first: 2 }));
                   } else if (count === 2) {
-                    expect(resultQuery.loading).toBe(false);
-                    expect(resultQuery.data).toEqual(peopleData1);
-                  } else if (count === 3) {
-                    // "first: 2" loading
                     expect(resultQuery.loading).toBe(true);
-                  } else if (count === 4) {
-                    // "first: 2" loaded
+                    expect(resultQuery.data).toBeUndefined();
+                  } else if (count === 3) {
                     expect(resultQuery.loading).toBe(false);
                     expect(resultQuery.data).toEqual(peopleData2);
                     setTimeout(() => createTodo());
-                  } else if (count === 5) {
+                  } else if (count === 4) {
                     // mutation loading
                     expect(resultMutation.loading).toBe(true);
-                  } else if (count === 6) {
+                  } else if (count === 5) {
                     // mutation loaded
                     expect(resultMutation.loading).toBe(false);
-                  } else if (count === 7) {
+                  } else if (count === 6) {
                     // query refetched
                     expect(resultQuery.loading).toBe(false);
                     expect(resultMutation.loading).toBe(false);
                     expect(resultQuery.data).toEqual(peopleData3);
+                  } else {
+                    reject(`Too many renders (${count})`);
                   }
                   count++;
                 } catch (err) {
@@ -1074,7 +1073,7 @@ describe('General Mutation testing', () => {
     );
 
     waitFor(() => {
-      expect(count).toEqual(8);
+      expect(count).toEqual(7);
     }).then(resolve, reject);
   }));
 

--- a/src/react/components/__tests__/client/Query.test.tsx
+++ b/src/react/components/__tests__/client/Query.test.tsx
@@ -1062,15 +1062,17 @@ describe('Query component', () => {
           return (
             <AllPeopleQuery query={query} variables={variables}>
               {(result: any) => {
-                if (result.loading) {
-                  return null;
-                }
-
                 try {
-                  switch (count) {
-                    case 0:
+                  switch (++count) {
+                    case 1:
+                      expect(result.loading).toBe(true);
+                      expect(result.data).toBeUndefined();
                       expect(variables).toEqual({ first: 1 });
+                      break;
+                    case 2:
+                      expect(result.loading).toEqual(false);
                       expect(result.data).toEqual(data1);
+                      expect(variables).toEqual({ first: 1 });
                       setTimeout(() => {
                         this.setState({
                           variables: {
@@ -1079,20 +1081,23 @@ describe('Query component', () => {
                         });
                       });
                       break;
-                    case 1:
+                    case 3:
+                      expect(result.loading).toEqual(true);
+                      expect(result.data).toBeUndefined();
                       expect(variables).toEqual({ first: 2 });
-                      expect(result.data).toEqual(data1);
                       break;
-                    case 2:
-                      expect(variables).toEqual({ first: 2 });
+                    case 4:
+                      expect(result.loading).toEqual(false);
                       expect(result.data).toEqual(data2);
+                      expect(variables).toEqual({ first: 2 });
                       break;
+                    default:
+                      reject(`Too many renders (${count})`);
                   }
                 } catch (error) {
                   reject(error);
                 }
 
-                count++;
                 return null;
               }}
             </AllPeopleQuery>
@@ -1106,7 +1111,7 @@ describe('Query component', () => {
         </MockedProvider>
       );
 
-      waitFor(() => expect(count).toBe(3)).then(resolve, reject);
+      waitFor(() => expect(count).toBe(4)).then(resolve, reject);
     });
 
     itAsync('if the query changes', (resolve, reject) => {
@@ -1232,27 +1237,27 @@ describe('Query component', () => {
             <AllPeopleQuery query={query} variables={variables}>
               {(result: any) => {
                 try {
-                  switch (count) {
-                    case 0:
+                  switch (++count) {
+                    case 1:
                       expect(result.loading).toBe(true);
                       expect(result.data).toBeUndefined();
                       expect(result.networkStatus).toBe(NetworkStatus.loading);
                       break;
-                    case 1:
-                      setTimeout(() => {
-                        this.setState({ variables: { first: 2 } });
-                      });
-                      // fallthrough
                     case 2:
                       expect(result.loading).toBe(false);
                       expect(result.data).toEqual(data1);
                       expect(result.networkStatus).toBe(NetworkStatus.ready);
+                      setTimeout(() => {
+                        this.setState({ variables: { first: 2 } });
+                      });
                       break;
                     case 3:
                       expect(result.loading).toBe(true);
+                      expect(result.data).toBeUndefined();
                       expect(result.networkStatus).toBe(NetworkStatus.setVariables);
                       break;
                     case 4:
+                      expect(result.loading).toBe(false);
                       expect(result.data).toEqual(data2);
                       expect(result.networkStatus).toBe(NetworkStatus.ready);
                       break;
@@ -1261,7 +1266,6 @@ describe('Query component', () => {
                   reject(err);
                 }
 
-                count++;
                 return null;
               }}
             </AllPeopleQuery>
@@ -1275,7 +1279,7 @@ describe('Query component', () => {
         </MockedProvider>
       );
 
-      waitFor(() => expect(count).toBe(5)).then(resolve, reject);
+      waitFor(() => expect(count).toBe(4)).then(resolve, reject);
     });
 
     itAsync('should update if a manual `refetch` is triggered after a state change', (resolve, reject) => {
@@ -1720,17 +1724,18 @@ describe('Query component', () => {
             onCompleted={this.onCompleted}
           >
             {({ loading, data }: any) => {
-              switch (renderCount) {
-                case 0:
-                  expect(loading).toBe(true);
-                  break;
+              switch (++renderCount) {
                 case 1:
+                  expect(loading).toBe(true);
+                  expect(data).toBeUndefined();
+                  break;
                 case 2:
                   expect(loading).toBe(false);
                   expect(data).toEqual(data1);
                   break;
                 case 3:
                   expect(loading).toBe(true);
+                  expect(data).toBeUndefined();
                   break;
                 case 4:
                   expect(loading).toBe(false);
@@ -1738,16 +1743,14 @@ describe('Query component', () => {
                   setTimeout(() => {
                     this.setState({ variables: { first: 1 } });
                   });
-                case 5:
-                  expect(loading).toBe(false);
-                  expect(data).toEqual(data2);
                   break;
-                case 6:
+                case 5:
                   expect(loading).toBe(false);
                   expect(data).toEqual(data1);
                   break;
+                default:
+                  reject(`Too many renders (${renderCount})`);
               }
-              renderCount += 1;
               return null;
             }}
           </AllPeopleQuery>
@@ -1762,6 +1765,7 @@ describe('Query component', () => {
     );
 
     waitFor(() => {
+      expect(renderCount).toBe(5);
       expect(onCompletedCallCount).toBe(3);
     }).then(resolve, reject);
   });

--- a/src/react/hoc/__tests__/queries/errors.test.tsx
+++ b/src/react/hoc/__tests__/queries/errors.test.tsx
@@ -224,18 +224,15 @@ describe('[queries] errors', () => {
               try {
                 if (iteration === 1) {
                   // initial loading state is done, we have data
-                  expect(props.data!.allPeople).toEqual(
-                    data.allPeople
-                  );
+                  expect(props.data!.loading).toBe(false);
+                  expect(props.data!.allPeople).toEqual(data.allPeople);
                   props.setVar(2);
                 } else if (iteration === 2) {
-                  expect(props.data!.allPeople).toEqual(
-                    data.allPeople
-                  );
+                  expect(props.data!.loading).toBe(true);
+                  expect(props.data!.allPeople).toBeUndefined();
                 } else if (iteration === 3) {
-                  // variables have changed, wee are loading again but also have data
-                  expect(props.data!.loading).toBeTruthy();
-                } else if (iteration === 4) {
+                  expect(props.data!.loading).toBe(false);
+                  expect(props.data!.allPeople).toBeUndefined();
                   // the second request had an error!
                   expect(props.data!.error).toBeTruthy();
                   expect(props.data!.error!.networkError).toBeTruthy();
@@ -248,6 +245,8 @@ describe('[queries] errors', () => {
                     }
                     done = true;
                   });
+                } else {
+                  reject(`Too many iterations (${iteration})`);
                 }
               } catch (err) {
                 reject(err);
@@ -266,7 +265,10 @@ describe('[queries] errors', () => {
         </ApolloProvider>
       );
 
-      waitFor(() => expect(done).toBeTruthy()).then(resolve, reject);
+      waitFor(() => {
+        expect(done).toBeTruthy();
+        expect(iteration).toBe(3);
+      }).then(resolve, reject);
     });
   });
 

--- a/src/react/hoc/__tests__/queries/index.test.tsx
+++ b/src/react/hoc/__tests__/queries/index.test.tsx
@@ -182,13 +182,9 @@ describe('queries', () => {
           break;
         case 2:
           expect(data!.loading).toBe(true);
-          expect(data!.variables).toEqual({ someId: 1 });
-          break;
-        case 3:
-          expect(data!.loading).toBe(true);
           expect(data!.variables).toEqual({ someId: 2 });
           break;
-        case 4:
+        case 3:
           expect(data!.loading).toBe(false);
           expect(data!.variables).toEqual({ someId: 2 });
           break;
@@ -211,7 +207,7 @@ describe('queries', () => {
     );
 
     waitFor(() => {
-      expect(count).toBe(4);
+      expect(count).toBe(3);
     }).then(resolve, reject);
   });
 

--- a/src/react/hoc/__tests__/queries/lifecycle.test.tsx
+++ b/src/react/hoc/__tests__/queries/lifecycle.test.tsx
@@ -639,14 +639,6 @@ describe('[queries] lifecycle', () => {
                 break;
               case 6:
                 expect({ loading, a, b, c }).toEqual({
-                  loading: true,
-                  a: void 0,
-                  b: void 0,
-                  c: void 0,
-                });
-                break;
-              case 7:
-                expect({ loading, a, b, c }).toEqual({
                   loading: false,
                   a: 4,
                   b: 5,
@@ -654,7 +646,7 @@ describe('[queries] lifecycle', () => {
                 });
                 refetchQuery!();
                 break;
-              case 8:
+              case 7:
                 expect({ loading, a, b, c }).toEqual({
                   loading: true,
                   a: 4,
@@ -662,7 +654,7 @@ describe('[queries] lifecycle', () => {
                   c: 6
                 });
                 break;
-              case 9:
+              case 8:
                 expect({ loading, a, b, c }).toEqual({
                   loading: false,
                   a: 4,
@@ -673,23 +665,15 @@ describe('[queries] lifecycle', () => {
                   switchClient!(client3);
                 });
                 break;
+              case 9:
+                expect({ loading, a, b, c }).toEqual({
+                  loading: true,
+                  a: void 0,
+                  b: void 0,
+                  c: void 0,
+                });
+                break;
               case 10:
-                expect({ loading, a, b, c }).toEqual({
-                  loading: true,
-                  a: void 0,
-                  b: void 0,
-                  c: void 0,
-                });
-                break;
-              case 11:
-                expect({ loading, a, b, c }).toEqual({
-                  loading: true,
-                  a: void 0,
-                  b: void 0,
-                  c: void 0,
-                });
-                break;
-              case 12:
                 expect({ loading, a, b, c }).toEqual({
                   loading: false,
                   a: 7,
@@ -700,15 +684,7 @@ describe('[queries] lifecycle', () => {
                   switchClient!(client1);
                 });
                 break;
-              case 13:
-                expect({ loading, a, b, c }).toEqual({
-                  loading: false,
-                  a: 1,
-                  b: 2,
-                  c: 3,
-                });
-                break;
-              case 14:
+              case 11:
                 expect({ loading, a, b, c }).toEqual({
                   loading: false,
                   a: 1,
@@ -719,7 +695,7 @@ describe('[queries] lifecycle', () => {
                   switchClient!(client3);
                 });
                 break;
-              case 15:
+              case 12:
                 expect({ loading, a, b, c }).toEqual({
                   loading: false,
                   a: 7,
@@ -727,14 +703,8 @@ describe('[queries] lifecycle', () => {
                   c: 9,
                 });
                 break;
-              case 16:
-                expect({ loading, a, b, c }).toEqual({
-                  loading: false,
-                  a: 7,
-                  b: 8,
-                  c: 9
-                });
-                break;
+              default:
+                reject(`Unexpectedly many renders (${count})`);
             }
           } catch (err) {
             reject(err);
@@ -767,7 +737,7 @@ describe('[queries] lifecycle', () => {
 
     render(<ClientSwitcher />);
 
-    waitFor(() => expect(count).toBe(16)).then(resolve, reject);
+    waitFor(() => expect(count).toBe(12)).then(resolve, reject);
   });
 
   itAsync('handles synchronous racecondition with prefilled data from the server', (resolve, reject) => {

--- a/src/react/hoc/__tests__/queries/lifecycle.test.tsx
+++ b/src/react/hoc/__tests__/queries/lifecycle.test.tsx
@@ -53,15 +53,10 @@ describe('[queries] lifecycle', () => {
         componentDidUpdate(prevProps: ChildProps<Vars, Data, Vars>) {
           try {
             const { data } = this.props;
-            switch (count) {
-              case 0:
+            switch (++count) {
+              case 1:
                 expect(prevProps.data!.loading).toBe(true);
                 expect(prevProps.data!.allPeople).toBe(undefined);
-                expect(data!.loading).toBe(false);
-                expect(data!.variables).toEqual(variables1);
-                expect(data!.allPeople).toEqual(data1.allPeople);
-                break;
-              case 1:
                 expect(data!.loading).toBe(false);
                 expect(data!.variables).toEqual(variables1);
                 expect(data!.allPeople).toEqual(data1.allPeople);
@@ -76,9 +71,9 @@ describe('[queries] lifecycle', () => {
                 expect(data!.variables).toEqual(variables2);
                 expect(data!.allPeople).toEqual(data2.allPeople);
                 break;
+              default:
+                reject(`Too many renders (${count})`);
             }
-
-            count++;
           } catch (err) {
             reject(err);
           }
@@ -110,7 +105,7 @@ describe('[queries] lifecycle', () => {
       </ApolloProvider>
     );
 
-    waitFor(() => expect(count).toBe(4)).then(resolve, reject);
+    waitFor(() => expect(count).toBe(3)).then(resolve, reject);
   });
 
   itAsync('rebuilds the queries on prop change when using `options`', (resolve, reject) => {
@@ -215,16 +210,11 @@ describe('[queries] lifecycle', () => {
         componentDidUpdate(prevProps: ChildProps<Vars, Data, Vars>) {
           try {
             const { data } = this.props;
-            switch (count) {
-              case 0:
+            switch (++count) {
+              case 1:
                 expect(prevProps.data!.loading).toBe(true);
                 expect(prevProps.data!.variables).toEqual({ first: 1 });
                 expect(prevProps.data!.allPeople).toBe(undefined);
-                expect(data!.loading).toBe(false);
-                expect(data!.variables).toEqual({ first: 1 });
-                expect(data!.allPeople).toEqual(data1.allPeople);
-                break;
-              case 1:
                 expect(data!.loading).toBe(false);
                 expect(data!.variables).toEqual({ first: 1 });
                 expect(data!.allPeople).toEqual(data1.allPeople);
@@ -239,12 +229,12 @@ describe('[queries] lifecycle', () => {
                 expect(data!.variables).toEqual({ first: 2 });
                 expect(data!.allPeople).toEqual(data2.allPeople);
                 break;
+              default:
+                reject(`Too many renders (${count})`);
             }
           } catch (err) {
             reject(err);
           }
-
-          count++;
         }
 
         render() {
@@ -273,7 +263,7 @@ describe('[queries] lifecycle', () => {
       </ApolloProvider>
     );
 
-    waitFor(() => expect(count).toBe(4)).then(resolve, reject);
+    waitFor(() => expect(count).toBe(3)).then(resolve, reject);
   });
 
   itAsync('reruns the queries on prop change when using passed props', (resolve, reject) => {
@@ -312,16 +302,11 @@ describe('[queries] lifecycle', () => {
         componentDidUpdate(prevProps: ChildProps<Vars, Data, Vars>) {
           try {
             const { data } = this.props;
-            switch (count) {
-              case 0:
+            switch (++count) {
+              case 1:
                 expect(prevProps.data!.loading).toBe(true);
                 expect(prevProps.data!.variables).toEqual({ first: 1 });
                 expect(prevProps.data!.allPeople).toBe(undefined);
-                expect(data!.loading).toBe(false);
-                expect(data!.variables).toEqual({ first: 1 });
-                expect(data!.allPeople).toEqual(data1.allPeople);
-                break;
-              case 1:
                 expect(data!.loading).toBe(false);
                 expect(data!.variables).toEqual({ first: 1 });
                 expect(data!.allPeople).toEqual(data1.allPeople);
@@ -340,8 +325,6 @@ describe('[queries] lifecycle', () => {
           } catch (err) {
             reject(err);
           }
-
-          count++;
         }
         render() {
           return null;
@@ -369,7 +352,7 @@ describe('[queries] lifecycle', () => {
       </ApolloProvider>
     );
 
-    waitFor(() => expect(count).toBe(4)).then(resolve, reject);
+    waitFor(() => expect(count).toBe(3)).then(resolve, reject);
   });
 
   itAsync('stays subscribed to updates after irrelevant prop changes', (resolve, reject) => {

--- a/src/react/hoc/__tests__/queries/loading.test.tsx
+++ b/src/react/hoc/__tests__/queries/loading.test.tsx
@@ -187,8 +187,8 @@ describe('[queries] loading', () => {
         componentDidUpdate(prevProps: ChildProps<Vars, Data, Vars>) {
           try {
             // variables changed, new query is loading, but old data is still there
-            switch (count) {
-              case 0:
+            switch (++count) {
+              case 1:
                 expect(prevProps.data!.loading).toBe(true);
                 expect(prevProps.data!.variables).toEqual(variables1);
                 expect(prevProps.data!.allPeople).toBe(undefined);
@@ -199,19 +199,6 @@ describe('[queries] loading', () => {
                 expect(this.props.data!.allPeople).toEqual(data1.allPeople);
                 expect(this.props.data!.error).toBe(undefined);
                 expect(this.props.data!.networkStatus).toBe(NetworkStatus.ready);
-                break;
-              case 1:
-                // TODO: What is this extra render
-                expect(prevProps.data!.loading).toBe(false);
-                expect(prevProps.data!.variables).toEqual(variables1);
-                expect(prevProps.data!.allPeople).toEqual(data1.allPeople);
-                expect(prevProps.data!.error).toBe(undefined);
-                expect(prevProps.data!.networkStatus).toBe(NetworkStatus.ready);
-                expect(this.props.data!.loading).toBe(false);
-                expect(this.props.data!.variables).toEqual(variables1);
-                expect(this.props.data!.allPeople).toEqual(data1.allPeople);
-                expect(this.props.data!.error).toBe(undefined);
-                expect(prevProps.data!.networkStatus).toBe(NetworkStatus.ready);
                 break;
               case 2:
                 expect(prevProps.data!.loading).toBe(false);
@@ -238,7 +225,6 @@ describe('[queries] loading', () => {
                 done = true;
                 break;
             }
-            count++;
           } catch (err) {
             reject(err);
           }
@@ -642,23 +628,24 @@ describe('[queries] loading', () => {
             try {
               switch (count) {
                 case 0:
-                  expect(this.props.data!.loading).toBeTruthy(); // has initial data
+                  expect(this.props.data!.loading).toBe(true);
+                  expect(this.props.data!.allPeople).toBeUndefined();
                   break;
                 case 1:
-                  expect(this.props.data!.loading).toBeFalsy();
+                  expect(this.props.data!.loading).toBe(false);
+                  expect(this.props.data!.allPeople).toBe(data.allPeople);
                   setTimeout(() => {
                     this.props.setFirst(2);
                   });
                   break;
                 case 2:
-                  expect(this.props.data!.loading).toBeFalsy(); // on variables change
-                  break;
-                case 3:
-                  expect(this.props.data!.loading).toBeTruthy(); // on variables change
+                  expect(this.props.data!.loading).toBe(true); // on variables change
+                  expect(this.props.data!.allPeople).toBeUndefined();
                   break;
                 case 4:
                   // new data after fetch
-                  expect(this.props.data!.loading).toBeFalsy();
+                  expect(this.props.data!.loading).toBe(false);
+                  expect(this.props.data!.allPeople).toBe(data.allPeople);
                   break;
               }
             } catch (err) {
@@ -679,7 +666,7 @@ describe('[queries] loading', () => {
       </ApolloProvider>
     );
 
-    waitFor(() => expect(count).toBe(5)).then(resolve, reject);
+    waitFor(() => expect(count).toBe(4)).then(resolve, reject);
   });
 
   itAsync(
@@ -761,26 +748,24 @@ describe('[queries] loading', () => {
             render() {
               const { props } = this;
               try {
-                switch (count) {
-                  case 0:
-                    expect(props.data!.loading).toBeTruthy();
-                    break;
+                switch (++count) {
                   case 1:
+                    expect(props.data!.loading).toBe(true);
+                    break;
+                  case 2:
+                    expect(props.data!.loading).toBe(false); // has initial data
+                    expect(props.data!.allPeople).toEqual(data.allPeople);
                     setTimeout(() => {
                       this.props.setFirst(2);
                     });
-                    //fallthrough
-                  case 2:
-                    expect(props.data!.loading).toBeFalsy(); // has initial data
-                    expect(props.data!.allPeople).toEqual(data.allPeople);
                     break;
-
                   case 3:
-                    expect(props.data!.loading).toBeTruthy(); // on variables change
+                    expect(props.data!.loading).toBe(true);
+                    expect(props.data!.allPeople).toBeUndefined();
                     break;
                   case 4:
                     // new data after fetch
-                    expect(props.data!.loading).toBeFalsy();
+                    expect(props.data!.loading).toBe(false);
                     expect(props.data!.allPeople).toEqual(data.allPeople);
                     break;
                 }
@@ -788,7 +773,6 @@ describe('[queries] loading', () => {
                 reject(err);
               }
 
-              count++;
               return null;
             }
           }
@@ -801,7 +785,7 @@ describe('[queries] loading', () => {
         </ApolloProvider>
       );
 
-      waitFor(() => expect(count).toBe(5)).then(resolve, reject);
+      waitFor(() => expect(count).toBe(4)).then(resolve, reject);
     }
   );
 });

--- a/src/react/hoc/__tests__/queries/skip.test.tsx
+++ b/src/react/hoc/__tests__/queries/skip.test.tsx
@@ -173,23 +173,21 @@ describe('[queries] skip', () => {
         componentDidUpdate() {
           try {
             const { props } = this;
-            switch (count) {
-              case 0:
+            switch (++count) {
               case 1:
-                expect(props.data!.loading).toBeTruthy();
+                expect(props.data!.loading).toBe(true);
                 break;
               case 2:
+                expect(props.data!.loading).toBe(false);
                 expect(props.data!.allPeople).toEqual(data.allPeople);
-                break;
-              case 3:
                 expect(renderCount).toBe(3);
                 break;
+              default:
+                reject(`Too many renders (${count})`);
             }
           } catch (err) {
             reject(err);
           }
-
-          count++;
         }
         render() {
           renderCount++;
@@ -218,7 +216,7 @@ describe('[queries] skip', () => {
       </ApolloProvider>
     );
 
-    waitFor(() => expect(count).toBe(3)).then(resolve, reject);
+    waitFor(() => expect(count).toBe(2)).then(resolve, reject);
   });
 
   itAsync("doesn't run options or props when skipped, including option.client", (resolve, reject) => {
@@ -666,19 +664,17 @@ describe('[queries] skip', () => {
                 setTimeout(() => {
                   this.props.setSkip(false);
                 }, 10);
-                // fallthrough
-              case 4:
                 expect(this.props.skip).toBe(true);
                 expect(this.props.data).toBeUndefined();
                 expect(ranQuery).toBe(1);
                 break;
-              case 5:
+              case 4:
                 expect(this.props.skip).toBe(false);
                 expect(this.props.data!.loading).toBe(true);
                 expect(this.props.data.allPeople).toEqual(data.allPeople);
-                expect(ranQuery).toBe(2);
+                expect(ranQuery).toBe(1);
                 break;
-              case 6:
+              case 5:
                 expect(this.props.skip).toBe(false);
                 expect(this.props.data!.loading).toBe(false);
                 expect(this.props.data.allPeople).toEqual(nextData.allPeople);
@@ -691,13 +687,13 @@ describe('[queries] skip', () => {
                   this.props.data.refetch();
                 }, 10);
                 break;
-              case 7:
+              case 6:
                 expect(this.props.skip).toBe(false);
                 expect(this.props.data!.loading).toBe(true);
                 expect(this.props.data.allPeople).toEqual(nextData.allPeople);
                 expect(ranQuery).toBe(3);
                 break;
-              case 8:
+              case 7:
                 // The next batch of data has loaded.
                 expect(this.props.skip).toBe(false);
                 expect(this.props.data!.loading).toBe(false);
@@ -734,7 +730,7 @@ describe('[queries] skip', () => {
       </ApolloProvider>
     );
 
-    waitFor(() => expect(count).toEqual(8)).then(resolve, reject);
+    waitFor(() => expect(count).toEqual(7)).then(resolve, reject);
   }));
 
   // This test might have value, but is currently broken (the count === 0 test

--- a/src/react/hoc/__tests__/queries/skip.test.tsx
+++ b/src/react/hoc/__tests__/queries/skip.test.tsx
@@ -676,15 +676,10 @@ describe('[queries] skip', () => {
                 expect(this.props.skip).toBe(false);
                 expect(this.props.data!.loading).toBe(true);
                 expect(this.props.data.allPeople).toEqual(data.allPeople);
-                expect(ranQuery).toBe(1);
+                expect(ranQuery).toBe(2);
                 break;
               case 6:
                 expect(this.props.skip).toBe(false);
-                expect(this.props.data!.loading).toBe(true);
-                expect(this.props.data.allPeople).toEqual(data.allPeople);
-                expect(ranQuery).toBe(2);
-                break;
-              case 7:
                 expect(this.props.data!.loading).toBe(false);
                 expect(this.props.data.allPeople).toEqual(nextData.allPeople);
                 expect(ranQuery).toBe(2);
@@ -696,13 +691,13 @@ describe('[queries] skip', () => {
                   this.props.data.refetch();
                 }, 10);
                 break;
-              case 8:
+              case 7:
                 expect(this.props.skip).toBe(false);
                 expect(this.props.data!.loading).toBe(true);
                 expect(this.props.data.allPeople).toEqual(nextData.allPeople);
                 expect(ranQuery).toBe(3);
                 break;
-              case 9:
+              case 8:
                 // The next batch of data has loaded.
                 expect(this.props.skip).toBe(false);
                 expect(this.props.data!.loading).toBe(false);
@@ -739,10 +734,13 @@ describe('[queries] skip', () => {
       </ApolloProvider>
     );
 
-    waitFor(() => expect(count).toEqual(9)).then(resolve, reject);
+    waitFor(() => expect(count).toEqual(8)).then(resolve, reject);
   }));
 
-  it('removes the injected props if skip becomes true', async () => {
+  // This test might have value, but is currently broken (the count === 0 test
+  // is never hit, for example, because count++ happens the first time before
+  // componentDidUpdate is called), so we are skipping it for now.
+  it.skip('removes the injected props if skip becomes true', async () => {
     let count = 0;
     const query: DocumentNode = gql`
       query people($first: Int) {

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -126,7 +126,7 @@ describe('useQuery Hook', () => {
       expectFrames(result, [
         { loading: true, data: void 0, networkStatus: NetworkStatus.loading },
         { loading: false, data: { hello: "world 1" }, networkStatus: NetworkStatus.ready },
-        UNNEEDED_FRAME,
+        // UNNEEDED_FRAME,
         { loading: true, data: void 0, networkStatus: NetworkStatus.setVariables },
         { loading: false, data: { hello: "world 2" }, networkStatus: NetworkStatus.ready },
       ]);

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -124,11 +124,11 @@ describe('useQuery Hook', () => {
       rerender({ variables: { id: 2 } });
       await waitFor(() => result.current.loading === false);
       expectFrames(result, [
-        { loading: true, data: void 0 },
-        { loading: false, data: { hello: "world 1" } },
+        { loading: true, data: void 0, networkStatus: NetworkStatus.loading },
+        { loading: false, data: { hello: "world 1" }, networkStatus: NetworkStatus.ready },
         UNNEEDED_FRAME,
-        { loading: true, data: void 0 },
-        { loading: false, data: { hello: "world 2" } },
+        { loading: true, data: void 0, networkStatus: NetworkStatus.setVariables },
+        { loading: false, data: { hello: "world 2" }, networkStatus: NetworkStatus.ready },
       ]);
     });
 

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -1,3 +1,4 @@
+import { RenderResult } from "@testing-library/react-hooks/src/types";
 import React, { Fragment, useEffect, useState } from 'react';
 import { DocumentNode, GraphQLError } from 'graphql';
 import gql from 'graphql-tag';
@@ -17,9 +18,9 @@ import { ApolloProvider } from '../../context';
 import { Observable, Reference, concatPagination } from '../../../utilities';
 import { ApolloLink } from '../../../link/core';
 import { itAsync, MockLink, MockedProvider, mockSingleLink } from '../../../testing';
+import { QueryResult } from "../../types/types";
 import { useQuery } from '../useQuery';
 import { useMutation } from '../useMutation';
-import { QueryResult } from '../../types/types';
 
 describe('useQuery Hook', () => {
   describe('General use', () => {
@@ -60,6 +61,75 @@ describe('useQuery Hook', () => {
       const oldResult = result.current;
       rerender({ children: null });
       expect(oldResult === result.current).toBe(true);
+    });
+
+    const expectFrames = <TData, TVariables>(result: RenderResult<QueryResult<TData, TVariables>>, expectedPartialFrames: Partial<QueryResult<TData, TVariables>>[]) => {
+      const actualPartialFrames = result.all.map((actualFrame, i) => {
+      const expectedPartialFrame = expectedPartialFrames[i];
+        if (actualFrame instanceof Error) {
+          return {
+            error: actualFrame,
+          };
+        }
+        if (expectedPartialFrame) {
+          const actualPartialFrame: Partial<Record<keyof QueryResult<TData, TVariables>, any>> = {};
+          (Object.keys(expectedPartialFrame) as (keyof typeof expectedPartialFrame)[]).forEach((key) => {
+            actualPartialFrame[key] = actualFrame[key];
+          });
+          return actualPartialFrame;
+        }
+        return {};
+      });
+      expect(actualPartialFrames).toEqual(expectedPartialFrames);
+    };
+
+    const UNNEEDED_FRAME = {};
+
+    it("useQuery produces the expected frames initially", async () => {
+      const query = gql`{ hello }`;
+      const mocks = [ {
+        request: { query },
+        result: { data: { hello: "world" } },
+      } ];
+      const wrapper = ({ children }: any) => <MockedProvider mocks={mocks}>{children}</MockedProvider>;
+      const { result, waitFor, rerender } = renderHook(() => useQuery(query), { wrapper });
+      await waitFor(() => result.current.loading === false);
+      rerender({ children: null });
+      expectFrames(result, [
+        { loading: true, data: void 0 },
+        { loading: false, data: { hello: "world" } },
+        UNNEEDED_FRAME
+      ]);
+    });
+
+    it("useQuery produces the expected frames when variables change", async () => {
+      const query = gql`
+        query ($id: Int) {
+        hello(id: $id)
+      }
+      `;
+      const mocks = [ {
+        request: { query, variables: { id: 1 } },
+        result: { data: { hello: "world 1" } },
+      }, {
+        request: { query, variables: { id: 2 } },
+        result: { data: { hello: "world 2" } },
+      } ];
+      const wrapper = ({ children }: any) => <MockedProvider mocks={mocks}>{children}</MockedProvider>;
+      const { result, rerender, waitFor } = renderHook(
+        (options) => useQuery(query, options),
+        { wrapper, initialProps: { variables: { id: 1 } } },
+      );
+      await waitFor(() => result.current.loading === false);
+      rerender({ variables: { id: 2 } });
+      await waitFor(() => result.current.loading === false);
+      expectFrames(result, [
+        { loading: true, data: void 0 },
+        { loading: false, data: { hello: "world 1" } },
+        UNNEEDED_FRAME,
+        { loading: true, data: void 0 },
+        { loading: false, data: { hello: "world 2" } },
+      ]);
     });
 
     it('should read and write results from the cache', async () => {

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -83,8 +83,6 @@ describe('useQuery Hook', () => {
       expect(actualPartialFrames).toEqual(expectedPartialFrames);
     };
 
-    const UNNEEDED_FRAME = {};
-
     it("useQuery produces the expected frames initially", async () => {
       const query = gql`{ hello }`;
       const mocks = [ {
@@ -98,7 +96,8 @@ describe('useQuery Hook', () => {
       expectFrames(result, [
         { loading: true, data: void 0 },
         { loading: false, data: { hello: "world" } },
-        UNNEEDED_FRAME
+        // Repeat frame because rerender forces useQuery to be called again
+        { loading: false, data: { hello: "world" } },
       ]);
     });
 
@@ -126,7 +125,6 @@ describe('useQuery Hook', () => {
       expectFrames(result, [
         { loading: true, data: void 0, networkStatus: NetworkStatus.loading },
         { loading: false, data: { hello: "world 1" }, networkStatus: NetworkStatus.ready },
-        // UNNEEDED_FRAME,
         { loading: true, data: void 0, networkStatus: NetworkStatus.setVariables },
         { loading: false, data: { hello: "world 2" }, networkStatus: NetworkStatus.ready },
       ]);

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -213,7 +213,6 @@ class InternalState<TData, TVariables> {
     // allows us to depend on the referential stability of
     // this.watchQueryOptions elsewhere.
     const currentWatchQueryOptions = this.watchQueryOptions;
-    const originalResult = this.result;
     let resolveFetchBlockingPromise: undefined | ((result: boolean) => any);
 
     if (!equal(watchQueryOptions, currentWatchQueryOptions)) {
@@ -250,23 +249,10 @@ class InternalState<TData, TVariables> {
     }
 
     useEffect(() => {
-      // If we called this.observable.reobserve above, and this.result hasn't
-      // changed since then, report the latest current result to this.setResult.
       if (resolveFetchBlockingPromise) {
         resolveFetchBlockingPromise(true);
-
-        // If we set this.result to void 0 above, we still need to call
-        // this.setResult with the new result (but here in useEffect, since
-        // setResult typically calls forceUpdate), assuming latestResult is
-        // different from what we started with.
-        if (!this.result) {
-          const latestResult = this.getCurrentResult();
-          if (!equal(latestResult, originalResult)) {
-            this.setResult(latestResult);
-          }
-        }
       }
-    }, [resolveFetchBlockingPromise, originalResult]);
+    }, [resolveFetchBlockingPromise]);
 
     this.ssrDisabled = !!(
       options.ssr === false ||

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -215,9 +215,35 @@ class InternalState<TData, TVariables> {
     // Update this.watchQueryOptions, but only when they have changed, which
     // allows us to depend on the referential stability of
     // this.watchQueryOptions elsewhere.
-    if (!equal(watchQueryOptions, this.watchQueryOptions)) {
+    const currentWatchQueryOptions = this.watchQueryOptions;
+    const currentResult = this.result;
+    let needToSetResult = false;
+    if (!equal(watchQueryOptions, currentWatchQueryOptions)) {
       this.watchQueryOptions = watchQueryOptions;
+      if (currentWatchQueryOptions && this.observable) {
+        // Though it might be tempting to postpone this line to the useEffect
+        // block, we need getCurrentResult to return an appropriate loading
+        // result synchronously (later within the same call to useQuery). Since
+        // we already have this.observable here (not true for the very first
+        // call to useQuery), we are not initiating any new subscriptions,
+        // though it does feel less than ideal to be (potentially) kicking off a
+        // network request (for example, if the variables have changed).
+        this.observable.setOptions(watchQueryOptions).catch(() => {});
+        needToSetResult = true;
+      }
     }
+    useEffect(() => {
+      // If we called this.observable.reobserve above, and this.result hasn't
+      // changed since then, report the latest current result to this.setResult.
+      if (needToSetResult && this.result === currentResult) {
+        const latestResult = this.observable.getCurrentResult();
+        if (!equal(latestResult, currentResult)) {
+          // This usually forces a rerender, which is why it must be done in
+          // useEffect.
+          this.setResult(latestResult);
+        }
+      }
+    }, [needToSetResult, currentResult]);
 
     this.ssrDisabled = !!(
       options.ssr === false ||
@@ -459,27 +485,6 @@ class InternalState<TData, TVariables> {
         obsQuery.setOptions(this.watchQueryOptions).catch(() => {});
       }
     }
-
-    const prevOptionsRef = useRef({
-      watchQueryOptions: this.watchQueryOptions,
-    });
-
-    // An effect to keep obsQuery.options up to date in case
-    // state.watchQueryOptions changes.
-    useEffect(() => {
-      if (this.renderPromises) {
-        // Do nothing during server rendering.
-      } else if (
-        // The useOptions method only updates this.watchQueryOptions if new new
-        // watchQueryOptions are not deep-equal to the previous options, so we
-        // only need a reference check (!==) here.
-        this.watchQueryOptions !== prevOptionsRef.current.watchQueryOptions
-      ) {
-        obsQuery.setOptions(this.watchQueryOptions).catch(() => {});
-        prevOptionsRef.current.watchQueryOptions = this.watchQueryOptions;
-        this.setResult(obsQuery.getCurrentResult());
-      }
-    }, [obsQuery, this.watchQueryOptions]);
 
     return obsQuery;
   }

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -463,34 +463,7 @@ class InternalState<TData, TVariables> {
 
       if (!this.ssrDisabled && obsQuery.getCurrentResult().loading) {
         // TODO: This is a legacy API which could probably be cleaned up
-        this.renderPromises.addQueryPromise({
-          // The only options which seem to actually be used by the
-          // RenderPromises class are query and variables.
-          getOptions: () => obsQuery.options,
-          fetchData: () => new Promise<void>((resolve) => {
-            const sub = obsQuery.subscribe({
-              next(result) {
-                if (!result.loading) {
-                  resolve()
-                  sub.unsubscribe();
-                }
-              },
-              error() {
-                resolve();
-                sub.unsubscribe();
-              },
-              complete() {
-                resolve();
-              },
-            });
-          }),
-        },
-        // This callback never seemed to do anything
-        () => null);
-
-        // TODO: This is a hack to make sure useLazyQuery executions update the
-        // obsevable query options for ssr.
-        obsQuery.setOptions(this.watchQueryOptions).catch(() => {});
+        this.renderPromises.addObservableQueryPromise(obsQuery);
       }
     }
 

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -228,14 +228,14 @@ class InternalState<TData, TVariables> {
         // variables have changed). To prevent any risk of premature/unwanted
         // network traffic, we use a fetchBlockingPromise, which will only be
         // unblocked once the useEffect has fired.
-        this.observable.setOptions({
+        this.observable.reobserve({
           fetchBlockingPromise: new Promise<boolean>(resolve => {
             resolveFetchBlockingPromise = resolve;
           }),
           // If watchQueryOptions.fetchBlockingPromise is also defined, it takes
           // precedence over the fetchBlockingPromise we just created.
           ...watchQueryOptions,
-        }).catch(() => {});
+        });
 
         this.previousData = this.result?.data || this.previousData;
         this.result = void 0;

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -184,6 +184,9 @@ class InternalState<TData, TVariables> {
         this.client.disableNetworkFetches,
       ]),
 
+      // TODO This may return an old result when we really should start a full
+      // reobservation (possibly including a network request). Need to determine
+      // based on options when a new request is being made.
       () => this.getCurrentResult(),
     );
 

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -195,6 +195,8 @@ export type MutationTuple<
 > = [
   (
     options?: MutationFunctionOptions<TData, TVariables, TContext, TCache>
+    // TODO This FetchResult<TData> seems strange here, as opposed to an
+    // ApolloQueryResult<TData>
   ) => Promise<FetchResult<TData>>,
   MutationResult<TData>,
 ];


### PR DESCRIPTION
This PR builds on #9508, fixing the unexpected frame by transitioning to a `loading: true` result synchronously when variables change or the query is refetched.

Since we do not want to commit to making any network requests synchronously during rendering, I have come up with a new way to block all network requests, by passing a `fetchBlockingPromise: Promise<boolean>` option that intercepts a part of the request pipeline that is already safely asynchronous.

As a happy side effect, this `fetchBlockingPromise` technique should also prevent making any network requests for extra `ObservableQuery` objects created during development when using React's `<StrictMode>`, since the extra component renders are never mounted, and thus `useEffect` never fires, leaving the `fetchBlockingPromise` unresolved until it times out and the fetch gets silently canceled (as desired).