### PR TITLE
fix(docs): fix sample code error in Quick start section of REST link

### DIFF
--- a/docs/source/api/link/apollo-link-rest.md
+++ b/docs/source/api/link/apollo-link-rest.md
@@ -59,7 +59,7 @@ You can then fetch your data using Apollo Client:
 ```js
 // Invoke the query and log the person's name
 client.query({ query }).then(response => {
-  console.log(response.data.name);
+  console.log(response.data.person.name);
 });
 ```
 


### PR DESCRIPTION
Current code example writes `undefined` to the console.

Fix the wrong code example in documentation by setting console.log to write response.data.person.name instead of response.data.name.