### PR TITLE
Use stricter imports to satisfy webpack 5

### DIFF
--- a/src/react/ssr/getDataFromTree.ts
+++ b/src/react/ssr/getDataFromTree.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { getApolloContext } from '../context';
 import { RenderPromises } from './RenderPromises';
+import { renderToStaticMarkup } from 'react-dom/server.js';
 
 export function getDataFromTree(
   tree: React.ReactNode,
@@ -11,7 +12,7 @@ export function getDataFromTree(
     context,
     // If you need to configure this renderFunction, call getMarkupFromTree
     // directly instead of getDataFromTree.
-    renderFunction: require('react-dom/server').renderToStaticMarkup
+    renderFunction: renderToStaticMarkup
   });
 }
 
@@ -29,7 +30,7 @@ export function getMarkupFromTree({
   // The rendering function is configurable! We use renderToStaticMarkup as
   // the default, because it's a little less expensive than renderToString,
   // and legacy usage of getDataFromTree ignores the return value anyway.
-  renderFunction = require('react-dom/server').renderToStaticMarkup
+  renderFunction = renderToStaticMarkup
 }: GetMarkupFromTreeOptions): Promise<string> {
   const renderPromises = new RenderPromises();
 

--- a/src/react/ssr/renderToStringWithData.ts
+++ b/src/react/ssr/renderToStringWithData.ts
@@ -1,11 +1,12 @@
 import { ReactElement } from 'react';
 import { getMarkupFromTree } from './getDataFromTree';
+import { renderToString } from 'react-dom/server.js';
 
 export function renderToStringWithData(
   component: ReactElement<any>
 ): Promise<string> {
   return getMarkupFromTree({
     tree: component,
-    renderFunction: require('react-dom/server').renderToString
+    renderFunction: renderToString
   });
 }


### PR DESCRIPTION
I run my server-side code through Webpack, in addition to my client-side code. As a part of my attempt to upgrade from Webpack v4 to v5, I have run into a problem whereby these `require` statements are no longer transformed by Webpack and so my application is broken. (Perhaps this is because the files are otherwise in an ESM style and Webpack v5 is being stricter than v4? Then again, this could just be a quirk in my set-up. - Has anyone else run into these problems?)

**Note:** I don't know if this solution is acceptable, as you may have had the `require` inline for a reason. (To avoid importing it when it isn't going to be overridden by the consumer?) There may also be a way to make Webpack v5 accept the code as it is. I've asked for guidance from the Webpack community here: https://github.com/webpack/webpack/discussions/15670

Please accept my apologies if I'm being silly.
