### PR TITLE
Update `@graphql-typed-document-node/core` to version 3.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.5.10",
       "license": "MIT",
       "dependencies": {
-        "@graphql-typed-document-node/core": "^3.0.0",
+        "@graphql-typed-document-node/core": "^3.1.1",
         "@wry/context": "^0.6.0",
         "@wry/equality": "^0.5.0",
         "@wry/trie": "^0.3.0",
@@ -701,11 +701,11 @@
       }
     },
     "node_modules/@graphql-typed-document-node/core": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.0.tgz",
-      "integrity": "sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.1.tgz",
+      "integrity": "sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==",
       "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -6773,9 +6773,9 @@
       }
     },
     "@graphql-typed-document-node/core": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.0.tgz",
-      "integrity": "sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.1.tgz",
+      "integrity": "sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==",
       "requires": {}
     },
     "@istanbuljs/load-nyc-config": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     }
   },
   "dependencies": {
-    "@graphql-typed-document-node/core": "^3.0.0",
+    "@graphql-typed-document-node/core": "^3.1.1",
     "@wry/context": "^0.6.0",
     "@wry/equality": "^0.5.0",
     "@wry/trie": "^0.3.0",


### PR DESCRIPTION
This should help with recent failures of dependency update PRs ([example](https://github.com/apollographql/apollo-client/pull/9575#issuecomment-1086610884)), by allowing `graphql@16` to be installed without violating the `peerDependencies` of the `@graphql-typed-document-node/core` package.

Adding support for `graphql@16` was the main/only feature of [`@graphql-typed-document-node/core@3.1.1`](https://github.com/dotansimha/graphql-typed-document-node/releases/tag/core%40v3.1.1). This new version is patch-compatible with our `"@graphql-typed-document-node/core": "^3.1.0"` constraint in `package.json`, but our `package-lock.json` file was enforcing the older 3.1.0 version, leading to package installation failures in CI.