### PR TITLE
Batched Renovate updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "fetch-mock": "9.11.0",
         "glob": "7.2.0",
         "graphql": "16.0.1",
-        "graphql-ws": "5.6.4",
+        "graphql-ws": "5.7.0",
         "jest": "27.5.1",
         "jest-fetch-mock": "3.0.3",
         "jest-junit": "13.0.0",
@@ -2936,9 +2936,9 @@
       }
     },
     "node_modules/graphql-ws": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.6.4.tgz",
-      "integrity": "sha512-5r8tAzznI1zeh7k12+3z07KkgXPckQbnC9h4kJ2TBDWG2wb26TJTbVHQOiAncDBgPbtXtc1A2BlttiRuPH2t/w==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.7.0.tgz",
+      "integrity": "sha512-8yYuvnyqIjlJ/WfebOyu2GSOQeFauRxnfuTveY9yvrDGs2g3kR9Nv4gu40AKvRHbXlSJwTbMJ6dVxAtEyKwVRA==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -8541,9 +8541,9 @@
       }
     },
     "graphql-ws": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.6.4.tgz",
-      "integrity": "sha512-5r8tAzznI1zeh7k12+3z07KkgXPckQbnC9h4kJ2TBDWG2wb26TJTbVHQOiAncDBgPbtXtc1A2BlttiRuPH2t/w==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.7.0.tgz",
+      "integrity": "sha512-8yYuvnyqIjlJ/WfebOyu2GSOQeFauRxnfuTveY9yvrDGs2g3kR9Nv4gu40AKvRHbXlSJwTbMJ6dVxAtEyKwVRA==",
       "dev": true,
       "requires": {}
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,8 +35,8 @@
         "@types/jest": "27.4.1",
         "@types/lodash": "4.14.182",
         "@types/node": "16.11.26",
-        "@types/react": "17.0.43",
-        "@types/react-dom": "17.0.14",
+        "@types/react": "17.0.44",
+        "@types/react-dom": "17.0.15",
         "bundlesize": "0.18.1",
         "cross-fetch": "3.1.5",
         "crypto-hash": "1.3.0",
@@ -1316,9 +1316,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "17.0.43",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.43.tgz",
-      "integrity": "sha512-8Q+LNpdxf057brvPu1lMtC5Vn7J119xrP1aq4qiaefNioQUYANF/CYeK4NsKorSZyUGJ66g0IM+4bbjwx45o2A==",
+      "version": "17.0.44",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.44.tgz",
+      "integrity": "sha512-Ye0nlw09GeMp2Suh8qoOv0odfgCoowfM/9MG6WeRD60Gq9wS90bdkdRtYbRkNhXOpG4H+YXGvj4wOWhAC0LJ1g==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -1327,12 +1327,12 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "17.0.14",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.14.tgz",
-      "integrity": "sha512-H03xwEP1oXmSfl3iobtmQ/2dHF5aBHr8aUMwyGZya6OW45G+xtdzmq6HkncefiBt5JU8DVyaWl/nWZbjZCnzAQ==",
+      "version": "17.0.15",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.15.tgz",
+      "integrity": "sha512-Tr9VU9DvNoHDWlmecmcsE5ZZiUkYx+nKBzum4Oxe1K0yJVyBlfbq7H3eXjxXqJczBKqPGq3EgfTru4MgKb9+Yw==",
       "dev": true,
       "dependencies": {
-        "@types/react": "*"
+        "@types/react": "^17"
       }
     },
     "node_modules/@types/react-test-renderer": {
@@ -7289,9 +7289,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "17.0.43",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.43.tgz",
-      "integrity": "sha512-8Q+LNpdxf057brvPu1lMtC5Vn7J119xrP1aq4qiaefNioQUYANF/CYeK4NsKorSZyUGJ66g0IM+4bbjwx45o2A==",
+      "version": "17.0.44",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.44.tgz",
+      "integrity": "sha512-Ye0nlw09GeMp2Suh8qoOv0odfgCoowfM/9MG6WeRD60Gq9wS90bdkdRtYbRkNhXOpG4H+YXGvj4wOWhAC0LJ1g==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -7300,12 +7300,12 @@
       }
     },
     "@types/react-dom": {
-      "version": "17.0.14",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.14.tgz",
-      "integrity": "sha512-H03xwEP1oXmSfl3iobtmQ/2dHF5aBHr8aUMwyGZya6OW45G+xtdzmq6HkncefiBt5JU8DVyaWl/nWZbjZCnzAQ==",
+      "version": "17.0.15",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.15.tgz",
+      "integrity": "sha512-Tr9VU9DvNoHDWlmecmcsE5ZZiUkYx+nKBzum4Oxe1K0yJVyBlfbq7H3eXjxXqJczBKqPGq3EgfTru4MgKb9+Yw==",
       "dev": true,
       "requires": {
-        "@types/react": "*"
+        "@types/react": "^17"
       }
     },
     "@types/react-test-renderer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "recast": "0.21.0",
         "resolve": "1.22.0",
         "rimraf": "3.0.2",
-        "rollup": "2.70.1",
+        "rollup": "2.70.2",
         "rollup-plugin-terser": "7.0.2",
         "rxjs": "6.6.7",
         "subscriptions-transport-ws": "0.11.0",
@@ -5124,9 +5124,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.70.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.1.tgz",
-      "integrity": "sha512-CRYsI5EuzLbXdxC6RnYhOuRdtz4bhejPMSWjsFLfVM/7w/85n2szZv6yExqUXsBdz5KT8eoubeyDUDjhLHEslA==",
+      "version": "2.70.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.2.tgz",
+      "integrity": "sha512-EitogNZnfku65I1DD5Mxe8JYRUCy0hkK5X84IlDtUs+O6JRMpRciXTzyCUuX11b5L5pvjH+OmFXiQ3XjabcXgg==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -10249,9 +10249,9 @@
       }
     },
     "rollup": {
-      "version": "2.70.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.1.tgz",
-      "integrity": "sha512-CRYsI5EuzLbXdxC6RnYhOuRdtz4bhejPMSWjsFLfVM/7w/85n2szZv6yExqUXsBdz5KT8eoubeyDUDjhLHEslA==",
+      "version": "2.70.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.2.tgz",
+      "integrity": "sha512-EitogNZnfku65I1DD5Mxe8JYRUCy0hkK5X84IlDtUs+O6JRMpRciXTzyCUuX11b5L5pvjH+OmFXiQ3XjabcXgg==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "fetch-mock": "9.11.0",
     "glob": "7.2.0",
     "graphql": "16.0.1",
-    "graphql-ws": "5.6.4",
+    "graphql-ws": "5.7.0",
     "jest": "27.5.1",
     "jest-fetch-mock": "3.0.3",
     "jest-junit": "13.0.0",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "recast": "0.21.0",
     "resolve": "1.22.0",
     "rimraf": "3.0.2",
-    "rollup": "2.70.1",
+    "rollup": "2.70.2",
     "rollup-plugin-terser": "7.0.2",
     "rxjs": "6.6.7",
     "subscriptions-transport-ws": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "@types/lodash": "4.14.182",
     "@types/node": "16.11.26",
     "@types/react": "17.0.43",
-    "@types/react-dom": "17.0.14",
+    "@types/react-dom": "17.0.15",
     "bundlesize": "0.18.1",
     "cross-fetch": "3.1.5",
     "crypto-hash": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "@types/jest": "27.4.1",
     "@types/lodash": "4.14.182",
     "@types/node": "16.11.26",
-    "@types/react": "17.0.43",
+    "@types/react": "17.0.44",
     "@types/react-dom": "17.0.15",
     "bundlesize": "0.18.1",
     "cross-fetch": "3.1.5",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@babel/parser": "7.17.9",
     "@graphql-tools/schema": "8.3.10",
     "@rollup/plugin-node-resolve": "11.2.1",
-    "@testing-library/react": "12.1.4",
+    "@testing-library/react": "12.1.5",
     "@testing-library/react-hooks": "7.0.2",
     "@types/fast-json-stable-stringify": "2.0.0",
     "@types/fetch-mock": "7.3.5",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "graphql-ws": "5.7.0",
     "jest": "27.5.1",
     "jest-fetch-mock": "3.0.3",
-    "jest-junit": "13.0.0",
+    "jest-junit": "13.2.0",
     "lodash": "4.17.21",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/src/link/subscriptions/__tests__/graphqlWsLink.ts
+++ b/src/link/subscriptions/__tests__/graphqlWsLink.ts
@@ -36,6 +36,7 @@ function mockClient(subscribe: Client["subscribe"]): Client {
     // GraphQLWsLink doesn't use these methods
     on: () => () => {},
     dispose: () => {},
+    terminate: () => {},
   };
 }
 


### PR DESCRIPTION
Instead of merging one Renovate update PR after another, fixing merge conflicts and rerunning tests with each commit (leading to lots of unnecessary CI time), I'm going to try batching the updates in this PR.