### PR TITLE
Allow `refetchQueries` to refetch observerless queries (again)

### DIFF
--- a/src/__tests__/refetchQueries.ts
+++ b/src/__tests__/refetchQueries.ts
@@ -461,6 +461,8 @@ describe("client.refetchQueries", () => {
           expect(diff.result).toEqual({ b: "B" });
         } else if (obs === abObs) {
           expect(diff.result).toEqual({ a: "A", b: "B" });
+        } else if (obs === extraObs) {
+          expect(diff.result).toEqual({ a: "A", b: "B" });
         } else {
           reject(`unexpected ObservableQuery ${
             obs.queryId
@@ -474,6 +476,7 @@ describe("client.refetchQueries", () => {
 
     expect(activeResults).toEqual([
       { a: "A" },
+      { a: "A", b: "B" },
       { a: "A", b: "B" },
       { b: "B" },
     ]);

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -765,10 +765,7 @@ export class QueryManager<TStore> {
           options: { fetchPolicy },
         } = oq;
 
-        if (
-          fetchPolicy === "standby" ||
-          (include === "active" && !oq.hasObservers())
-        ) {
+        if (fetchPolicy === "standby") {
           return;
         }
 

--- a/src/core/__tests__/QueryManager/index.ts
+++ b/src/core/__tests__/QueryManager/index.ts
@@ -3742,7 +3742,7 @@ describe('QueryManager', () => {
       }, 50);
     });
 
-    itAsync('should not call refetch on a non-subscribed Observable if the store is reset', (resolve, reject) => {
+    itAsync('should not call refetch on a standby Observable if the store is reset', (resolve, reject) => {
       const query = gql`
         query {
           author {
@@ -3758,6 +3758,7 @@ describe('QueryManager', () => {
 
       const options = {
         query,
+        fetchPolicy: "standby",
       } as WatchQueryOptions;
 
       let refetchCount = 0;
@@ -4225,7 +4226,7 @@ describe('QueryManager', () => {
       }, 50);
     });
 
-    itAsync('should not call refetch on a non-subscribed Observable', (resolve, reject) => {
+    itAsync('should not call refetch on a standby Observable', (resolve, reject) => {
       const query = gql`
         query {
           author {
@@ -4240,7 +4241,8 @@ describe('QueryManager', () => {
       });
 
       const options = {
-        query
+        query,
+        fetchPolicy: "standby",
       } as WatchQueryOptions;
 
       let refetchCount = 0;


### PR DESCRIPTION
This PR is a follow-up to PR #8825, which was first released in Apollo Client v3.4.14. As a number of commenters have reported in issue #5419, it appears we did not completely fix the problem, so this PR attempts to finish that work.

To reiterate the motivation behind #8825: an `ObservableQuery` redelivers the most recent result/error to new subscribers, so it is not completely pointless to refetch an `ObservableQuery` that (currently) has no subscribers.

However, any `ObservableQuery` in `standby` mode (whose `options.fetchPolicy` is `standby`) should still be excluded from "active" status as far as `refetchQueries` is concerned. This logic handles `useLazyQuery` queries that have not yet been executed, since they start out in `standby` mode until called.