### PR TITLE
Fix header name

### DIFF
--- a/docs/source/api/link/apollo-link-http.md
+++ b/docs/source/api/link/apollo-link-http.md
@@ -95,7 +95,7 @@ See [Customizing `fetch`](#customizing-fetch).
 
 <td>
 
-An object representing headers to include in every HTTP request, such as `{Authentication: 'Bearer abc123'}`.
+An object representing headers to include in every HTTP request, such as `{Authorization: 'Bearer abc123'}`.
 </td>
 </tr>
 


### PR DESCRIPTION
The standard header for authorization is "Authorization" and not "Authentication" so update the documentation to avoid confustion.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->