### PR TITLE
fix Missing getServerSnapshot on React 18 and Next 12

### DIFF
--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -184,6 +184,7 @@ class InternalState<TData, TVariables> {
       ]),
 
       () => this.getCurrentResult(),
+      () => this.getCurrentResult(),
     );
 
     // TODO Remove this method when we remove support for options.partialRefetch.


### PR DESCRIPTION
This PR fixed [https://github.com/apollographql/apollo-client/issues/9623](#9623) since `useSyncExternalStore` on React 18 required 3rd parameter (getServerSnapshot) must not be undefined while on server-side rendering.

At least it eliminates crashes on NextJS v12 & React v18. I have no idea what to do better on this.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
#9623 