### PR TITLE
Drastically simplify `useQuery` default options processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Apollo Client 3.6.3 (unreleased)
+
+### Bug Fixes
+
+- Simplify `useQuery(query, { defaultOptions })` default options processing in order to fix bug where `skip: true` queries failed to execute upon switching to `skip: false`. <br/>
+  [@benjamn](https://github.com/benjamn) in [#9665](https://github.com/apollographql/apollo-client/pull/9665)
+
 ## Apollo Client 3.6.2 (2022-05-02)
 
 ### Bug Fixes

--- a/src/utilities/common/mergeOptions.ts
+++ b/src/utilities/common/mergeOptions.ts
@@ -14,12 +14,12 @@ type OptionsUnion<TData, TVariables, TContext> =
 export function mergeOptions<
   TOptions extends OptionsUnion<any, any, any>
 >(
-  defaults: TOptions | Partial<TOptions>,
+  defaults: TOptions | Partial<TOptions> | undefined,
   options: TOptions | Partial<TOptions>,
 ): TOptions {
   return compact(defaults, options, options.variables && {
     variables: {
-      ...defaults.variables,
+      ...(defaults && defaults.variables),
       ...options.variables,
     },
   });


### PR DESCRIPTION
When implementing the new `useQuery(query, { defaultOptions })` functionality in #9563, I fell under the (thankfully mistaken) impression that I needed to handle all defaulting of `WatchQueryOptions` within the `createWatchQueryOptions` method of the `InternalState` class that `useQuery` uses internally.

This PR demonstrates we can avoid that computation entirely, and rely instead on existing defaulting mechanisms (in [`watchQuery`](https://github.com/apollographql/apollo-client/blob/release-3.6/src/core/ApolloClient.ts#L291-L293)) to do the same job. The trick is to use the `defaultOptions` from `useQuery(query, { defaultOptions })` only when we first create the `ObservableQuery` (that is, only when we call `client.watchQuery`). That way, the `defaultOptions` are only relevant once, and do not continue to interfere with `WatchQueryOptions` (re)computation after that.

This simplification means we no longer need to consider the "latest" values of default options in `createWatchQueryOptions`, because we no longer consider default options at all in `createWatchQueryOptions`. More generally, at the point in time when we provide `defaultOptions` (once, when calling `client.watchQuery`), we have not yet created the `ObservableQuery`, so there are no other option values to worry about, latest or otherwise.

By contrast, my previous code went to unnecessary lengths to give precedence to `this.observable.options` whenever there was a default option of the same name. Unfortunately, that trick (or at least the way I implemented it) did not work for the `fetchPolicy` option in conjunction with `skip`, since `skip: true` sets `this.observable.options.fetchPolicy = "standby"`, and we do not want to recycle that `standby` value (even though it is technically the "latest" value) when we switch back to `skip: false`. Instead, we want the original/initial `fetchPolicy` to be restored at that point. Fixing this problem fixes the reproduction in #9635.

Should fix the following issues:
- [ ] #9635