### PR TITLE
Update `ts-invariant` to version 0.10.2 to fix source map warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Add tests of skipping/unskipping and `useLazyQuery` with `defaultOptions`, and fix a bug causing duplicate requests. <br/>
   [@benjamn](https://github.com/benjamn) in [#9666](https://github.com/apollographql/apollo-client/pull/9666)
 
+- Update `ts-invariant` to version 0.10.2 to fix source map warnings. <br/>
+  [@benjamn](https://github.com/benjamn) in [#9672](https://github.com/apollographql/apollo-client/pull/9672)
+
 ## Apollo Client 3.6.2 (2022-05-02)
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "optimism": "^0.16.1",
         "prop-types": "^15.7.2",
         "symbol-observable": "^4.0.0",
-        "ts-invariant": "^0.10.0",
+        "ts-invariant": "^0.10.2",
         "tslib": "^2.3.0",
         "use-sync-external-store": "^1.0.0",
         "zen-observable-ts": "^1.2.0"
@@ -5836,9 +5836,9 @@
       }
     },
     "node_modules/ts-invariant": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.0.tgz",
-      "integrity": "sha512-3G4a/oVAh1Ql3dos3WkmV5zML1+Px5sE10nXuP7vjk8rSIexMRMGoopGUgWYpejOOX0f668PGPez8ihFtb/oyQ==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.2.tgz",
+      "integrity": "sha512-5BybOL23OXYmmnA0C8NYPkUo5Kb/I4IVQk31K1VcdBZpQIn4fWKMIORGBJqGkwvDLyu9cxUb4Zv4G6xA4/07IQ==",
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -10967,9 +10967,9 @@
       }
     },
     "ts-invariant": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.0.tgz",
-      "integrity": "sha512-3G4a/oVAh1Ql3dos3WkmV5zML1+Px5sE10nXuP7vjk8rSIexMRMGoopGUgWYpejOOX0f668PGPez8ihFtb/oyQ==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.2.tgz",
+      "integrity": "sha512-5BybOL23OXYmmnA0C8NYPkUo5Kb/I4IVQk31K1VcdBZpQIn4fWKMIORGBJqGkwvDLyu9cxUb4Zv4G6xA4/07IQ==",
       "requires": {
         "tslib": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "optimism": "^0.16.1",
     "prop-types": "^15.7.2",
     "symbol-observable": "^4.0.0",
-    "ts-invariant": "^0.10.0",
+    "ts-invariant": "^0.10.2",
     "tslib": "^2.3.0",
     "use-sync-external-store": "^1.0.0",
     "zen-observable-ts": "^1.2.0"


### PR DESCRIPTION
Includes https://github.com/apollographql/invariant-packages/pull/284, fixing https://github.com/apollographql/invariant-packages/issues/279.

These warnings have been causing red herrings in (probably) unrelated issues, most recently in #9662, so it makes sense to fix this problem even if it's arguably harmless.