### PR TITLE
Internalize `useSyncExternalStore` shim, for more control than `use-sync-external-store` provides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Apollo Client 3.6.4 (unreleased)
+
+### Improvements
+
+- Internalize `useSyncExternalStore` shim, for more control than `use-sync-external-store` provides, fixing some React Native issues. <br/>
+  [@benjamn](https://github.com/benjamn) in [#9675](https://github.com/apollographql/apollo-client/pull/9675)
+
 ## Apollo Client 3.6.3 (unreleased)
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "symbol-observable": "^4.0.0",
         "ts-invariant": "^0.10.2",
         "tslib": "^2.3.0",
-        "use-sync-external-store": "^1.0.0",
         "zen-observable-ts": "^1.2.0"
       },
       "devDependencies": {
@@ -38,7 +37,6 @@
         "@types/node": "16.11.33",
         "@types/react": "17.0.45",
         "@types/react-dom": "17.0.16",
-        "@types/use-sync-external-store": "0.0.3",
         "acorn": "8.7.1",
         "bundlesize": "0.18.1",
         "cross-fetch": "3.1.5",
@@ -1378,12 +1376,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
-      "dev": true
-    },
-    "node_modules/@types/use-sync-external-store": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
-      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -5065,6 +5057,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -6035,14 +6028,6 @@
       "dev": true,
       "engines": {
         "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/use-sync-external-store": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.0.0.tgz",
-      "integrity": "sha512-AFVsxg5GkFg8GDcxnl+Z0lMAz9rE8DGJCc28qnBuQF7lac57B5smLcT37aXpXIIPz75rW4g3eXHPjhHwdGskOw==",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0-rc"
       }
     },
     "node_modules/util-deprecate": {
@@ -7494,12 +7479,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
-      "dev": true
-    },
-    "@types/use-sync-external-store": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
-      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==",
       "dev": true
     },
     "@types/yargs": {
@@ -10359,6 +10338,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -11085,12 +11065,6 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
-    },
-    "use-sync-external-store": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.0.0.tgz",
-      "integrity": "sha512-AFVsxg5GkFg8GDcxnl+Z0lMAz9rE8DGJCc28qnBuQF7lac57B5smLcT37aXpXIIPz75rW4g3eXHPjhHwdGskOw==",
-      "requires": {}
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
+        "@types/use-sync-external-store": "^0.0.3",
         "@wry/context": "^0.6.0",
         "@wry/equality": "^0.5.0",
         "@wry/trie": "^0.3.0",
@@ -1377,6 +1378,11 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "node_modules/@types/yargs": {
       "version": "16.0.4",
@@ -7480,6 +7486,11 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
+    },
+    "@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "@types/yargs": {
       "version": "16.0.4",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     "symbol-observable": "^4.0.0",
     "ts-invariant": "^0.10.2",
     "tslib": "^2.3.0",
-    "use-sync-external-store": "^1.0.0",
     "zen-observable-ts": "^1.2.0"
   },
   "devDependencies": {
@@ -109,7 +108,6 @@
     "@types/node": "16.11.33",
     "@types/react": "17.0.45",
     "@types/react-dom": "17.0.16",
-    "@types/use-sync-external-store": "0.0.3",
     "acorn": "8.7.1",
     "bundlesize": "0.18.1",
     "cross-fetch": "3.1.5",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     {
       "name": "apollo-client",
       "path": "./dist/apollo-client.min.cjs",
-      "maxSize": "29.4kB"
+      "maxSize": "29.45kB"
     }
   ],
   "engines": {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
   },
   "dependencies": {
     "@graphql-typed-document-node/core": "^3.1.1",
+    "@types/use-sync-external-store": "^0.0.3",
     "@wry/context": "^0.6.0",
     "@wry/equality": "^0.5.0",
     "@wry/trie": "^0.3.0",

--- a/src/__tests__/__snapshots__/exports.ts.snap
+++ b/src/__tests__/__snapshots__/exports.ts.snap
@@ -347,6 +347,7 @@ Array [
   "argumentsObjectFromField",
   "asyncMap",
   "buildQueryFromSelectionSet",
+  "canUseDOM",
   "canUseSymbol",
   "canUseWeakMap",
   "canUseWeakSet",

--- a/src/__tests__/__snapshots__/exports.ts.snap
+++ b/src/__tests__/__snapshots__/exports.ts.snap
@@ -348,6 +348,7 @@ Array [
   "asyncMap",
   "buildQueryFromSelectionSet",
   "canUseDOM",
+  "canUseLayoutEffect",
   "canUseSymbol",
   "canUseWeakMap",
   "canUseWeakSet",

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -7,7 +7,7 @@ import {
   useRef,
   useState,
 } from 'react';
-import { useSyncExternalStore } from 'use-sync-external-store/shim/index.js';
+import { useSyncExternalStore } from './useSyncExternalStore';
 import { equal } from '@wry/equality';
 
 import { mergeOptions, OperationVariables, WatchQueryFetchPolicy } from '../../core';

--- a/src/react/hooks/useSyncExternalStore.ts
+++ b/src/react/hooks/useSyncExternalStore.ts
@@ -1,0 +1,113 @@
+import { invariant } from '../../utilities/globals';
+import * as React from 'react';
+
+import { canUseDOM } from '../../utilities';
+
+const ReactWithSESHook = React as (typeof React & {
+  useSyncExternalStore?: typeof useSyncExternalStore;
+});
+
+let didWarnUncachedGetSnapshot = false;
+
+export function useSyncExternalStore<Snapshot>(
+  subscribe: (onStoreChange: () => void) => () => void,
+  getSnapshot: () => Snapshot,
+  getServerSnapshot?: () => Snapshot,
+): Snapshot {
+  // When/if React.useSyncExternalStore is defined, delegate fully to it.
+  const realHook = ReactWithSESHook.useSyncExternalStore;
+  if (realHook) {
+    return realHook(subscribe, getSnapshot, getServerSnapshot);
+  }
+
+  // Read the current snapshot from the store on every render. Again, this
+  // breaks the rules of React, and only works here because of specific
+  // implementation details, most importantly that updates are
+  // always synchronous.
+  const value = getSnapshot();
+  if (
+    __DEV__ &&
+    !didWarnUncachedGetSnapshot &&
+    value !== getSnapshot()
+  ) {
+    didWarnUncachedGetSnapshot = true;
+    invariant.error(
+      'The result of getSnapshot should be cached to avoid an infinite loop',
+    );
+  }
+
+  // Because updates are synchronous, we don't queue them. Instead we force a
+  // re-render whenever the subscribed state changes by updating an some
+  // arbitrary useState hook. Then, during render, we call getSnapshot to read
+  // the current value.
+  //
+  // Because we don't actually use the state returned by the useState hook, we
+  // can save a bit of memory by storing other stuff in that slot.
+  //
+  // To implement the early bailout, we need to track some things on a mutable
+  // object. Usually, we would put that in a useRef hook, but we can stash it in
+  // our useState hook instead.
+  //
+  // To force a re-render, we call forceUpdate({inst}). That works because the
+  // new object always fails an equality check.
+  const [{inst}, forceUpdate] = React.useState({inst: {value, getSnapshot}});
+
+  // Track the latest getSnapshot function with a ref. This needs to be updated
+  // in the layout phase so we can access it during the tearing check that
+  // happens on subscribe.
+  if (canUseDOM) {
+    React.useLayoutEffect(() => {
+      Object.assign(inst, { value, getSnapshot });
+      // Whenever getSnapshot or subscribe changes, we need to check in the
+      // commit phase if there was an interleaved mutation. In concurrent mode
+      // this can happen all the time, but even in synchronous mode, an earlier
+      // effect may have mutated the store.
+      if (checkIfSnapshotChanged(inst)) {
+        // Force a re-render.
+        forceUpdate({inst});
+      }
+    }, [subscribe, value, getSnapshot]);
+  } else {
+    Object.assign(inst, { value, getSnapshot });
+  }
+
+  React.useEffect(() => {
+    // Check for changes right before subscribing. Subsequent changes will be
+    // detected in the subscription handler.
+    if (checkIfSnapshotChanged(inst)) {
+      // Force a re-render.
+      forceUpdate({inst});
+    }
+    const handleStoreChange = () => {
+      // TODO: Because there is no cross-renderer API for batching updates, it's
+      // up to the consumer of this library to wrap their subscription event
+      // with unstable_batchedUpdates. Should we try to detect when this isn't
+      // the case and print a warning in development?
+
+      // The store changed. Check if the snapshot changed since the last time we
+      // read from the store.
+      if (checkIfSnapshotChanged(inst)) {
+        // Force a re-render.
+        forceUpdate({inst});
+      }
+    };
+    // Subscribe to the store and return a clean-up function.
+    return subscribe(handleStoreChange);
+  }, [subscribe]);
+
+  return value;
+}
+
+function checkIfSnapshotChanged<Snapshot>({
+  value,
+  getSnapshot,
+}: {
+  value: Snapshot;
+  getSnapshot: () => Snapshot;
+}): boolean {
+  try {
+    return value !== getSnapshot();
+  } catch {
+    return true;
+  }
+}

--- a/src/react/hooks/useSyncExternalStore.ts
+++ b/src/react/hooks/useSyncExternalStore.ts
@@ -1,7 +1,7 @@
 import { invariant } from '../../utilities/globals';
 import * as React from 'react';
 
-import { canUseDOM } from '../../utilities';
+import { canUseLayoutEffect } from '../../utilities';
 
 const ReactWithSESHook = React as (typeof React & {
   useSyncExternalStore?: typeof useSyncExternalStore;
@@ -62,10 +62,11 @@ export function useSyncExternalStore<Snapshot>(
   // Track the latest getSnapshot function with a ref. This needs to be updated
   // in the layout phase so we can access it during the tearing check that
   // happens on subscribe.
-  if (canUseDOM) {
-    // DEVIATION: We avoid calling useLayoutEffect when !canUseDOM, which may
-    // seem like a conditional hook, but this code ends up behaving
-    // unconditionally (one way or the other) because canUseDOM is constant.
+  if (canUseLayoutEffect) {
+    // DEVIATION: We avoid calling useLayoutEffect when !canUseLayoutEffect,
+    // which may seem like a conditional hook, but this code ends up behaving
+    // unconditionally (one way or the other) because canUseLayoutEffect is
+    // constant.
     React.useLayoutEffect(() => {
       Object.assign(inst, { value, getSnapshot });
       // Whenever getSnapshot or subscribe changes, we need to check in the

--- a/src/react/hooks/useSyncExternalStore.ts
+++ b/src/react/hooks/useSyncExternalStore.ts
@@ -3,22 +3,27 @@ import * as React from 'react';
 
 import { canUseLayoutEffect } from '../../utilities';
 
-const ReactWithSESHook = React as (typeof React & {
-  useSyncExternalStore?: typeof useSyncExternalStore;
-});
-
 let didWarnUncachedGetSnapshot = false;
+
+type RealUseSESHookType =
+  // This import depends only on the @types/use-sync-external-store package, not
+  // the actual use-sync-external-store package, which is not installed. It
+  // might be nice to get this type from React 18, but it still needs to work
+  // when only React 17 or earlier is installed.
+  typeof import("use-sync-external-store").useSyncExternalStore;
 
 // Adapted from https://www.npmjs.com/package/use-sync-external-store, with
 // Apollo Client deviations called out by "// DEVIATION ..." comments.
 
-export function useSyncExternalStore<Snapshot>(
-  subscribe: (onStoreChange: () => void) => () => void,
-  getSnapshot: () => Snapshot,
-  getServerSnapshot?: () => Snapshot,
-): Snapshot {
+export const useSyncExternalStore: RealUseSESHookType = (
+  subscribe,
+  getSnapshot,
+  getServerSnapshot,
+) => {
   // When/if React.useSyncExternalStore is defined, delegate fully to it.
-  const realHook = ReactWithSESHook.useSyncExternalStore;
+  const realHook = (React as {
+    useSyncExternalStore?: RealUseSESHookType;
+  }).useSyncExternalStore;
   if (realHook) {
     return realHook(subscribe, getSnapshot, getServerSnapshot);
   }

--- a/src/utilities/common/__tests__/canUse.ts
+++ b/src/utilities/common/__tests__/canUse.ts
@@ -1,0 +1,8 @@
+import { canUseDOM } from "../canUse";
+
+describe("canUse* boolean constants", () => {
+  // https://github.com/apollographql/apollo-client/pull/9675
+  it("sets canUseDOM to false when using jsdom", () => {
+    expect(canUseDOM).toBe(false);
+  });
+});

--- a/src/utilities/common/__tests__/canUse.ts
+++ b/src/utilities/common/__tests__/canUse.ts
@@ -1,8 +1,11 @@
-import { canUseDOM } from "../canUse";
+import { canUseDOM, canUseLayoutEffect } from "../canUse";
 
 describe("canUse* boolean constants", () => {
   // https://github.com/apollographql/apollo-client/pull/9675
-  it("sets canUseDOM to false when using jsdom", () => {
-    expect(canUseDOM).toBe(false);
+  it("sets canUseDOM to true when using Jest in Node.js with jsdom", () => {
+    expect(canUseDOM).toBe(true);
+  });
+  it("sets canUseLayoutEffect to false when using Jest in Node.js with jsdom", () => {
+    expect(canUseLayoutEffect).toBe(false);
   });
 });

--- a/src/utilities/common/canUse.ts
+++ b/src/utilities/common/canUse.ts
@@ -1,10 +1,14 @@
-export const canUseWeakMap = typeof WeakMap === 'function' && !(
-  typeof navigator === 'object' &&
-  navigator.product === 'ReactNative'
-);
+import { maybe } from "../globals";
+
+export const canUseWeakMap =
+  typeof WeakMap === 'function' &&
+  maybe(() => navigator.product) !== 'ReactNative';
 
 export const canUseWeakSet = typeof WeakSet === 'function';
 
 export const canUseSymbol =
   typeof Symbol === 'function' &&
   typeof Symbol.for === 'function';
+
+export const canUseDOM =
+  typeof maybe(() => window.document.createElement) === "function";

--- a/src/utilities/common/canUse.ts
+++ b/src/utilities/common/canUse.ts
@@ -10,5 +10,8 @@ export const canUseSymbol =
   typeof Symbol === 'function' &&
   typeof Symbol.for === 'function';
 
+const isNode = !!maybe(() => `v${process.versions.node}` === process.version);
+
 export const canUseDOM =
+  !isNode &&
   typeof maybe(() => window.document.createElement) === "function";

--- a/src/utilities/common/canUse.ts
+++ b/src/utilities/common/canUse.ts
@@ -10,8 +10,20 @@ export const canUseSymbol =
   typeof Symbol === 'function' &&
   typeof Symbol.for === 'function';
 
-const isNode = !!maybe(() => `v${process.versions.node}` === process.version);
+const usingJSDOM: boolean =
+  // Following advice found in this comment from @domenic (maintainer of jsdom):
+  // https://github.com/jsdom/jsdom/issues/1537#issuecomment-229405327. Since we
+  // control the version of Jest used when running Apollo Client tests, and that
+  // version includes jsdom/x.y.z at the end of the user agent string, I believe
+  // this case is all we need to test for.
+  maybe(() => navigator.userAgent.indexOf("jsdom") >= 0) || false;
 
 export const canUseDOM =
-  !isNode &&
+  // Our tests should all continue to pass if we remove the !usingJSDOM
+  // condition, thereby allowing canUseDOM to be true when using jsdom.
+  // Unfortunately, if we allow that, then useSyncExternalStore generates a lot
+  // of warnings about useLayoutEffect doing nothing on the server. While these
+  // warnings are harmless, this !usingJSDOM condition seems to be the best way
+  // to prevent them (i.e. skipping useLayoutEffect when using jsdom).
+  !usingJSDOM &&
   typeof maybe(() => window.document.createElement) === "function";

--- a/src/utilities/common/canUse.ts
+++ b/src/utilities/common/canUse.ts
@@ -10,20 +10,24 @@ export const canUseSymbol =
   typeof Symbol === 'function' &&
   typeof Symbol.for === 'function';
 
+export const canUseDOM =
+  typeof maybe(() => window.document.createElement) === "function";
+
 const usingJSDOM: boolean =
   // Following advice found in this comment from @domenic (maintainer of jsdom):
-  // https://github.com/jsdom/jsdom/issues/1537#issuecomment-229405327. Since we
-  // control the version of Jest used when running Apollo Client tests, and that
-  // version includes jsdom/x.y.z at the end of the user agent string, I believe
-  // this case is all we need to test for.
+  // https://github.com/jsdom/jsdom/issues/1537#issuecomment-229405327
+  //
+  // Since we control the version of Jest and jsdom used when running Apollo
+  // Client tests, and that version is recent enought to include " jsdom/x.y.z"
+  // at the end of the user agent string, I believe this case is all we need to
+  // check. Testing for "Node.js" was recommended for backwards compatibility
+  // with older version of jsdom, but we don't have that problem.
   maybe(() => navigator.userAgent.indexOf("jsdom") >= 0) || false;
 
-export const canUseDOM =
-  // Our tests should all continue to pass if we remove the !usingJSDOM
-  // condition, thereby allowing canUseDOM to be true when using jsdom.
-  // Unfortunately, if we allow that, then useSyncExternalStore generates a lot
-  // of warnings about useLayoutEffect doing nothing on the server. While these
-  // warnings are harmless, this !usingJSDOM condition seems to be the best way
-  // to prevent them (i.e. skipping useLayoutEffect when using jsdom).
-  !usingJSDOM &&
-  typeof maybe(() => window.document.createElement) === "function";
+// Our tests should all continue to pass if we remove this !usingJSDOM
+// condition, thereby allowing useLayoutEffect when using jsdom. Unfortunately,
+// if we allow useLayoutEffect, then useSyncExternalStore generates many
+// warnings about useLayoutEffect doing nothing on the server. While these
+// warnings are harmless, this !usingJSDOM condition seems to be the best way to
+// prevent them (i.e. skipping useLayoutEffect when using jsdom).
+export const canUseLayoutEffect = canUseDOM && !usingJSDOM;


### PR DESCRIPTION
This internalization solves several problems with the official [`use-sync-external-store/shim`](https://www.npmjs.com/package/use-sync-external-store) package:
- We can ensure `useLayoutEffect` is called only on the client, eliminating noisy warnings
- We can use our own internal mechanisms like `__DEV__` to gate development-only code
- We don't have to use an `Object.is` polyfill because we know our snapshots won't need it
- Because the `useSyncExternalStore` shim is now implemented/exported using ECMAScript module syntax, issues like #9670 should be resolved

If there was some way to selectively import the different client/server versions of the `useSyncExternalStore` hook from `use-sync-external-store/shim`, I would be happy to keep using that package, but the difficulty of making the official package work exceeded the difficulty of implementing our own shim (this PR), and this approach gives us more control over the shimming.