### PR TITLE
Fix failing regression test for skipped SSR `useQuery` stuck in standby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Update `ts-invariant` to version 0.10.2 to fix source map warnings. <br/>
   [@benjamn](https://github.com/benjamn) in [#9672](https://github.com/apollographql/apollo-client/pull/9672)
 
+- Test that `useQuery` queries with `skip: true` do not stall server-side rendering. <br/>
+  [@nathanmarks](https://github.com/nathanmarks) and [@benjamn](https://github.com/benjamn) in [#9677](https://github.com/apollographql/apollo-client/pull/9677)
+
 ## Apollo Client 3.6.2 (2022-05-02)
 
 ### Bug Fixes

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -384,15 +384,15 @@ class InternalState<TData, TVariables> {
       subscribeToMore: obsQuery.subscribeToMore.bind(obsQuery),
     }), [obsQuery]);
 
-    if (this.renderPromises) {
+    const ssrAllowed = !(
+      this.queryHookOptions.ssr === false ||
+      this.queryHookOptions.skip
+    );
+
+    if (this.renderPromises && ssrAllowed) {
       this.renderPromises.registerSSRObservable(obsQuery);
 
-      const ssrAllowed = !(
-        this.queryHookOptions.ssr === false ||
-        this.queryHookOptions.skip
-      );
-
-      if (ssrAllowed && obsQuery.getCurrentResult().loading) {
+      if (obsQuery.getCurrentResult().loading) {
         // TODO: This is a legacy API which could probably be cleaned up
         this.renderPromises.addObservableQueryPromise(obsQuery);
       }


### PR DESCRIPTION
Test borrowed from issue #9658, thanks to @nathanmarks.

I'm expecting this test to fail at first.