### PR TITLE
Add missing assumeImmutableResults documentation

### DIFF
--- a/docs/source/api/core/ApolloClient.mdx
+++ b/docs/source/api/core/ApolloClient.mdx
@@ -207,6 +207,22 @@ See the [example object below](#example-defaultoptions-object).
 </td>
 </tr>
 
+
+<tr>
+<td>
+
+###### `assumeImmutableResults`
+
+`Boolean`
+</td>
+<td>
+
+If `true`, Apollo Client will assume results read from the cache are never mutated by application code, which enables substantial performance optimizations.
+
+The default value is `false`.
+</td>
+</tr>
+
 </tbody>
 </table>
 

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -113,9 +113,7 @@ export class ApolloClient<TCacheShape> implements DataProxy {
    *
    * @param assumeImmutableResults When this option is true, the client will assume results
    *                               read from the cache are never mutated by application code,
-   *                               which enables substantial performance optimizations. Passing
-   *                               `{ freezeResults: true }` to the `InMemoryCache` constructor
-   *                               can help enforce this immutability.
+   *                               which enables substantial performance optimizations.
    *
    * @param name A custom name that can be used to identify this client, when
    *             using Apollo client awareness features. E.g. "iOS".


### PR DESCRIPTION
A colleague has been profiling one of our apps and has found that setting `assumeImmutableResults: true` has a positive impact to performance. We noticed that this option is not in the documentation so I opened this PR. Is this intentionally undocumented? 

I also wonder, if using `InMemoryCache` is there any reason to not set `assumeImmutableResults: true`? Let me know if there's something obvious that I'm missing. Thanks!

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
