### PR TITLE
Prevent `useLazyQuery` from making duplicate requests when execution function first called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 - Test that `useQuery` queries with `skip: true` do not stall server-side rendering. <br/>
   [@nathanmarks](https://github.com/nathanmarks) and [@benjamn](https://github.com/benjamn) in [#9677](https://github.com/apollographql/apollo-client/pull/9677)
 
+- Prevent `useLazyQuery` from making duplicate requests when its execution function is first called, and stop rejecting the `Promise` it returns when `result.error` is defined. <br/>
+  [@benjamn](https://github.com/benjamn) in [#9684](https://github.com/apollographql/apollo-client/pull/9684)
+
 ## Apollo Client 3.6.2 (2022-05-02)
 
 ### Bug Fixes

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -265,7 +265,7 @@ describe('useLazyQuery Hook', () => {
     setTimeout(() => execute());
 
     await waitForNextUpdate();
-    expect(result.current[1].loading).toBe(false);
+    expect(result.current[1].loading).toBe(true);
     expect(result.current[1].data).toEqual({ hello: 'world 1' });
 
     await waitForNextUpdate();
@@ -687,34 +687,36 @@ describe('useLazyQuery Hook', () => {
     );
 
     const execute = result.current[0];
-    let executeResult: any;
     expect(result.current[1].loading).toBe(false);
-    expect(result.current[1].data).toBe(undefined);
-    setTimeout(() => {
-      executeResult = execute();
-      executeResult.catch(() => {});
-    });
+    expect(result.current[1].data).toBeUndefined();
+
+    const executePromise = Promise.resolve().then(() => execute());
 
     await waitForNextUpdate();
     expect(result.current[1].loading).toBe(true);
-    expect(result.current[1].data).toBe(undefined);
+    expect(result.current[1].data).toBeUndefined();
     expect(result.current[1].error).toBe(undefined);
 
     await waitForNextUpdate();
     expect(result.current[1].loading).toBe(false);
-    expect(result.current[1].data).toBe(undefined);
+    expect(result.current[1].data).toBeUndefined();
     expect(result.current[1].error).toEqual(new Error('error 1'));
 
-    await expect(executeResult).rejects.toEqual(new Error('error 1'));
-
-    setTimeout(() => {
-      executeResult = execute();
-      executeResult.catch(() => {});
+    await executePromise.then(result => {
+      expect(result.loading).toBe(false);
+      expect(result.data).toBeUndefined();
+      expect(result.error!.message).toBe('error 1');
     });
 
+    await expect(waitForNextUpdate({
+      timeout: 20,
+    })).rejects.toThrow('Timed out');
+
+    setTimeout(() => execute());
+
     await waitForNextUpdate();
-    expect(result.current[1].loading).toBe(false);
-    expect(result.current[1].data).toBe(undefined);
+    expect(result.current[1].loading).toBe(true);
+    expect(result.current[1].data).toBeUndefined();
     expect(result.current[1].error).toEqual(new Error('error 1'));
 
     await waitForNextUpdate();

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -11,17 +11,20 @@ import { useLazyQuery } from '../useLazyQuery';
 import { QueryResult } from '../../types/types';
 
 describe('useLazyQuery Hook', () => {
+  const helloQuery: TypedDocumentNode<{
+    hello: string;
+  }> = gql`query { hello }`;
+
   it('should hold query execution until manually triggered', async () => {
-    const query = gql`{ hello }`;
     const mocks = [
       {
-        request: { query },
+        request: { query: helloQuery },
         result: { data: { hello: 'world' } },
         delay: 20,
       },
     ];
     const { result, waitForNextUpdate } = renderHook(
-      () => useLazyQuery(query),
+      () => useLazyQuery(helloQuery),
       {
         wrapper: ({ children }) => (
           <MockedProvider mocks={mocks}>
@@ -45,16 +48,15 @@ describe('useLazyQuery Hook', () => {
   });
 
   it('should set `called` to false by default', async () => {
-    const query = gql`{ hello }`;
     const mocks = [
       {
-        request: { query },
+        request: { query: helloQuery },
         result: { data: { hello: 'world' } },
         delay: 20,
       },
     ];
     const { result } = renderHook(
-      () => useLazyQuery(query),
+      () => useLazyQuery(helloQuery),
       {
         wrapper: ({ children }) => (
           <MockedProvider mocks={mocks}>
@@ -70,17 +72,16 @@ describe('useLazyQuery Hook', () => {
   });
 
   it('should set `called` to true after calling the lazy execute function', async () => {
-    const query = gql`{ hello }`;
     const mocks = [
       {
-        request: { query },
+        request: { query: helloQuery },
         result: { data: { hello: 'world' } },
         delay: 20,
       },
     ];
 
     const { result, waitForNextUpdate } = renderHook(
-      () => useLazyQuery(query),
+      () => useLazyQuery(helloQuery),
       {
         wrapper: ({ children }) => (
           <MockedProvider mocks={mocks}>
@@ -105,10 +106,9 @@ describe('useLazyQuery Hook', () => {
   });
 
   it('should override `skip` if lazy mode execution function is called', async () => {
-    const query = gql`{ hello }`;
     const mocks = [
       {
-        request: { query },
+        request: { query: helloQuery },
         result: { data: { hello: 'world' } },
         delay: 20,
       },
@@ -116,7 +116,7 @@ describe('useLazyQuery Hook', () => {
 
     const { result, waitForNextUpdate } = renderHook(
       // skip isn’t actually an option on the types
-      () => useLazyQuery(query, { skip: true } as any),
+      () => useLazyQuery(helloQuery, { skip: true } as any),
       {
         wrapper: ({ children }) => (
           <MockedProvider mocks={mocks}>
@@ -225,22 +225,21 @@ describe('useLazyQuery Hook', () => {
   });
 
   it('should fetch data each time the execution function is called, when using a "network-only" fetch policy', async () => {
-    const query = gql`{ hello }`;
     const mocks = [
       {
-        request: { query },
+        request: { query: helloQuery },
         result: { data: { hello: 'world 1' } },
         delay: 20,
       },
       {
-        request: { query },
+        request: { query: helloQuery },
         result: { data: { hello: 'world 2' } },
         delay: 20,
       },
     ];
 
     const { result, waitForNextUpdate } = renderHook(
-      () => useLazyQuery(query, {
+      () => useLazyQuery(helloQuery, {
         fetchPolicy: 'network-only',
       }),
       {
@@ -275,22 +274,21 @@ describe('useLazyQuery Hook', () => {
   });
 
   it('should persist previous data when a query is re-run', async () => {
-    const query = gql`{ hello }`;
     const mocks = [
       {
-        request: { query },
+        request: { query: helloQuery },
         result: { data: { hello: 'world 1' } },
         delay: 20,
       },
       {
-        request: { query },
+        request: { query: helloQuery },
         result: { data: { hello: 'world 2' } },
         delay: 20,
       },
     ];
 
     const { result, waitForNextUpdate } = renderHook(
-      () => useLazyQuery(query, {
+      () => useLazyQuery(helloQuery, {
         notifyOnNetworkStatusChange: true,
       }),
       {
@@ -333,19 +331,18 @@ describe('useLazyQuery Hook', () => {
   });
 
   it('should allow for the query to start with polling', async () => {
-    const query = gql`{ hello }`;
     const mocks = [
       {
-        request: { query },
+        request: { query: helloQuery },
         result: { data: { hello: "world 1" } },
         delay: 10,
       },
       {
-        request: { query },
+        request: { query: helloQuery },
         result: { data: { hello: "world 2" } },
       },
       {
-        request: { query },
+        request: { query: helloQuery },
         result: { data: { hello: "world 3" } },
       },
     ];
@@ -355,7 +352,7 @@ describe('useLazyQuery Hook', () => {
     );
 
     const { result, waitForNextUpdate } = renderHook(
-      () => useLazyQuery(query),
+      () => useLazyQuery(helloQuery),
       { wrapper },
     );
 
@@ -466,12 +463,10 @@ describe('useLazyQuery Hook', () => {
   });
 
   it('should work with cache-and-network fetch policy', async () => {
-    const query = gql`{ hello }`;
-
     const cache = new InMemoryCache();
     const link = mockSingleLink(
       {
-        request: { query },
+        request: { query: helloQuery },
         result: { data: { hello: 'from link' } },
         delay: 20,
       },
@@ -482,10 +477,10 @@ describe('useLazyQuery Hook', () => {
       cache,
     });
 
-    cache.writeQuery({ query, data: { hello: 'from cache' }});
+    cache.writeQuery({ query: helloQuery, data: { hello: 'from cache' }});
 
     const { result, waitForNextUpdate } = renderHook(
-      () => useLazyQuery(query, { fetchPolicy: 'cache-and-network' }),
+      () => useLazyQuery(helloQuery, { fetchPolicy: 'cache-and-network' }),
       {
         wrapper: ({ children }) => (
           <ApolloProvider client={client}>
@@ -512,16 +507,15 @@ describe('useLazyQuery Hook', () => {
   });
 
   it('should return a promise from the execution function which resolves with the result', async () => {
-    const query = gql`{ hello }`;
     const mocks = [
       {
-        request: { query },
+        request: { query: helloQuery },
         result: { data: { hello: 'world' } },
         delay: 20,
       },
     ];
     const { result, waitForNextUpdate } = renderHook(
-      () => useLazyQuery(query),
+      () => useLazyQuery(helloQuery),
       {
         wrapper: ({ children }) => (
           <MockedProvider mocks={mocks}>
@@ -664,17 +658,16 @@ describe('useLazyQuery Hook', () => {
   });
 
   it('the promise should reject with errors the “way useMutation does”', async () => {
-    const query = gql`{ hello }`;
     const mocks = [
       {
-        request: { query },
+        request: { query: helloQuery },
         result: {
           errors: [new GraphQLError('error 1')],
         },
         delay: 20,
       },
       {
-        request: { query },
+        request: { query: helloQuery },
         result: {
           errors: [new GraphQLError('error 2')],
         },
@@ -683,7 +676,7 @@ describe('useLazyQuery Hook', () => {
     ];
 
     const { result, waitForNextUpdate } = renderHook(
-      () => useLazyQuery(query),
+      () => useLazyQuery(helloQuery),
       {
         wrapper: ({ children }) => (
           <MockedProvider mocks={mocks}>
@@ -729,14 +722,15 @@ describe('useLazyQuery Hook', () => {
     expect(result.current[1].data).toBe(undefined);
     expect(result.current[1].error).toEqual(new Error('error 2'));
 
-    await expect(executeResult).rejects.toEqual(new Error('error 2'));
+    await expect(waitForNextUpdate({
+      timeout: 20,
+    })).rejects.toThrow('Timed out');
   });
 
   it('the promise should not cause an unhandled rejection', async () => {
-    const query = gql`{ hello }`;
     const mocks = [
       {
-        request: { query },
+        request: { query: helloQuery },
         result: {
           errors: [new GraphQLError('error 1')],
         },
@@ -744,7 +738,7 @@ describe('useLazyQuery Hook', () => {
     ];
 
     const { result, waitForNextUpdate } = renderHook(
-      () => useLazyQuery(query),
+      () => useLazyQuery(helloQuery),
       {
         wrapper: ({ children }) => (
           <MockedProvider mocks={mocks}>

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -108,6 +108,7 @@ export function useLazyQuery<TData = any, TVariables = OperationVariables>(
     }).then(queryResult => Object.assign(queryResult, eagerMethods));
 
     // Deliver the loading state for this reobservation immediately.
+    // TODO What if internalState.forceUpdate returned a Promise for the result?
     internalState.forceUpdate();
 
     // Because the return value of `useLazyQuery` is usually floated, we need

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -3,7 +3,6 @@ import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { useCallback, useMemo, useRef } from 'react';
 
 import { OperationVariables } from '../../core';
-import { ApolloError } from '../../errors';
 import {
   LazyQueryHookOptions,
   LazyQueryResultTuple,
@@ -11,7 +10,6 @@ import {
 } from '../types/types';
 import { useInternalState } from './useQuery';
 import { useApolloClient } from './useApolloClient';
-import { isNonEmptyArray } from '../../utilities';
 
 // The following methods, when called will execute the query, regardless of
 // whether the useLazyQuery execute function was called before.
@@ -73,43 +71,16 @@ export function useLazyQuery<TData = any, TVariables = OperationVariables>(
   const execute = useCallback<
     LazyQueryResultTuple<TData, TVariables>[0]
   >(executeOptions => {
-    const promise = result.reobserve(
-      execOptionsRef.current = executeOptions ? {
-        ...executeOptions,
-        fetchPolicy: executeOptions.fetchPolicy || initialFetchPolicy,
-      } : {
-        fetchPolicy: initialFetchPolicy,
-      },
-    ).then(apolloQueryResult => {
-      // If this.observable.options.fetchPolicy is "standby", the
-      // apolloQueryResult we receive here can be undefined, so we call
-      // getCurrentResult to obtain a stub result.
-      // TODO Investigate whether standby queries could return this stub result
-      // in the first place.
-      apolloQueryResult = apolloQueryResult || internalState["getCurrentResult"]();
+    execOptionsRef.current = executeOptions ? {
+      ...executeOptions,
+      fetchPolicy: executeOptions.fetchPolicy || initialFetchPolicy,
+    } : {
+      fetchPolicy: initialFetchPolicy,
+    };
 
-      if (
-        apolloQueryResult.error ||
-        isNonEmptyArray(apolloQueryResult.errors)
-      ) {
-        const {
-          errorPolicy = "none",
-        } = result.observable.options;
-
-        if (errorPolicy === "none") {
-          throw apolloQueryResult.error || new ApolloError({
-            graphQLErrors: apolloQueryResult.errors,
-          });
-        }
-      }
-
-      return internalState.toQueryResult(apolloQueryResult);
-
-    }).then(queryResult => Object.assign(queryResult, eagerMethods));
-
-    // Deliver the loading state for this reobservation immediately.
-    // TODO What if internalState.forceUpdate returned a Promise for the result?
-    internalState.forceUpdate();
+    const promise = internalState
+      .asyncUpdate() // Like internalState.forceUpdate, but returns a Promise.
+      .then(queryResult => Object.assign(queryResult, eagerMethods));
 
     // Because the return value of `useLazyQuery` is usually floated, we need
     // to catch the promise to prevent unhandled rejections.

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -1,3 +1,5 @@
+import { invariant } from '../../utilities/globals';
+
 import {
   useCallback,
   useContext,
@@ -28,7 +30,7 @@ import {
 
 import { DocumentType, verifyDocumentType } from '../parser';
 import { useApolloClient } from './useApolloClient';
-import { canUseWeakMap, isNonEmptyArray, maybeDeepFreeze } from '../../utilities';
+import { canUseWeakMap, canUseWeakSet, isNonEmptyArray, maybeDeepFreeze } from '../../utilities';
 
 const {
   prototype: {
@@ -87,7 +89,24 @@ class InternalState<TData, TVariables> {
 
   forceUpdate() {
     // Replaced (in useInternalState) with a method that triggers an update.
+    invariant.warn("Calling default no-op implementation of InternalState#forceUpdate");
   }
+
+  asyncUpdate() {
+    return new Promise<QueryResult<TData, TVariables>>(resolve => {
+      this.asyncResolveFns.add(resolve);
+      this.optionsToIgnoreOnce.add(this.watchQueryOptions);
+      this.forceUpdate();
+    });
+  }
+
+  private asyncResolveFns = new Set<
+    (result: QueryResult<TData, TVariables>) => void
+  >();
+
+  private optionsToIgnoreOnce = new (canUseWeakSet ? WeakSet : Set)<
+    WatchQueryOptions<TVariables, TData>
+  >();
 
   // Methods beginning with use- should be called according to the standard
   // rules of React hooks: only at the top level of the calling function, and
@@ -190,7 +209,14 @@ class InternalState<TData, TVariables> {
     // TODO Remove this method when we remove support for options.partialRefetch.
     this.unsafeHandlePartialRefetch(result);
 
-    return this.toQueryResult(result);
+    const queryResult = this.toQueryResult(result);
+
+    if (!queryResult.loading && this.asyncResolveFns.size) {
+      this.asyncResolveFns.forEach(resolve => resolve(queryResult));
+      this.asyncResolveFns.clear();
+    }
+
+    return queryResult;
   }
 
   // These members (except for renderPromises) are all populated by the
@@ -212,9 +238,27 @@ class InternalState<TData, TVariables> {
     // allows us to depend on the referential stability of
     // this.watchQueryOptions elsewhere.
     const currentWatchQueryOptions = this.watchQueryOptions;
-    if (!equal(watchQueryOptions, currentWatchQueryOptions)) {
+
+    // To force this equality test to "fail," thereby reliably triggering
+    // observable.reobserve, add any current WatchQueryOptions object(s) you
+    // want to be ignored to this.optionsToIgnoreOnce. A similar effect could be
+    // achieved by nullifying this.watchQueryOptions so the equality test
+    // immediately fails because currentWatchQueryOptions is null, but this way
+    // we can promise a truthy this.watchQueryOptions at all times.
+    if (
+      this.optionsToIgnoreOnce.has(currentWatchQueryOptions) ||
+      !equal(watchQueryOptions, currentWatchQueryOptions)
+    ) {
       this.watchQueryOptions = watchQueryOptions;
+
       if (currentWatchQueryOptions && this.observable) {
+        // As advertised in the -Once of this.optionsToIgnoreOnce, this trick is
+        // only good for one forced execution of observable.reobserve per
+        // ignored WatchQueryOptions object, though it is unlikely we will ever
+        // see this exact currentWatchQueryOptions object again here, since we
+        // just replaced this.watchQueryOptions with watchQueryOptions.
+        this.optionsToIgnoreOnce.delete(currentWatchQueryOptions);
+
         // Though it might be tempting to postpone this reobserve call to the
         // useEffect block, we need getCurrentResult to return an appropriate
         // loading:true result synchronously (later within the same call to
@@ -224,6 +268,10 @@ class InternalState<TData, TVariables> {
         // (potentially) kicks off a network request (for example, when the
         // variables have changed), which is technically a side-effect.
         this.observable.reobserve(watchQueryOptions);
+
+        // Make sure getCurrentResult returns a fresh ApolloQueryResult<TData>,
+        // but save the current data as this.previousData, just like setResult
+        // usually does.
         this.previousData = this.result?.data || this.previousData;
         this.result = void 0;
       }


### PR DESCRIPTION
This PR should fix the following issues:
- [ ] #9655 
- [x] #9669

As justification for #9669, none of our [error policies](https://www.apollographql.com/docs/react/data/error-handling/#graphql-error-policies) say anything about throwing errors; they just control whether/when the `result.data` and/or `result.error` properties will be defined. Throwing an error is similar to the default policy, `none`, but needlessly discards result properties other than `result.error`. If you want a rejected `Promise`, attach a `then` callback and throw `result.error` when it's defined.

I'm giving this justification because I am aware it stands in conflict with an issue we recently "fixed" (perhaps a bit too hastily): https://github.com/apollographql/apollo-client/issues/9142#issuecomment-1118972947