### PR TITLE
fix(utilities): missing incoming field handling in offsetLimitPagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 - Provide `@apollo/client/**/*.cjs.native.js` versions of every `@apollo/client/**/*.cjs` bundle (including dependencies `ts-invariant` and `zen-observable-ts`) to help React Native's Metro bundler automatically resolve CommonJS entry point modules. **These changes should render unnecessary [the advice we gave in the v3.5.4 section below about `metro.config.js`](#apollo-client-354-2021-11-19).** <br/>
   [@benjamn](https://github.com/benjamn) in [#9716](https://github.com/apollographql/apollo-client/pull/9716)
 
+- Handle falsy `incoming` data more gracefully in `offetLimitPagination().merge` function. <br/>
+  [@shobhitsharma](https://github.com/shobhitsharma) in [#9705](https://github.com/apollographql/apollo-client/pull/9705)
+
 ## Apollo Client 3.6.3 (tagged as `next` on npm)
 
 ### Bug Fixes

--- a/src/utilities/policies/pagination.ts
+++ b/src/utilities/policies/pagination.ts
@@ -32,6 +32,9 @@ export function offsetLimitPagination<T = Reference>(
     keyArgs,
     merge(existing, incoming, { args }) {
       const merged = existing ? existing.slice(0) : [];
+
+      if (!incoming) return merged;
+
       if (args) {
         // Assume an offset of 0 if args.offset omitted.
         const { offset = 0 } = args;

--- a/src/utilities/policies/pagination.ts
+++ b/src/utilities/policies/pagination.ts
@@ -33,21 +33,22 @@ export function offsetLimitPagination<T = Reference>(
     merge(existing, incoming, { args }) {
       const merged = existing ? existing.slice(0) : [];
 
-      if (!incoming) return merged;
-
-      if (args) {
-        // Assume an offset of 0 if args.offset omitted.
-        const { offset = 0 } = args;
-        for (let i = 0; i < incoming.length; ++i) {
-          merged[offset + i] = incoming[i];
+      if (incoming) {
+        if (args) {
+          // Assume an offset of 0 if args.offset omitted.
+          const { offset = 0 } = args;
+          for (let i = 0; i < incoming.length; ++i) {
+            merged[offset + i] = incoming[i];
+          }
+        } else {
+          // It's unusual (probably a mistake) for a paginated field not
+          // to receive any arguments, so you might prefer to throw an
+          // exception here, instead of recovering by appending incoming
+          // onto the existing array.
+          merged.push.apply(merged, incoming);
         }
-      } else {
-        // It's unusual (probably a mistake) for a paginated field not
-        // to receive any arguments, so you might prefer to throw an
-        // exception here, instead of recovering by appending incoming
-        // onto the existing array.
-        merged.push.apply(merged, incoming);
       }
+
       return merged;
     },
   };


### PR DESCRIPTION
This handles an edge case reported https://github.com/apollographql/apollo-client/issues/8708, where missing `incoming` argument is `null` or an empty value that throws TypeError when fetch call returns an error.

### Stacktrace

![image-2022-03-25-09-28-52-401](https://user-images.githubusercontent.com/772855/167845229-bbfd466c-2209-4d9e-b721-e65952df054d.png)

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
