### PR TITLE
Fix useSubscription bug in React v18 StrictMode (#9664)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Guarantee `Concast` cleanup without `Observable cancelled prematurely` rejection, potentially solving long-standing issues involving that error. <br/>
   [@benjamn](https://github.com/benjamn) in [#9701](https://github.com/apollographql/apollo-client/pull/9701)
 
+- Ensure `useSubscription` subscriptions are properly restarted after unmounting/remounting by React 18 in `<StrictMode>`. <br/>
+  [@benjamn](https://github.com/benjamn) in [#9707](https://github.com/apollographql/apollo-client/pull/9707)
+
 ### Improvements
 
 - Internalize `useSyncExternalStore` shim, for more control than `use-sync-external-store` provides, fixing some React Native issues. <br/>

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     {
       "name": "apollo-client",
       "path": "./dist/apollo-client.min.cjs",
-      "maxSize": "29.45kB"
+      "maxSize": "29.5kB"
     }
   ],
   "engines": {

--- a/src/react/hooks/useSubscription.ts
+++ b/src/react/hooks/useSubscription.ts
@@ -9,7 +9,7 @@ import {
   SubscriptionHookOptions,
   SubscriptionResult
 } from '../types/types';
-import { OperationVariables } from '../../core';
+import { FetchResult, Observable, OperationVariables } from '../../core';
 import { useApolloClient } from './useApolloClient';
 
 export function useSubscription<TData = any, TVariables = OperationVariables>(
@@ -25,18 +25,20 @@ export function useSubscription<TData = any, TVariables = OperationVariables>(
     variables: options?.variables,
   });
 
-  const [observable, setObservable] = useState(() => {
+  const [observable, setObservable] = useState<Observable<FetchResult<TData>> | null>(null);
+
+  useEffect(() => {
     if (options?.skip) {
-      return null;
+      return;
     }
 
-    return client.subscribe({
+    setObservable(client.subscribe({
       query: subscription,
       variables: options?.variables,
       fetchPolicy: options?.fetchPolicy,
       context: options?.context,
-    });
-  });
+    }));
+  }, []);
 
   const ref = useRef({ client, subscription, options });
   useEffect(() => {


### PR DESCRIPTION
Fix #9664

React18 automatically unmounts and remounts components in StrictMode. When React remount a component, the previous state is restored. However, if the previous state is reused, the subscription will not work.
So we should recreate the necessary object when React remounts the component.

For more information on why we should not reuse the object, see https://github.com/apollographql/apollo-client/issues/9664#issuecomment-1123480304

---

Currently, Apollo Client includes React17 in its devDependencies.

I have made this fix and confirmed that it works in a sample application.
At this time, I changed Apollo Client's React version to 18.
But I confirmed that some unrelated tests failed due to the impact of updating React to 18, so I did not commit package.json.

Therefore, I have not included in this commit the additional tests needed to prove the fix in React18.