### PR TITLE
Help React Native import `@apollo/client/main.cjs` and other CommonJS bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - Internalize `useSyncExternalStore` shim, for more control than `use-sync-external-store` provides, fixing some React Native issues. <br/>
   [@benjamn](https://github.com/benjamn) in [#9675](https://github.com/apollographql/apollo-client/pull/9675) and [#9709](https://github.com/apollographql/apollo-client/pull/9709)
 
+- Provide `@apollo/client/**/*.cjs.native.js` versions of every `@apollo/client/**/*.cjs` bundle (including dependencies `ts-invariant` and `zen-observable-ts`) to help React Native's Metro bundler automatically resolve CommonJS entry point modules. These changes render unnecessary the advice we gave in the v3.5.4 section below about `metro.config.js`. <br/>
+  [@benjamn](https://github.com/benjamn) in [#9716](https://github.com/apollographql/apollo-client/pull/9716)
+
 ## Apollo Client 3.6.3 (unreleased)
 
 ### Bug Fixes
@@ -174,10 +177,13 @@ In upcoming v3.6.x and v3.7 (beta) releases, we will be completely overhauling o
 
 ### Notices
 
+> ⚠️ The following advice about `metro.config.js` should no longer be necessary, as of Apollo Client v3.6.4.
+
 - [Relevant if you use Apollo Client with React Native] Since Apollo Client v3.5.0, CommonJS bundles provided by `@apollo/client` use a `.cjs` file extension rather than `.cjs.js`, so Node.js won't interpret them as ECMAScript modules. While this change should be an implementation detail, it may cause problems for the [Metro bundler](https://facebook.github.io/metro/) used by React Native, whose [`resolver.sourceExts`](https://facebook.github.io/metro/docs/configuration#sourceexts) configuration does not include the `cjs` extension by default.
 
   As a workaround until [this issue](https://github.com/facebook/metro/issues/535) is resolved, you can configure Metro to understand the `.cjs` file extension by creating a `metro.config.js` file in the root of your React Native project:
   ```js
+  // NOTE: No longer necessary in @apollo/client@3.6.4!
   const { getDefaultConfig } = require("metro-config");
   const { resolver: defaultResolver } = getDefaultConfig.getDefaultValues();
   exports.resolver = {

--- a/config/helpers.ts
+++ b/config/helpers.ts
@@ -22,8 +22,9 @@ export function eachFile(dir: string, callback: (
         if (relPath.startsWith("../")) return;
 
         // Avoid re-transforming CommonJS bundle files.
-        if (relPath.endsWith(".cjs.js")) return;
         if (relPath.endsWith(".cjs")) return;
+        if (relPath.endsWith(".cjs.js")) return;
+        if (relPath.endsWith(".cjs.native.js")) return;
 
         // Avoid re-transforming CommonJS bundle files.
         if (relPath.endsWith(".min.js")) return;

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "symbol-observable": "^4.0.0",
         "ts-invariant": "^0.10.2",
         "tslib": "^2.3.0",
-        "zen-observable-ts": "^1.2.0"
+        "zen-observable-ts": "^1.2.5"
       },
       "devDependencies": {
         "@babel/parser": "7.17.10",
@@ -6446,9 +6446,9 @@
       "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
     },
     "node_modules/zen-observable-ts": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.0.tgz",
-      "integrity": "sha512-3IklmJSChXaqAD2gPz6yKHThAnZL46D51x5EPpN/MHuPjrepVdSg3qI7f5fh1RT8Y+K46Owo9fpVuJiuJXLMMA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz",
+      "integrity": "sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==",
       "dependencies": {
         "zen-observable": "0.8.15"
       }
@@ -11413,9 +11413,9 @@
       "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
     },
     "zen-observable-ts": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.0.tgz",
-      "integrity": "sha512-3IklmJSChXaqAD2gPz6yKHThAnZL46D51x5EPpN/MHuPjrepVdSg3qI7f5fh1RT8Y+K46Owo9fpVuJiuJXLMMA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz",
+      "integrity": "sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==",
       "requires": {
         "zen-observable": "0.8.15"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "optimism": "^0.16.1",
         "prop-types": "^15.7.2",
         "symbol-observable": "^4.0.0",
-        "ts-invariant": "^0.10.2",
+        "ts-invariant": "^0.10.3",
         "tslib": "^2.3.0",
         "zen-observable-ts": "^1.2.5"
       },
@@ -5836,9 +5836,9 @@
       }
     },
     "node_modules/ts-invariant": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.2.tgz",
-      "integrity": "sha512-5BybOL23OXYmmnA0C8NYPkUo5Kb/I4IVQk31K1VcdBZpQIn4fWKMIORGBJqGkwvDLyu9cxUb4Zv4G6xA4/07IQ==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
+      "integrity": "sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==",
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -10960,9 +10960,9 @@
       }
     },
     "ts-invariant": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.2.tgz",
-      "integrity": "sha512-5BybOL23OXYmmnA0C8NYPkUo5Kb/I4IVQk31K1VcdBZpQIn4fWKMIORGBJqGkwvDLyu9cxUb4Zv4G6xA4/07IQ==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
+      "integrity": "sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==",
       "requires": {
         "tslib": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "optimism": "^0.16.1",
     "prop-types": "^15.7.2",
     "symbol-observable": "^4.0.0",
-    "ts-invariant": "^0.10.2",
+    "ts-invariant": "^0.10.3",
     "tslib": "^2.3.0",
     "zen-observable-ts": "^1.2.5"
   },

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "symbol-observable": "^4.0.0",
     "ts-invariant": "^0.10.2",
     "tslib": "^2.3.0",
-    "zen-observable-ts": "^1.2.0"
+    "zen-observable-ts": "^1.2.5"
   },
   "devDependencies": {
     "@babel/parser": "7.17.10",


### PR DESCRIPTION
We use the `.cjs` file extension for our CommonJS bundle entry points (such as `@apollo/client/core/core.cjs`) to indicate to Node.js that `"type": "module"` in `@apollo/client/package.json` does not apply to those files.

Without additional configuration of its Metro bundler, React Native refuses to resolve `.cjs` files by default, but it will attempt to append various file extensions, including the (relatively) React Native-specific ending `.native.js`. By providing a `dist/**/*.cjs.native.js` file for every existing `dist/**/*.cjs` file we ship, React Native should always have a safe fallback to find the right code.

If this works, it will completely supersede/obviate the manual advice involving `metro.config.js` we added to `CHANGELOG.md` in #9084.

There is some risk of the dual package hazard (importing the same module multiple times unexpectedly), but as long as Metro consistently resolves the `.native.js` version of the file, all should be well. Apollo Client should completely ignore the `.native.js` version of the file, so React Native is the only reason those alternate modules should ever be used.

This PR incorporates the following PRs for dependency packages that also used `.cjs` bundle files:
* https://github.com/apollographql/zen-observable-ts/pull/273
* https://github.com/apollographql/invariant-packages/pull/293

Issues potentially fixed:
- [ ] #9437