### PR TITLE
Preserve `previousData` even when different client or query passed to `useQuery`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Apollo Client 3.6.5 (unreleased)
+
+### Bug Fixes
+
+- Preserve `previousData` even when different query or client provided to `useQuery`, instead of resetting `previousData` to undefined in those cases, matching behavior prior to v3.6.0. <br/>
+  [@benjamn](https://github.com/benjamn) in [#9734](https://github.com/apollographql/apollo-client/pull/9734)
+
 ## Apollo Client 3.6.4 (2022-05-16)
 
 ### Bug Fixes

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -4319,14 +4319,14 @@ describe('useQuery Hook', () => {
         const { loading, data, previousData } = result.current.useQueryResult;
         expect(loading).toBe(true);
         expect(data).toBeUndefined();
-        expect(previousData).toBeUndefined();
+        expect(previousData).toEqual({ a: "a" });
       }
       await waitForNextUpdate();
       {
         const { loading, data, previousData } = result.current.useQueryResult;
         expect(loading).toBe(false);
         expect(data).toEqual({ a: "aa", b: 1 });
-        expect(previousData).toBe(undefined);
+        expect(previousData).toEqual({ a: "a" });
       }
 
       await expect(waitForNextUpdate({
@@ -4357,7 +4357,7 @@ describe('useQuery Hook', () => {
         const { loading, data, previousData } = result.current.useQueryResult;
         expect(loading).toBe(true);
         expect(data).toEqual({ b: 2 });
-        expect(previousData).toEqual({ a: "aa", b: 1 });
+        expect(previousData).toEqual({ a: "aaa", b: 2 });
       }
       await waitForNextUpdate();
       {

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -86,10 +86,12 @@ class InternalState<TData, TVariables> {
     previous?: InternalState<TData, TVariables>,
   ) {
     verifyDocumentType(query, DocumentType.Query);
-    const previousData = previous && previous.previousData;
+
+    // Reuse previousData from previous InternalState (if any) to provide
+    // continuity of previousData even if/when the query or client changes.
+    const previousResult = previous && previous.result;
+    const previousData = previousResult && previousResult.data;
     if (previousData) {
-      // Reuse previousData from previous InternalState (if any) to provide
-      // continuity of previousData even if/when the query or client changes.
       this.previousData = previousData;
     }
   }

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -90,7 +90,7 @@ class InternalState<TData, TVariables> {
     if (previousData) {
       // Reuse previousData from previous InternalState (if any) to provide
       // continuity of previousData even if/when the query or client changes.
-      this.previousData = previous.previousData;
+      this.previousData = previousData;
     }
   }
 

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -61,7 +61,7 @@ export function useInternalState<TData, TVariables>(
     client !== stateRef.current.client ||
     query !== stateRef.current.query
   ) {
-    stateRef.current = new InternalState(client, query);
+    stateRef.current = new InternalState(client, query, stateRef.current);
   }
   const state = stateRef.current;
 
@@ -83,8 +83,15 @@ class InternalState<TData, TVariables> {
   constructor(
     public readonly client: ReturnType<typeof useApolloClient>,
     public readonly query: DocumentNode | TypedDocumentNode<TData, TVariables>,
+    previous?: InternalState<TData, TVariables>,
   ) {
     verifyDocumentType(query, DocumentType.Query);
+    const previousData = previous && previous.previousData;
+    if (previousData) {
+      // Reuse previousData from previous InternalState (if any) to provide
+      // continuity of previousData even if/when the query or client changes.
+      this.previousData = previous.previousData;
+    }
   }
 
   forceUpdate() {


### PR DESCRIPTION
Based on @ValentinH's description in issue #9733, I believe we can preserve the `previousData` property even when the client or query given to `useQuery` change. Such changes are drastic enough to warrant a whole new `InternalState` object, but that doesn't mean we have to throw away everything from the old `InternalState` object (if we have one).