### PR TITLE
Fix bug where onCompleted and onError are stale for useMutation. onCompleted and onError could not be changed while a mutation is executing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Preserve `previousData` even when different query or client provided to `useQuery`, instead of resetting `previousData` to undefined in those cases, matching behavior prior to v3.6.0. <br/>
   [@benjamn](https://github.com/benjamn) in [#9734](https://github.com/apollographql/apollo-client/pull/9734)
 
+- Fix bug where `onCompleted()` and `onError()` are stale for `useMutation()`. <br/>
+  [@charle692](https://github.com/charle692) in [#9740](https://github.com/apollographql/apollo-client/pull/9740)
+
 ## Apollo Client 3.6.4 (2022-05-16)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     {
       "name": "apollo-client",
       "path": "./dist/apollo-client.min.cjs",
-      "maxSize": "29.5kB"
+      "maxSize": "29.55kB"
     }
   ],
   "engines": {

--- a/src/react/hooks/useMutation.ts
+++ b/src/react/hooks/useMutation.ts
@@ -101,7 +101,7 @@ export function useMutation<
         }
       }
 
-      baseOptions.onCompleted?.(response.data!);
+      ref.current.options?.onCompleted?.(response.data!);
       executeOptions.onCompleted?.(response.data!);
       return response;
     }).catch((error) => {
@@ -122,8 +122,8 @@ export function useMutation<
         }
       }
 
-      if (baseOptions.onError || clientOptions.onError) {
-        baseOptions.onError?.(error);
+      if (ref.current.options?.onError || clientOptions.onError) {
+        ref.current.options?.onError?.(error);
         executeOptions.onError?.(error);
         // TODO(brian): why are we returning this here???
         return { data: void 0, errors: error };


### PR DESCRIPTION
fixes #9714
fixes #9493
Related to #9111

Since 3.5.0 there's been a bug with the `useMutation` hook from this [PR](https://github.com/apollographql/apollo-client/pull/8596/files#diff-12d1e8016a676839edfe21e2917bf5acfae3f2bb817955e21394bf88a9fd937cR95) that has been preventing us from upgrading to the latest version. 

Currently, `onCompleted` and `onError` are stale and cannot be updated while a mutation is executing. See [here](https://github.com/apollographql/apollo-client/issues/9714#issuecomment-1126292437) for example on how to reproduce this issue.

The reason for this is that `useMutation` invokes `onCompleted` and `onError` via `baseOptions` rather than directly from the `ref.current`. Due to this, it doesn't have the latest copy of the callbacks once the operation is complete.

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
