### PR TITLE
Restore pre-v3.6 `variables` replacement behavior of `ObservableQuery#reobserve` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Apollo Client 3.6.5 (unreleased)
+
+### Bug Fixes
+
+- Restore pre-v3.6 `variables` replacement behavior of `ObservableQuery#reobserve` method, fixing a regression that prevented removal of variables. <br/>
+  [@benjamn](https://github.com/benjamn) in [#9741](https://github.com/apollographql/apollo-client/pull/9741)
+
 ## Apollo Client 3.6.4 (2022-05-16)
 
 ### Bug Fixes

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -6,6 +6,7 @@ import { NetworkStatus, isNetworkRequestInFlight } from './networkStatus';
 import {
   Concast,
   cloneDeep,
+  compact,
   getOperationDefinition,
   Observable,
   Observer,
@@ -14,7 +15,6 @@ import {
   isNonEmptyArray,
   fixObservableSubclass,
   getQueryDefinition,
-  mergeOptions,
 } from '../utilities';
 import { ApolloError } from '../errors';
 import { QueryManager } from './QueryManager';
@@ -792,7 +792,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`);
     const oldVariables = this.options.variables;
     const oldFetchPolicy = this.options.fetchPolicy;
 
-    const mergedOptions = mergeOptions(this.options, newOptions || {});
+    const mergedOptions = compact(this.options, newOptions || {});
     const options = useDisposableConcast
       // Disposable Concast fetches receive a shallow copy of this.options
       // (merged with newOptions), leaving this.options unmodified.


### PR DESCRIPTION
~This failing test demonstrates issues #9671 and #9736.~

This PR fixes a regression reported in issues #9671 and #9736, which first officially shipped in `@apollo/client@3.6.0`, or unofficially in `@apollo/client@3.6.0-beta.11`, due to my commit 8903456a2540d71e1825e78a976fa9fbf1e9711c in PR #9563.

While it might seem like a good idea to merge individual `variables` when calling `useQuery(query, { variables })` with different/new `variables`, wholesale replacement is more powerful, because it allows removing some of the variables rather than only adding new ones.

Also, replacement still allows you to spread the existing `...observable.variables` when passing the new variables, so the merging behavior is still possible. In the other direction (in the always-merge approach accidentally introduced in v3.6.0), we've lost the ability to remove variables, even if we wanted to. Asymmetric tradeoffs!

Finally, replacement was the behavior before v3.6.0, so this definitely counts as a regression that we should fix before it trips up too many more people, especially those with existing apps that relied on the old behavior.