### PR TITLE
Restrict `DeepMerger` mutable object reuse to fix subtle production-only bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Fix bug where `onCompleted()` and `onError()` are stale for `useMutation()`. <br/>
   [@charle692](https://github.com/charle692) in [#9740](https://github.com/apollographql/apollo-client/pull/9740)
 
+- Limit scope of `DeepMerger` object reuse, and avoid using `Object.isFrozen`, which can introduce differences between development and production if objects that were frozen using `Object.freeze` in development are left unfrozen in production. <br/>
+  [@benjamn](https://github.com/benjamn) in [#9742](https://github.com/apollographql/apollo-client/pull/9742)
+
 ## Apollo Client 3.6.4 (2022-05-16)
 
 ### Bug Fixes

--- a/src/utilities/common/mergeDeep.ts
+++ b/src/utilities/common/mergeDeep.ts
@@ -101,21 +101,17 @@ export class DeepMerger<TContextArgs extends any[]> {
 
   public shallowCopyForMerge<T>(value: T): T {
     if (isNonNullObject(value)) {
-      if (this.pastCopies.has(value)) {
-        // In order to reuse a past copy, it must be mutable, but copied objects
-        // can sometimes be frozen while this DeepMerger is still active.
-        if (!Object.isFrozen(value)) return value;
-        this.pastCopies.delete(value);
+      if (!this.pastCopies.has(value)) {
+        if (Array.isArray(value)) {
+          value = (value as any).slice(0);
+        } else {
+          value = {
+            __proto__: Object.getPrototypeOf(value),
+            ...value,
+          };
+        }
+        this.pastCopies.add(value);
       }
-      if (Array.isArray(value)) {
-        value = (value as any).slice(0);
-      } else {
-        value = {
-          __proto__: Object.getPrototypeOf(value),
-          ...value,
-        };
-      }
-      this.pastCopies.add(value);
     }
     return value;
   }


### PR DESCRIPTION
Issue #9735 appears to be due to a bug I introduced in my commit 756ab87e01e8d48eab99d82b4806f3fdefb5bf70 in PR #8734. This PR takes us (partially) back to the way things worked before that commit.

I believe I've found two complementary ways to fix this problem:

> #### [Stop using shared `DeepMerger` in `ReadContext` for `executeSelectionSet`](https://github.com/apollographql/apollo-client/pull/9742/commits/fc4a5670617399a21fde2e09132f73df2ce12bee)
>
> Premature optimization has a bad reputation already, but you can add this PR to the mountain of evidence in its disfavor.

> #### [Avoid using `Object.isFrozen` to prevent dev/prod differences](https://github.com/apollographql/apollo-client/pull/9742/commits/debe124b15dab9408b3ec431eeff0d18fc5d6009)
>
> If you revert the previous commit and run `npm test`, you'll see all the tests this dynamic `Object.isFrozen` check has been silently protecting from failing, but only (and this is the important part) in development.
>
> Since we only actually freeze objects with `Object.freeze` in development, this `Object.isFrozen` check does not help in production, so an object that would have been frozen in development could be reused as a mutable copy in production, potentially acquiring properties it should not acquire (a bug fixed by the previous commit, first reported in issue #9735).

Thanks very much to @akallem for some deep debugging and an excellent reproduction in #9735.