### PR TITLE
Merge `variables` from original `useLazyQuery(query, { variables })` with `variables` passed to execution function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 - Limit scope of `DeepMerger` object reuse, and avoid using `Object.isFrozen`, which can introduce differences between development and production if objects that were frozen using `Object.freeze` in development are left unfrozen in production. <br/>
   [@benjamn](https://github.com/benjamn) in [#9742](https://github.com/apollographql/apollo-client/pull/9742)
 
+- Properly merge `variables` from original `useLazyQuery(query, { variables })` with `variables` passed to execution function. <br/>
+  [@benjamn](https://github.com/benjamn) in [#9758](https://github.com/apollographql/apollo-client/pull/9758)
+
 ## Apollo Client 3.6.4 (2022-05-16)
 
 ### Bug Fixes

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { GraphQLError } from 'graphql';
 import gql from 'graphql-tag';
 import { renderHook } from '@testing-library/react-hooks';
+import { act } from 'react-dom/test-utils';
 
 import { ApolloClient, ApolloLink, ErrorPolicy, InMemoryCache, NetworkStatus, TypedDocumentNode } from '../../../core';
 import { Observable } from '../../../utilities';
@@ -9,7 +10,6 @@ import { ApolloProvider } from '../../../react';
 import { MockedProvider, mockSingleLink } from '../../../testing';
 import { useLazyQuery } from '../useLazyQuery';
 import { QueryResult } from '../../types/types';
-import { act } from '@testing-library/react';
 
 describe('useLazyQuery Hook', () => {
   const helloQuery: TypedDocumentNode<{

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -229,10 +229,13 @@ describe('useLazyQuery Hook', () => {
     const counterQuery: TypedDocumentNode<{
       counter: number;
     }, {
-      varPassedDirectlyToHook?: any;
-      varPassedToExecFunc?: any;
+      hookVar?: any;
+      execVar?: any;
     }> = gql`
-      query GetCounter {
+      query GetCounter (
+        $hookVar: Boolean
+        $execVar: Boolean
+      ) {
         counter
         vars
       }
@@ -265,7 +268,7 @@ describe('useLazyQuery Hook', () => {
         const [exec, query] = useLazyQuery(counterQuery, {
           notifyOnNetworkStatusChange: true,
           variables: {
-            varPassedDirectlyToHook: true,
+            hookVar: true,
           },
         });
         return {
@@ -293,14 +296,14 @@ describe('useLazyQuery Hook', () => {
     const expectedFinalData = {
       counter: 1,
       vars: {
-        varPassedDirectlyToHook: true,
-        varPassedToExecFunc: true,
+        hookVar: true,
+        execVar: true,
       },
     };
 
     const execPromise = act(() => result.current.exec({
       variables: {
-        varPassedToExecFunc: true,
+        execVar: true,
       }
     }).then(finalResult => {
       expect(finalResult.loading).toBe(false);

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -9,6 +9,7 @@ import { ApolloProvider } from '../../../react';
 import { MockedProvider, mockSingleLink } from '../../../testing';
 import { useLazyQuery } from '../useLazyQuery';
 import { QueryResult } from '../../types/types';
+import { act } from '@testing-library/react';
 
 describe('useLazyQuery Hook', () => {
   const helloQuery: TypedDocumentNode<{
@@ -222,6 +223,104 @@ describe('useLazyQuery Hook', () => {
     await waitForNextUpdate();
     expect(result.current[1].loading).toBe(false);
     expect(result.current[1].data).toEqual({ hello: 'world 2' });
+  });
+
+  it('should merge variables from original hook and execution function', async () => {
+    const counterQuery: TypedDocumentNode<{
+      counter: number;
+    }, {
+      varPassedDirectlyToHook?: any;
+      varPassedToExecFunc?: any;
+    }> = gql`
+      query GetCounter {
+        counter
+        vars
+      }
+    `;
+
+    let count = 0;
+    const client = new ApolloClient({
+      cache: new InMemoryCache(),
+      link: new ApolloLink(request => new Observable(observer => {
+        if (request.operationName === "GetCounter") {
+          observer.next({
+            data: {
+              counter: ++count,
+              vars: request.variables,
+            },
+          });
+          setTimeout(() => {
+            observer.complete();
+          }, 10);
+        } else {
+          observer.error(new Error(`Unknown query: ${
+            request.operationName || request.query
+          }`));
+        }
+      })),
+    });
+
+    const { result, waitForNextUpdate } = renderHook(
+      () => {
+        const [exec, query] = useLazyQuery(counterQuery, {
+          notifyOnNetworkStatusChange: true,
+          variables: {
+            varPassedDirectlyToHook: true,
+          },
+        });
+        return {
+          exec,
+          query,
+        };
+      },
+      {
+        wrapper: ({ children }) => (
+          <ApolloProvider client={client}>
+            {children}
+          </ApolloProvider>
+        ),
+      },
+    );
+
+    expect(result.current.query.loading).toBe(false);
+    expect(result.current.query.called).toBe(false);
+    expect(result.current.query.data).toBeUndefined();
+
+    await expect(waitForNextUpdate({
+      timeout: 20,
+    })).rejects.toThrow('Timed out');
+
+    const expectedFinalData = {
+      counter: 1,
+      vars: {
+        varPassedDirectlyToHook: true,
+        varPassedToExecFunc: true,
+      },
+    };
+
+    const execPromise = act(() => result.current.exec({
+      variables: {
+        varPassedToExecFunc: true,
+      }
+    }).then(finalResult => {
+      expect(finalResult.loading).toBe(false);
+      expect(finalResult.called).toBe(true);
+      expect(finalResult.data).toEqual(expectedFinalData);
+    }));
+
+    expect(result.current.query.loading).toBe(true);
+    expect(result.current.query.called).toBe(true);
+    expect(result.current.query.data).toBeUndefined();
+    await waitForNextUpdate();
+    expect(result.current.query.loading).toBe(false);
+    expect(result.current.query.called).toBe(true);
+    expect(result.current.query.data).toEqual(expectedFinalData);
+
+    await execPromise;
+
+    await expect(waitForNextUpdate({
+      timeout: 20,
+    })).rejects.toThrow('Timed out');
   });
 
   it('should fetch data each time the execution function is called, when using a "network-only" fetch policy', async () => {

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -3,6 +3,7 @@ import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { useCallback, useMemo, useRef } from 'react';
 
 import { OperationVariables } from '../../core';
+import { mergeOptions } from '../../utilities';
 import {
   LazyQueryHookOptions,
   LazyQueryResultTuple,
@@ -32,10 +33,12 @@ export function useLazyQuery<TData = any, TVariables = OperationVariables>(
   );
 
   const execOptionsRef = useRef<Partial<LazyQueryHookOptions<TData, TVariables>>>();
+  const merged = execOptionsRef.current
+    ? mergeOptions(options, execOptionsRef.current)
+    : options;
 
   const useQueryResult = internalState.useQuery({
-    ...options,
-    ...execOptionsRef.current,
+    ...merged,
     skip: !execOptionsRef.current,
   });
 


### PR DESCRIPTION
Should fix issue #9152.