### PR TITLE
Allow `useLazyQuery(query, { defaultOptions })` to benefit from `defaultOptions.variables`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Apollo Client 3.6.6 (unreleased)
+
+### Bug Fixes
+
+- Allow `useLazyQuery(query, { defaultOptions })` to benefit from `defaultOptions.variables` and `client.defaultOptions.watchQuery.variables` merging. <br/>
+  [@benjamn](https://github.com/benjamn) in [#9762](https://github.com/apollographql/apollo-client/pull/9762)
+
 ## Apollo Client 3.6.5 (2022-05-23)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     {
       "name": "apollo-client",
       "path": "./dist/apollo-client.min.cjs",
-      "maxSize": "29.55kB"
+      "maxSize": "29.6kB"
     }
   ],
   "engines": {

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -268,27 +268,6 @@ class InternalState<TData, TVariables> {
         // just replaced this.watchQueryOptions with watchQueryOptions.
         this.optionsToIgnoreOnce.delete(currentWatchQueryOptions);
 
-        const toMerge: Partial<WatchQueryOptions<TVariables, TData>>[] = [];
-        const globalDefaults = this.client.defaultOptions.watchQuery;
-        if (globalDefaults) toMerge.push(globalDefaults);
-        if (options.defaultOptions) {
-          toMerge.push(options.defaultOptions);
-        }
-        // We use compact rather than mergeOptions for this part of the merge,
-        // because we want watchQueryOptions.variables (if defined) to replace
-        // this.observable.options.variables whole. This replacement allows
-        // removing variables by removing them from the variables input to
-        // useQuery. If the variables were always merged together (rather than
-        // replaced), there would be no way to remove existing variables.
-        // However, the variables from options.defaultOptions and globalDefaults
-        // (if provided) should be merged, to ensure individual defaulted
-        // variables always have values, if not otherwise defined in
-        // observable.options or watchQueryOptions.
-        toMerge.push(compact(
-          this.observable.options,
-          watchQueryOptions,
-        ));
-        const reobserveOptions = toMerge.reduce(mergeOptions);
         // Though it might be tempting to postpone this reobserve call to the
         // useEffect block, we need getCurrentResult to return an appropriate
         // loading:true result synchronously (later within the same call to
@@ -297,7 +276,7 @@ class InternalState<TData, TVariables> {
         // subscriptions, though it does feel less than ideal that reobserve
         // (potentially) kicks off a network request (for example, when the
         // variables have changed), which is technically a side-effect.
-        this.observable.reobserve(reobserveOptions);
+        this.observable.reobserve(this.getObsQueryOptions());
 
         // Make sure getCurrentResult returns a fresh ApolloQueryResult<TData>,
         // but save the current data as this.previousData, just like setResult
@@ -345,6 +324,38 @@ class InternalState<TData, TVariables> {
     ) {
       this.result = void 0;
     }
+  }
+
+  private getObsQueryOptions(): WatchQueryOptions<TVariables, TData> {
+    const toMerge: Array<
+      Partial<WatchQueryOptions<TVariables, TData>>
+    > = [];
+
+    const globalDefaults = this.client.defaultOptions.watchQuery;
+    if (globalDefaults) toMerge.push(globalDefaults);
+
+    if (this.queryHookOptions.defaultOptions) {
+      toMerge.push(this.queryHookOptions.defaultOptions);
+    }
+
+    // We use compact rather than mergeOptions for this part of the merge,
+    // because we want watchQueryOptions.variables (if defined) to replace
+    // this.observable.options.variables whole. This replacement allows
+    // removing variables by removing them from the variables input to
+    // useQuery. If the variables were always merged together (rather than
+    // replaced), there would be no way to remove existing variables.
+    // However, the variables from options.defaultOptions and globalDefaults
+    // (if provided) should be merged, to ensure individual defaulted
+    // variables always have values, if not otherwise defined in
+    // observable.options or watchQueryOptions.
+    toMerge.push(compact(
+      this.observable && this.observable.options,
+      this.watchQueryOptions,
+    ));
+
+    return toMerge.reduce(
+      mergeOptions
+    ) as WatchQueryOptions<TVariables, TData>;
   }
 
   private ssrDisabledResult = maybeDeepFreeze({
@@ -445,13 +456,7 @@ class InternalState<TData, TVariables> {
       this.renderPromises
         && this.renderPromises.getSSRObservable(this.watchQueryOptions)
         || this.observable // Reuse this.observable if possible (and not SSR)
-        || this.client.watchQuery(mergeOptions(
-          // Any options.defaultOptions passed to useQuery serve as default
-          // options because we use them only here, when first creating the
-          // ObservableQuery by calling client.watchQuery.
-          this.queryHookOptions.defaultOptions,
-          this.watchQueryOptions,
-        ));
+        || this.client.watchQuery(this.getObsQueryOptions());
 
     this.obsQueryFields = useMemo(() => ({
       refetch: obsQuery.refetch.bind(obsQuery),


### PR DESCRIPTION
After implementing PR #9758, I noticed that `useLazyQuery` was unable to see/use any `defaultOptions.variables` passed to `useLazyQuery(query, { defaultOptions: { variables }})` (a feature introduced by PR #9563), because the `defaultOptions` only mattered when the `ObservableQuery` was first created with `client.watchQuery` (see #9665), and not when the `useLazyQuery` execution function is later called. This PR fixes that oversight, allowing `useLazyQuery` to benefit from `options.defaultOptions.variables`, and also ensures global `client.defaultOptions.watchQuery.variables` are merged at the same time.