### PR TITLE
Allow registering named fragments with `InMemoryCache` to support using `...FragmentName` in queries without redeclaring `FragmentName` in every query

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     {
       "name": "apollo-client",
       "path": "./dist/apollo-client.min.cjs",
-      "maxSize": "31.46kB"
+      "maxSize": "31.65kB"
     }
   ],
   "engines": {

--- a/src/__tests__/__snapshots__/exports.ts.snap
+++ b/src/__tests__/__snapshots__/exports.ts.snap
@@ -72,6 +72,7 @@ Array [
   "Policies",
   "cacheSlot",
   "canonicalStringify",
+  "createFragmentRegistry",
   "defaultDataIdFromObject",
   "fieldNameFromStoreName",
   "isReference",

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -97,7 +97,15 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
 
   // Optional API
 
+  // Called once per input document, allowing the cache to make static changes
+  // to the query, such as adding __typename fields.
   public transformDocument(document: DocumentNode): DocumentNode {
+    return document;
+  }
+
+  // Called before each ApolloLink request, allowing the cache to make dynamic
+  // changes to the query, such as filling in missing fragment definitions.
+  public transformForLink(document: DocumentNode): DocumentNode {
     return document;
   }
 
@@ -111,12 +119,6 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
 
   public modify(options: Cache.ModifyOptions): boolean {
     return false;
-  }
-
-  // Experimental API
-
-  public transformForLink(document: DocumentNode): DocumentNode {
-    return document;
   }
 
   // DataProxy API

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -48,4 +48,9 @@ export {
   canonicalStringify,
 } from './inmemory/object-canon';
 
+export {
+  FragmentRegistryAPI,
+  createFragmentRegistry,
+} from './inmemory/fragmentRegistry';
+
 export * from './inmemory/types';

--- a/src/cache/inmemory/__tests__/fragmentRegistry.ts
+++ b/src/cache/inmemory/__tests__/fragmentRegistry.ts
@@ -1,0 +1,180 @@
+import { ApolloClient, ApolloLink, gql, NetworkStatus } from "../../../core";
+import { getFragmentDefinitions, Observable } from "../../../utilities";
+import { InMemoryCache, createFragmentRegistry } from "../../index";
+import { itAsync, subscribeAndCount } from "../../../testing";
+
+describe("FragmentRegistry", () => {
+  it("can be passed to InMemoryCache", () => {
+    const cache = new InMemoryCache({
+      fragments: createFragmentRegistry(gql`
+        fragment BasicFragment on Query {
+          basic
+        }
+      `),
+    });
+
+    // TODO Allow writeFragment to just use fragmentName:"BasicFragment"?
+    cache.writeQuery({
+      query: gql`
+        query {
+          ...BasicFragment
+        }
+      `,
+      data: {
+        basic: true,
+      },
+    });
+
+    const result = cache.readQuery({
+      query: gql`
+        query {
+          ...BasicFragment
+        }
+      `,
+    });
+
+    expect(result).toEqual({
+      basic: true,
+    });
+  });
+
+  itAsync("influences ApolloClient and ApolloLink", (resolve, reject) => {
+    const cache = new InMemoryCache({
+      fragments: createFragmentRegistry(gql`
+        fragment SourceFragment on Query {
+          source
+        }
+      `),
+    });
+
+    const client = new ApolloClient({
+      cache,
+      link: new ApolloLink(operation => new Observable(observer => {
+        expect(
+          getFragmentDefinitions(operation.query).map(def => def.name.value).sort()
+        ).toEqual([
+          // Proof that the missing SourceFragment definition was appended to
+          // operation.query before it was passed into the link.
+          "SourceFragment",
+        ]);
+
+        observer.next({
+          data: {
+            source: "link",
+          },
+        });
+
+        observer.complete();
+      })),
+    });
+
+    const query = gql`
+      query SourceQuery {
+        ...SourceFragment
+      }
+    `;
+
+    cache.writeQuery({
+      query,
+      data: {
+        source: "local",
+      },
+    });
+
+    subscribeAndCount(reject, client.watchQuery({
+      query,
+      fetchPolicy: "cache-and-network",
+    }), (count, result) => {
+      if (count === 1) {
+        expect(result).toEqual({
+          loading: true,
+          networkStatus: NetworkStatus.loading,
+          data: {
+            source: "local",
+          },
+        });
+
+      } else if (count === 2) {
+        expect(result).toEqual({
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          data: {
+            source: "link",
+          },
+        });
+
+        expect(cache.readQuery({ query })).toEqual({
+          source: "link",
+        });
+
+        setTimeout(resolve, 10);
+      } else {
+        reject(`Unexpectedly many results (${count})`);
+      }
+    });
+  });
+
+  it("can register fragments with unbound ...spreads", () => {
+    const cache = new InMemoryCache({
+      fragments: createFragmentRegistry(gql`
+        fragment NeedsExtra on Person {
+          __typename
+          id
+          # This fragment spread has a default definition below, but can be
+          # selectively overridden by queries.
+          ...ExtraFields
+        }
+
+        fragment ExtraFields on Person {
+          __typename
+        }
+      `),
+    });
+
+    const query = gql`
+      query GetMe {
+        me {
+          ...NeedsExtra
+        }
+      }
+
+      # This version of the ExtraFields fragment will be used instead of the one
+      # registered in the FragmentRegistry, because explicit definitions take
+      # precedence over registered fragments.
+      fragment ExtraFields on Person {
+        name
+      }
+    `;
+
+    cache.writeQuery({
+      query,
+      data: {
+        me: {
+          __typename: "Person",
+          id: 12345,
+          name: "Alice",
+        },
+      },
+    });
+
+    expect(cache.extract()).toEqual({
+      ROOT_QUERY: {
+        __typename: "Query",
+        me: { __ref: "Person:12345" },
+      },
+      "Person:12345": {
+        __typename: "Person",
+        id: 12345,
+        name: "Alice",
+      },
+    });
+
+    expect(cache.readQuery({ query })).toEqual({
+      me: {
+        __typename: "Person",
+        id: 12345,
+        name: "Alice",
+      },
+    });
+  });
+});

--- a/src/cache/inmemory/__tests__/writeToStore.ts
+++ b/src/cache/inmemory/__tests__/writeToStore.ts
@@ -17,8 +17,6 @@ import {
   StoreObject,
   addTypenameToDocument,
   cloneDeep,
-  createFragmentMap,
-  getFragmentDefinitions,
   getMainDefinition,
 } from '../../../utilities';
 import { itAsync } from '../../../testing/core';
@@ -27,6 +25,7 @@ import { defaultNormalizedCacheFactory, writeQueryToStore } from './helpers';
 import { InMemoryCache } from '../inMemoryCache';
 import { withErrorSpy, withWarningSpy } from '../../../testing';
 import { TypedDocumentNode } from '../../../core'
+import { extractFragmentContext } from '../helpers';
 
 const getIdField = ({ id }: { id: string }) => id;
 
@@ -3118,7 +3117,6 @@ describe('writing to the store', () => {
       },
     ) {
       const { selectionSet } = getMainDefinition(query);
-      const fragmentMap = createFragmentMap(getFragmentDefinitions(query));
 
       const flat = writer["flattenFields"](selectionSet, {
         __typename: "Query",
@@ -3126,7 +3124,7 @@ describe('writing to the store', () => {
         bField: "b",
         rootField: "root",
       }, {
-        fragmentMap,
+        ...extractFragmentContext(query),
         clientOnly: false,
         deferred: false,
         flavors: new Map,

--- a/src/cache/inmemory/fragmentRegistry.ts
+++ b/src/cache/inmemory/fragmentRegistry.ts
@@ -133,8 +133,6 @@ class FragmentRegistry implements FragmentRegistryAPI {
         const def = map[name];
         if (def) {
           defsToAppend.push(def);
-        } else {
-          // TODO Warn? Error?
         }
       });
 

--- a/src/cache/inmemory/fragmentRegistry.ts
+++ b/src/cache/inmemory/fragmentRegistry.ts
@@ -1,0 +1,149 @@
+import {
+  DocumentNode,
+  ASTNode,
+  FragmentDefinitionNode,
+  FragmentSpreadNode,
+  visit,
+} from "graphql";
+
+import { wrap } from "optimism";
+
+import { FragmentMap, getFragmentDefinitions } from "../../utilities";
+
+export class FragmentRegistry {
+  private registry: FragmentMap = Object.create(null);
+
+  static from(...fragments: DocumentNode[]): FragmentRegistry {
+    const registry = new this();
+    return registry.register.apply(registry, fragments);
+  }
+
+  // Call static method FragmentRegistry.from(...) instead of invoking the
+  // FragmentRegistry constructor directly. This reserves the constructor for
+  // future configuration of the FragmentRegistry.
+  protected constructor() {
+    this.resetCaches();
+  }
+
+  public register(...fragments: DocumentNode[]): this {
+    const definitions = new Map<string, FragmentDefinitionNode>();
+    fragments.forEach(doc => {
+      getFragmentDefinitions(doc).forEach(node => {
+        definitions.set(node.name.value, node);
+      });
+    });
+
+    definitions.forEach((node, name) => {
+      if (node !== this.registry[name]) {
+        this.registry[name] = node;
+        this.invalidate(name);
+      }
+    });
+
+    return this;
+  }
+
+  // Overridden in the resetCaches method below.
+  private invalidate(name: string) {}
+
+  public resetCaches() {
+    this.invalidate = (
+      this.lookup = this.cacheUnaryMethod("lookup")
+    ).dirty; // This dirty function is bound to the wrapped lookup method.
+    this.transform = this.cacheUnaryMethod("transform");
+    this.findFragmentSpreads = this.cacheUnaryMethod("findFragmentSpreads");
+  }
+
+  private cacheUnaryMethod<TName extends keyof Pick<FragmentRegistry,
+    | "lookup"
+    | "transform"
+    | "findFragmentSpreads"
+  >>(name: TName) {
+    const registry = this;
+    const originalMethod = FragmentRegistry.prototype[name];
+    return wrap(function () {
+      return originalMethod.apply(registry, arguments);
+    }, {
+      makeCacheKey: arg => arg,
+    });
+  }
+
+  public lookup(fragmentName: string) {
+    return this.registry[fragmentName] || null;
+  }
+
+  public transform<D extends DocumentNode>(document: D): D {
+    const defined = new Map<string, FragmentDefinitionNode>();
+    getFragmentDefinitions(document).forEach(def => {
+      defined.set(def.name.value, def);
+    });
+
+    const unbound = new Set<string>();
+    const enqueue = (spreadName: string) => {
+      if (!defined.has(spreadName)) {
+        unbound.add(spreadName);
+      }
+    };
+
+    const enqueueChildSpreads = (node: ASTNode) => Object.keys(
+      this.findFragmentSpreads(node)
+    ).forEach(enqueue);
+
+    enqueueChildSpreads(document);
+
+    const missing: string[] = [];
+    const map: FragmentMap = Object.create(null);
+
+    // This Set forEach loop can be extended during iteration by adding
+    // additional strings to the unbound set.
+    unbound.forEach(fragmentName => {
+      const knownFragmentDef = defined.get(fragmentName);
+      if (knownFragmentDef) {
+        enqueueChildSpreads(map[fragmentName] = knownFragmentDef);
+      } else {
+        missing.push(fragmentName);
+        const def = this.lookup(fragmentName);
+        if (def) {
+          enqueueChildSpreads(map[fragmentName] = def);
+        }
+      }
+    });
+
+    if (missing.length) {
+      const defsToAppend: FragmentDefinitionNode[] = [];
+      missing.forEach(name => {
+        const def = map[name];
+        if (def) {
+          defsToAppend.push(def);
+        } else {
+          // TODO Warn? Error?
+        }
+      });
+
+      if (defsToAppend.length) {
+        document = {
+          ...document,
+          definitions: document.definitions.concat(defsToAppend),
+        };
+      }
+    }
+
+    return document;
+  }
+
+  public findFragmentSpreads(root: ASTNode): FragmentSpreadMap {
+    const spreads: FragmentSpreadMap = Object.create(null);
+
+    visit(root, {
+      FragmentSpread(node) {
+        spreads[node.name.value] = node;
+      },
+    });
+
+    return spreads;
+  }
+}
+
+interface FragmentSpreadMap {
+  [fragmentSpreadName: string]: FragmentSpreadNode;
+}

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -91,6 +91,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
 
   private resetResultCache(resetResultIdentities?: boolean) {
     const previousReader = this.storeReader;
+    const { fragments } = this.config;
 
     // The StoreWriter is mostly stateless and so doesn't really need to be
     // reset, but it does need to have its writer.storeReader reference updated,
@@ -105,7 +106,9 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
         canon: resetResultIdentities
           ? void 0
           : previousReader && previousReader.canon,
+        fragments,
       }),
+      fragments,
     );
 
     this.maybeBroadcastWatch = wrap((
@@ -512,6 +515,13 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
       return result;
     }
     return document;
+  }
+
+  public transformForLink(document: DocumentNode): DocumentNode {
+    const { fragments } = this.config;
+    return fragments
+      ? fragments.transform(document)
+      : document;
   }
 
   protected broadcastWatches(options?: BroadcastOptions) {

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -181,11 +181,11 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
       }).result || null;
     } catch (e) {
       if (e instanceof MissingFieldError) {
-        // Swallow MissingFieldError and return null, so callers do not
-        // need to worry about catching "normal" exceptions resulting from
-        // incomplete cache data. Unexpected errors will be re-thrown. If
-        // you need more information about which fields were missing, use
-        // cache.diff instead, and examine diffResult.missing.
+        // Swallow MissingFieldError and return null, so callers do not need to
+        // worry about catching "normal" exceptions resulting from incomplete
+        // cache data. Unexpected errors will be re-thrown. If you need more
+        // information about which fields were missing, use cache.diff instead,
+        // and examine diffResult.missing.
         return null;
       }
       throw e;

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -1,8 +1,9 @@
-import { invariant } from '../../utilities/globals';
+import { invariant, InvariantError } from '../../utilities/globals';
 
 import {
   DocumentNode,
   FieldNode,
+  Kind,
   SelectionSetNode,
 } from 'graphql';
 import { wrap, OptimisticWrapperFunction } from 'optimism';
@@ -405,6 +406,10 @@ export class StoreReader {
           selection,
           context.lookupFragment,
         );
+
+        if (!fragment && selection.kind === Kind.FRAGMENT_SPREAD) {
+          throw new InvariantError(`No fragment named ${selection.name.value}`);
+        }
 
         if (fragment && policies.fragmentMatches(fragment, typename)) {
           fragment.selectionSet.selections.forEach(workSet.add, workSet);

--- a/src/cache/inmemory/types.ts
+++ b/src/cache/inmemory/types.ts
@@ -21,6 +21,8 @@ import {
   CanReadFunction,
 } from '../core/types/common';
 
+import { FragmentRegistryAPI } from './fragmentRegistry';
+
 export { StoreObject, StoreValue, Reference }
 
 export interface IdGetterObj extends Object {
@@ -130,6 +132,7 @@ export interface InMemoryCacheConfig extends ApolloReducerConfig {
   typePolicies?: TypePolicies;
   resultCacheMaxSize?: number;
   canonizeResults?: boolean;
+  fragments?: FragmentRegistryAPI;
 }
 
 export interface MergeInfo {

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -4,6 +4,7 @@ import { Trie } from '@wry/trie';
 import {
   SelectionSetNode,
   FieldNode,
+  Kind,
 } from 'graphql';
 
 import {
@@ -565,6 +566,10 @@ export class StoreWriter {
             selection,
             context.lookupFragment,
           );
+
+          if (!fragment && selection.kind === Kind.FRAGMENT_SPREAD) {
+            throw new InvariantError(`No fragment named ${selection.name.value}`);
+          }
 
           if (fragment &&
               policies.fragmentMatches(

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -7,11 +7,10 @@ import {
 } from 'graphql';
 
 import {
-  createFragmentMap,
   FragmentMap,
+  FragmentMapFunction,
   getFragmentFromSelection,
   getDefaultValues,
-  getFragmentDefinitions,
   getOperationDefinition,
   getTypenameFromResult,
   makeReference,
@@ -28,8 +27,8 @@ import {
   argumentsObjectFromField,
 } from '../../utilities';
 
-import { NormalizedCache, ReadMergeModifyContext, MergeTree } from './types';
-import { makeProcessedFieldsMerger, fieldNameFromStoreName, storeValueIsStoreObject, isArray } from './helpers';
+import { NormalizedCache, ReadMergeModifyContext, MergeTree, InMemoryCacheConfig } from './types';
+import { isArray, makeProcessedFieldsMerger, fieldNameFromStoreName, storeValueIsStoreObject, extractFragmentContext } from './helpers';
 import { StoreReader } from './readFromStore';
 import { InMemoryCache } from './inMemoryCache';
 import { EntityStore } from './entityStore';
@@ -42,7 +41,8 @@ export interface WriteContext extends ReadMergeModifyContext {
   readonly written: {
     [dataId: string]: SelectionSetNode[];
   };
-  readonly fragmentMap?: FragmentMap;
+  readonly fragmentMap: FragmentMap;
+  lookupFragment: FragmentMapFunction;
   // General-purpose deep-merge function for use during writes.
   merge<T>(existing: T, incoming: T): T;
   // If true, merge functions will be called with undefined existing data.
@@ -104,6 +104,7 @@ export class StoreWriter {
   constructor(
     public readonly cache: InMemoryCache,
     private reader?: StoreReader,
+    private fragments?: InMemoryCacheConfig["fragments"],
   ) {}
 
   public writeToStore(store: NormalizedCache, {
@@ -129,7 +130,7 @@ export class StoreWriter {
       },
       variables,
       varString: canonicalStringify(variables),
-      fragmentMap: createFragmentMap(getFragmentDefinitions(query)),
+      ...extractFragmentContext(query, this.fragments),
       overwrite: !!overwrite,
       incomingById: new Map,
       clientOnly: false,
@@ -475,6 +476,7 @@ export class StoreWriter {
     | "deferred"
     | "flavors"
     | "fragmentMap"
+    | "lookupFragment"
     | "variables"
   >>(
     selectionSet: SelectionSetNode,
@@ -559,8 +561,10 @@ export class StoreWriter {
           );
 
         } else {
-          const fragment =
-            getFragmentFromSelection(selection, context.fragmentMap);
+          const fragment = getFragmentFromSelection(
+            selection,
+            context.lookupFragment,
+          );
 
           if (fragment &&
               policies.fragmentMatches(

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -356,6 +356,7 @@ export class QueryInfo {
 
   public markResult<T>(
     result: FetchResult<T>,
+    document: DocumentNode,
     options: Pick<WatchQueryOptions,
       | "variables"
       | "fetchPolicy"
@@ -406,7 +407,7 @@ export class QueryInfo {
         this.cache.performTransaction(cache => {
           if (this.shouldWrite(result, options.variables)) {
             cache.writeQuery({
-              query: this.document!,
+              query: document,
               data: result.data as T,
               variables: options.variables,
               overwrite: cacheWriteBehavior === CacheWriteBehavior.OVERWRITE,

--- a/src/utilities/graphql/fragments.ts
+++ b/src/utilities/graphql/fragments.ts
@@ -132,11 +132,12 @@ export function getFragmentFromSelection(
       return selection;
     case 'FragmentSpread': {
       const fragmentName = selection.name.value;
-      const fragment = typeof fragmentMap === "function"
-        ? fragmentMap(fragmentName)
-        : fragmentMap && fragmentMap[fragmentName];
-      invariant(fragment, `No fragment named ${fragmentName}.`);
-      return fragment!;
+      if (typeof fragmentMap === "function") {
+        return fragmentMap(fragmentName);
+      }
+      const fragment = fragmentMap && fragmentMap[fragmentName];
+      invariant(fragment, `No fragment named ${fragmentName}`);
+      return fragment || null;
     }
     default:
       return null;

--- a/src/utilities/graphql/fragments.ts
+++ b/src/utilities/graphql/fragments.ts
@@ -108,6 +108,9 @@ export interface FragmentMap {
   [fragmentName: string]: FragmentDefinitionNode;
 }
 
+export type FragmentMapFunction =
+  (fragmentName: string) => FragmentDefinitionNode | null;
+
 // Utility function that takes a list of fragment definitions and makes a hash out of them
 // that maps the name of the fragment to the fragment definition.
 export function createFragmentMap(
@@ -122,14 +125,17 @@ export function createFragmentMap(
 
 export function getFragmentFromSelection(
   selection: SelectionNode,
-  fragmentMap?: FragmentMap,
+  fragmentMap?: FragmentMap | FragmentMapFunction,
 ): InlineFragmentNode | FragmentDefinitionNode | null {
   switch (selection.kind) {
     case 'InlineFragment':
       return selection;
     case 'FragmentSpread': {
-      const fragment = fragmentMap && fragmentMap[selection.name.value];
-      invariant(fragment, `No fragment named ${selection.name.value}.`);
+      const fragmentName = selection.name.value;
+      const fragment = typeof fragmentMap === "function"
+        ? fragmentMap(fragmentName)
+        : fragmentMap && fragmentMap[fragmentName];
+      invariant(fragment, `No fragment named ${fragmentName}.`);
       return fragment!;
     }
     default:

--- a/src/utilities/graphql/transform.ts
+++ b/src/utilities/graphql/transform.ts
@@ -66,12 +66,11 @@ const TYPENAME_FIELD: FieldNode = {
 
 function isEmpty(
   op: OperationDefinitionNode | FragmentDefinitionNode,
-  fragments: FragmentMap,
+  fragmentMap: FragmentMap,
 ): boolean {
-  return op.selectionSet.selections.every(
-    selection =>
-      selection.kind === 'FragmentSpread' &&
-      isEmpty(fragments[selection.name.value], fragments),
+  return !op || op.selectionSet.selections.every(
+    selection => selection.kind === 'FragmentSpread' &&
+      isEmpty(fragmentMap[selection.name.value], fragmentMap)
   );
 }
 

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -14,6 +14,7 @@ export {
 
 export {
   FragmentMap,
+  FragmentMapFunction,
   createFragmentMap,
   getFragmentQueryDocument,
   getFragmentFromSelection,


### PR DESCRIPTION
When a query uses a named fragment, or when fragments use other fragments by name, [our current recommendation](https://www.apollographql.com/docs/react/data/fragments/#creating-colocated-fragments) is to `${...}`-interpolate the necessary fragment declarations into the query's `gql` template string.

While this pattern works in small examples, it gets cumbersome when there are multiple (layers of) fragments, and it's all too easy to end up duplicating fragment declarations in the resulting query, if they accidentally get interpolated twice (or more!).

This PR attempts to make this situation substantially easier, by allowing you to pre-register certain named fragments with your `InMemoryCache`, so that you can refer to them by name elsewhere, without needing to interpolate their declarations. That interpolation now happens behind the scenes, each time the query is about to be sent over the network. The dynamic nature of the interpolation guarantees each fragment will be included only once, only if/when it's used.

Queries can still declare their own local versions of named fragments, which will take precedence over the pre-registered ones, even if the local fragment is only indirectly referenced by other fragments (see tests for example).

Although fragments and queries still need to be parsed individually at some point, they can be recombined at runtime in a way that requires no re-parsing, so this system should eliminate needless (re)parsing of query documents that directly include associated fragment declarations.

Finally, to prove to myself that this is possible, I structured these changes so the implementation of the `FragmentRegistry` is not automatically included in your JavaScript bundle, unless you choose to import `createFragmentRegistry` and actually use it. This works because the `InMemoryCache` implementation knows only about the abstract `FragmentRegistryAPI` (and how to use it), and does not directly import or depend on any of the code implementing that API (the `FragmentRegistry` class isn't even exported from the module, for example).