### PR TITLE
Fix: useQuery returns called value based on skip option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Improve repository build scripts to work better on Windows. <br/>
   [@dylanwulf](https://github.com/dylanwulf) in [#9805](https://github.com/apollographql/apollo-client/pull/9805)
 
+- Ensure `useQuery(query, { skip: true }).called === false` rather than always returning `called` as `true`. <br/>
+  [@KucharskiPiotr](https://github.com/KucharskiPiotr) in [#9798](https://github.com/apollographql/apollo-client/pull/9798)
+
 ## Apollo Client 3.6.7 (2022-06-10)
 
 ### Bug Fixes

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -218,6 +218,29 @@ describe('useQuery Hook', () => {
       unmount();
     });
 
+    it('should set called to false when skip option is true', async () => {
+      const query = gql`{ hello }`;
+      const mocks = [
+        {
+          request: { query },
+          result: { data: { hello: "world" } },
+        },
+      ];
+
+      const cache = new InMemoryCache();
+      const wrapper = ({ children }: any) => (
+          <MockedProvider mocks={mocks} cache={cache}>{children}</MockedProvider>
+      );
+
+      const { result, unmount } = renderHook(
+          () => useQuery(query, { skip: true }),
+          { wrapper },
+      );
+
+      expect(result.current.called).toBe(false);
+      unmount();
+    });
+
     it('should work with variables', async () => {
       const query = gql`
         query ($id: Int) {

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -546,7 +546,7 @@ class InternalState<TData, TVariables> {
       client: this.client,
       observable: this.observable,
       variables: this.observable.variables,
-      called: true,
+      called: !this.queryHookOptions.skip,
       previousData: this.previousData,
     });
 


### PR DESCRIPTION
Changed returned `called` value of `QueryResult` to be false, when
the `skip` parameter of `QueryHookOptions` is set to true. Otherwise,
`called` value should return true like it used to do by default.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests

### Reason to change:

`useQuery` [result documentation](https://www.apollographql.com/docs/react/data/queries/#called) states that `called` value should be `true` only if the query has been executed. Currently, when `useQuery` is called with option `{ skip: true }`, the value of `called` remains `true`, even though the network request hasn't been done. This was discussed in https://github.com/apollographql/apollo-client/issues/7931.

This Pull Request changes value of `called` to be based on the `skip` option - if the option was set to `true`, the `called` value will be set to `false`, which should work as expected.