### PR TITLE
Delay execution of callback functions to fix React errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 - Replace `concast.cleanup` method with simpler `concast.beforeNext` API, which promises to call the given callback function just before the next result/error is delivered. In addition, `concast.removeObserver` no longer takes a `quietly?: boolean` parameter, since that parameter was partly responsible for cleanup callbacks sometimes not getting called. <br/>
   [@benjamn](https://github.com/benjamn) in [#9718](https://github.com/apollographql/apollo-client/pull/9718)
 
+### Improvements
+
+- Delay calling `onCompleted` and `onError` callbacks passed to `useQuery` using `Promise.resolve().then(() => ...)` to fix issue [#9794](https://github.com/apollographql/apollo-client/pull/9794). <br/>
+  [@dylanwulf](https://github.com/dylanwulf) in [#9823](https://github.com/apollographql/apollo-client/pull/9823)
+
 ## Apollo Client 3.6.9 (2022-06-21)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     {
       "name": "apollo-client",
       "path": "./dist/apollo-client.min.cjs",
-      "maxSize": "29.9kB"
+      "maxSize": "29.95kB"
     }
   ],
   "engines": {

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -511,6 +511,8 @@ class InternalState<TData, TVariables> {
         } else if (result.data) {
           this.onCompleted(result.data);
         }
+      }).catch(error => {
+        invariant.warn(error);
       });
     }
   }

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -504,11 +504,14 @@ class InternalState<TData, TVariables> {
 
   private handleErrorOrCompleted(result: ApolloQueryResult<TData>) {
     if (!result.loading) {
-      if (result.error) {
-        this.onError(result.error);
-      } else if (result.data) {
-        this.onCompleted(result.data);
-      }
+      // wait a tick in case we are in the middle of rendering a component
+      Promise.resolve().then(() => {
+        if (result.error) {
+          this.onError(result.error);
+        } else if (result.data) {
+          this.onCompleted(result.data);
+        }
+      });
     }
   }
 
@@ -517,8 +520,9 @@ class InternalState<TData, TVariables> {
     // the same (===) result object, unless state.setResult has been called, or
     // we're doing server rendering and therefore override the result below.
     if (!this.result) {
-      const result = (this.result = this.observable.getCurrentResult());
-      setTimeout(() => this.handleErrorOrCompleted(result), 0);
+      this.handleErrorOrCompleted(
+        this.result = this.observable.getCurrentResult()
+      );
     }
     return this.result;
   }

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -517,9 +517,8 @@ class InternalState<TData, TVariables> {
     // the same (===) result object, unless state.setResult has been called, or
     // we're doing server rendering and therefore override the result below.
     if (!this.result) {
-      this.handleErrorOrCompleted(
-        this.result = this.observable.getCurrentResult()
-      );
+      const result = (this.result = this.observable.getCurrentResult());
+      setTimeout(() => this.handleErrorOrCompleted(result), 0);
     }
     return this.result;
   }


### PR DESCRIPTION
As described in #9794, calling a setState function (or dispatching a redux action) from inside of `onCompleted` will sometimes cause React errors to be printed to the console. This appears to be due to `onCompleted` being called during the render phase if the result is available in the cache. This PR delays execution of `onCompleted` and `onError` using `setTimeout` in order to fix this error. A new test was added which will fail without this change.

Fixes #9794

### Checklist:

- [X] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [X] Make sure all of the significant new logic is covered by tests
