### PR TITLE
Fix build config to work on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Fix incorrect `variables` passed in `FieldFunctionOptions` for nested `readField` calls in `read` and `merge` functions. <br/>
   [@stardustxx](https://github.com/stardustxx) in [#9808](https://github.com/apollographql/apollo-client/pull/9808)
 
+- Improve repository build scripts to work better on Windows. <br/>
+  [@dylanwulf](https://github.com/dylanwulf) in [#9805](https://github.com/apollographql/apollo-client/pull/9805)
+
 ## Apollo Client 3.6.7 (2022-06-10)
 
 ### Bug Fixes

--- a/config/helpers.ts
+++ b/config/helpers.ts
@@ -12,7 +12,7 @@ export function eachFile(dir: string, callback: (
   const promises: Promise<any>[] = [];
 
   return new Promise<void>((resolve, reject) => {
-    glob(`${dir}/**/*.js`, (error, files) => {
+    glob(`${dir.replace(/\\/g, '/')}/**/*.js`, (error, files) => {
       if (error) return reject(error);
 
       files.sort().forEach(file => {

--- a/config/rewriteSourceMaps.ts
+++ b/config/rewriteSourceMaps.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 import { distDir } from './helpers';
 import glob = require("glob");
 
-glob(`${distDir}/**/*.js.map`, (error, files) => {
+glob(`${distDir.replace(/\\/g, '/')}/**/*.js.map`, (error, files) => {
   if (error) throw error;
 
   const rootDir = path.dirname(distDir);

--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -8,31 +8,31 @@ const entryPoints = require('./entryPoints');
 const distDir = './dist';
 
 function isExternal(id, parentId, entryPointsAreExternal = true) {
+  let posixId = toPosixPath(id)
+  const posixParentId = toPosixPath(parentId);
   // Rollup v2.26.8 started passing absolute id strings to this function, thanks
   // apparently to https://github.com/rollup/rollup/pull/3753, so we relativize
   // the id again in those cases.
   if (path.isAbsolute(id)) {
-    const posixId = toPosixPath(id);
-    const posixParentId = toPosixPath(parentId);
-    id = path.posix.relative(
+    posixId = path.posix.relative(
       path.posix.dirname(posixParentId),
       posixId,
     );
-    if (!id.startsWith(".")) {
-      id = "./" + id;
+    if (!posixId.startsWith(".")) {
+      posixId = "./" + posixId;
     }
   }
 
   const isRelative =
-    id.startsWith("./") ||
-    id.startsWith("../");
+    posixId.startsWith("./") ||
+    posixId.startsWith("../");
 
   if (!isRelative) {
     return true;
   }
 
   if (entryPointsAreExternal &&
-      entryPoints.check(id, parentId)) {
+      entryPoints.check(posixId, posixParentId)) {
     return true;
   }
 


### PR DESCRIPTION
Fix the build config to work on Windows. 
The changes to `rollup.config.js` resulted from this discussion (almost a year ago!): https://github.com/apollographql/apollo-client/pull/8341#discussion_r657514329
The changes to `helpers.ts` and `rewriteSourceMaps.ts` were needed because the `glob` package no longer supports backslashes as path separators in v8.0: https://github.com/isaacs/node-glob/blob/main/changelog.md#80