### PR TITLE
Remove Ignoring errors sections in link and error handling docs.

### DIFF
--- a/docs/source/api/link/apollo-link-error.md
+++ b/docs/source/api/link/apollo-link-error.md
@@ -123,15 +123,3 @@ A function that calls the next link down the chain. Calling `return forward(oper
 An error is passed as a `networkError` if a link further down the chain called the `error` callback on the observable. In most cases, `graphQLErrors` is the `errors` field of the result from the last `next` call.
 
 A `networkError` can contain additional fields, such as a GraphQL object in the case of a failing HTTP status code. In this situation, `graphQLErrors` is an alias for `networkError.result.errors` if the property exists.
-
-## Ignoring errors
-
-If you want to conditionally ignore errors, you can set `response.errors = null;` within the error handler:
-
-```js
-onError(({ response, operation }) => {
-  if (operation.operationName === "IgnoreErrorsQuery") {
-    response.errors = null;
-  }
-});
-```

--- a/docs/source/data/error-handling.mdx
+++ b/docs/source/data/error-handling.mdx
@@ -214,18 +214,6 @@ To retry operations that encounter a network error, we recommend adding a `Retry
 
 See the [documentation for `RetryLink`](../api/link/apollo-link-retry/).
 
-### Ignoring errors
-
-To conditionally ignore errors, you can set `response.errors` to `null` in your `onError` link:
-
-```js
-onError(({ response, operation }) => {
-  if (operation.operationName === "IgnoreErrorsQuery") {
-    response.errors = null;
-  }
-});
-```
-
 ### `onError` link options
 
 See the [`onError` API reference](../api/link/apollo-link-error/#options).


### PR DESCRIPTION
This PR removes two identical sections on ignoring errors in both the [Error Link](https://www.apollographql.com/docs/react/api/link/apollo-link-error/#ignoring-errors) and [Error Handling](https://www.apollographql.com/docs/react/data/error-handling/#ignoring-errors) docs as ignoring errors by setting `response.errors = null;` is no longer a recommended practice.

Closes https://github.com/apollographql/apollo-client/issues/6758

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes) **N/A**
- [x] Make sure all of the significant new logic is covered by tests **N/A**