### PR TITLE
Avoid letting `defaultDataIdFromObject` normalize objects with nullish ids

### DIFF
--- a/src/cache/inmemory/__tests__/writeToStore.ts
+++ b/src/cache/inmemory/__tests__/writeToStore.ts
@@ -673,6 +673,186 @@ describe('writing to the store', () => {
     });
   });
 
+  it('refuses to normalize objects with nullish id fields', () => {
+    const query: TypedDocumentNode<{
+      objects: Array<{
+        __typename: string;
+        id?: any;
+        text?: string;
+      }>;
+    }> = gql`
+      query {
+        objects {
+          id
+          text
+        }
+      }
+    `;
+
+    const cache = new InMemoryCache({
+      // No keyFields type policy or dataIdFromObject, so we're using/testing
+      // the default implementation, defaultDataIdFromObject.
+    });
+
+    cache.writeQuery({
+      query,
+      data: {
+        objects: [
+          { __typename: "Object", text: "a", id: 123 },
+          { __typename: "Object", text: "b", id: null },
+          { __typename: "Object", text: "c", id: void 0 },
+          { __typename: "Object", text: "d", id: 0 },
+          { __typename: "Object", text: "e", id: "" },
+          { __typename: "Object", text: "f", id: false },
+          { __typename: "Object", text: "g" },
+        ]
+      },
+    });
+
+    expect(cache.extract()).toEqual({
+     "Object:123": {
+       __typename: "Object",
+       id: 123,
+       text: "a",
+     },
+     "Object:0": {
+      __typename: "Object",
+      id: 0,
+      text: "d",
+    },
+    "Object:": {
+      __typename: "Object",
+      id: "",
+      text: "e",
+    },
+    "Object:false": {
+      __typename: "Object",
+      id: false,
+      text: "f",
+    },
+     "ROOT_QUERY": {
+       __typename: "Query",
+       objects: [
+         { __ref: "Object:123" },
+         {
+           __typename: "Object",
+           id: null,
+           text: "b",
+         },
+         { __typename: "Object", text: "c" },
+         { __ref: "Object:0" },
+         { __ref: "Object:" },
+         { __ref: "Object:false" },
+         { __typename: "Object", text: "g" },
+       ],
+     },
+    });
+
+    expect(cache.readQuery({
+      query: gql`query { objects { text }}`,
+    })).toEqual({
+      objects: [
+        { __typename: "Object", text: "a" },
+        { __typename: "Object", text: "b" },
+        { __typename: "Object", text: "c" },
+        { __typename: "Object", text: "d" },
+        { __typename: "Object", text: "e" },
+        { __typename: "Object", text: "f" },
+        { __typename: "Object", text: "g" },
+      ],
+    });
+  });
+
+  it('refuses to normalize objects with nullish id fields', () => {
+    const query: TypedDocumentNode<{
+      objects: Array<{
+        __typename: string;
+        _id?: any;
+        text?: string;
+      }>;
+    }> = gql`
+      query {
+        objects {
+          _id
+          text
+        }
+      }
+    `;
+
+    const cache = new InMemoryCache({
+      // No keyFields type policy or dataIdFromObject, so we're using/testing
+      // the default implementation, defaultDataIdFromObject.
+    });
+
+    cache.writeQuery({
+      query,
+      data: {
+        objects: [
+          { __typename: "Object", text: "a", _id: 123 },
+          { __typename: "Object", text: "b", _id: null },
+          { __typename: "Object", text: "c", _id: void 0 },
+          { __typename: "Object", text: "d", _id: 0 },
+          { __typename: "Object", text: "e", _id: "" },
+          { __typename: "Object", text: "f", _id: false },
+          { __typename: "Object", text: "g" },
+        ]
+      },
+    });
+
+    expect(cache.extract()).toEqual({
+     "Object:123": {
+       __typename: "Object",
+       _id: 123,
+       text: "a",
+     },
+     "Object:0": {
+      __typename: "Object",
+      _id: 0,
+      text: "d",
+    },
+    "Object:": {
+      __typename: "Object",
+      _id: "",
+      text: "e",
+    },
+    "Object:false": {
+      __typename: "Object",
+      _id: false,
+      text: "f",
+    },
+     "ROOT_QUERY": {
+       __typename: "Query",
+       objects: [
+         { __ref: "Object:123" },
+         {
+           __typename: "Object",
+           _id: null,
+           text: "b",
+         },
+         { __typename: "Object", text: "c" },
+         { __ref: "Object:0" },
+         { __ref: "Object:" },
+         { __ref: "Object:false" },
+         { __typename: "Object", text: "g" },
+       ],
+     },
+    });
+
+    expect(cache.readQuery({
+      query: gql`query { objects { text }}`,
+    })).toEqual({
+      objects: [
+        { __typename: "Object", text: "a" },
+        { __typename: "Object", text: "b" },
+        { __typename: "Object", text: "c" },
+        { __typename: "Object", text: "d" },
+        { __typename: "Object", text: "e" },
+        { __typename: "Object", text: "f" },
+        { __typename: "Object", text: "g" },
+      ],
+    });
+  });
+
   it('properly normalizes an object occurring in different graphql paths twice', () => {
     const query = gql`
       {

--- a/src/cache/inmemory/helpers.ts
+++ b/src/cache/inmemory/helpers.ts
@@ -24,6 +24,10 @@ export const {
   hasOwnProperty: hasOwn,
 } = Object.prototype;
 
+export function isNullish(value: any): value is null | undefined {
+  return value === null || value === void 0;
+}
+
 export function defaultDataIdFromObject(
   { __typename, id, _id }: Readonly<StoreObject>,
   context?: KeyFieldsContext,
@@ -31,13 +35,17 @@ export function defaultDataIdFromObject(
   if (typeof __typename === "string") {
     if (context) {
       context.keyObject =
-         id !== void 0 ? {  id } :
-        _id !== void 0 ? { _id } :
+        !isNullish(id) ? { id } :
+        !isNullish(_id) ? { _id } :
         void 0;
     }
+
     // If there is no object.id, fall back to object._id.
-    if (id === void 0) id = _id;
-    if (id !== void 0) {
+    if (isNullish(id) && !isNullish(_id)) {
+      id = _id;
+    }
+
+    if (!isNullish(id)) {
       return `${__typename}:${(
         typeof id === "number" ||
         typeof id === "string"


### PR DESCRIPTION
Should fix issue #9814, by not allowing objects with `id: null` or `id: void 0` fields to be normalized.

This change mostly affects applications that have not configured [`keyFields`](https://www.apollographql.com/docs/react/caching/cache-configuration/#customizing-cache-ids) or a custom `dataIdFromObject` function when creating the `InMemoryCache`, though I suppose the same confusion could happen when `keyFields: ["id"]` is explicitly configured and the `object.id` happens to be `null` or undefined.

I'm borrowing the "nullish" terminology introduced by the [Nullish Coalescing Operator `??`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator), which treats only `null` and undefined as falsy (not `""`, `0`, or `false`).

This distinction allows objects with `id: ""` and `id: 0` to be normalized, even though `""` and `0` are falsy values. While `""` and `0` may be unusual ID values, it's conceivable that an incrementing counter could start at 0, or a string ID could sometimes be the empty string.

You could perhaps argue that objects with `id: false` also should not be normalized, since `false` a constant value that's uncommon for IDs, but `null` and undefined show up due to ordinary GraphQL error behavior, so `id: false` suggests some actual intention to return a constant value. My mind isn't fully made up about this, but I'm erring on the side of preserving existing behavior.