### PR TITLE
Add defensive isMounted checks before setting state via useMutation Hook

### DIFF
--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -204,6 +204,49 @@ describe('useMutation Hook', () => {
       expect(result.current[1].data).toEqual(data2);
     });
 
+    it('should not call setResult on an unmounted component', async () => {
+      const errorSpy = jest.spyOn(console, "error");
+      const variables = {
+        description: 'Get milk!'
+      };
+
+      const mocks = [
+        {
+          request: {
+            query: CREATE_TODO_MUTATION,
+            variables
+          },
+          result: { data: CREATE_TODO_RESULT }
+        }
+      ];
+
+      const useCreateTodo = () => {
+        const [createTodo, { reset }] = useMutation(
+          CREATE_TODO_MUTATION
+        );
+        return { reset, createTodo };
+      };
+
+      const { result, unmount } = renderHook(
+        () => useCreateTodo(),
+        { wrapper: ({ children }) => (
+          <MockedProvider mocks={mocks}>
+            {children}
+          </MockedProvider>
+        )},
+      );
+
+      unmount();
+
+      await act(async () => {
+        await result.current.createTodo({ variables });
+        await result.current.reset();
+      })
+
+      expect(errorSpy).not.toHaveBeenCalled();
+      errorSpy.mockRestore();
+    });
+
     it('should resolve mutate function promise with mutation results', async () => {
       const variables = {
         description: 'Get milk!'

--- a/src/react/hooks/useMutation.ts
+++ b/src/react/hooks/useMutation.ts
@@ -61,7 +61,7 @@ export function useMutation<
   ) => {
     const {client, options, mutation} = ref.current;
     const baseOptions = { ...options, mutation };
-    if (!ref.current.result.loading && !baseOptions.ignoreResults) {
+    if (!ref.current.result.loading && !baseOptions.ignoreResults && ref.current.isMounted) {
       setResult(ref.current.result = {
         loading: true,
         error: void 0,
@@ -134,7 +134,9 @@ export function useMutation<
   }, []);
 
   const reset = useCallback(() => {
-    setResult({ called: false, loading: false, client });
+    if (ref.current.isMounted) {
+      setResult({ called: false, loading: false, client });
+    }
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
This PR adds checks in two places inside of `useMutation` to verify that the component is mounted before setting state with `setResult`, which fixes https://github.com/apollographql/apollo-client/issues/9858. ~The code changes are trivial, and while I initially thought it might be possible to add some test coverage for this minor change, that's proven more difficult than anticipated.~ (see edit below)

## Testing

When initially calling `createTodo` in my test component's cleanup function, I was not seeing the expected React error re: setting state on an unmounted component, but I did see the error when I called `reset` after `unmount` (which was also calling `setResult` without checking the `isMounted` boolean).
 
![Screen Shot 2022-07-05 at 12 32 09 PM](https://user-images.githubusercontent.com/5139846/177403137-984b0b59-5bac-4eb0-a517-da2818bccbda.png)

~It looks like I'm at an impasse when it comes to making assertions against component state **after the component unmounts** (I want to call unmount in the middle of my test—it's also called automatically after each test via cleanup function—in order to ensure the state _hasn't_ changed), as subsequent calls to `waitForNextUpdate` time out. Would love any suggestions, I'll also ask around in the Testing Library community :-) I'd really like to have tests in place to prevent regressions, but regardless, it's a needed fix for `useMutation`.~

Edit: spying on console.error here is sufficient. I've updated the tests, which now fail if either `isMounted` check added in the PR is removed.

### Checklist:

- [x] ~If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)~
- [x] Make sure all of the significant new logic is covered by tests
