### PR TITLE
Updates testing docs to use Testing Library

### DIFF
--- a/docs/source/development-testing/testing.mdx
+++ b/docs/source/development-testing/testing.mdx
@@ -70,7 +70,7 @@ it("renders without error", async () => {
 });
 ```
 
-> Note that `@testing-library/jest-dom` is typically imported in your [test setup file](https://jestjs.io/docs/configuration) and makes certain [custom jest matchers](https://github.com/testing-library/jest-dom#custom-matchers) like `toBeInTheDocument` available. It is included in the code you'll find on this page for completeness.
+> **Note:** Usually, you import `@testing-library/jest-dom` in your [test setup file](https://jestjs.io/docs/configuration), which provides certain [custom jest matchers](https://github.com/testing-library/jest-dom#custom-matchers) (such as `toBeInTheDocument`). The import is included in these examples for completeness.
 
 #### Defining mocked responses
 
@@ -164,7 +164,7 @@ To test how your component is rendered after its query completes, Testing Librar
 
 > `findBy` queries work when you expect an element to appear but the change to the DOM might not happen immediately.
 
-We can use the asynchronous `screen.findByText` method to query the DOM elements containing the loading message first, followed by the success message `"Buck is a poodle"` which appears after our query completes:
+We can use the asynchronous `screen.findByText` method to query the DOM elements containing the loading message first, followed by the success message `"Buck is a poodle"` (which appears after our query completes):
 
 ```jsx
 it("should render dog", async () => {

--- a/docs/source/development-testing/testing.mdx
+++ b/docs/source/development-testing/testing.mdx
@@ -5,7 +5,7 @@ description: Using MockedProvider and associated APIs
 
 This article describes best practices for testing React components that use Apollo Client.
 
-The examples below use [Jest](https://facebook.github.io/jest/docs/en/tutorial-react.html) and React's [test renderer](https://reactjs.org/docs/test-renderer.html) instead of tools like [Enzyme](https://github.com/airbnb/enzyme) or [react-testing-library](https://github.com/kentcdodds/react-testing-library), but the concepts apply to any testing framework.
+The examples below use [Jest](https://facebook.github.io/jest/docs/en/tutorial-react.html) and [React Testing Library](https://github.com/testing-library/react-testing-library), but the concepts apply to any testing framework.
 
 ## The `MockedProvider` component
 
@@ -39,8 +39,7 @@ export function Dog({ name }) {
     variables: { name },
   });
   if (loading) return <p>Loading...</p>;
-  if (error) return <p>Error!</p>;
-
+  if (error) return <p>{error.message}</p>;
   return (
     <p>
       {data.dog.name} is a {data.dog.breed}
@@ -54,23 +53,24 @@ export function Dog({ name }) {
 A basic rendering test for the component looks like this (minus mocked responses):
 
 ```jsx title="dog.test.js"
-import TestRenderer from "react-test-renderer";
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
 import { MockedProvider } from "@apollo/client/testing";
-import { GET_DOG_QUERY, Dog } from "./dog";
+import { GET_DOG_QUERY, Dog } from "./Dog";
 
 const mocks = []; // We'll fill this in next
 
-it("renders without error", () => {
-  const component = TestRenderer.create(
+it("renders without error", async () => {
+  render(
     <MockedProvider mocks={mocks} addTypename={false}>
       <Dog name="Buck" />
     </MockedProvider>
   );
-
-  const tree = component.toJSON();
-  expect(tree.children).toContain("Loading...");
+  expect(await screen.findByText("Loading...")).toBeInTheDocument();
 });
 ```
+
+> Note that `@testing-library/jest-dom` is typically imported in your [test setup file](https://jestjs.io/docs/configuration) and makes certain [custom jest matchers](https://github.com/testing-library/jest-dom#custom-matchers) like `toBeInTheDocument` available. It is included in the code you'll find on this page for completeness.
 
 #### Defining mocked responses
 
@@ -117,9 +117,10 @@ Combining our code above, we get the following complete test:
 <ExpansionPanel title="Click to expand 🐶">
 
 ```jsx title="dog.test.js"
-import TestRenderer from "react-test-renderer";
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
 import { MockedProvider } from "@apollo/client/testing";
-import { GET_DOG_QUERY, Dog } from "./dog";
+import { GET_DOG_QUERY, Dog } from "./Dog";
 
 const mocks = [
   {
@@ -137,23 +138,17 @@ const mocks = [
   },
 ];
 
-it("renders without error", () => {
-  const component = TestRenderer.create(
+it("renders without error", async () => {
+  render(
     <MockedProvider mocks={mocks} addTypename={false}>
       <Dog name="Buck" />
     </MockedProvider>
   );
-
-  const tree = component.toJSON();
-  expect(tree.children).toContain("Loading...");
+  expect(await screen.findByText("Loading...")).toBeInTheDocument();
 });
 ```
 
 </ExpansionPanel>
-
-> **Important:** As it's written, this test checks whether the `Dog` component renders successfully and displays a `Loading...` message. However, it _doesn't_ wait for `MockedProvider` to respond to `GET_DOG_QUERY`. Even when GraphQL operations are mocked, they're `Promise`-based and therefore asynchronous. Because of this, this test always completes while the component is still in its initial [loading state](#testing-the-loading-state).
->
-> To test a component's rendering _after_ `MockedProvider` responds, see [The "completed" state](#testing-the-success-state) and [Error states](#testing-error-states).
 
 ### Setting `addTypename`
 
@@ -163,15 +158,13 @@ We _don't_ want to automatically add `__typename` to `GET_DOG_QUERY` in our test
 
 Unless you explicitly configure your mocks to expect a `__typename` field, always set `addTypename` to `false` in your tests.
 
-## Testing the "loading" state
+## Testing the "loading" and "success" states
 
-You can test how your component is rendered while it's still awaiting a query result. In fact, this is a test's default behavior if it doesn't _explicitly_ wait for the `Promise`-based result from `MockedProvider`.
+To test how your component is rendered after its query completes, Testing Library provides several `findBy` methods. From the [Testing Library docs](https://testing-library.com/docs/dom-testing-library/api-async/#findby-queries):
 
-[The example above](#example) shows a test that renders a component in its "loading" state without awaiting a result from `MockedProvider`.
+> `findBy` queries work when you expect an element to appear but the change to the DOM might not happen immediately.
 
-## Testing the "success" state
-
-To test how your component is rendered after its query completes, you can `await` a zero-millisecond timeout before performing your checks. This delays the checks until the next "tick" of the event loop, which gives `MockedProvider` an opportunity to populate the mocked result:
+We can use the asynchronous `screen.findByText` method to query the DOM elements containing the loading message first, followed by the success message `"Buck is a poodle"` which appears after our query completes:
 
 ```jsx
 it("should render dog", async () => {
@@ -184,21 +177,15 @@ it("should render dog", async () => {
       data: { dog: { id: 1, name: "Buck", breed: "poodle" } },
     },
   };
-
-  const component = TestRenderer.create(
+  render(
     <MockedProvider mocks={[dogMock]} addTypename={false}>
       <Dog name="Buck" />
     </MockedProvider>
   );
-
-  await new Promise((resolve) => setTimeout(resolve, 0)); // highlight-line
-
-  const p = component.root.findByType("p");
-  expect(p.children.join("")).toContain("Buck is a poodle");
+  expect(await screen.findByText("Loading...")).toBeInTheDocument();
+  expect(await screen.findByText("Buck is a poodle")).toBeInTheDocument();
 });
 ```
-
-If your component performs complex calculations or includes delays in its render logic, you can increase the timeout's duration accordingly. You can also use a package like [`wait-for-expect`](https://npm.im/wait-for-expect) to delay until the render has occurred. The risk of using a package like this everywhere is that _every_ test might take up to five seconds to execute (or longer if the default timeout is increased).
 
 ## Testing error states
 
@@ -206,8 +193,6 @@ Your component's error states are just as important to test as its success state
 
 * Network errors are errors that occur while your client attempts to communicate with your GraphQL server.
 * GraphQL errors are errors that occur while your GraphQL server attempts to resolve your client's operation.
-
-> Tests for error states require the same zero-millisecond timeout as [tests for the success state](#testing-the-success-state).
 
 ### Network errors
 
@@ -222,17 +207,12 @@ it("should show error UI", async () => {
     },
     error: new Error("An error occurred"),
   };
-
-  const component = TestRenderer.create(
+  render(
     <MockedProvider mocks={[dogMock]} addTypename={false}>
       <Dog name="Buck" />
     </MockedProvider>
   );
-
-  await new Promise((resolve) => setTimeout(resolve, 0)); // wait for response
-
-  const tree = component.toJSON();
-  expect(tree.children).toContain("An error occurred");
+  expect(await screen.findByText("An error occurred")).toBeInTheDocument();
 });
 ```
 
@@ -262,6 +242,9 @@ You test components that use `useMutation` similarly to how you test components 
 The following `DeleteButton` component executes the `DELETE_DOG_MUTATION` to delete a dog named `Buck` from our graph (don't worry, Buck will be fine 🐶):
 
 ```jsx title="delete-dog.jsx"
+import React from "react";
+import { gql, useMutation } from "@apollo/client";
+
 export const DELETE_DOG_MUTATION = gql`
   mutation deleteDog($name: String!) {
     deleteDog(name: $name) {
@@ -290,12 +273,14 @@ export function DeleteButton() {
 We can test the initial rendering of this component just like we [tested our `Dog` component](#example):
 
 ```jsx title="delete-dog.test.js"
-import TestRenderer from "react-test-renderer";
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import { MockedProvider } from "@apollo/client/testing";
-import DeleteButton, { DELETE_DOG_MUTATION } from "./delete-dog";
+import { DeleteButton, DELETE_DOG_MUTATION } from "./delete-dog";
 
 it("should render without error", () => {
-  TestRenderer.create(
+  render(
     <MockedProvider mocks={[]}>
       <DeleteButton />
     </MockedProvider>
@@ -308,7 +293,7 @@ In the test above, `DELETE_DOG_MUTATION` is _not_ executed, because the mutate f
 The following test _does_ execute the mutation by clicking the button:
 
 ```jsx title="delete-dog.test.js"
-it("should render loading state initially", () => {
+it("should render loading state initially", async () => {
   const deleteDog = { name: "Buck", breed: "Poodle", id: 1 };
   const mocks = [
     {
@@ -320,68 +305,26 @@ it("should render loading state initially", () => {
     },
   ];
 
-  const component = TestRenderer.create(
+  render(
     <MockedProvider mocks={mocks} addTypename={false}>
       <DeleteButton />
     </MockedProvider>
   );
 
-  // find the button and simulate a click
-  const button = component.root.findByType("button");
-  button.props.onClick(); // fires the mutation
+  // Find the button element...
+  const button = await screen.findByText("Click to Delete Buck");
+  userEvent.click(button); // Simulate a click and fire the mutation
 
-  const tree = component.toJSON();
-  expect(tree.children).toContain("Loading...");
+  expect(await screen.findByText("Loading...")).toBeInTheDocument();
+  expect(await screen.findByText("Deleted!")).toBeInTheDocument();
 });
 ```
 
-Again, this example is similar to [the `useQuery`-based component above](#example), but it differs after the rendering is completed. Because this component relies on a button click to fire a mutation, we use the renderer's API to find the button and simulate a click with its `onClick` handler. This fires off the mutation, and the rest of the test runs as expected.
-
-> Other test utilities like [Enzyme](https://github.com/airbnb/enzyme) and [react-testing-library](https://github.com/kentcdodds/react-testing-library) have built-in tools for finding elements and simulating events, but the concept is the same: find the button and simulate a click on it.
-
-To test for a successful mutation after simulating the click, use a zero-millisecond timeout, as shown in [Testing the "success" state](#testing-the-success-state):
-
-<ExpansionPanel title="Click to expand 🐶">
-
-```jsx
-import TestRenderer from "react-test-renderer";
-import { MockedProvider } from "@apollo/client/testing";
-import DeleteButton, { DELETE_DOG_MUTATION } from "./delete-dog";
-
-it("should delete and give visual feedback", async () => {
-  const deleteDog = { name: "Buck", breed: "Poodle", id: 1 };
-  const mocks = [
-    {
-      request: {
-        query: DELETE_DOG_MUTATION,
-        variables: { name: "Buck" },
-      },
-      result: { data: deleteDog },
-    },
-  ];
-
-  const component = TestRenderer.create(
-    <MockedProvider mocks={mocks} addTypename={false}>
-      <DeleteButton />
-    </MockedProvider>
-  );
-
-  // find the button and simulate a click
-  const button = component.root.findByType("button");
-  button.props.onClick(); // fires the mutation
-
-  await new Promise((resolve) => setTimeout(resolve, 0)); // wait for response
-
-  const tree = component.toJSON();
-  expect(tree.children).toContain("Deleted!");
-});
-```
-
-</ExpansionPanel>
+Again, this example is similar to [the `useQuery`-based component above](#example), but it differs after the rendering is completed. Because this component relies on a button click to fire a mutation, we use Testing Library's [user-event](https://github.com/testing-library/user-event) library to simulate a click with its `click` method. This fires off the mutation, and the rest of the test runs as expected.
 
 Remember that the mock's value for `result` can also be a function, so you can perform arbitrary logic (like setting a boolean to indicate that the mutation completed) before returning its result.
 
-[Testing error states](#testing-error-states) for mutations is identical to testing them for queries..
+[Testing error states](#testing-error-states) for mutations is identical to testing them for queries.
 
 ## Testing with the cache
 

--- a/docs/source/development-testing/testing.mdx
+++ b/docs/source/development-testing/testing.mdx
@@ -36,7 +36,7 @@ export const GET_DOG_QUERY = gql`
 
 export function Dog({ name }) {
   const { loading, error, data } = useQuery(GET_DOG_QUERY, {
-    variables: { name },
+    variables: { name }
   });
   if (loading) return <p>Loading...</p>;
   if (error) return <p>{error.message}</p>;
@@ -53,10 +53,10 @@ export function Dog({ name }) {
 A basic rendering test for the component looks like this (minus mocked responses):
 
 ```jsx title="dog.test.js"
-import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
 import { MockedProvider } from "@apollo/client/testing";
-import { GET_DOG_QUERY, Dog } from "./Dog";
+import { GET_DOG_QUERY, Dog } from "./dog";
 
 const mocks = []; // We'll fill this in next
 
@@ -82,15 +82,15 @@ const mocks = [
     request: {
       query: GET_DOG_QUERY,
       variables: {
-        name: "Buck",
-      },
+        name: "Buck"
+      }
     },
     result: {
       data: {
-        dog: { id: "1", name: "Buck", breed: "bulldog" },
-      },
-    },
-  },
+        dog: { id: "1", name: "Buck", breed: "bulldog" }
+      }
+    }
+  }
 ];
 ```
 
@@ -117,25 +117,25 @@ Combining our code above, we get the following complete test:
 <ExpansionPanel title="Click to expand 🐶">
 
 ```jsx title="dog.test.js"
-import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
 import { MockedProvider } from "@apollo/client/testing";
-import { GET_DOG_QUERY, Dog } from "./Dog";
+import { GET_DOG_QUERY, Dog } from "./dog";
 
 const mocks = [
   {
     request: {
       query: GET_DOG_QUERY,
       variables: {
-        name: "Buck",
-      },
+        name: "Buck"
+      }
     },
     result: {
       data: {
-        dog: { id: "1", name: "Buck", breed: "bulldog" },
-      },
-    },
-  },
+        dog: { id: "1", name: "Buck", breed: "bulldog" }
+      }
+    }
+  }
 ];
 
 it("renders without error", async () => {
@@ -171,11 +171,11 @@ it("should render dog", async () => {
   const dogMock = {
     request: {
       query: GET_DOG_QUERY,
-      variables: { name: "Buck" },
+      variables: { name: "Buck" }
     },
     result: {
-      data: { dog: { id: 1, name: "Buck", breed: "poodle" } },
-    },
+      data: { dog: { id: 1, name: "Buck", breed: "poodle" } }
+    }
   };
   render(
     <MockedProvider mocks={[dogMock]} addTypename={false}>
@@ -203,9 +203,9 @@ it("should show error UI", async () => {
   const dogMock = {
     request: {
       query: GET_DOG_QUERY,
-      variables: { name: "Buck" },
+      variables: { name: "Buck" }
     },
-    error: new Error("An error occurred"),
+    error: new Error("An error occurred")
   };
   render(
     <MockedProvider mocks={[dogMock]} addTypename={false}>
@@ -293,16 +293,16 @@ In the test above, `DELETE_DOG_MUTATION` is _not_ executed, because the mutate f
 The following test _does_ execute the mutation by clicking the button:
 
 ```jsx title="delete-dog.test.js"
-it("should render loading state initially", async () => {
+it("should render loading and success states on delete", async () => {
   const deleteDog = { name: "Buck", breed: "Poodle", id: 1 };
   const mocks = [
     {
       request: {
         query: DELETE_DOG_MUTATION,
-        variables: { name: "Buck" },
+        variables: { name: "Buck" }
       },
-      result: { data: deleteDog },
-    },
+      result: { data: deleteDog }
+    }
   ];
 
   render(
@@ -433,4 +433,4 @@ This is necessary because otherwise, the `MockedProvider` component doesn't know
 
 For a working example that demonstrates how to test components, check out this project on CodeSandbox:
 
-[![Edit React-Apollo Testing](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/40k7j708n4)
+[![Edit React-Apollo Testing](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/react-apollo-testing-rwwrx6)


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

This PR updates the Apollo Client testing docs by removing references to [`react-test-renderer`](https://reactjs.org/docs/test-renderer.html) in favor of [React Testing Library](https://testing-library.com/docs/react-testing-library/intro/), [the UI testing library recommended in the official React docs](https://reactjs.org/docs/testing.html#tools). The goal is to improve the readability of our example tests while ensuring they pass, ideally without emitting any warnings.

These changes were the outcome of a quick look at https://github.com/apollographql/apollo-client/issues/9887: copying + pasting one of the tests from our current docs results in a warning which may cause some confusion. Other tests outright fail when copy + pasted, like the one in [Testing the Success State](https://www.apollographql.com/docs/react/development-testing/testing/#testing-the-success-state).

Let's look at the test from the "success state" section:

```jsx
it('should render dog', async () => {
  const dogMock = {
    request: {
      query: GET_DOG_QUERY,
      variables: { name: 'Buck' },
    },
    result: {
      data: { dog: { id: 1, name: 'Buck', breed: 'poodle' } },
    },
  };

  const component = TestRenderer.create(
    <MockedProvider mocks={[dogMock]} addTypename={false}>
      <Dog name="Buck" />
    </MockedProvider>,
  );

  await new Promise(resolve => setTimeout(resolve, 0));

  const p = component.root.findByType('p');
  expect(p.children.join('')).toContain('Buck is a poodle');
});
```

When I run this test locally, I first see that the test failed:

<img width="1057" alt="Screen Shot 2022-07-06 at 9 35 36 PM" src="https://user-images.githubusercontent.com/5139846/177693171-3781b5d6-c0df-45a8-a891-e27948a6d386.png">

...followed by the act warning:

<img width="1057" alt="Screen Shot 2022-07-06 at 9 35 43 PM" src="https://user-images.githubusercontent.com/5139846/177693206-cc6bbd88-57dd-4c97-b66e-979e418a85f9.png">

The issue stems from having to `await new Promise(resolve => setTimeout(resolve, 0));`: since `react-test-renderer` is mostly used for snapshot testing and doesn't have async utilities for awaiting DOM changes, our docs state that `you can await a zero-millisecond timeout before performing your checks. This delays the checks until the next "tick" of the event loop, which gives MockedProvider an opportunity to populate the mocked result`.

I got the above test to pass by adding a second 0ms setTimeout immediately after the one in the test, and the act warning remained. Using promisified setTimeouts to manually cycle through ticks of the event loop is a fairly brittle and unintuitive way of testing dynamic/interactive behavior, especially given the async utilities available via React Testing Library.

### The Testing Library Approach

The same test of the success state written with RTL looks like this:

```jsx
it("should render dog", async () => {
  const dogMock = {
    request: {
      query: GET_DOG_QUERY,
      variables: { name: "Buck" },
    },
    result: {
      data: { dog: { id: 1, name: "Buck", breed: "poodle" } },
    },
  };
  render(
    <MockedProvider mocks={[dogMock]} addTypename={false}>
      <Dog name="Buck" />
    </MockedProvider>
  );
  expect(await screen.findByText("Loading...")).toBeInTheDocument();
  expect(await screen.findByText("Buck is a poodle")).toBeInTheDocument();
});
```

Instead of using setTimeout, Testing Library provides several `findBy` methods. From the [Testing Library docs](https://testing-library.com/docs/dom-testing-library/api-async/#findby-queries):

> `findBy` queries work when you expect an element to appear but the change to the DOM might not happen immediately.

We can use the asynchronous `screen.findByText` to query the elements containing the loading message first, followed by the success message "Buck is a poodle" which appears after our query completes.

> Under the hood, the `findBy` utils check for the element every N ms (default 50ms) up to a default timeout of 1000ms so the user doesn't have to be concerned with manually advancing the event loop.

### Checklist:

- [x] Add a note about `import '@testing-library/jest-dom';` (explain that it's usually present in a setup file, but include it in examples for copy-pastability)
- [x] Create an updated codesandbox at the bottom of `testing.mdx` (the [current one](https://codesandbox.io/s/40k7j708n4) crashes when you open it)
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
