### PR TITLE
Clarify that id is optional on queries in cache.modify documentation

### DIFF
--- a/docs/source/api/cache/InMemoryCache.mdx
+++ b/docs/source/api/cache/InMemoryCache.mdx
@@ -970,20 +970,6 @@ Takes an `options` object as a parameter. Supported fields of this object are de
 <tr class="required">
 <td>
 
-###### `id`
-
-`String`
-</td>
-<td>
-
-**Required.** The ID of the cached object to modify.
-</td>
-</tr>
-
-
-<tr class="required">
-<td>
-
 ###### `fields`
 
 `Object`
@@ -996,6 +982,20 @@ See [Modifier function API](#modifier-function-api) below.
 </td>
 </tr>
 
+<tr class="required">
+<td>
+
+###### `id`
+
+`String`
+</td>
+<td>
+
+The ID of the cached object to modify. **Required** in most cases, but technically optional if the object being modified is a query, as the default value (ROOT_QUERY) is the hard-coded ID of the root query singleton object.
+
+The default value is `ROOT_QUERY`
+</td>
+</tr>
 
 <tr>
 <td>

--- a/docs/source/api/cache/InMemoryCache.mdx
+++ b/docs/source/api/cache/InMemoryCache.mdx
@@ -976,24 +976,24 @@ Takes an `options` object as a parameter. Supported fields of this object are de
 </td>
 <td>
 
-**Required.** A map that specifies the modifier function to call for each modified field.
+**Required.** A map that specifies the modifier function to call for each modified field of the cached object.
 
 See [Modifier function API](#modifier-function-api) below.
 </td>
 </tr>
 
-<tr class="required">
+<tr>
 <td>
 
 ###### `id`
 
-`String`
+`string`
 </td>
 <td>
 
-The ID of the cached object to modify. **Required** in most cases, but technically optional if the object being modified is a query, as the default value (ROOT_QUERY) is the hard-coded ID of the root query singleton object.
+The ID of the cached object to modify.
 
-The default value is `ROOT_QUERY`
+The default value is `ROOT_QUERY` (the ID of the root query singleton object).
 </td>
 </tr>
 


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->
Closes https://github.com/apollographql/apollo-client/issues/7862
From the above issue:
> Omitting the id is like calling cache.modify({ id: "ROOT_QUERY", fields }), since ROOT_QUERY happens to be the hard-coded ID of the root query singleton object.

ID isn't a required parameter for `cache.modify`, this updates the documentation to reflect that.
### Checklist:

- [X] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [X] Make sure all of the significant new logic is covered by tests
