### PR TITLE
Add onQueryUpdate missing parameters

### DIFF
--- a/docs/source/data/refetching.mdx
+++ b/docs/source/data/refetching.mdx
@@ -204,7 +204,7 @@ await client.refetchQueries({
     cache.evict({ fieldName: "someRootField" });
   },
 
-  onQueryUpdated(observableQuery) {
+  onQueryUpdated(observableQuery, { complete, result, missing }) {
     console.log(`Examining ObservableQuery ${
       observableQuery.queryName
     } whose latest result is ${JSON.stringify(result)} which is ${


### PR DESCRIPTION
onQueryUpdate callback requires the `result` and ` complete` fields. However, those fields are not defined in the callback function in the documentation.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
