### PR TITLE
Cascade out type parameters for TypeScript 4.8

### DIFF
--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -24,6 +24,7 @@ import { makeVar, forgetCache, recallCache } from './reactiveVars';
 import { Policies } from './policies';
 import { hasOwn, normalizeConfig, shouldCanonizeResults } from './helpers';
 import { canonicalStringify } from './object-canon';
+import { OperationVariables } from '../../core';
 
 type BroadcastOptions = Pick<
   Cache.BatchOptions<InMemoryCache>,
@@ -226,7 +227,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     }
   }
 
-  public diff<TData, TVariables = any>(
+  public diff<TData, TVariables extends OperationVariables = any>(
     options: Cache.DiffOptions<TData, TVariables>,
   ): Cache.DiffResult<TData> {
     return this.storeReader.diffQueryAgainstStore({

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -283,7 +283,7 @@ export class ApolloClient<TCacheShape> implements DataProxy {
    * See [here](https://medium.com/apollo-stack/the-concepts-of-graphql-bc68bd819be3#.3mb0cbcmc) for
    * a description of store reactivity.
    */
-  public watchQuery<T = any, TVariables = OperationVariables>(
+  public watchQuery<T = any, TVariables extends OperationVariables = OperationVariables>(
     options: WatchQueryOptions<TVariables, T>,
   ): ObservableQuery<T, TVariables> {
     if (this.defaultOptions.watchQuery) {
@@ -311,7 +311,7 @@ export class ApolloClient<TCacheShape> implements DataProxy {
    * describe how this query should be treated e.g. whether it should hit the
    * server at all or just resolve from the cache, etc.
    */
-  public query<T = any, TVariables = OperationVariables>(
+  public query<T = any, TVariables extends OperationVariables = OperationVariables>(
     options: QueryOptions<TVariables, T>,
   ): Promise<ApolloQueryResult<T>> {
     if (this.defaultOptions.query) {
@@ -342,8 +342,8 @@ export class ApolloClient<TCacheShape> implements DataProxy {
    */
   public mutate<
     TData = any,
-    TVariables = OperationVariables,
-    TContext = DefaultContext,
+    TVariables extends OperationVariables = OperationVariables,
+    TContext extends {} = DefaultContext,
     TCache extends ApolloCache<any> = ApolloCache<any>
   >(
     options: MutationOptions<TData, TVariables, TContext>,
@@ -358,7 +358,7 @@ export class ApolloClient<TCacheShape> implements DataProxy {
    * This subscribes to a graphql subscription according to the options specified and returns an
    * {@link Observable} which either emits received data or an error.
    */
-  public subscribe<T = any, TVariables = OperationVariables>(
+  public subscribe<T = any, TVariables extends OperationVariables = OperationVariables>(
     options: SubscriptionOptions<TVariables, T>,
   ): Observable<FetchResult<T>> {
     return this.queryManager.startGraphQLSubscription<T>(options);

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -63,7 +63,7 @@ interface Last<TData, TVariables> {
 
 export class ObservableQuery<
   TData = any,
-  TVariables = OperationVariables
+  TVariables extends OperationVariables = OperationVariables
 > extends Observable<ApolloQueryResult<TData>> {
   public readonly options: WatchQueryOptions<TVariables, TData>;
   public readonly queryId: string;
@@ -390,7 +390,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`);
 
   public fetchMore<
     TFetchData = TData,
-    TFetchVars = TVariables,
+    TFetchVars extends OperationVariables = TVariables,
   >(fetchMoreOptions: FetchMoreQueryOptions<TFetchVars, TFetchData> & {
     updateQuery?: (
       previousQueryResult: TData,
@@ -501,7 +501,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`);
   // and you can only do it by stopping the subscription and then subscribing again with new variables.
   public subscribeToMore<
     TSubscriptionData = TData,
-    TSubscriptionVariables = TVariables
+    TSubscriptionVariables extends OperationVariables = TVariables
   >(
     options: SubscribeToMoreOptions<
       TData,
@@ -599,7 +599,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`);
     }, NetworkStatus.setVariables);
   }
 
-  public updateQuery<TVars = TVariables>(
+  public updateQuery<TVars extends OperationVariables = TVariables>(
     mapFn: (
       previousQueryResult: TData,
       options: Pick<WatchQueryOptions<TVars, TData>, "variables">,
@@ -932,7 +932,7 @@ fixObservableSubclass(ObservableQuery);
 // this.options.fetchPolicy is "cache-and-network" or "network-only". When
 // this.options.fetchPolicy is any other policy ("cache-first", "cache-only",
 // "standby", or "no-cache"), we call this.reobserve() as usual.
-export function reobserveCacheFirst<TData, TVars>(
+export function reobserveCacheFirst<TData, TVars extends OperationVariables>(
   obsQuery: ObservableQuery<TData, TVars>,
 ) {
   const { fetchPolicy, nextFetchPolicy } = obsQuery.options;

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -159,8 +159,8 @@ export class QueryManager<TStore> {
 
   public async mutate<
     TData,
-    TVariables,
-    TContext,
+    TVariables extends OperationVariables,
+    TContext extends {},
     TCache extends ApolloCache<any>
   >({
     mutation,
@@ -514,7 +514,7 @@ export class QueryManager<TStore> {
     }, mutation.mutationId);
   }
 
-  public fetchQuery<TData, TVars>(
+  public fetchQuery<TData, TVars extends OperationVariables>(
     queryId: string,
     options: WatchQueryOptions<TVars, TData>,
     networkStatus?: NetworkStatus,
@@ -614,7 +614,7 @@ export class QueryManager<TStore> {
     };
   }
 
-  public watchQuery<T, TVariables = OperationVariables>(
+  public watchQuery<T, TVariables extends OperationVariables = OperationVariables>(
     options: WatchQueryOptions<TVariables, T>,
   ): ObservableQuery<T, TVariables> {
     // assign variable default values if supplied
@@ -648,7 +648,7 @@ export class QueryManager<TStore> {
     return observable;
   }
 
-  public query<TData, TVars = OperationVariables>(
+  public query<TData, TVars extends OperationVariables = OperationVariables>(
     options: QueryOptions<TVars, TData>,
     queryId = this.generateQueryId(),
   ): Promise<ApolloQueryResult<TData>> {
@@ -1023,7 +1023,7 @@ export class QueryManager<TStore> {
     return observable;
   }
 
-  private getResultsFromLink<TData, TVars>(
+  private getResultsFromLink<TData, TVars extends OperationVariables>(
     queryInfo: QueryInfo,
     cacheWriteBehavior: CacheWriteBehavior,
     options: Pick<WatchQueryOptions<TVars, TData>,
@@ -1086,7 +1086,7 @@ export class QueryManager<TStore> {
     );
   }
 
-  public fetchQueryObservable<TData, TVars>(
+  public fetchQueryObservable<TData, TVars extends OperationVariables>(
     queryId: string,
     options: WatchQueryOptions<TVars, TData>,
     // The initial networkStatus for this fetch, most often
@@ -1334,7 +1334,7 @@ export class QueryManager<TStore> {
     return results;
   }
 
-  private fetchQueryByPolicy<TData, TVars>(
+  private fetchQueryByPolicy<TData, TVars extends OperationVariables>(
     queryInfo: QueryInfo,
     { query,
       variables,

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -115,7 +115,7 @@ export interface QueryOptions<TVariables = OperationVariables, TData = any> {
 /**
  * Watched query options.
  */
-export interface WatchQueryOptions<TVariables = OperationVariables, TData = any>
+export interface WatchQueryOptions<TVariables extends OperationVariables = OperationVariables, TData = any>
   extends Omit<QueryOptions<TVariables, TData>, 'fetchPolicy'> {
   /**
    * Specifies the {@link FetchPolicy} to be used for this query.
@@ -147,7 +147,7 @@ export interface WatchQueryOptions<TVariables = OperationVariables, TData = any>
   refetchWritePolicy?: RefetchWritePolicy;
 }
 
-export interface NextFetchPolicyContext<TData, TVariables> {
+export interface NextFetchPolicyContext<TData, TVariables extends OperationVariables> {
   reason:
     | "after-fetch"
     | "variables-changed";

--- a/src/react/components/Query.tsx
+++ b/src/react/components/Query.tsx
@@ -4,7 +4,7 @@ import { OperationVariables } from '../../core';
 import { QueryComponentOptions } from './types';
 import { useQuery } from '../hooks';
 
-export function Query<TData = any, TVariables = OperationVariables>(
+export function Query<TData = any, TVariables extends OperationVariables = OperationVariables>(
   props: QueryComponentOptions<TData, TVariables>
 ) {
   const { children, query, ...options } = props;
@@ -12,7 +12,7 @@ export function Query<TData = any, TVariables = OperationVariables>(
   return result ? children(result as any) : null;
 }
 
-export interface Query<TData, TVariables> {
+export interface Query<TData, TVariables extends OperationVariables> {
   propTypes: PropTypes.InferProps<QueryComponentOptions<TData, TVariables>>;
 }
 

--- a/src/react/components/Subscription.tsx
+++ b/src/react/components/Subscription.tsx
@@ -4,14 +4,14 @@ import { OperationVariables } from '../../core';
 import { SubscriptionComponentOptions } from './types';
 import { useSubscription } from '../hooks';
 
-export function Subscription<TData = any, TVariables = OperationVariables>(
+export function Subscription<TData = any, TVariables extends OperationVariables = OperationVariables>(
   props: SubscriptionComponentOptions<TData, TVariables>
 ) {
   const result = useSubscription(props.subscription, props);
   return props.children && result ? props.children(result) : null;
 }
 
-export interface Subscription<TData, TVariables> {
+export interface Subscription<TData, TVariables extends OperationVariables> {
   propTypes: PropTypes.InferProps<SubscriptionComponentOptions<TData, TVariables>>;
 }
 

--- a/src/react/components/types.ts
+++ b/src/react/components/types.ts
@@ -14,7 +14,7 @@ import {
 
 export interface QueryComponentOptions<
   TData = any,
-  TVariables = OperationVariables
+  TVariables extends OperationVariables = OperationVariables
 > extends QueryFunctionOptions<TData, TVariables> {
   children: (result: QueryResult<TData, TVariables>) => JSX.Element | null;
   query: DocumentNode | TypedDocumentNode<TData, TVariables>;
@@ -35,7 +35,7 @@ export interface MutationComponentOptions<
 
 export interface SubscriptionComponentOptions<
   TData = any,
-  TVariables = OperationVariables
+  TVariables extends OperationVariables = OperationVariables
 > extends BaseSubscriptionOptions<TData, TVariables> {
   subscription: DocumentNode | TypedDocumentNode<TData, TVariables>;
   children?: null | ((result: SubscriptionResult<TData>) => JSX.Element | null);

--- a/src/react/hoc/graphql.tsx
+++ b/src/react/hoc/graphql.tsx
@@ -5,13 +5,16 @@ import { withQuery } from './query-hoc';
 import { withMutation } from './mutation-hoc';
 import { withSubscription } from './subscription-hoc';
 import { OperationOption, DataProps, MutateProps } from './types';
+import { OperationVariables } from '../../core';
+
+type ChildProps<TData extends {}, TGraphQLVariables extends OperationVariables> =
+  Partial<DataProps<TData, TGraphQLVariables>> & Partial<MutateProps<TData, TGraphQLVariables>>;
 
 export function graphql<
   TProps extends TGraphQLVariables | {} = {},
-  TData = {},
-  TGraphQLVariables = {},
-  TChildProps = Partial<DataProps<TData, TGraphQLVariables>> &
-    Partial<MutateProps<TData, TGraphQLVariables>>
+  TData extends {} = {},
+  TGraphQLVariables extends OperationVariables = {},
+  TChildProps extends ChildProps<TData, TGraphQLVariables> = ChildProps<TData, TGraphQLVariables>
 >(
   document: DocumentNode,
   operationOptions: OperationOption<

--- a/src/react/hoc/mutation-hoc.tsx
+++ b/src/react/hoc/mutation-hoc.tsx
@@ -3,7 +3,7 @@ import { DocumentNode } from 'graphql';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 
 import { parser } from '../parser';
-import { DefaultContext } from '../../core/types';
+import { DefaultContext, OperationVariables } from '../../core/types';
 import {
   BaseMutationOptions,
   MutationFunction,
@@ -23,9 +23,9 @@ import { ApolloCache } from '../../core';
 export function withMutation<
   TProps extends TGraphQLVariables | {} = {},
   TData extends Record<string, any> = {},
-  TGraphQLVariables = {},
+  TGraphQLVariables extends OperationVariables = {},
   TChildProps = MutateProps<TData, TGraphQLVariables>,
-  TContext = DefaultContext,
+  TContext extends DefaultContext = DefaultContext,
   TCache extends ApolloCache<any> = ApolloCache<any>,
 >(
   document: DocumentNode,

--- a/src/react/hoc/query-hoc.tsx
+++ b/src/react/hoc/query-hoc.tsx
@@ -16,9 +16,9 @@ import { OperationOption, OptionProps, DataProps } from './types';
 
 export function withQuery<
   TProps extends TGraphQLVariables | {} = {},
-  TData = {},
-  TGraphQLVariables = {},
-  TChildProps = DataProps<TData, TGraphQLVariables>
+  TData extends {} = {},
+  TGraphQLVariables extends {} = {},
+  TChildProps extends DataProps<TData, TGraphQLVariables> = DataProps<TData, TGraphQLVariables>
 >(
   document: DocumentNode,
   operationOptions: OperationOption<

--- a/src/react/hoc/query-hoc.tsx
+++ b/src/react/hoc/query-hoc.tsx
@@ -18,7 +18,7 @@ export function withQuery<
   TProps extends TGraphQLVariables | {} = {},
   TData extends {} = {},
   TGraphQLVariables extends {} = {},
-  TChildProps extends DataProps<TData, TGraphQLVariables> = DataProps<TData, TGraphQLVariables>
+  TChildProps extends Partial<DataProps<TData, TGraphQLVariables>> = DataProps<TData, TGraphQLVariables>
 >(
   document: DocumentNode,
   operationOptions: OperationOption<

--- a/src/react/hoc/subscription-hoc.tsx
+++ b/src/react/hoc/subscription-hoc.tsx
@@ -17,8 +17,8 @@ import { OperationOption, OptionProps, DataProps } from './types';
 export function withSubscription<
   TProps extends TGraphQLVariables | {} = {},
   TData = {},
-  TGraphQLVariables = {},
-  TChildProps = DataProps<TData, TGraphQLVariables>
+  TGraphQLVariables extends {} = {},
+  TChildProps extends { [x: string]: any; } = DataProps<TData, TGraphQLVariables>
 >(
   document: DocumentNode,
   operationOptions: OperationOption<

--- a/src/react/hoc/types.ts
+++ b/src/react/hoc/types.ts
@@ -89,7 +89,7 @@ export interface OptionProps<
 export interface OperationOption<
   TProps,
   TData,
-  TGraphQLVariables = OperationVariables,
+  TGraphQLVariables extends OperationVariables = OperationVariables,
   TChildProps = ChildProps<TProps, TData, TGraphQLVariables>,
   TContext = DefaultContext,
   TCache extends ApolloCache<any> = ApolloCache<any>,

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -23,7 +23,7 @@ const EAGER_METHODS = [
   'subscribeToMore',
 ] as const;
 
-export function useLazyQuery<TData = any, TVariables = OperationVariables>(
+export function useLazyQuery<TData = any, TVariables extends OperationVariables = OperationVariables>(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
   options?: LazyQueryHookOptions<TData, TVariables>
 ): LazyQueryResultTuple<TData, TVariables> {

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -40,7 +40,7 @@ const {
 
 export function useQuery<
   TData = any,
-  TVariables = OperationVariables,
+  TVariables extends OperationVariables = OperationVariables,
 >(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
   options: QueryHookOptions<TData, TVariables> = Object.create(null),
@@ -51,7 +51,7 @@ export function useQuery<
   ).useQuery(options);
 }
 
-export function useInternalState<TData, TVariables>(
+export function useInternalState<TData, TVariables extends OperationVariables>(
   client: ApolloClient<any>,
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
 ): InternalState<TData, TVariables> {
@@ -79,7 +79,7 @@ export function useInternalState<TData, TVariables>(
   return state;
 }
 
-class InternalState<TData, TVariables> {
+class InternalState<TData, TVariables extends OperationVariables> {
   constructor(
     public readonly client: ReturnType<typeof useApolloClient>,
     public readonly query: DocumentNode | TypedDocumentNode<TData, TVariables>,

--- a/src/react/hooks/useSubscription.ts
+++ b/src/react/hooks/useSubscription.ts
@@ -12,7 +12,7 @@ import {
 import { OperationVariables } from '../../core';
 import { useApolloClient } from './useApolloClient';
 
-export function useSubscription<TData = any, TVariables = OperationVariables>(
+export function useSubscription<TData = any, TVariables extends OperationVariables = OperationVariables>(
   subscription: DocumentNode | TypedDocumentNode<TData, TVariables>,
   options?: SubscriptionHookOptions<TData, TVariables>,
 ) {

--- a/src/react/ssr/RenderPromises.ts
+++ b/src/react/ssr/RenderPromises.ts
@@ -1,6 +1,6 @@
 import { DocumentNode } from 'graphql';
 
-import { ObservableQuery } from '../../core';
+import { ObservableQuery, OperationVariables } from '../../core';
 import { QueryDataOptions } from '../types/types';
 
 // TODO: A vestigial interface from when hooks were implemented with utility
@@ -42,7 +42,7 @@ export class RenderPromises {
   }
 
   // Registers the server side rendered observable.
-  public registerSSRObservable<TData, TVariables>(
+  public registerSSRObservable<TData, TVariables extends OperationVariables>(
     observable: ObservableQuery<any, TVariables>,
   ) {
     if (this.stopped) return;
@@ -50,7 +50,7 @@ export class RenderPromises {
   }
 
   // Get's the cached observable that matches the SSR Query instances query and variables.
-  public getSSRObservable<TData, TVariables>(
+  public getSSRObservable<TData, TVariables extends OperationVariables>(
     props: QueryDataOptions<TData, TVariables>
   ): ObservableQuery<any, TVariables> | null {
     return this.lookupQueryInfo(props).observable;
@@ -77,7 +77,7 @@ export class RenderPromises {
     return finish ? finish() : null;
   }
 
-  public addObservableQueryPromise<TData, TVariables>(
+  public addObservableQueryPromise<TData, TVariables extends OperationVariables>(
     obsQuery: ObservableQuery<TData, TVariables>,
   ) {
     return this.addQueryPromise({
@@ -127,7 +127,7 @@ export class RenderPromises {
     return Promise.all(promises);
   }
 
-  private lookupQueryInfo<TData, TVariables>(
+  private lookupQueryInfo<TData, TVariables extends OperationVariables>(
     props: QueryDataOptions<TData, TVariables>
   ): QueryInfo {
     const { queryInfoTrie } = this;

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -28,7 +28,7 @@ export type CommonOptions<TOptions> = TOptions & {
 
 /* Query types */
 
-export interface BaseQueryOptions<TVariables = OperationVariables>
+export interface BaseQueryOptions<TVariables extends OperationVariables = OperationVariables>
 extends Omit<WatchQueryOptions<TVariables>, "query"> {
   ssr?: boolean;
   client?: ApolloClient<any>;
@@ -37,7 +37,7 @@ extends Omit<WatchQueryOptions<TVariables>, "query"> {
 
 export interface QueryFunctionOptions<
   TData = any,
-  TVariables = OperationVariables
+  TVariables extends OperationVariables = OperationVariables
 > extends BaseQueryOptions<TVariables> {
   displayName?: string;
   skip?: boolean;
@@ -52,7 +52,7 @@ export interface QueryFunctionOptions<
   defaultOptions?: Partial<WatchQueryOptions<TVariables, TData>>;
 }
 
-export type ObservableQueryFields<TData, TVariables> = Pick<
+export type ObservableQueryFields<TData, TVariables extends OperationVariables> = Pick<
   ObservableQuery<TData, TVariables>,
   | 'startPolling'
   | 'stopPolling'
@@ -64,7 +64,7 @@ export type ObservableQueryFields<TData, TVariables> = Pick<
   | 'fetchMore'
 >;
 
-export interface QueryResult<TData = any, TVariables = OperationVariables>
+export interface QueryResult<TData = any, TVariables extends OperationVariables = OperationVariables>
   extends ObservableQueryFields<TData, TVariables> {
   client: ApolloClient<any>;
   observable: ObservableQuery<TData, TVariables>;
@@ -76,20 +76,20 @@ export interface QueryResult<TData = any, TVariables = OperationVariables>
   called: boolean;
 }
 
-export interface QueryDataOptions<TData = any, TVariables = OperationVariables>
+export interface QueryDataOptions<TData = any, TVariables extends OperationVariables = OperationVariables>
   extends QueryFunctionOptions<TData, TVariables> {
   children?: (result: QueryResult<TData, TVariables>) => ReactNode;
   query: DocumentNode | TypedDocumentNode<TData, TVariables>;
 }
 
-export interface QueryHookOptions<TData = any, TVariables = OperationVariables>
+export interface QueryHookOptions<TData = any, TVariables extends OperationVariables = OperationVariables>
   extends QueryFunctionOptions<TData, TVariables> {
   query?: DocumentNode | TypedDocumentNode<TData, TVariables>;
 }
 
 export interface LazyQueryHookOptions<
   TData = any,
-  TVariables = OperationVariables
+  TVariables extends OperationVariables = OperationVariables
 > extends Omit<QueryHookOptions<TData, TVariables>, 'skip'> {}
 
 /**
@@ -103,19 +103,19 @@ export interface QueryLazyOptions<TVariables> {
 /**
  * @deprecated TODO Delete this unused type alias.
  */
-export type LazyQueryResult<TData, TVariables> = QueryResult<TData, TVariables>;
+export type LazyQueryResult<TData, TVariables extends OperationVariables> = QueryResult<TData, TVariables>;
 
 /**
  * @deprecated TODO Delete this unused type alias.
  */
-export type QueryTuple<TData, TVariables> =
+export type QueryTuple<TData, TVariables extends OperationVariables> =
   LazyQueryResultTuple<TData, TVariables>;
 
-export type LazyQueryExecFunction<TData, TVariables> = (
+export type LazyQueryExecFunction<TData, TVariables extends OperationVariables> = (
   options?: Partial<LazyQueryHookOptions<TData, TVariables>>,
 ) => Promise<QueryResult<TData, TVariables>>;
 
-export type LazyQueryResultTuple<TData, TVariables> = [
+export type LazyQueryResultTuple<TData, TVariables extends OperationVariables> = [
   LazyQueryExecFunction<TData, TVariables>,
   QueryResult<TData, TVariables>,
 ];
@@ -210,7 +210,7 @@ export interface OnSubscriptionDataOptions<TData = any> {
 
 export interface BaseSubscriptionOptions<
   TData = any,
-  TVariables = OperationVariables
+  TVariables extends OperationVariables = OperationVariables
 > {
   variables?: TVariables;
   fetchPolicy?: FetchPolicy;
@@ -235,14 +235,14 @@ export interface SubscriptionResult<TData = any, TVariables = any> {
 
 export interface SubscriptionHookOptions<
   TData = any,
-  TVariables = OperationVariables
+  TVariables extends OperationVariables = OperationVariables
 > extends BaseSubscriptionOptions<TData, TVariables> {
   subscription?: DocumentNode | TypedDocumentNode<TData, TVariables>;
 }
 
 export interface SubscriptionDataOptions<
   TData = any,
-  TVariables = OperationVariables
+  TVariables extends OperationVariables = OperationVariables
 > extends BaseSubscriptionOptions<TData, TVariables> {
   subscription: DocumentNode | TypedDocumentNode<TData, TVariables>;
   children?: null | ((result: SubscriptionResult<TData>) => JSX.Element | null);

--- a/src/testing/core/subscribeAndCount.ts
+++ b/src/testing/core/subscribeAndCount.ts
@@ -3,7 +3,7 @@ import { ObservableSubscription, asyncMap } from '../../utilities';
 
 export default function subscribeAndCount<
   TData,
-  TVariables = OperationVariables,
+  TVariables extends OperationVariables = OperationVariables,
 >(
   reject: (reason: any) => any,
   observable: ObservableQuery<TData, TVariables>,

--- a/src/utilities/common/cloneDeep.ts
+++ b/src/utilities/common/cloneDeep.ts
@@ -27,7 +27,7 @@ function cloneDeepHelper<T>(val: T, seen?: Map<any, any>): T {
     // possible in all JS environments, so we will assume they exist/work.
     const copy = Object.create(Object.getPrototypeOf(val));
     seen.set(val, copy);
-    Object.keys(val).forEach(key => {
+    Object.keys(val as T & {}).forEach(key => {
       copy[key] = cloneDeepHelper((val as any)[key], seen);
     });
     return copy;

--- a/src/utilities/common/mergeOptions.ts
+++ b/src/utilities/common/mergeOptions.ts
@@ -2,11 +2,12 @@ import type {
   QueryOptions,
   WatchQueryOptions,
   MutationOptions,
+  OperationVariables,
 } from "../../core";
 
 import { compact } from "./compact";
 
-type OptionsUnion<TData, TVariables, TContext> =
+type OptionsUnion<TData, TVariables extends OperationVariables, TContext> =
   | WatchQueryOptions<TVariables, TData>
   | QueryOptions<TVariables, TData>
   | MutationOptions<TData, TVariables, TContext>;

--- a/src/utilities/policies/pagination.ts
+++ b/src/utilities/policies/pagination.ts
@@ -92,7 +92,7 @@ export type RelayFieldPolicy<TNode> = FieldPolicy<
 // As proof of the flexibility of field policies, this function generates
 // one that handles Relay-style pagination, without Apollo Client knowing
 // anything about connections, edges, cursors, or pageInfo objects.
-export function relayStylePagination<TNode = Reference>(
+export function relayStylePagination<TNode extends Reference = Reference>(
   keyArgs: KeyArgs = false,
 ): RelayFieldPolicy<TNode> {
   return {


### PR DESCRIPTION
Hi there! 👋

TypeScript recently added some stricter checking around unconstrained generics being incompatible with emptyish object types. The changes are only in nightly versions of TypeScript right now, but we've been exploring how open-source projects have been impacted. These are the changes necessary for apollo-client to build cleanly in TypeScript 4.8.