### PR TITLE
Makes error handling more consistent

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     {
       "name": "apollo-client",
       "path": "./dist/apollo-client.min.cjs",
-      "maxSize": "29.98kB"
+      "maxSize": "30.01kB"
     }
   ],
   "engines": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     {
       "name": "apollo-client",
       "path": "./dist/apollo-client.min.cjs",
-      "maxSize": "29.95kB"
+      "maxSize": "29.98kB"
     }
   ],
   "engines": {

--- a/src/cache/core/types/Cache.ts
+++ b/src/cache/core/types/Cache.ts
@@ -1,6 +1,8 @@
 import { DataProxy } from './DataProxy';
 import { Modifier, Modifiers } from './common';
 import { ApolloCache } from '../cache';
+import { ServerError } from '../../../core';
+import { GraphQLError } from 'graphql';
 
 export namespace Cache {
   export type WatchCallback<TData = any> = (
@@ -23,6 +25,8 @@ export namespace Cache {
   {
     dataId?: string;
     result: TResult;
+    error?: ServerError;
+    errors?: ReadonlyArray<GraphQLError>;
   }
 
   export interface DiffOptions<

--- a/src/cache/core/types/Cache.ts
+++ b/src/cache/core/types/Cache.ts
@@ -1,8 +1,6 @@
 import { DataProxy } from './DataProxy';
 import { Modifier, Modifiers } from './common';
 import { ApolloCache } from '../cache';
-import { ServerError } from '../../../core';
-import { GraphQLError } from 'graphql';
 
 export namespace Cache {
   export type WatchCallback<TData = any> = (
@@ -25,8 +23,6 @@ export namespace Cache {
   {
     dataId?: string;
     result: TResult;
-    error?: ServerError;
-    errors?: ReadonlyArray<GraphQLError>;
   }
 
   export interface DiffOptions<

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1047,7 +1047,7 @@ export class QueryManager<TStore> {
       ),
 
       result => {
-        const hasErrors = isNonEmptyArray(result.errors);
+        const hasErrors = isNonEmptyArray(result.errors) || result.error;
 
         // If we interrupted this request by calling getResultsFromLink again
         // with the same QueryInfo object, we ignore the old results.

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1056,6 +1056,7 @@ export class QueryManager<TStore> {
             // Throwing here effectively calls observer.error.
             throw queryInfo.markError(new ApolloError({
               graphQLErrors: result.errors,
+              networkError: result.error,
             }));
           }
           queryInfo.markResult(result, options, cacheWriteBehavior);
@@ -1070,6 +1071,7 @@ export class QueryManager<TStore> {
 
         if (hasErrors && options.errorPolicy !== "ignore") {
           aqr.errors = result.errors;
+          aqr.error = result.error;
           aqr.networkStatus = NetworkStatus.error;
         }
 

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -1860,9 +1860,11 @@ describe('ObservableQuery', () => {
     });
 
     itAsync('returns errors with data if errorPolicy is all', (resolve, reject) => {
+      const networkError = new ApolloError({errorMessage: "Oh no"})
+
       const queryManager = mockQueryManager(reject, {
         request: { query, variables },
-        result: { data: dataOne, errors: [error] },
+        result: { data: dataOne, errors: [error], error: networkError},
       });
 
       const observable = queryManager.watchQuery({
@@ -1877,7 +1879,7 @@ describe('ObservableQuery', () => {
         const currentResult = observable.getCurrentResult();
         expect(currentResult.loading).toBe(false);
         expect(currentResult.errors).toEqual([error]);
-        expect(currentResult.error).toBeUndefined();
+        expect(currentResult.error).toEqual(networkError);
       }).then(resolve, reject);
     });
 

--- a/src/link/core/types.ts
+++ b/src/link/core/types.ts
@@ -2,7 +2,7 @@ import { DocumentNode, ExecutionResult } from 'graphql';
 export { DocumentNode };
 
 import { Observable } from '../../utilities';
-
+import { ApolloError } from '../../errors';
 export interface GraphQLRequest {
   query: DocumentNode;
   variables?: Record<string, any>;
@@ -25,6 +25,7 @@ export interface FetchResult<
   TContext = Record<string, any>,
   TExtensions = Record<string, any>
 > extends ExecutionResult<TData, TExtensions> {
+  error?: ApolloError;
   data?: TData | null | undefined;
   extensions?: TExtensions;
   context?: TContext;

--- a/src/link/error/index.ts
+++ b/src/link/error/index.ts
@@ -34,9 +34,10 @@ export function onError(errorHandler: ErrorHandler): ApolloLink {
       try {
         sub = forward(operation).subscribe({
           next: result => {
-            if (result.errors) {
+            if (result.errors || result.error) {
               retriedResult = errorHandler({
                 graphQLErrors: result.errors,
+                networkError: result.error,
                 response: result,
                 operation,
                 forward,
@@ -58,10 +59,7 @@ export function onError(errorHandler: ErrorHandler): ApolloLink {
               operation,
               networkError,
               //Network errors can return GraphQL errors on for example a 403
-              graphQLErrors:
-                networkError &&
-                networkError.result &&
-                networkError.result.errors,
+              graphQLErrors: networkError?.result?.errors,
               forward,
             });
             if (retriedResult) {

--- a/src/link/http/__tests__/HttpLink.ts
+++ b/src/link/http/__tests__/HttpLink.ts
@@ -1026,18 +1026,15 @@ describe('HttpLink', () => {
 
   describe('Error handling', () => {
     let responseBody: any;
-    const networkError = new Error(`Response not successful: Received status code 400.`) as ServerError;
     const text = jest.fn(() => {
       const responseBodyText = '{}';
       responseBody = JSON.parse(responseBodyText);
-      responseBody.errorNetwork = networkError
       return Promise.resolve(responseBodyText);
     });
     const textWithData = jest.fn(() => {
       responseBody = {
         data: { stub: { id: 1 } },
         errors: [{ message: 'dangit' }],
-        errorNetwork: networkError,
       };
 
       return Promise.resolve(JSON.stringify(responseBody));
@@ -1046,7 +1043,6 @@ describe('HttpLink', () => {
     const textWithErrors = jest.fn(() => {
       responseBody = {
         errors: [{ message: 'dangit' }],
-        errorNetwork: networkError,
       };
 
       return Promise.resolve(JSON.stringify(responseBody));
@@ -1077,8 +1073,9 @@ describe('HttpLink', () => {
 
       execute(link, { query: sampleQuery }).subscribe(
         result => {
-          expect(result.errorNetwork?.statusCode).toEqual(401);
-          expect(result.errorNetwork?.message).toMatch(/Received status code 401/);
+          const error = result.error?.networkError as ServerError
+          expect(error.statusCode).toEqual(401);
+          expect(error.message).toMatch(/Received status code 401/);
           resolve();
         },
         () => {},
@@ -1091,9 +1088,10 @@ describe('HttpLink', () => {
 
       execute(link, { query: sampleQuery }).subscribe(
         result => {
-          expect(result.errorNetwork?.statusCode).toBe(400);
-          expect(result.errorNetwork?.message).toMatch(/Received status code 400/);
-          expect(result).toEqual(responseBody);
+          const error = result.error?.networkError as ServerError
+          expect(error.statusCode).toBe(400);
+          expect(error.message).toMatch(/Received status code 400/);
+          
           resolve();
         },
       );
@@ -1107,9 +1105,9 @@ describe('HttpLink', () => {
 
       execute(link, { query: sampleQuery }).subscribe(
         result => {
-          expect(result.errorNetwork?.statusCode).toBe(400);
-          expect(result.errorNetwork?.message).toMatch(/Received status code 400/);
-          expect(result).toEqual(responseBody);
+          const error = result.error?.networkError as ServerError
+          expect(error.statusCode).toBe(400);
+          expect(error.message).toMatch(/Received status code 400/);
           resolve();
         },
       );
@@ -1123,9 +1121,9 @@ describe('HttpLink', () => {
 
       execute(link, { query: sampleQuery }).subscribe(
         result => {
-          expect(result.errorNetwork?.statusCode).toEqual(400);
-          expect(result.errorNetwork?.message).toMatch(/Received status code 400/);
-          expect(result.errorNetwork?.result).toBe(undefined);
+          const error = result.error?.networkError as ServerError
+          expect(error.statusCode).toEqual(400);
+          expect(error.message).toMatch(/Received status code 400/);
           resolve();
         },
       );
@@ -1137,7 +1135,8 @@ describe('HttpLink', () => {
 
       execute(link, { query: sampleQuery }).subscribe(
         result => {
-          expect(result.errorNetwork?.message).toMatch(/Server response was missing for query 'SampleQuery'./);
+          const error = result.error?.networkError as ServerError
+          expect(error.message).toMatch(/Server response was missing for query 'SampleQuery'./);
           resolve();
         },
         

--- a/src/link/http/parseAndCheckHttpResponse.ts
+++ b/src/link/http/parseAndCheckHttpResponse.ts
@@ -1,3 +1,4 @@
+import { ApolloError } from '../../errors';
 import { Operation } from '../core';
 import { ServerError } from '../utils';
 const { hasOwnProperty } = Object.prototype;
@@ -33,7 +34,11 @@ export function parseAndCheckHttpResponse(
         error.name = 'ServerError';
         error.response = response;
         error.statusCode = response.status;
-        result.error = error;
+        if (result.error) {
+          result.error.networkError = error;
+        } else {
+          result.error = new ApolloError({networkError: error});
+        }
         return result;
       }
 
@@ -52,7 +57,11 @@ export function parseAndCheckHttpResponse(
         error.name = 'ServerError';
         error.response = response;
         error.statusCode = response.status;
-        result.error = error;        
+        if (result.error) {
+          result.error.networkError = error;
+        } else {
+          result.error = new ApolloError({networkError: error});
+        }  
       }
       return result;
     });

--- a/src/link/utils/throwServerError.ts
+++ b/src/link/utils/throwServerError.ts
@@ -1,6 +1,6 @@
 export type ServerError = Error & {
   response: Response;
-  result: Record<string, any>;
+  result: Record<string, any> | undefined;
   statusCode: number;
 };
 

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -560,7 +560,10 @@ class InternalState<TData, TVariables> {
       // decided upon, we map errors (graphQLErrors) to the error options.
       // TODO: Is it possible for both result.error and result.errors to be
       // defined here?
-      queryResult.error = new ApolloError({ graphQLErrors: result.errors });
+      queryResult.error = new ApolloError({ 
+        graphQLErrors: result.errors,
+        networkError: result.error,
+       });
     }
 
     return queryResult;


### PR DESCRIPTION
See this Issue for more information: https://github.com/apollographql/apollo-client/issues/9870

This PR aims to make the `networkError` and `graphQLErrors` fields on the result object behave as expected for all react hooks - on any 4/500 error code `networkError` will be populated, and if there's any GraphQL error from the server, it will be present in that field.

Behavior currently looks good with useQuery, useSubscription, and ApolloLink.
I tried to make the implementation as non-intrusive as possible, both for backwards compatability and to hopefully prevent regressions by touching too much code. 

TODO: Add test coverage

### Checklist:

- [X] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [X] Make sure all of the significant new logic is covered by tests
