### PR TITLE
Pin TypeDoc version in Netlify command

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   publish = "docs/public"
-  command = "npx typedoc src/index.ts --json docs/public/docs.json"
+  command = "npx typedoc@0.22.18 src/index.ts --json docs/public/docs.json"
 
 [build.environment]
   NODE_VERSION = "16"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   publish = "docs/public"
-  command = "npx typedoc@0.22.18 src/index.ts --json docs/public/docs.json"
+  command = "npx typedoc@0.22 src/index.ts --json docs/public/docs.json"
 
 [build.environment]
   NODE_VERSION = "16"


### PR DESCRIPTION
Fixes https://github.com/apollographql/apollo-client/issues/9947

It turns out that since we were running `npx typedoc` to generate the source for the ApolloClient API ref, it started building them using the latest version of `typedoc`, which introduced some breaking changes to the format that was produced.

Now we specify `typedoc@0.22` to ensure we get the v0.22 format that our docs framework expects.