### PR TITLE
chore: update renovate config and add .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/renovate.json
+++ b/renovate.json
@@ -1,16 +1,16 @@
 {
-  "extends": [
-    "apollo-open-source"
-  ],
+  "extends": ["apollo-open-source"],
   "pathRules": [
     {
-      "paths": [
-        "docs/package.json"
-      ],
-      "extends": [
-        "apollo-docs"
-      ]
+      "paths": ["docs/package.json"],
+      "extends": ["apollo-docs"]
     }
+  ],
+  "ignoreDeps": [
+    "typedoc",
+    "react-17",
+    "react-dom-17",
+    "@testing-library/react-12"
   ],
   "packageRules": {
     "excludePackageNames": [

--- a/renovate.json
+++ b/renovate.json
@@ -11,10 +11,5 @@
     "react-17",
     "react-dom-17",
     "@testing-library/react-12"
-  ],
-  "packageRules": {
-    "excludePackageNames": [
-      "typedoc"
-    ]
-  }
+  ]
 }


### PR DESCRIPTION
This PR updates `renovate.json` to ignore testing-related deps for React 17 as well as adding an `.npmrc` with `legacy-peer-deps=true` to unblock renovate automated PRs which are currently failing.

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
