### PR TITLE
Replace crypto-hash with a custom hashing function in tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
           name: Jest suite with coverage
           command: npm run test:ci
           environment:
-            JEST_JUNIT_OUTPUT: "reports/junit/js-test-results.xml"
+            JEST_JUNIT_OUTPUT_FILE: "reports/junit/js-test-results.xml"
       - store_test_results:
           path: reports/junit
       - store_artifacts:

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ junit.xml
 
 # Local Netlify folder
 .netlify
+
+# Ignore generated test report output
+reports

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,6 @@
         "acorn": "8.7.1",
         "bundlesize": "0.18.1",
         "cross-fetch": "3.1.5",
-        "crypto-hash": "1.3.0",
         "fetch-mock": "9.11.0",
         "glob": "8.0.3",
         "graphql": "16.5.0",
@@ -2726,18 +2725,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/crypto-hash": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/crypto-hash/-/crypto-hash-1.3.0.tgz",
-      "integrity": "sha512-lyAZ0EMyjDkVvz8WOeVnuCPvKVBXcMv1l5SVqO1yC7PzTwrD/pPje/BIRbWhMoPe436U+Y2nD7f5bFx0kt+Sbg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cssom": {
@@ -9935,12 +9922,6 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
-    },
-    "crypto-hash": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/crypto-hash/-/crypto-hash-1.3.0.tgz",
-      "integrity": "sha512-lyAZ0EMyjDkVvz8WOeVnuCPvKVBXcMv1l5SVqO1yC7PzTwrD/pPje/BIRbWhMoPe436U+Y2nD7f5bFx0kt+Sbg==",
-      "dev": true
     },
     "cssom": {
       "version": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "test:ci": "npm run test:coverage && npm run test:memory",
     "test:watch": "jest --config ./config/jest.config.js --watch",
     "test:memory": "cd scripts/memory && npm i && npm test",
-    "test:coverage": "npm run coverage -- --ci --maxWorkers=2 --reporters=default --reporters=jest-junit",
+    "test:coverage": "npm run coverage -- --ci --runInBand --reporters=default --reporters=jest-junit",
     "coverage": "jest --config ./config/jest.config.js --verbose --coverage",
     "bundlesize": "npm run build && bundlesize",
     "predeploy": "npm run build",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,6 @@
     "acorn": "8.7.1",
     "bundlesize": "0.18.1",
     "cross-fetch": "3.1.5",
-    "crypto-hash": "1.3.0",
     "fetch-mock": "9.11.0",
     "glob": "8.0.3",
     "graphql": "16.5.0",

--- a/src/link/persisted-queries/__tests__/index.ts
+++ b/src/link/persisted-queries/__tests__/index.ts
@@ -1,8 +1,8 @@
 import gql from 'graphql-tag';
-import { sha256 } from 'crypto-hash';
 import { print } from 'graphql';
 import { times } from 'lodash';
 import fetchMock from 'fetch-mock';
+import crypto from 'crypto';
 
 import { ApolloLink, execute } from '../../core';
 import { Observable } from '../../../utilities';
@@ -47,11 +47,17 @@ const errorResponse = JSON.stringify({ errors });
 const giveUpResponse = JSON.stringify({ errors: giveUpErrors });
 const multiResponse = JSON.stringify({ errors: multipleErrors });
 
+export function sha256(data: string) {
+  const hash = crypto.createHash('sha256');
+  hash.update(data);
+  return hash.digest('hex');
+}
+
+const hash = sha256(queryString);
+
 describe('happy path', () => {
-  let hash: string;
   beforeEach(async () => {
     fetchMock.restore();
-    hash = hash || await sha256(queryString);
   });
 
   itAsync('sends a sha256 hash of the query under extensions', (resolve, reject) => {
@@ -229,10 +235,8 @@ describe('happy path', () => {
 });
 
 describe('failure path', () => {
-  let hash: string;
   beforeEach(async () => {
     fetchMock.restore();
-    hash = hash || await sha256(queryString);
   });
 
   itAsync('correctly identifies the error shape from the server', (resolve, reject) => {

--- a/src/link/persisted-queries/__tests__/react.tsx
+++ b/src/link/persisted-queries/__tests__/react.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom/server';
 import gql from 'graphql-tag';
 import { print } from 'graphql';
-import { sha256 } from 'crypto-hash';
 import fetchMock from 'fetch-mock';
 
 import { ApolloProvider } from '../../../react/context';
@@ -13,6 +12,7 @@ import { createHttpLink } from '../../http/createHttpLink';
 import { graphql } from '../../../react/hoc/graphql';
 import { getDataFromTree } from '../../../react/ssr/getDataFromTree';
 import { createPersistedQueryLink as createPersistedQuery, VERSION } from '../';
+import { sha256 } from './index';
 
 // Necessary configuration in order to mock multiple requests
 // to a single (/graphql) endpoint
@@ -49,10 +49,7 @@ const response = JSON.stringify({ data });
 const response2 = JSON.stringify({ data: data2 });
 const queryString = print(query);
 
-let hash: string;
-(async () => {
-  hash = await sha256(queryString);
-})();
+const hash = sha256(queryString);
 
 describe('react application', () => {
   beforeEach(async () => {


### PR DESCRIPTION
It looks like some combination of the changes in #9928 and #9942 exposed a long running issue caused by using `crypto-hash` in our `@apollo/client/link/persisted-queries` tests. `crypto-hash` spawns a thread the first time it's called, and keeps that thread alive until the end of program execution, if worker threads are available (which they are for our tests since they're running in CI via Node). Unfortunately there appears to be some kind of a race condition between `crypto-hash` `unref`ing its worker and Jest reporting a successful test suite exit, which leads to Jest reporting the following (which is seen by running jest with the `--detectOpenHandles` setting enabled):

```
Jest has detected the following X open handles potentially keeping Jest from exiting:
```

This then appears to be leading to failed tests in CI.

We can look further into what's causing this race condition between `crypto-hash` and Jest, but just dropping the use of `crypto-hash` is likely a faster solution. We just need to verify that a hashing function can be successfully set and used with the persisted queries link, which means we can replace `crypto-hash` with our own simple function that doesn't use worker threads. This commit does just that by introducing a super simple custom `sha256` function that leverages Node `crypto`, and uses it instead.

Fixes #9982