### PR TITLE
Fix for ServerError obscured by ServerParseError

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     {
       "name": "apollo-client",
       "path": "./dist/apollo-client.min.cjs",
-      "maxSize": "29.63kB"
+      "maxSize": "29.66kB"
     }
   ],
   "engines": {

--- a/src/link/http/__tests__/HttpLink.ts
+++ b/src/link/http/__tests__/HttpLink.ts
@@ -1229,7 +1229,26 @@ describe('HttpLink', () => {
 
     const body = '{';
     const unparsableJson = jest.fn(() => Promise.resolve(body));
-    itAsync('throws an error if response is unparsable', (resolve, reject) => {
+    itAsync('throws a Server error if response is > 300 with unparsable json', (resolve, reject) => {
+      fetch.mockReturnValueOnce(
+        Promise.resolve({ status: 400, text: unparsableJson }),
+      );
+      const link = createHttpLink({ uri: 'data', fetch: fetch as any });
+
+      execute(link, { query: sampleQuery }).subscribe(
+        result => {
+          reject('next should have been thrown from the network');
+        },
+        makeCallback(resolve, reject, (e: ServerParseError) => {
+          expect(e.message).toMatch("Response not successful: Received status code 400");
+          expect(e.statusCode).toBe(400);
+          expect(e.response).toBeDefined();
+          expect(e.bodyText).toBe(undefined);
+        }),
+      );
+    });
+
+    itAsync('throws a ServerParse error if response is 200 with unparsable json', (resolve, reject) => {
       fetch.mockReturnValueOnce(
         Promise.resolve({ status: 200, text: unparsableJson }),
       );

--- a/src/link/http/__tests__/HttpLink.ts
+++ b/src/link/http/__tests__/HttpLink.ts
@@ -1231,7 +1231,7 @@ describe('HttpLink', () => {
     const unparsableJson = jest.fn(() => Promise.resolve(body));
     itAsync('throws an error if response is unparsable', (resolve, reject) => {
       fetch.mockReturnValueOnce(
-        Promise.resolve({ status: 400, text: unparsableJson }),
+        Promise.resolve({ status: 200, text: unparsableJson }),
       );
       const link = createHttpLink({ uri: 'data', fetch: fetch as any });
 
@@ -1241,7 +1241,7 @@ describe('HttpLink', () => {
         },
         makeCallback(resolve, reject, (e: ServerParseError) => {
           expect(e.message).toMatch(/JSON/);
-          expect(e.statusCode).toBe(400);
+          expect(e.statusCode).toBe(200);
           expect(e.response).toBeDefined();
           expect(e.bodyText).toBe(body);
         }),

--- a/src/link/http/__tests__/parseAndCheckHttpResponse.ts
+++ b/src/link/http/__tests__/parseAndCheckHttpResponse.ts
@@ -20,7 +20,23 @@ describe('parseAndCheckResponse', () => {
 
   const operations = [createOperation({}, { query })];
 
-  itAsync('throws a parse error with a status code on unparsable response', (resolve, reject) => {
+  itAsync('throws a Server error when response is > 300 with unparsable json', (resolve, reject) => {
+    const status = 400;
+    fetchMock.mock('begin:/error', status);
+    fetch('error')
+      .then(parseAndCheckHttpResponse(operations))
+      .then(reject)
+      .catch(e => {
+        expect(e.statusCode).toBe(status);
+        expect(e.name).toBe('ServerError');
+        expect(e).toHaveProperty('response');
+        expect(e.bodyText).toBe(undefined);
+        resolve();
+      })
+      .catch(reject);
+  });
+
+  itAsync('throws a ServerParse error when response is 200 with unparsable json', (resolve, reject) => {
     const status = 200;
     fetchMock.mock('begin:/error', status);
     fetch('error')

--- a/src/link/http/__tests__/parseAndCheckHttpResponse.ts
+++ b/src/link/http/__tests__/parseAndCheckHttpResponse.ts
@@ -21,7 +21,7 @@ describe('parseAndCheckResponse', () => {
   const operations = [createOperation({}, { query })];
 
   itAsync('throws a parse error with a status code on unparsable response', (resolve, reject) => {
-    const status = 400;
+    const status = 200;
     fetchMock.mock('begin:/error', status);
     fetch('error')
       .then(parseAndCheckHttpResponse(operations))

--- a/src/link/http/parseAndCheckHttpResponse.ts
+++ b/src/link/http/parseAndCheckHttpResponse.ts
@@ -15,6 +15,22 @@ export function parseAndCheckHttpResponse(
   return (response: Response) => response
     .text()
     .then(bodyText => {
+      if (response.status >= 300) {
+        // Network error
+        const getResult = () => {
+          try {
+            return JSON.parse(bodyText);
+          } catch (err) {
+            return bodyText
+          }
+        }
+        throwServerError(
+          response,
+          getResult(),
+          `Response not successful: Received status code ${response.status}`,
+        );
+      }
+
       try {
         return JSON.parse(bodyText);
       } catch (err) {
@@ -27,15 +43,6 @@ export function parseAndCheckHttpResponse(
       }
     })
     .then((result: any) => {
-      if (response.status >= 300) {
-        // Network error
-        throwServerError(
-          response,
-          result,
-          `Response not successful: Received status code ${response.status}`,
-        );
-      }
-
       if (
         !Array.isArray(result) &&
         !hasOwnProperty.call(result, 'data') &&


### PR DESCRIPTION
Fixes #8945 where not handling the response status code before parsing the response body text causes the apollo client to send a ServerParseError when it should send a ServerError.

The changes here are taken from #8974 which has been inactive for months