### PR TITLE
adds solid.js to integrations.md

### DIFF
--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -47,7 +47,7 @@ This documentation set focuses on React, but Apollo Client supports many other l
   - [Angular](https://apollo-angular.com)
   - [Vue](integrations/integrations/#vue)
   - [Svelte](integrations/integrations/#svelte)
-  - [Solid.js](https://github.com/merged-js/solid-apollo) (thanks to [Torsten85](https://github.com/Torsten85))
+  - [Solid.js](https://github.com/merged-js/solid-apollo)
   - [Ember](integrations/integrations/#ember)
   - [Meteor](https://www.meteor.com) (thanks to [DDP-Apollo](https://github.com/Swydo/ddp-apollo))
 - Web Components

--- a/docs/source/integrations/integrations.md
+++ b/docs/source/integrations/integrations.md
@@ -22,6 +22,10 @@ A [Svelte](https://svelte.dev) integration is maintained by Tim Hall ([@timhall]
 
 An [Angular](https://angular.io) integration is maintained by Kamil Kisiela ([@kamilkisiela](https://github.com/kamilkisiela)). See the [website](https://apollo-angular.com) for more details.
 
+## Solid.js
+
+A [Solid.js](https://www.solidjs.com/) integration is maintained by ([@Torsten85](https://github.com/Torsten85)). See the Github [repository](https://github.com/merged-js/solid-apollo) for more details.
+
 ## Ember
 
 An [Ember](http://emberjs.com/) integration is maintained by Josemar Luedke ([@josemarluedke](https://github.com/josemarluedke)). See the Github [repository](https://github.com/ember-graphql/ember-apollo-client) for more details. The creator of the project is Blake Gentry ([@bgentry](https://github.com/bgentry)).


### PR DESCRIPTION
This PR adds the solid.js library to our integrations page and remove the `thanks to` shout out from the index page.