### PR TITLE
Supports "no-cache" fetchPolicy with pollInterval

### DIFF
--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -739,7 +739,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`);
             // users wouldn't want to be polling the cache directly. However, network-only and
             // no-cache are both useful for when the user wants to control whether or not the
             // polled results are written to the cache.
-            fetchPolicy: this.options.fetchPolicy === 'no-cache' ? 'no-cache' : 'network-only',
+            fetchPolicy: this.options.initialFetchPolicy === 'no-cache' ? 'no-cache' : 'network-only',
           }, NetworkStatus.poll).then(poll, poll);
         } else {
           poll();

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -741,12 +741,8 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`);
     const maybeFetch = () => {
       if (this.pollingInfo) {
         if (!isNetworkRequestInFlight(this.queryInfo.networkStatus)) {
-          console.log(this.options.variables)
-          console.log(this)
-          
           this.reobserve({
             fetchPolicy: pollFetchPolicy,
-            variables: this.options.variables
           }, NetworkStatus.poll).then(poll, poll);
         } else {
           poll();

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -37,18 +37,6 @@ export type MutationFetchPolicy = Extract<
   | 'no-cache'     // alternate behavior (results not written to cache)
 >;
 
-/**
- * Most fetchPolicy options don't make sense to use in a polling context, as
- * users wouldn't want to be polling the cache directly. However, network-only and
- * no-cache are both useful for when the user wants to control whether or not the
- * polled results are written to the cache.
- */
-export type PollFetchPolicy = Extract<
-  FetchPolicy,
-  | 'network-only' // default behavior (polled results are written to the cache)
-  | 'no-cache'     // polled results not written to cache
->;
-
 export type RefetchWritePolicy = "merge" | "overwrite";
 
 /**

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -37,6 +37,18 @@ export type MutationFetchPolicy = Extract<
   | 'no-cache'     // alternate behavior (results not written to cache)
 >;
 
+/**
+ * Most fetchPolicy options don't make sense to use in a polling context, as
+ * users wouldn't want to be polling the cache directly. However, network-only and
+ * no-cache are both useful for when the user wants to control whether or not the
+ * polled results are written to the cache.
+ */
+export type PollFetchPolicy = Extract<
+  FetchPolicy,
+  | 'network-only' // default behavior (polled results are written to the cache)
+  | 'no-cache'     // polled results not written to cache
+>;
+
 export type RefetchWritePolicy = "merge" | "overwrite";
 
 /**


### PR DESCRIPTION
Fixes https://github.com/apollographql/apollo-client/issues/9691
Fixes https://github.com/apollographql/apollo-client/issues/6187

Adds support for the "no-cache" fetchPolicy to pollInterval.  

Most fetchPolicies don't make sense to use when polling, as users probably don't want to be polling the cache directly. As such, currently polling will overwrite the fetchPolicy with "network-only". 
However, "no-cache" is also useful for when the user wants to control whether or not their results are written to the cache, so this PR goes ahead and adds a check to allow that policy through, and a relevant test.

The check this adds looks similar to a fetchPolicy sieve in `refetch()`, and it might be worth looking into how to make that functionality a bit more generalized/cleaner.

I also went ahead and added a `pollFetchPolicy` type as a way to codify and clarify the rationale for this change, please let me know if I should change anything here!



<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [X] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [X] Make sure all of the significant new logic is covered by tests
