### PR TITLE
Return most recent result diff from useFragment, update test

### DIFF
--- a/src/react/hooks/__tests__/useFragment.test.tsx
+++ b/src/react/hooks/__tests__/useFragment.test.tsx
@@ -1,11 +1,21 @@
 import * as React from "react";
-import { render, waitFor } from "@testing-library/react";
+import { render, waitFor, screen } from "@testing-library/react";
 import { renderHook } from '@testing-library/react-hooks';
+import userEvent from '@testing-library/user-event';
 import { act } from "react-dom/test-utils";
 
 import { useFragment } from "../useFragment";
 import { MockedProvider } from "../../../testing";
-import { InMemoryCache, gql, TypedDocumentNode, Reference } from "../../../core";
+import { ApolloProvider } from "../../context";
+import {
+  InMemoryCache,
+  gql,
+  TypedDocumentNode,
+  Reference,
+  ApolloClient,
+  Observable,
+  ApolloLink,
+} from "../../../core";
 import { useQuery } from "../useQuery";
 
 describe("useFragment", () => {
@@ -763,5 +773,140 @@ describe("useFragment", () => {
     });
 
     expect(cache.gc().sort()).toEqual(["Item:5"]);
+  });
+
+  it("returns new diff when UseFragmentOptions change", async () => {
+    const ListFragment: TypedDocumentNode<QueryData> = gql`
+      fragment ListFragment on Query {
+        list {
+          id
+        }
+      }
+    `;
+
+    const cache = new InMemoryCache({
+      typePolicies: {
+        Item: {
+          fields: {
+            text(existing, { readField }) {
+              return existing || `Item #${readField("id")}`;
+            },
+          },
+        },
+      },
+    });
+
+    const client = new ApolloClient({
+      cache,
+      link: new ApolloLink(operation => new Observable(observer => {
+        if (operation.operationName === "ListQueryWithItemFragment") {
+          setTimeout(() => {
+            observer.next({
+              data: {
+                list: [
+                  { __typename: "Item", id: 1 },
+                  { __typename: "Item", id: 2 },
+                  { __typename: "Item", id: 5 },
+                ],
+              }
+            });
+            observer.complete();
+          }, 10);
+        } else {
+          observer.error(`unexpected query ${
+            operation.operationName ||
+            operation.query
+          }`);
+        }
+      })),
+    });
+
+    const listQuery: TypedDocumentNode<QueryData> = gql`
+      query ListQueryWithItemFragment {
+        list {
+          id
+          ...ItemFragment
+        }
+      }
+      ${ItemFragment}
+    `;
+
+    function List() {
+      const [currentItem, setCurrentItem] = React.useState(1);
+      useQuery(listQuery);
+
+      const { complete, data } = useFragment({
+        fragment: ListFragment,
+        from: { __typename: "Query" },
+      });
+
+      return complete ? (
+        <>
+          <select onChange={(e) => {
+            setCurrentItem(parseInt(e.currentTarget.value))
+          }}>
+            {data!.list.map(item => <option key={item.id} value={item.id}>Select item {item.id}</option>)}
+          </select>
+          <div>
+            <Item id={currentItem} />
+          </div>
+          <ol>
+          {data!.list.map(item => <Item key={item.id} id={item.id}/>)}
+          </ol>
+        </>
+      ) : null;
+    }
+
+    function Item({ id }: { id: number }) {
+      const { complete, data } = useFragment({
+        fragment: ItemFragment,
+        from: {
+          __typename: "Item",
+          id,
+        },
+      });
+      return <li>{complete ? data!.text : "incomplete"}</li>;
+    }
+
+    render(
+      <ApolloProvider client={client}>
+        <List />
+      </ApolloProvider>
+    );
+
+    function getItemTexts() {
+      return screen.getAllByText(/^Item/).map(
+        li => li.firstChild!.textContent
+      );
+    }
+
+    await waitFor(() => {
+      expect(getItemTexts()).toEqual([
+        // On initial render, Item #1 is selected
+        // and renders above the list
+        "Item #1",
+        "Item #1",
+        "Item #2",
+        "Item #5",
+      ]);
+    });
+
+    // Select "Item #2" via <select />
+    const user = userEvent.setup();
+    await user.selectOptions(
+      screen.getByRole('combobox'),
+      screen.getByRole('option', { name: 'Select item 2' })
+    );
+
+    await waitFor(() => {
+      expect(getItemTexts()).toEqual([
+        // Now the selected item at the top should render
+        // "Item #2" + the list of items below
+        "Item #2",
+        "Item #1",
+        "Item #2",
+        "Item #5",
+      ]);
+    });
   });
 });

--- a/src/react/hooks/useFragment.ts
+++ b/src/react/hooks/useFragment.ts
@@ -90,8 +90,11 @@ export function useFragment<TData, TVars>(
     },
 
     () => {
-      return resultRef.current ||
-        (resultRef.current = diffToResult(latestDiff));
+      const latestDiffToResult = diffToResult(latestDiff);
+      return resultRef.current &&
+        equal(resultRef.current.data, latestDiffToResult.data)
+        ? resultRef.current
+        : (resultRef.current = latestDiffToResult);
     },
   );
 }


### PR DESCRIPTION
This includes the same fix and adapts the tests from https://github.com/apollographql/apollo-client/pull/9918 while targeting the `release-3.7` branch. The tests use `useQuery` and the new test fails if the diff in `src/react/hooks/useFragment.ts` is reverted.

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
