### PR TITLE
remove obsolete displayName query option

### DIFF
--- a/docs/shared/query-options.mdx
+++ b/docs/shared/query-options.mdx
@@ -123,23 +123,6 @@ The default value is `false`.
 </tr>
 
 <tr>
-<td>
-
-###### `displayName`
-
-`string`
-</td>
-
-<td>
-
-The name of your component to be displayed in the React Developer Tools.
-
-The default value is `Query`.
-
-</td>
-</tr>
-
-<tr>
 <td colspan="2">
 
 **Networking options**

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -378,7 +378,6 @@ class InternalState<TData, TVariables> {
     ssr,
     onCompleted,
     onError,
-    displayName,
     defaultOptions,
     // The above options are useQuery-specific, so this ...otherOptions spread
     // makes otherOptions almost a WatchQueryOptions object, except for the

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -39,7 +39,6 @@ export interface QueryFunctionOptions<
   TData = any,
   TVariables = OperationVariables
 > extends BaseQueryOptions<TVariables> {
-  displayName?: string;
   skip?: boolean;
   onCompleted?: (data: TData) => void;
   onError?: (error: ApolloError) => void;


### PR DESCRIPTION
When reading the docs I was confused by the `displayName` option for the `useQuery()` query hook 
> The name of your component to be displayed in the React Developer Tools.

Since `useQuery` is a hook there is no component to set a display name to. I figured this was something that was carried over from `react-apollo` or was still used by Apollo Dev Tools or the legacy HOCs or components but from looking at the code it appears unused in those places. 

Let me know if I'm incorrect about any of this. Thanks!