### PR TITLE
docs: remove errant duplicated text

### DIFF
--- a/docs/source/caching/cache-field-behavior.mdx
+++ b/docs/source/caching/cache-field-behavior.mdx
@@ -114,8 +114,6 @@ query personWithFullName {
 }
 ```
 
-If a field accepts arguments, the second parameter includes the values of those arguments. The following `read` function checks to see if the `maxLength` argument is provided when the `name` field is queried. If it is, the function returns only the first `maxLength` characters of the person's name. Otherwise, the person's full name is returned.
-
 You can define a `read` function for a field that isn't even defined in your schema. For example, the following `read` function enables you to query a `userId` field that is always populated with locally stored data:
 
 ```ts


### PR DESCRIPTION
Reading though the docs for the first time in a while and I noticed a paragraph that was out of place and apparently  duplicated from one that is earlier in the document.

**Original blurb:**
https://github.com/apollographql/apollo-client/blob/04537470f754e48344197ddbcb4a0446dcdc6e26/docs/source/caching/cache-field-behavior.mdx#L58-L60

**Duplicate (removed in this PR):**
https://github.com/apollographql/apollo-client/blob/04537470f754e48344197ddbcb4a0446dcdc6e26/docs/source/caching/cache-field-behavior.mdx#L117
