### PR TITLE
docs: fixup onResetStore docs, convert to hooks

### DIFF
--- a/docs/source/caching/advanced-topics.mdx
+++ b/docs/source/caching/advanced-topics.mdx
@@ -88,13 +88,13 @@ The `client.onResetStore` method's return value is a function you can call to un
 import { useApolloClient } from '@apollo/client';
 
 function Foo (){
-  const [reset, setReset] = useState(false);
+  const [reset, setReset] = useState(0);
   const client = useApolloClient();
 
   useEffect(() => {
-    const unsubscribe = client.onResetStore(() => {
-      setReset(true)
-    });
+    const unsubscribe = client.onResetStore(() => 
+      new Promise(()=>setReset(reset + 1))
+    );
 
     return () => {
       unsubscribe();

--- a/docs/source/caching/advanced-topics.mdx
+++ b/docs/source/caching/advanced-topics.mdx
@@ -84,26 +84,27 @@ You can also call `client.onResetStore` from your React components. This can be 
 
 The `client.onResetStore` method's return value is a function you can call to unregister your callback:
 
-```js {6-8,12}
-import { withApollo } from "@apollo/react-hoc";
+```js {8-10,13}
+import { useApolloClient } from '@apollo/client';
 
-export class Foo extends Component {
-  constructor(props) {
-    super(props);
-    this.unsubscribe = props.client.onResetStore(
-      () => this.setState({ reset: false })
-    );
-    this.state = { reset: false };
-  }
-  componentDidUnmount() {
-    this.unsubscribe();
-  }
-  render() {
-    return this.state.reset ? <div /> : <span />
-  }
+function Foo (){
+  const [reset, setReset] = useState(false);
+  const client = useApolloClient();
+
+  useEffect(() => {
+    const unsubscribe = client.onResetStore(() => {
+      setReset(true)
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  });
+
+  return reset ? <div /> : <span />
 }
 
-export default withApollo(Foo);
+export default Foo;
 ```
 
 ## TypePolicy inheritence

--- a/docs/source/caching/advanced-topics.mdx
+++ b/docs/source/caching/advanced-topics.mdx
@@ -46,13 +46,18 @@ For advanced usage and additional configuration options, see the [README of `apo
 Sometimes, you might want to reset the cache entirely, such as [when a user logs out](../networking/authentication/#reset-store-on-logout). To accomplish this, call `client.resetStore`. This method is asynchronous, because it also refetches any of your active queries.
 
 ```js
-export default withApollo(graphql(PROFILE_QUERY, {
-  props: ({ data: { loading, currentUser }, ownProps: { client }}) => ({
-    loading,
-    currentUser,
-    resetOnLogout: async () => client.resetStore(),
-  }),
-})(Profile));
+import { useQuery } from '@apollo/client';
+function Profile() {
+    const { data, client } = useQuery(PROFILE_QUERY);
+    return (
+      <Fragment>
+        <p>Current user: {data?.currentUser}</p>
+        <button onClick={async ()=>client.resetStore()}>
+            Log out
+        </button>
+      </Fragment>
+    );
+}
 ```
 
 > To reset the cache _without_ refetching active queries, use `client.clearStore()` instead of `client.resetStore()`.


### PR DESCRIPTION
Found a couple issues with the existing `onResetStore` docs
- `componentDidUnmount` doesn't exists (`componentWillUnmount` does though)
- `this.state.reset` is always `false` and wasn't correctly being set
- It references the old `@apollo/react-hoc` module from `react-apollo`, which has not been mentioned if reading the docs in order

For this PR I also migrated to hooks since the HOCs are deprecate. Let me know if you would prefer it to be fixed up but still use the HOC. Thanks!