### PR TITLE
MissingFieldError once again extends Error

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     {
       "name": "apollo-client",
       "path": "./dist/apollo-client.min.cjs",
-      "maxSize": "29.6kB"
+      "maxSize": "29.62kB"
     }
   ],
   "engines": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     {
       "name": "apollo-client",
       "path": "./dist/apollo-client.min.cjs",
-      "maxSize": "29.62kB"
+      "maxSize": "29.63kB"
     }
   ],
   "engines": {

--- a/src/cache/core/types/common.ts
+++ b/src/cache/core/types/common.ts
@@ -22,13 +22,20 @@ export type MissingTree = string | {
   readonly [key: string]: MissingTree;
 };
 
-export class MissingFieldError {
+export class MissingFieldError extends Error {
   constructor(
     public readonly message: string,
     public readonly path: MissingTree | Array<string | number>,
     public readonly query: DocumentNode,
     public readonly variables?: Record<string, any>,
-  ) {}
+  ) {
+     // 'Error' breaks prototype chain here
+     super(message);
+
+     // We're not using `Object.setPrototypeOf` here as it isn't fully
+     // supported on Android (see issue #3236).
+     (this as any).__proto__ = MissingFieldError.prototype;
+  }
 }
 
 export interface FieldSpecifier {


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->
Based on the original PR here - https://github.com/apollographql/apollo-client/pull/9126 (Thanks @matthargett!) 

Opening this to address some changes that were requested in the above PR but never got picked up by the original author.
Assuming the original review by @benjamn still stands, this should be good to go :-)

**From previous discussion:**
Some crash reporting services were not categorizing the `MissingFieldError` with other custom errors because it does not extend from the base `Error` class. This was an intentional performance fix in https://github.com/apollographql/apollo-client/pull/8734, but because that PR also ended up batching huge arrays of `MissingFieldError`s into a single `MissingFieldError`, the overhead from the super() call to Error was no longer a huge issue - so we're reverting that change here.

### Checklist:

- [X] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] ~~Make sure all of the significant new logic is covered by tests~~
