### PR TITLE
Pass mutation options to handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Apollo Client 3.6.10 (unreleased)
+
+### Improvements
+
+- The client options (`variables`, `context`, etc.) used for `mutation` calls are now available as the second argument to the `onCompleted` and `onError` callback functions. <br/> [@MrDoomBringer](https://github.com/MrDoomBringer) in [#10052](https://github.com/apollographql/apollo-client/pull/10052)
+
 ## Apollo Client 3.6.9 (2022-06-21)
 
 ### Bug Fixes

--- a/docs/shared/mutation-options.mdx
+++ b/docs/shared/mutation-options.mdx
@@ -74,14 +74,14 @@ The default value is `none`, meaning that the mutation result includes error det
 
 ###### `onCompleted`
 
-`(data: TData | {}) => void`
+`(data?: TData, executeOptions?: MutationFunctionOptions) => void`
 </td>
 
 <td>
 
 A callback function that's called when your mutation successfully completes with zero errors (or if `errorPolicy` is `ignore` and partial data is returned).
 
-This function is passed the mutation's result `data`.
+This function is passed the mutation's result `data` and any options passed to the `useMutation` hook.
 
 </td>
 </tr>
@@ -91,14 +91,14 @@ This function is passed the mutation's result `data`.
 
 ###### `onError`
 
-`(error: ApolloError) => void`
+`(error: ApolloError, executeOptions?: MutationFunctionOptions) => void`
 </td>
 
 <td>
 
 A callback function that's called when the mutation encounters one or more errors (unless `errorPolicy` is `ignore`).
 
-This function is passed an [`ApolloError`](https://github.com/apollographql/apollo-client/blob/d96f4578f89b933c281bb775a39503f6cdb59ee8/src/errors/index.ts#L36-L39) object that contains either a `networkError` object or a `graphQLErrors` array, depending on the error(s) that occurred.
+This function is passed an [`ApolloError`](https://github.com/apollographql/apollo-client/blob/d96f4578f89b933c281bb775a39503f6cdb59ee8/src/errors/index.ts#L36-L39) object that contains either a `networkError` object or a `graphQLErrors` array, depending on the error(s) that occurred, as well as any options passed to the `useMutation` hook.
 
 </td>
 </tr>

--- a/docs/shared/mutation-options.mdx
+++ b/docs/shared/mutation-options.mdx
@@ -74,14 +74,14 @@ The default value is `none`, meaning that the mutation result includes error det
 
 ###### `onCompleted`
 
-`(data?: TData, executeOptions?: MutationFunctionOptions) => void`
+`(data?: TData, clientOptions?: BaseMutationOptions) => void`
 </td>
 
 <td>
 
 A callback function that's called when your mutation successfully completes with zero errors (or if `errorPolicy` is `ignore` and partial data is returned).
 
-This function is passed the mutation's result `data` and any options passed to the `useMutation` hook.
+This function is passed the mutation's result `data` and any options passed to the mutation.
 
 </td>
 </tr>
@@ -91,14 +91,14 @@ This function is passed the mutation's result `data` and any options passed to t
 
 ###### `onError`
 
-`(error: ApolloError, executeOptions?: MutationFunctionOptions) => void`
+`(error: ApolloError, clientOptions?: BaseMutationOptions) => void`
 </td>
 
 <td>
 
 A callback function that's called when the mutation encounters one or more errors (unless `errorPolicy` is `ignore`).
 
-This function is passed an [`ApolloError`](https://github.com/apollographql/apollo-client/blob/d96f4578f89b933c281bb775a39503f6cdb59ee8/src/errors/index.ts#L36-L39) object that contains either a `networkError` object or a `graphQLErrors` array, depending on the error(s) that occurred, as well as any options passed to the `useMutation` hook.
+This function is passed an [`ApolloError`](https://github.com/apollographql/apollo-client/blob/d96f4578f89b933c281bb775a39503f6cdb59ee8/src/errors/index.ts#L36-L39) object that contains either a `networkError` object or a `graphQLErrors` array, depending on the error(s) that occurred, as well as any options passed the mutation.
 
 </td>
 </tr>

--- a/src/react/components/__tests__/client/Mutation.test.tsx
+++ b/src/react/components/__tests__/client/Mutation.test.tsx
@@ -1568,7 +1568,7 @@ describe('General Mutation testing', () => {
       const checker = () => {
         setTimeout(() => {
           success = true;
-          expect(onCompletedFn).toHaveBeenCalledWith(data);
+          expect(onCompletedFn).toHaveBeenCalledWith(data, {});
         }, 100);
       };
 

--- a/src/react/components/__tests__/client/Mutation.test.tsx
+++ b/src/react/components/__tests__/client/Mutation.test.tsx
@@ -1564,11 +1564,12 @@ describe('General Mutation testing', () => {
     itAsync('calls the onCompleted prop after the mutation is complete', (resolve, reject) => {
       let finished = false;
       let success = false;
+      const context = { "foo": "bar" }
       const onCompletedFn = jest.fn();
       const checker = () => {
         setTimeout(() => {
           success = true;
-          expect(onCompletedFn).toHaveBeenCalledWith(data, {});
+          expect(onCompletedFn).toHaveBeenCalledWith(data, expect.objectContaining({context}));
         }, 100);
       };
 
@@ -1586,7 +1587,7 @@ describe('General Mutation testing', () => {
               <Mutation mutation={mutation} onCompleted={onCompletedFn}>
                 {(createTodo: any) => {
                   setTimeout(() => {
-                    createTodo().finally(() => {
+                    createTodo({ context }).finally(() => {
                       finished = true;
                     });
                     this.setState({ called: true }, checker);

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -644,7 +644,7 @@ describe('useMutation Hook', () => {
       expect(fetchResult).toEqual({ data: CREATE_TODO_DATA });
       expect(result.current[1].data).toEqual(CREATE_TODO_DATA);
       expect(onCompleted).toHaveBeenCalledTimes(1);
-      expect(onCompleted).toHaveBeenCalledWith(CREATE_TODO_DATA, { variables, onCompleted, onError });
+      expect(onCompleted).toHaveBeenCalledWith(CREATE_TODO_DATA, expect.objectContaining({variables}));
       expect(onError).toHaveBeenCalledTimes(0);
     });
 
@@ -698,7 +698,7 @@ describe('useMutation Hook', () => {
 
       expect(onCompleted).toHaveBeenCalledTimes(0);
       expect(onError).toHaveBeenCalledTimes(1);
-      expect(onError).toHaveBeenCalledWith(errors[0], { variables, onCompleted, onError });
+      expect(onError).toHaveBeenCalledWith(errors[0], expect.objectContaining({variables}));
     });
 
     it('should allow updating onError while mutation is executing', async () => {
@@ -763,7 +763,7 @@ describe('useMutation Hook', () => {
       expect(onCompleted).toHaveBeenCalledTimes(0);
       expect(onError).toHaveBeenCalledTimes(0);
       expect(onError1).toHaveBeenCalledTimes(1);
-      expect(onError1).toHaveBeenCalledWith(errors[0], { variables });
+      expect(onError1).toHaveBeenCalledWith(errors[0], expect.objectContaining({variables}));
     });
 
     it('should never allow onCompleted handler to be stale', async () => {
@@ -826,7 +826,7 @@ describe('useMutation Hook', () => {
       expect(result.current[1].data).toEqual(CREATE_TODO_DATA);
       expect(onCompleted).toHaveBeenCalledTimes(0);
       expect(onCompleted1).toHaveBeenCalledTimes(1);
-      expect(onCompleted1).toHaveBeenCalledWith(CREATE_TODO_DATA, { variables });
+      expect(onCompleted1).toHaveBeenCalledWith(CREATE_TODO_DATA, expect.objectContaining({variables}));
     });
 
     it('should allow updating onCompleted while mutation is executing', async () => {
@@ -891,7 +891,7 @@ describe('useMutation Hook', () => {
       expect(result.current[1].data).toEqual(CREATE_TODO_DATA);
       expect(onCompleted).toHaveBeenCalledTimes(0);
       expect(onCompleted1).toHaveBeenCalledTimes(1);
-      expect(onCompleted1).toHaveBeenCalledWith(CREATE_TODO_DATA, { variables });
+      expect(onCompleted1).toHaveBeenCalledWith(CREATE_TODO_DATA, expect.objectContaining({variables}));
     });
   });
 

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -600,14 +600,16 @@ describe('useMutation Hook', () => {
         },
       };
 
+      const variables = {
+        priority: 'Low',
+        description: 'Get milk.',
+      }
+
       const mocks = [
         {
           request: {
             query: CREATE_TODO_MUTATION,
-            variables: {
-              priority: 'Low',
-              description: 'Get milk.',
-            }
+            variables,
           },
           result: {
             data: CREATE_TODO_DATA,
@@ -633,7 +635,7 @@ describe('useMutation Hook', () => {
       const onError = jest.fn();
       await act(async () => {
         fetchResult = await createTodo({
-          variables: { priority: 'Low', description: 'Get milk.' },
+          variables,
           onCompleted,
           onError,
         });
@@ -642,20 +644,21 @@ describe('useMutation Hook', () => {
       expect(fetchResult).toEqual({ data: CREATE_TODO_DATA });
       expect(result.current[1].data).toEqual(CREATE_TODO_DATA);
       expect(onCompleted).toHaveBeenCalledTimes(1);
-      expect(onCompleted).toHaveBeenCalledWith(CREATE_TODO_DATA);
+      expect(onCompleted).toHaveBeenCalledWith(CREATE_TODO_DATA, { variables, onCompleted, onError });
       expect(onError).toHaveBeenCalledTimes(0);
     });
 
     it('should allow passing an onError handler to the execution function', async () => {
       const errors = [new GraphQLError(CREATE_TODO_ERROR)];
+      const variables = {
+        priority: 'Low',
+        description: 'Get milk.',
+      }
       const mocks = [
         {
           request: {
             query: CREATE_TODO_MUTATION,
-            variables: {
-              priority: 'Low',
-              description: 'Get milk.',
-            },
+            variables,
           },
           result: {
             errors,
@@ -681,7 +684,7 @@ describe('useMutation Hook', () => {
       const onError = jest.fn();
       await act(async () => {
         fetchResult = await createTodo({
-          variables: { priority: 'Low', description: 'Get milk.' },
+          variables,
           onCompleted,
           onError,
         });
@@ -695,19 +698,20 @@ describe('useMutation Hook', () => {
 
       expect(onCompleted).toHaveBeenCalledTimes(0);
       expect(onError).toHaveBeenCalledTimes(1);
-      expect(onError).toHaveBeenCalledWith(errors[0]);
+      expect(onError).toHaveBeenCalledWith(errors[0], { variables, onCompleted, onError });
     });
 
     it('should allow updating onError while mutation is executing', async () => {
       const errors = [new GraphQLError(CREATE_TODO_ERROR)];
+      const variables = {
+        priority: 'Low',
+        description: 'Get milk.',
+      }
       const mocks = [
         {
           request: {
             query: CREATE_TODO_MUTATION,
-            variables: {
-              priority: 'Low',
-              description: 'Get milk.',
-            },
+            variables,
           },
           result: {
             errors,
@@ -742,7 +746,7 @@ describe('useMutation Hook', () => {
       let fetchResult: any;
       const mutationPromise = act(async () => {
         fetchResult = await createTodo({
-          variables: { priority: 'Low', description: 'Get milk.' },
+          variables,
         });
       });
 
@@ -759,7 +763,7 @@ describe('useMutation Hook', () => {
       expect(onCompleted).toHaveBeenCalledTimes(0);
       expect(onError).toHaveBeenCalledTimes(0);
       expect(onError1).toHaveBeenCalledTimes(1);
-      expect(onError1).toHaveBeenCalledWith(errors[0]);
+      expect(onError1).toHaveBeenCalledWith(errors[0], { variables });
     });
 
     it('should never allow onCompleted handler to be stale', async () => {
@@ -772,14 +776,16 @@ describe('useMutation Hook', () => {
         },
       };
 
+      const variables = {
+        priority: 'Low',
+        description: 'Get milk2.',
+      }
+
       const mocks = [
         {
           request: {
             query: CREATE_TODO_MUTATION,
-            variables: {
-              priority: 'Low',
-              description: 'Get milk.',
-            }
+            variables
           },
           result: {
             data: CREATE_TODO_DATA,
@@ -812,7 +818,7 @@ describe('useMutation Hook', () => {
       let fetchResult: any;
       await act(async () => {
         fetchResult = await createTodo({
-          variables: { priority: 'Low', description: 'Get milk.' },
+          variables,
         });
       });
 
@@ -820,7 +826,7 @@ describe('useMutation Hook', () => {
       expect(result.current[1].data).toEqual(CREATE_TODO_DATA);
       expect(onCompleted).toHaveBeenCalledTimes(0);
       expect(onCompleted1).toHaveBeenCalledTimes(1);
-      expect(onCompleted1).toHaveBeenCalledWith(CREATE_TODO_DATA);
+      expect(onCompleted1).toHaveBeenCalledWith(CREATE_TODO_DATA, { variables });
     });
 
     it('should allow updating onCompleted while mutation is executing', async () => {
@@ -833,14 +839,16 @@ describe('useMutation Hook', () => {
         },
       };
 
+      const variables = {
+        priority: 'Low',
+        description: 'Get milk2.',
+      }
+
       const mocks = [
         {
           request: {
             query: CREATE_TODO_MUTATION,
-            variables: {
-              priority: 'Low',
-              description: 'Get milk.',
-            }
+            variables
           },
           result: {
             data: CREATE_TODO_DATA,
@@ -871,7 +879,7 @@ describe('useMutation Hook', () => {
       let fetchResult: any;
       const mutationPromise = act(async () => {
         fetchResult = await createTodo({
-          variables: { priority: 'Low', description: 'Get milk.' },
+          variables,
         });
       });
 
@@ -883,7 +891,7 @@ describe('useMutation Hook', () => {
       expect(result.current[1].data).toEqual(CREATE_TODO_DATA);
       expect(onCompleted).toHaveBeenCalledTimes(0);
       expect(onCompleted1).toHaveBeenCalledTimes(1);
-      expect(onCompleted1).toHaveBeenCalledWith(CREATE_TODO_DATA);
+      expect(onCompleted1).toHaveBeenCalledWith(CREATE_TODO_DATA, { variables });
     });
   });
 

--- a/src/react/hooks/useMutation.ts
+++ b/src/react/hooks/useMutation.ts
@@ -100,9 +100,8 @@ export function useMutation<
           setResult(ref.current.result = result);
         }
       }
-
-      ref.current.options?.onCompleted?.(response.data!);
-      executeOptions.onCompleted?.(response.data!);
+      ref.current.options?.onCompleted?.(response.data!, executeOptions);
+      executeOptions.onCompleted?.(response.data!, executeOptions);
       return response;
     }).catch((error) => {
       if (
@@ -123,8 +122,8 @@ export function useMutation<
       }
 
       if (ref.current.options?.onError || clientOptions.onError) {
-        ref.current.options?.onError?.(error);
-        executeOptions.onError?.(error);
+        ref.current.options?.onError?.(error, executeOptions);
+        executeOptions.onError?.(error, executeOptions);
         // TODO(brian): why are we returning this here???
         return { data: void 0, errors: error };
       }

--- a/src/react/hooks/useMutation.ts
+++ b/src/react/hooks/useMutation.ts
@@ -100,8 +100,8 @@ export function useMutation<
           setResult(ref.current.result = result);
         }
       }
-      ref.current.options?.onCompleted?.(response.data!, executeOptions);
-      executeOptions.onCompleted?.(response.data!, executeOptions);
+      ref.current.options?.onCompleted?.(response.data!, clientOptions);
+      executeOptions.onCompleted?.(response.data!, clientOptions);
       return response;
     }).catch((error) => {
       if (
@@ -122,8 +122,8 @@ export function useMutation<
       }
 
       if (ref.current.options?.onError || clientOptions.onError) {
-        ref.current.options?.onError?.(error, executeOptions);
-        executeOptions.onError?.(error, executeOptions);
+        ref.current.options?.onError?.(error, clientOptions);
+        executeOptions.onError?.(error, clientOptions);
         // TODO(brian): why are we returning this here???
         return { data: void 0, errors: error };
       }

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -137,8 +137,8 @@ export interface BaseMutationOptions<
 > {
   client?: ApolloClient<object>;
   notifyOnNetworkStatusChange?: boolean;
-  onCompleted?: (data: TData, executeOptions: MutationFunctionOptions) => void;
-  onError?: (error: ApolloError, executeOptions: MutationFunctionOptions) => void;
+  onCompleted?: (data: TData, clientOptions?: BaseMutationOptions) => void;
+  onError?: (error: ApolloError, clientOptions?: BaseMutationOptions) => void;
   ignoreResults?: boolean;
 }
 

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -137,8 +137,8 @@ export interface BaseMutationOptions<
 > {
   client?: ApolloClient<object>;
   notifyOnNetworkStatusChange?: boolean;
-  onCompleted?: (data: TData) => void;
-  onError?: (error: ApolloError) => void;
+  onCompleted?: (data: TData, executeOptions: MutationFunctionOptions) => void;
+  onError?: (error: ApolloError, executeOptions: MutationFunctionOptions) => void;
   ignoreResults?: boolean;
 }
 


### PR DESCRIPTION
Implementation of the changes originally proposed in https://github.com/apollographql/apollo-client/pull/6238, but fit for our current codebase. This PR passes mutation options into the onError and onCompleted hooks. See the previous PR for some discussion on the topic.

Tests have been updated to reflect this feature

### Checklist:

- [X] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [X] Make sure all of the significant new logic is covered by tests
