### PR TITLE
(Release 3.7) Rename useFragment -> useFragment_experimental

### DIFF
--- a/src/__tests__/__snapshots__/exports.ts.snap
+++ b/src/__tests__/__snapshots__/exports.ts.snap
@@ -53,7 +53,7 @@ Array [
   "throwServerError",
   "toPromise",
   "useApolloClient",
-  "useFragment",
+  "useFragment_experimental",
   "useLazyQuery",
   "useMutation",
   "useQuery",
@@ -243,7 +243,7 @@ Array [
   "parser",
   "resetApolloContext",
   "useApolloClient",
-  "useFragment",
+  "useFragment_experimental",
   "useLazyQuery",
   "useMutation",
   "useQuery",
@@ -282,7 +282,7 @@ Array [
 exports[`exports of public entry points @apollo/client/react/hooks 1`] = `
 Array [
   "useApolloClient",
-  "useFragment",
+  "useFragment_experimental",
   "useLazyQuery",
   "useMutation",
   "useQuery",

--- a/src/react/hooks/__tests__/useFragment.test.tsx
+++ b/src/react/hooks/__tests__/useFragment.test.tsx
@@ -4,7 +4,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import userEvent from '@testing-library/user-event';
 import { act } from "react-dom/test-utils";
 
-import { useFragment } from "../useFragment";
+import { useFragment_experimental as useFragment } from "../useFragment";
 import { MockedProvider } from "../../../testing";
 import { ApolloProvider } from "../../context";
 import {

--- a/src/react/hooks/useFragment.ts
+++ b/src/react/hooks/useFragment.ts
@@ -50,7 +50,7 @@ export interface UseFragmentResult<TData> {
   lastCompleteResult?: UseFragmentResult<TData>;
 }
 
-export function useFragment<TData, TVars>(
+export function useFragment_experimental<TData, TVars>(
   options: UseFragmentOptions<TData, TVars>,
 ): UseFragmentResult<TData> {
   const { cache } = useApolloClient();


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->
Per https://github.com/apollographql/apollo-client/issues/10074
We'll use the name `useFragment_experimental` to clarify that the useFragment hook implementation might change after the initial beta release

### Checklist:

- [X] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [X] Make sure all of the significant new logic is covered by tests
