### PR TITLE
adds defer docs

### DIFF
--- a/docs/source/config.json
+++ b/docs/source/config.json
@@ -16,7 +16,7 @@
       "Refetching": "/data/refetching",
       "Subscriptions": "/data/subscriptions",
       "Fragments": "/data/fragments",
-      "@defer support": "/data/defer",
+      "@defer support (preview)": "/data/defer",
       "Error handling": "/data/error-handling",
       "Best practices": "/data/operation-best-practices"
     },

--- a/docs/source/config.json
+++ b/docs/source/config.json
@@ -16,6 +16,7 @@
       "Refetching": "/data/refetching",
       "Subscriptions": "/data/subscriptions",
       "Fragments": "/data/fragments",
+      "@defer support": "/data/defer",
       "Error handling": "/data/error-handling",
       "Best practices": "/data/operation-best-practices"
     },

--- a/docs/source/data/defer.mdx
+++ b/docs/source/data/defer.mdx
@@ -31,7 +31,7 @@ query PersonQuery($personId: ID!) {
 }
 ```
 
-## Code Generation
+## Using with code generation
 
 If you currently use [GraphQL Code Generator](https://www.the-guild.dev/graphql/codegen) for your CodeGen needs, be advised it doesn't yet support the use of the `@defer` directive in the code output.
 

--- a/docs/source/data/defer.mdx
+++ b/docs/source/data/defer.mdx
@@ -3,7 +3,7 @@ title: 'Using the @defer directive in Apollo Client'
 description: Fetch slower schema fields asynchronously
 ---
 
-> ⚠️ **Defer is a [Stage 1 GraphQL specification proposal](https://github.com/graphql/graphql-spec/blob/main/CONTRIBUTING.md#stage-1-proposal).** Before it reaches acceptance, it might still change in backward incompatible ways. If you have feedback on it, please let us know via [GitHub issues](https://github.com/apollographql/apollo-client/issues/new?assignees=&labels=&template=bug.md)
+> ⚠️ **The `@defer` directive is a [Stage 1 GraphQL specification proposal](https://github.com/graphql/graphql-spec/blob/main/CONTRIBUTING.md#stage-1-proposal).** Before it reaches acceptance, it might still change in backward incompatible ways. If you have feedback on it, please let us know via [GitHub issues](https://github.com/apollographql/apollo-client/issues/new?assignees=&labels=&template=bug.md)
 
 Beginning with version REPLACE_ME, Apollo Web Client provides beta support for [the `@defer` directive](https://github.com/graphql/graphql-wg/blob/main/rfcs/DeferStream.md), which enables your queries to receive data for specific fields asynchronously. This is helpful whenever some fields in a query take much longer to resolve than the others.
 

--- a/docs/source/data/defer.mdx
+++ b/docs/source/data/defer.mdx
@@ -5,7 +5,7 @@ description: The @defer directive and Apollo Client
 
 > ⚠️ **Defer is a [Stage 1 GraphQL specification proposal](https://github.com/graphql/graphql-spec/blob/main/CONTRIBUTING.md#stage-1-proposal).** Before it reaches acceptance, it might still change in backward incompatible ways. If you have feedback on it, please let us know via [GitHub issues](https://github.com/apollographql/apollo-client/issues/new?assignees=&labels=&template=bug.md)
 
-Apollo Web Client supports [the `@defer` directive](https://github.com/graphql/graphql-wg/blob/main/rfcs/DeferStream.md), which allows receiving the fields of certain fragments of a query asynchronously.
+Beginning with version REPLACE_ME, Apollo Web Client provides beta support for [the `@defer` directive](https://github.com/graphql/graphql-wg/blob/main/rfcs/DeferStream.md), which enables your queries to receive data for specific fields asynchronously. This is helpful whenever some fields in a query take much longer to resolve than the others.
 
 For instance consider a service where retrieving basic information from a user is fast, but retrieving the user's friends may take more time. In that case it would make sense to display the basic information in the UI as soon as they arrive, and display a loading indicator in the UI while waiting for the friends.
 

--- a/docs/source/data/defer.mdx
+++ b/docs/source/data/defer.mdx
@@ -1,6 +1,6 @@
 ---
-title: '@defer support'
-description: The @defer directive and Apollo Client
+title: 'Using the @defer directive in Apollo Client'
+description: Fetch slower schema fields asynchronously
 ---
 
 > ⚠️ **Defer is a [Stage 1 GraphQL specification proposal](https://github.com/graphql/graphql-spec/blob/main/CONTRIBUTING.md#stage-1-proposal).** Before it reaches acceptance, it might still change in backward incompatible ways. If you have feedback on it, please let us know via [GitHub issues](https://github.com/apollographql/apollo-client/issues/new?assignees=&labels=&template=bug.md)

--- a/docs/source/data/defer.mdx
+++ b/docs/source/data/defer.mdx
@@ -5,7 +5,7 @@ description: Fetch slower schema fields asynchronously
 
 > ⚠️ **The `@defer` directive is a [Stage 2 GraphQL specification proposal](https://github.com/graphql/graphql-spec/blob/main/CONTRIBUTING.md#stage-1-proposal).** Before it reaches acceptance, it might still change in backward incompatible ways. If you have feedback on it, please let us know via [GitHub issues](https://github.com/apollographql/apollo-client/issues/new?assignees=&labels=&template=bug.md)
 
-Beginning with version REPLACE_ME, Apollo Web Client provides beta support for [the `@defer` directive](https://github.com/graphql/graphql-wg/blob/main/rfcs/DeferStream.md), which enables your queries to receive data for specific fields asynchronously. This is helpful whenever some fields in a query take much longer to resolve than the others.
+Beginning with version 3.7, Apollo Web Client provides preview support for [the `@defer` directive](https://github.com/graphql/graphql-wg/blob/main/rfcs/DeferStream.md), which enables your queries to receive data for specific fields asynchronously. This is helpful whenever some fields in a query take much longer to resolve than the others.
 
 For example, let's say we're building a social media application that can quickly fetch a user's basic profile information, but retrieving that user's friends takes longer. If we include _all_ of those fields in a single query, we want to be able to display the profile information as soon as it's available, instead of waiting for the friend fields to resolve.
 

--- a/docs/source/data/defer.mdx
+++ b/docs/source/data/defer.mdx
@@ -33,7 +33,7 @@ query PersonQuery($personId: ID!) {
 
 ## Using with code generation
 
-If you currently use [GraphQL Code Generator](https://www.the-guild.dev/graphql/codegen) for your CodeGen needs, be advised it doesn't yet support the use of the `@defer` directive in the code output.
+If you currently use [GraphQL Code Generator](https://www.the-guild.dev/graphql/codegen) for your codegen needs, note that it doesn't yet support the use of the `@defer` directive in the code output.
 
 You can refer to this [issue](https://github.com/dotansimha/graphql-code-generator/issues/7885) in the Github project for reference.
 

--- a/docs/source/data/defer.mdx
+++ b/docs/source/data/defer.mdx
@@ -9,7 +9,7 @@ Beginning with version REPLACE_ME, Apollo Web Client provides beta support for [
 
 For example, let's say we're building a social media application that can quickly fetch a user's basic profile information, but retrieving that user's friends takes longer. If we include _all_ of those fields in a single query, we want to be able to display the profile information as soon as it's available, instead of waiting for the friend fields to resolve.
 
-Applying the `@defer` directive to the fragment selecting the friends fields indicates that we are ready to receive them later, asynchronously:
+To achieve this, we can apply the `@defer` directive to an in-line fragment that contains all slow-resolving fields related to friend data:
 
 ```graphql
 query PersonQuery($personId: ID!) {

--- a/docs/source/data/defer.mdx
+++ b/docs/source/data/defer.mdx
@@ -1,5 +1,5 @@
 ---
-title: @defer support
+title: '@defer support'
 description: The @defer directive and Apollo Client
 ---
 

--- a/docs/source/data/defer.mdx
+++ b/docs/source/data/defer.mdx
@@ -7,7 +7,7 @@ description: The @defer directive and Apollo Client
 
 Beginning with version REPLACE_ME, Apollo Web Client provides beta support for [the `@defer` directive](https://github.com/graphql/graphql-wg/blob/main/rfcs/DeferStream.md), which enables your queries to receive data for specific fields asynchronously. This is helpful whenever some fields in a query take much longer to resolve than the others.
 
-For instance consider a service where retrieving basic information from a user is fast, but retrieving the user's friends may take more time. In that case it would make sense to display the basic information in the UI as soon as they arrive, and display a loading indicator in the UI while waiting for the friends.
+For example, let's say we're building a social media application that can quickly fetch a user's basic profile information, but retrieving that user's friends takes longer. If we include _all_ of those fields in a single query, we want to be able to display the profile information as soon as it's available, instead of waiting for the friend fields to resolve.
 
 Applying the `@defer` directive to the fragment selecting the friends fields indicates that we are ready to receive them later, asynchronously:
 

--- a/docs/source/data/defer.mdx
+++ b/docs/source/data/defer.mdx
@@ -1,0 +1,39 @@
+---
+title: @defer support
+description: The @defer directive and Apollo Client
+---
+
+> ⚠️ **Defer is a [Stage 1 GraphQL specification proposal](https://github.com/graphql/graphql-spec/blob/main/CONTRIBUTING.md#stage-1-proposal).** Before it reaches acceptance, it might still change in backward incompatible ways. If you have feedback on it, please let us know via [GitHub issues](https://github.com/apollographql/apollo-client/issues/new?assignees=&labels=&template=bug.md)
+
+Apollo Web Client supports [the `@defer` directive](https://github.com/graphql/graphql-wg/blob/main/rfcs/DeferStream.md), which allows receiving the fields of certain fragments of a query asynchronously.
+
+For instance consider a service where retrieving basic information from a user is fast, but retrieving the user's friends may take more time. In that case it would make sense to display the basic information in the UI as soon as they arrive, and display a loading indicator in the UI while waiting for the friends.
+
+Applying the `@defer` directive to the fragment selecting the friends fields indicates that we are ready to receive them later, asynchronously:
+
+```graphql
+query PersonQuery($personId: ID!) {
+  person(id: $personId) {
+    # Basic fields (fast)
+    id
+    firstName
+    lastName
+
+    # Friends (slow)
+    ... on User @defer {
+      friends {
+        id
+      }
+    }
+  }
+}
+```
+
+## Code Generation
+
+If you currently use [GraphQL Code Generator](https://www.the-guild.dev/graphql/codegen) for your CodeGen needs, be advised it doesn't yet support the use of the `@defer` directive in the code output.
+
+You can refer to this[issue](https://github.com/dotansimha/graphql-code-generator/issues/7885) in the Github project for reference.
+
+
+

--- a/docs/source/data/defer.mdx
+++ b/docs/source/data/defer.mdx
@@ -3,7 +3,7 @@ title: 'Using the @defer directive in Apollo Client'
 description: Fetch slower schema fields asynchronously
 ---
 
-> ⚠️ **The `@defer` directive is a [Stage 1 GraphQL specification proposal](https://github.com/graphql/graphql-spec/blob/main/CONTRIBUTING.md#stage-1-proposal).** Before it reaches acceptance, it might still change in backward incompatible ways. If you have feedback on it, please let us know via [GitHub issues](https://github.com/apollographql/apollo-client/issues/new?assignees=&labels=&template=bug.md)
+> ⚠️ **The `@defer` directive is a [Stage 2 GraphQL specification proposal](https://github.com/graphql/graphql-spec/blob/main/CONTRIBUTING.md#stage-1-proposal).** Before it reaches acceptance, it might still change in backward incompatible ways. If you have feedback on it, please let us know via [GitHub issues](https://github.com/apollographql/apollo-client/issues/new?assignees=&labels=&template=bug.md)
 
 Beginning with version REPLACE_ME, Apollo Web Client provides beta support for [the `@defer` directive](https://github.com/graphql/graphql-wg/blob/main/rfcs/DeferStream.md), which enables your queries to receive data for specific fields asynchronously. This is helpful whenever some fields in a query take much longer to resolve than the others.
 

--- a/docs/source/data/defer.mdx
+++ b/docs/source/data/defer.mdx
@@ -33,7 +33,7 @@ query PersonQuery($personId: ID!) {
 
 If you currently use [GraphQL Code Generator](https://www.the-guild.dev/graphql/codegen) for your CodeGen needs, be advised it doesn't yet support the use of the `@defer` directive in the code output.
 
-You can refer to this[issue](https://github.com/dotansimha/graphql-code-generator/issues/7885) in the Github project for reference.
+You can refer to this [issue](https://github.com/dotansimha/graphql-code-generator/issues/7885) in the Github project for reference.
 
 
 

--- a/docs/source/data/defer.mdx
+++ b/docs/source/data/defer.mdx
@@ -35,7 +35,7 @@ query PersonQuery($personId: ID!) {
 
 If you currently use [GraphQL Code Generator](https://www.the-guild.dev/graphql/codegen) for your codegen needs, note that it doesn't yet support the use of the `@defer` directive in the code output.
 
-You can refer to this [issue](https://github.com/dotansimha/graphql-code-generator/issues/7885) in the Github project for reference.
+For reference, refer to [this GitHub issue](https://github.com/dotansimha/graphql-code-generator/issues/7885).
 
 
 

--- a/docs/source/data/defer.mdx
+++ b/docs/source/data/defer.mdx
@@ -19,12 +19,14 @@ query PersonQuery($personId: ID!) {
     firstName
     lastName
 
-    # Friends (slow)
+    # highlight-start
+    # Friend fields (slower)
     ... on User @defer {
       friends {
         id
       }
     }
+    # highlight-end
   }
 }
 ```


### PR DESCRIPTION
This PR adds the initial BETA documentation for the  supporting the `@defer` directive  in Apollo Client 