### PR TITLE
Improvements to the `hasDirectives` utility function

### DIFF
--- a/src/__tests__/__snapshots__/exports.ts.snap
+++ b/src/__tests__/__snapshots__/exports.ts.snap
@@ -376,6 +376,8 @@ Array [
   "getStoreKeyName",
   "getTypenameFromResult",
   "graphQLResultHasError",
+  "hasAllDirectives",
+  "hasAnyDirectives",
   "hasClientExports",
   "hasDirectives",
   "isDocumentNode",

--- a/src/utilities/graphql/__tests__/directives.ts
+++ b/src/utilities/graphql/__tests__/directives.ts
@@ -1,8 +1,13 @@
 import gql from 'graphql-tag';
 import { cloneDeep } from 'lodash';
 
-import { shouldInclude, hasDirectives } from '../directives';
 import { getQueryDefinition } from '../getFromAST';
+import {
+  shouldInclude,
+  hasDirectives,
+  hasAnyDirectives,
+  hasAllDirectives,
+} from '../directives';
 
 describe('hasDirectives', () => {
   it('should allow searching the ast for a directive', () => {
@@ -91,7 +96,7 @@ describe('hasDirectives', () => {
 
   it('works with both any and all semantics', () => {
     expect(
-      hasDirectives(['client', 'defer'], gql`
+      hasAnyDirectives(['client', 'defer'], gql`
         query {
           meetings {
             id
@@ -100,22 +105,22 @@ describe('hasDirectives', () => {
             }
           }
         }
-      `, false) // This false forces the default behavior (any)
+      `)
     ).toBe(true);
 
     expect(
-      hasDirectives(['client', 'defer'], gql`
+      hasAnyDirectives(['client', 'defer'], gql`
         query {
           meetings {
             id
             room { size }
           }
         }
-      `, false) // This false forces the default behavior (any)
+      `)
     ).toBe(false);
 
     expect(
-      hasDirectives(['client', 'defer'], gql`
+      hasAnyDirectives(['client', 'defer'], gql`
         query {
           meetings {
             id
@@ -125,11 +130,11 @@ describe('hasDirectives', () => {
             }
           }
         }
-      `, false) // This false forces the default behavior (any)
+      `)
     ).toBe(true);
 
     expect(
-      hasDirectives(['client', 'defer'], gql`
+      hasAllDirectives(['client', 'defer'], gql`
         query {
           meetings {
             id
@@ -138,22 +143,22 @@ describe('hasDirectives', () => {
             }
           }
         }
-      `, true) // This true requires all directives to be present
+      `)
     ).toBe(false);
 
     expect(
-      hasDirectives(['client', 'defer'], gql`
+      hasAllDirectives(['client', 'defer'], gql`
         query {
           meetings {
             id
             room { size }
           }
         }
-      `, true) // This true requires all directives to be present
+      `)
     ).toBe(false);
 
     expect(
-      hasDirectives(['client', 'defer'], gql`
+      hasAllDirectives(['client', 'defer'], gql`
         query {
           meetings {
             id
@@ -163,11 +168,11 @@ describe('hasDirectives', () => {
             }
           }
         }
-      `, true) // This true requires all directives to be present
+      `)
     ).toBe(false);
 
     expect(
-      hasDirectives(['client', 'defer'], gql`
+      hasAllDirectives(['client', 'defer'], gql`
         query {
           meetings {
             id
@@ -179,11 +184,11 @@ describe('hasDirectives', () => {
             }
           }
         }
-      `, true) // This true requires all directives to be present
+      `)
     ).toBe(true);
 
     expect(
-      hasDirectives(['live', 'client', 'defer'], gql`
+      hasAllDirectives(['live', 'client', 'defer'], gql`
         query {
           meetings {
             id
@@ -195,11 +200,11 @@ describe('hasDirectives', () => {
             }
           }
         }
-      `, true) // This true requires all directives to be present
+      `)
     ).toBe(false);
 
     expect(
-      hasDirectives(['live', 'client', 'defer'], gql`
+      hasAllDirectives(['live', 'client', 'defer'], gql`
         query @live {
           meetings {
             room {
@@ -211,13 +216,13 @@ describe('hasDirectives', () => {
             id
           }
         }
-      `, true) // This true requires all directives to be present
+      `)
     ).toBe(true);
   });
 
   it('works when names are duplicated', () => {
     expect(
-      hasDirectives(['client', 'client', 'client'], gql`
+      hasAnyDirectives(['client', 'client', 'client'], gql`
         query {
           fromClient @client {
             asdf
@@ -228,18 +233,18 @@ describe('hasDirectives', () => {
     ).toBe(true);
 
     expect(
-      hasDirectives(['client', 'client', 'client'], gql`
+      hasAllDirectives(['client', 'client', 'client'], gql`
         query {
           fromClient @client {
             asdf
             foo
           }
         }
-      `, true) // This true requires all directives to be present
+      `)
     ).toBe(true);
 
     expect(
-      hasDirectives(['live', 'live', 'defer'], gql`
+      hasAnyDirectives(['live', 'live', 'defer'], gql`
         query {
           fromClient @client {
             asdf
@@ -250,18 +255,18 @@ describe('hasDirectives', () => {
     ).toBe(false);
 
     expect(
-      hasDirectives(['live', 'live', 'defer'], gql`
+      hasAllDirectives(['live', 'live', 'defer'], gql`
         query {
           fromClient @client {
             asdf
             foo @include(if: true)
           }
         }
-      `, true)
+      `)
     ).toBe(false);
 
     expect(
-      hasDirectives(['live', 'live', 'defer'], gql`
+      hasAllDirectives(['live', 'live', 'defer'], gql`
         query @live {
           fromClient @client {
             ... @defer {
@@ -270,7 +275,7 @@ describe('hasDirectives', () => {
             }
           }
         }
-      `, true)
+      `)
     ).toBe(true);
   });
 });

--- a/src/utilities/graphql/directives.ts
+++ b/src/utilities/graphql/directives.ts
@@ -55,6 +55,16 @@ export function getDirectiveNames(root: ASTNode) {
   return names;
 }
 
+export const hasAnyDirectives = (
+  names: string[],
+  root: ASTNode,
+) => hasDirectives(names, root, false);
+
+export const hasAllDirectives = (
+  names: string[],
+  root: ASTNode,
+) => hasDirectives(names, root, true);
+
 export function hasDirectives(
   names: string[],
   root: ASTNode,

--- a/src/utilities/graphql/directives.ts
+++ b/src/utilities/graphql/directives.ts
@@ -55,22 +55,28 @@ export function getDirectiveNames(root: ASTNode) {
   return names;
 }
 
-export function hasDirectives(names: string[], root: ASTNode) {
+export function hasDirectives(
+  names: string[],
+  root: ASTNode,
+  all?: boolean,
+) {
   const nameSet = new Set(names);
-  const nameCount = nameSet.size;
+  const uniqueCount = nameSet.size;
 
   visit(root, {
     Directive(node) {
-      if (nameSet.delete(node.name.value)) {
-        // We can abandon the traversal early as soon as we encounter any of the
-        // directives in the names array, since hasDirectives returns true when
-        // any (not necessarily all) of the named directives are found.
+      if (
+        nameSet.delete(node.name.value) &&
+        (!all || !nameSet.size)
+      ) {
         return BREAK;
       }
     },
   });
 
-  return nameSet.size < nameCount;
+  // If we found all the names, nameSet will be empty. If we only care about
+  // finding some of them, the < condition is sufficient.
+  return all ? !nameSet.size : nameSet.size < uniqueCount;
 }
 
 export function hasClientExports(document: DocumentNode) {

--- a/src/utilities/graphql/directives.ts
+++ b/src/utilities/graphql/directives.ts
@@ -90,11 +90,7 @@ export function hasDirectives(
 }
 
 export function hasClientExports(document: DocumentNode) {
-  return (
-    document &&
-    hasDirectives(['client'], document) &&
-    hasDirectives(['export'], document)
-  );
+  return document && hasDirectives(['client', 'export'], document, true);
 }
 
 export type InclusionDirectives = Array<{

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -5,6 +5,8 @@ export {
   InclusionDirectives,
   shouldInclude,
   hasDirectives,
+  hasAnyDirectives,
+  hasAllDirectives,
   hasClientExports,
   getDirectiveNames,
   getInclusionDirectives,


### PR DESCRIPTION
The `hasDirectives` utility function is ambiguously named, since it behaves as if it was named `hasAnyDirectives`, even though one could also imagine wanting to check that _all_ the provided directives are present, which calls for a name like `hasAllDirectives`. This PR introduces those two helper functions and adds a bunch of unit tests.

This PR builds on the optimization of `hasDirectives` that I began in #10018 with commit https://github.com/apollographql/apollo-client/pull/10018/commits/6d3ad04126f2da0f032603213be22f643c005cab, though it seemed sufficiently unrelated to that PR to be worth separating out into a second PR.