### PR TITLE
docs: Update the spec verbiage in the @defer docs

### DIFF
--- a/docs/source/data/defer.mdx
+++ b/docs/source/data/defer.mdx
@@ -3,7 +3,7 @@ title: 'Using the @defer directive in Apollo Client'
 description: Fetch slower schema fields asynchronously
 ---
 
-> ⚠️ **The `@defer` directive is a [Stage 2 GraphQL specification proposal](https://github.com/graphql/graphql-spec/blob/main/CONTRIBUTING.md#stage-1-proposal).** Before it reaches acceptance, it might still change in backward incompatible ways. If you have feedback on it, please let us know via [GitHub issues](https://github.com/apollographql/apollo-client/issues/new?assignees=&labels=&template=bug.md)
+> ⚠️ **The `@defer` directive is a [Stage 2 GraphQL specification draft](https://github.com/graphql/graphql-spec/blob/main/CONTRIBUTING.md#stage-2-draft).** Before it reaches acceptance, it might still change in backward incompatible ways. If you have feedback on it, please let us know via [GitHub issues](https://github.com/apollographql/apollo-client/issues/new?assignees=&labels=&template=bug.md)
 
 Beginning with version 3.7, Apollo Web Client provides preview support for [the `@defer` directive](https://github.com/graphql/graphql-wg/blob/main/rfcs/DeferStream.md), which enables your queries to receive data for specific fields asynchronously. This is helpful whenever some fields in a query take much longer to resolve than the others.
 
@@ -36,6 +36,3 @@ query PersonQuery($personId: ID!) {
 If you currently use [GraphQL Code Generator](https://www.the-guild.dev/graphql/codegen) for your codegen needs, note that it doesn't yet support the use of the `@defer` directive in the code output.
 
 For reference, refer to [this GitHub issue](https://github.com/dotansimha/graphql-code-generator/issues/7885).
-
-
-


### PR DESCRIPTION
* Updated the URL to point to the `Stage 2` header
* `s/proposal/draft` - Stage 1 is "proposal" and Stage 2 is "draft"

### Checklist:

- [ ] ~If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)~
- [ ] ~Make sure all of the significant new logic is covered by tests~
