### PR TITLE
Make it clear that @defer is available by installing beta

### DIFF
--- a/docs/source/data/defer.mdx
+++ b/docs/source/data/defer.mdx
@@ -3,7 +3,7 @@ title: 'Using the @defer directive in Apollo Client'
 description: Fetch slower schema fields asynchronously
 ---
 
-> ⚠️ **The `@defer` directive is currently [preview](https://www.apollographql.com/docs/resources/release-stages/#preview) in Apollo Client and enabled for use by default.** If you have feedback on it, please let us know via [GitHub issues](https://github.com/apollographql/apollo-client/issues/new?assignees=&labels=&template=bug.md)
+> ⚠️ **The `@defer` directive is currently at the [preview stage](https://www.apollographql.com/docs/resources/release-stages/#preview) in Apollo Client, and is available by installing `@apollo/client@beta`.** If you have feedback on it, please let us know via [GitHub issues](https://github.com/apollographql/apollo-client/issues/new?assignees=&labels=&template=bug.md)
 
 Beginning with version `3.7.0`, Apollo Web Client provides preview support for [the `@defer` directive](https://github.com/graphql/graphql-wg/blob/main/rfcs/DeferStream.md), which enables your queries to receive data for specific fields asynchronously. This is helpful whenever some fields in a query take much longer to resolve than the others.
 


### PR DESCRIPTION
Right now our defer docs say the functionality is enabled by default. This isn't accurate as `@defer` functionality is currently only available by installing `@apollo/client@beta`. This commit makes this more clear in the docs.