### PR TITLE
Bump up timeout time for batchLink, query and polling tests

### DIFF
--- a/src/link/batch/__tests__/batchLink.ts
+++ b/src/link/batch/__tests__/batchLink.ts
@@ -806,7 +806,8 @@ describe('BatchLink', () => {
   });
 
   itAsync('correctly follows batch interval', (resolve, reject) => {
-    const intervals = [10, 20, 30];
+    const TIME_SCALE = 100;
+    const intervals = [1*TIME_SCALE, 2*TIME_SCALE, 3*TIME_SCALE];
 
     const runBatchInterval = () => {
       const mock = jest.fn();
@@ -867,9 +868,9 @@ describe('BatchLink', () => {
         }
 
         runBatchInterval();
-      }, batchInterval + 5);
+      }, batchInterval + (.5*TIME_SCALE));
 
-      setTimeout(() => mock(batchHandler.mock.calls.length), batchInterval - 5);
+      setTimeout(() => mock(batchHandler.mock.calls.length), batchInterval - (.5*TIME_SCALE));
       setTimeout(() => mock(batchHandler.mock.calls.length), batchInterval / 2);
     };
     runBatchInterval();

--- a/src/react/hoc/__tests__/queries/index.test.tsx
+++ b/src/react/hoc/__tests__/queries/index.test.tsx
@@ -70,6 +70,7 @@ describe('queries', () => {
   });
 
   itAsync('includes the variables in the props', (resolve, reject) => {
+    const TIME_SCALE = 5000;
     let renderCount = 0;
     const query: DocumentNode = gql`
       query people($first: Int) {
@@ -122,7 +123,7 @@ describe('queries', () => {
 
     waitFor(() => {
       expect(renderCount).toBe(2);
-    }).then(resolve, reject);
+    }, {timeout: TIME_SCALE}).then(resolve, reject);
   });
 
   itAsync('should update query variables when props change', (resolve, reject) => {

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -1366,6 +1366,7 @@ describe('useQuery Hook', () => {
   });
 
   describe('polling', () => {
+    const TIME_SCALE = 10;
     it('should support polling', async () => {
       const query = gql`{ hello }`;
       const mocks = [
@@ -1437,7 +1438,7 @@ describe('useQuery Hook', () => {
 
       const cache = new InMemoryCache();
       const { result, rerender, waitForNextUpdate } = renderHook(
-        ({ skip }) => useQuery(query, { pollInterval: 10, skip }),
+        ({ skip }) => useQuery(query, { pollInterval: 10*TIME_SCALE, skip }),
         {
           wrapper: ({ children }) => (
             <MockedProvider mocks={mocks} cache={cache}>
@@ -1460,7 +1461,7 @@ describe('useQuery Hook', () => {
       expect(result.current.loading).toBe(false);
       expect(result.current.data).toBe(undefined);
 
-      await expect(waitForNextUpdate({ timeout: 20 })).rejects.toThrow('Timed out');
+      await expect(waitForNextUpdate({ timeout: 20*TIME_SCALE })).rejects.toThrow('Timed out');
 
       rerender({ skip: false });
       expect(result.current.loading).toBe(false);
@@ -1542,7 +1543,7 @@ describe('useQuery Hook', () => {
       );
 
       const { result, waitForNextUpdate, unmount } = renderHook(
-        () => useQuery(query, { pollInterval: 10 }),
+        () => useQuery(query, { pollInterval: 10*TIME_SCALE }),
         { wrapper },
       );
 
@@ -1554,7 +1555,7 @@ describe('useQuery Hook', () => {
       expect(result.current.data).toEqual({ hello: "world 1" });
 
       unmount();
-      await expect(waitForNextUpdate({ timeout: 20 })).rejects.toThrow('Timed out');
+      await expect(waitForNextUpdate({ timeout: 20*TIME_SCALE })).rejects.toThrow('Timed out');
       expect(requestSpy).toHaveBeenCalledTimes(1);
       expect(onErrorFn).toHaveBeenCalledTimes(0);
     });
@@ -1591,7 +1592,7 @@ describe('useQuery Hook', () => {
       );
 
       const { result, waitForNextUpdate, unmount } = renderHook(
-        () => useQuery(query, { pollInterval: 10 }),
+        () => useQuery(query, { pollInterval: 10*TIME_SCALE }),
         { wrapper },
       );
 
@@ -1604,7 +1605,7 @@ describe('useQuery Hook', () => {
 
       unmount();
 
-      await expect(waitForNextUpdate({ timeout: 20 })).rejects.toThrow('Timed out');
+      await expect(waitForNextUpdate({ timeout: 50*TIME_SCALE })).rejects.toThrow('Timed out');
       expect(requestSpy).toHaveBeenCalledTimes(1);
       expect(onErrorFn).toHaveBeenCalledTimes(0);
     });


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->
I've been noticing some test failures with these tests in particular every so often, and it's looking like they're often just being re-ran until they pass. 

The failing tests all rely on timeouts in some way, and manually lowering the timeout duration produces errors consistent with what I've been seeing. As such, I thought I'd bump up the timeouts a little so these tests pass more reliably, while still allowing unreasonably long runs to fail. 


### Checklist:

- [ ] ~~If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)~~
- [X] Make sure all of the significant new logic is covered by tests
