### PR TITLE
chore(docs): add useFragment_experimental documentation

### DIFF
--- a/docs/shared/useFragment-options.mdx
+++ b/docs/shared/useFragment-options.mdx
@@ -1,0 +1,137 @@
+<table class="field-table api-ref">
+
+<thead>
+    <tr>
+      <th>Name /<br/>Type</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+
+<tbody>
+
+<tr>
+<td colspan="2">
+
+**Operation options**
+
+</td>
+</tr>
+
+<tr class="required">
+<td>
+
+###### `from`
+
+`string | StoreObject | Reference`
+</td>
+
+<td>
+
+**Required.** An object containing a `__typename` and primary key fields (such as `id`) identifying the entity object from which the fragment will be retrieved, or a `{ __ref: "..." }` reference, or a `string` ID (uncommon).
+
+</td>
+</tr>
+
+<tr class="required">
+<td>
+
+###### `fragment`
+
+`DocumentNode`
+</td>
+
+<td>
+
+**Required.** A GraphQL fragment document parsed into an AST with the `gql` template literal.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+###### `fragmentName`
+
+`string`
+</td>
+
+<td>
+
+The name of the fragment defined in the [`fragment`](#fragment) document to use in the call.
+
+**Required** if the `fragment` document includes more than one fragment, optional otherwise.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+###### `optimistic`
+
+`boolean`
+</td>
+
+<td>
+
+If `true`, `readFragment` returns optimistic results.
+
+The default value is `true`.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+###### `variables`
+
+`{ [key: string]: any }`
+</td>
+
+<td>
+
+An object containing all of the GraphQL variables your fragment requires.
+
+Each key in the object corresponds to a variable name, and that key's value corresponds to the variable value.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+###### `returnPartialData`
+
+`boolean`
+</td>
+
+<td>
+
+If `true`, the query can return _partial_ results from the cache if the cache doesn't contain results for _all_ queried fields.
+
+The default value is `true`.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+###### `canonizeResults`
+
+`boolean`
+</td>
+
+<td>
+
+If `true`, result objects read from the cache will be _canonized_, which means deeply-equal objects will also be `===` (literally the same object), allowing much more efficient comparison of past/present results.
+
+The default value is `false`.
+
+</td>
+</tr>
+
+</tbody>
+
+</table>

--- a/docs/shared/useFragment-result.mdx
+++ b/docs/shared/useFragment-result.mdx
@@ -1,0 +1,69 @@
+<table class="field-table api-ref">
+
+<thead>
+    <tr>
+      <th>Name /<br/>Type</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+
+<tbody>
+
+<tr>
+<td colspan="2">
+
+**Operation result**
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+###### `data`
+
+`TData`
+</td>
+
+<td>
+
+An object containing the data for a given GraphQL fragment.
+
+This value might be `undefined` if a query results in one or more errors (depending on the query's `errorPolicy`).
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+###### `complete`
+
+`boolean`
+</td>
+
+<td>
+
+A boolean indicating whether the data returned for the fragment is complete. When `false`, the `missing` field should explain which fields were responsible for the incompleteness.
+
+</td>
+</tr>
+
+
+<tr>
+<td>
+
+###### `missing`
+
+`MissingTree`
+</td>
+
+<td>
+
+A tree of all `MissingFieldError` messages reported during fragment reading, where the branches of the tree indicate the paths of the errors within the query result.
+
+</td>
+</tr>
+
+</tbody>
+</table>

--- a/docs/source/api/react/hooks-experimental.mdx
+++ b/docs/source/api/react/hooks-experimental.mdx
@@ -1,0 +1,83 @@
+---
+title: Hooks (experimental)
+description: Apollo Client experimental react hooks API reference
+---
+
+import UseFragmentOptions from '../../../shared/useFragment-options.mdx';
+import UseFragmentResult from '../../../shared/useFragment-result.mdx';
+
+## `useFragment_experimental`
+
+### Installation
+
+> ⚠️ **The `useFragment_experimental` hook is currently at the [preview stage](https://www.apollographql.com/docs/resources/release-stages/#preview) in Apollo Client and is available by installing `@apollo/client@beta`.** If you have feedback on it, please let us know via [GitHub issues](https://github.com/apollographql/apollo-client/issues/new?assignees=&labels=&template=bug.md).
+
+Beginning with version `3.7.0`, Apollo Client Web has preview support for the `useFragment_experimental` hook, which represents a lightweight live binding into the Apollo Client Cache. This hook returns an always-up-to-date view of whatever data the cache currently contains for a given fragment. `useFragment_experimental` never triggers network requests of its own.
+
+`useFragment_experimental` enables Apollo Client to broadcast very specific fragment results to individual components. Note that the `useQuery` hook remains the primary hook responsible for querying and populating data in the cache ([see the API reference](./hooks#usequery)). As a result, the component reading the fragment data via `useFragment_experimental` is still subscribed to all changes in the query data, but receives updates only when that fragment's specific data change.
+
+### Using `useFragment_experimental`
+
+> A [GraphQL fragment](http://graphql.org/learn/queries/#fragments) is a piece of logic that can be shared between multiple queries and mutations. [See the API reference.](../../data/fragments)
+
+Given the following fragment definition:
+
+```js
+const ItemFragment = gql`
+  fragment ItemFragment on Item {
+    text
+  }
+`;
+```
+
+We can first use the `useQuery` hook to retrieve a list of items with `id`s.
+
+```jsx
+const listQuery = gql`
+  query {
+    list {
+      id
+    }
+  }
+`;
+function List() {
+  const { loading, data } = useQuery(listQuery);
+  return (
+    <ol>
+      {data!.list.map(item => <Item key={item.id} id={item.id}/>)}
+    </ol>
+  );
+}
+```
+
+We can then use `useFragment_experimental` from within the `<Item>` component to create a live binding for each item by providing the `fragment` document, `fragmentName` and object reference via `from`.
+
+```jsx
+function Item(props: { id: number }) {
+  const { complete, data } = useFragment_experimental({
+    fragment: ItemFragment,
+    fragmentName: "ItemFragment",
+    from: {
+      __typename: "Item",
+      id: props.id,
+    },
+  });
+  return <li>{complete ? data!.text : "incomplete"}</li>;
+}
+```
+
+### `useFragment_experimental` API
+
+Supported options and result fields for the `useFragment_experimental` hook are listed below.
+
+Most calls to `useFragment_experimental` can omit the majority of these options, but it's useful to know they exist.
+
+#### Options
+
+The `useFragment_experimental` hook accepts the following options:
+
+<UseFragmentOptions />
+
+#### Result
+
+<UseFragmentResult />

--- a/docs/source/caching/cache-interaction.mdx
+++ b/docs/source/caching/cache-interaction.mdx
@@ -9,7 +9,7 @@ Apollo Client supports multiple strategies for interacting with cached data:
 | Strategy | API | Description |
 |----------|-----|-------------|
 | [Using GraphQL queries](#using-graphql-queries) | `readQuery` / `writeQuery` / `updateQuery` | Use standard GraphQL queries for managing both remote and local data. |
-| [Using GraphQL fragments](#using-graphql-fragments) | `readFragment` / `writeFragment` / `updateFragment` | Access the fields of any cached object without composing an entire query to reach that object.  |
+| [Using GraphQL fragments](#using-graphql-fragments) | `readFragment` / `writeFragment` / `updateFragment` / `useFragment_experimental` | Access the fields of any cached object without composing an entire query to reach that object.  |
 | [Directly modifying cached fields](#using-cachemodify) | `cache.modify` | Manipulate cached data without using GraphQL at all. |
 
  You can use whichever combination of strategies and methods are most helpful for your use case.
@@ -263,6 +263,12 @@ If the update function shouldn't make _any_ changes to the cached data, it can r
 The update function's return value is passed to either `writeQuery` or `writeFragment`, which modifies the cached data.
 
 > See the full API reference for [`cache.updateQuery`](../api/cache/InMemoryCache/#updatequery) and [`cache.updateFragment`](../api/cache/InMemoryCache/#updatefragment).
+
+### `useFragment_experimental`
+
+> ⚠️ **The `useFragment_experimental` hook is currently at the [preview stage](https://www.apollographql.com/docs/resources/release-stages/#preview) in Apollo Client and is available by installing `@apollo/client@beta`.** If you have feedback on it, please let us know via [GitHub issues](https://github.com/apollographql/apollo-client/issues/new?assignees=&labels=&template=bug.md).
+
+You can read data for a given fragment directly from the cache using the `useFragment_experimental` hook. This hook returns an always-up-to-date view of whatever data the cache currently contains for a given fragment. [See the API reference.](../api/react/hooks-experimental)
 
 ## Using `cache.modify`
 

--- a/docs/source/config.json
+++ b/docs/source/config.json
@@ -75,6 +75,7 @@
     },
     "API - React": {
       "Hooks": "/api/react/hooks",
+      "Hooks (experimental)": "/api/react/hooks-experimental",
       "Testing": "/api/react/testing",
       "SSR": "/api/react/ssr",
       "Components (deprecated)": "/api/react/components",

--- a/docs/source/data/defer.mdx
+++ b/docs/source/data/defer.mdx
@@ -3,9 +3,9 @@ title: 'Using the @defer directive in Apollo Client'
 description: Fetch slower schema fields asynchronously
 ---
 
-> ⚠️ **The `@defer` directive is currently at the [preview stage](https://www.apollographql.com/docs/resources/release-stages/#preview) in Apollo Client, and is available by installing `@apollo/client@beta`.** If you have feedback on it, please let us know via [GitHub issues](https://github.com/apollographql/apollo-client/issues/new?assignees=&labels=&template=bug.md)
+> ⚠️ **The `@defer` directive is currently at the [preview stage](https://www.apollographql.com/docs/resources/release-stages/#preview) in Apollo Client, and is available by installing `@apollo/client@beta`.** If you have feedback on it, please let us know via [GitHub issues](https://github.com/apollographql/apollo-client/issues/new?assignees=&labels=&template=bug.md).
 
-Beginning with version `3.7.0`, Apollo Web Client provides preview support for [the `@defer` directive](https://github.com/graphql/graphql-wg/blob/main/rfcs/DeferStream.md), which enables your queries to receive data for specific fields asynchronously. This is helpful whenever some fields in a query take much longer to resolve than the others.
+Beginning with version `3.7.0`, Apollo Client Web provides preview support for [the `@defer` directive](https://github.com/graphql/graphql-wg/blob/main/rfcs/DeferStream.md), which enables your queries to receive data for specific fields asynchronously. This is helpful whenever some fields in a query take much longer to resolve than the others.
 
 For example, let's say we're building a social media application that can quickly fetch a user's basic profile information, but retrieving that user's friends takes longer. If we include _all_ of those fields in a single query, we want to be able to display the profile information as soon as it's available, instead of waiting for the friend fields to resolve.
 

--- a/docs/source/data/fragments.md
+++ b/docs/source/data/fragments.md
@@ -270,3 +270,7 @@ const cache = new InMemoryCache({
   possibleTypes,
 });
 ```
+
+## `useFragment_experimental`
+
+> ⚠️ **The `useFragment_experimental` hook is currently at the [preview stage](https://www.apollographql.com/docs/resources/release-stages/#preview) in Apollo Client and is available by installing `@apollo/client@beta`.** [See the API reference for more details.](../api/react/hooks-experimental)


### PR DESCRIPTION
Closes #10056. Adds `useFragment_experimental` documentation.

<img width="961" alt="CleanShot 2022-09-13 at 11 05 24@2x" src="https://user-images.githubusercontent.com/5139846/189937648-c0f0fedc-8d8b-4623-8657-e9b0884b3b39.png">

This PR:
- adds a [Hooks (experimental) page](https://deploy-preview-10099--apollo-client-docs.netlify.app/api/react/hooks-experimental) to the docs which documents AC web's first experimental hook, `useFragment_experimental`
- adds a section to the bottom of the [fragments page](https://deploy-preview-10099--apollo-client-docs.netlify.app/data/fragments/#usefragment_experimental)
- mention `useFragment_experimental` in the table at the top of the [cache interaction page](https://deploy-preview-10099--apollo-client-docs.netlify.app/caching/cache-interaction) and [section](https://deploy-preview-10099--apollo-client-docs.netlify.app/caching/cache-interaction#usefragment_experimental) that points people to the API reference for the hook

To do:
- [x] update types for options/result after discussing with @benjamn - PR https://github.com/apollographql/apollo-client/pull/10100
- [x] add section on `useFragment_experimental` to [cache-interaction](https://www.apollographql.com/docs/react/caching/cache-interaction) page

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
