### PR TITLE
chore: omit previousResult, lastCompleteResult from options/result

### DIFF
--- a/src/react/hooks/useFragment.ts
+++ b/src/react/hooks/useFragment.ts
@@ -18,6 +18,7 @@ extends Omit<
   | "id"
   | "query"
   | "optimistic"
+  | "previousResult"
 >, Omit<
   Cache.ReadFragmentOptions<TData, TVars>,
   | "id"
@@ -37,7 +38,6 @@ extends Omit<
 //   fragmentName?: string;
 //   optimistic?: boolean;
 //   variables?: TVars;
-//   previousResult?: any;
 //   returnPartialData?: boolean;
 //   canonizeResults?: boolean;
 // }
@@ -46,8 +46,6 @@ export interface UseFragmentResult<TData> {
   data: TData | undefined;
   complete: boolean;
   missing?: MissingTree;
-  previousResult?: UseFragmentResult<TData>;
-  lastCompleteResult?: UseFragmentResult<TData>;
 }
 
 export function useFragment_experimental<TData, TVars>(


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

After discussing with @benjamn today, it was determined `previousResult` can be omitted from `UseFragmentOptions`.

In documenting `UseFragmentResult` in PR https://github.com/apollographql/apollo-client/pull/10099, it seems we may be able to omit `previousResult` and `lastCompleteResult` from the result type as well. I've done some logging in our tests and don't see where they're used, but happy to add them back if they are.

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
