### PR TITLE
chore(docs): use optional chaining rather than non-null assertion

### DIFF
--- a/docs/source/api/react/hooks-experimental.mdx
+++ b/docs/source/api/react/hooks-experimental.mdx
@@ -44,7 +44,7 @@ function List() {
   const { loading, data } = useQuery(listQuery);
   return (
     <ol>
-      {data!.list.map(item => <Item key={item.id} id={item.id}/>)}
+      {data?.list.map(item => <Item key={item.id} id={item.id}/>)}
     </ol>
   );
 }


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

While reading through the excellent documentation of [`useFragment_experimental`](https://www.apollographql.com/docs/react/api/react/hooks-experimental/#usefragment_experimental), I noticed that the example using `useQuery` uses the [non-null assertion operator](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-0.html#non-null-assertion-operator) as a way to assert that `data` can't be null in this context, which is unfortunately not the case.

I think this usage could be confusing as the code snippet mentioned JavaScript, but that operator won't have any effects outside of TypeScript as the operator is simply removed in the emitted JavaScript code. Even with TypeScript, if someone copy-paste that example, it could lead to a runtime error are we're telling the compiler that `data` is a known non-null value, but we never asserted it was the case. If we omit it, then TypeScript will show the following error: `Cannot read properties of undefined (reading 'list')`, but since we're using the non-null assertion operator, we're just muting the error, which is leading to a runtime error.

I think it could make sense to use the non-null assertion operator combined with `strictNullChecks`, but only if we're making sure to assert it before! E.g.:

```tsx
if (loading) {
  return;
}

return (
  {data!.list.map(item => <Item key={item.id} id={item.id}/>)}
  {/* ^ We previously asserted that `loading` couldn't be true here, therefore, `data` must be defined. */}
);
```

The current code sample is failing with a runtime error with both JavaScript and TypeScript, and to remove some confusion for readers that could be wondering why they need the [non-null assertion operator (post-fix `!`)](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-0.html#non-null-assertion-operator), I would suggest we simplify this by using the [optional chaining operator (`?.`)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) instead.

cc @alessbell 

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
