### PR TITLE
[Docs] Add graphql-anywhere to peerDependency list

### DIFF
--- a/docs/source/api/link/apollo-link-rest.md
+++ b/docs/source/api/link/apollo-link-rest.md
@@ -21,7 +21,7 @@ With `apollo-link-rest`, you can call your endpoints inside your GraphQL queries
 To get started, first install Apollo Client and any `peerDependencies` we need:
 
 ```bash
-npm install --save @apollo/client apollo-link-rest graphql qs
+npm install --save @apollo/client apollo-link-rest  graphql graphql-anywhere qs
 ```
 
 After this, you're ready to setup the Apollo Client instance:


### PR DESCRIPTION
Added `graphql-anywhere` to `peerDependency` list.

An error occurs if this library isn't installed.