### PR TITLE
Update apollo-link-rest.md - Add graphql-anywhere to install list

### DIFF
--- a/docs/source/api/link/apollo-link-rest.md
+++ b/docs/source/api/link/apollo-link-rest.md
@@ -23,7 +23,7 @@ With `apollo-link-rest`, you can call your endpoints inside your GraphQL queries
 To get started, first install Apollo Client and any `peerDependencies` we need:
 
 ```bash
-npm install --save @apollo/client apollo-link-rest graphql qs
+npm install --save @apollo/client apollo-link-rest graphql graphql-anywhere qs
 ```
 
 After this, you're ready to setup the Apollo Client instance:


### PR DESCRIPTION
Added `graphql-anywhere` to the install string. `apollo-link-rest` does not work without this library installed.

Somewhat related:
https://github.com/apollographql/apollo-link-rest/issues/295