### PR TITLE
chore(tests): use node v16.10.0 for jest tests due to memory leaks in 16.11+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
 
   Tests:
     docker:
-      - image: circleci/node:16.13.1
+      - image: circleci/node:16.10.0
     steps:
       - checkout
       - run: npm run ci:precheck


### PR DESCRIPTION
While investigating flaky tests in this repo, I came across this issue: https://github.com/facebook/jest/issues/11956

We're currently running our tests on CircleCI with the image `circleci/node:16.13.1`. Local testing showed that the heap size nearly doubled when running with Node v16.13 vs. v16.10. 

While we investigate the root cause and longer-term fixes, this PR runs our Jest tests with v16.10, which should decrease memory consumption on CI and provide an admittedly band-aid solution to some of the flakiness we've seen lately.

![CleanShot 2022-09-22 at 17 00 56](https://user-images.githubusercontent.com/5139846/192831739-444cd676-c7b9-400c-953b-07bdfefbc289.png)
![CleanShot 2022-09-22 at 17 01 02](https://user-images.githubusercontent.com/5139846/192831737-4644cdbc-c24e-42e6-9fa8-f35f7adca015.png)


### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
