### PR TITLE
Exclude "cursor" argument to prevent separate cache instance

### DIFF
--- a/docs/source/pagination/cursor-based.mdx
+++ b/docs/source/pagination/cursor-based.mdx
@@ -173,6 +173,7 @@ const cache = new InMemoryCache({
     Query: {
       fields: {
         moreComments: {
+          keyArgs: false,
           merge(existing, incoming, { readField }) {
             const comments = existing ? { ...existing.comments } : {};
             incoming.comments.forEach(comment => {


### PR DESCRIPTION
keyArgs must be set to false to properly merge multiple requests in cache when paging because "cursor" is passed in as a query variable (even though it isn't referenced in the merge function)

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
