### PR TITLE
Experiment with not caching the `~/.npm` directory during Filesize/Tests CircleCI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,22 +7,8 @@ jobs:
     steps:
       - checkout
       - run: npm run ci:precheck
-      # - restore_cache:
-      #     keys:
-      #       # When lock file changes, use increasingly general patterns to
-      #       # restore cache
-      #       - npm-v3-{{ .Branch }}-{{ checksum "package-lock.json" }}
-      #       - npm-v3-{{ .Branch }}-
-      #       - npm-v3-
       - run: npm version
       - run: npm ci
-      # - save_cache:
-      #     key: npm-v3-{{ .Branch }}-{{ checksum "package-lock.json" }}
-      #     paths:
-      #       # This should cache the npm cache instead of node_modules, which is
-      #       # needed because npm ci actually removes node_modules before
-      #       # installing to guarantee a clean slate.
-      #       - ~/.npm
       - run: npm run bundlesize
 
   Tests:
@@ -31,22 +17,8 @@ jobs:
     steps:
       - checkout
       - run: npm run ci:precheck
-      # - restore_cache:
-      #     keys:
-      #       # When lock file changes, use increasingly general patterns to
-      #       # restore cache
-      #       - npm-v3-{{ .Branch }}-{{ checksum "package-lock.json" }}
-      #       - npm-v3-{{ .Branch }}-
-      #       - npm-v3-
       - run: npm version
       - run: npm ci
-      # - save_cache:
-      #     key: npm-v3-{{ .Branch }}-{{ checksum "package-lock.json" }}
-      #     paths:
-      #       # This should cache the npm cache instead of node_modules, which is
-      #       # needed because npm ci actually removes node_modules before
-      #       # installing to guarantee a clean slate.
-      #       - ~/.npm
       - run:
           name: Jest suite with coverage
           command: npm run test:ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,22 +31,22 @@ jobs:
     steps:
       - checkout
       - run: npm run ci:precheck
-      - restore_cache:
-          keys:
-            # When lock file changes, use increasingly general patterns to
-            # restore cache
-            - npm-v3-{{ .Branch }}-{{ checksum "package-lock.json" }}
-            - npm-v3-{{ .Branch }}-
-            - npm-v3-
+      # - restore_cache:
+      #     keys:
+      #       # When lock file changes, use increasingly general patterns to
+      #       # restore cache
+      #       - npm-v3-{{ .Branch }}-{{ checksum "package-lock.json" }}
+      #       - npm-v3-{{ .Branch }}-
+      #       - npm-v3-
       - run: npm version
       - run: npm ci
-      - save_cache:
-          key: npm-v3-{{ .Branch }}-{{ checksum "package-lock.json" }}
-          paths:
-            # This should cache the npm cache instead of node_modules, which is
-            # needed because npm ci actually removes node_modules before
-            # installing to guarantee a clean slate.
-            - ~/.npm
+      # - save_cache:
+      #     key: npm-v3-{{ .Branch }}-{{ checksum "package-lock.json" }}
+      #     paths:
+      #       # This should cache the npm cache instead of node_modules, which is
+      #       # needed because npm ci actually removes node_modules before
+      #       # installing to guarantee a clean slate.
+      #       - ~/.npm
       - run:
           name: Jest suite with coverage
           command: npm run test:ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,22 +7,22 @@ jobs:
     steps:
       - checkout
       - run: npm run ci:precheck
-      - restore_cache:
-          keys:
-            # When lock file changes, use increasingly general patterns to
-            # restore cache
-            - npm-v3-{{ .Branch }}-{{ checksum "package-lock.json" }}
-            - npm-v3-{{ .Branch }}-
-            - npm-v3-
+      # - restore_cache:
+      #     keys:
+      #       # When lock file changes, use increasingly general patterns to
+      #       # restore cache
+      #       - npm-v3-{{ .Branch }}-{{ checksum "package-lock.json" }}
+      #       - npm-v3-{{ .Branch }}-
+      #       - npm-v3-
       - run: npm version
       - run: npm ci
-      - save_cache:
-          key: npm-v3-{{ .Branch }}-{{ checksum "package-lock.json" }}
-          paths:
-            # This should cache the npm cache instead of node_modules, which is
-            # needed because npm ci actually removes node_modules before
-            # installing to guarantee a clean slate.
-            - ~/.npm
+      # - save_cache:
+      #     key: npm-v3-{{ .Branch }}-{{ checksum "package-lock.json" }}
+      #     paths:
+      #       # This should cache the npm cache instead of node_modules, which is
+      #       # needed because npm ci actually removes node_modules before
+      #       # installing to guarantee a clean slate.
+      #       - ~/.npm
       - run: npm run bundlesize
 
   Tests:


### PR DESCRIPTION
Looking at [a recent job](https://app.circleci.com/pipelines/github/apollographql/apollo-client/17326/workflows/4db5bc1c-718e-4f0b-b6ec-7089b9aa8b55/jobs/94670), restoring and later saving the cached `~/.npm` directory takes 13 and 14 seconds, respectively. This job took a total of 1 minute 11 seconds, so restoring/saving the (large) `~/.npm` directory accounts for ~38% of the total time.

If removing the caching altogether does not slow anything else down by that much (~27 total seconds), then the caching was not really delivering on its intended goals, and should be removed.

[New results](https://app.circleci.com/pipelines/github/apollographql/apollo-client/17327/workflows/0c21e96a-736e-48f2-b2a9-55dea5405342/jobs/94672) after running CI on this commit/PR. Now only 1 minute 1 second (noticeably less time without any caching)!

Notes:

* The "Spin up environment" step went from taking 2s to 19s, because the circleci/node@16.13.1 Docker image needed to be re-pulled. This seems like something that could be addressed separately, if we care.

* The `npm ci` step takes a little longer, 9s instead of 4s, but that's presumably because everything has to be installed without a cache. Still, this is much faster than restoring `~/.npm` from cache.

* By itself, this PR does not (yet) speed up the finishing time of CI checks, since running the tests (the other CI job) always takes longer than running the Filesize job does now (or did before).