### PR TITLE
Update Local Resolvers docs

### DIFF
--- a/docs/source/local-state/local-resolvers.mdx
+++ b/docs/source/local-state/local-resolvers.mdx
@@ -3,9 +3,9 @@ title: Local resolvers (deprecated)
 description: Manage local data with GraphQL like resolvers
 ---
 
-> ⚠️ **DEPRECATION WARNING:** Local resolvers are still available in Apollo Client 3, but they are deprecated. We recommend using field policies instead, as described in [Local-only fields](./managing-state-with-field-policies/).
+> 📄 **NOTE:** We recommend using field policies instead of local resolvers as described in [Local-only fields](./managing-state-with-field-policies/).
 >
-> Local resolver support will be removed from the core of Apollo Client in a future major release, but in a future major release it will be possible to achieve the functionality of local resolvers using an `ApolloLink`, as described in [this issue](https://github.com/apollographql/apollo-client/issues/10060).
+> Local resolver support will be moved out of the core of Apollo Client in a future major release. The same or similar functionality will be available via `ApolloLink`, as described in [this issue](https://github.com/apollographql/apollo-client/issues/10060).
 
 We've learned how to manage remote data from our GraphQL server with Apollo Client, but what should we do with our local data? We want to be able to access boolean flags and device API results from multiple components in our app, but don't want to maintain a separate Redux or MobX store. Ideally, we would like the Apollo cache to be the single source of truth for all data in our client application.
 


### PR DESCRIPTION
Fixes #10210

* Remove deprecation verbiage
* Retain local-only fields recommendation
* Wordsmith explanation of future plans

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
