### PR TITLE
Revert cloneDeep-ing request headers

### DIFF
--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -26,7 +26,6 @@ import {
   makeUniqueId,
   isDocumentNode,
   isNonNullObject,
-  cloneDeep,
 } from '../utilities';
 import { ApolloError, isApolloError } from '../errors';
 import {
@@ -1037,10 +1036,6 @@ export class QueryManager<TStore> {
       | "errorPolicy">,
   ): Observable<ApolloQueryResult<TData>> {
     const requestId = queryInfo.lastRequestId = this.generateRequestId();
-
-    // Make sure we write the result below using the same options we were given,
-    // even though the input object may have been modified in the meantime.
-    options = cloneDeep(options);
 
     // Performing transformForLink here gives this.cache a chance to fill in
     // missing fragment definitions (for example) before sending this document

--- a/src/utilities/common/cloneDeep.ts
+++ b/src/utilities/common/cloneDeep.ts
@@ -27,12 +27,12 @@ function cloneDeepHelper<T>(val: T, seen?: Map<any, any>): T {
     // possible in all JS environments, so we will assume they exist/work.
     const copy = Object.create(Object.getPrototypeOf(val));
     seen.set(val, copy);
-    Object.keys(val).forEach(key => {
+    Object.keys(val).concat(Object.getOwnPropertySymbols(val) as any).forEach(key => {
       copy[key] = cloneDeepHelper((val as any)[key], seen);
     });
     return copy;
   }
-
+  
   default:
     return val;
   }

--- a/src/utilities/common/cloneDeep.ts
+++ b/src/utilities/common/cloneDeep.ts
@@ -27,12 +27,12 @@ function cloneDeepHelper<T>(val: T, seen?: Map<any, any>): T {
     // possible in all JS environments, so we will assume they exist/work.
     const copy = Object.create(Object.getPrototypeOf(val));
     seen.set(val, copy);
-    Object.keys(val).concat(Object.getOwnPropertySymbols(val) as any).forEach(key => {
+    Object.keys(val).forEach(key => {
       copy[key] = cloneDeepHelper((val as any)[key], seen);
     });
     return copy;
   }
-  
+
   default:
     return val;
   }


### PR DESCRIPTION
Fixes https://github.com/apollographql/apollo-client/issues/10202
Fixes https://github.com/apollographql/apollo-client/issues/10166
(Potentially) Fixes https://github.com/apollographql/apollo-client/issues/10132

Release `3.7-alpha.4` implemented `cloneDeep` ([commit](https://github.com/apollographql/apollo-client/commit/b4ffcb60d7302d6297e084c0d99536c890475df1)) to clone options (including `options.context.headers`!) when fetching queries, however it didn't support JS Symbols - meaning the serverRequest (an [IncomingMessage](https://nodejs.org/api/http.html#class-httpincomingmessage)) field of `options.context` wasn't getting cloned properly. This caused some trouble with dynamic headers, as seen in the above issues.

This PR reverts that commit as it's looking like the current state (frequent issues with dynamic headers) is worse than what we had before. Will be finding another way to preserve options in the meantime.

### Checklist:

- [X] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] ~~Make sure all of the significant new logic is covered by tests~~
