### PR TITLE
Pass TCache generic to MutationHookOptions

### DIFF
--- a/src/react/hooks/useMutation.ts
+++ b/src/react/hooks/useMutation.ts
@@ -26,7 +26,7 @@ export function useMutation<
   TCache extends ApolloCache<any> = ApolloCache<any>,
 >(
   mutation: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  options?: MutationHookOptions<TData, TVariables, TContext>,
+  options?: MutationHookOptions<TData, TVariables, TContext, TCache>,
 ): MutationTuple<TData, TVariables, TContext, TCache> {
   const client = useApolloClient(options?.client);
   verifyDocumentType(mutation, DocumentType.Mutation);


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

Hey Apollo maintainers team! ✋ 

I was digging in apollo client internals and found that we actually don't pass `TCache` generic to `MutationHookOptions`, though `MutationHookOptions` accepts it

If we start passing the generic to `MutationHookOptions`, we'll get better type support for `update` function that we call in `useMutation` options (see the examples below 👇).

#### Before:
Cache in first `update` function is of type `ApolloCache<any>` where the 2nd `update` function's cache has `ApolloCache<CacheGeneric>` type

<img width="425" alt="Screenshot 2022-10-22 at 22 07 26" src="https://user-images.githubusercontent.com/36277508/197362680-accc67c8-1562-49b0-bbb8-3b3c48365447.png">

#### After:
Both `cache` objects have `ApolloCache<CacheGeneric>` type

<img width="425" alt="Screenshot 2022-10-22 at 22 07 37" src="https://user-images.githubusercontent.com/36277508/197362687-18250ba1-faa2-47ff-a88e-1126d291666c.png">

Appreciate your feedback on this, thank you ❤️ 


