### PR TITLE
fix: forceUpdate of asyncUpdate executeTime

### DIFF
--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -105,7 +105,10 @@ class InternalState<TData, TVariables> {
     return new Promise<QueryResult<TData, TVariables>>(resolve => {
       this.asyncResolveFns.add(resolve);
       this.optionsToIgnoreOnce.add(this.watchQueryOptions);
-    }).then(this.forceUpdate.bind(this));
+    }).then((ret)=>{
+      this.forceUpdate.bind(this)
+      return ret
+    });
   }
 
   private asyncResolveFns = new Set<

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -105,8 +105,7 @@ class InternalState<TData, TVariables> {
     return new Promise<QueryResult<TData, TVariables>>(resolve => {
       this.asyncResolveFns.add(resolve);
       this.optionsToIgnoreOnce.add(this.watchQueryOptions);
-      this.forceUpdate();
-    });
+    }).then(this.forceUpdate.bind(this));
   }
 
   private asyncResolveFns = new Set<


### PR DESCRIPTION
const resolvers= []
const promise = new Promise(resolve => {
    resolvers.push(resolve)
    console.log("forceUpdate");
})
console.log("spilt");
promise.then(() => console.log("expected exec time") )
VM9512:4 forceUpdate
VM9512:6 spilt
Promise {<pending>}

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
