### PR TITLE
chore(docs): remove graphql-anywhere from apollo-link-rest doc

### DIFF
--- a/docs/source/api/link/apollo-link-rest.md
+++ b/docs/source/api/link/apollo-link-rest.md
@@ -23,7 +23,7 @@ With `apollo-link-rest`, you can call your endpoints inside your GraphQL queries
 To get started, first install Apollo Client and any `peerDependencies` we need:
 
 ```bash
-npm install --save @apollo/client apollo-link-rest graphql graphql-anywhere qs
+npm install --save @apollo/client apollo-link-rest graphql qs
 ```
 
 After this, you're ready to setup the Apollo Client instance:


### PR DESCRIPTION
https://github.com/apollographql/apollo-link-rest/pull/301 has landed and with it `apollo-link-rest` no longer has a dependency on `graphql-anywhere` 🥳

[apollo-link-rest@0.9.0-rc.2](https://www.npmjs.com/package/apollo-link-rest/v/0.9.0-rc.2) has been released and [should become the stable `0.9` release this weekend](https://github.com/apollographql/apollo-link-rest/issues/295#issuecomment-1292415605). With that, we can remove the final reference to `graphql-anywhere` in our docs outside of CHANGELOG.md.

This is ready for review and I will hold off on merging until `0.9` is released.