### PR TITLE
Add array examples to reactive variable documentation

### DIFF
--- a/docs/source/local-state/reactive-variables.mdx
+++ b/docs/source/local-state/reactive-variables.mdx
@@ -75,6 +75,60 @@ export function Cart() {
   // ...
 ```
 
+## Troubleshooting
+
+### Updating Arrays
+
+Currently `useReactiveVar` only triggers component updates when new values are passed to the reactive var, since it uses strict equality checks (the `===` operator). Make sure you are alway passing cloned values when performing an update.
+
+Will __not__ trigger an update:
+
+```ts
+const listVar = makeVar([1, 2]);
+const list = listVar();
+
+list.push(3);
+listVar(list);
+```
+
+Will trigger an update:
+
+```ts
+const listVar = makeVar([1, 2]);
+const list = listVar();
+
+const nextList = [...list, 3];
+listVar(nextList);
+```
+
+### Updates Outside of Components
+
+If you are making updates to a reactive variable outside of a React component and your components that use `useReactiveVar` are not updating, try deferring the update to the next tick of the event loop.
+
+Here's an example that tracks GraphQL errors using the [onError Link](../api/link/apollo-link-error.md).
+
+```ts
+const errorsVar = makeVar<Error[]>([]);
+
+const errorLink = onError((error: ErrorResponse) => {
+  const errors = errorsVar();
+  
+  // making a copy of the current array value will trigger an update
+  const nextErrors = [...errors]; 
+
+  if (error.graphQLErrors) {
+    error.graphQLErrors.forEach((e) => nextErrors.push(e));
+  }
+
+  if (error.networkError) {
+    nextErrors.push(error.networkError);
+  }
+
+  // deferring the update to next tick will allow the update to reliably trigger a new component render
+  setTimeout(() => errorsVar(nextErrors)); 
+});
+```
+
 ## Example application
 
 [This example to-do list application](https://github.com/apollographql/ac3-state-management-examples/tree/master/apollo-local-state) uses reactive variables to track both the current list of to-do items and the filter that determines which items to display. See [`cache.tsx`](https://github.com/apollographql/ac3-state-management-examples/blob/master/apollo-local-state/src/cache.tsx) in particular.

--- a/docs/source/local-state/reactive-variables.mdx
+++ b/docs/source/local-state/reactive-variables.mdx
@@ -40,38 +40,20 @@ To modify the value of your reactive variable, call the function returned by `ma
 
 ```js
 const cartItemsVar = makeVar([]);
+const cartItemIds = [100, 101, 102];
 
-cartItemsVar([100, 101, 102]);
+cartItemsVar(cartItemIds);
 
 // Output: [100, 101, 102]
 console.log(cartItemsVar());
 
-cartItemsVar([456]);
+// Don't mutate an existing object or array.
+// cartItemIds.push(456) will not trigger an update.
+// Instead, pass a new copy:
+cartItemsVar([...cartItemIds, 456]);
 
-// Output: [456]
+// Output: [100, 101, 102, 456]
 console.log(cartItemsVar());
-```
-
-In the above example note that a new array is passed in every time to the reactive variable. Currently `useReactiveVar` only triggers component updates when new values are passed to the reactive variable. It uses strict equality checks (the `===` operator) to determine if the value has changed. Make sure you are always passing new values when performing an update.
-
-This will *not* trigger an update:
-
-```ts
-const cartItemsVar = makeVar([1, 2]);
-const cartItems = cartItemsVar();
-
-cartItems.push(3);
-cartItemsVarVar(cartItems);
-```
-
-This will trigger an update:
-
-```ts
-const cartItemsVar = makeVar([1, 2]);
-const cartItems = cartItemsVar();
-
-cartItemsVar([...cartItems, 3]); // spread operator to use existing values
-cartItemsVar(cartItems.concat(4)); // Array.concat creates a new array
 ```
 
 ## Reacting
@@ -95,36 +77,6 @@ export const cartItemsVar = makeVar([]);
 export function Cart() {
   const cartItems = useReactiveVar(cartItemsVar);
   // ...
-```
-
-## Troubleshooting
-
-### Updates Outside of Components
-
-If you are making updates to a reactive variable outside of a React component and your components that use `useReactiveVar` are not updating, try deferring the update to the next tick of the event loop.
-
-Here's an example that tracks GraphQL errors using the [onError Link](../api/link/apollo-link-error.md).
-
-```ts
-const errorsVar = makeVar<Error[]>([]);
-
-const errorLink = onError((error: ErrorResponse) => {
-  const errors = errorsVar();
-
-  // making a copy of the current array value will trigger an update
-  const nextErrors = [...errors];
-
-  if (error.graphQLErrors) {
-    error.graphQLErrors.forEach((e) => nextErrors.push(e));
-  }
-
-  if (error.networkError) {
-    nextErrors.push(error.networkError);
-  }
-
-  // deferring the update to next tick will allow the update to reliably trigger a new component render
-  setTimeout(() => errorsVar(nextErrors));
-});
 ```
 
 ## Example application

--- a/docs/source/local-state/reactive-variables.mdx
+++ b/docs/source/local-state/reactive-variables.mdx
@@ -52,6 +52,28 @@ cartItemsVar([456]);
 console.log(cartItemsVar());
 ```
 
+In the above example note that a new array is passed in every time to the reactive variable. Currently `useReactiveVar` only triggers component updates when new values are passed to the reactive variable. It uses strict equality checks (the `===` operator) to determine if the value has changed. Make sure you are always passing new values when performing an update.
+
+This will *not* trigger an update:
+
+```ts
+const cartItemsVar = makeVar([1, 2]);
+const cartItems = cartItemsVar();
+
+cartItems.push(3);
+cartItemsVarVar(cartItems);
+```
+
+This will trigger an update:
+
+```ts
+const cartItemsVar = makeVar([1, 2]);
+const cartItems = cartItemsVar();
+
+cartItemsVar([...cartItems, 3]); // spread operator to use existing values
+cartItemsVar(cartItems.concat(4)); // Array.concat creates a new array
+```
+
 ## Reacting
 
 As their name suggests, reactive variables can trigger reactive changes in your application. Whenever you modify the value of a reactive variable, queries that depend on that variable refresh, and your application's UI updates accordingly.
@@ -77,30 +99,6 @@ export function Cart() {
 
 ## Troubleshooting
 
-### Updating Arrays
-
-Currently `useReactiveVar` only triggers component updates when new values are passed to the reactive var, since it uses strict equality checks (the `===` operator). Make sure you are alway passing cloned values when performing an update.
-
-Will __not__ trigger an update:
-
-```ts
-const listVar = makeVar([1, 2]);
-const list = listVar();
-
-list.push(3);
-listVar(list);
-```
-
-Will trigger an update:
-
-```ts
-const listVar = makeVar([1, 2]);
-const list = listVar();
-
-const nextList = [...list, 3];
-listVar(nextList);
-```
-
 ### Updates Outside of Components
 
 If you are making updates to a reactive variable outside of a React component and your components that use `useReactiveVar` are not updating, try deferring the update to the next tick of the event loop.
@@ -112,9 +110,9 @@ const errorsVar = makeVar<Error[]>([]);
 
 const errorLink = onError((error: ErrorResponse) => {
   const errors = errorsVar();
-  
+
   // making a copy of the current array value will trigger an update
-  const nextErrors = [...errors]; 
+  const nextErrors = [...errors];
 
   if (error.graphQLErrors) {
     error.graphQLErrors.forEach((e) => nextErrors.push(e));
@@ -125,7 +123,7 @@ const errorLink = onError((error: ErrorResponse) => {
   }
 
   // deferring the update to next tick will allow the update to reliably trigger a new component render
-  setTimeout(() => errorsVar(nextErrors)); 
+  setTimeout(() => errorsVar(nextErrors));
 });
 ```
 


### PR DESCRIPTION
This PR adds examples to the docs on how to avoid some common pitfalls when using reactive vars.  It should hopefully help people get some time back when trying to triage issues with reactive vars mutations not triggering component updates in React applications.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

