### PR TITLE
Ensure remounted components properly adhere to `fetchPolicy` and `nextFetchPolicy`

### DIFF
--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -270,7 +270,6 @@ export class ObservableQuery<
         // terminates after a complete cache read, we can assume the next result
         // we receive will have NetworkStatus.ready and !loading.
         if (
-          diff.complete &&
           result.networkStatus === NetworkStatus.loading &&
           (fetchPolicy === 'cache-first' ||
           fetchPolicy === 'cache-only')

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -5638,6 +5638,7 @@ describe('useQuery Hook', () => {
 
       expect(result.current.loading).toBe(true);
       expect(result.current.data).toBe(undefined);
+      expect(result.current.networkStatus).toBe(NetworkStatus.loading);
       setTimeout(() => {
         link.simulateResult({
           result: {
@@ -5717,6 +5718,7 @@ describe('useQuery Hook', () => {
       expect(result.current.label).toBe(undefined);
       // @ts-ignore
       expect(result.current.extensions).toBe(undefined);
+      expect(result.current.networkStatus).toBe(NetworkStatus.error);
       expect(result.current.error).toBeInstanceOf(ApolloError);
       expect(result.current.error!.message).toBe('homeWorld for character with ID 1000 could not be fetched.');
 

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -1,5 +1,5 @@
 import { RenderResult } from "@testing-library/react-hooks/src/types";
-import React, { Fragment, useEffect, useState } from 'react';
+import React, { Fragment, ReactNode, useEffect, useState } from 'react';
 import { DocumentNode, GraphQLError } from 'graphql';
 import gql from 'graphql-tag';
 import { act } from 'react-dom/test-utils';
@@ -4924,6 +4924,102 @@ describe('useQuery Hook', () => {
       }).then(resolve, reject);
     });
   });
+
+  // https://github.com/apollographql/apollo-client/issues/10222
+  describe('regression test issue #10222', () => {
+    it('maintains initial fetch policy when component unmounts and remounts', async () => {
+      let helloCount = 1;
+      const query = gql`{ hello }`;
+      const link = new ApolloLink(() => {
+        return new Observable(observer => {
+          const timer = setTimeout(() => {
+            console.log('test observer.next', helloCount)
+            observer.next({ data: { hello: `hello ${helloCount++}` } });
+            observer.complete();
+          }, 50);
+
+          return () => {
+            clearTimeout(timer);
+          }
+        })
+      })
+
+      const cache = new InMemoryCache();
+
+      const client = new ApolloClient({
+        link,
+        cache
+      });
+
+      let setShow: Function
+      const Toggler = ({ children }: { children: ReactNode }) => {
+        const [show, _setShow] = useState(true);
+        setShow = _setShow;
+
+        return show ? <>{children}</> : null;
+      }
+
+      const counts = { mount: 0, unmount: 0 };
+
+      const { result, waitForNextUpdate } = renderHook(
+        () => {
+          useEffect(() => {
+            counts.mount++;
+
+            return () => {
+              counts.unmount++;
+            }
+          }, []);
+
+          const result = useQuery(query, {
+            fetchPolicy: 'network-only',
+            nextFetchPolicy: 'cache-first'
+          });
+
+          return result
+        },
+        {
+          wrapper: ({ children }) => (
+            <ApolloProvider client={client}>
+              <Toggler>{children}</Toggler>
+            </ApolloProvider>
+          ),
+        },
+      );
+
+      expect(counts).toEqual({ mount: 1, unmount: 0 });
+      expect(result.current.loading).toBe(true);
+      expect(result.current.data).toBeUndefined();
+
+      await waitForNextUpdate();
+
+      expect(result.current.loading).toBe(false);
+      expect(result.current.data).toEqual({ hello: 'hello 1' });
+      expect(cache.readQuery({ query })).toEqual({ hello: 'hello 1' })
+
+      act(() => {
+        setShow(false);
+      });
+
+      expect(counts).toEqual({ mount: 1, unmount: 1 });
+
+      act(() => {
+        setShow(true);
+      });
+
+      expect(counts).toEqual({ mount: 2, unmount: 1 });
+
+      expect(result.current.loading).toBe(true);
+      expect(result.current.data).toBeUndefined();
+
+      await waitForNextUpdate();
+
+      expect(result.current.loading).toBe(false);
+      expect(result.current.data).toEqual({ hello: 'hello 2' });
+      expect(cache.readQuery({ query })).toEqual({ hello: 'hello 2' })
+    });
+  });
+
 
   describe('defer', () => {
     it('should handle deferred queries', async () => {


### PR DESCRIPTION
Fixes #10222

This fix ensures the `fetchPolicy` and `nextFetchPolicy` is properly adhered to when a component unmounts, then remounts. In v3.6.8 and below, a `fetchPolicy` of `network-only` and `nextFetchPolicy` of `cache-first` would properly return the loading state when remounted. In v3.6.9 and above, a remounted component would return cached data too early due to a change in #9823 that synchronously updated the `fetchPolicy` as soon as the initial query was kicked off. 

Internally, we were using `observableQuery.getCurrentResult()` in our `onNext` function passed to the subscription to get the result of the query, rather than relying on the argument passed to `onNext`. This meant in some cases where `onNext` was triggered, we were calling `observableQuery.getCurrentResult()` with a fetch policy that had already been changed to the `nextFetchPolicy`, therefore we were returning cached data too early (in other words, the `network-only` result hadn't yet finished loading).

I opted to patch `useQuery` with some of the behavior in `observableQuery.getCurrentResult()` to try and limit the blast radius of the changes. The patch really should be a part of `QueryManager`, but I didn't know how how many people rely on the current behavior in how results are returned (which differ from `observableQuery.getCurrentResult()`.