### PR TITLE
Consider headers in query deduplication

### DIFF
--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -981,8 +981,9 @@ export class QueryManager<TStore> {
         const byVariables = inFlightLinkObservables.get(serverQuery) || new Map();
         inFlightLinkObservables.set(serverQuery, byVariables);
 
-        const varJson = canonicalStringify(variables);
+        const varJson = canonicalStringify({...variables, ...context.headers});
         observable = byVariables.get(varJson);
+        console.warn(varJson)
 
         if (!observable) {
           const concast = new Concast([

--- a/src/core/__tests__/QueryManager/index.ts
+++ b/src/core/__tests__/QueryManager/index.ts
@@ -5857,6 +5857,31 @@ describe('QueryManager', () => {
       expect(queryManager['inFlightLinkObservables'].size).toBe(1)
     });
 
+    it('should take headers into account when deduplicating', () => {
+      const query = gql`
+        query {
+          author {
+            lastName
+          }
+        }
+      `;
+      const queryManager = createQueryManager({
+        link: mockSingleLink({
+          request: { query },
+          result: {
+            data: {
+              author: { lastName: 'Doe' },
+            },
+          },
+        }),
+      });
+
+      queryManager.query({ query, context: { queryDeduplication: true } })
+      queryManager.query({ query, context: { headers: {"Foo": "Bar"}, queryDeduplication: true } })
+
+      expect(queryManager['inFlightLinkObservables'].size).toBe(1)
+    });
+  
     it('should allow overriding global queryDeduplication: true to false', () => {
       const query = gql`
         query {


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->
Fixes https://github.com/apollographql/apollo-client/issues/10207 (Tested locally with the example repo provided)

Currently our query deduplication logic only takes the query document and variables into account. One solution to this problem is to just bail out of query deduplication when we see the presence of query-specific context headers period, but as we've seen it can at times be valuable for someone uses the same query in many different documents with different headers, so with performance in mind we should try to consider supporting this. 

So right now in code and query manager, we make a string key from variables (a map from querydocument -> variables -> observable that can be shared), this PR adds context.variables into that string key. I believe headers are always JSON serializable, so I'm including them in the cache key.

One lingering question is that of security concerns, people often send authorization tokens through headers, so I want to make sure those aren't being stored in the client for too long - one solution could be sha256()'ing the context headers before creating the string key.


### Checklist:

- [X] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [X] Make sure all of the significant new logic is covered by tests
