### PR TITLE
Fix 'broken' links

### DIFF
--- a/docs/source/data/defer.mdx
+++ b/docs/source/data/defer.mdx
@@ -3,7 +3,7 @@ title: "Using the @defer directive in Apollo Client"
 description: Receive query response data incrementally
 ---
 
-> ⚠️ **The `@defer` directive is currently at the [preview stage](/resources/release-stages/#preview) in Apollo Client, and is available by installing `@apollo/client@latest`.** If you have feedback on it, please let us know via [GitHub issues](https://github.com/apollographql/apollo-client/issues/new?assignees=&labels=&template=bug.md).
+> ⚠️ **The `@defer` directive is currently at the [preview stage](/resources/product-launch-stages/#preview) in Apollo Client, and is available by installing `@apollo/client@latest`.** If you have feedback on it, please let us know via [GitHub issues](https://github.com/apollographql/apollo-client/issues/new?assignees=&labels=&template=bug.md).
 
 Beginning with version `3.7.0`, Apollo Client Web provides preview support for [the `@defer` directive](https://github.com/graphql/graphql-wg/blob/main/rfcs/DeferStream.md). This directive enables your queries to receive data for specific fields _incrementally_, instead of receiving all field data at the same time. This is helpful whenever some fields in a query take much longer to resolve than others.
 

--- a/docs/source/data/operation-best-practices.mdx
+++ b/docs/source/data/operation-best-practices.mdx
@@ -88,7 +88,7 @@ Beyond reusability, hardcoded arguments have other disadvantages relative to var
 
 If two otherwise identical queries have different hardcoded argument values, they're considered _entirely different operations_ by your GraphQL server's cache. The cache enables your server to _skip_ parsing and validating operations that it's encountered before, improving performance.
 
-The server-side cache also powers features like [automatic persisted queries](/apollo-server/performance/apq/) and query plans in a [federated gateway](/federation/gateway/). Hardcoded arguments reduce the performance gains of these features and take up useful space in the cache.
+The server-side cache also powers features like [automatic persisted queries](/apollo-server/performance/apq/) and query plans in a [federated gateway](/federation/building-supergraphs/router/). Hardcoded arguments reduce the performance gains of these features and take up useful space in the cache.
 
 #### Reduced information privacy
 
@@ -289,4 +289,4 @@ const client = new ApolloClient({
 
 If you specify these values, Apollo Client automatically adds them to each operation request as HTTP headers (`apollographql-client-name` and `apollographql-client-version`).
 
-Then if you've configured [metrics reporting in Apollo Studio](/studio/metrics/usage-reporting/), Apollo Server includes your app's `name` and `version` in the operation traces it reports to Studio. This enables you to [segment metrics by client](/studio/metrics/client-awareness/).
+Then if you've configured [metrics reporting in Apollo Studio](/graphos/metrics/usage-reporting/), Apollo Server includes your app's `name` and `version` in the operation traces it reports to Studio. This enables you to [segment metrics by client](/graphos/metrics/client-awareness/).

--- a/docs/source/development-testing/developer-tooling.md
+++ b/docs/source/development-testing/developer-tooling.md
@@ -3,20 +3,18 @@ title: Developer tools
 description: Improve your developer experience with these services and extensions
 ---
 
-## Apollo Studio
+## GraphOS and Apollo Studio
 
-[Apollo Studio](/studio/) (formerly Graph Manager) is a cloud app that provides a single, consolidated place for you to collaborate on the evolution of your graph.
+[GraphOS](/graphos/) is Apollo's all-purpose platform for growing and collaborating on your graph. **Apollo Studio** is the web interface for GraphOS, which provides helpful views into your graph's usage and performance.
 
-It provides the following features to all Apollo users for free:
+Among others, these GraphOS features are available to all Apollo users for free:
 
-- A query window that connects to all your environments and provides ergonomic ways to author and manage queries.
+- The Explorer, a powerful GraphQL IDE that connects to all your environments and provides ergonomic ways to author and manage queries.
 - A GraphQL schema registry that tracks the evolution of your graph across your environments.
 - Key insights into which parts of your schema are being actively used, and by whom.
 - Team collaboration via organizations
 
-Advanced features are available with a subscription to an Apollo Team or Enterprise plan.
-
-To learn more about Apollo Studio, check out the [overview](/studio/).
+To learn more about GraphOS, check out the [overview](/graphos/).
 
 ## Apollo Client Devtools
 
@@ -42,4 +40,3 @@ You can install the extension via the webstores for [Chrome](https://chrome.goog
 While your app is in dev mode, the Apollo Client Devtools will appear as an "Apollo" tab in your web browser inspector. To enable the devtools in your app in production, pass `connectToDevTools: true` to the `ApolloClient` constructor in your app. Pass `connectToDevTools: false` if want to manually disable this functionality.
 
 Find more information about contributing and debugging on the [Apollo Client Devtools GitHub page](https://github.com/apollographql/apollo-client-devtools).
-


### PR DESCRIPTION
These docs links work fine as-is thanks to redirects, but fixing them to remove them from broken link reports