### PR TITLE
docs: Update subscribeToMore example to use React hooks

### DIFF
--- a/docs/source/data/subscriptions.mdx
+++ b/docs/source/data/subscriptions.mdx
@@ -294,11 +294,10 @@ In the example above, we pass three options to `subscribeToMore`:
 
 Finally, in our definition of `CommentsPage`, we tell the component to `subscribeToNewComments` when it mounts:
 
-```js
-export class CommentsPage extends Component {
-  componentDidMount() {
-    this.props.subscribeToNewComments();
-  }
+```jsx
+export function CommentsPage({subscribeToNewComments}) {
+  useEffect(() => subscribeToNewComments(), []);
+  return <>...</>
 }
 ```
 


### PR DESCRIPTION
In the `subscribeToMore` example in the docs, we use a mix of function components (`CommentsPageWithData` uses `useQuery` hook) and class components, like the `CommentsPage` component in this PR.

This PR updates `CommentsPage` to be a function component and replaces `componentDidMount` with `useEffect(() => ..., [])`.