### PR TITLE
Better handle cached data with deferred queries

### DIFF
--- a/.changeset/shiny-balloons-matter.md
+++ b/.changeset/shiny-balloons-matter.md
@@ -1,0 +1,5 @@
+---
+'@apollo/client': patch
+---
+
+Better handle deferred queries that have cached or partial cached data for them

--- a/config/bundlesize.ts
+++ b/config/bundlesize.ts
@@ -3,7 +3,7 @@ import { join } from "path";
 import { gzipSync } from "zlib";
 import bytes from "bytes";
 
-const gzipBundleByteLengthLimit = bytes("31.85KB");
+const gzipBundleByteLengthLimit = bytes("31.87KB");
 const minFile = join("dist", "apollo-client.min.cjs");
 const minPath = join(__dirname, "..", minFile);
 const gzipByteLen = gzipSync(readFileSync(minPath)).byteLength;


### PR DESCRIPTION
When using `useQuery` with deferred queries that already have cache data written, the initial chunk of data returned from a server would overwrite anything in the cache, which meant cached data for deferred chunks would disappear. This primarily affected `cache-and-network` fetch policies with data written to the cache and `cache-first` fetch policies with partial data in the cache when using the `returnPartialData` option. This is now better handled by merging existing cache data with the initial deferred chunk to ensure a complete result set is still returned.

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
