### PR TITLE
Changesets updates

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -58,6 +58,7 @@ jobs:
         run: npm run changeset-publish
 
       - name: Send a Slack notification on publish
+        if: steps.changesets.outcome == 'success' && steps.changesets.outputs.published == 'true'
         id: slack
         uses: slackapi/slack-github-action@v1.23.0
         with:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -38,26 +38,35 @@ jobs:
       - name: Install dependencies with cache
         uses: bahmutov/npm-install@v1
 
-      - name: Enter prerelease mode
-        # if .changeset/pre.json does not exist and we did not recently exit
-        # prerelease mode, enter prerelease mode with tag alpha
-        run: |
-          [ ! -f .changeset/pre.json && !contains(github.event.head_commit.message, 'Exit prerelease') ] \
-            && npx changeset pre enter alpha \
-            || echo 'Already in pre mode or recently exited'
-
-      - name: Create release PR
-        id: changesets
-        uses: changesets/action@v1
+      - name: Check for pre.json file existence
+        id: check_files
+        uses: andstor/file-existence-action@v2.0.0
         with:
-          version: npm run changeset-version
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          files: ".changeset/pre.json"
 
-      - name: Publish alpha to npm
-        if: "! test -f .changeset/pre.json"
+      - name: Enter alpha prerelease mode
+        # If .changeset/pre.json does not exist and we did not recently exit
+        # prerelease mode, enter prerelease mode with tag alpha
+        if: ${{ steps.check_files.outputs.files_exists == 'false' && !contains(github.event.head_commit.message, 'Exit prerelease')}}
+        run: npx changeset pre enter alpha
+
+      - name: Run publish
+        id: changesets
+        # Only run publish if we're still in pre mode and the last commit was
+        # via an automatically created Version Packages PR
+        if: ${{ steps.check_files.outputs.files_exists == 'true' && startsWith(github.event.head_commit.message, 'Version Packages')}}
         run: npm run changeset-publish
 
-      # - name: Send a Slack notification on Publish
-      #   if: steps.changesets.outputs.published == 'true'
-      #   run: echo "Send message to Slack"
+      - name: Send a Slack notification on publish
+        id: slack
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          # Slack channel id, channel name, or user id to post message
+          # See also: https://api.slack.com/methods/chat.postMessage#channels
+          # You can pass in multiple channels to post to by providing
+          # a comma-delimited list of channel IDs
+          channel-id: 'C01PS0CB41G'
+          # For posting a simple plain text message
+          slack-message: "Published @apollo/client v${{ fromJson(steps.changesets.outputs.publishedPackages)[0].version }}"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Send a Slack notification on publish
+        if: steps.changesets.outcome == 'success' && steps.changesets.outputs.published == 'true'
         id: slack
         uses: slackapi/slack-github-action@v1.23.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      # - name: Send a Slack notification on Publish
-      #   if: steps.changesets.outputs.published == 'true'
-      #   run: echo "Send message to Slack"
+      - name: Send a Slack notification on publish
+        id: slack
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          # Slack channel id, channel name, or user id to post message
+          # See also: https://api.slack.com/methods/chat.postMessage#channels
+          # You can pass in multiple channels to post to by providing
+          # a comma-delimited list of channel IDs
+          channel-id: 'C01PS0CB41G'
+          # For posting a simple plain text message
+          slack-message: "Published @apollo/client v${{ fromJson(steps.changesets.outputs.publishedPackages)[0].version }}"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
Makes a few fixes to the prerelease workflow and adds a step to both prerelease + release workflows to send a Slack message on publish.

- Updates `prerelease.yml` to use `andstor/file-existence-action@v2.0.0` for detecting `pre.json` and determining whether to enter changeset's `pre` mode.
- Enter pre mode if we're not already in it and we didn't just exit.
- Run publish if we're in pre mode and just merged a "Version packages" PR.