### PR TITLE
Add the ability to allow `@client` fields to be sent to the link chain

### DIFF
--- a/.changeset/rude-mayflies-scream.md
+++ b/.changeset/rude-mayflies-scream.md
@@ -1,0 +1,5 @@
+---
+'@apollo/client': minor
+---
+
+Add the ability to allow `@client` fields to be sent to the link chain.

--- a/config/bundlesize.ts
+++ b/config/bundlesize.ts
@@ -3,7 +3,7 @@ import { join } from "path";
 import { gzipSync } from "zlib";
 import bytes from "bytes";
 
-const gzipBundleByteLengthLimit = bytes("33.01KB");
+const gzipBundleByteLengthLimit = bytes("33.17KB");
 const minFile = join("dist", "apollo-client.min.cjs");
 const minPath = join(__dirname, "..", minFile);
 const gzipByteLen = gzipSync(readFileSync(minPath)).byteLength;

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -941,7 +941,7 @@ describe('client', () => {
       .then(resolve, reject);
   });
 
-  it('removes client fields from the query before it reaches the link', async () => {
+  it('removes @client fields from the query before it reaches the link', async () => {
     const result: { current: Operation | undefined } = {
       current: undefined
     }
@@ -989,7 +989,7 @@ describe('client', () => {
     expect(print(result.current!.query)).toEqual(print(transformedQuery));
   });
 
-  it('sends client fields to the link when defaultOptions.transformQuery.removeClientFields is `false`', async () => {
+  it('sends @client fields to the link when defaultOptions.transformQuery.removeClientFields is `false`', async () => {
     const result: { current: Operation | undefined } = {
       current: undefined
     };

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -942,7 +942,9 @@ describe('client', () => {
   });
 
   it('removes client fields from the query before it reaches the link', async () => {
-    let operation: Operation;
+    const result: { current: Operation | undefined } = {
+      current: undefined
+    }
 
     const query = gql`
       query {
@@ -963,8 +965,8 @@ describe('client', () => {
       }
     `;
 
-    const link = new ApolloLink((_operation) => {
-      operation = _operation
+    const link = new ApolloLink((operation) => {
+      result.current = operation;
 
       return Observable.of({
         data: {
@@ -984,11 +986,13 @@ describe('client', () => {
 
     await client.query({ query });
 
-    expect(print(operation!.query)).toEqual(print(transformedQuery));
-  })
+    expect(print(result.current!.query)).toEqual(print(transformedQuery));
+  });
 
   it('sends client fields to the link when defaultOptions.transformQuery.removeClientFields is `false`', async () => {
-    let operation: Operation;
+    const result: { current: Operation | undefined } = {
+      current: undefined
+    };
 
     const query = gql`
       query {
@@ -1000,8 +1004,8 @@ describe('client', () => {
       }
     `;
 
-    const link = new ApolloLink((_operation) => {
-      operation = _operation
+    const link = new ApolloLink((operation) => {
+      result.current = operation
 
       return Observable.of({
         data: {
@@ -1026,8 +1030,8 @@ describe('client', () => {
 
     await client.query({ query });
 
-    expect(print(operation!.query)).toEqual(print(query));
-  })
+    expect(print(result.current!.query)).toEqual(print(query));
+  });
 
   itAsync('should handle named fragments on mutations', (resolve, reject) => {
     const mutation = gql`

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -20,6 +20,7 @@ import {
   RefetchQueriesResult,
   InternalRefetchQueriesResult,
   RefetchQueriesInclude,
+  TransformQueryOptions,
 } from './types';
 
 import {
@@ -39,6 +40,7 @@ export interface DefaultOptions {
   watchQuery?: Partial<WatchQueryOptions<any, any>>;
   query?: Partial<QueryOptions<any, any>>;
   mutate?: Partial<MutationOptions<any, any, any>>;
+  transformQuery?: Partial<TransformQueryOptions>;
 }
 
 let hasSuggestedDevtools = false;

--- a/src/core/LocalState.ts
+++ b/src/core/LocalState.ts
@@ -171,9 +171,16 @@ export class LocalState<TCacheShape> {
     return null;
   }
 
-  // Server queries are stripped of all @client based selection sets.
-  public serverQuery(document: DocumentNode) {
-    return removeClientSetsFromDocument(document);
+  // Server queries by default are stripped of all @client based selection sets.
+  public serverQuery(
+    document: DocumentNode,
+    options: { removeClientFields?: boolean } = Object.create(null)
+  ) {
+    const { removeClientFields = true } = options;
+
+    return removeClientFields
+      ? removeClientSetsFromDocument(document)
+      : document;
   }
 
   public prepareContext(context?: Record<string, any>) {

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -52,7 +52,6 @@ import {
   InternalRefetchQueriesOptions,
   InternalRefetchQueriesResult,
   InternalRefetchQueriesMap,
-  TransformQueryOptions,
 } from './types';
 import { LocalState } from './LocalState';
 

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -52,6 +52,7 @@ import {
   InternalRefetchQueriesOptions,
   InternalRefetchQueriesResult,
   InternalRefetchQueriesMap,
+  TransformQueryOptions,
 } from './types';
 import { LocalState } from './LocalState';
 
@@ -607,12 +608,17 @@ export class QueryManager<TStore> {
 
   public transform(document: DocumentNode) {
     const { transformCache } = this;
+    const {
+      removeClientFields = true
+    } = this.defaultOptions.transformQuery || Object.create(null);
 
     if (!transformCache.has(document)) {
       const transformed = this.cache.transformDocument(document);
       const noConnection = removeConnectionDirectiveFromDocument(transformed);
       const clientQuery = this.localState.clientQuery(transformed);
-      const serverQuery = noConnection && this.localState.serverQuery(noConnection);
+      const serverQuery =
+        noConnection &&
+          this.localState.serverQuery(noConnection, { removeClientFields });
 
       const cacheEntry: TransformCacheEntry = {
         document: transformed,

--- a/src/core/__tests__/QueryManager/links.ts
+++ b/src/core/__tests__/QueryManager/links.ts
@@ -362,7 +362,7 @@ describe('Link interactions', () => {
       });
   });
 
-  it('removes client fields from the query before it reaches the link', async () => {
+  it('removes @client fields from the query before it reaches the link', async () => {
     const result: { current: Operation | undefined } = {
       current: undefined
     };
@@ -409,7 +409,7 @@ describe('Link interactions', () => {
     expect(print(result.current!.query)).toEqual(print(expectedQuery))
   });
 
-  it('sends client directives to the link when defaultOptions.transformQuery.removeClientFields is false', async () => {
+  it('sends @client fields to the link when defaultOptions.transformQuery.removeClientFields is false', async () => {
     const result: { current: Operation | undefined } = {
       current: undefined
     };

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -140,7 +140,7 @@ export type ApolloQueryResult<T> = {
   */
   errors?: ReadonlyArray<GraphQLError>;
   /**
-  * The single Error object that is passed to onError and useQuery hooks, and is often thrown during manual `client.query` calls. 
+  * The single Error object that is passed to onError and useQuery hooks, and is often thrown during manual `client.query` calls.
   * This will contain both a NetworkError field and any GraphQLErrors.
   * See https://www.apollographql.com/docs/react/data/error-handling/ for more information.
   */
@@ -193,4 +193,12 @@ export interface Resolvers {
   [key: string]: {
     [ field: string ]: Resolver;
   };
+}
+
+export interface TransformQueryOptions {
+  /**
+  * Determines whether fields using the `@client` directive should be removed
+  * from the query before it is sent through the link chain. Defaults to `true`.
+  */
+  removeClientFields?: boolean
 }

--- a/src/link/batch-http/__tests__/batchHttpLink.ts
+++ b/src/link/batch-http/__tests__/batchHttpLink.ts
@@ -899,7 +899,7 @@ describe('SharedHttpTest', () => {
     );
   });
 
-  it('removes client fields from the query before sending it to the server', async () => {
+  it('removes @client fields from the query before sending it to the server', async () => {
     fetchMock.mock('https://example.com/graphql', {
       status: 200,
       body: JSON.stringify({

--- a/src/link/batch-http/batchHttpLink.ts
+++ b/src/link/batch-http/batchHttpLink.ts
@@ -104,7 +104,7 @@ export class BatchHttpLink extends ApolloLink {
           return removeClientSetsFromDocument(query);
         }
 
-        return query
+        return query;
       });
 
       // If we have a query that returned `null` after removing client-only
@@ -118,15 +118,15 @@ export class BatchHttpLink extends ApolloLink {
       }
 
       //uses fallback, link, and then context to build options
-      const optsAndBody = operations.map((operation, index) => {
-        return selectHttpOptionsAndBodyInternal(
+      const optsAndBody = operations.map((operation, index) =>
+        selectHttpOptionsAndBodyInternal(
           { ...operation, query: queries[index]! },
           print,
           fallbackHttpConfig,
           linkConfig,
           contextConfig,
-        )
-      });
+        ),
+      );
 
       const loadedBody = optsAndBody.map(({ body }) => body);
       const options = optsAndBody[0].options;

--- a/src/link/http/__tests__/HttpLink.ts
+++ b/src/link/http/__tests__/HttpLink.ts
@@ -1015,7 +1015,7 @@ describe('HttpLink', () => {
       );
     });
 
-    it('removes client fields from the query before sending it to the server', async () => {
+    it('removes @client fields from the query before sending it to the server', async () => {
       fetchMock.mock('https://example.com/graphql', {
         status: 200,
         body: JSON.stringify({

--- a/src/link/http/__tests__/HttpLink.ts
+++ b/src/link/http/__tests__/HttpLink.ts
@@ -1014,6 +1014,76 @@ describe('HttpLink', () => {
         () => {},
       );
     });
+
+    it('removes client fields from the query before sending it to the server', async () => {
+      fetchMock.mock('https://example.com/graphql', {
+        status: 200,
+        body: JSON.stringify({
+          data: {
+            author: { __typename: 'Author', name: 'Test User' }
+          }
+        }),
+        headers: { 'content-type': 'application/json' }
+      });
+
+      const query = gql`
+        query {
+          author {
+            name
+            isInCollection @client
+          }
+        }
+      `;
+
+      const serverQuery = gql`
+        query {
+          author {
+            name
+          }
+        }
+      `;
+
+      const link = createHttpLink({ uri: 'https://example.com/graphql' });
+
+      await new Promise((resolve, reject) => {
+        execute(link, { query }).subscribe({
+          next: resolve,
+          error: reject
+        });
+      });
+
+      const [, options] = fetchMock.lastCall()!;
+      const { body } = options!
+
+      expect(JSON.parse(body!.toString())).toEqual({
+        query: print(serverQuery),
+        variables: {}
+      });
+    });
+
+    it('responds with error when trying to send a client-only query', async () => {
+      const errorHandler = jest.fn()
+      const query = gql`
+        query {
+          author @client {
+            name
+          }
+        }
+      `;
+
+      const link = createHttpLink({ uri: 'https://example.com/graphql' });
+
+      await new Promise<void>((resolve, reject) => {
+        execute(link, { query }).subscribe({
+          next: reject,
+          error: errorHandler.mockImplementation(resolve)
+        });
+      });
+
+      expect(errorHandler).toHaveBeenCalledWith(
+        new Error('HttpLink: Trying to send a client-only query to the server. To send to the server, ensure a non-client field is added to the query or enable the `transformOptions.removeClientFields` option.')
+      );
+    })
   });
 
   describe('Dev warnings', () => {

--- a/src/link/http/__tests__/HttpLink.ts
+++ b/src/link/http/__tests__/HttpLink.ts
@@ -1081,7 +1081,7 @@ describe('HttpLink', () => {
       });
 
       expect(errorHandler).toHaveBeenCalledWith(
-        new Error('HttpLink: Trying to send a client-only query to the server. To send to the server, ensure a non-client field is added to the query or enable the `transformOptions.removeClientFields` option.')
+        new Error('HttpLink: Trying to send a client-only query to the server. To send to the server, ensure a non-client field is added to the query or set the `transformOptions.removeClientFields` option to `true`.')
       );
     })
   });

--- a/src/link/http/createHttpLink.ts
+++ b/src/link/http/createHttpLink.ts
@@ -92,7 +92,7 @@ export const createHttpLink = (linkOptions: HttpOptions = {}) => {
       if (!transformedQuery) {
         return fromError(
           new Error(
-            'HttpLink: Trying to send a client-only query to the server. To send to the server, ensure a non-client field is added to the query or enable the `transformOptions.removeClientFields` option.'
+            'HttpLink: Trying to send a client-only query to the server. To send to the server, ensure a non-client field is added to the query or set the `transformOptions.removeClientFields` option to `true`.'
           )
         );
       }


### PR DESCRIPTION
Closes #10303

By default, Apollo core will remove fields with an `@client` directive before it makes it to the link chain. We've now got [use cases](https://github.com/apollographql/apollo-client/issues/10228) that require the use of `@client` in the link chain. This PR adds an option to our client to allow `@client` fields to make it to the link chain. This is part of our larger effort to move local resolvers [back into the link chain](https://github.com/apollographql/apollo-client/issues/10060).

Because `@client` fields now have the possibility of making it to the link chain, the `HttpLink` and `BatchHttpLink` links have been updated to remove `@client` fields themselves. Once #10060 is done, we should be able to remove this behavior as the work to remove `@client` fields will likely end up in the new Apollo link instead.

## Design

The API introduced in this PR is as follows:

```tsx
new ApolloClient({
  defaultOptions: {
    transformQuery: {
      removeClientFields: false
    }
  }
});
```

**Why is `transformQuery` an object type?**

I for-see the possibility of wanting more query transformation options in our client. Rather than trying to invent new names for top-level options (one of the 2 hardest things in programming), keeping them in a cohesive namespace felt like it would scale better. Imagine for example if we wanted to offer the possibility of removing whitespace from queries before they are sent to the server:

```ts
transformQuery: {
  stripWhitespace: true
}
```

This reads nicely and keeps the name of the new option concise.

While we don't have any plans for additional transformation options at this time, I wanted something that could scale as we have/need more use cases.

**Why `defaultOptions`?**

Thinking long-term, I could see the possibility of wanting to opt in/out of this behavior for individual queries. We allow other options (e.g. `fetchPolicy`) to have default global values which can also be overridden on a per-query basis. To keep with the spirit of this notion, I aimed to introduce this under `defaultOptions`. Because these options are applied across all query types (`query` and `mutation`), I opted for a new "top-level" field under `defaultOptions` to convey that these are applied to all queries.

### Why not allow individual queries to opt in/out of this behavior now?

While I highly considered adding this behavior, something that gave me pause is how we handle our `addTypename` feature. This option also performs query transformation, but currently this is only available as a global option. There is no way to opt in/out of this behavior for an individual query. I decided to keep things simple as this has worked well for us thus far. We can always add this functionality later.

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
