### PR TITLE
fix: allow errors to be ignored by links

### DIFF
--- a/.changeset/beige-singers-grow.md
+++ b/.changeset/beige-singers-grow.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Allow links to ignore errors by returning a new fetch result

--- a/docs/source/api/link/apollo-link-error.md
+++ b/docs/source/api/link/apollo-link-error.md
@@ -123,3 +123,22 @@ A function that calls the next link down the chain. Calling `return forward(oper
 An error is passed as a `networkError` if a link further down the chain called the `error` callback on the observable. In most cases, `graphQLErrors` is the `errors` field of the result from the last `next` call.
 
 A `networkError` can contain additional fields, such as a GraphQL object in the case of a failing HTTP status code. In this situation, `graphQLErrors` is an alias for `networkError.result.errors` if the property exists.
+
+## Ignoring an error
+
+An error can be ignored by returning a new observable with and empty error array.
+
+```js
+import { onError } from "@apollo/client/link/error";
+import { Observable } from "@apollo/client";
+
+const errorLink = onError(({ operation }) => {
+  if (operation.operationName === "OperationErrorToBeIgnored") {
+    return Observable.of({
+      data: null,
+      // cleanup error from response
+      errors: [],
+    });
+  }
+});
+```

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -530,9 +530,15 @@ export function shouldWriteResult<T>(
   const ignoreErrors =
     errorPolicy === "ignore" ||
     errorPolicy === "all";
-  let writeWithErrors = !graphQLResultHasError(result);
-  if (!writeWithErrors && ignoreErrors && result.data) {
-    writeWithErrors = true;
+  const hasErrors = graphQLResultHasError(result);
+
+  if (!result.data) {
+    return false;
   }
-  return writeWithErrors;
+
+  if (hasErrors && !ignoreErrors) {
+    return false;
+  }
+
+  return true;
 }

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -468,8 +468,7 @@ describe('useMutation Hook', () => {
         });
 
         expect(fetchResult).toEqual({});
-        expect(errorMock).toHaveBeenCalledTimes(1);
-        expect(errorMock.mock.calls[0][0]).toMatch("Missing field");
+        expect(errorMock).not.toBeCalled();
         errorMock.mockRestore();
       });
     });

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -520,10 +520,7 @@ describe('useSubscription Hook', () => {
     await expect(waitForNextUpdate({ timeout: 20 }))
       .rejects.toThrow('Timed out');
 
-    expect(errorSpy).toHaveBeenCalledTimes(1);
-    expect(errorSpy.mock.calls[0][0]).toBe(
-      "Missing field 'car' while writing result {}",
-    );
+    expect(errorSpy).not.toBeCalled();
     errorSpy.mockRestore();
   });
 
@@ -588,16 +585,7 @@ describe('useSubscription Hook', () => {
     await expect(waitForNextUpdate({ timeout: 20 }))
       .rejects.toThrow('Timed out');
 
-    expect(errorSpy).toHaveBeenCalledTimes(3);
-    expect(errorSpy.mock.calls[0][0]).toBe(
-      "Missing field 'car' while writing result {}",
-    );
-    expect(errorSpy.mock.calls[1][0]).toBe(
-      "Missing field 'car' while writing result {}",
-    );
-    expect(errorSpy.mock.calls[2][0]).toBe(
-      "Missing field 'car' while writing result {}",
-    );
+    expect(errorSpy).not.toBeCalled();
     errorSpy.mockRestore();
   });
 


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

Hey Apollo team! ✋

This PR fixes issues #6070 and #6790 by allowing links to ignore errors by returning a new fetch result. To allow this behavior some changes had to be made on the shouldWriteResult function and therefore correlated tests. 

This is my first contribution so I appreciate any feedbacks. 
Thanks you
