### PR TITLE
Fix Changesets release workflow from default branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-## Apollo Client 3.7.2 (2022-12-06)
+# @apollo/client
 
-### Improvements
+## 3.7.2
+
+### Patch Changes
 
 - Only show dev tools suggestion in the console when `connectToDevTools` is `true`. <br/>
   [@chris110408](https://github.com/chris110408) in [#10258](https://github.com/apollographql/apollo-client/pull/10258)
@@ -17,9 +19,9 @@
 - Revert use of `cloneDeep` to clone options when fetching queries. <br />
   [@MrDoomBringer](https://github.com/MrDoomBringer) in [#10215](https://github.com/apollographql/apollo-client/pull/10215)
 
-## Apollo Client 3.7.1 (2022-10-20)
+## 3.7.1
 
-### Bug fixes
+### Patch Changes
 
 - Fix issue where `loading` remains `true` after `observer.refetch` is called repeatedly with different variables when the same data are returned. <br/>
   [@alessbell](https://github.com/alessbell) in [#10143](https://github.com/apollographql/apollo-client/pull/10143)
@@ -27,9 +29,9 @@
 - Fix race condition where `useFragment_experimental` could receive cache updates before initially calling `cache.watch` in `useEffect`. <br/>
   [@benjamn](https://github.com/benjamn) in [#10212](https://github.com/apollographql/apollo-client/pull/10212)
 
-## Apollo Client 3.7.0 (2022-09-30)
+## 3.7.0
 
-### New Features
+### Minor Changes
 
 - Implement preview support for the [`@defer` directive](https://github.com/graphql/graphql-spec/pull/742). <br/>
   [@alessbell](https://github.com/alessbell) and [@benjamn](https://github.com/benjamn) in [#10018](https://github.com/apollographql/apollo-client/pull/10018)
@@ -45,7 +47,8 @@
 
 - Implement `preserveHeaderCase` option for `http` context object, enabling preserved header capitalization for non-http-spec-compliant servers. <br/>
   [@mrdoombringer](https://github.com/mrdoombringer) in [#9891](https://github.com/apollographql/apollo-client/pull/9891)
-### Improvements
+
+### Patch Changes
 
 - Delay calling `onCompleted` and `onError` callbacks passed to `useQuery` using `Promise.resolve().then(() => ...)` to fix issue [#9794](https://github.com/apollographql/apollo-client/pull/9794). <br/>
   [@dylanwulf](https://github.com/dylanwulf) in [#9823](https://github.com/apollographql/apollo-client/pull/9823)

--- a/config/prepareChangesetsRelease.ts
+++ b/config/prepareChangesetsRelease.ts
@@ -1,0 +1,41 @@
+// The Apollo Client source that is published to npm is prepared via
+// config/prepareDist.js.
+//
+// If a release is being manually published, npm run build (which in turn runs
+// prepareDist.js via postbuild script) performs all of the necessary processing
+// to prepare the release. However, if a release is being automatically
+// published via Changesets, there are some additional required
+// steps:
+//
+// - Copy the .changeset folder into "dist" so Changesets can pick up the
+//   markdown changesets when generating the release.
+// - Copy CHANGELOG.md into "dist" so Changesets can use it to generate release
+//   notes.
+// - Add both .changeset and CHANGELOG.md to an .npmignore so they are not
+//   included in the published package.
+
+const fs = require("fs");
+const path = require("path");
+
+const distRoot = `${__dirname}/../dist`;
+const srcDir = `${__dirname}/..`;
+const destDir = `${srcDir}/dist`;
+
+// recursive copy function
+function copyDir(src: string, dest: string) {
+  fs.mkdirSync(dest, { recursive: true });
+  let entries = fs.readdirSync(src, { withFileTypes: true });
+
+  for (let entry of entries) {
+    let srcPath = path.join(src, entry.name);
+    let destPath = path.join(dest, entry.name);
+
+    entry.isDirectory()
+      ? copyDir(srcPath, destPath)
+      : fs.copyFileSync(srcPath, destPath);
+  }
+}
+
+fs.copyFileSync(`${srcDir}/CHANGELOG.md`, `${destDir}/CHANGELOG.md`);
+copyDir(`${srcDir}/.changeset`, `${destDir}/.changeset`);
+fs.writeFileSync(`${destDir}/.npmignore`, `.changeset\nCHANGELOG.md`);

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "sourcemaps": "ts-node-script config/rewriteSourceMaps.ts",
     "rollup": "rollup -c ./config/rollup.config.js",
     "prepdist": "node ./config/prepareDist.js",
-    "prepChangesetsRelease": "ts-node-script config/prepareChangesetsRelease.ts",
+    "prepdist:changesets": "ts-node-script config/prepareChangesetsRelease.ts",
     "postprocess-dist": "ts-node-script config/postprocessDist.ts",
     "clean": "rimraf -r dist coverage lib temp",
     "ci:precheck": "node config/precheck.js",
@@ -54,7 +54,7 @@
     "predeploy": "npm run build",
     "deploy": "cd dist && npm publish --tag next",
     "typedoc": "typedoc src/index.ts --json docs/public/docs.json",
-    "changeset-publish": "npm run build && npm run prepChangesetsRelease && cd dist && changeset publish",
+    "changeset-publish": "npm run build && npm run prepdist:changesets && cd dist && changeset publish",
     "changeset-check": "changeset status --verbose --since=origin/main",
     "changeset-version": "changeset version && npm i"
   },

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "sourcemaps": "ts-node-script config/rewriteSourceMaps.ts",
     "rollup": "rollup -c ./config/rollup.config.js",
     "prepdist": "node ./config/prepareDist.js",
+    "prepChangesetsRelease": "ts-node-script config/prepareChangesetsRelease.ts",
     "postprocess-dist": "ts-node-script config/postprocessDist.ts",
     "clean": "rimraf -r dist coverage lib temp",
     "ci:precheck": "node config/precheck.js",
@@ -53,7 +54,7 @@
     "predeploy": "npm run build",
     "deploy": "cd dist && npm publish --tag next",
     "typedoc": "typedoc src/index.ts --json docs/public/docs.json",
-    "changeset-publish": "npm run build && changeset publish",
+    "changeset-publish": "npm run build && npm run prepChangesetsRelease && cd dist && changeset publish",
     "changeset-check": "changeset status --verbose --since=origin/main",
     "changeset-version": "changeset version && npm i"
   },


### PR DESCRIPTION
There are two changes in this PR that pave the way for our first automated Changesets release from `main`, `3.7.3`:

- Update `CHANGELOG.md` to conform to Changesets heading defaults so the GitHub bot will have a better time generating future entries (I backfilled these changes to `3.7.0` for continuity).
- Add a script that prepares the `dist` folder for a Changesets release: it copies `CHANGELOG.md` and the `.changeset` folder inside of `dist` while adding both to an `.npmignore` so that our release workflow can `cd dist` and `changeset publish` Just Works. (This has been tested locally via `npm pack`.)

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
