### PR TITLE
Fixed minor grammar error in docs.

### DIFF
--- a/docs/source/data/mutations.mdx
+++ b/docs/source/data/mutations.mdx
@@ -215,7 +215,7 @@ Each element in the `refetchQueries` array is one of the following:
 
 * An object referencing `query` (a `DocumentNode` object parsed with the `gql` function) and `variables`
 * The name of a query you've previously executed, as a string (e.g., `GetComments`)
-  * To refer to queries by name, make sure each of your app's queries has a _unique_ name.
+  * To refer to queries by name, make sure each of your app's queries have a _unique_ name.
 
 Each included query is executed with its most recently provided set of variables.
 


### PR DESCRIPTION
Fixed minor grammar error in help bullet point subtitle.  

- To refer to queries by name, make sure each of your app's queries has a unique name.

 to

- To refer to queries by name, make sure each of your app's queries have a unique name.