### PR TITLE
Export `isNetworkRequestInFlight`

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -24,7 +24,10 @@ export {
   FetchMoreQueryOptions,
   SubscribeToMoreOptions,
 } from './watchQueryOptions';
-export { NetworkStatus } from './networkStatus';
+export { 
+  NetworkStatus,
+  isNetworkRequestInFlight
+} from './networkStatus';
 export * from './types';
 export {
   Resolver,


### PR DESCRIPTION
### Rationale:
`isNetworkRequestInFlight` is currently simple logic. However it is quite useful to have available when determining, for instance, if one should dispatch a `fetchMore` query for pagination.

It would be helpful to have access to this function provided by the standard library, rather than having to put it into my own utils package.

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests (n/a, I think?)
