### PR TITLE
Always throw network errors in `useSupenseQuery` regardless of the error policy

### DIFF
--- a/.changeset/short-bikes-mate.md
+++ b/.changeset/short-bikes-mate.md
@@ -1,0 +1,5 @@
+---
+'@apollo/client': patch
+---
+
+Always throw network errors in `useSuspenseQuery` regardless of the set `errorPolicy`.

--- a/src/react/hooks/useSuspenseQuery.ts
+++ b/src/react/hooks/useSuspenseQuery.ts
@@ -83,14 +83,17 @@ export function useSuspenseQuery_experimental<
   const hasPartialResult = result.data && result.partial;
   const usePartialResult = returnPartialData && hasPartialResult;
 
-  if (
-    result.error &&
-    errorPolicy === 'none' &&
+  const allowsThrownErrors =
     // If we've got a deferred query that errors on an incremental chunk, we
     // will have a partial result before the error is collected. We do not want
     // to throw errors that have been returned from incremental chunks. Instead
     // we offload those errors to the `error` property.
-    (!deferred || !hasPartialResult)
+    errorPolicy === 'none' && (!deferred || !hasPartialResult);
+
+  if (
+    result.error &&
+    // Always throw network errors regardless of the error policy
+    (result.error.networkError || allowsThrownErrors)
   ) {
     throw result.error;
   }


### PR DESCRIPTION
Closes #10384

Updates `useSuspenseQuery` to always throw network errors, regardless of the `errorPolicy` set in options. This is more in-line with how `useQuery` works when encountering a network error since the `error` is retained and the `onError` callback is called.

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
