### PR TITLE
Prefer the callbacks passed to the execute function returned from `useMutation`

### DIFF
--- a/.changeset/metal-hats-cough.md
+++ b/.changeset/metal-hats-cough.md
@@ -1,0 +1,5 @@
+---
+'@apollo/client': patch
+---
+
+Prefer the `onError` and `onCompleted` callback functions passed to the execute function returned from `useMutation` instead of calling both callback handlers.

--- a/docs/shared/mutation-result.mdx
+++ b/docs/shared/mutation-result.mdx
@@ -23,6 +23,8 @@ A function to trigger the mutation from your UI. You can optionally pass this fu
 * `awaitRefetchQueries`
 * `context`
 * `fetchPolicy`
+* `onCompleted`
+* `onError`
 * `optimisticResponse`
 * `refetchQueries`
 * `update`

--- a/src/react/hooks/useMutation.ts
+++ b/src/react/hooks/useMutation.ts
@@ -100,8 +100,10 @@ export function useMutation<
           setResult(ref.current.result = result);
         }
       }
-      ref.current.options?.onCompleted?.(response.data!, clientOptions);
-      executeOptions.onCompleted?.(response.data!, clientOptions);
+
+      const onCompleted = executeOptions.onCompleted || ref.current.options?.onCompleted
+      onCompleted?.(response.data!, clientOptions);
+
       return response;
     }).catch((error) => {
       if (
@@ -121,9 +123,11 @@ export function useMutation<
         }
       }
 
-      if (ref.current.options?.onError || clientOptions.onError) {
-        ref.current.options?.onError?.(error, clientOptions);
-        executeOptions.onError?.(error, clientOptions);
+      const onError = executeOptions.onError || ref.current.options?.onError
+
+      if (onError) {
+        onError(error, clientOptions);
+
         // TODO(brian): why are we returning this here???
         return { data: void 0, errors: error };
       }


### PR DESCRIPTION
Closes #10287

Prefer calling the `onError` and `onCompleted` functions passed to the execute function returned by the `useMutation`. Currently both the callbacks passed to the execute function and the callbacks passed to the hook itself are called. According to our [docs](https://www.apollographql.com/docs/react/data/mutations#mutate), this should not happen as the options passed to the execute function should override the hook options. 

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](../CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
