### PR TITLE
Abort in-flight promises returned from `useLazyQuery` when component unmounts

### DIFF
--- a/.changeset/brown-tomatoes-walk.md
+++ b/.changeset/brown-tomatoes-walk.md
@@ -1,0 +1,5 @@
+---
+'@apollo/client': patch
+---
+
+Ensure in-flight promises executed by `useLazyQuery` are rejected when `useLazyQuery` unmounts.

--- a/config/bundlesize.ts
+++ b/config/bundlesize.ts
@@ -3,7 +3,7 @@ import { join } from "path";
 import { gzipSync } from "zlib";
 import bytes from "bytes";
 
-const gzipBundleByteLengthLimit = bytes("32.03KB");
+const gzipBundleByteLengthLimit = bytes("32.12KB");
 const minFile = join("dist", "apollo-client.min.cjs");
 const minPath = join(__dirname, "..", minFile);
 const gzipByteLen = gzipSync(readFileSync(minPath)).byteLength;

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -101,8 +101,6 @@ export function useLazyQuery<TData = any, TVariables = OperationVariables>(
         return Object.assign(queryResult, eagerMethods);
       });
 
-    // Because the return value of `useLazyQuery` is usually floated, we need
-    // to catch the promise to prevent unhandled rejections.
     promise.catch(() => {
       abortControllersRef.current.delete(controller);
     });

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -1,6 +1,6 @@
 import { DocumentNode } from 'graphql';
 import { TypedDocumentNode } from '@graphql-typed-document-node/core';
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 
 import { OperationVariables } from '../../core';
 import { mergeOptions } from '../../utilities';
@@ -27,6 +27,7 @@ export function useLazyQuery<TData = any, TVariables = OperationVariables>(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
   options?: LazyQueryHookOptions<TData, TVariables>
 ): LazyQueryResultTuple<TData, TVariables> {
+  const abortControllersRef = useRef(new Set<AbortController>());
   const internalState = useInternalState(
     useApolloClient(options && options.client),
     query,
@@ -71,9 +72,20 @@ export function useLazyQuery<TData = any, TVariables = OperationVariables>(
 
   Object.assign(result, eagerMethods);
 
+  useEffect(() => {
+    return () => {
+      abortControllersRef.current.forEach((controller) => {
+        controller.abort();
+      });
+    }
+  }, [])
+
   const execute = useCallback<
     LazyQueryResultTuple<TData, TVariables>[0]
   >(executeOptions => {
+    const controller = new AbortController();
+    abortControllersRef.current.add(controller);
+
     execOptionsRef.current = executeOptions ? {
       ...executeOptions,
       fetchPolicy: executeOptions.fetchPolicy || initialFetchPolicy,
@@ -82,12 +94,18 @@ export function useLazyQuery<TData = any, TVariables = OperationVariables>(
     };
 
     const promise = internalState
-      .asyncUpdate() // Like internalState.forceUpdate, but returns a Promise.
-      .then(queryResult => Object.assign(queryResult, eagerMethods));
+      .asyncUpdate(controller.signal) // Like internalState.forceUpdate, but returns a Promise.
+      .then(queryResult => {
+        abortControllersRef.current.delete(controller);
+
+        return Object.assign(queryResult, eagerMethods);
+      });
 
     // Because the return value of `useLazyQuery` is usually floated, we need
     // to catch the promise to prevent unhandled rejections.
-    promise.catch(() => {});
+    promise.catch(() => {
+      abortControllersRef.current.delete(controller);
+    });
 
     return promise;
   }, []);

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -101,10 +101,20 @@ class InternalState<TData, TVariables> {
     invariant.warn("Calling default no-op implementation of InternalState#forceUpdate");
   }
 
-  asyncUpdate() {
-    return new Promise<QueryResult<TData, TVariables>>(resolve => {
+  asyncUpdate(signal: AbortSignal) {
+    return new Promise<QueryResult<TData, TVariables>>((resolve, reject) => {
+      const watchQueryOptions = this.watchQueryOptions;
+
+      const handleAborted = () => {
+        this.asyncResolveFns.delete(resolve)
+        this.optionsToIgnoreOnce.delete(watchQueryOptions);
+        signal.removeEventListener('abort', handleAborted)
+        reject(signal.reason);
+      };
+
       this.asyncResolveFns.add(resolve);
-      this.optionsToIgnoreOnce.add(this.watchQueryOptions);
+      this.optionsToIgnoreOnce.add(watchQueryOptions);
+      signal.addEventListener('abort', handleAborted)
       this.forceUpdate();
     });
   }


### PR DESCRIPTION
Closes #10365

Ensure in-flight promises returned from `useLazyQuery`'s execute function are aborted when `useLazyQuery` unmounts. Currently the promise is stuck in a pending state indefinitely with no way to resolve/reject it.

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](../CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
