### PR TITLE
chore: fix prerelease notification and upgrade to rich markdown

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Enter alpha prerelease mode
         # If .changeset/pre.json does not exist and we did not recently exit
         # prerelease mode, enter prerelease mode with tag alpha
-        if: ${{ steps.check_files.outputs.files_exists == 'false' && !contains(github.event.head_commit.message, 'Exit prerelease')}}
+        if: steps.check_files.outputs.files_exists == 'false' && !contains(github.event.head_commit.message, 'Exit prerelease')
         run: npx changeset pre enter alpha
 
       - name: Create alpha release PR
@@ -57,15 +57,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: get-npm-version
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@main
+
       - name: Run publish
         id: changesets
         # Only run publish if we're still in pre mode and the last commit was
         # via an automatically created Version Packages PR
-        if: ${{ steps.check_files.outputs.files_exists == 'true' && startsWith(github.event.head_commit.message, 'Version Packages')}}
+        if: steps.check_files.outputs.files_exists == 'true' && startsWith(github.event.head_commit.message, 'Version Packages')
         run: npm run changeset-publish
 
       - name: Send a Slack notification on publish
-        if: steps.changesets.outcome == 'success' && steps.changesets.outputs.published == 'true'
+        if: steps.changesets.outcome == 'success'
         id: slack
         uses: slackapi/slack-github-action@v1.23.0
         with:
@@ -75,6 +79,38 @@ jobs:
           # a comma-delimited list of channel IDs
           channel-id: 'C01PS0CB41G'
           # For posting a simple plain text message
-          slack-message: "Published @apollo/client v${{ fromJson(steps.changesets.outputs.publishedPackages)[0].version }}"
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "A new version of `@apollo/client` was released :rocket:"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Version:*\n`${{ steps.package-version.outputs.current-version}}`"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Tag:*\n`alpha`"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*GitHub release:*\nN/A"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*npm releases:*\n<https://www.npmjs.com/package/@apollo/client?activeTab=versions|link>"
+                    }
+                  ]
+                }
+              ]
+            }
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,10 +45,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Echo values from changesets step
-        if: steps.changesets.outcome == 'success'
-        run: echo "${{steps.changesets.outcome}} v${{ fromJson(steps.changesets.outputs.publishedPackages)[0].version }}"
-
       - name: Send a Slack notification on publish
         if: steps.changesets.outcome == 'success' && steps.changesets.outputs.published == 'true'
         id: slack
@@ -59,7 +55,38 @@ jobs:
           # You can pass in multiple channels to post to by providing
           # a comma-delimited list of channel IDs
           channel-id: 'C01PS0CB41G'
-          # For posting a simple plain text message
-          slack-message: "Published v${{ fromJson(steps.changesets.outputs.publishedPackages)[0].version }}"
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "A new version of `@apollo/client` was released :rocket:"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Version:*\n`${{ fromJson(steps.changesets.outputs.publishedPackages)[0].version }}`"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Tag:*\n`next`"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*GitHub release:*\n<https://github.com/apollographql/apollo-client/releases/tag/v${{ fromJson(steps.changesets.outputs.publishedPackages)[0].version }}|link>"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*npm releases:*\n<https://www.npmjs.com/package/@apollo/client?activeTab=versions|link>"
+                    }
+                  ]
+                }
+              ]
+            }
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
The prerelease GitHub action is still failing while trying to interact with SlackBot: `steps.changesets.outputs.publishedPackages` is undefined after a prerelease, so trying to index into the array in the `parseJSON` call causes the error.

Instead of using the changesets action's output, we'll just use an existing action from the marketplace to grab the version from `package.json`. This PR also formats the Slack message using their "blocks" API.