### PR TITLE
docs(community-links): add live query link

### DIFF
--- a/docs/source/api/link/community-links.md
+++ b/docs/source/api/link/community-links.md
@@ -26,3 +26,4 @@ Thank you to all the Apollo community members who have contributed custom Apollo
 | [apollo-link-segment](https://github.com/hobochild/apollo-link-segment) | [@hobochild](https://github.com/hobochild) | Automatically track apollo operations with [segment](https://segment.com/). |
 | [apollo-link-observable](https://github.com/dragozin/apollo-link-observable) | [@dragozin](https://github.com/dragozin) | Link that allows you to make side effects of graphql queries using [RxJS](http://github.com/ReactiveX/RxJS). |
 | [apollo-multi-endpoint-link](https://github.com/habx/apollo-multi-endpoint-link) | [@habx](https://github.com/habx) | Add directive to redirect requests to right endpoint |
+| [@grafbase/apollo-link](https://github.com/grafbase/playground/tree/main/packages/grafbase-apollo-link) | [@grafbase](https://github.com/grafbase) | Use GraphQL `@live` queries with Server-Sent Events.


### PR DESCRIPTION
Adds `@grafbase/live-apollo` to the community link directory. This ApolloLink enables [Live Queries](https://grafbase.com/docs/realtime/live-queries).