### PR TITLE
Add support for `subscribeToMore` and `client` from `useSuspenseQuery`

### DIFF
--- a/.changeset/wild-mice-nail.md
+++ b/.changeset/wild-mice-nail.md
@@ -1,0 +1,5 @@
+---
+'@apollo/client': patch
+---
+
+Add support for `subscribeToMore` from `useSuspenseQuery`

--- a/.changeset/wild-mice-nail.md
+++ b/.changeset/wild-mice-nail.md
@@ -2,4 +2,4 @@
 '@apollo/client': patch
 ---
 
-Add support for `subscribeToMore` from `useSuspenseQuery`
+Add support for the `subscribeToMore` and `client` fields returned in the `useSuspenseQuery` result.

--- a/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
@@ -636,6 +636,28 @@ describe('useSuspenseQuery', () => {
     ]);
   });
 
+  it('returns the client used in the result', async () => {
+    const { query } = useSimpleQueryCase();
+
+    const client = new ApolloClient({
+      link: new ApolloLink(() =>
+        Observable.of({ data: { greeting: 'hello' } })
+      ),
+      cache: new InMemoryCache(),
+    });
+
+    const { result } = renderSuspenseHook(() => useSuspenseQuery(query), {
+      client,
+    });
+
+    // wait for query to finish suspending to avoid warnings
+    await waitFor(() => {
+      expect(result.current.data).toEqual({ greeting: 'hello' });
+    });
+
+    expect(result.current.client).toBe(client);
+  });
+
   it('does not suspend when data is in the cache and using a "cache-first" fetch policy', async () => {
     const { query, mocks } = useSimpleQueryCase();
 

--- a/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
@@ -20,9 +20,16 @@ import {
   DocumentNode,
   InMemoryCache,
   Observable,
+  OperationVariables,
+  SubscribeToMoreOptions,
   TypedDocumentNode,
+  split,
 } from '../../../core';
-import { compact, concatPagination } from '../../../utilities';
+import {
+  compact,
+  concatPagination,
+  getMainDefinition,
+} from '../../../utilities';
 import {
   MockedProvider,
   MockedResponse,
@@ -4904,6 +4911,97 @@ describe('useSuspenseQuery', () => {
         },
         error: undefined,
       },
+    ]);
+  });
+
+  it('can subscribe to subscriptions and react to cache updates via `subscribeToMore`', async () => {
+    interface SubscriptionData {
+      greetingUpdated: string;
+    }
+
+    interface QueryData {
+      greeting: string;
+    }
+
+    type UpdateQueryFn = NonNullable<
+      SubscribeToMoreOptions<
+        QueryData,
+        OperationVariables,
+        SubscriptionData
+      >['updateQuery']
+    >;
+
+    const { mocks, query } = useSimpleQueryCase();
+
+    const wsLink = new MockSubscriptionLink();
+    const mockLink = new MockLink(mocks);
+
+    const link = split(
+      ({ query }) => {
+        const definition = getMainDefinition(query);
+
+        return (
+          definition.kind === 'OperationDefinition' &&
+          definition.operation === 'subscription'
+        );
+      },
+      wsLink,
+      mockLink
+    );
+
+    const { result, renders } = renderSuspenseHook(
+      () => useSuspenseQuery(query, { errorPolicy: 'ignore' }),
+      { link }
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual({ greeting: 'Hello' });
+    });
+
+    const updateQuery = jest.fn<
+      ReturnType<UpdateQueryFn>,
+      Parameters<UpdateQueryFn>
+    >((_, { subscriptionData: { data } }) => {
+      return { greeting: data.greetingUpdated };
+    });
+
+    result.current.subscribeToMore<SubscriptionData>({
+      document: gql`
+        subscription {
+          greetingUpdated
+        }
+      `,
+      updateQuery,
+    });
+
+    wsLink.simulateResult({
+      result: {
+        data: {
+          greetingUpdated: 'Subscription hello',
+        },
+      },
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual({
+        greeting: 'Subscription hello',
+      });
+    });
+
+    expect(updateQuery).toHaveBeenCalledTimes(1);
+    expect(updateQuery).toHaveBeenCalledWith(
+      { greeting: 'Hello' },
+      expect.objectContaining({
+        subscriptionData: {
+          data: { greetingUpdated: 'Subscription hello' },
+        },
+      })
+    );
+
+    expect(renders.count).toBe(3);
+    expect(renders.frames).toMatchObject([
+      { data: { greeting: 'Hello' } },
+      { data: { greeting: 'Subscription hello' } },
     ]);
   });
 });

--- a/src/react/hooks/useSuspenseQuery.ts
+++ b/src/react/hooks/useSuspenseQuery.ts
@@ -1,10 +1,4 @@
-import {
-  useRef,
-  useEffect,
-  useCallback,
-  useMemo,
-  useState,
-} from 'react';
+import { useRef, useEffect, useCallback, useMemo, useState } from 'react';
 import { equal } from '@wry/equality';
 import {
   ApolloClient,
@@ -42,6 +36,7 @@ export interface UseSuspenseQueryResult<
   error: ApolloError | undefined;
   fetchMore: ObservableQueryFields<TData, TVariables>['fetchMore'];
   refetch: ObservableQueryFields<TData, TVariables>['refetch'];
+  subscribeToMore: ObservableQueryFields<TData, TVariables>['subscribeToMore'];
 }
 
 const SUPPORTED_FETCH_POLICIES: WatchQueryFetchPolicy[] = [
@@ -173,6 +168,7 @@ export function useSuspenseQuery_experimental<
 
         return promise;
       },
+      subscribeToMore: (options) => observable.subscribeToMore(options),
     };
   }, [result, observable, errorPolicy]);
 }

--- a/src/react/hooks/useSuspenseQuery.ts
+++ b/src/react/hooks/useSuspenseQuery.ts
@@ -32,6 +32,7 @@ export interface UseSuspenseQueryResult<
   TData = any,
   TVariables = OperationVariables
 > {
+  client: ApolloClient<any>;
   data: TData;
   error: ApolloError | undefined;
   fetchMore: ObservableQueryFields<TData, TVariables>['fetchMore'];
@@ -146,6 +147,7 @@ export function useSuspenseQuery_experimental<
 
   return useMemo(() => {
     return {
+      client,
       data: result.data,
       error: errorPolicy === 'ignore' ? void 0 : toApolloError(result),
       fetchMore: (options) => {
@@ -170,7 +172,7 @@ export function useSuspenseQuery_experimental<
       },
       subscribeToMore: (options) => observable.subscribeToMore(options),
     };
-  }, [result, observable, errorPolicy]);
+  }, [client, result, observable, errorPolicy]);
 }
 
 function validateOptions(options: WatchQueryOptions) {


### PR DESCRIPTION
Closes #10429

Return the `subscribeToMore` and `client` fields in the `useSuspenseQuery` result.

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](../CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
