### PR TITLE
Remove beta version from useFragment docs

### DIFF
--- a/docs/source/api/react/hooks-experimental.mdx
+++ b/docs/source/api/react/hooks-experimental.mdx
@@ -10,7 +10,7 @@ import UseFragmentResult from '../../../shared/useFragment-result.mdx';
 
 ### Installation
 
-> ⚠️ **The `useFragment_experimental` hook is currently at the [preview stage](https://www.apollographql.com/docs/resources/release-stages/#preview) in Apollo Client and is available by installing `@apollo/client@beta`.** If you have feedback on it, please let us know via [GitHub issues](https://github.com/apollographql/apollo-client/issues/new?assignees=&labels=&template=bug.md).
+> ⚠️ **The `useFragment_experimental` hook is currently at the [preview stage](https://www.apollographql.com/docs/resources/release-stages/#preview) in Apollo Client.** If you have feedback on it, please let us know via [GitHub issues](https://github.com/apollographql/apollo-client/issues/new?assignees=&labels=&template=bug.md).
 
 Beginning with version `3.7.0`, Apollo Client Web has preview support for the `useFragment_experimental` hook, which represents a lightweight live binding into the Apollo Client Cache. This hook returns an always-up-to-date view of whatever data the cache currently contains for a given fragment. `useFragment_experimental` never triggers network requests of its own.
 

--- a/docs/source/caching/cache-interaction.mdx
+++ b/docs/source/caching/cache-interaction.mdx
@@ -194,7 +194,7 @@ All subscribers to the Apollo Client cache (including all active queries) see th
 
 ### `useFragment_experimental`
 
-> ⚠️ **The `useFragment_experimental` hook is currently at the [preview stage](https://www.apollographql.com/docs/resources/release-stages/#preview) in Apollo Client and is available by installing `@apollo/client@beta`.** If you have feedback on it, please let us know via [GitHub issues](https://github.com/apollographql/apollo-client/issues/new?assignees=&labels=&template=bug.md).
+> ⚠️ **The `useFragment_experimental` hook is currently at the [preview stage](https://www.apollographql.com/docs/resources/release-stages/#preview) in Apollo Client.** If you have feedback on it, please let us know via [GitHub issues](https://github.com/apollographql/apollo-client/issues/new?assignees=&labels=&template=bug.md).
 
 You can read data for a given fragment directly from the cache using the `useFragment_experimental` hook. This hook returns an always-up-to-date view of whatever data the cache currently contains for a given fragment. [See the API reference.](../api/react/hooks-experimental)
 

--- a/docs/source/data/fragments.md
+++ b/docs/source/data/fragments.md
@@ -273,4 +273,4 @@ const cache = new InMemoryCache({
 
 ## `useFragment_experimental`
 
-> ⚠️ **The `useFragment_experimental` hook is currently at the [preview stage](https://www.apollographql.com/docs/resources/release-stages/#preview) in Apollo Client and is available by installing `@apollo/client@beta`.** [See the API reference for more details.](../api/react/hooks-experimental)
+> ⚠️ **The `useFragment_experimental` hook is currently at the [preview stage](https://www.apollographql.com/docs/resources/release-stages/#preview) in Apollo Client.** [See the API reference for more details.](../api/react/hooks-experimental)


### PR DESCRIPTION
`useFragment_experimental` was released in 3.7 so we don't need to specify `@beta` anymore 🎉 