### PR TITLE
Set Stale Action debug to false, increase operations-per-run

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -123,7 +123,7 @@ jobs:
         remove-pr-stale-when-updated: false
 
         # Run the processor in debug mode without actually performing any operations on live issues.
-        debug-only: true
+        debug-only: false
 
         # # The order to get issues or pull requests. Defaults to false, which is descending.
         # ascending: # optional, default is false

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -111,7 +111,7 @@ jobs:
         # only-pr-labels: # optional, default is 
 
         # The maximum number of operations per run, used to control rate limiting (GitHub API CRUD related).
-        operations-per-run: 100 # optional, default is 30
+        operations-per-run: 500 # optional, default is 30
 
         # Remove stale labels from issues and pull requests when they are updated or commented on.
         remove-stale-when-updated: false


### PR DESCRIPTION
I've been looking over the [logs](https://github.com/apollographql/apollo-client/actions/runs/3955601813/jobs/6774029079) from the `🏓  awaiting-contributor-response` Action and found that it's working as expected.  So let's let it run for real 🚀   I'd also like to propose bumping up the `operation-per-run` value since the job exhausts itself before reaching the end of our issues.