### PR TITLE
chore: fix netlify ignore script

### DIFF
--- a/docs/source/integrations/integrations.md
+++ b/docs/source/integrations/integrations.md
@@ -3,7 +3,7 @@ title: View integrations
 description: How to use Apollo Client with the view layer your application is developed in!
 ---
 
-## React
+## React foo
 
 Apollo Client's built-in React support allows you to fetch data from your GraphQL server and use it in building complex and reactive UIs using the React framework. Apollo Client may be used in any context that React may be used. In the browser, in React Native, or in Node.js when you want to server side render.
 

--- a/docs/source/integrations/integrations.md
+++ b/docs/source/integrations/integrations.md
@@ -3,7 +3,7 @@ title: View integrations
 description: How to use Apollo Client with the view layer your application is developed in!
 ---
 
-## React foo
+## React
 
 Apollo Client's built-in React support allows you to fetch data from your GraphQL server and use it in building complex and reactive UIs using the React framework. Apollo Client may be used in any context that React may be used. In the browser, in React Native, or in Node.js when you want to server side render.
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,10 +3,11 @@
   command = "npm run typedoc"
 
 [build.environment]
-  NODE_VERSION = "16"
+  NODE_VERSION = "18"
 
 [context.deploy-preview.build]
   base = "docs"
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF"
   command = """\
   cd ../
   rm -rf monodocs

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@
 
 [context.deploy-preview.build]
   base = "docs"
-  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ./docs"
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ."
   command = """\
   cd ../
   rm -rf monodocs

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,6 @@
 
 [context.deploy-preview.build]
   base = "docs"
-  ignore = "exit 1"
   command = """\
   cd ../
   rm -rf monodocs

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@
 
 [context.deploy-preview.build]
   base = "docs"
-  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF"
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ./docs"
   command = """\
   cd ../
   rm -rf monodocs


### PR DESCRIPTION
The previous `ignore` script of `git diff --quiet HEAD^ HEAD .` was no longer detecting changes inside of `docs`, so it was temporarily disabled causing docs previews to build on all PRs.

This PR reinstates the ignore script using the [most recent recommendation from the docs](https://docs.netlify.com/configure-builds/ignore-builds/#mimic-default-behavior), `git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF .` and bumps the `NODE_VERSION` to 18.