### PR TITLE
Add default values for useFragment generic types

### DIFF
--- a/.changeset/wicked-dots-knock.md
+++ b/.changeset/wicked-dots-knock.md
@@ -1,0 +1,5 @@
+---
+'@apollo/client': patch
+---
+
+Add generic type defaults when using `useFragment` to allow passing `TData` directly to the function without needing to specify `TVars`.

--- a/src/react/hooks/useFragment.ts
+++ b/src/react/hooks/useFragment.ts
@@ -11,6 +11,7 @@ import {
 
 import { useApolloClient } from "./useApolloClient";
 import { useSyncExternalStore } from "./useSyncExternalStore";
+import { OperationVariables } from "../../core";
 
 export interface UseFragmentOptions<TData, TVars>
 extends Omit<
@@ -48,7 +49,10 @@ export interface UseFragmentResult<TData> {
   missing?: MissingTree;
 }
 
-export function useFragment_experimental<TData, TVars>(
+export function useFragment_experimental<
+  TData = any,
+  TVars = OperationVariables
+>(
   options: UseFragmentOptions<TData, TVars>,
 ): UseFragmentResult<TData> {
   const { cache } = useApolloClient();


### PR DESCRIPTION
This PR adds default types for the `useFragment` generic definitions. This improves the experience when passing generic types directly to the `useFragment` function.

Currently, you can get proper types on `data` when using `TypedDocumentNode`. Take the following example:

```ts
const ItemFragment: TypedDocumentNode<Item> = gql`
  fragment ItemFragment on Item {
    text
  }
`

const { data } = useFragment({ fragment: ItemFragment })

type Data = typeof data; 
// type Data = Item | undefined
```

If using the generic `gql` helper, you get `unknown` as expected:

```ts
const ItemFragment = gql`
  fragment ItemFragment on Item {
    text
  }
`

const { data } = useFragment({ fragment: ItemFragment })

type Data = typeof data; 
// type Data = unknown
```

If, however, I want to provide my own types to `useFragment`, the current implementation forces you to provide the `TArgs` type.

```ts
const ItemFragment = gql`
  fragment ItemFragment on Item {
    text
  }
`

const { data } = useFragment<Item>({ fragment: ItemFragment }) // [Error] Expected 2 type arguments, but got 1.
```

This is rather annoying because I have to import `OperationVariables` just to use `TData`.

This PR ensures a default value is properly set so that I can just pass the `TData` generic and get proper types.

```ts
const ItemFragment = gql`
  fragment ItemFragment on Item {
    text
  }
`

const { data } = useFragment<Item>({ fragment: ItemFragment }) 
type Data = typeof data
// type Data = Item | undefined
```

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](../CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
