### PR TITLE
chore: adds changeset snapshot action

### DIFF
--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -1,0 +1,72 @@
+name: Snapshot Release
+
+on:
+  issue_comment:
+    types:
+      - created
+
+jobs:
+  release_next:
+    name: release:next
+    runs-on: ubuntu-latest
+
+    if: |
+      github.repository == 'apollographql/apollo-client' &&
+      github.event.issue.pull_request &&
+      (
+        github.event.sender.login == 'benjamn' ||
+        github.event.sender.login == 'alessbell' ||
+        github.event.sender.login == 'bignimbus' ||
+        github.event.sender.login == 'hwillson' ||
+        github.event.sender.login == 'jerelmiller'
+      ) &&
+      startsWith(github.event.comment.body, '/release:pr')
+
+    steps:
+      - uses: xt0rted/pull-request-comment-branch@v1
+        id: comment-branch
+
+      - name: Checkout head ref
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ steps.comment-branch.outputs.head_ref }}
+          fetch-depth: 0
+
+      - name: Append NPM token to .npmrc
+        run: |
+          cat << EOF > "$HOME/.npmrc"
+            //registry.npmjs.org/:_authToken=$NPM_TOKEN
+          EOF
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Setup Node.js 18.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+
+      - name: Install dependencies (with cache)
+        uses: bahmutov/npm-install@v1
+
+      # https://github.com/atlassian/changesets/blob/master/docs/snapshot-releases.md
+      - name: Release to pr tag
+        run: |
+          npx changeset version --snapshot pr-${{ github.event.issue.number }} && npm i
+          npm run build
+          npm run prepdist:changesets
+          cd dist
+          npx changeset publish --no-git-tag --snapshot --tag pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Get released version
+        id: version
+        run: echo ::set-output name=version::$(node -p "require('./dist/package.json').version")
+
+      - name: Create comment
+        uses: peter-evans/create-or-update-comment@v2.1.0
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            A new release has been made for this PR. You can install it with `npm i @apollo/client@${{ steps.version.outputs.version }}`.


### PR DESCRIPTION
## Snapshot Releases

This PR adds a GitHub action to automate creating "snapshot" one-off releases so that Apollo community members can test out the changes on a PR before it's merged.

If an Apollo maintainer adds a comment beginning with `/release:pr` on a PR _that already contains a changeset markdown file_, the following happens:

- the PR is checked out at its latest commit
- the code is built and changeset versions the library with the following naming convention: `0.0.0-${some tag we set}-${current timestamp on CI}`, for example `0.0.0-pr-10479-20230126204300`. This is the naming convention chosen by changesets and only the middle tag value is configurable which I set to the current PR number to make it easier to associate snapshot releases to their originating PRs
- this version number is only used for publishing at the time the action is run; it is not committed to the branch or otherwise persisted
- a "snapshot" of the current PR is published at the above version number under the npm tag `pr` (no GitHub tag is created)
- a GitHub bot comments on the PR with instructions to install via e.g. `npm i @apollo/client@0.0.0-pr-10479-20230126204300`

### One minor note
At first I thought we might, but we don't actually want a per-PR npm tag as unique tags are listed above the fold on our npm page, and we never want to install via a semantic tag with snapshots, just via inscrutable version number since 1. these are throwaway releases and 2. it should be somewhat effortful to install them.

There are no other side effects of this PR, meaning our existing changesets workflows remain as they are 🎉 

I tested this action out in a demo repo and it worked really nicely 🚀 

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](../CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
