### PR TITLE
Allow `useLazyQuery` trigger fn to change `query`

### DIFF
--- a/.changeset/seven-cameras-kiss.md
+++ b/.changeset/seven-cameras-kiss.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Allow useLazyQuery trigger fn to change query

--- a/.changeset/seven-cameras-kiss.md
+++ b/.changeset/seven-cameras-kiss.md
@@ -2,4 +2,4 @@
 "@apollo/client": patch
 ---
 
-Allow useLazyQuery trigger fn to change query
+Allow the execution function returned by `useLazyQuery` to change the query.

--- a/config/bundlesize.ts
+++ b/config/bundlesize.ts
@@ -3,7 +3,7 @@ import { join } from "path";
 import { gzipSync } from "zlib";
 import bytes from "bytes";
 
-const gzipBundleByteLengthLimit = bytes("32.37KB");
+const gzipBundleByteLengthLimit = bytes("32.42KB");
 const minFile = join("dist", "apollo-client.min.cjs");
 const minPath = join(__dirname, "..", minFile);
 const gzipByteLen = gzipSync(readFileSync(minPath)).byteLength;

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -28,15 +28,14 @@ export function useLazyQuery<TData = any, TVariables extends OperationVariables 
   options?: LazyQueryHookOptions<TData, TVariables>
 ): LazyQueryResultTuple<TData, TVariables> {
   const abortControllersRef = useRef(new Set<AbortController>());
-  const internalState = useInternalState(
-    useApolloClient(options && options.client),
-    query,
-  );
 
   const execOptionsRef = useRef<Partial<LazyQueryHookOptions<TData, TVariables>>>();
-  const merged = execOptionsRef.current
-    ? mergeOptions(options, execOptionsRef.current)
-    : options;
+  const merged = execOptionsRef.current ? mergeOptions(options, execOptionsRef.current) : options;
+
+  const internalState = useInternalState<TData, TVariables>(
+    useApolloClient(options && options.client),
+    merged?.query ?? query
+  );
 
   const useQueryResult = internalState.useQuery({
     ...merged,

--- a/src/utilities/common/mergeOptions.ts
+++ b/src/utilities/common/mergeOptions.ts
@@ -13,7 +13,7 @@ type OptionsUnion<TData, TVariables extends OperationVariables, TContext> =
   | MutationOptions<TData, TVariables, TContext>;
 
 export function mergeOptions<
-  TOptions extends OptionsUnion<any, any, any>
+  TOptions extends Partial<OptionsUnion<any, any, any>>
 >(
   defaults: TOptions | Partial<TOptions> | undefined,
   options: TOptions | Partial<TOptions>,


### PR DESCRIPTION
fixes #10496

Locally, many of the tests were erroring out for me - but independently of the `useLazyQuery` tests and even without my changes. So let's see what CI has to say about this.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](../CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
