### PR TITLE
chore: adds GHA workflow to lock closed + dormant issues

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,32 @@
+name: 'Lock Threads'
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions: {}
+jobs:
+  lock:
+    permissions:
+      issues: write # to lock issues (dessant/lock-threads)
+      pull-requests: write # to lock PRs (dessant/lock-threads)
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+          issue-inactive-days: '30'
+          exclude-any-issue-labels: '💬 discussion'
+          issue-comment: >
+            This issue has been automatically locked since there has not been any recent activity after it was closed. Please open a new issue for related bugs.
+
+            Please note this issue tracker is not a help forum. We recommend using [StackOverflow](https://stackoverflow.com/questions/tagged/apollo-client) or our [discord server](https://discord.gg/graphos) for questions.
+
+          pr-inactive-days: '30'
+          exclude-any-pr-labels: '💬 discussion'
+          pr-comment: >
+            This pull request has been automatically locked since there has not been any recent activity after it was closed. Please open a new issue for related bugs.
+
+            Please note this issue tracker is not a help forum. We recommend using [StackOverflow](https://stackoverflow.com/questions/tagged/apollo-client) or our [discord server](https://discord.gg/graphos) for questions.

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -2,7 +2,7 @@ name: 'Lock Threads'
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 * * * *'
 
 permissions: {}
 jobs:
@@ -19,14 +19,14 @@ jobs:
 
           issue-inactive-days: '30'
           exclude-any-issue-labels: '💬 discussion'
-          issue-comment: >
-            This issue has been automatically locked since there has not been any recent activity after it was closed. Please open a new issue for related bugs.
+          # issue-comment: >
+          #   This issue has been automatically locked since there has not been any recent activity after it was closed. Please open a new issue for related bugs.
 
-            Please note this issue tracker is not a help forum. We recommend using [StackOverflow](https://stackoverflow.com/questions/tagged/apollo-client) or our [discord server](https://discord.gg/graphos) for questions.
+          #   Please note this issue tracker is not a help forum. We recommend using [StackOverflow](https://stackoverflow.com/questions/tagged/apollo-client) or our [discord server](https://discord.gg/graphos) for questions.
 
           pr-inactive-days: '30'
           exclude-any-pr-labels: '💬 discussion'
-          pr-comment: >
-            This pull request has been automatically locked since there has not been any recent activity after it was closed. Please open a new issue for related bugs.
+          # pr-comment: >
+          #   This pull request has been automatically locked since there has not been any recent activity after it was closed. Please open a new issue for related bugs.
 
-            Please note this issue tracker is not a help forum. We recommend using [StackOverflow](https://stackoverflow.com/questions/tagged/apollo-client) or our [discord server](https://discord.gg/graphos) for questions.
+          #   Please note this issue tracker is not a help forum. We recommend using [StackOverflow](https://stackoverflow.com/questions/tagged/apollo-client) or our [discord server](https://discord.gg/graphos) for questions.


### PR DESCRIPTION
Adds workflow to lock closed issues + PR that have not had new comments within the last 30 days.