### PR TITLE
Log unmatched mocks to the console for tests

### DIFF
--- a/.changeset/funny-files-suffer.md
+++ b/.changeset/funny-files-suffer.md
@@ -2,4 +2,4 @@
 '@apollo/client': patch
 ---
 
-Log a warning to the console when a mock passed to `MockedProvider` or `MockLink` cannot be matched to a query during a test. This makes it easier to debug user errors in the mock setup, such as typos, especially if the query under test is using an `errorPolicy` set to `ignore`, which makes it difficult to know a mismatch occurred.
+Log a warning to the console when a mock passed to `MockedProvider` or `MockLink` cannot be matched to a query during a test. This makes it easier to debug user errors in the mock setup, such as typos, especially if the query under test is using an `errorPolicy` set to `ignore`, which makes it difficult to know that a match did not occur.

--- a/.changeset/funny-files-suffer.md
+++ b/.changeset/funny-files-suffer.md
@@ -1,0 +1,5 @@
+---
+'@apollo/client': patch
+---
+
+Log a warning to the console when a mock passed to `MockedProvider` or `MockLink` cannot be matched to a query during a test. This makes it easier to debug user errors in the mock setup, such as typos, especially if the query under test is using an `errorPolicy` set to `ignore`, which makes it difficult to know a mismatch occurred.

--- a/docs/source/api/react/testing.md
+++ b/docs/source/api/react/testing.md
@@ -130,7 +130,7 @@ Props to pass down to the `MockedProvider`'s child.
 
 When a request fails to match a mock, a warning is logged to the console to indicate the mismatch. Set this to `false` to silence these warnings.
 
-The default value is `false`.
+The default value is `true`.
 
 </td>
 </tr>

--- a/docs/source/api/react/testing.md
+++ b/docs/source/api/react/testing.md
@@ -119,6 +119,22 @@ Props to pass down to the `MockedProvider`'s child.
 </td>
 </tr>
 
+<tr>
+<td>
+
+###### `silenceWarnings`
+
+`boolean`
+</td>
+<td>
+
+When a request fails to match a mock, a warning is logged to the console to indicate the mismatch. Set this to `true` to silence these warnings.
+
+The default value is `false`.
+
+</td>
+</tr>
+
 </tbody>
 </table>
 

--- a/docs/source/api/react/testing.md
+++ b/docs/source/api/react/testing.md
@@ -122,13 +122,13 @@ Props to pass down to the `MockedProvider`'s child.
 <tr>
 <td>
 
-###### `silenceWarnings`
+###### `showWarnings`
 
 `boolean`
 </td>
 <td>
 
-When a request fails to match a mock, a warning is logged to the console to indicate the mismatch. Set this to `true` to silence these warnings.
+When a request fails to match a mock, a warning is logged to the console to indicate the mismatch. Set this to `false` to silence these warnings.
 
 The default value is `false`.
 

--- a/docs/source/development-testing/testing.mdx
+++ b/docs/source/development-testing/testing.mdx
@@ -401,12 +401,12 @@ const {
   cache,
   resolvers,
   link,
-  silenceWarnings 
+  showWarnings,
 } = this.props;
 const client = new ApolloClient({
   cache: cache || new Cache({ addTypename }),
   defaultOptions,
-  link: link || new MockLink(mocks || [], addTypename, { silenceWarnings }),
+  link: link || new MockLink(mocks || [], addTypename, { showWarnings }),
   resolvers,
 });
 ```

--- a/docs/source/development-testing/testing.mdx
+++ b/docs/source/development-testing/testing.mdx
@@ -394,12 +394,19 @@ In order to properly test local state using `MockedProvider`, you'll need to pas
 `MockedProvider` creates its own ApolloClient instance behind the scenes like this:
 
 ```jsx
-const { mocks, addTypename, defaultOptions, cache, resolvers, link } =
-  this.props;
+const { 
+  mocks,
+  addTypename,
+  defaultOptions,
+  cache,
+  resolvers,
+  link,
+  silenceWarnings 
+} = this.props;
 const client = new ApolloClient({
   cache: cache || new Cache({ addTypename }),
   defaultOptions,
-  link: link || new MockLink(mocks || [], addTypename),
+  link: link || new MockLink(mocks || [], addTypename, { silenceWarnings }),
   resolvers,
 });
 ```

--- a/src/testing/core/index.ts
+++ b/src/testing/core/index.ts
@@ -2,6 +2,7 @@ export {
   MockLink,
   mockSingleLink,
   MockedResponse,
+  MockLinkOptions,
   ResultFunction
 } from './mocking/mockLink';
 export {

--- a/src/testing/core/mocking/mockLink.ts
+++ b/src/testing/core/mocking/mockLink.ts
@@ -30,7 +30,7 @@ export interface MockedResponse<TData = Record<string, any>> {
 }
 
 export interface MockLinkOptions {
-  silenceWarnings?: boolean;
+  showWarnings?: boolean;
 }
 
 function requestToKey(request: GraphQLRequest, addTypename: Boolean): string {
@@ -44,17 +44,17 @@ function requestToKey(request: GraphQLRequest, addTypename: Boolean): string {
 export class MockLink extends ApolloLink {
   public operation: Operation;
   public addTypename: Boolean = true;
-  public silenceWarnings: boolean = false;
+  public showWarnings: boolean = true;
   private mockedResponsesByKey: { [key: string]: MockedResponse[] } = {};
 
   constructor(
     mockedResponses: ReadonlyArray<MockedResponse>,
     addTypename: Boolean = true,
-    options: MockLinkOptions = {}
+    options: MockLinkOptions = Object.create(null)
   ) {
     super();
     this.addTypename = addTypename;
-    this.silenceWarnings = options.silenceWarnings ?? false;
+    this.showWarnings = options.showWarnings ?? true;
 
     if (mockedResponses) {
       mockedResponses.forEach(mockedResponse => {
@@ -111,7 +111,7 @@ Failed to match ${unmatchedVars.length} mock${
 ${unmatchedVars.map(d => `  ${stringifyForDisplay(d)}`).join('\n')}
 ` : ""}`);
 
-      if (!this.silenceWarnings) {
+      if (this.showWarnings) {
         console.warn(
           configError.message + 
             '\nThis typically indicates a configuration error in your mocks ' +

--- a/src/testing/core/mocking/mockLink.ts
+++ b/src/testing/core/mocking/mockLink.ts
@@ -114,8 +114,8 @@ ${unmatchedVars.map(d => `  ${stringifyForDisplay(d)}`).join('\n')}
       if (!this.silenceWarnings) {
         console.warn(
           configError.message + 
-            '\nThis typically indicates an error in your mocks setup, usually ' +
-            'due to a typo.'
+            '\nThis typically indicates a configuration error in your mocks ' +
+            'setup, usually due to a typo or mismatched variable.'
         );
       }
     } else {

--- a/src/testing/react/MockedProvider.tsx
+++ b/src/testing/react/MockedProvider.tsx
@@ -17,6 +17,7 @@ export interface MockedProviderProps<TSerializedCache = {}> {
   childProps?: object;
   children?: any;
   link?: ApolloLink;
+  silenceWarnings?: boolean;
 }
 
 export interface MockedProviderState {
@@ -40,7 +41,8 @@ export class MockedProvider extends React.Component<
       defaultOptions,
       cache,
       resolvers,
-      link
+      link,
+      silenceWarnings,
     } = this.props;
     const client = new ApolloClient({
       cache: cache || new Cache({ addTypename }),
@@ -48,6 +50,7 @@ export class MockedProvider extends React.Component<
       link: link || new MockLink(
         mocks || [],
         addTypename,
+        { silenceWarnings }
       ),
       resolvers,
     });

--- a/src/testing/react/MockedProvider.tsx
+++ b/src/testing/react/MockedProvider.tsx
@@ -17,7 +17,7 @@ export interface MockedProviderProps<TSerializedCache = {}> {
   childProps?: object;
   children?: any;
   link?: ApolloLink;
-  silenceWarnings?: boolean;
+  showWarnings?: boolean;
 }
 
 export interface MockedProviderState {
@@ -42,7 +42,7 @@ export class MockedProvider extends React.Component<
       cache,
       resolvers,
       link,
-      silenceWarnings,
+      showWarnings,
     } = this.props;
     const client = new ApolloClient({
       cache: cache || new Cache({ addTypename }),
@@ -50,7 +50,7 @@ export class MockedProvider extends React.Component<
       link: link || new MockLink(
         mocks || [],
         addTypename,
-        { silenceWarnings }
+        { showWarnings }
       ),
       resolvers,
     });

--- a/src/testing/react/__tests__/MockedProvider.test.tsx
+++ b/src/testing/react/__tests__/MockedProvider.test.tsx
@@ -175,7 +175,7 @@ describe('General use', () => {
     };
 
     render(
-      <MockedProvider silenceWarnings mocks={mocks}>
+      <MockedProvider showWarnings={false} mocks={mocks}>
         <Component {...variables2} />
       </MockedProvider>
     );
@@ -215,7 +215,7 @@ describe('General use', () => {
     };
 
     render(
-      <MockedProvider silenceWarnings mocks={mocks2}>
+      <MockedProvider showWarnings={false} mocks={mocks2}>
         <Component {...variables2} />
       </MockedProvider>
     );
@@ -325,7 +325,7 @@ describe('General use', () => {
     ];
 
     render(
-      <MockedProvider silenceWarnings mocks={mocksDifferentQuery}>
+      <MockedProvider showWarnings={false} mocks={mocksDifferentQuery}>
         <Component {...variables} />
       </MockedProvider>
     );
@@ -437,7 +437,7 @@ describe('General use', () => {
 
     const link = ApolloLink.from([
       errorLink,
-      new MockLink([], true, { silenceWarnings: true })
+      new MockLink([], true, { showWarnings: false })
     ]);
 
     render(
@@ -533,7 +533,7 @@ describe('General use', () => {
     consoleSpy.mockRestore();
   });
 
-  it('silences console warning for unmatched mocks when silenceWarnings is `true`', async () => {
+  it('silences console warning for unmatched mocks when `showWarnings` is `false`', async () => {
     const consoleSpy = jest.spyOn(console, 'warn');
     let finished = false;
     function Component({ ...variables }: Variables) {
@@ -561,7 +561,7 @@ describe('General use', () => {
     ];
 
     render(
-      <MockedProvider mocks={mocksDifferentQuery} silenceWarnings={true}>
+      <MockedProvider mocks={mocksDifferentQuery} showWarnings={false}>
         <Component {...variables} />
       </MockedProvider>
     );
@@ -575,7 +575,7 @@ describe('General use', () => {
     consoleSpy.mockRestore();
   });
 
-  it('silences console warning for unmatched mocks when passing `silenceWarnings` to `MockLink` directly', async () => {
+  it('silences console warning for unmatched mocks when passing `showWarnings` to `MockLink` directly', async () => {
     const consoleSpy = jest.spyOn(console, 'warn');
     let finished = false;
     function Component({ ...variables }: Variables) {
@@ -605,7 +605,7 @@ describe('General use', () => {
     const link = new MockLink(
       mocksDifferentQuery,
       false,
-      { silenceWarnings: true }
+      { showWarnings: false }
     );
 
     render(
@@ -630,7 +630,7 @@ describe('General use', () => {
       return null;
     }
 
-    const mockLink = new MockLink([], true, { silenceWarnings: true });
+    const mockLink = new MockLink([], true, { showWarnings: false });
     mockLink.setOnError(error => {
       expect(error).toMatchSnapshot();
       finished = true;
@@ -659,7 +659,7 @@ describe('General use', () => {
       return null;
     }
 
-    const mockLink = new MockLink([], true, { silenceWarnings: true });
+    const mockLink = new MockLink([], true, { showWarnings: false });
     mockLink.setOnError(() => {
       throw new Error('oh no!');
     });

--- a/src/testing/react/__tests__/MockedProvider.test.tsx
+++ b/src/testing/react/__tests__/MockedProvider.test.tsx
@@ -175,7 +175,7 @@ describe('General use', () => {
     };
 
     render(
-      <MockedProvider mocks={mocks}>
+      <MockedProvider silenceWarnings mocks={mocks}>
         <Component {...variables2} />
       </MockedProvider>
     );
@@ -215,7 +215,7 @@ describe('General use', () => {
     };
 
     render(
-      <MockedProvider mocks={mocks2}>
+      <MockedProvider silenceWarnings mocks={mocks2}>
         <Component {...variables2} />
       </MockedProvider>
     );
@@ -325,7 +325,7 @@ describe('General use', () => {
     ];
 
     render(
-      <MockedProvider mocks={mocksDifferentQuery}>
+      <MockedProvider silenceWarnings mocks={mocksDifferentQuery}>
         <Component {...variables} />
       </MockedProvider>
     );
@@ -435,7 +435,10 @@ describe('General use', () => {
       return null;
     }
 
-    const link = ApolloLink.from([errorLink, new MockLink([])]);
+    const link = ApolloLink.from([
+      errorLink,
+      new MockLink([], true, { silenceWarnings: true })
+    ]);
 
     render(
       <MockedProvider link={link}>
@@ -627,7 +630,7 @@ describe('General use', () => {
       return null;
     }
 
-    const mockLink = new MockLink([]);
+    const mockLink = new MockLink([], true, { silenceWarnings: true });
     mockLink.setOnError(error => {
       expect(error).toMatchSnapshot();
       finished = true;
@@ -656,7 +659,7 @@ describe('General use', () => {
       return null;
     }
 
-    const mockLink = new MockLink([]);
+    const mockLink = new MockLink([], true, { silenceWarnings: true });
     mockLink.setOnError(() => {
       throw new Error('oh no!');
     });


### PR DESCRIPTION
Closes #5917

When using `MockedProvider` to mock responses for a component under test, there is a chance a mock is not matched when the request was made, typically due to user-error like a typo or mismatched variable. Currently this results in an error response returned from the `MockLink`. In some situations, limiting the mismatch to an error response made it difficult to debug issues with the test setup, such as when the `errorPolicy` was set to `ignore`, which discards errors returned from links. 

This PR will now log console warnings when a mock cannot be matched during a test. This should make it more obvious that there could be potential issues with the test setup.

<img width="1153" alt="Screenshot 2023-02-01 at 6 25 47 PM" src="https://user-images.githubusercontent.com/565661/216208242-16af6a7e-bde2-4dbc-afcc-dfdd2a0b1615.png">

Occasionally, an unmatched mock is expected for a test. In this case, you can disable these warnings with the newly introduced `silenceWarnings` option. This can be set either through the `MockedProvider` or `MockLink`.

```tsx
// Using `MockedProvider`
<MockedProvider silenceWarnings={true} />

// Using `MockLink`
new MockLink(mocks, false, { silenceWarnings: true });
```


### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](../CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
