### PR TITLE
Remove unused reject argument for mockQueryManager and mockWatchQuery

### DIFF
--- a/src/__tests__/local-state/resolvers.ts
+++ b/src/__tests__/local-state/resolvers.ts
@@ -43,7 +43,7 @@ const assertWithObserver = ({
   delay?: number;
   observer: Observer<ApolloQueryResult<any>>;
 }) => {
-  const queryManager = mockQueryManager(reject, {
+  const queryManager = mockQueryManager({
     request: { query: serverQuery || query, variables },
     result: serverResult,
     error,

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -86,7 +86,6 @@ describe('ObservableQuery', () => {
     describe('to change pollInterval', () => {
       itAsync('starts polling if goes from 0 -> something', (resolve, reject) => {
         const manager = mockQueryManager(
-          reject,
           {
             request: { query, variables },
             result: { data: dataOne },
@@ -121,7 +120,6 @@ describe('ObservableQuery', () => {
 
       itAsync('stops polling if goes from something -> 0', (resolve, reject) => {
         const manager = mockQueryManager(
-          reject,
           {
             request: { query, variables },
             result: { data: dataOne },
@@ -155,7 +153,6 @@ describe('ObservableQuery', () => {
 
       itAsync('can change from x>0 to y>0', (resolve, reject) => {
         const manager = mockQueryManager(
-          reject,
           {
             request: { query, variables },
             result: { data: dataOne },
@@ -209,7 +206,6 @@ describe('ObservableQuery', () => {
       const variables2 = { first: 1 };
 
       const queryManager = mockQueryManager(
-        reject,
         {
           request: {
             query: queryWithVars,
@@ -266,7 +262,6 @@ describe('ObservableQuery', () => {
       const data2 = { allPeople: { people: [{ name: 'Leia Skywalker' }] } };
 
       const queryManager = mockQueryManager(
-        reject,
         {
           request: {
             query,
@@ -324,7 +319,6 @@ describe('ObservableQuery', () => {
       const variables2 = { first: 1 };
 
       const observable: ObservableQuery<any> = mockWatchQuery(
-        reject,
         {
           request: {
             query,
@@ -365,9 +359,8 @@ describe('ObservableQuery', () => {
 
     // TODO: Something isn't quite right with this test. It's failing but not
     // for the right reasons.
-    itAsync.skip('if query is refetched, and an error is returned, no other observer callbacks will be called', (resolve, reject) => {
+    itAsync.skip('if query is refetched, and an error is returned, no other observer callbacks will be called', (resolve) => {
       const observable: ObservableQuery<any> = mockWatchQuery(
-        reject,
         {
           request: { query, variables },
           result: { data: dataOne },
@@ -404,7 +397,6 @@ describe('ObservableQuery', () => {
 
     itAsync('does a network request if fetchPolicy becomes networkOnly', (resolve, reject) => {
       const observable: ObservableQuery<any> = mockWatchQuery(
-        reject,
         {
           request: { query, variables },
           result: { data: dataOne },
@@ -631,7 +623,6 @@ describe('ObservableQuery', () => {
 
     itAsync('returns a promise which eventually returns data', (resolve, reject) => {
       const observable: ObservableQuery<any> = mockWatchQuery(
-        reject,
         {
           request: { query, variables },
           result: { data: dataOne },
@@ -658,7 +649,6 @@ describe('ObservableQuery', () => {
   describe('setVariables', () => {
     itAsync('reruns query if the variables change', (resolve, reject) => {
       const queryManager = mockQueryManager(
-        reject,
         {
           request: { query, variables },
           result: { data: dataOne },
@@ -693,7 +683,6 @@ describe('ObservableQuery', () => {
 
     itAsync('does invalidate the currentResult data if the variables change', (resolve, reject) => {
       const observable: ObservableQuery<any> = mockWatchQuery(
-        reject,
         {
           request: { query, variables },
           result: { data: dataOne },
@@ -754,7 +743,6 @@ describe('ObservableQuery', () => {
       };
 
       const observable: ObservableQuery<any> = mockWatchQuery(
-        reject,
         {
           request: { query, variables },
           result: { data: dataOne },
@@ -782,7 +770,6 @@ describe('ObservableQuery', () => {
 
     itAsync('does not invalidate the currentResult errors if the variables change', (resolve, reject) => {
       const queryManager = mockQueryManager(
-        reject,
         {
           request: { query, variables },
           result: { errors: [error] },
@@ -818,7 +805,7 @@ describe('ObservableQuery', () => {
 
     itAsync('does not perform a query when unsubscribed if variables change', (resolve, reject) => {
       // Note: no responses, will throw if a query is made
-      const queryManager = mockQueryManager(reject);
+      const queryManager = mockQueryManager();
       const observable = queryManager.watchQuery({ query, variables });
       return observable.setVariables(differentVariables)
         .then(resolve, reject);
@@ -836,7 +823,7 @@ describe('ObservableQuery', () => {
         },
       ];
 
-      const queryManager = mockQueryManager(reject, ...mockedResponses);
+      const queryManager = mockQueryManager(...mockedResponses);
       const firstRequest = mockedResponses[0].request;
       const observable = queryManager.watchQuery({
         query: firstRequest.query,
@@ -874,7 +861,7 @@ describe('ObservableQuery', () => {
         },
       ];
 
-      const queryManager = mockQueryManager(reject, ...mockedResponses);
+      const queryManager = mockQueryManager(...mockedResponses);
       const firstRequest = mockedResponses[0].request;
       const observable = queryManager.watchQuery({
         query: firstRequest.query,
@@ -902,7 +889,6 @@ describe('ObservableQuery', () => {
 
     itAsync('does not rerun query if variables do not change', (resolve, reject) => {
       const observable: ObservableQuery<any> = mockWatchQuery(
-        reject,
         {
           request: { query, variables },
           result: { data: dataOne },
@@ -933,7 +919,6 @@ describe('ObservableQuery', () => {
       // and the query stays in loading state until the result for the new variables
       // has returned.
       const observable: ObservableQuery<any> = mockWatchQuery(
-        reject,
         {
           request: { query, variables },
           result: { data: dataOne },
@@ -974,7 +959,7 @@ describe('ObservableQuery', () => {
         },
       ];
 
-      const queryManager = mockQueryManager(reject, ...mockedResponses);
+      const queryManager = mockQueryManager(...mockedResponses);
       const firstRequest = mockedResponses[0].request;
       const observable = queryManager.watchQuery({
         query: firstRequest.query,
@@ -1039,7 +1024,7 @@ describe('ObservableQuery', () => {
           },
         ];
 
-        const queryManager = mockQueryManager(reject, ...mockedResponses);
+        const queryManager = mockQueryManager(...mockedResponses);
         const firstRequest = mockedResponses[0].request;
         const observable = queryManager.watchQuery({
           query: firstRequest.query,
@@ -1090,7 +1075,6 @@ describe('ObservableQuery', () => {
       const variables2 = { first: 1 };
 
       const queryManager = mockQueryManager(
-        reject,
         {
           request: {
             query: queryWithVars,
@@ -1163,7 +1147,6 @@ describe('ObservableQuery', () => {
       const variables2 = { first: 1 };
 
       const queryManager = mockQueryManager(
-        reject,
         {
           request: {
             query: queryWithVars,
@@ -1428,7 +1411,6 @@ describe('ObservableQuery', () => {
         }
 
         const observableWithoutVariables: ObservableQuery<any> = mockWatchQuery(
-          reject,
           makeMock("a", "b", "c"),
           makeMock("d", "e"),
         );
@@ -1609,7 +1591,6 @@ describe('ObservableQuery', () => {
         }
 
         const observableWithVariablesVar: ObservableQuery<any> = mockWatchQuery(
-          reject,
           makeMock("a", "b", "c"),
           makeMock("d", "e"),
         );
@@ -1769,7 +1750,7 @@ describe('ObservableQuery', () => {
     });
 
     itAsync('returns the current query status immediately', (resolve, reject) => {
-      const observable: ObservableQuery<any> = mockWatchQuery(reject, {
+      const observable: ObservableQuery<any> = mockWatchQuery({
         request: { query, variables },
         result: { data: dataOne },
         delay: 100,
@@ -1805,7 +1786,7 @@ describe('ObservableQuery', () => {
     });
 
     itAsync('returns results from the store immediately', (resolve, reject) => {
-      const queryManager = mockQueryManager(reject, {
+      const queryManager = mockQueryManager({
         request: { query, variables },
         result: { data: dataOne },
       });
@@ -1828,8 +1809,8 @@ describe('ObservableQuery', () => {
       }).then(resolve, reject);
     });
 
-    itAsync('returns errors from the store immediately', (resolve, reject) => {
-      const queryManager = mockQueryManager(reject, {
+    itAsync('returns errors from the store immediately', (resolve) => {
+      const queryManager = mockQueryManager({
         request: { query, variables },
         result: { errors: [error] },
       });
@@ -1852,7 +1833,7 @@ describe('ObservableQuery', () => {
     });
 
     itAsync('returns referentially equal errors', (resolve, reject) => {
-      const queryManager = mockQueryManager(reject, {
+      const queryManager = mockQueryManager({
         request: { query, variables },
         result: { errors: [error] },
       });
@@ -1874,7 +1855,7 @@ describe('ObservableQuery', () => {
     });
 
     itAsync('returns errors with data if errorPolicy is all', (resolve, reject) => {
-      const queryManager = mockQueryManager(reject, {
+      const queryManager = mockQueryManager({
         request: { query, variables },
         result: { data: dataOne, errors: [error] },
       });
@@ -1896,7 +1877,7 @@ describe('ObservableQuery', () => {
     });
 
     itAsync('errors out if errorPolicy is none', (resolve, reject) => {
-      const queryManager = mockQueryManager(reject, {
+      const queryManager = mockQueryManager({
         request: { query, variables },
         result: { data: dataOne, errors: [error] },
       });
@@ -1916,7 +1897,7 @@ describe('ObservableQuery', () => {
     });
 
     itAsync('errors out if errorPolicy is none and the observable has completed', (resolve, reject) => {
-      const queryManager = mockQueryManager(reject, {
+      const queryManager = mockQueryManager({
         request: { query, variables },
         result: { data: dataOne, errors: [error] },
       },
@@ -1946,7 +1927,7 @@ describe('ObservableQuery', () => {
     });
 
     itAsync('ignores errors with data if errorPolicy is ignore', (resolve, reject) => {
-      const queryManager = mockQueryManager(reject, {
+      const queryManager = mockQueryManager({
         request: { query, variables },
         result: { errors: [error], data: dataOne },
       });
@@ -1985,7 +1966,6 @@ describe('ObservableQuery', () => {
       };
 
       const queryManager = mockQueryManager(
-        reject,
         {
           request: { query, variables },
           result: { data: dataOne },
@@ -2040,7 +2020,6 @@ describe('ObservableQuery', () => {
 
     itAsync('returns loading even if full data is available when using network-only fetchPolicy', (resolve, reject) => {
       const queryManager = mockQueryManager(
-        reject,
         {
           request: { query, variables },
           result: { data: dataOne },
@@ -2091,7 +2070,6 @@ describe('ObservableQuery', () => {
 
     itAsync('returns loading on no-cache fetchPolicy queries when calling getCurrentResult', (resolve, reject) => {
       const queryManager = mockQueryManager(
-        reject,
         {
           request: { query, variables },
           result: { data: dataOne },
@@ -2164,7 +2142,6 @@ describe('ObservableQuery', () => {
 
       itAsync('returns optimistic mutation results from the store', (resolve, reject) => {
         const queryManager = mockQueryManager(
-          reject,
           {
             request: { query, variables },
             result: { data: dataOne },
@@ -2217,7 +2194,7 @@ describe('ObservableQuery', () => {
   });
 
   describe('assumeImmutableResults', () => {
-    itAsync('should prevent costly (but safe) cloneDeep calls', async (resolve, reject) => {
+    itAsync('should prevent costly (but safe) cloneDeep calls', async (resolve) => {
       const queryOptions = {
         query: gql`
           query {
@@ -2301,10 +2278,10 @@ describe('ObservableQuery', () => {
   });
 
   describe('resetQueryStoreErrors', () => {
-    itAsync("should remove any GraphQLError's stored in the query store", (resolve, reject) => {
+    itAsync("should remove any GraphQLError's stored in the query store", (resolve) => {
       const graphQLError = new GraphQLError('oh no!');
 
-      const observable: ObservableQuery<any> = mockWatchQuery(reject, {
+      const observable: ObservableQuery<any> = mockWatchQuery({
         request: { query, variables },
         result: { errors: [graphQLError] },
       });
@@ -2323,10 +2300,10 @@ describe('ObservableQuery', () => {
       });
     });
 
-    itAsync("should remove network error's stored in the query store", (resolve, reject) => {
+    itAsync("should remove network error's stored in the query store", (resolve) => {
       const networkError = new Error('oh no!');
 
-      const observable: ObservableQuery<any> = mockWatchQuery(reject, {
+      const observable: ObservableQuery<any> = mockWatchQuery({
         request: { query, variables },
         result: { data: dataOne },
       });
@@ -2345,7 +2322,7 @@ describe('ObservableQuery', () => {
   });
 
   itAsync("QueryInfo does not notify for !== but deep-equal results", (resolve, reject) => {
-    const queryManager = mockQueryManager(reject, {
+    const queryManager = mockQueryManager({
       request: { query, variables },
       result: { data: dataOne },
     });
@@ -2418,7 +2395,7 @@ describe('ObservableQuery', () => {
   });
 
   itAsync("ObservableQuery#map respects Symbol.species", (resolve, reject) => {
-    const observable = mockWatchQuery(reject, {
+    const observable = mockWatchQuery({
       request: { query, variables },
       result: { data: dataOne },
     });

--- a/src/core/__tests__/QueryManager/index.ts
+++ b/src/core/__tests__/QueryManager/index.ts
@@ -107,7 +107,7 @@ describe('QueryManager', () => {
     delay?: number;
     observer: Observer<ApolloQueryResult<any>>;
   }) => {
-    const queryManager = mockQueryManager(reject, {
+    const queryManager = mockQueryManager({
       request: { query, variables },
       result,
       error,
@@ -168,13 +168,11 @@ describe('QueryManager', () => {
   // Helper method that takes a query with a first response and a second response.
   // Used to assert stuff about refetches.
   const mockRefetch = ({
-    reject,
     request,
     firstResult,
     secondResult,
     thirdResult,
   }: {
-    reject: (reason: any) => any;
     request: GraphQLRequest;
     firstResult: FetchResult;
     secondResult: FetchResult;
@@ -195,7 +193,7 @@ describe('QueryManager', () => {
       args.push({ request, result: thirdResult });
     }
 
-    return mockQueryManager(reject, ...args);
+    return mockQueryManager(...args);
   };
 
   function getCurrentQueryResult<TData, TVars extends object>(
@@ -671,7 +669,7 @@ describe('QueryManager', () => {
       },
     };
 
-    const handle = mockWatchQuery(reject, {
+    const handle = mockWatchQuery({
       request: {
         query: gql`
           query people {
@@ -732,7 +730,6 @@ describe('QueryManager', () => {
     };
 
     const queryManager = mockQueryManager(
-      reject,
       {
         request,
         result: { data: data1 },
@@ -802,7 +799,7 @@ describe('QueryManager', () => {
     });
   });
 
-  itAsync('resolves all queries when one finishes after another', (resolve, reject) => {
+  itAsync('resolves all queries when one finishes after another', (resolve) => {
     const request = {
       query: gql`
         query fetchLuke($id: String) {
@@ -860,7 +857,6 @@ describe('QueryManager', () => {
     };
 
     const queryManager = mockQueryManager(
-      reject,
       {
         request,
         result: { data: data1 },
@@ -926,7 +922,6 @@ describe('QueryManager', () => {
     };
 
     const queryManager = mockRefetch({
-      reject,
       request,
       firstResult: { data: data1 },
       secondResult: { data: data2 },
@@ -982,7 +977,6 @@ describe('QueryManager', () => {
     };
 
     const queryManager = mockRefetch({
-      reject,
       request,
       firstResult: { data: data1 },
       secondResult: { data: data2 },
@@ -1052,7 +1046,7 @@ describe('QueryManager', () => {
       d: { e: 3, f: { g: 4 } },
     };
 
-    const queryManager = mockQueryManager(reject, {
+    const queryManager = mockQueryManager({
       request,
       result: { data: data1 },
     });
@@ -1103,7 +1097,6 @@ describe('QueryManager', () => {
     };
 
     const queryManager = mockRefetch({
-      reject,
       request,
       firstResult: { data: data1 },
       secondResult: { data: data2 },
@@ -1147,7 +1140,6 @@ describe('QueryManager', () => {
     };
 
     const queryManager = mockRefetch({
-      reject,
       request,
       firstResult: { data: data1 },
       secondResult: { data: data2 },
@@ -1204,7 +1196,6 @@ describe('QueryManager', () => {
     };
 
     const queryManager = mockQueryManager(
-      reject,
       {
         request: { query: query },
         result: { data: data1 },
@@ -1273,7 +1264,6 @@ describe('QueryManager', () => {
     };
 
     const queryManager = mockQueryManager(
-      reject,
       {
         request: { query: query },
         result: { data: data1 },
@@ -1333,7 +1323,6 @@ describe('QueryManager', () => {
     };
 
     const queryManager = mockQueryManager(
-      reject,
       {
         request: { query },
         result: { data: data1 },
@@ -1368,7 +1357,7 @@ describe('QueryManager', () => {
     ).then(resolve, reject);
   });
 
-  itAsync('sets networkStatus to `poll` if a polling query is in flight', (resolve, reject) => {
+  itAsync('sets networkStatus to `poll` if a polling query is in flight', (resolve) => {
     const query = gql`
       {
         people_one(id: 1) {
@@ -1396,7 +1385,6 @@ describe('QueryManager', () => {
     };
 
     const queryManager = mockQueryManager(
-      reject,
       {
         request: { query },
         result: { data: data1 },
@@ -1433,7 +1421,7 @@ describe('QueryManager', () => {
     });
   });
 
-  itAsync('can handle null values in arrays (#1551)', (resolve, reject) => {
+  itAsync('can handle null values in arrays (#1551)', (resolve) => {
     const query = gql`
       {
         list {
@@ -1442,7 +1430,7 @@ describe('QueryManager', () => {
       }
     `;
     const data = { list: [null, { value: 1 }] };
-    const queryManager = mockQueryManager(reject, {
+    const queryManager = mockQueryManager({
       request: { query },
       result: { data },
     });
@@ -1483,7 +1471,7 @@ describe('QueryManager', () => {
       },
     };
 
-    const queryManager = mockQueryManager(reject, {
+    const queryManager = mockQueryManager({
       request: { query: primeQuery },
       result: { data: data1 },
     });
@@ -1716,7 +1704,6 @@ describe('QueryManager', () => {
     };
 
     const queryManager = mockQueryManager(
-      reject,
       {
         request: { query: query1 },
         result: { data: data1 },
@@ -1785,7 +1772,6 @@ describe('QueryManager', () => {
     };
 
     const queryManager = mockQueryManager(
-      reject,
       {
         request: { query: query1 },
         result: { data: data1 },
@@ -1817,8 +1803,8 @@ describe('QueryManager', () => {
     });
   });
 
-  itAsync('warns if you forget the template literal tag', async (resolve, reject) => {
-    const queryManager = mockQueryManager(reject);
+  itAsync('warns if you forget the template literal tag', async (resolve) => {
+    const queryManager = mockQueryManager();
     expect(() => {
       queryManager.query<any>({
         // Bamboozle TypeScript into letting us do this
@@ -1937,7 +1923,7 @@ describe('QueryManager', () => {
       }
     `;
     const networkError = new Error('Network error');
-    mockQueryManager(reject, {
+    mockQueryManager({
       request: { query },
       error: networkError,
     })
@@ -1966,7 +1952,7 @@ describe('QueryManager', () => {
       }
     `;
     const graphQLErrors = [new GraphQLError('GraphQL error')];
-    return mockQueryManager(reject, {
+    return mockQueryManager({
       request: { query },
       result: { errors: graphQLErrors },
     })
@@ -2000,7 +1986,6 @@ describe('QueryManager', () => {
       },
     };
     const queryManager = mockQueryManager(
-      reject,
       {
         request: { query },
         result: { data },
@@ -2051,7 +2036,7 @@ describe('QueryManager', () => {
       },
     };
 
-    const observable = mockQueryManager(reject, {
+    const observable = mockQueryManager({
       request: { query },
       result: { data },
     }).watchQuery({ query, pollInterval: 20 });
@@ -2086,7 +2071,6 @@ describe('QueryManager', () => {
       },
     };
     const queryManager = mockQueryManager(
-      reject,
       {
         request: { query },
         result: { data },
@@ -2139,7 +2123,6 @@ describe('QueryManager', () => {
       },
     };
     const queryManager = mockQueryManager(
-      reject,
       {
         request: { query },
         result: { data },
@@ -2718,7 +2701,6 @@ describe('QueryManager', () => {
     };
 
     const queryManager = mockRefetch({
-      reject,
       request,
       firstResult,
       secondResult,
@@ -2848,7 +2830,7 @@ describe('QueryManager', () => {
       },
     ];
 
-    const queryManager = mockQueryManager(reject, ...mockedResponses);
+    const queryManager = mockQueryManager(...mockedResponses);
     const queryOptions: WatchQueryOptions<any> = {
       query,
       variables,
@@ -2911,7 +2893,6 @@ describe('QueryManager', () => {
       };
 
       const queryManager = mockQueryManager(
-        reject,
         {
           request: { query, variables },
           result: { data: data1 },
@@ -3002,7 +2983,7 @@ describe('QueryManager', () => {
       });
     });
 
-    itAsync('should let you handle multiple polled queries and unsubscribe from one of them', (resolve, reject) => {
+    itAsync('should let you handle multiple polled queries and unsubscribe from one of them', (resolve) => {
       const query1 = gql`
         query {
           author {
@@ -3053,7 +3034,6 @@ describe('QueryManager', () => {
         },
       };
       const queryManager = mockQueryManager(
-        reject,
         {
           request: { query: query1 },
           result: { data: data11 },
@@ -3145,7 +3125,6 @@ describe('QueryManager', () => {
       };
 
       const queryManager = mockQueryManager(
-        reject,
         {
           request: { query, variables },
           result: { data: data1 },
@@ -3205,7 +3184,6 @@ describe('QueryManager', () => {
       };
 
       const queryManager = mockQueryManager(
-        reject,
         {
           request: { query, variables },
           result: { data: data1 },
@@ -3280,7 +3258,6 @@ describe('QueryManager', () => {
       };
 
       const queryManager = mockQueryManager(
-        reject,
         {
           request: { query, variables },
           result: { data: data1 },
@@ -3331,7 +3308,6 @@ describe('QueryManager', () => {
       };
 
       const queryManager = mockQueryManager(
-        reject,
         {
           request: { query, variables },
           result: { data: data1 },
@@ -3379,7 +3355,6 @@ describe('QueryManager', () => {
       };
 
       const queryManager = mockQueryManager(
-        reject,
         {
           request: { query, variables },
           result: { data: data1 },
@@ -3580,7 +3555,7 @@ describe('QueryManager', () => {
       );
     });
 
-    itAsync('should not refetch torn-down queries', (resolve, reject) => {
+    itAsync('should not refetch torn-down queries', (resolve) => {
       let queryManager: QueryManager<NormalizedCacheObject>;
       let observable: ObservableQuery<any>;
       const query = gql`
@@ -3730,7 +3705,7 @@ describe('QueryManager', () => {
           lastName: 'Smith',
         },
       };
-      const queryManager = mockQueryManager(reject, {
+      const queryManager = mockQueryManager({
         request: { query },
         result: { data },
         delay: 10000, //i.e. forever
@@ -3749,7 +3724,7 @@ describe('QueryManager', () => {
       setTimeout(() => resetStore(queryManager), 100);
     });
 
-    itAsync('should call refetch on a mocked Observable if the store is reset', (resolve, reject) => {
+    itAsync('should call refetch on a mocked Observable if the store is reset', (resolve) => {
       const query = gql`
         query {
           author {
@@ -3764,7 +3739,7 @@ describe('QueryManager', () => {
           lastName: 'Smith',
         },
       };
-      const queryManager = mockQueryManager(reject, {
+      const queryManager = mockQueryManager({
         request: { query },
         result: { data }
       });
@@ -4070,7 +4045,7 @@ describe('QueryManager', () => {
       });
     });
 
-    itAsync('should not refetch torn-down queries', (resolve, reject) => {
+    itAsync('should not refetch torn-down queries', (resolve) => {
       let queryManager: QueryManager<NormalizedCacheObject>;
       let observable: ObservableQuery<any>;
       const query = gql`
@@ -4180,7 +4155,7 @@ describe('QueryManager', () => {
           lastName: 'Smith',
         },
       };
-      const queryManager = mockQueryManager(reject, {
+      const queryManager = mockQueryManager({
         request: { query },
         result: { data },
         delay: 100,
@@ -4194,7 +4169,7 @@ describe('QueryManager', () => {
       queryManager.reFetchObservableQueries();
     });
 
-    itAsync('should call refetch on a mocked Observable if the observed queries are refetched', (resolve, reject) => {
+    itAsync('should call refetch on a mocked Observable if the observed queries are refetched', (resolve) => {
       const query = gql`
         query {
           author {
@@ -4209,7 +4184,7 @@ describe('QueryManager', () => {
           lastName: 'Smith',
         },
       };
-      const queryManager = mockQueryManager(reject, {
+      const queryManager = mockQueryManager({
         request: { query },
         result: { data },
       });
@@ -4513,7 +4488,7 @@ describe('QueryManager', () => {
       const data = {
         fortuneCookie: 'Buy it',
       };
-      return mockQueryManager(reject, {
+      return mockQueryManager({
         request: { query },
         result: { data },
       })
@@ -4547,7 +4522,6 @@ describe('QueryManager', () => {
       const fullData = { fortuneCookie, author };
 
       const queryManager = mockQueryManager(
-        reject,
         {
           request: { query },
           result: { data: fullData },
@@ -4632,7 +4606,6 @@ describe('QueryManager', () => {
         },
       };
       const queryManager = mockQueryManager(
-        reject,
         {
           request: { query: testQuery },
           result: { data: data1 },
@@ -4688,7 +4661,6 @@ describe('QueryManager', () => {
         b: { x2: 3, y2: 2, z2: 1 },
       };
       const queryManager = mockQueryManager(
-        reject,
         {
           request: { query: query1 },
           result: { data: data1 },
@@ -4777,7 +4749,6 @@ describe('QueryManager', () => {
       };
       const variables = { id: '1234' };
       const queryManager = mockQueryManager(
-        reject,
         {
           request: { query, variables },
           result: { data },
@@ -4847,7 +4818,6 @@ describe('QueryManager', () => {
         },
       };
       const queryManager = mockQueryManager(
-        reject,
         {
           request: { query },
           result: { data },
@@ -4919,7 +4889,6 @@ describe('QueryManager', () => {
         },
       };
       const queryManager = mockQueryManager(
-        reject,
         {
           request: { query },
           result: { data },
@@ -4989,7 +4958,6 @@ describe('QueryManager', () => {
       const variables = { id: '1234' };
       const mutationVariables = { id: '2345' };
       const queryManager = mockQueryManager(
-        reject,
         {
           request: { query, variables },
           result: { data },
@@ -5069,7 +5037,6 @@ describe('QueryManager', () => {
         },
       };
       const queryManager = mockQueryManager(
-        reject,
         {
           request: { query },
           result: { data },
@@ -5131,7 +5098,6 @@ describe('QueryManager', () => {
         },
       };
       const queryManager = mockQueryManager(
-        reject,
         {
           request: { query },
           result: { data },
@@ -5198,7 +5164,6 @@ describe('QueryManager', () => {
       };
       const variables = { id: '1234' };
       const queryManager = mockQueryManager(
-        reject,
         {
           request: { query, variables },
           result: { data },
@@ -5278,7 +5243,6 @@ describe('QueryManager', () => {
       };
       const variables = { id: '1234' };
       const queryManager = mockQueryManager(
-        reject,
         {
           request: { query, variables },
           result: { data },
@@ -5370,9 +5334,8 @@ describe('QueryManager', () => {
 
     const variables = { id: '1234' };
 
-    function makeQueryManager(reject: (reason?: any) => void) {
+    function makeQueryManager() {
       return mockQueryManager(
-        reject,
         {
           request: { query, variables },
           result: { data },
@@ -5389,7 +5352,7 @@ describe('QueryManager', () => {
     }
 
     itAsync('should refetch the right query when a result is successfully returned', (resolve, reject) => {
-      const queryManager = makeQueryManager(reject);
+      const queryManager = makeQueryManager();
 
       const observable = queryManager.watchQuery<any>({
         query,
@@ -5443,7 +5406,7 @@ describe('QueryManager', () => {
     });
 
     itAsync('should refetch using the original query context (if any)', (resolve, reject) => {
-      const queryManager = makeQueryManager(reject);
+      const queryManager = makeQueryManager();
 
       const headers = {
         someHeader: 'some value',
@@ -5493,7 +5456,7 @@ describe('QueryManager', () => {
     });
 
     itAsync('should refetch using the specified context, if provided', (resolve, reject) => {
-      const queryManager = makeQueryManager(reject);
+      const queryManager = makeQueryManager();
 
       const observable = queryManager.watchQuery<any>({
         query,
@@ -5588,7 +5551,6 @@ describe('QueryManager', () => {
       const refetchError = testQueryError ? new Error('Refetch failed') : undefined;
 
       const queryManager = mockQueryManager(
-        reject,
         {
           request: { query, variables },
           result: { data: queryData },
@@ -5936,7 +5898,6 @@ describe('QueryManager', () => {
       };
 
       const queryManager = mockQueryManager(
-        reject,
         {
           request: { query: query1 },
           result: { data: data1 },

--- a/src/testing/core/mocking/mockQueryManager.ts
+++ b/src/testing/core/mocking/mockQueryManager.ts
@@ -4,10 +4,7 @@ import { InMemoryCache } from '../../../cache';
 
 // Helper method for the tests that construct a query manager out of a
 // a list of mocked responses for a mocked network interface.
-export default (
-  reject: (reason: any) => any,
-  ...mockedResponses: MockedResponse[]
-) => {
+export default (...mockedResponses: MockedResponse[]) => {
   return new QueryManager({
     link: mockSingleLink(...mockedResponses),
     cache: new InMemoryCache({ addTypename: false }),

--- a/src/testing/core/mocking/mockWatchQuery.ts
+++ b/src/testing/core/mocking/mockWatchQuery.ts
@@ -2,11 +2,8 @@ import { MockedResponse } from './mockLink';
 import mockQueryManager from './mockQueryManager';
 import { ObservableQuery } from '../../../core';
 
-export default (
-  reject: (reason: any) => any,
-  ...mockedResponses: MockedResponse[]
-): ObservableQuery<any> => {
-  const queryManager = mockQueryManager(reject, ...mockedResponses);
+export default (...mockedResponses: MockedResponse[]): ObservableQuery<any> => {
+  const queryManager = mockQueryManager(...mockedResponses);
   const firstRequest = mockedResponses[0].request;
   return queryManager.watchQuery({
     query: firstRequest.query!,


### PR DESCRIPTION
While working on #10502, I noticed that `mockQueryManager` and `mockWatchQuery` both took a `reject` argument, but this argument wasn't used. For added simplicity, I simply removed this argument and updated all references to it accordingly.

These are internal testing utilities, so the breaking change to the API won't affect users.

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](../CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
