### PR TITLE
Add note discussing immutability to `update*` docs

### DIFF
--- a/docs/source/api/cache/InMemoryCache.mdx
+++ b/docs/source/api/cache/InMemoryCache.mdx
@@ -433,7 +433,7 @@ The update function of `updateQuery` takes a query's current cached value and re
 
 The returned value is automatically passed to [`writeQuery`](#writequery), which modifies the cached data.
 
-Please note update function has to calculate the new value in an immutable way. You can read more about immutable updates in [the React documentation](https://beta.reactjs.org/learn/updating-objects-in-state).
+Please note the `update` function has to calculate the new value in an immutable way. You can read more about immutable updates in the [React documentation](https://beta.reactjs.org/learn/updating-objects-in-state).
 
 ### Signature
 
@@ -894,7 +894,7 @@ The update function of `updateFragment` takes a fragment's current cached value 
 
 The returned value is automatically passed to [`writeFragment`](#writefragment), which modifies the cached data.
 
-Please note update function has to calculate the new value in an immutable way. You can read more about immutable updates in [the React documentation](https://beta.reactjs.org/learn/updating-objects-in-state).
+Please note the `update` function has to calculate the new value in an immutable way. You can read more about immutable updates in the [React documentation](https://beta.reactjs.org/learn/updating-objects-in-state).
 
 ### Signature
 

--- a/docs/source/api/cache/InMemoryCache.mdx
+++ b/docs/source/api/cache/InMemoryCache.mdx
@@ -433,6 +433,8 @@ The update function of `updateQuery` takes a query's current cached value and re
 
 The returned value is automatically passed to [`writeQuery`](#writequery), which modifies the cached data.
 
+Please note update function has to calculate the new value in an immutable way. You can read more about immutable updates in [the React documentation](https://beta.reactjs.org/learn/updating-objects-in-state).
+
 ### Signature
 
 ```ts title="src/cache/core/cache.ts"
@@ -891,6 +893,8 @@ The default value is `false`.
 The update function of `updateFragment` takes a fragment's current cached value and returns the value that should replace it (or `undefined` if no change should be made).
 
 The returned value is automatically passed to [`writeFragment`](#writefragment), which modifies the cached data.
+
+Please note update function has to calculate the new value in an immutable way. You can read more about immutable updates in [the React documentation](https://beta.reactjs.org/learn/updating-objects-in-state).
 
 ### Signature
 

--- a/docs/source/caching/cache-interaction.mdx
+++ b/docs/source/caching/cache-interaction.mdx
@@ -269,6 +269,8 @@ Each of these methods takes two parameters:
 
 After either method fetches data from the cache, it calls its update function and passes it the cached `data`. The update function can then return a value to _replace_ that `data` in the cache. In the example above, every cached `Todo` object has its `completed` field set to `true` (and other fields remain unchanged).
 
+Please note that the replacement value has to be calculated in an immutable way. You can read more about immutable updates in [the React documentation](https://beta.reactjs.org/learn/updating-objects-in-state).
+
 If the update function shouldn't make _any_ changes to the cached data, it can return `undefined`.
 
 The update function's return value is passed to either `writeQuery` or `writeFragment`, which modifies the cached data.


### PR DESCRIPTION
### Checklist:

- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](../CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests


It has recently come up on [twitter](https://twitter.com/franleplant/status/1621196243727704064) that none of the docs state that `updateQuery/updateFragment` updates should be made in an immutable fashion. 
In most cases, this should be caught by the fact that the data passed into the `update` function is frozen, but depending on `strict` mode being on or off, this can still be silently fail.

This adds a note for immutability in the most relevant places and links to the new React docs, that explain how to write immutable updates & potentially use `immer` for that purpose.

Note: I'm very happy for any suggestions on how to word this better, or style it as some kind of "hint".