### PR TITLE
fix: unblock snapshot releases on branches in prerelease mode

### DIFF
--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -48,6 +48,20 @@ jobs:
       - name: Install dependencies (with cache)
         uses: bahmutov/npm-install@v1
 
+      - name: Check for pre.json file existence
+        id: check_files
+        uses: andstor/file-existence-action@v2.0.0
+        with:
+          files: ".changeset/pre.json"
+
+      - name: Exit pre mode if pre.json exists
+        # Changesets prevents us from generating a snapshot release
+        # if we're in prerelease mode, so we remove `pre.json` if it exists
+        # (but do not commit this change since we want the branch to remain
+        # in pre mode)
+        if: steps.check_files.outputs.files_exists == 'true'
+        run: rm .changeset/pre.json
+
       # https://github.com/atlassian/changesets/blob/master/docs/snapshot-releases.md
       - name: Release to pr tag
         run: |


### PR DESCRIPTION
This PR makes a fix to our snapshot release workflow added in https://github.com/apollographql/apollo-client/pull/10480 which fixes errors [like this](https://github.com/apollographql/apollo-client/actions/runs/4088539427/jobs/7050324587): snapshot releases are not permitted in prerelease mode, so if `pre.json` is detected, we can remove it before proceeding with the release. (This was tested on a separate changesets demo repo I created [here](https://github.com/alessbell/good-snow-tire-demo/pull/65).)

NB: the snapshot release workflow still fails on branches that exist on forks, this will be resolved in a future PR.

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](../CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
