### PR TITLE
Tolerate undefined `concast.sources` if `complete` called earlier than `concast.start`

### DIFF
--- a/.changeset/shaggy-bees-attack.md
+++ b/.changeset/shaggy-bees-attack.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Tolerate undefined `concast.sources` if `complete` called earlier than `concast.start`


### PR DESCRIPTION
Fixes issue #10262, since `this.sources.shift()` throws when `complete` is called called before the `Promise` that should have initialized `this.sources` resolves, which can happen when the directive combination `@client @export(as: ...)` is used, because `@export` usage causes a `Promise<Observable[]>` to be passed to the `Concast` constructor instead of passing the `Observable[]` itself.

Although passing a `Promise` to the `Concast` constructor should work, we only exercise that code path in [one place](https://github.com/apollographql/apollo-client/blob/015a1ffff3febe4604956f4bb137a3111f3d8257/src/core/QueryManager.ts#L1226-L1241), and the additional wrinkle of calling `complete` before the `Promise` resolves was never tested.