### PR TITLE
chore: filter issues to lock by created at date

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+          exclude-issue-created-after: '2018-01-01T00:00:00Z'
           issue-inactive-days: '30'
           exclude-any-issue-labels: '💬 discussion'
           # issue-comment: >
@@ -24,6 +25,7 @@ jobs:
 
           #   Please note this issue tracker is not a help forum. We recommend using [StackOverflow](https://stackoverflow.com/questions/tagged/apollo-client) or our [discord server](https://discord.gg/graphos) for questions.
 
+          exclude-pr-created-after: '2018-01-01T00:00:00Z'
           pr-inactive-days: '30'
           exclude-any-pr-labels: '💬 discussion'
           # pr-comment: >


### PR DESCRIPTION
This PR updates the action that locks inactive closed issues and PRs to filter on created by date.

It's been running hourly but has only locked a fraction of long since closed issues, and after reading some issues on the action's repo this may have to do with how it fetches issues/PRs via GitHub API, so trying some batching here.

Currently there are [1337](https://github.com/apollographql/apollo-client/issues?q=is:issue+is:closed+created:%3C2018-01-01+) closed issues created before 2018-01-01 and only [137](https://github.com/search?q=repo:apollographql/apollo-client+is:closed+is:locked+created:%3C2018-01-01+&type=repositories) of them have been locked. Let's see if this helps, and if it does we can increment the year every day or so until the backlog is processed, then move the action to run daily.

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](../CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
