### PR TITLE
chore: debug lock action

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   lock:
+    if: github.repository == 'apollographql/apollo-client'
     runs-on: ubuntu-latest
     steps:
       - uses: dessant/lock-threads@v4

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -4,22 +4,22 @@ on:
   schedule:
     - cron: '0 * * * *'
 
-permissions: {}
+permissions:
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: lock
+
 jobs:
   lock:
-    permissions:
-      issues: write # to lock issues (dessant/lock-threads)
-      pull-requests: write # to lock PRs (dessant/lock-threads)
-
     runs-on: ubuntu-latest
     steps:
       - uses: dessant/lock-threads@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
           log-output: true
-          process-only: 'issues'
 
-          exclude-issue-created-after: '2018-01-01T00:00:00Z'
           issue-inactive-days: '30'
           exclude-any-issue-labels: '💬 discussion'
           # issue-comment: >
@@ -27,7 +27,6 @@ jobs:
 
           #   Please note this issue tracker is not a help forum. We recommend using [StackOverflow](https://stackoverflow.com/questions/tagged/apollo-client) or our [discord server](https://discord.gg/graphos) for questions.
 
-          exclude-pr-created-after: '2018-01-01T00:00:00Z'
           pr-inactive-days: '30'
           exclude-any-pr-labels: '💬 discussion'
           # pr-comment: >


### PR DESCRIPTION
Still debugging this :) `log-output: true` hasn't been logging anything when the action runs, and looking at the action's code that indicates the search for matching issues/PRs isn't returning anything (when I run it locally, the response includes both issues and PRs as expected).

This PR cleans up the action's formatting of permissions and uses `github.token` instead of `secrets.GITHUB_TOKEN`... Hopefully this will resolve the issue with the GitHub API search.

### Checklist:

- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](../CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
