### PR TITLE
Refactor `removeDirectivesFromDocument` to fix AST ordering sensitivities and avoid 1/3 AST traversals

### DIFF
--- a/.changeset/dry-radios-help.md
+++ b/.changeset/dry-radios-help.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Keep `__typename` fragment when it does not contain `@client` directive.

--- a/.changeset/dry-radios-help.md
+++ b/.changeset/dry-radios-help.md
@@ -2,4 +2,4 @@
 "@apollo/client": patch
 ---
 
-Keep `__typename` fragment when it does not contain `@client` directive.
+Keep `__typename` fragment when it does not contain `@client` directive and strip out inline fragments which use a `@client` directive. Thanks @Gazler and @mtsmfm!

--- a/.changeset/warm-rivers-develop.md
+++ b/.changeset/warm-rivers-develop.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Refactor `removeDirectivesFromDocument` to fix AST ordering sensitivities and avoid 1/3 AST traversals, potentially improving performance for large queries

--- a/config/bundlesize.ts
+++ b/config/bundlesize.ts
@@ -3,7 +3,7 @@ import { join } from "path";
 import { gzipSync } from "zlib";
 import bytes from "bytes";
 
-const gzipBundleByteLengthLimit = bytes("32.42KB");
+const gzipBundleByteLengthLimit = bytes("32.65KB");
 const minFile = join("dist", "apollo-client.min.cjs");
 const minPath = join(__dirname, "..", minFile);
 const gzipByteLen = gzipSync(readFileSync(minPath)).byteLength;

--- a/src/__tests__/__snapshots__/exports.ts.snap
+++ b/src/__tests__/__snapshots__/exports.ts.snap
@@ -386,6 +386,7 @@ Array [
   "hasAnyDirectives",
   "hasClientExports",
   "hasDirectives",
+  "isArray",
   "isDocumentNode",
   "isField",
   "isInlineFragment",

--- a/src/__tests__/local-state/resolvers.ts
+++ b/src/__tests__/local-state/resolvers.ts
@@ -218,10 +218,6 @@ describe('Basic resolver capabilities', () => {
     const serverQuery = gql`
       fragment Foo on Foo {
         bar
-        ...Foo2
-      }
-      fragment Foo2 on Foo {
-        __typename
       }
       query Mixed {
         foo {

--- a/src/cache/inmemory/helpers.ts
+++ b/src/cache/inmemory/helpers.ts
@@ -23,6 +23,7 @@ import {
   FragmentMapFunction,
   createFragmentMap,
   getFragmentDefinitions,
+  isArray,
 } from '../../utilities';
 
 export const {
@@ -33,7 +34,7 @@ export function isNullish(value: any): value is null | undefined {
   return value === null || value === void 0;
 }
 
-export const isArray: (a: any) => a is any[] | readonly any[] = Array.isArray;
+export { isArray };
 
 export function defaultDataIdFromObject(
   { __typename, id, _id }: Readonly<StoreObject>,

--- a/src/utilities/common/arrays.ts
+++ b/src/utilities/common/arrays.ts
@@ -1,3 +1,6 @@
+// A version of Array.isArray that works better with readonly arrays.
+export const isArray: (a: any) => a is any[] | readonly any[] = Array.isArray;
+
 export function isNonEmptyArray<T>(value?: ArrayLike<T>): value is Array<T> {
   return Array.isArray(value) && value.length > 0;
 }

--- a/src/utilities/graphql/__tests__/transform.ts
+++ b/src/utilities/graphql/__tests__/transform.ts
@@ -102,6 +102,39 @@ describe('removeFragmentSpreadFromDocument', () => {
   });
 });
 describe('removeDirectivesFromDocument', () => {
+ it('should remove inline fragments using a directive', () => {
+    const query = gql`
+      query Simple {
+        networkField
+        field {
+          ... on TypeA {
+            typeAThing
+          }
+          ... on TypeB @client {
+            typeBThing @client
+          }
+        }
+      }
+    `;
+
+    const expected = gql`
+      query Simple {
+        networkField
+        field {
+          ... on TypeA {
+            typeAThing
+          }
+        }
+      }
+    `;
+
+    const doc = removeDirectivesFromDocument(
+      [{ name: 'client', remove: true }],
+      query,
+    );
+    expect(print(doc)).toBe(print(expected));
+  });
+
   it('should not remove unused variable definitions unless the field is removed', () => {
     const query = gql`
       query Simple($variable: String!) {

--- a/src/utilities/graphql/__tests__/transform.ts
+++ b/src/utilities/graphql/__tests__/transform.ts
@@ -1087,4 +1087,238 @@ describe('removeClientSetsFromDocument', () => {
     const doc = removeClientSetsFromDocument(query)!;
     expect(print(doc)).toBe(print(expected));
   });
+
+  it("should not remove fragment referenced by fragment used by operation", () => {
+    const query = gql`
+      query {
+        author {
+          name
+          ...authorInfo
+        }
+      }
+
+      fragment authorInfo on Author {
+        __typename
+        ...moreAuthorInfo
+      }
+
+      fragment moreAuthorInfo on Author {
+        extraDetails
+        isLoggedIn @client
+      }
+    `;
+
+    const expected = gql`
+      query {
+        author {
+          name
+          ...authorInfo
+        }
+      }
+
+      fragment authorInfo on Author {
+        __typename
+        ...moreAuthorInfo
+      }
+
+      fragment moreAuthorInfo on Author {
+        extraDetails
+      }
+    `;
+
+    const doc = removeClientSetsFromDocument(query)!;
+    expect(print(doc)).toBe(print(expected));
+  });
+
+  it("should remove __typename only fragment after @client removal", () => {
+    const query = gql`
+      query {
+        author {
+          name
+          ...authorInfo
+        }
+      }
+
+      fragment authorInfo on Author {
+        __typename
+        ...moreAuthorInfo @client
+      }
+
+      fragment moreAuthorInfo on Author {
+        extraDetails
+        isLoggedIn @client
+      }
+    `;
+
+    const expected = gql`
+      query {
+        author {
+          name
+        }
+      }
+    `;
+
+    const doc = removeClientSetsFromDocument(query)!;
+    expect(print(doc)).toBe(print(expected));
+
+    const queryInAnotherOrder = gql`
+      fragment moreAuthorInfo on Author {
+        extraDetails
+        isLoggedIn @client
+      }
+
+      fragment authorInfo on Author {
+        __typename
+        ...moreAuthorInfo @client
+      }
+
+      query {
+        author {
+          name
+          ...authorInfo
+        }
+      }
+    `;
+
+    const docInAnotherOrder = removeClientSetsFromDocument(queryInAnotherOrder)!;
+    expect(print(docInAnotherOrder)).toBe(print(expected));
+  });
+
+  it("should keep moreAuthorInfo fragment if used elsewhere", () => {
+    const query = gql`
+      query {
+        author {
+          name
+          ...authorInfo
+          ...moreAuthorInfo
+        }
+      }
+
+      fragment authorInfo on Author {
+        __typename
+        ...moreAuthorInfo @client
+      }
+
+      fragment moreAuthorInfo on Author {
+        extraDetails
+        isLoggedIn @client
+      }
+    `;
+
+    const expected = gql`
+      query {
+        author {
+          name
+          ...moreAuthorInfo
+        }
+      }
+
+      fragment moreAuthorInfo on Author {
+        extraDetails
+      }
+    `;
+
+    const doc = removeClientSetsFromDocument(query)!;
+    expect(print(doc)).toBe(print(expected));
+
+    const queryInAnotherOrder = gql`
+      fragment authorInfo on Author {
+        ...moreAuthorInfo @client
+        __typename
+      }
+
+      query {
+        author {
+          name
+          ...authorInfo
+          ...moreAuthorInfo
+        }
+      }
+
+      fragment moreAuthorInfo on Author {
+        isLoggedIn @client
+        extraDetails
+      }
+    `;
+
+    const docInAnotherOrder = removeClientSetsFromDocument(queryInAnotherOrder)!;
+    expect(print(docInAnotherOrder)).toBe(print(expected));
+  });
+
+  it("should remove unused variables in nested fragments", () => {
+    const query = gql`
+      query SomeQuery ($someVar: String) {
+        someField {
+          ...SomeFragment
+        }
+      }
+
+      fragment SomeFragment on SomeType {
+        firstField {
+          ...SomeOtherFragment
+        }
+      }
+
+      fragment SomeOtherFragment on SomeType {
+        someField @client (someArg: $someVar)
+      }
+    `;
+
+    const expected = gql`
+      query SomeQuery {
+        someField {
+          ...SomeFragment
+        }
+      }
+
+      fragment SomeFragment on SomeType {
+        firstField
+      }
+    `;
+
+    const doc = removeClientSetsFromDocument(query)!;
+    expect(print(doc)).toBe(print(expected));
+  });
+
+  it("should not remove variables used in unremoved parts of query", () => {
+    const query = gql`
+      query SomeQuery ($someVar: String) {
+        someField {
+          ...SomeFragment
+        }
+      }
+
+      fragment SomeFragment on SomeType {
+        firstField {
+          ...SomeOtherFragment
+        }
+      }
+
+      fragment SomeOtherFragment on SomeType {
+        someField(someArg: $someVar) @client
+        yetAnotherField(someArg: $someVar)
+      }
+    `;
+
+    const expected = gql`
+      query SomeQuery ($someVar: String) {
+        someField {
+          ...SomeFragment
+        }
+      }
+
+      fragment SomeFragment on SomeType {
+        firstField {
+          ...SomeOtherFragment
+        }
+      }
+
+      fragment SomeOtherFragment on SomeType {
+        yetAnotherField(someArg: $someVar)
+      }
+    `;
+
+    const doc = removeClientSetsFromDocument(query)!;
+    expect(print(doc)).toBe(print(expected));
+  });
 });

--- a/src/utilities/graphql/__tests__/transform.ts
+++ b/src/utilities/graphql/__tests__/transform.ts
@@ -131,7 +131,7 @@ describe('removeDirectivesFromDocument', () => {
     const doc = removeDirectivesFromDocument(
       [{ name: 'client', remove: true }],
       query,
-    );
+    )!;
     expect(print(doc)).toBe(print(expected));
   });
 

--- a/src/utilities/graphql/__tests__/transform.ts
+++ b/src/utilities/graphql/__tests__/transform.ts
@@ -1036,7 +1036,7 @@ describe('removeClientSetsFromDocument', () => {
     expect(print(doc)).toBe(print(expected));
   });
 
-  it("should remove __typename only fragment (without @client) when query precedes fragment", () => {
+  it("should not remove __typename-only fragment (without @client) when query precedes fragment", () => {
     const query = gql`
       query {
         author {
@@ -1050,19 +1050,13 @@ describe('removeClientSetsFromDocument', () => {
       }
     `;
 
-    const expected = gql`
-      query {
-        author {
-          name
-        }
-      }
-    `;
+    const expected = query;
 
     const doc = removeClientSetsFromDocument(query)!;
     expect(print(doc)).toBe(print(expected));
   });
 
-  it("should remove __typename only fragment (without @client) when fragment precedes query", () => {
+  it("should not remove __typename-only fragment (without @client) when fragment precedes query", () => {
     const query = gql`
       fragment authorInfo on Author {
         __typename
@@ -1076,13 +1070,7 @@ describe('removeClientSetsFromDocument', () => {
       }
     `;
 
-    const expected = gql`
-      query {
-        author {
-          name
-        }
-      }
-    `;
+    const expected = query;
 
     const doc = removeClientSetsFromDocument(query)!;
     expect(print(doc)).toBe(print(expected));

--- a/src/utilities/graphql/__tests__/transform.ts
+++ b/src/utilities/graphql/__tests__/transform.ts
@@ -976,7 +976,7 @@ describe('removeClientSetsFromDocument', () => {
     expect(print(doc)).toBe(print(expected));
   });
 
-  it("should not remove __typename only fragment without @client", () => {
+  it("should not remove __typename only fragment (without @client)", () => {
     const query = gql`
       query {
         author {

--- a/src/utilities/graphql/__tests__/transform.ts
+++ b/src/utilities/graphql/__tests__/transform.ts
@@ -948,4 +948,62 @@ describe('removeClientSetsFromDocument', () => {
     const doc = removeClientSetsFromDocument(query)!;
     expect(print(doc)).toBe(print(expected));
   });
+
+  it("should remove @client and __typename only fragment", () => {
+    const query = gql`
+      query {
+        author {
+          name
+          ...toBeRemoved
+        }
+      }
+
+      fragment toBeRemoved on Author {
+        __typename
+        isLoggedIn @client
+      }
+    `;
+
+    const expected = gql`
+      query {
+        author {
+          name
+        }
+      }
+    `;
+
+    const doc = removeClientSetsFromDocument(query)!;
+    expect(print(doc)).toBe(print(expected));
+  });
+
+  it("should not remove __typename only fragment without @client", () => {
+    const query = gql`
+      query {
+        author {
+          name
+          ...authorInfo
+        }
+      }
+
+      fragment authorInfo on Author {
+        __typename
+      }
+    `;
+
+    const expected = gql`
+      query {
+        author {
+          name
+          ...authorInfo
+        }
+      }
+
+      fragment authorInfo on Author {
+        __typename
+      }
+    `;
+
+    const doc = removeClientSetsFromDocument(query)!;
+    expect(print(doc)).toBe(print(expected));
+  });
 });

--- a/src/utilities/graphql/__tests__/transform.ts
+++ b/src/utilities/graphql/__tests__/transform.ts
@@ -947,7 +947,7 @@ describe('query transforms', () => {
   });
 });
 
-describe.only('removeClientSetsFromDocument', () => {
+describe('removeClientSetsFromDocument', () => {
   it('should remove @client fields from document', () => {
     const query = gql`
       query Author {
@@ -1009,7 +1009,8 @@ describe.only('removeClientSetsFromDocument', () => {
     expect(print(doc)).toBe(print(expected));
   });
 
-  it.only("should remove @client and __typename only fragment when fragment precedes query", () => {
+  // TODO(FIXME): https://github.com/apollographql/apollo-client/issues/10539
+  it.skip("should remove @client and __typename only fragment when fragment precedes query", () => {
     const query = gql`
       fragment toBeRemoved on Author {
         __typename

--- a/src/utilities/graphql/__tests__/transform.ts
+++ b/src/utilities/graphql/__tests__/transform.ts
@@ -1009,8 +1009,7 @@ describe('removeClientSetsFromDocument', () => {
     expect(print(doc)).toBe(print(expected));
   });
 
-  // TODO(FIXME): https://github.com/apollographql/apollo-client/issues/10539
-  it.skip("should remove @client and __typename only fragment when fragment precedes query", () => {
+  it("should remove @client and __typename only fragment when fragment precedes query", () => {
     const query = gql`
       fragment toBeRemoved on Author {
         __typename
@@ -1037,7 +1036,7 @@ describe('removeClientSetsFromDocument', () => {
     expect(print(doc)).toBe(print(expected));
   });
 
-  it("should not remove __typename only fragment (without @client) when query precedes fragment", () => {
+  it("should remove __typename only fragment (without @client) when query precedes fragment", () => {
     const query = gql`
       query {
         author {
@@ -1055,12 +1054,7 @@ describe('removeClientSetsFromDocument', () => {
       query {
         author {
           name
-          ...authorInfo
         }
-      }
-
-      fragment authorInfo on Author {
-        __typename
       }
     `;
 
@@ -1068,7 +1062,7 @@ describe('removeClientSetsFromDocument', () => {
     expect(print(doc)).toBe(print(expected));
   });
 
-  it("should not remove __typename only fragment (without @client) when fragment precedes query", () => {
+  it("should remove __typename only fragment (without @client) when fragment precedes query", () => {
     const query = gql`
       fragment authorInfo on Author {
         __typename
@@ -1083,13 +1077,9 @@ describe('removeClientSetsFromDocument', () => {
     `;
 
     const expected = gql`
-      fragment authorInfo on Author {
-        __typename
-      }
       query {
         author {
           name
-          ...authorInfo
         }
       }
     `;

--- a/src/utilities/graphql/transform.ts
+++ b/src/utilities/graphql/transform.ts
@@ -207,7 +207,6 @@ export function removeDirectivesFromDocument(
 
       FragmentSpread: {
         enter(node) {
-          console.log(node.name.value, fragmentSpreadsInUse[node.name.value]);
           // Keep track of referenced fragment spreads. This is used to
           // determine if top level fragment definitions should be removed.
           fragmentSpreadsInUse[node.name.value] = true;

--- a/src/utilities/graphql/transform.ts
+++ b/src/utilities/graphql/transform.ts
@@ -194,6 +194,24 @@ export function removeDirectivesFromDocument(
         },
       },
 
+      InlineFragment: {
+        enter(node) {
+          if (directives && node.directives) {
+            const shouldRemoveField = directives.some(
+              directive => directive.remove,
+            );
+
+            if (
+              shouldRemoveField &&
+                node.directives &&
+                node.directives.some(getDirectiveMatcher(directives))
+            ) {
+              return null;
+            }
+          }
+        },
+      },
+
       Directive: {
         enter(node) {
           // If a matching directive is found, remove it.

--- a/src/utilities/graphql/transform.ts
+++ b/src/utilities/graphql/transform.ts
@@ -207,6 +207,7 @@ export function removeDirectivesFromDocument(
 
       FragmentSpread: {
         enter(node) {
+          console.log(node.name.value, fragmentSpreadsInUse[node.name.value]);
           // Keep track of referenced fragment spreads. This is used to
           // determine if top level fragment definitions should be removed.
           fragmentSpreadsInUse[node.name.value] = true;

--- a/src/utilities/graphql/transform.ts
+++ b/src/utilities/graphql/transform.ts
@@ -98,7 +98,9 @@ function getDirectiveMatcher(
 export function removeDirectivesFromDocument(
   directives: RemoveDirectiveConfig[],
   doc: DocumentNode,
-  {removeTypenameOnlyFragment}: {removeTypenameOnlyFragment: boolean} = {removeTypenameOnlyFragment: false}
+  { removeTypenameOnlyFragment }: { removeTypenameOnlyFragment: boolean } = {
+    removeTypenameOnlyFragment: false,
+  }
 ): DocumentNode | null {
   const variablesInUse: Record<string, boolean> = Object.create(null);
   let variablesToRemove: RemoveArgumentsConfig[] = [];

--- a/src/utilities/graphql/transform.ts
+++ b/src/utilities/graphql/transform.ts
@@ -84,13 +84,20 @@ function nullIfDocIsEmpty(doc: DocumentNode) {
 function getDirectiveMatcher(
   directives: (RemoveDirectiveConfig | GetDirectiveConfig)[],
 ) {
-  return function directiveMatcher(directive: DirectiveNode) {
-    return directives.some(
-      dir =>
-        (dir.name && dir.name === directive.name.value) ||
-        (dir.test && dir.test(directive)),
-    );
-  };
+  const nameSet = new Set<string>();
+  const tests: Array<(directive: DirectiveNode) => boolean> = [];
+  directives.forEach(directive => {
+    if (directive.name) {
+      nameSet.add(directive.name);
+    } else if (directive.test) {
+      tests.push(directive.test);
+    }
+  });
+
+  return (directive: DirectiveNode) => (
+    nameSet.has(directive.name.value) ||
+    tests.some(test => test(directive))
+  );
 }
 
 function shouldRemoveField(

--- a/src/utilities/graphql/transform.ts
+++ b/src/utilities/graphql/transform.ts
@@ -98,12 +98,16 @@ function getDirectiveMatcher(
 export function removeDirectivesFromDocument(
   directives: RemoveDirectiveConfig[],
   doc: DocumentNode,
+  {removeTypenameOnlyFragment}: {removeTypenameOnlyFragment: boolean} = {removeTypenameOnlyFragment: false}
 ): DocumentNode | null {
   const variablesInUse: Record<string, boolean> = Object.create(null);
   let variablesToRemove: RemoveArgumentsConfig[] = [];
 
   const fragmentSpreadsInUse: Record<string, boolean> = Object.create(null);
   let fragmentSpreadsToRemove: RemoveFragmentSpreadConfig[] = [];
+
+  const modifiedFragmentNames: string[] = [];
+  let currentFragmentName: string | undefined;
 
   let modifiedDoc = nullIfDocIsEmpty(
     visit(doc, {
@@ -122,6 +126,15 @@ export function removeDirectivesFromDocument(
         },
       },
 
+      FragmentDefinition: {
+        enter(node) {
+          currentFragmentName = node.name.value;
+        },
+        leave() {
+          currentFragmentName = undefined;
+        }
+      },
+
       Field: {
         enter(node) {
           if (directives && node.directives) {
@@ -136,6 +149,10 @@ export function removeDirectivesFromDocument(
               node.directives &&
               node.directives.some(getDirectiveMatcher(directives))
             ) {
+              if(currentFragmentName) {
+                modifiedFragmentNames.push(currentFragmentName);
+              }
+
               if (node.arguments) {
                 // Store field argument variables so they can be removed
                 // from the operation definition.
@@ -185,6 +202,27 @@ export function removeDirectivesFromDocument(
       },
     }),
   );
+
+  if (modifiedDoc && removeTypenameOnlyFragment && modifiedFragmentNames.length > 0) {
+    modifiedDoc = visit(modifiedDoc, {
+      FragmentDefinition: {
+        enter(node) {
+          if (node.selectionSet) {
+            const isTypenameOnly = node.selectionSet.selections.every(
+              selection =>
+                isField(selection) && selection.name.value === '__typename',
+            );
+            const name = node.name.value;
+            if (isTypenameOnly && modifiedFragmentNames.includes(name)) {
+              fragmentSpreadsToRemove.push({name});
+              fragmentSpreadsInUse[name] = false;
+              return null;
+            }
+          }
+        },
+      },
+    });
+  }
 
   // If we've removed fields with arguments, make sure the associated
   // variables are also removed from the rest of the document, as long as they
@@ -489,29 +527,12 @@ export function removeClientSetsFromDocument(
       },
     ],
     document,
+    // After a fragment definition has had its @client related document
+    // sets removed, if the only field it has left is a __typename field,
+    // remove the entire fragment operation to prevent it from being fired
+    // on the server.
+    {removeTypenameOnlyFragment: true}
   );
-
-  // After a fragment definition has had its @client related document
-  // sets removed, if the only field it has left is a __typename field,
-  // remove the entire fragment operation to prevent it from being fired
-  // on the server.
-  if (modifiedDoc) {
-    modifiedDoc = visit(modifiedDoc, {
-      FragmentDefinition: {
-        enter(node) {
-          if (node.selectionSet) {
-            const isTypenameOnly = node.selectionSet.selections.every(
-              selection =>
-                isField(selection) && selection.name.value === '__typename',
-            );
-            if (isTypenameOnly) {
-              return null;
-            }
-          }
-        },
-      },
-    });
-  }
 
   return modifiedDoc;
 }

--- a/src/utilities/graphql/transform.ts
+++ b/src/utilities/graphql/transform.ts
@@ -56,9 +56,9 @@ export type RemoveVariableDefinitionConfig = RemoveNodeConfig<
 >;
 
 const TYPENAME_FIELD: FieldNode = {
-  kind: 'Field' as Kind.FIELD,
+  kind: Kind.FIELD,
   name: {
-    kind: 'Name' as Kind.NAME,
+    kind: Kind.NAME,
     value: '__typename',
   },
 };
@@ -68,7 +68,7 @@ function isEmpty(
   fragmentMap: FragmentMap,
 ): boolean {
   return !op || op.selectionSet.selections.every(
-    selection => selection.kind === 'FragmentSpread' &&
+    selection => selection.kind === Kind.FRAGMENT_SPREAD &&
       isEmpty(fragmentMap[selection.name.value], fragmentMap)
   );
 }
@@ -161,7 +161,7 @@ export function removeDirectivesFromDocument(
 
   let operationCount = 0;
   for (let i = doc.definitions.length - 1; i >= 0; --i) {
-    if (doc.definitions[i].kind === 'OperationDefinition') {
+    if (doc.definitions[i].kind === Kind.OPERATION_DEFINITION) {
       ++operationCount;
     }
   }
@@ -258,7 +258,7 @@ export function removeDirectivesFromDocument(
           // only fragments makes the document useless.
           operationCount > 0 &&
           node.selectionSet.selections.every(selection => (
-            selection.kind === 'Field' &&
+            selection.kind === Kind.FIELD &&
             selection.name.value === '__typename'
           ))
         ) {
@@ -319,14 +319,14 @@ export function removeDirectivesFromDocument(
   // spreads used (transitively) by any operations in the document.
   const allFragmentNamesUsed = new Set<string>();
   docWithoutDirectiveSubtrees.definitions.forEach(def => {
-    if (def.kind === 'OperationDefinition') {
+    if (def.kind === Kind.OPERATION_DEFINITION) {
       populateTransitiveVars(
         getInUseByOperationName(def.name ? def.name.value : "")
       ).fragmentSpreads.forEach(childFragmentName => {
         allFragmentNamesUsed.add(childFragmentName);
       });
     } else if (
-      def.kind === 'FragmentDefinition' &&
+      def.kind === Kind.FRAGMENT_DEFINITION &&
       // If there are no operations in the document, then all fragment
       // definitions count as usages of their own fragment names. This heuristic
       // prevents accidentally removing all fragment definitions from the
@@ -422,7 +422,7 @@ export const addTypenameToDocument = Object.assign(function <
         // Don't add __typename to OperationDefinitions.
         if (
           parent &&
-          (parent as OperationDefinitionNode).kind === 'OperationDefinition'
+          (parent as OperationDefinitionNode).kind === Kind.OPERATION_DEFINITION
         ) {
           return;
         }
@@ -540,7 +540,7 @@ function getArgumentMatcher(config: RemoveArgumentsConfig[]) {
     return config.some(
       (aConfig: RemoveArgumentsConfig) =>
         argument.value &&
-        argument.value.kind === 'Variable' &&
+        argument.value.kind === Kind.VARIABLE &&
         argument.value.name &&
         (aConfig.name === argument.value.name.value ||
           (aConfig.test && aConfig.test(argument))),

--- a/src/utilities/graphql/transform.ts
+++ b/src/utilities/graphql/transform.ts
@@ -116,7 +116,7 @@ interface InternalInUseInfo {
 function makeInUseGetterFunction<TKey>() {
   const map = new Map<TKey, InternalInUseInfo>();
 
-  return function getInUse(key: TKey): InternalInUseInfo {
+  return function inUseGetterFunction(key: TKey): InternalInUseInfo {
     let inUse = map.get(key);
     if (!inUse) {
       map.set(key, inUse = {


### PR DESCRIPTION
This refactoring of `removeDirectivesFromDocument` builds on (rebases) the work begun in PR #6322, fixing both the original issue #6311 and the related issue #10539.

At a high level, these changes reduce the number of full-document AST traversals performed by `removeDirectivesFromDocument` from 3 to 2. Future work could potentially replace the second traversal with a more targeted manual cleanup pass, to improve performance further.

In the first of those two traversals, we gather as much information as we can about the AST, including all the variable references and fragments spreads used by each operation or fragment definition. At the same time, we can safely remove subtrees annotated with removal directives like `@client`, which effectively hides those removed subtrees from the information collected, and from future traversals.

For fragment definitions modified by these removals, if they are left with only a `__typename` field, we proactively remove the whole fragment definition along with any `...spread` references to it. However, if a fragment definition contains only a `__typename` field but is not otherwise modified, that fragment definition remains unmodified in the AST (preserving the spirit of #6311), unless there are no `...spread` references to it, in which case it must be removed, like any other unused fragment definition.

An additional exception is made for documents that contain only fragment definitions, with no operations consuming them: removing these "unused" fragments seems wrong, so the removal of unused and/or `__typename`-only fragment definitions is disabled when there are no operations in the document, on the presumption these "unused" fragment definitions must have a use beyond this document (for example, selecting a specific fragment from a document containing several definitions using `useFragment`'s `options.fragmentName`).

Using the information obtained in the first visit, a second visit brings all fragment spreads and definitions into agreement with each other, existence-wise, so there can be no dangling spreads or unused definitions in the final document. This pass also prunes variable declarations from operations that no longer use some of their declared variables, including usages directly within the operation and in any transitively included fragments.

I've added several more tests to enforce more edge cases around ordering sensitivity and transitive variable/fragment usage. I believe this PR has roughly the same level of backwards compatibility as the previous PR #6322, though of course the changes are more significant now, so we might want to add even more tests.