### PR TITLE
Allow `ApolloCache` implementations to specify default value for `assumeImmutableResults` client option

### DIFF
--- a/.changeset/small-tomatoes-explode.md
+++ b/.changeset/small-tomatoes-explode.md
@@ -1,0 +1,5 @@
+---
+'@apollo/client': minor
+---
+
+Allow `ApolloCache` implementations to specify default value for `assumeImmutableResults` client option, improving performance for applications currently using `InMemoryCache` without configuring `new ApolloClient({ assumeImmutableResults: true })`

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -12,6 +12,8 @@ import { Cache } from './types/Cache';
 export type Transaction<T> = (c: ApolloCache<T>) => void;
 
 export abstract class ApolloCache<TSerialized> implements DataProxy {
+  public readonly assumeImmutableResults: boolean = false;
+
   // required to implement
   // core API
   public abstract read<TData = any, TVariables = any>(

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -49,6 +49,10 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     any,
     [Cache.WatchOptions]>;
 
+  // Override the default value, since InMemoryCache result objects are frozen
+  // in development and expected to remain logically immutable in production.
+  public readonly assumeImmutableResults = true;
+
   // Dynamically imported code can augment existing typePolicies or
   // possibleTypes by calling cache.policies.addTypePolicies or
   // cache.policies.addPossibletypes.

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -127,6 +127,14 @@ export class ApolloClient<TCacheShape> implements DataProxy {
    *                you are using.
    */
   constructor(options: ApolloClientOptions<TCacheShape>) {
+    if (!options.cache) {
+      throw new InvariantError(
+        "To initialize Apollo Client, you must specify a 'cache' property " +
+        "in the options object. \n" +
+        "For more information, please visit: https://go.apollo.dev/c/docs"
+      );
+    }
+
     const {
       uri,
       credentials,
@@ -143,7 +151,7 @@ export class ApolloClient<TCacheShape> implements DataProxy {
         __DEV__,
       queryDeduplication = true,
       defaultOptions,
-      assumeImmutableResults = false,
+      assumeImmutableResults = cache.assumeImmutableResults,
       resolvers,
       typeDefs,
       fragmentMatcher,
@@ -157,14 +165,6 @@ export class ApolloClient<TCacheShape> implements DataProxy {
       link = uri
         ? new HttpLink({ uri, credentials, headers })
         : ApolloLink.empty();
-    }
-
-    if (!cache) {
-      throw new InvariantError(
-        "To initialize Apollo Client, you must specify a 'cache' property " +
-        "in the options object. \n" +
-        "For more information, please visit: https://go.apollo.dev/c/docs"
-      );
     }
 
     this.link = link;

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -38,9 +38,13 @@ const destructiveMethodCounts = new (
   canUseWeakMap ? WeakMap : Map
 )<ApolloCache<any>, number>();
 
+type KeyOfType<T, U> = {
+  [P in keyof T]: T[P] extends U ? P : never
+}[keyof T]
+
 function wrapDestructiveCacheMethod(
   cache: ApolloCache<any>,
-  methodName: keyof ApolloCache<any>,
+  methodName: KeyOfType<ApolloCache<any>, Function>,
 ) {
   const original = cache[methodName];
   if (typeof original === "function") {

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -6,7 +6,7 @@ import { DeepMerger } from "../utilities"
 import { mergeIncrementalData } from '../utilities';
 import { WatchQueryOptions, ErrorPolicy } from './watchQueryOptions';
 import { ObservableQuery, reobserveCacheFirst } from './ObservableQuery';
-import { QueryListener } from './types';
+import { QueryListener, MethodKeys } from './types';
 import { FetchResult } from '../link/core';
 import {
   ObservableSubscription,
@@ -38,13 +38,9 @@ const destructiveMethodCounts = new (
   canUseWeakMap ? WeakMap : Map
 )<ApolloCache<any>, number>();
 
-type KeyOfType<T, U> = {
-  [P in keyof T]: T[P] extends U ? P : never
-}[keyof T]
-
 function wrapDestructiveCacheMethod(
   cache: ApolloCache<any>,
-  methodName: KeyOfType<ApolloCache<any>, Function>,
+  methodName: MethodKeys<ApolloCache<any>>,
 ) {
   const original = cache[methodName];
   if (typeof original === "function") {

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -119,7 +119,7 @@ export class QueryManager<TStore> {
     ssrMode = false,
     clientAwareness = {},
     localState,
-    assumeImmutableResults,
+    assumeImmutableResults = !!cache.assumeImmutableResults,
   }: {
     cache: ApolloCache<TStore>;
     link: ApolloLink;
@@ -138,7 +138,7 @@ export class QueryManager<TStore> {
     this.clientAwareness = clientAwareness;
     this.localState = localState || new LocalState({ cache });
     this.ssrMode = ssrMode;
-    this.assumeImmutableResults = !!assumeImmutableResults;
+    this.assumeImmutableResults = assumeImmutableResults;
     if ((this.onBroadcast = onBroadcast)) {
       this.mutationStore = Object.create(null);
     }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -13,6 +13,10 @@ import { IsStrictlyAny } from '../utilities';
 
 export { TypedDocumentNode } from '@graphql-typed-document-node/core';
 
+export type MethodKeys<T> = {
+  [P in keyof T]: T[P] extends Function ? P : never
+}[keyof T];
+
 export interface DefaultContext extends Record<string, any> {};
 
 export type QueryListener = (queryInfo: QueryInfo) => void;


### PR DESCRIPTION
This commit allows the default value of the [`assumeImmutableResults` option](https://www.apollographql.com/docs/react/api/core/ApolloClient/#assumeimmutableresults) to be determined by the cache (any implementation of `ApolloCache`), which allows our implementation of `InMemoryCache` to express the safety of assuming `assumeImmutableResults` is `true`, unlocking significant performance savings (fewer defensive deep copies of query results), even if `assumeImmutableResults` is not configured.

Related past PRs/context:
- https://github.com/apollographql/apollo-client/pull/4543
- https://github.com/apollographql/apollo-client/pull/5153
- https://github.com/apollographql/apollo-client/pull/9680
- [Apollo Client 2.6 blog post](https://www.apollographql.com/blog/announcement/frontend/whats-new-in-apollo-client-2-6/#rewarding-immutability)