### PR TITLE
chore: run lock workflow daily

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -22,5 +22,10 @@ jobs:
           log-output: true
           issue-inactive-days: '30'
           exclude-any-issue-labels: 'discussion'
+          issue-comment: >
+            This issue has been automatically locked since there has not been any recent activity after it was closed. Please open a new issue for related bugs.
+
+            For general questions, we recommend using [StackOverflow](https://stackoverflow.com/questions/tagged/apollo-client) or our [discord server](https://discord.gg/graphos).
+
           pr-inactive-days: '30'
           exclude-any-pr-labels: 'discussion'

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -2,7 +2,7 @@ name: 'Lock Threads'
 
 on:
   schedule:
-    - cron: '0 * * * *'
+    - cron: '0 0 * * *'
 
 permissions:
   issues: write
@@ -20,17 +20,7 @@ jobs:
         with:
           github-token: ${{ github.token }}
           log-output: true
-
           issue-inactive-days: '30'
           exclude-any-issue-labels: 'discussion'
-          # issue-comment: >
-          #   This issue has been automatically locked since there has not been any recent activity after it was closed. Please open a new issue for related bugs.
-
-          #   Please note this issue tracker is not a help forum. We recommend using [StackOverflow](https://stackoverflow.com/questions/tagged/apollo-client) or our [discord server](https://discord.gg/graphos) for questions.
-
           pr-inactive-days: '30'
           exclude-any-pr-labels: 'discussion'
-          # pr-comment: >
-          #   This pull request has been automatically locked since there has not been any recent activity after it was closed. Please open a new issue for related bugs.
-
-          #   Please note this issue tracker is not a help forum. We recommend using [StackOverflow](https://stackoverflow.com/questions/tagged/apollo-client) or our [discord server](https://discord.gg/graphos) for questions.


### PR DESCRIPTION
Now that we've worked through the backlog, we can run this workflow daily instead of hourly.

### Checklist:

- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](../CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
