### PR TITLE
Chore: adds tests for WebSockets error cases and prevents `undefined` message

### DIFF
--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -21,7 +21,7 @@ const generateErrorMessage = (err: ApolloError) => {
     const errors = ((err.graphQLErrors || []) as readonly Error[])
       .concat(err.clientErrors || []);
     errors.forEach((error: Error) => {
-      const errorMessage = error
+      const errorMessage = error && error.message
         ? error.message
         : 'Error message not found.';
       message += `${errorMessage}\n`;

--- a/src/link/subscriptions/__tests__/graphqlWsLink.ts
+++ b/src/link/subscriptions/__tests__/graphqlWsLink.ts
@@ -1,8 +1,9 @@
 import { Client } from "graphql-ws";
-import { ExecutionResult } from "graphql";
+import { ExecutionResult, GraphQLError } from "graphql";
 import gql from "graphql-tag";
 
 import { Observable } from "../../../utilities";
+import { ApolloError } from "../../../errors";
 import { execute } from "../../core";
 import { GraphQLWsLink } from "..";
 
@@ -103,5 +104,69 @@ describe("GraphQLWSlink", () => {
 
     const obs = execute(link, { query: subscription });
     await expect(observableToArray(obs)).resolves.toEqual(results);
+  });
+
+  describe("should reject", () => {
+    it("with Error on subscription error via Error", async () => {
+      const subscribe: Client["subscribe"] = (_, sink) => {
+        sink.error(new Error("an error occurred"));
+        return () => {};
+      };
+      const client = mockClient(subscribe);
+      const link = new GraphQLWsLink(client);
+
+      const obs = execute(link, { query: subscription });
+      await expect(observableToArray(obs)).rejects.toEqual(
+        new Error("an error occurred")
+      );
+    });
+
+    it("with Error on subscription error via CloseEvent", async () => {
+      const subscribe: Client["subscribe"] = (_, sink) => {
+        sink.error(
+          new CloseEvent("an error occurred", { code: 1006, reason: "abnormally closed" })
+        );
+        return () => {};
+      };
+      const client = mockClient(subscribe);
+      const link = new GraphQLWsLink(client);
+
+      const obs = execute(link, { query: subscription });
+      await expect(observableToArray(obs)).rejects.toEqual(
+        new Error("Socket closed with event 1006 abnormally closed")
+      );
+    });
+
+    it("with ApolloError on subscription error via Event (network disconnected)", async () => {
+      const subscribe: Client["subscribe"] = (_, sink) => {
+        sink.error(new Event("an error occurred"));
+        return () => {};
+      };
+      const client = mockClient(subscribe);
+      const link = new GraphQLWsLink(client);
+
+      const obs = execute(link, { query: subscription });
+      await expect(observableToArray(obs)).rejects.toEqual(
+        new ApolloError({
+          networkError: new Error("Error message not found."),
+        })
+      );
+    });
+
+    it("with ApolloError on subscription error via GraphQLError[]", async () => {
+      const subscribe: Client["subscribe"] = (_, sink) => {
+        sink.error([new GraphQLError("Foo bar.")]);
+        return () => {};
+      };
+      const client = mockClient(subscribe);
+      const link = new GraphQLWsLink(client);
+
+      const obs = execute(link, { query: subscription });
+      await expect(observableToArray(obs)).rejects.toEqual(
+        new ApolloError({
+          graphQLErrors: [new GraphQLError("Foo bar.")],
+        })
+      );
+    });
   });
 });


### PR DESCRIPTION
In progress, closes #10394.

Adds tests and prevents `undefined` error message after a websocket connection is closed when network connection is lost.

### Checklist:

- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](../CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
