### PR TITLE
chore: narrow types of `getFromAST.ts` with type predicates

### DIFF
--- a/.changeset/clean-horses-prove.md
+++ b/.changeset/clean-horses-prove.md
@@ -1,5 +1,0 @@
----
-"@apollo/client": patch
----
-
-Narrow the type of `getFromAST.ts` utils with type predicates

--- a/.changeset/clean-horses-prove.md
+++ b/.changeset/clean-horses-prove.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Narrow the type of `getFromAST.ts` utils with type predicates

--- a/src/utilities/graphql/getFromAST.ts
+++ b/src/utilities/graphql/getFromAST.ts
@@ -9,6 +9,10 @@ import {
 
 import { valueToObjectRepresentation } from './storeUtils';
 
+type OperationDefinitionWithName = OperationDefinitionNode & {
+  name: NonNullable<OperationDefinitionNode['name']>;
+};
+
 // Checks the document for errors and throws an exception if there is an error.
 export function checkDocument(doc: DocumentNode) {
   invariant(
@@ -43,18 +47,19 @@ export function getOperationDefinition(
 ): OperationDefinitionNode | undefined {
   checkDocument(doc);
   return doc.definitions.filter(
-    definition => definition.kind === 'OperationDefinition',
-  )[0] as OperationDefinitionNode;
+    (definition): definition is OperationDefinitionNode =>
+      definition.kind === 'OperationDefinition',
+  )[0];
 }
 
 export function getOperationName(doc: DocumentNode): string | null {
   return (
     doc.definitions
       .filter(
-        definition =>
-          definition.kind === 'OperationDefinition' && definition.name,
+        (definition): definition is OperationDefinitionWithName =>
+          definition.kind === 'OperationDefinition' && !!definition.name,
       )
-      .map((x: OperationDefinitionNode) => x!.name!.value)[0] || null
+      .map((x) => x.name.value)[0] || null
   );
 }
 
@@ -63,12 +68,13 @@ export function getFragmentDefinitions(
   doc: DocumentNode,
 ): FragmentDefinitionNode[] {
   return doc.definitions.filter(
-    definition => definition.kind === 'FragmentDefinition',
-  ) as FragmentDefinitionNode[];
+    (definition): definition is FragmentDefinitionNode =>
+      definition.kind === 'FragmentDefinition',
+  );
 }
 
 export function getQueryDefinition(doc: DocumentNode): OperationDefinitionNode {
-  const queryDef = getOperationDefinition(doc) as OperationDefinitionNode;
+  const queryDef = getOperationDefinition(doc)!;
 
   invariant(
     queryDef && queryDef.operation === 'query',


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

Rather than type casting with [type assertions](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#type-assertions), we can leverage [type predicates](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates) to narrow down the type where we already have user-defined type guards (`Array.filter`). That's equivalent, but the next step will be correctly typed, and we won't need to type cast it.

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](../CONTRIBUTING.md#changesets))
- [x] Make sure all of the significant new logic is covered by tests
