### PR TITLE
chore: fix link to `CONTRIBUTING.md`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,6 +20,6 @@
 
 ### Checklist:
 
-- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](../CONTRIBUTING.md#changesets))
+- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
 - [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
 - [ ] Make sure all of the significant new logic is covered by tests


### PR DESCRIPTION
The link to `CONTRIBUTING.md` from `.github/PULL_REQUEST_TEMPLATE.md` works fine locally (at least from VSCode), but it doesn't work within the browser when we're typing the pull request description.

Let's make sure the link is always working.