### PR TITLE
chore: add ApolloLink.split example

### DIFF
--- a/docs/source/api/link/introduction.mdx
+++ b/docs/source/api/link/introduction.mdx
@@ -223,7 +223,9 @@ const additiveLink = from([
 
 ### Directional composition
 
-You might want your link chain's execution to branch, depending on the details of the operation being performed. You can define this logic with the `split` method of an `ApolloLink` instance. This method takes three parameters:
+You might want your link chain's execution to branch, depending on the details of the operation being performed.
+
+To support this, the `@apollo/client` library provides a `split` function that lets you use one of two different `Link`s, according to the result of a boolean check. You can also use the `split` method of an `ApolloLink` instance.
 
 | Name  | Description  |
 |---|---|
@@ -239,8 +241,8 @@ import { RetryLink } from '@apollo/client/link/retry';
 
 const directionalLink = new RetryLink().split(
   (operation) => operation.getContext().version === 1,
-  new HttpLink({ uri: "http://localhost:4000/v1/graphql" }),
-  new HttpLink({ uri: "http://localhost:4000/v2/graphql" })
+  new HttpLink({ uri: 'http://localhost:4000/v1/graphql' }),
+  new HttpLink({ uri: 'http://localhost:4000/v2/graphql' })
 );
 ```
 
@@ -253,12 +255,12 @@ Other uses for the `split` method include:
 In the following example, all subscription operations are sent to `GraphQLWsLink`, with all other operations sent to `HttpLink`:
 
 ```js
-import { ApolloLink, HttpLink } from '@apollo/client';
+import { split, HttpLink } from '@apollo/client';
 import { getMainDefinition } from '@apollo/client/utilities';
-import { GraphQLWsLink } from "@apollo/client/link/subscriptions";
-import { createClient } from "graphql-ws";
+import { GraphQLWsLink } from '@apollo/client/link/subscriptions';
+import { createClient } from 'graphql-ws';
 
-export const link = ApolloLink.split(
+export const link = split(
   ({ query }) => {
     const definition = getMainDefinition(query);
     return (
@@ -266,8 +268,8 @@ export const link = ApolloLink.split(
       definition.operation === 'subscription'
     );
   },
-  new GraphQLWsLink(createClient({ url: "ws://localhost:3000/subscriptions" })),
-  new HttpLink({ uri: "http://localhost:4000/graphql" })
+  new GraphQLWsLink(createClient({ url: 'ws://localhost:3000/subscriptions' })),
+  new HttpLink({ uri: 'http://localhost:4000/graphql' })
 );
 ```
 

--- a/docs/source/api/link/introduction.mdx
+++ b/docs/source/api/link/introduction.mdx
@@ -250,6 +250,24 @@ Other uses for the `split` method include:
 * Using different transport methods depending on the operation type (such as HTTP for queries and WebSocket for subscriptions)
 * Customizing logic depending on whether a user is logged in
 
+In the following example, all subscription operations are sent to `GraphQLWsLink`, with all other operations sent to `HttpLink`:
+
+```js
+import { ApolloLink, HttpLink } from '@apollo/client';
+import { GraphQLWsLink } from "@apollo/client/link/subscriptions";
+import { createClient } from "graphql-ws";
+
+const definitionIsSubscription = (d) => {
+  return d.kind === "OperationDefinition" && d.operation === "subscription";
+};
+
+export const link = ApolloLink.split(
+  (operation) => operation.query.definitions.some(definitionIsSubscription),
+  new GraphQLWsLink(createClient({ url: "wss://localhost:3000/subscriptions" })),
+  new HttpLink({ uri: "http://localhost:4000/graphql" })
+);
+```
+
 ### Providing to Apollo Client
 
 After you finish composing your entire link chain, you provide the resulting link to the constructor of `ApolloClient`, like so:

--- a/docs/source/api/link/introduction.mdx
+++ b/docs/source/api/link/introduction.mdx
@@ -254,16 +254,19 @@ In the following example, all subscription operations are sent to `GraphQLWsLink
 
 ```js
 import { ApolloLink, HttpLink } from '@apollo/client';
+import { getMainDefinition } from '@apollo/client/utilities';
 import { GraphQLWsLink } from "@apollo/client/link/subscriptions";
 import { createClient } from "graphql-ws";
 
-const definitionIsSubscription = (d) => {
-  return d.kind === "OperationDefinition" && d.operation === "subscription";
-};
-
 export const link = ApolloLink.split(
-  (operation) => operation.query.definitions.some(definitionIsSubscription),
-  new GraphQLWsLink(createClient({ url: "wss://localhost:3000/subscriptions" })),
+  ({ query }) => {
+    const definition = getMainDefinition(query);
+    return (
+      definition.kind === 'OperationDefinition' &&
+      definition.operation === 'subscription'
+    );
+  },
+  new GraphQLWsLink(createClient({ url: "ws://localhost:3000/subscriptions" })),
   new HttpLink({ uri: "http://localhost:4000/graphql" })
 );
 ```


### PR DESCRIPTION
A papercut I encountered while working on a separate subscriptions issue, and one it looks like [others have faced too](https://community.apollographql.com/t/apollolink-split-not-working-network-error-invariant-violation-request-is-not-implemented/2566).

On [Directional Composition](https://www.apollographql.com/docs/react/api/link/introduction/#directional-composition), the docs state:

> You can define this logic with the split method of an `ApolloLink` instance.

The only example we currently provide uses `RetryLink` like so:

```js
const directionalRetryLink = new RetryLink().split(
  (operation) => operation.getContext().version === 1,
  new HttpLink({ uri: "http://localhost:4000/v1/graphql" }),
  new HttpLink({ uri: "http://localhost:4000/v2/graphql" })
);
```

`RetryLink` extends `ApolloLink` and implements a `request` method, so this works. However, if we don't need retries and replace `RetryLink` with `ApolloLink`, its `request` method [throws with `request is not implemented`](https://github.com/apollographql/apollo-client/blob/main/src/link/core/ApolloLink.ts#L141). Instead we want to call `split` on the `ApolloLink` class directly, but the error can be confusing.

Hopefully an additional example of a common use case will make this more clear.