### PR TITLE
Use lexically-scoped `value` as fallback var value

### DIFF
--- a/src/cache/inmemory/reactiveVars.ts
+++ b/src/cache/inmemory/reactiveVars.ts
@@ -52,7 +52,7 @@ export function makeVar<T>(value: T): ReactiveVar<T> {
   const caches = new Set<ApolloCache<any>>();
   const listeners = new Set<ReactiveListener<T>>();
 
-  const rv: ReactiveVar<T> = function (newValue) {
+  const rv: ReactiveVar<T> = (newValue) => {
     if (arguments.length > 0) {
       if (value !== newValue) {
         value = newValue!;

--- a/src/cache/inmemory/reactiveVars.ts
+++ b/src/cache/inmemory/reactiveVars.ts
@@ -52,7 +52,7 @@ export function makeVar<T>(value: T): ReactiveVar<T> {
   const caches = new Set<ApolloCache<any>>();
   const listeners = new Set<ReactiveListener<T>>();
 
-  const rv: ReactiveVar<T> = function (newValue) {
+  const rv: ReactiveVar<T> = function (newValue: T) {
     if (arguments.length > 0) {
       if (value !== newValue) {
         value = newValue!;

--- a/src/cache/inmemory/reactiveVars.ts
+++ b/src/cache/inmemory/reactiveVars.ts
@@ -55,7 +55,7 @@ export function makeVar<T>(value: T): ReactiveVar<T> {
   // This is defined via an IIFE so that the `value` that was passed in as the
   // default is still available in the fallback scenario where a cache isn't
   // available.
-  const rv: ReactiveVar<T> = (() => function (newValue?: T) {
+  const rv = (() => function (newValue?: T) {
     if (arguments.length > 0) {
       if (value !== newValue) {
         value = newValue!;

--- a/src/cache/inmemory/reactiveVars.ts
+++ b/src/cache/inmemory/reactiveVars.ts
@@ -52,7 +52,10 @@ export function makeVar<T>(value: T): ReactiveVar<T> {
   const caches = new Set<ApolloCache<any>>();
   const listeners = new Set<ReactiveListener<T>>();
 
-  const rv: ReactiveVar<T> = function (newValue?: T) {
+  // This is defined via an IIFE so that the `value` that was passed in as the
+  // default is still available in the fallback scenario where a cache isn't
+  // available.
+  const rv: ReactiveVar<T> = (() => function (newValue?: T) {
     if (arguments.length > 0) {
       if (value !== newValue) {
         value = newValue!;
@@ -82,7 +85,7 @@ export function makeVar<T>(value: T): ReactiveVar<T> {
     }
 
     return value;
-  }.bind(this);
+  })()
 
   rv.onNextChange = listener => {
     listeners.add(listener);

--- a/src/cache/inmemory/reactiveVars.ts
+++ b/src/cache/inmemory/reactiveVars.ts
@@ -52,7 +52,7 @@ export function makeVar<T>(value: T): ReactiveVar<T> {
   const caches = new Set<ApolloCache<any>>();
   const listeners = new Set<ReactiveListener<T>>();
 
-  const rv: ReactiveVar<T> = function (newValue: T) {
+  const rv: ReactiveVar<T> = function (newValue?: T) {
     if (arguments.length > 0) {
       if (value !== newValue) {
         value = newValue!;

--- a/src/cache/inmemory/reactiveVars.ts
+++ b/src/cache/inmemory/reactiveVars.ts
@@ -52,7 +52,7 @@ export function makeVar<T>(value: T): ReactiveVar<T> {
   const caches = new Set<ApolloCache<any>>();
   const listeners = new Set<ReactiveListener<T>>();
 
-  const rv: ReactiveVar<T> = (newValue) => {
+  const rv: ReactiveVar<T> = function (newValue) {
     if (arguments.length > 0) {
       if (value !== newValue) {
         value = newValue!;
@@ -82,7 +82,7 @@ export function makeVar<T>(value: T): ReactiveVar<T> {
     }
 
     return value;
-  };
+  }.bind(this);
 
   rv.onNextChange = listener => {
     listeners.add(listener);


### PR DESCRIPTION
When fetching a reactive var's value, if `cache` doesn't exist yet, the fallback default value may be stale. By changing the definition of `rv` to be an arrow function, we ensure that we use the lexically-scoped `value`.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
