### PR TITLE
Fix tests by mocking optimism

### DIFF
--- a/src/cache/inmemory/__tests__/cache.ts
+++ b/src/cache/inmemory/__tests__/cache.ts
@@ -16,9 +16,6 @@ import { TypePolicies } from '../policies';
 disableFragmentWarnings();
 
 describe('Cache', () => {
-  afterAll(() => {
-    jest.restoreAllMocks();
-  });
   function itWithInitialData(
     message: string,
     initialDataForCaches: ({ [key: string]: any })[],

--- a/src/react/hooks/__tests__/useFragment.test.tsx
+++ b/src/react/hooks/__tests__/useFragment.test.tsx
@@ -17,10 +17,9 @@ import {
 } from "../../../core";
 import { useQuery } from "../useQuery";
 
+jest.mock('optimism')
+
 describe("useFragment", () => {
-  beforeEach(() => {
-    jest.restoreAllMocks();
-  });
   it("is importable and callable", () => {
     expect(typeof useFragment).toBe("function");
   });

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -12,10 +12,9 @@ import { QueryResult } from '../../types/types';
 
 const IS_REACT_18 = React.version.startsWith("18");
 
+jest.mock('optimism')
+
 describe('useLazyQuery Hook', () => {
-  beforeEach(() => {
-    jest.restoreAllMocks();
-  });
   afterEach(() => {
     resetApolloContext();
   });

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -15,10 +15,9 @@ import { useMutation } from '../useMutation';
 import { BatchHttpLink } from '../../../link/batch-http';
 import { FetchResult } from '../../../link/core';
 
+jest.mock('optimism')
+
 describe('useMutation Hook', () => {
-  beforeEach(() => {
-    jest.restoreAllMocks();
-  });
   afterEach(() => {
     resetApolloContext();
   });

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -1,9 +1,8 @@
 import React, { Fragment, useEffect, useState } from 'react';
 import { DocumentNode, GraphQLError } from 'graphql';
 import gql from 'graphql-tag';
-import { act } from 'react-dom/test-utils';
 import userEvent from '@testing-library/user-event';
-import { render, screen, waitFor, renderHook } from '@testing-library/react';
+import { act, render, screen, waitFor, renderHook } from '@testing-library/react';
 import {
   ApolloClient,
   ApolloError,
@@ -27,10 +26,9 @@ import { QueryResult } from "../../types/types";
 import { useQuery } from '../useQuery';
 import { useMutation } from '../useMutation';
 
+jest.mock('optimism')
+
 describe('useQuery Hook', () => {
-  beforeEach(() => {
-    jest.restoreAllMocks();
-  });
   afterEach(() => {
     resetApolloContext();
   });


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests

Running `npm run test` locally showed the following results:
```
Test Suites: 10 failed, 143 passed, 153 total
Tests:       312 failed, 16 skipped, 1973 passed, 2301 total
Snapshots:   1 failed, 143 passed, 144 total
```

Each failed failed due to at least one of these issues:
1. A snapshot had a non-ascii whitespace character
2. Four hooks did not mock `optimism`, so the tests would fail saying one of the functions it creates was missing
3. Several tests were restoring mocks after each test, which included restoring the `optimism` mock, causing subsequent tests to fail

This addresses issues 2 and 3, which means only the one snapshot test fails.
