### PR TITLE
Fix snapshot with non-ascii character

### DIFF
--- a/src/cache/inmemory/__tests__/__snapshots__/writeToStore.ts.snap
+++ b/src/cache/inmemory/__tests__/__snapshots__/writeToStore.ts.snap
@@ -5,7 +5,7 @@ Object {
   "ROOT_QUERY": Object {
     "__typename": "Query",
     "currentTime({\\"tz\\":\\"UTC-5\\"})": Object {
-      "localeString": "9/25/2020, 1:08:33 PM",
+      "localeString": "9/25/2020, 1:08:33 PM",
     },
     "someJSON": Object {
       "foos": Array [

--- a/src/cache/inmemory/__tests__/writeToStore.ts
+++ b/src/cache/inmemory/__tests__/writeToStore.ts
@@ -2030,8 +2030,6 @@ describe('writing to the store', () => {
         }
       `;
 
-      const date = new Date(1601053713081);
-
       cache.writeQuery({
         query,
         data: {
@@ -2040,9 +2038,7 @@ describe('writing to the store', () => {
             foos: ["bar", "baz"],
           },
           currentTime: {
-            localeString: date.toLocaleString("en-US", {
-              timeZone: "America/New_York",
-            }),
+            localeString: '9/25/2020, 1:08:33 PM'
           },
         },
       });
@@ -2058,7 +2054,7 @@ describe('writing to the store', () => {
             zxcv: "lower",
           },
           currentTime: {
-            msSinceEpoch: date.getTime(),
+            msSinceEpoch: 1601053713081,
           },
         },
       });


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests

When running the tests locally on my personal mac, one test would fail to match the snapshot because the snapshot contained invisible non-ASCII characters. Specifically, the issue was in a date string between the seconds and the meridian label.

Snapshot: `"localeString": "9/25/2020, 1:08:33 PM"`
Local output: `"localeString": "9/25/2020, 1:08:33 PM"`

You can see they appear the same, but using a character identifier will show that the [gap in the local output](https://software.hixie.ch/utilities/cgi/unicode-decoder/character-identifier?characters=+) is:

```
U+0020 SPACE character
```

Whereas the [gap in the snapshot](https://software.hixie.ch/utilities/cgi/unicode-decoder/character-identifier?characters=%E2%80%AF) contains:

```
U+00E2 LATIN SMALL LETTER A WITH CIRCUMFLEX character (&#x00E2;)
U+0080 <control> character (&#x0080;)
U+00AF MACRON character (&#x00AF;)
```

This is because `Date.toLocaleString()` is not guaranteed to return the same string value in every browser, which makes it unreliable for testing. For this reason, I updated the test to use hard coded values instead.

See [this StackOverflow post](https://stackoverflow.com/questions/25574963/ies-tolocalestring-has-strange-characters-in-results) for more details.
