### PR TITLE
Update Documentation: Fix grammar error "Instead, you to specify"

### DIFF
--- a/docs/source/api/react/testing.md
+++ b/docs/source/api/react/testing.md
@@ -14,7 +14,7 @@ api_reference: true
 import { MockedProvider } from "@apollo/client/testing";
 ```
 
-The `MockedProvider` component is a mocked version of [`ApolloProvider`](./hooks/#the-apolloprovider-component) that doesn't send network requests to your API. Instead, you to specify the exact response payload for a given GraphQL operation. This enables you to test your application's operations without communicating with a server.
+The `MockedProvider` component is a mocked version of [`ApolloProvider`](./hooks/#the-apolloprovider-component) that doesn't send network requests to your API. Instead, it allows you to specify the exact response payload for a given GraphQL operation. This enables you to test your application's operations without communicating with a server.
 
 #### Props
 


### PR DESCRIPTION
I fixed a grammar error in the documentation: from "Instead, you to specify" to "Instead, it allows you to specify". The error was in "docs/source/api/react/testing.md".