### PR TITLE
remove obsolete @types/fast-json-stable-stringify dev dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,6 @@
         "@testing-library/react-12": "npm:@testing-library/react@^12",
         "@testing-library/user-event": "14.4.3",
         "@types/bytes": "3.1.1",
-        "@types/fast-json-stable-stringify": "2.0.0",
         "@types/fetch-mock": "7.3.5",
         "@types/glob": "8.0.1",
         "@types/hoist-non-react-statics": "3.3.1",
@@ -2060,12 +2059,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@types/bytes/-/bytes-3.1.1.tgz",
       "integrity": "sha512-lOGyCnw+2JVPKU3wIV0srU0NyALwTBJlVSx5DfMQOFuuohA8y9S8orImpuIQikZ0uIQ8gehrRjxgQC1rLRi11w==",
-      "dev": true
-    },
-    "node_modules/@types/fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha512-mky/O83TXmGY39P1H9YbUpjV6l6voRYlufqfFCvel8l1phuy8HRjdWc1rrPuN53ITBJlbyMSV6z3niOySO5pgQ==",
       "dev": true
     },
     "node_modules/@types/fetch-mock": {
@@ -11511,12 +11504,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@types/bytes/-/bytes-3.1.1.tgz",
       "integrity": "sha512-lOGyCnw+2JVPKU3wIV0srU0NyALwTBJlVSx5DfMQOFuuohA8y9S8orImpuIQikZ0uIQ8gehrRjxgQC1rLRi11w==",
-      "dev": true
-    },
-    "@types/fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha512-mky/O83TXmGY39P1H9YbUpjV6l6voRYlufqfFCvel8l1phuy8HRjdWc1rrPuN53ITBJlbyMSV6z3niOySO5pgQ==",
       "dev": true
     },
     "@types/fetch-mock": {

--- a/package.json
+++ b/package.json
@@ -109,7 +109,6 @@
     "@testing-library/react-12": "npm:@testing-library/react@^12",
     "@testing-library/user-event": "14.4.3",
     "@types/bytes": "3.1.1",
-    "@types/fast-json-stable-stringify": "2.0.0",
     "@types/fetch-mock": "7.3.5",
     "@types/glob": "8.0.1",
     "@types/hoist-non-react-statics": "3.3.1",


### PR DESCRIPTION
It looks like this dev dep is no longer needed since Apollo Client broke the `fast-json-stable-stringify` dependency (https://github.com/apollographql/apollo-client/pull/8222)
