### PR TITLE
ObservableQuery.currentResult: skip the cache

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,6 @@
   "typescript.tsdk": "node_modules/typescript/lib",
   "cSpell.enableFiletypes": [
     "mdx"
-  ]
+  ],
+  "jest.jestCommandLine": "node_modules/.bin/jest --config ./config/jest.config.js --ignoreProjects 'ReactDOM 17' --runInBand",
 }

--- a/src/react/hoc/__tests__/queries/loading.test.tsx
+++ b/src/react/hoc/__tests__/queries/loading.test.tsx
@@ -421,7 +421,7 @@ describe('[queries] loading', () => {
       ]);
     }, { interval: 1 });
     await waitFor(() => {
-      expect(count).toBe(6);
+      expect(count).toBe(5);
     }, { interval: 1 });
   });
 

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect, useState } from 'react';
+import React, { Fragment, ReactNode, useEffect, useState } from 'react';
 import { DocumentNode, GraphQLError } from 'graphql';
 import gql from 'graphql-tag';
 import { act } from 'react-dom/test-utils';
@@ -5940,6 +5940,104 @@ describe('useQuery Hook', () => {
       });
     });
   });
+
+  // https://github.com/apollographql/apollo-client/issues/10222
+  describe('regression test issue #10222', () => {
+    it('maintains initial fetch policy when component unmounts and remounts', async () => {
+      let helloCount = 1;
+      const query = gql`{ hello }`;
+      const link = new ApolloLink(() => {
+        return new Observable(observer => {
+          const timer = setTimeout(() => {
+            console.log('test observer.next', helloCount)
+            observer.next({ data: { hello: `hello ${helloCount++}` } });
+            observer.complete();
+          }, 50);
+
+          return () => {
+            clearTimeout(timer);
+          }
+        })
+      })
+
+      const cache = new InMemoryCache();
+
+      const client = new ApolloClient({
+        link,
+        cache
+      });
+
+      let setShow: Function
+      const Toggler = ({ children }: { children: ReactNode }) => {
+        const [show, _setShow] = useState(true);
+        setShow = _setShow;
+
+        return show ? <>{children}</> : null;
+      }
+
+      const counts = { mount: 0, unmount: 0 };
+
+      const { result, waitForNextUpdate } = renderHook(
+        () => {
+          useEffect(() => {
+            counts.mount++;
+
+            return () => {
+              counts.unmount++;
+            }
+          }, []);
+
+          const result = useQuery(query, {
+            fetchPolicy: 'network-only',
+            nextFetchPolicy: 'cache-first'
+          });
+
+          return result
+        },
+        {
+          wrapper: ({ children }) => (
+            <ApolloProvider client={client}>
+              <Toggler>{children}</Toggler>
+            </ApolloProvider>
+          ),
+        },
+      );
+
+      expect(counts).toEqual({ mount: 1, unmount: 0 });
+      expect(result.current.loading).toBe(true);
+      expect(result.current.data).toBeUndefined();
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.data).toEqual({ hello: 'hello 1' });
+      expect(cache.readQuery({ query })).toEqual({ hello: 'hello 1' })
+
+      act(() => {
+        setShow(false);
+      });
+
+      expect(counts).toEqual({ mount: 1, unmount: 1 });
+
+      act(() => {
+        setShow(true);
+      });
+
+      expect(counts).toEqual({ mount: 2, unmount: 1 });
+
+      expect(result.current.loading).toBe(true);
+      expect(result.current.data).toBeUndefined();
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      })
+
+      expect(result.current.data).toEqual({ hello: 'hello 2' });
+      expect(cache.readQuery({ query })).toEqual({ hello: 'hello 2' })
+    });
+  });
+
 
   describe('defer', () => {
     it('should handle deferred queries', async () => {

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -1758,14 +1758,14 @@ describe('useQuery Hook', () => {
         expect(result.current.data).toEqual({ hello: "world 1" });
       }, { interval: 1 });
       expect(result.current.loading).toBe(false);
-      
+
 
       await waitFor(() => {
         expect(result.current.data).toEqual({ hello: "world 2" });
       }, { interval: 1 });
       expect(result.current.loading).toBe(false);
-      
-      
+
+
       result.current.stopPolling();
 
       await expect(waitFor(() => {
@@ -5949,7 +5949,6 @@ describe('useQuery Hook', () => {
       const link = new ApolloLink(() => {
         return new Observable(observer => {
           const timer = setTimeout(() => {
-            console.log('test observer.next', helloCount)
             observer.next({ data: { hello: `hello ${helloCount++}` } });
             observer.complete();
           }, 50);
@@ -5975,25 +5974,11 @@ describe('useQuery Hook', () => {
         return show ? <>{children}</> : null;
       }
 
-      const counts = { mount: 0, unmount: 0 };
-
-      const { result, waitForNextUpdate } = renderHook(
-        () => {
-          useEffect(() => {
-            counts.mount++;
-
-            return () => {
-              counts.unmount++;
-            }
-          }, []);
-
-          const result = useQuery(query, {
+      const { result } = renderHook(
+        () => useQuery(query, {
             fetchPolicy: 'network-only',
             nextFetchPolicy: 'cache-first'
-          });
-
-          return result
-        },
+          }),
         {
           wrapper: ({ children }) => (
             <ApolloProvider client={client}>
@@ -6003,7 +5988,6 @@ describe('useQuery Hook', () => {
         },
       );
 
-      expect(counts).toEqual({ mount: 1, unmount: 0 });
       expect(result.current.loading).toBe(true);
       expect(result.current.data).toBeUndefined();
 
@@ -6018,13 +6002,9 @@ describe('useQuery Hook', () => {
         setShow(false);
       });
 
-      expect(counts).toEqual({ mount: 1, unmount: 1 });
-
       act(() => {
         setShow(true);
       });
-
-      expect(counts).toEqual({ mount: 2, unmount: 1 });
 
       expect(result.current.loading).toBe(true);
       expect(result.current.data).toBeUndefined();
@@ -7083,7 +7063,7 @@ describe('useQuery Hook', () => {
         expect(requestSpy).toHaveBeenCalledTimes(shouldFetchOnFirstRender ? 1 : 0);
 
         // We need to wait a moment before the rerender for everything to settle down.
-        // This part is unfortunately bound to be flaky - but in some cases there is 
+        // This part is unfortunately bound to be flaky - but in some cases there is
         // just nothing to "wait for", except "a moment".
         await act(() => new Promise((resolve) => setTimeout(resolve, 10)));
 


### PR DESCRIPTION
This is my attempt at solving #10222.

The test is taken from @jerelmiller over in #10239.

I'm not sure if this covers all possible cases (what should happen if all of this plays out on a subsequent query? Is that even possible there?), but at least it gets all the tests green.

One of the HOC tests is now rerendering one less time, but not getting any new data.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
