### PR TITLE
Fix type policy inheritance involving fuzzy `possibleTypes`

### DIFF
--- a/.changeset/odd-students-crash.md
+++ b/.changeset/odd-students-crash.md
@@ -1,0 +1,5 @@
+---
+'@apollo/client': patch
+---
+
+Fix type policy inheritance involving fuzzy `possibleTypes`

--- a/config/bundlesize.ts
+++ b/config/bundlesize.ts
@@ -3,7 +3,7 @@ import { join } from "path";
 import { gzipSync } from "zlib";
 import bytes from "bytes";
 
-const gzipBundleByteLengthLimit = bytes("33.97KB");
+const gzipBundleByteLengthLimit = bytes("34.1KB");
 const minFile = join("dist", "apollo-client.min.cjs");
 const minPath = join(__dirname, "..", minFile);
 const gzipByteLen = gzipSync(readFileSync(minPath)).byteLength;

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -627,6 +627,138 @@ describe("type policies", function () {
     })).toBe('DeathAdder:{"tagId":"LethalAbacus666"}');
   });
 
+  it("typePolicies can be inherited from supertypes with fuzzy possibleTypes", () => {
+    const cache = new InMemoryCache({
+      possibleTypes: {
+        EntitySupertype: [".*Entity"],
+      },
+      typePolicies: {
+        Query: {
+          fields: {
+            coworkers: {
+              merge(existing, incoming) {
+                return existing ? existing.concat(incoming) : incoming;
+              },
+            },
+          },
+        },
+
+        // The point of this test is to ensure keyFields: ["uid"] can be
+        // registered for all __typename strings matching the RegExp /.*Entity/,
+        // without manually enumerating all of them.
+        EntitySupertype: {
+          keyFields: ["uid"],
+        },
+      },
+    });
+
+    type Coworker = {
+      __typename: "CoworkerEntity" | "ManagerEntity";
+      uid: string;
+      name: string;
+    }
+
+    const query: TypedDocumentNode<{
+      coworkers: Coworker[];
+    }> = gql`
+      query {
+        coworkers {
+          uid
+          name
+        }
+      }
+    `;
+
+    cache.writeQuery({
+      query,
+      data: {
+        coworkers: [
+          { __typename: "CoworkerEntity", uid: "qwer", name: "Alessia" },
+          { __typename: "CoworkerEntity", uid: "asdf", name: "Jerel" },
+          { __typename: "CoworkerEntity", uid: "zxcv", name: "Lenz" },
+          { __typename: "ManagerEntity", uid: "uiop", name: "Jeff" },
+        ],
+      },
+    });
+
+    expect(cache.extract()).toEqual({
+      ROOT_QUERY: {
+        __typename: "Query",
+        coworkers: [
+          { __ref: 'CoworkerEntity:{"uid":"qwer"}' },
+          { __ref: 'CoworkerEntity:{"uid":"asdf"}' },
+          { __ref: 'CoworkerEntity:{"uid":"zxcv"}' },
+          { __ref: 'ManagerEntity:{"uid":"uiop"}' },
+        ],
+      },
+      'CoworkerEntity:{"uid":"qwer"}': {
+        __typename: "CoworkerEntity",
+        uid: "qwer",
+        name: "Alessia",
+      },
+      'CoworkerEntity:{"uid":"asdf"}': {
+        __typename: "CoworkerEntity",
+        uid: "asdf",
+        name: "Jerel",
+      },
+      'CoworkerEntity:{"uid":"zxcv"}': {
+        __typename: "CoworkerEntity",
+        uid: "zxcv",
+        name: "Lenz",
+      },
+      'ManagerEntity:{"uid":"uiop"}': {
+        __typename: "ManagerEntity",
+        uid: "uiop",
+        name: "Jeff",
+      },
+    });
+
+    interface CoworkerWithAlias extends Omit<Coworker, "uid"> {
+      idAlias: string;
+    }
+
+    const queryWithAlias: TypedDocumentNode<{
+      coworkers: CoworkerWithAlias[];
+    }> = gql`
+      query {
+        coworkers {
+          idAlias: uid
+          name
+        }
+      }
+    `;
+
+    expect(cache.readQuery({ query: queryWithAlias })).toEqual({
+      coworkers: [
+        { __typename: "CoworkerEntity", idAlias: "qwer", name: "Alessia" },
+        { __typename: "CoworkerEntity", idAlias: "asdf", name: "Jerel" },
+        { __typename: "CoworkerEntity", idAlias: "zxcv", name: "Lenz" },
+        { __typename: "ManagerEntity", idAlias: "uiop", name: "Jeff" },
+      ],
+    });
+
+    cache.writeQuery({
+      query: queryWithAlias,
+      data: {
+        coworkers: [
+          { __typename: "CoworkerEntity", idAlias: "hjkl", name: "Martijn" },
+          { __typename: "ManagerEntity", idAlias: "vbnm", name: "Hugh" },
+        ],
+      },
+    });
+
+    expect(cache.readQuery({ query })).toEqual({
+      coworkers: [
+        { __typename: "CoworkerEntity", uid: "qwer", name: "Alessia" },
+        { __typename: "CoworkerEntity", uid: "asdf", name: "Jerel" },
+        { __typename: "CoworkerEntity", uid: "zxcv", name: "Lenz" },
+        { __typename: "ManagerEntity", uid: "uiop", name: "Jeff" },
+        { __typename: "CoworkerEntity", uid: "hjkl", name: "Martijn" },
+        { __typename: "ManagerEntity", uid: "vbnm", name: "Hugh" },
+      ],
+    });
+  });
+
   describe("field policies", function () {
     it(`can filter arguments using keyArgs`, function () {
       const cache = new InMemoryCache({

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -757,6 +757,50 @@ describe("type policies", function () {
         { __typename: "ManagerEntity", uid: "vbnm", name: "Hugh" },
       ],
     });
+
+    expect(cache.extract()).toEqual({
+      ROOT_QUERY: {
+        __typename: "Query",
+        coworkers: [
+          { __ref: 'CoworkerEntity:{"uid":"qwer"}' },
+          { __ref: 'CoworkerEntity:{"uid":"asdf"}' },
+          { __ref: 'CoworkerEntity:{"uid":"zxcv"}' },
+          { __ref: 'ManagerEntity:{"uid":"uiop"}' },
+          { __ref: 'CoworkerEntity:{"uid":"hjkl"}' },
+          { __ref: 'ManagerEntity:{"uid":"vbnm"}' },
+        ],
+      },
+      'CoworkerEntity:{"uid":"qwer"}': {
+        __typename: "CoworkerEntity",
+        uid: "qwer",
+        name: "Alessia",
+      },
+      'CoworkerEntity:{"uid":"asdf"}': {
+        __typename: "CoworkerEntity",
+        uid: "asdf",
+        name: "Jerel",
+      },
+      'CoworkerEntity:{"uid":"zxcv"}': {
+        __typename: "CoworkerEntity",
+        uid: "zxcv",
+        name: "Lenz",
+      },
+      'ManagerEntity:{"uid":"uiop"}': {
+        __typename: "ManagerEntity",
+        uid: "uiop",
+        name: "Jeff",
+      },
+      'CoworkerEntity:{"uid":"hjkl"}': {
+        __typename: "CoworkerEntity",
+        uid: "hjkl",
+        name: "Martijn",
+      },
+      'ManagerEntity:{"uid":"vbnm"}': {
+        __typename: "ManagerEntity",
+        uid: "vbnm",
+        name: "Hugh",
+      },
+    });
   });
 
   describe("field policies", function () {


### PR DESCRIPTION
In #10599 I suggested two typical/supported ways of configuring entity identification: [`keyFields: [...]`](https://www.apollographql.com/docs/react/caching/cache-configuration/#customizing-cache-ids) (preferred, `__typename`-specific) and defining a [`dataIdFromObject`](https://www.apollographql.com/docs/react/caching/cache-configuration/#customizing-identifier-generation-globally) function (legacy, catch-all). 

Unless you can enforce a blanket assumption that all your types must have a single `id` field (unlikely, brittle), both approaches ultimately require listing the `__typename`s of all the types whose `keyFields` you want to configure, which can be annoying if your application uses many different entity types.

**The good news:** I think I've found a way to combine a few different `InMemoryCache` features to achieve a blanket `keyFields` policy without enumerating all the relevant `__typename` strings. This approach combines the following features:
* Type policy inheritance (#7065, #9905) allows a supertype (`EntitySupertype` below) to define a single `keyFields: ["uid"]` configuration that subtypes can either inherit or override with their own definitions, according to [`possibleTypes`](https://www.apollographql.com/docs/react/data/fragments#using-fragments-with-unions-and-interfaces).
* "Fuzzy" `possibleTypes` (#6901) are capable of defining supertype-subtype relationships based on `RegExp` patterns in the subtype name strings (such as `EntitySupertype: [".*Entity"]` below), so the subtype strings are not required to match any known `__typename` exactly.

With these two existing features combined, `EntitySupertype` can define `keyFields: ["uid"]` just once (using `uid` instead of `id` here to make sure we aren't accidentally relying on default `id` behavior), and then any `__typename` that ends with `Entity` should automatically inherit that same `keyFields` configuration, even if the type has no other type/field policies defined.

Note that `EntitySupertype` is a made-up client-side type, and does not necessarily need to exist in your schema, though if you already have a common supertype that would work (like `Node`), I would recommend reusing that existing type instead of making up a new one.

Picking `".*Entity"` as a naming convention is obviously an opinionated choice, not appropriate for all schemas and types, but you can use several different patterns, as well as exact `__typename` strings, so hopefully there's enough flexibility here to make `EntitySupertype` cover all/most of your entity types.

**The bad news:** this story was slightly broken, since it implicitly required subtypes to have _some_ type/field policy configuration in order to be capable of inheriting from `EntitySupertype`. You could go through and add empty type policies for the relevant subtypes, but that brings back the chore of manually enumerating all relevant `__typename` strings.

Neither of these `InMemoryCache` features is new, and both are definitely on the obscure side, but it's important to me to keep all existing features working as intended (unless we decide to remove them in a major version), no matter how obscure they may be.