### PR TITLE
Add `networkStatus` to the result returned by `useSuspenseQuery`

### DIFF
--- a/.changeset/famous-ladybugs-reflect.md
+++ b/.changeset/famous-ladybugs-reflect.md
@@ -1,0 +1,5 @@
+---
+'@apollo/client': patch
+---
+
+Return `networkStatus` in the `useSuspenseQuery` result.

--- a/docs/shared/useSuspenseQuery-result.mdx
+++ b/docs/shared/useSuspenseQuery-result.mdx
@@ -60,6 +60,21 @@ This property can be ignored when using the default `errorPolicy` or an `errorPo
 <tr>
 <td>
 
+<tr>
+<td>
+
+###### `networkStatus`
+
+`NetworkStatus`
+</td>
+
+<td>
+
+A number indicating the current network state of the query's associated request. [See possible values.](https://github.com/apollographql/apollo-client/blob/d96f4578f89b933c281bb775a39503f6cdb59ee8/src/core/networkStatus.ts#L4)
+
+</td>
+</tr>
+
 ###### `client`
 
 `ApolloClient`

--- a/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
@@ -25,6 +25,7 @@ import {
   SubscribeToMoreOptions,
   TypedDocumentNode,
   split,
+  NetworkStatus,
 } from '../../../core';
 import {
   compact,
@@ -409,7 +410,11 @@ describe('useSuspenseQuery', () => {
     expect(renders.suspenseCount).toBe(1);
     expect(renders.count).toBe(2);
     expect(renders.frames).toMatchObject([
-      { ...mocks[0].result, error: undefined },
+      {
+        ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
     ]);
   });
 
@@ -431,7 +436,11 @@ describe('useSuspenseQuery', () => {
     expect(renders.suspenseCount).toBe(1);
     expect(renders.count).toBe(2);
     expect(renders.frames).toMatchObject([
-      { ...mocks[0].result, error: undefined },
+      {
+        ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
     ]);
   });
 
@@ -458,8 +467,16 @@ describe('useSuspenseQuery', () => {
     expect(renders.count).toBe(3);
     expect(renders.suspenseCount).toBe(1);
     expect(renders.frames).toMatchObject([
-      { ...mocks[0].result, error: undefined },
-      { ...mocks[0].result, error: undefined },
+      {
+        ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
+      {
+        ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
     ]);
   });
 
@@ -692,7 +709,11 @@ describe('useSuspenseQuery', () => {
     );
 
     expect(renders.frames).toMatchObject([
-      { data: { greeting: 'local hello' }, error: undefined },
+      {
+        data: { greeting: 'local hello' },
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
     ]);
   });
 
@@ -725,8 +746,16 @@ describe('useSuspenseQuery', () => {
     // React double invokes the render function in strict mode so we expect
     // to render 2 frames after the initial suspense.
     expect(renders.frames).toMatchObject([
-      { data: { greeting: 'local hello' }, error: undefined },
-      { data: { greeting: 'local hello' }, error: undefined },
+      {
+        data: { greeting: 'local hello' },
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
+      {
+        data: { greeting: 'local hello' },
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
     ]);
   });
 
@@ -769,13 +798,18 @@ describe('useSuspenseQuery', () => {
 
     expect(result.current).toMatchObject({
       data: { greeting: 'hello from cache' },
+      networkStatus: NetworkStatus.ready,
       error: undefined,
     });
 
     expect(renders.count).toBe(1);
     expect(renders.suspenseCount).toBe(0);
     expect(renders.frames).toMatchObject([
-      { data: { greeting: 'hello from cache' }, error: undefined },
+      {
+        data: { greeting: 'hello from cache' },
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
     ]);
   });
 
@@ -849,6 +883,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -856,7 +891,11 @@ describe('useSuspenseQuery', () => {
     expect(renders.count).toBe(2);
     expect(renders.suspenseCount).toBe(1);
     expect(renders.frames).toMatchObject([
-      { ...mocks[0].result, error: undefined },
+      {
+        ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
     ]);
   });
 
@@ -904,12 +943,14 @@ describe('useSuspenseQuery', () => {
     expect(renders.suspenseCount).toBe(0);
     expect(result.current).toMatchObject({
       data: { character: { id: '1' } },
+      networkStatus: NetworkStatus.loading,
       error: undefined,
     });
 
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -917,8 +958,16 @@ describe('useSuspenseQuery', () => {
     expect(renders.count).toBe(2);
     expect(renders.suspenseCount).toBe(0);
     expect(renders.frames).toMatchObject([
-      { data: { character: { id: '1' } }, error: undefined },
-      { ...mocks[0].result, error: undefined },
+      {
+        data: { character: { id: '1' } },
+        networkStatus: NetworkStatus.loading,
+        error: undefined,
+      },
+      {
+        ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
     ]);
   });
 
@@ -954,12 +1003,14 @@ describe('useSuspenseQuery', () => {
     expect(renders.suspenseCount).toBe(0);
     expect(result.current).toMatchObject({
       data: { character: { id: '1' } },
+      networkStatus: NetworkStatus.loading,
       error: undefined,
     });
 
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -969,6 +1020,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[1].result,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -976,10 +1028,26 @@ describe('useSuspenseQuery', () => {
     expect(renders.count).toBe(5);
     expect(renders.suspenseCount).toBe(1);
     expect(renders.frames).toMatchObject([
-      { data: { character: { id: '1' } }, error: undefined },
-      { ...mocks[0].result, error: undefined },
-      { ...mocks[0].result, error: undefined },
-      { ...mocks[1].result, error: undefined },
+      {
+        data: { character: { id: '1' } },
+        networkStatus: NetworkStatus.loading,
+        error: undefined,
+      },
+      {
+        ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
+      {
+        ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
+      {
+        ...mocks[1].result,
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
     ]);
   });
 
@@ -1001,6 +1069,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -1008,7 +1077,11 @@ describe('useSuspenseQuery', () => {
     expect(renders.count).toBe(2);
     expect(renders.suspenseCount).toBe(1);
     expect(renders.frames).toMatchObject([
-      { data: { greeting: 'Hello' }, error: undefined },
+      {
+        data: { greeting: 'Hello' },
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
     ]);
   });
 
@@ -1058,6 +1131,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -1065,7 +1139,11 @@ describe('useSuspenseQuery', () => {
     expect(renders.count).toBe(2);
     expect(renders.suspenseCount).toBe(1);
     expect(renders.frames).toMatchObject([
-      { ...mocks[0].result, error: undefined },
+      {
+        ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
     ]);
   });
 
@@ -1087,6 +1165,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -1096,7 +1175,11 @@ describe('useSuspenseQuery', () => {
     expect(renders.count).toBe(2);
     expect(renders.suspenseCount).toBe(1);
     expect(renders.frames).toMatchObject([
-      { data: { greeting: 'Hello' }, error: undefined },
+      {
+        data: { greeting: 'Hello' },
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
     ]);
     expect(cachedData).toEqual({ greeting: 'hello from cache' });
   });
@@ -1114,6 +1197,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -1121,20 +1205,33 @@ describe('useSuspenseQuery', () => {
     expect(renders.count).toBe(2);
     expect(renders.suspenseCount).toBe(1);
     expect(renders.frames).toMatchObject([
-      { data: { greeting: 'Hello' }, error: undefined },
+      {
+        data: { greeting: 'Hello' },
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
     ]);
 
     rerender();
 
     expect(result.current).toMatchObject({
       ...mocks[0].result,
+      networkStatus: NetworkStatus.ready,
       error: undefined,
     });
     expect(renders.count).toBe(3);
     expect(renders.suspenseCount).toBe(1);
     expect(renders.frames).toMatchObject([
-      { data: { greeting: 'Hello' }, error: undefined },
-      { data: { greeting: 'Hello' }, error: undefined },
+      {
+        data: { greeting: 'Hello' },
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
+      {
+        data: { greeting: 'Hello' },
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
     ]);
   });
 
@@ -1186,6 +1283,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -1193,7 +1291,11 @@ describe('useSuspenseQuery', () => {
     expect(renders.count).toBe(2);
     expect(renders.suspenseCount).toBe(1);
     expect(renders.frames).toMatchObject([
-      { ...mocks[0].result, error: undefined },
+      {
+        ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
     ]);
 
     consoleSpy.mockRestore();
@@ -1238,12 +1340,14 @@ describe('useSuspenseQuery', () => {
 
     expect(result.current).toMatchObject({
       data: { greeting: 'hello from cache' },
+      networkStatus: NetworkStatus.loading,
       error: undefined,
     });
 
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -1253,9 +1357,14 @@ describe('useSuspenseQuery', () => {
     expect(renders.frames).toMatchObject([
       {
         data: { greeting: 'hello from cache' },
+        networkStatus: NetworkStatus.loading,
         error: undefined,
       },
-      { data: { greeting: 'Hello' }, error: undefined },
+      {
+        data: { greeting: 'Hello' },
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
     ]);
   });
 
@@ -1303,12 +1412,14 @@ describe('useSuspenseQuery', () => {
     expect(renders.suspenseCount).toBe(0);
     expect(result.current).toMatchObject({
       data: { character: { id: '1' } },
+      networkStatus: NetworkStatus.loading,
       error: undefined,
     });
 
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -1316,8 +1427,16 @@ describe('useSuspenseQuery', () => {
     expect(renders.count).toBe(2);
     expect(renders.suspenseCount).toBe(0);
     expect(renders.frames).toMatchObject([
-      { data: { character: { id: '1' } }, error: undefined },
-      { ...mocks[0].result, error: undefined },
+      {
+        data: { character: { id: '1' } },
+        networkStatus: NetworkStatus.loading,
+        error: undefined,
+      },
+      {
+        ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
     ]);
   });
 
@@ -1353,12 +1472,14 @@ describe('useSuspenseQuery', () => {
     expect(renders.suspenseCount).toBe(0);
     expect(result.current).toMatchObject({
       data: { character: { id: '1' } },
+      networkStatus: NetworkStatus.loading,
       error: undefined,
     });
 
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -1368,6 +1489,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[1].result,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -1375,10 +1497,26 @@ describe('useSuspenseQuery', () => {
     expect(renders.count).toBe(5);
     expect(renders.suspenseCount).toBe(1);
     expect(renders.frames).toMatchObject([
-      { data: { character: { id: '1' } }, error: undefined },
-      { ...mocks[0].result, error: undefined },
-      { ...mocks[0].result, error: undefined },
-      { ...mocks[1].result, error: undefined },
+      {
+        data: { character: { id: '1' } },
+        networkStatus: NetworkStatus.loading,
+        error: undefined,
+      },
+      {
+        ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
+      {
+        ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
+      {
+        ...mocks[1].result,
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
     ]);
   });
 
@@ -1406,6 +1544,7 @@ describe('useSuspenseQuery', () => {
       await waitFor(() => {
         expect(result.current).toMatchObject({
           ...mocks[0].result,
+          networkStatus: NetworkStatus.ready,
           error: undefined,
         });
       });
@@ -1415,6 +1554,7 @@ describe('useSuspenseQuery', () => {
       await waitFor(() => {
         expect(result.current).toMatchObject({
           ...mocks[1].result,
+          networkStatus: NetworkStatus.ready,
           error: undefined,
         });
       });
@@ -1427,9 +1567,21 @@ describe('useSuspenseQuery', () => {
       expect(renders.count).toBe(4);
       expect(renders.suspenseCount).toBe(1);
       expect(renders.frames).toMatchObject([
-        { ...mocks[0].result, error: undefined },
-        { ...mocks[0].result, error: undefined },
-        { ...mocks[1].result, error: undefined },
+        {
+          ...mocks[0].result,
+          networkStatus: NetworkStatus.ready,
+          error: undefined,
+        },
+        {
+          ...mocks[0].result,
+          networkStatus: NetworkStatus.ready,
+          error: undefined,
+        },
+        {
+          ...mocks[1].result,
+          networkStatus: NetworkStatus.ready,
+          error: undefined,
+        },
       ]);
     }
   );
@@ -1511,14 +1663,23 @@ describe('useSuspenseQuery', () => {
       await waitFor(() => {
         expect(result.current).toMatchObject({
           data: { greeting: 'Updated hello' },
+          networkStatus: NetworkStatus.ready,
           error: undefined,
         });
       });
       expect(renders.suspenseCount).toBe(1);
       expect(renders.count).toBe(3);
       expect(renders.frames).toMatchObject([
-        { ...mocks[0].result, error: undefined },
-        { data: { greeting: 'Updated hello' }, error: undefined },
+        {
+          ...mocks[0].result,
+          networkStatus: NetworkStatus.ready,
+          error: undefined,
+        },
+        {
+          data: { greeting: 'Updated hello' },
+          networkStatus: NetworkStatus.ready,
+          error: undefined,
+        },
       ]);
     }
   );
@@ -1550,12 +1711,17 @@ describe('useSuspenseQuery', () => {
 
     expect(result.current).toMatchObject({
       ...mocks[0].result,
+      networkStatus: NetworkStatus.ready,
       error: undefined,
     });
     expect(renders.suspenseCount).toBe(1);
     expect(renders.count).toBe(2);
     expect(renders.frames).toMatchObject([
-      { ...mocks[0].result, error: undefined },
+      {
+        ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
     ]);
   });
 
@@ -1587,6 +1753,7 @@ describe('useSuspenseQuery', () => {
       await waitFor(() => {
         expect(result.current).toMatchObject({
           ...mocks[1].result,
+          networkStatus: NetworkStatus.ready,
           error: undefined,
         });
       });
@@ -1600,9 +1767,21 @@ describe('useSuspenseQuery', () => {
       expect(renders.count).toBe(5);
       expect(renders.suspenseCount).toBe(2);
       expect(renders.frames).toMatchObject([
-        { ...mocks[0].result, error: undefined },
-        { ...mocks[0].result, error: undefined },
-        { ...mocks[1].result, error: undefined },
+        {
+          ...mocks[0].result,
+          networkStatus: NetworkStatus.ready,
+          error: undefined,
+        },
+        {
+          ...mocks[0].result,
+          networkStatus: NetworkStatus.ready,
+          error: undefined,
+        },
+        {
+          ...mocks[1].result,
+          networkStatus: NetworkStatus.ready,
+          error: undefined,
+        },
       ]);
     }
   );
@@ -1647,6 +1826,7 @@ describe('useSuspenseQuery', () => {
       await waitFor(() => {
         expect(result.current).toMatchObject({
           ...mocks[0].result,
+          networkStatus: NetworkStatus.ready,
           error: undefined,
         });
       });
@@ -1656,6 +1836,7 @@ describe('useSuspenseQuery', () => {
       await waitFor(() => {
         expect(result.current).toMatchObject({
           ...mocks[1].result,
+          networkStatus: NetworkStatus.ready,
           error: undefined,
         });
       });
@@ -1669,9 +1850,21 @@ describe('useSuspenseQuery', () => {
       expect(renders.count).toBe(5);
       expect(renders.suspenseCount).toBe(2);
       expect(renders.frames).toMatchObject([
-        { ...mocks[0].result, error: undefined },
-        { ...mocks[0].result, error: undefined },
-        { ...mocks[1].result, error: undefined },
+        {
+          ...mocks[0].result,
+          networkStatus: NetworkStatus.ready,
+          error: undefined,
+        },
+        {
+          ...mocks[0].result,
+          networkStatus: NetworkStatus.ready,
+          error: undefined,
+        },
+        {
+          ...mocks[1].result,
+          networkStatus: NetworkStatus.ready,
+          error: undefined,
+        },
       ]);
     }
   );
@@ -1804,6 +1997,7 @@ describe('useSuspenseQuery', () => {
       await waitFor(() => {
         expect(result.current).toMatchObject({
           data: { greeting: 'Updated hello' },
+          networkStatus: NetworkStatus.ready,
           error: undefined,
         });
       });
@@ -1839,7 +2033,11 @@ describe('useSuspenseQuery', () => {
     expect(renders.count).toBe(2);
     expect(renders.suspenseCount).toBe(1);
     expect(renders.frames).toMatchObject([
-      { ...mocks[0].result, error: undefined },
+      {
+        ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
     ]);
   });
 
@@ -1864,12 +2062,17 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[1].result,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
 
     expect(renders.frames).toMatchObject([
-      { ...mocks[1].result, error: undefined },
+      {
+        ...mocks[1].result,
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
     ]);
   });
 
@@ -1894,6 +2097,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[1].result,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -1901,8 +2105,16 @@ describe('useSuspenseQuery', () => {
     // React double invokes the render function in strict mode so we expect 2
     // frames to be rendered here.
     expect(renders.frames).toMatchObject([
-      { ...mocks[1].result, error: undefined },
-      { ...mocks[1].result, error: undefined },
+      {
+        ...mocks[1].result,
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
+      {
+        ...mocks[1].result,
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
     ]);
   });
 
@@ -1942,6 +2154,7 @@ describe('useSuspenseQuery', () => {
         data: {
           vars: { source: 'local', globalOnlyVar: true, localOnlyVar: true },
         },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -1953,6 +2166,7 @@ describe('useSuspenseQuery', () => {
         data: {
           vars: { source: 'rerender', globalOnlyVar: true, localOnlyVar: true },
         },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -1962,18 +2176,21 @@ describe('useSuspenseQuery', () => {
         data: {
           vars: { source: 'local', globalOnlyVar: true, localOnlyVar: true },
         },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       },
       {
         data: {
           vars: { source: 'local', globalOnlyVar: true, localOnlyVar: true },
         },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       },
       {
         data: {
           vars: { source: 'rerender', globalOnlyVar: true, localOnlyVar: true },
         },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       },
     ]);
@@ -2012,6 +2229,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         data: { vars: { source: 'local' } },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -2023,7 +2241,11 @@ describe('useSuspenseQuery', () => {
     expect(result.current.data.vars).not.toHaveProperty('globalOnlyVar');
 
     expect(renders.frames).toMatchObject([
-      { data: { vars: { source: 'local' } }, error: undefined },
+      {
+        data: { vars: { source: 'local' } },
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
     ]);
   });
 
@@ -2057,6 +2279,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         data: { context: { valueA: 'A', valueB: 'B' } },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -2179,6 +2402,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -2238,6 +2462,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -2380,6 +2605,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         data: undefined,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -2389,7 +2615,7 @@ describe('useSuspenseQuery', () => {
     expect(renders.count).toBe(2);
     expect(renders.suspenseCount).toBe(1);
     expect(renders.frames).toMatchObject([
-      { data: undefined, error: undefined },
+      { data: undefined, networkStatus: NetworkStatus.ready, error: undefined },
     ]);
   });
 
@@ -2407,6 +2633,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         data: { currentUser: { id: '1', name: null } },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -2414,6 +2641,7 @@ describe('useSuspenseQuery', () => {
     expect(renders.frames).toMatchObject([
       {
         data: { currentUser: { id: '1', name: null } },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       },
     ]);
@@ -2435,12 +2663,13 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         data: undefined,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
 
     expect(renders.frames).toMatchObject([
-      { data: undefined, error: undefined },
+      { data: undefined, networkStatus: NetworkStatus.ready, error: undefined },
     ]);
   });
 
@@ -2497,6 +2726,7 @@ describe('useSuspenseQuery', () => {
     expect(renders.frames).toMatchObject([
       {
         data: undefined,
+        networkStatus: NetworkStatus.ready,
         error: new ApolloError({ graphQLErrors: [graphQLError] }),
       },
     ]);
@@ -2535,7 +2765,11 @@ describe('useSuspenseQuery', () => {
     expect(renders.count).toBe(2);
     expect(renders.suspenseCount).toBe(1);
     expect(renders.frames).toMatchObject([
-      { data: undefined, error: expectedError },
+      {
+        data: undefined,
+        networkStatus: NetworkStatus.ready,
+        error: expectedError,
+      },
     ]);
 
     const { error } = result.current;
@@ -2563,6 +2797,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         data: { currentUser: { id: '1', name: null } },
+        networkStatus: NetworkStatus.ready,
         error: expectedError,
       });
     });
@@ -2570,6 +2805,7 @@ describe('useSuspenseQuery', () => {
     expect(renders.frames).toMatchObject([
       {
         data: { currentUser: { id: '1', name: null } },
+        networkStatus: NetworkStatus.ready,
         error: expectedError,
       },
     ]);
@@ -2636,6 +2872,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         data: undefined,
+        networkStatus: NetworkStatus.ready,
         error: expectedError,
       });
     });
@@ -2645,6 +2882,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[1].result,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -2654,9 +2892,21 @@ describe('useSuspenseQuery', () => {
     expect(renders.errors).toEqual([]);
     expect(renders.suspenseCount).toBe(2);
     expect(renders.frames).toMatchObject([
-      { data: undefined, error: expectedError },
-      { data: undefined, error: expectedError },
-      { ...mocks[1].result, error: undefined },
+      {
+        data: undefined,
+        networkStatus: NetworkStatus.ready,
+        error: expectedError,
+      },
+      {
+        data: undefined,
+        networkStatus: NetworkStatus.ready,
+        error: expectedError,
+      },
+      {
+        ...mocks[1].result,
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
     ]);
   });
 
@@ -2702,6 +2952,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         data: undefined,
+        networkStatus: NetworkStatus.ready,
         error: expectedError,
       });
     });
@@ -2711,6 +2962,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[1].result,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -2720,9 +2972,21 @@ describe('useSuspenseQuery', () => {
     expect(renders.errors).toEqual([]);
     expect(renders.suspenseCount).toBe(1);
     expect(renders.frames).toMatchObject([
-      { data: undefined, error: expectedError },
-      { data: undefined, error: expectedError },
-      { ...mocks[1].result, error: undefined },
+      {
+        data: undefined,
+        networkStatus: NetworkStatus.ready,
+        error: expectedError,
+      },
+      {
+        data: undefined,
+        networkStatus: NetworkStatus.ready,
+        error: expectedError,
+      },
+      {
+        ...mocks[1].result,
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
     ]);
   });
 
@@ -2759,6 +3023,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -2770,6 +3035,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[1].result,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -2777,8 +3043,16 @@ describe('useSuspenseQuery', () => {
     expect(renders.count).toBe(4);
     expect(renders.suspenseCount).toBe(2);
     expect(renders.frames).toMatchObject([
-      { ...mocks[0].result, error: undefined },
-      { ...mocks[1].result, error: undefined },
+      {
+        ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
+      {
+        ...mocks[1].result,
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
     ]);
   });
 
@@ -2815,6 +3089,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -2826,14 +3101,23 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[1].result,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
     expect(renders.count).toBe(4);
     expect(renders.suspenseCount).toBe(2);
     expect(renders.frames).toMatchObject([
-      { ...mocks[0].result, error: undefined },
-      { ...mocks[1].result, error: undefined },
+      {
+        ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
+      {
+        ...mocks[1].result,
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
     ]);
   });
 
@@ -2887,6 +3171,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[1].result,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -2898,6 +3183,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[2].result,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -2905,9 +3191,21 @@ describe('useSuspenseQuery', () => {
     expect(renders.count).toBe(6);
     expect(renders.suspenseCount).toBe(3);
     expect(renders.frames).toMatchObject([
-      { ...mocks[0].result, error: undefined },
-      { ...mocks[1].result, error: undefined },
-      { ...mocks[2].result, error: undefined },
+      {
+        ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
+      {
+        ...mocks[1].result,
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
+      {
+        ...mocks[2].result,
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
     ]);
   });
 
@@ -2948,6 +3246,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -2959,6 +3258,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[1].result,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -2966,8 +3266,16 @@ describe('useSuspenseQuery', () => {
     expect(renders.count).toBe(3);
     expect(renders.suspenseCount).toBe(1);
     expect(renders.frames).toMatchObject([
-      { ...mocks[0].result, error: undefined },
-      { ...mocks[1].result, error: undefined },
+      {
+        ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
+      {
+        ...mocks[1].result,
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
     ]);
   });
 
@@ -3006,6 +3314,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -3024,7 +3333,11 @@ describe('useSuspenseQuery', () => {
       }),
     ]);
     expect(renders.frames).toMatchObject([
-      { ...mocks[0].result, error: undefined },
+      {
+        ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
     ]);
 
     consoleSpy.mockRestore();
@@ -3067,6 +3380,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -3078,8 +3392,16 @@ describe('useSuspenseQuery', () => {
     expect(renders.errorCount).toBe(0);
     expect(renders.errors).toEqual([]);
     expect(renders.frames).toMatchObject([
-      { ...mocks[0].result, error: undefined },
-      { ...mocks[0].result, error: undefined },
+      {
+        ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
+      {
+        ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
     ]);
   });
 
@@ -3124,6 +3446,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -3135,6 +3458,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
         error: expectedError,
       });
     });
@@ -3142,8 +3466,16 @@ describe('useSuspenseQuery', () => {
     expect(renders.errorCount).toBe(0);
     expect(renders.errors).toEqual([]);
     expect(renders.frames).toMatchObject([
-      { ...mocks[0].result, error: undefined },
-      { ...mocks[0].result, error: expectedError },
+      {
+        ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
+      {
+        ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
+        error: expectedError,
+      },
     ]);
   });
 
@@ -3200,6 +3532,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         data: mocks[1].result.data,
+        networkStatus: NetworkStatus.ready,
         error: expectedError,
       });
     });
@@ -3207,8 +3540,16 @@ describe('useSuspenseQuery', () => {
     expect(renders.errorCount).toBe(0);
     expect(renders.errors).toEqual([]);
     expect(renders.frames).toMatchObject([
-      { ...mocks[0].result, error: undefined },
-      { data: mocks[1].result.data, error: expectedError },
+      {
+        ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
+      {
+        data: mocks[1].result.data,
+        networkStatus: NetworkStatus.ready,
+        error: expectedError,
+      },
     ]);
   });
 
@@ -3223,6 +3564,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         data: { letters: data.slice(0, 2) },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -3234,6 +3576,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         data: { letters: data.slice(2, 4) },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -3241,8 +3584,16 @@ describe('useSuspenseQuery', () => {
     expect(renders.count).toBe(4);
     expect(renders.suspenseCount).toBe(2);
     expect(renders.frames).toMatchObject([
-      { data: { letters: data.slice(0, 2) }, error: undefined },
-      { data: { letters: data.slice(2, 4) }, error: undefined },
+      {
+        data: { letters: data.slice(0, 2) },
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
+      {
+        data: { letters: data.slice(2, 4) },
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
     ]);
   });
 
@@ -3261,6 +3612,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         data: { letters: data.slice(0, 2) },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -3272,6 +3624,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         data: { letters: data.slice(2, 4) },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -3279,8 +3632,16 @@ describe('useSuspenseQuery', () => {
     expect(renders.count).toBe(3);
     expect(renders.suspenseCount).toBe(1);
     expect(renders.frames).toMatchObject([
-      { data: { letters: data.slice(0, 2) }, error: undefined },
-      { data: { letters: data.slice(2, 4) }, error: undefined },
+      {
+        data: { letters: data.slice(0, 2) },
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
+      {
+        data: { letters: data.slice(2, 4) },
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
     ]);
   });
 
@@ -3316,8 +3677,16 @@ describe('useSuspenseQuery', () => {
     });
 
     expect(renders.frames).toMatchObject([
-      { data: { letters: data.slice(0, 2) }, error: undefined },
-      { data: { letters: data.slice(0, 4) }, error: undefined },
+      {
+        data: { letters: data.slice(0, 2) },
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
+      {
+        data: { letters: data.slice(0, 4) },
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
     ]);
   });
 
@@ -3342,6 +3711,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         data: { letters: data.slice(0, 2) },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -3353,13 +3723,22 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         data: { letters: data.slice(0, 4) },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
 
     expect(renders.frames).toMatchObject([
-      { data: { letters: data.slice(0, 2) }, error: undefined },
-      { data: { letters: data.slice(0, 4) }, error: undefined },
+      {
+        data: { letters: data.slice(0, 2) },
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
+      {
+        data: { letters: data.slice(0, 4) },
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      },
     ]);
   });
 
@@ -3403,6 +3782,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -3412,6 +3792,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         data: { character: { id: '2', name: 'Cached Black Widow' } },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -3470,6 +3851,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -3483,6 +3865,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[1].result,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -3544,6 +3927,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -3557,6 +3941,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         data: { primes: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29] },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -3617,6 +4002,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -3630,6 +4016,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[1].result,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -3684,6 +4071,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -3695,6 +4083,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[1].result,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -3706,6 +4095,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         ...mocks[2].result,
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -3746,6 +4136,7 @@ describe('useSuspenseQuery', () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         data: { greeting: { message: 'Hello world', __typename: 'Greeting' } },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -3774,6 +4165,7 @@ describe('useSuspenseQuery', () => {
             recipient: { __typename: 'Person', name: 'Alice' },
           },
         },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -3783,6 +4175,7 @@ describe('useSuspenseQuery', () => {
     expect(renders.frames).toMatchObject([
       {
         data: { greeting: { message: 'Hello world', __typename: 'Greeting' } },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       },
       {
@@ -3793,6 +4186,7 @@ describe('useSuspenseQuery', () => {
             recipient: { __typename: 'Person', name: 'Alice' },
           },
         },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       },
     ]);
@@ -3842,6 +4236,7 @@ describe('useSuspenseQuery', () => {
           data: {
             greeting: { message: 'Hello world', __typename: 'Greeting' },
           },
+          networkStatus: NetworkStatus.ready,
           error: undefined,
         });
       });
@@ -3870,6 +4265,7 @@ describe('useSuspenseQuery', () => {
               recipient: { __typename: 'Person', name: 'Alice' },
             },
           },
+          networkStatus: NetworkStatus.ready,
           error: undefined,
         });
       });
@@ -3881,6 +4277,7 @@ describe('useSuspenseQuery', () => {
           data: {
             greeting: { message: 'Hello world', __typename: 'Greeting' },
           },
+          networkStatus: NetworkStatus.ready,
           error: undefined,
         },
         {
@@ -3891,6 +4288,7 @@ describe('useSuspenseQuery', () => {
               recipient: { __typename: 'Person', name: 'Alice' },
             },
           },
+          networkStatus: NetworkStatus.ready,
           error: undefined,
         },
       ]);
@@ -3937,6 +4335,7 @@ describe('useSuspenseQuery', () => {
           recipient: { __typename: 'Person', name: 'Alice' },
         },
       },
+      networkStatus: NetworkStatus.ready,
       error: undefined,
     });
 
@@ -3950,6 +4349,7 @@ describe('useSuspenseQuery', () => {
             recipient: { __typename: 'Person', name: 'Alice' },
           },
         },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       },
     ]);
@@ -4002,6 +4402,7 @@ describe('useSuspenseQuery', () => {
           recipient: { __typename: 'Person', name: 'Cached Alice' },
         },
       },
+      networkStatus: NetworkStatus.loading,
       error: undefined,
     });
 
@@ -4021,6 +4422,7 @@ describe('useSuspenseQuery', () => {
             recipient: { __typename: 'Person', name: 'Cached Alice' },
           },
         },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -4049,6 +4451,7 @@ describe('useSuspenseQuery', () => {
             recipient: { __typename: 'Person', name: 'Alice' },
           },
         },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -4063,6 +4466,7 @@ describe('useSuspenseQuery', () => {
             recipient: { __typename: 'Person', name: 'Cached Alice' },
           },
         },
+        networkStatus: NetworkStatus.loading,
         error: undefined,
       },
       {
@@ -4073,6 +4477,7 @@ describe('useSuspenseQuery', () => {
             recipient: { __typename: 'Person', name: 'Cached Alice' },
           },
         },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       },
       {
@@ -4083,6 +4488,7 @@ describe('useSuspenseQuery', () => {
             recipient: { __typename: 'Person', name: 'Alice' },
           },
         },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       },
     ]);
@@ -4130,6 +4536,7 @@ describe('useSuspenseQuery', () => {
           recipient: { __typename: 'Person', name: 'Cached Alice' },
         },
       },
+      networkStatus: NetworkStatus.loading,
       error: undefined,
     });
 
@@ -4149,6 +4556,7 @@ describe('useSuspenseQuery', () => {
             recipient: { __typename: 'Person', name: 'Cached Alice' },
           },
         },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -4177,6 +4585,7 @@ describe('useSuspenseQuery', () => {
             recipient: { __typename: 'Person', name: 'Alice' },
           },
         },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -4192,6 +4601,7 @@ describe('useSuspenseQuery', () => {
             recipient: { __typename: 'Person', name: 'Cached Alice' },
           },
         },
+        networkStatus: NetworkStatus.loading,
         error: undefined,
       },
       {
@@ -4202,6 +4612,7 @@ describe('useSuspenseQuery', () => {
             recipient: { __typename: 'Person', name: 'Cached Alice' },
           },
         },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       },
       {
@@ -4212,6 +4623,7 @@ describe('useSuspenseQuery', () => {
             recipient: { __typename: 'Person', name: 'Alice' },
           },
         },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       },
     ]);
@@ -4260,6 +4672,7 @@ describe('useSuspenseQuery', () => {
             { __typename: 'Greeting', message: 'Hello again' },
           ],
         },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -4294,6 +4707,7 @@ describe('useSuspenseQuery', () => {
             },
           ],
         },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -4329,6 +4743,7 @@ describe('useSuspenseQuery', () => {
             },
           ],
         },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -4343,6 +4758,7 @@ describe('useSuspenseQuery', () => {
             { __typename: 'Greeting', message: 'Hello again' },
           ],
         },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       },
       {
@@ -4359,6 +4775,7 @@ describe('useSuspenseQuery', () => {
             },
           ],
         },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       },
       {
@@ -4376,6 +4793,7 @@ describe('useSuspenseQuery', () => {
             },
           ],
         },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       },
     ]);
@@ -4456,6 +4874,7 @@ describe('useSuspenseQuery', () => {
             },
           ],
         },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -4510,6 +4929,7 @@ describe('useSuspenseQuery', () => {
             },
           ],
         },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -4708,6 +5128,7 @@ describe('useSuspenseQuery', () => {
             name: 'R2-D2',
           },
         },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -4757,6 +5178,7 @@ describe('useSuspenseQuery', () => {
             name: 'R2-D2',
           },
         },
+        networkStatus: NetworkStatus.error,
         error: new ApolloError({
           graphQLErrors: [
             new GraphQLError(
@@ -4789,6 +5211,7 @@ describe('useSuspenseQuery', () => {
             name: 'R2-D2',
           },
         },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       },
       {
@@ -4807,6 +5230,7 @@ describe('useSuspenseQuery', () => {
             name: 'R2-D2',
           },
         },
+        networkStatus: NetworkStatus.error,
         error: new ApolloError({
           graphQLErrors: [
             new GraphQLError(
@@ -4880,6 +5304,7 @@ describe('useSuspenseQuery', () => {
             name: 'R2-D2',
           },
         },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -4931,6 +5356,7 @@ describe('useSuspenseQuery', () => {
             name: 'R2-D2',
           },
         },
+        networkStatus: NetworkStatus.ready,
         error: new ApolloError({
           graphQLErrors: [
             new GraphQLError(
@@ -4961,6 +5387,7 @@ describe('useSuspenseQuery', () => {
             name: 'R2-D2',
           },
         },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       },
       {
@@ -4981,6 +5408,7 @@ describe('useSuspenseQuery', () => {
             name: 'R2-D2',
           },
         },
+        networkStatus: NetworkStatus.ready,
         error: new ApolloError({
           graphQLErrors: [
             new GraphQLError(
@@ -5054,6 +5482,7 @@ describe('useSuspenseQuery', () => {
             name: 'R2-D2',
           },
         },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -5103,6 +5532,7 @@ describe('useSuspenseQuery', () => {
             name: 'R2-D2',
           },
         },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       });
     });
@@ -5126,6 +5556,7 @@ describe('useSuspenseQuery', () => {
             name: 'R2-D2',
           },
         },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       },
       {
@@ -5146,6 +5577,7 @@ describe('useSuspenseQuery', () => {
             name: 'R2-D2',
           },
         },
+        networkStatus: NetworkStatus.ready,
         error: undefined,
       },
     ]);
@@ -5238,8 +5670,11 @@ describe('useSuspenseQuery', () => {
 
     expect(renders.count).toBe(3);
     expect(renders.frames).toMatchObject([
-      { data: { greeting: 'Hello' } },
-      { data: { greeting: 'Subscription hello' } },
+      { data: { greeting: 'Hello' }, networkStatus: NetworkStatus.ready },
+      {
+        data: { greeting: 'Subscription hello' },
+        networkStatus: NetworkStatus.ready,
+      },
     ]);
   });
 });

--- a/src/react/hooks/useSuspenseQuery.ts
+++ b/src/react/hooks/useSuspenseQuery.ts
@@ -11,6 +11,7 @@ import {
   TypedDocumentNode,
   WatchQueryOptions,
   WatchQueryFetchPolicy,
+  NetworkStatus,
 } from '../../core';
 import {
   compact,
@@ -37,6 +38,7 @@ export interface UseSuspenseQueryResult<
   data: TData;
   error: ApolloError | undefined;
   fetchMore: ObservableQueryFields<TData, TVariables>['fetchMore'];
+  networkStatus: NetworkStatus;
   refetch: ObservableQueryFields<TData, TVariables>['refetch'];
   subscribeToMore: ObservableQueryFields<TData, TVariables>['subscribeToMore'];
 }
@@ -151,6 +153,7 @@ export function useSuspenseQuery_experimental<
       client,
       data: result.data,
       error: errorPolicy === 'ignore' ? void 0 : toApolloError(result),
+      networkStatus: result.networkStatus,
       fetchMore: (options) => {
         const promise = observable.fetchMore(options);
 


### PR DESCRIPTION
This PR adds the `networkStatus` to the result returned by `useSuspenseQuery`. This allows a user to have more control over the UX when loading data. For example, when using a `cache-and-network` fetch policy with data in the cache, a result is immediately returned from `useSuspenseQuery` while a network request is sent in the background. During this time, the `networkStatus` is reported as loading, which can be helpful if users would like to show some kind of indication that fresh data is being loaded from the server.

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
