### PR TITLE
Upgrade to TypeScript 5.0

### DIFF
--- a/.changeset/small-elephants-poke.md
+++ b/.changeset/small-elephants-poke.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Upgrades TypeScript to v5. This change is fully backward-compatible and transparent to users.

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "ts-jest": "29.0.5",
         "ts-node": "10.9.1",
         "typedoc": "0.22.18",
-        "typescript": "4.9.5",
+        "typescript": "5.0.2",
         "wait-for-observables": "1.0.3",
         "web-streams-polyfill": "3.2.1",
         "whatwg-fetch": "3.6.2"
@@ -9489,16 +9489,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
+      "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=12.20"
       }
     },
     "node_modules/unbox-primitive": {
@@ -17182,9 +17182,9 @@
       }
     },
     "typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
+      "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "ts-jest": "29.0.5",
     "ts-node": "10.9.1",
     "typedoc": "0.22.18",
-    "typescript": "4.9.5",
+    "typescript": "5.0.2",
     "wait-for-observables": "1.0.3",
     "web-streams-polyfill": "3.2.1",
     "whatwg-fetch": "3.6.2"


### PR DESCRIPTION
This PR upgrades to the [newly-released TypeScript v5.0](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/).

We anticipated this upgrade to be painless after making the necessary changes to adopt `v4.9.4` in https://github.com/apollographql/apollo-client/pull/10470. So far this seems to be true 🎉 

`npx tsc --noEmit` succeeds. Additionally I'll be running our E2E tests with a snapshot release of this branch (https://github.com/apollographql/client-router-e2e-tests/pull/75) and comparing the compiled output to determine whether this can be shipped at a patch or should target our `release-3.8` branch. (Edit: we're clear to proceed at a patch version bump!)