### PR TITLE
Remove all Jest mocking of `optimism` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@wry/trie": "^0.3.0",
         "graphql-tag": "^2.12.6",
         "hoist-non-react-statics": "^3.3.2",
-        "optimism": "^0.16.1",
+        "optimism": "^0.17.0",
         "prop-types": "^15.7.2",
         "response-iterator": "^0.2.6",
         "symbol-observable": "^4.0.0",
@@ -7487,23 +7487,13 @@
       }
     },
     "node_modules/optimism": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz",
-      "integrity": "sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.17.0.tgz",
+      "integrity": "sha512-EbyBcQxXp0scBym1CM0y2mWItyqE6/YpNHa7eDP4JXZfiPF5vGTJy1LlvO3n6/CUiGzXJJAbHEWg/hNiEBiTkw==",
       "dependencies": {
-        "@wry/context": "^0.6.0",
-        "@wry/trie": "^0.3.0"
-      }
-    },
-    "node_modules/optimism/node_modules/@wry/context": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.1.tgz",
-      "integrity": "sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==",
-      "dependencies": {
+        "@wry/context": "^0.7.0",
+        "@wry/trie": "^0.3.0",
         "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/optionator": {
@@ -15802,22 +15792,13 @@
       }
     },
     "optimism": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz",
-      "integrity": "sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.17.0.tgz",
+      "integrity": "sha512-EbyBcQxXp0scBym1CM0y2mWItyqE6/YpNHa7eDP4JXZfiPF5vGTJy1LlvO3n6/CUiGzXJJAbHEWg/hNiEBiTkw==",
       "requires": {
-        "@wry/context": "^0.6.0",
-        "@wry/trie": "^0.3.0"
-      },
-      "dependencies": {
-        "@wry/context": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.1.tgz",
-          "integrity": "sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==",
-          "requires": {
-            "tslib": "^2.3.0"
-          }
-        }
+        "@wry/context": "^0.7.0",
+        "@wry/trie": "^0.3.0",
+        "tslib": "^2.3.0"
       }
     },
     "optionator": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@wry/trie": "^0.3.0",
     "graphql-tag": "^2.12.6",
     "hoist-non-react-statics": "^3.3.2",
-    "optimism": "^0.16.1",
+    "optimism": "^0.17.0",
     "prop-types": "^15.7.2",
     "response-iterator": "^0.2.6",
     "symbol-observable": "^4.0.0",

--- a/src/cache/inmemory/__mocks__/optimism.ts
+++ b/src/cache/inmemory/__mocks__/optimism.ts
@@ -1,5 +1,0 @@
-const optimism = jest.requireActual('optimism');
-module.exports = {
-  ...optimism,
-  wrap: jest.fn(optimism.wrap),
-};

--- a/src/cache/inmemory/__tests__/cache.ts
+++ b/src/cache/inmemory/__tests__/cache.ts
@@ -6,8 +6,6 @@ import { Cache } from '../../../cache';
 import { InMemoryCache } from '../inMemoryCache';
 import { InMemoryCacheConfig } from '../types';
 
-jest.mock('optimism');
-import { wrap } from 'optimism';
 import { StoreReader } from '../readFromStore';
 import { StoreWriter } from '../writeToStore';
 import { ObjectCanon } from '../object-canon';
@@ -2011,32 +2009,21 @@ describe('Cache', () => {
 });
 
 describe('resultCacheMaxSize', () => {
-  let wrapSpy: jest.Mock = wrap as jest.Mock;
-  beforeEach(() => {
-    wrapSpy.mockClear();
-  });
+  const defaultMaxSize = Math.pow(2, 16);
 
-  it("does not set max size on caches if resultCacheMaxSize is not configured", () => {
-    new InMemoryCache();
-    expect(wrapSpy).toHaveBeenCalled();
-
-    // The first wrap call is for getFragmentQueryDocument which intentionally
-    // does not have a max set since it's not expected to grow.
-    wrapSpy.mock.calls.splice(1).forEach(([, { max }]) => {
-      expect(max).toBeUndefined();
-    })
+  it("uses default max size on caches if resultCacheMaxSize is not configured", () => {
+    const cache = new InMemoryCache();
+    expect(cache["maybeBroadcastWatch"].options.max).toBe(defaultMaxSize);
+    expect(cache["storeReader"]["executeSelectionSet"].options.max).toBe(defaultMaxSize);
+    expect(cache["getFragmentDoc"].options.max).toBe(defaultMaxSize);
   });
 
   it("configures max size on caches when resultCacheMaxSize is set", () => {
     const resultCacheMaxSize = 12345;
-    new InMemoryCache({ resultCacheMaxSize });
-    expect(wrapSpy).toHaveBeenCalled();
-
-    // The first wrap call is for getFragmentQueryDocument which intentionally
-    // does not have a max set since it's not expected to grow.
-    wrapSpy.mock.calls.splice(1).forEach(([, { max }]) => {
-      expect(max).toBe(resultCacheMaxSize);
-    })
+    const cache = new InMemoryCache({ resultCacheMaxSize });
+    expect(cache["maybeBroadcastWatch"].options.max).toBe(resultCacheMaxSize);
+    expect(cache["storeReader"]["executeSelectionSet"].options.max).toBe(resultCacheMaxSize);
+    expect(cache["getFragmentDoc"].options.max).toBe(defaultMaxSize);
   });
 });
 

--- a/src/cache/inmemory/__tests__/readFromStore.ts
+++ b/src/cache/inmemory/__tests__/readFromStore.ts
@@ -18,36 +18,21 @@ import {
   TypedDocumentNode,
 } from '../../../core';
 
-jest.mock('optimism');
-import { wrap } from 'optimism';
-
 describe('resultCacheMaxSize', () => {
   const cache = new InMemoryCache();
-  let wrapSpy: jest.Mock = wrap as jest.Mock;
-  beforeEach(() => {
-    wrapSpy.mockClear();
-  });
+  const defaultMaxSize = Math.pow(2, 16);
 
-  it("does not set max size on caches if resultCacheMaxSize is not configured", () => {
-    new StoreReader({ cache });
-    expect(wrapSpy).toHaveBeenCalled();
-
-    wrapSpy.mock.calls.forEach(([, { max }]) => {
-      expect(max).toBeUndefined();
-    })
+  it("uses default max size on caches if resultCacheMaxSize is not configured", () => {
+    const reader = new StoreReader({ cache });
+    expect(reader["executeSelectionSet"].options.max).toBe(defaultMaxSize);
   });
 
   it("configures max size on caches when resultCacheMaxSize is set", () => {
     const resultCacheMaxSize = 12345;
-    new StoreReader({ cache, resultCacheMaxSize });
-    expect(wrapSpy).toHaveBeenCalled();
-
-    wrapSpy.mock.calls.forEach(([, { max }]) => {
-      expect(max).toBe(resultCacheMaxSize);
-    })
+    const reader = new StoreReader({ cache, resultCacheMaxSize });
+    expect(reader["executeSelectionSet"].options.max).toBe(resultCacheMaxSize);
   });
 });
-
 
 describe('reading from the store', () => {
   const reader = new StoreReader({


### PR DESCRIPTION
Thanks to https://github.com/benjamn/optimism/pull/504, we no longer need mocking to find out the options used when wrapping functions. This mocking was introduced in #8107, when there was no better option.

Subjectively, this makes tests run a bit faster and more reliably on my machine, though I can't explain why that would be, unless the mocking was adding some kind of overhead to wrapped functions.