### PR TITLE
Fix optimism dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@wry/trie": "^0.3.0",
         "graphql-tag": "^2.12.6",
         "hoist-non-react-statics": "^3.3.2",
-        "optimism": "^0.16.1",
+        "optimism": "^0.16.2",
         "prop-types": "^15.7.2",
         "response-iterator": "^0.2.6",
         "symbol-observable": "^4.0.0",
@@ -7395,23 +7395,12 @@
       }
     },
     "node_modules/optimism": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz",
-      "integrity": "sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.2.tgz",
+      "integrity": "sha512-zWNbgWj+3vLEjZNIh/okkY2EUfX+vB9TJopzIZwT1xxaMqC5hRLLraePod4c5n4He08xuXNH+zhKFFCu390wiQ==",
       "dependencies": {
-        "@wry/context": "^0.6.0",
+        "@wry/context": "^0.7.0",
         "@wry/trie": "^0.3.0"
-      }
-    },
-    "node_modules/optimism/node_modules/@wry/context": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.1.tgz",
-      "integrity": "sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/optionator": {
@@ -15620,22 +15609,12 @@
       }
     },
     "optimism": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz",
-      "integrity": "sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.2.tgz",
+      "integrity": "sha512-zWNbgWj+3vLEjZNIh/okkY2EUfX+vB9TJopzIZwT1xxaMqC5hRLLraePod4c5n4He08xuXNH+zhKFFCu390wiQ==",
       "requires": {
-        "@wry/context": "^0.6.0",
+        "@wry/context": "^0.7.0",
         "@wry/trie": "^0.3.0"
-      },
-      "dependencies": {
-        "@wry/context": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.1.tgz",
-          "integrity": "sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==",
-          "requires": {
-            "tslib": "^2.3.0"
-          }
-        }
       }
     },
     "optionator": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@wry/trie": "^0.3.0",
     "graphql-tag": "^2.12.6",
     "hoist-non-react-statics": "^3.3.2",
-    "optimism": "^0.16.1",
+    "optimism": "^0.16.2",
     "prop-types": "^15.7.2",
     "response-iterator": "^0.2.6",
     "symbol-observable": "^4.0.0",


### PR DESCRIPTION
Since optimism's version starts with `0.`, every version can break things, so package managers will only match `^0.16.1` to `0.16.1`, and not the newer `0.16.2`. When this happens, we end up depending on two copies of `@wry/context`.

```
yarn why v1.22.19
[1/4] 🤔  Why do we have the module "@wry/context"...?
[2/4] 🚚  Initialising dependency graph...
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
=> Found "@wry/context@0.6.1"
info Reasons this module exists
   - "<project>#@apollo#client" depends on it
   - Hoisted from "<project>#@apollo#client#@wry#context"
info Disk size without dependencies: "100KB"
info Disk size with unique dependencies: "188KB"
info Disk size with transitive dependencies: "188KB"
info Number of shared dependencies: 1
=> Found "optimism#@wry/context@0.7.0"
info This module exists because "<project>#@apollo#client#optimism" depends on it.
info Disk size without dependencies: "104KB"
info Disk size with unique dependencies: "192KB"
info Disk size with transitive dependencies: "192KB"
info Number of shared dependencies: 1
✨  Done in 1.05s.
```

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
