### PR TITLE
Improve flaky useQuery tests by not hard-coding request counts

### DIFF
--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -1638,6 +1638,8 @@ describe('useQuery Hook', () => {
 
       await waitFor(() => {
         expect(result.current.loading).toBe(false);
+      }, { interval: 1 });
+      await waitFor(() => {
         expect(result.current.data).toEqual({ hello: "world 1" });
       }, { interval: 1 });
 
@@ -1654,7 +1656,6 @@ describe('useQuery Hook', () => {
 
       await expect(waitFor(() => {
         const newRequestCount = requestSpy.mock.calls.length;
-        expect(requestSpy).toHaveBeenCalledTimes(newRequestCount);
         expect(newRequestCount).toBeGreaterThan(requestCount);
       }, { interval: 1, timeout: 20 })).rejects.toThrow();
 

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -1638,22 +1638,30 @@ describe('useQuery Hook', () => {
 
       await waitFor(() => {
         expect(result.current.loading).toBe(false);
-      }, { interval: 1 });
-      await waitFor(() => {
         expect(result.current.data).toEqual({ hello: "world 1" });
-      });
+      }, { interval: 1 });
+
       await waitFor(() => {
-        expect(requestSpy).toHaveBeenCalledTimes(1);
-      })
+        expect(requestSpy).toHaveBeenCalled();
+      });
+
+      const requestCount = requestSpy.mock.calls.length;
+      expect(requestCount).toBeGreaterThan(0);
 
       unmount();
 
+      expect(requestSpy).toHaveBeenCalledTimes(requestCount);
+
       await expect(waitFor(() => {
-        expect(requestSpy).not.toHaveBeenCalledTimes(1);
+        const newRequestCount = requestSpy.mock.calls.length;
+        expect(requestSpy).toHaveBeenCalledTimes(newRequestCount);
+        expect(newRequestCount).toBeGreaterThan(requestCount);
       }, { interval: 1, timeout: 20 })).rejects.toThrow();
+
       await waitFor(() => {
         expect(onErrorFn).toHaveBeenCalledTimes(0);
       });
+
       requestSpy.mockRestore();
     });
 
@@ -1700,12 +1708,14 @@ describe('useQuery Hook', () => {
         expect(result.current.loading).toBe(false);
       }, { interval: 1 });
       expect(result.current.data).toEqual({ hello: "world 1" });
-      expect(requestSpy).toHaveBeenCalledTimes(1);
+
+      const requestCount = requestSpy.mock.calls.length;
+      expect(requestSpy).toHaveBeenCalledTimes(requestCount);
 
       unmount();
 
       await expect(waitFor(() => {
-        expect(requestSpy).not.toHaveBeenCalledTimes(1);
+        expect(requestSpy).toHaveBeenCalledTimes(requestCount + 1)
       }, { interval: 1, timeout: 20 })).rejects.toThrow();
       expect(onErrorFn).toHaveBeenCalledTimes(0);
       requestSpy.mockRestore();


### PR DESCRIPTION
I've noticed intermittent test failures on the `main` branch lately (for example, commit https://github.com/apollographql/apollo-client/commit/cdb98ae082ae4c7da6cd6a0fd5ad8457810fceda with [output](https://app.circleci.com/pipelines/github/apollographql/apollo-client/19342/workflows/629b65e1-e06f-49b4-9156-4d25fd565c75/jobs/100103)) that seem at least partially due to the testing anti-pattern of hard-coding request counts, which can change unexpectedly when the event loop is saturated during CI testing (so more 10ms polling intervals happen than expected).