### PR TITLE
Unmounting a component before a query is resolved via `useLazyQuery` lets the promise resolve instead of aborting the promise.

### DIFF
--- a/.changeset/nine-lemons-swim.md
+++ b/.changeset/nine-lemons-swim.md
@@ -1,0 +1,9 @@
+---
+'@apollo/client': patch
+---
+
+Changes the behavior of `useLazyQuery` introduced in [#10427](https://github.com/apollographql/apollo-client/pull/10427) where unmounting a component before a query was resolved would abort the promise. Instead, the promise will now resolve naturally with the result from the network request.
+
+Other notable fixes:
+- Kicking off multiple requests in parallel with the execution function will now ensure each returned promise is resolved with the correct data. Previously, each promise was resolved with data from the last execution.
+- Re-rendering `useLazyQuery` with a different query document will now ensure the execution function uses the updated query document. Previously, only the query document rendered the first time would be used for the request. 

--- a/.changeset/nine-lemons-swim.md
+++ b/.changeset/nine-lemons-swim.md
@@ -2,8 +2,8 @@
 '@apollo/client': patch
 ---
 
-Changes the behavior of `useLazyQuery` introduced in [#10427](https://github.com/apollographql/apollo-client/pull/10427) where unmounting a component before a query was resolved would abort the promise. Instead, the promise will now resolve naturally with the result from the network request.
+Changes the behavior of `useLazyQuery` introduced in [#10427](https://github.com/apollographql/apollo-client/pull/10427) where unmounting a component before a query was resolved would reject the promise with an abort error. Instead, the promise will now resolve naturally with the result from the request.
 
 Other notable fixes:
-- Kicking off multiple requests in parallel with the execution function will now ensure each returned promise is resolved with the correct data. Previously, each promise was resolved with data from the last execution.
+- Kicking off multiple requests in parallel with the execution function will now ensure each returned promise is resolved with the data from its request. Previously, each promise was resolved with data from the last execution.
 - Re-rendering `useLazyQuery` with a different query document will now ensure the execution function uses the updated query document. Previously, only the query document rendered the first time would be used for the request. 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -782,10 +782,10 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`);
     return this.last;
   }
 
-  public reobserve(
+  public reobserveAsConcast(
     newOptions?: Partial<WatchQueryOptions<TVariables, TData>>,
     newNetworkStatus?: NetworkStatus,
-  ): Promise<ApolloQueryResult<TData>> {
+  ): Concast<ApolloQueryResult<TData>> {
     this.isTornDown = false;
 
     const useDisposableConcast =
@@ -858,7 +858,14 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`);
 
     concast.addObserver(observer);
 
-    return concast.promise;
+    return concast;
+  }
+
+  public reobserve(
+    newOptions?: Partial<WatchQueryOptions<TVariables, TData>>,
+    newNetworkStatus?: NetworkStatus,
+  ) {
+    return this.reobserveAsConcast(newOptions, newNetworkStatus).promise;
   }
 
   // (Re)deliver the current result to this.observers without applying fetch

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -1285,6 +1285,7 @@ describe('useLazyQuery Hook', () => {
     );
   });
 
+  // https://github.com/apollographql/apollo-client/issues/10198
   it('uses the most recent query document when the hook rerenders before execution', async () => {
     const query = gql`
       query DummyQuery {

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -1201,16 +1201,16 @@ describe('useLazyQuery Hook', () => {
     const [execute] = result.current;
 
     await act(async () => {
-      const result1 = await execute({ variables: { id: '1' }});
-      const result2 = await execute({ variables: { id: '2' }});
+      const promise1 = execute({ variables: { id: '1' }});
+      const promise2 = execute({ variables: { id: '2' }});
 
-      expect(result1).toMatchObject({
+      await expect(promise1).resolves.toMatchObject({
         ...mocks[0].result,
         loading: false ,
         called: true,
       });
 
-      expect(result2).toMatchObject({
+      await expect(promise2).resolves.toMatchObject({
         ...mocks[1].result,
         loading: false ,
         called: true,

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -33,7 +33,7 @@ export function useLazyQuery<TData = any, TVariables extends OperationVariables 
   const merged = execOptionsRef.current ? mergeOptions(options, execOptionsRef.current) : options;
   const document = merged?.query ?? query;
 
-  optionsRef.current = options;
+  optionsRef.current = merged;
   queryRef.current = document;
 
   const internalState = useInternalState<TData, TVariables>(

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -33,6 +33,8 @@ export function useLazyQuery<TData = any, TVariables extends OperationVariables 
   const merged = execOptionsRef.current ? mergeOptions(options, execOptionsRef.current) : options;
   const document = merged?.query ?? query;
 
+  // Use refs to track options and the used query to ensure the `execute` 
+  // function remains referentially stable between renders.
   optionsRef.current = merged;
   queryRef.current = document;
 

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -101,20 +101,10 @@ class InternalState<TData, TVariables extends OperationVariables> {
     invariant.warn("Calling default no-op implementation of InternalState#forceUpdate");
   }
 
-  asyncUpdate(signal: AbortSignal) {
-    return new Promise<QueryResult<TData, TVariables>>((resolve, reject) => {
-      const watchQueryOptions = this.watchQueryOptions;
-
-      const handleAborted = () => {
-        this.asyncResolveFns.delete(resolve)
-        this.optionsToIgnoreOnce.delete(watchQueryOptions);
-        signal.removeEventListener('abort', handleAborted)
-        reject(signal.reason);
-      };
-
+  asyncUpdate() {
+    return new Promise<QueryResult<TData, TVariables>>((resolve) => {
       this.asyncResolveFns.add(resolve);
-      this.optionsToIgnoreOnce.add(watchQueryOptions);
-      signal.addEventListener('abort', handleAborted)
+      this.optionsToIgnoreOnce.add(this.watchQueryOptions);
       this.forceUpdate();
     });
   }

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -102,6 +102,10 @@ class InternalState<TData, TVariables extends OperationVariables> {
   }
 
   executeQuery(options: QueryHookOptions<TData, TVariables>) {
+    if (options.query) {
+      Object.assign(this, { query: options.query })
+    }
+
     const watchQueryOptions = this.createWatchQueryOptions(
       this.queryHookOptions = options,
     );

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -106,11 +106,9 @@ class InternalState<TData, TVariables extends OperationVariables> {
       Object.assign(this, { query: options.query })
     }
 
-    const watchQueryOptions = this.createWatchQueryOptions(
+    this.watchQueryOptions = this.createWatchQueryOptions(
       this.queryHookOptions = options,
     );
-
-    this.watchQueryOptions = watchQueryOptions;
 
     const concast = this.observable.reobserveAsConcast(
       this.getObsQueryOptions()

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -270,12 +270,6 @@ class InternalState<TData, TVariables extends OperationVariables> {
     // this.watchQueryOptions elsewhere.
     const currentWatchQueryOptions = this.watchQueryOptions;
 
-    // To force this equality test to "fail," thereby reliably triggering
-    // observable.reobserve, add any current WatchQueryOptions object(s) you
-    // want to be ignored to this.optionsToIgnoreOnce. A similar effect could be
-    // achieved by nullifying this.watchQueryOptions so the equality test
-    // immediately fails because currentWatchQueryOptions is null, but this way
-    // we can promise a truthy this.watchQueryOptions at all times.
     if (!equal(watchQueryOptions, currentWatchQueryOptions)) {
       this.watchQueryOptions = watchQueryOptions;
 


### PR DESCRIPTION
Fixes #9755
Fixes #10174
Fixes #10198
Fixes #10520
Fixes #10533

This PR addresses a few outstanding `useLazyQuery` issues and changes the behavior introduced in #10427 when a component unmounts before a query is fully resolved.

Prior to #10427, components that unmounted before the query was resolved were stuck awaiting the promise indefinitely since promise resolution was dependent on the `useQuery` render cycle to resolve the promise. #10427 attempted to fix this by aborting the promise any time the component unmounted. This change however was a bit too [spicy 🌶️ ](https://github.com/apollographql/apollo-client/issues/10520). Aborting the promise also made it impossible for [some use cases](https://github.com/apollographql/apollo-client/issues/10533) that relied upon promise resolution to work correctly.

This PR changes the behavior so that unmounting a component will no longer cause the promise to abort, but rather let the promise resolve naturally with the result from the server. This change had a number of positive side effects that resolved a number of other issues, for example, the ability to run the execution function multiple times with different variables in parallel will now resolve each of the promises with the correct data (#9755). 

This PR also makes it possible to dynamically change the query document passed to `useLazyQuery` and ensure the execute function will use the latest set document (#10198). Some additional tests were added to ensure rerendering with new variables before executing the query would use the proper option set.

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
