### PR TITLE
chore: document change in cache-and-network behavior in v3

### DIFF
--- a/docs/source/migrating/apollo-client-3-migration.mdx
+++ b/docs/source/migrating/apollo-client-3-migration.mdx
@@ -223,5 +223,13 @@ The following cache changes are **not** backward compatible. Take them into cons
       }
     });
   ```
+* `cache-and-network` fetch policy now initiates a network request whenever there are cache updates that affect the query, and is no longer limited to the first time the query is run. In order to recreate the default behavior from `v2.x.x`, please configure a `nextFetchPolicy` (available in versions `>=3.1.0`). For example:
+
+```js
+const { loading, error, data } = useQuery(GET_ALL_TODOS, {
+  fetchPolicy: "cache-and-network",
+  nextFetchPolicy: "cache-first",
+});
+```
 
   For more details around why `writeData` has been removed, see [PR #5923](https://github.com/apollographql/apollo-client/pull/5923).

--- a/docs/source/migrating/apollo-client-3-migration.mdx
+++ b/docs/source/migrating/apollo-client-3-migration.mdx
@@ -223,6 +223,8 @@ The following cache changes are **not** backward compatible. Take them into cons
       }
     });
   ```
+
+  For more details around why `writeData` has been removed, see [PR #5923](https://github.com/apollographql/apollo-client/pull/5923).
 * `cache-and-network` fetch policy now initiates a network request whenever there are cache updates that affect the query, and is no longer limited to the first time the query is run. In order to recreate the default behavior from `v2.x.x`, please configure a `nextFetchPolicy` (available in versions `>=3.1.0`). For example:
 
 ```js
@@ -231,5 +233,3 @@ const { loading, error, data } = useQuery(GET_ALL_TODOS, {
   nextFetchPolicy: "cache-first",
 });
 ```
-
-  For more details around why `writeData` has been removed, see [PR #5923](https://github.com/apollographql/apollo-client/pull/5923).


### PR DESCRIPTION
Closes https://github.com/apollographql/apollo-client/issues/6760.

Describes a change in behavior of the fetch policy `cache-and-network` from v2 to v3.
See: https://github.com/apollographql/apollo-client/issues/6760#issuecomment-870904729.

Link to the deployed docs page: https://deploy-preview-10714--apollo-client-docs.netlify.app/migrating/apollo-client-3-migration

![CleanShot 2023-04-03 at 13 03 44](https://user-images.githubusercontent.com/5139846/229578514-9c9ef38c-6768-4992-b7f1-5310c9bd0b53.png)