### PR TITLE
chore: update Retry Link docs with reference to onError link

### DIFF
--- a/docs/source/api/link/apollo-link-retry.md
+++ b/docs/source/api/link/apollo-link-retry.md
@@ -5,7 +5,9 @@ description: Attempt an operation multiple times if it fails due to network or s
 
 ## Overview
 
-`@apollo/client/link/retry` can be used to retry an operation a certain amount of times. This comes in handy when dealing with unreliable communication situations, where you would rather wait longer than explicitly fail an operation. `@apollo/client/link/retry` provides exponential backoff, and jitters delays between attempts by default. It does not (currently) handle retries for GraphQL errors in the response, only for network errors.
+`@apollo/client/link/retry` can be used to retry an operation a certain amount of times. This comes in handy when dealing with unreliable communication situations, where you would rather wait longer than explicitly fail an operation. `@apollo/client/link/retry` provides exponential backoff, and jitters delays between attempts by default.
+
+> **Note:** It does not currently handle retries for GraphQL errors in the response, only for network errors; the `onError` link can be used to retry an operation after a GraphQL error. For more information, see the [Error handling documentation](/react/data/error-handling/#on-graphql-errors).
 
 An example use case is to hold on to a request while a network connection is offline, and retry until it comes back online.
 


### PR DESCRIPTION
Related to discussion in https://github.com/apollographql/apollo-client/issues/6920.

Updates the docs to emphasize that Retry Link only receives network errors, and link to relevant section in the docs that describes the pattern for retrying after GraphQL errors via onError link.