### PR TITLE
Implement a `@nonreactive` directive for selectively skipping reactive comparisons of query result subtrees

### DIFF
--- a/.changeset/modern-peaches-marry.md
+++ b/.changeset/modern-peaches-marry.md
@@ -1,0 +1,5 @@
+---
+'@apollo/client': minor
+---
+
+Implement a `@nonreactive` directive for selectively skipping reactive comparisons of query result subtrees

--- a/.eslintrc
+++ b/.eslintrc
@@ -14,7 +14,8 @@
       "files": ["**/__tests__/**/*.[jt]sx", "**/?(*.)+(test).[jt]sx"],
       "extends": ["plugin:testing-library/react"],
       "rules": {
-        "testing-library/prefer-user-event": "error"
+        "testing-library/prefer-user-event": "error",
+        "testing-library/no-wait-for-multiple-assertions": "off"
       }
     }
   ]

--- a/.prettierignore
+++ b/.prettierignore
@@ -28,6 +28,10 @@ src/react/*
 # Allow src/react/cache
 !src/react/cache/
 
+# Allow certain core tests
+!src/core/__tests__/equalByQuery.ts
+!src/core/equalByQuery.ts
+
 # Allowed utilities
 !src/utilities/
 src/utilities/*

--- a/config/bundlesize.ts
+++ b/config/bundlesize.ts
@@ -3,7 +3,7 @@ import { join } from "path";
 import { gzipSync } from "zlib";
 import bytes from "bytes";
 
-const gzipBundleByteLengthLimit = bytes("34.14KB");
+const gzipBundleByteLengthLimit = bytes("34.5KB");
 const minFile = join("dist", "apollo-client.min.cjs");
 const minPath = join(__dirname, "..", minFile);
 const gzipByteLen = gzipSync(readFileSync(minPath)).byteLength;

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -32,6 +32,7 @@ import {
 import { QueryInfo } from './QueryInfo';
 import { MissingFieldError } from '../cache';
 import { MissingTree } from '../cache/core/types/common';
+import { compareResultsUsingQuery } from './compareResults';
 
 const {
   assign,
@@ -307,9 +308,23 @@ export class ObservableQuery<
     newResult: ApolloQueryResult<TData>,
     variables?: TVariables
   ) {
+    if (!this.last) {
+      return true;
+    }
+
+    const { query } = this.options;
+    const resultIsDifferent =
+      this.queryManager.transform(query).hasNonreactiveDirective
+        ? !compareResultsUsingQuery(
+            query,
+            this.last.result,
+            newResult,
+            this.variables,
+          )
+        : !equal(this.last.result, newResult);
+
     return (
-      !this.last ||
-      !equal(this.last.result, newResult) ||
+      resultIsDifferent ||
       (variables && !equal(this.last.variables, variables))
     );
   }

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -31,7 +31,7 @@ import {
 import { QueryInfo } from './QueryInfo';
 import { MissingFieldError } from '../cache';
 import { MissingTree } from '../cache/core/types/common';
-import { compareResultsUsingQuery } from './compareResults';
+import { equalByQuery } from './equalByQuery';
 
 const {
   assign,
@@ -314,7 +314,7 @@ export class ObservableQuery<
     const { query } = this.options;
     const resultIsDifferent =
       this.queryManager.transform(query).hasNonreactiveDirective
-        ? !compareResultsUsingQuery(
+        ? !equalByQuery(
             query,
             this.last.result,
             newResult,

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -10,6 +10,7 @@ import {
   hasDirectives,
   isExecutionPatchIncrementalResult,
   isExecutionPatchResult,
+  removeDirectivesFromDocument,
 } from '../utilities';
 import { Cache, ApolloCache, canonicalStringify } from '../cache';
 
@@ -20,7 +21,6 @@ import {
   hasClientExports,
   graphQLResultHasError,
   getGraphQLErrorsFromResult,
-  removeConnectionDirectiveFromDocument,
   canUseWeakMap,
   ObservableSubscription,
   Observable,
@@ -618,11 +618,12 @@ export class QueryManager<TStore> {
 
     if (!transformCache.has(document)) {
       const transformed = this.cache.transformDocument(document);
-      const noConnection = removeConnectionDirectiveFromDocument(transformed);
+      const serverQuery = removeDirectivesFromDocument([
+        removeClientFields ? { name: 'client', remove: true } : {},
+        { name: 'connection' },
+        { name: 'nonreactive' },
+      ], transformed);
       const clientQuery = this.localState.clientQuery(transformed);
-      const serverQuery =
-        noConnection &&
-          this.localState.serverQuery(noConnection, { removeClientFields });
 
       const cacheEntry: TransformCacheEntry = {
         document: transformed,

--- a/src/core/__tests__/compareResults.ts
+++ b/src/core/__tests__/compareResults.ts
@@ -1,4 +1,4 @@
-import { gql } from "../../../core";
+import { gql } from "../index";
 import { compareResultsUsingQuery } from "../compareResults";
 
 describe("compareResultsUsingQuery", () => {

--- a/src/core/__tests__/equalByQuery.ts
+++ b/src/core/__tests__/equalByQuery.ts
@@ -119,6 +119,132 @@ describe("equalByQuery", () => {
     )).toBe(false);
   });
 
+  describe("@skip and @include directives", () => {
+    // The @skip and @include directives use query variables to determine
+    // whether subtrees of the query should be executed at all, so they can
+    // influence the comparison of results in ways similar to @nonreactive. The
+    // key difference is that @skip and @include will be sent to the server,
+    // whereas @nonreactive is a client-only directive, and does not prevent
+    // execution of nonreactive fields/subtrees on the server.
+    it("respects @skip directive, depending on variables", () => {
+      const skipQuery = gql`
+        query SkipC ($condition: Boolean!) {
+          a
+          b
+          c @skip(if: $condition)
+        }
+      `;
+
+      expect(equalByQuery(
+        skipQuery,
+        { data: { a: 1, b: 2, c: 3 } },
+        { data: { a: 1, b: 2, c: 3 } },
+        { condition: false },
+      )).toBe(true);
+
+      expect(equalByQuery(
+        skipQuery,
+        { data: { a: 1, b: 2, c: 3 } },
+        { data: { a: 1, b: 2 } },
+        { condition: false },
+      )).toBe(false);
+
+      expect(equalByQuery(
+        skipQuery,
+        { data: { a: 1, b: 2, c: 3 } },
+        { data: { a: 1, b: 2 } },
+        { condition: true },
+      )).toBe(true);
+
+      expect(equalByQuery(
+        skipQuery,
+        { data: { a: 1, b: 2 } },
+        { data: { a: 1, b: 2, c: 3 } },
+        { condition: false },
+      )).toBe(false);
+
+      expect(equalByQuery(
+        skipQuery,
+        { data: { a: 1, b: 2 } },
+        { data: { a: 1, b: 2, c: 3 } },
+        { condition: true },
+      )).toBe(true);
+
+      expect(equalByQuery(
+        skipQuery,
+        { data: { a: 1, b: 2 } },
+        { data: { a: 1, b: 2 } },
+        { condition: false },
+      )).toBe(true);
+
+      expect(equalByQuery(
+        skipQuery,
+        { data: { a: 1, b: 2 } },
+        { data: { a: 1, b: 2 } },
+        { condition: true },
+      )).toBe(true);
+    });
+
+    it("respects @include directive, depending on variables", () => {
+      const includeQuery = gql`
+        query IncludeC ($condition: Boolean!) {
+          a
+          b
+          c @include(if: $condition)
+        }
+      `;
+
+      expect(equalByQuery(
+        includeQuery,
+        { data: { a: 1, b: 2, c: 3 } },
+        { data: { a: 1, b: 2, c: 3 } },
+        { condition: true },
+      )).toBe(true);
+
+      expect(equalByQuery(
+        includeQuery,
+        { data: { a: 1, b: 2, c: 3 } },
+        { data: { a: 1, b: 2 } },
+        { condition: true },
+      )).toBe(false);
+
+      expect(equalByQuery(
+        includeQuery,
+        { data: { a: 1, b: 2, c: 3 } },
+        { data: { a: 1, b: 2 } },
+        { condition: false },
+      )).toBe(true);
+
+      expect(equalByQuery(
+        includeQuery,
+        { data: { a: 1, b: 2 } },
+        { data: { a: 1, b: 2, c: 3 } },
+        { condition: true },
+      )).toBe(false);
+
+      expect(equalByQuery(
+        includeQuery,
+        { data: { a: 1, b: 2 } },
+        { data: { a: 1, b: 2, c: 3 } },
+        { condition: false },
+      )).toBe(true);
+
+      expect(equalByQuery(
+        includeQuery,
+        { data: { a: 1, b: 2 } },
+        { data: { a: 1, b: 2 } },
+        { condition: true },
+      )).toBe(true);
+
+      expect(equalByQuery(
+        includeQuery,
+        { data: { a: 1, b: 2 } },
+        { data: { a: 1, b: 2 } },
+        { condition: false },
+      )).toBe(true);
+    });
+  });
+
   it("considers errors as well as data", () => {
     const query = gql`
       query {

--- a/src/core/__tests__/equalByQuery.ts
+++ b/src/core/__tests__/equalByQuery.ts
@@ -1,10 +1,10 @@
 import { GraphQLError } from "graphql";
 import { gql } from "../index";
-import { compareResultsUsingQuery } from "../compareResults";
+import { equalByQuery } from "../equalByQuery";
 
-describe("compareResultsUsingQuery", () => {
+describe("equalByQuery", () => {
   it("is importable and a function", () => {
-    expect(typeof compareResultsUsingQuery).toBe("function");
+    expect(typeof equalByQuery).toBe("function");
   });
 
   it("works with a basic single-field query", () => {
@@ -14,61 +14,61 @@ describe("compareResultsUsingQuery", () => {
       }
     `;
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: { hello: "hi" } },
       { data: { hello: "hi" } },
     )).toBe(true);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: { hello: "hi", unrelated: 1 } },
       { data: { hello: "hi", unrelated: 100 } },
     )).toBe(true);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: { hello: "hi" } },
       { data: { hello: "hey" } },
     )).toBe(false);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: {} },
       { data: { hello: "hi" } },
     )).toBe(false);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: { hello: "hi" } },
       { data: {} },
     )).toBe(false);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: { hello: "hi" } },
       { data: null },
     )).toBe(false);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: null },
       { data: { hello: "hi" } },
     )).toBe(false);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: null },
       { data: null },
     )).toBe(true);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: {} },
       { data: {} },
     )).toBe(true);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: { unrelated: "whatever" } },
       { data: { unrelated: "no matter" } },
@@ -84,13 +84,13 @@ describe("compareResultsUsingQuery", () => {
       }
     `;
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: { a: 1, b: 2, c: 3 } },
       { data: { b: 2, c: 3, a: 1 } },
     )).toBe(true);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: { d: "bogus", a: 1, b: 2, c: 3 } },
       { data: { b: 2, c: 3, a: 1, d: "also bogus" } },
@@ -106,13 +106,13 @@ describe("compareResultsUsingQuery", () => {
       }
     `;
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: { a: 1, b: 2, c: 3 } },
       { data: { a: 1, b: 2, c: "different" } },
     )).toBe(true);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: { a: 1, b: 2, c: 3 } },
       { data: { a: "different", b: 2, c: 4 } },
@@ -132,49 +132,49 @@ describe("compareResultsUsingQuery", () => {
     const oopsError = new GraphQLError("oops");
     const differentError = new GraphQLError("different");
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: data123 },
       { data: data123, errors: [oopsError] },
     )).toBe(false);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: data123, errors: [oopsError] },
       { data: data123 },
     )).toBe(false);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: data123, errors: [oopsError] },
       { data: data123, errors: [oopsError] },
     )).toBe(true);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: data123, errors: [oopsError] },
       { data: data123, errors: [differentError] },
     )).toBe(false);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: data123, errors: [oopsError] },
       { data: data123, errors: [oopsError] },
     )).toBe(true);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: data123, errors: [oopsError] },
       { data: { ...data123, b: 100 }, errors: [oopsError] },
     )).toBe(true);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: data123, errors: [] },
       { data: data123, errors: [] },
     )).toBe(true);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: data123, errors: [] },
       { data: { ...data123, b: 100 }, errors: [] },
@@ -192,13 +192,13 @@ describe("compareResultsUsingQuery", () => {
       }
     `;
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: { a: 1, b: 2, c: 3 } },
       { data: { a: 1, b: 20, c: 30 } },
     )).toBe(true);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: { a: 1, b: 2, c: 3 } },
       { data: { a: 10, b: 20, c: 30 } },
@@ -218,25 +218,25 @@ describe("compareResultsUsingQuery", () => {
       }
     `;
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: { a: 1, b: 2, c: 3 } },
       { data: { a: 1, b: 2, c: 30 } },
     )).toBe(true);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: { a: 1, b: 2, c: 3 } },
       { data: { a: 1, b: 20, c: 3 } },
     )).toBe(true);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: { a: 1, b: 2, c: 3 } },
       { data: { a: 1, b: 20, c: 30 } },
     )).toBe(true);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: { a: 1, b: 2, c: 3 } },
       { data: { a: 10, b: 20, c: 30 } },
@@ -256,25 +256,25 @@ describe("compareResultsUsingQuery", () => {
       }
     `;
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: { a: 1, b: 2, c: 3 } },
       { data: { a: 1, b: 2, c: 30 } },
     )).toBe(true);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: { a: 1, b: 2, c: 3 } },
       { data: { a: 1, b: 20, c: 3 } },
     )).toBe(true);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: { a: 1, b: 2, c: 3 } },
       { data: { a: 1, b: 20, c: 30 } },
     )).toBe(true);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: { a: 1, b: 2, c: 3 } },
       { data: { a: 10, b: 20, c: 30 } },
@@ -294,37 +294,37 @@ describe("compareResultsUsingQuery", () => {
       }
     `;
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: { a: 1, b: 2, c: 3 } },
       { data: { a: 1, b: 2, c: 3 } },
     )).toBe(true);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: { a: 1, b: 2, c: 3 } },
       { data: { c: 3, a: 1, b: 2 } },
     )).toBe(true);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: { a: 1, b: 2, c: 3 } },
       { data: { a: 1, b: 2, c: 30 } },
     )).toBe(false);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: { a: 1, b: 2, c: 3 } },
       { data: { a: 1, b: 20, c: 3 } },
     )).toBe(false);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: { a: 1, b: 2, c: 3 } },
       { data: { a: 1, b: 20, c: 30 } },
     )).toBe(false);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: { a: 1, b: 2, c: 3 } },
       { data: { a: 10, b: 20, c: 30 } },
@@ -354,67 +354,67 @@ describe("compareResultsUsingQuery", () => {
       volatile: Math.random(),
     });
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: { things: "abc".split("").map(id => makeThing(id)) } },
       { data: { things: [makeThing("a"), makeThing("b"), makeThing("c")] } },
     )).toBe(true);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: { things: "abc".split("").map(id => makeThing(id)) } },
       { data: { things: "not an array" } },
     )).toBe(false);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: { things: {} } },
       { data: { things: [] } },
     )).toBe(false);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: { things: [] } },
       { data: { things: {} } },
     )).toBe(false);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: { things: [] } },
       { data: { things: [] } },
     )).toBe(true);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: { things: {} } },
       { data: { things: {} } },
     )).toBe(true);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: { things: "ab".split("").map(id => makeThing(id)) } },
       { data: { things: [makeThing("a"), makeThing("b")] } },
     )).toBe(true);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: { things: "ab".split("").map(id => makeThing(id)) } },
       { data: { things: [makeThing("b"), makeThing("a")] } },
     )).toBe(false);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: { things: "ab".split("").map(id => makeThing(id)) } },
       { data: { things: [makeThing("a"), makeThing("b", 2345)] } },
     )).toBe(false);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: { things: "ab".split("").map(id => makeThing(id)) } },
       { data: { things: [makeThing("a", 3456), makeThing("b")] } },
     )).toBe(false);
 
-    expect(compareResultsUsingQuery(
+    expect(equalByQuery(
       query,
       { data: { things: "ab".split("").map(id => makeThing(id)) } },
       { data: { things: [makeThing("b"), makeThing("a")] } },

--- a/src/core/compareResults.ts
+++ b/src/core/compareResults.ts
@@ -11,6 +11,7 @@ import {
   SelectionSetNode,
 } from "graphql";
 
+import { ApolloQueryResult } from "./types";
 import {
   createFragmentMap,
   FragmentMap,
@@ -29,15 +30,14 @@ export function compareResultsUsingQuery<
   TVariables extends Record<string, any> = Record<string, any>
 >(
   query: DocumentNode,
-  aResult: TData,
-  bResult: TData,
-  variables?: TVariables | undefined,
+  { data: aData, ...aRest }: Partial<ApolloQueryResult<TData>>,
+  { data: bData, ...bRest }: Partial<ApolloQueryResult<TData>>,
+  variables?: TVariables,
 ): boolean {
-  if (aResult === bResult) return true;
-  return compareResultsUsingSelectionSet(
+  return equal(aRest, bRest) && compareResultsUsingSelectionSet(
     getMainDefinition(query).selectionSet,
-    aResult,
-    bResult,
+    aData,
+    bData,
     {
       fragmentMap: createFragmentMap(getFragmentDefinitions(query)),
       variables,
@@ -58,6 +58,10 @@ function compareResultsUsingSelectionSet<TVariables extends Record<string, any>>
   bResult: any,
   context: CompareContext<TVariables>,
 ): boolean {
+  if (aResult === bResult) {
+    return true;
+  }
+
   const seenSelections = new Set<SelectionNode>();
 
   // Returning true from this Array.prototype.every callback function skips the

--- a/src/core/compareResults.ts
+++ b/src/core/compareResults.ts
@@ -20,15 +20,18 @@ import {
   isField,
   resultKeyNameFromField,
   shouldInclude,
-} from "../../utilities";
+} from "../utilities";
 
 // Returns true if aResult and bResult are deeply equal according to the fields
 // selected by the given query, ignoring any fields marked as @nonreactive.
-export function compareResultsUsingQuery(
+export function compareResultsUsingQuery<
+  TData,
+  TVariables extends Record<string, any> = Record<string, any>
+>(
   query: DocumentNode,
-  aResult: any,
-  bResult: any,
-  variables?: Record<string, any> | undefined,
+  aResult: TData,
+  bResult: TData,
+  variables?: TVariables | undefined,
 ): boolean {
   if (aResult === bResult) return true;
   return compareResultsUsingSelectionSet(
@@ -44,16 +47,16 @@ export function compareResultsUsingQuery(
 
 // Encapsulates the information used by compareResultsUsingSelectionSet that
 // does not change during the recursion.
-interface CompareContext {
+interface CompareContext<TVariables> {
   fragmentMap: FragmentMap;
-  variables: Record<string, any> | undefined;
+  variables: TVariables | undefined;
 }
 
-function compareResultsUsingSelectionSet(
+function compareResultsUsingSelectionSet<TVariables extends Record<string, any>>(
   selectionSet: SelectionSetNode,
   aResult: any,
   bResult: any,
-  context: CompareContext,
+  context: CompareContext<TVariables>,
 ): boolean {
   const seenSelections = new Set<SelectionNode>();
 

--- a/src/core/equalByQuery.ts
+++ b/src/core/equalByQuery.ts
@@ -11,7 +11,11 @@ import {
   SelectionSetNode,
 } from "graphql";
 
-import { ApolloQueryResult } from "./types";
+import {
+  ApolloQueryResult,
+  OperationVariables,
+} from "./types";
+
 import {
   createFragmentMap,
   FragmentMap,
@@ -25,14 +29,11 @@ import {
 
 // Returns true if aResult and bResult are deeply equal according to the fields
 // selected by the given query, ignoring any fields marked as @nonreactive.
-export function equalByQuery<
-  TData,
-  TVariables extends Record<string, any> = Record<string, any>
->(
+export function equalByQuery(
   query: DocumentNode,
-  { data: aData, ...aRest }: Partial<ApolloQueryResult<TData>>,
-  { data: bData, ...bRest }: Partial<ApolloQueryResult<TData>>,
-  variables?: TVariables,
+  { data: aData, ...aRest }: Partial<ApolloQueryResult<unknown>>,
+  { data: bData, ...bRest }: Partial<ApolloQueryResult<unknown>>,
+  variables?: OperationVariables,
 ): boolean {
   return equal(aRest, bRest) && equalBySelectionSet(
     getMainDefinition(query).selectionSet,
@@ -52,11 +53,11 @@ interface CompareContext<TVariables> {
   variables: TVariables | undefined;
 }
 
-function equalBySelectionSet<TVariables extends Record<string, any>>(
+function equalBySelectionSet(
   selectionSet: SelectionSetNode,
   aResult: any,
   bResult: any,
-  context: CompareContext<TVariables>,
+  context: CompareContext<OperationVariables>,
 ): boolean {
   if (aResult === bResult) {
     return true;

--- a/src/react/hooks/__tests__/useFragment.test.tsx
+++ b/src/react/hooks/__tests__/useFragment.test.tsx
@@ -305,18 +305,51 @@ describe("useFragment", () => {
     });
   });
 
-  it("Parent list component can use @nonreactive to avoid rerendering", async () => {
-    const query: TypedDocumentNode<{
-      list: Item[];
-    }> = gql`
+  it.each<TypedDocumentNode<{ list: Item[] }>>([
+    // This query uses a basic field-level @nonreactive directive.
+    gql`
       query GetItems {
         list {
           id
           text @nonreactive
         }
       }
-    `;
-
+    `,
+    // This query uses @nonreactive on an anonymous/inline ...spread directive.
+    gql`
+      query GetItems {
+        list {
+          id
+          ... @nonreactive {
+            text
+          }
+        }
+      }
+    `,
+    // This query uses @nonreactive on a ...spread with a type condition.
+    gql`
+      query GetItems {
+        list {
+          id
+          ... on Item @nonreactive {
+            text
+          }
+        }
+      }
+    `,
+    // This query uses @nonreactive directive on a named fragment ...spread.
+    gql`
+      query GetItems {
+        list {
+          id
+          ...ItemText @nonreactive
+        }
+      }
+      fragment ItemText on Item {
+        text
+      }
+    `,
+  ])("Parent list component can use @nonreactive to avoid rerendering", async (query) => {
     const cache = new InMemoryCache({
       typePolicies: {
         Query: {

--- a/src/react/hooks/__tests__/useFragment.test.tsx
+++ b/src/react/hooks/__tests__/useFragment.test.tsx
@@ -16,6 +16,7 @@ import {
   ApolloLink,
 } from "../../../core";
 import { useQuery } from "../useQuery";
+import { concatPagination } from "../../../utilities";
 
 describe("useFragment", () => {
   it("is importable and callable", () => {
@@ -301,6 +302,347 @@ describe("useFragment", () => {
           "Item:4",
         ],
       },
+    });
+  });
+
+  it("Parent list component can use @nonreactive to avoid rerendering", async () => {
+    const query: TypedDocumentNode<{
+      list: Item[];
+    }> = gql`
+      query GetItems {
+        list {
+          id
+          text @nonreactive
+        }
+      }
+    `;
+
+    const cache = new InMemoryCache({
+      typePolicies: {
+        Query: {
+          fields: {
+            list: concatPagination(),
+          },
+        },
+        Item: {
+          keyFields: ["id"],
+          // Configuring keyArgs:false for Item.text is one way to prevent field
+          // keys like text@nonreactive, but it's not the only way. Since
+          // @nonreactive is now in the KNOWN_DIRECTIVES array defined in
+          // utilities/graphql/storeUtils.ts, the '@nonreactive' suffix won't be
+          // automatically appended to field keys by default.
+          // fields: {
+          //   text: {
+          //     keyArgs: false,
+          //   },
+          // },
+        },
+      },
+    });
+
+    const client = new ApolloClient({
+      cache,
+      link: ApolloLink.empty(),
+    });
+
+    const renders: string[] = [];
+
+    function List() {
+      const { data } = useQuery(query);
+
+      renders.push("list");
+
+      return (
+        <ul>
+          {data?.list.map(item => <Item key={item.id} item={item} />)}
+        </ul>
+      );
+    }
+
+    function Item({ item }: { item: Item }) {
+      const { data } = useFragment({
+        fragment: ItemFragment,
+        fragmentName: "ItemFragment",
+        from: item,
+      });
+
+      renders.push(`item ${item.id}`);
+
+      if (!data) return null;
+
+      return <li>{`Item #${item.id}: ${data.text}`}</li>;
+    }
+
+    act(() => {
+      cache.writeQuery({
+        query,
+        data: {
+          list: [
+            { __typename: "Item", id: 1, text: "first" },
+            { __typename: "Item", id: 2, text: "second" },
+            { __typename: "Item", id: 3, text: "third" },
+          ],
+        },
+      });
+    });
+
+    expect(cache.extract()).toEqual({
+      ROOT_QUERY: {
+        __typename: "Query",
+        list: [
+          { __ref: 'Item:{"id":1}' },
+          { __ref: 'Item:{"id":2}' },
+          { __ref: 'Item:{"id":3}' },
+        ],
+      },
+      'Item:{"id":1}': {
+        __typename: "Item",
+        id: 1,
+        text: "first",
+      },
+      'Item:{"id":2}': {
+        __typename: "Item",
+        id: 2,
+        text: "second",
+      },
+      'Item:{"id":3}': {
+        __typename: "Item",
+        id: 3,
+        text: "third",
+      },
+    });
+
+    render(
+      <ApolloProvider client={client}>
+        <List />
+      </ApolloProvider>,
+    );
+
+    function getItemTexts() {
+      return screen.getAllByText(/Item #\d+/).map(el => el.textContent);
+    }
+
+    await waitFor(() => {
+      expect(getItemTexts()).toEqual([
+        "Item #1: first",
+        "Item #2: second",
+        "Item #3: third",
+      ]);
+    });
+
+    expect(renders).toEqual([
+      "list",
+      "item 1",
+      "item 2",
+      "item 3",
+    ]);
+
+    function appendLyToText(id: number) {
+      act(() => {
+        cache.modify({
+          id: cache.identify({ __typename: "Item", id })!,
+          fields: {
+            text(existing) {
+              return existing + "ly";
+            },
+          },
+        });
+      });
+    }
+
+    appendLyToText(2);
+
+    await waitFor(() => {
+      expect(renders).toEqual([
+        "list",
+        "item 1",
+        "item 2",
+        "item 3",
+        "item 2",
+      ]);
+
+      expect(getItemTexts()).toEqual([
+        "Item #1: first",
+        "Item #2: secondly",
+        "Item #3: third",
+      ]);
+    });
+
+    appendLyToText(1);
+
+    await waitFor(() => {
+      expect(renders).toEqual([
+        "list",
+        "item 1",
+        "item 2",
+        "item 3",
+        "item 2",
+        "item 1",
+      ]);
+
+      expect(getItemTexts()).toEqual([
+        "Item #1: firstly",
+        "Item #2: secondly",
+        "Item #3: third",
+      ]);
+    });
+
+    appendLyToText(3);
+
+    await waitFor(() => {
+      expect(renders).toEqual([
+        "list",
+        "item 1",
+        "item 2",
+        "item 3",
+        "item 2",
+        "item 1",
+        "item 3",
+      ]);
+
+      expect(getItemTexts()).toEqual([
+        "Item #1: firstly",
+        "Item #2: secondly",
+        "Item #3: thirdly",
+      ]);
+    });
+
+    act(() => {
+      cache.writeQuery({
+        query,
+        data: {
+          list: [
+            { __typename: "Item", id: 4, text: "fourth" },
+            { __typename: "Item", id: 5, text: "fifth" },
+          ],
+        },
+      });
+    });
+
+    expect(cache.extract()).toEqual({
+      ROOT_QUERY: {
+        __typename: "Query",
+        list: [
+          { __ref: 'Item:{"id":1}' },
+          { __ref: 'Item:{"id":2}' },
+          { __ref: 'Item:{"id":3}' },
+          { __ref: 'Item:{"id":4}' },
+          { __ref: 'Item:{"id":5}' },
+        ],
+      },
+      'Item:{"id":1}': {
+        __typename: "Item",
+        id: 1,
+        text: "firstly",
+      },
+      'Item:{"id":2}': {
+        __typename: "Item",
+        id: 2,
+        text: "secondly",
+      },
+      'Item:{"id":3}': {
+        __typename: "Item",
+        id: 3,
+        text: "thirdly",
+      },
+      'Item:{"id":4}': {
+        __typename: "Item",
+        id: 4,
+        text: "fourth",
+      },
+      'Item:{"id":5}': {
+        __typename: "Item",
+        id: 5,
+        text: "fifth",
+      },
+    });
+
+    await waitFor(() => {
+      expect(renders).toEqual([
+        "list",
+        "item 1",
+        "item 2",
+        "item 3",
+        "item 2",
+        "item 1",
+        "item 3",
+        // The whole list had to be rendered again to append 4 and 5
+        "list",
+        "item 1",
+        "item 2",
+        "item 3",
+        "item 4",
+        "item 5",
+      ]);
+
+      expect(getItemTexts()).toEqual([
+        "Item #1: firstly",
+        "Item #2: secondly",
+        "Item #3: thirdly",
+        "Item #4: fourth",
+        "Item #5: fifth",
+      ]);
+    });
+
+    appendLyToText(5);
+
+    await waitFor(() => {
+      expect(renders).toEqual([
+        "list",
+        "item 1",
+        "item 2",
+        "item 3",
+        "item 2",
+        "item 1",
+        "item 3",
+        "list",
+        "item 1",
+        "item 2",
+        "item 3",
+        "item 4",
+        "item 5",
+        // A single new render:
+        "item 5",
+      ]);
+
+      expect(getItemTexts()).toEqual([
+        "Item #1: firstly",
+        "Item #2: secondly",
+        "Item #3: thirdly",
+        "Item #4: fourth",
+        "Item #5: fifthly",
+      ]);
+    });
+
+    appendLyToText(4);
+
+    await waitFor(() => {
+      expect(renders).toEqual([
+        "list",
+        "item 1",
+        "item 2",
+        "item 3",
+        "item 2",
+        "item 1",
+        "item 3",
+        "list",
+        "item 1",
+        "item 2",
+        "item 3",
+        "item 4",
+        "item 5",
+        "item 5",
+        // A single new render:
+        "item 4",
+      ]);
+
+      expect(getItemTexts()).toEqual([
+        "Item #1: firstly",
+        "Item #2: secondly",
+        "Item #3: thirdly",
+        "Item #4: fourthly",
+        "Item #5: fifthly",
+      ]);
     });
   });
 

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -1643,7 +1643,7 @@ describe('useQuery Hook', () => {
         expect(result.current.data).toEqual({ hello: "world 1" });
       });
       await waitFor(() => {
-        expect(requestSpy).toHaveBeenCalledTimes(1);
+        expect(requestSpy).toHaveBeenCalled();
       });
 
       const requestSpyCallCount = requestSpy.mock.calls.length;
@@ -5017,7 +5017,7 @@ describe('useQuery Hook', () => {
       expect(result.current.data).toEqual(carData);
       expect(result.current.error).toBeUndefined();
 
-      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(errorSpy).toHaveBeenCalled();
       expect(errorSpy).toHaveBeenLastCalledWith(
         `Missing field 'vin' while writing result ${JSON.stringify({
           id: 1,

--- a/src/utilities/graphql/storeUtils.ts
+++ b/src/utilities/graphql/storeUtils.ts
@@ -185,6 +185,7 @@ const KNOWN_DIRECTIVES: string[] = [
   'client',
   'rest',
   'export',
+  'nonreactive',
 ];
 
 export const getStoreKeyName = Object.assign(function (

--- a/src/utilities/graphql/transform.ts
+++ b/src/utilities/graphql/transform.ts
@@ -30,7 +30,7 @@ import {
   createFragmentMap,
   FragmentMap,
 } from './fragments';
-import { isArray } from '../common/arrays';
+import { isArray, isNonEmptyArray } from '../common/arrays';
 
 export type RemoveNodeConfig<N> = {
   name?: string;
@@ -83,22 +83,39 @@ function nullIfDocIsEmpty(doc: DocumentNode) {
 }
 
 function getDirectiveMatcher(
-  directives: (RemoveDirectiveConfig | GetDirectiveConfig)[],
+  configs: (RemoveDirectiveConfig | GetDirectiveConfig)[],
 ) {
-  const nameSet = new Set<string>();
-  const tests: Array<(directive: DirectiveNode) => boolean> = [];
-  directives.forEach(directive => {
-    if (directive.name) {
-      nameSet.add(directive.name);
-    } else if (directive.test) {
-      tests.push(directive.test);
+  const names = new Map<
+    string,
+    RemoveDirectiveConfig | GetDirectiveConfig
+  >();
+
+  const tests = new Map<
+    (directive: DirectiveNode) => boolean,
+    RemoveDirectiveConfig | GetDirectiveConfig
+  >();
+
+  configs.forEach(directive => {
+    if (directive) {
+      if (directive.name) {
+        names.set(directive.name, directive);
+      } else if (directive.test) {
+        tests.set(directive.test, directive);
+      }
     }
   });
 
-  return (directive: DirectiveNode) => (
-    nameSet.has(directive.name.value) ||
-    tests.some(test => test(directive))
-  );
+  return (directive: DirectiveNode) => {
+    let config = names.get(directive.name.value);
+    if (!config && tests.size) {
+      tests.forEach((testConfig, test) => {
+        if (test(directive)) {
+          config = testConfig;
+        }
+      });
+    }
+    return config;
+  };
 }
 
 // Helper interface and function used by removeDirectivesFromDocument to keep
@@ -173,13 +190,12 @@ export function removeDirectivesFromDocument(
   }
 
   const directiveMatcher = getDirectiveMatcher(directives);
-  const hasRemoveDirective = directives.some(directive => directive.remove);
   const shouldRemoveField = (
     nodeDirectives: FieldNode["directives"]
-  ) => (
-    hasRemoveDirective &&
-    nodeDirectives &&
-    nodeDirectives.some(directiveMatcher)
+  ): boolean => (
+    isNonEmptyArray(nodeDirectives) &&
+    nodeDirectives.map(directiveMatcher).some(
+      (config: RemoveDirectiveConfig | undefined) => config && config.remove)
   );
 
   const originalFragmentDefsByPath = new Map<string, FragmentDefinitionNode>();

--- a/src/utilities/graphql/transform.ts
+++ b/src/utilities/graphql/transform.ts
@@ -192,9 +192,7 @@ export function removeDirectivesFromDocument(
   }
 
   const directiveMatcher = getDirectiveMatcher(directives);
-  const shouldRemoveField = (
-    nodeDirectives: FieldNode["directives"]
-  ): boolean => (
+  const shouldRemoveField = (nodeDirectives: FieldNode["directives"]) => (
     isNonEmptyArray(nodeDirectives) &&
     nodeDirectives.map(directiveMatcher).some(
       (config: RemoveDirectiveConfig | undefined) => config && config.remove)

--- a/src/utilities/graphql/transform.ts
+++ b/src/utilities/graphql/transform.ts
@@ -155,6 +155,8 @@ export function removeDirectivesFromDocument(
   directives: RemoveDirectiveConfig[],
   doc: DocumentNode,
 ): DocumentNode | null {
+  checkDocument(doc);
+
   // Passing empty strings to makeInUseGetterFunction means we handle anonymous
   // operations as if their names were "". Anonymous fragment definitions are
   // not supposed to be possible, but the same default naming strategy seems


### PR DESCRIPTION
As foretold in https://github.com/apollographql/apollo-client/issues/8694#issuecomment-1416187035, and building on work started in #10237, this PR adds support for a new query directive called `@nonreactive`, which can be used to mark query fields or fragment spreads, indicating changes to the data contained within the subtrees marked `@nonreactive` should *not* trigger rerendering, allowing parent components to fetch child data without rerendering themselves every time something changes about one/some of the children (assuming the child data is marked `@nonreactive` in the parent query).

This selective insensitivity of parent components to certain child data was originally planned to be a feature of [`useBackgroundQuery`](https://github.com/apollographql/apollo-client/pull/8783), but that hook has turned into something else, and `@nonreactive` seems like a better solution for the original problem anyway.

Since `@nonreactive` is implemented at a point in the query pipeline where we were already performing a deep equality check (`isDifferentFromLastResult` in `ObservableQuery`), and since we "compare" `@nonreactive` subtrees by ignoring them completely (cheap!), the use of `@nonreactive` has the potential to allow much faster comparisons.

However, because this behavior is slightly different from the previous deep equality check (for example, the previous implementation was sensitive to extraneous fields in the result not mentioned by the query), the new behavior (using `compareResultsUsingQuery`) is only enabled when the query contains at least one `@nonreactive` directive. Since no one is using the `@nonreactive` directive yet, all existing result comparisons should continue to work exactly as before.

I recommend reviewing this PR commit by commit, and reading the commit messages, since they explain several bug fixes and refactorings to support the `@nonreactive` implementation.