### PR TITLE
chore: add Troubleshooting section to React Native docs

### DIFF
--- a/docs/source/integrations/react-native.md
+++ b/docs/source/integrations/react-native.md
@@ -43,3 +43,21 @@ For more information on setting up Apollo Client, see [Getting started](../get-s
 1. Install React Native Debugger and open it.
 2. Enable "Debug JS Remotely" in your app.
 3. If you don't see the Developer Tools panel or the Apollo tab is missing from it, toggle the Developer Tools by right-clicking anywhere and selecting **Toggle Developer Tools**.
+
+## Troubleshooting
+
+Here are a few common React Native problems and solutions.
+
+* `Uncaught Error: Cannot read property 'prototype' of undefined`, or similar Metro build error -- This is due to the way [the Metro bundler supports `.cjs` and `.mjs` files](https://github.com/facebook/metro/issues/535#issuecomment-1198071838): it requires additional configuration to _implicitly_ resolve files with these extensions, so `import { ApolloClient, InMemoryCache } from '@apollo/client` will result in an error. You can amend your import statement to e.g. `import { ApolloClient, InMemoryCache } from '@apollo/client/main.cjs';`, or you can install `@expo/metro-config` and configure their implicit resolution via `metro.config.js` in the root of your project:
+
+```js
+const { getDefaultConfig } = require('@expo/metro-config');
+
+const config = getDefaultConfig(__dirname);
+
+config.resolver.sourceExts.push(
+  'cjs'
+);
+
+module.exports = config;
+```


### PR DESCRIPTION
Inspired by https://github.com/apollographql/apollo-client/issues/10719.

Adds a Troubleshooting section to the React Native docs with an initial bullet point about the Metro bundler's default configuration with respect to `.cjs`/`.mjs` files extensions.