### PR TITLE
Fix risky cross bundle warnings for recent suspense changes

### DIFF
--- a/src/__tests__/__snapshots__/exports.ts.snap
+++ b/src/__tests__/__snapshots__/exports.ts.snap
@@ -35,6 +35,7 @@ Array [
   "getApolloContext",
   "gql",
   "isApolloError",
+  "isNetworkRequestSettled",
   "isReference",
   "makeReference",
   "makeVar",
@@ -113,6 +114,7 @@ Array [
   "fromPromise",
   "gql",
   "isApolloError",
+  "isNetworkRequestSettled",
   "isReference",
   "makeReference",
   "makeVar",
@@ -406,6 +408,7 @@ Array [
   "isNonNullObject",
   "isReadableStream",
   "isReference",
+  "isStatefulPromise",
   "isStreamableBlob",
   "iterateObserversSafely",
   "makeReference",
@@ -428,6 +431,7 @@ Array [
   "storeKeyNameFromField",
   "stringifyForDisplay",
   "valueToObjectRepresentation",
+  "wrapPromiseWithState",
 ]
 `;
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -24,7 +24,7 @@ export {
   FetchMoreQueryOptions,
   SubscribeToMoreOptions,
 } from './watchQueryOptions';
-export { NetworkStatus } from './networkStatus';
+export { NetworkStatus, isNetworkRequestSettled } from './networkStatus';
 export * from './types';
 export {
   Resolver,

--- a/src/react/cache/QuerySubscription.ts
+++ b/src/react/cache/QuerySubscription.ts
@@ -6,7 +6,7 @@ import {
   ObservableQuery,
   OperationVariables,
 } from '../../core';
-import { isNetworkRequestSettled } from '../../core/networkStatus';
+import { isNetworkRequestSettled } from '../../core';
 import {
   Concast,
   ObservableSubscription,

--- a/src/react/hooks/internal/__use.ts
+++ b/src/react/hooks/internal/__use.ts
@@ -1,4 +1,4 @@
-import { wrapPromiseWithState } from '../../../utilities/promises/decoration';
+import { wrapPromiseWithState } from '../../../utilities';
 
 // TODO: Replace the use of this with React's use once its available. For now,
 // this mimics its functionality for promises by adding

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -9,7 +9,7 @@ export {
 } from './context';
 
 export * from './hooks';
-export * from './cache';
+export { SuspenseCache } from './cache';
 
 export {
   DocumentType,

--- a/src/testing/react/MockedProvider.tsx
+++ b/src/testing/react/MockedProvider.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { ApolloClient, DefaultOptions } from '../../core';
 import { InMemoryCache as Cache } from '../../cache';
 import { ApolloProvider } from '../../react/context';
-import { SuspenseCache } from '../../react/cache';
+import { SuspenseCache } from '../../react';
 import { MockLink, MockedResponse } from '../core';
 import { ApolloLink } from '../../link/core';
 import { Resolvers } from '../../core';

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -81,6 +81,11 @@ export {
   ObservableSubscription
 } from './observables/Observable';
 
+export { 
+  isStatefulPromise,
+  wrapPromiseWithState,
+} from './promises/decoration';
+
 export * from './common/mergeDeep';
 export * from './common/cloneDeep';
 export * from './common/maybeDeepFreeze';


### PR DESCRIPTION
With some recent PRs for Suspense, some "risky cross-entry-point" warnings were raised in the build. This PR fixes the newly introduced warnings. NOTE: This does not include the existing risky warnings on `main` since I don't know if those are intentional or not.

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
