### PR TITLE
fix: type errors after merge conflict

### DIFF
--- a/config/bundlesize.ts
+++ b/config/bundlesize.ts
@@ -3,7 +3,7 @@ import { join } from "path";
 import { gzipSync } from "zlib";
 import bytes from "bytes";
 
-const gzipBundleByteLengthLimit = bytes("34.52KB");
+const gzipBundleByteLengthLimit = bytes("34.82KB");
 const minFile = join("dist", "apollo-client.min.cjs");
 const minPath = join(__dirname, "..", minFile);
 const gzipByteLen = gzipSync(readFileSync(minPath)).byteLength;

--- a/src/__tests__/__snapshots__/exports.ts.snap
+++ b/src/__tests__/__snapshots__/exports.ts.snap
@@ -395,6 +395,7 @@ Array [
   "hasAnyDirectives",
   "hasClientExports",
   "hasDirectives",
+  "isApolloPayloadResult",
   "isArray",
   "isAsyncIterableIterator",
   "isBlob",

--- a/src/link/http/createHttpLink.ts
+++ b/src/link/http/createHttpLink.ts
@@ -1,4 +1,3 @@
-import '../../utilities/globals';
 import { __DEV__, invariant } from '../../utilities/globals';
 
 import { visit, DefinitionNode, VariableDefinitionNode } from 'graphql';

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -29,10 +29,10 @@ export function useLazyQuery<TData = any, TVariables extends OperationVariables 
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
   options?: LazyQueryHookOptions<NoInfer<TData>, NoInfer<TVariables>>
 ): LazyQueryResultTuple<TData, TVariables> {
-  const execOptionsRef = useRef<Partial<LazyQueryHookOptions<TData, TVariables>>>();
+  const execOptionsRef = useRef<Partial<LazyQueryHookExecOptions<TData, TVariables>>>();
   const optionsRef = useRef<LazyQueryHookOptions<TData, TVariables>>();
   const queryRef = useRef<DocumentNode | TypedDocumentNode<TData, TVariables>>();
-  const merged = execOptionsRef.current ? mergeOptions(options, execOptionsRef.current) : options;
+  const merged = mergeOptions(options, execOptionsRef?.current || {});
   const document = merged?.query ?? query;
 
   // Use refs to track options and the used query to ensure the `execute` 
@@ -95,7 +95,7 @@ export function useLazyQuery<TData = any, TVariables extends OperationVariables 
     })
 
     const promise = internalState
-      .executeQuery({ ...options, skip: false }) 
+      .executeQuery({ ...options, skip: false })
       .then((queryResult) => Object.assign(queryResult, eagerMethods));
 
     // Because the return value of `useLazyQuery` is usually floated, we need

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -102,7 +102,9 @@ class InternalState<TData, TVariables extends OperationVariables> {
     invariant.warn("Calling default no-op implementation of InternalState#forceUpdate");
   }
 
-  executeQuery(options: QueryHookOptions<TData, TVariables>) {
+  executeQuery(options: QueryHookOptions<TData, TVariables> & {
+    query?: DocumentNode;
+  }) {
     if (options.query) {
       Object.assign(this, { query: options.query })
     }
@@ -226,7 +228,7 @@ class InternalState<TData, TVariables extends OperationVariables> {
 
         // Do the "unsubscribe" with a short delay.
         // This way, an existing subscription can be reused without an additional
-        // request if "unsubscribe"  and "resubscribe" to the same ObservableQuery 
+        // request if "unsubscribe"  and "resubscribe" to the same ObservableQuery
         // happen in very fast succession.
         return () => setTimeout(() => subscription.unsubscribe());
       }, [

--- a/src/utilities/common/mergeOptions.ts
+++ b/src/utilities/common/mergeOptions.ts
@@ -13,11 +13,12 @@ type OptionsUnion<TData, TVariables extends OperationVariables, TContext> =
   | MutationOptions<TData, TVariables, TContext>;
 
 export function mergeOptions<
-  TOptions extends Partial<OptionsUnion<any, any, any>>
+  TDefaultOptions extends Partial<OptionsUnion<any, any, any>>,
+  TOptions extends TDefaultOptions
 >(
-  defaults: TOptions | Partial<TOptions> | undefined,
+  defaults: TDefaultOptions | Partial<TDefaultOptions> | undefined,
   options: TOptions | Partial<TOptions>,
-): TOptions {
+): TOptions & TDefaultOptions {
   return compact(defaults, options, options.variables && {
     variables: compact({
       ...(defaults && defaults.variables),


### PR DESCRIPTION
Resolves a few issues causing 5 type errors post-merge on `release-3.8`.

### Checklist:

- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
