### PR TITLE
change `UseFragmentResult` to union type

### DIFF
--- a/.changeset/grumpy-tips-know.md
+++ b/.changeset/grumpy-tips-know.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+change `UseFragmentResult` to union type

--- a/.changeset/grumpy-tips-know.md
+++ b/.changeset/grumpy-tips-know.md
@@ -2,4 +2,4 @@
 "@apollo/client": patch
 ---
 
-change `UseFragmentResult` to union type
+More robust types for the `data` property on `UseFragmentResult`. When a partial result is given, the type is now correctly set to `Partial<TData>`.

--- a/src/react/hooks/useFragment.ts
+++ b/src/react/hooks/useFragment.ts
@@ -1,7 +1,7 @@
 import { useRef } from "react";
 import { equal } from "@wry/equality";
 
-import { mergeDeepArray } from "../../utilities";
+import { DeepPartial, mergeDeepArray } from "../../utilities";
 import {
   Cache,
   Reference,
@@ -61,7 +61,7 @@ export type UseFragmentResult<TData> =
       missing?: never;
     }
   | {
-      data: Partial<TData>;
+      data: DeepPartial<TData>;
       complete: false;
       missing?: MissingTree;
     };
@@ -122,10 +122,10 @@ export function useFragment_experimental<
 function diffToResult<TData>(
   diff: Cache.DiffResult<TData>,
 ): UseFragmentResult<TData> {
-  const result: UseFragmentResult<TData> = {
+  const result = {
     data: diff.result!,
     complete: !!diff.complete,
-  };
+  } as UseFragmentResult<TData>;
 
   if (diff.missing) {
     result.missing = mergeDeepArray(

--- a/src/react/hooks/useFragment.ts
+++ b/src/react/hooks/useFragment.ts
@@ -54,11 +54,17 @@ extends Omit<
 //   canonizeResults?: boolean;
 // }
 
-export interface UseFragmentResult<TData> {
-  data: TData | undefined;
-  complete: boolean;
-  missing?: MissingTree;
-}
+export type UseFragmentResult<TData> =
+  | {
+      data: TData;
+      complete: true;
+      missing?: MissingTree;
+    }
+  | {
+      data: Partial<TData>;
+      complete: false;
+      missing?: MissingTree;
+    };
 
 export function useFragment_experimental<
   TData = any,
@@ -117,7 +123,7 @@ function diffToResult<TData>(
   diff: Cache.DiffResult<TData>,
 ): UseFragmentResult<TData> {
   const result: UseFragmentResult<TData> = {
-    data: diff.result,
+    data: diff.result!,
     complete: !!diff.complete,
   };
 

--- a/src/react/hooks/useFragment.ts
+++ b/src/react/hooks/useFragment.ts
@@ -58,7 +58,7 @@ export type UseFragmentResult<TData> =
   | {
       data: TData;
       complete: true;
-      missing?: MissingTree;
+      missing?: never;
     }
   | {
       data: Partial<TData>;


### PR DESCRIPTION
This should be merged after #10764 and is the second half of suggestions from #10760 and would address #10650.

It also adds a test to make sure the types actually reflect the real behaviour.


<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
