### PR TITLE
docs: adds `createFragmentRegistry` docs

### DIFF
--- a/docs/source/data/fragments.md
+++ b/docs/source/data/fragments.md
@@ -96,7 +96,7 @@ export const GET_POST_DETAILS = gql`
 
 ## Registering named fragments using `createFragmentRegistry`
 
-Starting in Apollo Client 3.7, fragments can be registered with your `InMemoryCache` so that they can be referred to by name elsewhere without needing to interpolate their declarations.
+Starting in Apollo Client 3.7, fragments can be registered with your `InMemoryCache` so that they can be referred to by name in any query or `InMemoryCache` operation (such as `cache.readFragment`, `cache.readQuery` and `cache.watch`) without needing to interpolate their declarations.
 
 Let's look at an example in React.
 
@@ -117,7 +117,7 @@ const client = new ApolloClient({
 });
 ```
 
-Since `ItemFragment` was registered with `InMemoryCache`, it can be referenced by name in any query, as can be seen below with the fragment spread inside of `GetItemList`.
+Since `ItemFragment` was registered with `InMemoryCache`, it can be referenced by name as seen below with the fragment spread inside of the `GetItemList` query.
 
 ```jsx title="ItemList.jsx" {4,13}
 const listQuery = gql`
@@ -143,7 +143,7 @@ function ToDoList() {
 
 Queries can declare their own local versions of named fragments which will take precendence over ones registered via `createFragmentRegistry`, even if the local fragment is only indirectly referenced by other registered fragments. Take the following example:
 
-```js title="index.js" {7-16}
+```js title="index.js" {7-17}
 import { ApolloClient, gql, InMemoryCache } from "@apollo/client";
 import { createFragmentRegistry } from "@apollo/client/cache";
 

--- a/docs/source/data/fragments.md
+++ b/docs/source/data/fragments.md
@@ -141,7 +141,7 @@ function ToDoList() {
 
 ### Overriding registered fragments with local versions
 
-Queries can still declare their own local versions of named fragments, which will take precendence over the pre-registered ones, even if the local fragment is only indirectly referenced by other fragments. Take the following example:
+Queries can declare their own local versions of named fragments which will take precendence over ones registered via `createFragmentRegistry`, even if the local fragment is only indirectly referenced by other registered fragments. Take the following example:
 
 ```js title="index.js" {7-16}
 import { ApolloClient, gql, InMemoryCache } from "@apollo/client";
@@ -165,7 +165,9 @@ const client = new ApolloClient({
 });
 ```
 
-```jsx title="ItemList.jsx" {8-15,22}
+The local version of the `ExtraFields` fragment declared in `ItemList.jsx` takes precedence over the `ExtraFields` originally registered with the `InMemoryCache`. Thus, its definition will be used when the `ExtraFields` fragment spread is parsed inside of the registered `ItemFragment` _only when `GetItemList` query is executed_, because explicit definitions take precedence over registered fragments.
+
+```jsx title="ItemList.jsx" {8-10,17}
 const listQuery = gql`
   query GetItemList {
     list {
@@ -173,10 +175,6 @@ const listQuery = gql`
     }
   }
 
-  # This version of the ExtraFields fragment, referenced via fragment spread
-  # on the registered ItemFragment, will be used instead of the one
-  # registered in the FragmentRegistry, because explicit definitions take
-  # precedence over registered fragments.
   fragment ExtraFields on Item {
     createdBy
   }

--- a/docs/source/data/fragments.md
+++ b/docs/source/data/fragments.md
@@ -100,7 +100,7 @@ Starting in Apollo Client 3.7, fragments can be registered with your `InMemoryCa
 
 Let's look at an example in React.
 
-```js title="index.js"
+```js title="index.js" {7-12}
 import { ApolloClient, gql, InMemoryCache } from "@apollo/client";
 import { createFragmentRegistry } from "@apollo/client/cache";
 
@@ -119,7 +119,7 @@ const client = new ApolloClient({
 
 Since `ItemFragment` was registered with `InMemoryCache`, it can be referenced by name in any query, as can be seen below with the fragment spread inside of `GetItemList`.
 
-```jsx title="ItemList.jsx"
+```jsx title="ItemList.jsx" {4,13}
 const listQuery = gql`
   query GetItemList {
     list {
@@ -131,7 +131,9 @@ function ToDoList() {
   const { data } = useQuery(listQuery);
   return (
     <ol>
-      {data?.list.map(item => <Item key={item.id} text={item.text} />)}
+      {data?.list.map(item => (
+        <Item key={item.id} text={item.text} />
+      ))}
     </ol>
   );
 }


### PR DESCRIPTION
Closes https://github.com/apollographql/apollo-client/issues/10185.

Link to section in deploy preview: https://deploy-preview-10780--apollo-client-docs.netlify.app/data/fragments/#registering-named-fragments-using-createfragmentregistry

![CleanShot 2023-04-17 at 15 15 41](https://user-images.githubusercontent.com/5139846/232588458-0b9529e1-838f-41a5-95f7-1d2e3dcc1174.png)
![CleanShot 2023-04-17 at 15 16 07](https://user-images.githubusercontent.com/5139846/232588502-35508b3c-3cf3-4dfb-a9a0-eee79b00ed14.png)


### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
