### PR TITLE
Support `startTransition` with `refetch` and `fetchMore` + deprecate `suspensePolicy`

### DIFF
--- a/src/react/cache/QuerySubscription.ts
+++ b/src/react/cache/QuerySubscription.ts
@@ -52,7 +52,6 @@ interface QuerySubscriptionOptions {
 interface PromiseChannel<TData> {
   main: Promise<ApolloQueryResult<TData>>;
   refetch?: Promise<ApolloQueryResult<TData>>;
-  fetchMore?: Promise<ApolloQueryResult<TData>>;
 }
 
 export class QuerySubscription<TData = any> {
@@ -126,7 +125,7 @@ export class QuerySubscription<TData = any> {
     );
   }
 
-  getPromise(channel: 'main' | 'refetch' | 'fetchMore') {
+  getPromise(channel: 'main' | 'refetch') {
     return this.channels[channel] || this.channels.main;
   }
 
@@ -154,7 +153,7 @@ export class QuerySubscription<TData = any> {
   fetchMore(options: FetchMoreOptions<TData>) {
     const promise = this.observable.fetchMore<TData>(options);
 
-    this.channels.fetchMore = promise;
+    this.channels.refetch = promise;
 
     return this.promise;
   }

--- a/src/react/cache/QuerySubscription.ts
+++ b/src/react/cache/QuerySubscription.ts
@@ -57,6 +57,8 @@ export class QuerySubscription<TData = any> {
   private listeners = new Set<Listener<TData>>();
   private autoDisposeTimeoutId: NodeJS.Timeout;
 
+  private promisesByKey = new Map<number, Promise<ApolloQueryResult<TData>>>();
+
   constructor(
     observable: ObservableQuery<TData>,
     options: QuerySubscriptionOptions = Object.create(null)
@@ -103,6 +105,10 @@ export class QuerySubscription<TData = any> {
     );
   }
 
+  getPromise(key: number) {
+    return this.promisesByKey.get(key) || this.promise;
+  }
+
   listen(listener: Listener<TData>) {
     // As soon as the component listens for updates, we know it has finished
     // suspending and is ready to receive updates, so we can remove the auto
@@ -116,10 +122,12 @@ export class QuerySubscription<TData = any> {
     };
   }
 
-  refetch(variables: OperationVariables | undefined) {
-    this.promise = this.observable.refetch(variables);
+  refetch(variables: OperationVariables | undefined, key: number) {
+    const promise = this.observable.refetch(variables);
 
-    return this.promise;
+    this.promisesByKey.set(key, promise);
+
+    return promise;
   }
 
   fetchMore(options: FetchMoreOptions<TData>) {

--- a/src/react/cache/QuerySubscription.ts
+++ b/src/react/cache/QuerySubscription.ts
@@ -22,6 +22,8 @@ type FetchMoreOptions<TData> = Parameters<
   ObservableQuery<TData>['fetchMore']
 >[0];
 
+export type Version = 'main' | 'network';
+
 function wrapWithCustomPromise<TData>(
   concast: Concast<ApolloQueryResult<TData>>
 ) {
@@ -115,8 +117,8 @@ export class QuerySubscription<TData = any> {
     );
   }
 
-  getPromise(channel: 'main' | 'refetch') {
-    if (channel === 'refetch') {
+  getPromise(version: Version) {
+    if (version === 'network') {
       return this.refetchPromise || this.promise;
     }
 

--- a/src/react/cache/QuerySubscription.ts
+++ b/src/react/cache/QuerySubscription.ts
@@ -49,7 +49,7 @@ interface QuerySubscriptionOptions {
   autoDisposeTimeoutMs?: number;
 }
 
-export class QuerySubscription<TData = any> {
+export class QuerySubscription<TData = unknown> {
   public result: ApolloQueryResult<TData>;
   public promise: Promise<ApolloQueryResult<TData>>;
   public refetchPromise: Promise<ApolloQueryResult<TData>> | null = null;

--- a/src/react/cache/QuerySubscription.ts
+++ b/src/react/cache/QuerySubscription.ts
@@ -22,8 +22,6 @@ type FetchMoreOptions<TData> = Parameters<
   ObservableQuery<TData>['fetchMore']
 >[0];
 
-export type Version = 'main' | 'network';
-
 function wrapWithCustomPromise<TData>(
   concast: Concast<ApolloQueryResult<TData>>
 ) {
@@ -53,13 +51,13 @@ interface QuerySubscriptionOptions {
 
 export class QuerySubscription<TData = any> {
   public result: ApolloQueryResult<TData>;
+  public promise: Promise<ApolloQueryResult<TData>>;
+  public refetchPromise: Promise<ApolloQueryResult<TData>> | null = null;
   public readonly observable: ObservableQuery<TData>;
 
   private subscription: ObservableSubscription;
   private listeners = new Set<Listener>();
   private autoDisposeTimeoutId: NodeJS.Timeout;
-  private promise: Promise<ApolloQueryResult<TData>>;
-  private refetchPromise: Promise<ApolloQueryResult<TData>> | null = null;
 
   constructor(
     observable: ObservableQuery<TData>,
@@ -115,14 +113,6 @@ export class QuerySubscription<TData = any> {
       this.dispose,
       options.autoDisposeTimeoutMs ?? 30_000
     );
-  }
-
-  getPromise(version: Version) {
-    if (version === 'network') {
-      return this.refetchPromise || this.promise;
-    }
-
-    return this.promise;
   }
 
   listen(listener: Listener) {

--- a/src/react/cache/QuerySubscription.ts
+++ b/src/react/cache/QuerySubscription.ts
@@ -176,8 +176,8 @@ export class QuerySubscription<TData = any> {
     }
 
     // If we encounter an error with the new result after we have successfully
-    // fetched a previous result, we should set the new result data to the last
-    // successful result.
+    // fetched a previous result, set the new result data to the last successful
+    // result.
     if (this.result.data && result.data === void 0) {
       result.data = this.result.data;
     }

--- a/src/react/cache/QuerySubscription.ts
+++ b/src/react/cache/QuerySubscription.ts
@@ -56,7 +56,6 @@ interface PromiseChannel<TData> {
 
 export class QuerySubscription<TData = any> {
   public result: ApolloQueryResult<TData>;
-  public promise: Promise<ApolloQueryResult<TData>>;
   public readonly observable: ObservableQuery<TData>;
 
   private subscription: ObservableSubscription;

--- a/src/react/cache/QuerySubscription.ts
+++ b/src/react/cache/QuerySubscription.ts
@@ -155,7 +155,7 @@ export class QuerySubscription<TData = any> {
 
     this.channels.refetch = promise;
 
-    return this.promise;
+    return promise;
   }
 
   dispose() {

--- a/src/react/cache/QuerySubscription.ts
+++ b/src/react/cache/QuerySubscription.ts
@@ -9,6 +9,7 @@ import { isNetworkRequestSettled } from '../../core';
 import {
   ObservableSubscription,
   createFulfilledPromise,
+  createRejectedPromise,
 } from '../../utilities';
 
 type Listener = () => void;
@@ -165,6 +166,9 @@ export class QuerySubscription<TData = unknown> {
     }
 
     this.result = result;
+    this.promises.main = result.data
+      ? createFulfilledPromise(result)
+      : createRejectedPromise(result);
     this.deliver();
   }
 

--- a/src/react/cache/QuerySubscription.ts
+++ b/src/react/cache/QuerySubscription.ts
@@ -91,12 +91,10 @@ export class QuerySubscription<TData = any> {
       };
     }
 
-    this.subscription = observable
-      .filter((result) => isNetworkRequestSettled(result.networkStatus))
-      .subscribe({
-        next: this.handleNext,
-        error: this.handleError,
-      });
+    this.subscription = observable.subscribe({
+      next: this.handleNext,
+      error: this.handleError,
+    });
 
     // This error should never happen since the `.subscribe` call above
     // will ensure a concast is set on the observable via the `reobserve`

--- a/src/react/cache/QuerySubscription.ts
+++ b/src/react/cache/QuerySubscription.ts
@@ -13,7 +13,6 @@ import {
   hasAnyDirectives,
   createFulfilledPromise,
 } from '../../utilities';
-import { equal } from '@wry/equality';
 import { invariant } from '../../utilities/globals';
 import { wrap } from 'optimism';
 
@@ -172,9 +171,10 @@ export class QuerySubscription<TData = any> {
   }
 
   private handleNext(result: ApolloQueryResult<TData>) {
-    if (equal(this.result, result)) {
+    if (result.data === this.result.data) {
       return;
     }
+
     // If we encounter an error with the new result after we have successfully
     // fetched a previous result, we should set the new result data to the last
     // successful result.

--- a/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
@@ -7008,4 +7008,125 @@ describe('useSuspenseQuery', () => {
       expect(todo).toHaveTextContent('Take out trash (completed)');
     });
   });
+
+  it('`refetch` works with startTransition to allow React to show stale UI until finished suspending', async () => {
+    type Variables = {
+      id: string;
+    };
+
+    interface Data {
+      todo: {
+        id: string;
+        name: string;
+        completed: boolean;
+      };
+    }
+    const user = userEvent.setup();
+
+    const query: TypedDocumentNode<Data, Variables> = gql`
+      query TodoItemQuery($id: ID!) {
+        todo(id: $id) {
+          id
+          name
+          completed
+        }
+      }
+    `;
+
+    const mocks: MockedResponse<Data, Variables>[] = [
+      {
+        request: { query, variables: { id: '1' } },
+        result: {
+          data: { todo: { id: '1', name: 'Clean room', completed: false } },
+        },
+        delay: 10,
+      },
+      {
+        request: { query, variables: { id: '1' } },
+        result: {
+          data: { todo: { id: '1', name: 'Clean room', completed: true } },
+        },
+        delay: 10,
+      },
+    ];
+
+    const client = new ApolloClient({
+      link: new MockLink(mocks),
+      cache: new InMemoryCache(),
+    });
+
+    const suspenseCache = new SuspenseCache();
+
+    function App() {
+      return (
+        <ApolloProvider client={client} suspenseCache={suspenseCache}>
+          <Suspense fallback={<SuspenseFallback />}>
+            <Todo id="1" />
+          </Suspense>
+        </ApolloProvider>
+      );
+    }
+
+    function SuspenseFallback() {
+      return <p>Loading</p>;
+    }
+
+    function Todo({ id }: { id: string }) {
+      const { data, refetch } = useSuspenseQuery(query, { variables: { id } });
+      const [isPending, startTransition] = React.useTransition();
+      const { todo } = data;
+
+      return (
+        <>
+          <button
+            onClick={() => {
+              startTransition(() => {
+                refetch();
+              });
+            }}
+          >
+            Refresh
+          </button>
+          <div data-testid="todo" aria-busy={isPending}>
+            {todo.name}
+            {todo.completed && ' (completed)'}
+          </div>
+        </>
+      );
+    }
+
+    render(<App />);
+
+    expect(screen.getByText('Loading')).toBeInTheDocument();
+
+    expect(await screen.findByTestId('todo')).toBeInTheDocument();
+
+    const todo = screen.getByTestId('todo');
+    const button = screen.getByText('Refresh');
+
+    expect(todo).toHaveTextContent('Clean room');
+
+    await act(() => user.click(button));
+
+    // startTransition will avoid rendering the suspense fallback for already
+    // revealed content if the state update inside the transition causes the
+    // component to suspend.
+    //
+    // Here we should not see the suspense fallback while the component suspends
+    // until the todo is finished loading. Seeing the suspense fallback is an
+    // indication that we are suspending the component too late in the process.
+    expect(screen.queryByText('Loading')).not.toBeInTheDocument();
+
+    // We can ensure this works with isPending from useTransition in the process
+    expect(todo).toHaveAttribute('aria-busy', 'true');
+
+    // Ensure we are showing the stale UI until the new todo has loaded
+    expect(todo).toHaveTextContent('Clean room');
+
+    // Eventually we should see the updated todo content once its done
+    // suspending.
+    await waitFor(() => {
+      expect(todo).toHaveTextContent('Clean room (completed)');
+    });
+  });
 });

--- a/src/react/hooks/useSuspenseQuery.ts
+++ b/src/react/hooks/useSuspenseQuery.ts
@@ -167,21 +167,25 @@ function useSubscription<TData, TVariables extends OperationVariables>(
   const setVersion = (version: Version) => setState({ version });
 
   useEffect(() => {
-    return subscription.listen(() => setVersion('main'));
+    return subscription.listen(() => {
+      setVersion('main');
+    });
   }, [subscription]);
 
   const fetchMore: FetchMoreFunction<TData, TVariables> = useCallback(
     (options) => {
+      const promise = subscription.fetchMore(options);
       setVersion('network');
-      return subscription.fetchMore(options);
+      return promise;
     },
     [subscription]
   );
 
   const refetch: RefetchFunction<TData, TVariables> = useCallback(
     (variables) => {
+      const promise = subscription.refetch(variables);
       setVersion('network');
-      return subscription.refetch(variables);
+      return promise;
     },
     [subscription]
   );
@@ -193,10 +197,7 @@ function useSubscription<TData, TVariables extends OperationVariables>(
     );
 
   return {
-    promise:
-      version === 'network'
-        ? subscription.refetchPromise || subscription.promise
-        : subscription.promise,
+    promise: subscription.promises[version] || subscription.promises.main,
     refetch,
     fetchMore,
     subscribeToMore,

--- a/src/react/hooks/useSuspenseQuery.ts
+++ b/src/react/hooks/useSuspenseQuery.ts
@@ -80,9 +80,7 @@ export function useSuspenseQuery_experimental<
     client.watchQuery(watchQueryOptions)
   );
 
-  const [[channel], setChannel] = useState<['main' | 'refetch' | 'fetchMore']>([
-    'main',
-  ]);
+  const [[channel], setChannel] = useState<['main' | 'refetch']>(['main']);
 
   const dispose = useTrackedSubscriptions(subscription);
 
@@ -98,7 +96,7 @@ export function useSuspenseQuery_experimental<
 
   const fetchMore: FetchMoreFunction<TData, TVariables> = useCallback(
     (options) => {
-      setChannel(['fetchMore']);
+      setChannel(['refetch']);
       return subscription.fetchMore(options);
     },
     [subscription]

--- a/src/react/hooks/useSuspenseQuery.ts
+++ b/src/react/hooks/useSuspenseQuery.ts
@@ -80,9 +80,9 @@ export function useSuspenseQuery_experimental<
     client.watchQuery(watchQueryOptions)
   );
 
-  const [[channel], setChannel] = useState<
-    ['main' | 'refetch' | 'fetchMore', number]
-  >(['main', 0]);
+  const [[channel], setChannel] = useState<['main' | 'refetch' | 'fetchMore']>([
+    'main',
+  ]);
 
   const dispose = useTrackedSubscriptions(subscription);
 
@@ -92,13 +92,13 @@ export function useSuspenseQuery_experimental<
 
   useEffect(() => {
     return subscription.listen(() => {
-      setChannel(([, version]) => ['main', version + 1]);
+      setChannel(['main']);
     });
   }, [subscription]);
 
   const fetchMore: FetchMoreFunction<TData, TVariables> = useCallback(
     (options) => {
-      setChannel(([, version]) => ['fetchMore', version]);
+      setChannel(['fetchMore']);
       return subscription.fetchMore(options);
     },
     [subscription]
@@ -106,7 +106,7 @@ export function useSuspenseQuery_experimental<
 
   const refetch: RefetchFunction<TData, TVariables> = useCallback(
     (variables) => {
-      setChannel(([, version]) => ['refetch', version + 1]);
+      setChannel(['refetch']);
       return subscription.refetch(variables);
     },
     [subscription]

--- a/src/react/hooks/useSuspenseQuery.ts
+++ b/src/react/hooks/useSuspenseQuery.ts
@@ -63,15 +63,16 @@ type Channel = 'main' | 'refetch';
 
 interface ReducerState {
   channel: Channel;
-  version: number;
 }
 
-const initialState: ReducerState = { channel: 'main', version: 0 };
+const initialState: ReducerState = { channel: 'main' };
 
-function reducer(state: ReducerState, channel: Channel) {
-  // `version` is not actually used by the hook, but allows us to force
-  // re-render the component when publishing to the same channel.
-  return { channel, version: state.version + 1 };
+function reducer(_: ReducerState, channel: Channel) {
+  // Return a new object each time the reducer is run to force re-render the
+  // component when publishing to the same channel. If returning the string
+  // directly, React may skip re-rendering the component since the state values
+  // are the same.
+  return { channel };
 }
 
 export function useSuspenseQuery_experimental<

--- a/src/react/hooks/useSuspenseQuery.ts
+++ b/src/react/hooks/useSuspenseQuery.ts
@@ -201,7 +201,7 @@ function useWatchQueryOptions<TData, TVariables extends OperationVariables>({
     () => ({
       ...options,
       query,
-      notifyOnNetworkStatusChange: true,
+      notifyOnNetworkStatusChange: false,
       nextFetchPolicy: void 0,
     }),
     [options, query]

--- a/src/react/hooks/useSuspenseQuery.ts
+++ b/src/react/hooks/useSuspenseQuery.ts
@@ -84,7 +84,7 @@ export function useSuspenseQuery_experimental<
 
   useTrackedSubscriptions(subscription);
 
-  const { promise, refetch, fetchMore, subscribeToMore } = useSubscribedPromise<
+  const { promise, refetch, fetchMore, subscribeToMore } = useSubscription<
     TData,
     TVariables
   >(subscription);
@@ -155,7 +155,7 @@ function useTrackedSubscriptions(subscription: QuerySubscription) {
   });
 }
 
-function useSubscribedPromise<TData, TVariables extends OperationVariables>(
+function useSubscription<TData, TVariables extends OperationVariables>(
   subscription: QuerySubscription<TData>
 ) {
   // Use an object as state to force React to re-render when we publish an

--- a/src/react/hooks/useSuspenseQuery.ts
+++ b/src/react/hooks/useSuspenseQuery.ts
@@ -87,9 +87,7 @@ export function useSuspenseQuery_experimental<
     TVariables
   >(subscription);
 
-  const dispose = useTrackedSubscriptions(subscription);
-
-  useStrictModeSafeCleanupEffect(dispose);
+  useTrackedSubscriptions(subscription);
 
   const result = __use(promise);
 
@@ -158,9 +156,9 @@ function useTrackedSubscriptions(subscription: QuerySubscription) {
 
   trackedSubscriptions.current.add(subscription);
 
-  return function dispose() {
+  useStrictModeSafeCleanupEffect(() => {
     trackedSubscriptions.current.forEach((sub) => sub.dispose());
-  };
+  });
 }
 
 function useSubscribedPromise<TData, TVariables extends OperationVariables>(

--- a/src/react/hooks/useSuspenseQuery.ts
+++ b/src/react/hooks/useSuspenseQuery.ts
@@ -164,10 +164,7 @@ function useSubscription<TData, TVariables extends OperationVariables>(
     version: 'main',
   });
 
-  const setVersion = useCallback(
-    (version: Version) => setState({ version }),
-    []
-  );
+  const setVersion = (version: Version) => setState({ version });
 
   useEffect(() => {
     return subscription.listen(() => setVersion('main'));
@@ -195,12 +192,15 @@ function useSubscription<TData, TVariables extends OperationVariables>(
       [subscription]
     );
 
-  const promise =
-    version === 'network'
-      ? subscription.refetchPromise || subscription.promise
-      : subscription.promise;
-
-  return { promise, refetch, fetchMore, subscribeToMore };
+  return {
+    promise:
+      version === 'network'
+        ? subscription.refetchPromise || subscription.promise
+        : subscription.promise,
+    refetch,
+    fetchMore,
+    subscribeToMore,
+  };
 }
 
 interface UseWatchQueryOptionsHookOptions<

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -100,15 +100,6 @@ export interface LazyQueryHookExecOptions<
   query?: DocumentNode | TypedDocumentNode<TData, TVariables>;
 }
 
-/**
- * suspensePolicy determines how suspense behaves for a refetch. The options are:
- * - always (default): Re-suspend a component when a refetch occurs
- * - initial: Only suspend on the first fetch
- */
-export type SuspensePolicy =
-  | 'always'
-  | 'initial'
-
 export type SuspenseQueryHookFetchPolicy = Extract<
   WatchQueryFetchPolicy,
   | 'cache-first'
@@ -131,7 +122,6 @@ export interface SuspenseQueryHookOptions<
   | 'refetchWritePolicy'
 > {
   fetchPolicy?: SuspenseQueryHookFetchPolicy;
-  suspensePolicy?: SuspensePolicy;
   suspenseCache?: SuspenseCache;
   queryKey?: string | number | any[];
 }

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -83,6 +83,8 @@ export {
 
 export { 
   isStatefulPromise,
+  createFulfilledPromise,
+  createRejectedPromise,
   wrapPromiseWithState,
 } from './promises/decoration';
 

--- a/src/utilities/promises/decoration.ts
+++ b/src/utilities/promises/decoration.ts
@@ -17,6 +17,24 @@ export type PromiseWithState<TValue> =
   | FulfilledPromise<TValue>
   | RejectedPromise<TValue>;
 
+export function createFulfilledPromise<TValue>(value: TValue) {
+  const promise = Promise.resolve(value) as FulfilledPromise<TValue>;
+
+  promise.status = 'fulfilled';
+  promise.value = value;
+
+  return promise;
+}
+
+export function createRejectedPromise<TValue = unknown>(reason: unknown) {
+  const promise = Promise.reject(reason) as RejectedPromise<TValue>;
+
+  promise.status = 'rejected';
+  promise.reason = reason;
+
+  return promise;
+}
+
 export function isStatefulPromise<TValue>(
   promise: Promise<TValue>
 ): promise is PromiseWithState<TValue> {


### PR DESCRIPTION
WIP

### Checklist:

- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
