### PR TITLE
chore: generate npm provenance statements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
     # Prevents action from creating a PR on forks
     if: github.repository == 'apollographql/apollo-client'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 legacy-peer-deps=true
+provenance=true


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

Just caught up on GH product announcements and noticed a new integration with GitHub Actions + npm to generate and display a package's provenance on its npm registry page ([blog post](https://github.blog/changelog/2023-04-19-npm-provenance-public-beta/)):

> npm packages built on a cloud CI/CD system (like GitHub Actions) can now publish with provenance, meaning the package has verifiable links back to its source code and build instructions. [...] Once published, packages display provenance on the [registry website](https://www.npmjs.com/package/sigstore#provenance):

![](https://i0.wp.com/user-images.githubusercontent.com/167759/223777293-fe4b08cf-7474-40fd-9853-1638e88fb611.png?ssl=1)

We're already publishing via GHA and can easily enable this: [npm docs](https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions).

Since changesets issues the `npm publish` command and hasn't yet added support for the `--provenance` flag, we can use a `provenance=true` entry in our `.npmrc` instead.

### Checklist:

- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
