### PR TITLE
fix: add permissions contents: read in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
     if: github.repository == 'apollographql/apollo-client'
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       id-token: write
     steps:
       - name: Checkout repo
@@ -65,7 +66,7 @@ jobs:
           # See also: https://api.slack.com/methods/chat.postMessage#channels
           # You can pass in multiple channels to post to by providing
           # a comma-delimited list of channel IDs
-          channel-id: 'C01PS0CB41G'
+          channel-id: "C01PS0CB41G"
           payload: |
             {
               "blocks": [


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

https://github.com/apollographql/apollo-client/pull/10814 was missing one additional piece of configuration, without which the release workflow errors out: since `permissions` are now configured to set `id-token: write`, `contents: read` must also be set. Without it, GHA is getting a 403 error trying to fetch the repository: https://github.com/apollographql/apollo-client/actions/runs/4822021178/jobs/8588694724

### Checklist:

- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
