### PR TITLE
fix: release workflow also needs pull-requests: write permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,12 @@ jobs:
     # Prevents action from creating a PR on forks
     if: github.repository == 'apollographql/apollo-client'
     runs-on: ubuntu-latest
+    # Permissions necessary for Changesets to push a new branch and open PRs
+    # (for automated Version Packages PRs), and request the JWT for provenance.
+    # More info: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings
     permissions:
-      contents: read
+      contents: write
+      pull-requests: write
       id-token: write
     steps:
       - name: Checkout repo
@@ -33,6 +37,7 @@ jobs:
       - name: Append NPM token to .npmrc
         run: |
           cat << EOF > "$HOME/.npmrc"
+            provenance=true
             //registry.npmjs.org/:_authToken=$NPM_TOKEN
           EOF
         env:

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 legacy-peer-deps=true
-provenance=true


### PR DESCRIPTION
Adds necessary permissions for Changesets (`contents: write` and `pull-requests: write`) and moves `provenance=true` to be appended to `.npmrc` via the release workflow so that any manual releases won't attempt to release with provenance, which is only possible via CI/CD runner like GitHub Actions.

### Checklist:

- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
