### PR TITLE
chore: npm provenance for prereleases and snapshot releases

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -14,6 +14,13 @@ jobs:
     # Prevents changesets action from creating a PR on forks
     if: github.repository == 'apollographql/apollo-client'
     runs-on: ubuntu-latest
+    # Permissions necessary for Changesets to push a new branch and open PRs
+    # (for automated Version Packages PRs), and request the JWT for provenance.
+    # More info: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -25,6 +32,7 @@ jobs:
       - name: Append NPM token to .npmrc
         run: |
           cat << EOF > "$HOME/.npmrc"
+            provenance=true
             //registry.npmjs.org/:_authToken=$NPM_TOKEN
           EOF
         env:
@@ -77,7 +85,7 @@ jobs:
           # See also: https://api.slack.com/methods/chat.postMessage#channels
           # You can pass in multiple channels to post to by providing
           # a comma-delimited list of channel IDs
-          channel-id: 'C01PS0CB41G'
+          channel-id: "C01PS0CB41G"
           # For posting a simple plain text message
           payload: |
             {

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -9,7 +9,13 @@ jobs:
   release_next:
     name: release:next
     runs-on: ubuntu-latest
-
+    # Permissions necessary for Changesets to push a new branch and open PRs
+    # (for automated Version Packages PRs), and request the JWT for provenance.
+    # More info: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
     if: |
       github.repository == 'apollographql/apollo-client' &&
       github.event.issue.pull_request &&
@@ -39,6 +45,7 @@ jobs:
       - name: Append NPM token to .npmrc
         run: |
           cat << EOF > "$HOME/.npmrc"
+            provenance=true
             //registry.npmjs.org/:_authToken=$NPM_TOKEN
           EOF
         env:


### PR DESCRIPTION
Adding provenance config to prereleases and snapshot releases since all releases can display verified commit + release build info on their npm release page. Already verified these settings prior to `3.7.13`'s release.

### Checklist:

- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
