### PR TITLE
Update `refetchQueries` docs with preferred syntax

### DIFF
--- a/docs/source/data/mutations.mdx
+++ b/docs/source/data/mutations.mdx
@@ -205,7 +205,7 @@ If you know that your app usually needs to refetch certain queries after a parti
 // Refetches two queries after mutation completes
 const [addTodo, { data, loading, error }] = useMutation(ADD_TODO, {
   refetchQueries: [
-    {query: GET_POST}, // DocumentNode object parsed with gql
+    GET_POST, // DocumentNode object parsed with gql
     'GetComments' // Query name
   ],
 });
@@ -213,7 +213,7 @@ const [addTodo, { data, loading, error }] = useMutation(ADD_TODO, {
 
 Each element in the `refetchQueries` array is one of the following:
 
-* An object referencing `query` (a `DocumentNode` object parsed with the `gql` function) and `variables`
+* A `DocumentNode` object parsed with the `gql` function
 * The name of a query you've previously executed, as a string (e.g., `GetComments`)
   * To refer to queries by name, make sure each of your app's queries have a _unique_ name.
 


### PR DESCRIPTION
Reverts apollographql/apollo-client#9708

Fixes https://github.com/apollographql/apollo-client/issues/10827

Though the `[{ query: MY_QUERY }]` syntax is supported, it behaves differently and less intuitively than an array of query document nodes and/or operation names.  See the linked issue for more context.