### PR TITLE
fix: throw errors when errors are returned after calling `refetch`

### DIFF
--- a/config/bundlesize.ts
+++ b/config/bundlesize.ts
@@ -3,7 +3,7 @@ import { join } from "path";
 import { gzipSync } from "zlib";
 import bytes from "bytes";
 
-const gzipBundleByteLengthLimit = bytes("34.98KB");
+const gzipBundleByteLengthLimit = bytes("35.03KB");
 const minFile = join("dist", "apollo-client.min.cjs");
 const minPath = join(__dirname, "..", minFile);
 const gzipByteLen = gzipSync(readFileSync(minPath)).byteLength;

--- a/src/__tests__/__snapshots__/exports.ts.snap
+++ b/src/__tests__/__snapshots__/exports.ts.snap
@@ -376,6 +376,8 @@ Array [
   "compact",
   "concatPagination",
   "createFragmentMap",
+  "createFulfilledPromise",
+  "createRejectedPromise",
   "fixObservableSubclass",
   "getDefaultValues",
   "getDirectiveNames",

--- a/src/react/cache/QuerySubscription.ts
+++ b/src/react/cache/QuerySubscription.ts
@@ -165,6 +165,7 @@ export class QuerySubscription<TData = unknown> {
 
     if (!this.initialized || this.refetching) {
       this.initialized = true;
+      this.refetching = false;
       this.reject(error);
       return;
     }

--- a/src/react/cache/QuerySubscription.ts
+++ b/src/react/cache/QuerySubscription.ts
@@ -36,6 +36,7 @@ export class QuerySubscription<TData = unknown> {
   private listeners = new Set<Listener>();
   private autoDisposeTimeoutId: NodeJS.Timeout;
   private initialized = false;
+  private refetching = false;
 
   private resolve: (result: ApolloQueryResult<TData>) => void;
   private reject: (error: unknown) => void;
@@ -62,6 +63,7 @@ export class QuerySubscription<TData = unknown> {
     ) {
       this.promises = { main: createFulfilledPromise(this.result) };
       this.initialized = true;
+      this.refetching = false;
     }
 
     this.subscription = observable.subscribe({
@@ -102,6 +104,8 @@ export class QuerySubscription<TData = unknown> {
   }
 
   refetch(variables: OperationVariables | undefined) {
+    this.refetching = true;
+
     const promise = this.observable.refetch(variables);
 
     this.promises.network = promise;
@@ -159,7 +163,7 @@ export class QuerySubscription<TData = unknown> {
 
     this.result = result;
 
-    if (!this.initialized) {
+    if (!this.initialized || this.refetching) {
       this.initialized = true;
       this.reject(error);
       return;

--- a/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
@@ -4052,7 +4052,7 @@ describe('useSuspenseQuery', () => {
     ]);
   });
 
-  it.skip('throws errors when errors are returned after calling `refetch`', async () => {
+  it('throws errors when errors are returned after calling `refetch`', async () => {
     const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
 
     const query = gql`


### PR DESCRIPTION
Adds a private refetching field to `QuerySubscription` in order to allow us to differentiate between refetches for previously initialized queries and cases where errors returned in incremental chunks should be returned/not thrown.

### Checklist:

- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
