### PR TITLE
docs: adds `useBackgroundQuery` and `useReadQuery` docs

### DIFF
--- a/docs/shared/useBackgroundQuery-options.mdx
+++ b/docs/shared/useBackgroundQuery-options.mdx
@@ -138,40 +138,6 @@ The default value is `cache-first`.
 </td>
 </tr>
 
-<tr>
-<td>
-
-###### `returnPartialData`
-
-`boolean`
-</td>
-
-<td>
-
-If `true`, the query can return _partial_ results from the cache if the cache doesn't contain results for _all_ queried fields.
-
-The default value is `false`.
-
-</td>
-</tr>
-
-<tr>
-<td>
-
-###### `refetchWritePolicy`
-
-`"merge" | "overwrite"`
-</td>
-
-<td>
-
-Watched queries must opt into overwriting existing data on refetch, by passing `refetchWritePolicy: "overwrite"` in their `WatchQueryOptions`.
-
-The default value is `""overwrite`.
-
-</td>
-</tr>
-
 </tbody>
 
 </table>

--- a/docs/shared/useBackgroundQuery-options.mdx
+++ b/docs/shared/useBackgroundQuery-options.mdx
@@ -47,7 +47,7 @@ Specifies how the query handles a response that returns both GraphQL errors and 
 
 For details, see [GraphQL error policies](/react/data/error-handling/#graphql-error-policies).
 
-The default value is `none`, which causes the hook to throw the error.
+The default value is `none`, which causes the `useReadQuery` hook to throw the error.
 </td>
 </tr>
 

--- a/docs/shared/useBackgroundQuery-result.mdx
+++ b/docs/shared/useBackgroundQuery-result.mdx
@@ -1,0 +1,79 @@
+<table class="field-table api-ref">
+
+<thead>
+  <tr>
+    <td>Name /<br/>Type</td>
+    <td>Description</td>
+  </tr>
+</thead>
+
+<tbody>
+
+<tr>
+<td colspan="2">
+
+**Query reference**
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+###### `queryRef`
+
+`QueryReference<TData>`
+</td>
+<td>
+
+In order to link a query initiated by a specific `useBackgroundQuery` call to the place its data are consumed—which can be uniquely identified not only by the query and variables passed, but also the optional `queryKey` supplied by the user—the hook returns a `queryRef` that can later be read by `useReadQuery`.
+
+</td>
+</tr>
+
+<tr>
+<td colspan="2">
+
+**Helper functions**
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+###### `refetch`
+
+`(variables?: Partial<TVariables>) => Promise<ApolloQueryResult>`
+</td>
+
+<td>
+
+A function that enables you to re-execute the query, optionally passing in new `variables`.
+
+To guarantee that the refetch performs a network request, its `fetchPolicy` is set to `network-only` (unless the original query's `fetchPolicy` is `no-cache` or `cache-and-network`, which also guarantee a network request).
+
+Calling this function will cause the component to re-suspend, , unless the call site is wrapped in [`startTransition`](https://react.dev/reference/react/startTransition).
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+###### `fetchMore`
+
+`({ query?: DocumentNode, variables?: TVariables, updateQuery: Function}) => Promise<ApolloQueryResult>`
+</td>
+
+<td>
+
+A function that helps you fetch the next set of results for a [paginated list field](/react/pagination/core-api/).
+
+Calling this function will cause the component to re-suspend, unless the call site is wrapped in [`startTransition`](https://react.dev/reference/react/startTransition).
+
+</td>
+</tr>
+
+</tbody>
+</table>

--- a/docs/shared/useBackgroundQuery-result.mdx
+++ b/docs/shared/useBackgroundQuery-result.mdx
@@ -26,7 +26,7 @@
 </td>
 <td>
 
-In order to link a query initiated by a specific `useBackgroundQuery` call to the place its data are consumed—which can be uniquely identified not only by the query and variables passed, but also the optional `queryKey` supplied by the user—the hook returns a `queryRef` that can later be read by `useReadQuery`.
+In order to link a query initiated by a specific `useBackgroundQuery` call to the place its data is consumed—which can be uniquely identified not only by the query and variables passed, but also the optional `queryKey` supplied by the user—the hook returns a `queryRef` that can later be read by `useReadQuery`.
 
 </td>
 </tr>

--- a/docs/shared/useBackgroundQuery-result.mdx
+++ b/docs/shared/useBackgroundQuery-result.mdx
@@ -53,7 +53,7 @@ A function that enables you to re-execute the query, optionally passing in new `
 
 To guarantee that the refetch performs a network request, its `fetchPolicy` is set to `network-only` (unless the original query's `fetchPolicy` is `no-cache` or `cache-and-network`, which also guarantee a network request).
 
-Calling this function will cause the component to re-suspend, , unless the call site is wrapped in [`startTransition`](https://react.dev/reference/react/startTransition).
+Calling this function will cause the component to re-suspend, unless the call site is wrapped in [`startTransition`](https://react.dev/reference/react/startTransition).
 
 </td>
 </tr>

--- a/docs/shared/useReadQuery-result.mdx
+++ b/docs/shared/useReadQuery-result.mdx
@@ -1,0 +1,68 @@
+<table class="field-table api-ref">
+
+<thead>
+  <tr>
+    <td>Name /<br/>Type</td>
+    <td>Description</td>
+  </tr>
+</thead>
+
+<tbody>
+
+<tr>
+<td colspan="2">
+
+**Operation result**
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+###### `data`
+
+`TData`
+</td>
+<td>
+
+An object containing the result of your GraphQL query after it completes.
+
+This value might be `undefined` if a query results in one or more errors (depending on the query's `errorPolicy`).
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+###### `error`
+
+`ApolloError`
+</td>
+<td>
+
+If the query produces one or more errors, this object contains either an array of `graphQLErrors` or a single `networkError`. Otherwise, this value is `undefined`.
+
+This property can be ignored when using the default `errorPolicy` or an `errorPolicy` of `none`. The hook will throw the error instead of setting this property.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+###### `networkStatus`
+
+`NetworkStatus`
+</td>
+
+<td>
+
+A number indicating the current network state of the query's associated request. [See possible values.](https://github.com/apollographql/apollo-client/blob/d96f4578f89b933c281bb775a39503f6cdb59ee8/src/core/networkStatus.ts#L4)
+
+</td>
+</tr>
+
+</tbody>
+</table>

--- a/docs/shared/useSuspenseQuery-options.mdx
+++ b/docs/shared/useSuspenseQuery-options.mdx
@@ -167,7 +167,7 @@ The default value is `false`.
 
 Watched queries must opt into overwriting existing data on refetch, by passing `refetchWritePolicy: "overwrite"` in their `WatchQueryOptions`.
 
-The default value is `""overwrite`.
+The default value is `"overwrite"`.
 
 </td>
 </tr>

--- a/docs/shared/useSuspenseQuery-result.mdx
+++ b/docs/shared/useSuspenseQuery-result.mdx
@@ -50,9 +50,24 @@ This property can be ignored when using the default `errorPolicy` or an `errorPo
 </tr>
 
 <tr>
+<td>
+
+###### `networkStatus`
+
+`NetworkStatus`
+</td>
+
+<td>
+
+A number indicating the current network state of the query's associated request. [See possible values.](https://github.com/apollographql/apollo-client/blob/d96f4578f89b933c281bb775a39503f6cdb59ee8/src/core/networkStatus.ts#L4)
+
+</td>
+</tr>
+
+<tr>
 <td colspan="2">
 
-**Network info**
+**Client**
 
 </td>
 </tr>
@@ -94,9 +109,9 @@ Can be useful for manually executing followup queries or writing data to the cac
 
 A function that enables you to re-execute the query, optionally passing in new `variables`.
 
-To guarantee that the refetch performs a network request, its `fetchPolicy` is set to `network-only` (unless the original query's `fetchPolicy` is `no-cache` or `cache-and-network`, which also guarantee a network request). 
+To guarantee that the refetch performs a network request, its `fetchPolicy` is set to `network-only` (unless the original query's `fetchPolicy` is `no-cache` or `cache-and-network`, which also guarantee a network request).
 
-Calling this function will cause the component to re-suspend, unless the `suspensePolicy` option is set to `initial`.
+Calling this function will cause the component to re-suspend, , unless the call site is wrapped in [`startTransition`](https://react.dev/reference/react/startTransition).
 
 </td>
 </tr>
@@ -113,7 +128,7 @@ Calling this function will cause the component to re-suspend, unless the `suspen
 
 A function that helps you fetch the next set of results for a [paginated list field](/react/pagination/core-api/).
 
-Calling this function will cause the component to re-suspend, unless the `suspensePolicy` option is set to `initial`.
+Calling this function will cause the component to re-suspend, unless the call site is wrapped in [`startTransition`](https://react.dev/reference/react/startTransition).
 
 </td>
 </tr>

--- a/docs/source/api/react/hooks-experimental.mdx
+++ b/docs/source/api/react/hooks-experimental.mdx
@@ -6,7 +6,82 @@ description: Apollo Client experimental react hooks API reference
 import UseFragmentOptions from '../../../shared/useFragment-options.mdx';
 import UseFragmentResult from '../../../shared/useFragment-result.mdx';
 import UseSuspenseQueryOptions from '../../../shared/useSuspenseQuery-options.mdx';
+import UseBackgroundQueryOptions from '../../../shared/useBackgroundQuery-options.mdx';
 import UseSuspenseQueryResult from '../../../shared/useSuspenseQuery-result.mdx';
+import UseBackgroundQueryResult from '../../../shared/useBackgroundQuery-result.mdx';
+import UseReadQueryResult from '../../../shared/useReadQuery-result.mdx';
+
+## `useBackgroundQuery_experimental` and `useReadQuery_experimental`
+
+### Installation
+
+> ⚠️ **The `useBackgroundQuery_experimental` and `useReadQuery_experimental` hooks are currently at the [alpha stage](https://www.apollographql.com/docs/resources/product-launch-stages/#alpha--beta) in Apollo Client.** If you have feedback on them, please let us know via [GitHub issues](https://github.com/apollographql/apollo-client/issues/new?assignees=&labels=&template=bug.md).
+
+Beginning with version `3.8.0-alpha.14`, Apollo Client Web has alpha support for the `useBackgroundQuery_experimental` and `useReadQuery_experimental` hooks, which work with React's [Suspense](https://react.dev/reference/react/Suspense) feature. You can install it via `npm install @apollo/client@alpha`.
+
+### Using `useBackgroundQuery_experimental` and `useReadQuery_experimental`
+
+TODO: fill in.
+
+### `useBackgroundQuery_experimental` API
+
+#### Function Signature
+
+```ts
+function useBackgroundQuery_experimental<
+  TData = any,
+  TVariables extends OperationVariables = OperationVariables
+>(
+  query: query: DocumentNode | TypedDocumentNode<TData, TVariables>,,
+  options: Omit<
+    SuspenseQueryHookOptions<TData, TVariables>,
+    'returnPartialData' | 'refetchWritePolicy'
+  >,
+): UseBackgroundQueryResult<TData> {}
+```
+
+#### Params
+
+##### `query`
+
+| Param   | Type         | Description                                                   |
+| ------- | ------------ | ------------------------------------------------------------- |
+| `query` | DocumentNode | A GraphQL query document parsed into an AST by `gql`. |
+
+
+##### `options`
+
+<UseBackgroundQueryOptions />
+
+#### Result
+
+<UseBackgroundQueryResult />
+
+### `useReadQuery_experimental` API
+
+#### Function Signature
+
+```ts
+function useReadQuery_experimental<TData>(
+  queryRef: QueryReference<TData>
+): {
+  data: TData;
+  networkStatus: NetworkStatus;
+  error: ApolloError | undefined;
+} {}
+```
+
+#### Params
+
+##### `queryRef`
+
+| Param   | Type         | Description                                                   |
+| ------- | ------------ | ------------------------------------------------------------- |
+| `queryRef` | QueryReference | An instance of the `QueryReference` class that was generated via `useBackgroundQuery`. |
+
+#### Result
+
+<UseReadQueryResult />
 
 ## `useFragment_experimental`
 
@@ -90,7 +165,7 @@ The `useFragment_experimental` hook accepts the following options:
 
 > ⚠️ **The `useSuspenseQuery_experimental` hook is currently at the [alpha stage](https://www.apollographql.com/docs/resources/product-launch-stages/#alpha--beta) in Apollo Client.** If you have feedback on it, please let us know via [GitHub issues](https://github.com/apollographql/apollo-client/issues/new?assignees=&labels=&template=bug.md).
 
-Beginning with version `3.8.0-alpha.0`, Apollo Client Web has alpha support for the `useSuspenseQuery_experimental` hook, which works with React's [Suspense](https://beta.reactjs.org/reference/react/Suspense) feature. You can install it via `npm install @apollo/client@alpha`.
+Beginning with version `3.8.0-alpha.0`, Apollo Client Web has alpha support for the `useSuspenseQuery_experimental` hook, which works with React's [Suspense](https://react.dev/reference/react/Suspense) feature. You can install it via `npm install @apollo/client@alpha`.
 
 ### Using `useSuspenseQuery_experimental`
 
@@ -104,7 +179,7 @@ const suspenseCache = new SuspenseCache();
 <ApolloProvider suspenseCache={suspenseCache} />
 ```
 
-Write queries using `useSuspenseQuery_experimental`. Ensure the component is wrapped with React's [`Suspense`](https://beta.reactjs.org/reference/react/Suspense) component. Note that the hook returns only `data` and `error`: since Suspense provides the tools to manage our application's loading states, `useSuspenseQuery_experimental` does not return a `loading` boolean.
+Write queries using `useSuspenseQuery_experimental`. Ensure the component is wrapped with React's [`Suspense`](https://react.dev/reference/react/Suspense) component. Note that the hook returns only `data` and `error`: since Suspense provides the tools to manage our application's loading states, `useSuspenseQuery_experimental` does not return a `loading` boolean.
 
 See the [API reference](#usesuspensequery_experimental-api) for supported options.
 

--- a/docs/source/api/react/hooks-experimental.mdx
+++ b/docs/source/api/react/hooks-experimental.mdx
@@ -21,7 +21,74 @@ Beginning with version `3.8.0-alpha.14`, Apollo Client Web has alpha support for
 
 ### Using `useBackgroundQuery_experimental` and `useReadQuery_experimental`
 
-TODO: fill in.
+Create and provide a `SuspenseCache` instance to your `ApolloProvider`.
+
+```js
+import { SuspenseCache } from '@apollo/client';
+
+const suspenseCache = new SuspenseCache();
+
+<ApolloProvider suspenseCache={suspenseCache} />
+```
+
+`useBackgroundQuery_experimental` allows a user to initiate a query outside of the component that will read and render the data with `useReadQuery_experimental`, which triggers the nearest Suspense boundary while the query is pending. This means a query can be initiated higher up in the React render tree and your application can begin requesting data before the component that has a dependency on those data begins rendering.
+
+Ensure the component tree is wrapped with React's [`Suspense`](https://react.dev/reference/react/Suspense) component. Note that the `useReadQuery_experimental` hook returns only `data` and `error` (and `networkStatus`, though it should rarely be needed): since Suspense provides the tools to manage our application's loading states, `useReadQuery_experimental` does not return a `loading` boolean.
+
+See the API references for [`useBackgroundQuery_experimental`](#usebackgroundquery_experimental-api) and [`useReadQuery_experimental`](#usereadquery_experimental-api) for supported options.
+
+```jsx
+import { Suspense } from 'react';
+import {
+  ApolloClient,
+  InMemoryCache,
+  SuspenseCache,
+  useBackgroundQuery_experimental as useBackgroundQuery,
+  useReadQuery_experimental as useReadQuery,
+} from '@apollo/client';
+
+const query = gql`
+  foo {
+    bar
+  }
+`;
+
+const suspenseCache = new SuspenseCache();
+
+const client = new ApolloClient({
+  uri: "http://localhost:4000/graphql",
+  cache: new InMemoryCache()
+});
+
+function SuspenseFallback() {
+  return <div>Loading...</div>;
+}
+
+function Child({ queryRef }) {
+  const { data } = useReadQuery(queryRef);
+
+  return <div>{data.foo.bar}</div>;
+}
+
+function Parent() {
+  const [queryRef] = useBackgroundQuery(query);
+
+  return <Child queryRef={queryRef} />;
+}
+
+function App() {
+  return (
+    <ApolloProvider client={client} suspenseCache={suspenseCache}>
+      <ErrorBoundary fallback={<div>Error</div>}>
+        <Suspense fallback={<SuspenseFallback />}>
+          <Parent />
+        </Suspense>
+      </ErrorBoundary>
+    </ApolloProvider>
+  );
+}
+
+```
 
 ### `useBackgroundQuery_experimental` API
 

--- a/docs/source/api/react/hooks-experimental.mdx
+++ b/docs/source/api/react/hooks-experimental.mdx
@@ -28,12 +28,12 @@ import { SuspenseCache } from '@apollo/client';
 
 const suspenseCache = new SuspenseCache();
 
-<ApolloProvider suspenseCache={suspenseCache} />
+<ApolloProvider suspenseCache={suspenseCache} />;
 ```
 
 `useBackgroundQuery_experimental` allows a user to initiate a query outside of the component that will read and render the data with `useReadQuery_experimental`, which triggers the nearest Suspense boundary while the query is pending. This means a query can be initiated higher up in the React render tree and your application can begin requesting data before the component that has a dependency on that data begins rendering.
 
-Ensure the component tree is wrapped with React's [`Suspense`](https://react.dev/reference/react/Suspense) component. Note that the `useReadQuery_experimental` hook returns only `data` and `error` (and `networkStatus`, though it should rarely be needed): since Suspense provides the tools to manage our application's loading states, `useReadQuery_experimental` does not return a `loading` boolean.
+Ensure the component tree that uses `useReadQuery_experimental` is wrapped with React's [`Suspense`](https://react.dev/reference/react/Suspense) component. Note that the `useReadQuery_experimental` hook returns only `data`, `error` and `networkStatus` (though `networkStatus` should rarely be needed). Since Suspense provides the tools to manage our application's loading states, `useReadQuery_experimental` does not return a `loading` boolean.
 
 See the API references for [`useBackgroundQuery_experimental`](#usebackgroundquery_experimental-api) and [`useReadQuery_experimental`](#usereadquery_experimental-api) for supported options.
 
@@ -73,16 +73,18 @@ function Child({ queryRef }) {
 function Parent() {
   const [queryRef] = useBackgroundQuery(query);
 
-  return <Child queryRef={queryRef} />;
+  return (
+    <Suspense fallback={<SuspenseFallback />}>
+      <Child queryRef={queryRef} />
+    </Suspense>
+  );
 }
 
 function App() {
   return (
     <ApolloProvider client={client} suspenseCache={suspenseCache}>
       <ErrorBoundary fallback={<div>Error</div>}>
-        <Suspense fallback={<SuspenseFallback />}>
           <Parent />
-        </Suspense>
       </ErrorBoundary>
     </ApolloProvider>
   );
@@ -245,7 +247,7 @@ import { SuspenseCache } from '@apollo/client';
 
 const suspenseCache = new SuspenseCache();
 
-<ApolloProvider suspenseCache={suspenseCache} />
+<ApolloProvider suspenseCache={suspenseCache} />;
 ```
 
 Write queries using `useSuspenseQuery_experimental`. Ensure the component is wrapped with React's [`Suspense`](https://react.dev/reference/react/Suspense) component. Note that the hook returns only `data` and `error`: since Suspense provides the tools to manage our application's loading states, `useSuspenseQuery_experimental` does not return a `loading` boolean.

--- a/docs/source/api/react/hooks-experimental.mdx
+++ b/docs/source/api/react/hooks-experimental.mdx
@@ -144,7 +144,7 @@ function useReadQuery_experimental<TData>(
 
 | Param   | Type         | Description                                                   |
 | ------- | ------------ | ------------------------------------------------------------- |
-| `queryRef` | QueryReference | An instance of the `QueryReference` class that was generated via `useBackgroundQuery`. |
+| `queryRef` | QueryReference | The [`queryRef`](#queryref) that was generated via `useBackgroundQuery`. |
 
 #### Result
 

--- a/docs/source/api/react/hooks-experimental.mdx
+++ b/docs/source/api/react/hooks-experimental.mdx
@@ -31,7 +31,7 @@ const suspenseCache = new SuspenseCache();
 <ApolloProvider suspenseCache={suspenseCache} />
 ```
 
-`useBackgroundQuery_experimental` allows a user to initiate a query outside of the component that will read and render the data with `useReadQuery_experimental`, which triggers the nearest Suspense boundary while the query is pending. This means a query can be initiated higher up in the React render tree and your application can begin requesting data before the component that has a dependency on those data begins rendering.
+`useBackgroundQuery_experimental` allows a user to initiate a query outside of the component that will read and render the data with `useReadQuery_experimental`, which triggers the nearest Suspense boundary while the query is pending. This means a query can be initiated higher up in the React render tree and your application can begin requesting data before the component that has a dependency on that data begins rendering.
 
 Ensure the component tree is wrapped with React's [`Suspense`](https://react.dev/reference/react/Suspense) component. Note that the `useReadQuery_experimental` hook returns only `data` and `error` (and `networkStatus`, though it should rarely be needed): since Suspense provides the tools to manage our application's loading states, `useReadQuery_experimental` does not return a `loading` boolean.
 

--- a/docs/source/api/react/hooks-experimental.mdx
+++ b/docs/source/api/react/hooks-experimental.mdx
@@ -84,7 +84,7 @@ function App() {
   return (
     <ApolloProvider client={client} suspenseCache={suspenseCache}>
       <ErrorBoundary fallback={<div>Error</div>}>
-          <Parent />
+        <Parent />
       </ErrorBoundary>
     </ApolloProvider>
   );
@@ -190,7 +190,9 @@ function List() {
   const { loading, data } = useQuery(listQuery);
   return (
     <ol>
-      {data?.list.map(item => <Item key={item.id} id={item.id}/>)}
+      {data?.list.map(item => (
+        <Item key={item.id} id={item.id}/>
+      ))}
     </ol>
   );
 }

--- a/docs/source/api/react/hooks-experimental.mdx
+++ b/docs/source/api/react/hooks-experimental.mdx
@@ -99,7 +99,7 @@ function useBackgroundQuery_experimental<
   TData = any,
   TVariables extends OperationVariables = OperationVariables
 >(
-  query: query: DocumentNode | TypedDocumentNode<TData, TVariables>,,
+  query: query: DocumentNode | TypedDocumentNode<TData, TVariables>,
   options: Omit<
     SuspenseQueryHookOptions<TData, TVariables>,
     'returnPartialData' | 'refetchWritePolicy'

--- a/docs/source/api/react/hooks-experimental.mdx
+++ b/docs/source/api/react/hooks-experimental.mdx
@@ -17,7 +17,7 @@ import UseReadQueryResult from '../../../shared/useReadQuery-result.mdx';
 
 > ⚠️ **The `useBackgroundQuery_experimental` and `useReadQuery_experimental` hooks are currently at the [alpha stage](https://www.apollographql.com/docs/resources/product-launch-stages/#alpha--beta) in Apollo Client.** If you have feedback on them, please let us know via [GitHub issues](https://github.com/apollographql/apollo-client/issues/new?assignees=&labels=&template=bug.md).
 
-Beginning with version `3.8.0-alpha.14`, Apollo Client Web has alpha support for the `useBackgroundQuery_experimental` and `useReadQuery_experimental` hooks, which work with React's [Suspense](https://react.dev/reference/react/Suspense) feature. You can install it via `npm install @apollo/client@alpha`.
+Beginning with version `3.8.0-alpha.14`, Apollo Client has alpha support for the `useBackgroundQuery_experimental` and `useReadQuery_experimental` hooks, which work with React's [Suspense](https://react.dev/reference/react/Suspense) feature. You can install it via `npm install @apollo/client@alpha`.
 
 ### Using `useBackgroundQuery_experimental` and `useReadQuery_experimental`
 


### PR DESCRIPTION
Closes https://github.com/apollographql/apollo-client/issues/10874.

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
