### PR TITLE
docs: add directives page and update docs nav

### DIFF
--- a/docs/source/api/react/hooks-experimental.mdx
+++ b/docs/source/api/react/hooks-experimental.mdx
@@ -14,7 +14,7 @@ import UseSuspenseQueryResult from '../../../shared/useSuspenseQuery-result.mdx'
 
 > ⚠️ **The `useFragment_experimental` hook is currently at the [preview stage](https://www.apollographql.com/docs/resources/release-stages/#preview) in Apollo Client.** If you have feedback on it, please let us know via [GitHub issues](https://github.com/apollographql/apollo-client/issues/new?assignees=&labels=&template=bug.md).
 
-Beginning with version `3.7.0`, Apollo Client Web has preview support for the `useFragment_experimental` hook, which represents a lightweight live binding into the Apollo Client Cache. This hook returns an always-up-to-date view of whatever data the cache currently contains for a given fragment. `useFragment_experimental` never triggers network requests of its own.
+Beginning with version `3.7.0`, Apollo Client has preview support for the `useFragment_experimental` hook, which represents a lightweight live binding into the Apollo Client Cache. This hook returns an always-up-to-date view of whatever data the cache currently contains for a given fragment. `useFragment_experimental` never triggers network requests of its own.
 
 `useFragment_experimental` enables Apollo Client to broadcast very specific fragment results to individual components. Note that the `useQuery` hook remains the primary hook responsible for querying and populating data in the cache ([see the API reference](./hooks#usequery)). As a result, the component reading the fragment data via `useFragment_experimental` is still subscribed to all changes in the query data, but receives updates only when that fragment's specific data change.
 
@@ -92,7 +92,7 @@ The `useFragment_experimental` hook accepts the following options:
 
 > ⚠️ **The `useSuspenseQuery_experimental` hook is currently at the [preview stage](https://www.apollographql.com/docs/resources/product-launch-stages/#alpha--beta) in Apollo Client.** If you have feedback on it, please let us know via [GitHub issues](https://github.com/apollographql/apollo-client/issues/new?assignees=&labels=&template=bug.md).
 
-Beginning with version `3.8.0-alpha.0`, Apollo Client Web has alpha support for the `useSuspenseQuery_experimental` hook, which works with React's [Suspense](https://beta.reactjs.org/reference/react/Suspense) feature. You can install it via `npm install @apollo/client@alpha`.
+Beginning with version `3.8.0-alpha.0`, Apollo Client has alpha support for the `useSuspenseQuery_experimental` hook, which works with React's [Suspense](https://beta.reactjs.org/reference/react/Suspense) feature. You can install it via `npm install @apollo/client@alpha`.
 
 ### Using `useSuspenseQuery_experimental`
 

--- a/docs/source/api/react/hooks-experimental.mdx
+++ b/docs/source/api/react/hooks-experimental.mdx
@@ -68,6 +68,8 @@ function Item(props: { id: number }) {
 }
 ```
 
+> `useFragment_experimental` can be used in combination with the `@nonreactive` directive in cases where list items should react to individual cache updates without rerendering the entire list. For more information, see the [`@nonreactive` docs](/react/data/directives#nonreactive).
+
 ### `useFragment_experimental` API
 
 Supported options and result fields for the `useFragment_experimental` hook are listed below.
@@ -88,7 +90,7 @@ The `useFragment_experimental` hook accepts the following options:
 
 ### Installation
 
-> ⚠️ **The `useSuspenseQuery_experimental` hook is currently at the [alpha stage](https://www.apollographql.com/docs/resources/product-launch-stages/#alpha--beta) in Apollo Client.** If you have feedback on it, please let us know via [GitHub issues](https://github.com/apollographql/apollo-client/issues/new?assignees=&labels=&template=bug.md).
+> ⚠️ **The `useSuspenseQuery_experimental` hook is currently at the [preview stage](https://www.apollographql.com/docs/resources/product-launch-stages/#alpha--beta) in Apollo Client.** If you have feedback on it, please let us know via [GitHub issues](https://github.com/apollographql/apollo-client/issues/new?assignees=&labels=&template=bug.md).
 
 Beginning with version `3.8.0-alpha.0`, Apollo Client Web has alpha support for the `useSuspenseQuery_experimental` hook, which works with React's [Suspense](https://beta.reactjs.org/reference/react/Suspense) feature. You can install it via `npm install @apollo/client@alpha`.
 

--- a/docs/source/config.json
+++ b/docs/source/config.json
@@ -16,7 +16,7 @@
       "Refetching": "/data/refetching",
       "Subscriptions": "/data/subscriptions",
       "Fragments": "/data/fragments",
-      "@defer support": "/data/defer",
+      "Directives": "/data/directives",
       "Error handling": "/data/error-handling",
       "Best practices": "/data/operation-best-practices"
     },

--- a/docs/source/data/defer.mdx
+++ b/docs/source/data/defer.mdx
@@ -5,7 +5,7 @@ description: Receive query response data incrementally
 
 > **The `@defer` directive is currently at the [General Availability stage](/resources/product-launch-stages/#general-availability) in Apollo Client, and is available by installing `@apollo/client@latest`.** If you have feedback on it, please let us know via [GitHub issues](https://github.com/apollographql/apollo-client/issues/new?assignees=&labels=&template=bug.md).
 
-Beginning with version `3.7.0`, Apollo Client Web provides preview support for [the `@defer` directive](https://github.com/graphql/graphql-wg/blob/main/rfcs/DeferStream.md). This directive enables your queries to receive data for specific fields _incrementally_, instead of receiving all field data at the same time. This is helpful whenever some fields in a query take much longer to resolve than others.
+Beginning with version `3.7.0`, Apollo Client provides preview support for [the `@defer` directive](https://github.com/graphql/graphql-wg/blob/main/rfcs/DeferStream.md). This directive enables your queries to receive data for specific fields _incrementally_, instead of receiving all field data at the same time. This is helpful whenever some fields in a query take much longer to resolve than others.
 
 > For a query to defer fields successfully, the queried endpoint must _also_ support the `@defer` directive. Entity-based `@defer` support is also at the General Availability stage in [Apollo Router](/router/executing-operations/defer-support/) and is compatible with all [federation-compatible subgraph libraries](/federation/building-supergraphs/supported-subgraphs/).
 

--- a/docs/source/data/directives.mdx
+++ b/docs/source/data/directives.mdx
@@ -42,6 +42,14 @@ For more information about the `@client` directive, see this section on [local-o
 
 The `@connection` directive allows you to specify a custom cache key for paginated results. For more information, see this section on the [`@connection` directive](/react/caching/advanced-topics/#the-connection-directive).
 
+```graphql
+query Feed($offset: Int, $limit: Int) {
+  feed(offset: $offset, limit: $limit) @connection(key: "feed") {
+    ...FeedFields
+  }
+}
+```
+
 ## `@defer`
 
 Beginning with version `3.7.0`, Apollo Client provides preview support for [the `@defer` directive](https://github.com/graphql/graphql-wg/blob/main/rfcs/DeferStream.md). This directive enables your queries to receive data for specific fields _incrementally_, instead of receiving all field data at the same time. This is helpful whenever some fields in a query take much longer to resolve than others.

--- a/docs/source/data/directives.mdx
+++ b/docs/source/data/directives.mdx
@@ -170,4 +170,4 @@ const Trail = ({ id }) => {
 };
 ```
 
-Notice that the `Trail` component isn't receiving the entire `trail` object via props, only the `id` which is used along with the fragment document to create a live binding for each trail item in the cache. This allows each `Trail` component to react to the cache updates for a single trail independently, without the entire list rerendering. Updates to a trail's `status` will not cause the parent `App` component to rerender given the `@nonreactive` directive applied to the `TrailFragment` spread, a fragment which includes the `status` field.
+Notice that the `Trail` component isn't receiving the entire `trail` object via props, only the `id` which is used along with the fragment document to create a live binding for each trail item in the cache. This allows each `Trail` component to react to the cache updates for a single trail independently. Updates to a trail's `status` will not cause the parent `App` component to rerender since the `@nonreactive` directive is applied to the `TrailFragment` spread, a fragment that includes the `status` field.

--- a/docs/source/data/directives.mdx
+++ b/docs/source/data/directives.mdx
@@ -170,4 +170,4 @@ const Trail = ({ id }) => {
 };
 ```
 
-Notice that the `Trail` component isn't receiving the entire `trail` object via props, only the `id` which is used along with the fragment document to create a live binding for each trail item in the cache. This allows each `Trail` component to react to the cache updates for a single trail independently, without the entire list re-rendering. Updates to a trail's `status` will not cause the parent `App` component to rerender given the `@nonreactive` directive applied to the `TrailFragment` spread, a fragment which includes the `status` field.
+Notice that the `Trail` component isn't receiving the entire `trail` object via props, only the `id` which is used along with the fragment document to create a live binding for each trail item in the cache. This allows each `Trail` component to react to the cache updates for a single trail independently, without the entire list rerendering. Updates to a trail's `status` will not cause the parent `App` component to rerender given the `@nonreactive` directive applied to the `TrailFragment` spread, a fragment which includes the `status` field.

--- a/docs/source/data/directives.mdx
+++ b/docs/source/data/directives.mdx
@@ -20,7 +20,7 @@ This example shows the `@skip` directive, which is a default directive (i.e., it
 
 ## `@client`
 
-The `@client` directive tells Apollo Client _not_ to send the field(s) it is annotating to the server.
+The `@client` directive allows you to resolve client-only data alongside your server data. These fields are not sent to the GraphQL server.
 
 ```graphql
 query LaunchDetails($launchId: ID!) {
@@ -28,8 +28,8 @@ query LaunchDetails($launchId: ID!) {
     site
     rocket {
       type
-      # populated via the read function configured on InMemoryCache's typePolicies,
-      # never sent with the request to the server
+      # resolved locally on the client,
+      # removed from the request to the server
       description @client
     }
   }
@@ -40,7 +40,7 @@ For more information about the `@client` directive, see this section on [local-o
 
 ## `@connection`
 
-- /react/caching/advanced-topics/#the-connection-directive
+The `@connection` directive allows you to specify a custom cache key for paginated results. For more information, see this section on the [`@connection` directive](/react/caching/advanced-topics/#the-connection-directive).
 
 ## `@defer`
 
@@ -87,4 +87,4 @@ In the query above, the result of the local-only field `currentAuthorId` is used
 
 You can do this even if `postCount` is also a local-only field (i.e., if it's also marked as `@client`).
 
-For more information about the `@export` directive and other considerations when using `@export`, check out the [local-only fields docs](/react/local-state/managing-state-with-field-policies/#using-local-only-fields-as-graphql-variables).
+For more information and other considerations when using the `@export` directive, check out the [local-only fields docs](/react/local-state/managing-state-with-field-policies/#using-local-only-fields-as-graphql-variables).

--- a/docs/source/data/directives.mdx
+++ b/docs/source/data/directives.mdx
@@ -44,7 +44,7 @@ The `@connection` directive allows you to specify a custom cache key for paginat
 
 ## `@defer`
 
-Beginning with version `3.7.0`, Apollo Client Web provides preview support for [the `@defer` directive](https://github.com/graphql/graphql-wg/blob/main/rfcs/DeferStream.md). This directive enables your queries to receive data for specific fields _incrementally_, instead of receiving all field data at the same time. This is helpful whenever some fields in a query take much longer to resolve than others.
+Beginning with version `3.7.0`, Apollo Client provides preview support for [the `@defer` directive](https://github.com/graphql/graphql-wg/blob/main/rfcs/DeferStream.md). This directive enables your queries to receive data for specific fields _incrementally_, instead of receiving all field data at the same time. This is helpful whenever some fields in a query take much longer to resolve than others.
 
 To use the `@defer` directive, we apply it to an inline or named fragment that contains all slow-resolving fields:
 

--- a/docs/source/data/directives.mdx
+++ b/docs/source/data/directives.mdx
@@ -88,3 +88,78 @@ In the query above, the result of the local-only field `currentAuthorId` is used
 You can do this even if `postCount` is also a local-only field (i.e., if it's also marked as `@client`).
 
 For more information and other considerations when using the `@export` directive, check out the [local-only fields docs](/react/local-state/managing-state-with-field-policies/#using-local-only-fields-as-graphql-variables).
+
+## `@nonreactive`
+
+> ⚠️ **The `@nonreactive` directive is currently at the [preview stage](/resources/product-launch-stages/#general-availability) in Apollo Client, and is available by installing `@apollo/client@alpha`.** If you have feedback on it, please let us know via [GitHub issues](https://github.com/apollographql/apollo-client/issues/new?assignees=&labels=&template=bug.md).
+
+The `@nonreactive` directive can be used to mark query fields or fragment spreads and is used to indicate that changes to the data contained within the subtrees marked `@nonreactive` should _not_ trigger rerendering. This allows parent components to fetch data to be rendered by their children without rerendering themselves when the data corresponding with fields marked as `@nonreactive` change.
+
+Consider an `App` component that fetches and renders a list of ski trails:
+
+```jsx
+const TrailFragment = gql`
+  fragment TrailFragment on Trail {
+    name
+    status
+  }
+`;
+
+const ALL_TRAILS = gql`
+  query allTrails {
+    allTrails {
+      id
+      ...TrailFragment @nonreactive
+    }
+  }
+  ${TrailFragment}
+`;
+
+function App() {
+  const { data, loading } = useQuery(ALL_TRAILS);
+  return (
+    <main>
+      <h2>Ski Trails</h2>
+      <ul>
+        {data?.trails.map((trail) => (
+          <Trail key={trail.id} id={trail.id} />
+        ))}
+      </ul>
+    </main>
+  );
+}
+```
+
+The `Trail` component renders a trail's name and status and allows the user to execute a mutation to toggle the status of the trail between `"OPEN"` and `"CLOSED"`:
+
+```jsx
+const Trail = ({ id }) => {
+  const [updateTrail] = useMutation(UPDATE_TRAIL);
+  const { data } = useFragment({
+    fragment: TrailFragment,
+    from: {
+      __typename: "Trail",
+      id,
+    },
+  });
+  return (
+    <li key={id}>
+      {data.name} - {data.status}
+      <input
+        checked={data.status === "OPEN" ? true : false}
+        type="checkbox"
+        onChange={(e) => {
+          updateTrail({
+            variables: {
+              trailId: id,
+              status: e.target.checked ? "OPEN" : "CLOSED",
+            },
+          });
+        }}
+      />
+    </li>
+  );
+};
+```
+
+Notice that the `Trail` component isn't receiving the entire `trail` object via props, only the `id` which is used along with the fragment document to create a live binding for each trail item in the cache. This allows each `Trail` component to react to the cache updates for a single trail independently, without the entire list re-rendering. Updates to a trail's `status` will not cause the parent `App` component to rerender given the `@nonreactive` directive applied to the `TrailFragment` spread, a fragment which includes the `status` field.

--- a/docs/source/data/directives.mdx
+++ b/docs/source/data/directives.mdx
@@ -1,0 +1,90 @@
+---
+title: "Using GraphQL directives in Apollo Client"
+description: Configure GraphQL fields and fragments
+---
+
+A directive decorates part of a GraphQL schema or operation with additional configuration. Tools like Apollo Client can read a GraphQL document's directives and perform custom logic as appropriate.
+
+Directives are preceded by the `@` character, like so:
+
+```graphql
+query myQuery($someTest: Boolean) {
+  experimentalField @skip(if: $someTest)
+}
+```
+
+This example shows the `@skip` directive, which is a default directive (i.e., it's part of the [GraphQL specification](http://spec.graphql.org/June2018/#sec--deprecated)). It demonstrates the following about directives:
+
+- Directives can take arguments of their own (`if` in this case).
+- Directives appear after the declaration of what they decorate (the `experimentalField` field in this case).
+
+## `@client`
+
+The `@client` directive tells Apollo Client _not_ to send the field(s) it is annotating to the server.
+
+```graphql
+query LaunchDetails($launchId: ID!) {
+  launch(id: $launchId) {
+    site
+    rocket {
+      type
+      # populated via the read function configured on InMemoryCache's typePolicies,
+      # never sent with the request to the server
+      description @client
+    }
+  }
+}
+```
+
+For more information about the `@client` directive, see this section on [local-only fields](/react/local-state/managing-state-with-field-policies/). The `@client` directive is also useful for [client schema mocking](/react/development-testing/client-schema-mocking/#3-query-with-the-client-directive) before a given field is supported in the GraphQL API your application is consuming.
+
+## `@connection`
+
+- /react/caching/advanced-topics/#the-connection-directive
+
+## `@defer`
+
+Beginning with version `3.7.0`, Apollo Client Web provides preview support for [the `@defer` directive](https://github.com/graphql/graphql-wg/blob/main/rfcs/DeferStream.md). This directive enables your queries to receive data for specific fields _incrementally_, instead of receiving all field data at the same time. This is helpful whenever some fields in a query take much longer to resolve than others.
+
+To use the `@defer` directive, we apply it to a field or fragment (in-line or named) that contains all slow-resolving fields:
+
+```graphql
+query PersonQuery($personId: ID!) {
+  person(id: $personId) {
+    # Basic fields (fast)
+    id
+    firstName
+    lastName
+
+    # Friend fields (slower)
+    ... @defer {
+      friends {
+        id
+      }
+    }
+  }
+}
+```
+
+For more information about the `@defer` directive, check out the [`@defer` docs](/react/data/defer).
+
+## `@export`
+
+If your GraphQL query uses variables, the local-only fields of that query can provide the values of those variables.
+
+To do so, you apply the `@export(as: "variableName")` directive, like so:
+
+```js
+const GET_CURRENT_AUTHOR_POST_COUNT = gql`
+  query CurrentAuthorPostCount($authorId: Int!) {
+    currentAuthorId @client @export(as: "authorId")
+    postCount(authorId: $authorId)
+  }
+`;
+```
+
+In the query above, the result of the local-only field `currentAuthorId` is used as the value of the `$authorId` variable that's passed to `postCount`.
+
+You can do this even if `postCount` is also a local-only field (i.e., if it's also marked as `@client`).
+
+For more information about the `@export` directive and other considerations when using `@export`, check out the [local-only fields docs](/react/local-state/managing-state-with-field-policies/#using-local-only-fields-as-graphql-variables).


### PR DESCRIPTION
Adds a directives page to the Apollo Client docs to centralize information about supported directives in preparation for documenting `@nonreactive` in the `release-3.8` branch.

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
