### PR TITLE
Use `optimism` 0.17.4

### DIFF
--- a/.changeset/small-pots-applaud.md
+++ b/.changeset/small-pots-applaud.md
@@ -1,0 +1,5 @@
+---
+'@apollo/client': patch
+---
+
+Bumps optimism to 0.17.2

--- a/.changeset/small-pots-applaud.md
+++ b/.changeset/small-pots-applaud.md
@@ -2,4 +2,11 @@
 '@apollo/client': patch
 ---
 
-Bumps optimism to 0.17.2
+Updates dependency versions in `package.json` by bumping:
+
+- `@wry/context` to `^0.7.3`
+- `@wry/equality` to `^0.5.6`
+- `@wry/trie` to `^0.4.3`
+- `optimism` to `^0.17.4`
+
+to 1. [fix sourcemap warnings](https://github.com/benjamn/wryware/pull/497) and 2. a Codesandbox [sandpack (in-browser) bundler transpilation bug](https://github.com/codesandbox/sandpack/issues/940) with an [upstream optimism workaround](https://github.com/benjamn/optimism/pull/550).

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
-        "@wry/context": "^0.7.0",
-        "@wry/equality": "^0.5.0",
+        "@wry/context": "^0.7.3",
+        "@wry/equality": "^0.5.6",
         "@wry/trie": "^0.4.0",
         "graphql-tag": "^2.12.6",
         "hoist-non-react-statics": "^3.3.2",
@@ -3149,9 +3149,9 @@
       }
     },
     "node_modules/@wry/context": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.0.tgz",
-      "integrity": "sha512-LcDAiYWRtwAoSOArfk7cuYvFXytxfVrdX7yxoUmK7pPITLk5jYh2F8knCwS7LjgYL8u1eidPlKKV6Ikqq0ODqQ==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.3.tgz",
+      "integrity": "sha512-Nl8WTesHp89RF803Se9X3IiHjdmLBrIvPMaJkl+rKVJAYyPsz1TEUbu89943HpvujtSJgDUx9W4vZw3K1Mr3sA==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -3160,11 +3160,11 @@
       }
     },
     "node_modules/@wry/equality": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.1.tgz",
-      "integrity": "sha512-FZKbdpbcVcbDxQrKcaBClNsQaMg9nof1RKM7mReJe5DKUzM5u8S7T+PqwNqvib5O2j2xxF1R4p5O3+b6baTrbw==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.6.tgz",
+      "integrity": "sha512-D46sfMTngaYlrH+OspKf8mIJETntFnf6Hsjb0V41jAXJ7Bx2kB8Rv8RCUujuVWYttFtHkUNp7g+FwxNQAr6mXA==",
       "dependencies": {
-        "tslib": "^2.1.0"
+        "tslib": "^2.3.0"
       },
       "engines": {
         "node": ">=8"
@@ -13013,19 +13013,19 @@
       }
     },
     "@wry/context": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.0.tgz",
-      "integrity": "sha512-LcDAiYWRtwAoSOArfk7cuYvFXytxfVrdX7yxoUmK7pPITLk5jYh2F8knCwS7LjgYL8u1eidPlKKV6Ikqq0ODqQ==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.3.tgz",
+      "integrity": "sha512-Nl8WTesHp89RF803Se9X3IiHjdmLBrIvPMaJkl+rKVJAYyPsz1TEUbu89943HpvujtSJgDUx9W4vZw3K1Mr3sA==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@wry/equality": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.1.tgz",
-      "integrity": "sha512-FZKbdpbcVcbDxQrKcaBClNsQaMg9nof1RKM7mReJe5DKUzM5u8S7T+PqwNqvib5O2j2xxF1R4p5O3+b6baTrbw==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.6.tgz",
+      "integrity": "sha512-D46sfMTngaYlrH+OspKf8mIJETntFnf6Hsjb0V41jAXJ7Bx2kB8Rv8RCUujuVWYttFtHkUNp7g+FwxNQAr6mXA==",
       "requires": {
-        "tslib": "^2.1.0"
+        "tslib": "^2.3.0"
       }
     },
     "@wry/trie": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@wry/trie": "^0.4.0",
         "graphql-tag": "^2.12.6",
         "hoist-non-react-statics": "^3.3.2",
-        "optimism": "^0.16.2",
+        "optimism": "^0.17.2",
         "prop-types": "^15.7.2",
         "response-iterator": "^0.2.6",
         "symbol-observable": "^4.0.0",
@@ -8113,12 +8113,13 @@
       }
     },
     "node_modules/optimism": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.2.tgz",
-      "integrity": "sha512-zWNbgWj+3vLEjZNIh/okkY2EUfX+vB9TJopzIZwT1xxaMqC5hRLLraePod4c5n4He08xuXNH+zhKFFCu390wiQ==",
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.17.2.tgz",
+      "integrity": "sha512-RVLg6dNItML36HMLVAw91Rz8Bqn+35NgbXT8x5z3EI9rLH4HAN9t2B6hXG/t+PuzvutJ5CHDovnky/dgcRo8GA==",
       "dependencies": {
         "@wry/context": "^0.7.0",
-        "@wry/trie": "^0.3.0"
+        "@wry/trie": "^0.3.0",
+        "tslib": "^2.3.0"
       }
     },
     "node_modules/optimism/node_modules/@wry/trie": {
@@ -16713,12 +16714,13 @@
       }
     },
     "optimism": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.2.tgz",
-      "integrity": "sha512-zWNbgWj+3vLEjZNIh/okkY2EUfX+vB9TJopzIZwT1xxaMqC5hRLLraePod4c5n4He08xuXNH+zhKFFCu390wiQ==",
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.17.2.tgz",
+      "integrity": "sha512-RVLg6dNItML36HMLVAw91Rz8Bqn+35NgbXT8x5z3EI9rLH4HAN9t2B6hXG/t+PuzvutJ5CHDovnky/dgcRo8GA==",
       "requires": {
         "@wry/context": "^0.7.0",
-        "@wry/trie": "^0.3.0"
+        "@wry/trie": "^0.3.0",
+        "tslib": "^2.3.0"
       },
       "dependencies": {
         "@wry/trie": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@wry/trie": "^0.4.3",
         "graphql-tag": "^2.12.6",
         "hoist-non-react-statics": "^3.3.2",
-        "optimism": "^0.17.2",
+        "optimism": "^0.17.4",
         "prop-types": "^15.7.2",
         "response-iterator": "^0.2.6",
         "symbol-observable": "^4.0.0",
@@ -8113,9 +8113,9 @@
       }
     },
     "node_modules/optimism": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.17.2.tgz",
-      "integrity": "sha512-RVLg6dNItML36HMLVAw91Rz8Bqn+35NgbXT8x5z3EI9rLH4HAN9t2B6hXG/t+PuzvutJ5CHDovnky/dgcRo8GA==",
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.17.4.tgz",
+      "integrity": "sha512-KoRKlIfGkU9j9FPlaIMvKJ8caF1Xdi2zeonabg1UPYutHp8jqoJCezR2XzP1yzBggs8LwTDBtQbwIY1BHpp1iw==",
       "dependencies": {
         "@wry/context": "^0.7.0",
         "@wry/trie": "^0.3.0",
@@ -16714,9 +16714,9 @@
       }
     },
     "optimism": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.17.2.tgz",
-      "integrity": "sha512-RVLg6dNItML36HMLVAw91Rz8Bqn+35NgbXT8x5z3EI9rLH4HAN9t2B6hXG/t+PuzvutJ5CHDovnky/dgcRo8GA==",
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.17.4.tgz",
+      "integrity": "sha512-KoRKlIfGkU9j9FPlaIMvKJ8caF1Xdi2zeonabg1UPYutHp8jqoJCezR2XzP1yzBggs8LwTDBtQbwIY1BHpp1iw==",
       "requires": {
         "@wry/context": "^0.7.0",
         "@wry/trie": "^0.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@wry/trie": "^0.4.0",
         "graphql-tag": "^2.12.6",
         "hoist-non-react-statics": "^3.3.2",
-        "optimism": "^0.17.0",
+        "optimism": "^0.16.2",
         "prop-types": "^15.7.2",
         "response-iterator": "^0.2.6",
         "symbol-observable": "^4.0.0",
@@ -8113,13 +8113,12 @@
       }
     },
     "node_modules/optimism": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.17.0.tgz",
-      "integrity": "sha512-EbyBcQxXp0scBym1CM0y2mWItyqE6/YpNHa7eDP4JXZfiPF5vGTJy1LlvO3n6/CUiGzXJJAbHEWg/hNiEBiTkw==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.2.tgz",
+      "integrity": "sha512-zWNbgWj+3vLEjZNIh/okkY2EUfX+vB9TJopzIZwT1xxaMqC5hRLLraePod4c5n4He08xuXNH+zhKFFCu390wiQ==",
       "dependencies": {
         "@wry/context": "^0.7.0",
-        "@wry/trie": "^0.3.0",
-        "tslib": "^2.3.0"
+        "@wry/trie": "^0.3.0"
       }
     },
     "node_modules/optimism/node_modules/@wry/trie": {
@@ -16714,13 +16713,12 @@
       }
     },
     "optimism": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.17.0.tgz",
-      "integrity": "sha512-EbyBcQxXp0scBym1CM0y2mWItyqE6/YpNHa7eDP4JXZfiPF5vGTJy1LlvO3n6/CUiGzXJJAbHEWg/hNiEBiTkw==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.2.tgz",
+      "integrity": "sha512-zWNbgWj+3vLEjZNIh/okkY2EUfX+vB9TJopzIZwT1xxaMqC5hRLLraePod4c5n4He08xuXNH+zhKFFCu390wiQ==",
       "requires": {
         "@wry/context": "^0.7.0",
-        "@wry/trie": "^0.3.0",
-        "tslib": "^2.3.0"
+        "@wry/trie": "^0.3.0"
       },
       "dependencies": {
         "@wry/trie": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@graphql-typed-document-node/core": "^3.1.1",
         "@wry/context": "^0.7.3",
         "@wry/equality": "^0.5.6",
-        "@wry/trie": "^0.4.0",
+        "@wry/trie": "^0.4.3",
         "graphql-tag": "^2.12.6",
         "hoist-non-react-statics": "^3.3.2",
         "optimism": "^0.17.2",
@@ -3171,9 +3171,9 @@
       }
     },
     "node_modules/@wry/trie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.4.2.tgz",
-      "integrity": "sha512-VXmoAZgeKmGU/ouIx5+p9tCCZzCr08qkyx+yuJUtkVvBlxTGNLbnq0aQ/GhqDDLSjBpQxM7B/yXXWmGZctoZag==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.4.3.tgz",
+      "integrity": "sha512-I6bHwH0fSf6RqQcnnXLJKhkSXG45MFral3GxPaY4uAl0LYDZM+YDVDAiU9bYwjTuysy1S0IeecWtmq1SZA3M1w==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -13029,9 +13029,9 @@
       }
     },
     "@wry/trie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.4.2.tgz",
-      "integrity": "sha512-VXmoAZgeKmGU/ouIx5+p9tCCZzCr08qkyx+yuJUtkVvBlxTGNLbnq0aQ/GhqDDLSjBpQxM7B/yXXWmGZctoZag==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.4.3.tgz",
+      "integrity": "sha512-I6bHwH0fSf6RqQcnnXLJKhkSXG45MFral3GxPaY4uAl0LYDZM+YDVDAiU9bYwjTuysy1S0IeecWtmq1SZA3M1w==",
       "requires": {
         "tslib": "^2.3.0"
       }

--- a/package.json
+++ b/package.json
@@ -86,8 +86,8 @@
   },
   "dependencies": {
     "@graphql-typed-document-node/core": "^3.1.1",
-    "@wry/context": "^0.7.0",
-    "@wry/equality": "^0.5.0",
+    "@wry/context": "^0.7.3",
+    "@wry/equality": "^0.5.6",
     "@wry/trie": "^0.4.0",
     "graphql-tag": "^2.12.6",
     "hoist-non-react-statics": "^3.3.2",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@wry/trie": "^0.4.0",
     "graphql-tag": "^2.12.6",
     "hoist-non-react-statics": "^3.3.2",
-    "optimism": "^0.17.0",
+    "optimism": "^0.16.2",
     "prop-types": "^15.7.2",
     "response-iterator": "^0.2.6",
     "symbol-observable": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@wry/trie": "^0.4.3",
     "graphql-tag": "^2.12.6",
     "hoist-non-react-statics": "^3.3.2",
-    "optimism": "^0.17.2",
+    "optimism": "^0.17.4",
     "prop-types": "^15.7.2",
     "response-iterator": "^0.2.6",
     "symbol-observable": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@wry/trie": "^0.4.0",
     "graphql-tag": "^2.12.6",
     "hoist-non-react-statics": "^3.3.2",
-    "optimism": "^0.16.2",
+    "optimism": "^0.17.2",
     "prop-types": "^15.7.2",
     "response-iterator": "^0.2.6",
     "symbol-observable": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@graphql-typed-document-node/core": "^3.1.1",
     "@wry/context": "^0.7.3",
     "@wry/equality": "^0.5.6",
-    "@wry/trie": "^0.4.0",
+    "@wry/trie": "^0.4.3",
     "graphql-tag": "^2.12.6",
     "hoist-non-react-statics": "^3.3.2",
     "optimism": "^0.17.2",


### PR DESCRIPTION
Closes https://github.com/apollographql/apollo-client/issues/10856.

Unblocks use of alphas/snapshot releases from branches targeting `release-3.8` with Codesandbox - upstream workaround landed in `optimism@0.17.4`.

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
