### PR TITLE
Fix `@defer` with payload containing "---"

### DIFF
--- a/.changeset/angry-weeks-marry.md
+++ b/.changeset/angry-weeks-marry.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+fix @defer for multipart responses containing "---" (or other boundary)

--- a/.changeset/angry-weeks-marry.md
+++ b/.changeset/angry-weeks-marry.md
@@ -2,4 +2,4 @@
 "@apollo/client": patch
 ---
 
-fix @defer for multipart responses containing "---" (or other boundary)
+Fixes a bug in how multipart responses are read when using `@defer`. When reading a multipart body, `HttpLink` no longer attempts to parse the boundary (e.g. `"---"` or other boundary string) within the response data itself, only when reading the beginning of each mulitpart chunked message.

--- a/src/link/http/__tests__/HttpLink.ts
+++ b/src/link/http/__tests__/HttpLink.ts
@@ -1360,7 +1360,10 @@ describe('HttpLink', () => {
         'Content-Type: application/json; charset=utf-8',
         'Content-Length: 58',
         '',
-        '{"hasNext":false, "incremental": [{"data":{"name":"stubby"},"path":["stub"],"extensions":{"timestamp":1633038919}}]}',
+        // Intentionally using the boundary value `---` within the “name” to
+        // validate that boundary delimiters are not parsed within the response
+        // data itself, only read at the beginning of each chunk.
+        '{"hasNext":false, "incremental": [{"data":{"name":"stubby---"},"path":["stub"],"extensions":{"timestamp":1633038919}}]}',
         '-----',
       ].join("\r\n");
 
@@ -1418,7 +1421,7 @@ describe('HttpLink', () => {
                 expect(result).toEqual({
                   incremental: [{
                     data: {
-                      name: 'stubby',
+                      name: 'stubby---',
                     },
                     extensions: {
                       timestamp: 1633038919,
@@ -1544,7 +1547,7 @@ describe('HttpLink', () => {
                 expect(result).toEqual({
                   incremental: [{
                     data: {
-                      name: 'stubby',
+                      name: 'stubby---',
                     },
                     extensions: {
                       timestamp: 1633038919,


### PR DESCRIPTION
When using `@defer` if the response payload contains "---" then the query will fail with an error message such as:

		ApolloError: Unterminated string in JSON at position 15378

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [X] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
