### PR TITLE
Improve TypeScript type-safety of `cache.modify`

### DIFF
--- a/.changeset/afraid-zebras-punch.md
+++ b/.changeset/afraid-zebras-punch.md
@@ -1,0 +1,27 @@
+---
+"@apollo/client": minor
+---
+
+Add generic type parameter for the cache `Modifiers` type. Improves TypeScript
+type inference for that type's fields and values of those fields.
+
+Example:
+
+```ts
+cache.modify({
+  id: cache.identify(someBook),
+  fields: {
+    title: (title) => {
+      // title has type `string`.
+      // It used to be `any`.
+    },
+    author: (author) => {
+      // author has type `Reference | Book["author"]`.
+      // It used to be `any`.
+    },
+  } satisfies Modifiers<Book>,
+});
+```
+
+To take advantage of the type inference, use [the `satisfies Modifiers<...>`
+operator](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-9.html).

--- a/.changeset/afraid-zebras-punch.md
+++ b/.changeset/afraid-zebras-punch.md
@@ -2,13 +2,13 @@
 "@apollo/client": minor
 ---
 
-Add generic type parameter for the cache `Modifiers` type. Improves TypeScript
-type inference for that type's fields and values of those fields.
+Add generic type parameter for the entity modified in `cache.modify`. Improves
+TypeScript type inference for that type's fields and values of those fields.
 
 Example:
 
 ```ts
-cache.modify({
+cache.modify<Book>({
   id: cache.identify(someBook),
   fields: {
     title: (title) => {
@@ -19,9 +19,6 @@ cache.modify({
       // author has type `Reference | Book["author"]`.
       // It used to be `any`.
     },
-  } satisfies Modifiers<Book>,
+  },
 });
 ```
-
-To take advantage of the type inference, use [the `satisfies Modifiers<...>`
-operator](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-9.html).

--- a/.changeset/cold-tips-accept.md
+++ b/.changeset/cold-tips-accept.md
@@ -1,0 +1,9 @@
+---
+"@apollo/client": minor
+---
+
+Use unique opaque types for the `DELETE` and `INVALIDATE` Apollo cache modifiers.
+
+This increases type safety, since these 2 modifiers no longer have the `any` type.
+Moreover, it no longer triggers [the `@typescript-eslint/no-unsafe-return`
+rule](https://typescript-eslint.io/rules/no-unsafe-return/).

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -120,7 +120,7 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
     return [];
   }
 
-  public modify<Entity = Record<string, any>>(options: Cache.ModifyOptions<Entity>): boolean {
+  public modify<Entity extends Record<string, any> = Record<string, any>>(options: Cache.ModifyOptions<Entity>): boolean {
     return false;
   }
 

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -120,7 +120,7 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
     return [];
   }
 
-  public modify<Entity = any>(options: Cache.ModifyOptions<Entity>): boolean {
+  public modify<Entity = Record<string, any>>(options: Cache.ModifyOptions<Entity>): boolean {
     return false;
   }
 

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -120,7 +120,7 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
     return [];
   }
 
-  public modify(options: Cache.ModifyOptions): boolean {
+  public modify<Entity = any>(options: Cache.ModifyOptions<Entity>): boolean {
     return false;
   }
 

--- a/src/cache/core/types/Cache.ts
+++ b/src/cache/core/types/Cache.ts
@@ -57,9 +57,11 @@ export namespace Cache {
     discardWatches?: boolean;
   }
 
-  export interface ModifyOptions {
+  export interface ModifyOptions<Entity = any> {
     id?: string;
-    fields: Modifiers<Record<string, any>> | Modifier<any>;
+    fields: Entity extends Record<string, unknown>
+      ? Modifiers<Entity> | Modifier<Entity>
+      : Modifier<Entity>;
     optimistic?: boolean;
     broadcast?: boolean;
   }

--- a/src/cache/core/types/Cache.ts
+++ b/src/cache/core/types/Cache.ts
@@ -1,5 +1,5 @@
 import { DataProxy } from './DataProxy';
-import type { Modifier, Modifiers } from './common';
+import type { AllFieldsModifier, Modifiers } from './common';;
 import type { ApolloCache } from '../cache';
 
 export namespace Cache {
@@ -57,11 +57,9 @@ export namespace Cache {
     discardWatches?: boolean;
   }
 
-  export interface ModifyOptions<Entity = Record<string, any>> {
+  export interface ModifyOptions<Entity extends Record<string, any> = Record<string, any>> {
     id?: string;
-    fields: Entity extends Record<string, unknown>
-      ? Modifiers<Entity> | Modifier<Entity>
-      : Modifier<Entity>;
+    fields: Modifiers<Entity> | AllFieldsModifier<Entity>;
     optimistic?: boolean;
     broadcast?: boolean;
   }

--- a/src/cache/core/types/Cache.ts
+++ b/src/cache/core/types/Cache.ts
@@ -59,7 +59,7 @@ export namespace Cache {
 
   export interface ModifyOptions {
     id?: string;
-    fields: Modifiers | Modifier<any>;
+    fields: Modifiers<Record<string, any>> | Modifier<any>;
     optimistic?: boolean;
     broadcast?: boolean;
   }

--- a/src/cache/core/types/Cache.ts
+++ b/src/cache/core/types/Cache.ts
@@ -57,7 +57,7 @@ export namespace Cache {
     discardWatches?: boolean;
   }
 
-  export interface ModifyOptions<Entity = any> {
+  export interface ModifyOptions<Entity = Record<string, any>> {
     id?: string;
     fields: Entity extends Record<string, unknown>
       ? Modifiers<Entity> | Modifier<Entity>

--- a/src/cache/core/types/common.ts
+++ b/src/cache/core/types/common.ts
@@ -107,7 +107,9 @@ type StoreObjectValueMaybeReference<StoreVal> = StoreVal extends Record<
   ? StoreVal | Reference
   : StoreVal;
 
-export type Modifiers<T extends Record<string, unknown>> = Partial<{
+export type Modifiers<
+  T extends Record<string, unknown> = Record<string, unknown>
+> = Partial<{
   [FieldName in keyof T]: Modifier<
     StoreObjectValueMaybeReference<Exclude<T[FieldName], undefined>>
   >;

--- a/src/cache/core/types/common.ts
+++ b/src/cache/core/types/common.ts
@@ -76,9 +76,14 @@ export type ToReferenceFunction = (
 
 export type CanReadFunction = (value: StoreValue) => boolean;
 
+declare const _deleteModifier: unique symbol;
+export type DeleteModifier = typeof _deleteModifier
+declare const _invalidateModifier: unique symbol;
+export type InvalidateModifier = typeof _invalidateModifier
+
 export type ModifierDetails = {
-  DELETE: any;
-  INVALIDATE: any;
+  DELETE: DeleteModifier;
+  INVALIDATE: InvalidateModifier;
   fieldName: string;
   storeFieldName: string;
   readField: ReadFieldFunction;
@@ -88,7 +93,10 @@ export type ModifierDetails = {
   storage: StorageType;
 }
 
-export type Modifier<T> = (value: T, details: ModifierDetails) => T;
+export type Modifier<T> = (
+  value: T,
+  details: ModifierDetails
+) => T | DeleteModifier | InvalidateModifier;
 
 export type Modifiers = {
   [fieldName: string]: Modifier<any>;

--- a/src/cache/core/types/common.ts
+++ b/src/cache/core/types/common.ts
@@ -98,17 +98,21 @@ export type Modifier<T> = (
   details: ModifierDetails
 ) => T | DeleteModifier | InvalidateModifier;
 
-type StoreObjectValueMaybeReference<StoreVal> = StoreVal extends Record<
-  string,
-  unknown
->[]
-  ? StoreVal | Reference[]
-  : StoreVal extends Record<string, unknown>
+type StoreObjectValueMaybeReference<StoreVal> = 
+  StoreVal extends Record<string, any>[]
+  ? Readonly<StoreVal> | readonly Reference[]
+  : StoreVal extends Record<string, any>
   ? StoreVal | Reference
   : StoreVal;
 
+export type AllFieldsModifier<
+  Entity extends Record<string, any>
+> = Modifier<Entity[keyof Entity] extends infer Value ? 
+  StoreObjectValueMaybeReference<Exclude<Value, undefined>>
+  : never>;
+
 export type Modifiers<
-  T extends Record<string, unknown> = Record<string, unknown>
+  T extends Record<string, any> = Record<string, unknown>
 > = Partial<{
   [FieldName in keyof T]: Modifier<
     StoreObjectValueMaybeReference<Exclude<T[FieldName], undefined>>

--- a/src/cache/core/types/common.ts
+++ b/src/cache/core/types/common.ts
@@ -98,6 +98,17 @@ export type Modifier<T> = (
   details: ModifierDetails
 ) => T | DeleteModifier | InvalidateModifier;
 
-export type Modifiers = {
-  [fieldName: string]: Modifier<any>;
-};
+type StoreObjectValueMaybeReference<StoreVal> = StoreVal extends Record<
+  string,
+  unknown
+>[]
+  ? StoreVal | Reference[]
+  : StoreVal extends Record<string, unknown>
+  ? StoreVal | Reference
+  : StoreVal;
+
+export type Modifiers<T extends Record<string, unknown>> = Partial<{
+  [FieldName in keyof T]: Modifier<
+    StoreObjectValueMaybeReference<Exclude<T[FieldName], undefined>>
+  >;
+}>;

--- a/src/cache/core/types/common.ts
+++ b/src/cache/core/types/common.ts
@@ -77,9 +77,9 @@ export type ToReferenceFunction = (
 export type CanReadFunction = (value: StoreValue) => boolean;
 
 declare const _deleteModifier: unique symbol;
-export type DeleteModifier = typeof _deleteModifier
+export interface DeleteModifier { [_deleteModifier]: true }
 declare const _invalidateModifier: unique symbol;
-export type InvalidateModifier = typeof _invalidateModifier
+export interface InvalidateModifier { [_invalidateModifier]: true}
 
 export type ModifierDetails = {
   DELETE: DeleteModifier;

--- a/src/cache/inmemory/__tests__/cache.ts
+++ b/src/cache/inmemory/__tests__/cache.ts
@@ -4056,7 +4056,7 @@ describe('TypedDocumentNode<Data, Variables>', () => {
       ): ExpectedType extends ActualType ? void : never =>
         void 0 as any;
 
-    cache.modify({
+    cache.modify<Book>({
       id: cache.identify(ffplBook),
       fields: {
         isbn: (value) => {
@@ -4077,7 +4077,7 @@ describe('TypedDocumentNode<Data, Variables>', () => {
 
           return DELETE;
         },
-      } satisfies Modifiers<Book>,
+      },
     });
   });
 });

--- a/src/cache/inmemory/__tests__/cache.ts
+++ b/src/cache/inmemory/__tests__/cache.ts
@@ -1,4 +1,5 @@
 import gql, { disableFragmentWarnings } from 'graphql-tag';
+import { expectTypeOf } from 'expect-type'
 
 import { cloneDeep } from '../../../utilities/common/cloneDeep';
 import { makeReference, Reference, makeVar, TypedDocumentNode, isReference, DocumentNode } from '../../../core';
@@ -4038,7 +4039,7 @@ describe('TypedDocumentNode<Data, Variables>', () => {
     });
   });
 
-  it("should infer the types of modifier fields", () => {
+  it.skip("should infer the types of modifier fields", () => {
     const cache = getBookCache();
 
     cache.writeQuery({
@@ -4049,31 +4050,23 @@ describe('TypedDocumentNode<Data, Variables>', () => {
       },
     });
 
-    /** Asserts the inferred TypeScript type of a value matches the expected type */
-    const assertType =
-      <ExpectedType>() =>
-      <ActualType extends ExpectedType>(
-        _value: ActualType
-      ): ExpectedType extends ActualType ? void : never =>
-        void 0 as any;
-
     cache.modify<Book>({
       id: cache.identify(ffplBook),
       fields: {
         isbn: (value) => {
-          assertType<string>()(value);
+          expectTypeOf(value).toEqualTypeOf<string>();
           return value;
         },
         title: (value, { INVALIDATE }) => {
-          assertType<string>()(value);
+          expectTypeOf(value).toEqualTypeOf<string>();
           return INVALIDATE;
         },
         author: (value, { DELETE, isReference }) => {
-          assertType<Reference | Book["author"]>()(value);
+          expectTypeOf(value).toEqualTypeOf<Reference | Book["author"]>();
           if (isReference(value)) {
-            assertType<Reference>()(value);
+            expectTypeOf(value).toEqualTypeOf<Reference>();
           } else {
-            assertType<Book["author"]>()(value);
+            expectTypeOf(value).toEqualTypeOf<Book["author"]>();
           }
 
           return DELETE;

--- a/src/cache/inmemory/__tests__/cache.ts
+++ b/src/cache/inmemory/__tests__/cache.ts
@@ -2,7 +2,7 @@ import gql, { disableFragmentWarnings } from 'graphql-tag';
 
 import { cloneDeep } from '../../../utilities/common/cloneDeep';
 import { makeReference, Reference, makeVar, TypedDocumentNode, isReference, DocumentNode } from '../../../core';
-import { Cache, Modifiers } from '../../../cache';
+import { Cache } from '../../../cache';
 import { InMemoryCache } from '../inMemoryCache';
 import { InMemoryCacheConfig } from '../types';
 
@@ -2817,7 +2817,7 @@ describe("InMemoryCache#modify", () => {
 
     cache.modify({
       fields: {
-        comments(comments: Reference[], { readField }) {
+        comments(comments: readonly Reference[], { readField }) {
           expect(Object.isFrozen(comments)).toBe(true);
           expect(comments.length).toBe(3);
           const filtered = comments.filter(comment => {
@@ -2902,6 +2902,7 @@ describe("InMemoryCache#modify", () => {
         expect(fieldName).not.toBe("b");
         if (fieldName === "a") expect(value).toBe(1);
         if (fieldName === "c") expect(value).toBe(3);
+        return value;
       },
       optimistic: true,
     });

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -195,7 +195,7 @@ export abstract class EntityStore implements NormalizedCache {
 
   public modify(
     dataId: string,
-    fields: Modifier<any> | Modifiers,
+    fields: Modifier<any> | Modifiers<Record<string, any>>,
   ): boolean {
     const storeObject = this.lookup(dataId);
 
@@ -226,7 +226,7 @@ export abstract class EntityStore implements NormalizedCache {
         const fieldName = fieldNameFromStoreName(storeFieldName);
         let fieldValue = storeObject[storeFieldName];
         if (fieldValue === void 0) return;
-        const modify: Modifier<StoreValue> = typeof fields === "function"
+        const modify: Modifier<StoreValue> | undefined = typeof fields === "function"
           ? fields
           : fields[storeFieldName] || fields[fieldName];
         if (modify) {

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -27,11 +27,14 @@ import type {
   ReadFieldOptions,
   ToReferenceFunction,
   CanReadFunction,
+  InvalidateModifier,
+  DeleteModifier,
+  ModifierDetails,
 } from '../core/types/common';
 
-const DELETE: any = Object.create(null);
+const DELETE: DeleteModifier = Object.create(null);
 const delModifier: Modifier<any> = () => DELETE;
-const INVALIDATE: any = Object.create(null);
+const INVALIDATE: InvalidateModifier = Object.create(null);
 
 export abstract class EntityStore implements NormalizedCache {
   protected data: NormalizedCacheObject = Object.create(null);
@@ -217,7 +220,7 @@ export abstract class EntityStore implements NormalizedCache {
           } : fieldNameOrOptions,
           { store: this },
         ),
-      };
+      } satisfies Partial<ModifierDetails>;
 
       Object.keys(storeObject).forEach(storeFieldName => {
         const fieldName = fieldNameFromStoreName(storeFieldName);

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -214,7 +214,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     }
   }
 
-  public modify(options: Cache.ModifyOptions): boolean {
+  public modify<Entity = any>(options: Cache.ModifyOptions<Entity>): boolean {
     if (hasOwn.call(options, "id") && !options.id) {
       // To my knowledge, TypeScript does not currently provide a way to
       // enforce that an optional property?:type must *not* be undefined

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -214,7 +214,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     }
   }
 
-  public modify<Entity = any>(options: Cache.ModifyOptions<Entity>): boolean {
+  public modify<Entity = Record<string, any>>(options: Cache.ModifyOptions<Entity>): boolean {
     if (hasOwn.call(options, "id") && !options.id) {
       // To my knowledge, TypeScript does not currently provide a way to
       // enforce that an optional property?:type must *not* be undefined

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -214,7 +214,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     }
   }
 
-  public modify<Entity = Record<string, any>>(options: Cache.ModifyOptions<Entity>): boolean {
+  public modify<Entity extends Record<string, any> = Record<string, any>>(options: Cache.ModifyOptions<Entity>): boolean {
     if (hasOwn.call(options, "id") && !options.id) {
       // To my knowledge, TypeScript does not currently provide a way to
       // enforce that an optional property?:type must *not* be undefined

--- a/src/cache/inmemory/types.ts
+++ b/src/cache/inmemory/types.ts
@@ -15,10 +15,10 @@ import type {
   FieldMergeFunction,
 } from './policies';
 import type {
-  Modifier,
   Modifiers,
   ToReferenceFunction,
   CanReadFunction,
+  AllFieldsModifier,
 } from '../core/types/common';
 
 import type { FragmentRegistryAPI } from './fragmentRegistry';
@@ -49,8 +49,7 @@ export interface NormalizedCache {
   merge(olderId: string, newerObject: StoreObject): void;
   merge(olderObject: StoreObject, newerId: string): void;
 
-  modify<Entity extends Record<string, any>>(dataId: string, fields: Modifiers<Entity>): boolean;
-  modify<Entity>(dataId: string, modifier: Modifier<Entity>): boolean;
+  modify<Entity extends Record<string, any>>(dataId: string, fields: Modifiers<Entity> | AllFieldsModifier<Entity>): boolean;
   delete(dataId: string, fieldName?: string): boolean;
   clear(): void;
 

--- a/src/cache/inmemory/types.ts
+++ b/src/cache/inmemory/types.ts
@@ -49,7 +49,7 @@ export interface NormalizedCache {
   merge(olderId: string, newerObject: StoreObject): void;
   merge(olderObject: StoreObject, newerId: string): void;
 
-  modify(dataId: string, fields: Modifiers | Modifier<any>): boolean;
+  modify(dataId: string, fields: Modifiers<Record<string, any>> | Modifier<any>): boolean;
   delete(dataId: string, fieldName?: string): boolean;
   clear(): void;
 

--- a/src/cache/inmemory/types.ts
+++ b/src/cache/inmemory/types.ts
@@ -49,7 +49,8 @@ export interface NormalizedCache {
   merge(olderId: string, newerObject: StoreObject): void;
   merge(olderObject: StoreObject, newerId: string): void;
 
-  modify(dataId: string, fields: Modifiers<Record<string, any>> | Modifier<any>): boolean;
+  modify<Entity extends Record<string, any>>(dataId: string, fields: Modifiers<Entity>): boolean;
+  modify<Entity>(dataId: string, modifier: Modifier<Entity>): boolean;
   delete(dataId: string, fieldName?: string): boolean;
   clear(): void;
 


### PR DESCRIPTION
This PR contains 2 changes that aim to improve the type safety of `fields` in `cache.modify`.

1. Add unique opaque types for the `DELETE` and `INVALIDATE` modifiers, so they are not `any`. This helps make [the `@typescript-eslint/no-unsafe-return` rule](https://typescript-eslint.io/rules/no-unsafe-return/) happy.
2. Add a generic type parameter for the `Modifiers` type to get type inference for `fields` names and values.

I described the changes in the commits. Look at their descriptions for more information.

Both changes only affect TypeScript types. There are no runtime changes.

I understand the 2nd commit is riskier than the first commit. I can split it into 2 PRs if you want to take longer with the review.

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes) **small feature, does not apply**
- [x] Make sure all of the significant new logic is covered by tests
