### PR TITLE
add `errors` docs page

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,5 @@
 # format "ObservableQuery" test (in #10597)
 104bf11765b1db50292f9656aa8fe48e2d749a83
+
+# Format "DisplayClientError.js" (#10909)
+0cb68364f2c3828badde8c74de44e9c1864fb6d4

--- a/docs/shared/DisplayClientError.js
+++ b/docs/shared/DisplayClientError.js
@@ -143,7 +143,7 @@ export default function DisplayClientError() {
       { error ? (
         <>
           <MDX.h3>
-            Error loading error codes
+            ⚠️ Unable to fetch error code
           </MDX.h3>
           <MDX.blockquote>{error.toString()}</MDX.blockquote>
         </>
@@ -152,7 +152,7 @@ export default function DisplayClientError() {
           {!errorMessage ? null : (
             <>
               <MDX.h2>
-                Error Message
+                Error message
               </MDX.h2>
               <MDX.blockquote>{errorMessage}</MDX.blockquote>
             </>

--- a/docs/shared/DisplayClientError.js
+++ b/docs/shared/DisplayClientError.js
@@ -1,0 +1,125 @@
+import React, {useEffect} from 'react';
+import {useMDXComponents} from '@mdx-js/react';
+
+/** @returns {{ file: string, condition?: string, errorMessage?: string }} */
+async function getErrorMessage(
+  /** @type {string} */ version,
+  /** @type {number} */ id,
+  /** @type {unknown[]} */ args
+) {
+  /** @type {{ [key: string]: { [key: number]: { file: string, condition?: string, message?: string } }}} */
+  const invariantErrorCodes = await window[
+    Symbol.for('importInvariantErrorCodes')
+  ](version);
+
+  /** @type { [key: number]: { file: string, condition?: string, message?: string }} */
+  const data = {};
+  for (const codes of Object.values(invariantErrorCodes)) {
+    Object.assign(data, codes);
+  }
+  if (!data[id]) {
+    throw 'Error message could not be found!';
+  }
+  // eslint-disable-next-line prefer-const
+  let {file, condition, message: errorMessage} = data[id];
+
+  if (errorMessage) {
+    errorMessage = /** @type{string} */ (
+      args.reduce(
+        (/** @type{string} */ acc, arg) => acc.replace('%s', String(arg)),
+        String(errorMessage)
+      )
+    );
+  }
+  return {file, condition, errorMessage};
+}
+
+export default function DisplayClientError() {
+
+  const MDX = useMDXComponents()
+
+  const [{file, errorMessage, condition, error}, updateErrorDetails] =
+    React.useState({
+      file: '',
+      errorMessage: '',
+      condition: ''
+    });
+  const scriptRef = React.useRef(null);
+  useEffect(() => {
+    if (scriptRef.current.children.length === 0) {
+      const script = document.createElement('script');
+      script.type = 'module';
+      script.textContent =`
+        globalThis[Symbol.for("importInvariantErrorCodes")] = (version) => {
+          if (!version || !/^[0-9a-zA-Z.-]+$/.test(version)) {
+            throw 'Invalid Version!';
+          }
+          return import("https://cdn.jsdelivr.net/npm/@apollo/client@" + version + "/invariantErrorCodes.js");
+        }
+        `;
+      scriptRef.current.appendChild(script);
+    }
+
+    let mounted = true;
+    const listener = async () => {
+      const hash = decodeURIComponent(location.hash.substring(1)) || '{}';
+      const parsedHash = JSON.parse(hash);
+
+      const {version = 'latest', message = -1, args = []} = parsedHash;
+
+      try {
+        const data = await getErrorMessage(version, message, args)
+        if (!mounted) return;
+        updateErrorDetails(data);
+      } catch (e) {
+        updateErrorDetails({error: String(e)});
+      }
+    };
+    addEventListener('hashchange', listener);
+    listener();
+    return () => {
+      mounted = false;
+      removeEventListener('hashchange', listener);
+    }
+  }, []);
+  return (
+    <div>
+      <div ref={scriptRef}></div>
+      {error ? (
+        <>
+          <MDX.h3>
+            Error loading error codes
+          </MDX.h3>
+          <MDX.blockquote>{error}</MDX.blockquote>
+        </>
+      ) : (
+        <>
+          {!errorMessage ? null : (
+            <>
+              <MDX.h2>
+                Error Message
+              </MDX.h2>
+              <MDX.blockquote>{errorMessage}</MDX.blockquote>
+            </>
+          )}
+          {!file ? null : (
+            <>
+              <MDX.h3>
+                File
+              </MDX.h3>
+              <MDX.inlineCode>{file}</MDX.inlineCode>
+            </>
+          )}
+          {!condition ? null : (
+            <>
+              <MDX.h3>
+                Condition
+              </MDX.h3>
+              <MDX.inlineCode>{condition}</MDX.inlineCode>
+            </>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/docs/shared/DisplayClientError.js
+++ b/docs/shared/DisplayClientError.js
@@ -80,7 +80,7 @@ export default function DisplayClientError() {
     try {
       return JSON.parse(decodeURIComponent(hash.substring(1)) || '{}');
     } catch {
-      return { parsingError: 'Could not parse Url.' };
+      return { parsingError: 'Could not parse URL.' };
     }
   }, [hash]);
   const {

--- a/docs/shared/DisplayClientError.js
+++ b/docs/shared/DisplayClientError.js
@@ -1,12 +1,13 @@
 // @ts-check
 // this whole file
 
-import React, {useEffect, useState, useMemo} from 'react';
+import React, { useEffect, useState, useMemo } from 'react';
 // @ts-ignore
-import {useHash as _useHash} from 'react-use';
-import {useMDXComponents} from '@mdx-js/react';
+import { useHash as _useHash } from 'react-use';
+// @ts-ignore
+import { useMDXComponents } from '@mdx-js/react';
 
-const useHash = typeof window !== "undefined" ? _useHash : () => "#{}";
+const useHash = typeof window !== 'undefined' ? _useHash : () => '#{}';
 
 /**
  * @typedef {{ [key: number]: { file: string, condition?: string, message?: string }}} Messages
@@ -26,23 +27,27 @@ async function loadData(version) {
   return data;
 }
 
-function useInjectLoaderScript(){
+function useInjectLoaderScript() {
   // do not do this in SSR
-  if (typeof window === "undefined") return false;
+  if (typeof window === 'undefined') return false;
 
-  const scriptLoader = globalThis[Symbol.for("importInvariantErrorCodes")];
+  const scriptLoader = globalThis[Symbol.for('importInvariantErrorCodes')];
   const [scriptInitialized, setScriptInitialized] = useState(!!scriptLoader);
   useEffect(() => {
     if (scriptInitialized) {
-     return;
+      return;
     }
     if (scriptLoader) {
       setScriptInitialized(true);
       return;
     }
-    addEventListener('importInvariantErrorCodes', () => {
-      setScriptInitialized(true);
-    }, {once: true});
+    addEventListener(
+      'importInvariantErrorCodes',
+      () => {
+        setScriptInitialized(true);
+      },
+      { once: true }
+    );
     addScript();
   }, []);
 
@@ -53,7 +58,7 @@ function useInjectLoaderScript(){
       const script = document.createElement('script');
       script.id = 'importInvariantErrorCodes';
       script.type = 'module';
-      script.textContent =`
+      script.textContent = `
         globalThis[Symbol.for("importInvariantErrorCodes")] = (version) => {
           if (!version || !/^[0-9a-zA-Z.-]+$/.test(version)) {
             throw 'Invalid Version!';
@@ -68,57 +73,73 @@ function useInjectLoaderScript(){
 }
 
 export default function DisplayClientError() {
-    const MDX = /** @type {any} */ (useMDXComponents());
+  const MDX = /** @type {any} */ (useMDXComponents());
 
-    const [hash] = useHash();
-    const parsedHash = useMemo(() => {
-      try {
-        return JSON.parse(decodeURIComponent(hash.substring(1)) || '{}');
-      } catch {
-        return { parsingError: 'Could not parse Url.' }
-      }
-    }, [hash]);
-    const {version = 'latest', message: id = -1, args = [], parsingError} = parsedHash;
+  const [hash] = useHash();
+  const parsedHash = useMemo(() => {
+    try {
+      return JSON.parse(decodeURIComponent(hash.substring(1)) || '{}');
+    } catch {
+      return { parsingError: 'Could not parse Url.' };
+    }
+  }, [hash]);
+  const {
+    version = 'latest',
+    message: id = -1,
+    args = [],
+    parsingError,
+  } = parsedHash;
 
-    const [data, setData] = useState(/** @type {null | Messages | { dataError: string }} */ (null))
-    const scriptInitialized = useInjectLoaderScript();
-    useEffect(() => {
-      if (!scriptInitialized) return;
-      let active = true;
-      loadData(version).then(data => { if (active) setData(data)}).catch(dataError => setData({dataError}));
-      return () => {
-        active = false;
-      }
-    }, [version, scriptInitialized]);
+  const [data, setData] = useState(
+    /** @type {null | Messages | { dataError: string }} */ (null)
+  );
+  const scriptInitialized = useInjectLoaderScript();
+  useEffect(() => {
+    if (!scriptInitialized) return;
+    let active = true;
+    loadData(version)
+      .then((data) => {
+        if (active) setData(data);
+      })
+      .catch((dataError) => setData({ dataError }));
+    return () => {
+      active = false;
+    };
+  }, [version, scriptInitialized]);
 
-    const {file, errorMessage, condition, error: dataError} = useMemo(() => {
-      if (!data) return {
+  const {
+    file,
+    errorMessage,
+    condition,
+    error: dataError,
+  } = useMemo(() => {
+    if (!data)
+      return {
         file: 'Loading...',
         errorMessage: 'Loading...',
-        condition: 'Loading...'
-      }
+        condition: 'Loading...',
+      };
 
-      if ('dataError' in data) {
-        return { error: data.dataError };
-      }
+    if ('dataError' in data) {
+      return { error: data.dataError };
+    }
 
-      if (!data[id]) {
-        return { error: 'Error message could not be found!' };
-      }
-      let {file, condition, message: errorMessage} = data[id];
+    if (!data[id]) {
+      return { error: 'Error message could not be found!' };
+    }
+    let { file, condition, message: errorMessage } = data[id];
 
-      if (errorMessage) {
-        errorMessage = /** @type{string} */ (
-          args.reduce(
-            (/** @type{string} */ acc, arg) => acc.replace('%s', String(arg)),
-            String(errorMessage)
-          )
-        );
-      }
+    if (errorMessage) {
+      errorMessage = /** @type{string} */ (
+        args.reduce(
+          (/** @type{string} */ acc, arg) => acc.replace('%s', String(arg)),
+          String(errorMessage)
+        )
+      );
+    }
 
-      return {file, condition, errorMessage};
-    }, [data, id, args])
-
+    return { file, condition, errorMessage };
+  }, [data, id, args]);
 
   useEffect(() => {
     // replacing all links within this help page with spans to prevent them
@@ -126,9 +147,9 @@ export default function DisplayClientError() {
     for (const link of [...document.querySelectorAll('main h2 a, main h3 a')]) {
       var replacement = document.createElement('span');
       replacement.innerHTML = link.innerHTML;
-      link.replaceWith(replacement)
+      link.replaceWith(replacement);
     }
-  }, [])
+  }, []);
 
   if (hash.length <= 0) {
     // the page was loaded without a hash, so we don't know what to display
@@ -139,37 +160,31 @@ export default function DisplayClientError() {
   const error = dataError || parsingError;
 
   return (
-    <div style={errorMessage == 'Loading...'? {filter: "blur(5px)"} : undefined}>
-      { error ? (
+    <div
+      style={errorMessage == 'Loading...' ? { filter: 'blur(5px)' } : undefined}
+    >
+      {error ? (
         <>
-          <MDX.h3>
-            ⚠️ Unable to fetch error code
-          </MDX.h3>
+          <MDX.h3>⚠️ Unable to fetch error code</MDX.h3>
           <MDX.blockquote>{error.toString()}</MDX.blockquote>
         </>
       ) : (
         <>
           {!errorMessage ? null : (
             <>
-              <MDX.h2>
-                Error message
-              </MDX.h2>
+              <MDX.h2>Error message</MDX.h2>
               <MDX.blockquote>{errorMessage}</MDX.blockquote>
             </>
           )}
           {!file ? null : (
             <>
-              <MDX.h3>
-                File
-              </MDX.h3>
+              <MDX.h3>File</MDX.h3>
               <MDX.inlineCode>{file}</MDX.inlineCode>
             </>
           )}
           {!condition ? null : (
             <>
-              <MDX.h3>
-                Condition
-              </MDX.h3>
+              <MDX.h3>Condition</MDX.h3>
               <MDX.inlineCode>{condition}</MDX.inlineCode>
             </>
           )}

--- a/docs/shared/DisplayClientError.js
+++ b/docs/shared/DisplayClientError.js
@@ -3,8 +3,10 @@
 
 import React, {useEffect, useState, useMemo} from 'react';
 // @ts-ignore
-import {useHash} from 'react-use';
+import {useHash as _useHash} from 'react-use';
 import {useMDXComponents} from '@mdx-js/react';
+
+const useHash = typeof window !== "undefined" ? _useHash : () => "#{}";
 
 /**
  * @typedef {{ [key: number]: { file: string, condition?: string, message?: string }}} Messages

--- a/docs/shared/DisplayClientError.js
+++ b/docs/shared/DisplayClientError.js
@@ -159,37 +159,37 @@ export default function DisplayClientError() {
 
   const error = dataError || parsingError;
 
+  if (error) {
+    return (
+      <>
+        <MDX.h3>⚠️ Unable to fetch error code</MDX.h3>
+        <MDX.blockquote>{error.toString()}</MDX.blockquote>
+      </>
+    );
+  }
+
   return (
     <div
       style={{
         filter: errorMessage === 'Loading...' ? 'blur(5px)' : undefined,
       }}
     >
-      {error ? (
+      {!errorMessage ? null : (
         <>
-          <MDX.h3>⚠️ Unable to fetch error code</MDX.h3>
-          <MDX.blockquote>{error.toString()}</MDX.blockquote>
+          <MDX.h2>Error message</MDX.h2>
+          <MDX.blockquote>{errorMessage}</MDX.blockquote>
         </>
-      ) : (
+      )}
+      {!file ? null : (
         <>
-          {!errorMessage ? null : (
-            <>
-              <MDX.h2>Error message</MDX.h2>
-              <MDX.blockquote>{errorMessage}</MDX.blockquote>
-            </>
-          )}
-          {!file ? null : (
-            <>
-              <MDX.h3>File</MDX.h3>
-              <MDX.inlineCode>{file}</MDX.inlineCode>
-            </>
-          )}
-          {!condition ? null : (
-            <>
-              <MDX.h3>Condition</MDX.h3>
-              <MDX.inlineCode>{condition}</MDX.inlineCode>
-            </>
-          )}
+          <MDX.h3>File</MDX.h3>
+          <MDX.inlineCode>{file}</MDX.inlineCode>
+        </>
+      )}
+      {!condition ? null : (
+        <>
+          <MDX.h3>Condition</MDX.h3>
+          <MDX.inlineCode>{condition}</MDX.inlineCode>
         </>
       )}
     </div>

--- a/docs/shared/DisplayClientError.js
+++ b/docs/shared/DisplayClientError.js
@@ -161,7 +161,9 @@ export default function DisplayClientError() {
 
   return (
     <div
-      style={errorMessage == 'Loading...' ? { filter: 'blur(5px)' } : undefined}
+      style={
+        errorMessage === 'Loading...' ? { filter: 'blur(5px)' } : undefined
+      }
     >
       {error ? (
         <>

--- a/docs/shared/DisplayClientError.js
+++ b/docs/shared/DisplayClientError.js
@@ -100,17 +100,15 @@ function useLoadedErrorMessage(version, messageId) {
 
         const details = data[messageId];
 
-        setTimeout(() => {
-          setState(
-            details
-              ? { loading: false, error: null, data: details }
-              : {
-                  loading: false,
-                  error: new Error('Error message could not be found.'),
-                  data: null,
-                }
-          );
-        }, 5000);
+        setState(
+          details
+            ? { loading: false, error: null, data: details }
+            : {
+                loading: false,
+                error: new Error('Error message could not be found.'),
+                data: null,
+              }
+        );
       })
       .catch((error) => setState({ error, loading: false, data: null }));
 

--- a/docs/shared/DisplayClientError.js
+++ b/docs/shared/DisplayClientError.js
@@ -161,9 +161,9 @@ export default function DisplayClientError() {
 
   return (
     <div
-      style={
-        errorMessage === 'Loading...' ? { filter: 'blur(5px)' } : undefined
-      }
+      style={{
+        filter: errorMessage === 'Loading...' ? 'blur(5px)' : undefined,
+      }}
     >
       {error ? (
         <>

--- a/docs/shared/DisplayClientError.js
+++ b/docs/shared/DisplayClientError.js
@@ -25,6 +25,9 @@ async function loadData(version) {
 }
 
 function useInjectLoaderScript(){
+  // do not do this in SSR
+  if (typeof window === "undefined") return false;
+
   const scriptLoader = globalThis[Symbol.for("importInvariantErrorCodes")];
   const [scriptInitialized, setScriptInitialized] = useState(!!scriptLoader);
   useEffect(() => {

--- a/docs/shared/DisplayClientError.js
+++ b/docs/shared/DisplayClientError.js
@@ -151,7 +151,7 @@ export default function DisplayClientError() {
     }
   }, []);
 
-  if (hash.length <= 0) {
+  if (hash.length === 0) {
     // the page was loaded without a hash, so we don't know what to display
     // just display the page itself without error information
     return null;

--- a/docs/source/errors.mdx
+++ b/docs/source/errors.mdx
@@ -1,30 +1,36 @@
 ---
 title: Error code details
+description: For Apollo Client
 toc: false
 ---
 import DisplayClientError from '../shared/DisplayClientError.js';
 
 <DisplayClientError />
 
-## Why am I seeing this?
+## What is this page?
 
-In Apollo Client 3.8 and later, we are shipping the error messages separately to save bundle size. You can still load them manually, but this is an opt-in mechanism.
+Beginning with version 3.8, Apollo Client _omits_ error messages from its core bundle to reduce its bundle size. Instead, errors direct you to this page to view details.
 
-### Opting in to error message inclusion
+**If you prefer, you can add Apollo Client error messages to your app:**
 
-You can call the `loadErrorMessages` function from `"@apollo/client/dev"` to
-load error messages. Similarly, you can use `loadDevMessages` to import development-time console messages.
-
-### Limiting error message inclusion to development builds
-
-In most environments, you can check for `__DEV__` to make sure that you are in a development environment. So your code to load the error messages conditionally could for example look like this:
-
-```js
+```js title="App.js"
 import { loadErrorMessages, loadDevMessages } from "@apollo/client/dev";
-if (__DEV__) {
-  loadErrorMessages();
+
+if (__DEV__) {  // Adds messages only in a dev environment
   loadDevMessages();
+  loadErrorMessages();
 }
 ```
 
-Not all environments support `__DEV__`, so if that doesn't work, you maybe want to check for `process.env.NODE_ENV !== "production"` instead.
+- `loadDevMessages()` loads messages for errors that are raised _only in a development environment_.
+- `loadErrorMessages()` loads messages for errors that are raised in _all_ environments.
+
+You can call either or both of these methods on application load.
+
+<blockquote>
+
+**Note:** The example above checks for the presence of the `__DEV__` variable and loads error messages only if it's present (indicating a dev environment). This can provide a helpful development experience while minimizing your bundle size in production.
+
+The `__DEV__` variable isn't available in all environments. As an alternative, you can check whether `process.env.NODE_ENV !== "production"`.
+
+</blockquote>

--- a/docs/source/errors.mdx
+++ b/docs/source/errors.mdx
@@ -21,7 +21,7 @@ messages.
 ### Only shipping error messages in development builds
 
 In most environments, you can check for `__DEV__`
-to make sure that you are in a developement environment.
+to make sure that you are in a development environment.
 So your code to load the error messages conditionally could for example look like this:
 
 ```js

--- a/docs/source/errors.mdx
+++ b/docs/source/errors.mdx
@@ -1,0 +1,36 @@
+---
+title: Error Code Details
+---
+import DisplayClientError from '../shared/DisplayClientError.js';
+
+<DisplayClientError />
+
+## Why am I seeing this?
+
+Since Apollo Client 3.8, we are shipping the error messages separately to save
+bundle size.<br/>
+You can still load them manually, but this is an opt-in mechanism.
+
+### Opt-in into shipping error messages
+
+You can call the `loadErrorMessages` function from `"@apollo/client/dev"` to
+load error messages.<br/>
+Similarly, you can use `loadDevMessages` to import development-time console
+messages.
+
+### Only shipping error messages in development builds
+
+In most environments, you can check for `__DEV__`
+to make sure that you are in a developement environment.
+So your code to load the error messages conditionally could for example look like this:
+
+```js
+import { loadErrorMessages, loadDevMessages } from "@apollo/client/dev";
+if (__DEV__) {
+  loadErrorMessages();
+  loadDevMessages();
+}
+```
+
+Not all environments support `__DEV__`, so if that doesn't work, you maybe want to
+check for `process.env.NODE_ENV !== "production"` instead.

--- a/docs/source/errors.mdx
+++ b/docs/source/errors.mdx
@@ -1,5 +1,5 @@
 ---
-title: Error Code Details
+title: Error code details
 ---
 import DisplayClientError from '../shared/DisplayClientError.js';
 
@@ -7,22 +7,16 @@ import DisplayClientError from '../shared/DisplayClientError.js';
 
 ## Why am I seeing this?
 
-Since Apollo Client 3.8, we are shipping the error messages separately to save
-bundle size.<br/>
-You can still load them manually, but this is an opt-in mechanism.
+In Apollo Client 3.8 and later, we are shipping the error messages separately to save bundle size. You can still load them manually, but this is an opt-in mechanism.
 
-### Opt-in into shipping error messages
+### Opting in to error message inclusion
 
 You can call the `loadErrorMessages` function from `"@apollo/client/dev"` to
-load error messages.<br/>
-Similarly, you can use `loadDevMessages` to import development-time console
-messages.
+load error messages. Similarly, you can use `loadDevMessages` to import development-time console messages.
 
-### Only shipping error messages in development builds
+### Limiting error message inclusion to development builds
 
-In most environments, you can check for `__DEV__`
-to make sure that you are in a development environment.
-So your code to load the error messages conditionally could for example look like this:
+In most environments, you can check for `__DEV__` to make sure that you are in a development environment. So your code to load the error messages conditionally could for example look like this:
 
 ```js
 import { loadErrorMessages, loadDevMessages } from "@apollo/client/dev";
@@ -32,5 +26,4 @@ if (__DEV__) {
 }
 ```
 
-Not all environments support `__DEV__`, so if that doesn't work, you maybe want to
-check for `process.env.NODE_ENV !== "production"` instead.
+Not all environments support `__DEV__`, so if that doesn't work, you maybe want to check for `process.env.NODE_ENV !== "production"` instead.

--- a/docs/source/errors.mdx
+++ b/docs/source/errors.mdx
@@ -1,5 +1,6 @@
 ---
 title: Error code details
+toc: false
 ---
 import DisplayClientError from '../shared/DisplayClientError.js';
 


### PR DESCRIPTION
This adds a new page for https://www.apollographql.com/docs/react/errors

For testing this locally, check out `https://github.com/apollographql/docs` in parallel to the `apollo-client` repo and run `npm run start:local -- ../apollo-client` - the page will be available at [local url](http://localhost:3000/errors#{%22version%22:%20%220.0.0-pr-10887-20230522141246%22,%20%22message%22:%208,%20%22args%22:%20[%22foo%22,%20%22bar%22]})

Or, in the [deployed preview link](https://deploy-preview-10909--apollo-client-docs.netlify.app/errors/#{%22version%22:%20%220.0.0-pr-10887-20230522141246%22,%20%22message%22:%208,%20%22args%22:%20[%22foo%22,%20%22bar%22]})

![image](https://github.com/apollographql/apollo-client/assets/4282439/0ca861c8-ee30-4886-9a9d-65665a54337d)
