### PR TITLE
Update docs on @defer directive usage with GraphQL Code Generator

### DIFF
--- a/docs/source/data/defer.mdx
+++ b/docs/source/data/defer.mdx
@@ -78,6 +78,4 @@ For this reason, `@defer` can be thought of as a tool to improve initial renderi
 
 ## Using with code generation
 
-If you currently use [GraphQL Code Generator](https://www.the-guild.dev/graphql/codegen) for your codegen needs, note that it doesn't yet support the use of the `@defer` directive in the code output.
-
-The status of this support is tracked in [this GitHub issue](https://github.com/dotansimha/graphql-code-generator/issues/7885).
+If you currently use [GraphQL Code Generator](https://www.the-guild.dev/graphql/codegen) for your codegen needs, you'll need to use the Codegen version `4.0.0` or higher. Please refer to the [Codegen documentation](https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#fragment-masking-with-defer-directive) for more information.


### PR DESCRIPTION
We recently added and released a `@defer`  directive support in GraphQL Code Generator — https://github.com/dotansimha/graphql-code-generator/pull/9196. This PR updates the Apollo Client documentation on the status of defer support in the Codegen.

### Checklist:

- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
