### PR TITLE
Ensure `operation.getContext` and `operation.setContext` functions are callable for links after `removeTypenameFromVariables`

### DIFF
--- a/.changeset/popular-beers-move.md
+++ b/.changeset/popular-beers-move.md
@@ -1,0 +1,5 @@
+---
+'@apollo/client': patch
+---
+
+Fix an issue when using a link that relied on `operation.getContext` and `operation.setContext` would error out when it was declared after the `removeTypenameFromVariables` link.

--- a/src/link/remove-typename/__tests__/removeTypenameFromVariables.ts
+++ b/src/link/remove-typename/__tests__/removeTypenameFromVariables.ts
@@ -517,3 +517,24 @@ test('handles when declared variables are unused', async () => {
     },
   });
 });
+
+test('ensures operation.getContext and operation.setContext functions are properly forwarded', async () => {
+  const query = gql`
+    query Test($foo: FooInput) {
+      someField(foo: $foo)
+    }
+  `;
+
+  const link = removeTypenameFromVariables();
+
+  const operationWithoutVariables = await execute(link, { query });
+  const operationWithVariables = await execute(link, {
+    query,
+    variables: { foo: { __typename: 'FooInput', bar: true } },
+  });
+
+  expect(typeof operationWithoutVariables.getContext).toBe('function');
+  expect(typeof operationWithoutVariables.setContext).toBe('function');
+  expect(typeof operationWithVariables.getContext).toBe('function');
+  expect(typeof operationWithVariables.setContext).toBe('function');
+});

--- a/src/link/remove-typename/removeTypenameFromVariables.ts
+++ b/src/link/remove-typename/removeTypenameFromVariables.ts
@@ -26,12 +26,11 @@ export function removeTypenameFromVariables(
       return forward(operation);
     }
 
-    return forward({
-      ...operation,
-      variables: except
-        ? maybeStripTypenameUsingConfig(query, variables, except)
-        : stripTypename(variables),
-    });
+    operation.variables = except
+      ? maybeStripTypenameUsingConfig(query, variables, except)
+      : stripTypename(variables);
+
+    return forward(operation);
   });
 }
 


### PR DESCRIPTION
#10853 introduced a new Apollo Link that automatically removes `__typename` from variables before a request is made. After trying this link out in the [Spotify showcase](https://github.com/apollographql/spotify-showcase), I found that `operation.getContext` and `operation.setContext` functions were not callable, thus the page would blow up.

This was due to the fact that `operation.getContext` and `operation.setContext` were not declared [enumerable](https://github.com/apollographql/apollo-client/blob/249076fd908c79350077369961ea8e78fb06d862/src/link/utils/createOperation.ts#L17-L25). This link originally forwarded the operation by using the spread syntax, which omitted these functions from the `operation`.

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
