### PR TITLE
Move `DocumentTransform` to `utilities` package to avoid circular dependency

### DIFF
--- a/.changeset/fast-tomatoes-peel.md
+++ b/.changeset/fast-tomatoes-peel.md
@@ -1,0 +1,5 @@
+---
+'@apollo/client': patch
+---
+
+Moves `DocumentTransform` to the `utilities` sub-package to avoid a circular dependency between the `core` and `cache` sub-packages.

--- a/.prettierignore
+++ b/.prettierignore
@@ -49,9 +49,7 @@ src/core/*
 !src/core/__tests__/
 src/core/tests/*
 !src/core/__tests__/equalByQuery.ts
-!src/core/__tests__/DocumentTransform.ts
 !src/core/equalByQuery.ts
-!src/core/DocumentTransform.ts
 
 # Allowed utilities
 !src/utilities/
@@ -76,6 +74,10 @@ src/utilities/globals/*
 !src/utilities/graphql
 src/utilities/graphql/*
 !src/utilities/graphql/operations.ts
+!src/utilities/graphql/DocumentTransform.ts
+!src/utilities/graphql/__tests__/
+src/utilities/graphql/__tests__/*
+!src/utilities/graphql/__tests__/DocumentTransform.ts
 
 # Allowed links
 !src/link

--- a/src/__tests__/__snapshots__/exports.ts.snap
+++ b/src/__tests__/__snapshots__/exports.ts.snap
@@ -383,6 +383,7 @@ Array [
   "Concast",
   "DEV",
   "DeepMerger",
+  "DocumentTransform",
   "Observable",
   "addTypenameToDocument",
   "argumentsObjectFromField",

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -4,7 +4,6 @@ import gql from 'graphql-tag';
 
 import {
   ApolloClient,
-  DocumentTransform,
   FetchPolicy,
   WatchQueryFetchPolicy,
   QueryOptions,
@@ -14,7 +13,7 @@ import {
   NetworkStatus,
 } from '../core';
 
-import { Observable, ObservableSubscription, offsetLimitPagination, removeDirectivesFromDocument } from '../utilities';
+import { DocumentTransform, Observable, ObservableSubscription, offsetLimitPagination, removeDirectivesFromDocument } from '../utilities';
 import { ApolloLink } from '../link/core';
 import { createFragmentRegistry, InMemoryCache, makeVar, PossibleTypesMap } from '../cache';
 import { ApolloError } from '../errors';

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -17,6 +17,7 @@ import type {
 import {
   addTypenameToDocument,
   isReference,
+  DocumentTransform,
 } from '../../utilities';
 import type {
   InMemoryCacheConfig,
@@ -29,7 +30,6 @@ import { makeVar, forgetCache, recallCache } from './reactiveVars';
 import { Policies } from './policies';
 import { hasOwn, normalizeConfig, shouldCanonizeResults } from './helpers';
 import { canonicalStringify } from './object-canon';
-import { DocumentTransform } from '../../core';
 import type { OperationVariables } from '../../core';
 
 type BroadcastOptions = Pick<

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -5,12 +5,11 @@ import type { ExecutionResult, DocumentNode } from 'graphql';
 import type { FetchResult, GraphQLRequest} from '../link/core';
 import { ApolloLink, execute } from '../link/core';
 import type { ApolloCache, DataProxy, Reference } from '../cache';
-import type { Observable } from '../utilities';
+import type { DocumentTransform, Observable } from '../utilities';
 import { version } from '../version';
 import type { UriFunction } from '../link/http';
 import { HttpLink } from '../link/http';
 
-import type { DocumentTransform } from './DocumentTransform';
 import { QueryManager } from './QueryManager';
 import type { ObservableQuery } from './ObservableQuery';
 

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -34,6 +34,7 @@ import {
   makeUniqueId,
   isDocumentNode,
   isNonNullObject,
+  DocumentTransform,
 } from '../utilities';
 import { mergeIncrementalData } from '../utilities/common/incrementalResult';
 import { ApolloError, isApolloError, graphQLResultHasProtocolErrors } from '../errors';
@@ -57,7 +58,6 @@ import type {
   InternalRefetchQueriesResult,
   InternalRefetchQueriesMap,
 } from './types';
-import { DocumentTransform } from './DocumentTransform';
 import { LocalState } from './LocalState';
 
 import type {

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -4,14 +4,13 @@ import { TypedDocumentNode } from "@graphql-typed-document-node/core";
 
 import { 
   ApolloClient,
-  DocumentTransform,
   NetworkStatus,
   WatchQueryFetchPolicy
 } from "../../core";
 import { ObservableQuery } from "../ObservableQuery";
 import { QueryManager } from "../QueryManager";
 
-import { Observable, removeDirectivesFromDocument } from "../../utilities";
+import { DocumentTransform, Observable, removeDirectivesFromDocument } from "../../utilities";
 import { ApolloLink, FetchResult } from "../../link/core";
 import { InMemoryCache, NormalizedCacheObject } from "../../cache";
 import { ApolloError } from "../../errors";

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -31,11 +31,6 @@ export {
   FragmentMatcher,
 } from './LocalState';
 export { isApolloError, ApolloError } from '../errors';
-export { 
-  DocumentTransform,
-  DocumentTransformCacheKey
-} from './DocumentTransform';
-
 /* Cache */
 
 export {
@@ -77,6 +72,8 @@ export {
 /* Utilities */
 
 export {
+  DocumentTransform,
+  DocumentTransformCacheKey,
   Observable,
   Observer,
   ObservableSubscription,

--- a/src/utilities/graphql/DocumentTransform.ts
+++ b/src/utilities/graphql/DocumentTransform.ts
@@ -1,6 +1,7 @@
 import { Trie } from '@wry/trie';
-import { canUseWeakMap, canUseWeakSet, checkDocument } from '../utilities';
-import { invariant } from '../utilities/globals';
+import { canUseWeakMap, canUseWeakSet } from '../common/canUse';
+import { checkDocument } from './getFromAST';
+import { invariant } from '../globals';
 import type { DocumentNode } from 'graphql';
 
 export type DocumentTransformCacheKey = ReadonlyArray<unknown>;

--- a/src/utilities/graphql/__tests__/DocumentTransform.ts
+++ b/src/utilities/graphql/__tests__/DocumentTransform.ts
@@ -1,9 +1,6 @@
 import { DocumentTransform } from '../DocumentTransform';
-import {
-  isMutationOperation,
-  isQueryOperation,
-  removeDirectivesFromDocument,
-} from '../../utilities';
+import { isMutationOperation, isQueryOperation } from '../operations';
+import { removeDirectivesFromDocument } from '../transform';
 import { gql } from 'graphql-tag';
 import { DocumentNode, visit, Kind } from 'graphql';
 

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -12,6 +12,11 @@ export {
   getInclusionDirectives,
 } from './graphql/directives';
 
+export { 
+  DocumentTransform,
+  DocumentTransformCacheKey
+} from './graphql/DocumentTransform';
+
 export {
   FragmentMap,
   FragmentMapFunction,


### PR DESCRIPTION
Fixes #10936

Moves the `DocumentTransform` class to the `utilities` sub-package to avoid a circular dependency between the `core` and `cache` sub-packages.

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
