### PR TITLE
Deduplicate InMemoryCache maybeBroadcastWatch calls for duplicate watches / queries

### DIFF
--- a/.changeset/metal-kings-compete.md
+++ b/.changeset/metal-kings-compete.md
@@ -1,0 +1,8 @@
+---
+"@apollo/client": patch
+---
+
+Deduplicate `maybeBroadcastWatch` calls in `InMemoryCache` by cache key to
+improve duplicate watch scalability. Move watch callback in `QueryInfo` to
+referentially consistent private static function and pass `Cache.WatchOption`'s
+`watcher` property into it.

--- a/config/bundlesize.ts
+++ b/config/bundlesize.ts
@@ -3,7 +3,7 @@ import { join } from "path";
 import { gzipSync } from "zlib";
 import bytes from "bytes";
 
-const gzipBundleByteLengthLimit = bytes("33.02KB");
+const gzipBundleByteLengthLimit = bytes("33.09KB");
 const minFile = join("dist", "apollo-client.min.cjs");
 const minPath = join(__dirname, "..", minFile);
 const gzipByteLen = gzipSync(readFileSync(minPath)).byteLength;

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -3195,7 +3195,7 @@ describe('@connection', () => {
     const aResults = watch(aQuery);
     const bResults = watch(bQuery);
 
-    expect(cache["watches"].size).toBe(2);
+    expect(cache["watchesByCacheKey"].size).toBe(2);
 
     expect(aResults).toEqual([]);
     expect(bResults).toEqual([]);
@@ -3213,10 +3213,10 @@ describe('@connection', () => {
     expect(aResults).toEqual([]);
     expect(bResults).toEqual([]);
 
-    expect(cache["watches"].size).toBe(0);
+    expect(cache["watchesByCacheKey"].size).toBe(0);
     const abResults = watch(abQuery);
     expect(abResults).toEqual([]);
-    expect(cache["watches"].size).toBe(1);
+    expect(cache["watchesByCacheKey"].size).toBe(1);
 
     await wait();
 

--- a/src/cache/core/types/Cache.ts
+++ b/src/cache/core/types/Cache.ts
@@ -6,6 +6,7 @@ export namespace Cache {
   export type WatchCallback<TData = any> = (
     diff: Cache.DiffResult<TData>,
     lastDiff?: Cache.DiffResult<TData>,
+    watcher?: object,
   ) => void;
 
   export interface ReadOptions<TVariables = any, TData = any>

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -307,6 +307,14 @@ export class QueryInfo {
 
   private lastWatch?: Cache.WatchOptions;
 
+  // consistent callback reference that can take advantage of Trie caching
+  // when generating cache keys
+  private static onWatch: Cache.WatchCallback = (diff, _lastDiff, watcher) => {
+    if (watcher instanceof QueryInfo) {
+      watcher.setDiff(diff);
+    }
+  };
+
   private updateWatch(variables = this.variables) {
     const oq = this.observableQuery;
     if (oq && oq.options.fetchPolicy === "no-cache") {
@@ -319,7 +327,7 @@ export class QueryInfo {
       // we can reuse getDiffOptions here, for consistency.
       ...this.getDiffOptions(variables),
       watcher: this,
-      callback: diff => this.setDiff(diff),
+      callback: QueryInfo.onWatch,
     };
 
     if (!this.lastWatch ||


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ x ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ x ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ x ] Make sure all of the significant new logic is covered by tests

This PR attempts to address https://github.com/apollographql/apollo-client/issues/10322 through the following changes:
* moving the watch callback `QueryInfo` passes into `InMemoryCache.watch` to a referentially consistent private static function within `QueryInfo` to ensure that watches corresponding to duplicate `useQuery` calls hit the same nodes within the key-making `Trie`.
* grouping `InMemoryCache.watches` by cache key to form a `Map<object, Set<Cache.WatchOptions>>` and calling `maybeBroadcastWatches` once per unique set instead of per watch when broadcasting all watches.

When profiled on a local development React project that uses a few thousand largely duplicate `useQuery` hooks across a long list of React components, the amount of time consumed by broadcasting watches decreased from the scale of ~12 seconds with current versions of `@apollo/client` to under 300 ms using this branch.


