### PR TITLE
Remove `useGETForQueries` option in `BatchHttpLink.Options`

### DIFF
--- a/.changeset/spicy-waves-shake.md
+++ b/.changeset/spicy-waves-shake.md
@@ -1,0 +1,5 @@
+---
+'@apollo/client': patch
+---
+
+Remove `useGETForQueries` option in `BatchHttpLink.Options` type since it is not supported.

--- a/src/link/batch-http/batchHttpLink.ts
+++ b/src/link/batch-http/batchHttpLink.ts
@@ -18,7 +18,7 @@ export namespace BatchHttpLink {
   export type Options = Pick<
     BatchLink.Options,
     'batchMax' | 'batchDebounce' | 'batchInterval' | 'batchKey'
-  > & HttpOptions;
+  > & Omit<HttpOptions, 'useGETForQueries'>;
 }
 
 /**


### PR DESCRIPTION
Fixes #10956

The `useGETForQueries` option is not supported in `BatchHttpLink`, but our TypeScript type currently allows this option. This PR removes support for that option in the TypeScript type to ensure devs trying to use this option are properly warned that the option is not supported.

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
