### PR TITLE
fix: variables incorrectly removed in `BatchHttpLink`

### DIFF
--- a/.changeset/odd-pumpkins-care.md
+++ b/.changeset/odd-pumpkins-care.md
@@ -1,0 +1,5 @@
+---
+'@apollo/client': patch
+---
+
+Fixes a bug in `BatchHttpLink` that removed variables from all requests by default.

--- a/src/link/batch-http/batchHttpLink.ts
+++ b/src/link/batch-http/batchHttpLink.ts
@@ -132,7 +132,7 @@ export class BatchHttpLink extends ApolloLink {
         );
 
         if (result.body.variables && !includeUnusedVariables) {
-          result.body.variables = filterOperationVariables(result.body, operation);
+          result.body.variables = filterOperationVariables(result.body.variables, operation);
         }
 
         return result;

--- a/src/link/batch-http/batchHttpLink.ts
+++ b/src/link/batch-http/batchHttpLink.ts
@@ -132,7 +132,10 @@ export class BatchHttpLink extends ApolloLink {
         );
 
         if (result.body.variables && !includeUnusedVariables) {
-          result.body.variables = filterOperationVariables(result.body.variables, operation);
+          result.body.variables = filterOperationVariables(
+            result.body.variables,
+            operation.query
+          );
         }
 
         return result;

--- a/src/link/http/createHttpLink.ts
+++ b/src/link/http/createHttpLink.ts
@@ -116,7 +116,7 @@ export const createHttpLink = (linkOptions: HttpOptions = {}) => {
     );
 
     if (body.variables && !includeUnusedVariables) {
-      body.variables = filterOperationVariables(body.variables, operation);
+      body.variables = filterOperationVariables(body.variables, operation.query);
     }
 
     let controller: any;

--- a/src/link/utils/__tests__/filterOperationVariables.ts
+++ b/src/link/utils/__tests__/filterOperationVariables.ts
@@ -1,6 +1,5 @@
 import gql from 'graphql-tag';
 import { filterOperationVariables } from '../filterOperationVariables';
-import { createOperation } from '../createOperation';
 
 const sampleQueryWithVariables = gql`
   query MyQuery($a: Int!) {
@@ -23,7 +22,7 @@ describe('filterOperationVariables', () => {
     const variables = { a: 1, b: 2, c: 3 };
     const result = filterOperationVariables(
       variables,
-      createOperation({}, { query: sampleQueryWithoutVariables, variables })
+      sampleQueryWithoutVariables
     );
     expect(result).toEqual({});
   });
@@ -32,7 +31,7 @@ describe('filterOperationVariables', () => {
     const variables = { a: 1, b: 2, c: 3 };
     const result = filterOperationVariables(
       variables,
-      createOperation({}, { query: sampleQueryWithVariables, variables })
+      sampleQueryWithVariables
     );
     expect(result).toEqual({ a: 1 });
   });

--- a/src/link/utils/filterOperationVariables.ts
+++ b/src/link/utils/filterOperationVariables.ts
@@ -1,23 +1,27 @@
-import type { VariableDefinitionNode} from "graphql";
-import { visit } from "graphql";
+import type { VariableDefinitionNode, DocumentNode } from 'graphql';
+import { visit } from 'graphql';
 
-import type { Operation } from "../core";
-
-export function filterOperationVariables(variables: Record<string, any>, operation: Operation) {
+export function filterOperationVariables(
+  variables: Record<string, any>,
+  query: DocumentNode
+) {
   const result = { ...variables };
   const unusedNames = new Set(Object.keys(variables));
-  visit(operation.query, {
+  visit(query, {
     Variable(node, _key, parent) {
       // A variable type definition at the top level of a query is not
       // enough to silence server-side errors about the variable being
       // unused, so variable definitions do not count as usage.
       // https://spec.graphql.org/draft/#sec-All-Variables-Used
-      if (parent && (parent as VariableDefinitionNode).kind !== 'VariableDefinition') {
+      if (
+        parent &&
+        (parent as VariableDefinitionNode).kind !== 'VariableDefinition'
+      ) {
         unusedNames.delete(node.name.value);
       }
     },
   });
-  unusedNames.forEach(name => {
+  unusedNames.forEach((name) => {
     delete result![name];
   });
   return result;


### PR DESCRIPTION
Fixes a bug in https://github.com/apollographql/apollo-client/pull/10754 which caused all variables to be removed from `BatchHttpLink` requests. Added the same integration test used in `HttpLink`'s test suite.

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
