### PR TITLE
Suspense cache: use Trie directly

### DIFF
--- a/.changeset/tasty-wasps-relate.md
+++ b/.changeset/tasty-wasps-relate.md
@@ -2,4 +2,4 @@
 '@apollo/client': patch
 ---
 
-SuspenseCache: use Trie directly
+Slightly decrease bundle size and memory footprint of `SuspenseCache` by changing how cache entries are stored internally.

--- a/.changeset/tasty-wasps-relate.md
+++ b/.changeset/tasty-wasps-relate.md
@@ -1,0 +1,5 @@
+---
+'@apollo/client': patch
+---
+
+SuspenseCache: use Trie directly

--- a/src/react/cache/SuspenseCache.ts
+++ b/src/react/cache/SuspenseCache.ts
@@ -19,10 +19,7 @@ interface SuspenseCacheOptions {
 }
 
 export class SuspenseCache {
-  private queryRefs = new Trie<{ current?: QueryReference }>(
-    canUseWeakMap,
-    () => Object.create(null)
-  );
+  private queryRefs = new Trie<{ current?: QueryReference }>(canUseWeakMap);
   private options: SuspenseCacheOptions;
 
   constructor(options: SuspenseCacheOptions = Object.create(null)) {

--- a/src/react/cache/SuspenseCache.ts
+++ b/src/react/cache/SuspenseCache.ts
@@ -37,10 +37,12 @@ export class SuspenseCache {
 
     if (!ref.current) {
       ref.current = new QueryReference(createObservable(), {
-          key: cacheKey,
-          autoDisposeTimeoutMs: this.options.autoDisposeTimeoutMs,
-          onDispose: () => { delete ref.current },
-        })
+        key: cacheKey,
+        autoDisposeTimeoutMs: this.options.autoDisposeTimeoutMs,
+        onDispose: () => {
+          delete ref.current;
+        },
+      });
     }
 
     return ref.current as QueryReference<TData>;

--- a/src/react/hooks/__tests__/useBackgroundQuery.test.tsx
+++ b/src/react/hooks/__tests__/useBackgroundQuery.test.tsx
@@ -697,8 +697,11 @@ describe('useBackgroundQuery', () => {
       }
     );
 
-    expect(directSuspenseCache['queryRefs'].size).toBe(1);
-    expect(contextSuspenseCache['queryRefs'].size).toBe(0);
+    expect(directSuspenseCache).toHaveSuspenseCacheEntryUsing(client, query);
+    expect(contextSuspenseCache).not.toHaveSuspenseCacheEntryUsing(
+      client,
+      query
+    );
   });
 
   it('passes context to the link', async () => {

--- a/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
@@ -47,51 +47,6 @@ import { ApolloProvider } from '../../context';
 import { SuspenseCache } from '../../cache';
 import { SuspenseQueryHookFetchPolicy } from '../../../react';
 import { useSuspenseQuery } from '../useSuspenseQuery';
-import { canonicalStringify } from '../../../cache';
-
-expect.extend({
-  toHaveSuspenseCacheEntryUsing(
-    suspenseCache: SuspenseCache,
-    client: ApolloClient<unknown>,
-    query: DocumentNode,
-    {
-      variables,
-      queryKey = [],
-    }: {
-      variables?: OperationVariables;
-      queryKey?: string | number | any[];
-    } = Object.create(null)
-  ) {
-    const cacheKey = (
-      [client, query, canonicalStringify(variables)] as any[]
-    ).concat(queryKey);
-    const queryRef = suspenseCache['queryRefs'].lookupArray(cacheKey)?.current;
-
-    return {
-      pass: !!queryRef,
-      message: () => {
-        return `Expected suspense cache ${
-          queryRef ? 'not ' : ''
-        }to have cache entry using key`;
-      },
-    };
-  },
-});
-
-declare global {
-  namespace jest {
-    interface Matchers<R = void> {
-      toHaveSuspenseCacheEntryUsing(
-        client: ApolloClient<unknown>,
-        query: DocumentNode,
-        options?: {
-          variables?: OperationVariables;
-          queryKey?: string | number | any[];
-        }
-      ): R;
-    }
-  }
-}
 
 type RenderSuspenseHookOptions<Props, TSerializedCache = {}> = Omit<
   RenderHookOptions<Props>,

--- a/src/testing/matchers/index.d.ts
+++ b/src/testing/matchers/index.d.ts
@@ -1,4 +1,8 @@
-import type { DocumentNode } from '../../core';
+import type {
+  ApolloClient,
+  DocumentNode,
+  OperationVariables,
+} from '../../core';
 
 interface ApolloCustomMatchers<R = void> {
   /**
@@ -6,6 +10,18 @@ interface ApolloCustomMatchers<R = void> {
    * comparing their printed values. The document must be parsed by `gql`.
    */
   toMatchDocument(document: DocumentNode): R;
+
+  /**
+   * Used to determine if the Suspense cache has a cache entry.
+   */
+  toHaveSuspenseCacheEntryUsing(
+    client: ApolloClient<unknown>,
+    query: DocumentNode,
+    options?: {
+      variables?: OperationVariables;
+      queryKey?: string | number | any[];
+    }
+  ): R;
 }
 
 declare global {

--- a/src/testing/matchers/index.ts
+++ b/src/testing/matchers/index.ts
@@ -1,6 +1,8 @@
 import { expect } from '@jest/globals';
 import { toMatchDocument } from './toMatchDocument';
+import { toHaveSuspenseCacheEntryUsing } from './toHaveSuspenseCacheEntryUsing';
 
 expect.extend({
+  toHaveSuspenseCacheEntryUsing,
   toMatchDocument,
 });

--- a/src/testing/matchers/toHaveSuspenseCacheEntryUsing.ts
+++ b/src/testing/matchers/toHaveSuspenseCacheEntryUsing.ts
@@ -1,0 +1,39 @@
+import type { MatcherFunction } from 'expect';
+import type { DocumentNode } from 'graphql';
+import type { ApolloClient, OperationVariables } from '../../core';
+import { SuspenseCache } from '../../react';
+import { canonicalStringify } from '../../cache';
+
+export const toHaveSuspenseCacheEntryUsing: MatcherFunction<
+  [
+    client: ApolloClient<unknown>,
+    query: DocumentNode,
+    options: {
+      variables?: OperationVariables;
+      queryKey?: string | number | any[];
+    }
+  ]
+> = function (
+  suspenseCache,
+  client,
+  query,
+  { variables, queryKey = [] } = Object.create(null)
+) {
+  if (!(suspenseCache instanceof SuspenseCache)) {
+    throw new Error('Actual must be an instance of `SuspenseCache`');
+  }
+
+  const cacheKey = (
+    [client, query, canonicalStringify(variables)] as any[]
+  ).concat(queryKey);
+  const queryRef = suspenseCache['queryRefs'].lookupArray(cacheKey)?.current;
+
+  return {
+    pass: !!queryRef,
+    message: () => {
+      return `Expected suspense cache ${
+        queryRef ? 'not ' : ''
+      }to have cache entry using key`;
+    },
+  };
+};


### PR DESCRIPTION
### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests


I saw this and thought we could save some bundle size here by using Trie directly - with the downside that this is a bit harder to test.
@jerelmiller what are your thoughts on this? If you think this makes sense, I'll try to find a way to rewrite those failing tests.