### PR TITLE
[Do Not Merge] Reverts fix in #10891 to unblock testing

### DIFF
--- a/.changeset/healthy-rocks-lay.md
+++ b/.changeset/healthy-rocks-lay.md
@@ -1,0 +1,5 @@
+---
+'@apollo/client': patch
+---
+
+Reverts fix in #10891 to unblock testing.

--- a/src/link/http/__tests__/HttpLink.ts
+++ b/src/link/http/__tests__/HttpLink.ts
@@ -1430,10 +1430,7 @@ describe('HttpLink', () => {
         'Content-Type: application/json; charset=utf-8',
         'Content-Length: 58',
         '',
-        // Intentionally using the boundary value `---` within the “name” to
-        // validate that boundary delimiters are not parsed within the response
-        // data itself, only read at the beginning of each chunk.
-        '{"hasNext":false, "incremental": [{"data":{"name":"stubby---"},"path":["stub"],"extensions":{"timestamp":1633038919}}]}',
+        '{"hasNext":false, "incremental": [{"data":{"name":"stubby"},"path":["stub"],"extensions":{"timestamp":1633038919}}]}',
         '-----',
       ].join("\r\n");
 
@@ -1491,7 +1488,7 @@ describe('HttpLink', () => {
                 expect(result).toEqual({
                   incremental: [{
                     data: {
-                      name: 'stubby---',
+                      name: 'stubby',
                     },
                     extensions: {
                       timestamp: 1633038919,
@@ -1617,7 +1614,7 @@ describe('HttpLink', () => {
                 expect(result).toEqual({
                   incremental: [{
                     data: {
-                      name: 'stubby---',
+                      name: 'stubby',
                     },
                     extensions: {
                       timestamp: 1633038919,

--- a/src/link/http/parseAndCheckHttpResponse.ts
+++ b/src/link/http/parseAndCheckHttpResponse.ts
@@ -39,7 +39,7 @@ export async function readMultipartBody<
         .trim()
     : "-";
 
-  const boundary = `\r\n--${boundaryVal}`;
+  let boundary = `--${boundaryVal}`;
   let buffer = "";
   const iterator = responseIterator(response);
   let running = true;
@@ -47,10 +47,9 @@ export async function readMultipartBody<
   while (running) {
     const { value, done } = await iterator.next();
     const chunk = typeof value === "string" ? value : decoder.decode(value);
-    const searchFrom = buffer.length - boundary.length + 1;
     running = !done;
     buffer += chunk;
-    let bi = buffer.indexOf(boundary, searchFrom);
+    let bi = buffer.indexOf(boundary);
 
     while (bi > -1) {
       let message: string;
@@ -58,24 +57,22 @@ export async function readMultipartBody<
         buffer.slice(0, bi),
         buffer.slice(bi + boundary.length),
       ];
-      const i = message.indexOf("\r\n\r\n");
-      const headers = parseHeaders(message.slice(0, i));
-      const contentType = headers["content-type"];
-      if (
-        contentType &&
-        contentType.toLowerCase().indexOf("application/json") === -1
-      ) {
-        throw new Error(
-          "Unsupported patch content type: application/json is required."
-        );
-      }
-      // nb: Technically you'd want to slice off the beginning "\r\n" but since
-      // this is going to be `JSON.parse`d there is no need.
-      const body = message.slice(i);
+      if (message.trim()) {
+        const i = message.indexOf("\r\n\r\n");
+        const headers = parseHeaders(message.slice(0, i));
+        const contentType = headers["content-type"];
+        if (
+          contentType &&
+          contentType.toLowerCase().indexOf("application/json") === -1
+        ) {
+          throw new Error(
+            "Unsupported patch content type: application/json is required."
+          );
+        }
+        const body = message.slice(i);
 
-      if (body) {
         try {
-          const result = parseJsonBody<T>(response, body);
+          const result = parseJsonBody<T>(response, body.replace("\r\n", ""));
           if (
             Object.keys(result).length > 1 ||
             "data" in result ||


### PR DESCRIPTION
Temporarily revert "Fix `@defer` with payload containing "---" (#10891)" to unblock testing until upstream fix is in place.

This reverts commit ab42a5c08840193cb915f4e66d71fac3834fec68.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
