### PR TITLE
chore: make tag name dynamic in postpublish message for prereleases

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Get npm tag from pre.json
         id: tag
-        uses: notiz-dev/github-action-json-property@release
+        uses: notiz-dev/github-action-json-property@v0.2.0
         with:
           path: ".changeset/pre.json"
           prop_path: "tag"


### PR DESCRIPTION
A small thing that was bothering me :) This reads the tag name from `pre.json` so we don't have to update that string manually every time we change the prerelease tag.

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
