### PR TITLE
replace `create-react-app` with `vite` in get started

### DIFF
--- a/docs/source/get-started.mdx
+++ b/docs/source/get-started.mdx
@@ -10,7 +10,7 @@ Hello! 👋 This short tutorial gets you up and running with Apollo Client.
 
 To start this tutorial, do one of the following:
 
-- Create a new React project locally with [Create React App](https://create-react-app.dev/), or
+- Create a new React project locally with [React Vite](https://vitejs.dev/), or
 - Create a new React sandbox on [CodeSandbox](https://codesandbox.io/).
 
 ## Step 2: Install dependencies


### PR DESCRIPTION
Since `create-react-app` is deprecated and no one longer uses it, I think in docs should be replaced with vite 

### Checklist:

- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
