### PR TITLE
`QueryReference`: check for `resolve`/`reject`

### DIFF
--- a/.changeset/little-schools-roll.md
+++ b/.changeset/little-schools-roll.md
@@ -1,0 +1,5 @@
+---
+'@apollo/client': patch
+---
+
+Fix a bug in `QueryReference` where `this.resolve` or `this.reject` might be executed even if `undefined`.

--- a/src/react/cache/QueryReference.ts
+++ b/src/react/cache/QueryReference.ts
@@ -36,8 +36,8 @@ export class QueryReference<TData = unknown> {
   private initialized = false;
   private refetching = false;
 
-  private resolve: (result: ApolloQueryResult<TData>) => void;
-  private reject: (error: unknown) => void;
+  private resolve: ((result: ApolloQueryResult<TData>) => void) | undefined;
+  private reject: ((error: unknown) => void) | undefined;
 
   constructor(
     observable: ObservableQuery<TData>,
@@ -157,7 +157,9 @@ export class QueryReference<TData = unknown> {
       this.initialized = true;
       this.refetching = false;
       this.result = result;
-      this.resolve(result);
+      if (this.resolve) {
+        this.resolve(result);
+      }
       return;
     }
 
@@ -182,7 +184,9 @@ export class QueryReference<TData = unknown> {
     if (!this.initialized || this.refetching) {
       this.initialized = true;
       this.refetching = false;
-      this.reject(error);
+      if (this.reject) {
+        this.reject(error);
+      }
       return;
     }
 


### PR DESCRIPTION
This came up in [this Discord message](https://discord.com/channels/1022972389463687228/1120746279849443439/1120746279849443439)

![image](https://github.com/apollographql/apollo-client/assets/4282439/8f8cf959-e66e-4aa9-ad24-2f38a7814cd1)

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
