### PR TITLE
Hide queryRef in a Symbol in `useBackgroundQuery` return value

### DIFF
--- a/.changeset/smooth-clouds-sort.md
+++ b/.changeset/smooth-clouds-sort.md
@@ -1,0 +1,5 @@
+---
+'@apollo/client': patch
+---
+
+Hide queryRef in a Symbol in `useBackgroundQuery`s return value.

--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -1,7 +1,7 @@
 const checks = [
   {
     path: "dist/apollo-client.min.cjs",
-    limit: "37700"
+    limit: "37750"
   },
   {
     path: "dist/main.cjs",
@@ -10,7 +10,7 @@ const checks = [
   {
     path: "dist/index.js",
     import: "{ ApolloClient, InMemoryCache, HttpLink }",
-    limit: "33269"
+    limit: "33375"
   },
   ...[
     "ApolloProvider",

--- a/src/react/cache/QueryReference.ts
+++ b/src/react/cache/QueryReference.ts
@@ -15,7 +15,7 @@ type Listener<TData> = (promise: Promise<ApolloQueryResult<TData>>) => void;
 
 type FetchMoreOptions<TData> = Parameters<
   ObservableQuery<TData>['fetchMore']
-  >[0];
+>[0];
 
 export const QUERY_REFERENCE_SYMBOL: unique symbol = Symbol();
 /**

--- a/src/react/cache/SuspenseCache.ts
+++ b/src/react/cache/SuspenseCache.ts
@@ -1,7 +1,7 @@
 import { Trie } from '@wry/trie';
 import type { ObservableQuery } from '../../core';
 import { canUseWeakMap } from '../../utilities';
-import { QueryReference } from './QueryReference';
+import { InternalQueryReference } from './QueryReference';
 import type { CacheKey } from './types';
 
 interface SuspenseCacheOptions {
@@ -19,7 +19,7 @@ interface SuspenseCacheOptions {
 }
 
 export class SuspenseCache {
-  private queryRefs = new Trie<{ current?: QueryReference }>(canUseWeakMap);
+  private queryRefs = new Trie<{ current?: InternalQueryReference }>(canUseWeakMap);
   private options: SuspenseCacheOptions;
 
   constructor(options: SuspenseCacheOptions = Object.create(null)) {
@@ -33,7 +33,7 @@ export class SuspenseCache {
     const ref = this.queryRefs.lookupArray(cacheKey);
 
     if (!ref.current) {
-      ref.current = new QueryReference(createObservable(), {
+      ref.current = new InternalQueryReference(createObservable(), {
         key: cacheKey,
         autoDisposeTimeoutMs: this.options.autoDisposeTimeoutMs,
         onDispose: () => {
@@ -42,6 +42,6 @@ export class SuspenseCache {
       });
     }
 
-    return ref.current as QueryReference<TData>;
+    return ref.current as InternalQueryReference<TData>;
   }
 }

--- a/src/react/hooks/__tests__/useBackgroundQuery.test.tsx
+++ b/src/react/hooks/__tests__/useBackgroundQuery.test.tsx
@@ -37,6 +37,7 @@ import {
 import { concatPagination, offsetLimitPagination } from '../../../utilities';
 import { useBackgroundQuery, useReadQuery } from '../useBackgroundQuery';
 import { ApolloProvider } from '../../context';
+import { QUERY_REFERENCE_SYMBOL } from '../../cache/QueryReference';
 import { SuspenseCache } from '../../cache';
 import { InMemoryCache } from '../../../cache';
 import {
@@ -617,7 +618,7 @@ describe('useBackgroundQuery', () => {
 
     const [queryRef] = result.current;
 
-    const _result = await queryRef.promise;
+    const _result = await queryRef[QUERY_REFERENCE_SYMBOL].promise;
 
     expect(_result).toEqual({
       data: { hello: 'world 1' },
@@ -654,7 +655,7 @@ describe('useBackgroundQuery', () => {
 
     const [queryRef] = result.current;
 
-    const _result = await queryRef.promise;
+    const _result = await queryRef[QUERY_REFERENCE_SYMBOL].promise;
 
     await waitFor(() => {
       expect(_result).toEqual({
@@ -739,7 +740,7 @@ describe('useBackgroundQuery', () => {
 
     const [queryRef] = result.current;
 
-    const _result = await queryRef.promise;
+    const _result = await queryRef[QUERY_REFERENCE_SYMBOL].promise;
 
     await waitFor(() => {
       expect(_result).toMatchObject({
@@ -803,7 +804,7 @@ describe('useBackgroundQuery', () => {
 
     const [queryRef] = result.current;
 
-    const _result = await queryRef.promise;
+    const _result = await queryRef[QUERY_REFERENCE_SYMBOL].promise;
     const resultSet = new Set(_result.data.results);
     const values = Array.from(resultSet).map((item) => item.value);
 
@@ -868,7 +869,7 @@ describe('useBackgroundQuery', () => {
 
     const [queryRef] = result.current;
 
-    const _result = await queryRef.promise;
+    const _result = await queryRef[QUERY_REFERENCE_SYMBOL].promise;
     const resultSet = new Set(_result.data.results);
     const values = Array.from(resultSet).map((item) => item.value);
 
@@ -913,7 +914,7 @@ describe('useBackgroundQuery', () => {
 
     const [queryRef] = result.current;
 
-    const _result = await queryRef.promise;
+    const _result = await queryRef[QUERY_REFERENCE_SYMBOL].promise;
 
     expect(_result).toEqual({
       data: { hello: 'from link' },
@@ -956,7 +957,7 @@ describe('useBackgroundQuery', () => {
 
     const [queryRef] = result.current;
 
-    const _result = await queryRef.promise;
+    const _result = await queryRef[QUERY_REFERENCE_SYMBOL].promise;
 
     expect(_result).toEqual({
       data: { hello: 'from cache' },
@@ -1006,7 +1007,7 @@ describe('useBackgroundQuery', () => {
 
     const [queryRef] = result.current;
 
-    const _result = await queryRef.promise;
+    const _result = await queryRef[QUERY_REFERENCE_SYMBOL].promise;
 
     expect(_result).toEqual({
       data: { foo: 'bar', hello: 'from link' },
@@ -1049,7 +1050,7 @@ describe('useBackgroundQuery', () => {
 
     const [queryRef] = result.current;
 
-    const _result = await queryRef.promise;
+    const _result = await queryRef[QUERY_REFERENCE_SYMBOL].promise;
 
     expect(_result).toEqual({
       data: { hello: 'from link' },
@@ -1095,7 +1096,7 @@ describe('useBackgroundQuery', () => {
 
     const [queryRef] = result.current;
 
-    const _result = await queryRef.promise;
+    const _result = await queryRef[QUERY_REFERENCE_SYMBOL].promise;
 
     expect(_result).toEqual({
       data: { hello: 'from link' },

--- a/src/react/hooks/useBackgroundQuery.ts
+++ b/src/react/hooks/useBackgroundQuery.ts
@@ -6,7 +6,10 @@ import type {
 } from '../../core';
 import { NetworkStatus } from '../../core';
 import { useApolloClient } from './useApolloClient';
-import type { QueryReference } from '../cache/QueryReference';
+import {
+  QUERY_REFERENCE_SYMBOL,
+  type QueryReference,
+} from '../cache/QueryReference';
 import type { SuspenseQueryHookOptions, NoInfer } from '../types/types';
 import { __use } from './internal';
 import { useSuspenseCache } from './useSuspenseCache';
@@ -188,7 +191,7 @@ export function useBackgroundQuery<
 
   return useMemo(() => {
     return [
-      queryRef,
+      { [QUERY_REFERENCE_SYMBOL]: queryRef},
       {
         fetchMore,
         refetch,
@@ -197,9 +200,9 @@ export function useBackgroundQuery<
   }, [queryRef, fetchMore, refetch]);
 }
 
-export function useReadQuery<TData>(queryRef: QueryReference<TData>) {
+export function useReadQuery<TData>(_queryRef: QueryReference<TData>) {
   const [, forceUpdate] = useState(0);
-
+  const queryRef = _queryRef[QUERY_REFERENCE_SYMBOL];
   invariant(
     queryRef.promiseCache,
     'It appears that `useReadQuery` was used outside of `useBackgroundQuery`. ' +
@@ -233,7 +236,7 @@ export function useReadQuery<TData>(queryRef: QueryReference<TData>) {
   }, [queryRef]);
 
   const result =
-    queryRef.watchQueryOptions.fetchPolicy === 'standby'
+  queryRef.watchQueryOptions.fetchPolicy === 'standby'
       ? skipResult
       : __use(promise);
 

--- a/src/react/hooks/useBackgroundQuery.ts
+++ b/src/react/hooks/useBackgroundQuery.ts
@@ -200,43 +200,43 @@ export function useBackgroundQuery<
   }, [queryRef, fetchMore, refetch]);
 }
 
-export function useReadQuery<TData>(_queryRef: QueryReference<TData>) {
+export function useReadQuery<TData>(queryRef: QueryReference<TData>) {
   const [, forceUpdate] = useState(0);
-  const queryRef = _queryRef[QUERY_REFERENCE_SYMBOL];
+  const internalQueryRef = queryRef[QUERY_REFERENCE_SYMBOL];
   invariant(
-    queryRef.promiseCache,
+    internalQueryRef.promiseCache,
     'It appears that `useReadQuery` was used outside of `useBackgroundQuery`. ' +
       '`useReadQuery` is only supported for use with `useBackgroundQuery`. ' +
       'Please ensure you are passing the `queryRef` returned from `useBackgroundQuery`.'
   );
 
   const skipResult = useMemo(() => {
-    const error = toApolloError(queryRef.result);
+    const error = toApolloError(internalQueryRef.result);
 
     return {
       loading: false,
-      data: queryRef.result.data,
+      data: internalQueryRef.result.data,
       networkStatus: error ? NetworkStatus.error : NetworkStatus.ready,
       error,
     };
-  }, [queryRef.result]);
+  }, [internalQueryRef.result]);
 
-  let promise = queryRef.promiseCache.get(queryRef.key);
+  let promise = internalQueryRef.promiseCache.get(internalQueryRef.key);
 
   if (!promise) {
-    promise = queryRef.promise;
-    queryRef.promiseCache.set(queryRef.key, promise);
+    promise = internalQueryRef.promise;
+    internalQueryRef.promiseCache.set(internalQueryRef.key, promise);
   }
 
   useEffect(() => {
-    return queryRef.listen((promise) => {
-      queryRef.promiseCache!.set(queryRef.key, promise);
+    return internalQueryRef.listen((promise) => {
+      internalQueryRef.promiseCache!.set(internalQueryRef.key, promise);
       forceUpdate((prevState) => prevState + 1);
     });
   }, [queryRef]);
 
   const result =
-    queryRef.watchQueryOptions.fetchPolicy === 'standby'
+    internalQueryRef.watchQueryOptions.fetchPolicy === 'standby'
       ? skipResult
       : __use(promise);
 

--- a/src/react/hooks/useBackgroundQuery.ts
+++ b/src/react/hooks/useBackgroundQuery.ts
@@ -191,7 +191,7 @@ export function useBackgroundQuery<
 
   return useMemo(() => {
     return [
-      { [QUERY_REFERENCE_SYMBOL]: queryRef},
+      { [QUERY_REFERENCE_SYMBOL]: queryRef },
       {
         fetchMore,
         refetch,
@@ -236,7 +236,7 @@ export function useReadQuery<TData>(_queryRef: QueryReference<TData>) {
   }, [queryRef]);
 
   const result =
-  queryRef.watchQueryOptions.fetchPolicy === 'standby'
+    queryRef.watchQueryOptions.fetchPolicy === 'standby'
       ? skipResult
       : __use(promise);
 

--- a/src/react/hooks/useSuspenseQuery.ts
+++ b/src/react/hooks/useSuspenseQuery.ts
@@ -22,7 +22,7 @@ import type {
 } from '../types/types';
 import { useDeepMemo, useStrictModeSafeCleanupEffect, __use } from './internal';
 import { useSuspenseCache } from './useSuspenseCache';
-import type { QueryReference } from '../cache/QueryReference';
+import type { InternalQueryReference } from '../cache/QueryReference';
 import { canonicalStringify } from '../../cache';
 
 export interface UseSuspenseQueryResult<
@@ -296,8 +296,8 @@ export function toApolloError(result: ApolloQueryResult<any>) {
     : result.error;
 }
 
-export function useTrackedQueryRefs(queryRef: QueryReference) {
-  const trackedQueryRefs = useRef(new Set<QueryReference>());
+export function useTrackedQueryRefs(queryRef: InternalQueryReference) {
+  const trackedQueryRefs = useRef(new Set<InternalQueryReference>());
 
   trackedQueryRefs.current.add(queryRef);
 


### PR DESCRIPTION
Closes #10875.

Renames `QueryReference` to `InternalQueryReference` so that the `QueryReference` type name can remain unchanged, which will be referenced in userland code for apps written in TS as is probably much less confusing than any alternative :)

Also adds some basic type docs to `QueryReference` to display in IDEs that support it:
![CleanShot 2023-06-23 at 14 44 09](https://github.com/apollographql/apollo-client/assets/5139846/5463b8a4-96a7-4ce2-926d-4f1df2a38853)

At first I thought maybe `SuspenseCache` should return a `QueryReference` when its `getQueryRef` method is called, but very quickly realized that any hook that returns a `QueryReference` should be responsible for stashing it behind the Symbol instead of within Apollo's Suspense-y internals. I hesitated to rename `queryRef` variable names > `internalQueryRef` everywhere for brevity, but if this is confusing I can make those changes too.

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
