### PR TITLE
Move use read query to own hooks file

### DIFF
--- a/src/react/hooks/__tests__/useBackgroundQuery.test.tsx
+++ b/src/react/hooks/__tests__/useBackgroundQuery.test.tsx
@@ -35,7 +35,8 @@ import {
   mockSingleLink,
 } from '../../../testing';
 import { concatPagination, offsetLimitPagination } from '../../../utilities';
-import { useBackgroundQuery, useReadQuery } from '../useBackgroundQuery';
+import { useBackgroundQuery } from '../useBackgroundQuery';
+import { useReadQuery } from '../useReadQuery';
 import { ApolloProvider } from '../../context';
 import { QUERY_REFERENCE_SYMBOL } from '../../cache/QueryReference';
 import { SuspenseCache } from '../../cache';

--- a/src/react/hooks/index.ts
+++ b/src/react/hooks/index.ts
@@ -16,6 +16,6 @@ export {
 } from './useSuspenseQuery';
 export {
   useBackgroundQuery,
-  useReadQuery,
   UseBackgroundQueryResult,
 } from './useBackgroundQuery';
+export { useReadQuery } from './useReadQuery';

--- a/src/react/hooks/useBackgroundQuery.ts
+++ b/src/react/hooks/useBackgroundQuery.ts
@@ -1,10 +1,9 @@
-import { useEffect, useState, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import type {
   DocumentNode,
   OperationVariables,
   TypedDocumentNode,
 } from '../../core';
-import { NetworkStatus } from '../../core';
 import { useApolloClient } from './useApolloClient';
 import {
   QUERY_REFERENCE_SYMBOL,
@@ -13,15 +12,10 @@ import {
 import type { SuspenseQueryHookOptions, NoInfer } from '../types/types';
 import { __use } from './internal';
 import { useSuspenseCache } from './useSuspenseCache';
-import {
-  toApolloError,
-  useTrackedQueryRefs,
-  useWatchQueryOptions,
-} from './useSuspenseQuery';
+import { useTrackedQueryRefs, useWatchQueryOptions } from './useSuspenseQuery';
 import type { FetchMoreFunction, RefetchFunction } from './useSuspenseQuery';
 import { canonicalStringify } from '../../cache';
 import type { DeepPartial } from '../../utilities';
-import { invariant } from '../../utilities/globals';
 
 export type UseBackgroundQueryResult<
   TData = unknown,
@@ -198,53 +192,4 @@ export function useBackgroundQuery<
       },
     ];
   }, [queryRef, fetchMore, refetch]);
-}
-
-export function useReadQuery<TData>(queryRef: QueryReference<TData>) {
-  const [, forceUpdate] = useState(0);
-  const internalQueryRef = queryRef[QUERY_REFERENCE_SYMBOL];
-  invariant(
-    internalQueryRef.promiseCache,
-    'It appears that `useReadQuery` was used outside of `useBackgroundQuery`. ' +
-      '`useReadQuery` is only supported for use with `useBackgroundQuery`. ' +
-      'Please ensure you are passing the `queryRef` returned from `useBackgroundQuery`.'
-  );
-
-  const skipResult = useMemo(() => {
-    const error = toApolloError(internalQueryRef.result);
-
-    return {
-      loading: false,
-      data: internalQueryRef.result.data,
-      networkStatus: error ? NetworkStatus.error : NetworkStatus.ready,
-      error,
-    };
-  }, [internalQueryRef.result]);
-
-  let promise = internalQueryRef.promiseCache.get(internalQueryRef.key);
-
-  if (!promise) {
-    promise = internalQueryRef.promise;
-    internalQueryRef.promiseCache.set(internalQueryRef.key, promise);
-  }
-
-  useEffect(() => {
-    return internalQueryRef.listen((promise) => {
-      internalQueryRef.promiseCache!.set(internalQueryRef.key, promise);
-      forceUpdate((prevState) => prevState + 1);
-    });
-  }, [queryRef]);
-
-  const result =
-    internalQueryRef.watchQueryOptions.fetchPolicy === 'standby'
-      ? skipResult
-      : __use(promise);
-
-  return useMemo(() => {
-    return {
-      data: result.data,
-      networkStatus: result.networkStatus,
-      error: toApolloError(result),
-    };
-  }, [result]);
 }


### PR DESCRIPTION
To make `useReadQuery` easier to discover, this PR moves the hook to its own file under `src/react/hooks/useReadQuery.ts`.

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
