### PR TITLE
chore: ignore rollup deps in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,5 +25,12 @@
       "matchUpdateTypes": ["patch"]
     }
   ],
-  "ignoreDeps": ["typedoc", "react-17", "react-dom-17", "@testing-library/react-12"]
+  "ignoreDeps": [
+    "typedoc",
+    "react-17",
+    "react-dom-17",
+    "@testing-library/react-12",
+    "@rollup/plugin-node-resolve",
+    "rollup"
+  ]
 }


### PR DESCRIPTION
Ignore rollup deps for now - these will either be upgraded in a v4 release or replaced with another bundling toolchain.

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
