### PR TITLE
Create separate `BackgroundQueryHookOptions` type and use it for `useBackgroundQuery`

### DIFF
--- a/.changeset/olive-pans-report.md
+++ b/.changeset/olive-pans-report.md
@@ -1,0 +1,5 @@
+---
+'@apollo/client': patch
+---
+
+`useBackgroundQuery` now uses its own options type called `BackgroundQueryHookOptions` rather than reusing `SuspenseQueryHookOptions`.

--- a/src/react/hooks/useBackgroundQuery.ts
+++ b/src/react/hooks/useBackgroundQuery.ts
@@ -9,7 +9,7 @@ import {
   QUERY_REFERENCE_SYMBOL,
   type QueryReference,
 } from '../cache/QueryReference';
-import type { SuspenseQueryHookOptions, NoInfer } from '../types/types';
+import type { BackgroundQueryHookOptions, NoInfer } from '../types/types';
 import { __use } from './internal';
 import { useSuspenseCache } from './useSuspenseCache';
 import { useTrackedQueryRefs, useWatchQueryOptions } from './useSuspenseQuery';
@@ -31,16 +31,10 @@ export type UseBackgroundQueryResult<
 export function useBackgroundQuery<
   TData,
   TVariables extends OperationVariables,
-  TOptions extends Omit<
-    SuspenseQueryHookOptions<TData>,
-    'variables' | 'returnPartialData' | 'refetchWritePolicy'
-  >
+  TOptions extends Omit<BackgroundQueryHookOptions<TData>, 'variables'>
 >(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  options?: Omit<
-    SuspenseQueryHookOptions<NoInfer<TData>, NoInfer<TVariables>>,
-    'returnPartialData' | 'refetchWritePolicy'
-  > &
+  options?: BackgroundQueryHookOptions<NoInfer<TData>, NoInfer<TVariables>> &
     TOptions
 ): UseBackgroundQueryResult<
   TOptions['errorPolicy'] extends 'ignore' | 'all'
@@ -56,10 +50,7 @@ export function useBackgroundQuery<
   TVariables extends OperationVariables = OperationVariables
 >(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  options: Omit<
-    SuspenseQueryHookOptions<NoInfer<TData>, NoInfer<TVariables>>,
-    'returnPartialData' | 'refetchWritePolicy'
-  > & {
+  options: BackgroundQueryHookOptions<NoInfer<TData>, NoInfer<TVariables>> & {
     returnPartialData: true;
     errorPolicy: 'ignore' | 'all';
   }
@@ -70,10 +61,7 @@ export function useBackgroundQuery<
   TVariables extends OperationVariables = OperationVariables
 >(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  options: Omit<
-    SuspenseQueryHookOptions<NoInfer<TData>, NoInfer<TVariables>>,
-    'returnPartialData' | 'refetchWritePolicy'
-  > & {
+  options: BackgroundQueryHookOptions<NoInfer<TData>, NoInfer<TVariables>> & {
     errorPolicy: 'ignore' | 'all';
   }
 ): UseBackgroundQueryResult<TData | undefined, TVariables>;
@@ -83,10 +71,7 @@ export function useBackgroundQuery<
   TVariables extends OperationVariables = OperationVariables
 >(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  options: Omit<
-    SuspenseQueryHookOptions<NoInfer<TData>, NoInfer<TVariables>>,
-    'returnPartialData' | 'refetchWritePolicy'
-  > & {
+  options: BackgroundQueryHookOptions<NoInfer<TData>, NoInfer<TVariables>> & {
     skip: boolean;
   }
 ): UseBackgroundQueryResult<TData | undefined, TVariables>;
@@ -99,10 +84,7 @@ export function useBackgroundQuery<
 //   TVariables extends OperationVariables = OperationVariables
 // >(
 //   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-//   options: Omit<
-//     SuspenseQueryHookOptions<NoInfer<TData>, NoInfer<TVariables>>,
-//     'returnPartialData' | 'refetchWritePolicy'
-//   > & {
+//   options: SuspenseQueryHookOptions<NoInfer<TData>, NoInfer<TVariables>> & {
 //     returnPartialData: true;
 //   }
 // ): UseBackgroundQueryResult<DeepPartial<TData>, TVariables>;
@@ -112,10 +94,7 @@ export function useBackgroundQuery<
   TVariables extends OperationVariables = OperationVariables
 >(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  options?: Omit<
-    SuspenseQueryHookOptions<NoInfer<TData>, NoInfer<TVariables>>,
-    'returnPartialData' | 'refetchWritePolicy'
-  >
+  options?: BackgroundQueryHookOptions<NoInfer<TData>, NoInfer<TVariables>>
 ): UseBackgroundQueryResult<TData, TVariables>;
 
 export function useBackgroundQuery<
@@ -123,9 +102,9 @@ export function useBackgroundQuery<
   TVariables extends OperationVariables = OperationVariables
 >(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  options: Omit<
-    SuspenseQueryHookOptions<TData, TVariables>,
-    'returnPartialData' | 'refetchWritePolicy'
+  options: BackgroundQueryHookOptions<
+    NoInfer<TData>,
+    NoInfer<TVariables>
   > = Object.create(null)
 ): UseBackgroundQueryResult<TData> {
   const suspenseCache = useSuspenseCache(options.suspenseCache);

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -131,6 +131,31 @@ export interface SuspenseQueryHookOptions<
   queryKey?: string | number | any[];
 }
 
+export type BackgroundQueryHookFetchPolicy = Extract<
+  WatchQueryFetchPolicy,
+  | 'cache-first'
+  | 'network-only'
+  | 'no-cache'
+  | 'cache-and-network'
+>;
+
+export interface BackgroundQueryHookOptions<
+  TData = unknown,
+  TVariables extends OperationVariables = OperationVariables
+> extends Pick<
+  QueryHookOptions<TData, TVariables>,
+  | 'client'
+  | 'variables'
+  | 'errorPolicy'
+  | 'context'
+  | 'canonizeResults'
+  | 'skip'
+> {
+  fetchPolicy?: BackgroundQueryHookFetchPolicy;
+  suspenseCache?: SuspenseCache;
+  queryKey?: string | number | any[];
+}
+
 /**
  * @deprecated TODO Delete this unused interface.
  */


### PR DESCRIPTION
It's very likely the APIs and options provided to `useBackgroundQuery` and `useSuspenseQuery` will grow and diverge over time. Currently, the `useBackgroundQuery` hook uses the same options type that `useSuspenseQuery` does, which makes it less flexible to grow over time.

This PR introduces a new `BackgroundQueryHookOptions` type that is used for `useBackgroundQuery` to ensure the options types can grow independently of each other. 

NOTE: #10960 will need to update this new type to include `returnPartialData` and `refetchWritePolicy`, depending on which PR is merged first. 

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
