### PR TITLE
Handle changed suspense query options

### DIFF
--- a/.changeset/ten-cherries-clap.md
+++ b/.changeset/ten-cherries-clap.md
@@ -1,0 +1,5 @@
+---
+'@apollo/client': patch
+---
+
+`useSuspenseQuery` and `useBackgroundQuery` will now properly apply changes to its options between renders.

--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -1,7 +1,7 @@
 const checks = [
   {
     path: "dist/apollo-client.min.cjs",
-    limit: "37925"
+    limit: "37915"
   },
   {
     path: "dist/main.cjs",
@@ -10,7 +10,7 @@ const checks = [
   {
     path: "dist/index.js",
     import: "{ ApolloClient, InMemoryCache, HttpLink }",
-    limit: "33389"
+    limit: "33413"
   },
   ...[
     "ApolloProvider",

--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -1,7 +1,7 @@
 const checks = [
   {
     path: "dist/apollo-client.min.cjs",
-    limit: "37750"
+    limit: "37925"
   },
   {
     path: "dist/main.cjs",

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -592,6 +592,13 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     return this.reobserve(newOptions);
   }
 
+  public silentSetOptions(
+    newOptions: Partial<WatchQueryOptions<TVariables, TData>>,
+  )  {
+    const mergedOptions = compact(this.options, newOptions || {});
+    assign(this.options, mergedOptions);
+  }
+
   /**
    * Update the variables of this observable query, and fetch the new results
    * if they've changed. Most users should prefer `refetch` instead of

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -594,7 +594,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
 
   public silentSetOptions(
     newOptions: Partial<WatchQueryOptions<TVariables, TData>>,
-  )  {
+  ) {
     const mergedOptions = compact(this.options, newOptions || {});
     assign(this.options, mergedOptions);
   }

--- a/src/react/cache/QueryReference.ts
+++ b/src/react/cache/QueryReference.ts
@@ -39,6 +39,7 @@ const OBSERVED_CHANGED_OPTIONS: Array<keyof WatchQueryOptions> = [
   'context',
   'errorPolicy',
   'refetchWritePolicy',
+  'returnPartialData',
 ];
 
 export class InternalQueryReference<TData = unknown> {

--- a/src/react/cache/QueryReference.ts
+++ b/src/react/cache/QueryReference.ts
@@ -38,6 +38,7 @@ const OBSERVED_CHANGED_OPTIONS: Array<keyof WatchQueryOptions> = [
   'canonizeResults',
   'context',
   'errorPolicy',
+  'refetchWritePolicy',
 ];
 
 export class InternalQueryReference<TData = unknown> {

--- a/src/react/cache/QueryReference.ts
+++ b/src/react/cache/QueryReference.ts
@@ -122,8 +122,8 @@ export class InternalQueryReference<TData = unknown> {
   applyOptions(watchQueryOptions: WatchQueryOptions) {
     const { fetchPolicy: currentFetchPolicy } = this.watchQueryOptions;
 
-    // Handle when changing from `skip: false` -> `skip: true` which is
-    // reflected by setting the `fetchPolicy` to 'standby'.
+    // "standby" is used when `skip` is set to `true`. Detect when we've
+    // enabled the query (i.e. `skip` is `false`) to execute a network request.
     if (
       currentFetchPolicy === 'standby' &&
       currentFetchPolicy !== watchQueryOptions.fetchPolicy

--- a/src/react/cache/QueryReference.ts
+++ b/src/react/cache/QueryReference.ts
@@ -35,6 +35,7 @@ interface InternalQueryReferenceOptions {
 }
 
 const OBSERVED_CHANGED_OPTIONS: Array<keyof WatchQueryOptions> = [
+  'canonizeResults',
   'context',
   'errorPolicy',
 ];
@@ -117,6 +118,11 @@ export class InternalQueryReference<TData = unknown> {
 
   applyOptions(watchQueryOptions: WatchQueryOptions) {
     this.observable.silentSetOptions(watchQueryOptions);
+
+    this.result = this.observable.getCurrentResult();
+    this.promise = createFulfilledPromise(this.result);
+
+    return this.promise;
   }
 
   listen(listener: Listener<TData>) {

--- a/src/react/cache/QueryReference.ts
+++ b/src/react/cache/QueryReference.ts
@@ -1,3 +1,4 @@
+import { equal } from '@wry/equality';
 import type {
   ApolloError,
   ApolloQueryResult,
@@ -34,6 +35,7 @@ interface InternalQueryReferenceOptions {
 }
 
 const OBSERVED_CHANGED_OPTIONS: Array<keyof WatchQueryOptions> = [
+  'context',
   'errorPolicy',
 ];
 
@@ -108,7 +110,8 @@ export class InternalQueryReference<TData = unknown> {
 
   didChangeOptions(watchQueryOptions: WatchQueryOptions) {
     return OBSERVED_CHANGED_OPTIONS.some(
-      (option) => watchQueryOptions[option] !== this.watchQueryOptions[option]
+      (option) =>
+        !equal(this.watchQueryOptions[option], watchQueryOptions[option])
     );
   }
 

--- a/src/react/cache/QueryReference.ts
+++ b/src/react/cache/QueryReference.ts
@@ -38,6 +38,7 @@ const OBSERVED_CHANGED_OPTIONS: Array<keyof WatchQueryOptions> = [
   'canonizeResults',
   'context',
   'errorPolicy',
+  'fetchPolicy',
   'refetchWritePolicy',
   'returnPartialData',
 ];
@@ -121,7 +122,7 @@ export class InternalQueryReference<TData = unknown> {
   applyOptions(watchQueryOptions: WatchQueryOptions) {
     this.observable.silentSetOptions(watchQueryOptions);
 
-    this.result = this.observable.getCurrentResult();
+    this.result = { ...this.result, ...this.observable.getCurrentResult() };
     this.promise = createFulfilledPromise(this.result);
 
     return this.promise;

--- a/src/react/cache/QueryReference.ts
+++ b/src/react/cache/QueryReference.ts
@@ -33,6 +33,10 @@ interface InternalQueryReferenceOptions {
   autoDisposeTimeoutMs?: number;
 }
 
+const OBSERVED_CHANGED_OPTIONS: Array<keyof WatchQueryOptions> = [
+  'errorPolicy',
+];
+
 export class InternalQueryReference<TData = unknown> {
   public result: ApolloQueryResult<TData>;
   public readonly key: CacheKey;
@@ -100,6 +104,16 @@ export class InternalQueryReference<TData = unknown> {
 
   get watchQueryOptions() {
     return this.observable.options;
+  }
+
+  didChangeOptions(watchQueryOptions: WatchQueryOptions) {
+    return OBSERVED_CHANGED_OPTIONS.some(
+      (option) => watchQueryOptions[option] !== this.watchQueryOptions[option]
+    );
+  }
+
+  applyOptions(watchQueryOptions: WatchQueryOptions) {
+    this.observable.silentSetOptions(watchQueryOptions);
   }
 
   listen(listener: Listener<TData>) {

--- a/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
@@ -5578,11 +5578,8 @@ describe('useSuspenseQuery', () => {
 
     const cacheKey = cache.identify({ __typename: 'Character', id: '1' })!;
 
-    cache.modify({
-      id: cacheKey,
-      fields: {
-        name: (_, { DELETE }) => DELETE,
-      },
+    act(() => {
+      result.current.refetch();
     });
 
     await waitFor(() => {
@@ -5600,10 +5597,11 @@ describe('useSuspenseQuery', () => {
     expect(cache.extract()[cacheKey]).toEqual({
       __typename: 'Character',
       id: '1',
+      name: 'Doctor Strangecache',
     });
 
-    expect(renders.count).toBe(3);
-    expect(renders.suspenseCount).toBe(0);
+    expect(renders.count).toBe(4);
+    expect(renders.suspenseCount).toBe(1);
     expect(renders.frames).toMatchObject([
       {
         data: {

--- a/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
@@ -5448,10 +5448,7 @@ describe('useSuspenseQuery', () => {
 
     const { result, renders, rerender } = renderSuspenseHook(
       ({ returnPartialData }) =>
-        useSuspenseQuery(fullQuery, {
-          fetchPolicy: 'cache-first',
-          returnPartialData,
-        }),
+        useSuspenseQuery(fullQuery, { returnPartialData }),
       { cache, mocks, initialProps: { returnPartialData: false } }
     );
 

--- a/src/react/hooks/useBackgroundQuery.ts
+++ b/src/react/hooks/useBackgroundQuery.ts
@@ -127,7 +127,7 @@ export function useBackgroundQuery<
   const suspenseCache = useSuspenseCache(options.suspenseCache);
   const client = useApolloClient(options.client);
   const watchQueryOptions = useWatchQueryOptions({ client, query, options });
-  const { fetchPolicy, variables } = watchQueryOptions;
+  const { variables } = watchQueryOptions;
   const { queryKey = [] } = options;
 
   const cacheKey = (
@@ -138,14 +138,12 @@ export function useBackgroundQuery<
     client.watchQuery(watchQueryOptions)
   );
 
-  const { fetchPolicy: currentFetchPolicy } = queryRef.watchQueryOptions;
-
   const [promiseCache, setPromiseCache] = useState(
     () => new Map([[queryRef.key, queryRef.promise]])
   );
 
-  if (currentFetchPolicy === 'standby' && fetchPolicy !== currentFetchPolicy) {
-    const promise = queryRef.reobserve({ fetchPolicy });
+  if (queryRef.didChangeOptions(watchQueryOptions)) {
+    const promise = queryRef.applyOptions(watchQueryOptions);
     promiseCache.set(queryRef.key, promise);
   }
 

--- a/src/react/hooks/useSuspenseQuery.ts
+++ b/src/react/hooks/useSuspenseQuery.ts
@@ -178,6 +178,8 @@ export function useSuspenseQuery<
   if (currentFetchPolicy === 'standby' && fetchPolicy !== currentFetchPolicy) {
     promise = queryRef.reobserve({ fetchPolicy });
     promiseCache.set(queryRef.key, promise);
+  } else if (queryRef.didChangeOptions(watchQueryOptions)) {
+    queryRef.applyOptions(watchQueryOptions);
   }
 
   if (!promise) {

--- a/src/react/hooks/useSuspenseQuery.ts
+++ b/src/react/hooks/useSuspenseQuery.ts
@@ -179,7 +179,8 @@ export function useSuspenseQuery<
     promise = queryRef.reobserve({ fetchPolicy });
     promiseCache.set(queryRef.key, promise);
   } else if (queryRef.didChangeOptions(watchQueryOptions)) {
-    queryRef.applyOptions(watchQueryOptions);
+    promise = queryRef.applyOptions(watchQueryOptions);
+    promiseCache.set(queryRef.key, promise);
   }
 
   if (!promise) {

--- a/src/react/hooks/useSuspenseQuery.ts
+++ b/src/react/hooks/useSuspenseQuery.ts
@@ -167,18 +167,13 @@ export function useSuspenseQuery<
     client.watchQuery(watchQueryOptions)
   );
 
-  const { fetchPolicy: currentFetchPolicy } = queryRef.watchQueryOptions;
-
   const [promiseCache, setPromiseCache] = useState(
     () => new Map([[queryRef.key, queryRef.promise]])
   );
 
   let promise = promiseCache.get(queryRef.key);
 
-  if (currentFetchPolicy === 'standby' && fetchPolicy !== currentFetchPolicy) {
-    promise = queryRef.reobserve({ fetchPolicy });
-    promiseCache.set(queryRef.key, promise);
-  } else if (queryRef.didChangeOptions(watchQueryOptions)) {
+  if (queryRef.didChangeOptions(watchQueryOptions)) {
     promise = queryRef.applyOptions(watchQueryOptions);
     promiseCache.set(queryRef.key, promise);
   }
@@ -209,8 +204,7 @@ export function useSuspenseQuery<
     };
   }, [queryRef.result]);
 
-  const result =
-    watchQueryOptions.fetchPolicy === 'standby' ? skipResult : __use(promise);
+  const result = fetchPolicy === 'standby' ? skipResult : __use(promise);
 
   const fetchMore: FetchMoreFunction<TData, TVariables> = useCallback(
     (options) => {


### PR DESCRIPTION
Closes #10680

In the current release of the library, changes to some options passed to `useSuspenseQuery` and `useBackgroundQuery` were not applied to the underlying `ObservableQuery`. For example, if someone wanted to change the `errorPolicy` between renders, the updated `errorPolicy` was not applied on the next fetch.

This PR now adds proper behavior when changing any option on these hooks. The following options have these behaviors:

* `errorPolicy` - Apply to the next fetch
* `context` - Apply to the next fetch
* `canonizeResults` - Immediately update `data` to use canonized results
* `returnPartialData` - Apply to the next fetch
* `refetchWritePolicy` - Apply to the next `refetch`
* `fetchPolicy` - Apply to the next fetch

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
