### PR TITLE
keep devTool warning

### DIFF
--- a/.changeset/cool-dogs-applaud.md
+++ b/.changeset/cool-dogs-applaud.md
@@ -1,0 +1,5 @@
+---
+'@apollo/client': patch
+---
+
+Prevents the DevTool installation warning to be turned into a documentation link.

--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -1,7 +1,7 @@
 const checks = [
   {
     path: "dist/apollo-client.min.cjs",
-    limit: "37750"
+    limit: "37731"
   },
   {
     path: "dist/main.cjs",
@@ -10,7 +10,7 @@ const checks = [
   {
     path: "dist/index.js",
     import: "{ ApolloClient, InMemoryCache, HttpLink }",
-    limit: "33375"
+    limit: "33389"
   },
   ...[
     "ApolloProvider",

--- a/config/processInvariants.ts
+++ b/config/processInvariants.ts
@@ -86,6 +86,12 @@ function getErrorCode(
         extractString(file, target, message.alternate, condition)
       );
     } else if (isStringOnly(message)) {
+
+      const messageText = reprint(message);
+      if (messageText.includes('Apollo DevTools')) {
+        return message;
+      }
+
       const obj = b.objectExpression([]);
       const numLit = b.numericLiteral(nextErrorCode++);
       target.push(b.property('init', numLit, obj));
@@ -113,7 +119,7 @@ function getErrorCode(
       throw new Error(`invariant minification error: node cannot have dynamical error argument!
         file: ${posix.join(distDir, file)}:${expr.loc?.start.line}
         code:
-  
+
         ${reprint(message)}
       `);
     }


### PR DESCRIPTION
This PR prevents the DevTool installation warning to be turned into a documentation link.

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
