### PR TITLE
Throw errors returned from incremental chunks when error policy is `none`

### DIFF
--- a/.changeset/sour-weeks-suffer.md
+++ b/.changeset/sour-weeks-suffer.md
@@ -1,0 +1,9 @@
+---
+'@apollo/client': patch
+---
+
+Throw errors in `useSuspenseQuery` for errors returned in incremental chunks when `errorPolicy` is `none`. This provides a more consistent behavior of the `errorPolicy` in the hook.
+
+### Potentially breaking change
+
+Previously, if you issued a query with `@defer` and relied on `errorPolicy: 'none'` to set the `error` property returned from `useSuspenseQuery` when the error was returned in an incremental chunk, this error is now thrown. Switch the `errorPolicy` to `all` to avoid throwing the error and instead return it in the `error` property.

--- a/src/react/cache/QueryReference.ts
+++ b/src/react/cache/QueryReference.ts
@@ -202,9 +202,7 @@ export class InternalQueryReference<TData = unknown> {
     }
 
     this.result = result;
-    this.promise = result.data
-      ? createFulfilledPromise(result)
-      : createRejectedPromise(result);
+    this.promise = createRejectedPromise(error);
     this.deliver(this.promise);
   }
 

--- a/src/react/cache/QueryReference.ts
+++ b/src/react/cache/QueryReference.ts
@@ -201,7 +201,6 @@ export class InternalQueryReference<TData = unknown> {
       return;
     }
 
-    this.result = result;
     this.promise = createRejectedPromise(error);
     this.deliver(this.promise);
   }

--- a/src/utilities/promises/decoration.ts
+++ b/src/utilities/promises/decoration.ts
@@ -29,6 +29,11 @@ export function createFulfilledPromise<TValue>(value: TValue) {
 export function createRejectedPromise<TValue = unknown>(reason: unknown) {
   const promise = Promise.reject(reason) as RejectedPromise<TValue>;
 
+  // prevent unhandled error rejections since this is usually used with __use
+  // which synchronously reads the `status` and `reason` properties to throw
+  // the error.
+  promise.catch(() => {});
+
   promise.status = 'rejected';
   promise.reason = reason;
 

--- a/src/utilities/promises/decoration.ts
+++ b/src/utilities/promises/decoration.ts
@@ -29,9 +29,7 @@ export function createFulfilledPromise<TValue>(value: TValue) {
 export function createRejectedPromise<TValue = unknown>(reason: unknown) {
   const promise = Promise.reject(reason) as RejectedPromise<TValue>;
 
-  // prevent unhandled error rejections since this is usually used with __use
-  // which synchronously reads the `status` and `reason` properties to throw
-  // the error.
+  // prevent potential edge cases leaking unhandled error rejections
   promise.catch(() => {});
 
   promise.status = 'rejected';


### PR DESCRIPTION
After some time away I came to realize that the behavior of `errorPolicy: 'none'` when an error is returned in an incremental chunk should be considered incorrect. `useSuspenseQuery` throws errors when error policy is none, except for this one case. This made the behavior of this error policy unpredictable.

Now all errors are thrown, regardless of whether they are in the first chunk or an incremental chunk when the `errorPolicy` is set to `none`. To get the previous behavior, set the `errorPolicy` to `all`, which also has the advantage that it keeps partial data.

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
