### PR TITLE
`HttpLink`/`BatchHttpLink`: Abort AbortController signal more granularly.

### DIFF
--- a/.changeset/smooth-goats-cheat.md
+++ b/.changeset/smooth-goats-cheat.md
@@ -1,0 +1,13 @@
+---
+'@apollo/client': minor
+---
+
+`HttpLink`/`BatchHttpLink`: Abort AbortController signal more granularly.
+Before this change, when `HttpLink`/`BatchHttpLink` created an `AbortController`
+internally, that would always be `.abort`ed after the request was finished in any
+way.
+This could cause issues with Sentry Session Replay and Next.js App Router Cache
+invalidations, which just replayed the fetch with the same options - including the
+cancelled `AbortSignal`.
+With this change, the `AbortController` will only be `.abort()`ed by outside events,
+not as a consequence of the request finishing or erroring.

--- a/src/link/batch-http/batchHttpLink.ts
+++ b/src/link/batch-http/batchHttpLink.ts
@@ -16,7 +16,6 @@ import {
   selectHttpOptionsAndBodyInternal,
   defaultPrinter,
   fallbackHttpConfig,
-  createSignalIfSupported,
 } from '../http';
 import { BatchLink } from '../batch';
 import { filterOperationVariables } from "../utils/filterOperationVariables";
@@ -158,10 +157,9 @@ export class BatchHttpLink extends ApolloLink {
       }
 
       let controller: AbortController | undefined;
-      if (!(options as any).signal) {
-        const { controller: _controller, signal } = createSignalIfSupported();
-        controller = _controller as AbortController;
-        if (controller) (options as any).signal = signal;
+      if (!options.signal && typeof AbortController !== 'undefined') {
+        controller = new AbortController();
+        options.signal = controller.signal;
       }
 
       return new Observable<FetchResult[]>(observer => {

--- a/src/link/batch-http/batchHttpLink.ts
+++ b/src/link/batch-http/batchHttpLink.ts
@@ -157,10 +157,10 @@ export class BatchHttpLink extends ApolloLink {
         return fromError<FetchResult[]>(parseError);
       }
 
-      let controller: any;
+      let controller: AbortController | undefined;
       if (!(options as any).signal) {
         const { controller: _controller, signal } = createSignalIfSupported();
-        controller = _controller;
+        controller = _controller as AbortController;
         if (controller) (options as any).signal = signal;
       }
 
@@ -173,12 +173,14 @@ export class BatchHttpLink extends ApolloLink {
           })
           .then(parseAndCheckHttpResponse(operations))
           .then(result => {
+            controller = undefined;
             // we have data and can send it to back up the link chain
             observer.next(result);
             observer.complete();
             return result;
           })
           .catch(err => {
+            controller = undefined;
             // fetch was cancelled so its already been cleaned up in the unsubscribe
             if (err.name === 'AbortError') return;
             // if it is a network error, BUT there is graphql result info

--- a/src/link/http/createHttpLink.ts
+++ b/src/link/http/createHttpLink.ts
@@ -20,7 +20,6 @@ import {
   defaultPrinter,
   fallbackHttpConfig
 } from './selectHttpOptionsAndBody';
-import { createSignalIfSupported } from './createSignalIfSupported';
 import { rewriteURIForGET } from './rewriteURIForGET';
 import { fromError, filterOperationVariables } from '../utils';
 import {
@@ -120,10 +119,9 @@ export const createHttpLink = (linkOptions: HttpOptions = {}) => {
     }
 
     let controller: AbortController | undefined;
-    if (!(options as any).signal) {
-      const { controller: _controller, signal } = createSignalIfSupported();
-      controller = _controller as AbortController;
-      if (controller) (options as any).signal = signal;
+    if (!options.signal && typeof AbortController !== 'undefined') {
+      controller = new AbortController();
+      options.signal = controller.signal;
     }
 
     // If requested, set method to GET if there are no mutations.

--- a/src/link/http/createHttpLink.ts
+++ b/src/link/http/createHttpLink.ts
@@ -119,10 +119,10 @@ export const createHttpLink = (linkOptions: HttpOptions = {}) => {
       body.variables = filterOperationVariables(body.variables, operation.query);
     }
 
-    let controller: any;
+    let controller: AbortController | undefined;
     if (!(options as any).signal) {
       const { controller: _controller, signal } = createSignalIfSupported();
-      controller = _controller;
+      controller = _controller as AbortController;
       if (controller) (options as any).signal = signal;
     }
 
@@ -195,9 +195,11 @@ export const createHttpLink = (linkOptions: HttpOptions = {}) => {
           }
         })
         .then(() => {
+          controller = undefined;
           observer.complete();
         })
         .catch(err => {
+          controller = undefined;
           handleError(err, observer)
         });
 

--- a/src/link/http/createSignalIfSupported.ts
+++ b/src/link/http/createSignalIfSupported.ts
@@ -1,3 +1,8 @@
+/**
+ * @deprecated 
+ * This is not used internally any more and will be removed in
+ * the next major version of Apollo Client.
+ */
 export const createSignalIfSupported = () => {
   if (typeof AbortController === 'undefined')
     return { controller: false, signal: false };


### PR DESCRIPTION
`HttpLink`/`BatchHttpLink`: Abort AbortController signal more granularly.
Before this change, when `HttpLink`/`BatchHttpLink` created an `AbortController`
internally, that would always be `.abort`ed after the request was finished in any
way.
This could cause issues with Sentry Session Replay and Next.js App Router Cache
invalidations, which just replayed the fetch with the same options - including the
cancelled `AbortSignal`.
With this change, the `AbortController` will only be `.abort()`ed by outside events,
not as a consequence of the request finishing or erroring.

Compare: https://github.com/getsentry/sentry-javascript/issues/8345 and https://github.com/apollographql/apollo-client-nextjs/issues/24


<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
