### PR TITLE
(chore) track production build sizes in 3.7 branch

### DIFF
--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -42,6 +42,16 @@ const checks = [
     "tslib",
     "zen-observable-ts"
   ],
-}));
+})).flatMap((value) => value.path == "dist/apollo-client.min.cjs" ? value : [{...value, limit: undefined}, {
+  ...value,
+  name: `${value.name} (production)`,
+  modifyEsbuildConfig(config){
+    config.define = {
+      "__DEV__": `false`,
+      "globalThis.__DEV__": `false`,
+    }
+    return config
+  }
+}]);
 
 module.exports = checks;


### PR DESCRIPTION
We need this in `main` for the check in the 3.8 PR to have something to compare to.