### PR TITLE
chore: bumps optimism dependency to 0.17.5. Closes #11041.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@wry/trie": "^0.4.3",
         "graphql-tag": "^2.12.6",
         "hoist-non-react-statics": "^3.3.2",
-        "optimism": "^0.17.4",
+        "optimism": "^0.17.5",
         "prop-types": "^15.7.2",
         "response-iterator": "^0.2.6",
         "symbol-observable": "^4.0.0",
@@ -8755,24 +8755,13 @@
       }
     },
     "node_modules/optimism": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.17.4.tgz",
-      "integrity": "sha512-KoRKlIfGkU9j9FPlaIMvKJ8caF1Xdi2zeonabg1UPYutHp8jqoJCezR2XzP1yzBggs8LwTDBtQbwIY1BHpp1iw==",
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.17.5.tgz",
+      "integrity": "sha512-TEcp8ZwK1RczmvMnvktxHSF2tKgMWjJ71xEFGX5ApLh67VsMSTy1ZUlipJw8W+KaqgOmQ+4pqwkeivY89j+4Vw==",
       "dependencies": {
         "@wry/context": "^0.7.0",
-        "@wry/trie": "^0.3.0",
+        "@wry/trie": "^0.4.3",
         "tslib": "^2.3.0"
-      }
-    },
-    "node_modules/optimism/node_modules/@wry/trie": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.2.tgz",
-      "integrity": "sha512-yRTyhWSls2OY/pYLfwff867r8ekooZ4UI+/gxot5Wj8EFwSf2rG+n+Mo/6LoLQm1TKA4GRj2+LCpbfS937dClQ==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/optionator": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@wry/trie": "^0.4.3",
     "graphql-tag": "^2.12.6",
     "hoist-non-react-statics": "^3.3.2",
-    "optimism": "^0.17.4",
+    "optimism": "^0.17.5",
     "prop-types": "^15.7.2",
     "response-iterator": "^0.2.6",
     "symbol-observable": "^4.0.0",


### PR DESCRIPTION
Closes https://github.com/apollographql/apollo-client/issues/11041. See lockfile for confirmation that bumping optimism indeed removes duplicate `node_modules/optimism/node_modules/@wry/trie` transitive dependency.

Opening PR intentionally without a changeset since we're preparing for an RC and there is a code freeze in place.

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
