### PR TITLE
Update operation helpers to use raw strings instead of OperationTypeNode

### DIFF
--- a/.changeset/seven-needles-remember.md
+++ b/.changeset/seven-needles-remember.md
@@ -1,0 +1,5 @@
+---
+'@apollo/client': patch
+---
+
+[#10509](https://github.com/apollographql/apollo-client/pull/10509) introduced some helpers for determining the type of operation for a GraphQL query. This imported the `OperationTypeNode` from graphql-js which is not available in GraphQL 14. To maintain compatibility with graphql-js v14, this has been reverted to use plain strings.

--- a/src/utilities/graphql/operations.ts
+++ b/src/utilities/graphql/operations.ts
@@ -1,19 +1,21 @@
-import { OperationTypeNode } from 'graphql';
 import type { DocumentNode } from '../../core/index.js';
 import { getOperationDefinition } from './getFromAST.js';
 
-function isOperation(document: DocumentNode, operation: OperationTypeNode) {
+function isOperation(
+  document: DocumentNode,
+  operation: 'query' | 'mutation' | 'subscription'
+) {
   return getOperationDefinition(document)?.operation === operation;
 }
 
 export function isMutationOperation(document: DocumentNode) {
-  return isOperation(document, OperationTypeNode.MUTATION);
+  return isOperation(document, 'mutation');
 }
 
 export function isQueryOperation(document: DocumentNode) {
-  return isOperation(document, OperationTypeNode.QUERY);
+  return isOperation(document, 'query');
 }
 
 export function isSubscriptionOperation(document: DocumentNode) {
-  return isOperation(document, OperationTypeNode.SUBSCRIPTION);
+  return isOperation(document, 'subscription');
 }


### PR DESCRIPTION
#10509 introduced some helpers for determining the type of operation for a GraphQL query. This imported the `OperationTypeNode` from graphql-js which is not available in GraphQL 14. To maintain compatibility with graphql-js v14, this has been reverted to use plain strings.

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
