### PR TITLE
chore: add note about React 18 automatic batching to useSubscription docs

### DIFF
--- a/docs/source/api/react/hooks.mdx
+++ b/docs/source/api/react/hooks.mdx
@@ -272,6 +272,61 @@ function DontReadTheComments({ repoFullName }) {
 
 > Refer to the [Subscriptions](../../data/subscriptions/) section for a more in-depth overview of `useSubscription`.
 
+#### React 18 Automatic Batching
+
+With React 18's [automatic batching](https://react.dev/blog/2022/03/29/react-v18#new-feature-automatic-batching), multiple state updates may be grouped into a single re-render for better performance.
+
+If your subscription API sends multiple messages at the same time or in very fast succession (within fractions of a millisecond), it is likely that only the last message received in that narrow time frame will result in a re-render.
+
+Consider the following component:
+
+```jsx
+export function Subscriptions({ useFailing }) {
+  const { data, error, loading } = useSubscription(query);
+  const [accumulatedData, setAccumulatedData] = useState([]);
+
+  useEffect(() => {
+    setAccumulatedData((prev) => [...prev, data]);
+  }, [data]);
+
+  return (
+    <>
+      {loading && <p>Loading...</p>}
+      {JSON.stringify(accumulatedData, undefined, 2)}
+    </>
+  );
+}
+```
+
+If your subscription back-end emits two messages with the same timestamp, only the last message received by Apollo Client will be rendered. This is because React 18 will batch these two state updates into a single re-render.
+
+Since the component above is using `useEffect` to push `data` into a piece of local state on each `Subscriptions` re-render, the first message will never be added to the `accumulatedData` array since its render was skipped.
+
+Instead of using `useEffect` here, we can re-write this component to use the `onData` callback function accepted in `useSubscription`'s `options` object:
+
+```jsx
+export function Subscriptions({ useFailing }) {
+  const [accumulatedData, setAccumulatedData] = useState([]);
+  const { data, error, loading } = useSubscription(
+    query,
+    {
+      onData({ data }) {
+        setAccumulatedData((prev) => [...prev, data])
+      }
+    }
+  );
+
+  return (
+    <>
+      {loading && <p>Loading...</p>}
+      {JSON.stringify(accumulatedData, undefined, 2)}
+    </>
+  );
+}
+```
+
+Now, the first message will be added to the `accumulatedData` array since `onData` is called _before_ the component re-renders. React 18 automatic batching is still in effect and results in a single re-render, but with `onData` we can guarantee each message received after the component mounts is added to `accumulatedData`.
+
 ### Function Signature
 
 ```ts

--- a/docs/source/api/react/hooks.mdx
+++ b/docs/source/api/react/hooks.mdx
@@ -272,7 +272,7 @@ function DontReadTheComments({ repoFullName }) {
 
 > Refer to the [Subscriptions](../../data/subscriptions/) section for a more in-depth overview of `useSubscription`.
 
-#### React 18 Automatic Batching
+#### Subscriptions and React 18 Automatic Batching
 
 With React 18's [automatic batching](https://react.dev/blog/2022/03/29/react-v18#new-feature-automatic-batching), multiple state updates may be grouped into a single re-render for better performance.
 

--- a/docs/source/api/react/hooks.mdx
+++ b/docs/source/api/react/hooks.mdx
@@ -281,7 +281,7 @@ If your subscription API sends multiple messages at the same time or in very fas
 Consider the following component:
 
 ```jsx
-export function Subscriptions({ useFailing }) {
+export function Subscriptions() {
   const { data, error, loading } = useSubscription(query);
   const [accumulatedData, setAccumulatedData] = useState([]);
 
@@ -305,7 +305,7 @@ Since the component above is using `useEffect` to push `data` into a piece of lo
 Instead of using `useEffect` here, we can re-write this component to use the `onData` callback function accepted in `useSubscription`'s `options` object:
 
 ```jsx
-export function Subscriptions({ useFailing }) {
+export function Subscriptions() {
   const [accumulatedData, setAccumulatedData] = useState([]);
   const { data, error, loading } = useSubscription(
     query,

--- a/docs/source/api/react/hooks.mdx
+++ b/docs/source/api/react/hooks.mdx
@@ -325,6 +325,8 @@ export function Subscriptions() {
 }
 ```
 
+> ⚠️ **Note:** The `useSubscription` option `onData` is available in Apollo Client >= 3.7. In previous versions, the equivalent option is named `onSubscriptionData`.
+
 Now, the first message will be added to the `accumulatedData` array since `onData` is called _before_ the component re-renders. React 18 automatic batching is still in effect and results in a single re-render, but with `onData` we can guarantee each message received after the component mounts is added to `accumulatedData`.
 
 ### Function Signature


### PR DESCRIPTION
Closes https://github.com/apollographql/apollo-client/issues/10001. See conversation on https://github.com/apollographql/apollo-client/pull/11066 for complete context.

Link to deployed preview: https://deploy-preview-11072--apollo-client-docs.netlify.app/api/react/hooks#subscriptions-and-react-18-automatic-batching

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
