### PR TITLE
Restore Apollo Client 3.7 `getApolloContext` behaviour

### DIFF
--- a/.changeset/tame-owls-lick.md
+++ b/.changeset/tame-owls-lick.md
@@ -1,0 +1,5 @@
+---
+'@apollo/client': patch
+---
+
+Restore Apollo Client 3.7 `getApolloContext` behaviour


### PR DESCRIPTION
This was triggered over in https://github.com/reduxjs/react-redux/issues/2053

TLDR: AliPay mini widgets deliberately remove anything that is global in their runtime: window, self, global, globalThis, you name it, it's gone.
This doesn't impact the globalThis.DEV, as that can be removed by a compiler, but it does impact situations where we attempt to write to globalThis - so I am rolling back this change to the 3.8 behaviour..

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
