### PR TITLE
Adjust relative timing of `useFragment` and `useQuery`

### DIFF
--- a/.changeset/honest-ads-act.md
+++ b/.changeset/honest-ads-act.md
@@ -2,4 +2,4 @@
 '@apollo/client': patch
 ---
 
-This needs a changeset for a PR release
+Ensures that `useQuery` triggers rerenders faster or at the same time as `useFragment`.

--- a/.changeset/honest-ads-act.md
+++ b/.changeset/honest-ads-act.md
@@ -1,0 +1,5 @@
+---
+'@apollo/client': patch
+---
+
+This needs a changeset for a PR release

--- a/.changeset/honest-ads-act.md
+++ b/.changeset/honest-ads-act.md
@@ -2,4 +2,4 @@
 '@apollo/client': patch
 ---
 
-Ensures that `useQuery` triggers rerenders faster or at the same time as `useFragment`.
+Adjust the rerender timing of `useQuery` to more closely align with `useFragment`. This means that cache updates delivered to both hooks should trigger renders at relatively the same time. Previously, the `useFragment` might rerender much faster leading to some confusion.

--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -1,7 +1,7 @@
 const checks = [
   {
     path: "dist/apollo-client.min.cjs",
-    limit: "38000"
+    limit: "38026"
   },
   {
     path: "dist/main.cjs",

--- a/src/react/components/__tests__/client/Mutation.test.tsx
+++ b/src/react/components/__tests__/client/Mutation.test.tsx
@@ -978,7 +978,7 @@ describe('General Mutation testing', () => {
     );
   });
 
-  it('allows a refetchQueries prop as string and variables have updated', async () => new Promise((resolve, reject) => {
+  it('allows a refetchQueries prop as string and variables have updated', async () => {
     const query = gql`
       query people($first: Int) {
         allPeople(first: $first) {
@@ -1026,6 +1026,7 @@ describe('General Mutation testing', () => {
     const refetchQueries = ['people'];
 
     let count = 0;
+    let testFailures: any[] = [];
 
     const Component: React.FC<PropsWithChildren<PropsWithChildren<any>>> = props => {
       const [variables, setVariables] = useState(props.variables);
@@ -1055,19 +1056,20 @@ describe('General Mutation testing', () => {
                     // mutation loading
                     expect(resultMutation.loading).toBe(true);
                   } else if (count === 5) {
-                    // mutation loaded
-                    expect(resultMutation.loading).toBe(false);
+                    // query refetched or mutation loaded
+                    // or both finished batched together 
+                    // hard to make assumptions here
                   } else if (count === 6) {
-                    // query refetched
+                    // both loaded
                     expect(resultQuery.loading).toBe(false);
                     expect(resultMutation.loading).toBe(false);
                     expect(resultQuery.data).toEqual(peopleData3);
                   } else {
-                    reject(`Too many renders (${count})`);
+                    throw new Error(`Too many renders (${count})`);
                   }
                   count++;
                 } catch (err) {
-                  reject(err);
+                  testFailures.push(err);
                 }
                 return null;
               }}
@@ -1083,10 +1085,16 @@ describe('General Mutation testing', () => {
       </MockedProvider>
     );
 
-    waitFor(() => {
-      expect(count).toEqual(IS_REACT_18 ? 6 : 7);
-    }).then(resolve, reject);
-  }));
+    await waitFor(() => {
+      if (testFailures.length > 0) {
+        throw testFailures[0];
+      }
+      expect(count).toEqual(IS_REACT_18 ? 7 : 7);
+    });
+    if (testFailures.length > 0) {
+      throw testFailures[0];
+    }
+  });
 
   it('allows refetchQueries to be passed to the mutate function', () => new Promise((resolve, reject) => {
     const query = gql`

--- a/src/react/components/__tests__/client/Mutation.test.tsx
+++ b/src/react/components/__tests__/client/Mutation.test.tsx
@@ -17,8 +17,6 @@ import {
 import { Query } from '../../Query';
 import { Mutation } from '../../Mutation';
 
-const IS_REACT_18 = React.version.startsWith('18');
-
 const mutation = gql`
   mutation createTodo($text: String!) {
     createTodo {
@@ -1089,11 +1087,8 @@ describe('General Mutation testing', () => {
       if (testFailures.length > 0) {
         throw testFailures[0];
       }
-      expect(count).toEqual(IS_REACT_18 ? 7 : 7);
+      expect(count).toEqual(7);
     });
-    if (testFailures.length > 0) {
-      throw testFailures[0];
-    }
   });
 
   it('allows refetchQueries to be passed to the mutate function', () => new Promise((resolve, reject) => {

--- a/src/react/components/__tests__/client/Query.test.tsx
+++ b/src/react/components/__tests__/client/Query.test.tsx
@@ -11,8 +11,6 @@ import { ApolloProvider } from '../../../context';
 import { itAsync, MockedProvider, mockSingleLink } from '../../../../testing';
 import { Query } from '../../Query';
 
-const IS_REACT_18 = React.version.startsWith('18');
-
 const allPeopleQuery: DocumentNode = gql`
   query people {
     allPeople(first: 1) {
@@ -293,11 +291,7 @@ describe('Query component', () => {
               }
               if (count === 3) {
                 // second data
-                if (IS_REACT_18) {
-                  expect(data).toEqual(data2);
-                } else {
-                  expect(data).toEqual(data2);
-                }
+                expect(data).toEqual(data2);
               }
               if (count === 5) {
                 // third data
@@ -338,11 +332,7 @@ describe('Query component', () => {
       );
 
       waitFor(() => {
-        if (IS_REACT_18) {
-          expect(count).toBe(6);
-        } else {
-          expect(count).toBe(6);
-        }
+        expect(count).toBe(6);
       }).then(resolve, reject);
     });
 
@@ -688,11 +678,7 @@ describe('Query component', () => {
                 });
               }
               if (count === 2) {
-                if (IS_REACT_18) {
-                  expect(result.loading).toBeTruthy();
-                } else {
-                  expect(result.loading).toBeTruthy();
-                }
+                expect(result.loading).toBeTruthy();
               }
               if (count === 3) {
                 expect(result.loading).toBeFalsy();
@@ -714,11 +700,7 @@ describe('Query component', () => {
       );
 
       waitFor(() => {
-        if (IS_REACT_18) {
-          expect(count).toBe(4)
-        } else {
-          expect(count).toBe(4)
-        }
+        expect(count).toBe(4)
       }).then(resolve, reject);
     });
 
@@ -1378,11 +1360,7 @@ describe('Query component', () => {
                       break;
                     case 3:
                       // Second response loading
-                      if (IS_REACT_18) {
-                        expect(props.loading).toBe(true);
-                      } else {
-                        expect(props.loading).toBe(true);
-                      }
+                      expect(props.loading).toBe(true);
                       break;
                     case 4:
                       // Second response received, fire another refetch
@@ -1416,11 +1394,7 @@ describe('Query component', () => {
       render(<SomeComponent />);
 
       waitFor(() => {
-        if (IS_REACT_18) {
-          expect(count).toBe(7)
-        } else {
-          expect(count).toBe(7)
-        }
+        expect(count).toBe(7)
       }).then(resolve, reject);
     });
   });
@@ -1531,11 +1505,7 @@ describe('Query component', () => {
                   break;
                 case 2:
                   // Waiting for the second result to load
-                  if (IS_REACT_18) {
-                    expect(result.loading).toBe(true);
-                  } else {
-                    expect(result.loading).toBe(true);
-                  }
+                  expect(result.loading).toBe(true);
                   break;
                 case 3:
                   setTimeout(() => {
@@ -1580,15 +1550,11 @@ describe('Query component', () => {
     );
 
     await waitFor(() => {
-      if (IS_REACT_18) {
-        expect(count).toBe(6)
-      } else {
-        expect(count).toBe(6)
+      if (testFailures.length > 0) {
+        throw testFailures[0];
       }
+      expect(count).toBe(6);
     });
-    if (testFailures.length > 0) {
-      throw testFailures[0];
-    }
   });
 
   itAsync(

--- a/src/react/components/__tests__/client/Query.test.tsx
+++ b/src/react/components/__tests__/client/Query.test.tsx
@@ -294,7 +294,7 @@ describe('Query component', () => {
               if (count === 3) {
                 // second data
                 if (IS_REACT_18) {
-                  expect(data).toEqual(data3);
+                  expect(data).toEqual(data2);
                 } else {
                   expect(data).toEqual(data2);
                 }
@@ -339,7 +339,7 @@ describe('Query component', () => {
 
       waitFor(() => {
         if (IS_REACT_18) {
-          expect(count).toBe(4);
+          expect(count).toBe(6);
         } else {
           expect(count).toBe(6);
         }
@@ -689,7 +689,7 @@ describe('Query component', () => {
               }
               if (count === 2) {
                 if (IS_REACT_18) {
-                  expect(result.loading).toBeFalsy();
+                  expect(result.loading).toBeTruthy();
                 } else {
                   expect(result.loading).toBeTruthy();
                 }
@@ -715,7 +715,7 @@ describe('Query component', () => {
 
       waitFor(() => {
         if (IS_REACT_18) {
-          expect(count).toBe(3)
+          expect(count).toBe(4)
         } else {
           expect(count).toBe(4)
         }
@@ -1379,7 +1379,7 @@ describe('Query component', () => {
                     case 3:
                       // Second response loading
                       if (IS_REACT_18) {
-                        expect(props.loading).toBe(false);
+                        expect(props.loading).toBe(true);
                       } else {
                         expect(props.loading).toBe(true);
                       }
@@ -1417,7 +1417,7 @@ describe('Query component', () => {
 
       waitFor(() => {
         if (IS_REACT_18) {
-          expect(count).toBe(4)
+          expect(count).toBe(7)
         } else {
           expect(count).toBe(7)
         }
@@ -1502,6 +1502,7 @@ describe('Query component', () => {
     });
 
     let count = 0;
+    let testFailures: any[] = [];
     const noop = () => null;
 
     const AllPeopleQuery2 = Query;
@@ -1531,7 +1532,7 @@ describe('Query component', () => {
                 case 2:
                   // Waiting for the second result to load
                   if (IS_REACT_18) {
-                    expect(result.loading).toBe(false);
+                    expect(result.loading).toBe(true);
                   } else {
                     expect(result.loading).toBe(true);
                   }
@@ -1561,7 +1562,10 @@ describe('Query component', () => {
                   throw new Error('Unexpected fall through');
               }
             } catch (e) {
-              fail(e);
+              // if we throw the error inside the component,
+              // we will get more rerenders in the test, but the `expect` error
+              // might not propagate anyways
+              testFailures.push(e);
             }
             return null;
           }}
@@ -1577,11 +1581,14 @@ describe('Query component', () => {
 
     await waitFor(() => {
       if (IS_REACT_18) {
-        expect(count).toBe(3)
+        expect(count).toBe(6)
       } else {
         expect(count).toBe(6)
       }
     });
+    if (testFailures.length > 0) {
+      throw testFailures[0];
+    }
   });
 
   itAsync(

--- a/src/react/components/__tests__/client/Subscription.test.tsx
+++ b/src/react/components/__tests__/client/Subscription.test.tsx
@@ -484,10 +484,12 @@ describe('should update', () => {
 
     link.simulateResult(results[0]);
 
-    await waitFor(() => expect(count).toBe(5));
-    if (testFailures.length > 0) {
-      throw testFailures[0];
-    }
+    await waitFor(() => {
+      if (testFailures.length > 0) {
+        throw testFailures[0];
+      }
+      expect(count).toBe(5);
+    });
   });
 
   itAsync('if the query changes', (resolve, reject) => {

--- a/src/react/hoc/__tests__/mutations/queries.test.tsx
+++ b/src/react/hoc/__tests__/mutations/queries.test.tsx
@@ -14,8 +14,6 @@ import {
 import { graphql } from '../../graphql';
 import { ChildProps } from '../../types';
 
-const IS_REACT_18 = React.version.startsWith('18');
-
 describe('graphql(mutation) query integration', () => {
   itAsync('allows for passing optimisticResponse for a mutation', (resolve, reject) => {
     const query: DocumentNode = gql`
@@ -194,15 +192,6 @@ describe('graphql(mutation) query integration', () => {
               mutationData.createTodo
             ]);
             break;
-          case 3:
-            if (IS_REACT_18) {
-              expect(this.props.data.todo_list.tasks).toEqual([
-                mutationData.createTodo
-              ]);
-            } else {
-              reject(`too many renders (${renderCount})`);
-            }
-            break;
           default:
             reject(`too many renders (${renderCount})`);
         }
@@ -220,11 +209,7 @@ describe('graphql(mutation) query integration', () => {
     );
 
     waitFor(() => {
-      if (IS_REACT_18) {
-        expect(renderCount).toBe(2);
-      } else {
-        expect(renderCount).toBe(2);
-      }
+      expect(renderCount).toBe(2);
     }).then(resolve, reject);
   });
 
@@ -325,11 +310,7 @@ describe('graphql(mutation) query integration', () => {
       class extends React.Component<ChildProps<Variables, Data>> {
         render() {
           if (count === 1) {
-            if (IS_REACT_18) {
-              expect(this.props.data!.mini).toEqual(queryData.mini);
-            } else {
-              expect(this.props.data!.mini).toEqual(queryData.mini);
-            }
+            expect(this.props.data!.mini).toEqual(queryData.mini);
           }
           if (count === 2) {
             expect(this.props.data!.mini).toEqual(
@@ -354,11 +335,7 @@ describe('graphql(mutation) query integration', () => {
     );
 
     waitFor(() => {
-      if (IS_REACT_18) {
-        expect(count).toBe(3);
-      } else {
-        expect(count).toBe(3);
-      }
+      expect(count).toBe(3);
     }).then(resolve, reject);
   });
 

--- a/src/react/hoc/__tests__/mutations/queries.test.tsx
+++ b/src/react/hoc/__tests__/mutations/queries.test.tsx
@@ -221,7 +221,7 @@ describe('graphql(mutation) query integration', () => {
 
     waitFor(() => {
       if (IS_REACT_18) {
-        expect(renderCount).toBe(3);
+        expect(renderCount).toBe(2);
       } else {
         expect(renderCount).toBe(2);
       }
@@ -326,7 +326,7 @@ describe('graphql(mutation) query integration', () => {
         render() {
           if (count === 1) {
             if (IS_REACT_18) {
-              expect(this.props.data!.mini).toEqual(mutationData.mini);
+              expect(this.props.data!.mini).toEqual(queryData.mini);
             } else {
               expect(this.props.data!.mini).toEqual(queryData.mini);
             }
@@ -355,7 +355,7 @@ describe('graphql(mutation) query integration', () => {
 
     waitFor(() => {
       if (IS_REACT_18) {
-        expect(count).toBe(2);
+        expect(count).toBe(3);
       } else {
         expect(count).toBe(3);
       }

--- a/src/react/hoc/__tests__/mutations/recycled-queries.test.tsx
+++ b/src/react/hoc/__tests__/mutations/recycled-queries.test.tsx
@@ -11,8 +11,6 @@ import { mockSingleLink } from '../../../../testing';
 import { graphql } from '../../graphql';
 import { ChildProps } from '../../types';
 
-const IS_REACT_18 = React.version.startsWith('18')
-
 describe('graphql(mutation) update queries', () => {
   // This is a long test that keeps track of a lot of stuff. It is testing
   // whether or not the `options.update` reducers will run even when a given
@@ -149,13 +147,11 @@ describe('graphql(mutation) update queries', () => {
                 break;
               case 1:
                 expect(this.props.data!.loading).toBeFalsy();
-                if (!IS_REACT_18) {
-                  expect(this.props.data!.todo_list).toEqual({
-                    id: '123',
-                    title: 'how to apollo',
-                    tasks: []
-                  });
-                }
+                expect(this.props.data!.todo_list).toEqual({
+                  id: '123',
+                  title: 'how to apollo',
+                  tasks: []
+                });
                 break;
               case 2:
                 expect(this.props.data!.loading).toBeFalsy();
@@ -227,15 +223,10 @@ describe('graphql(mutation) update queries', () => {
     }
 
     catchingSetTimeout(() => {
-      console.log('running mutation');
       mutate();
 
       catchingSetTimeout(() => {
-        if (IS_REACT_18) {
-          expect(queryUnmountCount).toBe(0);
-        } else {
-          expect(queryUnmountCount).toBe(0);
-        }
+        expect(queryUnmountCount).toBe(0);
         query1Unmount();
         expect(queryUnmountCount).toBe(1);
 

--- a/src/react/hoc/__tests__/queries/errors.test.tsx
+++ b/src/react/hoc/__tests__/queries/errors.test.tsx
@@ -13,8 +13,6 @@ import { Query } from '../../../components/Query';
 import { graphql } from '../../graphql';
 import { ChildProps, DataValue } from '../../types';
 
-const IS_REACT_18 = React.version.startsWith('18');
-
 describe('[queries] errors', () => {
   let error: typeof console.error;
   beforeEach(() => {
@@ -376,11 +374,7 @@ describe('[queries] errors', () => {
                 });
                 break;
               case 1:
-                if (IS_REACT_18) {
-                  expect(props.data!.loading).toBeTruthy();
-                } else {
-                  expect(props.data!.loading).toBeTruthy();
-                }
+                expect(props.data!.loading).toBeTruthy();
                 expect(props.data!.allPeople).toEqual(
                   data.allPeople
                 );
@@ -413,11 +407,7 @@ describe('[queries] errors', () => {
     );
 
     waitFor(() => {
-      if (IS_REACT_18) {
-        expect(count).toBe(3);
-      } else {
-        expect(count).toBe(3)
-      }
+      expect(count).toBe(3)
     }).then(resolve, reject);
   });
 
@@ -464,11 +454,7 @@ describe('[queries] errors', () => {
                   .catch(noop);
                 break;
               case 1:
-                if (IS_REACT_18) {
-                  expect(props.data!.loading).toBeTruthy();
-                } else {
-                  expect(props.data!.loading).toBeTruthy();
-                }
+                expect(props.data!.loading).toBeTruthy();
                 break;
               case 2:
                 expect(props.data!.loading).toBeFalsy();
@@ -511,11 +497,7 @@ describe('[queries] errors', () => {
     );
 
     waitFor(() => {
-      if (IS_REACT_18) {
-        expect(count).toBe(5)
-      } else {
-        expect(count).toBe(5)
-      }
+      expect(count).toBe(5)
     }).then(resolve, reject);
   });
 
@@ -636,9 +618,7 @@ describe('[queries] errors', () => {
     );
 
     waitFor(() => {
-      if (!IS_REACT_18) {
-        expect(done).toBeTruthy()
-      }
+      expect(done).toBeTruthy()
     }).then(resolve, reject);
   });
 

--- a/src/react/hoc/__tests__/queries/errors.test.tsx
+++ b/src/react/hoc/__tests__/queries/errors.test.tsx
@@ -377,7 +377,7 @@ describe('[queries] errors', () => {
                 break;
               case 1:
                 if (IS_REACT_18) {
-                  expect(props.data!.loading).toBeFalsy();
+                  expect(props.data!.loading).toBeTruthy();
                 } else {
                   expect(props.data!.loading).toBeTruthy();
                 }
@@ -414,7 +414,7 @@ describe('[queries] errors', () => {
 
     waitFor(() => {
       if (IS_REACT_18) {
-        expect(count).toBe(2);
+        expect(count).toBe(3);
       } else {
         expect(count).toBe(3)
       }
@@ -465,7 +465,7 @@ describe('[queries] errors', () => {
                 break;
               case 1:
                 if (IS_REACT_18) {
-                  expect(props.data!.loading).toBeFalsy();
+                  expect(props.data!.loading).toBeTruthy();
                 } else {
                   expect(props.data!.loading).toBeTruthy();
                 }
@@ -512,7 +512,7 @@ describe('[queries] errors', () => {
 
     waitFor(() => {
       if (IS_REACT_18) {
-        expect(count).toBe(2)
+        expect(count).toBe(5)
       } else {
         expect(count).toBe(5)
       }

--- a/src/react/hoc/__tests__/queries/lifecycle.test.tsx
+++ b/src/react/hoc/__tests__/queries/lifecycle.test.tsx
@@ -11,8 +11,6 @@ import { Query as QueryComponent } from '../../../components';
 import { graphql } from '../../graphql';
 import { ChildProps } from '../../types';
 
-const IS_REACT_18 = React.version.startsWith('18');
-
 describe('[queries] lifecycle', () => {
   // lifecycle
   it('reruns the query if it changes', async () => {
@@ -512,9 +510,7 @@ describe('[queries] lifecycle', () => {
     rerender = render(app).rerender;
 
     await waitFor(() => {
-      if (!IS_REACT_18) {
-        expect(done).toBeTruthy()
-      }
+      expect(done).toBeTruthy()
     });
   });
 
@@ -603,11 +599,7 @@ describe('[queries] lifecycle', () => {
                 refetchQuery!();
                 break;
               case 3:
-                if (IS_REACT_18) {
-                  expect({ loading }).toEqual({ loading: true });
-                } else {
-                  expect({ loading }).toEqual({ loading: true });
-                }
+                expect({ loading }).toEqual({ loading: true });
                 expect({ a, b, c }).toEqual({
                   a: 1,
                   b: 2,
@@ -734,15 +726,11 @@ describe('[queries] lifecycle', () => {
     render(<ClientSwitcher />);
 
     await waitFor(() => {
-      if (IS_REACT_18) {
-        expect(count).toBe(12)
-      } else {
-        expect(count).toBe(12)
+      if (testFailures.length > 0) {
+        throw testFailures[0];
       }
+      expect(count).toBe(12)
     });
-    if (testFailures.length > 0) {
-      throw testFailures[0];
-    }
   });
 
   it('handles synchronous racecondition with prefilled data from the server', async () => {

--- a/src/react/hoc/__tests__/queries/lifecycle.test.tsx
+++ b/src/react/hoc/__tests__/queries/lifecycle.test.tsx
@@ -571,6 +571,7 @@ describe('[queries] lifecycle', () => {
     let switchClient: (client: ApolloClient<any>) => void;
     let refetchQuery: () => void;
     let count = 0;
+    let testFailures: any[] = [];
 
     const Query = graphql<{}, Data>(query, {
       options: { notifyOnNetworkStatusChange: true }
@@ -603,7 +604,7 @@ describe('[queries] lifecycle', () => {
                 break;
               case 3:
                 if (IS_REACT_18) {
-                  expect({ loading }).toEqual({ loading: false });
+                  expect({ loading }).toEqual({ loading: true });
                 } else {
                   expect({ loading }).toEqual({ loading: true });
                 }
@@ -702,7 +703,7 @@ describe('[queries] lifecycle', () => {
                 fail(`Unexpectedly many renders (${count})`);
             }
           } catch (err) {
-            fail(err);
+            testFailures.push(err);
           }
 
           return null;
@@ -734,11 +735,14 @@ describe('[queries] lifecycle', () => {
 
     await waitFor(() => {
       if (IS_REACT_18) {
-        expect(count).toBe(3)
+        expect(count).toBe(12)
       } else {
         expect(count).toBe(12)
       }
     });
+    if (testFailures.length > 0) {
+      throw testFailures[0];
+    }
   });
 
   it('handles synchronous racecondition with prefilled data from the server', async () => {

--- a/src/react/hoc/__tests__/queries/loading.test.tsx
+++ b/src/react/hoc/__tests__/queries/loading.test.tsx
@@ -301,8 +301,8 @@ describe('[queries] loading', () => {
               break;
             case 1:
               if (IS_REACT_18) {
-                expect(data!.loading).toBeFalsy();
-                expect(data!.networkStatus).toBe(NetworkStatus.ready);
+                expect(data!.loading).toBeTruthy();
+                expect(data!.networkStatus).toBe(NetworkStatus.refetch);
               } else {
                 expect(data!.loading).toBeTruthy();
                 expect(data!.networkStatus).toBe(NetworkStatus.refetch);
@@ -333,7 +333,7 @@ describe('[queries] loading', () => {
 
     waitFor(() => {
       if (IS_REACT_18) {
-        expect(count).toBe(2)
+        expect(count).toBe(3)
       } else {
         expect(count).toBe(3)
       }

--- a/src/react/hoc/__tests__/queries/skip.test.tsx
+++ b/src/react/hoc/__tests__/queries/skip.test.tsx
@@ -11,8 +11,6 @@ import { itAsync, mockSingleLink } from '../../../../testing';
 import { graphql } from '../../graphql';
 import { ChildProps } from '../../types';
 
-const IS_REACT_18 = React.version.startsWith('18');
-
 describe('[queries] skip', () => {
   itAsync('allows you to skip a query without running it', (resolve, reject) => {
     const query: DocumentNode = gql`
@@ -691,14 +689,9 @@ describe('[queries] skip', () => {
                 break;
               case 6:
                 expect(this.props.skip).toBe(false);
-                if (IS_REACT_18) {
-                  expect(this.props.data!.loading).toBe(true);
-                  expect(this.props.data.allPeople).toEqual(nextData.allPeople);
-                } else {
-                  expect(ranQuery).toBe(3);
-                  expect(this.props.data.allPeople).toEqual(nextData.allPeople);
-                  expect(this.props.data!.loading).toBe(true);
-                }
+                expect(ranQuery).toBe(3);
+                expect(this.props.data.allPeople).toEqual(nextData.allPeople);
+                expect(this.props.data!.loading).toBe(true);
                 break;
               case 7:
                 // The next batch of data has loaded.
@@ -738,11 +731,7 @@ describe('[queries] skip', () => {
     );
 
     waitFor(() => {
-      if (IS_REACT_18) {
-        expect(count).toEqual(7)
-      } else {
-        expect(count).toEqual(7)
-      }
+      expect(count).toEqual(7)
     }).then(resolve, reject);
   }));
 

--- a/src/react/hoc/__tests__/queries/skip.test.tsx
+++ b/src/react/hoc/__tests__/queries/skip.test.tsx
@@ -692,8 +692,8 @@ describe('[queries] skip', () => {
               case 6:
                 expect(this.props.skip).toBe(false);
                 if (IS_REACT_18) {
-                  expect(this.props.data!.loading).toBe(false);
-                  expect(this.props.data.allPeople).toEqual(finalData.allPeople);
+                  expect(this.props.data!.loading).toBe(true);
+                  expect(this.props.data.allPeople).toEqual(nextData.allPeople);
                 } else {
                   expect(ranQuery).toBe(3);
                   expect(this.props.data.allPeople).toEqual(nextData.allPeople);
@@ -739,7 +739,7 @@ describe('[queries] skip', () => {
 
     waitFor(() => {
       if (IS_REACT_18) {
-        expect(count).toEqual(6)
+        expect(count).toEqual(7)
       } else {
         expect(count).toEqual(7)
       }

--- a/src/react/hooks/__tests__/useFragment.test.tsx
+++ b/src/react/hooks/__tests__/useFragment.test.tsx
@@ -1083,8 +1083,8 @@ describe("useFragment", () => {
       });
     });
 
+    await waitFor(() => void expect(renderResult.current.data).toEqual(data125));
     expect(renderResult.current.complete).toBe(false);
-    expect(renderResult.current.data).toEqual(data125);
     expect(renderResult.current.missing).toEqual({
       list: {
         // Even though Query.list is actually an array in the data, data paths
@@ -1118,8 +1118,8 @@ describe("useFragment", () => {
       });
     });
 
+    await waitFor(() => void expect(renderResult.current.data).toEqual(data182WithText));
     expect(renderResult.current.complete).toBe(true);
-    expect(renderResult.current.data).toEqual(data182WithText);
     expect(renderResult.current.missing).toBeUndefined();
 
     checkHistory(3);
@@ -1143,13 +1143,13 @@ describe("useFragment", () => {
       },
     }));
 
-    expect(renderResult.current.complete).toBe(false);
-    expect(renderResult.current.data).toEqual({
+    await waitFor(() => void expect(renderResult.current.data).toEqual({
       list: [
         { __typename: "Item", id: 1, text: "oyez1" },
         { __typename: "Item", id: 2 },
       ],
-    });
+    }));
+    expect(renderResult.current.complete).toBe(false);
     expect(renderResult.current.missing).toEqual({
       // TODO Figure out why Item:8 is not represented here. Likely because of
       // auto-filtering of dangling references from arrays, but that should

--- a/src/react/hooks/__tests__/useFragment.test.tsx
+++ b/src/react/hooks/__tests__/useFragment.test.tsx
@@ -1083,7 +1083,7 @@ describe("useFragment", () => {
       });
     });
 
-    await waitFor(() => void expect(renderResult.current.data).toEqual(data125));
+    await waitFor(() => expect(renderResult.current.data).toEqual(data125));
     expect(renderResult.current.complete).toBe(false);
     expect(renderResult.current.missing).toEqual({
       list: {
@@ -1118,7 +1118,7 @@ describe("useFragment", () => {
       });
     });
 
-    await waitFor(() => void expect(renderResult.current.data).toEqual(data182WithText));
+    await waitFor(() => expect(renderResult.current.data).toEqual(data182WithText));
     expect(renderResult.current.complete).toBe(true);
     expect(renderResult.current.missing).toBeUndefined();
 
@@ -1143,7 +1143,7 @@ describe("useFragment", () => {
       },
     }));
 
-    await waitFor(() => void expect(renderResult.current.data).toEqual({
+    await waitFor(() => expect(renderResult.current.data).toEqual({
       list: [
         { __typename: "Item", id: 1, text: "oyez1" },
         { __typename: "Item", id: 2 },
@@ -1563,6 +1563,17 @@ describe("has the same timing as `useQuery`", () => {
     }
   });
 
+  /**
+   * This would be optimal, but would only work if `useFragment` and
+   * `useQuery` had exactly the same timing, which is not the case with
+   * the current implementation.
+   * The best we can do is to make sure that `useFragment` is not
+   * faster than `useQuery` in reasonable cases (of course, `useQuery`
+   * could trigger a network request on cache update, which would be slower 
+   * than `useFragment`, no matter how much we delay it).
+   * If we change the core implementation into a more synchronous one,
+   * we should try to get this test to work, too.
+   */
   it.failing("`useFragment` in parent, `useQuery` in child", async () => {
     const item1 = { __typename: "Item", id: 1, title: "Item #1" };
     const item2 = { __typename: "Item", id: 2, title: "Item #2" };

--- a/src/react/hooks/useFragment.ts
+++ b/src/react/hooks/useFragment.ts
@@ -83,16 +83,21 @@ export function useFragment<
 
   return useSyncExternalStore(
     (forceUpdate) => {
-      return cache.watch({
+      let lastTimeout = 0;
+      const unsubcribe = cache.watch({
         ...diffOptions,
         immediate: true,
         callback(diff) {
           if (!equal(diff, latestDiff)) {
             resultRef.current = diffToResult((latestDiff = diff));
-            forceUpdate();
+            lastTimeout = setTimeout(forceUpdate) as any;
           }
         },
       });
+      return () => {
+        unsubcribe();
+        clearTimeout(lastTimeout);
+      }
     },
     getSnapshot,
     getSnapshot

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -68,7 +68,7 @@ export function useLazyQuery<TData = any, TVariables extends OperationVariables 
         if (!execOptionsRef.current) {
           execOptionsRef.current = Object.create(null);
           // Only the first time populating execOptionsRef.current matters here.
-          internalState.forceUpdate();
+          internalState.forceUpdateState();
         }
         return method.apply(this, arguments);
       };

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -103,6 +103,10 @@ class InternalState<TData, TVariables extends OperationVariables> {
     invariant.warn("Calling default no-op implementation of InternalState#forceUpdate");
   }
 
+  /**
+   * Will be overwritten by the `useSyncExternalStore` "force update" method
+   * whenever it is available and reset to `forceUpdateState` when it isn't.
+   */
   forceUpdate = () => this.forceUpdateState();
 
   executeQuery(options: QueryHookOptions<TData, TVariables> & {

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -160,7 +160,7 @@ class InternalState<TData, TVariables extends OperationVariables> {
     const obsQuery = this.useObservableQuery();
 
     const result = useSyncExternalStore(
-      React.useCallback(() => {
+      React.useCallback((handleStoreChange) => {
         if (this.renderPromises) {
           return () => {};
         }
@@ -181,7 +181,7 @@ class InternalState<TData, TVariables extends OperationVariables> {
             return;
           }
 
-          this.setResult(result);
+          this.setResult(result, handleStoreChange);
         };
 
         const onError = (error: Error) => {
@@ -217,7 +217,7 @@ class InternalState<TData, TVariables extends OperationVariables> {
               error: error as ApolloError,
               loading: false,
               networkStatus: NetworkStatus.error,
-            });
+            }, handleStoreChange);
           }
         };
 
@@ -495,7 +495,7 @@ class InternalState<TData, TVariables extends OperationVariables> {
   private result: undefined | ApolloQueryResult<TData>;
   private previousData: undefined | TData;
 
-  private setResult(nextResult: ApolloQueryResult<TData>) {
+  private setResult(nextResult: ApolloQueryResult<TData>, forceUpdate: () => void) {
     const previousResult = this.result;
     if (previousResult && previousResult.data) {
       this.previousData = previousResult.data;
@@ -503,7 +503,7 @@ class InternalState<TData, TVariables extends OperationVariables> {
     this.result = nextResult;
     // Calling state.setResult always triggers an update, though some call sites
     // perform additional equality checks before committing to an update.
-    this.forceUpdate();
+    forceUpdate();
     this.handleErrorOrCompleted(nextResult, previousResult);
   }
 

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -508,7 +508,6 @@ class InternalState<TData, TVariables extends OperationVariables> {
 
   private setResult(nextResult: ApolloQueryResult<TData>) {
     const previousResult = this.result;
-    //console.dir({equal: equal(previousResult, nextResult), previousResult, nextResult}, {maxDepth: 3})
     if (previousResult && previousResult.data) {
       this.previousData = previousResult.data;
     }


### PR DESCRIPTION
Ensures that `useQuery` triggers rerenders faster or at the same time as `useFragment`.

Before this change, `useQuery` used a `useState` setter callback to trigger a
rerender instead of the `useSyncExternalState` `forceRender` callback.
Due to a bug in React (https://github.com/facebook/react/issues/25191), these renders
are not batched together.
That could lead to situations where a child accessing a fragment that was evicted
from the cache would rerender (without data) before a parent `useQuery` component
had a chance to unmount the child.
After this change, `useQuery` and `useFragment` still don't rerender exactly at the same moment
in time - but it is guaranteed that `useQuery` will always rerender before `useFragment` will,
which should fix most problems.

I know, it's late for this, but this is the last moment in time we have to fix `useFragment` before it gets stable - and we should not release it and then immediately change it's timing.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
