### PR TITLE
Fix stuck pending state when refetching a query that returns a result that is deeply equal to data in the cache

### DIFF
--- a/.changeset/calm-bears-buy.md
+++ b/.changeset/calm-bears-buy.md
@@ -1,0 +1,5 @@
+---
+'@apollo/client': patch
+---
+
+Fix an issue where a call to `refetch`, `fetchMore`, or changing `skip` to `false` that returned a result deeply equal to data in the cache would get stuck in a pending state and never resolve.

--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -1,7 +1,7 @@
 const checks = [
   {
     path: "dist/apollo-client.min.cjs",
-    limit: "37965"
+    limit: "37990"
   },
   {
     path: "dist/main.cjs",

--- a/src/react/cache/QueryReference.ts
+++ b/src/react/cache/QueryReference.ts
@@ -184,6 +184,13 @@ export class InternalQueryReference<TData = unknown> {
 
     this.initiateFetch();
 
+    // If the data returned from the fetch is deeply equal to the data already
+    // in the cache, `handleNext` will not be triggered leaving the promise we
+    // created forever in a pending state. To avoid this situtation, we attempt
+    // to resolve or reject the promise as a fallback to guarantee it will be
+    // resolved.
+    promise.then(this.resolve, this.reject);
+
     return promise;
   }
 

--- a/src/react/cache/QueryReference.ts
+++ b/src/react/cache/QueryReference.ts
@@ -157,8 +157,18 @@ export class InternalQueryReference<TData = unknown> {
       currentFetchPolicy === 'standby' &&
       currentFetchPolicy !== watchQueryOptions.fetchPolicy
     ) {
-      this.observable.reobserve(watchQueryOptions);
+      const promise = this.observable.reobserve(watchQueryOptions);
       this.initiateFetch();
+
+      promise
+        .then((result) => {
+          if (this.status === 'loading') {
+            this.status = 'idle';
+            this.result = result;
+            this.resolve?.(result);
+          }
+        })
+        .catch(() => {});
     } else {
       this.observable.silentSetOptions(watchQueryOptions);
 


### PR DESCRIPTION
Fixes #11085

Fixes an issue where a call to `refetch`, `fetchMore`, or changing `skip` to `false` that returned a result deeply equal to data in the cache would get stuck in a pending state and never resolve. This meant the Suspense fallback would be displayed indefinitely.

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
