### PR TITLE
Add docs for `removeTypenameFromVariables` link

### DIFF
--- a/docs/source/api/link/apollo-link-remove-typename.mdx
+++ b/docs/source/api/link/apollo-link-remove-typename.mdx
@@ -6,7 +6,7 @@ minVersion: 3.8.0
 
 ## Overview
 
-Use the `removeTypenameFromVariables` link to automatically remove `__typename` fields from variables in operations. This is useful when you're reusing data from a query as an argument to another GraphQL operation.
+The `removeTypenameFromVariables` link automatically removes `__typename` fields from variables in operations. This is useful when reusing data from a query as an argument to another GraphQL operation.
 
 ```ts
 import { removeTypenameFromVariables } from '@apollo/client/link/remove-typename';

--- a/docs/source/api/link/apollo-link-remove-typename.mdx
+++ b/docs/source/api/link/apollo-link-remove-typename.mdx
@@ -1,0 +1,164 @@
+---
+title: Remove Typename Link
+description: Automatically remove __typename fields from variables.
+minVersion: 3.8.0
+---
+
+## Overview
+
+Use the `removeTypenameFromVariables` link to automatically remove `__typename` fields from variables in operations. This is useful when you're reusing data from a query as an argument to another GraphQL operation.
+
+```ts
+import { removeTypenameFromVariables } from '@apollo/client/link/remove-typename';
+
+const removeTypenameLink = removeTypenameFromVariables();
+```
+
+As an example, let's take the following query. Apollo Client will automatically add `__typename` fields to the query for each field selection set.
+
+```ts
+const query = gql`
+  query DashboardQuery($id: ID!) {
+    dashboard(id: $id) {
+      id
+      name
+    }
+  }
+`;
+
+const { data } = await client.query({ query, variables: { id: 1 }});
+// {
+//   "dashboard": {
+//     "__typename": "Dashboard",
+//     "id": 1,
+//     "name": "My Dashboard"
+//   }
+// }
+```
+
+Now let's update this dashboard by sending a mutation to our server. We'll use the `dashboard` as input to our mutation.
+
+```ts
+const mutation = gql`
+  mutation UpdateDashboardMutation($dashboard: DashboardInput!) {
+    updateDashboard(dashboard: $dashboard) {
+      id
+      name
+    }
+  }
+`;
+
+await client.mutate({ 
+  mutation,
+  variables: { 
+    dashboard: { ...data.dashboard, name: 'My Updated Dashboard' } 
+  }
+});
+```
+
+Without the use of the `removeTypenameFromVariables` link, the server will return an error because `data.dashboard` still contains the `__typename` field.
+
+## Keep `__typename` in JSON scalars
+
+The [GraphQL spec](https://spec.graphql.org/October2021/#sec-Input-Objects.Type-Validation) disallows input fields that begin with the characters "\_\_" (two underscores). When the input field is a JSON scalar (i.e. a scalar type that accepts raw JSON as input), this restriction is not applied. If your GraphQL server relies on the `__typename` field within a JSON scalar, you can configure the `removeTypenameFromVariables` link to keep `__typename`.
+
+> Note: the JSON scalar type does not need to be literally named `JSON` to be considered a JSON scalar.
+
+Provide an `except` option to map all variable types that should maintain `__typename`. This is done using the `KEEP` sentinel. Each key in the `except` option should correspond to an input type in your GraphQL schema.
+
+Here we tell the `removeTypenameFromVariables` link to keep all `__typename` fields for any variable that defines itself as a `JSON` scalar type.
+
+```ts
+import { removeTypenameFromVariables, KEEP } from '@apollo/client/link/remove-typename';
+
+const removeTypenameLink = removeTypenameFromVariables({
+  except: {
+    JSON: KEEP
+  }
+});
+```
+
+Variable types are inferred from the GraphQL query. Let's take the following GraphQL mutation:
+
+```graphql
+mutation ConfigureDashboardMutation($dashboardConfig: JSON) {
+  configureDashboard(config: $dashboardConfig) {
+    id
+  }
+}
+```
+
+Here we've declared a `dashboardConfig` variable as type `JSON`. When the query moves through the `removeTypenameFromVariables` link, the `dashboardConfig` variable will be detected as a `JSON` scalar type and all `__typename` fields are kept intact.
+
+### Nested JSON scalar fields in input variables
+
+Not all top-level variables may map to a JSON scalar type. For more complex input object types, the JSON scalar may be found on a nested field. The `except` option allows you to configured nested fields within these types to keep `__typename` intact for these fields.
+
+```ts
+import { removeTypenameFromVariables, KEEP } from '@apollo/client/link/remove-typename';
+
+const removeTypenameLink = removeTypenameFromVariables({
+  except: {
+    DashboardInput: {
+      config: KEEP
+    }
+  }
+});
+```
+
+Variables declared as type `DashboardInput` will have any top-level `__typename` fields removed, but keep `__typename` for the `config` field.
+
+This nesting can be as deep as needed and include as many fields as necessary. Use the `KEEP` sentinel to determine where `__typename` should be kept.
+
+```ts
+import { removeTypenameFromVariables, KEEP } from '@apollo/client/link/remove-typename';
+
+const removeTypenameLink = removeTypenameFromVariables({
+  except: {
+    // Keep __typename for `bar` and `baz` fields on any variable 
+    // declared as a `FooInput` type
+    FooInput: {
+      bar: KEEP,
+      baz: KEEP,
+    },
+
+    // Keep __typename for the `baz.qux` field on any variable 
+    // declared as a `BarInput` type
+    BarInput: {
+      baz: {
+        qux: KEEP
+      }
+    },
+
+    // Keep __typename on `bar.baz` and `bar.qux.foo` fields for any 
+    // variable declared as a `BazInput` type
+    BazInput: {
+      bar: {
+        baz: KEEP, 
+        qux: {
+          foo: KEEP
+        }
+      }
+    },
+  }
+});
+```
+
+To keep `__typename` for nested fields in arrays, use the same object notation as if the field were an object type.
+
+```ts
+import { removeTypenameFromVariables, KEEP } from '@apollo/client/link/remove-typename';
+
+const removeTypenameLink = removeTypenameFromVariables({
+  except: {
+    // Keep __typename on the `config` field for each widget 
+    // in the `widgets` array for variables declared as 
+    // a `DashboardInput` type
+    DashboardInput: {
+      widgets: {
+        config: KEEP
+      }
+    }
+  }
+});
+```

--- a/docs/source/api/link/apollo-link-remove-typename.mdx
+++ b/docs/source/api/link/apollo-link-remove-typename.mdx
@@ -66,7 +66,7 @@ The [GraphQL spec](https://spec.graphql.org/October2021/#sec-Input-Objects.Type-
 
 Provide an `except` option to map all variable types that should maintain `__typename`. This is done using the `KEEP` sentinel. Each key in the `except` option should correspond to an input type in your GraphQL schema.
 
-Here we tell the `removeTypenameFromVariables` link to keep all `__typename` fields for any variable that defines itself as a `JSON` scalar type.
+Here we tell the `removeTypenameFromVariables` link to keep all `__typename` fields for any variable that is declared as a `JSON` type.
 
 ```ts
 import { removeTypenameFromVariables, KEEP } from '@apollo/client/link/remove-typename';

--- a/docs/source/api/link/apollo-link-remove-typename.mdx
+++ b/docs/source/api/link/apollo-link-remove-typename.mdx
@@ -60,7 +60,7 @@ Without the use of the `removeTypenameFromVariables` link, the server will retur
 
 ## Keep `__typename` in JSON scalars
 
-The [GraphQL spec](https://spec.graphql.org/October2021/#sec-Input-Objects.Type-Validation) disallows input fields that begin with the characters "\_\_" (two underscores). When the input field is a JSON scalar (i.e. a scalar type that accepts raw JSON as input), this restriction is not applied. If your GraphQL server relies on the `__typename` field within a JSON scalar, you can configure the `removeTypenameFromVariables` link to keep `__typename`.
+While the [GraphQL spec](https://spec.graphql.org/October2021/#sec-Input-Objects.Type-Validation) disallows input fields that begin with the characters "\_\_" (two underscores), this restriction is not applied when the input field is a JSON scalar (i.e. a scalar type that accepts raw JSON as input). When your server relies on `__typename` within certain `JSON` scalars, you can configure the `removeTypenameFromVariables` link to retain `__typename`.
 
 > Note: the JSON scalar type does not need to be literally named `JSON` to be considered a JSON scalar.
 

--- a/docs/source/api/link/apollo-link-remove-typename.mdx
+++ b/docs/source/api/link/apollo-link-remove-typename.mdx
@@ -66,7 +66,15 @@ While the [GraphQL spec](https://spec.graphql.org/October2021/#sec-Input-Objects
 
 Provide an `except` option to map all variable types that should maintain `__typename`. This is done using the `KEEP` sentinel. Each key in the `except` option should correspond to an input type in your GraphQL schema.
 
-Here we tell the `removeTypenameFromVariables` link to keep all `__typename` fields for any variable that is declared as a `JSON` type.
+Here we tell the `removeTypenameFromVariables` link to keep all `__typename` fields for any variable that is declared as a `JSON` type. Variable types are inferred from the GraphQL query. Let's take the following GraphQL mutation:
+
+```graphql
+mutation ConfigureDashboardMutation($dashboardConfig: JSON) {
+  configureDashboard(config: $dashboardConfig) {
+    id
+  }
+}
+```
 
 ```ts
 import { removeTypenameFromVariables, KEEP } from '@apollo/client/link/remove-typename';
@@ -76,16 +84,6 @@ const removeTypenameLink = removeTypenameFromVariables({
     JSON: KEEP
   }
 });
-```
-
-Variable types are inferred from the GraphQL query. Let's take the following GraphQL mutation:
-
-```graphql
-mutation ConfigureDashboardMutation($dashboardConfig: JSON) {
-  configureDashboard(config: $dashboardConfig) {
-    id
-  }
-}
 ```
 
 Here we've declared a `dashboardConfig` variable as type `JSON`. When the query moves through the `removeTypenameFromVariables` link, the `dashboardConfig` variable will be detected as a `JSON` scalar type and all `__typename` fields are kept intact.

--- a/docs/source/api/link/apollo-link-remove-typename.mdx
+++ b/docs/source/api/link/apollo-link-remove-typename.mdx
@@ -162,3 +162,32 @@ const removeTypenameLink = removeTypenameFromVariables({
   }
 });
 ```
+
+## Options
+
+<table class="field-table">
+  <thead>
+    <tr>
+      <th>Name /<br/>Type</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+
+<tbody>
+<tr>
+<td>
+
+###### `except`
+
+`KeepTypenameConfig`
+</td>
+<td>
+
+Determines which input types should retain `__typename`. This maps the input type to the config, which is either the `KEEP` sentinel or a nested config of fields.
+
+</td>
+</tr>
+
+</tbody>
+</table>
+

--- a/docs/source/config.json
+++ b/docs/source/config.json
@@ -90,6 +90,7 @@
         "Context": "/api/link/apollo-link-context",
         "Error": "/api/link/apollo-link-error",
         "Persisted Queries": "/api/link/persisted-queries",
+        "Remove Typename": "/api/link/apollo-link-remove-typename",
         "REST": "/api/link/apollo-link-rest",
         "Retry": "/api/link/apollo-link-retry",
         "Schema": "/api/link/apollo-link-schema",


### PR DESCRIPTION
Closes #11020 

Adds a docs page for the `removeTypenameFromVariables` link.

I would really appreciate some good feedback here on the structure and content. For whatever reason, I found this difficult to talk about in a way that makes sense. Any and all feedback that can be provided to improve the information on this page would be much appreciated. Thanks!
