### PR TITLE
Remove remaining preview language for `useFragment` and `@nonreactive`

### DIFF
--- a/docs/source/caching/cache-interaction.mdx
+++ b/docs/source/caching/cache-interaction.mdx
@@ -192,7 +192,11 @@ client.writeFragment({
 
 All subscribers to the Apollo Client cache (including all active queries) see this change and update your application's UI accordingly.
 
+<MinVersion version="3.8.0">
+
 ### `useFragment`
+
+</MinVersion>
 
 You can read data for a given fragment directly from the cache using the `useFragment` hook. This hook returns an always-up-to-date view of whatever data the cache currently contains for a given fragment. [See the API reference.](../api/react/hooks#usefragment)
 

--- a/docs/source/caching/cache-interaction.mdx
+++ b/docs/source/caching/cache-interaction.mdx
@@ -194,9 +194,7 @@ All subscribers to the Apollo Client cache (including all active queries) see th
 
 ### `useFragment`
 
-> ⚠️ **The `useFragment` hook is currently at the [preview stage](https://www.apollographql.com/docs/resources/release-stages/#preview) in Apollo Client.** If you have feedback on it, please let us know via [GitHub issues](https://github.com/apollographql/apollo-client/issues/new?assignees=&labels=&template=bug.md).
-
-You can read data for a given fragment directly from the cache using the `useFragment` hook. This hook returns an always-up-to-date view of whatever data the cache currently contains for a given fragment. [See the API reference.](../api/react/hooks-experimental)
+You can read data for a given fragment directly from the cache using the `useFragment` hook. This hook returns an always-up-to-date view of whatever data the cache currently contains for a given fragment. [See the API reference.](../api/react/hooks#usefragment)
 
 ## Combining reads and writes
 

--- a/docs/source/data/directives.mdx
+++ b/docs/source/data/directives.mdx
@@ -97,7 +97,11 @@ You can do this even if `postCount` is also a local-only field (i.e., if it's al
 
 For more information and other considerations when using the `@export` directive, check out the [local-only fields docs](/react/local-state/managing-state-with-field-policies/#using-local-only-fields-as-graphql-variables).
 
+<MinVersion version="3.8.0">
+
 ## `@nonreactive`
+
+</MinVersion>
 
 The `@nonreactive` directive can be used to mark query fields or fragment spreads and is used to indicate that changes to the data contained within the subtrees marked `@nonreactive` should _not_ trigger rerendering. This allows parent components to fetch data to be rendered by their children without rerendering themselves when the data corresponding with fields marked as `@nonreactive` change.
 

--- a/docs/source/data/directives.mdx
+++ b/docs/source/data/directives.mdx
@@ -99,8 +99,6 @@ For more information and other considerations when using the `@export` directive
 
 ## `@nonreactive`
 
-> ⚠️ **The `@nonreactive` directive is currently at the [preview stage](/resources/product-launch-stages/#general-availability) in Apollo Client, and is available by installing `@apollo/client@alpha`.** If you have feedback on it, please let us know via [GitHub issues](https://github.com/apollographql/apollo-client/issues/new?assignees=&labels=&template=bug.md).
-
 The `@nonreactive` directive can be used to mark query fields or fragment spreads and is used to indicate that changes to the data contained within the subtrees marked `@nonreactive` should _not_ trigger rerendering. This allows parent components to fetch data to be rendered by their children without rerendering themselves when the data corresponding with fields marked as `@nonreactive` change.
 
 Consider an `App` component that fetches and renders a list of ski trails:


### PR DESCRIPTION
Something I noticed while browsing another docs PR in the deployed preview.

This PR removes the "preview stage" messaging about `useFragment` and `@nonreactive` in two remaining places and adds minversion annotations.

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
