### PR TITLE
Update /docs codeowner to Apollo docs team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/docs/ @stephenbarlow
+/docs/ @apollographql/docs


### PR DESCRIPTION
Updating `/docs/` codeowners to https://github.com/orgs/apollographql/teams/docs.

(Just me for now, but hopefully another team member soon!)