### PR TITLE
Use MinVersion component

### DIFF
--- a/docs/source/api/cache/InMemoryCache.mdx
+++ b/docs/source/api/cache/InMemoryCache.mdx
@@ -304,9 +304,11 @@ writeQuery<TData = any, TVariables = any>(
 ): Reference | undefined
 ```
 
+<MinVersion version="3.5">
+
 ## `updateQuery`
 
-> This method is available in Apollo Client 3.5 and later.
+</MinVersion>
 
 Fetches data from the cache in the shape of a provided GraphQL query, then _updates_ that cached data according to a provided update function.
 
@@ -758,10 +760,11 @@ writeFragment<TData = any, TVariables = any>(
   options: Cache.WriteFragmentOptions<TData, TVariables>,
 ): Reference | undefined
 ```
+<MinVersion version="3.5">
 
 ## `updateFragment`
 
-> This method is available in Apollo Client 3.5 and later.
+</MinVersion>
 
 Fetches data from the cache in the shape of a provided GraphQL fragment, then _updates_ that cached data according to a provided update function.
 

--- a/docs/source/caching/cache-interaction.mdx
+++ b/docs/source/caching/cache-interaction.mdx
@@ -238,9 +238,11 @@ client.writeQuery({
 
 </ExpansionPanel>
 
+<MinVersion version="3.5">
+
 ### Using `updateQuery` and `updateFragment`
 
-> These methods are available in Apollo Client 3.5 and later.
+</MinVersion>
 
 As a convenience, you can use `cache.updateQuery` or `cache.updateFragment` to combine reading and writing cached data with a single method call:
 

--- a/docs/source/data/queries.mdx
+++ b/docs/source/data/queries.mdx
@@ -278,8 +278,11 @@ const { loading, error, data } = useQuery(GET_DOGS, {
   fetchPolicy: 'network-only', // Doesn't check cache before making a network request
 });
 ```
+<MinVersion version="3.1">
 
 ### `nextFetchPolicy`
+
+</MinVersion>
 
 You can _also_ specify a query's `nextFetchPolicy`. If you do, `fetchPolicy` is used for the query's _first_ execution, and `nextFetchPolicy` is used to determine how the query responds to future cache updates:
 

--- a/docs/source/local-state/local-state-management.mdx
+++ b/docs/source/local-state/local-state-management.mdx
@@ -35,9 +35,11 @@ To support this flow, Apollo Client 3 introduces two complementary mechanisms fo
 
 > \* The [local resolver API](./local-resolvers/) from previous versions of Apollo Client is also available but is [deprecated](./local-resolvers/#deprecation-notice). Some additional steps may occur when using this, e.g. the `@client(always:true)` directive would recalculate local field resolvers after remote fields are cached.
 
+<MinVersion version="3.0">
+
 ## Field policies and local-only fields
 
-> Available in Apollo Client >= 3.0
+</MinVersion>
 
 **Field policies** enable you to define what happens when you query a particular field, _including fields that aren't defined in your GraphQL server's schema_. By defining field policies for these **local-only fields**, you can populate them with data that's stored anywhere, such as in `localStorage` or [reactive variables](#reactive-variables).
 
@@ -45,9 +47,11 @@ A single GraphQL query can include both local-only fields and remotely fetched f
 
 [Get started with local-only fields](./managing-state-with-field-policies/)
 
+<MinVersion version="3.0">
+
 ## Reactive variables
 
-> Available in Apollo Client >= 3.0
+</MinVersion>
 
 **Reactive variables** enable you to read and write local data anywhere in your application, without needing to use a GraphQL operation to do so. The [field policy](#field-policies-and-local-only-fields) of a local-only field can use a reactive variable to populate the field's current value.
 
@@ -57,9 +61,11 @@ Whenever the value of a reactive variable changes, Apollo Client automatically d
 
 [Get started with reactive variables](./reactive-variables)
 
+<MinVersion version="2.5">
+
 ## Local resolvers
 
-> Available in Apollo Client >= 2.5
+</MinVersion>
 
 In earlier versions of Apollo Client, you define **local resolvers** to populate and modify local-only fields. These resolvers are similar in structure and purpose to the [resolvers that your GraphQL server defines](/apollo-server/data/resolvers/).
 


### PR DESCRIPTION
This PR replaces uses of "available in version ..." with the new [`<MinVersion>` component](https://apollograph.slack.com/archives/C0721M2F6/p1690243600979049?thread_ts=1690218529.773819&cid=C0721M2F6).

It's likely not comprehensive, but at least replaces previous mentions of versions. (Searched for "available", "version", and "<=" in .mdx files.)
