### PR TITLE
Create GitHub release for prereleases

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -52,13 +52,13 @@ jobs:
         with:
           files: ".changeset/pre.json"
 
-      - name: Enter alpha prerelease mode
+      - name: Enter prerelease mode (alpha by default)
         # If .changeset/pre.json does not exist and we did not recently exit
         # prerelease mode, enter prerelease mode with tag alpha
         if: steps.check_files.outputs.files_exists == 'false' && !contains(github.event.head_commit.message, 'Exit prerelease')
         run: npx changeset pre enter alpha
 
-      - name: Create alpha release PR
+      - name: Create prerelease PR
         uses: changesets/action@v1
         with:
           version: npm run changeset-version
@@ -76,12 +76,18 @@ jobs:
           path: ".changeset/pre.json"
           prop_path: "tag"
 
-      - name: Run publish
+      - name: Publish to npm + GitHub
         id: changesets
         # Only run publish if we're still in pre mode and the last commit was
         # via an automatically created Version Packages PR
         if: steps.check_files.outputs.files_exists == 'true' && startsWith(github.event.head_commit.message, 'Version Packages')
-        run: npm run changeset-publish
+        uses: changesets/action@v1
+        with:
+          version: echo "This step should never version"
+          publish: npm run changeset-publish # by default, this will publish to npm and GitHub
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Send a Slack notification on publish
         if: steps.changesets.outcome == 'success'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
         uses: changesets/action@v1
         with:
           version: npm run changeset-version
-          publish: npm run changeset-publish -- --tag next
+          publish: npm run changeset-publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
         uses: changesets/action@v1
         with:
           version: npm run changeset-version
-          publish: npm run changeset-publish
+          publish: npm run changeset-publish -- --tag next
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
A prerelease workflow update that uses the Changesets action instead of bare publish script to automatically publish GitHub releases for prereleases.

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
