### PR TITLE
Fix type variables passed to BaseMutationOptions was not carried on to the callbacks

### DIFF
--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -244,8 +244,8 @@ export interface BaseMutationOptions<
   > {
   client?: ApolloClient<object>;
   notifyOnNetworkStatusChange?: boolean;
-  onCompleted?: (data: TData, clientOptions?: BaseMutationOptions) => void;
-  onError?: (error: ApolloError, clientOptions?: BaseMutationOptions) => void;
+  onCompleted?: (data: TData, clientOptions?: BaseMutationOptions<TData, TVariables, TContext, TCache>) => void;
+  onError?: (error: ApolloError, clientOptions?: BaseMutationOptions<TData, TVariables, TContext, TCache>) => void;
   ignoreResults?: boolean;
 }
 


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

The `clientOptions` parameter on the `onCompleted`, `onError` was missing the type parameters, making e.g. `variables: any`.

I don't know if this change warrants a changeset but I'm struggling to generate it:
```
❯ npx changeset
npm ERR! could not determine executable to run
```

### Checklist:

- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
