### PR TITLE
Docs: Remove `returnPartialData` from `useFragment` options

### DIFF
--- a/docs/shared/useFragment-options.mdx
+++ b/docs/shared/useFragment-options.mdx
@@ -101,23 +101,6 @@ Each key in the object corresponds to a variable name, and that key's value corr
 <tr>
 <td>
 
-###### `returnPartialData`
-
-`boolean`
-</td>
-
-<td>
-
-If `true`, the query can return _partial_ results from the cache if the cache doesn't contain results for _all_ queried fields.
-
-The default value is `true`.
-
-</td>
-</tr>
-
-<tr>
-<td>
-
 ###### `canonizeResults`
 
 `boolean`


### PR DESCRIPTION
`returnPartialData` option of `useFragment` has been deprecated in https://github.com/apollographql/apollo-client/pull/10764, so remove it from the docs as well.

https://github.com/apollographql/apollo-client/pull/10764

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
