### PR TITLE
Fixes race condition when changing back to initial variables before request finishes

### DIFF
--- a/.changeset/odd-beers-perform.md
+++ b/.changeset/odd-beers-perform.md
@@ -2,4 +2,4 @@
 "@apollo/client": patch
 ---
 
-Fixes an issue where triggering a query with different variables, then rapidly changing back to initial variables with a cached result would return the wrong result if the previous request finished after switching back to initial variables.
+Fix an issue where race conditions when rapidly switching between variables would sometimes result in the wrong `data` returned from the query. Specifically this occurs when a query is triggered with an initial set of variables (`VariablesA`), then triggers the same query with another set of variables (`VariablesB`) but switches back to the `VariablesA` before the response for `VariablesB` is returned. Previously this would result in the data for `VariablesB` to be displayed while `VariablesA` was active. The data is for `VariablesA` is now properly returned.

--- a/.changeset/odd-beers-perform.md
+++ b/.changeset/odd-beers-perform.md
@@ -2,4 +2,4 @@
 "@apollo/client": patch
 ---
 
-Fixes an issue where triggering a query with differnt variables then rapidly changing back to the initial variables with a cached result would return the wrong result if the previous request finished after switching back to initial variables.
+Fixes an issue where triggering a query with different variables, then rapidly changing back to initial variables with a cached result would return the wrong result if the previous request finished after switching back to initial variables.

--- a/.changeset/odd-beers-perform.md
+++ b/.changeset/odd-beers-perform.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fixes an issue where triggering a query with differnt variables then rapidly changing back to the initial variables with a cached result would return the wrong result if the previous request finished after switching back to initial variables.

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -157,14 +157,14 @@ export class QueryInfo {
     this.dirty = false;
   }
 
-  getDiff(variables = this.variables): Cache.DiffResult<any> {
-    const options = this.getDiffOptions(variables);
+  getDiff(): Cache.DiffResult<any> {
+    const options = this.getDiffOptions();
 
     if (this.lastDiff && equal(options, this.lastDiff.options)) {
       return this.lastDiff.diff;
     }
 
-    this.updateWatch((this.variables = variables));
+    this.updateWatch(this.variables);
 
     const oq = this.observableQuery;
     if (oq && oq.options.fetchPolicy === "no-cache") {

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1516,7 +1516,7 @@ export class QueryManager<TStore> {
       networkStatus,
     });
 
-    const readCache = () => queryInfo.getDiff(variables);
+    const readCache = () => queryInfo.getDiff();
 
     const resultsFromCache = (
       diff: Cache.DiffResult<TData>,

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -25,6 +25,7 @@ import {
   MockLink,
   mockSingleLink,
   subscribeAndCount,
+  wait,
 } from "../../testing";
 import mockQueryManager from "../../testing/core/mocking/mockQueryManager";
 import mockWatchQuery from "../../testing/core/mocking/mockWatchQuery";
@@ -3198,4 +3199,65 @@ test("regression test for #10587", async () => {
     expect(query2Spy.mock.calls).toEqual(finalExpectedCalls.query2)
   );
   expect(query1Spy.mock.calls).toEqual(finalExpectedCalls.query1);
+});
+
+// https://github.com/apollographql/apollo-client/issues/11184
+test("handles changing variables in rapid succession before other request is aborted", async () => {
+  interface UserCountQuery {
+    userCount: number;
+  }
+  interface UserCountVariables {
+    department: "HR" | null;
+  }
+
+  const query: TypedDocumentNode<UserCountQuery, UserCountVariables> = gql`
+    query UserCountQuery($department: Department) {
+      userCount(department: $department)
+    }
+  `;
+  const mocks = [
+    {
+      request: { query, variables: { department: null } },
+      result: { data: { userCount: 10 } },
+    },
+    {
+      request: { query, variables: { department: "HR" } },
+      result: { data: { userCount: 5 } },
+      delay: 50,
+    },
+  ];
+
+  const client = new ApolloClient({
+    link: new MockLink(mocks),
+    cache: new InMemoryCache(),
+  });
+
+  const observable = client.watchQuery<UserCountQuery, UserCountVariables>({
+    query,
+    variables: { department: null },
+  });
+
+  observable.subscribe(jest.fn());
+
+  await waitFor(() => {
+    expect(observable.getCurrentResult(false)).toEqual({
+      data: { userCount: 10 },
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+    });
+  });
+
+  observable.reobserve({ variables: { department: "HR" } });
+  await wait(10);
+  observable.reobserve({ variables: { department: null } });
+
+  // Wait for request to finish
+  await wait(50);
+
+  expect(observable.options.variables).toEqual({ department: null });
+  expect(observable.getCurrentResult(false)).toEqual({
+    data: { userCount: 10 },
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+  });
 });

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -3202,7 +3202,7 @@ test("regression test for #10587", async () => {
 });
 
 // https://github.com/apollographql/apollo-client/issues/11184
-test("handles changing variables in rapid succession before other request is aborted", async () => {
+test("handles changing variables in rapid succession before other request is completed", async () => {
   interface UserCountQuery {
     userCount: number;
   }


### PR DESCRIPTION
Fixes #11184 

Fixes an issue where the wrong result was returned when switching back to initial variables with a cached result before the request for previous changed variables finished.

Prior to [v3.7.11](https://github.com/apollographql/apollo-client/releases/tag/v3.7.11), changing variables would abort a previous request, which meant there was no cache update for the previous variables. This behavior had some edge cases and resulted in some race condition bugs. This was fixed by #10597, but because #10597 no longer aborted requests, the previous request would complete and the cache would be written, but the broadcasted result would be incorrectly associated with the current variables.

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
