### PR TITLE
chore: bumps typedoc version for ts 5.2 compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,7 @@
         "ts-jest": "29.1.1",
         "ts-jest-resolver": "2.0.1",
         "ts-node": "10.9.1",
-        "typedoc": "0.24.7",
+        "typedoc": "0.25.0",
         "typescript": "5.2.2",
         "wait-for-observables": "1.0.3",
         "web-streams-polyfill": "3.2.1",
@@ -10698,24 +10698,24 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.24.7",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.24.7.tgz",
-      "integrity": "sha512-zzfKDFIZADA+XRIp2rMzLe9xZ6pt12yQOhCr7cD7/PBTjhPmMyMvGrkZ2lPNJitg3Hj1SeiYFNzCsSDrlpxpKw==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.0.tgz",
+      "integrity": "sha512-FvCYWhO1n5jACE0C32qg6b3dSfQ8f2VzExnnRboowHtqUD6ARzM2r8YJeZFYXhcm2hI4C2oCRDgNPk/yaQUN9g==",
       "dev": true,
       "dependencies": {
         "lunr": "^2.3.9",
         "marked": "^4.3.0",
-        "minimatch": "^9.0.0",
+        "minimatch": "^9.0.3",
         "shiki": "^0.14.1"
       },
       "bin": {
         "typedoc": "bin/typedoc"
       },
       "engines": {
-        "node": ">= 14.14"
+        "node": ">= 16"
       },
       "peerDependencies": {
-        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x"
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x"
       }
     },
     "node_modules/typedoc/node_modules/brace-expansion": {
@@ -10728,9 +10728,9 @@
       }
     },
     "node_modules/typedoc/node_modules/minimatch": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.0.tgz",
-      "integrity": "sha512-0jJj8AvgKqWN05mrwuqi8QYKx1WmYSUoKSxu5Qhs9prezTz10sxAHGNZe9J9cqIJzta8DWsleh2KaVaLl6Ru2w==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "ts-jest": "29.1.1",
     "ts-jest-resolver": "2.0.1",
     "ts-node": "10.9.1",
-    "typedoc": "0.24.7",
+    "typedoc": "0.25.0",
     "typescript": "5.2.2",
     "wait-for-observables": "1.0.3",
     "web-streams-polyfill": "3.2.1",


### PR DESCRIPTION
Bumps `typedoc` to `latest`, `0.25.0` which is [compatible with TS `5.2`](https://github.com/TypeStrong/typedoc/issues/2373) and unblocks docs deploys.