### PR TITLE
Call devtools registration after ApolloClient is fully set up

### DIFF
--- a/.changeset/slow-gorillas-sniff.md
+++ b/.changeset/slow-gorillas-sniff.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Call devtools registration after ApolloClient is fully set up.

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -224,7 +224,7 @@ export class ApolloClient<TCacheShape> implements DataProxy {
         : void 0,
     });
 
-    this.connectToDevTools();
+    if (connectToDevTools) this.connectToDevTools();
   }
 
   private connectToDevTools() {

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -186,58 +186,6 @@ export class ApolloClient<TCacheShape> implements DataProxy {
     this.resetStore = this.resetStore.bind(this);
     this.reFetchObservableQueries = this.reFetchObservableQueries.bind(this);
 
-    if (connectToDevTools && typeof window === "object") {
-      type DevToolsConnector = {
-        push(client: ApolloClient<any>): void;
-      };
-      const windowWithDevTools = window as Window & {
-        [devtoolsSymbol]?: DevToolsConnector;
-        __APOLLO_CLIENT__?: ApolloClient<any>;
-      };
-      const devtoolsSymbol = Symbol.for("apollo.devtools");
-      (windowWithDevTools[devtoolsSymbol] =
-        windowWithDevTools[devtoolsSymbol] || ([] as DevToolsConnector)).push(
-        this
-      );
-      windowWithDevTools.__APOLLO_CLIENT__ = this;
-    }
-
-    /**
-     * Suggest installing the devtools for developers who don't have them
-     */
-    if (!hasSuggestedDevtools && connectToDevTools && __DEV__) {
-      hasSuggestedDevtools = true;
-      setTimeout(() => {
-        if (
-          typeof window !== "undefined" &&
-          window.document &&
-          window.top === window.self &&
-          !(window as any).__APOLLO_DEVTOOLS_GLOBAL_HOOK__
-        ) {
-          const nav = window.navigator;
-          const ua = nav && nav.userAgent;
-          let url: string | undefined;
-          if (typeof ua === "string") {
-            if (ua.indexOf("Chrome/") > -1) {
-              url =
-                "https://chrome.google.com/webstore/detail/" +
-                "apollo-client-developer-t/jdkknkkbebbapilgoeccciglkfbmbnfm";
-            } else if (ua.indexOf("Firefox/") > -1) {
-              url =
-                "https://addons.mozilla.org/en-US/firefox/addon/apollo-developer-tools/";
-            }
-          }
-          if (url) {
-            invariant.log(
-              "Download the Apollo DevTools for a better development " +
-                "experience: %s",
-              url
-            );
-          }
-        }
-      }, 10000);
-    }
-
     this.version = version;
 
     this.localState = new LocalState({
@@ -275,6 +223,62 @@ export class ApolloClient<TCacheShape> implements DataProxy {
           }
         : void 0,
     });
+
+    this.connectToDevTools();
+  }
+
+  private connectToDevTools(){
+    if (typeof window === "object") {
+      type DevToolsConnector = {
+        push(client: ApolloClient<any>): void;
+      };
+      const windowWithDevTools = window as Window & {
+        [devtoolsSymbol]?: DevToolsConnector;
+        __APOLLO_CLIENT__?: ApolloClient<any>;
+      };
+      const devtoolsSymbol = Symbol.for("apollo.devtools");
+      (windowWithDevTools[devtoolsSymbol] =
+        windowWithDevTools[devtoolsSymbol] || ([] as DevToolsConnector)).push(
+        this
+      );
+      windowWithDevTools.__APOLLO_CLIENT__ = this;
+    }
+
+    /**
+     * Suggest installing the devtools for developers who don't have them
+     */
+    if (!hasSuggestedDevtools && __DEV__) {
+      hasSuggestedDevtools = true;
+      setTimeout(() => {
+        if (
+          typeof window !== "undefined" &&
+          window.document &&
+          window.top === window.self &&
+          !(window as any).__APOLLO_DEVTOOLS_GLOBAL_HOOK__
+        ) {
+          const nav = window.navigator;
+          const ua = nav && nav.userAgent;
+          let url: string | undefined;
+          if (typeof ua === "string") {
+            if (ua.indexOf("Chrome/") > -1) {
+              url =
+                "https://chrome.google.com/webstore/detail/" +
+                "apollo-client-developer-t/jdkknkkbebbapilgoeccciglkfbmbnfm";
+            } else if (ua.indexOf("Firefox/") > -1) {
+              url =
+                "https://addons.mozilla.org/en-US/firefox/addon/apollo-developer-tools/";
+            }
+          }
+          if (url) {
+            invariant.log(
+              "Download the Apollo DevTools for a better development " +
+                "experience: %s",
+              url
+            );
+          }
+        }
+      }, 10000);
+    }
   }
 
   /**

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -227,7 +227,7 @@ export class ApolloClient<TCacheShape> implements DataProxy {
     this.connectToDevTools();
   }
 
-  private connectToDevTools(){
+  private connectToDevTools() {
     if (typeof window === "object") {
       type DevToolsConnector = {
         push(client: ApolloClient<any>): void;


### PR DESCRIPTION
This delays devtools registration until after the `ApolloClient` constructor has finished setting up the Apollo Client instance fully. 
As the new registration can happen synchronously if the devtools extension is already loaded at the time the `ApolloClient` instance is created, previously this would add to a `Cannot read properties of undefined` error, as the `ObservableQuery` had not been constructed yet.

Fixes #11192

Can be verified with these CodeSandboxes:

* [Apollo Client 3.8.2](https://mtl279.csb.app/) - [code](https://codesandbox.io/s/11193-mtl279?file=/src/index.mjs)
* [@apollo/client@0.0.0-pr-11193-20230905102117](https://55jyk2.csb.app/) - [code](https://codesandbox.io/s/11193-fixed-55jyk2?file=/src/index.mjs)

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
