### PR TITLE
Fix up error message argument wrapping and Error page styling

### DIFF
--- a/.changeset/tall-otters-wave.md
+++ b/.changeset/tall-otters-wave.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+For `invariant.log` etc., error arguments are now serialized correctly in the link to the error page.

--- a/docs/shared/DisplayClientError.js
+++ b/docs/shared/DisplayClientError.js
@@ -152,15 +152,17 @@ function ErrorDetails({ version, messageId, args }) {
       {(loading || errorMessage) && (
         <>
           <MDX.h2>Error message</MDX.h2>
-          <MDX.blockquote>{loading ? 'Loading' : errorMessage}</MDX.blockquote>
+          <MDX.blockquote style={{ lineHeight: "normal", whiteSpace: "pre-wrap" }}>{loading ? 'Loading' : errorMessage}</MDX.blockquote>
         </>
       )}
 
       <MDX.h3>File</MDX.h3>
       <MDX.inlineCode>{loading ? 'Loading' : data.file}</MDX.inlineCode>
 
-      <MDX.h3>Condition</MDX.h3>
-      <MDX.inlineCode>{loading ? 'Loading' : data.condition}</MDX.inlineCode>
+      <div style={{visibility: data?.condition ? 'visible' : 'hidden'}}>
+        <MDX.h3>Condition</MDX.h3>
+        <MDX.inlineCode>{data?.condition || ''}</MDX.inlineCode>
+      </div>
     </div>
   );
 }

--- a/src/utilities/globals/invariantWrappers.ts
+++ b/src/utilities/globals/invariantWrappers.ts
@@ -6,7 +6,11 @@ import { stringifyForDisplay } from "../common/stringifyForDisplay.js";
 
 function wrap(fn: (msg?: string, ...args: any[]) => void) {
   return function (message: string | number, ...args: any[]) {
-    fn(typeof message === "number" ? getErrorMsg(message) : message, ...args);
+    if (typeof message === "number") {
+      fn(getErrorMsg(message, args));
+    } else {
+      fn(message, ...args);
+    }
   };
 }
 


### PR DESCRIPTION
I noticed that someone shared an error link in the form 

https://go.apollo.dev/c/err#%7B%22version%22%3A%223.8.0-rc.2%22%2C%22message%22%3A12%2C%22args%22%3A%5B%5D%7D

which leads to this error page:
![image](https://github.com/apollographql/apollo-client/assets/4282439/1f7d0c82-ce5a-42c8-9ec3-f736a649dce5)

I could reproduce a code path that didn't serialize the args correctly.

This PR changes a few things:
* For `invariant.log` etc., error arguments are now serialized correctly in the link to the error page
* The error message is displayed with `lineHeight: "normal", whiteSpace: "pre-wrap"`
* The "condition" is now hidden if it is empty (but not removed - it still takes up space to prevent layout jumping as good as possible)

The generated link now looks like

https://go.apollo.dev/c/err#%7B%22version%22%3A%223.8.3%22%2C%22message%22%3A12%2C%22args%22%3A%5B%22fields%22%2C%22User%22%2C%22%22%2C%22User.fields%22%2C%22%5B%5Cn%20%20%7B%5Cn%20%20%20%20%5C%22foo%5C%22%3A%20%5C%22bar%5C%22%5Cn%20%20%7D%2C%5Cn%20%20%7B%5Cn%20%20%20%20%5C%22foo%5C%22%3A%20%5C%22baz%5C%22%5Cn%20%20%7D%5Cn%5D%22%2C%22%5B%5Cn%20%20%7B%5Cn%20%20%20%20%5C%22foo%5C%22%3A%20%5C%22bar%5C%22%5Cn%20%20%7D%5Cn%5D%22%5D%7D

And the rendering now looks like this:

![image](https://github.com/apollographql/apollo-client/assets/4282439/b335c8a6-47b6-4727-b46b-9a573f2d7d78)


This can be reproduced e.g. using this code snippet:

```ts
import { InMemoryCache, gql } from "./dist/index.js";

const cache = new InMemoryCache();
const query = gql`
  query {
    me {
      __typename
      id
      fields {
        foo
      }
    }
  }
`;
cache.writeQuery({
  query,
  data: {
    __typename: "Query",
    me: {
      __typename: "User",
      id: "123",
      fields: [
        {
          foo: "bar",
        },
        {
          foo: "baz",
        },
      ],
    },
  },
});

cache.writeQuery({
  query,
  data: {
    me: {
      __typename: "User",
      id: "123",
      fields: [
        {
          foo: "bar",
        },
      ],
    },
  },
});
```

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
