### PR TITLE
Prevent `QueryInfo#markResult` mutation of `result.data` and return cache data consistently whether complete or incomplete

### DIFF
--- a/.changeset/shaggy-ears-scream.md
+++ b/.changeset/shaggy-ears-scream.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": minor
+---
+
+Prevent `QueryInfo#markResult` mutation of `result.data` and return cache data consistently whether complete or incomplete.

--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -10,7 +10,7 @@ const checks = [
   {
     path: "dist/index.js",
     import: "{ ApolloClient, InMemoryCache, HttpLink }",
-    limit: "32044",
+    limit: "32052",
   },
   ...[
     "ApolloProvider",

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -2921,7 +2921,12 @@ describe("client", () => {
       return client
         .query({ query })
         .then(({ data }) => {
-          expect(data).toEqual(result.data);
+          const { price, ...todoWithoutPrice } = data.todos[0];
+          expect(data).toEqual({
+            todos: [
+              todoWithoutPrice,
+            ],
+          });
         })
         .then(resolve, reject);
     }

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -2923,9 +2923,7 @@ describe("client", () => {
         .then(({ data }) => {
           const { price, ...todoWithoutPrice } = data.todos[0];
           expect(data).toEqual({
-            todos: [
-              todoWithoutPrice,
-            ],
+            todos: [todoWithoutPrice],
           });
         })
         .then(resolve, reject);

--- a/src/cache/inmemory/__tests__/client.ts
+++ b/src/cache/inmemory/__tests__/client.ts
@@ -15,142 +15,152 @@ describe("InMemoryCache tests exercising ApolloClient", () => {
     "cache-and-network",
     "cache-only",
     "no-cache",
-  ])("results should be read from cache even when incomplete (fetchPolicy %s)", fetchPolicy => {
-    const dateString = new Date().toISOString();
+  ])(
+    "results should be read from cache even when incomplete (fetchPolicy %s)",
+    (fetchPolicy) => {
+      const dateString = new Date().toISOString();
 
-    const cache = new InMemoryCache({
-      typePolicies: {
-        Query: {
-          fields: {
-            date: {
-              read(existing) {
-                return new Date(existing || dateString);
+      const cache = new InMemoryCache({
+        typePolicies: {
+          Query: {
+            fields: {
+              date: {
+                read(existing) {
+                  return new Date(existing || dateString);
+                },
               },
             },
           },
         },
-      },
-    });
+      });
 
-    const client = new ApolloClient({
-      link: new ApolloLink(operation => new Observable(observer => {
-        observer.next({
-          data: {
-            // This raw string should be converted to a Date by the Query.date
-            // read function passed to InMemoryCache below.
-            date: dateString,
-            // Make sure we don't accidentally return fields not mentioned in
-            // the query just because the result is incomplete.
-            ignored: "irrelevant to the subscribed query",
-            // Note the Query.missing field is, well, missing.
-          },
-        });
-        setTimeout(() => {
-          observer.complete();
-        }, 10);
-      })),
-      cache,
-    });
+      const client = new ApolloClient({
+        link: new ApolloLink(
+          (operation) =>
+            new Observable((observer) => {
+              observer.next({
+                data: {
+                  // This raw string should be converted to a Date by the Query.date
+                  // read function passed to InMemoryCache below.
+                  date: dateString,
+                  // Make sure we don't accidentally return fields not mentioned in
+                  // the query just because the result is incomplete.
+                  ignored: "irrelevant to the subscribed query",
+                  // Note the Query.missing field is, well, missing.
+                },
+              });
+              setTimeout(() => {
+                observer.complete();
+              }, 10);
+            })
+        ),
+        cache,
+      });
 
-    const query = gql`
-      query {
-        date
-        missing
-      }
-    `;
-
-    const observable = client.watchQuery({
-      query,
-      fetchPolicy, // Varies with each test iteration
-      returnPartialData: true,
-    });
-
-    return new Promise<void>((resolve, reject) => {
-      subscribeAndCount(reject, observable, (handleCount, result) => {
-        let adjustedCount = handleCount;
-        if (
-          fetchPolicy === "network-only" ||
-          fetchPolicy === "no-cache" ||
-          fetchPolicy === "cache-only"
-        ) {
-          // The network-only, no-cache, and cache-only fetch policies do not
-          // deliver a loading:true result initially, so we adjust the
-          // handleCount to skip that case.
-          ++adjustedCount;
+      const query = gql`
+        query {
+          date
+          missing
         }
+      `;
 
-        // The only fetch policy that does not re-read results from the cache is
-        // the "no-cache" policy. In this test, that means the Query.date field
-        // will remain as a raw string rather than being converted to a Date by
-        // the read function.
-        const expectedDate =
-          fetchPolicy === "no-cache" ? dateString : new Date(dateString);
+      const observable = client.watchQuery({
+        query,
+        fetchPolicy, // Varies with each test iteration
+        returnPartialData: true,
+      });
 
-        if (adjustedCount === 1) {
-          expect(result.loading).toBe(true);
-          expect(result.data).toEqual({
-            date: expectedDate,
-          });
-
-        } else if (adjustedCount === 2) {
-          expect(result.loading).toBe(false);
-          expect(result.data).toEqual({
-            date: expectedDate,
-            // The no-cache fetch policy does return extraneous fields from the
-            // raw network result that were not requested in the query, since
-            // the cache is not consulted.
-            ...(fetchPolicy === "no-cache" ? {
-              ignored: "irrelevant to the subscribed query"
-            } : null),
-          });
-
-          if (fetchPolicy === "no-cache") {
-            // The "no-cache" fetch policy does not receive updates from the
-            // cache, so we finish the test early (passing).
-            setTimeout(() => resolve(), 20);
-
-          } else {
-            cache.writeQuery({
-              query: gql`query { missing }`,
-              data: {
-                missing: "not missing anymore",
-              },
-            });
+      return new Promise<void>((resolve, reject) => {
+        subscribeAndCount(reject, observable, (handleCount, result) => {
+          let adjustedCount = handleCount;
+          if (
+            fetchPolicy === "network-only" ||
+            fetchPolicy === "no-cache" ||
+            fetchPolicy === "cache-only"
+          ) {
+            // The network-only, no-cache, and cache-only fetch policies do not
+            // deliver a loading:true result initially, so we adjust the
+            // handleCount to skip that case.
+            ++adjustedCount;
           }
 
-        } else if (adjustedCount === 3) {
-          expect(result.loading).toBe(false);
-          expect(result.data).toEqual({
-            date: expectedDate,
-            missing: "not missing anymore",
-          });
+          // The only fetch policy that does not re-read results from the cache is
+          // the "no-cache" policy. In this test, that means the Query.date field
+          // will remain as a raw string rather than being converted to a Date by
+          // the read function.
+          const expectedDate =
+            fetchPolicy === "no-cache" ? dateString : new Date(dateString);
 
-          expect(cache.extract()).toEqual({
-            ROOT_QUERY: {
-              __typename: "Query",
-              // The cache-only fetch policy does not receive updates from the
-              // network, so it never ends up writing the date field into the
-              // cache explicitly, though Query.date can still be synthesized by
-              // the read function.
-              ...(fetchPolicy === "cache-only" ? null : {
-                // Make sure this field is stored internally as a raw string.
-                date: dateString,
-              }),
-              // Written explicitly with cache.writeQuery above.
+          if (adjustedCount === 1) {
+            expect(result.loading).toBe(true);
+            expect(result.data).toEqual({
+              date: expectedDate,
+            });
+          } else if (adjustedCount === 2) {
+            expect(result.loading).toBe(false);
+            expect(result.data).toEqual({
+              date: expectedDate,
+              // The no-cache fetch policy does return extraneous fields from the
+              // raw network result that were not requested in the query, since
+              // the cache is not consulted.
+              ...(fetchPolicy === "no-cache"
+                ? {
+                    ignored: "irrelevant to the subscribed query",
+                  }
+                : null),
+            });
+
+            if (fetchPolicy === "no-cache") {
+              // The "no-cache" fetch policy does not receive updates from the
+              // cache, so we finish the test early (passing).
+              setTimeout(() => resolve(), 20);
+            } else {
+              cache.writeQuery({
+                query: gql`
+                  query {
+                    missing
+                  }
+                `,
+                data: {
+                  missing: "not missing anymore",
+                },
+              });
+            }
+          } else if (adjustedCount === 3) {
+            expect(result.loading).toBe(false);
+            expect(result.data).toEqual({
+              date: expectedDate,
               missing: "not missing anymore",
-              // The ignored field is never written to the cache, because it is
-              // not included in the query.
-            },
-          });
+            });
 
-          // Wait 20ms to give the test a chance to fail if there are unexpected
-          // additional results.
-          setTimeout(() => resolve(), 20);
+            expect(cache.extract()).toEqual({
+              ROOT_QUERY: {
+                __typename: "Query",
+                // The cache-only fetch policy does not receive updates from the
+                // network, so it never ends up writing the date field into the
+                // cache explicitly, though Query.date can still be synthesized by
+                // the read function.
+                ...(fetchPolicy === "cache-only"
+                  ? null
+                  : {
+                      // Make sure this field is stored internally as a raw string.
+                      date: dateString,
+                    }),
+                // Written explicitly with cache.writeQuery above.
+                missing: "not missing anymore",
+                // The ignored field is never written to the cache, because it is
+                // not included in the query.
+              },
+            });
 
-        } else {
-          reject(new Error(`Unexpected count ${adjustedCount}`));
-        }
+            // Wait 20ms to give the test a chance to fail if there are unexpected
+            // additional results.
+            setTimeout(() => resolve(), 20);
+          } else {
+            reject(new Error(`Unexpected count ${adjustedCount}`));
+          }
+        });
       });
-    });
-  });
+    }
+  );
 });

--- a/src/cache/inmemory/__tests__/client.ts
+++ b/src/cache/inmemory/__tests__/client.ts
@@ -1,0 +1,156 @@
+// This file contains InMemoryCache-specific tests that exercise the
+// ApolloClient class. Other test modules in this directory only test
+// InMemoryCache and related utilities, without involving ApolloClient.
+
+import { ApolloClient, WatchQueryFetchPolicy, gql } from "../../../core";
+import { ApolloLink } from "../../../link/core";
+import { Observable } from "../../../utilities";
+import { InMemoryCache } from "../..";
+import { subscribeAndCount } from "../../../testing";
+
+describe("InMemoryCache tests exercising ApolloClient", () => {
+  it.each<WatchQueryFetchPolicy>([
+    "cache-first",
+    "network-only",
+    "cache-and-network",
+    "cache-only",
+    "no-cache",
+  ])("results should be read from cache even when incomplete (fetchPolicy %s)", fetchPolicy => {
+    const dateString = new Date().toISOString();
+
+    const cache = new InMemoryCache({
+      typePolicies: {
+        Query: {
+          fields: {
+            date: {
+              read(existing) {
+                return new Date(existing || dateString);
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const client = new ApolloClient({
+      link: new ApolloLink(operation => new Observable(observer => {
+        observer.next({
+          data: {
+            // This raw string should be converted to a Date by the Query.date
+            // read function passed to InMemoryCache below.
+            date: dateString,
+            // Make sure we don't accidentally return fields not mentioned in
+            // the query just because the result is incomplete.
+            ignored: "irrelevant to the subscribed query",
+            // Note the Query.missing field is, well, missing.
+          },
+        });
+        setTimeout(() => {
+          observer.complete();
+        }, 10);
+      })),
+      cache,
+    });
+
+    const query = gql`
+      query {
+        date
+        missing
+      }
+    `;
+
+    const observable = client.watchQuery({
+      query,
+      fetchPolicy, // Varies with each test iteration
+      returnPartialData: true,
+    });
+
+    return new Promise<void>((resolve, reject) => {
+      subscribeAndCount(reject, observable, (handleCount, result) => {
+        let adjustedCount = handleCount;
+        if (
+          fetchPolicy === "network-only" ||
+          fetchPolicy === "no-cache" ||
+          fetchPolicy === "cache-only"
+        ) {
+          // The network-only, no-cache, and cache-only fetch policies do not
+          // deliver a loading:true result initially, so we adjust the
+          // handleCount to skip that case.
+          ++adjustedCount;
+        }
+
+        // The only fetch policy that does not re-read results from the cache is
+        // the "no-cache" policy. In this test, that means the Query.date field
+        // will remain as a raw string rather than being converted to a Date by
+        // the read function.
+        const expectedDate =
+          fetchPolicy === "no-cache" ? dateString : new Date(dateString);
+
+        if (adjustedCount === 1) {
+          expect(result.loading).toBe(true);
+          expect(result.data).toEqual({
+            date: expectedDate,
+          });
+
+        } else if (adjustedCount === 2) {
+          expect(result.loading).toBe(false);
+          expect(result.data).toEqual({
+            date: expectedDate,
+            // The no-cache fetch policy does return extraneous fields from the
+            // raw network result that were not requested in the query, since
+            // the cache is not consulted.
+            ...(fetchPolicy === "no-cache" ? {
+              ignored: "irrelevant to the subscribed query"
+            } : null),
+          });
+
+          if (fetchPolicy === "no-cache") {
+            // The "no-cache" fetch policy does not receive updates from the
+            // cache, so we finish the test early (passing).
+            setTimeout(() => resolve(), 20);
+
+          } else {
+            cache.writeQuery({
+              query: gql`query { missing }`,
+              data: {
+                missing: "not missing anymore",
+              },
+            });
+          }
+
+        } else if (adjustedCount === 3) {
+          expect(result.loading).toBe(false);
+          expect(result.data).toEqual({
+            date: expectedDate,
+            missing: "not missing anymore",
+          });
+
+          expect(cache.extract()).toEqual({
+            ROOT_QUERY: {
+              __typename: "Query",
+              // The cache-only fetch policy does not receive updates from the
+              // network, so it never ends up writing the date field into the
+              // cache explicitly, though Query.date can still be synthesized by
+              // the read function.
+              ...(fetchPolicy === "cache-only" ? null : {
+                // Make sure this field is stored internally as a raw string.
+                date: dateString,
+              }),
+              // Written explicitly with cache.writeQuery above.
+              missing: "not missing anymore",
+              // The ignored field is never written to the cache, because it is
+              // not included in the query.
+            },
+          });
+
+          // Wait 20ms to give the test a chance to fail if there are unexpected
+          // additional results.
+          setTimeout(() => resolve(), 20);
+
+        } else {
+          reject(new Error(`Unexpected count ${adjustedCount}`));
+        }
+      });
+    });
+  });
+});

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -361,7 +361,7 @@ export class QueryInfo {
       "variables" | "fetchPolicy" | "errorPolicy"
     >,
     cacheWriteBehavior: CacheWriteBehavior
-  ) {
+  ): typeof result {
     const merger = new DeepMerger();
     const graphQLErrors = isNonEmptyArray(result.errors)
       ? result.errors.slice(0)
@@ -408,7 +408,10 @@ export class QueryInfo {
             });
 
             this.lastWrite = {
-              result,
+              // Make a shallow defensive copy of the result object, in case we
+              // later later modify result.data in place, since we don't want
+              // that mutation affecting the saved lastWrite.result.data.
+              result: { ...result },
               variables: options.variables,
               dmCount: destructiveMethodCounts.get(this.cache),
             };
@@ -448,7 +451,10 @@ export class QueryInfo {
             if (this.lastDiff && this.lastDiff.diff.complete) {
               // Reuse data from the last good (complete) diff that we
               // received, when possible.
-              result.data = this.lastDiff.diff.result;
+              result = {
+                ...result,
+                data: this.lastDiff.diff.result,
+              };
               return;
             }
             // If the previous this.diff was incomplete, fall through to
@@ -470,20 +476,23 @@ export class QueryInfo {
             this.updateWatch(options.variables);
           }
 
-          // If we're allowed to write to the cache, and we can read a
-          // complete result from the cache, update result.data to be the
-          // result from the cache, rather than the raw network result.
-          // Set without setDiff to avoid triggering a notify call, since
-          // we have other ways of notifying for this result.
+          // If we're allowed to write to the cache, update result.data to be
+          // the result as re-read from the cache, rather than the raw network
+          // result. Set without setDiff to avoid triggering a notify call,
+          // since we have other ways of notifying for this result.
           this.updateLastDiff(diff, diffOptions);
-          if (diff.complete) {
-            result.data = diff.result;
-          }
+          result = {
+            ...result,
+            // TODO Improve types so we don't need this cast.
+            data: diff.result as any,
+          };
         });
       } else {
         this.lastWrite = void 0;
       }
     }
+
+    return result;
   }
 
   public markReady() {

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -362,6 +362,7 @@ export class QueryInfo {
     >,
     cacheWriteBehavior: CacheWriteBehavior
   ): typeof result {
+    result = { ...result };
     const merger = new DeepMerger();
     const graphQLErrors = isNonEmptyArray(result.errors)
       ? result.errors.slice(0)
@@ -451,10 +452,7 @@ export class QueryInfo {
             if (this.lastDiff && this.lastDiff.diff.complete) {
               // Reuse data from the last good (complete) diff that we
               // received, when possible.
-              result = {
-                ...result,
-                data: this.lastDiff.diff.result,
-              };
+              result.data = this.lastDiff.diff.result;
               return;
             }
             // If the previous this.diff was incomplete, fall through to
@@ -481,11 +479,7 @@ export class QueryInfo {
           // result. Set without setDiff to avoid triggering a notify call,
           // since we have other ways of notifying for this result.
           this.updateLastDiff(diff, diffOptions);
-          result = {
-            ...result,
-            // TODO Improve types so we don't need this cast.
-            data: diff.result as any,
-          };
+          result.data = diff.result;
         });
       } else {
         this.lastWrite = void 0;

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1180,7 +1180,7 @@ export class QueryManager<TStore> {
             result,
             linkDocument,
             options,
-            cacheWriteBehavior,
+            cacheWriteBehavior
           );
           queryInfo.markReady();
         }

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1176,11 +1176,11 @@ export class QueryManager<TStore> {
           // Use linkDocument rather than queryInfo.document so the
           // operation/fragments used to write the result are the same as the
           // ones used to obtain it from the link.
-          queryInfo.markResult(
+          result = queryInfo.markResult(
             result,
             linkDocument,
             options,
-            cacheWriteBehavior
+            cacheWriteBehavior,
           );
           queryInfo.markReady();
         }

--- a/src/core/__tests__/QueryManager/index.ts
+++ b/src/core/__tests__/QueryManager/index.ts
@@ -66,14 +66,6 @@ export function resetStore(qm: QueryManager<any>) {
 }
 
 describe("QueryManager", () => {
-  // Standard "get id from object" method.
-  const dataIdFromObject = (object: any) => {
-    if (object.__typename && object.id) {
-      return object.__typename + "__" + object.id;
-    }
-    return undefined;
-  };
-
   // Helper method that serves as the constructor method for
   // QueryManager but has defaults that make sense for these
   // tests.
@@ -2225,107 +2217,6 @@ describe("QueryManager", () => {
   );
 
   itAsync(
-    "should not return stale data when we orphan a real-id node in the store with a real-id node",
-    (resolve, reject) => {
-      const query1 = gql`
-        query {
-          author {
-            name {
-              firstName
-              lastName
-            }
-            age
-            id
-            __typename
-          }
-        }
-      `;
-      const query2 = gql`
-        query {
-          author {
-            name {
-              firstName
-            }
-            id
-            __typename
-          }
-        }
-      `;
-      const data1 = {
-        author: {
-          name: {
-            firstName: "John",
-            lastName: "Smith",
-          },
-          age: 18,
-          id: "187",
-          __typename: "Author",
-        },
-      };
-      const data2 = {
-        author: {
-          name: {
-            firstName: "John",
-          },
-          id: "197",
-          __typename: "Author",
-        },
-      };
-      const reducerConfig = { dataIdFromObject };
-      const queryManager = createQueryManager({
-        link: mockSingleLink(
-          {
-            request: { query: query1 },
-            result: { data: data1 },
-          },
-          {
-            request: { query: query2 },
-            result: { data: data2 },
-          },
-          {
-            request: { query: query1 },
-            result: { data: data1 },
-          }
-        ).setOnError(reject),
-        config: reducerConfig,
-      });
-
-      const observable1 = queryManager.watchQuery<any>({ query: query1 });
-      const observable2 = queryManager.watchQuery<any>({ query: query2 });
-
-      // I'm not sure the waiting 60 here really is required, but the test used to do it
-      return Promise.all([
-        observableToPromise(
-          {
-            observable: observable1,
-            wait: 60,
-          },
-          (result) => {
-            expect(result).toEqual({
-              data: data1,
-              loading: false,
-              networkStatus: NetworkStatus.ready,
-            });
-          }
-        ),
-        observableToPromise(
-          {
-            observable: observable2,
-            wait: 60,
-          },
-          (result) => {
-            expect(result).toEqual({
-              data: data2,
-              loading: false,
-              networkStatus: NetworkStatus.ready,
-            });
-          }
-        ),
-      ]).then(resolve, reject);
-    }
-  );
-
-  itAsync(
     "should return partial data when configured when we orphan a real-id node in the store with a real-id node",
     (resolve, reject) => {
       const query1 = gql`
@@ -2519,9 +2410,7 @@ describe("QueryManager", () => {
             loading: false,
             networkStatus: NetworkStatus.ready,
             data: {
-              info: {
-                a: "ay",
-              },
+              info: {},
             },
           });
           setTimeout(resolve, 100);

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -5706,7 +5706,12 @@ describe("useQuery Hook", () => {
         },
         { interval: 1 }
       );
-      expect(result.current.data).toEqual(carData);
+      const { vine, ...carDataWithoutVine } = carData.cars[0];
+      expect(result.current.data).toEqual({
+        cars: [
+          carDataWithoutVine,
+        ],
+      });
       expect(result.current.error).toBeUndefined();
 
       expect(errorSpy).toHaveBeenCalled();

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -5708,9 +5708,7 @@ describe("useQuery Hook", () => {
       );
       const { vine, ...carDataWithoutVine } = carData.cars[0];
       expect(result.current.data).toEqual({
-        cars: [
-          carDataWithoutVine,
-        ],
+        cars: [carDataWithoutVine],
       });
       expect(result.current.error).toBeUndefined();
 


### PR DESCRIPTION
This PR fixes issue #9293 by ensuring all cache-friendly fetch policies (including `cache-{first,only,and-network}` and `network-only` but excluding `no-cache`) return result data after re-reading the data from the cache, even when the data are incomplete (fixing #9293), so any custom `read` functions (or other cache logic) can be applied consistently whether or not the cache data are complete. I've added a new test that exercises all the fetch policies, since test coverage was previously inadequate in this area.

While diagnosing this problem, I noticed `QueryInfo#markResult` previously updated `result.data` using a destructive mutation, which could easily go unnoticed by the caller of `markResult`, so I refactored that code a bit to return a new `result` object instead of modifying the one provided.

As @CarsonF's [reproduction](https://github.com/apollographql/apollo-client/issues/9293#issuecomment-1435426921) from #9293 suggests, consistently returning cache data is important when using a `read` function to implement a scalar wrapper like `Date` for an otherwise string-valued field. I tested these changes against the [reproduction repo](https://github.com/CarsonF/apollo-reproduction-read-policy-ignored), and while there's still some weirdness related to the use of `offsetLimitPagination` for the `Query.people` list field, the problem of the disappearing `Date` wrappers seems to be solved. More generally, I believe this change allows a more reliable implementation our most popular feature request (by 👍 reactions), https://github.com/apollographql/apollo-feature-requests/issues/368.

While I stand behind the logic of this change for consistency's sake, it's worth mentioning the old behavior allowed returning raw network results with extraneous fields not present in the query, in cases where the server violates GraphQL validation rules by returning more properties than requested, but also does not return all the requested properties. See my test changes involving `todoWithoutPrice` and `carDataWithoutVine` for examples of this edge case. Now that we always re-read results from the cache using the provided query, you should always receive only the queried fields, so any extraneous properties will (correctly) disappear.