### PR TITLE
remove default variables in execute function

### DIFF
--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -95,6 +95,14 @@ export function useLazyQuery<
             fetchPolicy: initialFetchPolicy,
           };
 
+      if (
+          execOptionsRef.current.variables &&
+          optionsRef.current &&
+          optionsRef.current.variables
+      ) {
+        delete optionsRef.current.variables
+      }
+
       const options = mergeOptions(optionsRef.current, {
         query: queryRef.current,
         ...execOptionsRef.current,


### PR DESCRIPTION
This pull request fixes #11201.
The variables that I pass to the function from the useLazyquery hook should completely replace the variables of the previous request.
Small example https://codesandbox.io/s/gracious-water-w6259q?file=/src/index.jsx (look console)