### PR TITLE
Apollo Devtools extension download message check if does not exist

### DIFF
--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -85,6 +85,7 @@ export class ApolloClient<TCacheShape> implements DataProxy {
   public defaultOptions: DefaultOptions;
   public readonly typeDefs: ApolloClientOptions<TCacheShape>["typeDefs"];
 
+  private EXTENSION_ID = 'jdkknkkbebbapilgoeccciglkfbmbnfm';
   private queryManager: QueryManager<TCacheShape>;
   private devToolsHookCb: Function;
   private resetStoreCallbacks: Array<() => Promise<any>> = [];

--- a/src/utilities/common/detectExtension.ts
+++ b/src/utilities/common/detectExtension.ts
@@ -1,0 +1,12 @@
+export function detectExtension(extensionId: string, callback: (status: boolean) => void) {
+  const img = new Image();
+  img.src = `chrome-extension://${extensionId}/images/logo64.png`;
+
+  img.onload = function () {
+    callback(true);
+  };
+
+  img.onerror = function () {
+    callback(false);
+  };
+}

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -120,6 +120,7 @@ export * from "./common/makeUniqueId.js";
 export * from "./common/stringifyForDisplay.js";
 export * from "./common/mergeOptions.js";
 export * from "./common/incrementalResult.js";
+export * from "./common/detectExtension.js";
 
 export { omitDeep } from "./common/omitDeep.js";
 export { stripTypename } from "./common/stripTypename.js";


### PR DESCRIPTION
This PR is about having a working check before logging "_Download the Apollo DevTools for a better development..._" message.