### PR TITLE
Clean up subscriptions using requestIdleCallback instead of setTimeout

### DIFF
--- a/.changeset/brown-cats-report.md
+++ b/.changeset/brown-cats-report.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Clean up subscriptions using requestIdleCallback instead of setTimeout

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -17,6 +17,7 @@ import {
   fixObservableSubclass,
   getQueryDefinition,
 } from "../utilities/index.js";
+import { requestIdleCallback } from "../utilities/common/requestIdleCallback.js";
 import type { ApolloError } from "../errors/index.js";
 import type { QueryManager } from "./QueryManager.js";
 import type {
@@ -204,7 +205,7 @@ export class ObservableQuery<
           //
           // We do this in order to prevent observers piling up within
           // the QueryManager. Notice that we only fully unsubscribe
-          // from the subscription in a setTimeout(..., 0)  call. This call can
+          // from the subscription in an idle callback. This callback can
           // actually be handled by the browser at a much later time. If queries
           // are fired in the meantime, observers that should have been removed
           // from the QueryManager will continue to fire, causing an unnecessary
@@ -214,9 +215,9 @@ export class ObservableQuery<
             this.queryManager.removeQuery(this.queryId);
           }
 
-          setTimeout(() => {
+          requestIdleCallback(() => {
             subscription.unsubscribe();
-          }, 0);
+          });
         },
         error: reject,
       };

--- a/src/utilities/common/__tests__/requestIdleCallback.ts
+++ b/src/utilities/common/__tests__/requestIdleCallback.ts
@@ -1,0 +1,39 @@
+import { requestIdleCallback } from "../requestIdleCallback";
+
+describe("requestIdleCallback", () => {
+  const originalRequestIdleCallback = window.requestIdleCallback;
+
+  afterAll(() => {
+    Object.defineProperty(window, "requestIdleCallback", {
+      value: originalRequestIdleCallback,
+    });
+  });
+
+  it("should use the window method when possible", () => {
+    Object.defineProperty(window, "requestIdleCallback", {
+      value: jest.fn((callback) => callback()),
+      configurable: true,
+    });
+
+    const task = jest.fn();
+    requestIdleCallback(task);
+    expect(task).toHaveBeenCalled();
+  });
+
+  it("should fall back to setTimeout when the window method is not available", () => {
+    // @ts-expect-error
+    delete window.requestIdleCallback;
+
+    jest.useFakeTimers();
+
+    const task = jest.fn();
+    requestIdleCallback(task);
+
+    expect(task).not.toHaveBeenCalled();
+
+    jest.runAllTimers();
+    expect(task).toHaveBeenCalled();
+
+    jest.useRealTimers();
+  });
+});

--- a/src/utilities/common/requestIdleCallback.ts
+++ b/src/utilities/common/requestIdleCallback.ts
@@ -1,0 +1,15 @@
+/**
+ * Light polyfill for requestIdleCallback when used in non-browser environments.
+ */
+export function requestIdleCallback(
+  callback: () => void,
+  options?: IdleRequestOptions
+) {
+  if (
+    !Object.prototype.hasOwnProperty.call(window, "requestIdleCallback") ||
+    typeof window.requestIdleCallback === "undefined"
+  ) {
+    return setTimeout(callback, options?.timeout ?? 0);
+  }
+  return window.requestIdleCallback(callback, options);
+}


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests

Referenced in #11214.