### PR TITLE
Remove superfluous SuspenseCache export

### DIFF
--- a/.changeset/pretty-readers-lick.md
+++ b/.changeset/pretty-readers-lick.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Remove (already throwing) SuspenseCache export that should have been removed in 3.8.

--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -1,7 +1,7 @@
 const checks = [
   {
     path: "dist/apollo-client.min.cjs",
-    limit: "38190",
+    limit: "37986",
   },
   {
     path: "dist/main.cjs",
@@ -10,7 +10,7 @@ const checks = [
   {
     path: "dist/index.js",
     import: "{ ApolloClient, InMemoryCache, HttpLink }",
-    limit: "32044",
+    limit: "32019",
   },
   ...[
     "ApolloProvider",

--- a/src/react/cache/index.ts
+++ b/src/react/cache/index.ts
@@ -1,27 +1,2 @@
 export type { SuspenseCacheOptions } from "./SuspenseCache.js";
 export { getSuspenseCache } from "./getSuspenseCache.js";
-
-import { SuspenseCache as RealSuspenseCache } from "./SuspenseCache.js";
-
-// TODO: remove export with release 3.8
-// replace with
-// export type { SuspenseCache } from './SuspenseCache.js';
-/**
- * @deprecated
- * It is no longer necessary to create a `SuspenseCache` instance and pass it into the `ApolloProvider`.
- * Please remove this code from your application.
- *
- * This export will be removed with the final 3.8 release.
- */
-export class SuspenseCache extends RealSuspenseCache {
-  constructor() {
-    super();
-    // throwing an error here instead of using invariant - we do not want this error
-    // message to be link-ified, but to directly show up as bold as possible
-    throw new Error(
-      "It is no longer necessary to create a `SuspenseCache` instance and pass it into the `ApolloProvider`.\n" +
-        "Please remove this code from your application. \n\n" +
-        "This export will be removed with the final 3.8 release."
-    );
-  }
-}

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -9,8 +9,6 @@ export {
 } from "./context/index.js";
 
 export * from "./hooks/index.js";
-// TODO: remove export with release 3.8
-export { SuspenseCache } from "./cache/index.js";
 
 export type { IDocumentDefinition } from "./parser/index.js";
 export { DocumentType, operationName, parser } from "./parser/index.js";

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -21,7 +21,6 @@ import type {
   WatchQueryOptions,
   WatchQueryFetchPolicy,
 } from "../../core/index.js";
-import type { SuspenseCache } from "../cache/index.js";
 
 /* QueryReference type */
 
@@ -134,7 +133,6 @@ export interface SuspenseQueryHookOptions<
     | "refetchWritePolicy"
   > {
   fetchPolicy?: SuspenseQueryHookFetchPolicy;
-  suspenseCache?: SuspenseCache;
   queryKey?: string | number | any[];
 
   /**
@@ -172,7 +170,6 @@ export interface BackgroundQueryHookOptions<
     | "refetchWritePolicy"
   > {
   fetchPolicy?: BackgroundQueryHookFetchPolicy;
-  suspenseCache?: SuspenseCache;
   queryKey?: string | number | any[];
 
   /**


### PR DESCRIPTION
Isn't it nice to have a PR that just removes code? :)

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
