### PR TITLE
`variables/options` should only be required if `TVariables` is empty or default

### DIFF
--- a/.changeset/slow-planets-design.md
+++ b/.changeset/slow-planets-design.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+useQuery: `variables/options` should only be required if `TVariables` is empty or default

--- a/integration-tests/cra4/package.json
+++ b/integration-tests/cra4/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.7.16",
-    "graphql": "^16.7.1",
+    "graphql": "^16.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.5",

--- a/integration-tests/cra5/package.json
+++ b/integration-tests/cra5/package.json
@@ -10,7 +10,7 @@
     "react-scripts": "5.0.1",
     "typescript": "^4.9.5",
     "@apollo/client": "^3.7.16",
-    "graphql": "^16.7.1"
+    "graphql": "^16.8.1"
   },
   "scripts": {
     "start": "PORT=3000 react-scripts start",

--- a/integration-tests/next/package.json
+++ b/integration-tests/next/package.json
@@ -18,7 +18,7 @@
     "@types/react": "18.2.14",
     "@types/react-dom": "18.2.6",
     "deepmerge": "^4.3.1",
-    "graphql": "^16.7.1",
+    "graphql": "^16.8.1",
     "lodash": "^4.17.21",
     "next": "13.4.7",
     "react": "18.2.0",

--- a/integration-tests/package-lock.json
+++ b/integration-tests/package-lock.json
@@ -33,7 +33,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@apollo/client": "^3.7.16",
-        "graphql": "^16.7.1",
+        "graphql": "^16.8.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-redux": "^8.0.5",
@@ -11396,7 +11396,7 @@
         "@apollo/client": "^3.7.16",
         "@types/react": "^18.2.14",
         "@types/react-dom": "^18.2.6",
-        "graphql": "^16.7.1",
+        "graphql": "^16.8.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-scripts": "5.0.1",
@@ -11428,7 +11428,7 @@
         "@types/react": "18.2.14",
         "@types/react-dom": "18.2.6",
         "deepmerge": "^4.3.1",
-        "graphql": "^16.7.1",
+        "graphql": "^16.8.1",
         "lodash": "^4.17.21",
         "next": "13.4.7",
         "react": "18.2.0",
@@ -21134,9 +21134,9 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="
     },
     "node_modules/graphql": {
-      "version": "16.7.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.7.1.tgz",
-      "integrity": "sha512-DRYR9tf+UGU0KOsMcKAlXeFfX89UiiIZ0dRU3mR0yJfu6OjZqUcp68NnFLnqQU5RexygFoDy1EW+ccOYcPfmHg==",
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
+      "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -29588,7 +29588,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@apollo/client": "^3.7.16",
-        "graphql": "^16.7.1",
+        "graphql": "^16.8.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },

--- a/integration-tests/vite/package.json
+++ b/integration-tests/vite/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.7.16",
-    "graphql": "^16.7.1",
+    "graphql": "^16.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -8236,4 +8236,116 @@ describe.skip("Type Tests", () => {
     // @ts-expect-error
     variables?.nonExistingVariable;
   });
+
+  describe("optional/required options/variables scenarios", () => {
+    test("untyped document node, variables are optional and can be anything", () => {
+      const query = {} as DocumentNode;
+      useQuery(query);
+      useQuery(query, {});
+      useQuery(query, { variables: {} });
+      useQuery(query, { variables: { opt: "opt" } });
+      useQuery(query, { variables: { req: "req" } });
+    });
+    test("typed document node with unspecified TVariables, variables are optional and can be anything", () => {
+      const query = {} as TypedDocumentNode<{ result: string }>;
+      useQuery(query);
+      useQuery(query, {});
+      useQuery(query, { variables: {} });
+      useQuery(query, { variables: { opt: "opt" } });
+      useQuery(query, { variables: { req: "req" } });
+    });
+    test("empty variables are optional", () => {
+      const query = {} as TypedDocumentNode<
+        { result: string },
+        Record<string, never>
+      >;
+      useQuery(query);
+      useQuery(query, {});
+      useQuery(query, { variables: {} });
+      useQuery(query, {
+        variables: {
+          // @ts-expect-error on unknown variable
+          foo: "bar",
+        },
+      });
+    });
+    test("all-optional variables are optional", () => {
+      const query = {} as TypedDocumentNode<
+        { result: string },
+        { opt?: string }
+      >;
+      useQuery(query);
+      useQuery(query, {});
+      useQuery(query, { variables: {} });
+      useQuery(query, { variables: { opt: "opt" } });
+      useQuery(query, {
+        variables: {
+          // @ts-expect-error on unknown variable
+          foo: "bar",
+        },
+      });
+      useQuery(query, {
+        variables: {
+          opt: "opt",
+          // @ts-expect-error on unknown variable
+          foo: "bar",
+        },
+      });
+    });
+    test("non-optional variables are required", () => {
+      const query = {} as TypedDocumentNode<
+        { result: string },
+        { req: string }
+      >;
+      // @ts-expect-error on missing options
+      useQuery(query);
+      useQuery(
+        query,
+        // @ts-expect-error on missing variables
+        {}
+      );
+      useQuery(query, {
+        // @ts-expect-error on empty variables
+        variables: {},
+      });
+      useQuery(query, {
+        variables: {
+          // @ts-expect-error on unknown variable
+          foo: "bar",
+        },
+      });
+      useQuery(query, { variables: { req: "req" } });
+      useQuery(query, {
+        variables: {
+          req: "req",
+          // @ts-expect-error on unknown variable
+          foo: "bar",
+        },
+      });
+    });
+    test("mixed variables are required", () => {
+      const query = {} as TypedDocumentNode<
+        { result: string },
+        { req: string; opt?: string }
+      >;
+      // @ts-expect-error on missing options
+      useQuery(query);
+      // @ts-expect-error on missing variables
+      useQuery(query, {});
+
+      useQuery(query, {
+        // @ts-expect-error on empty variables
+        variables: {},
+      });
+
+      useQuery(query, {
+        // @ts-expect-error on missing required variable
+        variables: {
+          opt: "opt",
+        },
+      });
+      useQuery(query, { variables: { req: "req" } });
+      useQuery(query, { variables: { req: "req", opt: "opt" } });
+    });
+  });
 });

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -41,6 +41,37 @@ const {
   prototype: { hasOwnProperty },
 } = Object;
 
+interface QueryHookOptionsWithVariables<
+  TData,
+  TVariables extends OperationVariables,
+> extends Omit<QueryHookOptions<TData, TVariables>, "variables"> {
+  variables: TVariables;
+}
+
+type OnlyRequiredProperties<T> = {
+  [K in keyof T as {} extends Pick<T, K> ? never : K]-?: T[K];
+};
+
+type HasRequiredVariables<T, TrueCase, FalseCase> =
+  {} extends OnlyRequiredProperties<T> ? FalseCase : TrueCase;
+
+export function useQuery<
+  TData = any,
+  TVariables extends OperationVariables = OperationVariables,
+>(
+  query: DocumentNode | TypedDocumentNode<TData, TVariables>,
+  ...[options]: HasRequiredVariables<
+    TVariables,
+    [
+      optionsWithVariables: QueryHookOptionsWithVariables<
+        NoInfer<TData>,
+        NoInfer<TVariables>
+      >,
+    ],
+    [options?: QueryHookOptions<NoInfer<TData>, NoInfer<TVariables>>]
+  >
+): QueryResult<TData, TVariables>;
+
 export function useQuery<
   TData = any,
   TVariables extends OperationVariables = OperationVariables,


### PR DESCRIPTION
This would address #10857

I'm opening this PR now to get feedback on it - if we agree that this is the way forward, it would need to be done for all other hooks as well - maybe we can find a nice type helper for it, although the implicitly created interface with a name helps for autocomplete readability.

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
