### PR TITLE
fix one-tick-race condition in asyncMap

### DIFF
--- a/.changeset/hungry-vans-walk.md
+++ b/.changeset/hungry-vans-walk.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+fixes a one-tick-race condition in `asyncMap`

--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -1,7 +1,7 @@
 const checks = [
   {
     path: "dist/apollo-client.min.cjs",
-    limit: "37986",
+    limit: "37994",
   },
   {
     path: "dist/main.cjs",
@@ -10,7 +10,7 @@ const checks = [
   {
     path: "dist/index.js",
     import: "{ ApolloClient, InMemoryCache, HttpLink }",
-    limit: "32019",
+    limit: "32025",
   },
   ...[
     "ApolloProvider",

--- a/src/utilities/observables/asyncMap.ts
+++ b/src/utilities/observables/asyncMap.ts
@@ -33,20 +33,21 @@ export function asyncMap<V, R>(
             .then(both, both)
             .then(
               (result) => {
-                --activeCallbackCount;
                 next && next.call(observer, result);
-                if (completed) {
-                  handler.complete!();
-                }
               },
               (error) => {
-                --activeCallbackCount;
                 throw error;
               }
             )
             .catch((caught) => {
               error && error.call(observer, caught);
             });
+          promiseQueue.finally(() => {
+            --activeCallbackCount;
+            if (completed) {
+              handler.complete!();
+            }
+          });
         };
       } else {
         return (arg) => delegate && delegate.call(observer, arg);


### PR DESCRIPTION
Fixes #11149
(hopefully 🤞 )

Can be tried out in https://github.com/quocluongha/rn-apollo-test - I can't reproduce it in the browser. It seems this specific timing only triggers in React Native.

I'll try to explain this one in comments...

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
(This seems impossible to test for, but trying out in the linked repo it seems to fix the bug)