### PR TITLE
Decouple `canonicalStringify` from `ObjectCanon`

### DIFF
--- a/.api-reports/api-report-cache.md
+++ b/.api-reports/api-report-cache.md
@@ -192,7 +192,7 @@ export const cacheSlot: {
 
 // @public (undocumented)
 export const canonicalStringify: ((value: any) => string) & {
-    reset: typeof resetCanonicalStringify;
+    reset(): void;
 };
 
 // @public (undocumented)
@@ -859,9 +859,6 @@ export interface Reference {
 }
 
 // @public (undocumented)
-function resetCanonicalStringify(): void;
-
-// @public (undocumented)
 type SafeReadonly<T> = T extends object ? Readonly<T> : T;
 
 // @public (undocumented)
@@ -947,10 +944,9 @@ interface WriteContext extends ReadMergeModifyContext {
 
 // Warnings were encountered during analysis:
 //
-// src/cache/inmemory/object-canon.ts:203:32 - (ae-forgotten-export) The symbol "resetCanonicalStringify" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/policies.ts:98:3 - (ae-forgotten-export) The symbol "FragmentMap" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/policies.ts:167:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/policies.ts:167:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:92:3 - (ae-forgotten-export) The symbol "FragmentMap" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:161:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:161:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/types.ts:126:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-core.md
+++ b/.api-reports/api-report-core.md
@@ -2179,9 +2179,9 @@ interface WriteContext extends ReadMergeModifyContext {
 
 // Warnings were encountered during analysis:
 //
-// src/cache/inmemory/policies.ts:98:3 - (ae-forgotten-export) The symbol "FragmentMap" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/policies.ts:167:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/policies.ts:167:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:92:3 - (ae-forgotten-export) The symbol "FragmentMap" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:161:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:161:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/types.ts:126:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:112:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:113:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report-utilities.md
+++ b/.api-reports/api-report-utilities.md
@@ -1077,7 +1077,11 @@ export function getOperationName(doc: DocumentNode): string | null;
 export function getQueryDefinition(doc: DocumentNode): OperationDefinitionNode;
 
 // @public (undocumented)
-export function getStoreKeyName(fieldName: string, args?: Record<string, any> | null, directives?: Directives): string;
+export const getStoreKeyName: ((fieldName: string, args?: Record<string, any> | null, directives?: Directives) => string) & {
+    setStringify(s: typeof storeKeyNameStringify): ((value: any) => string) & {
+        reset(): void;
+    };
+};
 
 // @public (undocumented)
 export function getTypenameFromResult(result: Record<string, any>, selectionSet: SelectionSetNode, fragmentMap?: FragmentMap): string | undefined;
@@ -2288,6 +2292,11 @@ type StorageType = Record<string, any>;
 export function storeKeyNameFromField(field: FieldNode, variables?: Object): string;
 
 // @public (undocumented)
+let storeKeyNameStringify: ((value: any) => string) & {
+    reset(): void;
+};
+
+// @public (undocumented)
 export interface StoreObject {
     // (undocumented)
     [storeFieldName: string]: StoreValue;
@@ -2517,6 +2526,7 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/core/types.ts:178:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:205:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:191:3 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
+// src/utilities/graphql/storeUtils.ts:208:12 - (ae-forgotten-export) The symbol "storeKeyNameStringify" needs to be exported by the entry point index.d.ts
 // src/utilities/policies/pagination.ts:76:3 - (ae-forgotten-export) The symbol "TRelayEdge" needs to be exported by the entry point index.d.ts
 // src/utilities/policies/pagination.ts:77:3 - (ae-forgotten-export) The symbol "TRelayPageInfo" needs to be exported by the entry point index.d.ts
 

--- a/.api-reports/api-report-utilities.md
+++ b/.api-reports/api-report-utilities.md
@@ -1078,9 +1078,7 @@ export function getQueryDefinition(doc: DocumentNode): OperationDefinitionNode;
 
 // @public (undocumented)
 export const getStoreKeyName: ((fieldName: string, args?: Record<string, any> | null, directives?: Directives) => string) & {
-    setStringify(s: typeof storeKeyNameStringify): ((value: any) => string) & {
-        reset(): void;
-    };
+    setStringify(s: typeof storeKeyNameStringify): (value: any) => string;
 };
 
 // @public (undocumented)
@@ -2292,9 +2290,7 @@ type StorageType = Record<string, any>;
 export function storeKeyNameFromField(field: FieldNode, variables?: Object): string;
 
 // @public (undocumented)
-let storeKeyNameStringify: ((value: any) => string) & {
-    reset(): void;
-};
+let storeKeyNameStringify: (value: any) => string;
 
 // @public (undocumented)
 export interface StoreObject {

--- a/.api-reports/api-report-utilities.md
+++ b/.api-reports/api-report-utilities.md
@@ -463,6 +463,11 @@ const enum CacheWriteBehavior {
 }
 
 // @public (undocumented)
+export const canonicalStringify: ((value: any) => string) & {
+    reset(): void;
+};
+
+// @public (undocumented)
 type CanReadFunction = (value: StoreValue) => boolean;
 
 // @public (undocumented)
@@ -1072,9 +1077,7 @@ export function getOperationName(doc: DocumentNode): string | null;
 export function getQueryDefinition(doc: DocumentNode): OperationDefinitionNode;
 
 // @public (undocumented)
-export const getStoreKeyName: ((fieldName: string, args?: Record<string, any> | null, directives?: Directives) => string) & {
-    setStringify(s: typeof stringify): (value: any) => string;
-};
+export function getStoreKeyName(fieldName: string, args?: Record<string, any> | null, directives?: Directives): string;
 
 // @public (undocumented)
 export function getTypenameFromResult(result: Record<string, any>, selectionSet: SelectionSetNode, fragmentMap?: FragmentMap): string | undefined;
@@ -2299,9 +2302,6 @@ type StoreObjectValueMaybeReference<StoreVal> = StoreVal extends Record<string, 
 export type StoreValue = number | string | string[] | Reference | Reference[] | null | undefined | void | Object;
 
 // @public (undocumented)
-let stringify: (value: any) => string;
-
-// @public (undocumented)
 export function stringifyForDisplay(value: any, space?: number): string;
 
 // @public (undocumented)
@@ -2498,11 +2498,11 @@ interface WriteContext extends ReadMergeModifyContext {
 // Warnings were encountered during analysis:
 //
 // src/cache/core/types/DataProxy.ts:141:5 - (ae-forgotten-export) The symbol "MissingFieldError" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/policies.ts:63:3 - (ae-forgotten-export) The symbol "TypePolicy" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/policies.ts:167:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/policies.ts:167:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/policies.ts:168:3 - (ae-forgotten-export) The symbol "FieldReadFunction" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/policies.ts:169:3 - (ae-forgotten-export) The symbol "FieldMergeFunction" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:57:3 - (ae-forgotten-export) The symbol "TypePolicy" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:161:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:161:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:162:3 - (ae-forgotten-export) The symbol "FieldReadFunction" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:163:3 - (ae-forgotten-export) The symbol "FieldMergeFunction" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/types.ts:126:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/writeToStore.ts:65:7 - (ae-forgotten-export) The symbol "MergeTree" needs to be exported by the entry point index.d.ts
 // src/core/ApolloClient.ts:47:3 - (ae-forgotten-export) The symbol "UriFunction" needs to be exported by the entry point index.d.ts
@@ -2517,7 +2517,6 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/core/types.ts:178:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:205:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:191:3 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
-// src/utilities/graphql/storeUtils.ts:202:12 - (ae-forgotten-export) The symbol "stringify" needs to be exported by the entry point index.d.ts
 // src/utilities/policies/pagination.ts:76:3 - (ae-forgotten-export) The symbol "TRelayEdge" needs to be exported by the entry point index.d.ts
 // src/utilities/policies/pagination.ts:77:3 - (ae-forgotten-export) The symbol "TRelayPageInfo" needs to be exported by the entry point index.d.ts
 

--- a/.api-reports/api-report.md
+++ b/.api-reports/api-report.md
@@ -2858,9 +2858,9 @@ interface WriteContext extends ReadMergeModifyContext {
 
 // Warnings were encountered during analysis:
 //
-// src/cache/inmemory/policies.ts:98:3 - (ae-forgotten-export) The symbol "FragmentMap" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/policies.ts:167:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/policies.ts:167:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:92:3 - (ae-forgotten-export) The symbol "FragmentMap" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:161:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:161:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/types.ts:126:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:112:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:113:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts

--- a/.changeset/beige-geese-wink.md
+++ b/.changeset/beige-geese-wink.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Decouple `canonicalStringify` from `ObjectCanon` for better time and memory performance.

--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -1,7 +1,7 @@
 const checks = [
   {
     path: "dist/apollo-client.min.cjs",
-    limit: "38083",
+    limit: "38049",
   },
   {
     path: "dist/main.cjs",
@@ -10,7 +10,7 @@ const checks = [
   {
     path: "dist/index.js",
     import: "{ ApolloClient, InMemoryCache, HttpLink }",
-    limit: "32123",
+    limit: "32082",
   },
   ...[
     "ApolloProvider",

--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -1,7 +1,7 @@
 const checks = [
   {
     path: "dist/apollo-client.min.cjs",
-    limit: "38000",
+    limit: "38060",
   },
   {
     path: "dist/main.cjs",
@@ -10,7 +10,7 @@ const checks = [
   {
     path: "dist/index.js",
     import: "{ ApolloClient, InMemoryCache, HttpLink }",
-    limit: "32052",
+    limit: "32095",
   },
   ...[
     "ApolloProvider",

--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -1,7 +1,7 @@
 const checks = [
   {
     path: "dist/apollo-client.min.cjs",
-    limit: "38060",
+    limit: "38083",
   },
   {
     path: "dist/main.cjs",
@@ -10,7 +10,7 @@ const checks = [
   {
     path: "dist/index.js",
     import: "{ ApolloClient, InMemoryCache, HttpLink }",
-    limit: "32095",
+    limit: "32123",
   },
   ...[
     "ApolloProvider",

--- a/src/__tests__/__snapshots__/exports.ts.snap
+++ b/src/__tests__/__snapshots__/exports.ts.snap
@@ -395,6 +395,7 @@ Array [
   "canUseSymbol",
   "canUseWeakMap",
   "canUseWeakSet",
+  "canonicalStringify",
   "checkDocument",
   "cloneDeep",
   "compact",

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -14,7 +14,11 @@ export type {
 export { MissingFieldError } from "./core/types/common.js";
 
 export type { Reference } from "../utilities/index.js";
-export { isReference, makeReference } from "../utilities/index.js";
+export {
+  isReference,
+  makeReference,
+  canonicalStringify,
+} from "../utilities/index.js";
 
 export { EntityStore } from "./inmemory/entityStore.js";
 export {
@@ -37,8 +41,6 @@ export type {
   PossibleTypesMap,
 } from "./inmemory/policies.js";
 export { Policies } from "./inmemory/policies.js";
-
-export { canonicalStringify } from "./inmemory/object-canon.js";
 
 export type { FragmentRegistryAPI } from "./inmemory/fragmentRegistry.js";
 export { createFragmentRegistry } from "./inmemory/fragmentRegistry.js";

--- a/src/cache/inmemory/__tests__/key-extractor.ts
+++ b/src/cache/inmemory/__tests__/key-extractor.ts
@@ -1,5 +1,5 @@
 import { KeySpecifier } from "../policies";
-import { canonicalStringify } from "../object-canon";
+import { canonicalStringify } from "../../../utilities";
 import {
   getSpecifierPaths,
   collectSpecifierPaths,

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -16,6 +16,7 @@ import {
   addTypenameToDocument,
   isReference,
   DocumentTransform,
+  canonicalStringify,
 } from "../../utilities/index.js";
 import type { InMemoryCacheConfig, NormalizedCacheObject } from "./types.js";
 import { StoreReader } from "./readFromStore.js";
@@ -24,7 +25,6 @@ import { EntityStore, supportsResultCaching } from "./entityStore.js";
 import { makeVar, forgetCache, recallCache } from "./reactiveVars.js";
 import { Policies } from "./policies.js";
 import { hasOwn, normalizeConfig, shouldCanonizeResults } from "./helpers.js";
-import { canonicalStringify } from "./object-canon.js";
 import type { OperationVariables } from "../../core/index.js";
 
 type BroadcastOptions = Pick<

--- a/src/cache/inmemory/object-canon.ts
+++ b/src/cache/inmemory/object-canon.ts
@@ -195,35 +195,3 @@ type SortedKeysInfo = {
   sorted: string[];
   json: string;
 };
-
-// Since the keys of canonical objects are always created in lexicographically
-// sorted order, we can use the ObjectCanon to implement a fast and stable
-// version of JSON.stringify, which automatically sorts object keys.
-export const canonicalStringify = Object.assign(
-  function (value: any): string {
-    if (isObjectOrArray(value)) {
-      if (stringifyCanon === void 0) {
-        resetCanonicalStringify();
-      }
-      const canonical = stringifyCanon.admit(value);
-      let json = stringifyCache.get(canonical);
-      if (json === void 0) {
-        stringifyCache.set(canonical, (json = JSON.stringify(canonical)));
-      }
-      return json;
-    }
-    return JSON.stringify(value);
-  },
-  {
-    reset: resetCanonicalStringify,
-  }
-);
-
-// Can be reset by calling canonicalStringify.reset().
-let stringifyCanon: ObjectCanon;
-let stringifyCache: WeakMap<object, string>;
-
-function resetCanonicalStringify() {
-  stringifyCanon = new ObjectCanon();
-  stringifyCache = new (canUseWeakMap ? WeakMap : Map)();
-}

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -20,6 +20,7 @@ import {
   getStoreKeyName,
   isNonNullObject,
   stringifyForDisplay,
+  canonicalStringify,
 } from "../../utilities/index.js";
 import type {
   IdGetter,
@@ -48,10 +49,6 @@ import type {
 } from "../core/types/common.js";
 import type { WriteContext } from "./writeToStore.js";
 
-// Upgrade to a faster version of the default stable JSON.stringify function
-// used by getStoreKeyName. This function is used when computing storeFieldName
-// strings (when no keyArgs has been configured for a field).
-import { canonicalStringify } from "./object-canon.js";
 import {
   keyArgsFnFromSpecifier,
   keyFieldsFnFromSpecifier,

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -20,7 +20,6 @@ import {
   getStoreKeyName,
   isNonNullObject,
   stringifyForDisplay,
-  canonicalStringify,
 } from "../../utilities/index.js";
 import type {
   IdGetter,
@@ -53,8 +52,6 @@ import {
   keyArgsFnFromSpecifier,
   keyFieldsFnFromSpecifier,
 } from "./key-extractor.js";
-
-getStoreKeyName.setStringify(canonicalStringify);
 
 export type TypePolicies = {
   [__typename: string]: TypePolicy;

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -28,6 +28,7 @@ import {
   isNonNullObject,
   canUseWeakMap,
   compact,
+  canonicalStringify,
 } from "../../utilities/index.js";
 import type { Cache } from "../core/types/Cache.js";
 import type {
@@ -50,7 +51,7 @@ import type { Policies } from "./policies.js";
 import type { InMemoryCache } from "./inMemoryCache.js";
 import type { MissingTree } from "../core/types/common.js";
 import { MissingFieldError } from "../core/types/common.js";
-import { canonicalStringify, ObjectCanon } from "./object-canon.js";
+import { ObjectCanon } from "./object-canon.js";
 
 export type VariableMap = { [name: string]: any };
 

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -25,6 +25,7 @@ import {
   addTypenameToDocument,
   isNonEmptyArray,
   argumentsObjectFromField,
+  canonicalStringify,
 } from "../../utilities/index.js";
 
 import type {
@@ -44,7 +45,6 @@ import type { StoreReader } from "./readFromStore.js";
 import type { InMemoryCache } from "./inMemoryCache.js";
 import type { EntityStore } from "./entityStore.js";
 import type { Cache } from "../../core/index.js";
-import { canonicalStringify } from "./object-canon.js";
 import { normalizeReadFieldOptions } from "./policies.js";
 import type { ReadFieldFunction } from "../core/types/common.js";
 

--- a/src/utilities/common/__tests__/canonicalStringify.ts
+++ b/src/utilities/common/__tests__/canonicalStringify.ts
@@ -1,0 +1,132 @@
+import {
+  canonicalStringify,
+  lookupSortedKeys,
+} from "../canonicalStringify";
+
+function forEachPermutation(
+  keys: string[],
+  callback: (permutation: string[]) => void,
+) {
+  if (keys.length <= 1) {
+    callback(keys);
+    return;
+  }
+  const first = keys[0];
+  const rest = keys.slice(1);
+  forEachPermutation(rest, (permutation) => {
+    for (let i = 0; i <= permutation.length; ++i) {
+      callback([
+        ...permutation.slice(0, i),
+        first,
+        ...permutation.slice(i),
+      ]);
+    }
+  });
+}
+
+function allObjectPermutations<T extends Record<string, any>>(obj: T) {
+  const keys = Object.keys(obj);
+  const permutations: T[] = [];
+  forEachPermutation(keys, permutation => {
+    const permutationObj =
+      Object.create(Object.getPrototypeOf(obj));
+    permutation.forEach(key => {
+      permutationObj[key] = obj[key];
+    });
+    permutations.push(permutationObj);
+  });
+  return permutations;
+}
+
+describe("canonicalStringify", () => {
+  beforeEach(() => {
+    canonicalStringify.reset();
+  });
+
+  it("should not modify original object", () => {
+    const obj = { c: 3, a: 1, b: 2 };
+    expect(canonicalStringify(obj)).toBe('{"a":1,"b":2,"c":3}');
+    expect(Object.keys(obj)).toEqual(["c", "a", "b"]);
+  });
+
+  it("forEachPermutation should work", () => {
+    const permutations: string[][] = [];
+    forEachPermutation(["a", "b", "c"], (permutation) => {
+      permutations.push(permutation);
+    });
+    expect(permutations).toEqual([
+      ["a", "b", "c"],
+      ["b", "a", "c"],
+      ["b", "c", "a"],
+      ["a", "c", "b"],
+      ["c", "a", "b"],
+      ["c", "b", "a"],
+    ]);
+  });
+
+  it("canonicalStringify should stably stringify all permutations of an object", () => {
+    const unstableStrings = new Set<string>();
+    const stableStrings = new Set<string>();
+
+    allObjectPermutations({
+      c: 3,
+      a: 1,
+      b: 2,
+    }).forEach(obj => {
+      unstableStrings.add(JSON.stringify(obj));
+      stableStrings.add(canonicalStringify(obj));
+
+      expect(canonicalStringify(obj)).toBe('{"a":1,"b":2,"c":3}');
+
+      allObjectPermutations({
+        z: "z",
+        y: ["y", obj, "why"],
+        x: "x",
+      }).forEach(parent => {
+        expect(canonicalStringify(parent)).toBe(
+          '{"x":"x","y":["y",{"a":1,"b":2,"c":3},"why"],"z":"z"}',
+        );
+      });
+    });
+
+    expect(unstableStrings.size).toBe(6);
+    expect(stableStrings.size).toBe(1);
+  });
+
+  it("lookupSortedKeys(keys, false) should reuse same sorted array for all permutations", () => {
+    const keys = ["z", "a", "c", "b"];
+    const sorted = lookupSortedKeys(["z", "a", "b", "c"], false);
+    expect(sorted).toEqual(["a", "b", "c", "z"]);
+    forEachPermutation(keys, permutation => {
+      expect(lookupSortedKeys(permutation, false)).toBe(sorted);
+    });
+  });
+
+  it("lookupSortedKeys(keys, true) should return same array if already sorted", () => {
+    const keys = ["a", "b", "c", "x", "y", "z"].sort();
+    const sorted = lookupSortedKeys(keys, true);
+    expect(sorted).toBe(keys);
+
+    forEachPermutation(keys, permutation => {
+      const sortedTrue = lookupSortedKeys(permutation, true);
+      const sortedFalse = lookupSortedKeys(permutation, false);
+
+      expect(sortedTrue).toEqual(sorted);
+      expect(sortedFalse).toEqual(sorted);
+
+      const wasPermutationSorted =
+        permutation.every((key, i) => key === keys[i]);
+
+      if (wasPermutationSorted) {
+        expect(sortedTrue).toBe(permutation);
+        expect(sortedTrue).not.toBe(sorted);
+      } else {
+        expect(sortedTrue).not.toBe(permutation);
+        expect(sortedTrue).toBe(sorted);
+      }
+
+      expect(sortedFalse).not.toBe(permutation);
+      expect(sortedFalse).toBe(sorted);
+    });
+  });
+});

--- a/src/utilities/common/__tests__/canonicalStringify.ts
+++ b/src/utilities/common/__tests__/canonicalStringify.ts
@@ -1,11 +1,8 @@
-import {
-  canonicalStringify,
-  lookupSortedKeys,
-} from "../canonicalStringify";
+import { canonicalStringify, lookupSortedKeys } from "../canonicalStringify";
 
 function forEachPermutation(
   keys: string[],
-  callback: (permutation: string[]) => void,
+  callback: (permutation: string[]) => void
 ) {
   if (keys.length <= 1) {
     callback(keys);
@@ -15,11 +12,7 @@ function forEachPermutation(
   const rest = keys.slice(1);
   forEachPermutation(rest, (permutation) => {
     for (let i = 0; i <= permutation.length; ++i) {
-      callback([
-        ...permutation.slice(0, i),
-        first,
-        ...permutation.slice(i),
-      ]);
+      callback([...permutation.slice(0, i), first, ...permutation.slice(i)]);
     }
   });
 }
@@ -27,10 +20,9 @@ function forEachPermutation(
 function allObjectPermutations<T extends Record<string, any>>(obj: T) {
   const keys = Object.keys(obj);
   const permutations: T[] = [];
-  forEachPermutation(keys, permutation => {
-    const permutationObj =
-      Object.create(Object.getPrototypeOf(obj));
-    permutation.forEach(key => {
+  forEachPermutation(keys, (permutation) => {
+    const permutationObj = Object.create(Object.getPrototypeOf(obj));
+    permutation.forEach((key) => {
       permutationObj[key] = obj[key];
     });
     permutations.push(permutationObj);
@@ -72,7 +64,7 @@ describe("canonicalStringify", () => {
       c: 3,
       a: 1,
       b: 2,
-    }).forEach(obj => {
+    }).forEach((obj) => {
       unstableStrings.add(JSON.stringify(obj));
       stableStrings.add(canonicalStringify(obj));
 
@@ -82,9 +74,9 @@ describe("canonicalStringify", () => {
         z: "z",
         y: ["y", obj, "why"],
         x: "x",
-      }).forEach(parent => {
+      }).forEach((parent) => {
         expect(canonicalStringify(parent)).toBe(
-          '{"x":"x","y":["y",{"a":1,"b":2,"c":3},"why"],"z":"z"}',
+          '{"x":"x","y":["y",{"a":1,"b":2,"c":3},"why"],"z":"z"}'
         );
       });
     });
@@ -97,7 +89,7 @@ describe("canonicalStringify", () => {
     const keys = ["z", "a", "c", "b"];
     const sorted = lookupSortedKeys(["z", "a", "b", "c"], false);
     expect(sorted).toEqual(["a", "b", "c", "z"]);
-    forEachPermutation(keys, permutation => {
+    forEachPermutation(keys, (permutation) => {
       expect(lookupSortedKeys(permutation, false)).toBe(sorted);
     });
   });
@@ -107,15 +99,16 @@ describe("canonicalStringify", () => {
     const sorted = lookupSortedKeys(keys, true);
     expect(sorted).toBe(keys);
 
-    forEachPermutation(keys, permutation => {
+    forEachPermutation(keys, (permutation) => {
       const sortedTrue = lookupSortedKeys(permutation, true);
       const sortedFalse = lookupSortedKeys(permutation, false);
 
       expect(sortedTrue).toEqual(sorted);
       expect(sortedFalse).toEqual(sorted);
 
-      const wasPermutationSorted =
-        permutation.every((key, i) => key === keys[i]);
+      const wasPermutationSorted = permutation.every(
+        (key, i) => key === keys[i]
+      );
 
       if (wasPermutationSorted) {
         expect(sortedTrue).toBe(permutation);

--- a/src/utilities/common/canonicalStringify.ts
+++ b/src/utilities/common/canonicalStringify.ts
@@ -63,16 +63,16 @@ type SortingTrie = Map<string, SortingTrie> & {
   // The contents of the Map represent the next level(s) of the trie, branching
   // out for each possible next key.
   sorted?: readonly string[];
-}
+};
 
-const sortingTrieRoot: SortingTrie = new Map;
+const sortingTrieRoot: SortingTrie = new Map();
 
 // Sort the given keys using a lookup trie, with an option to return the same
 // (===) array in case it was already sorted, so we can avoid always creating a
 // new object in the replacer function above.
 export function lookupSortedKeys(
   keys: readonly string[],
-  returnKeysIfAlreadySorted: boolean,
+  returnKeysIfAlreadySorted: boolean
 ): readonly string[] {
   let node = sortingTrieRoot;
   let alreadySorted = true;
@@ -81,17 +81,19 @@ export function lookupSortedKeys(
     if (k > 0 && keys[k - 1] > key) {
       alreadySorted = false;
     }
-    node = node.get(key) || node.set(key, new Map).get(key)!;
+    node = node.get(key) || node.set(key, new Map()).get(key)!;
   }
 
   if (alreadySorted) {
     return node.sorted
-      // There may already be a node.sorted array that's equivalent to the
-      // already-sorted keys array, but if keys was already sorted, we want to
-      // return the keys reference as-is when returnKeysIfAlreadySorted is true.
-      // This behavior helps us decide whether we need to create a new object in
-      // the stableObjectReplacer function above.
-      ? (returnKeysIfAlreadySorted ? keys : node.sorted)
+      ? // There may already be a node.sorted array that's equivalent to the
+        // already-sorted keys array, but if keys was already sorted, we want to
+        // return the keys reference as-is when returnKeysIfAlreadySorted is true.
+        // This behavior helps us decide whether we need to create a new object in
+        // the stableObjectReplacer function above.
+        returnKeysIfAlreadySorted
+        ? keys
+        : node.sorted
       : (node.sorted = keys);
   }
 
@@ -109,7 +111,7 @@ export function lookupSortedKeys(
   // be stored as the one true array and returned here. Since we are passing in
   // an array that is definitely already sorted, this call to lookupSortedKeys
   // will never actually have to call .sort(), so this lookup is always linear.
-  return node.sorted || (
-    node.sorted = lookupSortedKeys(keys.slice(0).sort(), false)
+  return (
+    node.sorted || (node.sorted = lookupSortedKeys(keys.slice(0).sort(), false))
   );
 }

--- a/src/utilities/common/canonicalStringify.ts
+++ b/src/utilities/common/canonicalStringify.ts
@@ -1,0 +1,11 @@
+export const canonicalStringify = Object.assign(
+  function canonicalStringify(value: any): string {
+    // TODO
+    return JSON.stringify(value);
+  },
+  {
+    reset() {
+      // TODO
+    },
+  }
+);

--- a/src/utilities/common/canonicalStringify.ts
+++ b/src/utilities/common/canonicalStringify.ts
@@ -1,7 +1,7 @@
+// Like JSON.stringify, but with object keys always sorted in the same order.
 export const canonicalStringify = Object.assign(
   function canonicalStringify(value: any): string {
-    // TODO
-    return JSON.stringify(value);
+    return JSON.stringify(value, stableObjectReplacer);
   },
   {
     reset() {
@@ -9,3 +9,32 @@ export const canonicalStringify = Object.assign(
     },
   }
 );
+
+// The JSON.stringify function takes an optional second argument called a
+// replacer function. This function is called for each key-value pair in the
+// object being stringified, and its return value is used instead of the
+// original value. If the replacer function returns a new value, that value is
+// stringified as JSON instead of the original value of the property.
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#the_replacer_parameter
+function stableObjectReplacer(key: string, value: any) {
+  if (value && typeof value === "object") {
+    const proto = Object.getPrototypeOf(value);
+    // We don't want to mess with objects that are not "plain" objects, which
+    // means their prototype is either Object.prototype or null.
+    if (proto === Object.prototype || proto === null) {
+      const sorted = Object.create(null);
+      // TODO This sorting step can be sped up in two ways:
+      // 1. If the keys are already sorted, we can skip the sorting step.
+      // 2. If we have sorted this sequence of keys before, we can look up the
+      //    previously sorted sequence in linear time rather than O(n log n)
+      //    time, which is the typical cost of sorting.
+      Object.keys(value)
+        .sort()
+        .forEach((key) => {
+          sorted[key] = value[key];
+        });
+      return sorted;
+    }
+  }
+  return value;
+}

--- a/src/utilities/common/canonicalStringify.ts
+++ b/src/utilities/common/canonicalStringify.ts
@@ -70,7 +70,7 @@ const sortingTrieRoot: SortingTrie = new Map;
 // Sort the given keys using a lookup trie, with an option to return the same
 // (===) array in case it was already sorted, so we can avoid always creating a
 // new object in the replacer function above.
-function lookupSortedKeys(
+export function lookupSortedKeys(
   keys: readonly string[],
   returnKeysIfAlreadySorted: boolean,
 ): readonly string[] {

--- a/src/utilities/common/canonicalStringify.ts
+++ b/src/utilities/common/canonicalStringify.ts
@@ -1,19 +1,19 @@
 /**
  * Like JSON.stringify, but with object keys always sorted in the same order.
  *
- * To achieve performant sorting, this function uses a trie to store the sorted
- * key names of objects that have already been encountered, bringing "memoized"
- * sort actions down to O(n) from O(n log n).
+ * To achieve performant sorting, this function uses a Map from JSON-serialized
+ * arrays of keys (in any order) to sorted arrays of the same keys, with a
+ * single sorted array reference shared by all permutations of the keys.
  *
- * As a drawback, this function will add a little bit more memory for every object
- * is called with that has different (more, less, a different order) keys than
- * in the past.
+ * As a drawback, this function will add a little bit more memory for every
+ * object encountered that has different (more, less, a different order of) keys
+ * than in the past.
  *
- * In a typical application, this should not play a significant role, as
- * `canonicalStringify` will be called for only a limited number of object shapes,
- * and the cache will not grow beyond a certain point.
- * But in some edge cases, this could be a problem, so we provide a `reset` method
- * that will clear the cache and could be called at intervals from userland.
+ * In a typical application, this extra memory usage should not play a
+ * significant role, as `canonicalStringify` will be called for only a limited
+ * number of object shapes, and the cache will not grow beyond a certain point.
+ * But in some edge cases, this could be a problem, so we provide
+ * canonicalStringify.reset() as a way of clearing the cache.
  * */
 export const canonicalStringify = Object.assign(
   function canonicalStringify(value: any): string {
@@ -21,13 +21,15 @@ export const canonicalStringify = Object.assign(
   },
   {
     reset() {
-      // Blowing away the root-level trie map will reclaim all memory stored in
-      // the trie, without affecting the logical results of canonicalStringify,
-      // but potentially sacrificing performance until the trie is refilled.
-      sortingTrieRoot.clear();
+      // Clearing the sortingMap will reclaim all cached memory, without
+      // affecting the logical results of canonicalStringify, but potentially
+      // sacrificing performance until the cache is refilled.
+      sortingMap.clear();
     },
   }
 );
+
+const sortingMap = new Map<string, readonly string[]>();
 
 // The JSON.stringify function takes an optional second argument called a
 // replacer function. This function is called for each key-value pair in the
@@ -39,79 +41,39 @@ function stableObjectReplacer(key: string, value: any) {
   if (value && typeof value === "object") {
     const proto = Object.getPrototypeOf(value);
     // We don't want to mess with objects that are not "plain" objects, which
-    // means their prototype is either Object.prototype or null.
+    // means their prototype is either Object.prototype or null. This check also
+    // prevents needlessly rearranging the indices of arrays.
     if (proto === Object.prototype || proto === null) {
       const keys = Object.keys(value);
-      const sortedKeys = lookupSortedKeys(keys, true);
-      if (sortedKeys !== keys) {
-        const sorted = Object.create(null);
-        // Reassigning the keys in sorted order will cause JSON.stringify to
-        // serialize them in sorted order.
-        sortedKeys.forEach((key) => {
-          sorted[key] = value[key];
-        });
-        return sorted;
+      if (isArraySorted(keys)) return value;
+      const unsortedKey = JSON.stringify(keys);
+      let sortedKeys = sortingMap.get(unsortedKey);
+      if (!sortedKeys) {
+        keys.sort();
+        const sortedKey = JSON.stringify(keys);
+        // Checking for sortedKey in the sortingMap allows us to share the same
+        // sorted array reference for all permutations of the same set of keys.
+        sortedKeys = sortingMap.get(sortedKey) || keys;
+        sortingMap.set(unsortedKey, sortedKeys);
+        sortingMap.set(sortedKey, sortedKeys);
       }
+      const sortedObject = Object.create(Object.getPrototypeOf(value));
+      // Reassigning the keys in sorted order will cause JSON.stringify to
+      // serialize them in sorted order.
+      sortedKeys.forEach((key) => {
+        sortedObject[key] = value[key];
+      });
+      return sortedObject;
     }
   }
   return value;
 }
 
-type SortingTrie = Map<string, SortingTrie> & {
-  // If there is an entry in the trie for the sequence of keys leading up to
-  // this node, the node.sorted array will contain those keys in sorted order.
-  // The contents of the Map represent the next level(s) of the trie, branching
-  // out for each possible next key.
-  sorted?: readonly string[];
-};
-
-const sortingTrieRoot: SortingTrie = new Map();
-
-// Sort the given keys using a lookup trie, with an option to return the same
-// (===) array in case it was already sorted, so we can avoid always creating a
-// new object in the replacer function above.
-export function lookupSortedKeys(
-  keys: readonly string[],
-  returnKeysIfAlreadySorted: boolean
-): readonly string[] {
-  let node = sortingTrieRoot;
-  let alreadySorted = true;
-  for (let k = 0, len = keys.length; k < len; ++k) {
-    const key = keys[k];
-    if (k > 0 && keys[k - 1] > key) {
-      alreadySorted = false;
+function isArraySorted(keys: readonly string[]): boolean {
+  for (let k = 1, len = keys.length; k < len; ++k) {
+    if (keys[k - 1] > keys[k]) {
+      return false;
     }
-    node = node.get(key) || node.set(key, new Map()).get(key)!;
   }
-
-  if (alreadySorted) {
-    return node.sorted
-      ? // There may already be a node.sorted array that's equivalent to the
-        // already-sorted keys array, but if keys was already sorted, we want to
-        // return the keys reference as-is when returnKeysIfAlreadySorted is true.
-        // This behavior helps us decide whether we need to create a new object in
-        // the stableObjectReplacer function above.
-        returnKeysIfAlreadySorted
-        ? keys
-        : node.sorted
-      : (node.sorted = keys);
-  }
-
-  // To conserve the total number of sorted arrays we store in the trie, we
-  // always use the same sorted array reference for a given set of strings,
-  // regardless of which permutation of the strings led to this SortingTrie
-  // node. To obtain this one true array, we do a little extra work to look up
-  // the sorted array associated with the sorted permutation, since there will
-  // be one unique path through the trie for the sorted permutation (even if
-  // there were duplicate keys). We can reuse the lookupSortedKeys function to
-  // perform this lookup, but we pass false for returnKeysIfAlreadySorted so it
-  // will return the existing array (if any) rather than the new sorted array we
-  // use to perform the lookup. If there is no existing array associated with
-  // the sorted permutation, the new array produced by keys.slice(0).sort() will
-  // be stored as the one true array and returned here. Since we are passing in
-  // an array that is definitely already sorted, this call to lookupSortedKeys
-  // will never actually have to call .sort(), so this lookup is always linear.
-  return (
-    node.sorted || (node.sorted = lookupSortedKeys(keys.slice(0).sort(), false))
-  );
+  return true;
 }

--- a/src/utilities/common/canonicalStringify.ts
+++ b/src/utilities/common/canonicalStringify.ts
@@ -1,4 +1,20 @@
-// Like JSON.stringify, but with object keys always sorted in the same order.
+/**
+ * Like JSON.stringify, but with object keys always sorted in the same order.
+ *
+ * To achieve performant sorting, this function uses a trie to store the sorted
+ * key names of objects that have already been encountered, bringing "memoized"
+ * sort actions down to O(n) from O(n log n).
+ *
+ * As a drawback, this function will add a little bit more memory for every object
+ * is called with that has different (more, less, a different order) keys than
+ * in the past.
+ *
+ * In a typical application, this should not play a significant role, as
+ * `canonicalStringify` will be called for only a limited number of object shapes,
+ * and the cache will not grow beyond a certain point.
+ * But in some edge cases, this could be a problem, so we provide a `reset` method
+ * that will clear the cache and could be called at intervals from userland.
+ * */
 export const canonicalStringify = Object.assign(
   function canonicalStringify(value: any): string {
     return JSON.stringify(value, stableObjectReplacer);

--- a/src/utilities/common/canonicalStringify.ts
+++ b/src/utilities/common/canonicalStringify.ts
@@ -5,7 +5,10 @@ export const canonicalStringify = Object.assign(
   },
   {
     reset() {
-      // TODO
+      // Blowing away the root-level trie map will reclaim all memory stored in
+      // the trie, without affecting the logical results of canonicalStringify,
+      // but potentially sacrificing performance until the trie is refilled.
+      sortingTrieRoot.next = Object.create(null);
     },
   }
 );
@@ -22,19 +25,54 @@ function stableObjectReplacer(key: string, value: any) {
     // We don't want to mess with objects that are not "plain" objects, which
     // means their prototype is either Object.prototype or null.
     if (proto === Object.prototype || proto === null) {
-      const sorted = Object.create(null);
-      // TODO This sorting step can be sped up in two ways:
-      // 1. If the keys are already sorted, we can skip the sorting step.
-      // 2. If we have sorted this sequence of keys before, we can look up the
-      //    previously sorted sequence in linear time rather than O(n log n)
-      //    time, which is the typical cost of sorting.
-      Object.keys(value)
-        .sort()
-        .forEach((key) => {
+      const keys = Object.keys(value);
+      const sortedKeys = sortKeys(keys);
+      if (sortedKeys !== keys) {
+        const sorted = Object.create(null);
+        // Reassigning the keys in sorted order will cause JSON.stringify to
+        // serialize them in sorted order.
+        sortedKeys.forEach((key) => {
           sorted[key] = value[key];
         });
-      return sorted;
+        return sorted;
+      }
     }
   }
   return value;
+}
+
+interface SortingTrie {
+  sorted?: readonly string[];
+  next: Record<string, SortingTrie>;
+}
+
+const sortingTrieRoot: SortingTrie = {
+  sorted: [],
+  next: Object.create(null),
+};
+
+// Sort the given keys using a lookup trie, and return the same (===) array in
+// case it was already sorted, so we can avoid always creating a new object in
+// the replacer function above.
+function sortKeys(keys: readonly string[]): readonly string[] {
+  let node = sortingTrieRoot;
+  let alreadySorted = true;
+  for (let k = 0, len = keys.length; k < len; ++k) {
+    const key = keys[k];
+    if (k > 0 && keys[k - 1] > key) {
+      alreadySorted = false;
+    }
+    const next = node.next;
+    node = next[key] || (next[key] = { next: Object.create(null) });
+  }
+  if (alreadySorted) {
+    // There may already be a node.sorted array that's equivalent to the
+    // already-sorted keys array, but if keys was already sorted, we always want
+    // to return that array, not node.sorted.
+    return node.sorted ? keys : (node.sorted = keys);
+  }
+  // The .slice(0) is necessary so that we do not modify the original keys array
+  // by calling keys.sort(), and also so that we always return a new (!==)
+  // sorted array when keys was not already sorted.
+  return node.sorted || (node.sorted = keys.slice(0).sort());
 }

--- a/src/utilities/common/canonicalStringify.ts
+++ b/src/utilities/common/canonicalStringify.ts
@@ -29,6 +29,8 @@ export const canonicalStringify = Object.assign(
   }
 );
 
+// Values are JSON-serialized arrays of object keys (in any order), and values
+// are sorted arrays of the same keys.
 const sortingMap = new Map<string, readonly string[]>();
 
 // The JSON.stringify function takes an optional second argument called a
@@ -57,7 +59,7 @@ function stableObjectReplacer(key: string, value: any) {
         sortingMap.set(unsortedKey, sortedKeys);
         sortingMap.set(sortedKey, sortedKeys);
       }
-      const sortedObject = Object.create(Object.getPrototypeOf(value));
+      const sortedObject = Object.create(proto);
       // Reassigning the keys in sorted order will cause JSON.stringify to
       // serialize them in sorted order.
       sortedKeys.forEach((key) => {

--- a/src/utilities/graphql/storeUtils.ts
+++ b/src/utilities/graphql/storeUtils.ts
@@ -198,7 +198,7 @@ const KNOWN_DIRECTIVES: string[] = [
 // Default stable JSON.stringify implementation used by getStoreKeyName. Can be
 // updated/replaced with something better by calling
 // getStoreKeyName.setStringify(newStringifyFunction).
-let storeKeyNameStringify = canonicalStringify;
+let storeKeyNameStringify: (value: any) => string = canonicalStringify;
 
 export const getStoreKeyName = Object.assign(
   function (

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -120,6 +120,7 @@ export * from "./common/makeUniqueId.js";
 export * from "./common/stringifyForDisplay.js";
 export * from "./common/mergeOptions.js";
 export * from "./common/incrementalResult.js";
+export * from "./common/canonicalStringify.js";
 
 export { omitDeep } from "./common/omitDeep.js";
 export { stripTypename } from "./common/stripTypename.js";

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -120,8 +120,8 @@ export * from "./common/makeUniqueId.js";
 export * from "./common/stringifyForDisplay.js";
 export * from "./common/mergeOptions.js";
 export * from "./common/incrementalResult.js";
-export * from "./common/canonicalStringify.js";
 
+export { canonicalStringify } from "./common/canonicalStringify.js";
 export { omitDeep } from "./common/omitDeep.js";
 export { stripTypename } from "./common/stripTypename.js";
 


### PR DESCRIPTION
Because the [`ObjectCanon`](https://github.com/apollographql/apollo-client/blob/main/src/cache/inmemory/object-canon.ts) happens to produce canonical objects whose keys have been sorted alphabetically/lexicographically, it seemed convenient and efficient for implementing a stable `JSON.stringify` utility (see PR #8222), but the additional memory overhead of fully canonizing (duplicating) the objects was probably not justified, especially since (as this PR suggests) an independent implementation of `canonicalStringify` can be even faster while using much less memory.