### PR TITLE
scope `canonicalStringify` to a cache instance

### DIFF
--- a/.changeset/late-horses-invent.md
+++ b/.changeset/late-horses-invent.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+scope `canonicalStringify` to a cache instance

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -138,7 +138,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
               // separation is to include c.callback in the cache key for
               // maybeBroadcastWatch calls. See issue #5733.
               c.callback,
-              canonicalStringify({ optimistic, id, variables })
+              canonicalStringify({ optimistic, id, variables }, this)
             );
           }
         },
@@ -292,7 +292,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     // Defaults to false.
     resetResultIdentities?: boolean;
   }) {
-    canonicalStringify.reset();
+    canonicalStringify.reset(this);
     const ids = this.optimisticData.gc();
     if (options && !this.txCount) {
       if (options.resetResultCache) {
@@ -368,7 +368,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
   public reset(options?: Cache.ResetOptions): Promise<void> {
     this.init();
 
-    canonicalStringify.reset();
+    canonicalStringify.reset(this);
 
     if (options && options.discardWatches) {
       // Similar to what happens in the unsubscribe function returned by

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -57,8 +57,6 @@ import {
   keyFieldsFnFromSpecifier,
 } from "./key-extractor.js";
 
-getStoreKeyName.setStringify(canonicalStringify);
-
 export type TypePolicies = {
   [__typename: string]: TypePolicy;
 };
@@ -803,9 +801,16 @@ export class Policies {
     }
 
     if (storeFieldName === void 0) {
-      storeFieldName = fieldSpec.field
-        ? storeKeyNameFromField(fieldSpec.field, fieldSpec.variables)
-        : getStoreKeyName(fieldName, argsFromFieldSpecifier(fieldSpec));
+      let prev = getStoreKeyName.setStringify((v) =>
+        canonicalStringify(v, this.cache)
+      );
+      try {
+        storeFieldName = fieldSpec.field
+          ? storeKeyNameFromField(fieldSpec.field, fieldSpec.variables)
+          : getStoreKeyName(fieldName, argsFromFieldSpecifier(fieldSpec));
+      } finally {
+        getStoreKeyName.setStringify(prev);
+      }
     }
 
     // Returning false from a keyArgs function is like configuring

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -256,7 +256,7 @@ export class StoreReader {
         query,
         policies,
         variables,
-        varString: canonicalStringify(variables),
+        varString: canonicalStringify(variables, this.config.cache),
         canonizeResults,
         ...extractFragmentContext(query, this.config.fragments),
       },

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -141,7 +141,7 @@ export class StoreWriter {
         return merger.merge(existing, incoming) as T;
       },
       variables,
-      varString: canonicalStringify(variables),
+      varString: canonicalStringify(variables, this.cache),
       ...extractFragmentContext(query, this.fragments),
       overwrite: !!overwrite,
       incomingById: new Map(),

--- a/src/react/hooks/useBackgroundQuery.ts
+++ b/src/react/hooks/useBackgroundQuery.ts
@@ -192,7 +192,7 @@ export function useBackgroundQuery<
 
   const cacheKey: CacheKey = [
     query,
-    canonicalStringify(variables),
+    canonicalStringify(variables, client.cache),
     ...([] as any[]).concat(queryKey),
   ];
 

--- a/src/react/hooks/useSuspenseQuery.ts
+++ b/src/react/hooks/useSuspenseQuery.ts
@@ -184,7 +184,7 @@ export function useSuspenseQuery<
 
   const cacheKey: CacheKey = [
     query,
-    canonicalStringify(variables),
+    canonicalStringify(variables, client.cache),
     ...([] as any[]).concat(queryKey),
   ];
 

--- a/src/testing/matchers/toHaveSuspenseCacheEntryUsing.ts
+++ b/src/testing/matchers/toHaveSuspenseCacheEntryUsing.ts
@@ -27,7 +27,7 @@ export const toHaveSuspenseCacheEntryUsing: MatcherFunction<
 
   const cacheKey: CacheKey = [
     query,
-    canonicalStringify(variables),
+    canonicalStringify(variables, client.cache),
     ...([] as any[]).concat(queryKey),
   ];
   const queryRef = suspenseCache["queryRefs"].lookupArray(cacheKey)?.current;


### PR DESCRIPTION
In the context of #11242 I'm looking into potential memory leaks (with focus on SSR), and something that has come up multiple times in issues is that `canonicalStringify` just keeps growing for people, even if an ApolloClient instance is discarded.

One possible solution for that is #11254, this is yet another suggestion for a fix - I want to build a package and test this locally.

### Checklist:

- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
