### PR TITLE
Improve the QueryManager performance

### DIFF
--- a/src/core/LocalState.ts
+++ b/src/core/LocalState.ts
@@ -104,6 +104,10 @@ export class LocalState<TCacheShape> {
     }
   }
 
+  public getCache() {
+    return this.cache
+  }
+
   public addResolvers(resolvers: Resolvers | Resolvers[]) {
     this.resolvers = this.resolvers || {};
     if (Array.isArray(resolvers)) {

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -32,6 +32,7 @@ import {
   asyncMap,
   isNonEmptyArray,
   Concast,
+  StoreObject,
   makeUniqueId,
   isDocumentNode,
   isNonNullObject,
@@ -1082,9 +1083,8 @@ export class QueryManager<TStore> {
         query: serverQuery,
         variables,
         operationName: getOperationName(serverQuery) || void 0,
-        context: this.prepareContext({
-          ...context,
-          forceFetch: !deduplication,
+        context: this.prepareContext(context, {
+          forceFetch: !deduplication
         }),
       };
 
@@ -1664,10 +1664,16 @@ export class QueryManager<TStore> {
     return this.queries.get(queryId)!;
   }
 
-  private prepareContext(context = {}) {
-    const newContext = this.localState.prepareContext(context);
+  private prepareContext(context = {}, options?: {}) {
+    const cache = this.localState.getCache()
     return {
-      ...newContext,
+      ...context,
+      ...options,
+      cache,
+      // Getting an entry's cache key is useful for local state resolvers.
+      getCacheKey(obj: StoreObject) {
+        return cache.identify(obj);
+      },
       clientAwareness: this.clientAwareness,
     };
   }

--- a/src/link/utils/createOperation.ts
+++ b/src/link/utils/createOperation.ts
@@ -12,7 +12,7 @@ export function createOperation(
       context = { ...context, ...next };
     }
   };
-  const getContext = () => ({ ...context });
+  const getContext = () => context;
 
   Object.defineProperty(operation, "setContext", {
     enumerable: false,


### PR DESCRIPTION
When there are a lot of queries and the context object is very large, cloning the context object becomes expensive and adds to the latency of a scenario. We can reduce the number of times we clone the context object to improve performance.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
