### PR TITLE
Don't crash if some (but not all) Error Codes are loaded

### DIFF
--- a/.changeset/heavy-camels-double.md
+++ b/.changeset/heavy-camels-double.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix a bug that allows to only call `loadErrorMessages` without also calling `loadDevErrorMessages`.

--- a/src/dev/loadErrorMessageHandler.ts
+++ b/src/dev/loadErrorMessageHandler.ts
@@ -16,7 +16,7 @@ export function loadErrorMessageHandler(...errorCodes: ErrorCodes[]) {
   function handler(message: string | number, args: unknown[]) {
     if (typeof message === "number") {
       const definition = global[ApolloErrorMessageHandler]![message];
-      if (!message || !definition.message) return;
+      if (!message || !definition?.message) return;
       message = definition.message;
     }
     return args.reduce<string>(

--- a/src/utilities/globals/__tests__/invariantWrappers.test.ts
+++ b/src/utilities/globals/__tests__/invariantWrappers.test.ts
@@ -99,3 +99,20 @@ test("invariant.log(5, ...), with handlers", () => {
     { a: 1 }
   );
 });
+
+test("base invariant(false, 6, ...), raises fallback", () => {
+  using _ = mockErrorMessageHandler();
+  expect(() => {
+    invariant(false, 6, "hello");
+  }).toThrow(
+    new InvariantError(
+      'An error occurred! For more details, see the full error text at https://go.apollo.dev/c/err#' +
+      encodeURIComponent(
+        JSON.stringify({
+          version: "local",
+          message: 6,
+          args: ["hello"],
+        })
+      )
+    ));
+});

--- a/src/utilities/globals/__tests__/invariantWrappers.test.ts
+++ b/src/utilities/globals/__tests__/invariantWrappers.test.ts
@@ -106,13 +106,14 @@ test("base invariant(false, 6, ...), raises fallback", () => {
     invariant(false, 6, "hello");
   }).toThrow(
     new InvariantError(
-      'An error occurred! For more details, see the full error text at https://go.apollo.dev/c/err#' +
-      encodeURIComponent(
-        JSON.stringify({
-          version: "local",
-          message: 6,
-          args: ["hello"],
-        })
-      )
-    ));
+      "An error occurred! For more details, see the full error text at https://go.apollo.dev/c/err#" +
+        encodeURIComponent(
+          JSON.stringify({
+            version: "local",
+            message: 6,
+            args: ["hello"],
+          })
+        )
+    )
+  );
 });


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

<!--
### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
-->

### Problem

I call `loadErrorMessages()` but not `loadDevErrorMessages()` on application startup. When a "dev" error code is encountered, I get the following error:
```
| TypeError: Cannot read properties of undefined (reading 'message')
|     at handler (.../node_modules/@apollo/client/dev/dev.cjs:613:41)
|     at getErrorMsg (.../node_modules/@apollo/client/utilities/globals/globals.cjs:85:44)
|     at Function.warn (.../node_modules/@apollo/client/utilities/globals/globals.cjs:48:16)
|     at Object.useSubscription (.../node_modules/@apollo/client/react/hooks/hooks.cjs:550:63)
|     ...
```

### Proposed Solution

It seems reasonable for unloaded error codes revert to the fallback, rather than causing the app to crash.