### PR TITLE
feat(performance): cache internal fieldNameFromStoreName

### DIFF
--- a/.changeset/unlucky-carrots-hunt.md
+++ b/.changeset/unlucky-carrots-hunt.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": minor
+---
+
+improves InMemory cache performance by caching fieldNameFromStoreNameCache results

--- a/src/cache/inmemory/helpers.ts
+++ b/src/cache/inmemory/helpers.ts
@@ -96,9 +96,18 @@ export function getTypenameFromStoreObject(
 
 export const TypeOrFieldNameRegExp = /^[_a-z][_0-9a-z]*/i;
 
+const fieldNameFromStoreNameCache: { [storeFieldName: string]: string } = {};
+
 export function fieldNameFromStoreName(storeFieldName: string): string {
+  if (fieldNameFromStoreNameCache[storeFieldName])
+    return fieldNameFromStoreNameCache[storeFieldName];
+
   const match = storeFieldName.match(TypeOrFieldNameRegExp);
-  return match ? match[0] : storeFieldName;
+  const value = match ? match[0] : storeFieldName;
+
+  fieldNameFromStoreNameCache[storeFieldName] = value;
+
+  return value;
 }
 
 export function selectionSetMatchesResult(


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
### What changed

We noticed in our rather large app that some simple `useQuery` methods were taking some time to render, particularly on low end devices. I started to profile the app (a react-native app) and noticed that this `fieldNameFromStore` function was taking 11ms on a single `useQuery` hook.

![Screenshot 2023-10-13 at 12 59 22 PM](https://github.com/apollographql/apollo-client/assets/17029928/7737e487-ec2b-49a5-98c6-89beb3e53e4f)

The regex, although well optimized. is still relatively expensive to run due to the sheer number of times this utility is ran.

We have a rather large application and on initial app load, `fieldNameFromStore` ends up being called 24000 times, which results in about 33ms of time. With this caching in place, this was reduced down to about 17ms, which is almost a 50% performance gain. The increased memory size due to the cache is minor - for our application (approx 9KB - calculated by just JSON.stringifying the in-memory cache and saving a file).

