### PR TITLE
Add an explicit return type for `useReadQuery`

### DIFF
--- a/.api-reports/api-report-react.md
+++ b/.api-reports/api-report-react.md
@@ -2101,11 +2101,17 @@ export function useQuery<TData = any, TVariables extends OperationVariables = Op
 export function useReactiveVar<T>(rv: ReactiveVar<T>): T;
 
 // @public (undocumented)
-export function useReadQuery<TData>(queryRef: QueryReference<TData>): {
+export function useReadQuery<TData>(queryRef: QueryReference<TData>): UseReadQueryResult<TData>;
+
+// @public (undocumented)
+export interface UseReadQueryResult<TData = unknown> {
+    // (undocumented)
     data: TData;
-    networkStatus: NetworkStatus;
+    // (undocumented)
     error: ApolloError | undefined;
-};
+    // (undocumented)
+    networkStatus: NetworkStatus;
+}
 
 // @public (undocumented)
 export function useSubscription<TData = any, TVariables extends OperationVariables = OperationVariables>(subscription: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: SubscriptionHookOptions<NoInfer<TData>, NoInfer<TVariables>>): SubscriptionResult<TData, TVariables>;

--- a/.api-reports/api-report-react_hooks.md
+++ b/.api-reports/api-report-react_hooks.md
@@ -1988,11 +1988,17 @@ export function useQuery<TData = any, TVariables extends OperationVariables = Op
 export function useReactiveVar<T>(rv: ReactiveVar<T>): T;
 
 // @public (undocumented)
-export function useReadQuery<TData>(queryRef: QueryReference<TData>): {
+export function useReadQuery<TData>(queryRef: QueryReference<TData>): UseReadQueryResult<TData>;
+
+// @public (undocumented)
+export interface UseReadQueryResult<TData = unknown> {
+    // (undocumented)
     data: TData;
-    networkStatus: NetworkStatus;
+    // (undocumented)
     error: ApolloError | undefined;
-};
+    // (undocumented)
+    networkStatus: NetworkStatus;
+}
 
 // Warning: (ae-forgotten-export) The symbol "SubscriptionHookOptions" needs to be exported by the entry point index.d.ts
 //

--- a/.api-reports/api-report.md
+++ b/.api-reports/api-report.md
@@ -2742,11 +2742,17 @@ export function useQuery<TData = any, TVariables extends OperationVariables = Op
 export function useReactiveVar<T>(rv: ReactiveVar<T>): T;
 
 // @public (undocumented)
-export function useReadQuery<TData>(queryRef: QueryReference<TData>): {
+export function useReadQuery<TData>(queryRef: QueryReference<TData>): UseReadQueryResult<TData>;
+
+// @public (undocumented)
+export interface UseReadQueryResult<TData = unknown> {
+    // (undocumented)
     data: TData;
-    networkStatus: NetworkStatus;
+    // (undocumented)
     error: ApolloError | undefined;
-};
+    // (undocumented)
+    networkStatus: NetworkStatus;
+}
 
 // @public (undocumented)
 export function useSubscription<TData = any, TVariables extends OperationVariables = OperationVariables>(subscription: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: SubscriptionHookOptions<NoInfer<TData>, NoInfer<TVariables>>): SubscriptionResult<TData, TVariables>;

--- a/.changeset/good-experts-repair.md
+++ b/.changeset/good-experts-repair.md
@@ -2,4 +2,4 @@
 "@apollo/client": patch
 ---
 
-Add an explicit `UseReadQueryResult` TypeScript type for the `useReadQuery` hook.
+Add an explicit return type for the `useReadQuery` hook called `UseReadQueryResult`. Previously the return type of this hook was inferred from the return value.

--- a/.changeset/good-experts-repair.md
+++ b/.changeset/good-experts-repair.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Add an explicit `UseReadQueryResult` TypeScript type for the `useReadQuery` hook.

--- a/src/react/hooks/index.ts
+++ b/src/react/hooks/index.ts
@@ -11,6 +11,7 @@ export type { UseSuspenseQueryResult } from "./useSuspenseQuery.js";
 export { useSuspenseQuery } from "./useSuspenseQuery.js";
 export type { UseBackgroundQueryResult } from "./useBackgroundQuery.js";
 export { useBackgroundQuery } from "./useBackgroundQuery.js";
+export type { UseReadQueryResult } from "./useReadQuery.js";
 export { useReadQuery } from "./useReadQuery.js";
 export { skipToken } from "./constants.js";
 export type { SkipToken } from "./constants.js";

--- a/src/react/hooks/useReadQuery.ts
+++ b/src/react/hooks/useReadQuery.ts
@@ -5,8 +5,18 @@ import { __use } from "./internal/index.js";
 import { toApolloError } from "./useSuspenseQuery.js";
 import { invariant } from "../../utilities/globals/index.js";
 import { useSyncExternalStore } from "./useSyncExternalStore.js";
+import type { ApolloError } from "../../errors/index.js";
+import type { NetworkStatus } from "../../core/index.js";
 
-export function useReadQuery<TData>(queryRef: QueryReference<TData>) {
+export interface UseReadQueryResult<TData = unknown> {
+  data: TData;
+  error: ApolloError | undefined;
+  networkStatus: NetworkStatus;
+}
+
+export function useReadQuery<TData>(
+  queryRef: QueryReference<TData>
+): UseReadQueryResult<TData> {
   const internalQueryRef = unwrapQueryRef(queryRef);
   invariant(
     internalQueryRef.promiseCache,

--- a/src/react/hooks/useReadQuery.ts
+++ b/src/react/hooks/useReadQuery.ts
@@ -9,8 +9,27 @@ import type { ApolloError } from "../../errors/index.js";
 import type { NetworkStatus } from "../../core/index.js";
 
 export interface UseReadQueryResult<TData = unknown> {
+  /**
+   * An object containing the result of your GraphQL query after it completes.
+   *
+   * This value might be `undefined` if a query results in one or more errors
+   * (depending on the query's `errorPolicy`).
+   */
   data: TData;
+  /**
+   * If the query produces one or more errors, this object contains either an
+   * array of `graphQLErrors` or a single `networkError`. Otherwise, this value
+   * is `undefined`.
+   *
+   * This property can be ignored when using the default `errorPolicy` or an
+   * `errorPolicy` of `none`. The hook will throw the error instead of setting
+   * this property.
+   */
   error: ApolloError | undefined;
+  /**
+   * A number indicating the current network state of the query's associated
+   * request. {@link https://github.com/apollographql/apollo-client/blob/d96f4578f89b933c281bb775a39503f6cdb59ee8/src/core/networkStatus.ts#L4 | See possible values}.
+   */
   networkStatus: NetworkStatus;
 }
 


### PR DESCRIPTION
The `useReadQuery` hook currently uses type inference for the return type from the hook. For consistency, I added a `UseReadQueryResult` type that can be used to get a typed return type rather than having to rely on `typeof useReadQuery`, which doesn't allow the use of the generic `TData` type argument.

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
