### PR TITLE
update circleci secops orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  secops: apollo/circleci-secops-orb@2.0.0
+  secops: apollo/circleci-secops-orb@2.0.1
 
 jobs:
   # Filesize:


### PR DESCRIPTION
## Motivation / Implements

This updates the version of the circleci-secops-orb used by apollo-client. This change will address ongoing issues with running Gitleaks scans on PRs from forks. 

This PR was open by @peakematt via a second Github account to validate that gitleaks will now run successfully on a pull request from a fork. 