### PR TITLE
bump engines field to include npm 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "changeset-version": "changeset version && npm i"
   },
   "engines": {
-    "npm": "^7.20.3 || ^8.0.0 || ^9.0.0"
+    "npm": "^7.20.3 || ^8.0.0 || ^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0",


### PR DESCRIPTION
Seems CI is failing since it's now using npm 10. Bumping the version.

### Checklist:

- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
