### PR TITLE
Fix link to localhost in react-native.md

### DIFF
--- a/docs/source/integrations/react-native.md
+++ b/docs/source/integrations/react-native.md
@@ -17,7 +17,7 @@ import { ApolloClient, InMemoryCache, ApolloProvider } from '@apollo/client';
 
 // Initialize Apollo Client
 const client = new ApolloClient({
-  uri: 'localhost:4000/graphql',
+  uri: 'http://localhost:4000/graphql',
   cache: new InMemoryCache()
 });
 


### PR DESCRIPTION
Without the `http://` prefix, a "No suitable URL request handler found" error will occur. See https://stackoverflow.com/questions/38099684/no-suitable-url-request-handler-found This really confused me and made me spend a lot of time trying to figure out what went wrong. The other example in the same document already includes this prefix properly.

### Checklist:

- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
