### PR TITLE
Introduce IDE-only `tsconfig.json` to check tests too.

### DIFF
--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,0 +1,14 @@
+// `tsconfig.json` for the editor only
+// this config includes additional files (e.g. tests) that
+// we don't want to see hooked up to the main build
+// it can also add a few more types for that purpose
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "lib": ["es2015", "esnext.asynciterable", "dom"],
+    "types": ["jest", "node", "./testing/matchers/index.d.ts"]
+  },
+  "extends": "../tsconfig.json",
+  "include": ["./**/*.ts", "./**/*.tsx"],
+  "exclude": []
+}

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,3 +1,3 @@
 {
-  "extends": "src/tsconfig.json"
+  "extends": "./src/tsconfig.json"
 }

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,5 +1,3 @@
 {
-  "extends": "./tsconfig.json",
-  "include": ["src/**/__tests__/**/*.ts", "src/**/__tests__/**/*.tsx"],
-  "exclude": []
+  "extends": "src/tsconfig.json",
 }

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,3 +1,3 @@
 {
-  "extends": "src/tsconfig.json",
+  "extends": "src/tsconfig.json"
 }


### PR DESCRIPTION
This creates a new `tsconfig.json` in `src` that will be picked up by VSCode and apply the rules of the parent `tsconfig.json` to tests as well - without tooling that relies on the `<root>/tsconfig.json` (e.g. the build steps) having to pick up all the test files.

It should also fix the matcher inclusion problem (`toRerender` in `expect(ProfiledHook).not.toRerender();` being unknown unless another editor window has the `matches/index.d.ts` open).

I'm opening this PR against the `strict: true` PR as that PR fixes a lot of problems we'd otherwise see in our tests.