### PR TITLE
fix up type in 3.9 branch after merge

### DIFF
--- a/.api-reports/api-report-testing.md
+++ b/.api-reports/api-report-testing.md
@@ -880,7 +880,7 @@ export interface MockedProviderProps<TSerializedCache = {}> {
     // (undocumented)
     link?: ApolloLink;
     // (undocumented)
-    mocks?: ReadonlyArray<MockedResponse>;
+    mocks?: ReadonlyArray<MockedResponse<any, any>>;
     // (undocumented)
     resolvers?: Resolvers;
     // (undocumented)

--- a/.api-reports/api-report-testing.md
+++ b/.api-reports/api-report-testing.md
@@ -925,7 +925,7 @@ interface MockedSubscriptionResult {
 
 // @public (undocumented)
 export class MockLink extends ApolloLink {
-    constructor(mockedResponses: ReadonlyArray<MockedResponse>, addTypename?: Boolean, options?: MockLinkOptions);
+    constructor(mockedResponses: ReadonlyArray<MockedResponse<any, any>>, addTypename?: Boolean, options?: MockLinkOptions);
     // (undocumented)
     addMockedResponse(mockedResponse: MockedResponse): void;
     // (undocumented)

--- a/.api-reports/api-report-testing_core.md
+++ b/.api-reports/api-report-testing_core.md
@@ -879,7 +879,7 @@ interface MockedSubscriptionResult {
 
 // @public (undocumented)
 export class MockLink extends ApolloLink {
-    constructor(mockedResponses: ReadonlyArray<MockedResponse>, addTypename?: Boolean, options?: MockLinkOptions);
+    constructor(mockedResponses: ReadonlyArray<MockedResponse<any, any>>, addTypename?: Boolean, options?: MockLinkOptions);
     // (undocumented)
     addMockedResponse(mockedResponse: MockedResponse): void;
     // (undocumented)

--- a/src/testing/core/mocking/mockLink.ts
+++ b/src/testing/core/mocking/mockLink.ts
@@ -57,7 +57,7 @@ export class MockLink extends ApolloLink {
   private mockedResponsesByKey: { [key: string]: MockedResponse[] } = {};
 
   constructor(
-    mockedResponses: ReadonlyArray<MockedResponse>,
+    mockedResponses: ReadonlyArray<MockedResponse<any, any>>,
     addTypename: Boolean = true,
     options: MockLinkOptions = Object.create(null)
   ) {

--- a/src/testing/react/MockedProvider.tsx
+++ b/src/testing/react/MockedProvider.tsx
@@ -11,7 +11,7 @@ import type { Resolvers } from "../../core/index.js";
 import type { ApolloCache } from "../../cache/index.js";
 
 export interface MockedProviderProps<TSerializedCache = {}> {
-  mocks?: ReadonlyArray<MockedResponse>;
+  mocks?: ReadonlyArray<MockedResponse<any, any>>;
   addTypename?: boolean;
   defaultOptions?: DefaultOptions;
   cache?: ApolloCache<TSerializedCache>;


### PR DESCRIPTION
Doing this as a PR to check in CI if this fixes up all the type problems we got by merging `main` into `3.9`.

The problem seems to have been introduced by adding the `variableMatcher?: VariableMatcher<TVariables>;` property and also referencing `TVariables` in the `ResultFunction` signature for `result`, both over in #11178.