### PR TITLE
Doc update: Remove { breed: 'new_dog_breed' } from queries.mdx

### DIFF
--- a/docs/source/data/queries.mdx
+++ b/docs/source/data/queries.mdx
@@ -155,7 +155,7 @@ function DogPhoto({ breed }) {
   return (
     <div>
       <img src={data.dog.displayImage} style={{ height: 100, width: 100 }} />
-      <button onClick={() => refetch({ breed: 'new_dog_breed' })}>
+      <button onClick={() => refetch()}>
         Refetch new breed!
       </button>
     </div>
@@ -211,7 +211,7 @@ function DogPhoto({ breed }) {
   return (
     <div>
       <img src={data.dog.displayImage} style={{ height: 100, width: 100 }} />
-      <button onClick={() => refetch({ breed: 'new_dog_breed' })}>
+      <button onClick={() => refetch()}>
         Refetch!
       </button>
     </div>


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

Hello! I found copy-pasting these bits of code from the docs to be confusing since I would get broken dog images as a result of using it. Turns out it was because refetch was sending `new_dog_breed` as a variable which isn't a dog breed.

<img width="357" alt="Screen Shot 2023-11-16 at 10 01 43 PM" src="https://github.com/apollographql/apollo-client/assets/5070227/b5be48ef-e838-4de7-9e29-7749ef4fe11d">


Anyways, I think this will hopefully help a future newb like me not spend more time than necessary on this section, chasing an unknown bug. There is also already a more [in-depth explanation](https://www.apollographql.com/docs/react/data/queries/#providing-new-variables-to-refetch) in the docs about how this would work.
