### PR TITLE
Clarify types of `EntityStore.makeCacheKey`

### DIFF
--- a/.api-reports/api-report-cache.md
+++ b/.api-reports/api-report-cache.md
@@ -355,6 +355,12 @@ export abstract class EntityStore implements NormalizedCache {
     // (undocumented)
     protected lookup(dataId: string, dependOnExistence?: boolean): StoreObject | undefined;
     // (undocumented)
+    makeCacheKey(document: DocumentNode, callback: Cache_2.WatchCallback<any>, details: string): object;
+    // (undocumented)
+    makeCacheKey(selectionSet: SelectionSetNode, parent: string | StoreObject, varString: string | undefined, canonizeResults: boolean): object;
+    // (undocumented)
+    makeCacheKey(field: FieldNode, array: readonly any[], varString: string | undefined): object;
+    // (undocumented)
     makeCacheKey(...args: any[]): object;
     // (undocumented)
     merge(older: string | StoreObject, newer: StoreObject | string): void;

--- a/.api-reports/api-report-core.md
+++ b/.api-reports/api-report-core.md
@@ -670,6 +670,12 @@ abstract class EntityStore implements NormalizedCache {
     // (undocumented)
     protected lookup(dataId: string, dependOnExistence?: boolean): StoreObject | undefined;
     // (undocumented)
+    makeCacheKey(document: DocumentNode, callback: Cache_2.WatchCallback<any>, details: string): object;
+    // (undocumented)
+    makeCacheKey(selectionSet: SelectionSetNode, parent: string | StoreObject, varString: string | undefined, canonizeResults: boolean): object;
+    // (undocumented)
+    makeCacheKey(field: FieldNode, array: readonly any[], varString: string | undefined): object;
+    // (undocumented)
     makeCacheKey(...args: any[]): object;
     // (undocumented)
     merge(older: string | StoreObject, newer: StoreObject | string): void;

--- a/.api-reports/api-report-utilities.md
+++ b/.api-reports/api-report-utilities.md
@@ -827,6 +827,12 @@ abstract class EntityStore implements NormalizedCache {
     // (undocumented)
     protected lookup(dataId: string, dependOnExistence?: boolean): StoreObject | undefined;
     // (undocumented)
+    makeCacheKey(document: DocumentNode, callback: Cache_2.WatchCallback<any>, details: string): object;
+    // (undocumented)
+    makeCacheKey(selectionSet: SelectionSetNode, parent: string | StoreObject, varString: string | undefined, canonizeResults: boolean): object;
+    // (undocumented)
+    makeCacheKey(field: FieldNode, array: readonly any[], varString: string | undefined): object;
+    // (undocumented)
     makeCacheKey(...args: any[]): object;
     // (undocumented)
     merge(older: string | StoreObject, newer: StoreObject | string): void;

--- a/.api-reports/api-report.md
+++ b/.api-reports/api-report.md
@@ -831,6 +831,12 @@ abstract class EntityStore implements NormalizedCache {
     // (undocumented)
     protected lookup(dataId: string, dependOnExistence?: boolean): StoreObject | undefined;
     // (undocumented)
+    makeCacheKey(document: DocumentNode, callback: Cache_2.WatchCallback<any>, details: string): object;
+    // (undocumented)
+    makeCacheKey(selectionSet: SelectionSetNode, parent: string | StoreObject, varString: string | undefined, canonizeResults: boolean): object;
+    // (undocumented)
+    makeCacheKey(field: FieldNode, array: readonly any[], varString: string | undefined): object;
+    // (undocumented)
     makeCacheKey(...args: any[]): object;
     // (undocumented)
     merge(older: string | StoreObject, newer: StoreObject | string): void;

--- a/.changeset/thick-mice-collect.md
+++ b/.changeset/thick-mice-collect.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Clarify types of `EntityStore.makeCacheKey`.

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -32,6 +32,7 @@ import type {
   DeleteModifier,
   ModifierDetails,
 } from "../core/types/common.js";
+import type { DocumentNode, FieldNode, SelectionSetNode } from "graphql";
 
 const DELETE: DeleteModifier = Object.create(null);
 const delModifier: Modifier<any> = () => DELETE;
@@ -522,7 +523,25 @@ export abstract class EntityStore implements NormalizedCache {
   }
 
   // Used to compute cache keys specific to this.group.
-  public makeCacheKey(...args: any[]): object;
+  /** overload for `InMemoryCache.maybeBroadcastWatch` */
+  public makeCacheKey(
+    document: DocumentNode,
+    callback: Cache.WatchCallback<any>,
+    details: string
+  ): object;
+  /** overload for `StoreReader.executeSelectionSet` */
+  public makeCacheKey(
+    selectionSet: SelectionSetNode,
+    parent: string /* = ( Reference.__ref ) */ | StoreObject,
+    varString: string | undefined,
+    canonizeResults: boolean
+  ): object;
+  /** overload for `StoreReader.executeSubSelectedArray` */
+  public makeCacheKey(
+    field: FieldNode,
+    array: readonly any[],
+    varString: string | undefined
+  ): object;
   public makeCacheKey() {
     return this.group.keyMaker.lookupArray(arguments);
   }

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -542,6 +542,9 @@ export abstract class EntityStore implements NormalizedCache {
     array: readonly any[],
     varString: string | undefined
   ): object;
+  /** @deprecated This is only meant for internal usage,
+   * in your own code please use a `Trie` instance instead. */
+  public makeCacheKey(...args: any[]): object;
   public makeCacheKey() {
     return this.group.keyMaker.lookupArray(arguments);
   }

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -153,6 +153,10 @@ export class StoreReader {
 
     this.canon = config.canon || new ObjectCanon();
 
+    // memoized functions in this class will be "garbage-collected"
+    // by recreating the whole `StoreReader` in
+    // `InMemoryCache.resetResultsCache`
+    // (triggered from `InMemoryCache.gc` with `resetResultCache: true`)
     this.executeSelectionSet = wrap(
       (options) => {
         const { canonizeResults } = options.context;


### PR DESCRIPTION
This is just a clarification to internal types to make it more apparent where/how `keyMaker` is used.

I don't expect this has been used by anyone outside of the AC core, but in case it was used in other places, I've kept the original "generic" overload, but added a `@deprecated` comment with a note to please use a custom `Trie` instance instead.

### Checklist:

- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
