### PR TITLE
`DocumentTransform`: use a `WeakCache`

### DIFF
--- a/.api-reports/api-report-core.md
+++ b/.api-reports/api-report-core.md
@@ -601,7 +601,7 @@ export class DocumentTransform {
     // (undocumented)
     static identity(): DocumentTransform;
     // (undocumented)
-    resetCache(): void;
+    resetCache(enableCaching?: boolean): void;
     // (undocumented)
     static split(predicate: (document: DocumentNode) => boolean, left: DocumentTransform, right?: DocumentTransform): DocumentTransform;
     // (undocumented)

--- a/.api-reports/api-report-core.md
+++ b/.api-reports/api-report-core.md
@@ -595,7 +595,7 @@ export class DocumentTransform {
     concat(otherTransform: DocumentTransform): DocumentTransform;
     // (undocumented)
     getStableCacheEntry(document: DocumentNode): {
-        key: DocumentTransformCacheKey;
+        key?: undefined;
         value?: DocumentNode | undefined;
     } | undefined;
     // (undocumented)

--- a/.api-reports/api-report-react.md
+++ b/.api-reports/api-report-react.md
@@ -722,7 +722,7 @@ class DocumentTransform {
     concat(otherTransform: DocumentTransform): DocumentTransform;
     // (undocumented)
     getStableCacheEntry(document: DocumentNode): {
-        key: DocumentTransformCacheKey;
+        key?: undefined;
         value?: DocumentNode | undefined;
     } | undefined;
     // (undocumented)
@@ -742,6 +742,8 @@ type DocumentTransformCacheKey = ReadonlyArray<unknown>;
 interface DocumentTransformOptions {
     // (undocumented)
     cache?: boolean;
+    // Warning: (ae-forgotten-export) The symbol "DocumentTransformCacheKey" needs to be exported by the entry point index.d.ts
+    //
     // (undocumented)
     getCacheKey?: (document: DocumentNode) => DocumentTransformCacheKey | undefined;
 }
@@ -2221,7 +2223,6 @@ interface WatchQueryOptions<TVariables extends OperationVariables = OperationVar
 // src/core/watchQueryOptions.ts:191:3 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:26:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:27:3 - (ae-forgotten-export) The symbol "RefetchFunction" needs to be exported by the entry point index.d.ts
-// src/utilities/graphql/DocumentTransform.ts:130:7 - (ae-forgotten-export) The symbol "DocumentTransformCacheKey" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report-react.md
+++ b/.api-reports/api-report-react.md
@@ -728,7 +728,7 @@ class DocumentTransform {
     // (undocumented)
     static identity(): DocumentTransform;
     // (undocumented)
-    resetCache(): void;
+    resetCache(enableCaching?: boolean): void;
     // (undocumented)
     static split(predicate: (document: DocumentNode) => boolean, left: DocumentTransform, right?: DocumentTransform): DocumentTransform;
     // (undocumented)

--- a/.api-reports/api-report-react_components.md
+++ b/.api-reports/api-report-react_components.md
@@ -629,7 +629,7 @@ class DocumentTransform {
     concat(otherTransform: DocumentTransform): DocumentTransform;
     // (undocumented)
     getStableCacheEntry(document: DocumentNode): {
-        key: DocumentTransformCacheKey;
+        key?: undefined;
         value?: DocumentNode | undefined;
     } | undefined;
     // (undocumented)
@@ -649,6 +649,8 @@ type DocumentTransformCacheKey = ReadonlyArray<unknown>;
 interface DocumentTransformOptions {
     // (undocumented)
     cache?: boolean;
+    // Warning: (ae-forgotten-export) The symbol "DocumentTransformCacheKey" needs to be exported by the entry point index.d.ts
+    //
     // (undocumented)
     getCacheKey?: (document: DocumentNode) => DocumentTransformCacheKey | undefined;
 }
@@ -1753,7 +1755,6 @@ interface WatchQueryOptions<TVariables extends OperationVariables = OperationVar
 // src/core/types.ts:178:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:205:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:191:3 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
-// src/utilities/graphql/DocumentTransform.ts:130:7 - (ae-forgotten-export) The symbol "DocumentTransformCacheKey" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report-react_components.md
+++ b/.api-reports/api-report-react_components.md
@@ -635,7 +635,7 @@ class DocumentTransform {
     // (undocumented)
     static identity(): DocumentTransform;
     // (undocumented)
-    resetCache(): void;
+    resetCache(enableCaching?: boolean): void;
     // (undocumented)
     static split(predicate: (document: DocumentNode) => boolean, left: DocumentTransform, right?: DocumentTransform): DocumentTransform;
     // (undocumented)

--- a/.api-reports/api-report-react_context.md
+++ b/.api-reports/api-report-react_context.md
@@ -612,7 +612,7 @@ class DocumentTransform {
     concat(otherTransform: DocumentTransform): DocumentTransform;
     // (undocumented)
     getStableCacheEntry(document: DocumentNode): {
-        key: DocumentTransformCacheKey;
+        key?: undefined;
         value?: DocumentNode | undefined;
     } | undefined;
     // (undocumented)
@@ -632,6 +632,8 @@ type DocumentTransformCacheKey = ReadonlyArray<unknown>;
 interface DocumentTransformOptions {
     // (undocumented)
     cache?: boolean;
+    // Warning: (ae-forgotten-export) The symbol "DocumentTransformCacheKey" needs to be exported by the entry point index.d.ts
+    //
     // (undocumented)
     getCacheKey?: (document: DocumentNode) => DocumentTransformCacheKey | undefined;
 }
@@ -1649,7 +1651,6 @@ interface WatchQueryOptions<TVariables extends OperationVariables = OperationVar
 // src/core/types.ts:178:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:205:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:191:3 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
-// src/utilities/graphql/DocumentTransform.ts:130:7 - (ae-forgotten-export) The symbol "DocumentTransformCacheKey" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report-react_context.md
+++ b/.api-reports/api-report-react_context.md
@@ -618,7 +618,7 @@ class DocumentTransform {
     // (undocumented)
     static identity(): DocumentTransform;
     // (undocumented)
-    resetCache(): void;
+    resetCache(enableCaching?: boolean): void;
     // (undocumented)
     static split(predicate: (document: DocumentNode) => boolean, left: DocumentTransform, right?: DocumentTransform): DocumentTransform;
     // (undocumented)

--- a/.api-reports/api-report-react_hoc.md
+++ b/.api-reports/api-report-react_hoc.md
@@ -614,7 +614,7 @@ class DocumentTransform {
     concat(otherTransform: DocumentTransform): DocumentTransform;
     // (undocumented)
     getStableCacheEntry(document: DocumentNode): {
-        key: DocumentTransformCacheKey;
+        key?: undefined;
         value?: DocumentNode | undefined;
     } | undefined;
     // (undocumented)
@@ -634,6 +634,8 @@ type DocumentTransformCacheKey = ReadonlyArray<unknown>;
 interface DocumentTransformOptions {
     // (undocumented)
     cache?: boolean;
+    // Warning: (ae-forgotten-export) The symbol "DocumentTransformCacheKey" needs to be exported by the entry point index.d.ts
+    //
     // (undocumented)
     getCacheKey?: (document: DocumentNode) => DocumentTransformCacheKey | undefined;
 }
@@ -1694,7 +1696,6 @@ export function withSubscription<TProps extends TGraphQLVariables | {} = {}, TDa
 // src/core/types.ts:178:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:205:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:191:3 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
-// src/utilities/graphql/DocumentTransform.ts:130:7 - (ae-forgotten-export) The symbol "DocumentTransformCacheKey" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report-react_hoc.md
+++ b/.api-reports/api-report-react_hoc.md
@@ -620,7 +620,7 @@ class DocumentTransform {
     // (undocumented)
     static identity(): DocumentTransform;
     // (undocumented)
-    resetCache(): void;
+    resetCache(enableCaching?: boolean): void;
     // (undocumented)
     static split(predicate: (document: DocumentNode) => boolean, left: DocumentTransform, right?: DocumentTransform): DocumentTransform;
     // (undocumented)

--- a/.api-reports/api-report-react_hooks.md
+++ b/.api-reports/api-report-react_hooks.md
@@ -699,7 +699,7 @@ class DocumentTransform {
     // (undocumented)
     static identity(): DocumentTransform;
     // (undocumented)
-    resetCache(): void;
+    resetCache(enableCaching?: boolean): void;
     // (undocumented)
     static split(predicate: (document: DocumentNode) => boolean, left: DocumentTransform, right?: DocumentTransform): DocumentTransform;
     // (undocumented)

--- a/.api-reports/api-report-react_hooks.md
+++ b/.api-reports/api-report-react_hooks.md
@@ -693,7 +693,7 @@ class DocumentTransform {
     concat(otherTransform: DocumentTransform): DocumentTransform;
     // (undocumented)
     getStableCacheEntry(document: DocumentNode): {
-        key: DocumentTransformCacheKey;
+        key?: undefined;
         value?: DocumentNode | undefined;
     } | undefined;
     // (undocumented)
@@ -713,6 +713,8 @@ type DocumentTransformCacheKey = ReadonlyArray<unknown>;
 interface DocumentTransformOptions {
     // (undocumented)
     cache?: boolean;
+    // Warning: (ae-forgotten-export) The symbol "DocumentTransformCacheKey" needs to be exported by the entry point index.d.ts
+    //
     // (undocumented)
     getCacheKey?: (document: DocumentNode) => DocumentTransformCacheKey | undefined;
 }
@@ -2115,7 +2117,6 @@ interface WatchQueryOptions<TVariables extends OperationVariables = OperationVar
 // src/core/watchQueryOptions.ts:191:3 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:26:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:27:3 - (ae-forgotten-export) The symbol "RefetchFunction" needs to be exported by the entry point index.d.ts
-// src/utilities/graphql/DocumentTransform.ts:130:7 - (ae-forgotten-export) The symbol "DocumentTransformCacheKey" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report-react_ssr.md
+++ b/.api-reports/api-report-react_ssr.md
@@ -588,7 +588,7 @@ class DocumentTransform {
     // (undocumented)
     static identity(): DocumentTransform;
     // (undocumented)
-    resetCache(): void;
+    resetCache(enableCaching?: boolean): void;
     // (undocumented)
     static split(predicate: (document: DocumentNode) => boolean, left: DocumentTransform, right?: DocumentTransform): DocumentTransform;
     // (undocumented)

--- a/.api-reports/api-report-react_ssr.md
+++ b/.api-reports/api-report-react_ssr.md
@@ -582,7 +582,7 @@ class DocumentTransform {
     concat(otherTransform: DocumentTransform): DocumentTransform;
     // (undocumented)
     getStableCacheEntry(document: DocumentNode): {
-        key: DocumentTransformCacheKey;
+        key?: undefined;
         value?: DocumentNode | undefined;
     } | undefined;
     // (undocumented)
@@ -602,6 +602,8 @@ type DocumentTransformCacheKey = ReadonlyArray<unknown>;
 interface DocumentTransformOptions {
     // (undocumented)
     cache?: boolean;
+    // Warning: (ae-forgotten-export) The symbol "DocumentTransformCacheKey" needs to be exported by the entry point index.d.ts
+    //
     // (undocumented)
     getCacheKey?: (document: DocumentNode) => DocumentTransformCacheKey | undefined;
 }
@@ -1635,7 +1637,6 @@ interface WatchQueryOptions<TVariables extends OperationVariables = OperationVar
 // src/core/types.ts:178:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:205:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:191:3 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
-// src/utilities/graphql/DocumentTransform.ts:130:7 - (ae-forgotten-export) The symbol "DocumentTransformCacheKey" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report-testing.md
+++ b/.api-reports/api-report-testing.md
@@ -576,7 +576,7 @@ class DocumentTransform {
     concat(otherTransform: DocumentTransform): DocumentTransform;
     // (undocumented)
     getStableCacheEntry(document: DocumentNode): {
-        key: DocumentTransformCacheKey;
+        key?: undefined;
         value?: DocumentNode | undefined;
     } | undefined;
     // (undocumented)
@@ -596,6 +596,8 @@ type DocumentTransformCacheKey = ReadonlyArray<unknown>;
 interface DocumentTransformOptions {
     // (undocumented)
     cache?: boolean;
+    // Warning: (ae-forgotten-export) The symbol "DocumentTransformCacheKey" needs to be exported by the entry point index.d.ts
+    //
     // (undocumented)
     getCacheKey?: (document: DocumentNode) => DocumentTransformCacheKey | undefined;
 }
@@ -1698,7 +1700,6 @@ export function withWarningSpy<TArgs extends any[], TResult>(it: (...args: TArgs
 // src/core/types.ts:178:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:205:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:191:3 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
-// src/utilities/graphql/DocumentTransform.ts:130:7 - (ae-forgotten-export) The symbol "DocumentTransformCacheKey" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report-testing.md
+++ b/.api-reports/api-report-testing.md
@@ -582,7 +582,7 @@ class DocumentTransform {
     // (undocumented)
     static identity(): DocumentTransform;
     // (undocumented)
-    resetCache(): void;
+    resetCache(enableCaching?: boolean): void;
     // (undocumented)
     static split(predicate: (document: DocumentNode) => boolean, left: DocumentTransform, right?: DocumentTransform): DocumentTransform;
     // (undocumented)

--- a/.api-reports/api-report-testing_core.md
+++ b/.api-reports/api-report-testing_core.md
@@ -581,7 +581,7 @@ class DocumentTransform {
     // (undocumented)
     static identity(): DocumentTransform;
     // (undocumented)
-    resetCache(): void;
+    resetCache(enableCaching?: boolean): void;
     // (undocumented)
     static split(predicate: (document: DocumentNode) => boolean, left: DocumentTransform, right?: DocumentTransform): DocumentTransform;
     // (undocumented)

--- a/.api-reports/api-report-testing_core.md
+++ b/.api-reports/api-report-testing_core.md
@@ -575,7 +575,7 @@ class DocumentTransform {
     concat(otherTransform: DocumentTransform): DocumentTransform;
     // (undocumented)
     getStableCacheEntry(document: DocumentNode): {
-        key: DocumentTransformCacheKey;
+        key?: undefined;
         value?: DocumentNode | undefined;
     } | undefined;
     // (undocumented)
@@ -595,6 +595,8 @@ type DocumentTransformCacheKey = ReadonlyArray<unknown>;
 interface DocumentTransformOptions {
     // (undocumented)
     cache?: boolean;
+    // Warning: (ae-forgotten-export) The symbol "DocumentTransformCacheKey" needs to be exported by the entry point index.d.ts
+    //
     // (undocumented)
     getCacheKey?: (document: DocumentNode) => DocumentTransformCacheKey | undefined;
 }
@@ -1654,7 +1656,6 @@ export function withWarningSpy<TArgs extends any[], TResult>(it: (...args: TArgs
 // src/core/types.ts:178:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:205:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:191:3 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
-// src/utilities/graphql/DocumentTransform.ts:130:7 - (ae-forgotten-export) The symbol "DocumentTransformCacheKey" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report-utilities.md
+++ b/.api-reports/api-report-utilities.md
@@ -753,7 +753,7 @@ export class DocumentTransform {
     concat(otherTransform: DocumentTransform): DocumentTransform;
     // (undocumented)
     getStableCacheEntry(document: DocumentNode): {
-        key: DocumentTransformCacheKey;
+        key?: undefined;
         value?: DocumentNode | undefined;
     } | undefined;
     // (undocumented)

--- a/.api-reports/api-report-utilities.md
+++ b/.api-reports/api-report-utilities.md
@@ -759,7 +759,7 @@ export class DocumentTransform {
     // (undocumented)
     static identity(): DocumentTransform;
     // (undocumented)
-    resetCache(): void;
+    resetCache(enableCaching?: boolean): void;
     // (undocumented)
     static split(predicate: (document: DocumentNode) => boolean, left: DocumentTransform, right?: DocumentTransform): DocumentTransform;
     // (undocumented)

--- a/.api-reports/api-report.md
+++ b/.api-reports/api-report.md
@@ -751,7 +751,7 @@ export class DocumentTransform {
     // (undocumented)
     static identity(): DocumentTransform;
     // (undocumented)
-    resetCache(): void;
+    resetCache(enableCaching?: boolean): void;
     // (undocumented)
     static split(predicate: (document: DocumentNode) => boolean, left: DocumentTransform, right?: DocumentTransform): DocumentTransform;
     // (undocumented)

--- a/.api-reports/api-report.md
+++ b/.api-reports/api-report.md
@@ -745,7 +745,7 @@ export class DocumentTransform {
     concat(otherTransform: DocumentTransform): DocumentTransform;
     // (undocumented)
     getStableCacheEntry(document: DocumentNode): {
-        key: DocumentTransformCacheKey;
+        key?: undefined;
         value?: DocumentNode | undefined;
     } | undefined;
     // (undocumented)

--- a/.changeset/dirty-kids-crash.md
+++ b/.changeset/dirty-kids-crash.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+`documentTransform`: use `WeakCache` instead of directly storing data on the `Trie`

--- a/.changeset/polite-avocados-warn.md
+++ b/.changeset/polite-avocados-warn.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+`print`: use `WeakCache` instead of `WeakMap`

--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -1,7 +1,7 @@
 const checks = [
   {
     path: "dist/apollo-client.min.cjs",
-    limit: "38164",
+    limit: "38178",
   },
   {
     path: "dist/main.cjs",
@@ -10,7 +10,7 @@ const checks = [
   {
     path: "dist/index.js",
     import: "{ ApolloClient, InMemoryCache, HttpLink }",
-    limit: "32188",
+    limit: "32206",
   },
   ...[
     "ApolloProvider",
@@ -35,6 +35,7 @@ const checks = [
       "react",
       "react-dom",
       "@graphql-typed-document-node/core",
+      "@wry/caches",
       "@wry/context",
       "@wry/equality",
       "@wry/trie",

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 37975,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 32019
+  "dist/apollo-client.min.cjs": 38178,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 32206
 }

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 38164,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 32188
+  "dist/apollo-client.min.cjs": 38178,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 32206
 }

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 38178,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 32206
+  "dist/apollo-client.min.cjs": 38189,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 32209
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
+        "@wry/caches": "^1.0.0",
         "@wry/context": "^0.7.3",
         "@wry/equality": "^0.5.6",
         "@wry/trie": "^0.4.3",
@@ -3292,6 +3293,17 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@wry/caches": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wry/caches/-/caches-1.0.0.tgz",
+      "integrity": "sha512-FHRUDe2tqrXAj6A/1D39No68lFWbbnh+NCpG9J/6idhL/2Mb/AaxBTYg/sbUVImEo8a4mWeOewUlB1W7uLjByA==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@wry/context": {

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
   },
   "dependencies": {
     "@graphql-typed-document-node/core": "^3.1.1",
+    "@wry/caches": "^1.0.0",
     "@wry/context": "^0.7.3",
     "@wry/equality": "^0.5.6",
     "@wry/trie": "^0.4.3",

--- a/src/utilities/graphql/print.ts
+++ b/src/utilities/graphql/print.ts
@@ -1,23 +1,20 @@
 import type { ASTNode } from "graphql";
 import { print as origPrint } from "graphql";
-import { canUseWeakMap } from "../common/canUse.js";
+import { WeakCache } from "@wry/caches"
 
-let printCache: undefined | WeakMap<ASTNode, string>;
-// further TODO: replace with `optimism` with a `WeakCache` once those are available
+let printCache!: WeakCache<ASTNode, string>;
 export const print = Object.assign(
   (ast: ASTNode) => {
-    let result;
-    result = printCache?.get(ast);
+    let result = printCache.get(ast);
 
     if (!result) {
-      result = origPrint(ast);
-      printCache?.set(ast, result);
+      printCache.set(ast, result = origPrint(ast));
     }
     return result;
   },
   {
     reset() {
-      printCache = canUseWeakMap ? new WeakMap() : undefined;
+      printCache = new WeakCache<ASTNode, string>(/** TODO: decide on a maximum size (will do all max sizes in a combined separate PR) */);
     },
   }
 );

--- a/src/utilities/graphql/print.ts
+++ b/src/utilities/graphql/print.ts
@@ -1,6 +1,6 @@
 import type { ASTNode } from "graphql";
 import { print as origPrint } from "graphql";
-import { WeakCache } from "@wry/caches"
+import { WeakCache } from "@wry/caches";
 
 let printCache!: WeakCache<ASTNode, string>;
 export const print = Object.assign(
@@ -8,13 +8,16 @@ export const print = Object.assign(
     let result = printCache.get(ast);
 
     if (!result) {
-      printCache.set(ast, result = origPrint(ast));
+      printCache.set(ast, (result = origPrint(ast)));
     }
     return result;
   },
   {
     reset() {
-      printCache = new WeakCache<ASTNode, string>(/** TODO: decide on a maximum size (will do all max sizes in a combined separate PR) */);
+      printCache = new WeakCache<
+        ASTNode,
+        string
+      >(/** TODO: decide on a maximum size (will do all max sizes in a combined separate PR) */);
     },
   }
 );


### PR DESCRIPTION
This is option 1 of 2 - I'll open a PR going a bit further and replacing a lot of the logic with `optimism` in a bit. Will be linked here.

### Checklist:

- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
