### PR TITLE
Add tsdoc for `refetch`, `fetchMore` and other returned values for suspense hooks

### DIFF
--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -364,7 +364,7 @@ export class ObservableQuery<
    * Update the variables of this observable query, and fetch the new results.
    * This method should be preferred over `setVariables` in most use cases.
    *
-   * @param variables: The new set of variables. If there are missing variables,
+   * @param variables - The new set of variables. If there are missing variables,
    * the previous values of those variables will be used.
    */
   public refetch(

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -412,6 +412,14 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     return this.reobserve(reobserveOptions, NetworkStatus.refetch);
   }
 
+  /**
+   * A function that helps you fetch the next set of results for a [paginated
+   * list field](https://www.apollographql.com/docs/react/pagination/core-api/).
+   *
+   * @param fetchMoreOptions - Options that are shallow merged with existing
+   * options to determine how to fetch the result. Pass an `updateQuery` option
+   * to instruct Apollo Client with how to write the value to the cache.
+   */
   public fetchMore<
     TFetchData = TData,
     TFetchVars extends OperationVariables = TVariables,

--- a/src/react/hooks/useBackgroundQuery.ts
+++ b/src/react/hooks/useBackgroundQuery.ts
@@ -23,7 +23,9 @@ export type UseBackgroundQueryResult<
   TData = unknown,
   TVariables extends OperationVariables = OperationVariables,
 > = {
+  /** {@inheritDoc @apollo/client!ObservableQuery#fetchMore:member(1)} */
   fetchMore: FetchMoreFunction<TData, TVariables>;
+  /** {@inheritDoc @apollo/client!ObservableQuery#refetch:member(1)} */
   refetch: RefetchFunction<TData, TVariables>;
 };
 

--- a/src/react/hooks/useLoadableQuery.ts
+++ b/src/react/hooks/useLoadableQuery.ts
@@ -46,7 +46,9 @@ export type UseLoadableQueryResult<
   LoadQueryFunction<TVariables>,
   QueryReference<TData> | null,
   {
+    /** {@inheritDoc @apollo/client!ObservableQuery#fetchMore:member(1)} */
     fetchMore: FetchMoreFunction<TData, TVariables>;
+    /** {@inheritDoc @apollo/client!ObservableQuery#refetch:member(1)} */
     refetch: RefetchFunction<TData, TVariables>;
     reset: ResetFunction;
   },

--- a/src/react/hooks/useLoadableQuery.ts
+++ b/src/react/hooks/useLoadableQuery.ts
@@ -50,6 +50,9 @@ export type UseLoadableQueryResult<
     fetchMore: FetchMoreFunction<TData, TVariables>;
     /** {@inheritDoc @apollo/client!ObservableQuery#refetch:member(1)} */
     refetch: RefetchFunction<TData, TVariables>;
+    /**
+     * Disposes of the `queryRef` and sets it back to `null`.
+     */
     reset: ResetFunction;
   },
 ];

--- a/src/react/hooks/useSuspenseQuery.ts
+++ b/src/react/hooks/useSuspenseQuery.ts
@@ -34,8 +34,10 @@ export interface UseSuspenseQueryResult<
   client: ApolloClient<any>;
   data: TData;
   error: ApolloError | undefined;
+  /** {@inheritDoc @apollo/client!ObservableQuery#fetchMore:member(1)} */
   fetchMore: FetchMoreFunction<TData, TVariables>;
   networkStatus: NetworkStatus;
+  /** {@inheritDoc @apollo/client!ObservableQuery#refetch:member(1)} */
   refetch: RefetchFunction<TData, TVariables>;
   subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
 }

--- a/src/react/hooks/useSuspenseQuery.ts
+++ b/src/react/hooks/useSuspenseQuery.ts
@@ -31,14 +31,46 @@ export interface UseSuspenseQueryResult<
   TData = unknown,
   TVariables extends OperationVariables = OperationVariables,
 > {
+  /**
+   * The instance of Apollo Client that executed the query.
+   *
+   * Can be useful for manually executing followup queries or writing data to
+   * the cache.
+   */
   client: ApolloClient<any>;
+  /**
+   * An object containing the result of your GraphQL query after it completes.
+   *
+   * This value might be `undefined` if a query results in one or more errors
+   * (depending on the query's `errorPolicy`).
+   */
   data: TData;
+  /**
+   * If the query produces one or more errors, this object contains either an
+   * array of `graphQLErrors` or a single `networkError`. Otherwise, this value
+   * is `undefined`.
+   *
+   * This property can be ignored when using the default `errorPolicy` or an
+   * `errorPolicy` of `none`. The hook will throw the error instead of setting
+   * this property.
+   */
   error: ApolloError | undefined;
   /** {@inheritDoc @apollo/client!ObservableQuery#fetchMore:member(1)} */
   fetchMore: FetchMoreFunction<TData, TVariables>;
+  /**
+   * A number indicating the current network state of the query's associated
+   * request. [See possible values](https://github.com/apollographql/apollo-client/blob/d96f4578f89b933c281bb775a39503f6cdb59ee8/src/core/networkStatus.ts#L4).
+   */
   networkStatus: NetworkStatus;
   /** {@inheritDoc @apollo/client!ObservableQuery#refetch:member(1)} */
   refetch: RefetchFunction<TData, TVariables>;
+  /**
+   * A function that enables you to execute a [subscription](https://www.apollographql.com/docs/react/data/subscriptions/),
+   * usually to subscribe to specific fields that were included in the query.
+   *
+   * This function returns another function that you can call to terminate the
+   * subscription.
+   */
   subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
 }
 


### PR DESCRIPTION
Adds tsdoc comments to the result objects returned from our existing suspense hooks.

Original ask: 
* https://github.com/apollographql/apollo-client/pull/11300#discussion_r1407559786
* https://github.com/apollographql/apollo-client/pull/11300#discussion_r1407561667




