### PR TITLE
Add more documentation on how to use the `removeTypenameFromVariables` link to reduce confusion

### DIFF
--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 37973,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 32022
+  "dist/apollo-client.min.cjs": 37960,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 32018
 }

--- a/docs/source/api/link/apollo-link-remove-typename.mdx
+++ b/docs/source/api/link/apollo-link-remove-typename.mdx
@@ -14,6 +14,50 @@ import { removeTypenameFromVariables } from '@apollo/client/link/remove-typename
 const removeTypenameLink = removeTypenameFromVariables();
 ```
 
+Use this link before your [terminating link](https://www.apollographql.com/docs/react/api/link/introduction#the-terminating-link)
+to ensure `__typename` fields are removed from variables for all operations.
+
+```ts
+import { from } from '@apollo/client';
+
+const link = from([removeTypenameLink, httpLink]);
+
+const client = new ApolloClient({
+  link,
+  // ... other options
+});
+```
+
+If you're using [directional composition](https://www.apollographql.com/docs/react/api/link/introduction#directional-composition), 
+for example to [send a subcription to a websocket connection](https://www.apollographql.com/docs/react/data/subscriptions#3-split-communication-by-operation-recommended),
+place this link before the split link to ensure `__typename` is removed from variables for all operations.
+
+```ts
+import { from, split } from '@apollo/client';
+import { removeTypenameFromVariables } from '@apollo/client/link/remove-typename';
+
+const removeTypenameLink = removeTypenameFromVariables();
+
+const splitLink = split(
+  ({ query }) => {
+    const definition = getMainDefinition(query);
+    return (
+      definition.kind === 'OperationDefinition' &&
+      definition.operation === 'subscription'
+    );
+  },
+  wsLink,
+  httpLink,
+);
+
+const link = from([removeTypenameLink, splitLink]);
+
+const client = new ApolloClient({
+  link,
+  // ... other options
+});
+```
+
 ## Remove `__typename` from all variables
 
 As an example, take the following query. Apollo Client automatically adds `__typename` fields for each field selection set.
@@ -194,4 +238,3 @@ Determines which input types should retain `__typename`. This maps the input typ
 
 </tbody>
 </table>
-

--- a/docs/source/api/link/apollo-link-remove-typename.mdx
+++ b/docs/source/api/link/apollo-link-remove-typename.mdx
@@ -30,7 +30,7 @@ const client = new ApolloClient({
 
 If you're using [directional composition](./link/introduction#directional-composition), 
 for example to [send a subcription to a websocket connection](https://www.apollographql.com/docs/react/data/subscriptions#3-split-communication-by-operation-recommended),
-place this link before the split link to ensure `__typename` is removed from variables for all operations.
+place `removeTypenameLink` before `splitLink` to remove `__typename` from variables for all operations.
 
 ```ts
 import { from, split } from '@apollo/client';

--- a/docs/source/api/link/apollo-link-remove-typename.mdx
+++ b/docs/source/api/link/apollo-link-remove-typename.mdx
@@ -15,7 +15,7 @@ const removeTypenameLink = removeTypenameFromVariables();
 ```
 
 Use this link before your [terminating link](https://www.apollographql.com/docs/react/api/link/introduction#the-terminating-link)
-to ensure `__typename` fields are removed from variables for all operations.
+to remove `__typename` fields from variables for all operations.
 
 ```ts
 import { from } from '@apollo/client';

--- a/docs/source/api/link/apollo-link-remove-typename.mdx
+++ b/docs/source/api/link/apollo-link-remove-typename.mdx
@@ -6,7 +6,57 @@ minVersion: 3.8.0
 
 ## Overview
 
-When reusing data from a query as an argument to another GraphQL operation, `__typename` fields can cause errors. To avoid this, you can use the `removeTypenameFromVariables` link to automatically remove `__typename` fields from variables in operations. You can import and instantiate it like so:
+When reusing data from a query as an argument to another GraphQL operation, `__typename` fields can cause errors. To avoid this, you can use the `removeTypenameFromVariables` link to automatically remove `__typename` fields from variables in operations. 
+
+## Remove `__typename` from all variables
+
+As an example, take the following query. Apollo Client automatically adds `__typename` fields for each field selection set.
+
+```ts
+const query = gql`
+  query DashboardQuery($id: ID!) {
+    dashboard(id: $id) {
+      id
+      name
+    }
+  }
+`;
+
+const { data } = await client.query({ query, variables: { id: 1 }});
+// {
+//   "dashboard": {
+//     "__typename": "Dashboard",
+//     "id": 1,
+//     "name": "My Dashboard"
+//   }
+// }
+```
+
+Now let's update this dashboard by sending a mutation to our server. We'll use the `dashboard` returned from the previous query as input to our mutation.
+
+```ts
+const mutation = gql`
+  mutation UpdateDashboardMutation($dashboard: DashboardInput!) {
+    updateDashboard(dashboard: $dashboard) {
+      id
+      name
+    }
+  }
+`;
+
+await client.mutate({
+  mutation,
+  variables: {
+    dashboard: { ...data.dashboard, name: 'My Updated Dashboard' }
+  }
+});
+```
+
+Without the use of the `removeTypenameFromVariables` link, the server will return an error because `data.dashboard` still contains the `__typename` field.
+
+## Usage
+
+You can import and instantiate it like so:
 
 ```ts
 import { removeTypenameFromVariables } from '@apollo/client/link/remove-typename';
@@ -57,52 +107,6 @@ const client = new ApolloClient({
   // ... other options
 });
 ```
-
-## Remove `__typename` from all variables
-
-As an example, take the following query. Apollo Client automatically adds `__typename` fields for each field selection set.
-
-```ts
-const query = gql`
-  query DashboardQuery($id: ID!) {
-    dashboard(id: $id) {
-      id
-      name
-    }
-  }
-`;
-
-const { data } = await client.query({ query, variables: { id: 1 }});
-// {
-//   "dashboard": {
-//     "__typename": "Dashboard",
-//     "id": 1,
-//     "name": "My Dashboard"
-//   }
-// }
-```
-
-Now let's update this dashboard by sending a mutation to our server. We'll use the `dashboard` returned from the previous query as input to our mutation.
-
-```ts
-const mutation = gql`
-  mutation UpdateDashboardMutation($dashboard: DashboardInput!) {
-    updateDashboard(dashboard: $dashboard) {
-      id
-      name
-    }
-  }
-`;
-
-await client.mutate({
-  mutation,
-  variables: {
-    dashboard: { ...data.dashboard, name: 'My Updated Dashboard' }
-  }
-});
-```
-
-Without the use of the `removeTypenameFromVariables` link, the server will return an error because `data.dashboard` still contains the `__typename` field.
 
 ## Keep `__typename` in JSON scalars
 

--- a/docs/source/api/link/apollo-link-remove-typename.mdx
+++ b/docs/source/api/link/apollo-link-remove-typename.mdx
@@ -29,7 +29,7 @@ const client = new ApolloClient({
 ```
 
 If you're using [directional composition](./link/introduction#directional-composition), 
-for example to [send a subcription to a websocket connection](https://www.apollographql.com/docs/react/data/subscriptions#3-split-communication-by-operation-recommended),
+for example, to [send a subscription to a websocket connection](../data/subscriptions#3-split-communication-by-operation-recommended),
 place `removeTypenameLink` before `splitLink` to remove `__typename` from variables for all operations.
 
 ```ts

--- a/docs/source/api/link/apollo-link-remove-typename.mdx
+++ b/docs/source/api/link/apollo-link-remove-typename.mdx
@@ -28,7 +28,7 @@ const client = new ApolloClient({
 });
 ```
 
-If you're using [directional composition](https://www.apollographql.com/docs/react/api/link/introduction#directional-composition), 
+If you're using [directional composition](./link/introduction#directional-composition), 
 for example to [send a subcription to a websocket connection](https://www.apollographql.com/docs/react/data/subscriptions#3-split-communication-by-operation-recommended),
 place this link before the split link to ensure `__typename` is removed from variables for all operations.
 

--- a/docs/source/api/link/apollo-link-remove-typename.mdx
+++ b/docs/source/api/link/apollo-link-remove-typename.mdx
@@ -14,7 +14,7 @@ import { removeTypenameFromVariables } from '@apollo/client/link/remove-typename
 const removeTypenameLink = removeTypenameFromVariables();
 ```
 
-Use this link before your [terminating link](https://www.apollographql.com/docs/react/api/link/introduction#the-terminating-link)
+Include `removeTypeNameLink`  anywhere in your [link chain](./introduction/#your-first-link-chain) before your [terminating link](./introduction#the-terminating-link)
 to remove `__typename` fields from variables for all operations.
 
 ```ts


### PR DESCRIPTION
We've had a number of complaints that users don't know how to use the [`removeTypenameFromVariables` link](https://www.apollographql.com/docs/react/api/link/apollo-link-remove-typename). For example, in recent feedback from our docs pages:

> Rating: :star: 1/5
> Comment: The topic doesn’t solve the problem. It doesn’t event show the way of using this func

This PR seeks to add some additional example code to clarify that this is meant to be used in the link chain.