### PR TITLE
attempt at preventing feuds in combination with a `read` function

### DIFF
--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -184,6 +184,17 @@ export class QueryInfo {
     diff: Cache.DiffResult<any> | null,
     options?: Cache.DiffOptions
   ) {
+    // some very long comment about feuds
+    if (
+      diff &&
+      !diff.complete &&
+      this.lastDiff &&
+      this.lastDiff.diff.complete &&
+      this.lastWrite &&
+      this.lastWrite.dmCount === destructiveMethodCounts.get(this.cache)
+    ) {
+      return;
+    }
     this.lastDiff =
       diff ?
         {

--- a/src/core/__tests__/QueryManager/index.ts
+++ b/src/core/__tests__/QueryManager/index.ts
@@ -2397,23 +2397,7 @@ describe("QueryManager", () => {
               },
             },
           });
-        } else if (count === 3) {
-          expect(result).toEqual({
-            loading: true,
-            networkStatus: NetworkStatus.loading,
-            data: {
-              info: {},
-            },
-            partial: true,
-          });
-        } else if (count === 4) {
-          expect(result).toEqual({
-            loading: false,
-            networkStatus: NetworkStatus.ready,
-            data: {
-              info: {},
-            },
-          });
+
           setTimeout(resolve, 100);
         } else {
           reject(new Error(`Unexpected ${JSON.stringify({ count, result })}`));


### PR DESCRIPTION
This *might* address the feud showcased in #7028 - I'll have to give it a PR release and a spin.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
