### PR TITLE
change re-subscription order

### DIFF
--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1029,6 +1029,9 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     this.subscriptions.clear();
     this.queryManager.stopQuery(this.queryId);
     this.observers.clear();
+    // this would actually be a good idea to prevent accidental errors,
+    // but would also be bound to make this class a lot more complicated
+    // this.queryInfo = undefined;
     this.isTornDown = true;
   }
 

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -320,6 +320,8 @@ export class QueryInfo {
   private lastWatch?: Cache.WatchOptions;
 
   private updateWatch(variables = this.variables) {
+    // this is not *required* to make the tests pass, but would be a good idea?
+    // this.stopped = false;
     const oq = this.observableQuery;
     if (oq && oq.options.fetchPolicy === "no-cache") {
       return;

--- a/src/react/cache/QueryReference.ts
+++ b/src/react/cache/QueryReference.ts
@@ -189,6 +189,8 @@ export class InternalQueryReference<TData = unknown> {
     if (originalFetchPolicy !== "no-cache") {
       observable.resetLastResults();
       observable.silentSetOptions({ fetchPolicy: "cache-first" });
+    } else {
+      observable.silentSetOptions({ fetchPolicy: "standby" });
     }
 
     this.subscription = observable


### PR DESCRIPTION
fixes test "useReadQuery auto-resubscribes the query after its disposed", ~but breaks the next one 😓~ (fixed it 🎉 )

CC @jerelmiller take a look :)

### Checklist:

- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
