### PR TITLE
Remove docs changeset to avoid patch change

### DIFF
--- a/.changeset/fuzzy-eyes-lick.md
+++ b/.changeset/fuzzy-eyes-lick.md
@@ -1,5 +1,0 @@
----
-"@apollo/client": patch
----
-
-Update react-native.md - Adds react native devtool in the documentation


### PR DESCRIPTION
Removes docs changeset created by https://github.com/apollographql/apollo-client/pull/11364. We don't release new client versions for docs-related changes, so I'd like to avoid the changeset here.