### PR TITLE
Remove `retain` call from `useBackgroundQuery` to allow for auto disposal

### DIFF
--- a/.changeset/wise-news-grab.md
+++ b/.changeset/wise-news-grab.md
@@ -1,0 +1,7 @@
+---
+'@apollo/client': minor
+---
+
+Remove the need to call `retain` from `useBackgroundQuery` since `useReadQuery` will now retain the query. This means that a `queryRef` that is not consumed by `useReadQuery` within the given `autoDisposeTimeoutMs` will now be auto diposed for you.
+
+Thanks to [#11412](https://github.com/apollographql/apollo-client/pull/11412), disposed query refs will be automatically resubscribed to the query when consumed by `useReadQuery` after it has been disposed.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 39135,
+  "dist/apollo-client.min.cjs": 39130,
   "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 32651
 }

--- a/src/react/hooks/__tests__/useBackgroundQuery.test.tsx
+++ b/src/react/hooks/__tests__/useBackgroundQuery.test.tsx
@@ -351,7 +351,7 @@ it("will resubscribe after disposed when mounting useReadQuery", async () => {
     });
   }
 
-  await expect(Profiler).not.toRerender();
+  await expect(Profiler).not.toRerender({ timeout: 50 });
 });
 
 it("auto resubscribes when mounting useReadQuery after naturally disposed by useReadQuery", async () => {

--- a/src/react/hooks/__tests__/useBackgroundQuery.test.tsx
+++ b/src/react/hooks/__tests__/useBackgroundQuery.test.tsx
@@ -55,6 +55,10 @@ import {
   useTrackRenders,
 } from "../../../testing/internal";
 
+afterEach(() => {
+  jest.useRealTimers();
+});
+
 function createDefaultTrackedComponents<
   Snapshot extends { result: UseReadQueryResult<any> | null },
   TData = Snapshot["result"] extends UseReadQueryResult<infer TData> | null ?

--- a/src/react/hooks/useBackgroundQuery.ts
+++ b/src/react/hooks/useBackgroundQuery.ts
@@ -219,8 +219,6 @@ export function useBackgroundQuery<
     updateWrappedQueryRef(wrappedQueryRef, promise);
   }
 
-  React.useEffect(() => queryRef.retain(), [queryRef]);
-
   const fetchMore: FetchMoreFunction<TData, TVariables> = React.useCallback(
     (options) => {
       const promise = queryRef.fetchMore(options as FetchMoreQueryOptions<any>);


### PR DESCRIPTION
Thanks to the work in https://github.com/apollographql/apollo-client/pull/11412, we no longer need to `retain` the `queryRef` produced by `useBackgroundQuery` since this is handled in `useReadQuery` for us. This means that a `queryRef` not consumed by `useReadQuery` within the given `autoDisposeTimeoutMs` will now be auto disposed, removing the need for the query to hang out as active while not used. https://github.com/apollographql/apollo-client/pull/11412 enabled the ability to auto resubscribe to a disposed `queryRef`, so when the `queryRef` is consumed after it has been disposed, it will automatically resubscribe.

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
