### PR TITLE
add deprecation warnings for HOC and Render Prop docblocks

### DIFF
--- a/.api-reports/api-report-react_components.md
+++ b/.api-reports/api-report-react_components.md
@@ -944,7 +944,7 @@ type Modifiers<T extends Record<string, any> = Record<string, unknown>> = Partia
     [FieldName in keyof T]: Modifier<StoreObjectValueMaybeReference<Exclude<T[FieldName], undefined>>>;
 }>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export function Mutation<TData = any, TVariables = OperationVariables>(props: MutationComponentOptions<TData, TVariables>): ReactTypes.JSX.Element | null;
 
 // @public (undocumented)
@@ -1214,7 +1214,7 @@ type OperationVariables = Record<string, any>;
 // @public (undocumented)
 type Path = ReadonlyArray<string | number>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export function Query<TData = any, TVariables extends OperationVariables = OperationVariables>(props: QueryComponentOptions<TData, TVariables>): ReactTypes.JSX.Element | null;
 
 // @public (undocumented)
@@ -1617,7 +1617,7 @@ type SubscribeToMoreOptions<TData = any, TSubscriptionVariables = OperationVaria
     context?: DefaultContext;
 };
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export function Subscription<TData = any, TVariables extends OperationVariables = OperationVariables>(props: SubscriptionComponentOptions<TData, TVariables>): ReactTypes.JSX.Element | null;
 
 // @public (undocumented)

--- a/.api-reports/api-report-react_hoc.md
+++ b/.api-reports/api-report-react_hoc.md
@@ -754,7 +754,7 @@ const getApolloClientMemoryInternals: (() => {
     };
 }) | undefined;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export function graphql<TProps extends TGraphQLVariables | {} = {}, TData extends object = {}, TGraphQLVariables extends OperationVariables = {}, TChildProps extends object = Partial<DataProps<TData, TGraphQLVariables>> & Partial<MutateProps<TData, TGraphQLVariables>>>(document: DocumentNode, operationOptions?: OperationOption<TProps, TData, TGraphQLVariables, TChildProps>): (WrappedComponent: ReactTypes.ComponentType<TProps & TChildProps>) => ReactTypes.ComponentClass<TProps>;
 
 // @public (undocumented)
@@ -1666,7 +1666,7 @@ interface WatchQueryOptions<TVariables extends OperationVariables = OperationVar
     variables?: TVariables;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export function withApollo<TProps, TResult = any>(WrappedComponent: ReactTypes.ComponentType<WithApolloClient<Omit<TProps, "client">>>, operationOptions?: OperationOption<TProps, TResult>): ReactTypes.ComponentClass<Omit<TProps, "client">>;
 
 // @public (undocumented)
@@ -1674,13 +1674,13 @@ export type WithApolloClient<P> = P & {
     client?: ApolloClient<any>;
 };
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export function withMutation<TProps extends TGraphQLVariables | {} = {}, TData extends Record<string, any> = {}, TGraphQLVariables extends OperationVariables = {}, TChildProps = MutateProps<TData, TGraphQLVariables>, TContext extends Record<string, any> = DefaultContext, TCache extends ApolloCache<any> = ApolloCache<any>>(document: DocumentNode, operationOptions?: OperationOption<TProps, TData, TGraphQLVariables, TChildProps>): (WrappedComponent: ReactTypes.ComponentType<TProps & TChildProps>) => ReactTypes.ComponentClass<TProps>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export function withQuery<TProps extends TGraphQLVariables | Record<string, any> = Record<string, any>, TData extends object = {}, TGraphQLVariables extends object = {}, TChildProps extends object = DataProps<TData, TGraphQLVariables>>(document: DocumentNode, operationOptions?: OperationOption<TProps, TData, TGraphQLVariables, TChildProps>): (WrappedComponent: ReactTypes.ComponentType<TProps & TChildProps>) => ReactTypes.ComponentClass<TProps>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export function withSubscription<TProps extends TGraphQLVariables | {} = {}, TData extends object = {}, TGraphQLVariables extends object = {}, TChildProps extends object = DataProps<TData, TGraphQLVariables>>(document: DocumentNode, operationOptions?: OperationOption<TProps, TData, TGraphQLVariables, TChildProps>): (WrappedComponent: ReactTypes.ComponentType<TProps & TChildProps>) => ReactTypes.ComponentClass<TProps>;
 
 // Warnings were encountered during analysis:

--- a/.changeset/chatty-comics-yawn.md
+++ b/.changeset/chatty-comics-yawn.md
@@ -2,7 +2,7 @@
 "@apollo/client": patch
 ---
 
-Adds a deprecation warning to the HOC exports.
+Adds a deprecation warning to the HOC and render prop APIs.
 
-The HOC exports have already been deprecated since 2020,
+The HOC and render prop APIs have already been deprecated since 2020,
 but we previously didn't have a @deprecated tag in the DocBlocks.

--- a/.changeset/chatty-comics-yawn.md
+++ b/.changeset/chatty-comics-yawn.md
@@ -1,0 +1,8 @@
+---
+"@apollo/client": patch
+---
+
+Adds a deprecation warning to the HOC exports.
+
+The HOC exports have already been deprecated since 2020,
+but we previously didn't have a @deprecated tag in the DocBlocks.

--- a/src/react/components/Mutation.tsx
+++ b/src/react/components/Mutation.tsx
@@ -5,6 +5,12 @@ import type { OperationVariables } from "../../core/index.js";
 import type { MutationComponentOptions } from "./types.js";
 import { useMutation } from "../hooks/index.js";
 
+/**
+ * @deprecated
+ * Official support for React Apollo render prop components ended in March 2020.
+ * This library is still included in the `@apollo/client` package,
+ * but it no longer receives feature updates or bug fixes.
+ */
 export function Mutation<TData = any, TVariables = OperationVariables>(
   props: MutationComponentOptions<TData, TVariables>
 ): ReactTypes.JSX.Element | null {

--- a/src/react/components/Query.tsx
+++ b/src/react/components/Query.tsx
@@ -5,6 +5,12 @@ import type { OperationVariables } from "../../core/index.js";
 import type { QueryComponentOptions } from "./types.js";
 import { useQuery } from "../hooks/index.js";
 
+/**
+ * @deprecated
+ * Official support for React Apollo render prop components ended in March 2020.
+ * This library is still included in the `@apollo/client` package,
+ * but it no longer receives feature updates or bug fixes.
+ */
 export function Query<
   TData = any,
   TVariables extends OperationVariables = OperationVariables,

--- a/src/react/components/Subscription.tsx
+++ b/src/react/components/Subscription.tsx
@@ -5,6 +5,12 @@ import type { OperationVariables } from "../../core/index.js";
 import type { SubscriptionComponentOptions } from "./types.js";
 import { useSubscription } from "../hooks/index.js";
 
+/**
+ * @deprecated
+ * Official support for React Apollo render prop components ended in March 2020.
+ * This library is still included in the `@apollo/client` package,
+ * but it no longer receives feature updates or bug fixes.
+ */
 export function Subscription<
   TData = any,
   TVariables extends OperationVariables = OperationVariables,

--- a/src/react/hoc/graphql.tsx
+++ b/src/react/hoc/graphql.tsx
@@ -8,6 +8,11 @@ import { withSubscription } from "./subscription-hoc.js";
 import type { OperationOption, DataProps, MutateProps } from "./types.js";
 import type { OperationVariables } from "../../core/index.js";
 
+/**
+ * @deprecated
+ * Official support for React Apollo higher order components ended in March 2020.
+ * This library is still included in the `@apollo/client` package, but it no longer receives feature updates or bug fixes.
+ */
 export function graphql<
   TProps extends TGraphQLVariables | {} = {},
   TData extends object = {},

--- a/src/react/hoc/mutation-hoc.tsx
+++ b/src/react/hoc/mutation-hoc.tsx
@@ -21,6 +21,11 @@ import {
 import type { OperationOption, OptionProps, MutateProps } from "./types.js";
 import type { ApolloCache } from "../../core/index.js";
 
+/**
+ * @deprecated
+ * Official support for React Apollo higher order components ended in March 2020.
+ * This library is still included in the `@apollo/client` package, but it no longer receives feature updates or bug fixes.
+ */
 export function withMutation<
   TProps extends TGraphQLVariables | {} = {},
   TData extends Record<string, any> = {},

--- a/src/react/hoc/query-hoc.tsx
+++ b/src/react/hoc/query-hoc.tsx
@@ -15,6 +15,11 @@ import {
 } from "./hoc-utils.js";
 import type { OperationOption, OptionProps, DataProps } from "./types.js";
 
+/**
+ * @deprecated
+ * Official support for React Apollo higher order components ended in March 2020.
+ * This library is still included in the `@apollo/client` package, but it no longer receives feature updates or bug fixes.
+ */
 export function withQuery<
   TProps extends TGraphQLVariables | Record<string, any> = Record<string, any>,
   TData extends object = {},

--- a/src/react/hoc/subscription-hoc.tsx
+++ b/src/react/hoc/subscription-hoc.tsx
@@ -15,6 +15,11 @@ import {
 } from "./hoc-utils.js";
 import type { OperationOption, OptionProps, DataProps } from "./types.js";
 
+/**
+ * @deprecated
+ * Official support for React Apollo higher order components ended in March 2020.
+ * This library is still included in the `@apollo/client` package, but it no longer receives feature updates or bug fixes.
+ */
 export function withSubscription<
   TProps extends TGraphQLVariables | {} = {},
   TData extends object = {},

--- a/src/react/hoc/withApollo.tsx
+++ b/src/react/hoc/withApollo.tsx
@@ -10,6 +10,11 @@ function getDisplayName<P>(WrappedComponent: ReactTypes.ComponentType<P>) {
   return WrappedComponent.displayName || WrappedComponent.name || "Component";
 }
 
+/**
+ * @deprecated
+ * Official support for React Apollo higher order components ended in March 2020.
+ * This library is still included in the `@apollo/client` package, but it no longer receives feature updates or bug fixes.
+ */
 export function withApollo<TProps, TResult = any>(
   WrappedComponent: ReactTypes.ComponentType<
     WithApolloClient<Omit<TProps, "client">>


### PR DESCRIPTION
The wording was taken from the docs:
https://www.apollographql.com/docs/react/api/react/hoc/
![image](https://github.com/apollographql/apollo-client/assets/4282439/76ba6180-2e53-4077-ad33-38e00166c92d)


### Checklist:

- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
