### PR TITLE
remove references to "dom" ts lib

### DIFF
--- a/src/link/http/__tests__/HttpLink.ts
+++ b/src/link/http/__tests__/HttpLink.ts
@@ -887,10 +887,7 @@ describe("HttpLink", () => {
 
     itAsync("allows uri to be a function", (resolve, reject) => {
       const variables = { params: "stub" };
-      const customFetch: WindowOrWorkerGlobalScope["fetch"] = (
-        uri,
-        options
-      ) => {
+      const customFetch: typeof fetch = (uri, options) => {
         const { operationName } = convertBatchedBody(options!.body);
         try {
           expect(operationName).toBe("SampleQuery");

--- a/src/link/http/checkFetcher.ts
+++ b/src/link/http/checkFetcher.ts
@@ -1,8 +1,6 @@
 import { newInvariantError } from "../../utilities/globals/index.js";
 
-export const checkFetcher = (
-  fetcher: WindowOrWorkerGlobalScope["fetch"] | undefined
-) => {
+export const checkFetcher = (fetcher: typeof fetch | undefined) => {
   if (!fetcher && typeof fetch === "undefined") {
     throw newInvariantError(`
 "fetch" has not been found globally and no fetcher has been \

--- a/src/link/http/selectHttpOptionsAndBody.ts
+++ b/src/link/http/selectHttpOptionsAndBody.ts
@@ -36,7 +36,7 @@ export interface HttpOptions {
   /**
    * A `fetch`-compatible API to use when making requests.
    */
-  fetch?: WindowOrWorkerGlobalScope["fetch"];
+  fetch?: typeof fetch;
 
   /**
    * An object representing values to be sent as headers on the request.

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -5,7 +5,7 @@
 {
   "compilerOptions": {
     "noEmit": true,
-    "lib": ["es2015", "esnext.asynciterable", "dom"],
+    "lib": ["es2015", "esnext.asynciterable"],
     "types": ["jest", "node", "./testing/matchers/index.d.ts"]
   },
   "extends": "../tsconfig.json",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "esModuleInterop": true,
     "experimentalDecorators": true,
     "outDir": "./dist",
-    "lib": ["es2015", "esnext.asynciterable", "dom"],
+    "lib": ["es2015", "esnext.asynciterable"],
     "jsx": "react",
     "strict": true
   },


### PR DESCRIPTION
Since `@types/node` now also ships `fetch`, we can replace references to `WindowOrWorkerGlobalScope["fetch"]` with `typeof fetch`, with the benefit that we don't need `lib: ["dom"]` any more.

This enables consumers to keep `skipLibCheck: false` in their `tsconfig.json` and not get any errors if they either have `@types/node` or `lib: ["dom"]` in their project.

### Checklist:

- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
