### PR TITLE
chore: add docs for skipping an optimistic update via optimisticResponse

### DIFF
--- a/docs/source/performance/optimistic-ui.mdx
+++ b/docs/source/performance/optimistic-ui.mdx
@@ -73,6 +73,51 @@ As this example shows, the value of `optimisticResponse` is an object that match
 
 5. Apollo Client notifies all affected queries again. The associated components re-render, but if the server's response matches our `optimisticResponse`, this is invisible to the user.
 
+## Bailing out of an optimistic update
+
+In some cases you may want to skip an optimisitic update. For example, you may want to perform an optimistic update _only_ when certain variables are passed to the mutation. In order to skip an update, you can pass a function to `optimisticResponse` and use the `IGNORE` sentinel object available on the second argument passed to your `optimisticResponse` function to bail out of the optimistic update.
+
+Consider this example:
+
+```tsx
+const UPDATE_COMMENT = gql`
+  mutation UpdateComment($commentId: ID!, $commentContent: String!) {
+    updateComment(commentId: $commentId, content: $commentContent) {
+      id
+      __typename
+      content
+    }
+  }
+`;
+
+function CommentPageWithData() {
+  const [mutate] = useMutation(UPDATE_COMMENT);
+
+  return (
+    <Comment
+      updateComment={({ commentId, commentContent }) =>
+        mutate({
+          variables: { commentId, commentContent },
+          optimisticResponse: (vars, { IGNORE }) => {
+            if (commentContent === "foo") {
+              // conditionally bail out of optimistic updates
+              return IGNORE;
+            }
+            return {
+              updateComment: {
+                id: commentId,
+                __typename: "Comment",
+                content: commentContent
+              }
+            }
+          },
+        })
+      }
+    />
+  );
+}
+```
+
 ## Example: Adding a new object to a list
 
 The previous example shows how to provide an optimistic result for an object that's _already_ in the Apollo Client cache. But what about a mutation that creates a _new_ object? This works similarly.

--- a/docs/source/performance/optimistic-ui.mdx
+++ b/docs/source/performance/optimistic-ui.mdx
@@ -75,7 +75,7 @@ As this example shows, the value of `optimisticResponse` is an object that match
 
 ## Bailing out of an optimistic update
 
-In some cases you may want to skip an optimisitic update. For example, you may want to perform an optimistic update _only_ when certain variables are passed to the mutation. In order to skip an update, you can pass a function to `optimisticResponse` and use the `IGNORE` sentinel object available on the second argument passed to your `optimisticResponse` function to bail out of the optimistic update.
+In some cases you may want to skip an optimistic update. For example, you may want to perform an optimistic update _only_ when certain variables are passed to the mutation. To skip an update, pass a function to the `optimisticResponse` option and return the `IGNORE` sentinel object available on the second argument to bail out of the optimistic update.
 
 Consider this example:
 


### PR DESCRIPTION
Adds docs for https://github.com/apollographql/apollo-client/pull/11410.

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
