### PR TITLE
fix: behavior of delay: Infinity in a mock response

### DIFF
--- a/.changeset/fresh-jeans-retire.md
+++ b/.changeset/fresh-jeans-retire.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix delay: Infinity when set on a MockResponse passed to Mocked Provider so it indefinitely enters loading state.

--- a/src/testing/core/mocking/mockLink.ts
+++ b/src/testing/core/mocking/mockLink.ts
@@ -102,6 +102,12 @@ export class MockLink extends ApolloLink {
     const response =
       responseIndex >= 0 ? mockedResponses[responseIndex] : void 0;
 
+    // There have been platform- and engine-dependent differences with
+    // setInterval(fn, Infinity), so we pass 0 instead (but detect
+    // Infinity where we call observer.error or observer.next to pend
+    // indefinitely in those cases.)
+    const delay = response?.delay === Infinity ? 0 : response?.delay ?? 0;
+
     let configError: Error;
 
     if (!response) {
@@ -144,38 +150,35 @@ ${unmatchedVars.map((d) => `  ${stringifyForDisplay(d)}`).join("\n")}
     }
 
     return new Observable((observer) => {
-      const timer = setTimeout(
-        () => {
-          if (configError) {
-            try {
-              // The onError function can return false to indicate that
-              // configError need not be passed to observer.error. For
-              // example, the default implementation of onError calls
-              // observer.error(configError) and then returns false to
-              // prevent this extra (harmless) observer.error call.
-              if (this.onError(configError, observer) !== false) {
-                throw configError;
-              }
-            } catch (error) {
-              observer.error(error);
+      const timer = setTimeout(() => {
+        if (configError) {
+          try {
+            // The onError function can return false to indicate that
+            // configError need not be passed to observer.error. For
+            // example, the default implementation of onError calls
+            // observer.error(configError) and then returns false to
+            // prevent this extra (harmless) observer.error call.
+            if (this.onError(configError, observer) !== false) {
+              throw configError;
             }
-          } else if (response) {
-            if (response.error && response.delay !== Infinity) {
-              observer.error(response.error);
-            } else {
-              if (response.result && response.delay !== Infinity) {
-                observer.next(
-                  typeof response.result === "function" ?
-                    (response.result as ResultFunction<FetchResult>)()
-                  : response.result
-                );
-              }
-              observer.complete();
-            }
+          } catch (error) {
+            observer.error(error);
           }
-        },
-        (response && response.delay) || 0
-      );
+        } else if (response) {
+          if (response.error && response.delay !== Infinity) {
+            observer.error(response.error);
+          } else {
+            if (response.result && response.delay !== Infinity) {
+              observer.next(
+                typeof response.result === "function" ?
+                  (response.result as ResultFunction<FetchResult>)()
+                : response.result
+              );
+            }
+            observer.complete();
+          }
+        }
+      }, delay);
 
       return () => {
         clearTimeout(timer);

--- a/src/testing/core/mocking/mockLink.ts
+++ b/src/testing/core/mocking/mockLink.ts
@@ -164,11 +164,11 @@ ${unmatchedVars.map((d) => `  ${stringifyForDisplay(d)}`).join("\n")}
           } catch (error) {
             observer.error(error);
           }
-        } else if (response) {
-          if (response.error && response.delay !== Infinity) {
+        } else if (response && response.delay !== Infinity) {
+          if (response.error) {
             observer.error(response.error);
           } else {
-            if (response.result && response.delay !== Infinity) {
+            if (response.result) {
               observer.next(
                 typeof response.result === "function" ?
                   (response.result as ResultFunction<FetchResult>)()

--- a/src/testing/core/mocking/mockLink.ts
+++ b/src/testing/core/mocking/mockLink.ts
@@ -160,7 +160,7 @@ ${unmatchedVars.map((d) => `  ${stringifyForDisplay(d)}`).join("\n")}
               observer.error(error);
             }
           } else if (response) {
-            if (response.error) {
+            if (response.error && response.delay !== Infinity) {
               observer.error(response.error);
             } else {
               if (response.result && response.delay !== Infinity) {

--- a/src/testing/core/mocking/mockLink.ts
+++ b/src/testing/core/mocking/mockLink.ts
@@ -163,7 +163,7 @@ ${unmatchedVars.map((d) => `  ${stringifyForDisplay(d)}`).join("\n")}
             if (response.error) {
               observer.error(response.error);
             } else {
-              if (response.result) {
+              if (response.result && response.delay !== Infinity) {
                 observer.next(
                   typeof response.result === "function" ?
                     (response.result as ResultFunction<FetchResult>)()

--- a/src/testing/react/__tests__/MockedProvider.test.tsx
+++ b/src/testing/react/__tests__/MockedProvider.test.tsx
@@ -709,7 +709,7 @@ describe("General use", () => {
     }
   );
 
-  it.only("should support loading state testing with delay", async () => {
+  it("should support loading state testing with delay", async () => {
     jest.useFakeTimers();
 
     function Component({ username }: Variables) {
@@ -750,7 +750,7 @@ describe("General use", () => {
     jest.useRealTimers();
   });
 
-  it.only("should support an infinite loading state with result and delay: Infinity", async () => {
+  it("should support an infinite loading state with result and delay: Infinity", async () => {
     jest.useFakeTimers();
 
     function Component({ username }: Variables) {
@@ -796,7 +796,7 @@ describe("General use", () => {
     jest.useRealTimers();
   });
 
-  it.only("should support an infinite loading state with error and delay: Infinity", async () => {
+  it("should support an infinite loading state with error and delay: Infinity", async () => {
     jest.useFakeTimers();
 
     function Component({ username }: Variables) {


### PR DESCRIPTION
Closes https://github.com/apollographql/apollo-client/issues/11471.

When we [updated the docs](https://github.com/apollographql/apollo-client/pull/11287) to suggest developers use `delay: Infinity` to test loading states, a test was added to verify that this actually works. In the test, the mock response contained neither an `error` or `result` which was triggering an uncaught error in `MockLink` (`Mocked response should contain either result or error`), so the test was lying to us: a mock response with `delay: Infinity` resolves after 1 second[^1] if a result is present.

In the first commit here, a fixed up test fails with `delay: Infinity` but passes with `delay: 30000`.

We can still use `delay: Infinity` value to produce this forever-loading behavior, but we'd have to add an explicit condition for that, which is what this PR does.

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests

[^1]: When delay is larger than 2147483647 or less than 1, the delay will be set to 1. Non-integer delays are truncated to an integer. [link](https://nodejs.org/api/timers.html#timers_settimeout_callback_delay_args)

