### PR TITLE
fix: warnAboutDataLoss: warn with object substitution

### DIFF
--- a/.changeset/cold-socks-yawn.md
+++ b/.changeset/cold-socks-yawn.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix Cannot convert object to primitive value when trying to console object as String with missing toString prototype

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -857,8 +857,8 @@ This could cause additional (usually avoidable) network requests to fetch data t
 
 To address this problem (which is not a bug in Apollo Client), %sdefine a custom merge function for the %s field, so InMemoryCache can safely merge these objects:
 
-  existing: %s
-  incoming: %s
+  existing: %o
+  incoming: %o
 
 For more information about these options, please refer to the documentation:
 


### PR DESCRIPTION
Fix `Cannot convert object to primitive value` when trying to console object as String with missing toString prototype

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [X] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [X] Make sure all of the significant new logic is covered by tests
