### PR TITLE
Add stricter typing to useFragment

### DIFF
--- a/.changeset/healthy-timers-sleep.md
+++ b/.changeset/healthy-timers-sleep.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Add stricter typing for \_\_typename in useFragment

--- a/src/react/hooks/useFragment.ts
+++ b/src/react/hooks/useFragment.ts
@@ -31,7 +31,7 @@ export interface UseFragmentOptions<TData, TVars>
 }
 
 type FragmentStoreObject<TData> =
-  TData extends { __typename: string | undefined } ?
+  TData extends { __typename?: string | undefined } ?
     StoreObject<TData["__typename"]>
   : StoreObject;
 

--- a/src/react/hooks/useFragment.ts
+++ b/src/react/hooks/useFragment.ts
@@ -25,7 +25,7 @@ export interface UseFragmentOptions<TData, TVars>
       Cache.ReadFragmentOptions<TData, TVars>,
       "id" | "variables" | "returnPartialData"
     > {
-  from: StoreObject | Reference | string;
+  from: StoreObject<TData> | Reference | string;
   // Override this field to make it optional (default: true).
   optimistic?: boolean;
 }

--- a/src/react/hooks/useFragment.ts
+++ b/src/react/hooks/useFragment.ts
@@ -25,7 +25,7 @@ export interface UseFragmentOptions<TData, TVars>
       Cache.ReadFragmentOptions<TData, TVars>,
       "id" | "variables" | "returnPartialData"
     > {
-  from: Reference | string | FragmentStoreObject<TData>;
+  from: FragmentStoreObject<TData> | Reference | string;
   // Override this field to make it optional (default: true).
   optimistic?: boolean;
 }

--- a/src/react/hooks/useFragment.ts
+++ b/src/react/hooks/useFragment.ts
@@ -25,10 +25,15 @@ export interface UseFragmentOptions<TData, TVars>
       Cache.ReadFragmentOptions<TData, TVars>,
       "id" | "variables" | "returnPartialData"
     > {
-  from: StoreObject<TData> | Reference | string;
+  from: Reference | string | FragmentStoreObject<TData>;
   // Override this field to make it optional (default: true).
   optimistic?: boolean;
 }
+
+type FragmentStoreObject<TData> =
+  TData extends { __typename: string | undefined } ?
+    StoreObject<TData["__typename"]>
+  : StoreObject;
 
 export type UseFragmentResult<TData> =
   | {

--- a/src/utilities/graphql/storeUtils.ts
+++ b/src/utilities/graphql/storeUtils.ts
@@ -50,8 +50,10 @@ export type StoreValue =
   | void
   | Object;
 
-export interface StoreObject {
-  __typename?: string;
+export interface StoreObject<TData = any> {
+  __typename?: TData extends { __typename: string | undefined } ?
+    TData["__typename"]
+  : string | undefined;
   [storeFieldName: string]: StoreValue;
 }
 

--- a/src/utilities/graphql/storeUtils.ts
+++ b/src/utilities/graphql/storeUtils.ts
@@ -50,10 +50,10 @@ export type StoreValue =
   | void
   | Object;
 
-export interface StoreObject<TData = any> {
-  __typename?: TData extends { __typename: string | undefined } ?
-    TData["__typename"]
-  : string | undefined;
+export interface StoreObject<
+  TName extends string | undefined = string | undefined,
+> {
+  __typename?: TName;
   [storeFieldName: string]: StoreValue;
 }
 


### PR DESCRIPTION
Adds stricter typing for the useFragment function `from` property. This benefits you only if you're passing in a typed document node into the fragment option.

I'm not aware of any type tests written here but I suppose it it passes compiling it should be okay?

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
