### PR TITLE
Add stricter typing to `from` in `useFragment`

### DIFF
--- a/.changeset/healthy-timers-sleep.md
+++ b/.changeset/healthy-timers-sleep.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Add stricter typing for \_\_typename in useFragment

--- a/.changeset/healthy-timers-sleep.md
+++ b/.changeset/healthy-timers-sleep.md
@@ -2,4 +2,4 @@
 "@apollo/client": patch
 ---
 
-Add stricter typing for \_\_typename in useFragment
+Add stricter typing to `from` in `useFragment`

--- a/src/react/hooks/__tests__/useFragment.test.tsx
+++ b/src/react/hooks/__tests__/useFragment.test.tsx
@@ -24,7 +24,6 @@ import {
   ApolloClient,
   Observable,
   ApolloLink,
-  StoreObject,
   DocumentNode,
   FetchResult,
 } from "../../../core";

--- a/src/react/hooks/__tests__/useFragment.test.tsx
+++ b/src/react/hooks/__tests__/useFragment.test.tsx
@@ -9,7 +9,11 @@ import {
 import userEvent from "@testing-library/user-event";
 import { act } from "react-dom/test-utils";
 
-import { UseFragmentOptions, useFragment } from "../useFragment";
+import {
+  FragmentStoreObject,
+  UseFragmentOptions,
+  useFragment,
+} from "../useFragment";
 import { MockedProvider } from "../../../testing";
 import { ApolloProvider } from "../../context";
 import {
@@ -1715,7 +1719,7 @@ describe.skip("Type Tests", () => {
 
   test("UseFragmentOptions interface shape", <TData, TVars>() => {
     expectTypeOf<UseFragmentOptions<TData, TVars>>().branded.toEqualTypeOf<{
-      from: string | StoreObject | Reference;
+      from: string | FragmentStoreObject<TData> | Reference;
       fragment: DocumentNode | TypedDocumentNode<TData, TVars>;
       fragmentName?: string;
       optimistic?: boolean;

--- a/src/react/hooks/useFragment.ts
+++ b/src/react/hooks/useFragment.ts
@@ -31,7 +31,7 @@ export interface UseFragmentOptions<TData, TVars>
 }
 
 type FragmentStoreObject<TData> =
-  TData extends { __typename: string | undefined } ?
+  TData extends { __typename?: string | undefined } ?
     StoreObject<TData["__typename"]>
   : StoreObject;
 

--- a/src/react/hooks/useFragment.ts
+++ b/src/react/hooks/useFragment.ts
@@ -25,7 +25,7 @@ export interface UseFragmentOptions<TData, TVars>
       Cache.ReadFragmentOptions<TData, TVars>,
       "id" | "variables" | "returnPartialData"
     > {
-  from: StoreObject | Reference | string;
+  from: StoreObject<TData> | Reference | string;
   // Override this field to make it optional (default: true).
   optimistic?: boolean;
 }

--- a/src/react/hooks/useFragment.ts
+++ b/src/react/hooks/useFragment.ts
@@ -30,7 +30,7 @@ export interface UseFragmentOptions<TData, TVars>
   optimistic?: boolean;
 }
 
-type FragmentStoreObject<TData> =
+export type FragmentStoreObject<TData> =
   TData extends { __typename?: string | undefined } ?
     StoreObject<TData["__typename"]>
   : StoreObject;

--- a/src/react/hooks/useFragment.ts
+++ b/src/react/hooks/useFragment.ts
@@ -25,7 +25,7 @@ export interface UseFragmentOptions<TData, TVars>
       Cache.ReadFragmentOptions<TData, TVars>,
       "id" | "variables" | "returnPartialData"
     > {
-  from: Reference | string | FragmentStoreObject<TData>;
+  from: FragmentStoreObject<TData> | Reference | string;
   // Override this field to make it optional (default: true).
   optimistic?: boolean;
 }

--- a/src/react/hooks/useFragment.ts
+++ b/src/react/hooks/useFragment.ts
@@ -25,10 +25,15 @@ export interface UseFragmentOptions<TData, TVars>
       Cache.ReadFragmentOptions<TData, TVars>,
       "id" | "variables" | "returnPartialData"
     > {
-  from: StoreObject<TData> | Reference | string;
+  from: Reference | string | FragmentStoreObject<TData>;
   // Override this field to make it optional (default: true).
   optimistic?: boolean;
 }
+
+type FragmentStoreObject<TData> =
+  TData extends { __typename: string | undefined } ?
+    StoreObject<TData["__typename"]>
+  : StoreObject;
 
 export type UseFragmentResult<TData> =
   | {

--- a/src/utilities/graphql/storeUtils.ts
+++ b/src/utilities/graphql/storeUtils.ts
@@ -50,8 +50,10 @@ export type StoreValue =
   | void
   | Object;
 
-export interface StoreObject {
-  __typename?: string;
+export interface StoreObject<TData = any> {
+  __typename?: TData extends { __typename: string | undefined } ?
+    TData["__typename"]
+  : string | undefined;
   [storeFieldName: string]: StoreValue;
 }
 

--- a/src/utilities/graphql/storeUtils.ts
+++ b/src/utilities/graphql/storeUtils.ts
@@ -50,10 +50,10 @@ export type StoreValue =
   | void
   | Object;
 
-export interface StoreObject<TData = any> {
-  __typename?: TData extends { __typename: string | undefined } ?
-    TData["__typename"]
-  : string | undefined;
+export interface StoreObject<
+  TName extends string | undefined = string | undefined,
+> {
+  __typename?: TName;
   [storeFieldName: string]: StoreValue;
 }
 


### PR DESCRIPTION
Optimises the type to infer the __typename of the TypedDocumentNode that is passed in. I don't think you would ever pass in a different __typename but happy to be corrected.

I wasn't sure if the `TData extends { __typename?: string | undefined }` logic belonged within StoreObject itself so I added another type to contain that logic.

Or possibly the type for `from` could be a Partial of TData?

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
