### PR TITLE
fix: `networkStatus` update Issue in `useSuspenseQuery` with `cache-and-network` policy

### DIFF
--- a/.changeset/soft-roses-sit.md
+++ b/.changeset/soft-roses-sit.md
@@ -2,4 +2,4 @@
 "@apollo/client": patch
 ---
 
-Fix `networkStatus` Update Issue in `useSuspenseQuery` with `cache-and-network` Policy
+Fix `networkStatus` with `useSuspenseQuery` not properly updating to ready state when using a `cache-and-network` fetch policy that returns data equal to what is already in the cache.

--- a/.changeset/soft-roses-sit.md
+++ b/.changeset/soft-roses-sit.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix `networkStatus` Update Issue in `useSuspenseQuery` with `cache-and-network` Policy

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 37922,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 31974
+  "dist/apollo-client.min.cjs": 37930,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 31972
 }

--- a/src/react/cache/QueryReference.ts
+++ b/src/react/cache/QueryReference.ts
@@ -238,7 +238,10 @@ export class InternalQueryReference<TData = unknown> {
         // This occurs when switching to a result that is fully cached when this
         // class is instantiated. ObservableQuery will run reobserve when
         // subscribing, which delivers a result from the cache.
-        if (result.data === this.result.data && result.networkStatus === this.result.networkStatus) {
+        if (
+          result.data === this.result.data &&
+          result.networkStatus === this.result.networkStatus
+        ) {
           return;
         }
 

--- a/src/react/cache/QueryReference.ts
+++ b/src/react/cache/QueryReference.ts
@@ -238,7 +238,7 @@ export class InternalQueryReference<TData = unknown> {
         // This occurs when switching to a result that is fully cached when this
         // class is instantiated. ObservableQuery will run reobserve when
         // subscribing, which delivers a result from the cache.
-        if (result.data === this.result.data) {
+        if (result.data === this.result.data && result.networkStatus === this.result.networkStatus) {
           return;
         }
 


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

This PR resolves a bug where `useSuspenseQuery` with a `cache-and-network` fetch policy does not update its `networkStatus` when there's a concurrent `useReadQuery` with the same fetch policy. 

There is no test code in the cache folder, so I was unable to write a test, please advise if this is necessary.

 I am attaching a reproduction of the error instead of the test code.


![image](https://github.com/apollographql/apollo-client/assets/41789633/f82cb4d3-773f-43bb-85e9-5e83814eb990)

The expected result is that all networkStatus should be 7 (networkStatus.ready).
[repro codesandbox](https://codesandbox.io/p/devbox/vibrant-banzai-38y7nc?layout=%257B%2522sidebarPanel%2522%253A%2522EXPLORER%2522%252C%2522rootPanelGroup%2522%253A%257B%2522direction%2522%253A%2522horizontal%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522id%2522%253A%2522ROOT_LAYOUT%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522clrf2a25300073b6iam7baep1%2522%252C%2522sizes%2522%253A%255B70%252C30%255D%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522EDITOR%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522id%2522%253A%2522clrf2a25300023b6icuwkq7nl%2522%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522SHELLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522id%2522%253A%2522clrf2a25300043b6ifberlihw%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522DEVTOOLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522id%2522%253A%2522clrf2a25300063b6iiq644veg%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%252C%2522sizes%2522%253A%255B50%252C50%255D%257D%252C%2522tabbedPanels%2522%253A%257B%2522clrf2a25300023b6icuwkq7nl%2522%253A%257B%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clrf2a25200013b6i27siz6hg%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522filepath%2522%253A%2522%252FREADME.md%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%252C%257B%2522id%2522%253A%2522clrf3nkjo00023b6hshqirkpy%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522initialSelections%2522%253A%255B%257B%2522startLineNumber%2522%253A38%252C%2522startColumn%2522%253A2%252C%2522endLineNumber%2522%253A39%252C%2522endColumn%2522%253A1%257D%255D%252C%2522filepath%2522%253A%2522%252Fsrc%252Findex.jsx%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%255D%252C%2522id%2522%253A%2522clrf2a25300023b6icuwkq7nl%2522%252C%2522activeTabId%2522%253A%2522clrf3nkjo00023b6hshqirkpy%2522%257D%252C%2522clrf2a25300063b6iiq644veg%2522%253A%257B%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clrf2a25300053b6ipbzunzxf%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522TASK_PORT%2522%252C%2522taskId%2522%253A%2522start%2522%252C%2522port%2522%253A3000%252C%2522path%2522%253A%2522%252F%2522%257D%255D%252C%2522id%2522%253A%2522clrf2a25300063b6iiq644veg%2522%252C%2522activeTabId%2522%253A%2522clrf2a25300053b6ipbzunzxf%2522%257D%252C%2522clrf2a25300043b6ifberlihw%2522%253A%257B%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clrf2a25300033b6i1ycxkpdd%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522TASK_LOG%2522%252C%2522taskId%2522%253A%2522start%2522%257D%255D%252C%2522id%2522%253A%2522clrf2a25300043b6ifberlihw%2522%252C%2522activeTabId%2522%253A%2522clrf2a25300033b6i1ycxkpdd%2522%257D%257D%252C%2522showDevtools%2522%253Atrue%252C%2522showShells%2522%253Atrue%252C%2522showSidebar%2522%253Atrue%252C%2522sidebarPanelSize%2522%253A15%257D)

### Bug Repro
```tsx

function PersonList() {
  const { data, networkStatus } = useSuspenseQuery(ALL_PEOPLE, {
    fetchPolicy: "cache-and-network",
    variables: {},
  });

  return (
    <div>


      {/* Expected result:7, actual result: 1 */}
      <p>networkStatus: {networkStatus}</p>


      <ul>
        {data.people.map((person) => (
          <li key={person.id}>{person.name}</li>
        ))}
      </ul>
    </div>
  );
}

function App() {
  const [queryRef] = useBackgroundQuery(ALL_PEOPLE, {
    fetchPolicy: "cache-and-network",
  });
  const { data, networkStatus } = useReadQuery(queryRef);

  return (
    <main>
      <h2>Background Query & Read Query</h2>
      <p>networkStatus: {networkStatus}</p>
      {data?.people.map((person) => (
        <li key={person.id}>{person.name}</li>
      ))}

      <h2>Suspense Query</h2>
      <Suspense fallback={<p>Loading…</p>}>
        <PersonList />
      </Suspense>
    </main>
  );
}
```
 
### Checklist:

- [X] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [X] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
