### PR TITLE
Increase default memory limits

### DIFF
--- a/.api-reports/api-report-utilities.md
+++ b/.api-reports/api-report-utilities.md
@@ -729,9 +729,9 @@ export const enum defaultCacheSizes {
     // (undocumented)
     "fragmentRegistry.transform" = 2000,
     // (undocumented)
-    "inMemoryCache.executeSelectionSet" = 10000,
+    "inMemoryCache.executeSelectionSet" = 50000,
     // (undocumented)
-    "inMemoryCache.executeSubSelectedArray" = 5000,
+    "inMemoryCache.executeSubSelectedArray" = 10000,
     // (undocumented)
     "inMemoryCache.maybeBroadcastWatch" = 5000,
     // (undocumented)

--- a/.changeset/pink-apricots-yawn.md
+++ b/.changeset/pink-apricots-yawn.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Increase the default memory limits for `executeSelectionSet` and `executeSelectionSetArray`.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 39201,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 32694
+  "dist/apollo-client.min.cjs": 39141,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 32647
 }

--- a/src/utilities/caching/sizes.ts
+++ b/src/utilities/caching/sizes.ts
@@ -314,6 +314,6 @@ export const enum defaultCacheSizes {
   "cache.fragmentQueryDocuments" = 1000,
   "removeTypenameFromVariables.getVariableDefinitions" = 2000,
   "inMemoryCache.maybeBroadcastWatch" = 5000,
-  "inMemoryCache.executeSelectionSet" = 10000,
-  "inMemoryCache.executeSubSelectedArray" = 5000,
+  "inMemoryCache.executeSelectionSet" = 50000,
+  "inMemoryCache.executeSubSelectedArray" = 10000,
 }


### PR DESCRIPTION
Based on some internal testing, we've decided to increase the default memory limits for `inMemoryCache.executeSelectionSet` and `inMemoryCache.executeSelectionSetArray`.

### Checklist:

- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
