### PR TITLE
Ignore `prettier` in renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -34,6 +34,7 @@
     "@testing-library/react-12",
     "@rollup/plugin-node-resolve",
     "rollup",
-    "glob"
+    "glob",
+    "prettier"
   ]
 }


### PR DESCRIPTION
Since we lint our codebase for formatting violations against `prettier`, updates to that package may result in the need to reformat our codebase. I'm taking this out of the renovate rotation so that we can make this update by hand if/when we are ready to upgrade to the next version, which would include adding an entry to `.git-blame-ignore-revs`.
