### PR TITLE
Update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,10 +16,9 @@
 
   Please look at the following checklist to ensure that your PR
   can be accepted quickly:
--->
 
 ### Checklist:
-
 - [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
 - [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
 - [ ] Make sure all of the significant new logic is covered by tests
+-->


### PR DESCRIPTION
Updates the PR template by moving the checklist into the markdown comment. We'd like to solicit more of a description in community PRs and we think by moving the checklist out of the rendered view will make it SUPER obvious when there is no additional information.
