### PR TITLE
Add changeset to bump rc version

### DIFF
--- a/.changeset/six-rocks-arrive.md
+++ b/.changeset/six-rocks-arrive.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Release changes from [`v3.8.10`](https://github.com/apollographql/apollo-client/releases/tag/v3.8.10)


### PR DESCRIPTION
Adding changeset to bump rc version to include changes from [3.8.10](https://github.com/apollographql/apollo-client/releases/tag/v3.8.10)