### PR TITLE
Add field asking for `@apollo/client` version to our bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -22,3 +22,10 @@ body:
       description: Please provide any additional non-trivial steps required to reproduce the issue.
     validations:
       required: false
+  - type: input
+    attributes:
+      label: "`@apollo/client` version"
+      description: "What version of Apollo Client are you running?"
+      placeholder: "ex: 3.8.10"
+    validations:
+      required: true


### PR DESCRIPTION
Adds a field to our bug issue template that asks for the apollo client version.