### PR TITLE
Add doc comment for `headers` property on ApolloClient

### DIFF
--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -52,7 +52,7 @@ export interface ApolloClientOptions<TCacheShape> {
   uri?: string | UriFunction;
   credentials?: string;
   /**
-   * An object representing headers to include in eery HTTP request, such as `{Authorization: 'Bearer 1234'}`
+   * An object representing headers to include in every HTTP request, such as `{Authorization: 'Bearer 1234'}`
    *
    * This value will be ignored when using the `link` option.
    */

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -51,6 +51,11 @@ export interface ApolloClientOptions<TCacheShape> {
    */
   uri?: string | UriFunction;
   credentials?: string;
+  /**
+   * An object representing headers to include in eery HTTP request, such as `{Authorization: 'Bearer 1234'}`
+   *
+   * This value will be ignored when using the `link` option.
+   */
   headers?: Record<string, string>;
   /**
    * You can provide an {@link ApolloLink} instance to serve as Apollo Client's network layer. For more information, see [Advanced HTTP networking](https://www.apollographql.com/docs/react/networking/advanced-http-networking/).


### PR DESCRIPTION
Closes #11506

Adds a doc comment for the `headers` option that mentions that it will be ignored when using the `link` option.
