### PR TITLE
Document new React APIs in 3.9 - Part 1 of 2

### DIFF
--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
   "dist/apollo-client.min.cjs": 37930,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 31972
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 31974
 }

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -568,7 +568,7 @@ We begin loading data as soon as our `preloadQuery` function is called rather th
 
 #### Usage with data loading routers
 
-Popular routers such as [React Router](https://reactrouter.com/en/main) and [TanStack Router](https://tanstack.com/router) include APIs to start loading data before the route component renders (e.g. such as the [`loader` function](https://reactrouter.com/en/main/route/route#loader) from React Router). These APIs have the benefit that they can begin loading data in parallel without the need to wait for the route components to render. This is especially useful for nested routes where a parent route might otherwise suspend and create request waterfalls for child routes.
+Popular routers such as [React Router](https://reactrouter.com/en/main) and [TanStack Router](https://tanstack.com/router) provide APIs to load data before route components are rendered (e.g. such as the [`loader` function](https://reactrouter.com/en/main/route/route#loader) from React Router). This is especially useful for nested routes where data loading is parallelized and prevents situtations where parent route components might otherwise suspend and create request waterfalls for child route components.
 
 The `preloadQuery` API pairs nicely with these router APIs as it lets you take advantage of the optimizations these routers provide without sacrificing the ability to respond to cache updates in your route components.
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -561,7 +561,7 @@ The `preloadQuery` API pairs nicely with these router APIs as it lets you take a
 
 Let's update our example using React Router's `loader` function to begin loading data when we transition to our route.
 
-```ts
+```ts {4,8-9}
 import { useLoaderData } from 'react-router-dom';
 
 export function loader() {

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -439,7 +439,7 @@ The `useBackgroundQuery` hook used in a parent component is responsible for kick
 
 </MinVersion>
 
-`useSuspenseQuery` and `useBackgroundQuery` are useful hooks that will begin loading data as soon as the hook is mounted. But what happens when you'd like to start loading your query in response to a user interaction? With `useSuspenseQuery` and `useBackgroundQuery`, data fetching is bound to the component render. You would have to trigger a rerender to start fetching data for a different set of `variables` (e.g. by changing local component state).
+`useSuspenseQuery` and `useBackgroundQuery` are useful hooks that will begin loading data as soon as the hook is mounted. But what happens when you'd like to start loading your query in response to a user interaction? With `useSuspenseQuery` and `useBackgroundQuery`, data fetching is bound to the component render. You would have to trigger a rerender to start fetching data for a different set of variables (e.g. by changing local component state).
 
 Starting with Apollo Client `3.9.0`, you can use `useLoadableQuery` to start loading data in response to user interaction. This is not only more ergonomic, but starts loading the query immediately, providing a nice performance benefit.
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -765,7 +765,7 @@ function App() {
 // ...
 ```
 
-We begin loading `GET_BREEDS_QUERY` outside of React with the `preloadQuery` function. We use the `useQueryRefHandlers` hook to get the `refetch` function which refetches the query when the button is clicked.
+We begin loading our `GET_BREEDS_QUERY` outside of React with the `preloadQuery` function. We pass the `queryRef` returned from `preloadQuery` to the `useQueryRefHandlers` hook which provides us with a `refetch` function we can use to refetch the query when the button is clicked.
 
 #### Accessing query ref handlers produced from other hooks
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -774,7 +774,7 @@ function App() {
 
 We begin loading our `GET_BREEDS_QUERY` outside of React with the `preloadQuery` function. We pass the `queryRef` returned from `preloadQuery` to the `useQueryRefHandlers` hook which provides us with a `refetch` function we can use to refetch the query when the button is clicked.
 
-#### Accessing query ref handlers produced from other hooks
+#### Using `useQueryRefHandlers` with query refs produced from other Suspense hooks
 
 `useQueryRefHandlers` can also be used in combination with any hook that returns a `queryRef`, such as `useBackgroundQuery` or `useLoadableQuery`. This is useful when you need access to the `refetch` and `fetchMore` functions in components where the `queryRef` is passed through deeply.
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -564,7 +564,7 @@ root.render(
 );
 ```
 
-We begin loading data as soon as our `preloadQuery` function is called. We no longer need to wait for React to render our `<App />` component before our `GET_DOGS_QUERY` begins loading, but still get the benefit of suspense!
+We begin loading data as soon as our `preloadQuery` function is called rather than waiting for React to render our `<App />` component. Because the `preloadedQueryRef` is passed to `useReadQuery` in our `App` component, we still get the benefit of suspense and cache updates!
 
 #### Usage with data loading routers
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -448,8 +448,7 @@ Starting with Apollo Client `3.9.0`, you can use `useLoadableQuery` to start loa
 Let's update our example to start loading the dog's details as a result of selecting from a dropdown.
 
 ```tsx
-function App() {
-  const { data } = useSuspenseQuery(GET_DOGS_QUERY);
+function App({ dogs }) {
   const [queryRef, loadDog] = useLoadableQuery(GET_DOG_QUERY)
 
   return (
@@ -457,7 +456,7 @@ function App() {
       <select
         onChange={(e) => loadDog({ id: e.target.value })}
       >
-        {data.dogs.map(({ id, name }) => (
+        {dogs.map(({ id, name }) => (
           <option key={id} value={id}>
             {name}
           </option>

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -511,7 +511,7 @@ This API is experimental in `3.9.0` and may change in `3.10.0`. We are specifica
 
 Before you can preload queries, you first need to create a preload function with `createQueryPreloader`. `createQueryPreloader` is given an `ApolloClient` instance as an argument and returns a function that when called, will begin fetching the query. By making `createQueryPreloader` a [curried](https://en.wikipedia.org/wiki/Currying) function, you can easily export your preload function alongside any `ApolloClient` instance you create.
 
-The preload function returns a `queryRef` that can then be passed to `useReadQuery` to read the query data and suspend the component while loading. `useReadQuery` will also ensure that your component containing the preloaded query will be kept up-to-date with any cache updates for that query.
+The preload function returns a `queryRef` that is passed to `useReadQuery` to read the query data and suspend the component while loading. `useReadQuery` will ensure that your component is kept up-to-date with cache updates for the preloaded query.
 
 Let's update our example to start loading the `GET_DOGS_QUERY` before our app is rendered.
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -521,12 +521,15 @@ It is safe to unmount components that contain preloaded queries. Doing so puts t
 
 Let's update our example to start loading the `GET_DOGS_QUERY` before our app is rendered.
 
-```tsx {3,6-7,10,33,35}
+```tsx {3,9-10,13,36,38}
 import {
   // ...
   createQueryPreloader
 } from '@apollo/client';
 
+// This `preloadQuery` function does not have to be created each time you 
+// need to preload a new query. You may prefer to export this function 
+// alongside your client instead. 
 const preloadQuery = createQueryPreloader(client);
 const preloadedQueryRef = preloadQuery(GET_DOGS_QUERY);
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -877,6 +877,10 @@ More details on `useBackgroundQuery`'s API can be found in [its API docs](../api
 
 More details on `useLoadableQuery`'s API can be found in [its API docs](../api/react/hooks/#useloadablequery).
 
+## useQueryRefHandlers API
+
+More details on `useQueryRefHandlers`'s API can be found in [its API docs](../api/react/hooks/#usequeryrefhandlers).
+
 ## useReadQuery API
 
 More details on `useReadQuery`'s API can be found in [its API docs](../api/react/hooks/#usereadquery).

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -441,7 +441,7 @@ The `useBackgroundQuery` hook used in a parent component is responsible for kick
 
 `useSuspenseQuery` and `useBackgroundQuery` are useful hooks that will begin loading data as soon as the hook is mounted. But what happens when you'd like to start loading your query in response to a user interaction? With `useSuspenseQuery` and `useBackgroundQuery`, data fetching is bound to the component render. You would have to trigger a rerender to start fetching data for a different set of variables (e.g. by changing local component state).
 
-Starting with Apollo Client `3.9.0`, you can use `useLoadableQuery` to start loading data in response to user interaction. This is not only more ergonomic, but starts loading the query immediately, providing a nice performance benefit.
+Starting with Apollo Client `3.9.0`, you can use `useLoadableQuery` to start loading data in response to user interaction. This avoids adding additional component state to trigger rerenders and provides a more ergonomic experience.
 
 `useLoadableQuery` returns a both an execution function and `queryRef`. The execution function begins fetching the query when called with the provided variables. Like `useBackgroundQuery`, passing the `queryRef` to `useReadQuery` in a child component suspends the child component until the query finishes loading.
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -527,9 +527,9 @@ import {
   createQueryPreloader
 } from '@apollo/client';
 
-// This `preloadQuery` function does not have to be created each time you 
-// need to preload a new query. You may prefer to export this function 
-// alongside your client instead. 
+// This `preloadQuery` function does not have to be created each time you
+// need to preload a new query. You may prefer to export this function
+// alongside your client instead.
 const preloadQuery = createQueryPreloader(client);
 const preloadedQueryRef = preloadQuery(GET_DOGS_QUERY);
 
@@ -598,7 +598,7 @@ React Router calls the `loader` function which we use to begin loading the `GET_
 <Note>
 
 The `preloadQuery` function only works with client-side routing. The `queryRef` returned from `preloadQuery` is not serializable across the wire and as such, will not work with routers that fetch on the server such as [Remix](https://remix.run/).
-  
+
 </Note>
 
 #### Preventing route transitions until the query is loaded
@@ -612,7 +612,7 @@ export async function loader() {
   return queryRef;
 }
 
-// You may also return the promise directly from loader. 
+// You may also return the promise directly from loader.
 // This is equivalent to the above.
 export async function loader() {
   return preloadQuery(GET_DOGS_QUERY).toPromise();
@@ -729,7 +729,7 @@ import {
   useQueryRefHandlers,
 } from "@apollo/client";
 
-const queryRef = preloadQuery(GET_BREEDS_QUERY); 
+const queryRef = preloadQuery(GET_BREEDS_QUERY);
 
 function App() {
   const [isPending, startTransition] = useTransition();

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -555,7 +555,7 @@ We begin loading data as soon as our `preloadQuery` function is called. We no lo
 
 #### Usage with data loading routers
 
-Popular routers such as [React Router](https://reactrouter.com/en/main) and [TanStack Router](https://tanstack.com/router) include APIs to start loading data before the route component renders (e.g. such as the [`loader` function](https://reactrouter.com/en/main/route/route#loader) from React Router). These APIs have the benefit that they can begin loading data in parallel without the need to wait for the route component to render. This is especially useful for nested routes where a parent route would otherwise suspend and create request waterfalls for child routes.
+Popular routers such as [React Router](https://reactrouter.com/en/main) and [TanStack Router](https://tanstack.com/router) include APIs to start loading data before the route component renders (e.g. such as the [`loader` function](https://reactrouter.com/en/main/route/route#loader) from React Router). These APIs have the benefit that they can begin loading data in parallel without the need to wait for the route components to render. This is especially useful for nested routes where a parent route might otherwise suspend and create request waterfalls for child routes.
 
 The `preloadQuery` API pairs nicely with these router APIs as it lets you take advantage of the optimizations these routers provide without sacrificing the ability to respond to cache updates in your route components.
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -763,7 +763,7 @@ We begin loading `GET_BREEDS_QUERY` outside of React with the `preloadQuery` fun
 
 Let's update our last example back to `useBackgroundQuery` and get access to `refetch` from `useQueryRefHandlers` in our `Dog` component without passing the `refetch` function from the parent.
 
-```tsx {12,16,18-22,30}
+```tsx {15,16,18-22,30}
 function App() {
   const [queryRef] = useBackgroundQuery(GET_BREEDS_QUERY);
 
@@ -775,10 +775,10 @@ function App() {
 }
 
 function Dog({ id, queryRef }: DogProps) {
-  const [isPending, startTransition] = useTransition();
   const { data } = useSuspenseQuery(GET_DOG_QUERY, {
     variables: { id },
   });
+  const [isPending, startTransition] = useTransition();
   const { refetch } = useQueryRefHandlers(queryRef);
 
   function handleRefetch() {

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -822,6 +822,12 @@ function Dog({ id, queryRef }: DogProps) {
 // ...
 ```
 
+<Note>
+
+Using the handlers returned from `useQueryRefHandlers` does not prevent you from using the handlers produced by query ref hooks. You can use the handlers in both locations, with or without React transitions to produce the desired result.
+
+</Note>
+
 ## Distinguishing between queries with `queryKey`
 
 Apollo Client uses the combination of `query` and `variables` to uniquely identify each query when using Apollo's Suspense data fetching hooks.

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -439,7 +439,7 @@ The `useBackgroundQuery` hook used in a parent component is responsible for kick
 
 </MinVersion>
 
-`useSuspenseQuery` and `useBackgroundQuery` are useful hooks that will begin loading data as soon as the hook is mounted. But what happens when you'd like to start loading your query in response to a user interaction? With `useSuspenseQuery` and `useBackgroundQuery`, data fetching is bound to the component render. You would have to trigger a rerender to start fetching data for a different set of variables (e.g. by changing local component state).
+`useSuspenseQuery` and `useBackgroundQuery` are useful for loading data as soon as the component calling the hook mounts. But what about loading a query in response to user interaction? For example, we may want to start loading some data when a user hovers on a link.
 
 Starting with Apollo Client `3.9.0`, you can use `useLoadableQuery` to start loading data in response to user interaction. This avoids adding additional component state to trigger rerenders and provides a more ergonomic experience.
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -570,7 +570,7 @@ We begin loading data as soon as our `preloadQuery` function is called rather th
 
 Popular routers such as [React Router](https://reactrouter.com/en/main) and [TanStack Router](https://tanstack.com/router) provide APIs to load data before route components are rendered (e.g. such as the [`loader` function](https://reactrouter.com/en/main/route/route#loader) from React Router). This is especially useful for nested routes where data loading is parallelized and prevents situtations where parent route components might otherwise suspend and create request waterfalls for child route components.
 
-The `preloadQuery` API pairs nicely with these router APIs as it lets you take advantage of the optimizations these routers provide without sacrificing the ability to respond to cache updates in your route components.
+The `preloadQuery` API pairs nicely with these router APIs as it lets you take advantage of those optimizations without sacrificing the ability to rerender with cache updates in your route components.
 
 Let's update our example using React Router's `loader` function to begin loading data when we transition to our route.
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -771,7 +771,7 @@ We begin loading `GET_BREEDS_QUERY` outside of React with the `preloadQuery` fun
 
 `useQueryRefHandlers` can also be used in combination with any hook that returns a `queryRef`, such as `useBackgroundQuery` or `useLoadableQuery`. This is useful when you need access to the `refetch` and `fetchMore` functions in components where the `queryRef` is passed through deeply.
 
-Let's update our last example back to `useBackgroundQuery` and get the `refetch` function from the `useQueryRefHandlers` hook in the `Dog` component.
+Let's update our example to use `useBackgroundQuery` again and see how we can access a `refetch` function in our `Dog` component using `useQueryRefHandlers`:
 
 ```tsx {15,16,18-22,30}
 function App() {

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -505,7 +505,7 @@ Starting with Apollo Client `3.9.0`, it is possible to start loading queries out
 
 <ExperimentalFeature>
 
-This API is experimental in `3.9.0` and may change in `3.10.0`. We are specifically looking for user feedback on the API design choices. The underlying behavior is otherwise fully implemented. If you'd like to provide feedback for this feature before it is stabilized in `3.10.0`, please visit [#11519](https://github.com/apollographql/apollo-client/issues/11519) and add a comment.
+This feature is in [alpha stage](https://www.apollographql.com/docs/resources/product-launch-stages/#alpha--beta) for version `3.9.0` and may be subject to change before `3.10.0`. We consider this feature production-ready, but may be subject to change depending on feedback. If you'd like to provide feedback for this feature before it is stabilized in `3.10.0`, please visit [#11519](https://github.com/apollographql/apollo-client/issues/11519) and add a comment.
 
 </ExperimentalFeature>
 
@@ -627,6 +627,12 @@ export function RouteComponent() {
 ```
 
 This instructs React Router to wait for the query to finish loading before the route transitions. When the route transitions after the promise resolves, the data is rendered immediately without the need to show a loading fallback in the route component.
+
+<ExperimentalFeature>
+
+`queryRef.toPromise` is [experimental](https://www.apollographql.com/docs/resources/product-launch-stages/#experimental-features) for version `3.9.0` and may be subject to breaking changes before `3.10.0`. If you'd like to provide feedback for this feature before it is stabilized in `3.10.0`, please visit [#11519](https://github.com/apollographql/apollo-client/issues/11519) and add a comment.
+
+</ExperimentalFeature>
 
 #### Why prevent access to `data` in `toPromise`?
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -705,7 +705,7 @@ In this example, our `App` component renders a `Dog` component that fetches a si
 
 When loading queries [outside React](#initiating-queries-outside-react), the `preloadQuery` function returns a `queryRef` with no access to `refetch` or `fetchMore` functions. This presents a challenge if you need to refresh or paginate on the data returned by the query ref.
 
-You can gain access to `refetch` and `fetchMore` functions by using the `useQueryRefHandlers` hook. This hook integrates with React transitions, giving you the ability to update without suspending.
+You can gain access to `refetch` and `fetchMore` functions by using the `useQueryRefHandlers` hook. This hook integrates with React transitions, giving you the ability to refetch or paginate without showing the loading fallback.
 
 Let's update our example to preload our `GET_BREEDS_QUERY` outside React and utilize `useQueryRefHandlers` to refetch our query.
 
@@ -776,13 +776,13 @@ function Breeds({ isPending }: BreedsProps) {
 }
 ```
 
-We begin loading `GET_BREEDS_QUERY` outside of React with the `preloadQuery` function. We use the `useQueryRefHandlers` hook to get access to the `refetch` function which lets us reload the query when the button is clicked.
+We begin loading `GET_BREEDS_QUERY` outside of React with the `preloadQuery` function. We use the `useQueryRefHandlers` hook to get access to the `refetch` function which lets us refetch the query when the button is clicked.
 
 #### Accessing query ref handlers produced from other hooks
 
 `useQueryRefHandlers` is not limited to the `preloadQuery` API and can be used with any hook that produces a `queryRef` such as `useBackgroundQuery` or `useLoadableQuery`. This can be useful in situations where you may need access to the `refetch` and `fetchMore` functions in components where the `queryRef` was passed through deeply.
 
-Let's update our last example back to `useBackgroundQuery` and get access to `refetch` in our `Dog` component instead without needing to pass it from the parent.
+Let's update our last example back to `useBackgroundQuery` and get access to `refetch` from `useQueryRefHandlers` in our `Dog` component without passing the `refetch` function from the parent.
 
 ```tsx {12,16,18-22,30}
 function App() {

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -509,7 +509,7 @@ This API is experimental in `3.9.0` and may change in `3.10.0`. We are specifica
 
 </ExperimentalFeature>
 
-To begin loading data immediately, you first need to create a preload function with `createQueryPreloader`. `createQueryPreloader` is given an `ApolloClient` instance as an argument and returns a function that when called, will begin fetching the query. By making `createQueryPreloader` a [curried](https://en.wikipedia.org/wiki/Currying) function, this makes it easy to export your preload function alongside any `ApolloClient` instance you create.
+Before you can preload queries, you first need to create a preload function with `createQueryPreloader`. `createQueryPreloader` is given an `ApolloClient` instance as an argument and returns a function that when called, will begin fetching the query. By making `createQueryPreloader` a [curried](https://en.wikipedia.org/wiki/Currying) function, this makes it easy to export your preload function alongside any `ApolloClient` instance you create.
 
 The preload function returns a `queryRef` that can then be passed to `useReadQuery` to read the query data and suspend the component while loading. `useReadQuery` will also ensure that your component containing the preloaded query will be kept up-to-date with any cache updates for that query.
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -493,7 +493,7 @@ function Dog({ queryRef }) {
 }
 ```
 
-We begin fetching our `GET_DOG_QUERY` as soon as a dog is selected by calling the `loadDog` function. When the `Dog` component renders, `useReadQuery` suspends the component while the `GET_DOG_QUERY` loads, then provides `data` to the component. As a result of this change, we've also removed the need to track the selected dog ID as part of React state!
+We begin fetching our `GET_DOG_QUERY` by calling the `loadDog` function inside of the `onChange` handler function when a dog is selected. Once the network request is initiated, the `queryRef` is no longer `null` which renders the `Dog` component. In the `Dog` component, `useReadQuery` suspends the component while the network request finishes, then returns `data` to the component. As a result of this change, we've also eliminated the need to track the selected dog `id` in component state!
 
 <MinVersion version="3.9.0">
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -626,7 +626,7 @@ export function RouteComponent() {
 }
 ```
 
-This instructs React Router to wait for the query to finish loading before the route transitions. When the route transitions after the promise resolves, the data will be rendered immediately without the need to show a loading fallback in the route component.
+This instructs React Router to wait for the query to finish loading before the route transitions. When the route transitions after the promise resolves, the data is rendered immediately without the need to show a loading fallback in the route component.
 
 #### Why prevent access to `data` in `toPromise`?
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -501,23 +501,24 @@ We begin fetching our `GET_DOG_QUERY` by calling the `loadDog` function inside o
 
 </MinVersion>
 
-Starting with Apollo Client `3.9.0`, queries can be initiated outside of React. This allows your app to begin fetching data _before_ React renders your components, and can provide performance benefits.
-
 <ExperimentalFeature>
 
 This feature is in [alpha stage](https://www.apollographql.com/docs/resources/product-launch-stages/#alpha--beta) for version `3.9.0` and may be subject to change before `3.10.0`. We consider this feature production-ready, but may be subject to change depending on feedback. If you'd like to provide feedback for this feature before it is stabilized in `3.10.0`, please visit [#11519](https://github.com/apollographql/apollo-client/issues/11519) and add a comment.
 
 </ExperimentalFeature>
 
+Starting with Apollo Client `3.9.0`, queries can be initiated outside of React. This allows your app to begin fetching data _before_ React renders your components, and can provide performance benefits.
+
 To preload queries, you first need to create a preload function with `createQueryPreloader`. `createQueryPreloader` takes an `ApolloClient` instance as an argument and returns a function that, when called, initiates a network request.
+
+<Tip>
+
+Consider exporting your preload function along with your `ApolloClient` instance. This allows you to import that function directly without having to pass around your `ApolloClient` instance each time you preload a query.
+
+</Tip>
 
 The preload function returns a `queryRef` that is passed to `useReadQuery` to read the query data and suspend the component while loading. `useReadQuery` will ensure that your component is kept up-to-date with cache updates for the preloaded query.
 
-<Note>
-
-Unmounting components that contain preloaded queries is safe and diposes of the `queryRef`. When the component re-mounts, `useReadQuery` automatically resubscribes to the `queryRef` and any cache updates that occurred in the interim are read immediately as if the preloaded query had never been unmounted.
-
-</Note>
 
 Let's update our example to start loading the `GET_DOGS_QUERY` before our app is rendered.
 
@@ -565,6 +566,12 @@ root.render(
 ```
 
 We begin loading data as soon as our `preloadQuery` function is called rather than waiting for React to render our `<App />` component. Because the `preloadedQueryRef` is passed to `useReadQuery` in our `App` component, we still get the benefit of suspense and cache updates!
+
+<Note>
+
+Unmounting components that contain preloaded queries is safe and diposes of the `queryRef`. When the component re-mounts, `useReadQuery` automatically resubscribes to the `queryRef` and any cache updates that occurred in the interim are read immediately as if the preloaded query had never been unmounted.
+
+</Note>
 
 #### Usage with data loading routers
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -439,7 +439,7 @@ The `useBackgroundQuery` hook used in a parent component is responsible for kick
 
 </MinVersion>
 
-`useSuspenseQuery` and `useBackgroundQuery` are useful hooks that will begin loading data as soon as the hook is mounted. But what happens when you'd like to start loading your query in response to a user interaction? With `useSuspenseQuery` and `useBackgroundQuery`, you'd need to update React state in response to the user interaction in order to re-render your component.
+`useSuspenseQuery` and `useBackgroundQuery` are useful hooks that will begin loading data as soon as the hook is mounted. But what happens when you'd like to start loading your query in response to a user interaction? With `useSuspenseQuery` and `useBackgroundQuery`, data fetching is bound to the component render. You would have to trigger a rerender to start fetching data for a different set of `variables` (e.g. by changing local component state).
 
 Starting with Apollo Client `3.9.0`, you can use `useLoadableQuery` to start loading data in response to user interaction. This is not only more ergonomic, but starts loading the query immediately, providing a nice performance benefit.
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -505,7 +505,9 @@ This API is experimental in `3.9.0` and may change in `3.10.0`. We are specifica
 
 </ExperimentalFeature>
 
-To begin loading data immediately, you first need to create a preloading function with `createQueryPreloader`. `createQueryPreloader` is given the `client` as an argument and returns a function that when called, will begin fetching the query. The preload function returns a `queryRef` that can then be passed to `useReadQuery` to read the query data, and if still loading, suspend that component.
+To begin loading data immediately, you first need to create a preload function with `createQueryPreloader`. `createQueryPreloader` is given an `ApolloClient` instance as an argument and returns a function that when called, will begin fetching the query. By making `createQueryPreloader` a [curried](https://en.wikipedia.org/wiki/Currying) function, this makes it easy to export your preload function alongside any `ApolloClient` instance you create.
+
+The preload function returns a `queryRef` that can then be passed to `useReadQuery` to read the query data and suspend the component while loading. `useReadQuery` will also ensure that your component containing the preloaded query will be kept up-to-date with any cache updates for that query.
 
 Let's update our example to start loading the `GET_DOGS_QUERY` before our app is rendered.
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -584,7 +584,7 @@ We load our query as soon as React Router calls our `loader` function. This star
 
 <Note>
 
-The `preloadQuery` API only works with client-side routing. The `queryRef` returned from `preloadQuery` is not serializable across the wire and as such, will not work with routers that render on the server, such as [Remix](https://remix.run/).
+The `preloadQuery` API only works with client-side routing. The `queryRef` returned from `preloadQuery` is not serializable across the wire and as such, will not work with routers that fetch on the server such as [Remix](https://remix.run/).
   
 </Note>
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -603,7 +603,11 @@ The `preloadQuery` function only works with client-side routing. The `queryRef` 
 
 #### Preventing route transitions until the query is loaded
 
-By default, `preloadQuery` works similar to a [deferred loader](https://reactrouter.com/en/main/guides/deferred) in that routes will transition immediately and suspend with `useReadQuery` until the query is loaded. You may instead want to prevent the route from transitioning until the data is fully loaded. Use the `toPromise` method on the `queryRef` to get a promise that resolves when the query is loaded. This promise resolves with the `queryRef` itself, making it easy to use with hooks such as `useLoaderData`.
+By default, `preloadQuery` works similar to a [deferred loader](https://reactrouter.com/en/main/guides/deferred): the route will transition immediately and the incoming page that's attempting to read the data via `useReadQuery` will suspend until the network request finishes.
+
+But what if we want to prevent the route from transitioning until the data is fully loaded? The `toPromise` method on a `queryRef` provides access to a promise that resolves when the network request has completed. This promise resolves with the `queryRef` itself, making it easy to use with hooks such as `useLoaderData`.
+
+Here's an example:
 
 ```ts
 export async function loader() {

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -433,6 +433,59 @@ When the network request for `GET_DOG_QUERY` completes, the `Dog` component unsu
 
 The `useBackgroundQuery` hook used in a parent component is responsible for kicking off fetches, but doesn't deal with reading or rendering data. This is delegated to the `useReadQuery` hook used in a child component. This separation of concerns provides a nice performance benefit because cache updates are observed by `useReadQuery` and re-render only the child component. You may find this as a useful tool to optimize your component structure to avoid unnecessarily re-rendering parent components when cache data changes.
 
+<MinVersion version="3.9.0">
+
+### Querying in response to user interaction
+
+</MinVersion>
+
+`useSuspenseQuery` and `useBackgroundQuery` are useful hooks that will begin loading data as soon as the hook is mounted. But what happens when you'd like to start loading your query in response to a user interaction? With `useSuspenseQuery` and `useBackgroundQuery`, you'd need to update React state in response to the user interaction in order to re-render your component.
+
+Starting with Apollo Client `3.9.0`, you can use `useLoadableQuery` to start loading data in response to user interaction. This is not only more ergonomic, but starts loading the query immediately, providing a nice performance benefit.
+
+`useLoadableQuery` returns a function that when called will begin fetching the query with the provided variables. Like `useBackgroundQuery`, you get access to a `queryRef` that is passed to `useReadQuery` to read the data in a child component. When the child component renders before the query has finished loading, the child component suspends.
+
+Let's update our example to start loading the dog's details as a result of selecting from a dropdown.
+
+```tsx
+function App() {
+  const { data } = useSuspenseQuery(GET_DOGS_QUERY);
+  const [queryRef, loadDog] = useLoadableQuery(GET_DOG_QUERY)
+
+  return (
+    <>
+      <select
+        onChange={(e) => loadDog({ id: e.target.value })}
+      >
+        {data.dogs.map(({ id, name }) => (
+          <option key={id} value={id}>
+            {name}
+          </option>
+        ))}
+      </select>
+      <Suspense fallback={<div>Loading...</div>}>
+        {queryRef && <Dog queryRef={queryRef} />}
+      </Suspense>
+    </>
+  );
+}
+
+function Dog({ queryRef }) {
+  const { data } = useReadQuery(queryRef)
+
+  return (
+    <>
+      <div>Name: {data.dog.name}</div>
+      <div>Breed: {data.dog.breed}</div>
+    </>
+  );
+}
+```
+
+> It's important to note that the `queryRef` is `null` until the query loading function is called for the first time. You should conditionally render the child component when the query has not yet been loaded.
+
+We begin fetching our `GET_DOG_QUERY` as soon as a new dog is selected rather than waiting for our `Dog` component to re-render. When the `Dog` component renders, it reads data from the `GET_DOG_QUERY`, and if not ready, will suspend. As a result of this change, we've also removed the need to track the selected dog ID as part of React state!
+
 ### Refetching and pagination
 
 Apollo's Suspense data fetching hooks return functions for refetching query data via the `refetch` function, and fetching additional pages of data via the `fetchMore` function.

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -570,7 +570,7 @@ We begin loading data as soon as our `preloadQuery` function is called rather th
 
 Popular routers such as [React Router](https://reactrouter.com/en/main) and [TanStack Router](https://tanstack.com/router) provide APIs to load data before route components are rendered (e.g. such as the [`loader` function](https://reactrouter.com/en/main/route/route#loader) from React Router). This is especially useful for nested routes where data loading is parallelized and prevents situtations where parent route components might otherwise suspend and create request waterfalls for child route components.
 
-The `preloadQuery` API pairs nicely with these router APIs as it lets you take advantage of those optimizations without sacrificing the ability to rerender with cache updates in your route components.
+`preloadQuery` pairs nicely with these router APIs as it lets you take advantage of those optimizations without sacrificing the ability to rerender with cache updates in your route components.
 
 Let's update our example using React Router's `loader` function to begin loading data when we transition to our route.
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -689,6 +689,127 @@ function Breeds({ queryRef, isPending }: BreedsProps) {
 
 In this example, our `App` component renders a `Dog` component that fetches a single dog's record via `useSuspenseQuery`. When React attempts to render `Dog` for the first time, the cache can't fulfill the request for the `GetDog` query, so `useSuspenseQuery` initiates a network request. `Dog` suspends while the network request is pending, triggering the nearest `Suspense` boundary _above_ the suspended component in `App` which renders our "Loading..." fallback. Once the network request is complete, `Dog` renders with the newly cached `name` for the dog whose `id="3"`: Mozzarella the Corgi.
 
+#### Usage with query preloading
+
+When loading queries [outside React](#initiating-queries-outside-react), the `preloadQuery` function returns a `queryRef` with no access to `refetch` or `fetchMore` functions. This presents a challenge if you need to refresh or paginate on the data returned by the query ref.
+
+You can gain access to `refetch` and `fetchMore` functions by using the `useQueryRefHandlers` hook. This hook integrates with React transitions, giving you the ability to update without suspending.
+
+Let's update our example to preload our `GET_BREEDS_QUERY` outside React and utilize `useQueryRefHandlers` to refetch our query.
+
+```tsx {4,7-8,12}
+// ...
+import {
+  // ...
+  useQueryRefHandlers,
+} from "@apollo/client";
+
+const preloadQuery = createQueryPreloader(client);
+const queryRef = preloadQuery(GET_BREEDS_QUERY); 
+
+function App() {
+  const [isPending, startTransition] = useTransition();
+  const { refetch } = useQueryRefHandlers(queryRef);
+
+  function handleRefetch() {
+    startTransition(() => {
+      refetch();
+    });
+  };
+
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <Dog
+        id="3"
+        isPending={isPending}
+        onRefetch={handleRefetch}
+      />
+    </Suspense>
+  );
+}
+
+function Dog({
+  id,
+  isPending,
+  onRefetch,
+}: DogProps) {
+  const { data } = useSuspenseQuery(GET_DOG_QUERY, {
+    variables: { id },
+  });
+
+  return (
+    <>
+      Name: {data.dog.name}
+      <Suspense fallback={<div>Loading breeds...</div>}>
+        <Breeds isPending={isPending} />
+      </Suspense>
+      <button onClick={onRefetch}>Refetch!</button>
+    </>
+  );
+}
+
+function Breeds({ isPending }: BreedsProps) {
+  const { data } = useReadQuery(queryRef);
+
+  return data.breeds.map(({ characteristics }) =>
+    characteristics.map((characteristic) => (
+      <div
+        style={{ opacity: isPending ? 0.5 : 1 }}
+        key={characteristic}
+      >
+        {characteristic}
+      </div>
+    ))
+  );
+}
+```
+
+We begin loading `GET_BREEDS_QUERY` outside of React with the `preloadQuery` function. We use the `useQueryRefHandlers` hook to get access to the `refetch` function which lets us reload the query when the button is clicked.
+
+#### Accessing query ref handlers produced from other hooks
+
+`useQueryRefHandlers` is not limited to the `preloadQuery` API and can be used with any hook that produces a `queryRef` such as `useBackgroundQuery` or `useLoadableQuery`. This can be useful in situations where you may need access to the `refetch` and `fetchMore` functions in components where the `queryRef` was passed through deeply.
+
+Let's update our last example back to `useBackgroundQuery` and get access to `refetch` in our `Dog` component instead without needing to pass it from the parent.
+
+```tsx {12,16,18-22,30}
+function App() {
+  const [queryRef] = useBackgroundQuery(GET_BREEDS_QUERY);
+
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <Dog id="3" queryRef={queryRef} />
+    </Suspense>
+  );
+}
+
+function Dog({ id, queryRef }: DogProps) {
+  const [isPending, startTransition] = useTransition();
+  const { data } = useSuspenseQuery(GET_DOG_QUERY, {
+    variables: { id },
+  });
+  const { refetch } = useQueryRefHandlers(queryRef);
+
+  function handleRefetch() {
+    startTransition(() => {
+      refetch();
+    });
+  };
+
+  return (
+    <>
+      Name: {data.dog.name}
+      <Suspense fallback={<div>Loading breeds...</div>}>
+        <Breeds queryRef={queryRef} isPending={isPending} />
+      </Suspense>
+      <button onClick={handleRefetch}>Refetch!</button>
+    </>
+  );
+}
+
+// ...
+```
+
 ## Distinguishing between queries with `queryKey`
 
 Apollo Client uses the combination of `query` and `variables` to uniquely identify each query when using Apollo's Suspense data fetching hooks.

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -461,7 +461,7 @@ import {
 
 function App() {
   const { data } = useSuspenseQuery(GET_DOGS_QUERY);
-  const [queryRef, loadDog] = useLoadableQuery(GET_DOG_QUERY)
+  const [queryRef, loadDog] = useLoadableQuery(GET_DOG_QUERY);
 
   return (
     <>

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -509,7 +509,7 @@ This API is experimental in `3.9.0` and may change in `3.10.0`. We are specifica
 
 </ExperimentalFeature>
 
-Before you can preload queries, you first need to create a preload function with `createQueryPreloader`. `createQueryPreloader` is given an `ApolloClient` instance as an argument and returns a function that when called, will begin fetching the query. By making `createQueryPreloader` a [curried](https://en.wikipedia.org/wiki/Currying) function, this makes it easy to export your preload function alongside any `ApolloClient` instance you create.
+Before you can preload queries, you first need to create a preload function with `createQueryPreloader`. `createQueryPreloader` is given an `ApolloClient` instance as an argument and returns a function that when called, will begin fetching the query. By making `createQueryPreloader` a [curried](https://en.wikipedia.org/wiki/Currying) function, you can easily export your preload function alongside any `ApolloClient` instance you create.
 
 The preload function returns a `queryRef` that can then be passed to `useReadQuery` to read the query data and suspend the component while loading. `useReadQuery` will also ensure that your component containing the preloaded query will be kept up-to-date with any cache updates for that query.
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -769,7 +769,7 @@ We begin loading `GET_BREEDS_QUERY` outside of React with the `preloadQuery` fun
 
 #### Accessing query ref handlers produced from other hooks
 
-`useQueryRefHandlers` is not limited to the `preloadQuery` function and can be used with any hook that produces a `queryRef` such as `useBackgroundQuery` or `useLoadableQuery`. This is useful in situations where you need access to the `refetch` and `fetchMore` functions in components where the `queryRef` is passed through deeply.
+`useQueryRefHandlers` can also be used in combination with any hook that returns a `queryRef`, such as `useBackgroundQuery` or `useLoadableQuery`. This is useful when you need access to the `refetch` and `fetchMore` functions in components where the `queryRef` is passed through deeply.
 
 Let's update our last example back to `useBackgroundQuery` and get the `refetch` function from the `useQueryRefHandlers` hook in the `Dog` component.
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -435,7 +435,7 @@ The `useBackgroundQuery` hook used in a parent component is responsible for kick
 
 <MinVersion version="3.9.0">
 
-### Querying in response to user interaction
+### Fetching in response to user interaction
 
 </MinVersion>
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -630,7 +630,7 @@ This instructs React Router to wait for the query to finish loading before the r
 
 #### Why prevent access to `data` in `toPromise`?
 
-You may be wondering why we resolve `toPromise` with the `queryRef` itself, rather than the data loaded from the query. This is because we want to encourage you to leverage `useReadQuery` to avoid missing out on cache updates for your query. If `data` were available, it would be tempting to consume it in your `loader` functions and expose it to your route components. Doing so means missing out on cache updates.
+You may be wondering why we resolve `toPromise` with the `queryRef` itself, rather than the data loaded from the query. We want to encourage you to leverage `useReadQuery` to avoid missing out on cache updates for your query. If `data` were available, it would be tempting to consume it in your `loader` functions and expose it to your route components. Doing so means missing out on cache updates.
 
 If you need access to raw query data in your `loader` functions, use [`client.query()`](../api/core/ApolloClient#query) directly.
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -509,7 +509,7 @@ This feature is in [alpha stage](https://www.apollographql.com/docs/resources/pr
 
 </ExperimentalFeature>
 
-Before you can preload queries, you first need to create a preload function with `createQueryPreloader`. `createQueryPreloader` is given an `ApolloClient` instance as an argument and returns a function that when called, will begin fetching the query. By making `createQueryPreloader` a [curried](https://en.wikipedia.org/wiki/Currying) function, you can easily export your preload function alongside any `ApolloClient` instance you create.
+To preload queries, you first need to create a preload function with `createQueryPreloader`. `createQueryPreloader` takes an `ApolloClient` instance as an argument and returns a function that, when called, initiates a network request.
 
 The preload function returns a `queryRef` that is passed to `useReadQuery` to read the query data and suspend the component while loading. `useReadQuery` will ensure that your component is kept up-to-date with cache updates for the preloaded query.
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -447,7 +447,12 @@ Starting with Apollo Client `3.9.0`, you can use `useLoadableQuery` to start loa
 
 Let's update our example to start loading the dog's details as a result of selecting from a dropdown.
 
-```tsx {3,8,17,24}
+```tsx {3,8,13,22,29}
+import {
+  // ...
+  useLoadableQuery
+} from '@apollo/client';
+
 function App() {
   const { data } = useSuspenseQuery(GET_DOGS_QUERY);
   const [queryRef, loadDog] = useLoadableQuery(GET_DOG_QUERY)
@@ -504,7 +509,12 @@ To begin loading data immediately, you first need to create a preloading functio
 
 Let's update our example to start loading the `GET_DOGS_QUERY` before our app is rendered.
 
-```tsx {1-2,5,28,30}
+```tsx {3,6-7,10,33,35}
+import {
+  // ...
+  createQueryPreloader
+} from '@apollo/client';
+
 const preloadQuery = createQueryPreloader(client);
 const dogsQueryRef = preloadQuery(GET_DOGS_QUERY);
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -513,6 +513,12 @@ Before you can preload queries, you first need to create a preload function with
 
 The preload function returns a `queryRef` that is passed to `useReadQuery` to read the query data and suspend the component while loading. `useReadQuery` will ensure that your component is kept up-to-date with cache updates for the preloaded query.
 
+<Note>
+
+It is safe to unmount components that contain preloaded queries. Doing so puts the `queryRef` in a dormant state until the component is mounted again. Any cache updates that may have happened while dormant will be read immediately as if the preloaded query had never been unmounted.
+
+</Note>
+
 Let's update our example to start loading the `GET_DOGS_QUERY` before our app is rendered.
 
 ```tsx {3,6-7,10,33,35}

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -569,7 +569,7 @@ We begin loading data as soon as our `preloadQuery` function is called rather th
 
 <Note>
 
-Unmounting components that contain preloaded queries is safe and diposes of the `queryRef`. When the component re-mounts, `useReadQuery` automatically resubscribes to the `queryRef` and any cache updates that occurred in the interim are read immediately as if the preloaded query had never been unmounted.
+Unmounting components that contain preloaded queries is safe and disposes of the `queryRef`. When the component re-mounts, `useReadQuery` automatically resubscribes to the `queryRef` and any cache updates that occurred in the interim are read immediately as if the preloaded query had never been unmounted.
 
 </Note>
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -553,7 +553,7 @@ root.render(
 
 We begin loading data as soon as our `preloadQuery` function is called. We no longer need to wait for React to render our `<App />` component before our `GET_DOGS_QUERY` begins loading, but still get the benefit of suspense!
 
-#### Usage with routers
+#### Usage with data loading routers
 
 Popular routers such as [React Router](https://reactrouter.com/en/main) and [TanStack Router](https://tanstack.com/router) include APIs to start loading data before the route component renders (e.g. such as the [`loader` function](https://reactrouter.com/en/main/route/route#loader) from React Router). These APIs have the benefit that they can begin loading data in parallel without the need to wait for the route component to render. This is especially useful for nested routes where a parent route would otherwise suspend and create request waterfalls for child routes.
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -515,7 +515,7 @@ The preload function returns a `queryRef` that is passed to `useReadQuery` to re
 
 <Note>
 
-Unmounting components that contain preloaded queries is safe and puts the `queryRef` in a dormant state. Once the component re-mounts, any cache updates that occurred in the interim are read immediately as if the preloaded query had never been unmounted.
+Unmounting components that contain preloaded queries is safe and diposes of the `queryRef`. When the component re-mounts, `useReadQuery` automatically resubscribes to the `queryRef` and any cache updates that occurred in the interim are read immediately as if the preloaded query had never been unmounted.
 
 </Note>
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -628,6 +628,10 @@ More details on `useSuspenseQuery`'s API can be found in [its API docs](../api/r
 
 More details on `useBackgroundQuery`'s API can be found in [its API docs](../api/react/hooks/#usebackgroundquery).
 
+## useLoadableQuery API
+
+More details on `useLoadableQuery`'s API can be found in [its API docs](../api/react/hooks/#useloadablequery).
+
 ## useReadQuery API
 
 More details on `useReadQuery`'s API can be found in [its API docs](../api/react/hooks/#usereadquery).

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -755,7 +755,7 @@ function App() {
 // ...
 ```
 
-We begin loading `GET_BREEDS_QUERY` outside of React with the `preloadQuery` function. We use the `useQueryRefHandlers` hook to get access to the `refetch` function which lets us refetch the query when the button is clicked.
+We begin loading `GET_BREEDS_QUERY` outside of React with the `preloadQuery` function. We use the `useQueryRefHandlers` hook to get the `refetch` function which refetches the query when the button is clicked.
 
 #### Accessing query ref handlers produced from other hooks
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -461,7 +461,7 @@ import {
 
 function App() {
   const { data } = useSuspenseQuery(GET_DOGS_QUERY);
-  const [queryRef, loadDog] = useLoadableQuery(GET_DOG_QUERY);
+  const [loadDog, queryRef] = useLoadableQuery(GET_DOG_QUERY);
 
   return (
     <>

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -716,11 +716,11 @@ In this example, our `App` component renders a `Dog` component that fetches a si
 
 #### Usage with query preloading
 
-When loading queries [outside React](#initiating-queries-outside-react), the `preloadQuery` function returns a `queryRef` with no access to `refetch` or `fetchMore` functions. This presents a challenge if you need to refresh or paginate on the data returned by the query ref.
+When loading queries [outside React](#initiating-queries-outside-react), the `preloadQuery` function returns a `queryRef` with no access to `refetch` or `fetchMore` functions. This presents a challenge when you need to refetch or paginate the preloaded query.
 
 You can gain access to `refetch` and `fetchMore` functions by using the `useQueryRefHandlers` hook. This hook integrates with React transitions, giving you the ability to refetch or paginate without showing the loading fallback.
 
-Let's update our example to preload our `GET_BREEDS_QUERY` outside React and utilize `useQueryRefHandlers` to refetch our query.
+Let's update our example to preload our `GET_BREEDS_QUERY` outside React and use the `useQueryRefHandlers` hook to refetch our query.
 
 ```tsx {4,7-8,12}
 // ...

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -515,7 +515,7 @@ The preload function returns a `queryRef` that is passed to `useReadQuery` to re
 
 <Note>
 
-It is safe to unmount components that contain preloaded queries. Doing so puts the `queryRef` in a dormant state until the component is mounted again. Any cache updates that may have happened while dormant will be read immediately as if the preloaded query had never been unmounted.
+Unmounting components that contain preloaded queries is safe and puts the `queryRef` in a dormant state. Once the component re-mounts, any cache updates that occurred in the interim are read immediately as if the preloaded query had never been unmounted.
 
 </Note>
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -518,10 +518,10 @@ import {
 } from '@apollo/client';
 
 const preloadQuery = createQueryPreloader(client);
-const dogsQueryRef = preloadQuery(GET_DOGS_QUERY);
+const preloadedQueryRef = preloadQuery(GET_DOGS_QUERY);
 
 function App() {
-  const { data } = useReadQuery(dogsQueryRef);
+  const { data } = useReadQuery(preloadedQueryRef);
   const [queryRef, loadDog] = useLoadableQuery(GET_DOG_QUERY)
 
   return (

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -580,7 +580,7 @@ export function RouteComponent() {
 
 > Note: The `loader` function is available in React Router versions 6.4 and above.
 
-We load our query as soon as React Router calls our `loader` function. This starts fetching before our route component is rendered. When our route component renders, we can get access to the `queryRef`, which is passed to `useReadQuery` to read the data. This means our route component has the ability to update itself when our cache is updated!
+We load our query as soon as React Router calls our `loader` function. This starts fetching before our route component is rendered. When our route component renders, we can get access to the `queryRef` created by our `preloadQuery` function via the `useLoaderData` hook, which is then passed to `useReadQuery` to read the data. We get the benefit of loading our data early in the routing lifecycle, while our route component has the ability to update itself when the cache is updated!
 
 <Note>
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -493,8 +493,7 @@ function Dog({ queryRef }) {
 }
 ```
 
-
-We begin fetching our `GET_DOG_QUERY` as soon as a new dog is selected rather than waiting for our `Dog` component to re-render. When the `Dog` component renders, it reads data from the `GET_DOG_QUERY`, and if not ready, will suspend. As a result of this change, we've also removed the need to track the selected dog ID as part of React state!
+We begin fetching our `GET_DOG_QUERY` as soon as a dog is selected by calling the `loadDog` function. When the `Dog` component renders, `useReadQuery` suspends the component while the `GET_DOG_QUERY` loads, then provides `data` to the component. As a result of this change, we've also removed the need to track the selected dog ID as part of React state!
 
 <MinVersion version="3.9.0">
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -447,7 +447,7 @@ Available as of Apollo Client `3.9.0`, the `useLoadableQuery` hook initiates a n
 
 <Note>
 
-The `queryRef` is `null` until the execution function is called for the first time. You should conditionally render the child component when the query has not yet been loaded.
+The `queryRef` is `null` until the execution function is called for the first time. For this reason, any child components attempting to read data using the `queryRef` should be conditionally rendered.
 
 </Note>
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -441,7 +441,7 @@ The `useBackgroundQuery` hook used in a parent component is responsible for kick
 
 `useSuspenseQuery` and `useBackgroundQuery` are useful for loading data as soon as the component calling the hook mounts. But what about loading a query in response to user interaction? For example, we may want to start loading some data when a user hovers on a link.
 
-Starting with Apollo Client `3.9.0`, you can use `useLoadableQuery` to start loading data in response to user interaction. This avoids adding additional component state to trigger rerenders and provides a more ergonomic experience.
+Available as of Apollo Client `3.9.0`, the `useLoadableQuery` hook initiates a network request in response to user interaction.
 
 `useLoadableQuery` returns a both an execution function and `queryRef`. The execution function begins fetching the query when called with the provided variables. Like `useBackgroundQuery`, passing the `queryRef` to `useReadQuery` in a child component suspends the child component until the query finishes loading.
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -759,9 +759,9 @@ We begin loading `GET_BREEDS_QUERY` outside of React with the `preloadQuery` fun
 
 #### Accessing query ref handlers produced from other hooks
 
-`useQueryRefHandlers` is not limited to the `preloadQuery` API and can be used with any hook that produces a `queryRef` such as `useBackgroundQuery` or `useLoadableQuery`. This can be useful in situations where you may need access to the `refetch` and `fetchMore` functions in components where the `queryRef` was passed through deeply.
+`useQueryRefHandlers` is not limited to the `preloadQuery` function and can be used with any hook that produces a `queryRef` such as `useBackgroundQuery` or `useLoadableQuery`. This is useful in situations where you need access to the `refetch` and `fetchMore` functions in components where the `queryRef` is passed through deeply.
 
-Let's update our last example back to `useBackgroundQuery` and get access to `refetch` from `useQueryRefHandlers` in our `Dog` component without passing the `refetch` function from the parent.
+Let's update our last example back to `useBackgroundQuery` and get the `refetch` function from the `useQueryRefHandlers` hook in the `Dog` component.
 
 ```tsx {15,16,18-22,30}
 function App() {

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -447,8 +447,9 @@ Starting with Apollo Client `3.9.0`, you can use `useLoadableQuery` to start loa
 
 Let's update our example to start loading the dog's details as a result of selecting from a dropdown.
 
-```tsx
-function App({ dogs }) {
+```tsx {3,8,17,24}
+function App() {
+  const { data } = useSuspenseQuery(GET_DOGS_QUERY);
   const [queryRef, loadDog] = useLoadableQuery(GET_DOG_QUERY)
 
   return (
@@ -456,7 +457,7 @@ function App({ dogs }) {
       <select
         onChange={(e) => loadDog({ id: e.target.value })}
       >
-        {dogs.map(({ id, name }) => (
+        {data.dogs.map(({ id, name }) => (
           <option key={id} value={id}>
             {name}
           </option>
@@ -484,6 +485,129 @@ function Dog({ queryRef }) {
 > It's important to note that the `queryRef` is `null` until the query loading function is called for the first time. You should conditionally render the child component when the query has not yet been loaded.
 
 We begin fetching our `GET_DOG_QUERY` as soon as a new dog is selected rather than waiting for our `Dog` component to re-render. When the `Dog` component renders, it reads data from the `GET_DOG_QUERY`, and if not ready, will suspend. As a result of this change, we've also removed the need to track the selected dog ID as part of React state!
+
+<MinVersion version="3.9.0">
+
+### Initiating queries outside React
+
+</MinVersion>
+
+Starting with Apollo Client `3.9.0`, it is possible to start loading queries outside React. This avoids the need to wait for React to render your components before the query begins loading, providing a nice performance benefit.
+
+<ExperimentalFeature>
+
+This API is experimental in `3.9.0` and may change in `3.10.0`. We are specifically looking for user feedback on the API design choices. The underlying behavior is otherwise fully implemented. If you'd like to provide feedback for this feature before it is stabilized in `3.10.0`, please [open an issue](https://github.com/apollographql/apollo-client/issues/new).
+
+</ExperimentalFeature>
+
+To begin loading data immediately, you first need to create a preloading function with `createQueryPreloader`. `createQueryPreloader` is given the `client` as an argument and returns a function that when called, will begin fetching the query. The preload function returns a `queryRef` that can then be passed to `useReadQuery` to read the query data, and if still loading, suspend that component.
+
+Let's update our example to start loading the `GET_DOGS_QUERY` before our app is rendered.
+
+```tsx {1-2,5,28,30}
+const preloadQuery = createQueryPreloader(client);
+const dogsQueryRef = preloadQuery(GET_DOGS_QUERY);
+
+function App() {
+  const { data } = useReadQuery(dogsQueryRef);
+  const [queryRef, loadDog] = useLoadableQuery(GET_DOG_QUERY)
+
+  return (
+    <>
+      <select
+        onChange={(e) => loadDog({ id: e.target.value })}
+      >
+        {data.dogs.map(({ id, name }) => (
+          <option key={id} value={id}>{name}</option>
+        ))}
+      </select>
+      <Suspense fallback={<div>Loading...</div>}>
+        <Dog queryRef={queryRef} />
+      </Suspense>
+    </>
+  );
+}
+
+const root = createRoot(document.getElementById('app'));
+
+root.render(
+  <ApolloProvider client={client}>
+    <Suspense fallback={<div>Loading...</div>}>
+      <App />
+    </Suspense>
+  </ApolloProvider>
+);
+```
+
+We begin loading data as soon as our `preloadQuery` function is called. We no longer need to wait for React to render our `<App />` component before our `GET_DOGS_QUERY` begins loading, but still get the benefit of suspense!
+
+#### Usage with routers
+
+Popular routers such as [React Router](https://reactrouter.com/en/main) and [TanStack Router](https://tanstack.com/router) include APIs to start loading data before the route component renders (e.g. such as the [`loader` function](https://reactrouter.com/en/main/route/route#loader) from React Router). These APIs have the benefit that they can begin loading data in parallel without the need to wait for the route component to render. This is especially useful for nested routes where a parent route would otherwise suspend and create request waterfalls for child routes.
+
+The `preloadQuery` API pairs nicely with these router APIs as it lets you take advantage of the optimizations these routers provide without sacrificing the ability to respond to cache updates in your route components.
+
+Let's update our example using React Router's `loader` function to begin loading data when we transition to our route.
+
+```ts
+import { useLoaderData } from 'react-router-dom';
+
+export function loader() {
+  return preloadQuery(GET_DOGS_QUERY);
+}
+
+export function RouteComponent() {
+  const queryRef = useLoaderData();
+  const { data } = useReadQuery(queryRef);
+
+  return (
+    // ...
+  );
+}
+```
+
+> Note: The `loader` function is only available in React Router versions 6.4 and above.
+
+We load our query as soon as React Router calls our `loader` function. This starts fetching before our route component is rendered. When our route component renders, we can get access to the `queryRef`, which is passed to `useReadQuery` to read the data. This means our route component has the ability to update itself when our cache is updated!
+
+<Note>
+
+The `preloadQuery` API only works with client-side routing. The `queryRef` returned from `preloadQuery` is not serializable across the wire and as such, will not work with routers that render on the server, such as [Remix](https://remix.run/).
+  
+</Note>
+
+#### Preventing route transitions until the query is loaded
+
+By default, `preloadQuery` works similar to a [deferred loader](https://reactrouter.com/en/main/guides/deferred) in that routes will transition immediately and suspend with `useReadQuery` until the query is loaded. You may instead want to prevent the route from transitioning until the data is fully loaded. Use the `toPromise` method on the `queryRef` to get a promise that resolves when the query is loaded. This promise resolves with the `queryRef` itself, making it easy to use with hooks such as `useLoaderData`.
+
+```ts
+export async function loader() {
+  const queryRef = await preloadQuery(GET_DOGS_QUERY).toPromise();
+
+  return queryRef;
+}
+
+// You may also return the promise directly from loader. 
+// This is equivalent to the above.
+export async function loader() {
+  return preloadQuery(GET_DOGS_QUERY).toPromise();
+}
+
+export function RouteComponent() {
+  const queryRef = useLoaderData();
+  const { data } = useReadQuery(queryRef);
+
+  // ...
+}
+```
+
+This instructs React Router to wait for the query to finish loading before the route transitions. When the route does transition, the data will be rendered immediately without the need to show a loading fallback in the route component.
+
+#### Why prevent access to `data` in `toPromise`?
+
+You may be wondering why we resolve `toPromise` with the `queryRef` itself, rather than the data loaded from the query. This is because we want to encourage you to leverage `useReadQuery` to avoid missing out on cache updates for your query. If `data` were available, it would be tempting to consume it in your `loader` functions and expose it to your route components. Doing so means missing out on cache updates.
+
+If you need access to raw query data in your `loader` functions, use [`client.query()`](../api/core/ApolloClient#query) directly.
 
 ### Refetching and pagination
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -443,7 +443,7 @@ The `useBackgroundQuery` hook used in a parent component is responsible for kick
 
 Available as of Apollo Client `3.9.0`, the `useLoadableQuery` hook initiates a network request in response to user interaction.
 
-`useLoadableQuery` returns a both an execution function and `queryRef`. The execution function begins fetching the query when called with the provided variables. Like `useBackgroundQuery`, passing the `queryRef` to `useReadQuery` in a child component suspends the child component until the query finishes loading.
+`useLoadableQuery` returns both an execution function and a `queryRef`. The execution function initiates a network request when called with the provided variables. Like `useBackgroundQuery`, passing the `queryRef` to `useReadQuery` in a child component suspends the child component until the query finishes loading.
 
 <Note>
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -578,7 +578,7 @@ export function RouteComponent() {
 }
 ```
 
-> Note: The `loader` function is only available in React Router versions 6.4 and above.
+> Note: The `loader` function is available in React Router versions 6.4 and above.
 
 We load our query as soon as React Router calls our `loader` function. This starts fetching before our route component is rendered. When our route component renders, we can get access to the `queryRef`, which is passed to `useReadQuery` to read the data. This means our route component has the ability to update itself when our cache is updated!
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -505,7 +505,7 @@ Starting with Apollo Client `3.9.0`, it is possible to start loading queries out
 
 <ExperimentalFeature>
 
-This API is experimental in `3.9.0` and may change in `3.10.0`. We are specifically looking for user feedback on the API design choices. The underlying behavior is otherwise fully implemented. If you'd like to provide feedback for this feature before it is stabilized in `3.10.0`, please [open an issue](https://github.com/apollographql/apollo-client/issues/new).
+This API is experimental in `3.9.0` and may change in `3.10.0`. We are specifically looking for user feedback on the API design choices. The underlying behavior is otherwise fully implemented. If you'd like to provide feedback for this feature before it is stabilized in `3.10.0`, please visit [#11519](https://github.com/apollographql/apollo-client/issues/11519) and add a comment.
 
 </ExperimentalFeature>
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -481,7 +481,7 @@ function App() {
   );
 }
 
-function Dog({ queryRef }) {
+function Dog({ queryRef }: DogProps) {
   const { data } = useReadQuery(queryRef)
 
   return (

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -613,7 +613,7 @@ export function RouteComponent() {
 }
 ```
 
-This instructs React Router to wait for the query to finish loading before the route transitions. When the route does transition, the data will be rendered immediately without the need to show a loading fallback in the route component.
+This instructs React Router to wait for the query to finish loading before the route transitions. When the route transitions after the promise resolves, the data will be rendered immediately without the need to show a loading fallback in the route component.
 
 #### Why prevent access to `data` in `toPromise`?
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -722,14 +722,13 @@ You can gain access to `refetch` and `fetchMore` functions by using the `useQuer
 
 Let's update our example to preload our `GET_BREEDS_QUERY` outside React and use the `useQueryRefHandlers` hook to refetch our query.
 
-```tsx {4,7-8,12}
+```tsx {4,7,11}
 // ...
 import {
   // ...
   useQueryRefHandlers,
 } from "@apollo/client";
 
-const preloadQuery = createQueryPreloader(client);
 const queryRef = preloadQuery(GET_BREEDS_QUERY); 
 
 function App() {
@@ -753,40 +752,7 @@ function App() {
   );
 }
 
-function Dog({
-  id,
-  isPending,
-  onRefetch,
-}: DogProps) {
-  const { data } = useSuspenseQuery(GET_DOG_QUERY, {
-    variables: { id },
-  });
-
-  return (
-    <>
-      Name: {data.dog.name}
-      <Suspense fallback={<div>Loading breeds...</div>}>
-        <Breeds isPending={isPending} />
-      </Suspense>
-      <button onClick={onRefetch}>Refetch!</button>
-    </>
-  );
-}
-
-function Breeds({ isPending }: BreedsProps) {
-  const { data } = useReadQuery(queryRef);
-
-  return data.breeds.map(({ characteristics }) =>
-    characteristics.map((characteristic) => (
-      <div
-        style={{ opacity: isPending ? 0.5 : 1 }}
-        key={characteristic}
-      >
-        {characteristic}
-      </div>
-    ))
-  );
-}
+// ...
 ```
 
 We begin loading `GET_BREEDS_QUERY` outside of React with the `preloadQuery` function. We use the `useQueryRefHandlers` hook to get access to the `refetch` function which lets us refetch the query when the button is clicked.

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -593,11 +593,11 @@ export function RouteComponent() {
 
 > The `loader` function is available in React Router versions 6.4 and above.
 
-We load our query as soon as React Router calls our `loader` function. This starts fetching before our route component is rendered. When our route component renders, we can get access to the `queryRef` created by our `preloadQuery` function via the `useLoaderData` hook, which is then passed to `useReadQuery` to read the data. We get the benefit of loading our data early in the routing lifecycle, while our route component has the ability to update itself when the cache is updated!
+React Router calls the `loader` function which we use to begin loading the `GET_DOG_QUERY` query by calling the `preloadQuery` function. The `queryRef` created by `preloadQuery` is returned from the `loader` function making it accessible in the route component. When the route component renders, we access the `queryRef` from the `useLoaderData` hook, which is then passed to `useReadQuery`. We get the benefit of loading our data early in the routing lifecycle, while our route component maintains the ability to rerender with cache updates!
 
 <Note>
 
-The `preloadQuery` API only works with client-side routing. The `queryRef` returned from `preloadQuery` is not serializable across the wire and as such, will not work with routers that fetch on the server such as [Remix](https://remix.run/).
+The `preloadQuery` function only works with client-side routing. The `queryRef` returned from `preloadQuery` is not serializable across the wire and as such, will not work with routers that fetch on the server such as [Remix](https://remix.run/).
   
 </Note>
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -443,7 +443,13 @@ The `useBackgroundQuery` hook used in a parent component is responsible for kick
 
 Starting with Apollo Client `3.9.0`, you can use `useLoadableQuery` to start loading data in response to user interaction. This is not only more ergonomic, but starts loading the query immediately, providing a nice performance benefit.
 
-`useLoadableQuery` returns a function that when called will begin fetching the query with the provided variables. Like `useBackgroundQuery`, you get access to a `queryRef` that is passed to `useReadQuery` to read the data in a child component. When the child component renders before the query has finished loading, the child component suspends.
+`useLoadableQuery` returns a both an execution function and `queryRef`. The execution function begins fetching the query when called with the provided variables. Like `useBackgroundQuery`, passing the `queryRef` to `useReadQuery` in a child component suspends the child component until the query finishes loading.
+
+<Note>
+
+The `queryRef` is `null` until the execution function is called for the first time. You should conditionally render the child component when the query has not yet been loaded.
+
+</Note>
 
 Let's update our example to start loading the dog's details as a result of selecting from a dropdown.
 
@@ -487,7 +493,6 @@ function Dog({ queryRef }) {
 }
 ```
 
-> It's important to note that the `queryRef` is `null` until the query loading function is called for the first time. You should conditionally render the child component when the query has not yet been loaded.
 
 We begin fetching our `GET_DOG_QUERY` as soon as a new dog is selected rather than waiting for our `Dog` component to re-render. When the `Dog` component renders, it reads data from the `GET_DOG_QUERY`, and if not ready, will suspend. As a result of this change, we've also removed the need to track the selected dog ID as part of React state!
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -501,7 +501,7 @@ We begin fetching our `GET_DOG_QUERY` by calling the `loadDog` function inside o
 
 </MinVersion>
 
-Starting with Apollo Client `3.9.0`, it is possible to start loading queries outside React. This avoids the need to wait for React to render your components before the query begins loading, providing a nice performance benefit.
+Starting with Apollo Client `3.9.0`, queries can be initiated outside of React. This allows your app to begin fetching data _before_ React renders your components, and can provide performance benefits.
 
 <ExperimentalFeature>
 

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -578,7 +578,7 @@ export function RouteComponent() {
 }
 ```
 
-> Note: The `loader` function is available in React Router versions 6.4 and above.
+> The `loader` function is available in React Router versions 6.4 and above.
 
 We load our query as soon as React Router calls our `loader` function. This starts fetching before our route component is rendered. When our route component renders, we can get access to the `queryRef` created by our `preloadQuery` function via the `useLoaderData` hook, which is then passed to `useReadQuery` to read the data. We get the benefit of loading our data early in the routing lifecycle, while our route component has the ability to update itself when the cache is updated!
 


### PR DESCRIPTION
Closes https://github.com/apollographql/apollo-client/issues/11491
Closes [#11493](https://github.com/apollographql/apollo-client/issues/11493)
Closes https://github.com/apollographql/apollo-client/issues/11494

Adds new sections to our [suspense docs](https://www.apollographql.com/docs/react/data/suspense) for `useLoadableQuery`, `createQueryPreloader`, and `useQueryRefHandlers`.

NOTE: This only addresses the "guide" part of the documentation. A followup PR to ensure the API documentation for the hook is available (options, return values, etc.). This may require edits to code and will fall in line with the changes in https://github.com/apollographql/apollo-client/pull/11381