### PR TITLE
Document new React APIs in code - Part 2 of 2

### DIFF
--- a/.api-reports/api-report-react.md
+++ b/.api-reports/api-report-react.md
@@ -547,7 +547,7 @@ type ConcastSourcesIterable<T> = Iterable<Source<T>>;
 export interface Context extends Record<string, any> {
 }
 
-// @public
+// @alpha
 export function createQueryPreloader(client: ApolloClient<any>): PreloadQueryFunction;
 
 // @public (undocumented)
@@ -2231,7 +2231,7 @@ export type UseFragmentResult<TData> = {
 // @public
 export function useLazyQuery<TData = any, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: LazyQueryHookOptions<NoInfer<TData>, NoInfer<TVariables>>): LazyQueryResultTuple<TData, TVariables>;
 
-// @public (undocumented)
+// @public
 export function useLoadableQuery<TData, TVariables extends OperationVariables, TOptions extends LoadableQueryHookOptions>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: LoadableQueryHookOptions & TOptions): UseLoadableQueryResult<TOptions["errorPolicy"] extends "ignore" | "all" ? TOptions["returnPartialData"] extends true ? DeepPartial<TData> | undefined : TData | undefined : TOptions["returnPartialData"] extends true ? DeepPartial<TData> : TData, TVariables>;
 
 // @public (undocumented)
@@ -2254,14 +2254,18 @@ export function useLoadableQuery<TData = unknown, TVariables extends OperationVa
 export function useLoadableQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: LoadableQueryHookOptions): UseLoadableQueryResult<TData, TVariables>;
 
 // @public (undocumented)
-export type UseLoadableQueryResult<TData = unknown, TVariables extends OperationVariables = OperationVariables> = [
-LoadQueryFunction<TVariables>,
-QueryReference<TData, TVariables> | null,
-    {
+export interface UseLoadableQueryHandlers<TData, TVariables extends OperationVariables> {
     fetchMore: FetchMoreFunction<TData, TVariables>;
     refetch: RefetchFunction<TData, TVariables>;
+    // Warning: (ae-forgotten-export) The symbol "ResetFunction" needs to be exported by the entry point index.d.ts
     reset: ResetFunction;
 }
+
+// @public (undocumented)
+export type UseLoadableQueryResult<TData = unknown, TVariables extends OperationVariables = OperationVariables> = [
+loadQuery: LoadQueryFunction<TVariables>,
+queryRef: QueryReference<TData, TVariables> | null,
+handlers: UseLoadableQueryHandlers<TData, TVariables>
 ];
 
 // @public
@@ -2397,7 +2401,6 @@ interface WatchQueryOptions<TVariables extends OperationVariables = OperationVar
 // src/core/watchQueryOptions.ts:269:2 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:29:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:30:3 - (ae-forgotten-export) The symbol "RefetchFunction" needs to be exported by the entry point index.d.ts
-// src/react/hooks/useLoadableQuery.ts:49:5 - (ae-forgotten-export) The symbol "ResetFunction" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report-react.md
+++ b/.api-reports/api-report-react.md
@@ -1759,13 +1759,12 @@ interface QueryOptions<TVariables = OperationVariables, TData = any> {
 //
 // @public
 export interface QueryReference<TData = unknown, TVariables = unknown> {
-    // (undocumented)
+    // @internal (undocumented)
     [PROMISE_SYMBOL]: QueryRefPromise<TData>;
     // Warning: (ae-forgotten-export) The symbol "InternalQueryReference" needs to be exported by the entry point index.d.ts
     //
-    // (undocumented)
+    // @internal (undocumented)
     readonly [QUERY_REFERENCE_SYMBOL]: InternalQueryReference<TData>;
-    // (undocumented)
     toPromise(): Promise<QueryReference<TData, TVariables>>;
 }
 

--- a/.api-reports/api-report-react.md
+++ b/.api-reports/api-report-react.md
@@ -1765,6 +1765,7 @@ export interface QueryReference<TData = unknown, TVariables = unknown> {
     //
     // @internal (undocumented)
     readonly [QUERY_REFERENCE_SYMBOL]: InternalQueryReference<TData>;
+    // @alpha
     toPromise(): Promise<QueryReference<TData, TVariables>>;
 }
 

--- a/.api-reports/api-report-react.md
+++ b/.api-reports/api-report-react.md
@@ -2232,7 +2232,7 @@ export type UseFragmentResult<TData> = {
 // @public
 export function useLazyQuery<TData = any, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: LazyQueryHookOptions<NoInfer<TData>, NoInfer<TVariables>>): LazyQueryResultTuple<TData, TVariables>;
 
-// @public
+// @public (undocumented)
 export function useLoadableQuery<TData, TVariables extends OperationVariables, TOptions extends LoadableQueryHookOptions>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: LoadableQueryHookOptions & TOptions): UseLoadableQueryResult<TOptions["errorPolicy"] extends "ignore" | "all" ? TOptions["returnPartialData"] extends true ? DeepPartial<TData> | undefined : TData | undefined : TOptions["returnPartialData"] extends true ? DeepPartial<TData> : TData, TVariables>;
 
 // @public (undocumented)
@@ -2251,22 +2251,18 @@ export function useLoadableQuery<TData = unknown, TVariables extends OperationVa
     returnPartialData: true;
 }): UseLoadableQueryResult<DeepPartial<TData>, TVariables>;
 
-// @public (undocumented)
+// @public
 export function useLoadableQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: LoadableQueryHookOptions): UseLoadableQueryResult<TData, TVariables>;
-
-// @public (undocumented)
-export interface UseLoadableQueryHandlers<TData, TVariables extends OperationVariables> {
-    fetchMore: FetchMoreFunction<TData, TVariables>;
-    refetch: RefetchFunction<TData, TVariables>;
-    // Warning: (ae-forgotten-export) The symbol "ResetFunction" needs to be exported by the entry point index.d.ts
-    reset: ResetFunction;
-}
 
 // @public (undocumented)
 export type UseLoadableQueryResult<TData = unknown, TVariables extends OperationVariables = OperationVariables> = [
 loadQuery: LoadQueryFunction<TVariables>,
 queryRef: QueryReference<TData, TVariables> | null,
-handlers: UseLoadableQueryHandlers<TData, TVariables>
+    {
+    fetchMore: FetchMoreFunction<TData, TVariables>;
+    refetch: RefetchFunction<TData, TVariables>;
+    reset: ResetFunction;
+}
 ];
 
 // @public
@@ -2402,6 +2398,7 @@ interface WatchQueryOptions<TVariables extends OperationVariables = OperationVar
 // src/core/watchQueryOptions.ts:269:2 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:29:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:30:3 - (ae-forgotten-export) The symbol "RefetchFunction" needs to be exported by the entry point index.d.ts
+// src/react/hooks/useLoadableQuery.ts:106:1 - (ae-forgotten-export) The symbol "ResetFunction" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report-react_hooks.md
+++ b/.api-reports/api-report-react_hooks.md
@@ -2072,7 +2072,7 @@ export function useLazyQuery<TData = any, TVariables extends OperationVariables 
 
 // Warning: (ae-forgotten-export) The symbol "LoadableQueryHookOptions" needs to be exported by the entry point index.d.ts
 //
-// @public
+// @public (undocumented)
 export function useLoadableQuery<TData, TVariables extends OperationVariables, TOptions extends LoadableQueryHookOptions>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: LoadableQueryHookOptions & TOptions): UseLoadableQueryResult<TOptions["errorPolicy"] extends "ignore" | "all" ? TOptions["returnPartialData"] extends true ? DeepPartial<TData> | undefined : TData | undefined : TOptions["returnPartialData"] extends true ? DeepPartial<TData> : TData, TVariables>;
 
 // @public (undocumented)
@@ -2091,22 +2091,18 @@ export function useLoadableQuery<TData = unknown, TVariables extends OperationVa
     returnPartialData: true;
 }): UseLoadableQueryResult<DeepPartial<TData>, TVariables>;
 
-// @public (undocumented)
+// @public
 export function useLoadableQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: LoadableQueryHookOptions): UseLoadableQueryResult<TData, TVariables>;
-
-// @public (undocumented)
-export interface UseLoadableQueryHandlers<TData, TVariables extends OperationVariables> {
-    fetchMore: FetchMoreFunction<TData, TVariables>;
-    refetch: RefetchFunction<TData, TVariables>;
-    // Warning: (ae-forgotten-export) The symbol "ResetFunction" needs to be exported by the entry point index.d.ts
-    reset: ResetFunction;
-}
 
 // @public (undocumented)
 export type UseLoadableQueryResult<TData = unknown, TVariables extends OperationVariables = OperationVariables> = [
 loadQuery: LoadQueryFunction<TVariables>,
 queryRef: QueryReference<TData, TVariables> | null,
-handlers: UseLoadableQueryHandlers<TData, TVariables>
+    {
+    fetchMore: FetchMoreFunction<TData, TVariables>;
+    refetch: RefetchFunction<TData, TVariables>;
+    reset: ResetFunction;
+}
 ];
 
 // Warning: (ae-forgotten-export) The symbol "MutationHookOptions" needs to be exported by the entry point index.d.ts
@@ -2238,6 +2234,7 @@ interface WatchQueryOptions<TVariables extends OperationVariables = OperationVar
 // src/core/watchQueryOptions.ts:269:2 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:29:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:30:3 - (ae-forgotten-export) The symbol "RefetchFunction" needs to be exported by the entry point index.d.ts
+// src/react/hooks/useLoadableQuery.ts:106:1 - (ae-forgotten-export) The symbol "ResetFunction" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report-react_hooks.md
+++ b/.api-reports/api-report-react_hooks.md
@@ -1634,13 +1634,12 @@ interface QueryOptions<TVariables = OperationVariables, TData = any> {
 //
 // @public
 interface QueryReference<TData = unknown, TVariables = unknown> {
-    // (undocumented)
+    // @internal (undocumented)
     [PROMISE_SYMBOL]: QueryRefPromise<TData>;
     // Warning: (ae-forgotten-export) The symbol "InternalQueryReference" needs to be exported by the entry point index.d.ts
     //
-    // (undocumented)
+    // @internal (undocumented)
     readonly [QUERY_REFERENCE_SYMBOL]: InternalQueryReference<TData>;
-    // (undocumented)
     toPromise(): Promise<QueryReference<TData, TVariables>>;
 }
 

--- a/.api-reports/api-report-react_hooks.md
+++ b/.api-reports/api-report-react_hooks.md
@@ -2071,7 +2071,7 @@ export function useLazyQuery<TData = any, TVariables extends OperationVariables 
 
 // Warning: (ae-forgotten-export) The symbol "LoadableQueryHookOptions" needs to be exported by the entry point index.d.ts
 //
-// @public (undocumented)
+// @public
 export function useLoadableQuery<TData, TVariables extends OperationVariables, TOptions extends LoadableQueryHookOptions>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: LoadableQueryHookOptions & TOptions): UseLoadableQueryResult<TOptions["errorPolicy"] extends "ignore" | "all" ? TOptions["returnPartialData"] extends true ? DeepPartial<TData> | undefined : TData | undefined : TOptions["returnPartialData"] extends true ? DeepPartial<TData> : TData, TVariables>;
 
 // @public (undocumented)
@@ -2094,14 +2094,18 @@ export function useLoadableQuery<TData = unknown, TVariables extends OperationVa
 export function useLoadableQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: LoadableQueryHookOptions): UseLoadableQueryResult<TData, TVariables>;
 
 // @public (undocumented)
-export type UseLoadableQueryResult<TData = unknown, TVariables extends OperationVariables = OperationVariables> = [
-LoadQueryFunction<TVariables>,
-QueryReference<TData, TVariables> | null,
-    {
+export interface UseLoadableQueryHandlers<TData, TVariables extends OperationVariables> {
     fetchMore: FetchMoreFunction<TData, TVariables>;
     refetch: RefetchFunction<TData, TVariables>;
+    // Warning: (ae-forgotten-export) The symbol "ResetFunction" needs to be exported by the entry point index.d.ts
     reset: ResetFunction;
 }
+
+// @public (undocumented)
+export type UseLoadableQueryResult<TData = unknown, TVariables extends OperationVariables = OperationVariables> = [
+loadQuery: LoadQueryFunction<TVariables>,
+queryRef: QueryReference<TData, TVariables> | null,
+handlers: UseLoadableQueryHandlers<TData, TVariables>
 ];
 
 // Warning: (ae-forgotten-export) The symbol "MutationHookOptions" needs to be exported by the entry point index.d.ts
@@ -2233,7 +2237,6 @@ interface WatchQueryOptions<TVariables extends OperationVariables = OperationVar
 // src/core/watchQueryOptions.ts:269:2 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:29:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:30:3 - (ae-forgotten-export) The symbol "RefetchFunction" needs to be exported by the entry point index.d.ts
-// src/react/hooks/useLoadableQuery.ts:49:5 - (ae-forgotten-export) The symbol "ResetFunction" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report-react_hooks.md
+++ b/.api-reports/api-report-react_hooks.md
@@ -1640,6 +1640,7 @@ interface QueryReference<TData = unknown, TVariables = unknown> {
     //
     // @internal (undocumented)
     readonly [QUERY_REFERENCE_SYMBOL]: InternalQueryReference<TData>;
+    // @alpha
     toPromise(): Promise<QueryReference<TData, TVariables>>;
 }
 

--- a/.api-reports/api-report-react_internal.md
+++ b/.api-reports/api-report-react_internal.md
@@ -1402,6 +1402,7 @@ export interface QueryReference<TData = unknown, TVariables = unknown> {
     [PROMISE_SYMBOL]: QueryRefPromise<TData>;
     // @internal (undocumented)
     readonly [QUERY_REFERENCE_SYMBOL]: InternalQueryReference<TData>;
+    // @alpha
     toPromise(): Promise<QueryReference<TData, TVariables>>;
 }
 

--- a/.api-reports/api-report-react_internal.md
+++ b/.api-reports/api-report-react_internal.md
@@ -1398,11 +1398,10 @@ interface QueryOptions<TVariables = OperationVariables, TData = any> {
 //
 // @public
 export interface QueryReference<TData = unknown, TVariables = unknown> {
-    // (undocumented)
+    // @internal (undocumented)
     [PROMISE_SYMBOL]: QueryRefPromise<TData>;
-    // (undocumented)
+    // @internal (undocumented)
     readonly [QUERY_REFERENCE_SYMBOL]: InternalQueryReference<TData>;
-    // (undocumented)
     toPromise(): Promise<QueryReference<TData, TVariables>>;
 }
 

--- a/.api-reports/api-report.md
+++ b/.api-reports/api-report.md
@@ -2885,7 +2885,7 @@ export type UseFragmentResult<TData> = {
 // @public
 export function useLazyQuery<TData = any, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: LazyQueryHookOptions<NoInfer<TData>, NoInfer<TVariables>>): LazyQueryResultTuple<TData, TVariables>;
 
-// @public
+// @public (undocumented)
 export function useLoadableQuery<TData, TVariables extends OperationVariables, TOptions extends LoadableQueryHookOptions>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: LoadableQueryHookOptions & TOptions): UseLoadableQueryResult<TOptions["errorPolicy"] extends "ignore" | "all" ? TOptions["returnPartialData"] extends true ? DeepPartial<TData> | undefined : TData | undefined : TOptions["returnPartialData"] extends true ? DeepPartial<TData> : TData, TVariables>;
 
 // @public (undocumented)
@@ -2904,22 +2904,18 @@ export function useLoadableQuery<TData = unknown, TVariables extends OperationVa
     returnPartialData: true;
 }): UseLoadableQueryResult<DeepPartial<TData>, TVariables>;
 
-// @public (undocumented)
+// @public
 export function useLoadableQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: LoadableQueryHookOptions): UseLoadableQueryResult<TData, TVariables>;
-
-// @public (undocumented)
-export interface UseLoadableQueryHandlers<TData, TVariables extends OperationVariables> {
-    fetchMore: FetchMoreFunction<TData, TVariables>;
-    refetch: RefetchFunction<TData, TVariables>;
-    // Warning: (ae-forgotten-export) The symbol "ResetFunction" needs to be exported by the entry point index.d.ts
-    reset: ResetFunction;
-}
 
 // @public (undocumented)
 export type UseLoadableQueryResult<TData = unknown, TVariables extends OperationVariables = OperationVariables> = [
 loadQuery: LoadQueryFunction<TVariables>,
 queryRef: QueryReference<TData, TVariables> | null,
-handlers: UseLoadableQueryHandlers<TData, TVariables>
+    {
+    fetchMore: FetchMoreFunction<TData, TVariables>;
+    refetch: RefetchFunction<TData, TVariables>;
+    reset: ResetFunction;
+}
 ];
 
 // @public
@@ -3081,6 +3077,7 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/link/http/selectHttpOptionsAndBody.ts:128:32 - (ae-forgotten-export) The symbol "HttpQueryOptions" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:29:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:30:3 - (ae-forgotten-export) The symbol "RefetchFunction" needs to be exported by the entry point index.d.ts
+// src/react/hooks/useLoadableQuery.ts:106:1 - (ae-forgotten-export) The symbol "ResetFunction" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report.md
+++ b/.api-reports/api-report.md
@@ -2329,6 +2329,7 @@ export interface QueryReference<TData = unknown, TVariables = unknown> {
     //
     // @internal (undocumented)
     readonly [QUERY_REFERENCE_SYMBOL]: InternalQueryReference<TData>;
+    // @alpha
     toPromise(): Promise<QueryReference<TData, TVariables>>;
 }
 

--- a/.api-reports/api-report.md
+++ b/.api-reports/api-report.md
@@ -2323,13 +2323,12 @@ export { QueryOptions }
 //
 // @public
 export interface QueryReference<TData = unknown, TVariables = unknown> {
-    // (undocumented)
+    // @internal (undocumented)
     [PROMISE_SYMBOL]: QueryRefPromise<TData>;
     // Warning: (ae-forgotten-export) The symbol "InternalQueryReference" needs to be exported by the entry point index.d.ts
     //
-    // (undocumented)
+    // @internal (undocumented)
     readonly [QUERY_REFERENCE_SYMBOL]: InternalQueryReference<TData>;
-    // (undocumented)
     toPromise(): Promise<QueryReference<TData, TVariables>>;
 }
 

--- a/.api-reports/api-report.md
+++ b/.api-reports/api-report.md
@@ -544,7 +544,7 @@ export const concat: typeof ApolloLink.concat;
 // @public (undocumented)
 export const createHttpLink: (linkOptions?: HttpOptions) => ApolloLink;
 
-// @public
+// @alpha
 export function createQueryPreloader(client: ApolloClient<any>): PreloadQueryFunction;
 
 // @public @deprecated (undocumented)
@@ -2884,7 +2884,7 @@ export type UseFragmentResult<TData> = {
 // @public
 export function useLazyQuery<TData = any, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: LazyQueryHookOptions<NoInfer<TData>, NoInfer<TVariables>>): LazyQueryResultTuple<TData, TVariables>;
 
-// @public (undocumented)
+// @public
 export function useLoadableQuery<TData, TVariables extends OperationVariables, TOptions extends LoadableQueryHookOptions>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: LoadableQueryHookOptions & TOptions): UseLoadableQueryResult<TOptions["errorPolicy"] extends "ignore" | "all" ? TOptions["returnPartialData"] extends true ? DeepPartial<TData> | undefined : TData | undefined : TOptions["returnPartialData"] extends true ? DeepPartial<TData> : TData, TVariables>;
 
 // @public (undocumented)
@@ -2907,14 +2907,18 @@ export function useLoadableQuery<TData = unknown, TVariables extends OperationVa
 export function useLoadableQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: LoadableQueryHookOptions): UseLoadableQueryResult<TData, TVariables>;
 
 // @public (undocumented)
-export type UseLoadableQueryResult<TData = unknown, TVariables extends OperationVariables = OperationVariables> = [
-LoadQueryFunction<TVariables>,
-QueryReference<TData, TVariables> | null,
-    {
+export interface UseLoadableQueryHandlers<TData, TVariables extends OperationVariables> {
     fetchMore: FetchMoreFunction<TData, TVariables>;
     refetch: RefetchFunction<TData, TVariables>;
+    // Warning: (ae-forgotten-export) The symbol "ResetFunction" needs to be exported by the entry point index.d.ts
     reset: ResetFunction;
 }
+
+// @public (undocumented)
+export type UseLoadableQueryResult<TData = unknown, TVariables extends OperationVariables = OperationVariables> = [
+loadQuery: LoadQueryFunction<TVariables>,
+queryRef: QueryReference<TData, TVariables> | null,
+handlers: UseLoadableQueryHandlers<TData, TVariables>
 ];
 
 // @public
@@ -3076,7 +3080,6 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/link/http/selectHttpOptionsAndBody.ts:128:32 - (ae-forgotten-export) The symbol "HttpQueryOptions" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:29:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:30:3 - (ae-forgotten-export) The symbol "RefetchFunction" needs to be exported by the entry point index.d.ts
-// src/react/hooks/useLoadableQuery.ts:49:5 - (ae-forgotten-export) The symbol "ResetFunction" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -29,6 +29,8 @@
 /docs/shared/**
 !/docs/shared/ApiDoc
 !/docs/shared/ApiDoc/**
+!/docs/shared/Overrides
+!/docs/shared/Overrides/**
 
 node_modules/
 .yalc/

--- a/docs/shared/Overrides/UseLoadableQueryResult.js
+++ b/docs/shared/Overrides/UseLoadableQueryResult.js
@@ -1,0 +1,58 @@
+import React from "react";
+import { useMDXComponents } from "@mdx-js/react";
+import { ManualTuple } from "../ApiDoc";
+
+const HANDLERS = `{
+  fetchMore: FetchMoreFunction<TData, TVariables>;
+  refetch: RefetchFunction<TData, TVariables>;
+  reset: ResetFunction;
+}`;
+
+const RETURN_VALUE = `[
+  loadQuery: LoadQueryFunction<TVariables>,
+  queryRef: QueryReference<TData, TVariables>,
+  {
+    fetchMore: FetchMoreFunction<TData, TVariables>;
+    refetch: RefetchFunction<TData, TVariables>;
+    reset: ResetFunction;
+  }
+]`;
+
+export function UseLoadableQueryResult() {
+  const MDX = useMDXComponents();
+
+  return (
+    <div>
+      <MDX.pre>
+        <code className="language-ts">{RETURN_VALUE}</code>
+      </MDX.pre>
+      A tuple of three values:
+      <ManualTuple
+        idPrefix="useloadablequery-result"
+        elements={[
+          {
+            name: "loadQuery",
+            type: "LoadQueryFunction<TVariables>",
+            description:
+              "A function used to imperatively load a query. Calling this function will create or update the `queryRef` returned by `useLoadableQuery`, which should be passed to `useReadQuery`.",
+          },
+          {
+            name: "queryRef",
+            type: "QueryReference<TData, TVariables>",
+            description:
+              "The `queryRef` used by `useReadQuery` to read the query result.",
+            canonicalReference: "@apollo/client!QueryReference:interface",
+          },
+          {
+            name: "handlers",
+            description:
+              "Additional handlers used for the query, such as `refetch`.",
+            type: HANDLERS,
+          },
+        ]}
+      />
+    </div>
+  );
+}
+
+UseLoadableQueryResult.propTypes = {};

--- a/docs/shared/Overrides/UseLoadableQueryResult.js
+++ b/docs/shared/Overrides/UseLoadableQueryResult.js
@@ -10,7 +10,7 @@ const HANDLERS = `{
 
 const RETURN_VALUE = `[
   loadQuery: LoadQueryFunction<TVariables>,
-  queryRef: QueryReference<TData, TVariables>,
+  queryRef: QueryReference<TData, TVariables> | null,
   {
     fetchMore: FetchMoreFunction<TData, TVariables>;
     refetch: RefetchFunction<TData, TVariables>;
@@ -38,7 +38,7 @@ export function UseLoadableQueryResult() {
           },
           {
             name: "queryRef",
-            type: "QueryReference<TData, TVariables>",
+            type: "QueryReference<TData, TVariables> | null",
             description:
               "The `queryRef` used by `useReadQuery` to read the query result.",
             canonicalReference: "@apollo/client!QueryReference:interface",

--- a/docs/source/api/react/hooks.mdx
+++ b/docs/source/api/react/hooks.mdx
@@ -416,7 +416,7 @@ result={<div>
 A tuple of three values:
 
 <ManualTuple
-  idPrefix="usepreloadedquery-result"
+  idPrefix="useloadablequery-result"
   elements={[
     {
       name: "loadQuery",

--- a/docs/source/api/react/hooks.mdx
+++ b/docs/source/api/react/hooks.mdx
@@ -426,7 +426,7 @@ A tuple of three values:
     {
       name: "queryRef",
       type: "QueryReference<TData, TVariables>",
-      description: "The `queryRef` used by `useReadQuery` to read the query result."
+      description: "The `queryRef` used by `useReadQuery` to read the query result.",
       canonicalReference: "@apollo/client!QueryReference:interface"
     },
     {

--- a/docs/source/api/react/hooks.mdx
+++ b/docs/source/api/react/hooks.mdx
@@ -11,6 +11,7 @@ api_doc:
   - "@apollo/client!useApolloClient:function(1)"
   - "@apollo/client!useReactiveVar:function(1)"
   - "@apollo/client!useLoadableQuery:function(1)"
+  - "@apollo/client!useQueryRefHandlers:function(1)"
 ---
 
 import UseFragmentOptions from '../../../shared/useFragment-options.mdx';
@@ -480,3 +481,4 @@ In this case, it becomes apparent for TypeScript that there is a direct connecti
 </blockquote>
 
 <FunctionDetails canonicalReference="@apollo/client!useLoadableQuery:function(1)" headingLevel={2} />
+<FunctionDetails canonicalReference="@apollo/client!useQueryRefHandlers:function(1)" headingLevel={2} />

--- a/docs/source/api/react/hooks.mdx
+++ b/docs/source/api/react/hooks.mdx
@@ -10,7 +10,7 @@ api_doc:
   - "@apollo/client!useSubscription:function(1)"
   - "@apollo/client!useApolloClient:function(1)"
   - "@apollo/client!useReactiveVar:function(1)"
-  - "@apollo/client!useLoadableQuery:function(1)"
+  - "@apollo/client!useLoadableQuery:function(5)"
   - "@apollo/client!useQueryRefHandlers:function(1)"
 ---
 
@@ -21,6 +21,7 @@ import UseSuspenseQueryResult from '../../../shared/useSuspenseQuery-result.mdx'
 import UseBackgroundQueryResult from '../../../shared/useBackgroundQuery-result.mdx';
 import UseReadQueryResult from '../../../shared/useReadQuery-result.mdx';
 import { FunctionDetails, PropertySignatureTable, ManualTuple, InterfaceDetails } from '../../../shared/ApiDoc';
+import { UseLoadableQueryResult } from '../../../shared/Overrides/UseLoadableQueryResult'
 
 ## The `ApolloProvider` component
 
@@ -407,38 +408,12 @@ function useReadQuery<TData>(
 
 <UseReadQueryResult />
 
-<FunctionDetails canonicalReference="@apollo/client!useLoadableQuery:function(1)" headingLevel={2}
-result={<div>
-<pre><code class="language-ts">
-[loadQuery: LoadQueryFunction&lt;TVariables&gt;, queryRef: QueryReference&lt;TData, TVariables&gt;, handlers: UseLoadableQueryHandlers&lt;TData, TVariables&gt;]
-</code></pre>
-
-A tuple of three values:
-
-<ManualTuple
-  idPrefix="useloadablequery-result"
-  elements={[
-    {
-      name: "loadQuery",
-      type: "LoadQueryFunction<TVariables>",
-      description: "A function used to imperatively load a query. Calling this function will create or update the `queryRef` returned by `useLoadableQuery`, which should be passed to `useReadQuery`."
-    },
-    {
-      name: "queryRef",
-      type: "QueryReference<TData, TVariables>",
-      description: "The `queryRef` used by `useReadQuery` to read the query result.",
-      canonicalReference: "@apollo/client!QueryReference:interface"
-    },
-    {
-      name: "handlers",
-      type: "UseLoadableQueryHandlers<TData, TVariables>",
-      description: "",
-      canonicalReference: "@apollo/client!UseLoadableQueryHandlers:interface"
-    }
-  ]}
+<FunctionDetails
+  canonicalReference="@apollo/client!useLoadableQuery:function(5)"
+  headingLevel={2}
+  result={<UseLoadableQueryResult />}
 />
-</div>}
-/>
+
 <FunctionDetails canonicalReference="@apollo/client!useQueryRefHandlers:function(1)" headingLevel={2} />
 
 <MinVersion version="3.8.0">

--- a/docs/source/api/react/hooks.mdx
+++ b/docs/source/api/react/hooks.mdx
@@ -407,6 +407,40 @@ function useReadQuery<TData>(
 
 <UseReadQueryResult />
 
+<FunctionDetails canonicalReference="@apollo/client!useLoadableQuery:function(1)" headingLevel={2}
+result={<div>
+<pre><code class="language-ts">
+[loadQuery: LoadQueryFunction&lt;TVariables&gt;, queryRef: QueryReference&lt;TData, TVariables&gt;, handlers: UseLoadableQueryHandlers&lt;TData, TVariables&gt;]
+</code></pre>
+
+A tuple of three values:
+
+<ManualTuple
+  idPrefix="usepreloadedquery-result"
+  elements={[
+    {
+      name: "loadQuery",
+      type: "LoadQueryFunction<TVariables>",
+      description: "A function used to imperatively load a query. Calling this function will create or update the `queryRef` returned by `useLoadableQuery`, which should be passed to `useReadQuery`."
+    },
+    {
+      name: "queryRef",
+      type: "QueryReference<TData, TVariables>",
+      description: "The `queryRef` used by `useReadQuery` to read the query result."
+      canonicalReference: "@apollo/client!QueryReference:interface"
+    },
+    {
+      name: "handlers",
+      type: "UseLoadableQueryHandlers<TData, TVariables>",
+      description: "",
+      canonicalReference: "@apollo/client!UseLoadableQueryHandlers:interface"
+    }
+  ]}
+/>
+</div>}
+/>
+<FunctionDetails canonicalReference="@apollo/client!useQueryRefHandlers:function(1)" headingLevel={2} />
+
 <MinVersion version="3.8.0">
 
 ## `skipToken`
@@ -479,6 +513,3 @@ const { data } = useSuspenseQuery(
 In this case, it becomes apparent for TypeScript that there is a direct connection between skipping and the `variables` option - and it will work without unsafe workarounds.
 
 </blockquote>
-
-<FunctionDetails canonicalReference="@apollo/client!useLoadableQuery:function(1)" headingLevel={2} />
-<FunctionDetails canonicalReference="@apollo/client!useQueryRefHandlers:function(1)" headingLevel={2} />

--- a/docs/source/api/react/hooks.mdx
+++ b/docs/source/api/react/hooks.mdx
@@ -10,6 +10,7 @@ api_doc:
   - "@apollo/client!useSubscription:function(1)"
   - "@apollo/client!useApolloClient:function(1)"
   - "@apollo/client!useReactiveVar:function(1)"
+  - "@apollo/client!useLoadableQuery:function(1)"
 ---
 
 import UseFragmentOptions from '../../../shared/useFragment-options.mdx';
@@ -477,3 +478,5 @@ const { data } = useSuspenseQuery(
 In this case, it becomes apparent for TypeScript that there is a direct connection between skipping and the `variables` option - and it will work without unsafe workarounds.
 
 </blockquote>
+
+<FunctionDetails canonicalReference="@apollo/client!useLoadableQuery:function(1)" headingLevel={2} />

--- a/docs/source/api/react/preloading.mdx
+++ b/docs/source/api/react/preloading.mdx
@@ -1,0 +1,11 @@
+---
+title: Preloading
+description: Apollo Client preloading API reference
+minVersion: 3.9.0
+api_doc:
+  - "@apollo/client!createQueryPreloader:function(1)"
+---
+
+import { FunctionDetails } from '../../../shared/ApiDoc';
+
+<FunctionDetails canonicalReference="@apollo/client!createQueryPreloader:function(1)" headingLevel={2} />

--- a/docs/source/config.json
+++ b/docs/source/config.json
@@ -80,6 +80,7 @@
       },
       "React": {
         "Hooks": "/api/react/hooks",
+        "Preloading": "/api/react/preloading",
         "Testing": "/api/react/testing",
         "SSR": "/api/react/ssr",
         "Components (deprecated)": "/api/react/components",

--- a/src/react/hooks/index.ts
+++ b/src/react/hooks/index.ts
@@ -14,7 +14,6 @@ export { useBackgroundQuery } from "./useBackgroundQuery.js";
 export type {
   LoadQueryFunction,
   UseLoadableQueryResult,
-  UseLoadableQueryHandlers,
 } from "./useLoadableQuery.js";
 export { useLoadableQuery } from "./useLoadableQuery.js";
 export type { UseQueryRefHandlersResult } from "./useQueryRefHandlers.js";

--- a/src/react/hooks/index.ts
+++ b/src/react/hooks/index.ts
@@ -14,6 +14,7 @@ export { useBackgroundQuery } from "./useBackgroundQuery.js";
 export type {
   LoadQueryFunction,
   UseLoadableQueryResult,
+  UseLoadableQueryHandlers,
 } from "./useLoadableQuery.js";
 export { useLoadableQuery } from "./useLoadableQuery.js";
 export type { UseQueryRefHandlersResult } from "./useQueryRefHandlers.js";

--- a/src/react/hooks/useLoadableQuery.ts
+++ b/src/react/hooks/useLoadableQuery.ts
@@ -50,6 +50,51 @@ export type UseLoadableQueryResult<
   },
 ];
 
+/**
+ * A hook for imperatively loading a query, such as responding to a user
+ * interaction.
+ *
+ * > Refer to the [Suspense - Fetching in response to user interaction](https://www.apollographql.com/docs/react/data/suspense#fetching-in-response-to-user-interaction) section for a more in-depth overview of `useLoadableQuery`.
+ *
+ * @example
+ * ```jsx
+ * import { gql, useLoadableQuery } from "@apollo/client";
+ *
+ * const GET_GREETING = gql`
+ *   query GetGreeting($language: String!) {
+ *     greeting(language: $language) {
+ *       message
+ *     }
+ *   }
+ * `;
+ *
+ * function App() {
+ *   const [loadGreeting, queryRef] = useLoadableQuery(GET_GREETING);
+ *
+ *   return (
+ *     <>
+ *       <button onClick={() => loadGreeting({ language: "english" })}>
+ *         Load greeting
+ *       </button>
+ *       <Suspense fallback={<div>Loading...</div>}>
+ *         {queryRef && <Hello queryRef={queryRef} />}
+ *       </Suspense>
+ *     </>
+ *   );
+ * }
+ *
+ * function Hello({ queryRef }) {
+ *   const { data } = useReadQuery(queryRef);
+ *
+ *   return <div>{data.greeting.message}</div>;
+ * }
+ * ```
+ *
+ * @since 3.9.0
+ * @param query - A GraphQL query document parsed into an AST by `gql`.
+ * @param options - Options to control how the query is executed.
+ * @returns A tuple in the form of `[loadQuery, queryRef, handlers]`
+ */
 export function useLoadableQuery<
   TData,
   TVariables extends OperationVariables,
@@ -106,51 +151,6 @@ export function useLoadableQuery<
   options?: LoadableQueryHookOptions
 ): UseLoadableQueryResult<TData, TVariables>;
 
-/**
- * A hook for imperatively loading a query, such as responding to a user
- * interaction.
- *
- * > Refer to the [Suspense - Fetching in response to user interaction](https://www.apollographql.com/docs/react/data/suspense#fetching-in-response-to-user-interaction) section for a more in-depth overview of `useLoadableQuery`.
- *
- * @example
- * ```jsx
- * import { gql, useLoadableQuery } from "@apollo/client";
- *
- * const GET_GREETING = gql`
- *   query GetGreeting($language: String!) {
- *     greeting(language: $language) {
- *       message
- *     }
- *   }
- * `;
- *
- * function App() {
- *   const [loadGreeting, queryRef] = useLoadableQuery(GET_GREETING);
- *
- *   return (
- *     <>
- *       <button onClick={() => loadGreeting({ language: "english" })}>
- *         Load greeting
- *       </button>
- *       <Suspense fallback={<div>Loading...</div>}>
- *         {queryRef && <Hello queryRef={queryRef} />}
- *       </Suspense>
- *     </>
- *   );
- * }
- *
- * function Hello({ queryRef }) {
- *   const { data } = useReadQuery(queryRef);
- *
- *   return <div>{data.greeting.message}</div>;
- * }
- * ```
- *
- * @since 3.9.0
- * @param query - A GraphQL query document parsed into an AST by `gql`.
- * @param options - Options to control how the query is executed.
- * @returns A tuple in the form of `[loadQuery, queryRef, handlers]`
- */
 export function useLoadableQuery<
   TData = unknown,
   TVariables extends OperationVariables = OperationVariables,

--- a/src/react/hooks/useLoadableQuery.ts
+++ b/src/react/hooks/useLoadableQuery.ts
@@ -37,27 +37,22 @@ export type LoadQueryFunction<TVariables extends OperationVariables> = (
 
 type ResetFunction = () => void;
 
-export interface UseLoadableQueryHandlers<
-  TData,
-  TVariables extends OperationVariables,
-> {
-  /** {@inheritDoc @apollo/client!QueryResultDocumentation#fetchMore:member} */
-  fetchMore: FetchMoreFunction<TData, TVariables>;
-  /** {@inheritDoc @apollo/client!QueryResultDocumentation#refetch:member} */
-  refetch: RefetchFunction<TData, TVariables>;
-  /**
-   * A function that resets the `queryRef` back to `null`.
-   */
-  reset: ResetFunction;
-}
-
 export type UseLoadableQueryResult<
   TData = unknown,
   TVariables extends OperationVariables = OperationVariables,
 > = [
   loadQuery: LoadQueryFunction<TVariables>,
   queryRef: QueryReference<TData, TVariables> | null,
-  handlers: UseLoadableQueryHandlers<TData, TVariables>,
+  {
+    /** {@inheritDoc @apollo/client!QueryResultDocumentation#fetchMore:member} */
+    fetchMore: FetchMoreFunction<TData, TVariables>;
+    /** {@inheritDoc @apollo/client!QueryResultDocumentation#refetch:member} */
+    refetch: RefetchFunction<TData, TVariables>;
+    /**
+     * A function that resets the `queryRef` back to `null`.
+     */
+    reset: ResetFunction;
+  },
 ];
 
 /**

--- a/src/react/hooks/useLoadableQuery.ts
+++ b/src/react/hooks/useLoadableQuery.ts
@@ -106,6 +106,51 @@ export function useLoadableQuery<
   options?: LoadableQueryHookOptions
 ): UseLoadableQueryResult<TData, TVariables>;
 
+/**
+ * A hook for imperatively loading a query, such as responding to a user
+ * interaction.
+ *
+ * > Refer to the [Suspense - Fetching in response to user interaction](https://www.apollographql.com/docs/react/data/suspense#fetching-in-response-to-user-interaction) section for a more in-depth overview of `useLoadableQuery`.
+ *
+ * @example
+ * ```jsx
+ * import { gql, useLoadableQuery } from "@apollo/client";
+ *
+ * const GET_GREETING = gql`
+ *   query GetGreeting($language: String!) {
+ *     greeting(language: $language) {
+ *       message
+ *     }
+ *   }
+ * `;
+ *
+ * function App() {
+ *   const [loadGreeting, queryRef] = useLoadableQuery(GET_GREETING);
+ *
+ *   return (
+ *     <>
+ *       <button onClick={() => loadGreeting({ language: "english" })}>
+ *         Load greeting
+ *       </button>
+ *       <Suspense fallback={<div>Loading...</div>}>
+ *         {queryRef && <Hello queryRef={queryRef} />}
+ *       </Suspense>
+ *     </>
+ *   );
+ * }
+ *
+ * function Hello({ queryRef }) {
+ *   const { data } = useReadQuery(queryRef);
+ *
+ *   return <div>{data.greeting.message}</div>;
+ * }
+ * ```
+ *
+ * @since 3.9.0
+ * @param query - A GraphQL query document parsed into an AST by `gql`.
+ * @param options - Options to control how the query is executed.
+ * @returns A tuple in the form of `[loadQuery, queryRef, handlers]`
+ */
 export function useLoadableQuery<
   TData = unknown,
   TVariables extends OperationVariables = OperationVariables,

--- a/src/react/hooks/useLoadableQuery.ts
+++ b/src/react/hooks/useLoadableQuery.ts
@@ -55,51 +55,6 @@ export type UseLoadableQueryResult<
   },
 ];
 
-/**
- * A hook for imperatively loading a query, such as responding to a user
- * interaction.
- *
- * > Refer to the [Suspense - Fetching in response to user interaction](https://www.apollographql.com/docs/react/data/suspense#fetching-in-response-to-user-interaction) section for a more in-depth overview of `useLoadableQuery`.
- *
- * @example
- * ```jsx
- * import { gql, useLoadableQuery } from "@apollo/client";
- *
- * const GET_GREETING = gql`
- *   query GetGreeting($language: String!) {
- *     greeting(language: $language) {
- *       message
- *     }
- *   }
- * `;
- *
- * function App() {
- *   const [loadGreeting, queryRef] = useLoadableQuery(GET_GREETING);
- *
- *   return (
- *     <>
- *       <button onClick={() => loadGreeting({ language: "english" })}>
- *         Load greeting
- *       </button>
- *       <Suspense fallback={<div>Loading...</div>}>
- *         {queryRef && <Hello queryRef={queryRef} />}
- *       </Suspense>
- *     </>
- *   );
- * }
- *
- * function Hello({ queryRef }) {
- *   const { data } = useReadQuery(queryRef);
- *
- *   return <div>{data.greeting.message}</div>;
- * }
- * ```
- *
- * @since 3.9.0
- * @param query - A GraphQL query document parsed into an AST by `gql`.
- * @param options - Options to control how the query is executed.
- * @returns A tuple in the form of `[loadQuery, queryRef, handlers]`
- */
 export function useLoadableQuery<
   TData,
   TVariables extends OperationVariables,
@@ -148,6 +103,51 @@ export function useLoadableQuery<
   }
 ): UseLoadableQueryResult<DeepPartial<TData>, TVariables>;
 
+/**
+ * A hook for imperatively loading a query, such as responding to a user
+ * interaction.
+ *
+ * > Refer to the [Suspense - Fetching in response to user interaction](https://www.apollographql.com/docs/react/data/suspense#fetching-in-response-to-user-interaction) section for a more in-depth overview of `useLoadableQuery`.
+ *
+ * @example
+ * ```jsx
+ * import { gql, useLoadableQuery } from "@apollo/client";
+ *
+ * const GET_GREETING = gql`
+ *   query GetGreeting($language: String!) {
+ *     greeting(language: $language) {
+ *       message
+ *     }
+ *   }
+ * `;
+ *
+ * function App() {
+ *   const [loadGreeting, queryRef] = useLoadableQuery(GET_GREETING);
+ *
+ *   return (
+ *     <>
+ *       <button onClick={() => loadGreeting({ language: "english" })}>
+ *         Load greeting
+ *       </button>
+ *       <Suspense fallback={<div>Loading...</div>}>
+ *         {queryRef && <Hello queryRef={queryRef} />}
+ *       </Suspense>
+ *     </>
+ *   );
+ * }
+ *
+ * function Hello({ queryRef }) {
+ *   const { data } = useReadQuery(queryRef);
+ *
+ *   return <div>{data.greeting.message}</div>;
+ * }
+ * ```
+ *
+ * @since 3.9.0
+ * @param query - A GraphQL query document parsed into an AST by `gql`.
+ * @param options - Options to control how the query is executed.
+ * @returns A tuple in the form of `[loadQuery, queryRef, handlers]`
+ */
 export function useLoadableQuery<
   TData = unknown,
   TVariables extends OperationVariables = OperationVariables,

--- a/src/react/hooks/useLoadableQuery.ts
+++ b/src/react/hooks/useLoadableQuery.ts
@@ -41,8 +41,13 @@ export interface UseLoadableQueryHandlers<
   TData,
   TVariables extends OperationVariables,
 > {
+  /** {@inheritDoc @apollo/client!QueryResultDocumentation#fetchMore:member} */
   fetchMore: FetchMoreFunction<TData, TVariables>;
+  /** {@inheritDoc @apollo/client!QueryResultDocumentation#refetch:member} */
   refetch: RefetchFunction<TData, TVariables>;
+  /**
+   * A function that resets the `queryRef` back to `null`.
+   */
   reset: ResetFunction;
 }
 

--- a/src/react/hooks/useLoadableQuery.ts
+++ b/src/react/hooks/useLoadableQuery.ts
@@ -37,17 +37,22 @@ export type LoadQueryFunction<TVariables extends OperationVariables> = (
 
 type ResetFunction = () => void;
 
+export interface UseLoadableQueryHandlers<
+  TData,
+  TVariables extends OperationVariables,
+> {
+  fetchMore: FetchMoreFunction<TData, TVariables>;
+  refetch: RefetchFunction<TData, TVariables>;
+  reset: ResetFunction;
+}
+
 export type UseLoadableQueryResult<
   TData = unknown,
   TVariables extends OperationVariables = OperationVariables,
 > = [
-  LoadQueryFunction<TVariables>,
-  QueryReference<TData, TVariables> | null,
-  {
-    fetchMore: FetchMoreFunction<TData, TVariables>;
-    refetch: RefetchFunction<TData, TVariables>;
-    reset: ResetFunction;
-  },
+  loadQuery: LoadQueryFunction<TVariables>,
+  queryRef: QueryReference<TData, TVariables> | null,
+  handlers: UseLoadableQueryHandlers<TData, TVariables>,
 ];
 
 /**

--- a/src/react/hooks/useQueryRefHandlers.ts
+++ b/src/react/hooks/useQueryRefHandlers.ts
@@ -36,7 +36,7 @@ export interface UseQueryRefHandlersResult<
  *   // ...
  * }
  * ```
- *
+ * @since 3.9.0
  * @param queryRef - A `QueryReference` returned from `useBackgroundQuery`, `useLoadableQuery`, or `createQueryPreloader`.
  */
 export function useQueryRefHandlers<

--- a/src/react/internal/cache/QueryReference.ts
+++ b/src/react/internal/cache/QueryReference.ts
@@ -40,8 +40,8 @@ export interface QueryReference<TData = unknown, TVariables = unknown> {
   /** @internal */
   [PROMISE_SYMBOL]: QueryRefPromise<TData>;
   /**
-   * Returns a promise that resolves when the query has finished loading. The
-   * promise resolves with the `QueryReference` itself.
+   * A function that returns a promise that resolves when the query has finished
+   * loading. The promise resolves with the `QueryReference` itself.
    *
    * @remarks
    * This method is useful for preloading queries in data loading routers, such

--- a/src/react/internal/cache/QueryReference.ts
+++ b/src/react/internal/cache/QueryReference.ts
@@ -39,6 +39,43 @@ export interface QueryReference<TData = unknown, TVariables = unknown> {
   readonly [QUERY_REFERENCE_SYMBOL]: InternalQueryReference<TData>;
   /** @internal */
   [PROMISE_SYMBOL]: QueryRefPromise<TData>;
+  /**
+   * Returns a promise that resolves when the query has finished loading. The
+   * promise resolves with the `QueryReference` itself.
+   *
+   * @remarks
+   * This method is useful for preloading queries in data loading routers, such
+   * as [React Router](https://reactrouter.com/en/main) or [TanStack Router](https://tanstack.com/router),
+   * to prevent routes from transitioning until the query has finished loading.
+   * `data` is not exposed on the promise to discourage using the data in
+   * `loader` functions and exposing it to your route components. Instead, we
+   * prefer you rely on `useReadQuery` to access the data to ensure your
+   * component can rerender with cache updates. If you need to access raw query
+   * data, use `client.query()` directly.
+   *
+   * @example
+   * Here's an example using React Router's `loader` function:
+   * ```ts
+   * import { createQueryPreloader } from "@apollo/client";
+   *
+   * const preloadQuery = createQueryPreloader(client);
+   *
+   * export async function loader() {
+   *   const queryRef = preloadQuery(GET_DOGS_QUERY);
+   *
+   *   return queryRef.toPromise();
+   * }
+   *
+   * export function RouteComponent() {
+   *   const queryRef = useLoaderData();
+   *   const { data } = useReadQuery(queryRef);
+   *
+   *   // ...
+   * }
+   * ```
+   *
+   * @experimental
+   */
   toPromise(): Promise<QueryReference<TData, TVariables>>;
 }
 

--- a/src/react/internal/cache/QueryReference.ts
+++ b/src/react/internal/cache/QueryReference.ts
@@ -35,7 +35,9 @@ const PROMISE_SYMBOL: unique symbol = Symbol();
  * suspend until the promise resolves.
  */
 export interface QueryReference<TData = unknown, TVariables = unknown> {
+  /** @internal */
   readonly [QUERY_REFERENCE_SYMBOL]: InternalQueryReference<TData>;
+  /** @internal */
   [PROMISE_SYMBOL]: QueryRefPromise<TData>;
   toPromise(): Promise<QueryReference<TData, TVariables>>;
 }

--- a/src/react/internal/cache/QueryReference.ts
+++ b/src/react/internal/cache/QueryReference.ts
@@ -74,7 +74,7 @@ export interface QueryReference<TData = unknown, TVariables = unknown> {
    * }
    * ```
    *
-   * @experimental
+   * @alpha
    */
   toPromise(): Promise<QueryReference<TData, TVariables>>;
 }

--- a/src/react/query-preloader/createQueryPreloader.ts
+++ b/src/react/query-preloader/createQueryPreloader.ts
@@ -164,7 +164,7 @@ export interface PreloadQueryFunction {
  * const preloadQuery = createQueryPreloader(client);
  * ```
  * @since 3.9.0
- * @experimental
+ * @alpha
  */
 export function createQueryPreloader(
   client: ApolloClient<any>

--- a/src/react/query-preloader/createQueryPreloader.ts
+++ b/src/react/query-preloader/createQueryPreloader.ts
@@ -153,7 +153,7 @@ export interface PreloadQueryFunction {
  * when you want to start loading a query as early as possible outside of a
  * React component.
  *
- * @param client - The ApolloClient instance that will be used to load queries
+ * @param client - The `ApolloClient` instance that will be used to load queries
  * from the returned `preloadQuery` function.
  * @returns The `preloadQuery` function.
  *

--- a/src/react/query-preloader/createQueryPreloader.ts
+++ b/src/react/query-preloader/createQueryPreloader.ts
@@ -161,6 +161,7 @@ export interface PreloadQueryFunction {
  * ```js
  * const preloadQuery = createQueryPreloader(client);
  * ```
+ * @since 3.9.0
  * @experimental
  */
 export function createQueryPreloader(

--- a/src/react/query-preloader/createQueryPreloader.ts
+++ b/src/react/query-preloader/createQueryPreloader.ts
@@ -153,6 +153,8 @@ export interface PreloadQueryFunction {
  * when you want to start loading a query as early as possible outside of a
  * React component.
  *
+ * > Refer to the [Suspense - Initiating queries outside React](https://www.apollographql.com/docs/react/data/suspense#initiating-queries-outside-react) section for a more in-depth overview.
+ *
  * @param client - The `ApolloClient` instance that will be used to load queries
  * from the returned `preloadQuery` function.
  * @returns The `preloadQuery` function.


### PR DESCRIPTION
This is a continuation of https://github.com/apollographql/apollo-client/pull/11512 that adds the necessary code-level documentation that will be used to document the new APIs in our editors and docs.