### PR TITLE
Add component for API members that are marked as alpha/beta

### DIFF
--- a/docs/shared/ApiDoc/DocBlock.js
+++ b/docs/shared/ApiDoc/DocBlock.js
@@ -11,10 +11,12 @@ export function DocBlock({
   example = false,
   remarksCollapsible = false,
   deprecated = false,
+  releaseTag = false,
 }) {
   return (
     <Stack spacing="4">
       {deprecated && <Deprecated canonicalReference={canonicalReference} />}
+      {releaseTag && <ReleaseTag canonicalReference={canonicalReference} />}
       {summary && <Summary canonicalReference={canonicalReference} />}
       {remarks && (
         <Remarks
@@ -129,4 +131,31 @@ Example.propTypes = {
   canonicalReference: PropTypes.string.isRequired,
   collapsible: PropTypes.bool,
   index: PropTypes.number,
+};
+
+export function ReleaseTag({ canonicalReference }) {
+  const getItem = useApiDocContext();
+  const item = getItem(canonicalReference);
+  const MDX = useMDXComponents();
+
+  if (item.releaseTag === "Public") {
+    return null;
+  }
+
+  return (
+    <MDX.ExperimentalFeature>
+      This is in{" "}
+      <MDX.PrimaryLink
+        href="https://www.apollographql.com/docs/resources/product-launch-stages/#alpha--beta"
+        target="_blank"
+      >
+        {item.releaseTag.toLowerCase()} stage
+      </MDX.PrimaryLink>{" "}
+      and is subject to breaking changes.
+    </MDX.ExperimentalFeature>
+  );
+}
+
+ReleaseTag.propTypes = {
+  canonicalReference: PropTypes.string.isRequired,
 };

--- a/docs/shared/ApiDoc/Function.js
+++ b/docs/shared/ApiDoc/Function.js
@@ -109,7 +109,12 @@ export function FunctionDetails({
         headingLevel={headingLevel}
         since
       />
-      <DocBlock canonicalReference={canonicalReference} deprecated remarks />
+      <DocBlock
+        canonicalReference={canonicalReference}
+        deprecated
+        remarks
+        releaseTag
+      />
       {item.comment?.examples.length == 0 ? null : (
         <>
           <SubHeading

--- a/docs/shared/ApiDoc/PropertySignatureTable.js
+++ b/docs/shared/ApiDoc/PropertySignatureTable.js
@@ -7,7 +7,6 @@ import {
   FunctionSignature,
   useApiDocContext,
   ApiDocHeading,
-  SectionHeading,
 } from ".";
 import { GridItem, Text } from "@chakra-ui/react";
 import { ResponsiveGrid } from "./ResponsiveGrid";

--- a/docs/shared/ApiDoc/PropertySignatureTable.js
+++ b/docs/shared/ApiDoc/PropertySignatureTable.js
@@ -104,6 +104,7 @@ export function PropertySignatureTable({
                       summary
                       remarks
                       remarkCollapsible
+                      releaseTag
                     />
                   </GridItem>
                 </React.Fragment>

--- a/docs/shared/ApiDoc/index.js
+++ b/docs/shared/ApiDoc/index.js
@@ -1,5 +1,12 @@
 export { useApiDocContext } from "./Context";
-export { DocBlock, Deprecated, Example, Remarks, Summary } from "./DocBlock";
+export {
+  DocBlock,
+  Deprecated,
+  Example,
+  Remarks,
+  ReleaseTag,
+  Summary,
+} from "./DocBlock";
 export { PropertySignatureTable } from "./PropertySignatureTable";
 export { ApiDocHeading, SubHeading, SectionHeading } from "./Heading";
 export { InterfaceDetails } from "./InterfaceDetails";


### PR DESCRIPTION
Adds a component to our documentation components that will show features marked as alpha/beta with the `<ExperimentalFeature />` component exported by the docs repo.

(NOTE: These screenshots are not of real alpha/beta features. I added some for testing this change)

<img width="752" alt="Screenshot 2024-01-26 at 11 32 15 AM" src="https://github.com/apollographql/apollo-client/assets/565661/75d91731-3f5b-411e-a5cb-931db7533d49">
<img width="842" alt="Screenshot 2024-01-26 at 11 39 38 AM" src="https://github.com/apollographql/apollo-client/assets/565661/6b7e4db2-8cf4-462e-90d2-1c64e7e55a0e">
<img width="742" alt="Screenshot 2024-01-26 at 11 44 26 AM" src="https://github.com/apollographql/apollo-client/assets/565661/cd7c568e-2e03-4a70-bce7-4c4c5a401f73">
