### PR TITLE
chore: use Node.js v20 in GitHub Actions workflows

### DIFF
--- a/.github/workflows/api-extractor.yml
+++ b/.github/workflows/api-extractor.yml
@@ -11,10 +11,10 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Setup Node.js 18.x
+      - name: Setup Node.js 20.x
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
 
       - name: Install dependencies (with cache)
         uses: bahmutov/npm-install@v1

--- a/.github/workflows/arethetypeswrong.yml
+++ b/.github/workflows/arethetypeswrong.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-      - name: Setup Node.js 18.x
+      - name: Setup Node.js 20.x
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
       - name: Install dependencies (with cache)
         uses: bahmutov/npm-install@v1
 

--- a/.github/workflows/cleanup-checks.yml
+++ b/.github/workflows/cleanup-checks.yml
@@ -30,10 +30,10 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Setup Node.js 18.x
+      - name: Setup Node.js 20.x
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
 
       - name: Install dependencies (with cache)
         uses: bahmutov/npm-install@v1

--- a/.github/workflows/compare-build-output.yml
+++ b/.github/workflows/compare-build-output.yml
@@ -17,10 +17,10 @@ jobs:
         with:
           # Fetch entire git history so we have the parent commit to compare against
           fetch-depth: 0
-      - name: Setup Node.js 18.x
+      - name: Setup Node.js 20.x
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
       - name: Install dependencies (with cache)
         uses: bahmutov/npm-install@v1
 

--- a/.github/workflows/exit-prerelease.yml
+++ b/.github/workflows/exit-prerelease.yml
@@ -27,10 +27,10 @@ jobs:
           # with the correct commits
           fetch-depth: 0
 
-      - name: Setup Node.js 18.x
+      - name: Setup Node.js 20.x
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
 
       - name: Get latest tagged version
         id: previoustag

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -38,10 +38,10 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Setup Node.js 18.x
+      - name: Setup Node.js 20.x
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
 
       - name: Install dependencies with cache
         uses: bahmutov/npm-install@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,10 +43,10 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Setup Node.js 18.x
+      - name: Setup Node.js 20.x
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
 
       - name: Install dependencies (with cache)
         uses: bahmutov/npm-install@v1

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-      - name: Setup Node.js 18.x
+      - name: Setup Node.js 20.x
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
       - name: Install dependencies (with cache)
         uses: bahmutov/npm-install@v1
       - name: Run size-limit

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -56,10 +56,10 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Setup Node.js 18.x
+      - name: Setup Node.js 20.x
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
 
       - name: Install dependencies (with cache)
         uses: bahmutov/npm-install@v1


### PR DESCRIPTION
v20 became LTS in October 2023, this PR updates all our GHA workflows to use it.