### PR TITLE
chore: only open a prerelease version packages PR when still in prerelease mode

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -59,6 +59,7 @@ jobs:
         run: npx changeset pre enter alpha
 
       - name: Create prerelease PR
+        if: steps.check_files.outputs.files_exists == 'true'
         uses: changesets/action@v1
         with:
           version: npm run changeset-version


### PR DESCRIPTION
Avoids opening a PR after we've exited prerelease mode and before the release branch has been merged. Example of erroneous PR: https://github.com/apollographql/apollo-client/pull/11538