### PR TITLE
Use `main` to deploy client docs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -13,7 +13,7 @@
   npm run docmodel
   cd ../
   rm -rf monodocs
-  git clone https://github.com/apollographql/docs --branch pr/parse-ts --single-branch monodocs
+  git clone https://github.com/apollographql/docs --branch main --single-branch monodocs
   cd monodocs
   npm i
   cp -r ../docs local


### PR DESCRIPTION
Followup of #11527.

Switches the branch used to deploy client docs back to `main`.
