### PR TITLE
Revert "Replace Generics in PropertySignatureTable"

### DIFF
--- a/docs/shared/ApiDoc/EnumDetails.js
+++ b/docs/shared/ApiDoc/EnumDetails.js
@@ -47,6 +47,7 @@ export function EnumDetails({
               mr="1"
               as={Text}
               since
+              link
               id={`${item.displayName.toLowerCase()}-member-${member.displayName.toLowerCase()}`}
             />
             <DocBlock

--- a/docs/shared/ApiDoc/ParameterTable.js
+++ b/docs/shared/ApiDoc/ParameterTable.js
@@ -3,7 +3,12 @@ import { useMDXComponents } from "@mdx-js/react";
 import PropTypes from "prop-types";
 import React from "react";
 import { GridItem, Text } from "@chakra-ui/react";
-import { PropertySignatureTable, useApiDocContext } from ".";
+import {
+  PropertySignatureTable,
+  SectionHeading,
+  getInterfaceReference,
+  useApiDocContext,
+} from ".";
 import { ResponsiveGrid } from "./ResponsiveGrid";
 
 export function ParameterTable({ canonicalReference }) {
@@ -20,10 +25,11 @@ export function ParameterTable({ canonicalReference }) {
         <GridItem className="cell heading">Description</GridItem>
 
         {item.parameters.map((parameter) => {
-          const interfaceReference =
-            parameter.primaryCanonicalReference?.endsWith(":interface") ?
-              parameter.primaryCanonicalReference
-            : undefined;
+          const interfaceReference = getInterfaceReference(
+            parameter.type,
+            item,
+            getItem
+          );
           const id = `${item.displayName.toLowerCase()}-parameters-${parameter.name.toLowerCase()}`;
 
           return (
@@ -62,8 +68,7 @@ export function ParameterTable({ canonicalReference }) {
                     Show/hide child attributes
                   </GridItem>
                   <PropertySignatureTable
-                    canonicalReference={interfaceReference}
-                    genericNames={parameter.primaryGenericArguments}
+                    canonicalReference={interfaceReference.canonicalReference}
                     display="child"
                     idPrefix={id}
                   />

--- a/docs/shared/ApiDoc/PropertySignatureTable.js
+++ b/docs/shared/ApiDoc/PropertySignatureTable.js
@@ -19,7 +19,6 @@ export function PropertySignatureTable({
   display = "parent",
   customOrder = [],
   idPrefix = "",
-  genericNames,
 }) {
   const MDX = useMDXComponents();
   const getItem = useApiDocContext();
@@ -36,29 +35,6 @@ export function PropertySignatureTable({
       item.childrenIncompleteDetails
     );
   }
-
-  const replaceGenericNames = React.useMemo(() => {
-    if (!genericNames) return (str) => str;
-
-    const replacements = {};
-    item.typeParameters.forEach((p, i) => {
-      if (genericNames[i] === p.name) return;
-      replacements[p.name] = genericNames[i];
-    });
-    if (!Object.values(replacements).length) return (str) => str;
-
-    const genericReplacementRegex = new RegExp(
-      `\\b(${Object.keys(replacements).join("|")})\\b`,
-      "g"
-    );
-    function replace(match) {
-      console.log({ match, replacement: replacements[match] });
-      return replacements[match] || match;
-    }
-    return function replaceGenericNames(str) {
-      return str.replace(genericReplacementRegex, replace);
-    };
-  });
 
   return (
     <>
@@ -79,7 +55,7 @@ export function PropertySignatureTable({
         : null}
         {Object.entries(groupedProperties).map(
           ([groupName, sortedProperties]) => (
-            <React.Fragment key={groupName}>
+            <>
               {groupName ?
                 <GridItem className="row heading">{groupName}</GridItem>
               : null}
@@ -103,6 +79,7 @@ export function PropertySignatureTable({
                         : null
                       }
                       suffix={property.optional ? <em> (optional)</em> : null}
+                      link={!!idPrefix}
                       id={
                         idPrefix ?
                           `${idPrefix}-${property.displayName.toLowerCase()}`
@@ -117,7 +94,7 @@ export function PropertySignatureTable({
                           parameterTypes
                           arrow
                         />
-                      : replaceGenericNames(property.type)}
+                      : property.type}
                     </MDX.inlineCode>
                   </GridItem>
                   <GridItem className="cell" fontSize="md" lineHeight="base">
@@ -132,7 +109,7 @@ export function PropertySignatureTable({
                   </GridItem>
                 </React.Fragment>
               ))}
-            </React.Fragment>
+            </>
           )
         )}
       </Wrapper>
@@ -147,5 +124,4 @@ PropertySignatureTable.propTypes = {
   display: PropTypes.oneOf(["parent", "child"]),
   customOrder: PropTypes.arrayOf(PropTypes.string),
   idPrefix: PropTypes.string,
-  genericNames: PropTypes.arrayOf(PropTypes.string),
 };

--- a/docs/shared/ApiDoc/getInterfaceReference.js
+++ b/docs/shared/ApiDoc/getInterfaceReference.js
@@ -1,0 +1,8 @@
+export function getInterfaceReference(type, item, getItem) {
+  const baseType = type.replace(/\b(Partial|Omit|Promise)</g, "").split("<")[0];
+  const reference = getItem(
+    item.references?.find((r) => r.text === baseType)?.canonicalReference,
+    false
+  );
+  return reference?.kind === "Interface" ? reference : null;
+}

--- a/docs/shared/ApiDoc/index.js
+++ b/docs/shared/ApiDoc/index.js
@@ -15,4 +15,5 @@ export { ParameterTable } from "./ParameterTable";
 export { PropertyDetails } from "./PropertyDetails";
 export { EnumDetails } from "./EnumDetails";
 export { ManualTuple } from "./Tuple";
+export { getInterfaceReference } from "./getInterfaceReference";
 export { SourceLink } from "./SourceLink";

--- a/netlify.toml
+++ b/netlify.toml
@@ -13,7 +13,7 @@
   npm run docmodel
   cd ../
   rm -rf monodocs
-  git clone https://github.com/apollographql/docs --branch pr/parse-ts --single-branch monodocs
+  git clone https://github.com/apollographql/docs --branch main --single-branch monodocs
   cd monodocs
   npm i
   cp -r ../docs local


### PR DESCRIPTION
Reverts apollographql/apollo-client#11527

Unfortunately there are a few too many cases where we aren't able to parse the nodes due to complex types, so I'm reverting this for now in an effort to ensure docs PRs can continue to be merged.

Here is the log for reference: https://app.netlify.com/sites/apollo-monodocs/deploys/65bae51fbe2f2506e3406166