### PR TITLE
Update import to `rehackt` in `useLazyRef`

### DIFF
--- a/.changeset/young-dots-breathe.md
+++ b/.changeset/young-dots-breathe.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix import in `useLazyRef` causing import issues in the nextjs package.

--- a/src/react/hooks/internal/useLazyRef.ts
+++ b/src/react/hooks/internal/useLazyRef.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "rehackt";
 
 const INIT = {};
 


### PR DESCRIPTION
Fixes https://github.com/apollographql/apollo-client-nextjs/issues/186

`useLazyRef` was introduced by https://github.com/apollographql/apollo-client/pull/11464 and released in in [`3.8.9`](https://github.com/apollographql/apollo-client/releases/tag/v3.8.9), but the import had not been updated to `rehackt` before our 3.9 release causing some import issues in our experimental package.