### PR TITLE
chore: rebuild docs on src changes

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@
 
 [context.deploy-preview.build]
   base = "docs"
-  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ."
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../src"
   command = """\
   npm i
   npm run docmodel


### PR DESCRIPTION
Now that our docs are generated from docblocks, we should also build a deploy preview when something in src changes.