### PR TITLE
feat(mocking): make response error and result not required when delay is infinite

### DIFF
--- a/.changeset/tiny-vans-draw.md
+++ b/.changeset/tiny-vans-draw.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Mocks with an infinite delay no longer require result or error

--- a/src/testing/core/mocking/__tests__/mockLink.ts
+++ b/src/testing/core/mocking/__tests__/mockLink.ts
@@ -1,0 +1,64 @@
+import gql from "graphql-tag";
+import { MockLink } from "../mockLink";
+import { execute } from "../../../../link/core/execute";
+
+/*
+We've chosen this value as the MAXIMUM_DELAY since values that don't fit into a 32-bit signed int cause setTimeout to fire immediately
+*/
+const MAXIMUM_DELAY = 0x7f_ff_ff_ff;
+
+describe("mockLink", () => {
+  beforeAll(() => jest.useFakeTimers());
+  afterAll(() => jest.useRealTimers());
+
+  const query = gql`
+    query A {
+      a
+    }
+  `;
+
+  it("should not require a result or error when delay equals Infinity", async () => {
+    const mockLink = new MockLink([
+      {
+        request: {
+          query,
+        },
+        delay: Infinity,
+      },
+    ]);
+
+    const observable = execute(mockLink, { query });
+
+    const subscription = observable.subscribe(
+      () => fail("onNext was called"),
+      () => fail("onError was called"),
+      () => fail("onComplete was called")
+    );
+    jest.advanceTimersByTime(MAXIMUM_DELAY);
+    subscription.unsubscribe();
+  });
+
+  it("should require result or error when delay is just large", (done) => {
+    const mockLink = new MockLink([
+      {
+        request: {
+          query,
+        },
+        delay: MAXIMUM_DELAY,
+      },
+    ]);
+
+    execute(mockLink, { query }).subscribe(
+      () => fail("onNext was called"),
+      (error) => {
+        expect(error).toBeInstanceOf(Error);
+        expect(error.message).toMatch(
+          /^Mocked response should contain either `result`, `error` or a `delay` of `Infinity`: /
+        );
+        done();
+      }
+    );
+
+    jest.advanceTimersByTime(MAXIMUM_DELAY);
+  });
+});

--- a/src/testing/core/mocking/mockLink.ts
+++ b/src/testing/core/mocking/mockLink.ts
@@ -154,9 +154,9 @@ ${unmatchedVars.map((d) => `  ${stringifyForDisplay(d)}`).join("\n")}
         mockedResponses.push(response);
       }
 
-      if (!response.result && !response.error) {
+      if (!response.result && !response.error && response.delay !== Infinity) {
         configError = new Error(
-          `Mocked response should contain either result or error: ${key}`
+          `Mocked response should contain either \`result\`, \`error\` or a \`delay\` of \`Infinity\`: ${key}`
         );
       }
     }

--- a/src/testing/react/__tests__/__snapshots__/MockedProvider.test.tsx.snap
+++ b/src/testing/react/__tests__/__snapshots__/MockedProvider.test.tsx.snap
@@ -78,7 +78,7 @@ Object {
 
 exports[`General use should pipe exceptions thrown in custom onError functions through the link chain 1`] = `[ApolloError: oh no!]`;
 
-exports[`General use should return "Mocked response should contain" errors in response 1`] = `[ApolloError: Mocked response should contain either result or error: {"query":"query GetUser($username: String!) {\\n  user(username: $username) {\\n    id\\n    __typename\\n  }\\n}"}]`;
+exports[`General use should return "Mocked response should contain" errors in response 1`] = `[ApolloError: Mocked response should contain either \`result\`, \`error\` or a \`delay\` of \`Infinity\`: {"query":"query GetUser($username: String!) {\\n  user(username: $username) {\\n    id\\n    __typename\\n  }\\n}"}]`;
 
 exports[`General use should return "No more mocked responses" errors in response 1`] = `
 [ApolloError: No more mocked responses for the query: query GetUser($username: String!) {


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:

### Checklist:
- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
-->

Without the changes in this PR mocks always require a result or an error for a response. However, when an infinite delay is specified, that response is never returned, so it might as well be omitted.
With the changes in this PR omission of `result` and `error` no longer causes an error, when a delay of `Infinity` is specified.
```ts
const mocks = [
  {
    delay: Infinity
    request: {
      query: GET_DOG_QUERY,
      variables: {
        name: "Buck"
      }
    },
    result: {                                             // all of this
      data: {                                             // makes no
        dog: { id: "1", name: "Buck", breed: "bulldog" }  // sense with
      }                                                   // an infinite
    }                                                     // delay
  }
];


it("renders without error", async () => {
  render(
    <MockedProvider mocks={mocks} addTypename={false}>
      <Dog name="Buck" />
    </MockedProvider>
  );
  expect(await screen.findByText("Loading...")).toBeInTheDocument();
});
```