### PR TITLE
Add `exports` to `package.json`

### DIFF
--- a/.changeset/green-roses-flow.md
+++ b/.changeset/green-roses-flow.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Added `exports` field to `package.json` for better ESM interop

--- a/.github/workflows/arethetypeswrong.yml
+++ b/.github/workflows/arethetypeswrong.yml
@@ -25,5 +25,5 @@ jobs:
         run: npm run build
       - name: Run AreTheTypesWrong
         id: attw
-        # only include the entrypoints
-        run: ./node_modules/.bin/attw --format ascii --pack --include-entrypoints $(node -e 'console.log(require("./config/entryPoints.js").map(ep=>ep.dirs.join("/")).filter(Boolean).join(" "))') dist > $GITHUB_STEP_SUMMARY
+        # ignore legacy cjs files
+        run: ./node_modules/.bin/attw --format ascii --pack dist --exclude-entrypoints main.cjs apollo-client.cjs > $GITHUB_STEP_SUMMARY

--- a/.github/workflows/arethetypeswrong.yml
+++ b/.github/workflows/arethetypeswrong.yml
@@ -25,4 +25,5 @@ jobs:
         run: npm run build
       - name: Run AreTheTypesWrong
         id: attw
-        run: ./node_modules/.bin/attw --format ascii --pack dist > $GITHUB_STEP_SUMMARY
+        # we exclude apollo-client.cjs because it's only a workaround for older bundlers (issue #8605)
+        run: ./node_modules/.bin/attw --format ascii --pack dist --exclude-entrypoints apollo-client.cjs > $GITHUB_STEP_SUMMARY

--- a/.github/workflows/arethetypeswrong.yml
+++ b/.github/workflows/arethetypeswrong.yml
@@ -25,5 +25,5 @@ jobs:
         run: npm run build
       - name: Run AreTheTypesWrong
         id: attw
-        # we exclude apollo-client.cjs because it's only a workaround for older bundlers (issue #8605)
-        run: ./node_modules/.bin/attw --format ascii --pack dist --exclude-entrypoints apollo-client.cjs > $GITHUB_STEP_SUMMARY
+        # only include the entrypoints
+        run: ./node_modules/.bin/attw --format ascii --pack --include-entrypoints $(node -e 'console.log(require("./config/entryPoints.js").map(ep=>ep.dirs.join("/")).filter(Boolean).join(" "))') dist > $GITHUB_STEP_SUMMARY

--- a/config/entryPoints.js
+++ b/config/entryPoints.js
@@ -51,6 +51,10 @@ exports.map = function map(callback, context) {
   return entryPoints.map(callback, context);
 };
 
+exports.reduce = function (callback, context) {
+  return entryPoints.reduce(callback, context);
+};
+
 const path = require("path").posix;
 
 exports.check = function (id, parentId) {

--- a/config/prepareDist.js
+++ b/config/prepareDist.js
@@ -47,12 +47,10 @@ packageJson.exports = {
   [`./index.js`]: {
     types: packageJson.types,
     default: packageJson.module,
-
   },
   [`./main.cjs`]: {
     types: packageJson.types,
     default: packageJson.main,
-
   },
   "./package.json": {
     default: "./package.json",

--- a/config/prepareDist.js
+++ b/config/prepareDist.js
@@ -55,9 +55,15 @@ packageJson.exports = {
       import: `${path}/index.js`,
       require: `${path}/${bundleName}.cjs`,
     };
+
+    // allows imports like `import { ApolloClient } from "@apollo/client/index.js";`
+    acc[`${path}/index.js`] = {
+      types: `${path}/index.d.ts`,
+      default: `${path}/index.js`,
+    };
     return acc;
   }, {}),
-}
+};
 
 // The root package.json points to the CJS/ESM source in "dist", to support
 // on-going package development (e.g. running tests, supporting npm link, etc.).

--- a/config/prepareDist.js
+++ b/config/prepareDist.js
@@ -44,11 +44,11 @@ packageJson.exports = {
     import: packageJson.module,
     require: packageJson.main,
   },
-  [`./index.js`]: {
+  "./index.js": {
     types: packageJson.types,
     default: packageJson.module,
   },
-  [`./main.cjs`]: {
+  "./main.cjs": {
     types: packageJson.types,
     default: packageJson.main,
   },

--- a/config/prepareDist.js
+++ b/config/prepareDist.js
@@ -65,11 +65,10 @@ packageJson.exports = {
       require: `${path}/${bundleName}.cjs`,
     };
 
-    // allows imports like `import { ApolloClient } from "@apollo/client/index.js";`
-    acc[`${path}/index.js`] = {
-      types: `${path}/index.d.ts`,
-      default: `${path}/index.js`,
-    };
+    // this works like a wildcard, so that deep imports will continue to work
+    // such as `import * as ApolloClientCore from '@apollo/client/core/core.cjs';`
+    acc[`${path}/`] = `${path}/`;
+
     return acc;
   }, {}),
 };

--- a/config/prepareDist.js
+++ b/config/prepareDist.js
@@ -44,8 +44,17 @@ packageJson.exports = {
     import: packageJson.module,
     require: packageJson.main,
   },
+  "./index.js": {
+    types: packageJson.types,
+    import: packageJson.module,
+    require: packageJson.main,
+  },
   "./package.json": {
     default: "./package.json",
+  },
+  // related to issue #8605
+  "./apollo-client.cjs": {
+    require: "./apollo-client.cjs",
   },
   ...entryPoints.reduce((acc, { dirs, bundleName = dirs[dirs.length - 1] }) => {
     if (!dirs.length) return acc;

--- a/config/prepareDist.js
+++ b/config/prepareDist.js
@@ -38,6 +38,27 @@ delete packageJson.scripts;
 delete packageJson.bundlesize;
 delete packageJson.engines;
 
+packageJson.exports = {
+  ".": {
+    types: packageJson.types,
+    import: packageJson.module,
+    require: packageJson.main,
+  },
+  "./package.json": {
+    default: "./package.json",
+  },
+  ...entryPoints.reduce((acc, { dirs, bundleName = dirs[dirs.length - 1] }) => {
+    if (!dirs.length) return acc;
+    const path = `./${dirs.join("/")}`;
+    acc[path] = {
+      types: `${path}/index.d.ts`,
+      import: `${path}/index.js`,
+      require: `${path}/${bundleName}.cjs`,
+    };
+    return acc;
+  }, {}),
+}
+
 // The root package.json points to the CJS/ESM source in "dist", to support
 // on-going package development (e.g. running tests, supporting npm link, etc.).
 // When publishing from "dist" however, we need to update the package.json

--- a/config/prepareDist.js
+++ b/config/prepareDist.js
@@ -68,9 +68,9 @@ packageJson.exports = {
       require: `${path}/${bundleName}.cjs`,
     };
 
-    // this works like a wildcard, so that deep imports will continue to work
+    // wildcard, so that deep imports will continue to work
     // such as `import * as ApolloClientCore from '@apollo/client/core/core.cjs';`
-    acc[`${path}/`] = `${path}/`;
+    acc[`${path}/*`] = `${path}/*`;
 
     return acc;
   }, {}),

--- a/config/prepareDist.js
+++ b/config/prepareDist.js
@@ -44,10 +44,15 @@ packageJson.exports = {
     import: packageJson.module,
     require: packageJson.main,
   },
-  "./index.js": {
+  [`./index.js`]: {
     types: packageJson.types,
-    import: packageJson.module,
-    require: packageJson.main,
+    default: packageJson.module,
+
+  },
+  [`./main.cjs`]: {
+    types: packageJson.types,
+    default: packageJson.main,
+
   },
   "./package.json": {
     default: "./package.json",

--- a/integration-tests/node-esm/test-cjs.cjs
+++ b/integration-tests/node-esm/test-cjs.cjs
@@ -31,8 +31,11 @@ for (let [fn, name, category] of entries) {
 
 const moduleNames = [
   ["@apollo/client", "/main.cjs"],
+  ["@apollo/client/main.cjs", "/main.cjs"],
   ["@apollo/client/react", "/react/react.cjs"],
+  ["@apollo/client/react/react.cjs", "/react/react.cjs"],
   ["@apollo/client/link/http", "/link/http/http.cjs"],
+  ["@apollo/client/link/http/http.cjs", "/link/http/http.cjs"],
 ];
 
 for (let [moduleName, expectedFilename] of moduleNames) {

--- a/integration-tests/node-esm/test-esm.mjs
+++ b/integration-tests/node-esm/test-esm.mjs
@@ -39,6 +39,7 @@ const moduleNames = [
   ["@apollo/client/index.js", "/index.js"],
   ["@apollo/client/react", "/react/index.js"],
   ["@apollo/client/react/index.js", "/react/index.js"],
+  ["@apollo/client/link/http", "/link/http/index.js"],
   ["@apollo/client/link/http/index.js", "/link/http/index.js"],
 ];
 

--- a/integration-tests/node-esm/test-esm.mjs
+++ b/integration-tests/node-esm/test-esm.mjs
@@ -35,7 +35,9 @@ for (let [fn, name, category] of entries) {
 }
 
 const moduleNames = [
+  ["@apollo/client", "/index.js"],
   ["@apollo/client/index.js", "/index.js"],
+  ["@apollo/client/react", "/react/index.js"],
   ["@apollo/client/react/index.js", "/react/index.js"],
   ["@apollo/client/link/http/index.js", "/link/http/index.js"],
 ];

--- a/integration-tests/node-standard/test-cjs.js
+++ b/integration-tests/node-standard/test-cjs.js
@@ -31,8 +31,11 @@ for (let [fn, name, category] of entries) {
 
 const moduleNames = [
   ["@apollo/client", "/main.cjs"],
+  ["@apollo/client/main.cjs", "/main.cjs"],
   ["@apollo/client/react", "/react/react.cjs"],
+  ["@apollo/client/react/react.cjs", "/react/react.cjs"],
   ["@apollo/client/link/http", "/link/http/http.cjs"],
+  ["@apollo/client/link/http/http.cjs", "/link/http/http.cjs"],
 ];
 
 for (let [moduleName, expectedFilename] of moduleNames) {

--- a/integration-tests/node-standard/test-esm.mjs
+++ b/integration-tests/node-standard/test-esm.mjs
@@ -39,6 +39,7 @@ const moduleNames = [
   ["@apollo/client/index.js", "/index.js"],
   ["@apollo/client/react", "/react/index.js"],
   ["@apollo/client/react/index.js", "/react/index.js"],
+  ["@apollo/client/link/http", "/link/http/index.js"],
   ["@apollo/client/link/http/index.js", "/link/http/index.js"],
 ];
 

--- a/integration-tests/node-standard/test-esm.mjs
+++ b/integration-tests/node-standard/test-esm.mjs
@@ -35,7 +35,9 @@ for (let [fn, name, category] of entries) {
 }
 
 const moduleNames = [
+  ["@apollo/client", "/index.js"],
   ["@apollo/client/index.js", "/index.js"],
+  ["@apollo/client/react", "/react/index.js"],
   ["@apollo/client/react/index.js", "/react/index.js"],
   ["@apollo/client/link/http/index.js", "/link/http/index.js"],
 ];


### PR DESCRIPTION
Updated the `prepareDist.js` script to generate an `exports` field, which will help ESM loaders properly identify which entry point to use.

Fixes #11569 #9925 #9976 #9048 #9156 #8218 https://github.com/apollographql/apollo-feature-requests/issues/287

Generates:

```json
"exports": {
    ".": {
      "types": "./index.d.ts",
      "import": "./index.js",
      "require": "./main.cjs"
    },
    "./index.js": {
      "types": "./index.d.ts",
      "default": "./index.js"
    },
    "./main.cjs": {
      "types": "./index.d.ts",
      "default": "./main.cjs"
    },
    "./package.json": {
      "default": "./package.json"
    },
    "./apollo-client.cjs": {
      "require": "./apollo-client.cjs"
    },
    "./cache": {
      "types": "./cache/index.d.ts",
      "import": "./cache/index.js",
      "require": "./cache/cache.cjs"
    },
    "./cache/*": "./cache/*",
    "./core": {
      "types": "./core/index.d.ts",
      "import": "./core/index.js",
      "require": "./core/core.cjs"
    },
    "./core/*": "./core/*",
    "./dev": {
      "types": "./dev/index.d.ts",
      "import": "./dev/index.js",
      "require": "./dev/dev.cjs"
    },
    "./dev/*": "./dev/*",
    "./errors": {
      "types": "./errors/index.d.ts",
      "import": "./errors/index.js",
      "require": "./errors/errors.cjs"
    },
    "./errors/*": "./errors/*",
    "./link/batch": {
      "types": "./link/batch/index.d.ts",
      "import": "./link/batch/index.js",
      "require": "./link/batch/batch.cjs"
    },
    "./link/batch/*": "./link/batch/*",
    "./link/batch-http": {
      "types": "./link/batch-http/index.d.ts",
      "import": "./link/batch-http/index.js",
      "require": "./link/batch-http/batch-http.cjs"
    },
    "./link/batch-http/*": "./link/batch-http/*",
    "./link/context": {
      "types": "./link/context/index.d.ts",
      "import": "./link/context/index.js",
      "require": "./link/context/context.cjs"
    },
    "./link/context/*": "./link/context/*",
    "./link/core": {
      "types": "./link/core/index.d.ts",
      "import": "./link/core/index.js",
      "require": "./link/core/core.cjs"
    },
    "./link/core/*": "./link/core/*",
    "./link/error": {
      "types": "./link/error/index.d.ts",
      "import": "./link/error/index.js",
      "require": "./link/error/error.cjs"
    },
    "./link/error/*": "./link/error/*",
    "./link/http": {
      "types": "./link/http/index.d.ts",
      "import": "./link/http/index.js",
      "require": "./link/http/http.cjs"
    },
    "./link/http/*": "./link/http/*",
    "./link/persisted-queries": {
      "types": "./link/persisted-queries/index.d.ts",
      "import": "./link/persisted-queries/index.js",
      "require": "./link/persisted-queries/persisted-queries.cjs"
    },
    "./link/persisted-queries/*": "./link/persisted-queries/*",
    "./link/retry": {
      "types": "./link/retry/index.d.ts",
      "import": "./link/retry/index.js",
      "require": "./link/retry/retry.cjs"
    },
    "./link/retry/*": "./link/retry/*",
    "./link/remove-typename": {
      "types": "./link/remove-typename/index.d.ts",
      "import": "./link/remove-typename/index.js",
      "require": "./link/remove-typename/remove-typename.cjs"
    },
    "./link/remove-typename/*": "./link/remove-typename/*",
    "./link/schema": {
      "types": "./link/schema/index.d.ts",
      "import": "./link/schema/index.js",
      "require": "./link/schema/schema.cjs"
    },
    "./link/schema/*": "./link/schema/*",
    "./link/subscriptions": {
      "types": "./link/subscriptions/index.d.ts",
      "import": "./link/subscriptions/index.js",
      "require": "./link/subscriptions/subscriptions.cjs"
    },
    "./link/subscriptions/*": "./link/subscriptions/*",
    "./link/utils": {
      "types": "./link/utils/index.d.ts",
      "import": "./link/utils/index.js",
      "require": "./link/utils/utils.cjs"
    },
    "./link/utils/*": "./link/utils/*",
    "./link/ws": {
      "types": "./link/ws/index.d.ts",
      "import": "./link/ws/index.js",
      "require": "./link/ws/ws.cjs"
    },
    "./link/ws/*": "./link/ws/*",
    "./react": {
      "types": "./react/index.d.ts",
      "import": "./react/index.js",
      "require": "./react/react.cjs"
    },
    "./react/*": "./react/*",
    "./react/components": {
      "types": "./react/components/index.d.ts",
      "import": "./react/components/index.js",
      "require": "./react/components/components.cjs"
    },
    "./react/components/*": "./react/components/*",
    "./react/context": {
      "types": "./react/context/index.d.ts",
      "import": "./react/context/index.js",
      "require": "./react/context/context.cjs"
    },
    "./react/context/*": "./react/context/*",
    "./react/hoc": {
      "types": "./react/hoc/index.d.ts",
      "import": "./react/hoc/index.js",
      "require": "./react/hoc/hoc.cjs"
    },
    "./react/hoc/*": "./react/hoc/*",
    "./react/hooks": {
      "types": "./react/hooks/index.d.ts",
      "import": "./react/hooks/index.js",
      "require": "./react/hooks/hooks.cjs"
    },
    "./react/hooks/*": "./react/hooks/*",
    "./react/internal": {
      "types": "./react/internal/index.d.ts",
      "import": "./react/internal/index.js",
      "require": "./react/internal/internal.cjs"
    },
    "./react/internal/*": "./react/internal/*",
    "./react/parser": {
      "types": "./react/parser/index.d.ts",
      "import": "./react/parser/index.js",
      "require": "./react/parser/parser.cjs"
    },
    "./react/parser/*": "./react/parser/*",
    "./react/ssr": {
      "types": "./react/ssr/index.d.ts",
      "import": "./react/ssr/index.js",
      "require": "./react/ssr/ssr.cjs"
    },
    "./react/ssr/*": "./react/ssr/*",
    "./testing": {
      "types": "./testing/index.d.ts",
      "import": "./testing/index.js",
      "require": "./testing/testing.cjs"
    },
    "./testing/*": "./testing/*",
    "./testing/core": {
      "types": "./testing/core/index.d.ts",
      "import": "./testing/core/index.js",
      "require": "./testing/core/core.cjs"
    },
    "./testing/core/*": "./testing/core/*",
    "./utilities": {
      "types": "./utilities/index.d.ts",
      "import": "./utilities/index.js",
      "require": "./utilities/utilities.cjs"
    },
    "./utilities/*": "./utilities/*",
    "./utilities/subscriptions/relay": {
      "types": "./utilities/subscriptions/relay/index.d.ts",
      "import": "./utilities/subscriptions/relay/index.js",
      "require": "./utilities/subscriptions/relay/relay.cjs"
    },
    "./utilities/subscriptions/relay/*": "./utilities/subscriptions/relay/*",
    "./utilities/subscriptions/urql": {
      "types": "./utilities/subscriptions/urql/index.d.ts",
      "import": "./utilities/subscriptions/urql/index.js",
      "require": "./utilities/subscriptions/urql/urql.cjs"
    },
    "./utilities/subscriptions/urql/*": "./utilities/subscriptions/urql/*",
    "./utilities/globals": {
      "types": "./utilities/globals/index.d.ts",
      "import": "./utilities/globals/index.js",
      "require": "./utilities/globals/globals.cjs"
    },
    "./utilities/globals/*": "./utilities/globals/*"
  }
```


