### PR TITLE
Add failing test for changing variables with observableQuery

### DIFF
--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -3643,7 +3643,7 @@ test("does not return partial cache data when `returnPartialData` is false and n
     link: ApolloLink.empty(),
   });
 
-  const query = gql`
+  const partialQuery = gql`
     query MyCar($id: ID) {
       car(id: $id) {
         id
@@ -3652,7 +3652,7 @@ test("does not return partial cache data when `returnPartialData` is false and n
     }
   `;
 
-  const partialQuery = gql`
+  const query = gql`
     query MyCar($id: ID) {
       car(id: $id) {
         id
@@ -3663,7 +3663,7 @@ test("does not return partial cache data when `returnPartialData` is false and n
   `;
 
   cache.writeQuery({
-    query,
+    query: partialQuery,
     variables: { id: 1 },
     data: {
       car: {
@@ -3676,7 +3676,7 @@ test("does not return partial cache data when `returnPartialData` is false and n
   });
 
   cache.writeQuery({
-    query: partialQuery,
+    query,
     variables: { id: 2 },
     data: {
       car: {
@@ -3689,7 +3689,7 @@ test("does not return partial cache data when `returnPartialData` is false and n
   });
 
   const observable = client.watchQuery({
-    query: partialQuery,
+    query,
     variables: { id: 2 },
     returnPartialData: false,
     notifyOnNetworkStatusChange: true,
@@ -3709,7 +3709,7 @@ test("does not return partial cache data when `returnPartialData` is false and n
 
   expect(await stream.takeNext()).toEqual({
     loading: true,
-    networkStatus: NetworkStatus.loading,
+    networkStatus: NetworkStatus.setVariables,
     data: undefined,
   });
 });

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -3722,7 +3722,19 @@ test("does not return partial cache data when `returnPartialData` is false and n
     data: undefined,
   });
 
+  expect(observable.getCurrentResult()).toEqual({
+    loading: true,
+    networkStatus: NetworkStatus.setVariables,
+    data: undefined,
+  });
+
   expect(await stream.takeNext()).toEqual({
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    data: { __typename: "Car", id: 1, make: "Ford", model: "Pinto" },
+  });
+
+  expect(observable.getCurrentResult()).toEqual({
     loading: false,
     networkStatus: NetworkStatus.ready,
     data: { __typename: "Car", id: 1, make: "Ford", model: "Pinto" },

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -3706,7 +3706,7 @@ test("does not return partial cache data when `returnPartialData` is false and n
 
   const stream = new ObservableStream(observable);
 
-  expect(await stream.takeNext()).toEqual({
+  await expect(stream).toEmitValue({
     loading: false,
     networkStatus: NetworkStatus.ready,
     data: {
@@ -3714,9 +3714,9 @@ test("does not return partial cache data when `returnPartialData` is false and n
     },
   });
 
-  observable.reobserve({ variables: { id: 1 } });
+  await observable.reobserve({ variables: { id: 1 } });
 
-  expect(await stream.takeNext()).toEqual({
+  await expect(stream).toEmitValue({
     loading: true,
     networkStatus: NetworkStatus.setVariables,
     data: undefined,
@@ -3728,7 +3728,7 @@ test("does not return partial cache data when `returnPartialData` is false and n
     data: undefined,
   });
 
-  expect(await stream.takeNext()).toEqual({
+  await expect(stream).toEmitValue({
     loading: false,
     networkStatus: NetworkStatus.ready,
     data: { __typename: "Car", id: 1, make: "Ford", model: "Pinto" },

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -3672,7 +3672,7 @@ test("does not return partial cache data when `returnPartialData` is false and n
   });
 
   cache.writeQuery({
-    query: partialQuery,
+    query,
     variables: { id: 1 },
     data: {
       car: {
@@ -3685,7 +3685,7 @@ test("does not return partial cache data when `returnPartialData` is false and n
   });
 
   cache.writeQuery({
-    query,
+    query: partialQuery,
     variables: { id: 2 },
     data: {
       car: {
@@ -3699,7 +3699,7 @@ test("does not return partial cache data when `returnPartialData` is false and n
 
   const observable = client.watchQuery({
     query,
-    variables: { id: 2 },
+    variables: { id: 1 },
     returnPartialData: false,
     notifyOnNetworkStatusChange: true,
   });
@@ -3710,11 +3710,11 @@ test("does not return partial cache data when `returnPartialData` is false and n
     loading: false,
     networkStatus: NetworkStatus.ready,
     data: {
-      car: { __typename: "Car", id: 2, make: "Ford", model: "Bronco" },
+      car: { __typename: "Car", id: 1, make: "Ford", model: "Pinto" },
     },
   });
 
-  await observable.reobserve({ variables: { id: 1 } });
+  await observable.reobserve({ variables: { id: 2 } });
 
   await expect(stream).toEmitValue({
     loading: true,
@@ -3731,12 +3731,12 @@ test("does not return partial cache data when `returnPartialData` is false and n
   await expect(stream).toEmitValue({
     loading: false,
     networkStatus: NetworkStatus.ready,
-    data: { __typename: "Car", id: 1, make: "Ford", model: "Pinto" },
+    data: { __typename: "Car", id: 2, make: "Ford", model: "Bronco" },
   });
 
   expect(observable.getCurrentResult()).toEqual({
     loading: false,
     networkStatus: NetworkStatus.ready,
-    data: { __typename: "Car", id: 1, make: "Ford", model: "Pinto" },
+    data: { __typename: "Car", id: 2, make: "Ford", model: "Bronco" },
   });
 });


### PR DESCRIPTION
Adding this as a point of discussion for our team on how core behavior should work relative to our React hooks.

This demonstrates a failing test for `ObservableQuery` core behavior where changing variables with `returnPartialData: false` will report partial data to `next`. This is in contrast to `useQuery` where we expect `data` in this same situation to return `undefined`: https://github.com/apollographql/apollo-client/blob/65ab695470741e8dcaef1ebd7742c3c397526354/src/react/hooks/__tests__/useQuery.test.tsx#L6179-L6272