### PR TITLE
Fixes issue where `data` would sometimes return as `{}` instead of `undefined`

### DIFF
--- a/.changeset/itchy-bugs-drop.md
+++ b/.changeset/itchy-bugs-drop.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fixes an issue where executing a query with a fetch policy of `network-only` multiple times with `useLazyQuery` that returned errors would return `{}` instead of `undefined` as the value of `data` after the first fetch.

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -248,6 +248,10 @@ export class ObservableQuery<
       networkStatus,
     } as ApolloQueryResult<TData>;
 
+    if (equal(result.data, {})) {
+      result.data = void 0 as any;
+    }
+
     const { fetchPolicy = "cache-first" } = this.options;
     if (
       // These fetch policies should never deliver data from the cache, unless
@@ -270,10 +274,6 @@ export class ObservableQuery<
 
       if (diff.complete || this.options.returnPartialData) {
         result.data = diff.result;
-      }
-
-      if (equal(result.data, {})) {
-        result.data = void 0 as any;
       }
 
       if (diff.complete) {

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -1802,7 +1802,16 @@ describe("useLazyQuery Hook", () => {
       ProfiledHook.getCurrentSnapshot()[0]({ variables: { id: 0 } })
     );
 
-    // there should be an additional render here for the loading state :/
+    if (React.version.startsWith("17")) {
+      const [, result] = await ProfiledHook.takeSnapshot();
+
+      expect(result).toMatchObject({
+        data: undefined,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+      });
+    }
+
     {
       const [, result] = await ProfiledHook.takeSnapshot();
 
@@ -1818,7 +1827,16 @@ describe("useLazyQuery Hook", () => {
       ProfiledHook.getCurrentSnapshot()[0]({ variables: { id: 0 } })
     );
 
-    // there should be an additional render here for the loading state :/
+    if (React.version.startsWith("17")) {
+      const [, result] = await ProfiledHook.takeSnapshot();
+
+      expect(result).toMatchObject({
+        data: undefined,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+      });
+    }
+
     {
       const [, result] = await ProfiledHook.takeSnapshot();
 


### PR DESCRIPTION
Fixes https://github.com/apollographql/apollo-client/issues/10369

Our cache reports `data` as `{}` in cases where all fields are missing from the cache. We have a conditional check in our `getCurrentResult` that will set `data` to `undefined` when the value is `{}`, but this was skipped for cache policies. In this case, the offending cache policy was `network-only`.

This change now unconditionally sets `data` to `undefined` if its an empty object, rather than only doing this for fetch policies that read from the cache.

