### PR TITLE
docs: remove errant comma in useSuspenseQuery docs

### DIFF
--- a/docs/shared/useSuspenseQuery-result.mdx
+++ b/docs/shared/useSuspenseQuery-result.mdx
@@ -111,7 +111,7 @@ A function that enables you to re-execute the query, optionally passing in new `
 
 To guarantee that the refetch performs a network request, its `fetchPolicy` is set to `network-only` (unless the original query's `fetchPolicy` is `no-cache` or `cache-and-network`, which also guarantee a network request).
 
-Calling this function will cause the component to re-suspend, , unless the call site is wrapped in [`startTransition`](https://react.dev/reference/react/startTransition).
+Calling this function will cause the component to re-suspend, unless the call site is wrapped in [`startTransition`](https://react.dev/reference/react/startTransition).
 
 </td>
 </tr>


### PR DESCRIPTION
I was re-reading the docs for the first time in a while and noticed this typo. Thanks! 
