### PR TITLE
Use stricter ESM imports to satisfy webpack 5

### DIFF
--- a/.changeset/three-dodos-search.md
+++ b/.changeset/three-dodos-search.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix issue in which webpack will complain due to missing file extension in ESM imports

--- a/src/react/ssr/getDataFromTree.ts
+++ b/src/react/ssr/getDataFromTree.ts
@@ -2,7 +2,7 @@ import * as React from "rehackt";
 import type * as ReactTypes from "react";
 import { getApolloContext } from "../context/index.js";
 import { RenderPromises } from "./RenderPromises.js";
-import { renderToStaticMarkup } from "react-dom/server";
+import { renderToStaticMarkup } from "react-dom/server.js";
 
 export function getDataFromTree(
   tree: ReactTypes.ReactNode,

--- a/src/react/ssr/renderToStringWithData.ts
+++ b/src/react/ssr/renderToStringWithData.ts
@@ -1,6 +1,6 @@
 import type * as ReactTypes from "react";
 import { getMarkupFromTree } from "./getDataFromTree.js";
-import { renderToString } from "react-dom/server";
+import { renderToString } from "react-dom/server.js";
 
 export function renderToStringWithData(
   component: ReactTypes.ReactElement<any>


### PR DESCRIPTION
Fixes an issue in which webpack 5 will complain due to requiring the file extension (`.js`) for ESM imports. (In this case the built NPM package has `"type": "module"`.)

This manifests as an error message similar to the following:
```
ERROR in node_modules/@apollo/client/react/ssr/getDataFromTree.js 5:0-56
Module not found: Error: Can't resolve 'react-dom/server' in '/path/to/your/project/node_modules/@apollo/client/react/ssr'
Did you mean 'server.js'?
BREAKING CHANGE: The request 'react-dom/server' failed to resolve only because it was resolved as fully specified
(probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.
```

(FWIW, this is somewhat a reprisal of a previous PR, that couldn't go in due to other issues at that time: #9601 )

I think this will have been an issue for some time, but presumably not so many people will be using SSR, and even fewer will be running their server-side code through webpack.