### PR TITLE
fix(documentation): use correct query names in partial example

### DIFF
--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -257,7 +257,7 @@ const PARTIAL_GET_DOG_QUERY: TypedDocumentNode<
 // Write partial data for Buck to the cache
 // so it is available when Dog renders
 client.writeQuery({
-  query: GET_DOG_QUERY_PARTIAL,
+  query: PARTIAL_GET_DOG_QUERY,
   variables: { id: "1" },
   data: { dog: { id: "1", name: "Buck" } },
 });

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -273,7 +273,7 @@ function App() {
 }
 
 function Dog({ id }: DogProps) {
-  const { data } = useSuspenseQuery(GET_DOG_QUERY, {
+  const { data } = useSuspenseQuery(PARTIAL_GET_DOG_QUERY, {
     variables: { id },
     returnPartialData: true,
   });

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -273,7 +273,7 @@ function App() {
 }
 
 function Dog({ id }: DogProps) {
-  const { data } = useSuspenseQuery(PARTIAL_GET_DOG_QUERY, {
+  const { data } = useSuspenseQuery(GET_DOG_QUERY, {
     variables: { id },
     returnPartialData: true,
   });


### PR DESCRIPTION
Correct name of query in example. These are supposed to be the same right?

GET_DOG_QUERY_PARTIAL -> PARTIAL_GET_DOG_QUERY


<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:

### Checklist:
- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
-->
