### PR TITLE
fix: Add statusCode in ApolloError for server errors (#11634)

### DIFF
--- a/.changeset/tender-tools-compete.md
+++ b/.changeset/tender-tools-compete.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": minor
+---
+
+Add statusCode in ApolloError for server errors

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -81,6 +81,7 @@ export class ApolloError extends Error {
   }>;
   public clientErrors: ReadonlyArray<Error>;
   public networkError: Error | ServerParseError | ServerError | null;
+  public statusCode?: number;
 
   // An object that can be used to provide some additional information
   // about an error, e.g. specifying the type of error this is. Used
@@ -106,6 +107,10 @@ export class ApolloError extends Error {
     this.networkError = networkError || null;
     this.message = errorMessage || generateErrorMessage(this);
     this.extraInfo = extraInfo;
+    this.statusCode =
+      networkError && "statusCode" in networkError ?
+        networkError.statusCode
+      : undefined;
 
     // We're not using `Object.setPrototypeOf` here as it isn't fully
     // supported on Android (see issue #3236).


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:

### Checklist:
- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
-->

Fix for: [Missing statusCode in ApolloError causes inconsistent error handling in Nuxt #11634 ](https://github.com/apollographql/apollo-client/issues/11634)
