### PR TITLE
Allow query manager to intercept useMutation hook functionality

### DIFF
--- a/.changeset/eight-apples-listen.md
+++ b/.changeset/eight-apples-listen.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": minor
+---
+
+Allow query manager to intercept useMutation hook functionality

--- a/src/react/hooks/internal/wrapHook.ts
+++ b/src/react/hooks/internal/wrapHook.ts
@@ -4,6 +4,7 @@ import type {
   useBackgroundQuery,
   useReadQuery,
   useFragment,
+  useMutation,
 } from "../index.js";
 import type { QueryManager } from "../../../core/QueryManager.js";
 import type { ApolloClient } from "../../../core/ApolloClient.js";
@@ -17,6 +18,7 @@ interface WrappableHooks {
   useBackgroundQuery: typeof useBackgroundQuery;
   useReadQuery: typeof useReadQuery;
   useFragment: typeof useFragment;
+  useMutation: typeof useMutation;
 }
 
 /**

--- a/src/react/hooks/useMutation.ts
+++ b/src/react/hooks/useMutation.ts
@@ -20,6 +20,7 @@ import { equal } from "@wry/equality";
 import { DocumentType, verifyDocumentType } from "../parser/index.js";
 import { ApolloError } from "../../errors/index.js";
 import { useApolloClient } from "./useApolloClient.js";
+import { wrapHook } from "./internal/index.js";
 
 /**
  *
@@ -69,6 +70,27 @@ import { useApolloClient } from "./useApolloClient.js";
  * @returns A tuple in the form of `[mutate, result]`
  */
 export function useMutation<
+  TData = any,
+  TVariables = OperationVariables,
+  TContext = DefaultContext,
+  TCache extends ApolloCache<any> = ApolloCache<any>,
+>(
+  mutation: DocumentNode | TypedDocumentNode<TData, TVariables>,
+  options?: MutationHookOptions<
+    NoInfer<TData>,
+    NoInfer<TVariables>,
+    TContext,
+    TCache
+  >
+): MutationTuple<TData, TVariables, TContext, TCache> {
+  return wrapHook(
+    "useMutation",
+    _useMutation,
+    useApolloClient(options && options.client)
+  )(mutation, options);
+}
+
+function _useMutation<
   TData = any,
   TVariables = OperationVariables,
   TContext = DefaultContext,


### PR DESCRIPTION
Hi, building on the recent introduction to apollo client for wrapping various hooks, I would like to add `useMutation` hook to the list of wrappable hooks if that's okay.

I have a use case where adding some extra logic to `useMutation` would be very desirable, thanks.