### PR TITLE
fix: allow suppressing invariant log messages

### DIFF
--- a/.changeset/rude-rats-do.md
+++ b/.changeset/rude-rats-do.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Allow suppressing invariant log messages

--- a/docs/source/errors.mdx
+++ b/docs/source/errors.mdx
@@ -34,3 +34,13 @@ You can call either or both of these methods on application load.
 The `__DEV__` variable isn't available in all environments. As an alternative, you can check whether `process.env.NODE_ENV !== "production"`.
 
 </blockquote>
+
+**You can also suppress the error messages completely:**
+
+```js title="App.js"
+import { suppressErrorMessages } from "@apollo/client/dev";
+
+if (process.env.NODE_ENV === "production") {  // Suppress messages only in production
+  suppressErrorMessages();
+}
+```

--- a/src/__tests__/__snapshots__/exports.ts.snap
+++ b/src/__tests__/__snapshots__/exports.ts.snap
@@ -145,6 +145,7 @@ Array [
   "loadDevMessages",
   "loadErrorMessageHandler",
   "loadErrorMessages",
+  "suppressErrorMessages",
 ]
 `;
 

--- a/src/dev/index.ts
+++ b/src/dev/index.ts
@@ -1,3 +1,4 @@
 export { loadDevMessages } from "./loadDevMessages.js";
 export { loadErrorMessageHandler } from "./loadErrorMessageHandler.js";
 export { loadErrorMessages } from "./loadErrorMessages.js";
+export { suppressErrorMessages } from "./suppressErrorMessages.js";

--- a/src/dev/suppressErrorMessages.ts
+++ b/src/dev/suppressErrorMessages.ts
@@ -1,0 +1,6 @@
+import { global } from "../utilities/globals/index.js";
+import { ApolloSuppressErrorMessages } from "../utilities/globals/invariantWrappers.js";
+
+export function suppressErrorMessages(): void {
+  global[ApolloSuppressErrorMessages] = true;
+}

--- a/src/utilities/globals/invariantWrappers.ts
+++ b/src/utilities/globals/invariantWrappers.ts
@@ -4,6 +4,23 @@ import global from "./global.js";
 import type { ErrorCodes } from "../../invariantErrorCodes.js";
 import { stringifyForDisplay } from "../common/stringifyForDisplay.js";
 
+const ApolloErrorMessageHandler = Symbol.for(
+  "ApolloErrorMessageHandler_" + version
+);
+
+const ApolloSuppressErrorMessages = Symbol.for(
+  "ApolloSuppressErrorMessages_" + version
+);
+
+declare global {
+  interface Window {
+    [ApolloErrorMessageHandler]?: {
+      (message: string | number, args: unknown[]): string | undefined;
+    } & ErrorCodes;
+    [ApolloSuppressErrorMessages]?: true;
+  }
+}
+
 function wrap(fn: (msg?: string, ...args: any[]) => void) {
   return function (message?: string | number, ...args: any[]) {
     if (typeof message === "number") {
@@ -14,6 +31,7 @@ function wrap(fn: (msg?: string, ...args: any[]) => void) {
         args = [];
       }
     }
+    if (ApolloSuppressErrorMessages in global) return;
     fn(...[message].concat(args));
   };
 }
@@ -105,17 +123,6 @@ function newInvariantError(
   );
 }
 
-const ApolloErrorMessageHandler = Symbol.for(
-  "ApolloErrorMessageHandler_" + version
-);
-declare global {
-  interface Window {
-    [ApolloErrorMessageHandler]?: {
-      (message: string | number, args: unknown[]): string | undefined;
-    } & ErrorCodes;
-  }
-}
-
 function stringify(arg: any) {
   return typeof arg == "string" ? arg : (
       stringifyForDisplay(arg, 2).slice(0, 1000)
@@ -152,4 +159,5 @@ export {
   InvariantError,
   newInvariantError,
   ApolloErrorMessageHandler,
+  ApolloSuppressErrorMessages,
 };


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:

### Checklist:
- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
-->

Hello,

as a happy user of Apolllo Client, I would like to completely suppress the invariant log errors in my production environment. I don't want to load all the error codes into the bundle, nor do I want to output the fallback message linking to https://go.apollo.dev/ into the console.

I opened this small PR that adds a new method for achieving this:

```ts
import { suppressErrorMessages } from "@apollo/client/dev";

if (process.env.NODE_ENV === "production") {  // Suppress messages only in production
  suppressErrorMessages();
}
```

When called, `suppressErrorMessages()` will set a global symbol for `ApolloSuppressErrorMessages` in a similar fashion to the existing `ApolloErrorMessageHandler` symbol. If this symbol exists, the final `console` method inside the `invariant()` will not be called.

~~There doesn't seem to be any existing tests for this functionality, but I'm happy to create some if necessary.~~ EDIT: I found a place to add an unit test.

Feel free to merge, edit, or reject this pull request. Since the change is small enough, I figured it's easier to just create a PR rather than submit an issue for the feature request first.