### PR TITLE
#11630 `useQuery` error when changing query

### DIFF
--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -3706,6 +3706,11 @@ describe("useQuery Hook", () => {
       { name: "D", position: 4 },
     ];
 
+    const ef = [
+      { name: "E", position: 5 },
+      { name: "F", position: 6 },
+    ];
+
     const mocks = [
       {
         request: { query, variables: { limit: 2 } },
@@ -4020,6 +4025,187 @@ describe("useQuery Hook", () => {
         { interval: 1 }
       );
       expect(result.current.data).toEqual({ countries });
+    });
+
+    it("should handle inconsistent cache items", async () => {
+      const query1 = gql`
+        query letters($limit: Int, $offset: Int) {
+          letters(limit: $limit, offset: $offset) {
+            name
+          }
+        }
+      `;
+
+      const query2 = gql`
+        query letters($limit: Int, $offset: Int) {
+          letters(limit: $limit, offset: $offset) {
+            name
+            position
+          }
+        }
+      `;
+
+      const mocks = [
+        {
+          request: { query: query1, variables: { limit: 2, offset: 0 } },
+          result: {
+            data: {
+              letters: ab.map(({ position, ...letter }) => letter),
+            },
+          },
+        },
+        {
+          request: { query: query1, variables: { limit: 2, offset: 2 } },
+          result: {
+            data: {
+              letters: cd.map(({ position, ...letter }) => letter),
+            },
+          },
+        },
+        {
+          request: { query: query1, variables: { limit: 2, offset: 4 } },
+          result: {
+            data: {
+              letters: ef.map(({ position, ...letter }) => letter),
+            },
+          },
+        },
+        {
+          request: { query: query2, variables: { limit: 2, offset: 0 } },
+          result: {
+            data: {
+              letters: ab,
+            },
+          },
+        },
+        {
+          request: { query: query2, variables: { limit: 2, offset: 2 } },
+          result: {
+            data: {
+              letters: cd,
+            },
+          },
+        },
+      ];
+
+      const cache = new InMemoryCache({
+        typePolicies: {
+          Query: {
+            fields: {
+              letters: {
+                keyArgs: false,
+                merge(existing, incoming, { args }) {
+                  if (!incoming) {
+                    return existing;
+                  }
+                  if (!existing) {
+                    return incoming;
+                  }
+                  const result = [...existing];
+                  for (let i = 0; i < incoming.length; i++) {
+                    result[(args?.offset ?? 0) + i] = incoming[i];
+                  }
+                  return result;
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const wrapper = ({ children }: any) => (
+        <MockedProvider mocks={mocks} cache={cache}>
+          {children}
+        </MockedProvider>
+      );
+
+      const { result, rerender } = renderHook(
+        ({ query, variables }) =>
+          useQuery(query, {
+            variables,
+            fetchPolicy: "network-only",
+            notifyOnNetworkStatusChange: true,
+          }),
+        {
+          wrapper,
+          initialProps: { query: query1, variables: { limit: 2, offset: 0 } },
+        }
+      );
+
+      expect(result.current.loading).toBe(true);
+      expect(result.current.networkStatus).toBe(NetworkStatus.loading);
+      expect(result.current.data).toBe(undefined);
+
+      await waitFor(
+        () => {
+          expect(result.current.loading).toBe(false);
+        },
+        { interval: 1 }
+      );
+
+      expect(result.current.networkStatus).toBe(NetworkStatus.ready);
+      expect(result.current.data.letters).toEqual(
+        ab.map(({ position, ...letter }) => letter)
+      );
+
+      act(() => void result.current.fetchMore({ variables: { limit: 2, offset: 2 } }));
+
+      expect(result.current.loading).toBe(true);
+      expect(result.current.networkStatus).toBe(NetworkStatus.fetchMore);
+
+      await waitFor(
+        () => {
+          expect(result.current.loading).toBe(false);
+        },
+        { interval: 1 }
+      );
+
+      expect(result.current.networkStatus).toBe(NetworkStatus.ready);
+      expect(result.current.data.letters).toEqual(
+        ab.concat(cd).map(({ position, ...letter }) => letter)
+      );
+
+      act(() => void result.current.fetchMore({ variables: { limit: 2, offset: 4 } }));
+
+      expect(result.current.loading).toBe(true);
+      expect(result.current.networkStatus).toBe(NetworkStatus.fetchMore);
+
+      await waitFor(
+        () => {
+          expect(result.current.loading).toBe(false);
+        },
+        { interval: 1 }
+      );
+
+      expect(result.current.networkStatus).toBe(NetworkStatus.ready);
+      expect(result.current.data.letters).toEqual(
+        ab
+          .concat(cd)
+          .concat(ef)
+          .map(({ position, ...letter }) => letter)
+      );
+
+      rerender({ query: query2, variables: { limit: 2, offset: 0 } });
+
+      expect(result.current.loading).toBe(true);
+      expect(result.current.networkStatus).toBe(NetworkStatus.loading);
+
+      await waitFor(
+        () => {
+          expect(result.current.loading).toBe(false);
+        },
+        { interval: 1 }
+      );
+
+      expect(result.current.networkStatus).toBe(NetworkStatus.ready);
+      expect(result.current.data.letters).toEqual(ab);
+
+      act(() => void result.current.fetchMore({ variables: { limit: 2, offset: 2 } }));
+
+      await new Promise((resolve) => setTimeout(resolve, 40));
+
+      // expect(result.current.networkStatus).toBe(NetworkStatus.ready);
+      expect(result.current.data.letters).toEqual(ab.concat(cd));
     });
   });
 


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:

### Checklist:
- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
-->

Test for proof of #11630 