### PR TITLE
chore: add minVersion to docs for bailing out of optimistic updates

### DIFF
--- a/docs/source/performance/optimistic-ui.mdx
+++ b/docs/source/performance/optimistic-ui.mdx
@@ -73,7 +73,11 @@ As this example shows, the value of `optimisticResponse` is an object that match
 
 5. Apollo Client notifies all affected queries again. The associated components re-render, but if the server's response matches our `optimisticResponse`, this is invisible to the user.
 
+<MinVersion version="3.9.0">
+
 ## Bailing out of an optimistic update
+
+</MinVersion>
 
 In some cases you may want to skip an optimistic update. For example, you may want to perform an optimistic update _only_ when certain variables are passed to the mutation. To skip an update, pass a function to the `optimisticResponse` option and return the `IGNORE` sentinel object available on the second argument to bail out of the optimistic update.
 


### PR DESCRIPTION
This feature is not available in version <3.9.0. This PR updates the docs with a `minVersion`.

After:

![CleanShot 2024-03-12 at 14 42 32](https://github.com/apollographql/apollo-client/assets/5139846/f3409223-1e0a-4172-90b2-a2e8127c94a3)