### PR TITLE
fix: re-export `setVerbosity` from `ts-invariant`

### DIFF
--- a/.changeset/rude-rats-do.md
+++ b/.changeset/rude-rats-do.md
@@ -1,0 +1,6 @@
+---
+"@apollo/client": patch
+---
+
+Export `setVerbosity` from `@apollo/client/dev` so that invariant error messages
+can be silenced with `setVerbosity("silent")`.

--- a/docs/source/errors.mdx
+++ b/docs/source/errors.mdx
@@ -34,3 +34,13 @@ You can call either or both of these methods on application load.
 The `__DEV__` variable isn't available in all environments. As an alternative, you can check whether `process.env.NODE_ENV !== "production"`.
 
 </blockquote>
+
+**You can also silence the error messages completely:**
+
+```js title="App.js"
+import { setVerbosity } from "@apollo/client/dev";
+
+if (!__DEV__) {  // Silence messages when not in a dev environment
+  setVerbosity("silent");
+}
+```

--- a/src/__tests__/__snapshots__/exports.ts.snap
+++ b/src/__tests__/__snapshots__/exports.ts.snap
@@ -145,6 +145,7 @@ Array [
   "loadDevMessages",
   "loadErrorMessageHandler",
   "loadErrorMessages",
+  "setVerbosity",
 ]
 `;
 

--- a/src/dev/index.ts
+++ b/src/dev/index.ts
@@ -1,3 +1,5 @@
+export { setVerbosity } from "ts-invariant";
+
 export { loadDevMessages } from "./loadDevMessages.js";
 export { loadErrorMessageHandler } from "./loadErrorMessageHandler.js";
 export { loadErrorMessages } from "./loadErrorMessages.js";

--- a/src/utilities/globals/__tests__/invariantWrappers.test.ts
+++ b/src/utilities/globals/__tests__/invariantWrappers.test.ts
@@ -1,4 +1,4 @@
-import { loadErrorMessageHandler } from "../../../dev";
+import { loadErrorMessageHandler, setVerbosity } from "../../../dev";
 import { spyOnConsole, withCleanup } from "../../../testing/internal";
 import {
   ApolloErrorMessageHandler,
@@ -24,6 +24,16 @@ function mockErrorMessageHandler() {
 
   return withCleanup({ original }, ({ original }) => {
     window[ApolloErrorMessageHandler] = original;
+  });
+}
+
+function restoreVerbosity() {
+  return withCleanup({}, () => {
+    /**
+     * This is the default verbosity level of "ts-invariant"
+     * @see https://github.com/apollographql/invariant-packages/blob/885d687b654102a8ff1fb5419c94461795909f96/packages/ts-invariant/src/invariant.ts#L34
+     */
+    setVerbosity("log");
   });
 }
 
@@ -116,4 +126,12 @@ test("base invariant(false, 6, ...), raises fallback", () => {
         )
     )
   );
+});
+
+test("setVerbosity('silent') disables logging to console", () => {
+  using _ = restoreVerbosity();
+  using consoleSpy = spyOnConsole("log");
+  setVerbosity("silent");
+  invariant.log(5, "string", 1, 1.1, { a: 1 });
+  expect(consoleSpy.log).not.toHaveBeenCalled();
 });


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:

### Checklist:
- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
-->

Hello,

as a happy user of Apollo Client, I would like to completely suppress the invariant log errors in my production environment. I don't want to load all the error codes into the bundle, nor do I want to output the fallback message linking to https://go.apollo.dev/ into the console.

I opened this small PR that adds a new method for achieving this:

```ts
import { setVerbosity } from "@apollo/client/dev";

if (!__DEV__) {  // Silence messages when not in a dev environment
  setVerbosity("silent");
}
```

Where `setVerbosity` is just directly re-exported from `ts-invariant`.

~~There doesn't seem to be any existing tests for this functionality, but I'm happy to create some if necessary.~~ EDIT: I found a place to add an unit test.

Feel free to merge, edit, or reject this pull request. Since the change is small enough, I figured it's easier to just create a PR rather than submit an issue for the feature request first.