### PR TITLE
chore: remove NODE_VERSION from netlify.toml to unblock preview deploys

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,9 +2,6 @@
   publish = "docs/public"
   command = "npm run typedoc; npm run docmodel > docs/public/log.txt || true"
 
-[build.environment]
-  NODE_VERSION = "18"
-
 [context.deploy-preview.build]
   base = "docs"
   ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../src"


### PR DESCRIPTION
As a side effect of https://github.com/apollographql/odyssey/pull/976/files, preview deploys are currently failing (example: https://app.netlify.com/sites/apollo-client-docs/deploys/65f88d0e78880e00084cd36f, see private Slack thread [here](https://apollograph.slack.com/archives/C0721M2F6/p1710521565467909) for more info.)

This PR removes the `NODE_VERSION` specified in `netlify.toml` so it can be set via Netlify GUI.