### PR TITLE
Fix issue where an empty array returned from `fetchMore` would rerender with an empty list

### DIFF
--- a/.changeset/curly-berries-hammer.md
+++ b/.changeset/curly-berries-hammer.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix issue in all suspense hooks where returning an empty array after calling `fetchMore` would rerender the component with an empty list.

--- a/src/react/hooks/__tests__/useBackgroundQuery.test.tsx
+++ b/src/react/hooks/__tests__/useBackgroundQuery.test.tsx
@@ -4795,6 +4795,15 @@ describe("refetch", () => {
 describe("fetchMore", () => {
   it("re-suspends when calling `fetchMore` with different variables", async () => {
     const { query, link } = setupPaginatedCase();
+    const cache = new InMemoryCache({
+      typePolicies: {
+        Query: {
+          fields: {
+            letters: { keyArgs: false },
+          },
+        },
+      },
+    });
     const user = userEvent.setup();
     const Profiler = createDefaultProfiler<PaginatedCaseData>();
     const { SuspenseFallback, ReadQueryHook } =
@@ -4818,7 +4827,7 @@ describe("fetchMore", () => {
       );
     }
 
-    renderWithMocks(<App />, { link, wrapper: Profiler });
+    renderWithMocks(<App />, { cache, link, wrapper: Profiler });
 
     {
       const { renderedComponents } = await Profiler.takeRender();

--- a/src/react/hooks/__tests__/useLoadableQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLoadableQuery.test.tsx
@@ -49,6 +49,7 @@ import {
   Profiler,
   SimpleCaseData,
   createProfiler,
+  setupPaginatedCase,
   setupSimpleCase,
   spyOnConsole,
   useTrackRenders,
@@ -3205,7 +3206,22 @@ it("`refetch` works with startTransition to allow React to show stale UI until f
 });
 
 it("re-suspends when calling `fetchMore` with different variables", async () => {
-  const { query, client } = usePaginatedQueryCase();
+  const { query, link } = setupPaginatedCase();
+
+  const client = new ApolloClient({
+    link,
+    cache: new InMemoryCache({
+      typePolicies: {
+        Query: {
+          fields: {
+            letters: {
+              keyArgs: false,
+            },
+          },
+        },
+      },
+    }),
+  });
 
   const Profiler = createDefaultProfiler<PaginatedQueryData>();
   const { SuspenseFallback, ReadQueryHook } =
@@ -3244,8 +3260,8 @@ it("re-suspends when calling `fetchMore` with different variables", async () => 
     expect(snapshot.result).toEqual({
       data: {
         letters: [
-          { letter: "A", position: 1 },
-          { letter: "B", position: 2 },
+          { __typename: "Letter", letter: "A", position: 1 },
+          { __typename: "Letter", letter: "B", position: 2 },
         ],
       },
       error: undefined,
@@ -3268,8 +3284,8 @@ it("re-suspends when calling `fetchMore` with different variables", async () => 
     expect(snapshot.result).toEqual({
       data: {
         letters: [
-          { letter: "C", position: 3 },
-          { letter: "D", position: 4 },
+          { __typename: "Letter", letter: "C", position: 3 },
+          { __typename: "Letter", letter: "D", position: 4 },
         ],
       },
       error: undefined,

--- a/src/react/hooks/__tests__/useQueryRefHandlers.test.tsx
+++ b/src/react/hooks/__tests__/useQueryRefHandlers.test.tsx
@@ -1100,7 +1100,18 @@ test("resuspends when calling `fetchMore`", async () => {
 
   const user = userEvent.setup();
 
-  const client = new ApolloClient({ cache: new InMemoryCache(), link });
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      typePolicies: {
+        Query: {
+          fields: {
+            letters: { keyArgs: false },
+          },
+        },
+      },
+    }),
+    link,
+  });
   const preloadQuery = createQueryPreloader(client);
 
   const Profiler = createProfiler({
@@ -1397,7 +1408,18 @@ test("paginates from queryRefs produced by useBackgroundQuery", async () => {
   const { query, link } = setupPaginatedCase();
 
   const user = userEvent.setup();
-  const client = new ApolloClient({ cache: new InMemoryCache(), link });
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      typePolicies: {
+        Query: {
+          fields: {
+            letters: { keyArgs: false },
+          },
+        },
+      },
+    }),
+    link,
+  });
 
   const Profiler = createProfiler({
     initialSnapshot: {
@@ -1489,7 +1511,18 @@ test("paginates from queryRefs produced by useLoadableQuery", async () => {
   const { query, link } = setupPaginatedCase();
 
   const user = userEvent.setup();
-  const client = new ApolloClient({ cache: new InMemoryCache(), link });
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      typePolicies: {
+        Query: {
+          fields: {
+            letters: { keyArgs: false },
+          },
+        },
+      },
+    }),
+    link,
+  });
 
   const Profiler = createProfiler({
     initialSnapshot: {
@@ -1589,7 +1622,18 @@ test("`fetchMore` works with startTransition", async () => {
   const { query, link } = setupPaginatedCase();
 
   const user = userEvent.setup();
-  const client = new ApolloClient({ cache: new InMemoryCache(), link });
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      typePolicies: {
+        Query: {
+          fields: {
+            letters: { keyArgs: false },
+          },
+        },
+      },
+    }),
+    link,
+  });
   const preloadQuery = createQueryPreloader(client);
 
   const Profiler = createProfiler({
@@ -1708,7 +1752,18 @@ test("`fetchMore` works with startTransition from useBackgroundQuery and useQuer
   const { query, link } = setupPaginatedCase();
 
   const user = userEvent.setup();
-  const client = new ApolloClient({ cache: new InMemoryCache(), link });
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      typePolicies: {
+        Query: {
+          fields: {
+            letters: { keyArgs: false },
+          },
+        },
+      },
+    }),
+    link,
+  });
 
   const Profiler = createProfiler({
     initialSnapshot: {

--- a/src/react/internal/cache/QueryReference.ts
+++ b/src/react/internal/cache/QueryReference.ts
@@ -377,7 +377,7 @@ export class InternalQueryReference<TData = unknown> {
     // to resolve the promise if `handleNext` hasn't been run to ensure the
     // promise is resolved correctly.
     returnedPromise
-      .then((result) => {
+      .then(() => {
         // In the case of `fetchMore`, this promise is resolved before a cache
         // result is emitted due to the fact that `fetchMore` sets a `no-cache`
         // fetch policy and runs `cache.batch` in its `.then` handler. Because
@@ -390,8 +390,16 @@ export class InternalQueryReference<TData = unknown> {
         // more information
         setTimeout(() => {
           if (this.promise.status === "pending") {
-            this.result = result;
-            this.resolve?.(result);
+            // Use the current result from the observable instead of the value
+            // resolved from the promise. This avoids issues in some cases where
+            // the raw resolved value should not be the emitted value, such as
+            // when a `fetchMore` call returns an empty array after it has
+            // reached the end of the list.
+            //
+            // See the following for more information:
+            // https://github.com/apollographql/apollo-client/issues/11642
+            this.result = this.observable.getCurrentResult();
+            this.resolve?.(this.result);
           }
         });
       })


### PR DESCRIPTION
Fixes #11642

When using `fetchMore` with any suspense hook, an empty array was returned from the query whenever the server returned an empty array. This was because we were attaching the raw server value on the promise and emitting that value. This PR updates the resolved value to call `getCurrentResult` which contains the full cached result.