### PR TITLE
Use bot token in prerelease workflows

### DIFF
--- a/.github/workflows/change-prerelease-tag.yml
+++ b/.github/workflows/change-prerelease-tag.yml
@@ -29,7 +29,7 @@ jobs:
           app-id: 47012416
           private-key: ${{ secrets.APOLLO_GITHUB_ACTIONS_BOT_PRIVATE_KEY }}
           repositories: ${{ github.repository }}
-          owner: ${{ github.repository_owner }}
+          owner: mdg-private
 
       # Check out the repository, using the Github Actions Bot app's token so
       # that we can push later.

--- a/.github/workflows/change-prerelease-tag.yml
+++ b/.github/workflows/change-prerelease-tag.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/create-github-app-token@v1
         id: github-actions-bot-app-token
         with:
-          app-id: 48725422
+          app-id: 819772
           private-key: ${{ secrets.APOLLO_GITHUB_ACTIONS_BOT_PRIVATE_KEY }}
           repositories: ${{ github.repository }}
           owner: ${{ github.repository_owner }}

--- a/.github/workflows/change-prerelease-tag.yml
+++ b/.github/workflows/change-prerelease-tag.yml
@@ -26,10 +26,10 @@ jobs:
       - uses: actions/create-github-app-token@v1
         id: github-actions-bot-app-token
         with:
-          app-id: 47012416
+          app-id: 48725422
           private-key: ${{ secrets.APOLLO_GITHUB_ACTIONS_BOT_PRIVATE_KEY }}
           repositories: ${{ github.repository }}
-          owner: mdg-private
+          owner: ${{ github.repository_owner }}
 
       # Check out the repository, using the Github Actions Bot app's token so
       # that we can push later.

--- a/.github/workflows/change-prerelease-tag.yml
+++ b/.github/workflows/change-prerelease-tag.yml
@@ -48,14 +48,17 @@ jobs:
         with:
           node-version: 20.x
 
-      - name: Write previous version to package.json and package-lock.json
+      - name: Write latest version to package.json and package-lock.json
         run: |
           version=$(npm show @apollo/client version)
           npm pkg set version="$version"
           npm i
 
-      # - name: Change prerelease tag
-      # run: |
+      - name: Update prerelease tag in .changeset/pre.json
+        uses: restackio/update-json-file-action@v2.1
+        with:
+          file: .changeset/pre.json
+          fields: '{"tag": "${{github.event.inputs.tag}}"}'
 
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:

--- a/.github/workflows/change-prerelease-tag.yml
+++ b/.github/workflows/change-prerelease-tag.yml
@@ -1,17 +1,22 @@
-name: Exit Prerelease Mode
+name: Change Prerelease Tag
 
 on:
   workflow_dispatch:
     inputs:
       branch:
-        description: "Exit prerelease mode on release branch"
+        description: "Branch name"
         type: string
         default: "release-"
         required: true
+      tag:
+        description: "New tag name"
+        type: string
+        default: "rc"
+        required: true
 
 jobs:
-  exit_prerelease:
-    name: Changesets Exit Prerelease
+  change_prerelease_tag:
+    name: Changesets Update Prerelease Tag
     runs-on: ubuntu-latest
     # Allow GITHUB_TOKEN to have write permissions
     permissions:
@@ -49,11 +54,11 @@ jobs:
           npm pkg set version="$version"
           npm i
 
-      - name: Remove pre.json
-        run: npx rimraf .changeset/pre.json
+      # - name: Change prerelease tag
+      # run: |
 
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: Exit prerelease mode
+          commit_message: Prepare for ${{ github.event.inputs.tag }} release
           # Commit these changes to the branch workflow is running against
           branch: ${{ github.event.inputs.branch }}

--- a/.github/workflows/exit-prerelease.yml
+++ b/.github/workflows/exit-prerelease.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           node-version: 20.x
 
-      - name: Write previous version to package.json and package-lock.json
+      - name: Write latest version to package.json and package-lock.json
         run: |
           version=$(npm show @apollo/client version)
           npm pkg set version="$version"

--- a/.github/workflows/exit-prerelease.yml
+++ b/.github/workflows/exit-prerelease.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/create-github-app-token@v1
         id: github-actions-bot-app-token
         with:
-          app-id: 48725422
+          app-id: 819772
           private-key: ${{ secrets.APOLLO_GITHUB_ACTIONS_BOT_PRIVATE_KEY }}
           repositories: ${{ github.repository }}
           owner: ${{ github.repository_owner }}

--- a/.github/workflows/exit-prerelease.yml
+++ b/.github/workflows/exit-prerelease.yml
@@ -21,10 +21,10 @@ jobs:
       - uses: actions/create-github-app-token@v1
         id: github-actions-bot-app-token
         with:
-          app-id: 47012416
+          app-id: 48725422
           private-key: ${{ secrets.APOLLO_GITHUB_ACTIONS_BOT_PRIVATE_KEY }}
           repositories: ${{ github.repository }}
-          owner: mdg-private
+          owner: ${{ github.repository_owner }}
 
       # Check out the repository, using the Github Actions Bot app's token so
       # that we can push later.

--- a/.github/workflows/exit-prerelease.yml
+++ b/.github/workflows/exit-prerelease.yml
@@ -24,7 +24,7 @@ jobs:
           app-id: 47012416
           private-key: ${{ secrets.APOLLO_GITHUB_ACTIONS_BOT_PRIVATE_KEY }}
           repositories: ${{ github.repository }}
-          owner: ${{ github.repository_owner }}
+          owner: mdg-private
 
       # Check out the repository, using the Github Actions Bot app's token so
       # that we can push later.

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -25,10 +25,10 @@ jobs:
       - uses: actions/create-github-app-token@v1
         id: github-actions-bot-app-token
         with:
-          app-id: 47012416
+          app-id: 48725422
           private-key: ${{ secrets.APOLLO_GITHUB_ACTIONS_BOT_PRIVATE_KEY }}
           repositories: ${{ github.repository }}
-          owner: mdg-private
+          owner: ${{ github.repository_owner }}
 
       # Check out the repository, using the Github Actions Bot app's token so
       # that we can push later.

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/create-github-app-token@v1
         id: github-actions-bot-app-token
         with:
-          app-id: 48725422
+          app-id: 819772
           private-key: ${{ secrets.APOLLO_GITHUB_ACTIONS_BOT_PRIVATE_KEY }}
           repositories: ${{ github.repository }}
           owner: ${{ github.repository_owner }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -22,9 +22,20 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: github-actions-bot-app-token
+        with:
+          app-id: 47012416
+          private-key: ${{ secrets.APOLLO_GITHUB_ACTIONS_BOT_PRIVATE_KEY }}
+          repositories: ${{ github.repository }}
+          owner: ${{ github.repository_owner }}
+
+      # Check out the repository, using the Github Actions Bot app's token so
+      # that we can push later.
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
+          token: ${{ steps.github-actions-bot-app-token.outputs.token }}
           # Fetch entire git history so  Changesets can generate changelogs
           # with the correct commits
           fetch-depth: 0
@@ -56,7 +67,7 @@ jobs:
         # If .changeset/pre.json does not exist and we did not recently exit
         # prerelease mode, enter prerelease mode with tag alpha
         if: steps.check_files.outputs.files_exists == 'false' && !contains(github.event.head_commit.message, 'Exit prerelease')
-        run: npx changeset pre enter alpha
+        run: npx changeset pre enter alpha && git add -A && git commit -m 'Enter prerelease mode' && git push
 
       - name: Create prerelease PR
         # If .changeset/pre.json exists and we are not currently cutting a

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -28,7 +28,7 @@ jobs:
           app-id: 47012416
           private-key: ${{ secrets.APOLLO_GITHUB_ACTIONS_BOT_PRIVATE_KEY }}
           repositories: ${{ github.repository }}
-          owner: ${{ github.repository_owner }}
+          owner: mdg-private
 
       # Check out the repository, using the Github Actions Bot app's token so
       # that we can push later.


### PR DESCRIPTION
Uses github bot token to push to protected branches via workflow dispatch events or push event to protected `release-*` branches for:

* entering prerelease mode
* switching prerelease tags
* exiting prerelease mode