### PR TITLE
fix: skip PR creation if no prerelease changesets exist

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -73,10 +73,25 @@ jobs:
           git commit -m 'Enter prerelease mode'
           git push
 
+      - name: Get prerelease changesets
+        id: prerelease-changesets
+        uses: notiz-dev/github-action-json-property@release
+        with:
+          path: ".changeset/pre.json"
+          prop_path: "changesets"
+
+      - name: Get changesets array length
+        id: number-of-changesets
+        run: |
+          arrayLength=$(echo '${{steps.prerelease-changesets.outputs.prop}}' | jq '. | length')
+          echo "length=$arrayLength" >> "$GITHUB_OUTPUT"
+
       - name: Create prerelease PR
-        # If .changeset/pre.json exists and we are not currently cutting a
-        # release after merging a Version Packages PR
-        if: steps.check_files.outputs.files_exists == 'true' && !startsWith(github.event.head_commit.message, 'Version Packages')
+        # Only attempt to create a PR if:
+        # 1. .changeset/pre.json exists
+        # 2. we are not actively publishing after merging a Version Packages PR
+        # 3. AND we have prerelease changesets to publish (otherwise it errors)
+        if: steps.check_files.outputs.files_exists == 'true' && !startsWith(github.event.head_commit.message, 'Version Packages') && steps.number-of-changesets.outputs.length > 0
         uses: changesets/action@v1
         with:
           version: npm run changeset-version
@@ -85,8 +100,8 @@ jobs:
 
       - name: Publish to npm + GitHub
         id: changesets
-        # Only run publish if we're still in pre mode and the last commit was
-        # via an automatically created Version Packages PR
+        # Only publish if we're still in pre mode and the last commit was
+        # from an automatically created Version Packages PR
         if: steps.check_files.outputs.files_exists == 'true' && startsWith(github.event.head_commit.message, 'Version Packages')
         uses: changesets/action@v1
         with:


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:

### Checklist:
- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
-->
