### PR TITLE
chore: configure git user directly in prerelease workflows

### DIFF
--- a/.github/workflows/change-prerelease-tag.yml
+++ b/.github/workflows/change-prerelease-tag.yml
@@ -58,14 +58,10 @@ jobs:
           file: .changeset/pre.json
           fields: '{"tag": "${{github.event.inputs.tag}}"}'
 
-      - uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: Prepare for ${{ github.event.inputs.tag }} release
-          # must manually set these values since the defaults come from
-          # the workflow_dispatch event which does not contain the email
-          # for the user dispatching the event which breaks the CLA check
-          commit_user_name: github-actions[bot]
-          commit_user_email: 41898282+github-actions[bot]@users.noreply.github.com
-          commit_author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
-          # Commit these changes to the branch workflow is running against
-          branch: ${{ github.event.inputs.branch }}
+      - name: Commit and push changes
+        run: |
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git add -A
+          git commit -m 'Prepare for ${{ github.event.inputs.tag }} release'
+          git push

--- a/.github/workflows/change-prerelease-tag.yml
+++ b/.github/workflows/change-prerelease-tag.yml
@@ -59,9 +59,11 @@ jobs:
           fields: '{"tag": "${{github.event.inputs.tag}}"}'
 
       - name: Commit and push changes
+        env:
+          TAG: ${{ github.event.inputs.tag }}
         run: |
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
           git add -A
-          git commit -m 'Prepare for ${{ github.event.inputs.tag }} release'
+          git commit -m "Prepare for "$TAG" release"
           git push

--- a/.github/workflows/exit-prerelease.yml
+++ b/.github/workflows/exit-prerelease.yml
@@ -51,11 +51,9 @@ jobs:
         run: npx rimraf .changeset/pre.json
 
       - name: Commit and push changes
-        env:
-          BRANCH: ${{ github.event.inputs.branch }}
         run: |
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
           git add -A
-          git commit -m "Prepare for "$BRANCH" release"
+          git commit -m "Exit prerelease mode"
           git push

--- a/.github/workflows/exit-prerelease.yml
+++ b/.github/workflows/exit-prerelease.yml
@@ -50,14 +50,10 @@ jobs:
       - name: Remove pre.json
         run: npx rimraf .changeset/pre.json
 
-      - uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: Exit prerelease mode
-          # must manually set these values since the defaults come from
-          # the workflow_dispatch event which does not contain the email
-          # for the user dispatching the event which breaks the CLA check
-          commit_user_name: github-actions[bot]
-          commit_user_email: 41898282+github-actions[bot]@users.noreply.github.com
-          commit_author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
-          # Commit these changes to the branch workflow is running against
-          branch: ${{ github.event.inputs.branch }}
+      - name: Commit and push changes
+        run: |
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git add -A
+          git commit -m 'Prepare for ${{ github.event.inputs.branch }} release'
+          git push

--- a/.github/workflows/exit-prerelease.yml
+++ b/.github/workflows/exit-prerelease.yml
@@ -51,9 +51,11 @@ jobs:
         run: npx rimraf .changeset/pre.json
 
       - name: Commit and push changes
+        env:
+          BRANCH: ${{ github.event.inputs.branch }}
         run: |
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
           git add -A
-          git commit -m 'Prepare for ${{ github.event.inputs.branch }} release'
+          git commit -m "Prepare for "$BRANCH" release"
           git push


### PR DESCRIPTION
`stefanzweifel/git-auto-commit-action` sets the git `author` which appears to break our CLA. Manually setting the git user name and email to the default `github-actions[bot]` values should allow the CLA check to pass.