### PR TITLE
chore: use delimiter in accorance with docs to handle strings with newlines in snapshot release action 

### DIFF
--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -45,7 +45,10 @@ jobs:
       - name: Detect new changesets
         id: added-files
         run: |
-          echo "changesets=$(git diff --name-only --diff-filter=A ${{ steps.comment-branch.outputs.base_sha }} ${{ steps.comment-branch.outputs.head_sha }} .changeset/*.md)" >> "$GITHUB_OUTPUT"
+          delimiter="$(openssl rand -hex 8)"
+          echo "changesets<<${delimiter}" >> "${GITHUB_OUTPUT}"
+          echo "$(git diff --name-only --diff-filter=A ${{ steps.comment-branch.outputs.base_sha }} ${{ steps.comment-branch.outputs.head_sha }} .changeset/*.md)" >> "${GITHUB_OUTPUT}"
+          echo "${delimiter}" >> "${GITHUB_OUTPUT}"
 
       - name: Append NPM token to .npmrc
         run: |


### PR DESCRIPTION
Fixes failing snapshot release action with multiple changesets, see https://github.com/apollographql/apollo-client/actions/runs/8510609697/job/23308544668.

See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings for docs on using mutli-line strings with `GITHUB_OUTPUT` GHA env variable.