### PR TITLE
Remove alpha designation for query preloading

### DIFF
--- a/.api-reports/api-report-react.md
+++ b/.api-reports/api-report-react.md
@@ -541,7 +541,7 @@ type ConcastSourcesIterable<T> = Iterable<Source<T>>;
 export interface Context extends Record<string, any> {
 }
 
-// @alpha
+// @public
 export function createQueryPreloader(client: ApolloClient<any>): PreloadQueryFunction;
 
 // @public (undocumented)
@@ -1757,7 +1757,6 @@ export interface QueryReference<TData = unknown, TVariables = unknown> {
     //
     // @internal (undocumented)
     readonly [QUERY_REFERENCE_SYMBOL]: InternalQueryReference<TData>;
-    // @alpha
     toPromise(): Promise<QueryReference<TData, TVariables>>;
 }
 

--- a/.api-reports/api-report-react_hooks.md
+++ b/.api-reports/api-report-react_hooks.md
@@ -1632,7 +1632,6 @@ interface QueryReference<TData = unknown, TVariables = unknown> {
     //
     // @internal (undocumented)
     readonly [QUERY_REFERENCE_SYMBOL]: InternalQueryReference<TData>;
-    // @alpha
     toPromise(): Promise<QueryReference<TData, TVariables>>;
 }
 

--- a/.api-reports/api-report-react_internal.md
+++ b/.api-reports/api-report-react_internal.md
@@ -1518,7 +1518,6 @@ export interface QueryReference<TData = unknown, TVariables = unknown> {
     [PROMISE_SYMBOL]: QueryRefPromise<TData>;
     // @internal (undocumented)
     readonly [QUERY_REFERENCE_SYMBOL]: InternalQueryReference<TData>;
-    // @alpha
     toPromise(): Promise<QueryReference<TData, TVariables>>;
 }
 

--- a/.api-reports/api-report.md
+++ b/.api-reports/api-report.md
@@ -545,7 +545,7 @@ export const concat: typeof ApolloLink.concat;
 // @public (undocumented)
 export const createHttpLink: (linkOptions?: HttpOptions) => ApolloLink;
 
-// @alpha
+// @public
 export function createQueryPreloader(client: ApolloClient<any>): PreloadQueryFunction;
 
 // @public @deprecated (undocumented)
@@ -2330,7 +2330,6 @@ export interface QueryReference<TData = unknown, TVariables = unknown> {
     //
     // @internal (undocumented)
     readonly [QUERY_REFERENCE_SYMBOL]: InternalQueryReference<TData>;
-    // @alpha
     toPromise(): Promise<QueryReference<TData, TVariables>>;
 }
 

--- a/.changeset/tiny-bugs-tap.md
+++ b/.changeset/tiny-bugs-tap.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": minor
+---
+
+Remove alpha designation for `queryRef.toPromise()` to stabilize the API.

--- a/.changeset/twelve-apples-vanish.md
+++ b/.changeset/twelve-apples-vanish.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": minor
+---
+
+Remove alpha designation for `createQueryPreloader` to stabilize the API.

--- a/docs/source/data/suspense.mdx
+++ b/docs/source/data/suspense.mdx
@@ -535,12 +535,6 @@ We begin fetching our `GET_DOG_QUERY` by calling the `loadDog` function inside o
 
 </MinVersion>
 
-<ExperimentalFeature>
-
-This feature is in [alpha](https://www.apollographql.com/docs/resources/product-launch-stages/#alpha--beta) in version `3.9.0` and is subject to change before `3.10.0`. We consider this feature production-ready, but it may change depending on feedback. If you'd like to provide feedback before it is stabilized in `3.10.0`, please comment on [#11519](https://github.com/apollographql/apollo-client/issues/11519).
-
-</ExperimentalFeature>
-
 Starting with Apollo Client `3.9.0`, queries can be initiated outside of React. This allows your app to begin fetching data before React renders your components, and can provide performance benefits.
 
 To preload queries, you first need to create a preload function with `createQueryPreloader`. `createQueryPreloader` takes an `ApolloClient` instance as an argument and returns a function that, when called, initiates a network request.
@@ -676,12 +670,6 @@ export function RouteComponent() {
 ```
 
 This instructs React Router to wait for the query to finish loading before the route transitions. When the route transitions after the promise resolves, the data is rendered immediately without the need to show a loading fallback in the route component.
-
-<ExperimentalFeature>
-
-`queryRef.toPromise` is [experimental](https://www.apollographql.com/docs/resources/product-launch-stages/#experimental-features) in version `3.9.0` and is subject to breaking changes before `3.10.0`. If you'd like to provide feedback for this feature before it is stabilized in `3.10.0`, please comment on [#11519](https://github.com/apollographql/apollo-client/issues/11519).
-
-</ExperimentalFeature>
 
 #### Why prevent access to `data` in `toPromise`?
 

--- a/src/react/internal/cache/QueryReference.ts
+++ b/src/react/internal/cache/QueryReference.ts
@@ -72,6 +72,8 @@ export interface QueryReference<TData = unknown, TVariables = unknown> {
    *   // ...
    * }
    * ```
+   *
+   * @since 3.9.0
    */
   toPromise(): Promise<QueryReference<TData, TVariables>>;
 }

--- a/src/react/internal/cache/QueryReference.ts
+++ b/src/react/internal/cache/QueryReference.ts
@@ -72,8 +72,6 @@ export interface QueryReference<TData = unknown, TVariables = unknown> {
    *   // ...
    * }
    * ```
-   *
-   * @alpha
    */
   toPromise(): Promise<QueryReference<TData, TVariables>>;
 }

--- a/src/react/query-preloader/createQueryPreloader.ts
+++ b/src/react/query-preloader/createQueryPreloader.ts
@@ -164,7 +164,6 @@ export interface PreloadQueryFunction {
  * const preloadQuery = createQueryPreloader(client);
  * ```
  * @since 3.9.0
- * @alpha
  */
 export function createQueryPreloader(
   client: ApolloClient<any>


### PR DESCRIPTION
Removes the `@alpha` designation for `createQueryPreloader` and `queryRef.toPromise()` in preparation for 3.10