### PR TITLE
use native AbortController

### DIFF
--- a/config/FixJSDOMEnvironment.js
+++ b/config/FixJSDOMEnvironment.js
@@ -14,7 +14,7 @@ class FixJSDOMEnvironment extends JSDOMEnvironment {
     // and setting AbortController breaks PersistedQueryLink tests, which may
     // indicate a memory leak
     // this.global.fetch = fetch;
-    // this.global.AbortController = AbortController;
+    this.global.AbortController = AbortController;
   }
 }
 

--- a/src/link/persisted-queries/__tests__/persisted-queries.test.ts
+++ b/src/link/persisted-queries/__tests__/persisted-queries.test.ts
@@ -573,7 +573,11 @@ describe("failure path", () => {
           variables,
         }).subscribe({ complete })
       );
-
+      // fetch-mock holds a history of all options it has been called with
+      // that includes the `signal` option, which (with the native `AbortController`)
+      // has a reference to the `Request` instance, which will somehow reference our
+      // hash object
+      fetchMock.resetHistory();
       await expect(hashRefs[0]).toBeGarbageCollected();
     }
   );


### PR DESCRIPTION
This is a follow-up to #11751 

Using the native `AbortController` previously created a memory leak in our tests, because `mock-fetch` keeps a history of requests - which referenced the `signal` - and the `signal` keeps a reference to the `AbortController`, so the `AbortController` itself was never cleared up, and the `Request` somehow stayed in memory, including a reference to our `ref`.