### PR TITLE
fix: Cannot convert object to primitive value

### DIFF
--- a/.changeset/curly-kings-behave.md
+++ b/.changeset/curly-kings-behave.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+fix: Cannot convert object to primitive value error

--- a/src/cache/inmemory/__tests__/__snapshots__/writeToStore.ts.snap
+++ b/src/cache/inmemory/__tests__/__snapshots__/writeToStore.ts.snap
@@ -68,8 +68,9 @@ This could cause additional (usually avoidable) network requests to fetch data t
 
 To address this problem (which is not a bug in Apollo Client), %sdefine a custom merge function for the %s field, so InMemoryCache can safely merge these objects:
 
-  existing: %o
-  incoming: %o
+  existing: %s
+
+  incoming: %s
 
 For more information about these options, please refer to the documentation:
 
@@ -80,12 +81,8 @@ For more information about these options, please refer to the documentation:
       "Query",
       "",
       "Query.someJSON",
-      Object {
-        "name": "Tom",
-      },
-      Object {
-        "age": 20,
-      },
+      "{\\"name\\":\\"Tom\\"}",
+      "{\\"age\\":20}",
     ],
   ],
   "results": Array [

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -97,7 +97,7 @@ function getContextFlavor<TContext extends FlavorableWriteContext>(
       (flavored =
         context.clientOnly === clientOnly && context.deferred === deferred ?
           context
-        : {
+          : {
             ...context,
             clientOnly,
             deferred,
@@ -120,7 +120,7 @@ export class StoreWriter {
     public readonly cache: InMemoryCache,
     private reader?: StoreReader,
     private fragments?: InMemoryCacheConfig["fragments"]
-  ) {}
+  ) { }
 
   public writeToStore(
     store: NormalizedCache,
@@ -332,7 +332,7 @@ export class StoreWriter {
           // values before processing nested selection sets.
           field.selectionSet ?
             getContextFlavor(context, false, false)
-          : context,
+            : context,
           childTree
         );
 
@@ -641,7 +641,7 @@ export class StoreWriter {
           (isReference(existing) || storeValueIsStoreObject(existing))
         ) ?
           existing
-        : void 0;
+          : void 0;
 
       // This narrowing is implied by mergeTree.map.size > 0 and
       // !isReference(incoming), though TypeScript understandably cannot
@@ -671,8 +671,8 @@ export class StoreWriter {
           isArray(from) ?
             typeof name === "number" ?
               from[name]
-            : void 0
-          : context.store.getFieldValue(from, String(name))
+              : void 0
+            : context.store.getFieldValue(from, String(name))
         );
       };
 
@@ -748,13 +748,13 @@ function mergeMergeTrees(
         ...left.info,
         ...right.info,
       }
-    : left.info || right.info;
+      : left.info || right.info;
 
   const needToMergeMaps = left.map.size && right.map.size;
   const map =
     needToMergeMaps ? new Map()
-    : left.map.size ? left.map
-    : right.map;
+      : left.map.size ? left.map
+        : right.map;
 
   const merged = { info, map };
 
@@ -857,8 +857,9 @@ This could cause additional (usually avoidable) network requests to fetch data t
 
 To address this problem (which is not a bug in Apollo Client), %sdefine a custom merge function for the %s field, so InMemoryCache can safely merge these objects:
 
-  existing: %o
-  incoming: %o
+  existing: %s
+
+  incoming: %s
 
 For more information about these options, please refer to the documentation:
 
@@ -869,11 +870,11 @@ For more information about these options, please refer to the documentation:
     parentType,
     childTypenames.length ?
       "either ensure all objects of type " +
-        childTypenames.join(" and ") +
-        " have an ID or a custom merge function, or "
-    : "",
+      childTypenames.join(" and ") +
+      " have an ID or a custom merge function, or "
+      : "",
     typeDotName,
-    existing,
-    incoming
+    JSON.stringify(existing),
+    JSON.stringify(incoming)
   );
 }

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -97,7 +97,7 @@ function getContextFlavor<TContext extends FlavorableWriteContext>(
       (flavored =
         context.clientOnly === clientOnly && context.deferred === deferred ?
           context
-          : {
+        : {
             ...context,
             clientOnly,
             deferred,
@@ -120,7 +120,7 @@ export class StoreWriter {
     public readonly cache: InMemoryCache,
     private reader?: StoreReader,
     private fragments?: InMemoryCacheConfig["fragments"]
-  ) { }
+  ) {}
 
   public writeToStore(
     store: NormalizedCache,
@@ -332,7 +332,7 @@ export class StoreWriter {
           // values before processing nested selection sets.
           field.selectionSet ?
             getContextFlavor(context, false, false)
-            : context,
+          : context,
           childTree
         );
 
@@ -641,7 +641,7 @@ export class StoreWriter {
           (isReference(existing) || storeValueIsStoreObject(existing))
         ) ?
           existing
-          : void 0;
+        : void 0;
 
       // This narrowing is implied by mergeTree.map.size > 0 and
       // !isReference(incoming), though TypeScript understandably cannot
@@ -671,8 +671,8 @@ export class StoreWriter {
           isArray(from) ?
             typeof name === "number" ?
               from[name]
-              : void 0
-            : context.store.getFieldValue(from, String(name))
+            : void 0
+          : context.store.getFieldValue(from, String(name))
         );
       };
 
@@ -748,13 +748,13 @@ function mergeMergeTrees(
         ...left.info,
         ...right.info,
       }
-      : left.info || right.info;
+    : left.info || right.info;
 
   const needToMergeMaps = left.map.size && right.map.size;
   const map =
     needToMergeMaps ? new Map()
-      : left.map.size ? left.map
-        : right.map;
+    : left.map.size ? left.map
+    : right.map;
 
   const merged = { info, map };
 
@@ -870,9 +870,9 @@ For more information about these options, please refer to the documentation:
     parentType,
     childTypenames.length ?
       "either ensure all objects of type " +
-      childTypenames.join(" and ") +
-      " have an ID or a custom merge function, or "
-      : "",
+        childTypenames.join(" and ") +
+        " have an ID or a custom merge function, or "
+    : "",
     typeDotName,
     JSON.stringify(existing),
     JSON.stringify(incoming)


### PR DESCRIPTION
Closes: #11639, 
this used to be %s with the direct object, which caused the same issue. 
An attempt to fix this was by changing %s to %o, which didn't seem to resolve the issue. 
Now back to %s, but stringify the object

### Checklist:
- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
