### PR TITLE
Fix issue where a network request is made when using `skip`/`skipToken` with `useSuspenseQuery` in strict mode

### DIFF
--- a/.changeset/thick-buttons-juggle.md
+++ b/.changeset/thick-buttons-juggle.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix an issue where using `skipToken` or the `skip` option with `useSuspenseQuery` in React's strict mode would perform a network request.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 39368,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 32634
+  "dist/apollo-client.min.cjs": 39373,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 32636
 }

--- a/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
@@ -5631,8 +5631,7 @@ describe("useSuspenseQuery", () => {
     });
 
     const { result, rerender } = renderSuspenseHook(
-      ({ skip, id }) =>
-        useSuspenseQuery(query, { skip, variables: { id } }),
+      ({ skip, id }) => useSuspenseQuery(query, { skip, variables: { id } }),
       { mocks, link, strictMode: true, initialProps: { skip: true, id: "1" } }
     );
 

--- a/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
@@ -5560,6 +5560,54 @@ describe("useSuspenseQuery", () => {
     expect(fetchCount).toBe(1);
   });
 
+  // https://github.com/apollographql/apollo-client/issues/11768
+  it("does not make network requests when using `skipToken` with strict mode", async () => {
+    const { query, mocks } = useVariablesQueryCase();
+
+    let fetchCount = 0;
+
+    const link = new ApolloLink((operation) => {
+      return new Observable((observer) => {
+        fetchCount++;
+
+        const mock = mocks.find(({ request }) =>
+          equal(request.variables, operation.variables)
+        );
+
+        if (!mock) {
+          throw new Error("Could not find mock for operation");
+        }
+
+        observer.next(mock.result);
+        observer.complete();
+      });
+    });
+
+    const { result, rerender } = renderSuspenseHook(
+      ({ skip, id }) =>
+        useSuspenseQuery(query, skip ? skipToken : { variables: { id } }),
+      { mocks, link, strictMode: true, initialProps: { skip: true, id: "1" } }
+    );
+
+    expect(fetchCount).toBe(0);
+
+    rerender({ skip: false, id: "1" });
+
+    expect(fetchCount).toBe(1);
+
+    await waitFor(() => {
+      expect(result.current).toMatchObject({
+        ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      });
+    });
+
+    rerender({ skip: true, id: "2" });
+
+    expect(fetchCount).toBe(1);
+  });
+
   it("`skip` result is referentially stable", async () => {
     const { query, mocks } = useSimpleQueryCase();
 

--- a/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
@@ -5608,6 +5608,53 @@ describe("useSuspenseQuery", () => {
     expect(fetchCount).toBe(1);
   });
 
+  it("does not make network requests when using `skip` with strict mode", async () => {
+    const { query, mocks } = useVariablesQueryCase();
+
+    let fetchCount = 0;
+
+    const link = new ApolloLink((operation) => {
+      return new Observable((observer) => {
+        fetchCount++;
+
+        const mock = mocks.find(({ request }) =>
+          equal(request.variables, operation.variables)
+        );
+
+        if (!mock) {
+          throw new Error("Could not find mock for operation");
+        }
+
+        observer.next(mock.result);
+        observer.complete();
+      });
+    });
+
+    const { result, rerender } = renderSuspenseHook(
+      ({ skip, id }) =>
+        useSuspenseQuery(query, { skip, variables: { id } }),
+      { mocks, link, strictMode: true, initialProps: { skip: true, id: "1" } }
+    );
+
+    expect(fetchCount).toBe(0);
+
+    rerender({ skip: false, id: "1" });
+
+    expect(fetchCount).toBe(1);
+
+    await waitFor(() => {
+      expect(result.current).toMatchObject({
+        ...mocks[0].result,
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      });
+    });
+
+    rerender({ skip: true, id: "2" });
+
+    expect(fetchCount).toBe(1);
+  });
+
   it("`skip` result is referentially stable", async () => {
     const { query, mocks } = useSimpleQueryCase();
 

--- a/src/react/internal/cache/QueryReference.ts
+++ b/src/react/internal/cache/QueryReference.ts
@@ -207,18 +207,20 @@ export class InternalQueryReference<TData = unknown> {
     const { observable } = this;
 
     const originalFetchPolicy = this.watchQueryOptions.fetchPolicy;
+    const avoidNetworkRequests =
+      originalFetchPolicy === "no-cache" || originalFetchPolicy === "standby";
 
     try {
-      if (originalFetchPolicy !== "no-cache") {
+      if (avoidNetworkRequests) {
+        observable.silentSetOptions({ fetchPolicy: "standby" });
+      } else {
         observable.resetLastResults();
         observable.silentSetOptions({ fetchPolicy: "cache-first" });
-      } else {
-        observable.silentSetOptions({ fetchPolicy: "standby" });
       }
 
       this.subscribeToQuery();
 
-      if (originalFetchPolicy === "no-cache") {
+      if (avoidNetworkRequests) {
         return;
       }
 


### PR DESCRIPTION
Fixes #11768

#11738 made it possible to dispose of the queryRef synchronously in our suspense hooks which released in 3.9.10. Unfortunately this caused a regression with strict mode where a network request was actually made. This change ensures that `standby` is properly handled in the queryRef `reinitialize` function.

NOTE: This only seemed to affect `useSuspenseQuery`. I've added tests for `useBackgroundQuery` as well to ensure we don't have future regressions, but the bug didn't seem to exhibit itself in this hook.

