### PR TITLE
Wrap `useQueryRefHandlers` in `wrapHook`.

### DIFF
--- a/.api-reports/api-report-react_internal.md
+++ b/.api-reports/api-report-react_internal.md
@@ -1936,6 +1936,17 @@ type UseFragmentResult<TData> = {
 // @public
 function useQuery<TData = any, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: QueryHookOptions<NoInfer<TData>, NoInfer<TVariables>>): QueryResult<TData, TVariables>;
 
+// Warning: (ae-forgotten-export) The symbol "UseQueryRefHandlersResult" needs to be exported by the entry point index.d.ts
+//
+// @public
+function useQueryRefHandlers<TData = unknown, TVariables extends OperationVariables = OperationVariables>(queryRef: QueryReference<TData, TVariables>): UseQueryRefHandlersResult<TData, TVariables>;
+
+// @public (undocumented)
+interface UseQueryRefHandlersResult<TData = unknown, TVariables extends OperationVariables = OperationVariables> {
+    fetchMore: FetchMoreFunction<TData, TVariables>;
+    refetch: RefetchFunction<TData, TVariables>;
+}
+
 // Warning: (ae-forgotten-export) The symbol "UseReadQueryResult" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
@@ -2056,6 +2067,10 @@ interface WrappableHooks {
     //
     // (undocumented)
     useQuery: typeof useQuery;
+    // Warning: (ae-forgotten-export) The symbol "useQueryRefHandlers" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    useQueryRefHandlers: typeof useQueryRefHandlers;
     // Warning: (ae-forgotten-export) The symbol "useReadQuery" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)

--- a/.changeset/kind-foxes-float.md
+++ b/.changeset/kind-foxes-float.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Wrap `useQueryRefHandlers` in `wrapHook`.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 39523,
+  "dist/apollo-client.min.cjs": 39534,
   "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 32809
 }

--- a/src/react/hooks/internal/wrapHook.ts
+++ b/src/react/hooks/internal/wrapHook.ts
@@ -4,6 +4,7 @@ import type {
   useBackgroundQuery,
   useReadQuery,
   useFragment,
+  useQueryRefHandlers,
 } from "../index.js";
 import type { QueryManager } from "../../../core/QueryManager.js";
 import type { ApolloClient } from "../../../core/ApolloClient.js";
@@ -17,6 +18,7 @@ interface WrappableHooks {
   useBackgroundQuery: typeof useBackgroundQuery;
   useReadQuery: typeof useReadQuery;
   useFragment: typeof useFragment;
+  useQueryRefHandlers: typeof useQueryRefHandlers;
 }
 
 /**


### PR DESCRIPTION
Besides #11757, this is another prerequisite for https://github.com/apollographql/apollo-client-nextjs/pull/258 