### PR TITLE
Call `createMockSchema` inside `createTestSchema`

### DIFF
--- a/.api-reports/api-report-testing.md
+++ b/.api-reports/api-report-testing.md
@@ -450,11 +450,6 @@ type ConcastSourcesIterable<T> = Iterable<Source<T>>;
 export function createMockClient<TData>(data: TData, query: DocumentNode, variables?: {}): ApolloClient<NormalizedCacheObject>;
 
 // @alpha
-export const createMockSchema: (staticSchema: GraphQLSchema, mocks: {
-    [key: string]: any;
-}) => GraphQLSchema;
-
-// @alpha
 export const createSchemaFetch: (schema: GraphQLSchema, mockFetchOpts?: {
     validate: boolean;
 }) => {
@@ -462,10 +457,11 @@ export const createSchemaFetch: (schema: GraphQLSchema, mockFetchOpts?: {
     restore: () => void;
 } & Disposable;
 
+// Warning: (ae-forgotten-export) The symbol "TestSchemaOptions" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "ProxiedSchema" needs to be exported by the entry point index.d.ts
 //
 // @alpha
-export const createTestSchema: (schemaWithMocks: GraphQLSchema, resolvers: Resolvers) => ProxiedSchema;
+export const createTestSchema: (schemaWithTypeDefs: GraphQLSchema, options: TestSchemaOptions) => ProxiedSchema;
 
 // @public (undocumented)
 namespace DataProxy {
@@ -1286,24 +1282,10 @@ type Path = ReadonlyArray<string | number>;
 // @public (undocumented)
 type Primitive = null | undefined | string | number | boolean | symbol | bigint;
 
-// Warning: (ae-forgotten-export) The symbol "ProxiedSchemaFns" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "TestSchemaFns" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-type ProxiedSchema = GraphQLSchema & ProxiedSchemaFns;
-
-// @public (undocumented)
-interface ProxiedSchemaFns {
-    // (undocumented)
-    add: (addOptions: {
-        resolvers: Resolvers;
-    }) => ProxiedSchema;
-    // (undocumented)
-    fork: (forkOptions?: {
-        resolvers?: Resolvers;
-    }) => ProxiedSchema;
-    // (undocumented)
-    reset: () => void;
-}
+type ProxiedSchema = GraphQLSchema & TestSchemaFns;
 
 // @public (undocumented)
 class QueryInfo {
@@ -1679,6 +1661,30 @@ interface SubscriptionOptions<TVariables = OperationVariables, TData = any> {
     fetchPolicy?: FetchPolicy;
     query: DocumentNode | TypedDocumentNode<TData, TVariables>;
     variables?: TVariables;
+}
+
+// @public (undocumented)
+interface TestSchemaFns {
+    // (undocumented)
+    add: (addOptions: {
+        resolvers: Resolvers;
+    }) => ProxiedSchema;
+    // (undocumented)
+    fork: (forkOptions?: {
+        resolvers?: Resolvers;
+    }) => ProxiedSchema;
+    // (undocumented)
+    reset: () => void;
+}
+
+// @public (undocumented)
+interface TestSchemaOptions {
+    // (undocumented)
+    mocks?: {
+        [key: string]: any;
+    };
+    // (undocumented)
+    resolvers: Resolvers;
 }
 
 // @public (undocumented)

--- a/.api-reports/api-report-testing_core.md
+++ b/.api-reports/api-report-testing_core.md
@@ -456,10 +456,11 @@ export const createSchemaFetch: (schema: GraphQLSchema, mockFetchOpts?: {
     restore: () => void;
 } & Disposable;
 
+// Warning: (ae-forgotten-export) The symbol "TestSchemaOptions" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "ProxiedSchema" needs to be exported by the entry point index.d.ts
 //
 // @alpha
-export const createTestSchema: (schemaWithMocks: GraphQLSchema, resolvers: Resolvers) => ProxiedSchema;
+export const createTestSchema: (schemaWithTypeDefs: GraphQLSchema, options: TestSchemaOptions) => ProxiedSchema;
 
 // @public (undocumented)
 namespace DataProxy {
@@ -1236,24 +1237,10 @@ type Path = ReadonlyArray<string | number>;
 // @public (undocumented)
 type Primitive = null | undefined | string | number | boolean | symbol | bigint;
 
-// Warning: (ae-forgotten-export) The symbol "ProxiedSchemaFns" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "TestSchemaFns" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-type ProxiedSchema = GraphQLSchema & ProxiedSchemaFns;
-
-// @public (undocumented)
-interface ProxiedSchemaFns {
-    // (undocumented)
-    add: (addOptions: {
-        resolvers: Resolvers;
-    }) => ProxiedSchema;
-    // (undocumented)
-    fork: (forkOptions?: {
-        resolvers?: Resolvers;
-    }) => ProxiedSchema;
-    // (undocumented)
-    reset: () => void;
-}
+type ProxiedSchema = GraphQLSchema & TestSchemaFns;
 
 // @public (undocumented)
 class QueryInfo {
@@ -1631,6 +1618,30 @@ interface SubscriptionOptions<TVariables = OperationVariables, TData = any> {
     fetchPolicy?: FetchPolicy;
     query: DocumentNode | TypedDocumentNode<TData, TVariables>;
     variables?: TVariables;
+}
+
+// @public (undocumented)
+interface TestSchemaFns {
+    // (undocumented)
+    add: (addOptions: {
+        resolvers: Resolvers;
+    }) => ProxiedSchema;
+    // (undocumented)
+    fork: (forkOptions?: {
+        resolvers?: Resolvers;
+    }) => ProxiedSchema;
+    // (undocumented)
+    reset: () => void;
+}
+
+// @public (undocumented)
+interface TestSchemaOptions {
+    // (undocumented)
+    mocks?: {
+        [key: string]: any;
+    };
+    // (undocumented)
+    resolvers: Resolvers;
 }
 
 // @public (undocumented)

--- a/.changeset/spotty-garlics-knock.md
+++ b/.changeset/spotty-garlics-knock.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": minor
+---
+
+Call `createMockSchema` inside `createTestSchema`.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 39523,
+  "dist/apollo-client.min.cjs": 39530,
   "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 32809
 }

--- a/src/__tests__/__snapshots__/exports.ts.snap
+++ b/src/__tests__/__snapshots__/exports.ts.snap
@@ -369,7 +369,6 @@ Array [
   "MockSubscriptionLink",
   "MockedProvider",
   "createMockClient",
-  "createMockSchema",
   "createSchemaFetch",
   "createTestSchema",
   "itAsync",

--- a/src/testing/core/__tests__/createTestSchema.test.tsx
+++ b/src/testing/core/__tests__/createTestSchema.test.tsx
@@ -17,7 +17,6 @@ import { createTestSchema } from "../createTestSchema.js";
 import { GraphQLError, buildSchema } from "graphql";
 import type { UseSuspenseQueryResult } from "../../../react/index.js";
 import { useMutation, useSuspenseQuery } from "../../../react/index.js";
-import { createMockSchema } from "../../graphql-tools/utils.js";
 import userEvent from "@testing-library/user-event";
 import { act, screen } from "@testing-library/react";
 import { createSchemaFetch } from "../createSchemaFetch.js";
@@ -140,33 +139,34 @@ interface ViewerQueryData {
 }
 
 describe("schema proxy", () => {
-  const schemaWithMocks = createMockSchema(schemaWithTypeDefs, {
-    ID: () => "1",
-    Int: () => 42,
-    String: () => "String",
-    Date: () => new Date("January 1, 2024 01:00:00").toJSON().split("T")[0],
-  });
-
-  const schema = createTestSchema(schemaWithMocks, {
-    Query: {
-      viewer: () => ({
-        name: "Jane Doe",
-        book: {
-          text: "Hello World",
-          title: "The Book",
-        },
-      }),
-    },
-    Book: {
-      __resolveType: (obj) => {
-        if ("text" in obj) {
-          return "TextBook";
-        }
-        if ("colors" in obj) {
-          return "ColoringBook";
-        }
-        throw new Error("Could not resolve type");
+  const schema = createTestSchema(schemaWithTypeDefs, {
+    resolvers: {
+      Query: {
+        viewer: () => ({
+          name: "Jane Doe",
+          book: {
+            text: "Hello World",
+            title: "The Book",
+          },
+        }),
       },
+      Book: {
+        __resolveType: (obj) => {
+          if ("text" in obj) {
+            return "TextBook";
+          }
+          if ("colors" in obj) {
+            return "ColoringBook";
+          }
+          throw new Error("Could not resolve type");
+        },
+      },
+    },
+    mocks: {
+      ID: () => "1",
+      Int: () => 42,
+      String: () => "String",
+      Date: () => new Date("January 1, 2024 01:00:00").toJSON().split("T")[0],
     },
   });
 
@@ -849,26 +849,34 @@ describe("schema proxy", () => {
   it("preserves resolvers from previous calls to .add on subsequent calls to .fork", async () => {
     let name = "Virginia";
 
-    const schema = createTestSchema(schemaWithMocks, {
-      Query: {
-        viewer: () => ({
-          name,
-          book: {
-            text: "Hello World",
-            title: "The Book",
-          },
-        }),
-      },
-      Book: {
-        __resolveType: (obj) => {
-          if ("text" in obj) {
-            return "TextBook";
-          }
-          if ("colors" in obj) {
-            return "ColoringBook";
-          }
-          throw new Error("Could not resolve type");
+    const schema = createTestSchema(schemaWithTypeDefs, {
+      resolvers: {
+        Query: {
+          viewer: () => ({
+            name,
+            book: {
+              text: "Hello World",
+              title: "The Book",
+            },
+          }),
         },
+        Book: {
+          __resolveType: (obj) => {
+            if ("text" in obj) {
+              return "TextBook";
+            }
+            if ("colors" in obj) {
+              return "ColoringBook";
+            }
+            throw new Error("Could not resolve type");
+          },
+        },
+      },
+      mocks: {
+        ID: () => "1",
+        Int: () => 42,
+        String: () => "String",
+        Date: () => new Date("January 1, 2024 01:00:00").toJSON().split("T")[0],
       },
     });
 

--- a/src/testing/core/__tests__/createTestSchema.test.tsx
+++ b/src/testing/core/__tests__/createTestSchema.test.tsx
@@ -162,7 +162,7 @@ describe("schema proxy", () => {
         },
       },
     },
-    mocks: {
+    scalars: {
       ID: () => "1",
       Int: () => 42,
       String: () => "String",
@@ -872,7 +872,7 @@ describe("schema proxy", () => {
           },
         },
       },
-      mocks: {
+      scalars: {
         ID: () => "1",
         Int: () => 42,
         String: () => "String",

--- a/src/testing/core/createTestSchema.ts
+++ b/src/testing/core/createTestSchema.ts
@@ -26,7 +26,7 @@ interface TestSchemaOptions {
  * resolvers to the original proxied schema.
  *
  * @param schema - A `GraphQLSchema`.
- * @param options - An `options` object that accepts `mocks` and `resolvers` objects.
+ * @param options - An `options` object that accepts `scalars` and `resolvers` objects.
  * @returns A `ProxiedSchema` with `add`, `fork` and `reset` methods.
  *
  * @example
@@ -40,7 +40,7 @@ interface TestSchemaOptions {
          }),
        }
      },
-     mocks: {
+     scalars: {
        ID: () => "1",
        Int: () => 36,
        String: () => "String",

--- a/src/testing/core/createTestSchema.ts
+++ b/src/testing/core/createTestSchema.ts
@@ -14,7 +14,7 @@ interface TestSchemaFns {
 
 interface TestSchemaOptions {
   resolvers: Resolvers;
-  mocks?: { [key: string]: any };
+  scalars?: { [key: string]: any };
 }
 
 /**
@@ -57,7 +57,7 @@ const createTestSchema = (
 ): ProxiedSchema => {
   let targetResolvers = { ...options.resolvers };
   let targetSchema = addResolversToSchema({
-    schema: createMockSchema(schemaWithTypeDefs, options.mocks ?? {}),
+    schema: createMockSchema(schemaWithTypeDefs, options.scalars ?? {}),
     resolvers: targetResolvers,
   });
 
@@ -75,7 +75,7 @@ const createTestSchema = (
     fork: ({ resolvers: newResolvers } = {}) => {
       return createTestSchema(targetSchema, {
         resolvers: newResolvers ?? targetResolvers,
-        mocks: options.mocks,
+        scalars: options.scalars,
       });
     },
 

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -2,4 +2,3 @@ import "../utilities/globals/index.js";
 export type { MockedProviderProps } from "./react/MockedProvider.js";
 export { MockedProvider } from "./react/MockedProvider.js";
 export * from "./core/index.js";
-export { createMockSchema } from "./graphql-tools/utils.js";


### PR DESCRIPTION
Closes https://github.com/apollographql/apollo-client/issues/11776. Simplifies usage for developers by adding the mocks in a single pass inside `createTestSchema`.