### PR TITLE
suggestion: mock global `fetch` explicitly

### DIFF
--- a/.api-reports/api-report-testing.md
+++ b/.api-reports/api-report-testing.md
@@ -461,10 +461,11 @@ export const createSchemaFetch: (schema: GraphQLSchema, mockFetchOpts?: {
         min: number;
         max: number;
     };
-}) => {
-    mock: (uri: any, options: any) => Promise<Response>;
-    restore: () => void;
-} & Disposable;
+}) => ((uri: any, options: any) => Promise<Response>) & {
+    mockGlobal: () => {
+        restore: () => void;
+    } & Disposable;
+};
 
 // Warning: (ae-forgotten-export) The symbol "ProxiedSchema" needs to be exported by the entry point index.d.ts
 //

--- a/.api-reports/api-report-testing.md
+++ b/.api-reports/api-report-testing.md
@@ -456,7 +456,11 @@ export const createMockSchema: (staticSchema: GraphQLSchema, mocks: {
 
 // @alpha
 export const createSchemaFetch: (schema: GraphQLSchema, mockFetchOpts?: {
-    validate: boolean;
+    validate?: boolean;
+    delay?: {
+        min: number;
+        max: number;
+    };
 }) => {
     mock: (uri: any, options: any) => Promise<Response>;
     restore: () => void;

--- a/.api-reports/api-report-testing_core.md
+++ b/.api-reports/api-report-testing_core.md
@@ -450,7 +450,11 @@ export function createMockClient<TData>(data: TData, query: DocumentNode, variab
 
 // @alpha
 export const createSchemaFetch: (schema: GraphQLSchema, mockFetchOpts?: {
-    validate: boolean;
+    validate?: boolean;
+    delay?: {
+        min: number;
+        max: number;
+    };
 }) => {
     mock: (uri: any, options: any) => Promise<Response>;
     restore: () => void;

--- a/.api-reports/api-report-testing_core.md
+++ b/.api-reports/api-report-testing_core.md
@@ -455,10 +455,11 @@ export const createSchemaFetch: (schema: GraphQLSchema, mockFetchOpts?: {
         min: number;
         max: number;
     };
-}) => {
-    mock: (uri: any, options: any) => Promise<Response>;
-    restore: () => void;
-} & Disposable;
+}) => ((uri: any, options: any) => Promise<Response>) & {
+    mockGlobal: () => {
+        restore: () => void;
+    } & Disposable;
+};
 
 // Warning: (ae-forgotten-export) The symbol "ProxiedSchema" needs to be exported by the entry point index.d.ts
 //

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 39538,
+  "dist/apollo-client.min.cjs": 39540,
   "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 32811
 }

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
   "dist/apollo-client.min.cjs": 39530,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 32809
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 32811
 }

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 39540,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 32811
+  "dist/apollo-client.min.cjs": 39539,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 32810
 }

--- a/src/testing/core/__tests__/__snapshots__/createTestSchema.test.tsx.snap
+++ b/src/testing/core/__tests__/__snapshots__/createTestSchema.test.tsx.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`schema proxy should call invariant.error if min delay is greater than max delay 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "Please configure a minimum delay that is less than the maximum delay.",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;

--- a/src/testing/core/__tests__/createTestSchema.test.tsx
+++ b/src/testing/core/__tests__/createTestSchema.test.tsx
@@ -173,7 +173,7 @@ describe("schema proxy", () => {
   it("mocks scalars and resolvers", async () => {
     const Profiler = createDefaultProfiler<ViewerQueryData>();
 
-    using _fetch = createSchemaFetch(schema);
+    using _fetch = createSchemaFetch(schema).mockGlobal();
 
     const client = new ApolloClient({
       cache: new InMemoryCache(),
@@ -266,7 +266,7 @@ describe("schema proxy", () => {
 
     const Profiler = createDefaultProfiler<ViewerQueryData>();
 
-    using _fetch = createSchemaFetch(forkedSchema);
+    using _fetch = createSchemaFetch(forkedSchema).mockGlobal();
 
     const client = new ApolloClient({
       cache: new InMemoryCache(),
@@ -349,7 +349,7 @@ describe("schema proxy", () => {
   it("does not pollute the original schema", async () => {
     const Profiler = createDefaultProfiler<ViewerQueryData>();
 
-    using _fetch = createSchemaFetch(schema);
+    using _fetch = createSchemaFetch(schema).mockGlobal();
 
     const client = new ApolloClient({
       cache: new InMemoryCache(),
@@ -444,7 +444,7 @@ describe("schema proxy", () => {
 
     const Profiler = createDefaultProfiler<ViewerQueryData>();
 
-    using _fetch = createSchemaFetch(forkedSchema);
+    using _fetch = createSchemaFetch(forkedSchema).mockGlobal();
 
     const client = new ApolloClient({
       cache: new InMemoryCache(),
@@ -566,7 +566,7 @@ describe("schema proxy", () => {
 
     const Profiler = createDefaultProfiler<ViewerQueryData>();
 
-    using _fetch = createSchemaFetch(forkedSchema);
+    using _fetch = createSchemaFetch(forkedSchema).mockGlobal();
 
     const client = new ApolloClient({
       cache: new InMemoryCache(),
@@ -709,7 +709,7 @@ describe("schema proxy", () => {
 
     const { ErrorBoundary } = createTrackedErrorComponents(Profiler);
 
-    using _fetch = createSchemaFetch(forkedSchema);
+    using _fetch = createSchemaFetch(forkedSchema).mockGlobal();
 
     const client = new ApolloClient({
       cache: new InMemoryCache(),
@@ -789,7 +789,7 @@ describe("schema proxy", () => {
     const { ErrorBoundary } = createTrackedErrorComponents(Profiler);
 
     // @ts-expect-error - we're intentionally passing an invalid schema
-    using _fetch = createSchemaFetch(forkedSchema);
+    using _fetch = createSchemaFetch(forkedSchema).mockGlobal();
 
     const client = new ApolloClient({
       cache: new InMemoryCache(),
@@ -908,7 +908,7 @@ describe("schema proxy", () => {
 
     const Profiler = createDefaultProfiler<ViewerQueryData>();
 
-    using _fetch = createSchemaFetch(forkedSchema);
+    using _fetch = createSchemaFetch(forkedSchema).mockGlobal();
 
     const client = new ApolloClient({
       cache: new InMemoryCache(),
@@ -1036,7 +1036,7 @@ describe("schema proxy", () => {
 
     using _fetch = createSchemaFetch(schema, {
       delay: { min: 10, max: maxDelay },
-    });
+    }).mockGlobal();
 
     const client = new ApolloClient({
       cache: new InMemoryCache(),
@@ -1140,7 +1140,7 @@ describe("schema proxy", () => {
 
     using _fetch = createSchemaFetch(schema, {
       delay: { min: 3000, max: 1000 },
-    });
+    }).mockGlobal();
 
     const client = new ApolloClient({
       cache: new InMemoryCache(),

--- a/src/testing/core/__tests__/createTestSchema.test.tsx
+++ b/src/testing/core/__tests__/createTestSchema.test.tsx
@@ -1035,7 +1035,7 @@ describe("schema proxy", () => {
     const maxDelay = 2000;
 
     using _fetch = createSchemaFetch(schema, {
-      delay: { min: 100, max: 2000 },
+      delay: { min: 10, max: maxDelay },
     });
 
     const client = new ApolloClient({
@@ -1112,8 +1112,91 @@ describe("schema proxy", () => {
     {
       // with a timeout > maxDelay, this passes
       const { snapshot } = await Profiler.takeRender({
-        timeout: maxDelay + 10,
+        timeout: maxDelay + 100,
       });
+
+      expect(snapshot.result?.data).toEqual({
+        viewer: {
+          __typename: "User",
+          age: 42,
+          id: "1",
+          name: "Jane Doe",
+          book: {
+            __typename: "TextBook",
+            id: "1",
+            publishedAt: "2024-01-01",
+            title: "The Book",
+          },
+        },
+      });
+    }
+
+    unmount();
+  });
+
+  it("should call invariant.error if min delay is greater than max delay", async () => {
+    using _consoleSpy = spyOnConsole.takeSnapshots("error");
+    const Profiler = createDefaultProfiler<ViewerQueryData>();
+
+    using _fetch = createSchemaFetch(schema, {
+      delay: { min: 3000, max: 1000 },
+    });
+
+    const client = new ApolloClient({
+      cache: new InMemoryCache(),
+      uri,
+    });
+
+    const query: TypedDocumentNode<ViewerQueryData> = gql`
+      query {
+        viewer {
+          id
+          name
+          age
+          book {
+            id
+            title
+            publishedAt
+          }
+        }
+      }
+    `;
+
+    const Fallback = () => {
+      useTrackRenders();
+      return <div>Loading...</div>;
+    };
+
+    const App = () => {
+      return (
+        <React.Suspense fallback={<Fallback />}>
+          <Child />
+        </React.Suspense>
+      );
+    };
+
+    const Child = () => {
+      const result = useSuspenseQuery(query);
+
+      useTrackRenders();
+
+      Profiler.mergeSnapshot({
+        result,
+      } as Partial<{}>);
+
+      return <div>Hello</div>;
+    };
+
+    const { unmount } = renderWithClient(<App />, {
+      client,
+      wrapper: Profiler,
+    });
+
+    // suspended render
+    await Profiler.takeRender();
+
+    {
+      const { snapshot } = await Profiler.takeRender();
 
       expect(snapshot.result?.data).toEqual({
         viewer: {

--- a/src/testing/core/createSchemaFetch.ts
+++ b/src/testing/core/createSchemaFetch.ts
@@ -3,12 +3,7 @@ import type { GraphQLError, GraphQLSchema } from "graphql";
 import { ApolloError, gql } from "../../core/index.js";
 import { withCleanup } from "../internal/index.js";
 import { wait } from "./wait.js";
-
-// const randomDelayWithinThreshold = (min: number, max: number) => {
-//   return new Promise((resolve) => {
-//     setTimeout(resolve, Math.random() * (max - min) + min);
-//   });
-// };
+import { invariant } from "../../utilities/globals/invariantWrappers.js";
 
 /**
  * A function that accepts a static `schema` and a `mockFetchOpts` object and
@@ -51,11 +46,17 @@ const createSchemaFetch = (
     options
   ) => {
     if (mockFetchOpts.delay) {
-      const randomDelay =
-        Math.random() * (mockFetchOpts.delay.max - mockFetchOpts.delay.min) +
-        mockFetchOpts.delay.min;
+      if (mockFetchOpts.delay.min > mockFetchOpts.delay.max) {
+        invariant.error(
+          "Please configure a minimum delay that is less than the maximum delay."
+        );
+      } else {
+        const randomDelay =
+          Math.random() * (mockFetchOpts.delay.max - mockFetchOpts.delay.min) +
+          mockFetchOpts.delay.min;
 
-      await wait(randomDelay);
+        await wait(randomDelay);
+      }
     }
 
     return new Promise(async (resolve) => {

--- a/src/testing/core/createSchemaFetch.ts
+++ b/src/testing/core/createSchemaFetch.ts
@@ -94,13 +94,23 @@ const createSchemaFetch = (
     });
   };
 
-  window.fetch = mockFetch;
+  function mockGlobal() {
+    window.fetch = mockFetch;
 
-  const restore = () => {
-    window.fetch = prevFetch;
-  };
+    const restore = () => {
+      if (window.fetch === mockFetch) {
+        window.fetch = prevFetch;
+      }
+    };
 
-  return withCleanup({ mock: mockFetch, restore }, restore);
+    return withCleanup({ restore }, restore);
+  }
+
+  return Object.assign(mockFetch, {
+    mockGlobal,
+    // if https://github.com/rbuckton/proposal-using-enforcement lands
+    // [Symbol.enter]: mockGlobal
+  });
 };
 
 export { createSchemaFetch };


### PR DESCRIPTION
@alessbell I'd love to hear your opinion on this:

It is just a thought that I just had when reviewing #11748 - should call `createSchemaFetch` always implicitly mock `window.fetch`?

That could cut down on the usability of the tool in some situations. 

Instead, what I'd suggest would be a `mockGlobal` propery.

So different usages might look like

```diff
    using _fetch = createSchemaFetch(schema, {
      delay: { min: 10, max: maxDelay },
-    });
+    }).mockGlobal();
```

or

```diff
    const { restore } = createSchemaFetch(schema, {
      delay: { min: 10, max: maxDelay },
-    });
+    }).mockGlobal();
```

While 
```js
    const fetch = createSchemaFetch(schema, {
      delay: { min: 10, max: maxDelay },
    });
```
would just return a `fetch` function that can be passed around, but won't pollute global scope.

With that, using the plain object with `using` would end up with (at least?) a TS error: 
```js
    // The initializer of a using declaration must be either an object with a [Symbol.dispose]() method, or be null or undefined.
    using _fetch = createSchemaFetch(schema, {
      delay: { min: 10, max: maxDelay },
    });
```

But once https://github.com/rbuckton/proposal-using-enforcement lands (it's suggested for stage 1/2 in todays TC39 meeting), we could make use of `[Symbol.enter]` to implicitly call `mockGlobal` once it's used with `using`, so in the long term, the above code would work and mock global again.


---

An alternative to that could be an option like
```js
    using _fetch = createSchemaFetch(schema, {
      delay: { min: 10, max: maxDelay },
      mockGlobal: true/false
    });
```
but I believe that might be a bit more clunky to handle.