### PR TITLE
chore: update static-typing.md to add "graphql" as install dependency

### DIFF
--- a/docs/source/development-testing/static-typing.md
+++ b/docs/source/development-testing/static-typing.md
@@ -16,7 +16,7 @@ Below, we'll guide you through installing and configuring GraphQL Code Generator
 To get started using GraphQL Code Generator, begin by installing the following packages (using Yarn or NPM):
 
 ```bash
-yarn add -D typescript @graphql-codegen/cli @graphql-codegen/client-preset @graphql-typed-document-node/core
+yarn add -D typescript graphql @graphql-codegen/cli @graphql-codegen/client-preset @graphql-typed-document-node/core
 ```
 
 Next, we'll create a configuration file for GraphQL Code Generator, named [`codegen.ts`](https://www.the-guild.dev/graphql/codegen/docs/config-reference/codegen-config), at the root of our project:


### PR DESCRIPTION
The graphql package is required by the generated files and thus should be included in the initial suggested packages to be installed.