### PR TITLE
chore: update alessbell/pull-request-comment-branch to v2.1.0

### DIFF
--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -30,7 +30,7 @@ jobs:
       startsWith(github.event.comment.body, '/release:pr')
 
     steps:
-      - uses: alessbell/pull-request-comment-branch@v1.1
+      - uses: alessbell/pull-request-comment-branch@v2.1.0
         id: comment-branch
 
       - name: Checkout head ref


### PR DESCRIPTION
Upgrades to a version of `alessbell/pull-request-comment-branch` that uses Node 20 to address the github action deprecation warning (previous version was 16). Tested on personal repo ([before](https://github.com/alessbell/good-snow-tire-demo/actions/runs/8710796011)/[after](https://github.com/alessbell/good-snow-tire-demo/actions/runs/8711060211)).