### PR TITLE
fix: initialFetchPolicy instead initialPolicy

### DIFF
--- a/docs/source/data/queries.mdx
+++ b/docs/source/data/queries.mdx
@@ -370,17 +370,17 @@ new ApolloClient({
           options,
           // The original value of options.fetchPolicy, before nextFetchPolicy was
           // applied for the first time.
-          initialPolicy,
+          initialFetchPolicy,
           // The ObservableQuery associated with this client.watchQuery call.
           observable,
         }
       ) {
         // When variables change, the default behavior is to reset
-        // options.fetchPolicy to context.initialPolicy. If you omit this logic,
+        // options.fetchPolicy to context.initialFetchPolicy. If you omit this logic,
         // your nextFetchPolicy function can override this default behavior to
         // prevent options.fetchPolicy from changing in this case.
         if (reason === 'variables-changed') {
-          return initialPolicy;
+          return initialFetchPolicy;
         }
 
         if (

--- a/src/core/__tests__/fetchPolicies.ts
+++ b/src/core/__tests__/fetchPolicies.ts
@@ -1274,7 +1274,7 @@ describe("nextFetchPolicy", () => {
 
       // The nextFetchPolicy function we provided always returnes cache-first,
       // even when context.reason is variables-changed (which by default
-      // resets the fetchPolicy to context.initialPolicy), so cache-first is
+      // resets the fetchPolicy to context.initialFetchPolicy), so cache-first is
       // still what we see here.
       expect(observable.options.fetchPolicy).toBe("cache-first");
     } else if (count === 3) {


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:

### Checklist:
- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
-->
Fixing [documentation](https://www.apollographql.com/docs/react/data/queries/#setting-a-fetch-policy) for `ApolloClient.defaultOptions.watchQuery.nextFetchPolicy` custom function.
Considerations:
- Context that is passed as second argument doesn't provide `initialPolicy`, but `initialFetchPolicy`:
- Type [definition](https://github.com/apollographql/apollo-client/blob/main/src/core/watchQueryOptions.ts#L154) raises error when `initialPolicy` is used 
- Search through code shows [`initialFetchPolicy` is used](https://github.com/search?q=repo%3Aapollographql%2Fapollo-client%20initialFetchPolicy&type=code) in many places 
- `initialPolicy` is obsolete and [not used at all](https://github.com/search?q=repo%3Aapollographql%2Fapollo-client%20initialPolicy&type=code)