### PR TITLE
add return type to `withinDOM` implementation

### DIFF
--- a/src/testing/internal/profile/Render.tsx
+++ b/src/testing/internal/profile/Render.tsx
@@ -124,7 +124,7 @@ export class RenderInstance<Snapshot> implements Render<Snapshot> {
     return (this._domSnapshot = body);
   }
 
-  get withinDOM() {
+  get withinDOM(): () => SyncScreen {
     const snapScreen = Object.assign(within(this.domSnapshot), {
       debug: (
         ...[dom = this.domSnapshot, ...rest]: Parameters<typeof screen.debug>


### PR DESCRIPTION
I am locally getting this error:

> The inferred type of 'withinDOM' cannot be named without a reference to '@testing-library/dom/node_modules/pretty-format'. This is likely not portable. A type annotation is necessary.ts(2742)

So adding that annotation to fix it - I don't believe we need a Changeset for this, as it's purely internal :)
