### PR TITLE
MockLink: update the function types returned by `ResultFunction` & `VariableMatcher` to define their own generics

### DIFF
--- a/.api-reports/api-report-testing.md
+++ b/.api-reports/api-report-testing.md
@@ -1553,7 +1553,7 @@ interface Resolvers {
 }
 
 // @public (undocumented)
-export type ResultFunction<T, V = Record<string, any>> = (variables: V) => T;
+export type ResultFunction<T, V = Record<string, any>> = <_V extends V = V>(variables: _V) => T;
 
 // @public (undocumented)
 type SafeReadonly<T> = T extends object ? Readonly<T> : T;
@@ -1698,7 +1698,7 @@ interface UriFunction {
 }
 
 // @public (undocumented)
-type VariableMatcher<V = Record<string, any>> = (variables: V) => boolean;
+type VariableMatcher<V = Record<string, any>> = <_V extends V = V>(variables: _V) => boolean;
 
 // @public (undocumented)
 export function wait(ms: number): Promise<void>;

--- a/.api-reports/api-report-testing_core.md
+++ b/.api-reports/api-report-testing_core.md
@@ -1510,7 +1510,7 @@ interface Resolvers {
 }
 
 // @public (undocumented)
-export type ResultFunction<T, V = Record<string, any>> = (variables: V) => T;
+export type ResultFunction<T, V = Record<string, any>> = <_V extends V = V>(variables: _V) => T;
 
 // @public (undocumented)
 type SafeReadonly<T> = T extends object ? Readonly<T> : T;
@@ -1655,7 +1655,7 @@ interface UriFunction {
 }
 
 // @public (undocumented)
-type VariableMatcher<V = Record<string, any>> = (variables: V) => boolean;
+type VariableMatcher<V = Record<string, any>> = <_V extends V = V>(variables: _V) => boolean;
 
 // @public (undocumented)
 export function wait(ms: number): Promise<void>;

--- a/.changeset/khaki-rivers-stare.md
+++ b/.changeset/khaki-rivers-stare.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+MockLink: Update the function types returned by the `ResultFunction` & `VariableMatcher` types to define their own generics which extend from and default to the variables (`V`) type.

--- a/src/testing/core/mocking/__tests__/mockLink.ts
+++ b/src/testing/core/mocking/__tests__/mockLink.ts
@@ -2,66 +2,95 @@ import gql from "graphql-tag";
 import { MockLink, MockedResponse } from "../mockLink";
 import { execute } from "../../../../link/core/execute";
 
-describe("MockedResponse.newData", () => {
-  const setup = () => {
-    const weaklyTypedMockResponse: MockedResponse = {
-      request: {
-        query: gql`
-          query A {
-            a
-          }
-        `,
-      },
-    };
+describe("MockedResponse", () => {
+  test("infers variable types correctly", () => {
+    function setup<M extends MockedResponse[]>(props: { mocks: M }) {
+      const { mocks } = props;
 
-    const stronglyTypedMockResponse: MockedResponse<
-      { a: string },
-      { input: string }
-    > = {
-      request: {
-        query: gql`
-          query A {
-            a
-          }
-        `,
-      },
-    };
+      return {
+        mocks,
+      };
+    }
 
-    return {
-      weaklyTypedMockResponse,
-      stronglyTypedMockResponse,
-    };
-  };
-
-  test("returned 'data' can be any object with untyped response", () => {
-    const { weaklyTypedMockResponse } = setup();
-
-    weaklyTypedMockResponse.newData = ({ fake: { faker } }) => ({
-      data: {
-        pretend: faker,
-      },
+    setup<[MockedResponse<{ a: string }, { a: string }>]>({
+      mocks: [
+        {
+          request: {
+            query: gql`
+              query A {
+                a
+              }
+            `,
+            variables: {
+              a: "a",
+            },
+          },
+        },
+      ],
     });
   });
 
-  test("can't return output that doesn't match TData", () => {
-    const { stronglyTypedMockResponse } = setup();
+  describe("newData", () => {
+    const setup = () => {
+      const weaklyTypedMockResponse: MockedResponse = {
+        request: {
+          query: gql`
+            query A {
+              a
+            }
+          `,
+        },
+      };
 
-    // @ts-expect-error return type does not match `TData`
-    stronglyTypedMockResponse.newData = () => ({
-      data: {
-        a: 123,
-      },
+      const stronglyTypedMockResponse: MockedResponse<
+        { a: string },
+        { input: string }
+      > = {
+        request: {
+          query: gql`
+            query A {
+              a
+            }
+          `,
+        },
+      };
+
+      return {
+        weaklyTypedMockResponse,
+        stronglyTypedMockResponse,
+      };
+    };
+
+    test("returned 'data' can be any object with untyped response", () => {
+      const { weaklyTypedMockResponse } = setup();
+
+      weaklyTypedMockResponse.newData = ({ fake: { faker } }) => ({
+        data: {
+          pretend: faker,
+        },
+      });
     });
-  });
 
-  test("can't use input variables that don't exist in TVariables", () => {
-    const { stronglyTypedMockResponse } = setup();
+    test("can't return output that doesn't match TData", () => {
+      const { stronglyTypedMockResponse } = setup();
 
-    // @ts-expect-error unknown variables
-    stronglyTypedMockResponse.newData = ({ fake: { faker } }) => ({
-      data: {
-        a: faker,
-      },
+      // @ts-expect-error return type does not match `TData`
+      stronglyTypedMockResponse.newData = () => ({
+        data: {
+          a: 123,
+        },
+      });
+    });
+
+    test("can't use input variables that don't exist in TVariables", () => {
+      const { stronglyTypedMockResponse } = setup();
+
+      // @ts-expect-error unknown variables
+      stronglyTypedMockResponse.newData = ({ fake: { faker } }) => ({
+        data: {
+          a: faker,
+        },
+      });
     });
   });
 });

--- a/src/testing/core/mocking/mockLink.ts
+++ b/src/testing/core/mocking/mockLink.ts
@@ -19,10 +19,12 @@ import {
   print,
 } from "../../../utilities/index.js";
 
-export type ResultFunction<T, V = Record<string, any>> = (variables: V) => T;
+export type ResultFunction<T, V = Record<string, any>> = <_V extends V = V>(
+  variables: _V
+) => T;
 
-export type VariableMatcher<V = Record<string, any>> = (
-  variables: V
+export type VariableMatcher<V = Record<string, any>> = <_V extends V = V>(
+  variables: _V
 ) => boolean;
 
 export interface MockedResponse<


### PR DESCRIPTION
## Issue

A feature introduced last year (#6701) which updated `MockLink`'s `ResultFunction` type and introduced a new `VariableMatcher` type (both referenced by `MockedResponse`) has caused a type issue our repository that is affecting our team's common practice of setting a generic which `extends` from `MockedResponse[]` on our test setup functions (e.g. `function setup<M extends MockedResponse[]>`).

This issue arises due to both types accepting a variables generic type (`V`),  and then returning a function type which uses this generic as its own argument type:

```tsx
export type ResultFunction<T, V = Record<string, any>> = (variables: V) => T;
export type VariableMatcher<V = Record<string, any>> = (variables: V) => boolean;
```

When these types are combined with our usage of `M extends MockedResponse[]`, TypeScript is unable to correctly infer the `variables` argument type for each of of the values in `M`.

## Example Failure
Here's an isolated example of this which will currently fail type checking:

<details>
  <summary>Failing Example:</summary>

```tsx
import { FetchResult, GraphQLRequest, gql } from "@apollo/client";

// The `ResultFunction`, `VariableMatcher` & `MockedResponse` types below are the current types
// defined in `mockLink.ts`.

type ResultFunction<T, V = Record<string, any>> = (variables: V) => T;
type VariableMatcher<V = Record<string, any>> = (variables: V) => boolean;

interface MockedResponse<
  TData = Record<string, any>,
  TVariables = Record<string, any>,
> {
  request: GraphQLRequest<TVariables>;
  maxUsageCount?: number;
  result?: FetchResult<TData> | ResultFunction<FetchResult<TData>, TVariables>;
  error?: Error;
  delay?: number;
  variableMatcher?: VariableMatcher<TVariables>;
  newData?: ResultFunction<FetchResult<TData>, TVariables>;
}

// ---- test case below

function setup<M extends MockedResponse[]>(props: { mocks: M }) {
  const { mocks } = props;

  return {
    mocks,
  };
}

// Type '[MockedResponse<{ a: string; }, { foo: string; }>]' does not satisfy the constraint 'MockedResponse<Record<string, any>, Record<string, any>>[]'.
//   Type 'MockedResponse<{ a: string; }, { foo: string; }>' is not assignable to type 'MockedResponse<Record<string, any>, Record<string, any>>'.
//     Types of property 'result' are incompatible.
//       Type 'FetchResult<{ a: string; }> | ResultFunction<FetchResult<{ a: string; }>, { foo: string; }> | undefined' is not assignable to type 'FetchResult<Record<string, any>> | ResultFunction<FetchResult<Record<string, any>>, Record<string, any>> | undefined'.
//         Type 'ResultFunction<FetchResult<{ a: string; }>, { foo: string; }>' is not assignable to type 'FetchResult<Record<string, any>> | ResultFunction<FetchResult<Record<string, any>>, Record<string, any>> | undefined'.
//           Type 'ResultFunction<FetchResult<{ a: string; }>, { foo: string; }>' is not assignable to type 'ResultFunction<FetchResult<Record<string, any>>, Record<string, any>>'.
//             Type 'Record<string, any>' is not assignable to type '{ foo: string; }'. ts(2344)
setup<[MockedResponse<{ a: string }, { foo: string }>]>({
  mocks: [
    {
      request: {
        query: gql`
          query A {
            a
          }
        `,
        variables: {
          foo: "bar",
        },
      },
    },
  ],
});
```

</details>

## Proposed Fix

I believe this can be fixed, without causing any breaking changes, by making the function types returned by `ResultFunction` & `VariableMatcher` declare their own generic type, which _extends_ from and _defaults_ to the `V` type.

This resolves the issue in the snippet above:

<details>
  <summary>Example Fix:</summary>

```tsx
import { FetchResult, GraphQLRequest, gql } from "@apollo/client";

// The `ResultFunction` & `VariableMatcher` types below have been updated to declare their own generics.

type ResultFunction<T, V = Record<string, any>> = <_V extends V = V>(
  variables: _V
) => T;

type VariableMatcher<V = Record<string, any>> = <_V extends V = V>(
  variables: _V
) => boolean;

// This is still the existing `MockedResponse` type from `mockLink.ts`.
export interface MockedResponse<
  TData = Record<string, any>,
  TVariables = Record<string, any>,
> {
  request: GraphQLRequest<TVariables>;
  maxUsageCount?: number;
  result?: FetchResult<TData> | ResultFunction<FetchResult<TData>, TVariables>;
  error?: Error;
  delay?: number;
  variableMatcher?: VariableMatcher<TVariables>;
  newData?: ResultFunction<FetchResult<TData>, TVariables>;
}

// ---- test case below

function setup<M extends MockedResponse[]>(props: { mocks: M }) {
  const { mocks } = props;

  return {
    mocks,
  };
}

// No type error anymore.
setup<[MockedResponse<{ a: string }, { foo: string }>]>({
  mocks: [
    {
      request: {
        query: gql`
          query A {
            a
          }
        `,
        variables: {
          foo: "bar",
        },
      },
    },
  ],
});

// A type error is still _correctly_ thrown below due to the `variables` type mismatch.
setup<[MockedResponse<{ a: string }, { foo: string }>]>({
  mocks: [
    {
      request: {
        query: gql`
          query A {
            a
          }
        `,
        variables: {
          // Object literal may only specify known properties, and 'not' does not exist in type '{ foo: string; }'. ts(2353)
          // types.d.ts(36, 5): The expected type comes from property 'variables' which is declared here on type 'GraphQLRequest<{ foo: string; }>'
          not: "found",
        },
      },
    },
  ],
});

```
</details>

I've implemented the change as part of this PR and added a test case which currently fails when run against `main`, but passes on this branch.

Please let me know if you have any questions / concerns about the changes — thanks!