### PR TITLE
fix: update link to sandbox in schema-driven testing docs page

### DIFF
--- a/docs/source/development-testing/schema-driven-testing.mdx
+++ b/docs/source/development-testing/schema-driven-testing.mdx
@@ -557,4 +557,4 @@ Please see [this issue](https://github.com/graphql/graphql-js/issues/4062) to tr
 
 For a working example that demonstrates how to use both Testing Library and Mock Service Worker to write integration tests with `createTestSchema`, check out this project on CodeSandbox:
 
-[![Edit Testing React Components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/apollographql/docs-examples/tree/main/apollo-client/v3/testing-react-components?file=/src/dog.test.js)
+[![Edit Testing React Components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/github/apollographql/docs-examples/tree/main/apollo-client/v3/schema-driven-testing)


### PR DESCRIPTION
Just noticed this :)