### PR TITLE
Upgrade TypeScript to the latest patch version and regenerate API report

### DIFF
--- a/.api-reports/api-report-core.md
+++ b/.api-reports/api-report-core.md
@@ -2031,7 +2031,7 @@ export function selectHttpOptionsAndBodyInternal(operation: Operation, printer: 
 };
 
 // @public (undocumented)
-export const selectURI: (operation: Operation, fallbackURI?: string | ((operation: Operation) => string) | undefined) => any;
+export const selectURI: (operation: Operation, fallbackURI?: string | ((operation: Operation) => string)) => any;
 
 // @public (undocumented)
 export const serializeFetchParameter: (p: any, label: string) => string;

--- a/.api-reports/api-report-link_http.md
+++ b/.api-reports/api-report-link_http.md
@@ -298,7 +298,7 @@ export function selectHttpOptionsAndBodyInternal(operation: Operation, printer: 
 };
 
 // @public (undocumented)
-export const selectURI: (operation: Operation, fallbackURI?: string | ((operation: Operation) => string) | undefined) => any;
+export const selectURI: (operation: Operation, fallbackURI?: string | ((operation: Operation) => string)) => any;
 
 // @public (undocumented)
 export const serializeFetchParameter: (p: any, label: string) => string;

--- a/.api-reports/api-report-utilities_subscriptions_urql.md
+++ b/.api-reports/api-report-utilities_subscriptions_urql.md
@@ -10,7 +10,7 @@ import { Observable } from 'zen-observable-ts';
 //
 // @public (undocumented)
 export function createFetchMultipartSubscription(uri: string, { fetch: preferredFetch, headers }?: CreateMultipartSubscriptionOptions): ({ query, variables, }: {
-    query?: string | undefined;
+    query?: string;
     variables: undefined | Record<string, any>;
 }) => Observable<unknown>;
 

--- a/.api-reports/api-report.md
+++ b/.api-reports/api-report.md
@@ -2541,7 +2541,7 @@ export function selectHttpOptionsAndBodyInternal(operation: Operation, printer: 
 };
 
 // @public (undocumented)
-export const selectURI: (operation: Operation, fallbackURI?: string | ((operation: Operation) => string) | undefined) => any;
+export const selectURI: (operation: Operation, fallbackURI?: string | ((operation: Operation) => string)) => any;
 
 // @public (undocumented)
 export const serializeFetchParameter: (p: any, label: string) => string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,7 +100,7 @@
         "ts-morph": "22.0.0",
         "ts-node": "10.9.2",
         "typedoc": "0.25.0",
-        "typescript": "5.4.3",
+        "typescript": "5.4.5",
         "wait-for-observables": "1.0.3",
         "web-streams-polyfill": "4.0.0",
         "whatwg-fetch": "3.6.20"
@@ -12248,9 +12248,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
-      "integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
     "ts-morph": "22.0.0",
     "ts-node": "10.9.2",
     "typedoc": "0.25.0",
-    "typescript": "5.4.3",
+    "typescript": "5.4.5",
     "wait-for-observables": "1.0.3",
     "web-streams-polyfill": "4.0.0",
     "whatwg-fetch": "3.6.20"


### PR DESCRIPTION
This should be the last blocker for merging in the renovate PRs like https://github.com/apollographql/apollo-client/pull/11766 which are currently failing due to the change in the API report.