### PR TITLE
Create a new object for console to have a prototype with toString method

### DIFF
--- a/.changeset/rich-geese-complain.md
+++ b/.changeset/rich-geese-complain.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix error "Cannot convert object to primitive value"

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -873,7 +873,7 @@ For more information about these options, please refer to the documentation:
         " have an ID or a custom merge function, or "
     : "",
     typeDotName,
-    existing,
-    incoming
+    { ...existing },
+    { ...incoming }
   );
 }


### PR DESCRIPTION
This is a fix for https://github.com/apollographql/apollo-client/issues/11639

Objects possibly can have null prototypes. This causes them not to have toString() method leading to an error when doing substitution with console.warn() leading to the error "Cannot convert object to primitive value".

The error happens because both `existing` and `incoming` objects do not have `.toString` method. In the Chrome debugger, I saved `incoming` object as `temp1` on the window and these are my observations:

```
console.log('%o', temp1)
> Uncaught TypeError: Cannot convert object to primitive value
```

```
console.log('%o', {...temp1} )
> {__typename: 'Configuration', totalNumber: 10, updatedAt: '2024-05-06T11:10:11.684236649Z' }
```

```
temp1.toString()
> Uncaught TypeError: temp1.toString is not a function
```

