### PR TITLE
chore(docs): fix url for reset function

### DIFF
--- a/docs/source/data/mutations.mdx
+++ b/docs/source/data/mutations.mdx
@@ -154,7 +154,7 @@ if (error) return `Submission error! ${error.message}`;
 
 ### Resetting mutation status
 
-The mutation result object returned by `useMutation` includes a [`reset` function](#reset):
+The mutation result object returned by `useMutation` includes a [`reset` function](#mutationresult-interface-reset):
 
 ```js
 const [login, { data, loading, error, reset }] = useMutation(LOGIN_MUTATION);


### PR DESCRIPTION
Since the following url does not match a hash, this fixed it.

https://www.apollographql.com/docs/react/data/mutations#reset

https://www.apollographql.com/docs/react/data/mutations#mutationresult-interface-reset