### PR TITLE
Honor `@nonreactive` with `useFragment` and `cache.watchFragment`

### DIFF
--- a/.changeset/kind-donkeys-clap.md
+++ b/.changeset/kind-donkeys-clap.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Honor the `@nonreactive` directive when using `cache.watchFragment` or the `useFragment` hook to avoid rerendering when using these directives.

--- a/src/__tests__/ApolloClient.ts
+++ b/src/__tests__/ApolloClient.ts
@@ -2365,7 +2365,7 @@ describe("ApolloClient", () => {
     });
     // The @nonreactive directive can only be used on fields or fragment
     // spreads in queries, and currently has no effect here
-    it.failing("does not support the @nonreactive directive", async () => {
+    it("supports the @nonreactive directive", async () => {
       const cache = new InMemoryCache();
       const client = new ApolloClient({
         cache,
@@ -2416,18 +2416,9 @@ describe("ApolloClient", () => {
         },
       });
 
-      {
-        const result = await stream.takeNext();
-
-        expect(result).toEqual({
-          data: {
-            __typename: "Item",
-            id: 5,
-            text: "Item #5",
-          },
-          complete: true,
-        });
-      }
+      await expect(stream.takeNext()).rejects.toThrow(
+        new Error("Timeout waiting for next event")
+      );
     });
   });
 

--- a/src/__tests__/ApolloClient.ts
+++ b/src/__tests__/ApolloClient.ts
@@ -2363,8 +2363,7 @@ describe("ApolloClient", () => {
         expect.any(Error)
       );
     });
-    // The @nonreactive directive can only be used on fields or fragment
-    // spreads in queries, and currently has no effect here
+
     it("supports the @nonreactive directive", async () => {
       const cache = new InMemoryCache();
       const client = new ApolloClient({

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -248,6 +248,8 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
         query,
         callback(diff) {
           if (
+            // Always ensure we deliver the first result
+            latestDiff &&
             equalByQuery(
               query,
               { data: diff.result },

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -229,23 +229,21 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
     options: WatchFragmentOptions<TData, TVars>
   ): Observable<WatchFragmentResult<TData>> {
     const { fragment, fragmentName, from, optimistic = true } = options;
+    const query = this.getFragmentDoc(fragment, fragmentName);
 
     const diffOptions: Cache.DiffOptions<TData, TVars> = {
       returnPartialData: true,
       id: typeof from === "string" ? from : this.identify(from),
-      query: this.getFragmentDoc(fragment, fragmentName),
+      query,
       optimistic,
     };
 
     let latestDiff: DataProxy.DiffResult<TData> | undefined;
 
     return new Observable((observer) => {
-      const query = this.getFragmentDoc(fragment, fragmentName);
-
       return this.watch<TData, TVars>({
         ...diffOptions,
         immediate: true,
-        query,
         callback(diff) {
           if (
             // Always ensure we deliver the first result

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -250,8 +250,8 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
             latestDiff &&
             equalByQuery(
               query,
-              { data: diff.result },
-              { data: latestDiff?.result }
+              { data: latestDiff?.result },
+              { data: diff.result }
             )
           ) {
             return;

--- a/src/react/hooks/__tests__/useFragment.test.tsx
+++ b/src/react/hooks/__tests__/useFragment.test.tsx
@@ -1414,6 +1414,73 @@ describe("useFragment", () => {
     await expect(ProfiledHook).not.toRerender();
   });
 
+  it("does not rerender when fields with @nonreactive change", async () => {
+    type Post = {
+      __typename: "User";
+      id: number;
+      title: string;
+      updatedAt: string;
+    };
+
+    const client = new ApolloClient({
+      cache: new InMemoryCache(),
+    });
+
+    const fragment: TypedDocumentNode<Post> = gql`
+      fragment PostFragment on Post {
+        id
+        title
+        updatedAt @nonreactive
+      }
+    `;
+
+    client.writeFragment({
+      fragment,
+      data: {
+        __typename: "Post",
+        id: 1,
+        title: "Blog post",
+        updatedAt: "2024-01-01",
+      },
+    });
+
+    const ProfiledHook = profileHook(() =>
+      useFragment({ fragment, from: { __typename: "Post", id: 1 } })
+    );
+
+    render(<ProfiledHook />, {
+      wrapper: ({ children }) => (
+        <ApolloProvider client={client}>{children}</ApolloProvider>
+      ),
+    });
+
+    {
+      const snapshot = await ProfiledHook.takeSnapshot();
+
+      expect(snapshot).toEqual({
+        complete: true,
+        data: {
+          __typename: "Post",
+          id: 1,
+          title: "Blog post",
+          updatedAt: "2024-01-01",
+        },
+      });
+    }
+
+    client.writeFragment({
+      fragment,
+      data: {
+        __typename: "Post",
+        id: 1,
+        title: "Blog post",
+        updatedAt: "2024-02-01",
+      },
+    });
+
+    await expect(ProfiledHook).not.toRerender();
+  });
+
   describe("tests with incomplete data", () => {
     let cache: InMemoryCache, wrapper: React.FunctionComponent;
     const ItemFragment = gql`

--- a/src/react/hooks/__tests__/useFragment.test.tsx
+++ b/src/react/hooks/__tests__/useFragment.test.tsx
@@ -1481,6 +1481,83 @@ describe("useFragment", () => {
     await expect(ProfiledHook).not.toRerender();
   });
 
+  it("does not rerender when fields with @nonreactive on nested fragment change", async () => {
+    type Post = {
+      __typename: "User";
+      id: number;
+      title: string;
+      updatedAt: string;
+    };
+
+    const client = new ApolloClient({
+      cache: new InMemoryCache(),
+    });
+
+    const fragment: TypedDocumentNode<Post> = gql`
+      fragment PostFragment on Post {
+        id
+        title
+        ...PostFields @nonreactive
+      }
+
+      fragment PostFields on Post {
+        updatedAt
+      }
+    `;
+
+    client.writeFragment({
+      fragment,
+      fragmentName: "PostFragment",
+      data: {
+        __typename: "Post",
+        id: 1,
+        title: "Blog post",
+        updatedAt: "2024-01-01",
+      },
+    });
+
+    const ProfiledHook = profileHook(() =>
+      useFragment({
+        fragment,
+        fragmentName: "PostFragment",
+        from: { __typename: "Post", id: 1 },
+      })
+    );
+
+    render(<ProfiledHook />, {
+      wrapper: ({ children }) => (
+        <ApolloProvider client={client}>{children}</ApolloProvider>
+      ),
+    });
+
+    {
+      const snapshot = await ProfiledHook.takeSnapshot();
+
+      expect(snapshot).toEqual({
+        complete: true,
+        data: {
+          __typename: "Post",
+          id: 1,
+          title: "Blog post",
+          updatedAt: "2024-01-01",
+        },
+      });
+    }
+
+    client.writeFragment({
+      fragment,
+      fragmentName: "PostFragment",
+      data: {
+        __typename: "Post",
+        id: 1,
+        title: "Blog post",
+        updatedAt: "2024-02-01",
+      },
+    });
+
+    await expect(ProfiledHook).not.toRerender();
+  });
+
   describe("tests with incomplete data", () => {
     let cache: InMemoryCache, wrapper: React.FunctionComponent;
     const ItemFragment = gql`


### PR DESCRIPTION
Fixes #11785

Uses `equalByQuery` to ensure that when we compare fragment diffs, we respect the `@nonreactive` directive within `cache.watchFragment` and `useFragment`.