### PR TITLE
Ensure covariant behavior: `MockedResponses<X,Y>` should be assignable to `MockedResponse`

### DIFF
--- a/.api-reports/api-report-testing.md
+++ b/.api-reports/api-report-testing.md
@@ -440,6 +440,11 @@ class Concast<T> extends Observable<T> {
 // @public (undocumented)
 type ConcastSourcesIterable<T> = Iterable<Source<T>>;
 
+// @internal (undocumented)
+type CovariantUnaryFunction<out Arg, out Ret> = {
+    fn(arg: Arg): Ret;
+}["fn"];
+
 // Warning: (ae-forgotten-export) The symbol "ApolloClient" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "NormalizedCacheObject" needs to be exported by the entry point index.d.ts
 //
@@ -954,7 +959,7 @@ interface MockedProviderState {
 }
 
 // @public (undocumented)
-export interface MockedResponse<TData = Record<string, any>, TVariables = Record<string, any>> {
+export interface MockedResponse<out TData = Record<string, any>, out TVariables = Record<string, any>> {
     // (undocumented)
     delay?: number;
     // (undocumented)
@@ -1552,8 +1557,10 @@ interface Resolvers {
     };
 }
 
+// Warning: (ae-forgotten-export) The symbol "CovariantUnaryFunction" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
-export type ResultFunction<T, V = Record<string, any>> = (variables: V) => T;
+export type ResultFunction<T, V = Record<string, any>> = CovariantUnaryFunction<V, T>;
 
 // @public (undocumented)
 type SafeReadonly<T> = T extends object ? Readonly<T> : T;
@@ -1698,7 +1705,7 @@ interface UriFunction {
 }
 
 // @public (undocumented)
-type VariableMatcher<V = Record<string, any>> = (variables: V) => boolean;
+type VariableMatcher<V = Record<string, any>> = CovariantUnaryFunction<V, boolean>;
 
 // @public (undocumented)
 export function wait(ms: number): Promise<void>;

--- a/.api-reports/api-report-testing_core.md
+++ b/.api-reports/api-report-testing_core.md
@@ -439,6 +439,11 @@ class Concast<T> extends Observable<T> {
 // @public (undocumented)
 type ConcastSourcesIterable<T> = Iterable<Source<T>>;
 
+// @internal (undocumented)
+type CovariantUnaryFunction<out Arg, out Ret> = {
+    fn(arg: Arg): Ret;
+}["fn"];
+
 // Warning: (ae-forgotten-export) The symbol "ApolloClient" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "NormalizedCacheObject" needs to be exported by the entry point index.d.ts
 //
@@ -909,7 +914,7 @@ interface MockApolloLink extends ApolloLink {
 }
 
 // @public (undocumented)
-export interface MockedResponse<TData = Record<string, any>, TVariables = Record<string, any>> {
+export interface MockedResponse<out TData = Record<string, any>, out TVariables = Record<string, any>> {
     // (undocumented)
     delay?: number;
     // (undocumented)
@@ -1509,8 +1514,10 @@ interface Resolvers {
     };
 }
 
+// Warning: (ae-forgotten-export) The symbol "CovariantUnaryFunction" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
-export type ResultFunction<T, V = Record<string, any>> = (variables: V) => T;
+export type ResultFunction<T, V = Record<string, any>> = CovariantUnaryFunction<V, T>;
 
 // @public (undocumented)
 type SafeReadonly<T> = T extends object ? Readonly<T> : T;
@@ -1655,7 +1662,7 @@ interface UriFunction {
 }
 
 // @public (undocumented)
-type VariableMatcher<V = Record<string, any>> = (variables: V) => boolean;
+type VariableMatcher<V = Record<string, any>> = CovariantUnaryFunction<V, boolean>;
 
 // @public (undocumented)
 export function wait(ms: number): Promise<void>;

--- a/.changeset/nasty-pens-dress.md
+++ b/.changeset/nasty-pens-dress.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Ensure covariant behavior: `MockedResponses<X,Y>` should be assignable to `MockedResponse`

--- a/.changeset/nasty-pens-dress.md
+++ b/.changeset/nasty-pens-dress.md
@@ -2,4 +2,4 @@
 "@apollo/client": patch
 ---
 
-Ensure covariant behavior: `MockedResponses<X,Y>` should be assignable to `MockedResponse`
+Ensure covariant behavior: `MockedResponse<X,Y>` should be assignable to `MockedResponse`

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 39573,
+  "dist/apollo-client.min.cjs": 39574,
   "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 32821
 }

--- a/src/testing/core/mocking/__tests__/mockLink.ts
+++ b/src/testing/core/mocking/__tests__/mockLink.ts
@@ -280,3 +280,35 @@ test("removes fields with @client directives", async () => {
     await expect(stream.takeNext()).resolves.toEqual({ data: { a: 3, b: 4 } });
   }
 });
+
+describe.skip("type tests", () => {
+  const ANY = {} as any;
+  test("covariant behaviour: `MockedResponses<X,Y>` should be assignable to `MockedResponse`", () => {
+    let unspecificArray: MockedResponse[] = [];
+    let specificArray: MockedResponse<{ foo: string }, { foo: string }>[] = [];
+    let unspecificResponse: MockedResponse = ANY;
+    let specificResponse: MockedResponse<{ foo: string }, { foo: string }> =
+      ANY;
+
+    unspecificArray.push(specificResponse);
+    unspecificArray.push(unspecificResponse);
+
+    specificArray.push(specificResponse);
+    // @ts-expect-error
+    specificArray.push(unspecificResponse);
+
+    unspecificArray = [specificResponse];
+    unspecificArray = [unspecificResponse];
+    unspecificArray = [specificResponse, unspecificResponse];
+
+    specificArray = [specificResponse];
+    // @ts-expect-error
+    specificArray = [unspecificResponse];
+    // @ts-expect-error
+    specificArray = [specificResponse, unspecificResponse];
+
+    unspecificResponse = specificResponse;
+    // @ts-expect-error
+    specificResponse = unspecificResponse;
+  });
+});

--- a/src/testing/core/mocking/mockLink.ts
+++ b/src/testing/core/mocking/mockLink.ts
@@ -20,15 +20,21 @@ import {
   checkDocument,
 } from "../../../utilities/index.js";
 
-export type ResultFunction<T, V = Record<string, any>> = (variables: V) => T;
+type CovariantUnaryFunction<out Arg, out Ret> = { fn(arg: Arg): Ret }["fn"];
 
-export type VariableMatcher<V = Record<string, any>> = (
-  variables: V
-) => boolean;
+export type ResultFunction<T, V = Record<string, any>> = CovariantUnaryFunction<
+  V,
+  T
+>;
+
+export type VariableMatcher<V = Record<string, any>> = CovariantUnaryFunction<
+  V,
+  boolean
+>;
 
 export interface MockedResponse<
-  TData = Record<string, any>,
-  TVariables = Record<string, any>,
+  out TData = Record<string, any>,
+  out TVariables = Record<string, any>,
 > {
   request: GraphQLRequest<TVariables>;
   maxUsageCount?: number;

--- a/src/testing/core/mocking/mockLink.ts
+++ b/src/testing/core/mocking/mockLink.ts
@@ -20,6 +20,7 @@ import {
   checkDocument,
 } from "../../../utilities/index.js";
 
+/** @internal */
 type CovariantUnaryFunction<out Arg, out Ret> = { fn(arg: Arg): Ret }["fn"];
 
 export type ResultFunction<T, V = Record<string, any>> = CovariantUnaryFunction<


### PR DESCRIPTION
Fixes #11842