### PR TITLE
[Data masking] Provide way to opt-in to data masking via the cache

### DIFF
--- a/src/cache/core/__tests__/cache.ts
+++ b/src/cache/core/__tests__/cache.ts
@@ -5,6 +5,7 @@ import { Reference } from "../../../utilities/graphql/storeUtils";
 import { expectTypeOf } from "expect-type";
 import { spyOnConsole } from "../../../testing/internal";
 import type { InlineFragmentNode } from "graphql";
+
 class TestCache extends ApolloCache<unknown> {
   constructor() {
     super();

--- a/src/cache/core/__tests__/cache.ts
+++ b/src/cache/core/__tests__/cache.ts
@@ -169,10 +169,20 @@ describe("abstract cache", () => {
       using consoleSpy = spyOnConsole("warn");
       const query = gql`
         query {
-          greeting
+          user {
+            __typename
+            id
+            ...UserFields
+          }
+        }
+
+        fragment UserFields on User {
+          name
         }
       `;
-      const data = { greeting: "Hello" };
+      const data = {
+        user: { __typename: "User", id: 1, name: "Mister Masked" },
+      };
       const cache = new TestCache();
 
       const result = cache.maskDocument(query, data);

--- a/src/cache/core/__tests__/cache.ts
+++ b/src/cache/core/__tests__/cache.ts
@@ -3,6 +3,7 @@ import { ApolloCache } from "../cache";
 import { Cache, DataProxy } from "../..";
 import { Reference } from "../../../utilities/graphql/storeUtils";
 import { expectTypeOf } from "expect-type";
+import { spyOnConsole } from "../../../testing/internal";
 class TestCache extends ApolloCache<unknown> {
   constructor() {
     super();
@@ -158,6 +159,27 @@ describe("abstract cache", () => {
 
       test.writeFragment(fragment);
       expect(test.write).toBeCalled();
+    });
+  });
+
+  describe("maskDocument", () => {
+    it("warns on caches that don't implement the required interface and returns original data", () => {
+      using consoleSpy = spyOnConsole("warn");
+      const query = gql`
+        query {
+          greeting
+        }
+      `;
+      const data = { greeting: "Hello" };
+      const cache = new TestCache();
+
+      const result = cache.maskDocument(query, data);
+
+      expect(result).toBe(data);
+      expect(consoleSpy.warn).toHaveBeenCalledTimes(1);
+      expect(consoleSpy.warn).toHaveBeenCalledWith(
+        expect.stringContaining("does not support data masking")
+      );
     });
   });
 

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -381,7 +381,7 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
       return data;
     }
 
-    return mask(data, document, this.fragmentMatches);
+    return mask(data, document, this.fragmentMatches.bind(this));
   }
 
   /**

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -23,6 +23,8 @@ import type {
 } from "../../core/types.js";
 import type { MissingTree } from "./types/common.js";
 import { equalByQuery } from "../../core/equalByQuery.js";
+import { mask } from "../../core/masking.js";
+import { invariant } from "../../utilities/globals/index.js";
 
 export type Transaction<T> = (c: ApolloCache<T>) => void;
 
@@ -366,6 +368,19 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
         return data;
       },
     });
+  }
+
+  public maskDocument<TData = unknown>(document: DocumentNode, data: TData) {
+    if (!this.fragmentMatches) {
+      if (__DEV__) {
+        invariant.warn(
+          "This cache does not support data masking which effectively disables the data masking feature. Please use a cache that supports data masking or disable data masking to silence this warning."
+        );
+      }
+      return data;
+    }
+
+    return mask(data, document, this.fragmentMatches);
   }
 
   /**

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -377,6 +377,7 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
           "This cache does not support data masking which effectively disables the data masking feature. Please use a cache that supports data masking or disable data masking to silence this warning."
         );
       }
+
       return data;
     }
 

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -1,4 +1,4 @@
-import type { DocumentNode } from "graphql";
+import type { DocumentNode, InlineFragmentNode } from "graphql";
 import { wrap } from "optimism";
 
 import type {
@@ -144,6 +144,19 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
   // Optimistic API
 
   public abstract removeOptimistic(id: string): void;
+
+  // Data masking API
+
+  // Used by data masking to determine if an inline fragment with a type
+  // condition matches a given typename.
+  //
+  // If not implemented by a cache subclass, data masking will effectively be
+  // disabled since we will not be able to accurately determine if a given type
+  // condition for a union or interface matches a particular type.
+  protected fragmentMatches?(
+    fragment: InlineFragmentNode,
+    typename: string
+  ): boolean;
 
   // Transactional API
 

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -528,7 +528,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     return this.addTypenameToDocument(this.addFragmentsToDocument(document));
   }
 
-  public fragmentMatches(
+  protected fragmentMatches(
     fragment: InlineFragmentNode,
     typename: string
   ): boolean {

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -3,7 +3,7 @@ import { invariant } from "../../utilities/globals/index.js";
 // Make builtins like Map and Set safe to use with non-extensible objects.
 import "./fixPolyfills.js";
 
-import type { DocumentNode } from "graphql";
+import type { DocumentNode, InlineFragmentNode } from "graphql";
 import type { OptimisticWrapperFunction } from "optimism";
 import { wrap } from "optimism";
 import { equal } from "@wry/equality";
@@ -526,6 +526,13 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
 
   public transformDocument(document: DocumentNode): DocumentNode {
     return this.addTypenameToDocument(this.addFragmentsToDocument(document));
+  }
+
+  public fragmentMatches(
+    fragment: InlineFragmentNode,
+    typename: string
+  ): boolean {
+    return this.policies.fragmentMatches(fragment, typename);
   }
 
   protected broadcastWatches(options?: BroadcastOptions) {

--- a/src/core/__tests__/masking.test.ts
+++ b/src/core/__tests__/masking.test.ts
@@ -1,0 +1,726 @@
+import { mask } from "../masking.js";
+import { InMemoryCache, gql } from "../index.js";
+import { InlineFragmentNode } from "graphql";
+import { deepFreeze } from "../../utilities/common/maybeDeepFreeze.js";
+
+test("strips top-level fragment data from query", () => {
+  const query = gql`
+    query {
+      foo
+      ...QueryFields
+    }
+
+    fragment QueryFields on Query {
+      bar
+    }
+  `;
+
+  const data = mask(
+    { foo: true, bar: true },
+    query,
+    createFragmentMatcher(new InMemoryCache())
+  );
+
+  expect(data).toEqual({ foo: true });
+});
+
+test("strips fragment data from nested object", () => {
+  const query = gql`
+    query {
+      user {
+        __typename
+        id
+        ...UserFields
+      }
+    }
+
+    fragment UserFields on User {
+      name
+    }
+  `;
+
+  const data = mask(
+    { user: { __typename: "User", id: 1, name: "Test User" } },
+    query,
+    createFragmentMatcher(new InMemoryCache())
+  );
+
+  expect(data).toEqual({ user: { __typename: "User", id: 1 } });
+});
+
+test("strips fragment data from arrays", () => {
+  const query = gql`
+    query {
+      users {
+        __typename
+        id
+        ...UserFields
+      }
+    }
+
+    fragment UserFields on User {
+      name
+    }
+  `;
+
+  const data = mask(
+    {
+      users: [
+        { __typename: "User", id: 1, name: "Test User 1" },
+        { __typename: "User", id: 2, name: "Test User 2" },
+      ],
+    },
+    query,
+    createFragmentMatcher(new InMemoryCache())
+  );
+
+  expect(data).toEqual({
+    users: [
+      { __typename: "User", id: 1 },
+      { __typename: "User", id: 2 },
+    ],
+  });
+});
+
+test("strips multiple fragments in the same selection set", () => {
+  const query = gql`
+    query {
+      user {
+        __typename
+        id
+        ...UserProfileFields
+        ...UserAvatarFields
+      }
+    }
+
+    fragment UserProfileFields on User {
+      age
+    }
+
+    fragment UserAvatarFields on User {
+      avatarUrl
+    }
+  `;
+
+  const data = mask(
+    {
+      user: {
+        __typename: "User",
+        id: 1,
+        age: 30,
+        avatarUrl: "https://example.com/avatar.jpg",
+      },
+    },
+    query,
+    createFragmentMatcher(new InMemoryCache())
+  );
+
+  expect(data).toEqual({
+    user: { __typename: "User", id: 1 },
+  });
+});
+
+test("strips multiple fragments across different selection sets", () => {
+  const query = gql`
+    query {
+      user {
+        __typename
+        id
+        ...UserFields
+      }
+      post {
+        __typename
+        id
+        ...PostFields
+      }
+    }
+
+    fragment UserFields on User {
+      name
+    }
+
+    fragment PostFields on Post {
+      title
+    }
+  `;
+
+  const data = mask(
+    {
+      user: {
+        __typename: "User",
+        id: 1,
+        name: "test user",
+      },
+      post: {
+        __typename: "Post",
+        id: 1,
+        title: "Test Post",
+      },
+    },
+    query,
+    createFragmentMatcher(new InMemoryCache())
+  );
+
+  expect(data).toEqual({
+    user: { __typename: "User", id: 1 },
+    post: { __typename: "Post", id: 1 },
+  });
+});
+
+test("leaves overlapping fields in query", () => {
+  const query = gql`
+    query {
+      user {
+        __typename
+        id
+        birthdate
+        ...UserProfileFields
+      }
+    }
+
+    fragment UserProfileFields on User {
+      birthdate
+      name
+    }
+  `;
+
+  const data = mask(
+    {
+      user: {
+        __typename: "User",
+        id: 1,
+        birthdate: "1990-01-01",
+        name: "Test User",
+      },
+    },
+    query,
+    createFragmentMatcher(new InMemoryCache())
+  );
+
+  expect(data).toEqual({
+    user: { __typename: "User", id: 1, birthdate: "1990-01-01" },
+  });
+});
+
+test("does not strip inline fragments", () => {
+  const cache = new InMemoryCache({
+    possibleTypes: { Profile: ["UserProfile"] },
+  });
+
+  const query = gql`
+    query {
+      user {
+        __typename
+        id
+        ... @defer {
+          name
+        }
+      }
+      profile {
+        __typename
+        ... on UserProfile {
+          avatarUrl
+        }
+      }
+    }
+  `;
+
+  const data = mask(
+    {
+      user: {
+        __typename: "User",
+        id: 1,
+        name: "Test User",
+      },
+      profile: {
+        __typename: "UserProfile",
+        avatarUrl: "https://example.com/avatar.jpg",
+      },
+    },
+    query,
+    createFragmentMatcher(cache)
+  );
+
+  expect(data).toEqual({
+    user: {
+      __typename: "User",
+      id: 1,
+      name: "Test User",
+    },
+    profile: {
+      __typename: "UserProfile",
+      avatarUrl: "https://example.com/avatar.jpg",
+    },
+  });
+});
+
+test("strips named fragments inside inline fragments", () => {
+  const cache = new InMemoryCache({
+    possibleTypes: { Industry: ["TechIndustry"], Profile: ["UserProfile"] },
+  });
+  const query = gql`
+    query {
+      user {
+        __typename
+        id
+        ... @defer {
+          name
+          ...UserFields
+        }
+      }
+      profile {
+        __typename
+        ... on UserProfile {
+          avatarUrl
+          ...UserProfileFields
+        }
+        industry {
+          __typename
+          ... on TechIndustry {
+            ...TechIndustryFields
+          }
+        }
+      }
+    }
+
+    fragment UserFields on User {
+      age
+    }
+
+    fragment UserProfileFields on UserProfile {
+      hometown
+    }
+
+    fragment TechIndustryFields on TechIndustry {
+      favoriteLanguage
+    }
+  `;
+
+  const data = mask(
+    {
+      user: {
+        __typename: "User",
+        id: 1,
+        name: "Test User",
+        age: 30,
+      },
+      profile: {
+        __typename: "UserProfile",
+        avatarUrl: "https://example.com/avatar.jpg",
+        industry: { __typename: "TechIndustry", primaryLanguage: "TypeScript" },
+      },
+    },
+    query,
+    createFragmentMatcher(cache)
+  );
+
+  expect(data).toEqual({
+    user: {
+      __typename: "User",
+      id: 1,
+      name: "Test User",
+    },
+    profile: {
+      __typename: "UserProfile",
+      avatarUrl: "https://example.com/avatar.jpg",
+      industry: { __typename: "TechIndustry" },
+    },
+  });
+});
+
+test("handles objects with no matching inline fragment condition", () => {
+  const cache = new InMemoryCache({
+    possibleTypes: {
+      Drink: ["HotChocolate", "Juice"],
+    },
+  });
+
+  const query = gql`
+    query {
+      drinks {
+        __typename
+        id
+        ... on Juice {
+          fruitBase
+        }
+      }
+    }
+  `;
+
+  const data = mask(
+    {
+      drinks: [
+        { __typename: "HotChocolate", id: 1 },
+        { __typename: "Juice", id: 2, fruitBase: "Strawberry" },
+      ],
+    },
+    query,
+    createFragmentMatcher(cache)
+  );
+
+  expect(data).toEqual({
+    drinks: [
+      { __typename: "HotChocolate", id: 1 },
+      { __typename: "Juice", id: 2, fruitBase: "Strawberry" },
+    ],
+  });
+});
+
+test("handles field aliases", () => {
+  const query = gql`
+    query {
+      user {
+        __typename
+        id
+        fullName: name
+        ... @defer {
+          userAddress: address
+        }
+      }
+    }
+  `;
+
+  const data = mask(
+    {
+      user: {
+        __typename: "User",
+        id: 1,
+        fullName: "Test User",
+        userAddress: "1234 Main St",
+      },
+    },
+    query,
+    createFragmentMatcher(new InMemoryCache())
+  );
+
+  expect(data).toEqual({
+    user: {
+      __typename: "User",
+      id: 1,
+      fullName: "Test User",
+      userAddress: "1234 Main St",
+    },
+  });
+});
+
+test("handles overlapping fields inside multiple inline fragments", () => {
+  const cache = new InMemoryCache({
+    possibleTypes: {
+      Drink: [
+        "Espresso",
+        "Latte",
+        "Cappuccino",
+        "Cortado",
+        "Juice",
+        "HotChocolate",
+      ],
+      Espresso: ["Latte", "Cappuccino", "Cortado"],
+    },
+  });
+  const query = gql`
+    query {
+      drinks {
+        __typename
+        id
+        ... @defer {
+          amount
+        }
+        ... on Espresso {
+          milkType
+          ... on Latte {
+            flavor {
+              __typename
+              name
+              ...FlavorFields
+            }
+          }
+          ... on Cappuccino {
+            roast
+          }
+          ... on Cortado {
+            ...CortadoFields
+          }
+        }
+        ... on Latte {
+          ... @defer {
+            shots
+          }
+        }
+        ... on Juice {
+          ...JuiceFields
+        }
+        ... on HotChocolate {
+          milkType
+          ...HotChocolateFields
+        }
+      }
+    }
+
+    fragment JuiceFields on Juice {
+      fruitBase
+    }
+
+    fragment HotChocolateFields on HotChocolate {
+      chocolateType
+    }
+
+    fragment FlavorFields on Flavor {
+      sweetness
+    }
+
+    fragment CortadoFields on Cortado {
+      temperature
+    }
+  `;
+
+  const data = mask(
+    {
+      drinks: [
+        {
+          __typename: "Latte",
+          id: 1,
+          amount: 12,
+          shots: 2,
+          milkType: "Cow",
+          flavor: {
+            __typename: "Flavor",
+            name: "Cookie Butter",
+            sweetness: "high",
+          },
+        },
+        {
+          __typename: "Cappuccino",
+          id: 2,
+          amount: 12,
+          milkType: "Cow",
+          roast: "medium",
+        },
+        {
+          __typename: "Cortado",
+          id: 3,
+          amount: 12,
+          milkType: "Cow",
+          temperature: 150,
+        },
+        { __typename: "Juice", id: 4, amount: 10, fruitBase: "Apple" },
+        {
+          __typename: "HotChocolate",
+          id: 5,
+          amount: 8,
+          milkType: "Cow",
+          chocolateType: "dark",
+        },
+      ],
+    },
+    query,
+    createFragmentMatcher(cache)
+  );
+
+  expect(data).toEqual({
+    drinks: [
+      {
+        __typename: "Latte",
+        id: 1,
+        amount: 12,
+        shots: 2,
+        milkType: "Cow",
+        flavor: {
+          __typename: "Flavor",
+          name: "Cookie Butter",
+        },
+      },
+      {
+        __typename: "Cappuccino",
+        id: 2,
+        amount: 12,
+        milkType: "Cow",
+        roast: "medium",
+      },
+      {
+        __typename: "Cortado",
+        id: 3,
+        amount: 12,
+        milkType: "Cow",
+      },
+      { __typename: "Juice", id: 4, amount: 10 },
+      {
+        __typename: "HotChocolate",
+        id: 5,
+        amount: 8,
+        milkType: "Cow",
+      },
+    ],
+  });
+});
+
+test("does nothing if there are no fragments to mask", () => {
+  const query = gql`
+    query {
+      user {
+        __typename
+        id
+        name
+      }
+    }
+  `;
+
+  const data = mask(
+    { user: { __typename: "User", id: 1, name: "Test User" } },
+    query,
+    createFragmentMatcher(new InMemoryCache())
+  );
+
+  expect(data).toEqual({
+    user: { __typename: "User", id: 1, name: "Test User" },
+  });
+});
+
+test("maintains referential equality on subtrees that did not change", () => {
+  const query = gql`
+    query {
+      user {
+        __typename
+        id
+        profile {
+          __typename
+          avatarUrl
+        }
+        ...UserFields
+      }
+      post {
+        __typename
+        id
+        title
+      }
+      authors {
+        __typename
+        id
+        name
+      }
+      industries {
+        __typename
+        ... on TechIndustry {
+          languageRequirements
+        }
+        ... on FinanceIndustry {
+          ...FinanceIndustryFields
+        }
+        ... on TradeIndustry {
+          id
+          yearsInBusiness
+          ...TradeIndustryFields
+        }
+      }
+      drink {
+        __typename
+        ... on SportsDrink {
+          saltContent
+        }
+        ... on Espresso {
+          __typename
+        }
+      }
+    }
+
+    fragment UserFields on User {
+      name
+    }
+
+    fragment FinanceIndustryFields on FinanceIndustry {
+      yearsInBusiness
+    }
+
+    fragment TradeIndustryFields on TradeIndustry {
+      languageRequirements
+    }
+  `;
+
+  const profile = {
+    __typename: "Profile",
+    avatarUrl: "https://example.com/avatar.jpg",
+  };
+  const user = { __typename: "User", id: 1, name: "Test User", profile };
+  const post = { __typename: "Post", id: 1, title: "Test Post" };
+  const authors = [{ __typename: "Author", id: 1, name: "A Author" }];
+  const industries = [
+    { __typename: "TechIndustry", languageRequirements: ["TypeScript"] },
+    { __typename: "FinanceIndustry", yearsInBusiness: 10 },
+    {
+      __typename: "TradeIndustry",
+      id: 10,
+      yearsInBusiness: 15,
+      languageRequirements: ["English", "German"],
+    },
+  ];
+  const drink = { __typename: "Espresso" };
+  const originalData = deepFreeze({ user, post, authors, industries, drink });
+
+  const data = mask(
+    originalData,
+    query,
+    createFragmentMatcher(new InMemoryCache())
+  );
+
+  expect(data).toEqual({
+    user: {
+      __typename: "User",
+      id: 1,
+      profile: {
+        __typename: "Profile",
+        avatarUrl: "https://example.com/avatar.jpg",
+      },
+    },
+    post: { __typename: "Post", id: 1, title: "Test Post" },
+    authors: [{ __typename: "Author", id: 1, name: "A Author" }],
+    industries: [
+      { __typename: "TechIndustry", languageRequirements: ["TypeScript"] },
+      { __typename: "FinanceIndustry" },
+      { __typename: "TradeIndustry", id: 10, yearsInBusiness: 15 },
+    ],
+    drink: { __typename: "Espresso" },
+  });
+
+  expect(data).not.toBe(originalData);
+  expect(data.user).not.toBe(user);
+  expect(data.user.profile).toBe(profile);
+  expect(data.post).toBe(post);
+  expect(data.authors).toBe(authors);
+  expect(data.industries).not.toBe(industries);
+  expect(data.industries[0]).toBe(industries[0]);
+  expect(data.industries[1]).not.toBe(industries[1]);
+  expect(data.industries[2]).not.toBe(industries[2]);
+  expect(data.drink).toBe(drink);
+});
+
+test("maintains referential equality the entire result if there are no fragments", () => {
+  const query = gql`
+    query {
+      user {
+        __typename
+        id
+        name
+      }
+    }
+  `;
+
+  const originalData = deepFreeze({
+    user: {
+      __typename: "User",
+      id: 1,
+      name: "Test User",
+    },
+  });
+
+  const data = mask(
+    originalData,
+    query,
+    createFragmentMatcher(new InMemoryCache())
+  );
+
+  expect(data).toBe(originalData);
+});
+
+function createFragmentMatcher(cache: InMemoryCache) {
+  return (node: InlineFragmentNode, typename: string) =>
+    cache.policies.fragmentMatches(node, typename);
+}

--- a/src/core/masking.ts
+++ b/src/core/masking.ts
@@ -11,14 +11,11 @@ type MatchesFragmentFn = (
   typename: string
 ) => boolean;
 
-export function mask<
-  TData extends Record<string, unknown>,
-  TMaskedData extends Record<string, unknown> = TData,
->(
+export function mask<TData = unknown>(
   data: TData,
   document: TypedDocumentNode<TData> | DocumentNode,
   matchesFragment: MatchesFragmentFn
-): TMaskedData {
+): TData {
   const definition = getMainDefinition(document);
   const [masked, changed] = maskSelectionSet(
     data,

--- a/src/core/masking.ts
+++ b/src/core/masking.ts
@@ -1,0 +1,103 @@
+import { Kind } from "graphql";
+import type { InlineFragmentNode, SelectionSetNode } from "graphql";
+import {
+  getMainDefinition,
+  resultKeyNameFromField,
+} from "../utilities/index.js";
+import type { DocumentNode, TypedDocumentNode } from "./index.js";
+
+type MatchesFragmentFn = (
+  fragmentNode: InlineFragmentNode,
+  typename: string
+) => boolean;
+
+export function mask<
+  TData extends Record<string, unknown>,
+  TMaskedData extends Record<string, unknown> = TData,
+>(
+  data: TData,
+  document: TypedDocumentNode<TData> | DocumentNode,
+  matchesFragment: MatchesFragmentFn
+): TMaskedData {
+  const definition = getMainDefinition(document);
+  const [masked, changed] = maskSelectionSet(
+    data,
+    definition.selectionSet,
+    matchesFragment
+  );
+
+  return changed ? masked : data;
+}
+
+function maskSelectionSet(
+  data: any,
+  selectionSet: SelectionSetNode,
+  matchesFragment: MatchesFragmentFn
+): [data: any, changed: boolean] {
+  if (Array.isArray(data)) {
+    let changed = false;
+
+    const masked = data.map((item) => {
+      const [masked, itemChanged] = maskSelectionSet(
+        item,
+        selectionSet,
+        matchesFragment
+      );
+      changed ||= itemChanged;
+
+      return itemChanged ? masked : item;
+    });
+
+    return [changed ? masked : data, changed];
+  }
+
+  return selectionSet.selections.reduce<[any, boolean]>(
+    ([memo, changed], selection) => {
+      switch (selection.kind) {
+        case Kind.FIELD: {
+          const keyName = resultKeyNameFromField(selection);
+          const childSelectionSet = selection.selectionSet;
+
+          memo[keyName] = data[keyName];
+
+          if (childSelectionSet) {
+            const [masked, childChanged] = maskSelectionSet(
+              data[keyName],
+              childSelectionSet,
+              matchesFragment
+            );
+
+            if (childChanged) {
+              memo[keyName] = masked;
+              changed = true;
+            }
+          }
+
+          return [memo, changed];
+        }
+        case Kind.INLINE_FRAGMENT: {
+          if (!matchesFragment(selection, data.__typename)) {
+            return [memo, changed];
+          }
+
+          const [fragmentData, childChanged] = maskSelectionSet(
+            data,
+            selection.selectionSet,
+            matchesFragment
+          );
+
+          return [
+            {
+              ...memo,
+              ...fragmentData,
+            },
+            changed || childChanged,
+          ];
+        }
+        default:
+          return [memo, true];
+      }
+    },
+    [Object.create(null), false]
+  );
+}

--- a/src/utilities/common/maybeDeepFreeze.ts
+++ b/src/utilities/common/maybeDeepFreeze.ts
@@ -1,6 +1,6 @@
 import { isNonNullObject } from "./objects.js";
 
-function deepFreeze(value: any) {
+export function deepFreeze(value: any) {
   const workSet = new Set([value]);
   workSet.forEach((obj) => {
     if (isNonNullObject(obj) && shallowFreeze(obj) === obj) {

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -108,7 +108,7 @@ export {
 
 export * from "./common/mergeDeep.js";
 export * from "./common/cloneDeep.js";
-export * from "./common/maybeDeepFreeze.js";
+export { maybeDeepFreeze } from "./common/maybeDeepFreeze.js";
 export * from "./observables/iteration.js";
 export * from "./observables/asyncMap.js";
 export * from "./observables/Concast.js";


### PR DESCRIPTION
Partially addresses #11672

Add interfaces to the `Cache` abstract class that allows a cache to opt-in to data masking. Data masking requires a `fragmentMatches` function that accepts an inline fragment and a typename and returns a boolean. This will be used by the `mask` function to determine if a type condition matches when selecting against an interface or union type.

This function is optional in order to provide backwards compatibility. If this function is not provided by the subclass, this effectively disables data masking and the data will be returned unchanged with a warning emitted.