### PR TITLE
refactor useQuery to not use an internal class

### DIFF
--- a/.changeset/nasty-olives-act.md
+++ b/.changeset/nasty-olives-act.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": minor
+---
+
+Rewrite big parts of `useQuery` and `useLazyQuery` to be more compliant with the Rules of React and React Compiler

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 39808,
+  "dist/apollo-client.min.cjs": 39819,
   "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 32851
 }

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 39604,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 32852
+  "dist/apollo-client.min.cjs": 39808,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 32851
 }

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -38,7 +38,6 @@ import { useApolloClient } from "../useApolloClient";
 import { useLazyQuery } from "../useLazyQuery";
 
 const IS_REACT_17 = React.version.startsWith("17");
-const IS_REACT_19 = React.version.startsWith("19");
 
 describe("useQuery Hook", () => {
   describe("General use", () => {
@@ -1536,33 +1535,7 @@ describe("useQuery Hook", () => {
 
       function checkObservableQueries(expectedLinkCount: number) {
         const obsQueries = client.getObservableQueries("all");
-        /*
-This is due to a timing change in React 19
-
-In React 18, you observe this pattern:
-
-  1.  render
-  2.  useState initializer
-  3.  component continues to render with first state
-  4.  strictMode: render again
-  5.  strictMode: call useState initializer again
-  6.  component continues to render with second state
-
-now, in React 19 it looks like this:
-
-  1.  render
-  2.  useState initializer
-  3.  strictMode: call useState initializer again
-  4.  component continues to render with one of these two states
-  5.  strictMode: render again
-  6.  component continues to render with the same state as during the first render
-
-Since useQuery breaks the rules of React and mutably creates an ObservableQuery on the state during render if none is present, React 18 did create two, while React 19 only creates one.
-
-This is pure coincidence though, and the useQuery rewrite that doesn't break the rules of hooks as much and creates the ObservableQuery as part of the state initializer will end up with behaviour closer to the old React 18 behaviour again.
-
-*/
-        expect(obsQueries.size).toBe(IS_REACT_19 ? 1 : 2);
+        expect(obsQueries.size).toBe(2);
 
         const activeSet = new Set<typeof result.current.observable>();
         const inactiveSet = new Set<typeof result.current.observable>();

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -20,6 +20,7 @@ import {
   createWatchQueryOptions,
   getDefaultFetchPolicy,
   getObsQueryOptions,
+  lastWatchOptions,
   toQueryResult,
   useQueryWithInternalState,
 } from "./useQuery.js";
@@ -196,7 +197,7 @@ function executeQuery<TData, TVariables extends OperationVariables>(
     internalState.query = options.query;
   }
 
-  internalState.watchQueryOptions = createWatchQueryOptions(
+  const watchQueryOptions = createWatchQueryOptions(
     internalState.client,
     internalState.query,
     options,
@@ -208,10 +209,11 @@ function executeQuery<TData, TVariables extends OperationVariables>(
     getObsQueryOptions(
       internalState.client,
       options,
-      internalState.watchQueryOptions,
+      watchQueryOptions,
       internalState.observable
     )
   );
+  internalState.observable[lastWatchOptions] = watchQueryOptions;
 
   // Make sure getCurrentResult returns a fresh ApolloQueryResult<TData>,
   // but save the current data as this.previousData, just like setResult

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -197,13 +197,20 @@ function executeQuery<TData, TVariables extends OperationVariables>(
   }
 
   internalState.watchQueryOptions = createWatchQueryOptions(
+    internalState.client,
+    internalState.query,
     options,
-    internalState,
-    hasRenderPromises
+    hasRenderPromises,
+    internalState.observable
   );
 
   const concast = internalState.observable.reobserveAsConcast(
-    getObsQueryOptions(internalState, options)
+    getObsQueryOptions(
+      internalState.client,
+      options,
+      internalState.watchQueryOptions,
+      internalState.observable
+    )
   );
 
   // Make sure getCurrentResult returns a fresh ApolloQueryResult<TData>,

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -92,19 +92,20 @@ export function useLazyQuery<
   optionsRef.current = options;
   queryRef.current = document;
 
+  const queryHookOptions = {
+    ...merged,
+    skip: !execOptionsRef.current,
+  };
   const {
     internalState,
     obsQueryFields,
     result: useQueryResult,
-  } = useQueryWithInternalState(document, {
-    ...merged,
-    skip: !execOptionsRef.current,
-  });
+  } = useQueryWithInternalState(document, queryHookOptions);
 
   const initialFetchPolicy =
     useQueryResult.observable.options.initialFetchPolicy ||
     getDefaultFetchPolicy(
-      internalState.queryHookOptions.defaultOptions,
+      queryHookOptions.defaultOptions,
       internalState.client.defaultOptions
     );
 
@@ -196,13 +197,13 @@ function executeQuery<TData, TVariables extends OperationVariables>(
   }
 
   internalState.watchQueryOptions = createWatchQueryOptions(
-    (internalState.queryHookOptions = options),
+    options,
     internalState,
     hasRenderPromises
   );
 
   const concast = internalState.observable.reobserveAsConcast(
-    getObsQueryOptions(internalState)
+    getObsQueryOptions(internalState, options)
   );
 
   // Make sure getCurrentResult returns a fresh ApolloQueryResult<TData>,

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -18,6 +18,7 @@ import type {
 import type { InternalState } from "./useQuery.js";
 import {
   createWatchQueryOptions,
+  getDefaultFetchPolicy,
   toQueryResult,
   useInternalState,
   useQueryWithInternalState,
@@ -103,7 +104,10 @@ export function useLazyQuery<
 
   const initialFetchPolicy =
     useQueryResult.observable.options.initialFetchPolicy ||
-    internalState.getDefaultFetchPolicy();
+    getDefaultFetchPolicy(
+      internalState.queryHookOptions.defaultOptions,
+      internalState.client.defaultOptions
+    );
 
   const { obsQueryFields } = internalState;
   const forceUpdateState = React.useReducer((tick) => tick + 1, 0)[1];

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -10,7 +10,7 @@ import type {
   LazyQueryResultTuple,
   NoInfer,
 } from "../types/types.js";
-import { useInternalState } from "./useQuery.js";
+import { useInternalState, useQueryWithInternalState } from "./useQuery.js";
 import { useApolloClient } from "./useApolloClient.js";
 
 // The following methods, when called will execute the query, regardless of
@@ -85,7 +85,7 @@ export function useLazyQuery<
     document
   );
 
-  const useQueryResult = internalState.useQuery({
+  const useQueryResult = useQueryWithInternalState(internalState, {
     ...merged,
     skip: !execOptionsRef.current,
   });

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -19,6 +19,7 @@ import type { InternalState } from "./useQuery.js";
 import {
   createWatchQueryOptions,
   getDefaultFetchPolicy,
+  getObsQueryOptions,
   toQueryResult,
   useInternalState,
   useQueryWithInternalState,
@@ -195,7 +196,7 @@ function executeQuery<TData, TVariables extends OperationVariables>(
   );
 
   const concast = internalState.observable.reobserveAsConcast(
-    internalState.getObsQueryOptions()
+    getObsQueryOptions(internalState)
   );
 
   // Make sure getCurrentResult returns a fresh ApolloQueryResult<TData>,

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -22,7 +22,7 @@ import type {
   UpdateInternalState,
 } from "./useQuery.js";
 import {
-  createWatchQueryOptions,
+  createMakeWatchQueryOptions,
   getDefaultFetchPolicy,
   getObsQueryOptions,
   lastWatchOptions,
@@ -167,7 +167,6 @@ export function useLazyQuery<
 
       const promise = executeQuery(
         { ...options, skip: false },
-        false,
         document,
         resultData,
         observable,
@@ -208,7 +207,6 @@ function executeQuery<TData, TVariables extends OperationVariables>(
   options: QueryHookOptions<TData, TVariables> & {
     query?: DocumentNode;
   },
-  hasRenderPromises: boolean,
   currentQuery: DocumentNode,
   resultData: InternalResult<TData, TVariables>,
   observable: ObsQueryWithMeta<TData, TVariables>,
@@ -216,13 +214,12 @@ function executeQuery<TData, TVariables extends OperationVariables>(
   updateInternalState: UpdateInternalState<TData, TVariables>
 ) {
   const query = options.query || currentQuery;
-  const watchQueryOptions = createWatchQueryOptions(
+  const watchQueryOptions = createMakeWatchQueryOptions(
     client,
     query,
     options,
-    hasRenderPromises,
-    observable
-  );
+    false
+  )(observable);
 
   const concast = observable.reobserveAsConcast(
     getObsQueryOptions(client, options, watchQueryOptions, observable)

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -27,7 +27,7 @@ import {
   getObsQueryOptions,
   lastWatchOptions,
   toQueryResult,
-  useQueryWithInternalState,
+  useQueryInternals,
 } from "./useQuery.js";
 
 // The following methods, when called will execute the query, regardless of
@@ -109,7 +109,7 @@ export function useLazyQuery<
     resultData,
     observable,
     updateInternalState,
-  } = useQueryWithInternalState(document, queryHookOptions);
+  } = useQueryInternals(document, queryHookOptions);
 
   const initialFetchPolicy =
     observable.options.initialFetchPolicy ||

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -142,7 +142,7 @@ export function useLazyQuery<
       });
 
       const promise = internalState
-        .executeQuery({ ...options, skip: false })
+        .executeQuery({ ...options, skip: false }, false)
         .then((queryResult) => Object.assign(queryResult, eagerMethods));
 
       // Because the return value of `useLazyQuery` is usually floated, we need

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -18,6 +18,7 @@ import type {
 import type { InternalState } from "./useQuery.js";
 import {
   createWatchQueryOptions,
+  toQueryResult,
   useInternalState,
   useQueryWithInternalState,
 } from "./useQuery.js";
@@ -214,13 +215,14 @@ function executeQuery<TData, TVariables extends OperationVariables>(
       },
       error: () => {
         resolve(
-          internalState.toQueryResult(
-            internalState.observable.getCurrentResult()
+          toQueryResult(
+            internalState.observable.getCurrentResult(),
+            internalState
           )
         );
       },
       complete: () => {
-        resolve(internalState.toQueryResult(result));
+        resolve(toQueryResult(result, internalState));
       },
     });
   });

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -25,6 +25,7 @@ import {
   toQueryResult,
   useQueryInternals,
 } from "./useQuery.js";
+import { useIsomorphicLayoutEffect } from "./internal/useIsomorphicLayoutEffect.js";
 
 // The following methods, when called will execute the query, regardless of
 // whether the useLazyQuery execute function was called before.
@@ -188,7 +189,7 @@ export function useLazyQuery<
   );
 
   const executeRef = React.useRef(execute);
-  React.useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     executeRef.current = execute;
   });
 
@@ -239,14 +240,16 @@ function executeQuery<TData, TVariables extends OperationVariables>(
         resolve(
           toQueryResult(
             observable.getCurrentResult(),
-            resultData,
+            resultData.previousData,
             observable,
             client
           )
         );
       },
       complete: () => {
-        resolve(toQueryResult(result, resultData, observable, client));
+        resolve(
+          toQueryResult(result, resultData.previousData, observable, client)
+        );
       },
     });
   });

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -276,18 +276,7 @@ export function useQueryInternals<
 
   const obsQueryFields = React.useMemo<
     Omit<ObservableQueryFields<TData, TVariables>, "variables">
-  >(
-    () => ({
-      refetch: observable.refetch.bind(observable),
-      reobserve: observable.reobserve.bind(observable),
-      fetchMore: observable.fetchMore.bind(observable),
-      updateQuery: observable.updateQuery.bind(observable),
-      startPolling: observable.startPolling.bind(observable),
-      stopPolling: observable.stopPolling.bind(observable),
-      subscribeToMore: observable.subscribeToMore.bind(observable),
-    }),
-    [observable]
-  );
+  >(() => bindObservableMethods(observable), [observable]);
 
   if (
     (renderPromises || disableNetworkFetches) &&
@@ -769,3 +758,17 @@ const skipStandbyResult = maybeDeepFreeze({
   error: void 0,
   networkStatus: NetworkStatus.ready,
 });
+
+function bindObservableMethods<TData, TVariables extends OperationVariables>(
+  observable: ObservableQuery<TData, TVariables>
+) {
+  return {
+    refetch: observable.refetch.bind(observable),
+    reobserve: observable.reobserve.bind(observable),
+    fetchMore: observable.fetchMore.bind(observable),
+    updateQuery: observable.updateQuery.bind(observable),
+    startPolling: observable.startPolling.bind(observable),
+    stopPolling: observable.stopPolling.bind(observable),
+    subscribeToMore: observable.subscribeToMore.bind(observable),
+  };
+}

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -552,7 +552,6 @@ export function toQueryResult<TData, TVariables extends OperationVariables>(
 ): InternalQueryResult<TData, TVariables> {
   const { data, partial, ...resultWithoutPartial } = result;
   const queryResult: InternalQueryResult<TData, TVariables> = {
-    [originalResult]: result,
     data, // Ensure always defined, even if result.data is missing.
     ...resultWithoutPartial,
     ...internalState.obsQueryFields,
@@ -561,7 +560,12 @@ export function toQueryResult<TData, TVariables extends OperationVariables>(
     variables: internalState.observable.variables,
     called: !internalState.queryHookOptions.skip,
     previousData: internalState.previousData,
-  };
+  } satisfies QueryResult<TData, TVariables> as InternalQueryResult<
+    TData,
+    TVariables
+  >;
+  // non-enumerable property to hold the original result, for referential equality checks
+  Object.defineProperty(queryResult, originalResult, { value: result });
 
   if (!queryResult.error && isNonEmptyArray(result.errors)) {
     // Until a set naming convention for networkError and graphQLErrors is

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -320,6 +320,8 @@ export function useQueryInternals<
       client
     );
   } else if (
+    // reset result if the last render was skipping for some reason,
+    // but this render isn't skipping anymore
     resultData.current &&
     (resultData.current[originalResult] === ssrDisabledResult ||
       resultData.current[originalResult] === skipStandbyResult)


### PR DESCRIPTION
After #11890, I'm fairly confident in this now.

This needs to be reviewed commit-by commit, although a bunch of merges added additional commits at the start and end - I'm really sorry for those! (I believe some of them will disappear here if #11890 gets merged first!)

There might be more PRs to further streamline the result handling, but I think this PR is big enough as it is right now.