### PR TITLE
[Data masking] Add function to mask fragment data

### DIFF
--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -23,7 +23,7 @@ import type {
 } from "../../core/types.js";
 import type { MissingTree } from "./types/common.js";
 import { equalByQuery } from "../../core/equalByQuery.js";
-import { mask } from "../../core/masking.js";
+import { maskQuery } from "../../core/masking.js";
 import { invariant } from "../../utilities/globals/index.js";
 
 export type Transaction<T> = (c: ApolloCache<T>) => void;
@@ -381,7 +381,7 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
       return data;
     }
 
-    return mask(data, document, this.fragmentMatches.bind(this));
+    return maskQuery(data, document, this.fragmentMatches.bind(this));
   }
 
   /**

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -370,7 +370,7 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
     });
   }
 
-  public maskDocument<TData = unknown>(document: DocumentNode, data: TData) {
+  public maskQuery<TData = unknown>(document: DocumentNode, data: TData) {
     if (!this.fragmentMatches) {
       if (__DEV__) {
         invariant.warn(

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -370,7 +370,7 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
     });
   }
 
-  public maskQuery<TData = unknown>(document: DocumentNode, data: TData) {
+  public maskDocument<TData = unknown>(document: DocumentNode, data: TData) {
     if (!this.fragmentMatches) {
       if (__DEV__) {
         invariant.warn(

--- a/src/core/__tests__/masking.test.ts
+++ b/src/core/__tests__/masking.test.ts
@@ -1,4 +1,4 @@
-import { mask } from "../masking.js";
+import { maskQuery } from "../masking.js";
 import { InMemoryCache, gql } from "../index.js";
 import { InlineFragmentNode } from "graphql";
 import { deepFreeze } from "../../utilities/common/maybeDeepFreeze.js";
@@ -15,7 +15,7 @@ test("strips top-level fragment data from query", () => {
     }
   `;
 
-  const data = mask(
+  const data = maskQuery(
     { foo: true, bar: true },
     query,
     createFragmentMatcher(new InMemoryCache())
@@ -39,7 +39,7 @@ test("strips fragment data from nested object", () => {
     }
   `;
 
-  const data = mask(
+  const data = maskQuery(
     { user: { __typename: "User", id: 1, name: "Test User" } },
     query,
     createFragmentMatcher(new InMemoryCache())
@@ -63,7 +63,7 @@ test("strips fragment data from arrays", () => {
     }
   `;
 
-  const data = mask(
+  const data = maskQuery(
     {
       users: [
         { __typename: "User", id: 1, name: "Test User 1" },
@@ -102,7 +102,7 @@ test("strips multiple fragments in the same selection set", () => {
     }
   `;
 
-  const data = mask(
+  const data = maskQuery(
     {
       user: {
         __typename: "User",
@@ -144,7 +144,7 @@ test("strips multiple fragments across different selection sets", () => {
     }
   `;
 
-  const data = mask(
+  const data = maskQuery(
     {
       user: {
         __typename: "User",
@@ -184,7 +184,7 @@ test("leaves overlapping fields in query", () => {
     }
   `;
 
-  const data = mask(
+  const data = maskQuery(
     {
       user: {
         __typename: "User",
@@ -225,7 +225,7 @@ test("does not strip inline fragments", () => {
     }
   `;
 
-  const data = mask(
+  const data = maskQuery(
     {
       user: {
         __typename: "User",
@@ -296,7 +296,7 @@ test("strips named fragments inside inline fragments", () => {
     }
   `;
 
-  const data = mask(
+  const data = maskQuery(
     {
       user: {
         __typename: "User",
@@ -347,7 +347,7 @@ test("handles objects with no matching inline fragment condition", () => {
     }
   `;
 
-  const data = mask(
+  const data = maskQuery(
     {
       drinks: [
         { __typename: "HotChocolate", id: 1 },
@@ -380,7 +380,7 @@ test("handles field aliases", () => {
     }
   `;
 
-  const data = mask(
+  const data = maskQuery(
     {
       user: {
         __typename: "User",
@@ -473,7 +473,7 @@ test("handles overlapping fields inside multiple inline fragments", () => {
     }
   `;
 
-  const data = mask(
+  const data = maskQuery(
     {
       drinks: [
         {
@@ -564,7 +564,7 @@ test("does nothing if there are no fragments to mask", () => {
     }
   `;
 
-  const data = mask(
+  const data = maskQuery(
     { user: { __typename: "User", id: 1, name: "Test User" } },
     query,
     createFragmentMatcher(new InMemoryCache())
@@ -655,7 +655,7 @@ test("maintains referential equality on subtrees that did not change", () => {
   const drink = { __typename: "Espresso" };
   const originalData = deepFreeze({ user, post, authors, industries, drink });
 
-  const data = mask(
+  const data = maskQuery(
     originalData,
     query,
     createFragmentMatcher(new InMemoryCache())
@@ -711,7 +711,7 @@ test("maintains referential equality the entire result if there are no fragments
     },
   });
 
-  const data = mask(
+  const data = maskQuery(
     originalData,
     query,
     createFragmentMatcher(new InMemoryCache())

--- a/src/core/__tests__/masking.test.ts
+++ b/src/core/__tests__/masking.test.ts
@@ -816,7 +816,7 @@ test("throws when document contains more than 1 fragment without a fragmentName"
     )
   ).toThrow(
     new InvariantError(
-      "Found 2 fragments. `fragmentName` must be provided when there is more than 1 fragment."
+      "Found 2 fragments. `fragmentName` must be provided when there is not exactly 1 fragment."
     )
   );
 });

--- a/src/core/masking.ts
+++ b/src/core/masking.ts
@@ -11,7 +11,7 @@ type MatchesFragmentFn = (
   typename: string
 ) => boolean;
 
-export function mask<TData = unknown>(
+export function maskQuery<TData = unknown>(
   data: TData,
   document: TypedDocumentNode<TData> | DocumentNode,
   matchesFragment: MatchesFragmentFn

--- a/src/core/masking.ts
+++ b/src/core/masking.ts
@@ -45,7 +45,7 @@ export function maskFragment<TData = unknown>(
   if (typeof fragmentName === "undefined") {
     invariant(
       fragments.length === 1,
-      `Found %s fragments. \`fragmentName\` must be provided when there is more than 1 fragment.`,
+      `Found %s fragments. \`fragmentName\` must be provided when there is not exactly 1 fragment.`,
       fragments.length
     );
     fragmentName = fragments[0].name.value;


### PR DESCRIPTION
Closes https://github.com/apollographql/apollo-client/issues/11671

This adds the other half of data masking which is to mask a fragment document with nested fragments. As such, the `mask` function has been renamed to `maskQuery` and a `maskFragment` function as been added.