### PR TITLE
[Data masking] Add ability to globally enable data masking for queries

### DIFF
--- a/.api-reports/api-report-cache.md
+++ b/.api-reports/api-report-cache.md
@@ -24,6 +24,8 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
     readonly assumeImmutableResults: boolean;
     // (undocumented)
     batch<U>(options: Cache_2.BatchOptions<this, U>): U;
+    // @internal (undocumented)
+    dataMaskingEnabledInClient: boolean;
     // (undocumented)
     abstract diff<T>(query: Cache_2.DiffOptions): Cache_2.DiffResult<T>;
     // (undocumented)

--- a/.api-reports/api-report-core.md
+++ b/.api-reports/api-report-core.md
@@ -39,6 +39,8 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
     readonly assumeImmutableResults: boolean;
     // (undocumented)
     batch<U>(options: Cache_2.BatchOptions<this, U>): U;
+    // @internal (undocumented)
+    dataMaskingEnabledInClient: boolean;
     // (undocumented)
     abstract diff<T>(query: Cache_2.DiffOptions): Cache_2.DiffResult<T>;
     // (undocumented)
@@ -151,6 +153,7 @@ export interface ApolloClientOptions<TCacheShape> {
     connectToDevTools?: boolean;
     // (undocumented)
     credentials?: string;
+    dataMasking?: boolean;
     // (undocumented)
     defaultContext?: Partial<DefaultContext>;
     defaultOptions?: DefaultOptions;

--- a/.api-reports/api-report-react.md
+++ b/.api-reports/api-report-react.md
@@ -35,6 +35,8 @@ abstract class ApolloCache<TSerialized> implements DataProxy {
     readonly assumeImmutableResults: boolean;
     // (undocumented)
     batch<U>(options: Cache_2.BatchOptions<this, U>): U;
+    // @internal (undocumented)
+    dataMaskingEnabledInClient: boolean;
     // (undocumented)
     abstract diff<T>(query: Cache_2.DiffOptions): Cache_2.DiffResult<T>;
     // (undocumented)
@@ -179,6 +181,7 @@ interface ApolloClientOptions<TCacheShape> {
     connectToDevTools?: boolean;
     // (undocumented)
     credentials?: string;
+    dataMasking?: boolean;
     // (undocumented)
     defaultContext?: Partial<Context>;
     defaultOptions?: DefaultOptions;

--- a/.api-reports/api-report-react_components.md
+++ b/.api-reports/api-report-react_components.md
@@ -35,6 +35,8 @@ abstract class ApolloCache<TSerialized> implements DataProxy {
     readonly assumeImmutableResults: boolean;
     // (undocumented)
     batch<U>(options: Cache_2.BatchOptions<this, U>): U;
+    // @internal (undocumented)
+    dataMaskingEnabledInClient: boolean;
     // (undocumented)
     abstract diff<T>(query: Cache_2.DiffOptions): Cache_2.DiffResult<T>;
     // (undocumented)
@@ -180,6 +182,7 @@ interface ApolloClientOptions<TCacheShape> {
     connectToDevTools?: boolean;
     // (undocumented)
     credentials?: string;
+    dataMasking?: boolean;
     // (undocumented)
     defaultContext?: Partial<DefaultContext>;
     defaultOptions?: DefaultOptions;

--- a/.api-reports/api-report-react_context.md
+++ b/.api-reports/api-report-react_context.md
@@ -34,6 +34,8 @@ abstract class ApolloCache<TSerialized> implements DataProxy {
     readonly assumeImmutableResults: boolean;
     // (undocumented)
     batch<U>(options: Cache_2.BatchOptions<this, U>): U;
+    // @internal (undocumented)
+    dataMaskingEnabledInClient: boolean;
     // (undocumented)
     abstract diff<T>(query: Cache_2.DiffOptions): Cache_2.DiffResult<T>;
     // (undocumented)
@@ -179,6 +181,7 @@ interface ApolloClientOptions<TCacheShape> {
     connectToDevTools?: boolean;
     // (undocumented)
     credentials?: string;
+    dataMasking?: boolean;
     // (undocumented)
     defaultContext?: Partial<DefaultContext>;
     defaultOptions?: DefaultOptions;

--- a/.api-reports/api-report-react_hoc.md
+++ b/.api-reports/api-report-react_hoc.md
@@ -34,6 +34,8 @@ abstract class ApolloCache<TSerialized> implements DataProxy {
     readonly assumeImmutableResults: boolean;
     // (undocumented)
     batch<U>(options: Cache_2.BatchOptions<this, U>): U;
+    // @internal (undocumented)
+    dataMaskingEnabledInClient: boolean;
     // (undocumented)
     abstract diff<T>(query: Cache_2.DiffOptions): Cache_2.DiffResult<T>;
     // (undocumented)
@@ -179,6 +181,7 @@ interface ApolloClientOptions<TCacheShape> {
     connectToDevTools?: boolean;
     // (undocumented)
     credentials?: string;
+    dataMasking?: boolean;
     // (undocumented)
     defaultContext?: Partial<DefaultContext>;
     defaultOptions?: DefaultOptions;

--- a/.api-reports/api-report-react_hooks.md
+++ b/.api-reports/api-report-react_hooks.md
@@ -33,6 +33,8 @@ abstract class ApolloCache<TSerialized> implements DataProxy {
     readonly assumeImmutableResults: boolean;
     // (undocumented)
     batch<U>(options: Cache_2.BatchOptions<this, U>): U;
+    // @internal (undocumented)
+    dataMaskingEnabledInClient: boolean;
     // (undocumented)
     abstract diff<T>(query: Cache_2.DiffOptions): Cache_2.DiffResult<T>;
     // (undocumented)
@@ -178,6 +180,7 @@ interface ApolloClientOptions<TCacheShape> {
     connectToDevTools?: boolean;
     // (undocumented)
     credentials?: string;
+    dataMasking?: boolean;
     // (undocumented)
     defaultContext?: Partial<DefaultContext>;
     defaultOptions?: DefaultOptions;

--- a/.api-reports/api-report-react_internal.md
+++ b/.api-reports/api-report-react_internal.md
@@ -33,6 +33,8 @@ abstract class ApolloCache<TSerialized> implements DataProxy {
     readonly assumeImmutableResults: boolean;
     // (undocumented)
     batch<U>(options: Cache_2.BatchOptions<this, U>): U;
+    // @internal (undocumented)
+    dataMaskingEnabledInClient: boolean;
     // (undocumented)
     abstract diff<T>(query: Cache_2.DiffOptions): Cache_2.DiffResult<T>;
     // (undocumented)
@@ -178,6 +180,7 @@ interface ApolloClientOptions<TCacheShape> {
     connectToDevTools?: boolean;
     // (undocumented)
     credentials?: string;
+    dataMasking?: boolean;
     // (undocumented)
     defaultContext?: Partial<DefaultContext>;
     defaultOptions?: DefaultOptions;

--- a/.api-reports/api-report-react_ssr.md
+++ b/.api-reports/api-report-react_ssr.md
@@ -34,6 +34,8 @@ abstract class ApolloCache<TSerialized> implements DataProxy {
     readonly assumeImmutableResults: boolean;
     // (undocumented)
     batch<U>(options: Cache_2.BatchOptions<this, U>): U;
+    // @internal (undocumented)
+    dataMaskingEnabledInClient: boolean;
     // (undocumented)
     abstract diff<T>(query: Cache_2.DiffOptions): Cache_2.DiffResult<T>;
     // (undocumented)
@@ -179,6 +181,7 @@ interface ApolloClientOptions<TCacheShape> {
     connectToDevTools?: boolean;
     // (undocumented)
     credentials?: string;
+    dataMasking?: boolean;
     // (undocumented)
     defaultContext?: Partial<DefaultContext>;
     defaultOptions?: DefaultOptions;

--- a/.api-reports/api-report-testing.md
+++ b/.api-reports/api-report-testing.md
@@ -34,6 +34,8 @@ abstract class ApolloCache<TSerialized> implements DataProxy {
     readonly assumeImmutableResults: boolean;
     // (undocumented)
     batch<U>(options: Cache_2.BatchOptions<this, U>): U;
+    // @internal (undocumented)
+    dataMaskingEnabledInClient: boolean;
     // (undocumented)
     abstract diff<T>(query: Cache_2.DiffOptions): Cache_2.DiffResult<T>;
     // (undocumented)
@@ -179,6 +181,7 @@ interface ApolloClientOptions<TCacheShape> {
     connectToDevTools?: boolean;
     // (undocumented)
     credentials?: string;
+    dataMasking?: boolean;
     // (undocumented)
     defaultContext?: Partial<DefaultContext>;
     defaultOptions?: DefaultOptions;

--- a/.api-reports/api-report-testing_core.md
+++ b/.api-reports/api-report-testing_core.md
@@ -33,6 +33,8 @@ abstract class ApolloCache<TSerialized> implements DataProxy {
     readonly assumeImmutableResults: boolean;
     // (undocumented)
     batch<U>(options: Cache_2.BatchOptions<this, U>): U;
+    // @internal (undocumented)
+    dataMaskingEnabledInClient: boolean;
     // (undocumented)
     abstract diff<T>(query: Cache_2.DiffOptions): Cache_2.DiffResult<T>;
     // (undocumented)
@@ -178,6 +180,7 @@ interface ApolloClientOptions<TCacheShape> {
     connectToDevTools?: boolean;
     // (undocumented)
     credentials?: string;
+    dataMasking?: boolean;
     // (undocumented)
     defaultContext?: Partial<DefaultContext>;
     defaultOptions?: DefaultOptions;

--- a/.api-reports/api-report-utilities.md
+++ b/.api-reports/api-report-utilities.md
@@ -50,6 +50,8 @@ abstract class ApolloCache<TSerialized> implements DataProxy {
     readonly assumeImmutableResults: boolean;
     // (undocumented)
     batch<U>(options: Cache_2.BatchOptions<this, U>): U;
+    // @internal (undocumented)
+    dataMaskingEnabledInClient: boolean;
     // (undocumented)
     abstract diff<T>(query: Cache_2.DiffOptions): Cache_2.DiffResult<T>;
     // (undocumented)
@@ -190,6 +192,7 @@ interface ApolloClientOptions<TCacheShape> {
     connectToDevTools?: boolean;
     // (undocumented)
     credentials?: string;
+    dataMasking?: boolean;
     // (undocumented)
     defaultContext?: Partial<DefaultContext>;
     defaultOptions?: DefaultOptions;

--- a/.api-reports/api-report.md
+++ b/.api-reports/api-report.md
@@ -41,6 +41,8 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
     readonly assumeImmutableResults: boolean;
     // (undocumented)
     batch<U>(options: Cache_2.BatchOptions<this, U>): U;
+    // @internal (undocumented)
+    dataMaskingEnabledInClient: boolean;
     // (undocumented)
     abstract diff<T>(query: Cache_2.DiffOptions): Cache_2.DiffResult<T>;
     // (undocumented)
@@ -153,6 +155,7 @@ export interface ApolloClientOptions<TCacheShape> {
     connectToDevTools?: boolean;
     // (undocumented)
     credentials?: string;
+    dataMasking?: boolean;
     // (undocumented)
     defaultContext?: Partial<DefaultContext>;
     defaultOptions?: DefaultOptions;

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 39829,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 33126
+  "dist/apollo-client.min.cjs": 39928,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 33220
 }

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -6589,7 +6589,95 @@ describe("data masking", () => {
           __typename: "User",
           id: 1,
           name: "Test User",
-          age: 30
+          age: 30,
+        },
+      });
+    }
+  });
+
+  it("masks queries updated by the cache", async () => {
+    interface Query {
+      currentUser: {
+        __typename: "User";
+        id: number;
+        name: string;
+      };
+    }
+
+    const query: TypedDocumentNode<Query, never> = gql`
+      query MaskedQuery {
+        currentUser {
+          id
+          name
+          ...UserFields
+        }
+      }
+
+      fragment UserFields on User {
+        age
+      }
+    `;
+
+    const mocks = [
+      {
+        request: { query },
+        result: {
+          data: {
+            currentUser: {
+              __typename: "User",
+              id: 1,
+              name: "Test User",
+              age: 30,
+            },
+          },
+        },
+      },
+    ];
+
+    const client = new ApolloClient({
+      dataMasking: true,
+      cache: new InMemoryCache(),
+      link: new MockLink(mocks),
+    });
+
+    const observable = client.watchQuery({ query });
+
+    const stream = new ObservableStream(observable);
+
+    {
+      const { data } = await stream.takeNext();
+
+      expect(data).toEqual({
+        currentUser: {
+          __typename: "User",
+          id: 1,
+          name: "Test User",
+        },
+      });
+    }
+
+    client.writeQuery({
+      query,
+      data: {
+        currentUser: {
+          __typename: "User",
+          id: 1,
+          name: "Test User (updated)",
+          // @ts-ignore TODO: Determine how to handle cache writes with masked
+          // query type
+          age: 35,
+        },
+      },
+    });
+
+    {
+      const { data } = await stream.takeNext();
+
+      expect(data).toEqual({
+        currentUser: {
+          __typename: "User",
+          id: 1,
+          name: "Test User (updated)",
         },
       });
     }

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -6469,6 +6469,131 @@ describe("data masking", () => {
       });
     }
   });
+
+  it("does not mask query when dataMasking is `false`", async () => {
+    interface Query {
+      currentUser: {
+        __typename: "User";
+        id: number;
+        name: string;
+      };
+    }
+
+    const query: TypedDocumentNode<Query, never> = gql`
+      query MaskedQuery {
+        currentUser {
+          id
+          name
+          ...UserFields
+        }
+      }
+
+      fragment UserFields on User {
+        age
+      }
+    `;
+
+    const mocks = [
+      {
+        request: { query },
+        result: {
+          data: {
+            currentUser: {
+              __typename: "User",
+              id: 1,
+              name: "Test User",
+              age: 30,
+            },
+          },
+        },
+      },
+    ];
+
+    const client = new ApolloClient({
+      dataMasking: false,
+      cache: new InMemoryCache(),
+      link: new MockLink(mocks),
+    });
+
+    const observable = client.watchQuery({ query });
+
+    const stream = new ObservableStream(observable);
+
+    {
+      const { data } = await stream.takeNext();
+
+      expect(data).toEqual({
+        currentUser: {
+          __typename: "User",
+          id: 1,
+          name: "Test User",
+          age: 30,
+        },
+      });
+    }
+  });
+
+  it("does not mask query by default", async () => {
+    interface Query {
+      currentUser: {
+        __typename: "User";
+        id: number;
+        name: string;
+      };
+    }
+
+    const query: TypedDocumentNode<Query, never> = gql`
+      query MaskedQuery {
+        currentUser {
+          id
+          name
+          ...UserFields
+        }
+      }
+
+      fragment UserFields on User {
+        age
+      }
+    `;
+
+    const mocks = [
+      {
+        request: { query },
+        result: {
+          data: {
+            currentUser: {
+              __typename: "User",
+              id: 1,
+              name: "Test User",
+              age: 30,
+            },
+          },
+        },
+      },
+    ];
+
+    const client = new ApolloClient({
+      cache: new InMemoryCache(),
+      link: new MockLink(mocks),
+    });
+
+    const observable = client.watchQuery({ query });
+
+    const stream = new ObservableStream(observable);
+
+    {
+      const { data } = await stream.takeNext();
+
+      expect(data).toEqual({
+        currentUser: {
+          __typename: "User",
+          id: 1,
+          name: "Test User",
+          age: 30
+        },
+      });
+    }
+  });
 });
 
 function clientRoundtrip(

--- a/src/cache/core/__tests__/cache.ts
+++ b/src/cache/core/__tests__/cache.ts
@@ -184,6 +184,7 @@ describe("abstract cache", () => {
         user: { __typename: "User", id: 1, name: "Mister Masked" },
       };
       const cache = new TestCache();
+      cache.dataMaskingEnabledInClient = true;
 
       const result = cache.maskDocument(query, data);
 
@@ -196,6 +197,8 @@ describe("abstract cache", () => {
 
     it("returns masked query for caches that implement required interface", () => {
       class MaskingCache extends TestCache {
+        public dataMaskingEnabledInClient = true;
+
         protected fragmentMatches(
           _fragment: InlineFragmentNode,
           _typename: string

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -102,6 +102,9 @@ export type WatchFragmentResult<TData> =
 export abstract class ApolloCache<TSerialized> implements DataProxy {
   public readonly assumeImmutableResults: boolean = false;
 
+  /** @internal */
+  public dataMaskingEnabledInClient: boolean = false;
+
   // required to implement
   // core API
   public abstract read<TData = any, TVariables = any>(

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -384,6 +384,10 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
       return data;
     }
 
+    if (!this.dataMaskingEnabledInClient) {
+      return data;
+    }
+
     return maskQuery(data, document, this.fragmentMatches.bind(this));
   }
 

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -374,6 +374,10 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
   }
 
   public maskDocument<TData = unknown>(document: DocumentNode, data: TData) {
+    if (!this.dataMaskingEnabledInClient) {
+      return data;
+    }
+
     if (!this.fragmentMatches) {
       if (__DEV__) {
         invariant.warn(
@@ -381,10 +385,6 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
         );
       }
 
-      return data;
-    }
-
-    if (!this.dataMaskingEnabledInClient) {
       return data;
     }
 

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -220,7 +220,7 @@ export class ApolloClient<TCacheShape> implements DataProxy {
       fragmentMatcher,
       name: clientAwarenessName,
       version: clientAwarenessVersion,
-      dataMasking = false,
+      dataMasking,
     } = options;
 
     let { link } = options;

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -120,6 +120,13 @@ export interface ApolloClientOptions<TCacheShape> {
    */
   version?: string;
   documentTransform?: DocumentTransform;
+
+  /**
+   * Determines if data masking is enabled for the client.
+   *
+   * @default false
+   */
+  dataMasking?: boolean;
 }
 
 // Though mergeOptions now resides in @apollo/client/utilities, it was
@@ -213,6 +220,7 @@ export class ApolloClient<TCacheShape> implements DataProxy {
       fragmentMatcher,
       name: clientAwarenessName,
       version: clientAwarenessVersion,
+      dataMasking = false,
     } = options;
 
     let { link } = options;
@@ -224,6 +232,7 @@ export class ApolloClient<TCacheShape> implements DataProxy {
 
     this.link = link;
     this.cache = cache;
+    this.cache.dataMaskingEnabledInClient = !!dataMasking;
     this.disableNetworkFetches = ssrMode || ssrForceFetchDelay > 0;
     this.queryDeduplication = queryDeduplication;
     this.defaultOptions = defaultOptions || Object.create(null);

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -269,10 +269,7 @@ export class ObservableQuery<
       const diff = this.queryInfo.getDiff();
 
       if (diff.complete || this.options.returnPartialData) {
-        result.data = this.queryManager.cache.maskDocument(
-          this.query,
-          diff.result
-        );
+        result.data = this.maskQuery(diff.result);
       }
 
       if (equal(result.data, {})) {
@@ -1011,7 +1008,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     result: ApolloQueryResult<TData>,
     variables: TVariables | undefined
   ) {
-    result.data = this.queryManager.cache.maskDocument(this.query, result.data);
+    result.data = this.maskQuery(result.data);
     const lastError = this.getLastError();
     const isDifferent = this.isDifferentFromLastResult(result, variables);
     // Update the last result even when isDifferentFromLastResult returns false,
@@ -1065,6 +1062,10 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
 
   private transformDocument(document: DocumentNode) {
     return this.queryManager.transform(document);
+  }
+
+  private maskQuery(data: TData) {
+    return this.queryManager.cache.maskDocument(this.query, data);
   }
 }
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1008,6 +1008,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     result: ApolloQueryResult<TData>,
     variables: TVariables | undefined
   ) {
+    result.data = this.queryManager.cache.maskDocument(this.query, result.data);
     const lastError = this.getLastError();
     const isDifferent = this.isDifferentFromLastResult(result, variables);
     // Update the last result even when isDifferentFromLastResult returns false,

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -269,7 +269,10 @@ export class ObservableQuery<
       const diff = this.queryInfo.getDiff();
 
       if (diff.complete || this.options.returnPartialData) {
-        result.data = diff.result;
+        result.data = this.queryManager.cache.maskDocument(
+          this.query,
+          diff.result
+        );
       }
 
       if (equal(result.data, {})) {

--- a/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
@@ -10566,6 +10566,886 @@ describe("useSuspenseQuery", () => {
     await expect(Profiler).not.toRerender();
   });
 
+  it("masks queries when dataMasking is `true`", async () => {
+    interface Query {
+      currentUser: {
+        __typename: "User";
+        id: number;
+        name: string;
+      };
+    }
+
+    const query: TypedDocumentNode<Query, never> = gql`
+      query MaskedQuery {
+        currentUser {
+          id
+          name
+          ...UserFields
+        }
+      }
+
+      fragment UserFields on User {
+        age
+      }
+    `;
+
+    const mocks = [
+      {
+        request: { query },
+        result: {
+          data: {
+            currentUser: {
+              __typename: "User",
+              id: 1,
+              name: "Test User",
+              age: 30,
+            },
+          },
+        },
+      },
+    ];
+
+    const client = new ApolloClient({
+      dataMasking: true,
+      cache: new InMemoryCache(),
+      link: new MockLink(mocks),
+    });
+
+    const Profiler = createProfiler({
+      initialSnapshot: {
+        result: null as UseSuspenseQueryResult<Query, never> | null,
+      },
+    });
+
+    function App() {
+      const result = useSuspenseQuery(query);
+
+      Profiler.replaceSnapshot({ result });
+
+      return null;
+    }
+
+    render(<App />, {
+      wrapper: ({ children }) => (
+        <ApolloProvider client={client}>
+          <Profiler>
+            <Suspense fallback={<div>Loading...</div>}>{children}</Suspense>
+          </Profiler>
+        </ApolloProvider>
+      ),
+    });
+
+    // loading
+    await Profiler.takeRender();
+
+    {
+      const { snapshot } = await Profiler.takeRender();
+      const { result } = snapshot;
+
+      expect(result?.data).toEqual({
+        currentUser: {
+          __typename: "User",
+          id: 1,
+          name: "Test User",
+        },
+      });
+    }
+  });
+
+  it("does not mask query when dataMasking is `false`", async () => {
+    interface Query {
+      currentUser: {
+        __typename: "User";
+        id: number;
+        name: string;
+      };
+    }
+
+    const query: TypedDocumentNode<Query, never> = gql`
+      query MaskedQuery {
+        currentUser {
+          id
+          name
+          ...UserFields
+        }
+      }
+
+      fragment UserFields on User {
+        age
+      }
+    `;
+
+    const mocks = [
+      {
+        request: { query },
+        result: {
+          data: {
+            currentUser: {
+              __typename: "User",
+              id: 1,
+              name: "Test User",
+              age: 30,
+            },
+          },
+        },
+      },
+    ];
+
+    const client = new ApolloClient({
+      dataMasking: false,
+      cache: new InMemoryCache(),
+      link: new MockLink(mocks),
+    });
+
+    const Profiler = createProfiler({
+      initialSnapshot: {
+        result: null as UseSuspenseQueryResult<Query, never> | null,
+      },
+    });
+
+    function App() {
+      const result = useSuspenseQuery(query);
+
+      Profiler.replaceSnapshot({ result });
+
+      return null;
+    }
+
+    render(<App />, {
+      wrapper: ({ children }) => (
+        <ApolloProvider client={client}>
+          <Profiler>
+            <Suspense fallback="Loading">{children}</Suspense>
+          </Profiler>
+        </ApolloProvider>
+      ),
+    });
+
+    // loading
+    await Profiler.takeRender();
+
+    const { snapshot } = await Profiler.takeRender();
+
+    expect(snapshot.result?.data).toEqual({
+      currentUser: {
+        __typename: "User",
+        id: 1,
+        name: "Test User",
+        age: 30,
+      },
+    });
+  });
+
+  it("does not mask query by default", async () => {
+    interface Query {
+      currentUser: {
+        __typename: "User";
+        id: number;
+        name: string;
+      };
+    }
+
+    const query: TypedDocumentNode<Query, never> = gql`
+      query MaskedQuery {
+        currentUser {
+          id
+          name
+          ...UserFields
+        }
+      }
+
+      fragment UserFields on User {
+        age
+      }
+    `;
+
+    const mocks = [
+      {
+        request: { query },
+        result: {
+          data: {
+            currentUser: {
+              __typename: "User",
+              id: 1,
+              name: "Test User",
+              age: 30,
+            },
+          },
+        },
+      },
+    ];
+
+    const client = new ApolloClient({
+      cache: new InMemoryCache(),
+      link: new MockLink(mocks),
+    });
+
+    const Profiler = createProfiler({
+      initialSnapshot: {
+        result: null as UseSuspenseQueryResult<Query, never> | null,
+      },
+    });
+
+    function App() {
+      const result = useSuspenseQuery(query);
+
+      Profiler.replaceSnapshot({ result });
+
+      return null;
+    }
+
+    render(<App />, {
+      wrapper: ({ children }) => (
+        <ApolloProvider client={client}>
+          <Profiler>
+            <Suspense fallback="Loading">{children}</Suspense>
+          </Profiler>
+        </ApolloProvider>
+      ),
+    });
+
+    // loading
+    await Profiler.takeRender();
+
+    const { snapshot } = await Profiler.takeRender();
+
+    expect(snapshot.result?.data).toEqual({
+      currentUser: {
+        __typename: "User",
+        id: 1,
+        name: "Test User",
+        age: 30,
+      },
+    });
+  });
+
+  it("masks queries updated by the cache", async () => {
+    interface Query {
+      currentUser: {
+        __typename: "User";
+        id: number;
+        name: string;
+      };
+    }
+
+    const query: TypedDocumentNode<Query, never> = gql`
+      query MaskedQuery {
+        currentUser {
+          id
+          name
+          ...UserFields
+        }
+      }
+
+      fragment UserFields on User {
+        age
+      }
+    `;
+
+    const mocks = [
+      {
+        request: { query },
+        result: {
+          data: {
+            currentUser: {
+              __typename: "User",
+              id: 1,
+              name: "Test User",
+              age: 30,
+            },
+          },
+        },
+      },
+    ];
+
+    const client = new ApolloClient({
+      dataMasking: true,
+      cache: new InMemoryCache(),
+      link: new MockLink(mocks),
+    });
+
+    const Profiler = createProfiler({
+      initialSnapshot: {
+        result: null as UseSuspenseQueryResult<Query, never> | null,
+      },
+    });
+
+    function App() {
+      const result = useSuspenseQuery(query);
+
+      Profiler.replaceSnapshot({ result });
+
+      return null;
+    }
+
+    render(<App />, {
+      wrapper: ({ children }) => (
+        <ApolloProvider client={client}>
+          <Profiler>
+            <Suspense fallback="Loading">{children}</Suspense>
+          </Profiler>
+        </ApolloProvider>
+      ),
+    });
+
+    // loading
+    await Profiler.takeRender();
+
+    {
+      const { snapshot } = await Profiler.takeRender();
+
+      expect(snapshot.result?.data).toEqual({
+        currentUser: {
+          __typename: "User",
+          id: 1,
+          name: "Test User",
+        },
+      });
+    }
+
+    client.writeQuery({
+      query,
+      data: {
+        currentUser: {
+          __typename: "User",
+          id: 1,
+          name: "Test User (updated)",
+          // @ts-ignore TODO: Determine how to handle cache writes with masked
+          // query type
+          age: 35,
+        },
+      },
+    });
+
+    {
+      const { snapshot } = await Profiler.takeRender();
+
+      expect(snapshot.result?.data).toEqual({
+        currentUser: {
+          __typename: "User",
+          id: 1,
+          name: "Test User (updated)",
+        },
+      });
+    }
+  });
+
+  it("does not rerender when updating field in named fragment", async () => {
+    interface Query {
+      currentUser: {
+        __typename: "User";
+        id: number;
+        name: string;
+      };
+    }
+
+    const query: TypedDocumentNode<Query, never> = gql`
+      query MaskedQuery {
+        currentUser {
+          id
+          name
+          ...UserFields
+        }
+      }
+
+      fragment UserFields on User {
+        age
+      }
+    `;
+
+    const mocks = [
+      {
+        request: { query },
+        result: {
+          data: {
+            currentUser: {
+              __typename: "User",
+              id: 1,
+              name: "Test User",
+              age: 30,
+            },
+          },
+        },
+      },
+    ];
+
+    const client = new ApolloClient({
+      dataMasking: true,
+      cache: new InMemoryCache(),
+      link: new MockLink(mocks),
+    });
+
+    const Profiler = createProfiler({
+      initialSnapshot: {
+        result: null as UseSuspenseQueryResult<Query, never> | null,
+      },
+    });
+
+    function App() {
+      const result = useSuspenseQuery(query);
+
+      Profiler.replaceSnapshot({ result });
+
+      return null;
+    }
+
+    render(<App />, {
+      wrapper: ({ children }) => (
+        <ApolloProvider client={client}>
+          <Profiler>
+            <Suspense fallback="Loading">{children}</Suspense>
+          </Profiler>
+        </ApolloProvider>
+      ),
+    });
+
+    // loading
+    await Profiler.takeRender();
+
+    {
+      const { snapshot } = await Profiler.takeRender();
+
+      expect(snapshot.result?.data).toEqual({
+        currentUser: {
+          __typename: "User",
+          id: 1,
+          name: "Test User",
+        },
+      });
+    }
+
+    client.writeQuery({
+      query,
+      data: {
+        currentUser: {
+          __typename: "User",
+          id: 1,
+          name: "Test User",
+          // @ts-ignore TODO: Determine how to handle cache writes with masked
+          // query type
+          age: 35,
+        },
+      },
+    });
+
+    await expect(Profiler).not.toRerender();
+
+    expect(client.readQuery({ query })).toEqual({
+      currentUser: {
+        __typename: "User",
+        id: 1,
+        name: "Test User",
+        age: 35,
+      },
+    });
+  });
+
+  it("masks result from cache when using with cache-first fetch policy", async () => {
+    interface Query {
+      currentUser: {
+        __typename: "User";
+        id: number;
+        name: string;
+      };
+    }
+
+    const query: TypedDocumentNode<Query, never> = gql`
+      query MaskedQuery {
+        currentUser {
+          id
+          name
+          ...UserFields
+        }
+      }
+
+      fragment UserFields on User {
+        age
+      }
+    `;
+
+    const mocks = [
+      {
+        request: { query },
+        result: {
+          data: {
+            currentUser: {
+              __typename: "User",
+              id: 1,
+              name: "Test User",
+              age: 30,
+            },
+          },
+        },
+      },
+    ];
+
+    const client = new ApolloClient({
+      dataMasking: true,
+      cache: new InMemoryCache(),
+      link: new MockLink(mocks),
+    });
+
+    client.writeQuery({
+      query,
+      data: {
+        currentUser: {
+          __typename: "User",
+          id: 1,
+          name: "Test User",
+          // @ts-expect-error TODO: Determine how to write this with masked types
+          age: 30,
+        },
+      },
+    });
+
+    const Profiler = createProfiler({
+      initialSnapshot: {
+        result: null as UseSuspenseQueryResult<Query, never> | null,
+      },
+    });
+
+    function App() {
+      const result = useSuspenseQuery(query, { fetchPolicy: "cache-first" });
+
+      Profiler.replaceSnapshot({ result });
+
+      return null;
+    }
+
+    render(<App />, {
+      wrapper: ({ children }) => (
+        <ApolloProvider client={client}>
+          <Profiler>
+            <Suspense fallback="Loading">{children}</Suspense>
+          </Profiler>
+        </ApolloProvider>
+      ),
+    });
+
+    const { snapshot } = await Profiler.takeRender();
+
+    expect(snapshot.result?.data).toEqual({
+      currentUser: {
+        __typename: "User",
+        id: 1,
+        name: "Test User",
+      },
+    });
+  });
+
+  it("masks cache and network result when using cache-and-network fetch policy", async () => {
+    interface Query {
+      currentUser: {
+        __typename: "User";
+        id: number;
+        name: string;
+      };
+    }
+
+    const query: TypedDocumentNode<Query, never> = gql`
+      query MaskedQuery {
+        currentUser {
+          id
+          name
+          ...UserFields
+        }
+      }
+
+      fragment UserFields on User {
+        age
+      }
+    `;
+
+    const mocks = [
+      {
+        request: { query },
+        result: {
+          data: {
+            currentUser: {
+              __typename: "User",
+              id: 1,
+              name: "Test User (server)",
+              age: 35,
+            },
+          },
+        },
+        delay: 20,
+      },
+    ];
+
+    const client = new ApolloClient({
+      dataMasking: true,
+      cache: new InMemoryCache(),
+      link: new MockLink(mocks),
+    });
+
+    client.writeQuery({
+      query,
+      data: {
+        currentUser: {
+          __typename: "User",
+          id: 1,
+          name: "Test User",
+          // @ts-expect-error TODO: Determine how to write this with masked types
+          age: 34,
+        },
+      },
+    });
+
+    const Profiler = createProfiler({
+      initialSnapshot: {
+        result: null as UseSuspenseQueryResult<Query, never> | null,
+      },
+    });
+
+    function App() {
+      const result = useSuspenseQuery(query, {
+        fetchPolicy: "cache-and-network",
+      });
+
+      Profiler.replaceSnapshot({ result });
+
+      return null;
+    }
+
+    render(<App />, {
+      wrapper: ({ children }) => (
+        <ApolloProvider client={client}>
+          <Profiler>
+            <Suspense fallback="Loading">{children}</Suspense>
+          </Profiler>
+        </ApolloProvider>
+      ),
+    });
+
+    {
+      const { snapshot } = await Profiler.takeRender();
+
+      expect(snapshot.result?.data).toEqual({
+        currentUser: {
+          __typename: "User",
+          id: 1,
+          name: "Test User",
+        },
+      });
+    }
+
+    {
+      const { snapshot } = await Profiler.takeRender();
+
+      expect(snapshot.result?.data).toEqual({
+        currentUser: {
+          __typename: "User",
+          id: 1,
+          name: "Test User (server)",
+        },
+      });
+    }
+  });
+
+  it("masks partial cache data when returnPartialData is `true`", async () => {
+    interface Query {
+      currentUser: {
+        __typename: "User";
+        id: number;
+        name: string;
+      };
+    }
+
+    const query: TypedDocumentNode<Query, never> = gql`
+      query MaskedQuery {
+        currentUser {
+          id
+          name
+          ...UserFields
+        }
+      }
+
+      fragment UserFields on User {
+        age
+      }
+    `;
+
+    const mocks = [
+      {
+        request: { query },
+        result: {
+          data: {
+            currentUser: {
+              __typename: "User",
+              id: 1,
+              name: "Test User (server)",
+              age: 35,
+            },
+          },
+        },
+        delay: 20,
+      },
+    ];
+
+    const client = new ApolloClient({
+      dataMasking: true,
+      cache: new InMemoryCache(),
+      link: new MockLink(mocks),
+    });
+
+    client.writeQuery({
+      query,
+      data: {
+        currentUser: {
+          __typename: "User",
+          id: 1,
+          // @ts-expect-error TODO: Determine how to write this with masked types
+          age: 34,
+        },
+      },
+    });
+
+    const Profiler = createProfiler({
+      initialSnapshot: {
+        result: null as UseSuspenseQueryResult<
+          DeepPartial<Query>,
+          never
+        > | null,
+      },
+    });
+
+    function App() {
+      const result = useSuspenseQuery(query, { returnPartialData: true });
+
+      Profiler.replaceSnapshot({ result });
+
+      return null;
+    }
+
+    render(<App />, {
+      wrapper: ({ children }) => (
+        <ApolloProvider client={client}>
+          <Profiler>
+            <Suspense fallback="Loading">{children}</Suspense>
+          </Profiler>
+        </ApolloProvider>
+      ),
+    });
+
+    {
+      const { snapshot } = await Profiler.takeRender();
+
+      expect(snapshot.result?.data).toEqual({
+        currentUser: {
+          __typename: "User",
+          id: 1,
+        },
+      });
+    }
+
+    {
+      const { snapshot } = await Profiler.takeRender();
+
+      expect(snapshot.result?.data).toEqual({
+        currentUser: {
+          __typename: "User",
+          id: 1,
+          name: "Test User (server)",
+        },
+      });
+    }
+  });
+
+  it("masks partial data returned from data on errors with errorPolicy `all`", async () => {
+    interface Query {
+      currentUser: {
+        __typename: "User";
+        id: number;
+        name: string;
+      };
+    }
+
+    const query: TypedDocumentNode<Query, never> = gql`
+      query MaskedQuery {
+        currentUser {
+          id
+          name
+          ...UserFields
+        }
+      }
+
+      fragment UserFields on User {
+        age
+      }
+    `;
+
+    const mocks = [
+      {
+        request: { query },
+        result: {
+          data: {
+            currentUser: {
+              __typename: "User",
+              id: 1,
+              name: null,
+              age: 34,
+            },
+          },
+          errors: [new GraphQLError("Couldn't get name")],
+        },
+        delay: 20,
+      },
+    ];
+
+    const client = new ApolloClient({
+      dataMasking: true,
+      cache: new InMemoryCache(),
+      link: new MockLink(mocks),
+    });
+
+    const Profiler = createProfiler({
+      initialSnapshot: {
+        result: null as UseSuspenseQueryResult<Query | undefined, never> | null,
+      },
+    });
+
+    function App() {
+      const result = useSuspenseQuery(query, { errorPolicy: "all" });
+
+      Profiler.replaceSnapshot({ result });
+
+      return null;
+    }
+
+    render(<App />, {
+      wrapper: ({ children }) => (
+        <ApolloProvider client={client}>
+          <Profiler>
+            <Suspense fallback="Loading">{children}</Suspense>
+          </Profiler>
+        </ApolloProvider>
+      ),
+    });
+
+    // loading
+    await Profiler.takeRender();
+
+    {
+      const { snapshot } = await Profiler.takeRender();
+      const { result } = snapshot;
+
+      expect(result?.data).toEqual({
+        currentUser: {
+          __typename: "User",
+          id: 1,
+          name: null,
+        },
+      });
+
+      expect(result?.error).toEqual(
+        new ApolloError({
+          graphQLErrors: [new GraphQLError("Couldn't get name")],
+        })
+      );
+    }
+  });
+
   describe.skip("type tests", () => {
     it("returns unknown when TData cannot be inferred", () => {
       const query = gql`

--- a/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
@@ -11289,17 +11289,20 @@ describe("useSuspenseQuery", () => {
       link: new MockLink(mocks),
     });
 
-    client.writeQuery({
-      query,
-      data: {
-        currentUser: {
-          __typename: "User",
-          id: 1,
-          // @ts-expect-error TODO: Determine how to write this with masked types
-          age: 34,
+    {
+      using _ = spyOnConsole("error");
+      client.writeQuery({
+        query,
+        data: {
+          currentUser: {
+            __typename: "User",
+            id: 1,
+            // @ts-expect-error TODO: Determine how to write this with masked types
+            age: 34,
+          },
         },
-      },
-    });
+      });
+    }
 
     const Profiler = createProfiler({
       initialSnapshot: {


### PR DESCRIPTION
Closes https://github.com/apollographql/apollo-client/issues/11672

Adds an option to `ApolloClient` that enables data masking. This also adds the implementation to return masked queries from `watchQuery` (i.e. `ObservableQuery`) so that network data and cache updates will be masked.

This work does NOT include any ability to read fragments from the parent objects. This will be done in a followup PR.