### PR TITLE
Fixing undefined issue of observer

### DIFF
--- a/src/utilities/observables/Concast.ts
+++ b/src/utilities/observables/Concast.ts
@@ -211,7 +211,7 @@ export class Concast<T> extends Observable<T> {
           iterateObserversSafely(this.observers, "complete");
         } else if (isPromiseLike(value)) {
           value.then(
-            (obs) => (this.sub = obs.subscribe(this.handlers)),
+            (obs) => (this.sub = obs?.subscribe(this.handlers)),
             this.handlers.error
           );
         } else {


### PR DESCRIPTION
I am getting "Cannot read properties of undefined (reading 'subscribe')" on Sentry.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:

### Checklist:
- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
-->
