### PR TITLE
Add support for `@unmask` directive to selectively disable masking on a query

### DIFF
--- a/src/__tests__/__snapshots__/exports.ts.snap
+++ b/src/__tests__/__snapshots__/exports.ts.snap
@@ -470,6 +470,7 @@ Array [
   "isReference",
   "isStatefulPromise",
   "isSubscriptionOperation",
+  "isUnmaskedDocument",
   "iterateObserversSafely",
   "makeReference",
   "makeUniqueId",

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -6609,7 +6609,7 @@ describe("data masking", () => {
     }
 
     const query: TypedDocumentNode<Query, never> = gql`
-      query UnmaskedQuery @unmask {
+      query UnmaskedQuery @unmasked {
         currentUser {
           id
           name

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -6600,7 +6600,7 @@ describe("data masking", () => {
     }
   });
 
-  it("does not mask queries marked with @unmasked", async () => {
+  it("does not mask queries marked with @unmask", async () => {
     interface Query {
       currentUser: {
         __typename: "User";
@@ -6610,7 +6610,7 @@ describe("data masking", () => {
     }
 
     const query: TypedDocumentNode<Query, never> = gql`
-      query UnmaskedQuery @unmasked {
+      query UnmaskedQuery @unmask {
         currentUser {
           id
           name
@@ -6663,7 +6663,7 @@ describe("data masking", () => {
     }
   });
 
-  it("does not mask queries marked with @unmasked added by document transforms", async () => {
+  it("does not mask queries marked with @unmask added by document transforms", async () => {
     const documentTransform = new DocumentTransform((document) => {
       return visit(document, {
         OperationDefinition(node) {
@@ -6672,7 +6672,7 @@ describe("data masking", () => {
             directives: [
               {
                 kind: Kind.DIRECTIVE,
-                name: { kind: Kind.NAME, value: "unmasked" },
+                name: { kind: Kind.NAME, value: "unmask" },
               },
             ],
           } satisfies OperationDefinitionNode;

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1066,8 +1066,11 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
 
   private maskQuery(data: TData) {
     const { queryManager } = this;
+    const shouldMask =
+      queryManager.dataMasking &&
+      !queryManager.getDocumentInfo(this.query).isUnmasked;
 
-    return queryManager.dataMasking ?
+    return shouldMask ?
         queryManager.cache.maskDocument(this.query, data)
       : data;
   }

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -697,7 +697,7 @@ export class QueryManager<TStore> {
             { name: "client", remove: true },
             { name: "connection" },
             { name: "nonreactive" },
-            { name: "unmasked" },
+            { name: "unmask" },
           ],
           document
         ),

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -694,6 +694,7 @@ export class QueryManager<TStore> {
             { name: "client", remove: true },
             { name: "connection" },
             { name: "nonreactive" },
+            { name: "unmasked" },
           ],
           document
         ),

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -26,6 +26,7 @@ import {
   getOperationDefinition,
   getOperationName,
   hasClientExports,
+  isUnmaskedDocument,
   graphQLResultHasError,
   getGraphQLErrorsFromResult,
   Observable,
@@ -95,6 +96,7 @@ interface TransformCacheEntry {
   hasClientExports: boolean;
   hasForcedResolvers: boolean;
   hasNonreactiveDirective: boolean;
+  isUnmasked: boolean;
   clientQuery: DocumentNode | null;
   serverQuery: DocumentNode | null;
   defaultVars: OperationVariables;
@@ -688,6 +690,7 @@ export class QueryManager<TStore> {
         hasClientExports: hasClientExports(document),
         hasForcedResolvers: this.localState.shouldForceResolvers(document),
         hasNonreactiveDirective: hasDirectives(["nonreactive"], document),
+        isUnmasked: isUnmaskedDocument(document),
         clientQuery: this.localState.clientQuery(document),
         serverQuery: removeDirectivesFromDocument(
           [

--- a/src/testing/core/mocking/mockLink.ts
+++ b/src/testing/core/mocking/mockLink.ts
@@ -211,7 +211,7 @@ ${unmatchedVars.map((d) => `  ${stringifyForDisplay(d)}`).join("\n")}
   ): MockedResponse {
     const newMockedResponse = cloneDeep(mockedResponse);
     const queryWithoutClientOnlyDirectives = removeDirectivesFromDocument(
-      [{ name: "connection" }, { name: "nonreactive" }],
+      [{ name: "connection" }, { name: "nonreactive" }, { name: "unmasked" }],
       checkDocument(newMockedResponse.request.query)
     );
     invariant(queryWithoutClientOnlyDirectives, "query is required");

--- a/src/testing/core/mocking/mockLink.ts
+++ b/src/testing/core/mocking/mockLink.ts
@@ -211,7 +211,7 @@ ${unmatchedVars.map((d) => `  ${stringifyForDisplay(d)}`).join("\n")}
   ): MockedResponse {
     const newMockedResponse = cloneDeep(mockedResponse);
     const queryWithoutClientOnlyDirectives = removeDirectivesFromDocument(
-      [{ name: "connection" }, { name: "nonreactive" }, { name: "unmasked" }],
+      [{ name: "connection" }, { name: "nonreactive" }, { name: "unmask" }],
       checkDocument(newMockedResponse.request.query)
     );
     invariant(queryWithoutClientOnlyDirectives, "query is required");

--- a/src/utilities/graphql/__tests__/directives.ts
+++ b/src/utilities/graphql/__tests__/directives.ts
@@ -574,7 +574,7 @@ describe("isUnmaskedDocument", () => {
     expect(result).toBe(false);
     expect(consoleSpy.warn).toHaveBeenCalledTimes(1);
     expect(consoleSpy.warn).toHaveBeenCalledWith(
-      "%s@unmasked directive is used in a location other than the document root which has no effect.",
+      "@unmasked directive used in %s is provided in a location other than the document root which is ignored.",
       "'MyQuery': "
     );
   });
@@ -599,7 +599,7 @@ describe("isUnmaskedDocument", () => {
     expect(result).toBe(true);
     expect(consoleSpy.warn).toHaveBeenCalledTimes(1);
     expect(consoleSpy.warn).toHaveBeenCalledWith(
-      "%s@unmasked directive is used in a location other than the document root.",
+      "@unmasked directive used in %s is provided in a location other than the document root which is ignored.",
       "'MyQuery': "
     );
   });

--- a/src/utilities/graphql/__tests__/directives.ts
+++ b/src/utilities/graphql/__tests__/directives.ts
@@ -516,9 +516,9 @@ describe("shouldInclude", () => {
 });
 
 describe("isUnmaskedDocument", () => {
-  it("returns true when @unmasked used on document", () => {
+  it("returns true when @unmask used on document", () => {
     const query = gql`
-      query MyQuery @unmasked {
+      query MyQuery @unmask {
         myField
       }
     `;
@@ -526,7 +526,7 @@ describe("isUnmaskedDocument", () => {
     expect(isUnmaskedDocument(query)).toBe(true);
   });
 
-  it("returns false when @unmasked is not used", () => {
+  it("returns false when @unmask is not used", () => {
     const query = gql`
       query MyQuery {
         myField
@@ -536,17 +536,17 @@ describe("isUnmaskedDocument", () => {
     expect(isUnmaskedDocument(query)).toBe(false);
   });
 
-  it("returns false when @unmasked is used in a location other than the document root", () => {
+  it("returns false when @unmask is used in a location other than the document root", () => {
     using _ = spyOnConsole("warn");
 
     const query = gql`
-      query MyQuery($id: ID! @unmasked) {
-        foo @unmasked
+      query MyQuery($id: ID! @unmask) {
+        foo @unmask
         bar(arg: true) {
-          ... @unmasked {
+          ... @unmask {
             baz
           }
-          ...MyFragment @unmasked
+          ...MyFragment @unmask
         }
       }
     `;
@@ -554,17 +554,17 @@ describe("isUnmaskedDocument", () => {
     expect(isUnmaskedDocument(query)).toBe(false);
   });
 
-  it("warns when using @unmasked directive in a location other than the document root", () => {
+  it("warns when using @unmask directive in a location other than the document root", () => {
     using consoleSpy = spyOnConsole("warn");
 
     const query = gql`
-      query MyQuery($id: ID! @unmasked) {
-        foo @unmasked
+      query MyQuery($id: ID! @unmask) {
+        foo @unmask
         bar(arg: true) {
-          ... @unmasked {
+          ... @unmask {
             baz
           }
-          ...MyFragment @unmasked
+          ...MyFragment @unmask
         }
       }
     `;
@@ -574,22 +574,22 @@ describe("isUnmaskedDocument", () => {
     expect(result).toBe(false);
     expect(consoleSpy.warn).toHaveBeenCalledTimes(1);
     expect(consoleSpy.warn).toHaveBeenCalledWith(
-      "@unmasked directive used in %s is provided in a location other than the document root which is ignored.",
+      "@unmask directive used in %s is provided in a location other than the document root which is ignored.",
       "'MyQuery': "
     );
   });
 
-  it("warns when using @unmasked directive a location other than the document root while also using @unmasked at the root", () => {
+  it("warns when using @unmask directive a location other than the document root while also using @unmask at the root", () => {
     using consoleSpy = spyOnConsole("warn");
 
     const query = gql`
-      query MyQuery($id: ID! @unmasked) @unmasked {
-        foo @unmasked
+      query MyQuery($id: ID! @unmask) @unmask {
+        foo @unmask
         bar(arg: true) {
-          ... @unmasked {
+          ... @unmask {
             baz
           }
-          ...MyFragment @unmasked
+          ...MyFragment @unmask
         }
       }
     `;
@@ -599,7 +599,7 @@ describe("isUnmaskedDocument", () => {
     expect(result).toBe(true);
     expect(consoleSpy.warn).toHaveBeenCalledTimes(1);
     expect(consoleSpy.warn).toHaveBeenCalledWith(
-      "@unmasked directive used in %s is provided in a location other than the document root which is ignored.",
+      "@unmask directive used in %s is provided in a location other than the document root which is ignored.",
       "'MyQuery': "
     );
   });

--- a/src/utilities/graphql/__tests__/directives.ts
+++ b/src/utilities/graphql/__tests__/directives.ts
@@ -574,7 +574,8 @@ describe("isUnmaskedDocument", () => {
     expect(result).toBe(false);
     expect(consoleSpy.warn).toHaveBeenCalledTimes(1);
     expect(consoleSpy.warn).toHaveBeenCalledWith(
-      "@unmasked directive is used in a location other than the document root which has no effect."
+      "%s@unmasked directive is used in a location other than the document root which has no effect.",
+      "'MyQuery': "
     );
   });
 
@@ -598,7 +599,8 @@ describe("isUnmaskedDocument", () => {
     expect(result).toBe(true);
     expect(consoleSpy.warn).toHaveBeenCalledTimes(1);
     expect(consoleSpy.warn).toHaveBeenCalledWith(
-      "@unmasked directive is used in a location other than the document root."
+      "%s@unmasked directive is used in a location other than the document root.",
+      "'MyQuery': "
     );
   });
 });

--- a/src/utilities/graphql/directives.ts
+++ b/src/utilities/graphql/directives.ts
@@ -175,6 +175,8 @@ export function isUnmaskedDocument(document: DocumentNode) {
             operationName ? `'${operationName}': ` : "anonymous operation"
           );
 
+          // We only want to warn once if we detect misused of @unmasked so we
+          // immediately stop traversal.
           return BREAK;
         }
       }

--- a/src/utilities/graphql/directives.ts
+++ b/src/utilities/graphql/directives.ts
@@ -144,13 +144,13 @@ export function isUnmaskedDocument(document: DocumentNode) {
 
       if (node.directives) {
         unmasked = node.directives.some(
-          (directive) => directive.name.value === "unmasked"
+          (directive) => directive.name.value === "unmask"
         );
       }
 
       if (__DEV__) {
         // Allow us to continue traversal in development to warn if we detect
-        // the unmasked directive anywhere else in the document.
+        // the unmask directive anywhere else in the document.
         return;
       }
 
@@ -158,24 +158,24 @@ export function isUnmaskedDocument(document: DocumentNode) {
     },
     Directive(node, _, __, ___, ancestors) {
       if (__DEV__) {
-        if (node.name.value !== "unmasked") {
+        if (node.name.value !== "unmask") {
           return;
         }
 
         const parent = ancestors[ancestors.length - 1];
 
-        // Make sure we aren't checking the `unmasked` directive defined on
+        // Make sure we aren't checking the `unmask` directive defined on
         // the operation, which we don't want to warn on.
         if (
           Array.isArray(parent) ||
           (parent as ASTNode).kind !== "OperationDefinition"
         ) {
           invariant.warn(
-            "@unmasked directive used in %s is provided in a location other than the document root which is ignored.",
+            "@unmask directive used in %s is provided in a location other than the document root which is ignored.",
             operationName ? `'${operationName}': ` : "anonymous operation"
           );
 
-          // We only want to warn once if we detect misused of @unmasked so we
+          // We only want to warn once if we detect misused of @unmask so we
           // immediately stop traversal.
           return BREAK;
         }

--- a/src/utilities/graphql/directives.ts
+++ b/src/utilities/graphql/directives.ts
@@ -171,10 +171,8 @@ export function isUnmaskedDocument(document: DocumentNode) {
           (parent as ASTNode).kind !== "OperationDefinition"
         ) {
           invariant.warn(
-            unmasked ?
-              "%s@unmasked directive is used in a location other than the document root."
-            : "%s@unmasked directive is used in a location other than the document root which has no effect.",
-            operationName ? `'${operationName}': ` : ""
+            "@unmasked directive used in %s is provided in a location other than the document root which is ignored.",
+            operationName ? `'${operationName}': ` : "anonymous operation"
           );
 
           return BREAK;

--- a/src/utilities/graphql/directives.ts
+++ b/src/utilities/graphql/directives.ts
@@ -136,9 +136,12 @@ export function getInclusionDirectives(
 
 export function isUnmaskedDocument(document: DocumentNode) {
   let unmasked = false;
+  let operationName: string | undefined;
 
   visit(document, {
     OperationDefinition(node) {
+      operationName = node.name?.value;
+
       if (node.directives) {
         unmasked = node.directives.some(
           (directive) => directive.name.value === "unmasked"
@@ -169,8 +172,9 @@ export function isUnmaskedDocument(document: DocumentNode) {
         ) {
           invariant.warn(
             unmasked ?
-              "@unmasked directive is used in a location other than the document root."
-            : "@unmasked directive is used in a location other than the document root which has no effect."
+              "%s@unmasked directive is used in a location other than the document root."
+            : "%s@unmasked directive is used in a location other than the document root which has no effect.",
+            operationName ? `'${operationName}': ` : ""
           );
 
           return BREAK;

--- a/src/utilities/graphql/directives.ts
+++ b/src/utilities/graphql/directives.ts
@@ -133,3 +133,7 @@ export function getInclusionDirectives(
 
   return result;
 }
+
+export function isUnmaskedDocument(document: DocumentNode) {
+  return false;
+}

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -12,6 +12,7 @@ export {
   hasClientExports,
   getDirectiveNames,
   getInclusionDirectives,
+  isUnmaskedDocument,
 } from "./graphql/directives.js";
 
 export type { DocumentTransformCacheKey } from "./graphql/DocumentTransform.js";


### PR DESCRIPTION
Closes https://github.com/apollographql/apollo-client/issues/11673

Adds support for an `@unmask` directive that will disable data masking for a query even when enabled by the client.