### PR TITLE
add `ignoreResults` option to `useSubscription`

### DIFF
--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -384,6 +384,7 @@ export interface BaseSubscriptionOptions<TData = any, TVariables extends Operati
     context?: Context;
     // Warning: (ae-forgotten-export) The symbol "FetchPolicy" needs to be exported by the entry point index.d.ts
     fetchPolicy?: FetchPolicy;
+    ignoreResults?: boolean;
     onComplete?: () => void;
     onData?: (options: OnDataOptions<TData>) => any;
     onError?: (error: ApolloError) => void;
@@ -1915,7 +1916,7 @@ export interface SubscriptionCurrentObservable {
     subscription?: Subscription;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export interface SubscriptionDataOptions<TData = any, TVariables extends OperationVariables = OperationVariables> extends BaseSubscriptionOptions<TData, TVariables> {
     // (undocumented)
     children?: null | ((result: SubscriptionResult<TData>) => ReactTypes.ReactNode);

--- a/.api-reports/api-report-react_components.api.md
+++ b/.api-reports/api-report-react_components.api.md
@@ -332,6 +332,7 @@ interface BaseSubscriptionOptions<TData = any, TVariables extends OperationVaria
     context?: DefaultContext;
     // Warning: (ae-forgotten-export) The symbol "FetchPolicy" needs to be exported by the entry point index.d.ts
     fetchPolicy?: FetchPolicy;
+    ignoreResults?: boolean;
     onComplete?: () => void;
     // Warning: (ae-forgotten-export) The symbol "OnDataOptions" needs to be exported by the entry point index.d.ts
     onData?: (options: OnDataOptions<TData>) => any;

--- a/.api-reports/api-report-react_hooks.api.md
+++ b/.api-reports/api-report-react_hooks.api.md
@@ -355,6 +355,7 @@ interface BaseSubscriptionOptions<TData = any, TVariables extends OperationVaria
     context?: DefaultContext;
     // Warning: (ae-forgotten-export) The symbol "FetchPolicy" needs to be exported by the entry point index.d.ts
     fetchPolicy?: FetchPolicy;
+    ignoreResults?: boolean;
     onComplete?: () => void;
     // Warning: (ae-forgotten-export) The symbol "OnDataOptions" needs to be exported by the entry point index.d.ts
     onData?: (options: OnDataOptions<TData>) => any;

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -355,6 +355,7 @@ export interface BaseSubscriptionOptions<TData = any, TVariables extends Operati
     client?: ApolloClient<object>;
     context?: DefaultContext;
     fetchPolicy?: FetchPolicy;
+    ignoreResults?: boolean;
     onComplete?: () => void;
     onData?: (options: OnDataOptions<TData>) => any;
     onError?: (error: ApolloError) => void;
@@ -2547,7 +2548,7 @@ export interface SubscriptionCurrentObservable {
     subscription?: ObservableSubscription;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export interface SubscriptionDataOptions<TData = any, TVariables extends OperationVariables = OperationVariables> extends BaseSubscriptionOptions<TData, TVariables> {
     // (undocumented)
     children?: null | ((result: SubscriptionResult<TData>) => ReactTypes.ReactNode);

--- a/.changeset/unlucky-birds-press.md
+++ b/.changeset/unlucky-birds-press.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+add `ignoreResults` option to `useSubscription`

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 39619,
+  "dist/apollo-client.min.cjs": 39641,
   "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 32852
 }

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -1500,6 +1500,7 @@ describe("ignoreResults", () => {
       error: undefined,
       data: undefined,
       variables: undefined,
+      restart: expect.any(Function),
     });
     link.simulateResult(results[0]);
 
@@ -1571,6 +1572,7 @@ describe("ignoreResults", () => {
       error: undefined,
       data: undefined,
       variables: undefined,
+      restart: expect.any(Function),
     });
     link.simulateResult(results[0]);
 
@@ -1633,6 +1635,7 @@ describe("ignoreResults", () => {
         error: undefined,
         data: undefined,
         variables: undefined,
+        restart: expect.any(Function),
       });
       expect(onData).toHaveBeenCalledTimes(0);
     }
@@ -1649,6 +1652,7 @@ describe("ignoreResults", () => {
         // `data` appears immediately after changing to `ignoreResults: false`
         data: results[0].result.data,
         variables: undefined,
+        restart: expect.any(Function),
       });
       // `onData` should not be called again for the same result
       expect(onData).toHaveBeenCalledTimes(1);
@@ -1662,6 +1666,7 @@ describe("ignoreResults", () => {
         error: undefined,
         data: results[1].result.data,
         variables: undefined,
+        restart: expect.any(Function),
       });
       expect(onData).toHaveBeenCalledTimes(2);
     }
@@ -1699,6 +1704,7 @@ describe("ignoreResults", () => {
         error: undefined,
         data: undefined,
         variables: undefined,
+        restart: expect.any(Function),
       });
       expect(onData).toHaveBeenCalledTimes(0);
     }
@@ -1710,6 +1716,7 @@ describe("ignoreResults", () => {
         error: undefined,
         data: results[0].result.data,
         variables: undefined,
+        restart: expect.any(Function),
       });
       expect(onData).toHaveBeenCalledTimes(1);
     }
@@ -1724,6 +1731,7 @@ describe("ignoreResults", () => {
         // switching back to the default `ignoreResults: true` return value
         data: undefined,
         variables: undefined,
+        restart: expect.any(Function),
       });
       // `onData` should not be called again
       expect(onData).toHaveBeenCalledTimes(1);

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -1172,12 +1172,16 @@ describe("ignoreResults", () => {
 
     await waitFor(() => {
       expect(onData).toHaveBeenCalledTimes(1);
-      expect(onData.mock.lastCall?.[0].data).toStrictEqual({
-        data: results[0].result.data,
-        error: undefined,
-        loading: false,
-        variables: undefined,
-      });
+      expect(onData).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          data: {
+            data: results[0].result.data,
+            error: undefined,
+            loading: false,
+            variables: undefined,
+          },
+        })
+      );
       expect(onError).toHaveBeenCalledTimes(0);
       expect(onComplete).toHaveBeenCalledTimes(0);
     });
@@ -1185,12 +1189,16 @@ describe("ignoreResults", () => {
     link.simulateResult(results[1], true);
     await waitFor(() => {
       expect(onData).toHaveBeenCalledTimes(2);
-      expect(onData.mock.lastCall?.[0].data).toStrictEqual({
-        data: results[1].result.data,
-        error: undefined,
-        loading: false,
-        variables: undefined,
-      });
+      expect(onData).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          data: {
+            data: results[1].result.data,
+            error: undefined,
+            loading: false,
+            variables: undefined,
+          },
+        })
+      );
       expect(onError).toHaveBeenCalledTimes(0);
       expect(onComplete).toHaveBeenCalledTimes(1);
     });
@@ -1235,12 +1243,16 @@ describe("ignoreResults", () => {
 
     await waitFor(() => {
       expect(onData).toHaveBeenCalledTimes(1);
-      expect(onData.mock.lastCall?.[0].data).toStrictEqual({
-        data: results[0].result.data,
-        error: undefined,
-        loading: false,
-        variables: undefined,
-      });
+      expect(onData).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          data: {
+            data: results[0].result.data,
+            error: undefined,
+            loading: false,
+            variables: undefined,
+          },
+        })
+      );
       expect(onError).toHaveBeenCalledTimes(0);
       expect(onComplete).toHaveBeenCalledTimes(0);
     });
@@ -1293,6 +1305,7 @@ describe("ignoreResults", () => {
     }
     link.simulateResult(results[0]);
     await expect(ProfiledHook).not.toRerender({ timeout: 20 });
+    expect(onData).toHaveBeenCalledTimes(1);
 
     rerender(<ProfiledHook ignoreResults={false} />);
     {

--- a/src/react/hooks/useSubscription.ts
+++ b/src/react/hooks/useSubscription.ts
@@ -191,7 +191,7 @@ export function useSubscription<
 
   const ignoreResultsRef = React.useRef(ignoreResults);
   useIsomorphicLayoutEffect(() => {
-    // We cannot directly reference `ignoreResults` directly in the effect below
+    // We cannot reference `ignoreResults` directly in the effect below
     // it would add a dependency to the `useEffect` deps array, which means the
     // subscription would be recreated if `ignoreResults` changes
     // As a result, on resubscription, the last result would be re-delivered,

--- a/src/react/hooks/useSubscription.ts
+++ b/src/react/hooks/useSubscription.ts
@@ -266,8 +266,7 @@ export function useSubscription<
 
         return () => {
           // immediately stop receiving subscription values, but do not unsubscribe
-          // until after a short delay in case another useSubscription hook
-          // (or this hook, after flipping `ignoreResults`) is
+          // until after a short delay in case another useSubscription hook is
           // reusing the same underlying observable and is about to subscribe
           subscriptionStopped = true;
           setTimeout(() => {

--- a/src/react/types/types.documentation.ts
+++ b/src/react/types/types.documentation.ts
@@ -533,6 +533,8 @@ export interface SubscriptionOptionsDocumentation {
 
   /**
    * If `true`, the hook will not cause the component to rerender. This is useful when you want to control the rendering of your component yourself with logic in the `onData` and `onError` callbacks.
+   *
+   * Changing this to `true` when the hook already has `data` will reset the `data` to `undefined`.
    */
   ignoreResults: unknown;
   /**

--- a/src/react/types/types.documentation.ts
+++ b/src/react/types/types.documentation.ts
@@ -532,7 +532,7 @@ export interface SubscriptionOptionsDocumentation {
   shouldResubscribe: unknown;
 
   /**
-   * If `true`, the hook will not cause a component to rerender - this is useful when you want to control the rendering of your component yourself with logic in the `onData` and `onError` callbacks.
+   * If `true`, the hook will not cause the component to rerender. This is useful when you want to control the rendering of your component yourself with logic in the `onData` and `onError` callbacks.
    */
   ignoreResults: unknown;
   /**

--- a/src/react/types/types.documentation.ts
+++ b/src/react/types/types.documentation.ts
@@ -532,6 +532,10 @@ export interface SubscriptionOptionsDocumentation {
   shouldResubscribe: unknown;
 
   /**
+   * If `true`, the hook will not cause a component to rerender - this is useful when you want to control the rendering of your component yourself with logic in the `onData` and `onError` callbacks.
+   */
+  ignoreResults: unknown;
+  /**
    * An `ApolloClient` instance. By default `useSubscription` / `Subscription` uses the client passed down via context, but a different client can be passed in.
    */
   client: unknown;

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -459,7 +459,7 @@ export interface BaseSubscriptionOptions<
   onSubscriptionComplete?: () => void;
   /**
    * {@inheritDoc @apollo/client!SubscriptionOptionsDocumentation#ignoreResults:member}
-   * @default false
+   * @defaultValue `false`
    */
   ignoreResults?: boolean;
 }
@@ -483,6 +483,19 @@ export interface SubscriptionHookOptions<
   TData = any,
   TVariables extends OperationVariables = OperationVariables,
 > extends BaseSubscriptionOptions<TData, TVariables> {}
+
+/**
+ * @deprecated This type is not used anymore. It will be removed in the next major version of Apollo Client
+ */
+export interface SubscriptionDataOptions<
+  TData = any,
+  TVariables extends OperationVariables = OperationVariables,
+> extends BaseSubscriptionOptions<TData, TVariables> {
+  subscription: DocumentNode | TypedDocumentNode<TData, TVariables>;
+  children?:
+    | null
+    | ((result: SubscriptionResult<TData>) => ReactTypes.ReactNode);
+}
 
 export interface SubscriptionCurrentObservable {
   query?: Observable<any>;

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -457,6 +457,11 @@ export interface BaseSubscriptionOptions<
   onError?: (error: ApolloError) => void;
   /** {@inheritDoc @apollo/client!SubscriptionOptionsDocumentation#onSubscriptionComplete:member} */
   onSubscriptionComplete?: () => void;
+  /**
+   * {@inheritDoc @apollo/client!SubscriptionOptionsDocumentation#ignoreResults:member}
+   * @default false
+   */
+  ignoreResults?: boolean;
 }
 
 export interface SubscriptionResult<TData = any, TVariables = any> {
@@ -478,16 +483,6 @@ export interface SubscriptionHookOptions<
   TData = any,
   TVariables extends OperationVariables = OperationVariables,
 > extends BaseSubscriptionOptions<TData, TVariables> {}
-
-export interface SubscriptionDataOptions<
-  TData = any,
-  TVariables extends OperationVariables = OperationVariables,
-> extends BaseSubscriptionOptions<TData, TVariables> {
-  subscription: DocumentNode | TypedDocumentNode<TData, TVariables>;
-  children?:
-    | null
-    | ((result: SubscriptionResult<TData>) => ReactTypes.ReactNode);
-}
 
 export interface SubscriptionCurrentObservable {
   query?: Observable<any>;


### PR DESCRIPTION
Resolves #10216 
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:

### Checklist:
- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
-->
