### PR TITLE
Add `subscribeToMore` function to `useBackgroundQuery`, `useQueryRefHandlers`, and `useLoadableQuery`

### DIFF
--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -2089,6 +2089,7 @@ UseBackgroundQueryResult<TData, TVariables>
 
 // @public (undocumented)
 export type UseBackgroundQueryResult<TData = unknown, TVariables extends OperationVariables = OperationVariables> = {
+    subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
     fetchMore: FetchMoreFunction<TData, TVariables>;
     refetch: RefetchFunction<TData, TVariables>;
 };
@@ -2165,6 +2166,7 @@ export function useQueryRefHandlers<TData = unknown, TVariables extends Operatio
 export interface UseQueryRefHandlersResult<TData = unknown, TVariables extends OperationVariables = OperationVariables> {
     fetchMore: FetchMoreFunction<TData, TVariables>;
     refetch: RefetchFunction<TData, TVariables>;
+    subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
 }
 
 // Warning: (ae-forgotten-export) The symbol "ReactiveVar" needs to be exported by the entry point index.d.ts
@@ -2240,8 +2242,6 @@ export interface UseSuspenseQueryResult<TData = unknown, TVariables extends Oper
     networkStatus: NetworkStatus;
     // (undocumented)
     refetch: RefetchFunction<TData, TVariables>;
-    // Warning: (ae-forgotten-export) The symbol "SubscribeToMoreFunction" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
 }
@@ -2305,8 +2305,9 @@ interface WatchQueryOptions<TVariables extends OperationVariables = OperationVar
 // src/core/types.ts:203:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:269:2 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:269:2 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
-// src/react/hooks/useBackgroundQuery.ts:29:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts
-// src/react/hooks/useBackgroundQuery.ts:30:3 - (ae-forgotten-export) The symbol "RefetchFunction" needs to be exported by the entry point index.d.ts
+// src/react/hooks/useBackgroundQuery.ts:38:3 - (ae-forgotten-export) The symbol "SubscribeToMoreFunction" needs to be exported by the entry point index.d.ts
+// src/react/hooks/useBackgroundQuery.ts:54:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts
+// src/react/hooks/useBackgroundQuery.ts:78:4 - (ae-forgotten-export) The symbol "RefetchFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useLoadableQuery.ts:107:1 - (ae-forgotten-export) The symbol "ResetFunction" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -2149,6 +2149,7 @@ queryRef: QueryRef<TData, TVariables> | null,
 handlers: {
     fetchMore: FetchMoreFunction<TData, TVariables>;
     refetch: RefetchFunction<TData, TVariables>;
+    subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
     reset: ResetFunction;
 }
 ];
@@ -2308,7 +2309,7 @@ interface WatchQueryOptions<TVariables extends OperationVariables = OperationVar
 // src/react/hooks/useBackgroundQuery.ts:38:3 - (ae-forgotten-export) The symbol "SubscribeToMoreFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:54:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:78:4 - (ae-forgotten-export) The symbol "RefetchFunction" needs to be exported by the entry point index.d.ts
-// src/react/hooks/useLoadableQuery.ts:107:1 - (ae-forgotten-export) The symbol "ResetFunction" needs to be exported by the entry point index.d.ts
+// src/react/hooks/useLoadableQuery.ts:120:9 - (ae-forgotten-export) The symbol "ResetFunction" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report-react_hooks.api.md
+++ b/.api-reports/api-report-react_hooks.api.md
@@ -1977,6 +1977,7 @@ queryRef: QueryRef<TData, TVariables> | null,
 handlers: {
     fetchMore: FetchMoreFunction<TData, TVariables>;
     refetch: RefetchFunction<TData, TVariables>;
+    subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
     reset: ResetFunction;
 }
 ];
@@ -2132,7 +2133,7 @@ interface WatchQueryOptions<TVariables extends OperationVariables = OperationVar
 // src/react/hooks/useBackgroundQuery.ts:38:3 - (ae-forgotten-export) The symbol "SubscribeToMoreFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:54:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:78:4 - (ae-forgotten-export) The symbol "RefetchFunction" needs to be exported by the entry point index.d.ts
-// src/react/hooks/useLoadableQuery.ts:107:1 - (ae-forgotten-export) The symbol "ResetFunction" needs to be exported by the entry point index.d.ts
+// src/react/hooks/useLoadableQuery.ts:120:9 - (ae-forgotten-export) The symbol "ResetFunction" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report-react_hooks.api.md
+++ b/.api-reports/api-report-react_hooks.api.md
@@ -1913,6 +1913,7 @@ UseBackgroundQueryResult<TData, TVariables>
 
 // @public (undocumented)
 export type UseBackgroundQueryResult<TData = unknown, TVariables extends OperationVariables = OperationVariables> = {
+    subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
     fetchMore: FetchMoreFunction<TData, TVariables>;
     refetch: RefetchFunction<TData, TVariables>;
 };
@@ -1996,6 +1997,7 @@ export function useQueryRefHandlers<TData = unknown, TVariables extends Operatio
 export interface UseQueryRefHandlersResult<TData = unknown, TVariables extends OperationVariables = OperationVariables> {
     fetchMore: FetchMoreFunction<TData, TVariables>;
     refetch: RefetchFunction<TData, TVariables>;
+    subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
 }
 
 // Warning: (ae-forgotten-export) The symbol "ReactiveVar" needs to be exported by the entry point index.d.ts
@@ -2075,8 +2077,6 @@ export interface UseSuspenseQueryResult<TData = unknown, TVariables extends Oper
     networkStatus: NetworkStatus;
     // (undocumented)
     refetch: RefetchFunction<TData, TVariables>;
-    // Warning: (ae-forgotten-export) The symbol "SubscribeToMoreFunction" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
 }
@@ -2129,8 +2129,9 @@ interface WatchQueryOptions<TVariables extends OperationVariables = OperationVar
 // src/core/types.ts:203:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:269:2 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:269:2 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
-// src/react/hooks/useBackgroundQuery.ts:29:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts
-// src/react/hooks/useBackgroundQuery.ts:30:3 - (ae-forgotten-export) The symbol "RefetchFunction" needs to be exported by the entry point index.d.ts
+// src/react/hooks/useBackgroundQuery.ts:38:3 - (ae-forgotten-export) The symbol "SubscribeToMoreFunction" needs to be exported by the entry point index.d.ts
+// src/react/hooks/useBackgroundQuery.ts:54:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts
+// src/react/hooks/useBackgroundQuery.ts:78:4 - (ae-forgotten-export) The symbol "RefetchFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useLoadableQuery.ts:107:1 - (ae-forgotten-export) The symbol "ResetFunction" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-react_internal.api.md
+++ b/.api-reports/api-report-react_internal.api.md
@@ -1923,6 +1923,7 @@ UseBackgroundQueryResult<TData, TVariables>
 
 // @public (undocumented)
 type UseBackgroundQueryResult<TData = unknown, TVariables extends OperationVariables = OperationVariables> = {
+    subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
     fetchMore: FetchMoreFunction<TData, TVariables>;
     refetch: RefetchFunction<TData, TVariables>;
 };
@@ -1967,6 +1968,7 @@ function useQueryRefHandlers<TData = unknown, TVariables extends OperationVariab
 interface UseQueryRefHandlersResult<TData = unknown, TVariables extends OperationVariables = OperationVariables> {
     fetchMore: FetchMoreFunction<TData, TVariables>;
     refetch: RefetchFunction<TData, TVariables>;
+    subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
 }
 
 // Warning: (ae-forgotten-export) The symbol "UseReadQueryResult" needs to be exported by the entry point index.d.ts
@@ -2039,8 +2041,6 @@ interface UseSuspenseQueryResult<TData = unknown, TVariables extends OperationVa
     networkStatus: NetworkStatus;
     // (undocumented)
     refetch: RefetchFunction<TData, TVariables>;
-    // Warning: (ae-forgotten-export) The symbol "SubscribeToMoreFunction" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
 }
@@ -2134,8 +2134,9 @@ export function wrapQueryRef<TData, TVariables extends OperationVariables>(inter
 // src/core/types.ts:203:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:269:2 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:269:2 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
-// src/react/hooks/useBackgroundQuery.ts:29:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts
-// src/react/hooks/useBackgroundQuery.ts:30:3 - (ae-forgotten-export) The symbol "RefetchFunction" needs to be exported by the entry point index.d.ts
+// src/react/hooks/useBackgroundQuery.ts:38:3 - (ae-forgotten-export) The symbol "SubscribeToMoreFunction" needs to be exported by the entry point index.d.ts
+// src/react/hooks/useBackgroundQuery.ts:54:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts
+// src/react/hooks/useBackgroundQuery.ts:78:4 - (ae-forgotten-export) The symbol "RefetchFunction" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -2812,6 +2812,7 @@ queryRef: QueryRef<TData, TVariables> | null,
 handlers: {
     fetchMore: FetchMoreFunction<TData, TVariables>;
     refetch: RefetchFunction<TData, TVariables>;
+    subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
     reset: ResetFunction;
 }
 ];
@@ -2997,7 +2998,7 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/react/hooks/useBackgroundQuery.ts:38:3 - (ae-forgotten-export) The symbol "SubscribeToMoreFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:54:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:78:4 - (ae-forgotten-export) The symbol "RefetchFunction" needs to be exported by the entry point index.d.ts
-// src/react/hooks/useLoadableQuery.ts:107:1 - (ae-forgotten-export) The symbol "ResetFunction" needs to be exported by the entry point index.d.ts
+// src/react/hooks/useLoadableQuery.ts:120:9 - (ae-forgotten-export) The symbol "ResetFunction" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -2752,6 +2752,7 @@ UseBackgroundQueryResult<TData, TVariables>
 
 // @public (undocumented)
 export type UseBackgroundQueryResult<TData = unknown, TVariables extends OperationVariables = OperationVariables> = {
+    subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
     fetchMore: FetchMoreFunction<TData, TVariables>;
     refetch: RefetchFunction<TData, TVariables>;
 };
@@ -2828,6 +2829,7 @@ export function useQueryRefHandlers<TData = unknown, TVariables extends Operatio
 export interface UseQueryRefHandlersResult<TData = unknown, TVariables extends OperationVariables = OperationVariables> {
     fetchMore: FetchMoreFunction<TData, TVariables>;
     refetch: RefetchFunction<TData, TVariables>;
+    subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
 }
 
 // @public
@@ -2901,8 +2903,6 @@ export interface UseSuspenseQueryResult<TData = unknown, TVariables extends Oper
     networkStatus: NetworkStatus;
     // (undocumented)
     refetch: RefetchFunction<TData, TVariables>;
-    // Warning: (ae-forgotten-export) The symbol "SubscribeToMoreFunction" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
 }
@@ -2994,8 +2994,9 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/core/watchQueryOptions.ts:269:2 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:269:2 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
 // src/link/http/selectHttpOptionsAndBody.ts:128:32 - (ae-forgotten-export) The symbol "HttpQueryOptions" needs to be exported by the entry point index.d.ts
-// src/react/hooks/useBackgroundQuery.ts:29:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts
-// src/react/hooks/useBackgroundQuery.ts:30:3 - (ae-forgotten-export) The symbol "RefetchFunction" needs to be exported by the entry point index.d.ts
+// src/react/hooks/useBackgroundQuery.ts:38:3 - (ae-forgotten-export) The symbol "SubscribeToMoreFunction" needs to be exported by the entry point index.d.ts
+// src/react/hooks/useBackgroundQuery.ts:54:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts
+// src/react/hooks/useBackgroundQuery.ts:78:4 - (ae-forgotten-export) The symbol "RefetchFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useLoadableQuery.ts:107:1 - (ae-forgotten-export) The symbol "ResetFunction" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.changeset/angry-ravens-mate.md
+++ b/.changeset/angry-ravens-mate.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": minor
+---
+
+Add support for `subscribeToMore` function to `useQueryRefHandlers`.

--- a/.changeset/chilly-dots-shake.md
+++ b/.changeset/chilly-dots-shake.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": minor
+---
+
+Add support for `subscribeToMore` function to `useLoadableQuery`.

--- a/.changeset/slimy-balloons-cheat.md
+++ b/.changeset/slimy-balloons-cheat.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": minor
+---
+
+Add support for `subscribeToMore` function to `useBackgroundQuery`.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 39856,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 32851
+  "dist/apollo-client.min.cjs": 39873,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 32865
 }

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 39825,
+  "dist/apollo-client.min.cjs": 39856,
   "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 32851
 }

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -163,6 +163,8 @@ export class ObservableQuery<
     this.waitForOwnResult = skipCacheDataFor(options.fetchPolicy);
     this.isTornDown = false;
 
+    this.subscribeToMore = this.subscribeToMore.bind(this);
+
     const {
       watchQuery: { fetchPolicy: defaultFetchPolicy = "cache-first" } = {},
     } = queryManager.defaultOptions;

--- a/src/react/hooks/__tests__/useQueryRefHandlers.test.tsx
+++ b/src/react/hooks/__tests__/useQueryRefHandlers.test.tsx
@@ -4,10 +4,16 @@ import {
   ApolloClient,
   InMemoryCache,
   NetworkStatus,
+  SubscribeToMoreOptions,
   TypedDocumentNode,
   gql,
+  split,
 } from "../../../core";
-import { MockLink, MockedResponse } from "../../../testing";
+import {
+  MockLink,
+  MockSubscriptionLink,
+  MockedResponse,
+} from "../../../testing";
 import {
   PaginatedCaseData,
   SimpleCaseData,
@@ -19,13 +25,14 @@ import {
 } from "../../../testing/internal";
 import { useQueryRefHandlers } from "../useQueryRefHandlers";
 import { UseReadQueryResult, useReadQuery } from "../useReadQuery";
+import type { SubscribeToMoreFunction } from "../useSuspenseQuery";
 import { Suspense } from "react";
 import { createQueryPreloader } from "../../query-preloader/createQueryPreloader";
 import userEvent from "@testing-library/user-event";
 import { QueryRef } from "../../internal";
 import { useBackgroundQuery } from "../useBackgroundQuery";
 import { useLoadableQuery } from "../useLoadableQuery";
-import { concatPagination } from "../../../utilities";
+import { concatPagination, getMainDefinition } from "../../../utilities";
 
 test("does not interfere with updates from useReadQuery", async () => {
   const { query, mocks } = setupSimpleCase();
@@ -1926,4 +1933,148 @@ test("`fetchMore` works with startTransition from useBackgroundQuery and useQuer
   }
 
   await expect(Profiler).not.toRerender();
+});
+
+test("can subscribe to subscriptions and react to cache updates via `subscribeToMore`", async () => {
+  interface SubscriptionData {
+    greetingUpdated: string;
+  }
+
+  type UpdateQueryFn = NonNullable<
+    SubscribeToMoreOptions<
+      SimpleCaseData,
+      Record<string, never>,
+      SubscriptionData
+    >["updateQuery"]
+  >;
+
+  const subscription: TypedDocumentNode<
+    SubscriptionData,
+    Record<string, never>
+  > = gql`
+    subscription {
+      greetingUpdated
+    }
+  `;
+
+  const { mocks, query } = setupSimpleCase();
+
+  const wsLink = new MockSubscriptionLink();
+  const mockLink = new MockLink(mocks);
+
+  const link = split(
+    ({ query }) => {
+      const definition = getMainDefinition(query);
+
+      return (
+        definition.kind === "OperationDefinition" &&
+        definition.operation === "subscription"
+      );
+    },
+    wsLink,
+    mockLink
+  );
+
+  const client = new ApolloClient({ link, cache: new InMemoryCache() });
+
+  const preloadQuery = createQueryPreloader(client);
+  const queryRef = preloadQuery(query);
+
+  const Profiler = createProfiler({
+    initialSnapshot: {
+      subscribeToMore: null as SubscribeToMoreFunction<
+        SimpleCaseData,
+        Record<string, never>
+      > | null,
+      result: null as UseReadQueryResult<SimpleCaseData> | null,
+    },
+  });
+
+  function SuspenseFallback() {
+    useTrackRenders();
+    return <p>Loading</p>;
+  }
+
+  function ReadQueryHook() {
+    useTrackRenders();
+    Profiler.mergeSnapshot({ result: useReadQuery(queryRef) });
+
+    return null;
+  }
+
+  function App() {
+    useTrackRenders();
+    // We can ignore the return result here since we are testing the mechanics
+    // of this hook to ensure it doesn't interfere with the updates from
+    // useReadQuery
+    const { subscribeToMore } = useQueryRefHandlers(queryRef);
+
+    Profiler.mergeSnapshot({ subscribeToMore });
+
+    return (
+      <Suspense fallback={<SuspenseFallback />}>
+        <ReadQueryHook />
+      </Suspense>
+    );
+  }
+
+  renderWithClient(<App />, { client, wrapper: Profiler });
+
+  {
+    const { renderedComponents } = await Profiler.takeRender();
+
+    expect(renderedComponents).toStrictEqual([App, SuspenseFallback]);
+  }
+
+  {
+    const { snapshot, renderedComponents } = await Profiler.takeRender();
+
+    expect(renderedComponents).toStrictEqual([ReadQueryHook]);
+    expect(snapshot.result).toEqual({
+      data: { greeting: "Hello" },
+      error: undefined,
+      networkStatus: NetworkStatus.ready,
+    });
+  }
+
+  const updateQuery = jest.fn<
+    ReturnType<UpdateQueryFn>,
+    Parameters<UpdateQueryFn>
+  >((_, { subscriptionData: { data } }) => {
+    return { greeting: data.greetingUpdated };
+  });
+
+  const { snapshot } = Profiler.getCurrentRender();
+
+  snapshot.subscribeToMore!({ document: subscription, updateQuery });
+
+  wsLink.simulateResult({
+    result: {
+      data: {
+        greetingUpdated: "Subscription hello",
+      },
+    },
+  });
+
+  {
+    const { snapshot, renderedComponents } = await Profiler.takeRender();
+
+    expect(renderedComponents).toStrictEqual([ReadQueryHook]);
+    expect(snapshot.result).toEqual({
+      data: { greeting: "Subscription hello" },
+      error: undefined,
+      networkStatus: NetworkStatus.ready,
+    });
+  }
+
+  expect(updateQuery).toHaveBeenCalledTimes(1);
+  expect(updateQuery).toHaveBeenCalledWith(
+    { greeting: "Hello" },
+    {
+      subscriptionData: {
+        data: { greetingUpdated: "Subscription hello" },
+      },
+      variables: {},
+    }
+  );
 });

--- a/src/react/hooks/useBackgroundQuery.ts
+++ b/src/react/hooks/useBackgroundQuery.ts
@@ -30,8 +30,11 @@ export type UseBackgroundQueryResult<
   TData = unknown,
   TVariables extends OperationVariables = OperationVariables,
 > = {
+  /** {@inheritDoc @apollo/client!ObservableQuery#subscribeToMore:member(1)} */
   subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
+  /** {@inheritDoc @apollo/client!ObservableQuery#fetchMore:member(1)} */
   fetchMore: FetchMoreFunction<TData, TVariables>;
+  /** {@inheritDoc @apollo/client!ObservableQuery#refetch:member(1)} */
   refetch: RefetchFunction<TData, TVariables>;
 };
 

--- a/src/react/hooks/useBackgroundQuery.ts
+++ b/src/react/hooks/useBackgroundQuery.ts
@@ -17,7 +17,11 @@ import type { CacheKey, QueryRef } from "../internal/index.js";
 import type { BackgroundQueryHookOptions, NoInfer } from "../types/types.js";
 import { wrapHook } from "./internal/index.js";
 import { useWatchQueryOptions } from "./useSuspenseQuery.js";
-import type { FetchMoreFunction, RefetchFunction } from "./useSuspenseQuery.js";
+import type {
+  FetchMoreFunction,
+  RefetchFunction,
+  SubscribeToMoreFunction,
+} from "./useSuspenseQuery.js";
 import { canonicalStringify } from "../../cache/index.js";
 import type { DeepPartial } from "../../utilities/index.js";
 import type { SkipToken } from "./constants.js";
@@ -26,6 +30,7 @@ export type UseBackgroundQueryResult<
   TData = unknown,
   TVariables extends OperationVariables = OperationVariables,
 > = {
+  subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
   fetchMore: FetchMoreFunction<TData, TVariables>;
   refetch: RefetchFunction<TData, TVariables>;
 };
@@ -277,10 +282,16 @@ function _useBackgroundQuery<
     [queryRef]
   );
 
+  const subscribeToMore: SubscribeToMoreFunction<TData, TVariables> =
+    React.useCallback(
+      (options) => queryRef.observable.subscribeToMore(options),
+      [queryRef]
+    );
+
   React.useEffect(() => queryRef.softRetain(), [queryRef]);
 
   return [
     didFetchResult.current ? wrappedQueryRef : void 0,
-    { fetchMore, refetch },
+    { fetchMore, refetch, subscribeToMore },
   ];
 }

--- a/src/react/hooks/useBackgroundQuery.ts
+++ b/src/react/hooks/useBackgroundQuery.ts
@@ -285,16 +285,14 @@ function _useBackgroundQuery<
     [queryRef]
   );
 
-  const subscribeToMore: SubscribeToMoreFunction<TData, TVariables> =
-    React.useCallback(
-      (options) => queryRef.observable.subscribeToMore(options),
-      [queryRef]
-    );
-
   React.useEffect(() => queryRef.softRetain(), [queryRef]);
 
   return [
     didFetchResult.current ? wrappedQueryRef : void 0,
-    { fetchMore, refetch, subscribeToMore },
+    {
+      fetchMore,
+      refetch,
+      subscribeToMore: queryRef.observable.subscribeToMore,
+    },
   ];
 }

--- a/src/react/hooks/useLoadableQuery.ts
+++ b/src/react/hooks/useLoadableQuery.ts
@@ -53,7 +53,7 @@ export type UseLoadableQueryResult<
     fetchMore: FetchMoreFunction<TData, TVariables>;
     /** {@inheritDoc @apollo/client!QueryResultDocumentation#refetch:member} */
     refetch: RefetchFunction<TData, TVariables>;
-    /** {@inheritDoc @apollo/client!QueryResultDocumentation#subscribeToMore:member(1)} */
+    /** {@inheritDoc @apollo/client!ObservableQuery#subscribeToMore:member(1)} */
     subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
     /**
      * A function that resets the `queryRef` back to `null`.

--- a/src/react/hooks/useLoadableQuery.ts
+++ b/src/react/hooks/useLoadableQuery.ts
@@ -18,7 +18,11 @@ import type { CacheKey, QueryRef } from "../internal/index.js";
 import type { LoadableQueryHookOptions } from "../types/types.js";
 import { __use, useRenderGuard } from "./internal/index.js";
 import { useWatchQueryOptions } from "./useSuspenseQuery.js";
-import type { FetchMoreFunction, RefetchFunction } from "./useSuspenseQuery.js";
+import type {
+  FetchMoreFunction,
+  RefetchFunction,
+  SubscribeToMoreFunction,
+} from "./useSuspenseQuery.js";
 import { canonicalStringify } from "../../cache/index.js";
 import type {
   DeepPartial,
@@ -49,6 +53,8 @@ export type UseLoadableQueryResult<
     fetchMore: FetchMoreFunction<TData, TVariables>;
     /** {@inheritDoc @apollo/client!QueryResultDocumentation#refetch:member} */
     refetch: RefetchFunction<TData, TVariables>;
+    /** {@inheritDoc @apollo/client!QueryResultDocumentation#subscribeToMore:member(1)} */
+    subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
     /**
      * A function that resets the `queryRef` back to `null`.
      */
@@ -255,9 +261,22 @@ export function useLoadableQuery<
     ]
   );
 
+  const subscribeToMore: SubscribeToMoreFunction<TData, TVariables> =
+    React.useCallback(
+      (options) => {
+        invariant(
+          internalQueryRef,
+          "The query has not been loaded. Please load the query."
+        );
+
+        return internalQueryRef.observable.subscribeToMore(options);
+      },
+      [internalQueryRef]
+    );
+
   const reset: ResetFunction = React.useCallback(() => {
     setQueryRef(null);
   }, []);
 
-  return [loadQuery, queryRef, { fetchMore, refetch, reset }];
+  return [loadQuery, queryRef, { fetchMore, refetch, reset, subscribeToMore }];
 }

--- a/src/react/hooks/useQueryRefHandlers.ts
+++ b/src/react/hooks/useQueryRefHandlers.ts
@@ -8,7 +8,11 @@ import {
 } from "../internal/index.js";
 import type { QueryRef } from "../internal/index.js";
 import type { OperationVariables } from "../../core/types.js";
-import type { RefetchFunction, FetchMoreFunction } from "./useSuspenseQuery.js";
+import type {
+  RefetchFunction,
+  FetchMoreFunction,
+  SubscribeToMoreFunction,
+} from "./useSuspenseQuery.js";
 import type { FetchMoreQueryOptions } from "../../core/watchQueryOptions.js";
 import { useApolloClient } from "./useApolloClient.js";
 import { wrapHook } from "./internal/index.js";
@@ -21,6 +25,8 @@ export interface UseQueryRefHandlersResult<
   refetch: RefetchFunction<TData, TVariables>;
   /** {@inheritDoc @apollo/client!ObservableQuery#fetchMore:member(1)} */
   fetchMore: FetchMoreFunction<TData, TVariables>;
+  /** {@inheritDoc @apollo/client!ObservableQuery#subscribeToMore:member(1)} */
+  subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
 }
 
 /**
@@ -112,5 +118,11 @@ function _useQueryRefHandlers<
     [internalQueryRef]
   );
 
-  return { refetch, fetchMore };
+  const subscribeToMore: SubscribeToMoreFunction<TData, TVariables> =
+    React.useCallback(
+      (options) => internalQueryRef.observable.subscribeToMore(options),
+      [internalQueryRef]
+    );
+
+  return { refetch, fetchMore, subscribeToMore };
 }

--- a/src/react/hooks/useQueryRefHandlers.ts
+++ b/src/react/hooks/useQueryRefHandlers.ts
@@ -118,11 +118,9 @@ function _useQueryRefHandlers<
     [internalQueryRef]
   );
 
-  const subscribeToMore: SubscribeToMoreFunction<TData, TVariables> =
-    React.useCallback(
-      (options) => internalQueryRef.observable.subscribeToMore(options),
-      [internalQueryRef]
-    );
-
-  return { refetch, fetchMore, subscribeToMore };
+  return {
+    refetch,
+    fetchMore,
+    subscribeToMore: internalQueryRef.observable.subscribeToMore,
+  };
 }

--- a/src/react/hooks/useSuspenseQuery.ts
+++ b/src/react/hooks/useSuspenseQuery.ts
@@ -274,13 +274,7 @@ function _useSuspenseQuery<
     [queryRef]
   );
 
-  const subscribeToMore: SubscribeToMoreFunction<
-    TData | undefined,
-    TVariables
-  > = React.useCallback(
-    (options) => queryRef.observable.subscribeToMore(options),
-    [queryRef]
-  );
+  const subscribeToMore = queryRef.observable.subscribeToMore;
 
   return React.useMemo<
     UseSuspenseQueryResult<TData | undefined, TVariables>


### PR DESCRIPTION
Closes #11818

Adds support for `subscribeToMore` in `useBackgroundQuery`, `useLoadableQuery`, and `useQueryRefHandlers` that was previously missing. This was available in `useSuspenseQuery` but not in the other three hooks.