### PR TITLE
Add `restart` function to `useSubscription`

### DIFF
--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -2183,7 +2183,13 @@ export interface UseReadQueryResult<TData = unknown> {
 }
 
 // @public
-export function useSubscription<TData = any, TVariables extends OperationVariables = OperationVariables>(subscription: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: SubscriptionHookOptions<NoInfer_2<TData>, NoInfer_2<TVariables>>): SubscriptionResult<TData, TVariables>;
+export function useSubscription<TData = any, TVariables extends OperationVariables = OperationVariables>(subscription: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: SubscriptionHookOptions<NoInfer_2<TData>, NoInfer_2<TVariables>>): {
+    restart(): void;
+    loading: boolean;
+    data?: TData | undefined;
+    error?: ApolloError;
+    variables?: TVariables | undefined;
+};
 
 // @public (undocumented)
 export function useSuspenseQuery<TData, TVariables extends OperationVariables, TOptions extends Omit<SuspenseQueryHookOptions<TData>, "variables">>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: SuspenseQueryHookOptions<NoInfer_2<TData>, NoInfer_2<TVariables>> & TOptions): UseSuspenseQueryResult<TOptions["errorPolicy"] extends "ignore" | "all" ? TOptions["returnPartialData"] extends true ? DeepPartial<TData> | undefined : TData | undefined : TOptions["returnPartialData"] extends true ? TOptions["skip"] extends boolean ? DeepPartial<TData> | undefined : DeepPartial<TData> : TOptions["skip"] extends boolean ? TData | undefined : TData, TVariables>;

--- a/.api-reports/api-report-react_hooks.api.md
+++ b/.api-reports/api-report-react_hooks.api.md
@@ -2016,7 +2016,13 @@ export interface UseReadQueryResult<TData = unknown> {
 // Warning: (ae-forgotten-export) The symbol "SubscriptionHookOptions" needs to be exported by the entry point index.d.ts
 //
 // @public
-export function useSubscription<TData = any, TVariables extends OperationVariables = OperationVariables>(subscription: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: SubscriptionHookOptions<NoInfer_2<TData>, NoInfer_2<TVariables>>): SubscriptionResult<TData, TVariables>;
+export function useSubscription<TData = any, TVariables extends OperationVariables = OperationVariables>(subscription: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: SubscriptionHookOptions<NoInfer_2<TData>, NoInfer_2<TVariables>>): {
+    restart(): void;
+    loading: boolean;
+    data?: TData | undefined;
+    error?: ApolloError;
+    variables?: TVariables | undefined;
+};
 
 // Warning: (ae-forgotten-export) The symbol "SuspenseQueryHookOptions" needs to be exported by the entry point index.d.ts
 //

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -2844,7 +2844,13 @@ export interface UseReadQueryResult<TData = unknown> {
 }
 
 // @public
-export function useSubscription<TData = any, TVariables extends OperationVariables = OperationVariables>(subscription: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: SubscriptionHookOptions<NoInfer_2<TData>, NoInfer_2<TVariables>>): SubscriptionResult<TData, TVariables>;
+export function useSubscription<TData = any, TVariables extends OperationVariables = OperationVariables>(subscription: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: SubscriptionHookOptions<NoInfer_2<TData>, NoInfer_2<TVariables>>): {
+    restart(): void;
+    loading: boolean;
+    data?: TData | undefined;
+    error?: ApolloError;
+    variables?: TVariables | undefined;
+};
 
 // @public (undocumented)
 export function useSuspenseQuery<TData, TVariables extends OperationVariables, TOptions extends Omit<SuspenseQueryHookOptions<TData>, "variables">>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: SuspenseQueryHookOptions<NoInfer_2<TData>, NoInfer_2<TVariables>> & TOptions): UseSuspenseQueryResult<TOptions["errorPolicy"] extends "ignore" | "all" ? TOptions["returnPartialData"] extends true ? DeepPartial<TData> | undefined : TData | undefined : TOptions["returnPartialData"] extends true ? TOptions["skip"] extends boolean ? DeepPartial<TData> | undefined : DeepPartial<TData> : TOptions["skip"] extends boolean ? TData | undefined : TData, TVariables>;

--- a/.changeset/clever-bikes-admire.md
+++ b/.changeset/clever-bikes-admire.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Add `restart` function to `useSubscription`.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 39825,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 32851
+  "dist/apollo-client.min.cjs": 39865,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 32852
 }

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 39924,
+  "dist/apollo-client.min.cjs": 39971,
   "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 32903
 }

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -1179,7 +1179,7 @@ describe("`restart` callback", () => {
         variables: { id: "1" },
       });
     }
-    await expect(ProfiledHook).not.toRerender({ timesout: 20 });
+    await expect(ProfiledHook).not.toRerender({ timeout: 20 });
     expect(onUnsubscribe).toHaveBeenCalledTimes(0);
     expect(onSubscribe).toHaveBeenCalledTimes(1);
 
@@ -1241,7 +1241,7 @@ describe("`restart` callback", () => {
         variables: { id: "1" },
       });
     }
-    await expect(ProfiledHook).not.toRerender({ timesout: 20 });
+    await expect(ProfiledHook).not.toRerender({ timeout: 20 });
     expect(onUnsubscribe).toHaveBeenCalledTimes(0);
     expect(onSubscribe).toHaveBeenCalledTimes(1);
 
@@ -1332,7 +1332,7 @@ describe("`restart` callback", () => {
         variables: { id: "1" },
       });
     }
-    await expect(ProfiledHook).not.toRerender({ timesout: 20 });
+    await expect(ProfiledHook).not.toRerender({ timeout: 20 });
     expect(onUnsubscribe).toHaveBeenCalledTimes(1);
     expect(onSubscribe).toHaveBeenCalledTimes(1);
 
@@ -1394,7 +1394,7 @@ describe("`restart` callback", () => {
         variables: { id: "1" },
       });
     }
-    await expect(ProfiledHook).not.toRerender({ timesout: 20 });
+    await expect(ProfiledHook).not.toRerender({ timeout: 20 });
     expect(onUnsubscribe).toHaveBeenCalledTimes(1);
     expect(onSubscribe).toHaveBeenCalledTimes(1);
 
@@ -1449,7 +1449,7 @@ describe("`restart` callback", () => {
       new InvariantError("A subscription that is skipped cannot be restarted.")
     );
 
-    await expect(ProfiledHook).not.toRerender({ timesout: 20 });
+    await expect(ProfiledHook).not.toRerender({ timeout: 20 });
     expect(onUnsubscribe).toHaveBeenCalledTimes(0);
     expect(onSubscribe).toHaveBeenCalledTimes(0);
   });

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -1348,8 +1348,8 @@ describe("`restart` callback", () => {
         variables: { id: "1" },
       });
     }
+    await waitFor(() => expect(onSubscribe).toHaveBeenCalledTimes(2));
     expect(onUnsubscribe).toHaveBeenCalledTimes(1);
-    expect(onSubscribe).toHaveBeenCalledTimes(2);
 
     link.simulateResult({ result: { data: { totalLikes: 2 } } });
     {
@@ -1410,8 +1410,8 @@ describe("`restart` callback", () => {
         variables: { id: "1" },
       });
     }
+    await waitFor(() => expect(onSubscribe).toHaveBeenCalledTimes(2));
     expect(onUnsubscribe).toHaveBeenCalledTimes(1);
-    expect(onSubscribe).toHaveBeenCalledTimes(2);
 
     link.simulateResult({ result: { data: { totalLikes: 2 } } });
     {

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { renderHook, waitFor } from "@testing-library/react";
+import { render, renderHook, waitFor } from "@testing-library/react";
 import gql from "graphql-tag";
 
 import {
@@ -14,7 +14,10 @@ import { InMemoryCache as Cache } from "../../../cache";
 import { ApolloProvider } from "../../context";
 import { MockSubscriptionLink } from "../../../testing";
 import { useSubscription } from "../useSubscription";
-import { spyOnConsole } from "../../../testing/internal";
+import { profileHook, spyOnConsole } from "../../../testing/internal";
+import { SubscriptionHookOptions } from "../../types/types";
+import { GraphQLError } from "graphql";
+import { InvariantError } from "ts-invariant";
 
 describe("useSubscription Hook", () => {
   it("should handle a simple subscription properly", async () => {
@@ -1119,6 +1122,336 @@ followed by new in-flight setup", async () => {
     expect(result.current.tails.data).toBeUndefined();
 
     unmount();
+  });
+});
+
+describe("`restart` callback", () => {
+  function setup() {
+    const subscription: TypedDocumentNode<
+      { totalLikes: number },
+      { id: string }
+    > = gql`
+      subscription ($id: ID!) {
+        totalLikes(postId: $id)
+      }
+    `;
+    const onSubscribe = jest.fn();
+    const onUnsubscribe = jest.fn();
+    const link = new MockSubscriptionLink();
+    link.onSetup(onSubscribe);
+    link.onUnsubscribe(onUnsubscribe);
+    const client = new ApolloClient({
+      link,
+      cache: new Cache(),
+    });
+    const ProfiledHook = profileHook(
+      (
+        options: SubscriptionHookOptions<{ totalLikes: number }, { id: string }>
+      ) => useSubscription(subscription, options)
+    );
+    return { client, link, ProfiledHook, onSubscribe, onUnsubscribe };
+  }
+  it("can restart a running subscription", async () => {
+    const { client, link, ProfiledHook, onSubscribe, onUnsubscribe } = setup();
+    render(<ProfiledHook variables={{ id: "1" }} />, {
+      wrapper: ({ children }) => (
+        <ApolloProvider client={client}>{children}</ApolloProvider>
+      ),
+    });
+    {
+      const snapshot = await ProfiledHook.takeSnapshot();
+      expect(snapshot).toStrictEqual({
+        loading: true,
+        data: undefined,
+        error: undefined,
+        restart: expect.any(Function),
+        variables: { id: "1" },
+      });
+    }
+    link.simulateResult({ result: { data: { totalLikes: 1 } } });
+    {
+      const snapshot = await ProfiledHook.takeSnapshot();
+      expect(snapshot).toStrictEqual({
+        loading: false,
+        data: { totalLikes: 1 },
+        error: undefined,
+        restart: expect.any(Function),
+        variables: { id: "1" },
+      });
+    }
+    await expect(ProfiledHook).not.toRerender({ timesout: 20 });
+    expect(onUnsubscribe).toHaveBeenCalledTimes(0);
+    expect(onSubscribe).toHaveBeenCalledTimes(1);
+
+    ProfiledHook.getCurrentSnapshot().restart();
+
+    {
+      const snapshot = await ProfiledHook.takeSnapshot();
+      expect(snapshot).toStrictEqual({
+        loading: true,
+        data: undefined,
+        error: undefined,
+        restart: expect.any(Function),
+        variables: { id: "1" },
+      });
+    }
+    await waitFor(() => expect(onUnsubscribe).toHaveBeenCalledTimes(1));
+    expect(onSubscribe).toHaveBeenCalledTimes(2);
+
+    link.simulateResult({ result: { data: { totalLikes: 2 } } });
+    {
+      const snapshot = await ProfiledHook.takeSnapshot();
+      expect(snapshot).toStrictEqual({
+        loading: false,
+        data: { totalLikes: 2 },
+        error: undefined,
+        restart: expect.any(Function),
+        variables: { id: "1" },
+      });
+    }
+  });
+  it("will use the most recently passed in options", async () => {
+    const { client, link, ProfiledHook, onSubscribe, onUnsubscribe } = setup();
+    const { rerender } = render(<ProfiledHook variables={{ id: "1" }} />, {
+      wrapper: ({ children }) => (
+        <ApolloProvider client={client}>{children}</ApolloProvider>
+      ),
+    });
+    {
+      const snapshot = await ProfiledHook.takeSnapshot();
+      expect(snapshot).toStrictEqual({
+        loading: true,
+        data: undefined,
+        error: undefined,
+        restart: expect.any(Function),
+        variables: { id: "1" },
+      });
+    }
+    // deliberately keeping a reference to a very old `restart` function
+    // to show that the most recent options are used even with that
+    const restart = ProfiledHook.getCurrentSnapshot().restart;
+    link.simulateResult({ result: { data: { totalLikes: 1 } } });
+    {
+      const snapshot = await ProfiledHook.takeSnapshot();
+      expect(snapshot).toStrictEqual({
+        loading: false,
+        data: { totalLikes: 1 },
+        error: undefined,
+        restart: expect.any(Function),
+        variables: { id: "1" },
+      });
+    }
+    await expect(ProfiledHook).not.toRerender({ timesout: 20 });
+    expect(onUnsubscribe).toHaveBeenCalledTimes(0);
+    expect(onSubscribe).toHaveBeenCalledTimes(1);
+
+    rerender(<ProfiledHook variables={{ id: "2" }} />);
+    await waitFor(() => expect(onUnsubscribe).toHaveBeenCalledTimes(1));
+    expect(onSubscribe).toHaveBeenCalledTimes(2);
+    expect(link.operation?.variables).toStrictEqual({ id: "2" });
+
+    {
+      const snapshot = await ProfiledHook.takeSnapshot();
+      expect(snapshot).toStrictEqual({
+        loading: true,
+        data: undefined,
+        error: undefined,
+        restart: expect.any(Function),
+        variables: { id: "2" },
+      });
+    }
+    link.simulateResult({ result: { data: { totalLikes: 1000 } } });
+    {
+      const snapshot = await ProfiledHook.takeSnapshot();
+      expect(snapshot).toStrictEqual({
+        loading: false,
+        data: { totalLikes: 1000 },
+        error: undefined,
+        restart: expect.any(Function),
+        variables: { id: "2" },
+      });
+    }
+
+    expect(onUnsubscribe).toHaveBeenCalledTimes(1);
+    expect(onSubscribe).toHaveBeenCalledTimes(2);
+    expect(link.operation?.variables).toStrictEqual({ id: "2" });
+
+    restart();
+
+    await waitFor(() => expect(onUnsubscribe).toHaveBeenCalledTimes(2));
+    expect(onSubscribe).toHaveBeenCalledTimes(3);
+    expect(link.operation?.variables).toStrictEqual({ id: "2" });
+
+    {
+      const snapshot = await ProfiledHook.takeSnapshot();
+      expect(snapshot).toStrictEqual({
+        loading: true,
+        data: undefined,
+        error: undefined,
+        restart: expect.any(Function),
+        variables: { id: "2" },
+      });
+    }
+    link.simulateResult({ result: { data: { totalLikes: 1005 } } });
+    {
+      const snapshot = await ProfiledHook.takeSnapshot();
+      expect(snapshot).toStrictEqual({
+        loading: false,
+        data: { totalLikes: 1005 },
+        error: undefined,
+        restart: expect.any(Function),
+        variables: { id: "2" },
+      });
+    }
+  });
+  it("can restart a subscription that has completed", async () => {
+    const { client, link, ProfiledHook, onSubscribe, onUnsubscribe } = setup();
+    render(<ProfiledHook variables={{ id: "1" }} />, {
+      wrapper: ({ children }) => (
+        <ApolloProvider client={client}>{children}</ApolloProvider>
+      ),
+    });
+    {
+      const snapshot = await ProfiledHook.takeSnapshot();
+      expect(snapshot).toStrictEqual({
+        loading: true,
+        data: undefined,
+        error: undefined,
+        restart: expect.any(Function),
+        variables: { id: "1" },
+      });
+    }
+    link.simulateResult({ result: { data: { totalLikes: 1 } } }, true);
+    {
+      const snapshot = await ProfiledHook.takeSnapshot();
+      expect(snapshot).toStrictEqual({
+        loading: false,
+        data: { totalLikes: 1 },
+        error: undefined,
+        restart: expect.any(Function),
+        variables: { id: "1" },
+      });
+    }
+    await expect(ProfiledHook).not.toRerender({ timesout: 20 });
+    expect(onUnsubscribe).toHaveBeenCalledTimes(1);
+    expect(onSubscribe).toHaveBeenCalledTimes(1);
+
+    ProfiledHook.getCurrentSnapshot().restart();
+
+    {
+      const snapshot = await ProfiledHook.takeSnapshot();
+      expect(snapshot).toStrictEqual({
+        loading: true,
+        data: undefined,
+        error: undefined,
+        restart: expect.any(Function),
+        variables: { id: "1" },
+      });
+    }
+    expect(onUnsubscribe).toHaveBeenCalledTimes(1);
+    expect(onSubscribe).toHaveBeenCalledTimes(2);
+
+    link.simulateResult({ result: { data: { totalLikes: 2 } } });
+    {
+      const snapshot = await ProfiledHook.takeSnapshot();
+      expect(snapshot).toStrictEqual({
+        loading: false,
+        data: { totalLikes: 2 },
+        error: undefined,
+        restart: expect.any(Function),
+        variables: { id: "1" },
+      });
+    }
+  });
+  it("can restart a subscription that has errored", async () => {
+    const { client, link, ProfiledHook, onSubscribe, onUnsubscribe } = setup();
+    render(<ProfiledHook variables={{ id: "1" }} />, {
+      wrapper: ({ children }) => (
+        <ApolloProvider client={client}>{children}</ApolloProvider>
+      ),
+    });
+    {
+      const snapshot = await ProfiledHook.takeSnapshot();
+      expect(snapshot).toStrictEqual({
+        loading: true,
+        data: undefined,
+        error: undefined,
+        restart: expect.any(Function),
+        variables: { id: "1" },
+      });
+    }
+    const error = new GraphQLError("error");
+    link.simulateResult({
+      result: { errors: [error] },
+    });
+    {
+      const snapshot = await ProfiledHook.takeSnapshot();
+      expect(snapshot).toStrictEqual({
+        loading: false,
+        data: undefined,
+        error: new ApolloError({ graphQLErrors: [error] }),
+        restart: expect.any(Function),
+        variables: { id: "1" },
+      });
+    }
+    await expect(ProfiledHook).not.toRerender({ timesout: 20 });
+    expect(onUnsubscribe).toHaveBeenCalledTimes(1);
+    expect(onSubscribe).toHaveBeenCalledTimes(1);
+
+    ProfiledHook.getCurrentSnapshot().restart();
+
+    {
+      const snapshot = await ProfiledHook.takeSnapshot();
+      expect(snapshot).toStrictEqual({
+        loading: true,
+        data: undefined,
+        error: undefined,
+        restart: expect.any(Function),
+        variables: { id: "1" },
+      });
+    }
+    expect(onUnsubscribe).toHaveBeenCalledTimes(1);
+    expect(onSubscribe).toHaveBeenCalledTimes(2);
+
+    link.simulateResult({ result: { data: { totalLikes: 2 } } });
+    {
+      const snapshot = await ProfiledHook.takeSnapshot();
+      expect(snapshot).toStrictEqual({
+        loading: false,
+        data: { totalLikes: 2 },
+        error: undefined,
+        restart: expect.any(Function),
+        variables: { id: "1" },
+      });
+    }
+  });
+  it("will not restart a subscription that has been `skip`ped", async () => {
+    const { client, ProfiledHook, onSubscribe, onUnsubscribe } = setup();
+    render(<ProfiledHook variables={{ id: "1" }} skip />, {
+      wrapper: ({ children }) => (
+        <ApolloProvider client={client}>{children}</ApolloProvider>
+      ),
+    });
+    {
+      const snapshot = await ProfiledHook.takeSnapshot();
+      expect(snapshot).toStrictEqual({
+        loading: false,
+        data: undefined,
+        error: undefined,
+        restart: expect.any(Function),
+        variables: { id: "1" },
+      });
+    }
+    expect(onUnsubscribe).toHaveBeenCalledTimes(0);
+    expect(onSubscribe).toHaveBeenCalledTimes(0);
+
+    expect(() => ProfiledHook.getCurrentSnapshot().restart()).toThrow(
+      new InvariantError("A subscription that is skipped cannot be restarted.")
+    );
+
+    await expect(ProfiledHook).not.toRerender({ timesout: 20 });
+    expect(onUnsubscribe).toHaveBeenCalledTimes(0);
+    expect(onSubscribe).toHaveBeenCalledTimes(0);
   });
 });
 

--- a/src/react/hooks/useSubscription.ts
+++ b/src/react/hooks/useSubscription.ts
@@ -295,12 +295,14 @@ function createSubscription<
     new Observable<FetchResult<TData>>((observer) => {
       // lazily start the subscription when the first observer subscribes
       // to get around strict mode
-      observable ||= client.subscribe({
+      if (!observable) {
+        observable = client.subscribe({
         query,
         variables,
         fetchPolicy,
         context,
       });
+      }
       const sub = observable.subscribe(observer);
       return () => sub.unsubscribe();
     }),


### PR DESCRIPTION
Naming is open for discussion, but I did pretty deliberately select something different from `refetch`:
* `refetch` feels wrong in the case of something long-running like a subscription
* it has very different usage (doesn't accept parameters, doesn't return anything) from existing `refetch` functions.


<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:

### Checklist:
- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
-->
