### PR TITLE
remove deprecated `watchFragment` option, `canonizeResults`

### DIFF
--- a/.api-reports/api-report-cache.api.md
+++ b/.api-reports/api-report-cache.api.md
@@ -976,8 +976,6 @@ export type TypePolicy = {
 
 // @public
 export interface WatchFragmentOptions<TData, TVars> {
-    // @deprecated (undocumented)
-    canonizeResults?: boolean;
     fragment: DocumentNode | TypedDocumentNode<TData, TVars>;
     fragmentName?: string;
     from: StoreObject | Reference | string;

--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -2231,8 +2231,6 @@ export interface UriFunction {
 
 // @public
 export interface WatchFragmentOptions<TData, TVars> {
-    // @deprecated (undocumented)
-    canonizeResults?: boolean;
     fragment: DocumentNode | TypedDocumentNode<TData, TVars>;
     fragmentName?: string;
     from: StoreObject | Reference | string;

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -2285,8 +2285,6 @@ TVariables
 
 // @public
 interface WatchFragmentOptions<TData, TVars> {
-    // @deprecated (undocumented)
-    canonizeResults?: boolean;
     fragment: DocumentNode | TypedDocumentNode<TData, TVars>;
     fragmentName?: string;
     from: StoreObject | Reference | string;

--- a/.api-reports/api-report-react_components.api.md
+++ b/.api-reports/api-report-react_components.api.md
@@ -1764,8 +1764,6 @@ interface UriFunction {
 
 // @public
 interface WatchFragmentOptions<TData, TVars> {
-    // @deprecated (undocumented)
-    canonizeResults?: boolean;
     fragment: DocumentNode | TypedDocumentNode<TData, TVars>;
     fragmentName?: string;
     from: StoreObject | Reference | string;

--- a/.api-reports/api-report-react_context.api.md
+++ b/.api-reports/api-report-react_context.api.md
@@ -1684,8 +1684,6 @@ interface UriFunction {
 
 // @public
 interface WatchFragmentOptions<TData, TVars> {
-    // @deprecated (undocumented)
-    canonizeResults?: boolean;
     fragment: DocumentNode | TypedDocumentNode<TData, TVars>;
     fragmentName?: string;
     from: StoreObject | Reference | string;

--- a/.api-reports/api-report-react_hoc.api.md
+++ b/.api-reports/api-report-react_hoc.api.md
@@ -1696,8 +1696,6 @@ interface UriFunction {
 
 // @public
 interface WatchFragmentOptions<TData, TVars> {
-    // @deprecated (undocumented)
-    canonizeResults?: boolean;
     fragment: DocumentNode | TypedDocumentNode<TData, TVars>;
     fragmentName?: string;
     from: StoreObject | Reference | string;

--- a/.api-reports/api-report-react_hooks.api.md
+++ b/.api-reports/api-report-react_hooks.api.md
@@ -2109,8 +2109,6 @@ export interface UseSuspenseQueryResult<TData = unknown, TVariables extends Oper
 
 // @public
 interface WatchFragmentOptions<TData, TVars> {
-    // @deprecated (undocumented)
-    canonizeResults?: boolean;
     fragment: DocumentNode | TypedDocumentNode<TData, TVars>;
     fragmentName?: string;
     from: StoreObject | Reference | string;

--- a/.api-reports/api-report-react_internal.api.md
+++ b/.api-reports/api-report-react_internal.api.md
@@ -2127,8 +2127,6 @@ TVariables
 
 // @public
 interface WatchFragmentOptions<TData, TVars> {
-    // @deprecated (undocumented)
-    canonizeResults?: boolean;
     fragment: DocumentNode | TypedDocumentNode<TData, TVars>;
     fragmentName?: string;
     from: StoreObject | Reference | string;

--- a/.api-reports/api-report-react_ssr.api.md
+++ b/.api-reports/api-report-react_ssr.api.md
@@ -1669,8 +1669,6 @@ interface UriFunction {
 
 // @public
 interface WatchFragmentOptions<TData, TVars> {
-    // @deprecated (undocumented)
-    canonizeResults?: boolean;
     fragment: DocumentNode | TypedDocumentNode<TData, TVars>;
     fragmentName?: string;
     from: StoreObject | Reference | string;

--- a/.api-reports/api-report-testing.api.md
+++ b/.api-reports/api-report-testing.api.md
@@ -1728,8 +1728,6 @@ export function wait(ms: number): Promise<void>;
 
 // @public
 interface WatchFragmentOptions<TData, TVars> {
-    // @deprecated (undocumented)
-    canonizeResults?: boolean;
     fragment: DocumentNode | TypedDocumentNode<TData, TVars>;
     fragmentName?: string;
     from: StoreObject | Reference | string;

--- a/.api-reports/api-report-testing_core.api.md
+++ b/.api-reports/api-report-testing_core.api.md
@@ -1685,8 +1685,6 @@ export function wait(ms: number): Promise<void>;
 
 // @public
 interface WatchFragmentOptions<TData, TVars> {
-    // @deprecated (undocumented)
-    canonizeResults?: boolean;
     fragment: DocumentNode | TypedDocumentNode<TData, TVars>;
     fragmentName?: string;
     from: StoreObject | Reference | string;

--- a/.api-reports/api-report-utilities.api.md
+++ b/.api-reports/api-report-utilities.api.md
@@ -2590,8 +2590,6 @@ export type VariableValue = (node: VariableNode) => any;
 
 // @public
 interface WatchFragmentOptions<TData, TVars> {
-    // @deprecated (undocumented)
-    canonizeResults?: boolean;
     fragment: DocumentNode | TypedDocumentNode<TData, TVars>;
     fragmentName?: string;
     from: StoreObject | Reference | string;

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -2946,8 +2946,6 @@ TVariables
 
 // @public
 export interface WatchFragmentOptions<TData, TVars> {
-    // @deprecated (undocumented)
-    canonizeResults?: boolean;
     fragment: DocumentNode | TypedDocumentNode<TData, TVars>;
     fragmentName?: string;
     from: StoreObject | Reference | string;

--- a/.changeset/curly-vans-draw.md
+++ b/.changeset/curly-vans-draw.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Remove deprecated `watchFragment` option, `canonizeResults`

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -69,17 +69,6 @@ export interface WatchFragmentOptions<TData, TVars> {
    * @docGroup 2. Cache options
    */
   optimistic?: boolean;
-  /**
-   * @deprecated
-   * Using `canonizeResults` can result in memory leaks so we generally do not
-   * recommend using this option anymore.
-   * A future version of Apollo Client will contain a similar feature.
-   *
-   * Whether to canonize cache results before returning them. Canonization
-   * takes some extra time, but it speeds up future deep equality comparisons.
-   * Defaults to false.
-   */
-  canonizeResults?: boolean;
 }
 
 /**


### PR DESCRIPTION
This removes an unused option from `watchFragment` that was already deprecated, `canonizeResults`.