### PR TITLE
Wrap note about creating new instance in `Caution`

### DIFF
--- a/docs/source/performance/server-side-rendering.mdx
+++ b/docs/source/performance/server-side-rendering.mdx
@@ -124,7 +124,11 @@ app.listen(basePort, () => console.log(
 
 So far, whenever this example server receives a request, it first initializes Apollo Client and then creates a React tree that's wrapped with the `ApolloProvider` and `StaticRouter` components. The contents of that tree depend on the request's path and the `StaticRouter`'s defined routes.
 
-> It's important to create an _entirely new instance_ of Apollo Client for each request. Otherwise, your response to a request might include sensitive cached query results from a _previous_ request.
+<Caution> 
+
+It's important to create an _entirely new instance_ of Apollo Client for each request. Otherwise, your response to a request might include sensitive cached query results from a _previous_ request.
+
+</Caution>
 
 ### Executing queries with `getDataFromTree`
 


### PR DESCRIPTION
Updates the note on the SSR docs page about creating a new client instance per-request in a `<Caution />` component.

**Before**
<img width="786" alt="Screenshot 2024-07-15 at 11 10 26 AM" src="https://github.com/user-attachments/assets/d6cb2155-b192-4d5f-bc86-d13b59cd6583">

**After**
<img width="780" alt="Screenshot 2024-07-15 at 11 10 05 AM" src="https://github.com/user-attachments/assets/dc7c7551-f3e7-4668-a01e-9f00534706ab">
