### PR TITLE
Fix incorrect default devtools config

### DIFF
--- a/.changeset/early-spoons-attack.md
+++ b/.changeset/early-spoons-attack.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix issue with default devtools config that did not connect to devtools in development.

--- a/.changeset/early-spoons-attack.md
+++ b/.changeset/early-spoons-attack.md
@@ -2,4 +2,4 @@
 "@apollo/client": patch
 ---
 
-Fix issue with default devtools config that did not connect to devtools in development.
+Remove check for `window.__APOLLO_CLIENT__` when determining whether to connect to Apollo Client Devtools when `connectToDevtools` or `devtools.enabled` is not specified. This now simply checks to see if the application is in development mode.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 40179,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 32990
+  "dist/apollo-client.min.cjs": 40164,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 32977
 }

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -260,7 +260,7 @@ export class ApolloClient<TCacheShape> implements DataProxy {
     if (this.devtoolsConfig.enabled === undefined) {
       this.devtoolsConfig.enabled =
         typeof window === "object" &&
-        (window as any).__APOLLO_CLIENT__ &&
+        !(window as any).__APOLLO_CLIENT__ &&
         __DEV__;
     }
 

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -258,10 +258,7 @@ export class ApolloClient<TCacheShape> implements DataProxy {
     };
 
     if (this.devtoolsConfig.enabled === undefined) {
-      this.devtoolsConfig.enabled =
-        typeof window === "object" &&
-        !(window as any).__APOLLO_CLIENT__ &&
-        __DEV__;
+      this.devtoolsConfig.enabled = __DEV__;
     }
 
     if (ssrForceFetchDelay) {


### PR DESCRIPTION
Closes #11707

I made an error and incorrectly copied over the [default value](https://github.com/apollographql/apollo-client/pull/11936/files#diff-b156746d5b1aac290dd27cf54cf4713d7ffbe0fce30e5a0dc6114d7b3529ea28L204-L206) to connect to devtools. I forgot the `!` to check if there is already a global client instance 🤦‍♂️.

Regardless, this gives us a chance to re-evaluate the check. Now that Apollo Client Devtools supports multiple clients, we can remove the additional checks for `window.__APOLLO_CLIENT__` when determining how to set the default value. The check will now simply look at `__DEV__` to determine whether to connect the client or not when the option is not specified.