### PR TITLE
Don't attempt to connect to devtools in non-browser environments

### DIFF
--- a/.changeset/famous-berries-remember.md
+++ b/.changeset/famous-berries-remember.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Prevent the `setTimeout` for suggesting devtools from running in non-browser environments.

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -345,29 +345,30 @@ export class ApolloClient<TCacheShape> implements DataProxy {
       if (
         window.document &&
         window.top === window.self &&
-        !(window as any).__APOLLO_DEVTOOLS_GLOBAL_HOOK__ &&
         /^(https?|file):$/.test(window.location.protocol)
       ) {
         setTimeout(() => {
-          const nav = window.navigator;
-          const ua = nav && nav.userAgent;
-          let url: string | undefined;
-          if (typeof ua === "string") {
-            if (ua.indexOf("Chrome/") > -1) {
-              url =
-                "https://chrome.google.com/webstore/detail/" +
-                "apollo-client-developer-t/jdkknkkbebbapilgoeccciglkfbmbnfm";
-            } else if (ua.indexOf("Firefox/") > -1) {
-              url =
-                "https://addons.mozilla.org/en-US/firefox/addon/apollo-developer-tools/";
+          if (!(window as any).__APOLLO_DEVTOOLS_GLOBAL_HOOK__) {
+            const nav = window.navigator;
+            const ua = nav && nav.userAgent;
+            let url: string | undefined;
+            if (typeof ua === "string") {
+              if (ua.indexOf("Chrome/") > -1) {
+                url =
+                  "https://chrome.google.com/webstore/detail/" +
+                  "apollo-client-developer-t/jdkknkkbebbapilgoeccciglkfbmbnfm";
+              } else if (ua.indexOf("Firefox/") > -1) {
+                url =
+                  "https://addons.mozilla.org/en-US/firefox/addon/apollo-developer-tools/";
+              }
             }
-          }
-          if (url) {
-            invariant.log(
-              "Download the Apollo DevTools for a better development " +
-                "experience: %s",
-              url
-            );
+            if (url) {
+              invariant.log(
+                "Download the Apollo DevTools for a better development " +
+                  "experience: %s",
+                url
+              );
+            }
           }
         }, 10000);
       }

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -319,21 +319,23 @@ export class ApolloClient<TCacheShape> implements DataProxy {
   }
 
   private connectToDevTools() {
-    if (typeof window === "object") {
-      type DevToolsConnector = {
-        push(client: ApolloClient<any>): void;
-      };
-      const windowWithDevTools = window as Window & {
-        [devtoolsSymbol]?: DevToolsConnector;
-        __APOLLO_CLIENT__?: ApolloClient<any>;
-      };
-      const devtoolsSymbol = Symbol.for("apollo.devtools");
-      (windowWithDevTools[devtoolsSymbol] =
-        windowWithDevTools[devtoolsSymbol] || ([] as DevToolsConnector)).push(
-        this
-      );
-      windowWithDevTools.__APOLLO_CLIENT__ = this;
+    if (typeof window === "undefined") {
+      return;
     }
+
+    type DevToolsConnector = {
+      push(client: ApolloClient<any>): void;
+    };
+    const windowWithDevTools = window as Window & {
+      [devtoolsSymbol]?: DevToolsConnector;
+      __APOLLO_CLIENT__?: ApolloClient<any>;
+    };
+    const devtoolsSymbol = Symbol.for("apollo.devtools");
+    (windowWithDevTools[devtoolsSymbol] =
+      windowWithDevTools[devtoolsSymbol] || ([] as DevToolsConnector)).push(
+      this
+    );
+    windowWithDevTools.__APOLLO_CLIENT__ = this;
 
     /**
      * Suggest installing the devtools for developers who don't have them
@@ -342,7 +344,6 @@ export class ApolloClient<TCacheShape> implements DataProxy {
       hasSuggestedDevtools = true;
       setTimeout(() => {
         if (
-          typeof window !== "undefined" &&
           window.document &&
           window.top === window.self &&
           !(window as any).__APOLLO_DEVTOOLS_GLOBAL_HOOK__ &&

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -342,13 +342,13 @@ export class ApolloClient<TCacheShape> implements DataProxy {
      */
     if (!hasSuggestedDevtools && __DEV__) {
       hasSuggestedDevtools = true;
-      setTimeout(() => {
-        if (
-          window.document &&
-          window.top === window.self &&
-          !(window as any).__APOLLO_DEVTOOLS_GLOBAL_HOOK__ &&
-          /^(https?|file):$/.test(window.location.protocol)
-        ) {
+      if (
+        window.document &&
+        window.top === window.self &&
+        !(window as any).__APOLLO_DEVTOOLS_GLOBAL_HOOK__ &&
+        /^(https?|file):$/.test(window.location.protocol)
+      ) {
+        setTimeout(() => {
           const nav = window.navigator;
           const ua = nav && nav.userAgent;
           let url: string | undefined;
@@ -369,8 +369,8 @@ export class ApolloClient<TCacheShape> implements DataProxy {
               url
             );
           }
-        }
-      }, 10000);
+        }, 10000);
+      }
     }
   }
 


### PR DESCRIPTION
This was mostly already doing this. With https://github.com/apollographql/apollo-client/pull/11969, we removed the check for `typeof window` to set the default value for `devtools.enabled`. The `connectToDevtools` function has some checks for `typeof window` as well, but currently it allows the `setTimeout` to run before it checks for `typeof window`. 

This PR simplifies this by returning early if `typeof window` is `undefined`.