### PR TITLE
Fix `fetchMore` for queries with `no-cache` fetch policies

### DIFF
--- a/.changeset/nice-worms-juggle.md
+++ b/.changeset/nice-worms-juggle.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Ensure `fetchMore` does not write to the cache when using a query with a `no-cache` fetch policy.

--- a/.changeset/nice-worms-juggle.md
+++ b/.changeset/nice-worms-juggle.md
@@ -2,4 +2,4 @@
 "@apollo/client": patch
 ---
 
-Fix issue where `fetchMore` would write it's result data to the cache when using it with a `no-cache` fetch policy.
+Fix an issue where `fetchMore` would write its result data to the cache when using it with a `no-cache` fetch policy.

--- a/.changeset/nice-worms-juggle.md
+++ b/.changeset/nice-worms-juggle.md
@@ -2,4 +2,4 @@
 "@apollo/client": patch
 ---
 
-Ensure `fetchMore` does not write to the cache when using a query with a `no-cache` fetch policy.
+Fix issue where `fetchMore` would write it's result data to the cache when using it with a `no-cache` fetch policy.

--- a/.changeset/pink-horses-pay.md
+++ b/.changeset/pink-horses-pay.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix issue where executing `fetchMore` with a `no-cache` fetch policy could sometimes result in multiple network requests.

--- a/.changeset/pink-horses-pay.md
+++ b/.changeset/pink-horses-pay.md
@@ -2,4 +2,4 @@
 "@apollo/client": patch
 ---
 
-Fix issue where executing `fetchMore` with a `no-cache` fetch policy could sometimes result in multiple network requests.
+Fix an issue where executing `fetchMore` with a `no-cache` fetch policy could sometimes result in multiple network requests.

--- a/.changeset/short-scissors-speak.md
+++ b/.changeset/short-scissors-speak.md
@@ -1,0 +1,7 @@
+---
+"@apollo/client": patch
+---
+
+**Potentially disruptive change**
+
+When calling `fetchMore` with a query that has a `no-cache` fetch policy, `fetchMore` will now throw if an `updateQuery` function is not provided. This ensures that Apollo Client can properly update and report the result of the query.

--- a/.changeset/short-scissors-speak.md
+++ b/.changeset/short-scissors-speak.md
@@ -4,4 +4,4 @@
 
 **Potentially disruptive change**
 
-When calling `fetchMore` with a query that has a `no-cache` fetch policy, `fetchMore` will now throw if an `updateQuery` function is not provided. This ensures that Apollo Client can properly update and report the result of the query.
+When calling `fetchMore` with a query that has a `no-cache` fetch policy, `fetchMore` will now throw if an `updateQuery` function is not provided. This provides a mechanism to merge the results from the `fetchMore` call with the query's previous result.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 40168,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 32974
+  "dist/apollo-client.min.cjs": 40245,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 33042
 }

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 40245,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 33042
+  "dist/apollo-client.min.cjs": 40243,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 33041
 }

--- a/docs/source/pagination/core-api.mdx
+++ b/docs/source/pagination/core-api.mdx
@@ -249,7 +249,7 @@ fetchMore({
 
 <Tip>
 
-We recommend defining field policies that contain at least a [`keyArgs`](/pagination/key-args/) value even if you use `updateQuery`. This prevents fragmenting the data unnecessarily in the cache.
+We recommend defining field policies that contain at least a [`keyArgs`](/pagination/key-args/) value even when you use `updateQuery`. This prevents fragmenting the data unnecessarily in the cache. Setting `keyArgs` to `false` is adequate for most situations to ignore the `offset` and `limit` arguments and write the paginated data as one big array.
 
 </Tip>
 

--- a/docs/source/pagination/core-api.mdx
+++ b/docs/source/pagination/core-api.mdx
@@ -247,6 +247,12 @@ fetchMore({
 })
 ```
 
+<Tip>
+
+We recommend defining field policies that contain at least a [`keyArgs`](/pagination/key-args/) value even if you use `updateQuery`. This prevents fragmenting the data unnecessarily in the cache.
+
+</Tip>
+
 ## `read` functions for paginated fields
 
 [As shown above](#defining-a-field-policy), a `merge` function helps you combine paginated query results from your GraphQL server into a single list in your client cache. But what if you also want to configure how that locally cached list is _read_? For that, you can define a **`read` function**.

--- a/docs/source/pagination/core-api.mdx
+++ b/docs/source/pagination/core-api.mdx
@@ -222,7 +222,7 @@ This logic handles sequential page writes the same way the single-line strategy 
 
 At times the call to `fetchMore` may need to perform additional cache updates for your query. While you can use the [`cache.readQuery`](/caching/cache-interaction#readquery) and [`cache.writeQuery`](/caching/cache-interaction#writequery) functions to to do this work yourself, it can be cumbsersome to use both of these together.
 
-As a shortcut, you can provide the `updateQuery` option to `fetchMore` to update your query with the result from the `fetchMore` call.
+As a shortcut, you can provide the `updateQuery` option to `fetchMore` to update your query using the result from the `fetchMore` call.
 
 <Note>
 

--- a/docs/source/pagination/core-api.mdx
+++ b/docs/source/pagination/core-api.mdx
@@ -226,7 +226,7 @@ As a shortcut, you can provide the `updateQuery` option to `fetchMore` to update
 
 <Note>
 
-`updateQuery` is not a replacement for your type policy `merge` functions. `merge` functions will still run using the result from `updateQuery`.
+`updateQuery` is not a replacement for your type policy `merge` functions. `merge` functions still run using the result from `updateQuery`.
 
 </Note>
 

--- a/docs/source/pagination/core-api.mdx
+++ b/docs/source/pagination/core-api.mdx
@@ -226,7 +226,7 @@ As a shortcut, you can provide the `updateQuery` option to `fetchMore` to update
 
 <Note>
 
-`updateQuery` is not a replacement for your field policy `merge` functions. `merge` functions still run using the result from `updateQuery`.
+`updateQuery` is not a replacement for your field policy `merge` functions. While you can use `updateQuery` without the need to define a `merge` function, `merge` functions defined for fields in the query will run using the result from `updateQuery`.
 
 </Note>
 

--- a/docs/source/pagination/core-api.mdx
+++ b/docs/source/pagination/core-api.mdx
@@ -226,11 +226,11 @@ As a shortcut, you can provide the `updateQuery` option to `fetchMore` to update
 
 <Note>
 
-`updateQuery` is not a replacement for your type policy `merge` functions. `merge` functions still run using the result from `updateQuery`.
+`updateQuery` is not a replacement for your field policy `merge` functions. `merge` functions still run using the result from `updateQuery`.
 
 </Note>
 
-Let's see the example above using `updateQuery` to merge results together instead of a type policy merge function:
+Let's see the example above using `updateQuery` to merge results together instead of a field policy merge function:
 
 ```ts
 fetchMore({

--- a/docs/source/pagination/core-api.mdx
+++ b/docs/source/pagination/core-api.mdx
@@ -218,6 +218,35 @@ const cache = new InMemoryCache({
 
 This logic handles sequential page writes the same way the single-line strategy does, but it can also tolerate repeated, overlapping, or out-of-order writes, without duplicating any list items.
 
+### Updating the query with the fetch more result
+
+At times the call to `fetchMore` may need to perform additional cache updates for your query. While you can use the [`cache.readQuery`](/caching/cache-interaction#readquery) and [`cache.writeQuery`](/caching/cache-interaction#writequery) functions to to do this work yourself, it can be cumbsersome to use both of these together.
+
+As a shortcut, you can provide the `updateQuery` option to `fetchMore` to update your query with the result from the `fetchMore` call.
+
+<Note>
+
+`updateQuery` is not a replacement for your type policy `merge` functions. `merge` functions will still run using the result from `updateQuery`.
+
+</Note>
+
+Let's see the example above using `updateQuery` to merge results together instead of a type policy merge function:
+
+```ts
+fetchMore({
+  variables: { offset: data.feed.length },
+  updateQuery(previousData, { fetchMoreResult, variables: { offset }}) {
+    // Slicing is necessary because the existing data is
+    // immutable, and frozen in development.
+    const updatedFeed = previousData.feed.slice(0);
+    for (let i = 0; i < fetchMoreResult.feed.length; ++i) {
+      updatedFeed[offset + i] = fetchMoreResult.feed[i];
+    }
+    return { ...previousData, feed: updatedFeed };
+  },
+})
+```
+
 ## `read` functions for paginated fields
 
 [As shown above](#defining-a-field-policy), a `merge` function helps you combine paginated query results from your GraphQL server into a single list in your client cache. But what if you also want to configure how that locally cached list is _read_? For that, you can define a **`read` function**.

--- a/docs/source/pagination/core-api.mdx
+++ b/docs/source/pagination/core-api.mdx
@@ -199,7 +199,7 @@ const cache = new InMemoryCache({
     Query: {
       fields: {
         feed: {
-          keyArgs: [],
+          keyArgs: false,
           merge(existing, incoming, { args: { offset = 0 }}) {
             // Slicing is necessary because the existing data is
             // immutable, and frozen in development.

--- a/docs/source/pagination/core-api.mdx
+++ b/docs/source/pagination/core-api.mdx
@@ -304,3 +304,38 @@ The `read` function for a paginated field can choose to _ignore_ arguments like 
 If you adopt this approach, you might not need to define a `read` function at all, because the cached list can be returned without any processing. That's why the [`offsetLimitPagination` helper function](./offset-based/#the-offsetlimitpagination-helper) is implemented _without_ a `read` function.
 
 Regardless of how you configure `keyArgs`, your `read` (and `merge`) functions can always examine any arguments passed to the field using the `options.args` object. See [The `keyArgs` API](./key-args) for a deeper discussion of how to reason about dividing argument-handling responsibility between `keyArgs` and your `read` or `merge` functions.
+
+## Using `fetchMore` with queries that set a `no-cache` fetch policy
+
+<Note>
+
+We recommend upgrading to version 3.11.3 or later to address bugs that exhibit unexpected behavior when using `fetchMore` with queries that set `no-cache` fetch policies. Please see pull request [#11974](https://github.com/apollographql/apollo-client/pull/11974) for more information.
+
+</Note>
+
+The examples shown above use type policies to update the result of a paginated field. But what about queries that use a `no-cache` fetch policy? Data is not written to the cache, so type policies have no effect.
+
+Instead we can take advantage of the `updateQuery` option available to the `fetchMore` function. `updateQuery` gives you control over how the query is merged with the result fetched from the `fetchMore` call.
+
+Let's use the example above, but instead provide the `updateQuery` function to `fetchMore` to update the query.
+
+```ts
+fetchMore({
+  variables: { offset: data.feed.length },
+  updateQuery(previousData, { fetchMoreResult, variables: { offset }}) {
+    // Slicing is necessary because the existing data is
+    // immutable, and frozen in development.
+    const updatedFeed = previousData.feed.slice(0);
+    for (let i = 0; i < fetchMoreResult.feed.length; ++i) {
+      updatedFeed[offset + i] = fetchMoreResult.feed[i];
+    }
+    return { ...previousData, feed: updatedFeed };
+  },
+})
+```
+
+<Note>
+
+As of Apollo Client version 3.11.3, the `updateQuery` option is required when using `fetchMore` with a `no-cache` fetch policy. This is required to correctly determine how the results should be merged with the absense of a type policy. Calling `fetchMore` without an `updateQuery` function will throw an error.
+
+</Note>

--- a/docs/source/pagination/core-api.mdx
+++ b/docs/source/pagination/core-api.mdx
@@ -371,6 +371,6 @@ fetchMore({
 
 <Note>
 
-As of Apollo Client version 3.11.3, the `updateQuery` option is required when using `fetchMore` with a `no-cache` fetch policy. This is required to correctly determine how the results should be merged with the absense of a type policy. Calling `fetchMore` without an `updateQuery` function will throw an error.
+As of Apollo Client version 3.11.3, the `updateQuery` option is required when using `fetchMore` with a `no-cache` fetch policy. This is required to correctly determine how the results should be merged since field policy `merge` functions are ignored. Calling `fetchMore` without an `updateQuery` function will throw an error.
 
 </Note>

--- a/docs/source/pagination/core-api.mdx
+++ b/docs/source/pagination/core-api.mdx
@@ -350,7 +350,7 @@ We recommend upgrading to version 3.11.3 or later to address bugs that exhibit u
 
 The examples shown above use field policies and `merge` functions to update the result of a paginated field. But what about queries that use a `no-cache` fetch policy? Data is not written to the cache, so field policies have no effect.
 
-Instead we can take advantage of the `updateQuery` option available to the `fetchMore` function. `updateQuery` gives you control over how the query is merged with the result fetched from the `fetchMore` call.
+To update our query, we provide the `updateQuery` option to the `fetchMore` function.
 
 Let's use the example above, but instead provide the `updateQuery` function to `fetchMore` to update the query.
 

--- a/docs/source/pagination/core-api.mdx
+++ b/docs/source/pagination/core-api.mdx
@@ -348,7 +348,7 @@ We recommend upgrading to version 3.11.3 or later to address bugs that exhibit u
 
 </Note>
 
-The examples shown above use type policies to update the result of a paginated field. But what about queries that use a `no-cache` fetch policy? Data is not written to the cache, so type policies have no effect.
+The examples shown above use field policies and `merge` functions to update the result of a paginated field. But what about queries that use a `no-cache` fetch policy? Data is not written to the cache, so field policies have no effect.
 
 Instead we can take advantage of the `updateQuery` option available to the `fetchMore` function. `updateQuery` gives you control over how the query is merged with the result fetched from the `fetchMore` call.
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -484,6 +484,15 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
 
     const updatedQuerySet = new Set<DocumentNode>();
 
+    const updateQuery = fetchMoreOptions?.updateQuery;
+
+    if (this.options.fetchPolicy === "no-cache") {
+      invariant(
+        updateQuery,
+        "When using `fetchMore` with a `no-cache` query, you must provide an `updateQuery` function."
+      );
+    }
+
     return this.queryManager
       .fetchQuery(qid, combinedOptions, NetworkStatus.fetchMore)
       .then((fetchMoreResult) => {
@@ -495,14 +504,14 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
 
         if (this.options.fetchPolicy === "no-cache") {
           const lastResult = this.getLast("result")!;
-          const data = fetchMoreOptions?.updateQuery?.(lastResult.data, {
+          const data = updateQuery!(lastResult.data, {
             fetchMoreResult: fetchMoreResult.data,
             variables: combinedOptions.variables as TFetchVars,
           });
 
           const result = {
             ...lastResult,
-            data: data!,
+            data,
             loading: false,
             networkStatus: NetworkStatus.ready,
           };

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -510,12 +510,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
             variables: combinedOptions.variables as TFetchVars,
           });
 
-          const result = {
-            ...lastResult,
-            data,
-          };
-
-          this.reportResult(result, this.variables);
+          this.reportResult({ ...lastResult, data }, this.variables);
         } else {
           // Performing this cache update inside a cache.batch transaction ensures
           // any affected cache.watch watchers are notified at most once about any

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -503,15 +503,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
           queryInfo.networkStatus = originalNetworkStatus;
         }
 
-        if (!isCached) {
-          const lastResult = this.getLast("result")!;
-          const data = updateQuery!(lastResult.data, {
-            fetchMoreResult: fetchMoreResult.data,
-            variables: combinedOptions.variables as TFetchVars,
-          });
-
-          this.reportResult({ ...lastResult, data }, this.variables);
-        } else {
+        if (isCached) {
           // Performing this cache update inside a cache.batch transaction ensures
           // any affected cache.watch watchers are notified at most once about any
           // updates. Most watchers will be using the QueryInfo class, which
@@ -554,6 +546,14 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
               updatedQuerySet.add(watch.query);
             },
           });
+        } else {
+          const lastResult = this.getLast("result")!;
+          const data = updateQuery!(lastResult.data, {
+            fetchMoreResult: fetchMoreResult.data,
+            variables: combinedOptions.variables as TFetchVars,
+          });
+
+          this.reportResult({ ...lastResult, data }, this.variables);
         }
 
         return fetchMoreResult;

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -547,6 +547,20 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
             },
           });
         } else {
+          // There is a possibility `lastResult` may not be set when
+          // `fetchMore` is called which would cause this to crash. This should
+          // only happen if we haven't previously reported a result. We don't
+          // quite know what the right behavior should be here since this block
+          // of code runs after the fetch result has executed on the network.
+          // We plan to let it crash in the meantime.
+          //
+          // If we get bug reports due to the `data` property access on
+          // undefined, this should give us a real-world scenario that we can
+          // use to test against and determine the right behavior. If we do end
+          // up changing this behavior, this may require, for example, an
+          // adjustment to the types on `updateQuery` since that function
+          // expects that the first argument always contains previous result
+          // data, but not `undefined`.
           const lastResult = this.getLast("result")!;
           const data = updateQuery!(lastResult.data, {
             fetchMoreResult: fetchMoreResult.data,

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -489,7 +489,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     if (this.options.fetchPolicy === "no-cache") {
       invariant(
         updateQuery,
-        "When using `fetchMore` with a `no-cache` query, you must provide an `updateQuery` function."
+        "You must provide an `updateQuery` function when using `fetchMore` with a `no-cache` fetch policy."
       );
     }
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -485,8 +485,9 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     const updatedQuerySet = new Set<DocumentNode>();
 
     const updateQuery = fetchMoreOptions?.updateQuery;
+    const isCached = this.options.fetchPolicy !== "no-cache";
 
-    if (this.options.fetchPolicy === "no-cache") {
+    if (!isCached) {
       invariant(
         updateQuery,
         "You must provide an `updateQuery` function when using `fetchMore` with a `no-cache` fetch policy."
@@ -502,7 +503,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
           queryInfo.networkStatus = originalNetworkStatus;
         }
 
-        if (this.options.fetchPolicy === "no-cache") {
+        if (!isCached) {
           const lastResult = this.getLast("result")!;
           const data = updateQuery!(lastResult.data, {
             fetchMoreResult: fetchMoreResult.data,
@@ -570,10 +571,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
         // likely because the written data were the same as what was already in
         // the cache, we still want fetchMore to deliver its final loading:false
         // result with the unchanged data.
-        if (
-          this.options.fetchPolicy !== "no-cache" &&
-          !updatedQuerySet.has(this.query)
-        ) {
+        if (isCached && !updatedQuerySet.has(this.query)) {
           reobserveCacheFirst(this);
         }
       });

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -513,8 +513,6 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
           const result = {
             ...lastResult,
             data,
-            loading: false,
-            networkStatus: NetworkStatus.ready,
           };
 
           this.reportResult(result, this.variables);

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -4296,21 +4296,15 @@ describe("useQuery Hook", () => {
       });
 
       {
-        const snapshot = await ProfiledHook.takeSnapshot();
+        const { loading } = await ProfiledHook.takeSnapshot();
 
-        expect(snapshot.loading).toBe(true);
+        expect(loading).toBe(true);
       }
 
       {
-        const snapshot = await ProfiledHook.takeSnapshot();
+        const { loading } = await ProfiledHook.takeSnapshot();
 
-        expect(snapshot.loading).toBe(false);
-        expect(snapshot.data).toStrictEqual({
-          letters: [
-            { __typename: "Letter", letter: "A", position: 1 },
-            { __typename: "Letter", letter: "B", position: 2 },
-          ],
-        });
+        expect(loading).toBe(false);
       }
 
       const { fetchMore } = ProfiledHook.getCurrentSnapshot();

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -4295,17 +4295,10 @@ describe("useQuery Hook", () => {
         ),
       });
 
-      {
-        const { loading } = await ProfiledHook.takeSnapshot();
-
-        expect(loading).toBe(true);
-      }
-
-      {
-        const { loading } = await ProfiledHook.takeSnapshot();
-
-        expect(loading).toBe(false);
-      }
+      // loading
+      await ProfiledHook.takeSnapshot();
+      // finished loading
+      await ProfiledHook.takeSnapshot();
 
       const { fetchMore } = ProfiledHook.getCurrentSnapshot();
 

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -4112,19 +4112,7 @@ describe("useQuery Hook", () => {
     });
 
     it("uses updateQuery to update the result of the query with no-cache queries", async () => {
-      const { query, data } = setupPaginatedCase();
-
-      const link = new ApolloLink((operation) => {
-        const { offset = 0, limit = 2 } = operation.variables;
-        const letters = data.slice(offset, offset + limit);
-
-        return new Observable((observer) => {
-          setTimeout(() => {
-            observer.next({ data: { letters } });
-            observer.complete();
-          }, 10);
-        });
-      });
+      const { query, link } = setupPaginatedCase();
 
       const client = new ApolloClient({ cache: new InMemoryCache(), link });
 

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -4103,7 +4103,10 @@ describe("useQuery Hook", () => {
       expect(fetches).toStrictEqual([{ variables: { limit: 2 } }]);
 
       const { fetchMore } = ProfiledHook.getCurrentSnapshot();
-      const result = await fetchMore({ variables: { offset: 2 } });
+      const result = await fetchMore({
+        variables: { offset: 2 },
+        updateQuery: (_, { fetchMoreResult }) => fetchMoreResult,
+      });
 
       expect(result.data).toStrictEqual({
         letters: [
@@ -4294,7 +4297,10 @@ describe("useQuery Hook", () => {
       await ProfiledHook.takeSnapshot();
 
       const { fetchMore } = ProfiledHook.getCurrentSnapshot();
-      await fetchMore({ variables: { offset: 2 } });
+      await fetchMore({
+        variables: { offset: 2 },
+        updateQuery: (_, { fetchMoreResult }) => fetchMoreResult,
+      });
 
       expect(client.extract()).toStrictEqual({});
     });

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -4336,10 +4336,12 @@ describe("useQuery Hook", () => {
       await ProfiledHook.takeSnapshot();
 
       const { fetchMore } = ProfiledHook.getCurrentSnapshot();
-      await fetchMore({
-        variables: { offset: 2 },
-        updateQuery: (_, { fetchMoreResult }) => fetchMoreResult,
-      });
+      await act(() =>
+        fetchMore({
+          variables: { offset: 2 },
+          updateQuery: (_, { fetchMoreResult }) => fetchMoreResult,
+        })
+      );
 
       expect(client.extract()).toStrictEqual({});
     });

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -4258,7 +4258,7 @@ describe("useQuery Hook", () => {
 
       expect(() => fetchMore({ variables: { offset: 2 } })).toThrow(
         new InvariantError(
-          "When using `fetchMore` with a `no-cache` query, you must provide an `updateQuery` function."
+          "You must provide an `updateQuery` function when using `fetchMore` with a `no-cache` fetch policy."
         )
       );
     });

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -4216,9 +4216,7 @@ describe("useQuery Hook", () => {
       act(() => {
         fetchMorePromise = fetchMore({
           variables: { offset: 4 },
-          updateQuery: (_, { fetchMoreResult }) => ({
-            letters: fetchMoreResult.letters,
-          }),
+          updateQuery: (_, { fetchMoreResult }) => fetchMoreResult,
         });
       });
 

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -4193,6 +4193,16 @@ describe("useQuery Hook", () => {
             { __typename: "Letter", letter: "D", position: 4 },
           ],
         });
+
+        // Ensure we store the merged result as the last result
+        expect(snapshot.observable.getCurrentResult(false).data).toEqual({
+          letters: [
+            { __typename: "Letter", letter: "A", position: 1 },
+            { __typename: "Letter", letter: "B", position: 2 },
+            { __typename: "Letter", letter: "C", position: 3 },
+            { __typename: "Letter", letter: "D", position: 4 },
+          ],
+        });
       }
 
       {
@@ -4213,6 +4223,13 @@ describe("useQuery Hook", () => {
         });
 
         expect(snapshot.data).toEqual({
+          letters: [
+            { __typename: "Letter", letter: "E", position: 5 },
+            { __typename: "Letter", letter: "F", position: 6 },
+          ],
+        });
+
+        expect(snapshot.observable.getCurrentResult(false).data).toEqual({
           letters: [
             { __typename: "Letter", letter: "E", position: 5 },
             { __typename: "Letter", letter: "F", position: 6 },

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -4083,37 +4083,27 @@ describe("useQuery Hook", () => {
       });
 
       {
-        const snapshot = await ProfiledHook.takeSnapshot();
+        const { loading } = await ProfiledHook.takeSnapshot();
 
-        expect(snapshot.loading).toBe(true);
+        expect(loading).toBe(true);
       }
 
       {
-        const snapshot = await ProfiledHook.takeSnapshot();
+        const { loading } = await ProfiledHook.takeSnapshot();
 
-        expect(snapshot.loading).toBe(false);
-        expect(snapshot.data).toStrictEqual({
-          letters: [
-            { __typename: "Letter", letter: "A", position: 1 },
-            { __typename: "Letter", letter: "B", position: 2 },
-          ],
-        });
+        expect(loading).toBe(false);
       }
 
       expect(fetches).toStrictEqual([{ variables: { limit: 2 } }]);
 
       const { fetchMore } = ProfiledHook.getCurrentSnapshot();
-      const result = await fetchMore({
-        variables: { offset: 2 },
-        updateQuery: (_, { fetchMoreResult }) => fetchMoreResult,
-      });
 
-      expect(result.data).toStrictEqual({
-        letters: [
-          { __typename: "Letter", letter: "C", position: 3 },
-          { __typename: "Letter", letter: "D", position: 4 },
-        ],
-      });
+      await act(() =>
+        fetchMore({
+          variables: { offset: 2 },
+          updateQuery: (_, { fetchMoreResult }) => fetchMoreResult,
+        })
+      );
 
       expect(fetches).toStrictEqual([
         { variables: { limit: 2 } },

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -4084,17 +4084,10 @@ describe("useQuery Hook", () => {
         ),
       });
 
-      {
-        const { loading } = await ProfiledHook.takeSnapshot();
-
-        expect(loading).toBe(true);
-      }
-
-      {
-        const { loading } = await ProfiledHook.takeSnapshot();
-
-        expect(loading).toBe(false);
-      }
+      // loading
+      await ProfiledHook.takeSnapshot();
+      // finished loading
+      await ProfiledHook.takeSnapshot();
 
       expect(fetches).toStrictEqual([{ variables: { limit: 2 } }]);
 

--- a/src/testing/internal/scenarios/index.ts
+++ b/src/testing/internal/scenarios/index.ts
@@ -106,5 +106,5 @@ export function setupPaginatedCase() {
     });
   });
 
-  return { query, link };
+  return { query, link, data };
 }


### PR DESCRIPTION
Fixes #11965

This fixes several issues when using `fetchMore` with `no-cache` queries.

* Ensures we don't run multiple network requests unnecessarily
* Does not write the `fetchMore` result to the cache
* Ensures the component is re-rendered using the result of the `updateQuery` function.

**Important**

This PR updates `fetchMore` to force the user to provide an `updateQuery` function when using a query with a `no-cache` fetch policy. Without this, there is no way for the user to determine how to merge the result with the current query data since other mechanisms rely on the cache to perform this functionality. Calling `fetchMore` without an `updateQuery` function will now throw.