### PR TITLE
chore: mark snapshot releases as deprecated in npm registry

### DIFF
--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -138,6 +138,10 @@ jobs:
         id: get-version
         run: echo "version=$(node -p "require('./dist/package.json').version")" >> "$GITHUB_OUTPUT"
 
+      - name: Deprecate version
+        if: ${{ steps.added-files.outputs.changesets != '' }}
+        run: npm deprecate @apollo/client@${{ steps.get-version.outputs.version }} "This is a snapshot release from https://github.com/apollographql/apollo-client/pull/${{ github.event.issue.number }}. Use at your own discretion."
+
       - name: Create comment
         if: ${{ steps.added-files.outputs.changesets != '' }}
         uses: peter-evans/create-or-update-comment@v4.0.0


### PR DESCRIPTION
I noticed the `graphql` package automatically marks one-off "canary" releases that are akin to our snapshot releases as deprecated, which automatically filters them out by default in the "versions" view https://www.npmjs.com/package/graphql?activeTab=versions.

If everyone is on board I'll run a script to deprecate past snapshot releases, but this will take care of them going forward. Already tested this with GraphQL Testing Library, works like a charm: https://www.npmjs.com/package/@apollo/graphql-testing-library?activeTab=versions

The message is inspired by the `graphql` deprecation message but open to suggestions!