### PR TITLE
Fix a potential crash when calling `clearStore` while a query was running.

### DIFF
--- a/.changeset/pink-guests-vanish.md
+++ b/.changeset/pink-guests-vanish.md
@@ -1,0 +1,11 @@
+---
+"@apollo/client": patch
+---
+
+Fix a potential crash when calling `clearStore` while a query was running.
+
+Previously, calling `client.clearStore()` while a query was running had one of these results:
+* `useQuery` would stay in a `loading: true` state.
+* `useLazyQuery` would stay in a `loading: true` state, but also crash with a `"Cannot read property 'data' of undefined"` error.
+
+Now, in both cases, the hook will enter an error state with a `networkError`, and the promise returned by the `useLazyQuery` `execute` function will return a result in an error state.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 40262,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 33048
+  "dist/apollo-client.min.cjs": 40271,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 33058
 }

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 40243,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 33041
+  "dist/apollo-client.min.cjs": 40262,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 33048
 }

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -25,6 +25,7 @@ import {
 import { useLazyQuery } from "../useLazyQuery";
 import { QueryResult } from "../../types/types";
 import { profileHook } from "../../../testing/internal";
+import { InvariantError } from "../../../utilities/globals";
 
 describe("useLazyQuery Hook", () => {
   const helloQuery: TypedDocumentNode<{
@@ -1921,6 +1922,68 @@ describe("useLazyQuery Hook", () => {
       const { options } = result.current.query.observable;
       expect(options.fetchPolicy).toBe(defaultFetchPolicy);
     });
+  });
+
+  test("regression for #11988: calling `clearStore` while a lazy query is running puts the hook into an error state and resolves the promise with an error result", async () => {
+    const link = new MockSubscriptionLink();
+    let requests = 0;
+    link.onSetup(() => requests++);
+    const client = new ApolloClient({
+      link,
+      cache: new InMemoryCache(),
+    });
+    const ProfiledHook = profileHook(() => useLazyQuery(helloQuery));
+    render(<ProfiledHook />, {
+      wrapper: ({ children }) => (
+        <ApolloProvider client={client}>{children}</ApolloProvider>
+      ),
+    });
+
+    {
+      const [, result] = await ProfiledHook.takeSnapshot();
+      expect(result.loading).toBe(false);
+      expect(result.data).toBeUndefined();
+    }
+    const execute = ProfiledHook.getCurrentSnapshot()[0];
+
+    const promise = execute();
+    expect(requests).toBe(1);
+
+    {
+      const [, result] = await ProfiledHook.takeSnapshot();
+      expect(result.loading).toBe(true);
+      expect(result.data).toBeUndefined();
+    }
+
+    client.clearStore();
+
+    const executionResult = await promise;
+    expect(executionResult.data).toBeUndefined();
+    expect(executionResult.loading).toBe(true);
+    expect(executionResult.error).toEqual(
+      new ApolloError({
+        networkError: new InvariantError(
+          "Store reset while query was in flight (not completed in link chain)"
+        ),
+      })
+    );
+
+    {
+      const [, result] = await ProfiledHook.takeSnapshot();
+      expect(result.loading).toBe(false);
+      expect(result.data).toBeUndefined();
+      expect(result.error).toEqual(
+        new ApolloError({
+          networkError: new InvariantError(
+            "Store reset while query was in flight (not completed in link chain)"
+          ),
+        })
+      );
+    }
+
+    link.simulateResult({ result: { data: { hello: "Greetings" } } }, true);
+    await expect(ProfiledHook).not.toRerender({ timeout: 50 });
+    expect(requests).toBe(1);
   });
 });
 

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -1924,7 +1924,8 @@ describe("useLazyQuery Hook", () => {
     });
   });
 
-  test("regression for #11988: calling `clearStore` while a lazy query is running puts the hook into an error state and resolves the promise with an error result", async () => {
+  // regression for https://github.com/apollographql/apollo-client/issues/11988
+  test("calling `clearStore` while a lazy query is running puts the hook into an error state and resolves the promise with an error result", async () => {
     const link = new MockSubscriptionLink();
     let requests = 0;
     link.onSetup(() => requests++);

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -10081,6 +10081,54 @@ describe("useQuery Hook", () => {
       }
     );
   });
+
+  test("calling `clearStore` while a query is running puts the hook into an error state", async () => {
+    const query = gql`
+      query {
+        hello
+      }
+    `;
+
+    const link = new MockSubscriptionLink();
+    let requests = 0;
+    link.onSetup(() => requests++);
+    const client = new ApolloClient({
+      link,
+      cache: new InMemoryCache(),
+    });
+    const ProfiledHook = profileHook(() => useQuery(query));
+    render(<ProfiledHook />, {
+      wrapper: ({ children }) => (
+        <ApolloProvider client={client}>{children}</ApolloProvider>
+      ),
+    });
+
+    expect(requests).toBe(1);
+    {
+      const result = await ProfiledHook.takeSnapshot();
+      expect(result.loading).toBe(true);
+      expect(result.data).toBeUndefined();
+    }
+
+    client.clearStore();
+
+    {
+      const result = await ProfiledHook.takeSnapshot();
+      expect(result.loading).toBe(false);
+      expect(result.data).toBeUndefined();
+      expect(result.error).toEqual(
+        new ApolloError({
+          networkError: new InvariantError(
+            "Store reset while query was in flight (not completed in link chain)"
+          ),
+        })
+      );
+    }
+
+    link.simulateResult({ result: { data: { hello: "Greetings" } } }, true);
+    await expect(ProfiledHook).not.toRerender({ timeout: 50 });
+    expect(requests).toBe(1);
+  });
 });
 
 describe.skip("Type Tests", () => {

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -10128,6 +10128,8 @@ describe("useQuery Hook", () => {
     link.simulateResult({ result: { data: { hello: "Greetings" } } }, true);
     await expect(ProfiledHook).not.toRerender({ timeout: 50 });
     expect(requests).toBe(1);
+  });
+
   // https://github.com/apollographql/apollo-client/issues/11938
   it("does not emit `data` on previous fetch when a 2nd fetch is kicked off and the result returns an error when errorPolicy is none", async () => {
     const query = gql`

--- a/src/utilities/observables/Concast.ts
+++ b/src/utilities/observables/Concast.ts
@@ -256,7 +256,7 @@ export class Concast<T> extends Observable<T> {
   public cancel = (reason: any) => {
     this.reject(reason);
     this.sources = [];
-    this.handlers.complete();
+    this.handlers.error(reason);
   };
 }
 


### PR DESCRIPTION
Fixes #11988 

Maybe fixes #11846