### PR TITLE
[Data masking] Warn when passing object to `useFragment`/`watchFragment` `from` that is not identifiable

### DIFF
--- a/src/__tests__/dataMasking.ts
+++ b/src/__tests__/dataMasking.ts
@@ -1212,7 +1212,8 @@ test("warns when passing parent object to `from` when id is masked", async () =>
 
   expect(console.warn).toHaveBeenCalledTimes(1);
   expect(console.warn).toHaveBeenCalledWith(
-    "Could not identify object passed to `from` either because the object is non-normalized or the key fields are missing. If you are masking this object, please ensure the key fields are requested by the parent object."
+    "Could not identify object passed to `from` for '%s' fragment, either because the object is non-normalized or the key fields are missing. If you are masking this object, please ensure the key fields are requested by the parent object.",
+    "UserFields"
   );
 
   const fragmentStream = new ObservableStream(fragmentObservable);
@@ -1288,7 +1289,8 @@ test("warns when passing parent object to `from` that is non-normalized", async 
 
   expect(console.warn).toHaveBeenCalledTimes(1);
   expect(console.warn).toHaveBeenCalledWith(
-    "Could not identify object passed to `from` either because the object is non-normalized or the key fields are missing. If you are masking this object, please ensure the key fields are requested by the parent object."
+    "Could not identify object passed to `from` for '%s' fragment, either because the object is non-normalized or the key fields are missing. If you are masking this object, please ensure the key fields are requested by the parent object.",
+    "UserFields"
   );
 
   const fragmentStream = new ObservableStream(fragmentObservable);

--- a/src/__tests__/dataMasking.ts
+++ b/src/__tests__/dataMasking.ts
@@ -1076,6 +1076,77 @@ test("warns when accessing a unmasked field while using @unmask with mode: 'migr
   }
 });
 
+test("reads fragment by passing parent object to `from`", async () => {
+  interface Query {
+    currentUser: {
+      __typename: "User";
+      id: number;
+      name: string;
+    };
+  }
+
+  interface Fragment {
+    age: number;
+  }
+
+  const fragment: TypedDocumentNode<Fragment, never> = gql`
+    fragment UserFields on User {
+      age
+    }
+  `;
+
+  const query: TypedDocumentNode<Query, never> = gql`
+    query MaskedQuery {
+      currentUser {
+        id
+        name
+        ...UserFields
+      }
+    }
+
+    ${fragment}
+  `;
+
+  const mocks = [
+    {
+      request: { query },
+      result: {
+        data: {
+          currentUser: {
+            __typename: "User",
+            id: 1,
+            name: "Test User",
+            age: 30,
+          },
+        },
+      },
+    },
+  ];
+
+  const client = new ApolloClient({
+    dataMasking: true,
+    cache: new InMemoryCache(),
+    link: new MockLink(mocks),
+  });
+
+  const queryStream = new ObservableStream(client.watchQuery({ query }));
+
+  const { data } = await queryStream.takeNext();
+  const fragmentObservable = client.watchFragment({
+    fragment,
+    from: data.currentUser,
+  });
+
+  const fragmentStream = new ObservableStream(fragmentObservable);
+
+  {
+    const { data, complete } = await fragmentStream.takeNext();
+
+    expect(complete).toBe(true);
+    expect(data).toEqual({ __typename: "User", age: 30 });
+  }
+});
+
 class TestCache extends ApolloCache<unknown> {
   public diff<T>(query: Cache.DiffOptions): DataProxy.DiffResult<T> {
     return {};

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -247,10 +247,12 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
     const query = this.getFragmentDoc(fragment, fragmentName);
     const id = typeof from === "string" ? from : this.identify(from);
 
-    if (!id) {
-      invariant.warn(
-        "Could not identify object passed to `from` either because the object is non-normalized or the key fields are missing. If you are masking this object, please ensure the key fields are requested by the parent object."
-      );
+    if (__DEV__) {
+      if (!id) {
+        invariant.warn(
+          "Could not identify object passed to `from` either because the object is non-normalized or the key fields are missing. If you are masking this object, please ensure the key fields are requested by the parent object."
+        );
+      }
     }
 
     const diffOptions: Cache.DiffOptions<TData, TVars> = {

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -245,10 +245,17 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
   ): Observable<WatchFragmentResult<TData>> {
     const { fragment, fragmentName, from, optimistic = true } = options;
     const query = this.getFragmentDoc(fragment, fragmentName);
+    const id = typeof from === "string" ? from : this.identify(from);
+
+    if (!id) {
+      invariant.warn(
+        "Could not identify object passed to `from` either because the object is non-normalized or the key fields are missing. If you are masking this object, please ensure the key fields are requested by the parent object."
+      );
+    }
 
     const diffOptions: Cache.DiffOptions<TData, TVars> = {
       returnPartialData: true,
-      id: typeof from === "string" ? from : this.identify(from),
+      id,
       query,
       optimistic,
     };

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -10,6 +10,7 @@ import {
   Observable,
   cacheSizes,
   defaultCacheSizes,
+  getFragmentDefinition,
   getFragmentQueryDocument,
   mergeDeepArray,
 } from "../../utilities/index.js";
@@ -248,9 +249,13 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
     const id = typeof from === "string" ? from : this.identify(from);
 
     if (__DEV__) {
+      const actuaFragmentName =
+        fragmentName || getFragmentDefinition(fragment).name.value;
+
       if (!id) {
         invariant.warn(
-          "Could not identify object passed to `from` either because the object is non-normalized or the key fields are missing. If you are masking this object, please ensure the key fields are requested by the parent object."
+          "Could not identify object passed to `from` for '%s' fragment, either because the object is non-normalized or the key fields are missing. If you are masking this object, please ensure the key fields are requested by the parent object.",
+          actuaFragmentName
         );
       }
     }

--- a/src/react/hooks/__tests__/useFragment.test.tsx
+++ b/src/react/hooks/__tests__/useFragment.test.tsx
@@ -1585,7 +1585,8 @@ describe("useFragment", () => {
 
     expect(console.warn).toHaveBeenCalledTimes(1);
     expect(console.warn).toHaveBeenCalledWith(
-      "Could not identify object passed to `from` either because the object is non-normalized or the key fields are missing. If you are masking this object, please ensure the key fields are requested by the parent object."
+      "Could not identify object passed to `from` for '%s' fragment, either because the object is non-normalized or the key fields are missing. If you are masking this object, please ensure the key fields are requested by the parent object.",
+      "UserFields"
     );
 
     {

--- a/src/react/hooks/__tests__/useFragment.test.tsx
+++ b/src/react/hooks/__tests__/useFragment.test.tsx
@@ -1558,6 +1558,45 @@ describe("useFragment", () => {
     await expect(ProfiledHook).not.toRerender();
   });
 
+  it("warns when passing parent object to `from` when key fields are missing", async () => {
+    using _ = spyOnConsole("warn");
+
+    interface Fragment {
+      age: number;
+    }
+
+    const fragment: TypedDocumentNode<Fragment, never> = gql`
+      fragment UserFields on User {
+        age
+      }
+    `;
+
+    const client = new ApolloClient({ cache: new InMemoryCache() });
+
+    const ProfiledHook = profileHook(() =>
+      useFragment({ fragment, from: { __typename: "User" } })
+    );
+
+    render(<ProfiledHook />, {
+      wrapper: ({ children }) => (
+        <ApolloProvider client={client}>{children}</ApolloProvider>
+      ),
+    });
+
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenCalledWith(
+      "Could not identify object passed to `from` either because the object is non-normalized or the key fields are missing. If you are masking this object, please ensure the key fields are requested by the parent object."
+    );
+
+    {
+      const { data, complete } = await ProfiledHook.takeSnapshot();
+
+      expect(data).toEqual({});
+      // TODO: Update when https://github.com/apollographql/apollo-client/issues/12003 is fixed
+      expect(complete).toBe(true);
+    }
+  });
+
   describe("tests with incomplete data", () => {
     let cache: InMemoryCache, wrapper: React.FunctionComponent;
     const ItemFragment = gql`


### PR DESCRIPTION
Closes #11675

Adds a warning when passing an object to the `from` property that is not identifiable from the cache (i.e. `cache.identify` returns `undefined`). This also adds some tests to check that objects returned from masked queries can be read from `watchFragment` and `useFragment`.