### PR TITLE
[Data masking] Fix bug where masked field could be returned in parent query

### DIFF
--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 40847,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 33674
+  "dist/apollo-client.min.cjs": 40870,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 33688
 }

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 40818,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 33647
+  "dist/apollo-client.min.cjs": 40847,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 33674
 }

--- a/src/core/__tests__/masking.test.ts
+++ b/src/core/__tests__/masking.test.ts
@@ -144,6 +144,46 @@ describe("maskOperation", () => {
     });
   });
 
+  test("masks fragments from nested objects when query gets fields from same object", () => {
+    const query = gql`
+      query {
+        user {
+          __typename
+          profile {
+            __typename
+            id
+          }
+          ...UserFields
+        }
+      }
+      fragment UserFields on User {
+        profile {
+          __typename
+          id
+          fullName
+        }
+      }
+    `;
+
+    const data = maskOperation(
+      deepFreeze({
+        user: {
+          __typename: "User",
+          profile: { __typename: "Profile", id: "1", fullName: "Test User" },
+        },
+      }),
+      query,
+      createFragmentMatcher(new InMemoryCache())
+    );
+
+    expect(data).toEqual({
+      user: {
+        __typename: "User",
+        profile: { __typename: "Profile", id: "1" },
+      },
+    });
+  });
+
   test("deep freezes the masked result if the original data is frozen", () => {
     const query = gql`
       query {

--- a/src/core/__tests__/masking.test.ts
+++ b/src/core/__tests__/masking.test.ts
@@ -148,7 +148,6 @@ describe("maskOperation", () => {
     const query = gql`
       query {
         user {
-          __typename
           profile {
             __typename
             id
@@ -158,7 +157,6 @@ describe("maskOperation", () => {
       }
       fragment UserFields on User {
         profile {
-          __typename
           id
           fullName
         }

--- a/src/core/masking.ts
+++ b/src/core/masking.ts
@@ -149,7 +149,7 @@ function maskSelectionSet(
           memo[keyName] = data[keyName];
 
           if (childSelectionSet) {
-            let [masked, childChanged] = maskSelectionSet(
+            const [masked, childChanged] = maskSelectionSet(
               data[keyName],
               childSelectionSet,
               context,

--- a/src/core/masking.ts
+++ b/src/core/masking.ts
@@ -156,17 +156,13 @@ function maskSelectionSet(
               __DEV__ ? `${path || ""}.${keyName}` : void 0
             );
 
-            // This check prevents cases where masked fields may accidentally be
-            // returned as part of this object when the fragment also selects
-            // additional fields from the same child selection.
             if (
-              !childChanged &&
+              childChanged ||
+              // This check prevents cases where masked fields may accidentally be
+              // returned as part of this object when the fragment also selects
+              // additional fields from the same child selection.
               Object.keys(masked).length !== Object.keys(data[keyName]).length
             ) {
-              childChanged = true;
-            }
-
-            if (childChanged) {
               memo[keyName] = masked;
               changed = true;
             }

--- a/src/core/masking.ts
+++ b/src/core/masking.ts
@@ -149,12 +149,22 @@ function maskSelectionSet(
           memo[keyName] = data[keyName];
 
           if (childSelectionSet) {
-            const [masked, childChanged] = maskSelectionSet(
+            let [masked, childChanged] = maskSelectionSet(
               data[keyName],
               childSelectionSet,
               context,
               __DEV__ ? `${path || ""}.${keyName}` : void 0
             );
+
+            // This check prevents cases where masked fields may accidentally be
+            // returned as part of this object when the fragment also selects
+            // additional fields from the same child selection.
+            if (
+              !childChanged &&
+              Object.keys(masked).length !== Object.keys(data[keyName]).length
+            ) {
+              childChanged = true;
+            }
 
             if (childChanged) {
               memo[keyName] = masked;


### PR DESCRIPTION
Because we try and retain object identities as much as possible when running the data masking algorithm, this causes an issue where would-be masked fields are returned in the query when a named fragment selects additional fields on the same child selection as the query.

For example, take this query:

```graphql
query {
  user {
    profile {
      id
    }
    ...UserFields
  }
}

fragment UserFields on User {
  profile {
    id
    age
  }
}
```

Here the parent asks only for the `id` on the `profile` field while the `UserFields` fragment selects `age` on `profile` as well. Prior to this fix, both `id` and `age` were returned as part of the parent query even though `age` should have been masked. This fix ensures `age` would be masked here as expected.