### PR TITLE
Always retain `__typename` during data masking

### DIFF
--- a/src/core/__tests__/masking.test.ts
+++ b/src/core/__tests__/masking.test.ts
@@ -86,7 +86,6 @@ describe("maskOperation", () => {
     const query = gql`
       query {
         user {
-          __typename
           id
           ...UserFields
         }
@@ -149,7 +148,6 @@ describe("maskOperation", () => {
     const query = gql`
       query {
         user {
-          __typename
           id
           ...UserFields
         }
@@ -180,7 +178,6 @@ describe("maskOperation", () => {
     const query = gql`
       query {
         users {
-          __typename
           id
           ...UserFields
         }
@@ -214,7 +211,6 @@ describe("maskOperation", () => {
     const query = gql`
       query {
         user {
-          __typename
           id
           ...UserProfileFields
           ...UserAvatarFields
@@ -252,12 +248,10 @@ describe("maskOperation", () => {
     const query = gql`
       query {
         user {
-          __typename
           id
           ...UserFields
         }
         post {
-          __typename
           id
           ...PostFields
         }
@@ -299,7 +293,6 @@ describe("maskOperation", () => {
     const query = gql`
       query {
         user {
-          __typename
           id
           birthdate
           ...UserProfileFields
@@ -338,14 +331,12 @@ describe("maskOperation", () => {
     const query = gql`
       query {
         user {
-          __typename
           id
           ... @defer {
             name
           }
         }
         profile {
-          __typename
           ... on UserProfile {
             avatarUrl
           }
@@ -389,7 +380,6 @@ describe("maskOperation", () => {
     const query = gql`
       query {
         user {
-          __typename
           id
           ... @defer {
             name
@@ -397,13 +387,11 @@ describe("maskOperation", () => {
           }
         }
         profile {
-          __typename
           ... on UserProfile {
             avatarUrl
             ...UserProfileFields
           }
           industry {
-            __typename
             ... on TechIndustry {
               ...TechIndustryFields
             }
@@ -469,7 +457,6 @@ describe("maskOperation", () => {
     const query = gql`
       query {
         drinks {
-          __typename
           id
           ... on Juice {
             fruitBase
@@ -501,7 +488,6 @@ describe("maskOperation", () => {
     const query = gql`
       query {
         user {
-          __typename
           id
           fullName: name
           ... @defer {
@@ -551,7 +537,6 @@ describe("maskOperation", () => {
     const query = gql`
       query {
         drinks {
-          __typename
           id
           ... @defer {
             amount
@@ -560,7 +545,6 @@ describe("maskOperation", () => {
             milkType
             ... on Latte {
               flavor {
-                __typename
                 name
                 ...FlavorFields
               }
@@ -688,7 +672,6 @@ describe("maskOperation", () => {
     const query = gql`
       query {
         user {
-          __typename
           id
           name
         }
@@ -710,26 +693,21 @@ describe("maskOperation", () => {
     const query = gql`
       query {
         user {
-          __typename
           id
           profile {
-            __typename
             avatarUrl
           }
           ...UserFields
         }
         post {
-          __typename
           id
           title
         }
         authors {
-          __typename
           id
           name
         }
         industries {
-          __typename
           ... on TechIndustry {
             languageRequirements
           }
@@ -743,7 +721,6 @@ describe("maskOperation", () => {
           }
         }
         drink {
-          __typename
           ... on SportsDrink {
             saltContent
           }
@@ -827,7 +804,6 @@ describe("maskOperation", () => {
     const query = gql`
       query {
         user {
-          __typename
           id
           name
         }
@@ -858,7 +834,6 @@ describe("maskOperation", () => {
           id
           name
           ...UserFields @unmask
-          __typename
         }
       }
 
@@ -889,26 +864,21 @@ describe("maskOperation", () => {
     const query = gql`
       query {
         user {
-          __typename
           id
           profile {
-            __typename
             avatarUrl
           }
           ...UserFields @unmask
         }
         post {
-          __typename
           id
           title
         }
         authors {
-          __typename
           id
           name
         }
         industries {
-          __typename
           ... on TechIndustry {
             ...TechIndustryFields @unmask
           }
@@ -1026,7 +996,6 @@ describe("maskOperation", () => {
     const query = gql`
       query UnmaskedQuery {
         currentUser {
-          __typename
           id
           name
           ...UserFields @unmask(mode: "migrate")
@@ -1041,7 +1010,6 @@ describe("maskOperation", () => {
     const anonymousQuery = gql`
       query {
         currentUser {
-          __typename
           id
           name
           ...UserFields @unmask(mode: "migrate")
@@ -1106,7 +1074,6 @@ describe("maskOperation", () => {
     const query = gql`
       query UnmaskedQuery {
         currentUser {
-          __typename
           id
           name
           ...UserFields @unmask(mode: "migrate")
@@ -1142,7 +1109,6 @@ describe("maskOperation", () => {
     const query = gql`
       query UnmaskedQuery {
         users {
-          __typename
           id
           name
           ...UserFields @unmask(mode: "migrate")
@@ -1190,7 +1156,6 @@ describe("maskOperation", () => {
     const query = gql`
       query UnmaskedQuery {
         currentUser {
-          __typename
           id
           name
           ...UserFields @unmask
@@ -1200,7 +1165,6 @@ describe("maskOperation", () => {
       fragment UserFields on User {
         age
         profile {
-          __typename
           email
           ... @defer {
             username
@@ -1208,7 +1172,6 @@ describe("maskOperation", () => {
           ...ProfileFields
         }
         skills {
-          __typename
           name
           ...SkillFields @unmask(mode: "migrate")
         }
@@ -1216,7 +1179,6 @@ describe("maskOperation", () => {
 
       fragment ProfileFields on Profile {
         settings {
-          __typename
           darkMode
         }
       }
@@ -1305,7 +1267,6 @@ describe("maskOperation", () => {
     const query = gql`
       query UnmaskedQuery {
         currentUser {
-          __typename
           id
           name
           ...UserFields @unmask(mode: "migrate")
@@ -1365,7 +1326,6 @@ describe("maskOperation", () => {
     const query = gql`
       query UnmaskedQuery {
         currentUser {
-          __typename
           id
           name
           ...UserFields @unmask(mode: "migrate")
@@ -1375,7 +1335,6 @@ describe("maskOperation", () => {
       fragment UserFields on User {
         age
         profile {
-          __typename
           email
           ... @defer {
             username
@@ -1383,7 +1342,6 @@ describe("maskOperation", () => {
           ...ProfileFields @unmask(mode: "migrate")
         }
         skills {
-          __typename
           name
           ...SkillFields @unmask(mode: "migrate")
         }
@@ -1391,7 +1349,6 @@ describe("maskOperation", () => {
 
       fragment ProfileFields on Profile {
         settings {
-          __typename
           dark: darkMode
         }
       }
@@ -1506,7 +1463,6 @@ describe("maskOperation", () => {
     const query = gql`
       query UnmaskedQuery {
         currentUser {
-          __typename
           id
           name
           age
@@ -1548,7 +1504,6 @@ describe("maskOperation", () => {
     const query = gql`
       query UnmaskedQuery {
         currentUser {
-          __typename
           id
           name
           ...UserFields @unmask
@@ -1584,7 +1539,6 @@ describe("maskOperation", () => {
     const subscription = gql`
       subscription {
         onUserUpdated {
-          __typename
           id
           ...UserFields
         }
@@ -1610,7 +1564,6 @@ describe("maskOperation", () => {
     const subscription = gql`
       subscription {
         onUserUpdated {
-          __typename
           id
           ...UserFields @unmask
         }
@@ -1640,7 +1593,6 @@ describe("maskOperation", () => {
     const subscription = gql`
       subscription UserUpdatedSubscription {
         onUserUpdated {
-          __typename
           id
           ...UserFields @unmask(mode: "migrate")
         }
@@ -1675,7 +1627,6 @@ describe("maskOperation", () => {
     const mutation = gql`
       mutation {
         updateUser {
-          __typename
           id
           ...UserFields
         }
@@ -1701,7 +1652,6 @@ describe("maskOperation", () => {
     const mutation = gql`
       mutation {
         updateUser {
-          __typename
           id
           ...UserFields @unmask
         }
@@ -1731,7 +1681,6 @@ describe("maskOperation", () => {
     const mutation = gql`
       mutation UpdateUserMutation {
         updateUser {
-          __typename
           id
           ...UserFields @unmask(mode: "migrate")
         }
@@ -1767,7 +1716,6 @@ describe("maskFragment", () => {
   test("masks named fragments in fragment documents", () => {
     const fragment = gql`
       fragment UserFields on User {
-        __typename
         id
         ...UserProfile
       }
@@ -1790,10 +1738,8 @@ describe("maskFragment", () => {
   test("masks named fragments in nested fragment objects", () => {
     const fragment = gql`
       fragment UserFields on User {
-        __typename
         id
         profile {
-          __typename
           ...UserProfile
         }
       }
@@ -1824,10 +1770,8 @@ describe("maskFragment", () => {
   test("deep freezes the masked result if the original data is frozen", () => {
     const fragment = gql`
       fragment UserFields on User {
-        __typename
         id
         profile {
-          __typename
           ...UserProfile
         }
       }
@@ -1866,7 +1810,6 @@ describe("maskFragment", () => {
   test("does not mask inline fragment in fragment documents", () => {
     const fragment = gql`
       fragment UserFields on User {
-        __typename
         id
         ... @defer {
           age
@@ -1887,7 +1830,6 @@ describe("maskFragment", () => {
   test("throws when document contains more than 1 fragment without a fragmentName", () => {
     const fragment = gql`
       fragment UserFields on User {
-        __typename
         id
         ...UserProfile
       }
@@ -1913,7 +1855,6 @@ describe("maskFragment", () => {
   test("throws when fragment cannot be found within document", () => {
     const fragment = gql`
       fragment UserFields on User {
-        __typename
         id
         ...UserProfile
       }
@@ -1938,19 +1879,15 @@ describe("maskFragment", () => {
   test("maintains referential equality on fragment subtrees that did not change", () => {
     const fragment = gql`
       fragment UserFields on User {
-        __typename
         id
         profile {
-          __typename
           ...ProfileFields
         }
         post {
-          __typename
           id
           title
         }
         industries {
-          __typename
           ... on TechIndustry {
             languageRequirements
           }
@@ -1964,7 +1901,6 @@ describe("maskFragment", () => {
           }
         }
         drinks {
-          __typename
           ... on SportsDrink {
             ...SportsDrinkFields
           }
@@ -2054,7 +1990,6 @@ describe("maskFragment", () => {
   test("maintains referential equality on fragment when no data is masked", () => {
     const fragment = gql`
       fragment UserFields on User {
-        __typename
         id
         age
       }
@@ -2077,7 +2012,6 @@ describe("maskFragment", () => {
         id
         name
         ...UserFields @unmask
-        __typename
       }
 
       fragment UserFields on User {
@@ -2106,7 +2040,6 @@ describe("maskFragment", () => {
     using _ = spyOnConsole("warn");
     const query = gql`
       fragment UnmaskedFragment on User {
-        __typename
         id
         name
         ...UserFields @unmask(mode: "migrate")
@@ -2151,19 +2084,15 @@ describe("maskFragment", () => {
   test("maintains referential equality on `@unmask` fragment subtrees", () => {
     const fragment = gql`
       fragment UserFields on User {
-        __typename
         id
         profile {
-          __typename
           ...ProfileFields @unmask
         }
         post {
-          __typename
           id
           title
         }
         industries {
-          __typename
           ... on TechIndustry {
             languageRequirements
           }
@@ -2177,7 +2106,6 @@ describe("maskFragment", () => {
           }
         }
         drinks {
-          __typename
           ... on SportsDrink {
             ...SportsDrinkFields @unmask
           }
@@ -2278,7 +2206,6 @@ describe("maskFragment", () => {
 
     const fragment = gql`
       fragment UnmaskedUser on User {
-        __typename
         id
         name
         ...UserFields @unmask(mode: "migrate")

--- a/src/core/__tests__/masking.test.ts
+++ b/src/core/__tests__/masking.test.ts
@@ -106,6 +106,45 @@ describe("maskOperation", () => {
     expect(data).toEqual({ user: { __typename: "User", id: 1 } });
   });
 
+  test("retains __typename in the result", () => {
+    const query = gql`
+      query {
+        user {
+          id
+          profile {
+            id
+          }
+          ...UserFields
+        }
+      }
+
+      fragment UserFields on Query {
+        age
+      }
+    `;
+
+    const data = maskOperation(
+      deepFreeze({
+        user: {
+          __typename: "User",
+          id: 1,
+          age: 30,
+          profile: { __typename: "Profile", id: 2 },
+        },
+      }),
+      query,
+      createFragmentMatcher(new InMemoryCache())
+    );
+
+    expect(data).toEqual({
+      user: {
+        __typename: "User",
+        id: 1,
+        profile: { __typename: "Profile", id: 2 },
+      },
+    });
+  });
+
   test("deep freezes the masked result if the original data is frozen", () => {
     const query = gql`
       query {

--- a/src/core/masking.ts
+++ b/src/core/masking.ts
@@ -139,7 +139,7 @@ function maskSelectionSet(
     return [changed ? masked : data, changed];
   }
 
-  return selectionSet.selections.reduce<[any, boolean]>(
+  const result = selectionSet.selections.reduce<[any, boolean]>(
     ([memo, changed], selection) => {
       switch (selection.kind) {
         case Kind.FIELD: {
@@ -223,6 +223,12 @@ function maskSelectionSet(
     },
     [Object.create(null), false]
   );
+
+  if ("__typename" in data && !("__typename" in result[0])) {
+    result[0].__typename = data.__typename;
+  }
+
+  return result;
 }
 
 function addFieldAccessorWarnings(


### PR DESCRIPTION
While working on data masking for nested fragments, I stumbled on a potential pitfall with the existing solution; the data masking algorithm only retains exactly whats defined in the selection set. This means that unless `__typename` is defined in the fragment, this property was removed from the returned object. This is mostly ok if you're just working with the query and one level of fragments, but as you introduce nested fragments with data masking, this made it difficult to work with. If you forget to include `__typename` with data masking enabled, this means the `from` option passed to `useFragment`/`watchFragment` was invalid, so the value returned was empty. This _could_ be solved in user-space by adding a `__typename` selection in the fragment, but we don't ask our users to do that with queries, nor does using `watchFragment` without masking behave this way today.

This PR retains `__typename` when present regardless of whether its present in the original document or not. 

