### PR TITLE
reproduction around `useQuery` loading with `cache-only` on an empty cache

### DIFF
--- a/src/react/hooks/__tests__/reproduction.test.tsx
+++ b/src/react/hooks/__tests__/reproduction.test.tsx
@@ -1,0 +1,34 @@
+import gql from "graphql-tag";
+import { ApolloClient, InMemoryCache } from "../../../core";
+import { useQuery, ApolloProvider } from "../../../react";
+import { profileHook } from "../../../testing/internal";
+import { render } from "@testing-library/react";
+import * as React from "react";
+
+it("flips to `loading: true`, then `loading: false` on an empty cache when using `cache-only`", async () => {
+  const query = gql`
+    query {
+      hello
+    }
+  `;
+  const client = new ApolloClient({ cache: new InMemoryCache() });
+  const UseQuery = profileHook(() =>
+    useQuery(query, { fetchPolicy: "cache-only" })
+  );
+  render(<UseQuery />, {
+    wrapper: ({ children }) => (
+      <ApolloProvider client={client}>{children}</ApolloProvider>
+    ),
+  });
+  {
+    const snapshot = await UseQuery.takeSnapshot();
+    expect(snapshot.loading).toBe(true);
+    expect(snapshot.data).toBe(undefined);
+  }
+  {
+    const snapshot = await UseQuery.takeSnapshot();
+    expect(snapshot.loading).toBe(false);
+    expect(snapshot.data).toBe(undefined);
+  }
+  expect(UseQuery).not.toRerender();
+});


### PR DESCRIPTION
This came up in
https://community.apollographql.com/t/loading-flips-to-true-at-first-even-with-fetchpolicy-cache-only/7771

I could at least reproduce this in 3.10 and 3.11, so it's not a result of the `useQuery` rewrite.

The question is also what the correct behaviour would be here.

v2 apparently had `loading: false`, but `data: undefined`.

I would argue that a constant `loading: true` would be preferrable until something else fills in the cache. 🤔 

I'll rewrite the test in an older style and do some more bisecting.