### PR TITLE
Type `MutationResult.reset` as an arrow function

### DIFF
--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -1178,7 +1178,7 @@ export interface MutationResult<TData = any> {
     data?: TData | null;
     error?: ApolloError;
     loading: boolean;
-    reset(): void;
+    reset: () => void;
 }
 
 // Warning: (ae-forgotten-export) The symbol "MutationBaseOptions" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report-react_components.api.md
+++ b/.api-reports/api-report-react_components.api.md
@@ -1059,7 +1059,7 @@ interface MutationResult<TData = any> {
     data?: TData | null;
     error?: ApolloError;
     loading: boolean;
-    reset(): void;
+    reset: () => void;
 }
 
 // Warning: (ae-forgotten-export) The symbol "MutationBaseOptions" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report-react_hoc.api.md
+++ b/.api-reports/api-report-react_hoc.api.md
@@ -1052,7 +1052,7 @@ interface MutationResult<TData = any> {
     data?: TData | null;
     error?: ApolloError;
     loading: boolean;
-    reset(): void;
+    reset: () => void;
 }
 
 // Warning: (ae-forgotten-export) The symbol "MutationBaseOptions" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report-react_hooks.api.md
+++ b/.api-reports/api-report-react_hooks.api.md
@@ -1120,7 +1120,7 @@ interface MutationResult<TData = any> {
     data?: TData | null;
     error?: ApolloError;
     loading: boolean;
-    reset(): void;
+    reset: () => void;
 }
 
 // Warning: (ae-forgotten-export) The symbol "MutationBaseOptions" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -1629,7 +1629,7 @@ export interface MutationResult<TData = any> {
     data?: TData | null;
     error?: ApolloError;
     loading: boolean;
-    reset(): void;
+    reset: () => void;
 }
 
 // Warning: (ae-forgotten-export) The symbol "MutationBaseOptions" needs to be exported by the entry point index.d.ts

--- a/.changeset/modern-cows-tease.md
+++ b/.changeset/modern-cows-tease.md
@@ -2,4 +2,4 @@
 "@apollo/client": patch
 ---
 
-Type Mutation.reset as an arrow function
+Type `MutationResult.reset` as an arrow function

--- a/.changeset/modern-cows-tease.md
+++ b/.changeset/modern-cows-tease.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Type Mutation.reset as an arrow function

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -380,7 +380,7 @@ export interface MutationResult<TData = any> {
   /** {@inheritDoc @apollo/client!MutationResultDocumentation#client:member} */
   client: ApolloClient<object>;
   /** {@inheritDoc @apollo/client!MutationResultDocumentation#reset:member} */
-  reset(): void;
+  reset: () => void;
 }
 
 export declare type MutationFunction<


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:

### Checklist:
- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
-->

Type Mutation.reset as an arrow function.

This function doesn't depend on `this`, so it can be safely passed around as value. Typing this as an arrow function makes it clear and plays nicer with https://typescript-eslint.io/rules/unbound-method/