### PR TITLE
[Data masking] Ensure masking algorithm properly handles nulls

### DIFF
--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 41255,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 33943
+  "dist/apollo-client.min.cjs": 41282,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 33969
 }

--- a/src/core/__tests__/masking.test.ts
+++ b/src/core/__tests__/masking.test.ts
@@ -56,6 +56,40 @@ describe("maskOperation", () => {
     );
   });
 
+  test("returns null when data is null", () => {
+    const query = gql`
+      query {
+        foo
+        ...QueryFields
+      }
+
+      fragment QueryFields on Query {
+        bar
+      }
+    `;
+
+    const data = maskOperation(null, query, new InMemoryCache());
+
+    expect(data).toBe(null);
+  });
+
+  test("returns undefined when data is undefined", () => {
+    const query = gql`
+      query {
+        foo
+        ...QueryFields
+      }
+
+      fragment QueryFields on Query {
+        bar
+      }
+    `;
+
+    const data = maskOperation(undefined, query, new InMemoryCache());
+
+    expect(data).toBe(undefined);
+  });
+
   test("strips top-level fragment data from query", () => {
     const query = gql`
       query {

--- a/src/core/__tests__/masking.test.ts
+++ b/src/core/__tests__/masking.test.ts
@@ -1821,6 +1821,39 @@ describe("maskOperation", () => {
 });
 
 describe("maskFragment", () => {
+  test("returns null when data is null", () => {
+    const fragment = gql`
+      fragment Foo on Query {
+        foo
+        ...QueryFields
+      }
+
+      fragment QueryFields on Query {
+        bar
+      }
+    `;
+
+    const data = maskFragment(null, fragment, new InMemoryCache(), "Foo");
+
+    expect(data).toBe(null);
+  });
+
+  test("returns undefined when data is undefined", () => {
+    const fragment = gql`
+      fragment Foo on Query {
+        foo
+        ...QueryFields
+      }
+
+      fragment QueryFields on Query {
+        bar
+      }
+    `;
+
+    const data = maskFragment(undefined, fragment, new InMemoryCache(), "Foo");
+
+    expect(data).toBe(undefined);
+  });
   test("masks named fragments in fragment documents", () => {
     const fragment = gql`
       fragment UserFields on User {

--- a/src/core/__tests__/masking.test.ts
+++ b/src/core/__tests__/masking.test.ts
@@ -264,22 +264,10 @@ describe("maskOperation", () => {
       }
     `;
 
-    const nullUsers = maskOperation(
+    const data = maskOperation(
       deepFreeze({
         users: [
           null,
-          {
-            __typename: "User",
-            profile: { __typename: "Profile", id: "1", fullName: "Test User" },
-          },
-        ],
-      }),
-      query,
-      new InMemoryCache()
-    );
-    const nullProfiles = maskOperation(
-      deepFreeze({
-        users: [
           { __typename: "User", profile: null },
           {
             __typename: "User",
@@ -291,14 +279,9 @@ describe("maskOperation", () => {
       new InMemoryCache()
     );
 
-    expect(nullUsers).toEqual({
+    expect(data).toEqual({
       users: [
         null,
-        { __typename: "User", profile: { __typename: "Profile", id: "1" } },
-      ],
-    });
-    expect(nullProfiles).toEqual({
-      users: [
         { __typename: "User", profile: null },
         { __typename: "User", profile: { __typename: "Profile", id: "1" } },
       ],

--- a/src/core/__tests__/masking.test.ts
+++ b/src/core/__tests__/masking.test.ts
@@ -211,6 +211,41 @@ describe("maskOperation", () => {
     });
   });
 
+  test("handles nulls in child selection sets", () => {
+    const query = gql`
+      query {
+        user {
+          profile {
+            id
+          }
+          ...UserFields
+        }
+      }
+      fragment UserFields on User {
+        profile {
+          id
+          fullName
+        }
+      }
+    `;
+
+    const nullUser = maskOperation(
+      deepFreeze({ user: null }),
+      query,
+      new InMemoryCache()
+    );
+    const nullProfile = maskOperation(
+      deepFreeze({ user: { __typename: "User", profile: null } }),
+      query,
+      new InMemoryCache()
+    );
+
+    expect(nullUser).toEqual({ user: null });
+    expect(nullProfile).toEqual({
+      user: { __typename: "User", profile: null },
+    });
+  });
+
   test("deep freezes the masked result if the original data is frozen", () => {
     const query = gql`
       query {

--- a/src/core/masking.ts
+++ b/src/core/masking.ts
@@ -40,6 +40,11 @@ export function maskOperation<TData = unknown>(
     "Expected a parsed GraphQL document with a query, mutation, or subscription."
   );
 
+  if (data == null) {
+    // Maintain the original `null` or `undefined` value
+    return data;
+  }
+
   const context: MaskingContext = {
     operationType: definition.operation,
     operationName: definition.name?.value,

--- a/src/core/masking.ts
+++ b/src/core/masking.ts
@@ -137,6 +137,10 @@ function maskSelectionSet(
     let changed = false;
 
     const masked = data.map((item, index) => {
+      if (item === null) {
+        return null;
+      }
+
       const [masked, itemChanged] = maskSelectionSet(
         item,
         selectionSet,

--- a/src/core/masking.ts
+++ b/src/core/masking.ts
@@ -160,7 +160,7 @@ function maskSelectionSet(
 
           memo[keyName] = data[keyName];
 
-          if (childSelectionSet) {
+          if (childSelectionSet && data[keyName] !== null) {
             const [masked, childChanged] = maskSelectionSet(
               data[keyName],
               childSelectionSet,

--- a/src/core/masking.ts
+++ b/src/core/masking.ts
@@ -105,6 +105,11 @@ export function maskFragment<TData = unknown>(
     fragmentName
   );
 
+  if (data == null) {
+    // Maintain the original `null` or `undefined` value
+    return data;
+  }
+
   const context: MaskingContext = {
     operationType: "fragment",
     operationName: fragment.name.value,


### PR DESCRIPTION
Fixes #12035

The data masking algorithm doesn't properly handle `null` when passed as a top-level value (which might happen if there were errors returned in the GraphQL response), as the value of an array item, or as the value of a key with a child selection set. This PR fixes all 3 of these situations.