### PR TITLE
Make it possible to extend ApolloCache<NormalizedCacheObject> in a InMemoryCache compatible way

### DIFF
--- a/scripts/memory/tests.js
+++ b/scripts/memory/tests.js
@@ -1,5 +1,6 @@
 const assert = require("assert");
 const {
+  $,
   ApolloClient,
   InMemoryCache,
   gql,
@@ -182,7 +183,7 @@ describe("garbage collection", () => {
         });
 
         function register(suffix) {
-          const reader = cache["storeReader"];
+          const reader = $(cache)["storeReader"];
           registry.register(reader, "StoreReader" + suffix);
           registry.register(reader.canon, "ObjectCanon" + suffix);
         }

--- a/src/__tests__/ApolloClient.ts
+++ b/src/__tests__/ApolloClient.ts
@@ -1,6 +1,7 @@
 import gql from "graphql-tag";
 
 import {
+  $,
   ApolloClient,
   ApolloError,
   DefaultOptions,
@@ -2745,7 +2746,7 @@ describe("ApolloClient", () => {
         `,
       });
 
-      expect((client.cache as any).data.data).toEqual({
+      expect($(client.cache).data["data"]).toEqual({
         ROOT_QUERY: {
           __typename: "Query",
           a: 1,
@@ -2753,7 +2754,7 @@ describe("ApolloClient", () => {
       });
 
       await client.clearStore();
-      expect((client.cache as any).data.data).toEqual({});
+      expect($(client.cache).data["data"]).toEqual({});
     });
   });
 

--- a/src/__tests__/__snapshots__/exports.ts.snap
+++ b/src/__tests__/__snapshots__/exports.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`exports of public entry points @apollo/client 1`] = `
 Array [
+  "$",
   "ApolloCache",
   "ApolloClient",
   "ApolloConsumer",
@@ -73,6 +74,7 @@ Array [
 
 exports[`exports of public entry points @apollo/client/cache 1`] = `
 Array [
+  "$",
   "ApolloCache",
   "Cache",
   "EntityStore",
@@ -92,6 +94,7 @@ Array [
 
 exports[`exports of public entry points @apollo/client/core 1`] = `
 Array [
+  "$",
   "ApolloCache",
   "ApolloClient",
   "ApolloError",

--- a/src/__tests__/resultCacheCleaning.ts
+++ b/src/__tests__/resultCacheCleaning.ts
@@ -3,6 +3,7 @@ import { makeExecutableSchema } from "@graphql-tools/schema";
 import { ApolloClient, Resolvers, gql } from "../core";
 import { InMemoryCache, NormalizedCacheObject } from "../cache";
 import { SchemaLink } from "../link/schema";
+import { $ } from "../cache/inmemory/privates";
 
 describe("resultCache cleaning", () => {
   const fragments = gql`
@@ -150,7 +151,7 @@ describe("resultCache cleaning", () => {
   });
 
   afterEach(() => {
-    const storeReader = (client.cache as InMemoryCache)["storeReader"];
+    const { storeReader } = $(client.cache);
     expect(storeReader["executeSubSelectedArray"].size).toBeGreaterThan(0);
     expect(storeReader["executeSelectionSet"].size).toBeGreaterThan(0);
     client.cache.evict({

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -273,7 +273,7 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
 
   // Make sure we compute the same (===) fragment query document every
   // time we receive the same fragment in readFragment.
-  private getFragmentDoc = wrap(getFragmentQueryDocument, {
+  getFragmentDoc = wrap(getFragmentQueryDocument, {
     max:
       cacheSizes["cache.fragmentQueryDocuments"] ||
       defaultCacheSizes["cache.fragmentQueryDocuments"],

--- a/src/cache/core/types/Cache.ts
+++ b/src/cache/core/types/Cache.ts
@@ -1,15 +1,19 @@
-import { DataProxy } from "./DataProxy.js";
+import type { DataProxy } from "./DataProxy.js";
 import type { AllFieldsModifier, Modifiers } from "./common.js";
 import type { ApolloCache } from "../cache.js";
 
 export namespace Cache {
+  // @ts-ignore
+  const _ = ""; // Make typescript export something
   export type WatchCallback<TData = any> = (
     diff: Cache.DiffResult<TData>,
     lastDiff?: Cache.DiffResult<TData>
   ) => void;
 
-  export interface ReadOptions<TVariables = any, TData = any>
-    extends DataProxy.Query<TVariables, TData> {
+  export type ReadOptions<TVariables = any, TData = any> = DataProxy.Query<
+    TVariables,
+    TData
+  > & {
     rootId?: string;
     previousResult?: any;
     optimistic: boolean;
@@ -22,7 +26,7 @@ export namespace Cache {
      * the risk of memory leaks.
      */
     canonizeResults?: boolean;
-  }
+  };
 
   export interface WriteOptions<TResult = any, TVariables = any>
     extends Omit<DataProxy.Query<TVariables, TResult>, "id">,
@@ -104,12 +108,23 @@ export namespace Cache {
     ) => any;
   }
 
-  export import DiffResult = DataProxy.DiffResult;
-  export import ReadQueryOptions = DataProxy.ReadQueryOptions;
-  export import ReadFragmentOptions = DataProxy.ReadFragmentOptions;
-  export import WriteQueryOptions = DataProxy.WriteQueryOptions;
-  export import WriteFragmentOptions = DataProxy.WriteFragmentOptions;
-  export import UpdateQueryOptions = DataProxy.UpdateQueryOptions;
-  export import UpdateFragmentOptions = DataProxy.UpdateFragmentOptions;
-  export import Fragment = DataProxy.Fragment;
+  export type DiffResult<T> = DataProxy.DiffResult<T>;
+  export type ReadQueryOptions<TData, TVariables> = DataProxy.ReadQueryOptions<
+    TData,
+    TVariables
+  >;
+  export type ReadFragmentOptions<TData, TVariables> =
+    DataProxy.ReadFragmentOptions<TData, TVariables>;
+  export type WriteQueryOptions<TData, TVariables> =
+    DataProxy.WriteQueryOptions<TData, TVariables>;
+  export type WriteFragmentOptions<TData, TVariables> =
+    DataProxy.WriteFragmentOptions<TData, TVariables>;
+  export type UpdateQueryOptions<TData, TVariables> =
+    DataProxy.UpdateQueryOptions<TData, TVariables>;
+  export type UpdateFragmentOptions<TData, TVariables> =
+    DataProxy.UpdateFragmentOptions<TData, TVariables>;
+  export type Fragment<TVariables, TData> = DataProxy.Fragment<
+    TVariables,
+    TData
+  >;
 }

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -32,6 +32,7 @@ export {
 } from "./inmemory/helpers.js";
 
 export { InMemoryCache } from "./inmemory/inMemoryCache.js";
+export { $ } from "./inmemory/privates.js";
 
 export type { ReactiveVar } from "./inmemory/reactiveVars.js";
 export { makeVar, cacheSlot } from "./inmemory/reactiveVars.js";

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -6,6 +6,7 @@ export type {
   WatchFragmentResult,
 } from "./core/cache.js";
 export { ApolloCache } from "./core/cache.js";
+// eslint-disable-next-line @typescript-eslint/consistent-type-exports
 export { Cache } from "./core/types/Cache.js";
 export type { DataProxy } from "./core/types/DataProxy.js";
 export type {

--- a/src/cache/inmemory/__tests__/entityStore.ts
+++ b/src/cache/inmemory/__tests__/entityStore.ts
@@ -16,6 +16,7 @@ import { TypedDocumentNode } from "@graphql-typed-document-node/core";
 import { stringifyForDisplay } from "../../../utilities";
 import { InvariantError } from "../../../utilities/globals";
 import { spyOnConsole } from "../../../testing/internal";
+import { $ } from "../privates";
 
 describe("EntityStore", () => {
   it("should support result caching if so configured", () => {
@@ -220,13 +221,13 @@ describe("EntityStore", () => {
 
     // Nothing left to collect, but let's also reset the result cache to
     // demonstrate that the recomputed cache results are unchanged.
-    const originalReader = cache["storeReader"];
+    const { storeReader: originalReader } = $(cache);
     expect(
       cache.gc({
         resetResultCache: true,
       })
     ).toEqual([]);
-    expect(cache["storeReader"]).not.toBe(originalReader);
+    expect($(cache).storeReader).not.toBe(originalReader);
     const resultAfterResetResultCache = read();
     expect(resultAfterResetResultCache).toBe(resultBeforeGC);
     expect(resultAfterResetResultCache).toBe(resultAfterGC);
@@ -1000,7 +1001,7 @@ describe("EntityStore", () => {
     expect(cache.gc()).toEqual([]);
 
     const willId = cache.identify(data.parent)!;
-    const store = cache["data"];
+    const { data: store } = $(cache);
     const storeRootData = store["data"];
     // Hacky way of injecting a stray __ref field into the Will Smith Person
     // object, clearing store.refs (which was populated by the previous GC).
@@ -2675,7 +2676,7 @@ describe("EntityStore", () => {
       },
     });
 
-    const store = cache["data"];
+    const { data: store } = $(cache);
 
     const query = gql`
       query Book($isbn: string) {

--- a/src/cache/inmemory/__tests__/optimistic.ts
+++ b/src/cache/inmemory/__tests__/optimistic.ts
@@ -1,6 +1,8 @@
 import gql from "graphql-tag";
 
 import { InMemoryCache } from "../inMemoryCache";
+import { ApolloCache } from "../../core/cache";
+import type { NormalizedCacheObject } from "../types";
 
 describe("optimistic cache layers", () => {
   it("return === results for repeated reads", () => {
@@ -28,7 +30,7 @@ describe("optimistic cache layers", () => {
       }
     `;
 
-    function readOptimistic(cache: InMemoryCache) {
+    function readOptimistic(cache: ApolloCache<NormalizedCacheObject>) {
       return cache.readQuery<{ book: any }>({ query }, true);
     }
 

--- a/src/cache/inmemory/__tests__/readFromStore.ts
+++ b/src/cache/inmemory/__tests__/readFromStore.ts
@@ -18,6 +18,7 @@ import {
   TypedDocumentNode,
 } from "../../../core";
 import { defaultCacheSizes } from "../../../utilities";
+import { $ } from "../privates";
 
 describe("resultCacheMaxSize", () => {
   const cache = new InMemoryCache();
@@ -2207,7 +2208,8 @@ describe("reading from the store", () => {
       },
     });
 
-    const canon = cache["storeReader"].canon;
+    const { storeReader } = $(cache);
+    const canon = storeReader.canon;
 
     const query = gql`
       query {
@@ -2263,7 +2265,8 @@ describe("reading from the store", () => {
       },
     });
 
-    const canon = cache["storeReader"].canon;
+    const { storeReader } = $(cache);
+    const canon = storeReader.canon;
 
     const fragment = gql`
       fragment CountFragment on Query {

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -878,3 +878,5 @@ export function supportsResultCaching(store: any): store is EntityStore {
   // When result caching is disabled, store.depend will be null.
   return !!(store instanceof EntityStore && store.group.caching);
 }
+
+export type LayerType = Layer;

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -34,9 +34,9 @@ import type {
 } from "../core/types/common.js";
 import type { DocumentNode, FieldNode, SelectionSetNode } from "graphql";
 
-const DELETE: DeleteModifier = Object.create(null);
-const delModifier: Modifier<any> = () => DELETE;
-const INVALIDATE: InvalidateModifier = Object.create(null);
+export const DELETE: DeleteModifier = Object.create(null);
+export const delModifier: Modifier<any> = () => DELETE;
+export const INVALIDATE: InvalidateModifier = Object.create(null);
 
 export abstract class EntityStore implements NormalizedCache {
   protected data: NormalizedCacheObject = Object.create(null);

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -52,6 +52,7 @@ import {
   keyArgsFnFromSpecifier,
   keyFieldsFnFromSpecifier,
 } from "./key-extractor.js";
+import { $ } from "./privates.js";
 
 export type TypePolicies = {
   [__typename: string]: TypePolicy;
@@ -381,7 +382,7 @@ export class Policies {
         function () {
           const options = normalizeReadFieldOptions(arguments, storeObject);
           return policies.readField(options, {
-            store: policies.cache["data"],
+            store: $(policies.cache)["data"],
             variables: options.variables,
           });
         },

--- a/src/cache/inmemory/privates.ts
+++ b/src/cache/inmemory/privates.ts
@@ -1,0 +1,49 @@
+import type { Cache } from "../core/types/Cache.js";
+import type { ApolloCache } from "../core/cache.js";
+import type { InMemoryCacheConfig, NormalizedCacheObject } from "./types.js";
+import type { OptimisticWrapperFunction } from "optimism";
+import type { EntityStore } from "./entityStore.js";
+import type { StoreReader } from "./readFromStore.js";
+import type { StoreWriter } from "./writeToStore.js";
+import type { DocumentTransform } from "../../utilities/index.js";
+
+export type BroadcastOptions = Pick<
+  Cache.BatchOptions<ApolloCache<NormalizedCacheObject>>,
+  "optimistic" | "onWatchUpdated"
+>;
+
+export type MaybeBroadcastWatch = OptimisticWrapperFunction<
+  [Cache.WatchOptions, BroadcastOptions?],
+  any,
+  [Cache.WatchOptions]
+>;
+
+export interface PrivateParts {
+  // Do not touch, what would you're priest say?
+  data: EntityStore;
+  optimisticData: EntityStore;
+  config: InMemoryCacheConfig;
+  watches: Set<Cache.WatchOptions>;
+  addTypename: boolean;
+  txCount: number;
+  storeReader: StoreReader;
+  storeWriter: StoreWriter;
+  addTypenameTransform: DocumentTransform;
+  maybeBroadcastWatch: MaybeBroadcastWatch;
+  init: () => void;
+  resetResultCache: (resetResultIdentities?: boolean) => void;
+}
+
+export const privateParts = new WeakMap<
+  ApolloCache<NormalizedCacheObject>,
+  PrivateParts
+>();
+
+/**
+ * @experimental
+ * @internal
+ * This is not a stable API
+ * Use at your own risk!
+ */
+export const $ = (cache: ApolloCache<NormalizedCacheObject>): PrivateParts =>
+  privateParts.get(cache)!;

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -159,6 +159,10 @@ export class StoreReader {
     // by recreating the whole `StoreReader` in
     // `InMemoryCache.resetResultsCache`
     // (triggered from `InMemoryCache.gc` with `resetResultCache: true`)
+    const max =
+      this.config.resultCacheMaxSize ||
+      cacheSizes["inMemoryCache.executeSelectionSet"] ||
+      defaultCacheSizes["inMemoryCache.executeSelectionSet"];
     this.executeSelectionSet = wrap(
       (options) => {
         const { canonizeResults } = options.context;
@@ -195,10 +199,7 @@ export class StoreReader {
         return this.execSelectionSetImpl(options);
       },
       {
-        max:
-          this.config.resultCacheMaxSize ||
-          cacheSizes["inMemoryCache.executeSelectionSet"] ||
-          defaultCacheSizes["inMemoryCache.executeSelectionSet"],
+        max: max,
         keyArgs: execSelectionSetKeyArgs,
         // Note that the parameters of makeCacheKey are determined by the
         // array returned by keyArgs.

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1705,9 +1705,9 @@ interface FetchConcastInfo {
   // Metadata properties that can be returned in addition to the Concast.
   fromLink: boolean;
 }
-interface SourcesAndInfo<TData> extends FetchConcastInfo {
+export interface SourcesAndInfo<TData> extends FetchConcastInfo {
   sources: ConcastSourcesArray<ApolloQueryResult<TData>>;
 }
-interface ConcastAndInfo<TData> extends FetchConcastInfo {
+export interface ConcastAndInfo<TData> extends FetchConcastInfo {
   concast: Concast<ApolloQueryResult<TData>>;
 }

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -39,11 +39,13 @@ import { SubscriptionObserver } from "zen-observable-ts";
 import { waitFor } from "@testing-library/react";
 import { ObservableStream } from "../../testing/internal";
 
-export const mockFetchQuery = (queryManager: QueryManager<any>) => {
-  const fetchConcastWithInfo = queryManager["fetchConcastWithInfo"];
-  const fetchQueryByPolicy: QueryManager<any>["fetchQueryByPolicy"] = (
-    queryManager as any
-  ).fetchQueryByPolicy;
+export const mockFetchQuery = (
+  queryManager: QueryManager<NormalizedCacheObject>
+) => {
+  const fetchConcastWithInfo: QueryManager<NormalizedCacheObject>["fetchConcastWithInfo"] =
+    queryManager["fetchConcastWithInfo"];
+  const fetchQueryByPolicy: QueryManager<NormalizedCacheObject>["fetchQueryByPolicy"] =
+    queryManager["fetchQueryByPolicy"];
 
   const mock = <
     T extends typeof fetchConcastWithInfo | typeof fetchQueryByPolicy,

--- a/src/core/__tests__/QueryManager/index.ts
+++ b/src/core/__tests__/QueryManager/index.ts
@@ -50,6 +50,7 @@ import { itAsync, subscribeAndCount } from "../../../testing/core";
 import { ApolloClient } from "../../../core";
 import { mockFetchQuery } from "../ObservableQuery";
 import { Concast, print } from "../../../utilities";
+import { $ } from "../../../cache/inmemory/privates";
 
 interface MockedMutation {
   reject: (reason: any) => any;
@@ -6020,8 +6021,7 @@ describe("QueryManager", () => {
             });
           })
           .then(() => {
-            // @ts-ignore
-            expect(cache.watches.size).toBe(0);
+            expect($(cache).watches.size).toBe(0);
           })
           .then(resolve, reject);
       }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -44,7 +44,7 @@ export type {
   WatchFragmentResult,
 } from "../cache/index.js";
 // eslint-disable-next-line @typescript-eslint/consistent-type-exports
-export { Cache } from "../cache/index.js";
+export { $, Cache } from "../cache/index.js";
 export {
   ApolloCache,
   InMemoryCache,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -43,8 +43,9 @@ export type {
   WatchFragmentOptions,
   WatchFragmentResult,
 } from "../cache/index.js";
+// eslint-disable-next-line @typescript-eslint/consistent-type-exports
+export { Cache } from "../cache/index.js";
 export {
-  Cache,
   ApolloCache,
   InMemoryCache,
   MissingFieldError,

--- a/src/link/persisted-queries/index.ts
+++ b/src/link/persisted-queries/index.ts
@@ -206,7 +206,7 @@ export const createPersistedQueryLink = (
                 (networkError.result.errors as GraphQLFormattedError[]);
             }
             if (isNonEmptyArray(networkErrors)) {
-              graphQLErrors.push(...networkErrors);
+              graphQLErrors.push(...(networkErrors as GraphQLFormattedError[]));
             }
 
             const disablePayload: ErrorResponse = {

--- a/src/link/retry/__tests__/delayFunction.ts
+++ b/src/link/retry/__tests__/delayFunction.ts
@@ -8,7 +8,7 @@ describe("buildDelayFunction", () => {
   }
 
   function delayRange(delayFunction: SimpleDelayFunction, count: number) {
-    const results = [];
+    const results: number[] = [];
     for (let i = 1; i <= count; i++) {
       results.push(delayFunction(i));
     }

--- a/src/react/hoc/__tests__/queries/index.test.tsx
+++ b/src/react/hoc/__tests__/queries/index.test.tsx
@@ -550,7 +550,7 @@ describe("queries", () => {
     });
     const Container = graphql<Vars, Data>(query)(() => null);
 
-    let errorCaught = null;
+    let errorCaught: unknown = null;
     try {
       const { unmount } = render(
         <ApolloProvider client={client}>

--- a/src/react/ssr/__tests__/useLazyQuery.test.tsx
+++ b/src/react/ssr/__tests__/useLazyQuery.test.tsx
@@ -1,5 +1,5 @@
 /** @jest-environment node */
-import React from "react";
+import React, { ReactElement } from "react";
 import { DocumentNode } from "graphql";
 import gql from "graphql-tag";
 import { mockSingleLink } from "../../../testing";
@@ -44,7 +44,7 @@ describe("useLazyQuery Hook SSR", () => {
     });
 
     const Component = () => {
-      let html = null;
+      let html: ReactElement | null = null;
       const [execute, { loading, called, data }] = useLazyQuery(CAR_QUERY);
 
       if (!loading && !called) {

--- a/src/utilities/caching/getMemoryInternals.ts
+++ b/src/utilities/caching/getMemoryInternals.ts
@@ -8,6 +8,7 @@ import type {
 import type { ApolloClient } from "../../core/index.js";
 import type { CacheSizes } from "./sizes.js";
 import { cacheSizes, defaultCacheSizes } from "./sizes.js";
+import { $ } from "../../cache/inmemory/privates.js";
 
 const globalCaches: {
   print?: () => number;
@@ -161,7 +162,9 @@ function _getApolloCacheMemoryInternals(this: ApolloCache<any>) {
 }
 
 function _getInMemoryCacheMemoryInternals(this: InMemoryCache) {
-  const fragments = this.config.fragments as
+  const { config, addTypenameTransform, storeReader, maybeBroadcastWatch } =
+    $(this);
+  const fragments = config.fragments as
     | undefined
     | {
         findFragmentSpreads?: Function;
@@ -171,15 +174,15 @@ function _getInMemoryCacheMemoryInternals(this: InMemoryCache) {
 
   return {
     ..._getApolloCacheMemoryInternals.apply(this as any),
-    addTypenameDocumentTransform: transformInfo(this["addTypenameTransform"]),
+    addTypenameDocumentTransform: transformInfo(addTypenameTransform),
     inMemoryCache: {
       executeSelectionSet: getWrapperInformation(
-        this["storeReader"]["executeSelectionSet"]
+        storeReader["executeSelectionSet"]
       ),
       executeSubSelectedArray: getWrapperInformation(
-        this["storeReader"]["executeSubSelectedArray"]
+        storeReader["executeSubSelectedArray"]
       ),
-      maybeBroadcastWatch: getWrapperInformation(this["maybeBroadcastWatch"]),
+      maybeBroadcastWatch: getWrapperInformation(maybeBroadcastWatch),
     },
     fragmentRegistry: {
       findFragmentSpreads: getWrapperInformation(

--- a/src/utilities/common/__tests__/mergeDeep.ts
+++ b/src/utilities/common/__tests__/mergeDeep.ts
@@ -1,5 +1,25 @@
 import { mergeDeep, mergeDeepArray, DeepMerger } from "../mergeDeep";
 
+type Value = {
+  value: number;
+};
+
+type Nested = {
+  [p: `nested${number}`]: Value;
+  value?: number;
+};
+
+type FromNested = {
+  [p: `from${number}`]: Value | Nested;
+  nested: Nested;
+  value?: number;
+};
+
+type UniqueConflict = {
+  [p: `unique${number}`]: Value | FromNested;
+  conflict: FromNested;
+};
+
 describe("mergeDeep", function () {
   it("should return an object if first argument falsy", function () {
     expect(mergeDeep()).toEqual({});
@@ -41,15 +61,15 @@ describe("mergeDeep", function () {
   });
 
   it("should resolve conflicts among more than two objects", function () {
-    const sources = [];
+    const sources: UniqueConflict[] = [];
 
     for (let i = 0; i < 100; ++i) {
       sources.push({
-        ["unique" + i]: { value: i },
+        [`unique${i}`]: { value: i },
         conflict: {
-          ["from" + i]: { value: i },
+          [`from${i}`]: { value: i },
           nested: {
-            ["nested" + i]: { value: i },
+            [`nested${i}`]: { value: i },
           },
         },
       });
@@ -58,17 +78,17 @@ describe("mergeDeep", function () {
     const merged = mergeDeep(...sources);
 
     sources.forEach((source, i) => {
-      expect(merged["unique" + i].value).toBe(i);
-      expect(source["unique" + i]).toBe(merged["unique" + i]);
+      expect(merged[`unique${i}`].value).toBe(i);
+      expect(source[`unique${i}`]).toBe(merged[`unique${i}`]);
 
       expect(merged.conflict).not.toBe(source.conflict);
-      expect(merged.conflict["from" + i].value).toBe(i);
-      expect(merged.conflict["from" + i]).toBe(source.conflict["from" + i]);
+      expect(merged.conflict[`from${i}`].value).toBe(i);
+      expect(merged.conflict[`from${i}`]).toBe(source.conflict[`from${i}`]);
 
       expect(merged.conflict.nested).not.toBe(source.conflict.nested);
-      expect(merged.conflict.nested["nested" + i].value).toBe(i);
-      expect(merged.conflict.nested["nested" + i]).toBe(
-        source.conflict.nested["nested" + i]
+      expect(merged.conflict.nested[`nested${i}`].value).toBe(i);
+      expect(merged.conflict.nested[`nested${i}`]).toBe(
+        source.conflict.nested[`nested${i}`]
       );
     });
   });


### PR DESCRIPTION
This pull request enables extending ApolloCache in such a way that a function having parameters of type InMemoryCache can accept these alternative implementations as well. I hope these changes are alright, or that we can find some other way to enable this use case.