### PR TITLE
Fix useSubscription restart was not cached

### DIFF
--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -2228,7 +2228,7 @@ export interface UseReadQueryResult<TData = unknown> {
 
 // @public
 export function useSubscription<TData = any, TVariables extends OperationVariables = OperationVariables>(subscription: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: SubscriptionHookOptions<NoInfer_2<TData>, NoInfer_2<TVariables>>): {
-    restart(): void;
+    restart: () => void;
     loading: boolean;
     data?: TData | undefined;
     error?: ApolloError;

--- a/.api-reports/api-report-react_hooks.api.md
+++ b/.api-reports/api-report-react_hooks.api.md
@@ -2061,7 +2061,7 @@ export interface UseReadQueryResult<TData = unknown> {
 //
 // @public
 export function useSubscription<TData = any, TVariables extends OperationVariables = OperationVariables>(subscription: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: SubscriptionHookOptions<NoInfer_2<TData>, NoInfer_2<TVariables>>): {
-    restart(): void;
+    restart: () => void;
     loading: boolean;
     data?: TData | undefined;
     error?: ApolloError;

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -2889,7 +2889,7 @@ export interface UseReadQueryResult<TData = unknown> {
 
 // @public
 export function useSubscription<TData = any, TVariables extends OperationVariables = OperationVariables>(subscription: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: SubscriptionHookOptions<NoInfer_2<TData>, NoInfer_2<TVariables>>): {
-    restart(): void;
+    restart: () => void;
     loading: boolean;
     data?: TData | undefined;
     error?: ApolloError;

--- a/.changeset/old-ghosts-agree.md
+++ b/.changeset/old-ghosts-agree.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Cache the `useSubscription` hook's `restart` function definition between re-renders.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 40252,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 33059
+  "dist/apollo-client.min.cjs": 40258,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 33058
 }

--- a/src/react/hooks/useSubscription.ts
+++ b/src/react/hooks/useSubscription.ts
@@ -304,19 +304,16 @@ export function useSubscription<
       : fallbackResult,
     () => fallbackResult
   );
-  return React.useMemo(
-    () => ({
-      ...ret,
-      restart() {
-        invariant(
-          !optionsRef.current.skip,
-          "A subscription that is skipped cannot be restarted."
-        );
-        setObservable(recreateRef.current());
-      },
-    }),
-    [ret]
-  );
+
+  const restart = React.useCallback(() => {
+    invariant(
+      !optionsRef.current.skip,
+      "A subscription that is skipped cannot be restarted."
+    );
+    setObservable(recreateRef.current());
+  }, [optionsRef, recreateRef]);
+
+  return React.useMemo(() => ({ ...ret, restart }), [ret, restart]);
 }
 
 function createSubscription<


### PR DESCRIPTION
This PR fixes that the `useSubscription` hook's definition of the recently added (#11927) `restart` function was not cached between rerenders (unlike other functions such as `refetch` and `fetchMore` returned by similar hooks). This made the `restart` unsuitable to be included in the dependency array of `React.useEffect`.

My use case is restarting a subscription when a React Native app is resumed from the background. @phryneas I assume it's evident from the code that `restart` is redefined every render. However, if you would like a reproducible, please let me know.