### PR TITLE
Fix obscure warning in `useFragment` when `cache.identify` returns `undefined`

### DIFF
--- a/.changeset/forty-news-turn.md
+++ b/.changeset/forty-news-turn.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fixes a regression from where passing an invalid identifier to `from` in `useFragment` would result in the warning `TypeError: Cannot read properties of undefined (reading '__typename')`.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 40249,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 33058
+  "dist/apollo-client.min.cjs": 40252,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 33066
 }

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -235,7 +235,7 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
         // calls` cache.identify` and provides that value to `from`. We are
         // adding this fix here however to ensure those using plain JavaScript
         // and using `cache.identify` themselves will avoid seeing the obscure
-        // warning when passing `undefined` to `this.identify` below.
+        // warning.
         typeof from === "undefined" || typeof from === "string" ?
           from
         : this.identify(from),

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -229,7 +229,16 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
     const diffOptions: Cache.DiffOptions<TData, TVars> = {
       ...otherOptions,
       returnPartialData: true,
-      id: typeof from === "string" ? from : this.identify(from),
+      id:
+        // While our TypeScript types do not allow for `undefined` as a valid
+        // `from`, its possible `useFragment` gives us an `undefined` since it
+        // calls` cache.identify` and provides that value to `from`. We are
+        // adding this fix here however to ensure those using plain JavaScript
+        // and using `cache.identify` themselves will avoid seeing the obscure
+        // warning when passing `undefined` to `this.identify` below.
+        typeof from === "undefined" || typeof from === "string" ?
+          from
+        : this.identify(from),
       query,
       optimistic,
     };


### PR DESCRIPTION
Fixes #12051

#12020 did some refactoring to `useFragment` to be more compatible with [Rules of React](https://react.dev/reference/rules) (specifically not writing to `ref` in render). In the process, `useFragment` now calls `cache.identify` directly to ensure that whole data objects passed to `from` don't trigger rewatches when non key fields change to that object. This change however introduced a regression where invalid identifiers (i.e. `cache.identify` returns `undefined`) would show a warning such as:

```
TypeError: Cannot read properties of undefined (reading '__typename')
```

This was a result of taking that `undefined` and passing it as the value to `cache.watchFragment`, which itself called `cache.identify(undefined)` and this triggered the warning. 

This change ensures that `cache.watchFragment` forwards `undefined` to `cache.watch` as `id` since it uses `ROOT_QUERY` as a fallback in that case.