### PR TITLE
Create `normalizedHeaders` as object with `Object` prototype.

### DIFF
--- a/.changeset/polite-toys-battle.md
+++ b/.changeset/polite-toys-battle.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fixed a bug where incorrect object access in some Safari extensions could cause a crash.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 40252,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 33066
+  "dist/apollo-client.min.cjs": 40251,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 33061
 }

--- a/src/link/http/selectHttpOptionsAndBody.ts
+++ b/src/link/http/selectHttpOptionsAndBody.ts
@@ -205,7 +205,7 @@ function removeDuplicateHeaders(
 ): typeof headers {
   // If we're not preserving the case, just remove duplicates w/ normalization.
   if (!preserveHeaderCase) {
-    const normalizedHeaders = Object.create(null);
+    const normalizedHeaders: Record<string, string> = {};
     Object.keys(Object(headers)).forEach((name) => {
       normalizedHeaders[name.toLowerCase()] = headers[name];
     });
@@ -216,7 +216,8 @@ function removeDuplicateHeaders(
   // preserving the original name.
   // This allows for non-http-spec-compliant servers that expect intentionally
   // capitalized header names (See #6741).
-  const headerData = Object.create(null);
+  const headerData: Record<string, { originalName: string; value: string }> =
+    {};
   Object.keys(Object(headers)).forEach((name) => {
     headerData[name.toLowerCase()] = {
       originalName: name,
@@ -224,7 +225,7 @@ function removeDuplicateHeaders(
     };
   });
 
-  const normalizedHeaders = Object.create(null);
+  const normalizedHeaders: Record<string, string> = {};
   Object.keys(headerData).forEach((name) => {
     normalizedHeaders[headerData[name].originalName] = headerData[name].value;
   });


### PR DESCRIPTION
Fixes #11555

We finally got enough information there that we could fix this on our side with this.