### PR TITLE
feat(types): allow type passing to enforce context types

### DIFF
--- a/.changeset/calm-garlics-share.md
+++ b/.changeset/calm-garlics-share.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Allow type passing of operation context to strictly enforce context types

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -51,7 +51,11 @@ export type ErrorPolicy = "none" | "ignore" | "all";
 /**
  * Query options.
  */
-export interface QueryOptions<TVariables = OperationVariables, TData = any> {
+export interface QueryOptions<
+  TVariables = OperationVariables,
+  TData = any,
+  TContext extends DefaultContext = DefaultContext,
+> {
   /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#query:member} */
   query: DocumentNode | TypedDocumentNode<TData, TVariables>;
 
@@ -62,7 +66,7 @@ export interface QueryOptions<TVariables = OperationVariables, TData = any> {
   errorPolicy?: ErrorPolicy;
 
   /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#context:member} */
-  context?: DefaultContext;
+  context?: TContext;
 
   /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#fetchPolicy:member} */
   fetchPolicy?: FetchPolicy;
@@ -97,6 +101,7 @@ export interface WatchQueryOptions<
 export interface SharedWatchQueryOptions<
   TVariables extends OperationVariables,
   TData,
+  TContext extends DefaultContext = DefaultContext,
 > {
   /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#fetchPolicy:member} */
   fetchPolicy?: WatchQueryFetchPolicy;
@@ -123,7 +128,7 @@ export interface SharedWatchQueryOptions<
   errorPolicy?: ErrorPolicy;
 
   /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#context:member} */
-  context?: DefaultContext;
+  context?: TContext;
 
   /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#pollInterval:member} */
   pollInterval?: number;
@@ -154,12 +159,16 @@ export interface NextFetchPolicyContext<
   initialFetchPolicy: WatchQueryFetchPolicy;
 }
 
-export interface FetchMoreQueryOptions<TVariables, TData = any> {
+export interface FetchMoreQueryOptions<
+  TVariables,
+  TData = any,
+  TContext extends DefaultContext = DefaultContext,
+> {
   /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#query:member} */
   query?: DocumentNode | TypedDocumentNode<TData, TVariables>;
   /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#variables:member} */
   variables?: Partial<TVariables>;
-  context?: DefaultContext;
+  context?: TContext;
 }
 
 export type UpdateQueryFn<
@@ -178,6 +187,7 @@ export type SubscribeToMoreOptions<
   TData = any,
   TSubscriptionVariables = OperationVariables,
   TSubscriptionData = TData,
+  TContext extends DefaultContext = DefaultContext,
 > = {
   document:
     | DocumentNode
@@ -185,12 +195,13 @@ export type SubscribeToMoreOptions<
   variables?: TSubscriptionVariables;
   updateQuery?: UpdateQueryFn<TData, TSubscriptionVariables, TSubscriptionData>;
   onError?: (error: Error) => void;
-  context?: DefaultContext;
+  context?: TContext;
 };
 
 export interface SubscriptionOptions<
   TVariables = OperationVariables,
   TData = any,
+  TContext extends DefaultContext = DefaultContext,
 > {
   /** {@inheritDoc @apollo/client!SubscriptionOptionsDocumentation#query:member} */
   query: DocumentNode | TypedDocumentNode<TData, TVariables>;
@@ -205,7 +216,7 @@ export interface SubscriptionOptions<
   errorPolicy?: ErrorPolicy;
 
   /** {@inheritDoc @apollo/client!SubscriptionOptionsDocumentation#context:member} */
-  context?: DefaultContext;
+  context?: TContext;
 
   /** {@inheritDoc @apollo/client!SubscriptionOptionsDocumentation#extensions:member} */
   extensions?: Record<string, any>;

--- a/src/link/context/index.ts
+++ b/src/link/context/index.ts
@@ -4,13 +4,15 @@ import type { ObservableSubscription } from "../../utilities/index.js";
 import { Observable } from "../../utilities/index.js";
 import type { DefaultContext } from "../../core/index.js";
 
-export type ContextSetter = (
+export type ContextSetter<TContext extends DefaultContext = DefaultContext> = (
   operation: GraphQLRequest,
-  prevContext: DefaultContext
-) => Promise<DefaultContext> | DefaultContext;
+  prevContext: TContext
+) => Promise<TContext> | TContext;
 
-export function setContext(setter: ContextSetter): ApolloLink {
-  return new ApolloLink((operation: Operation, forward: NextLink) => {
+export function setContext<TContext extends DefaultContext = DefaultContext>(
+  setter: ContextSetter<TContext>
+): ApolloLink {
+  return new ApolloLink((operation: Operation<TContext>, forward: NextLink) => {
     const { ...request } = operation;
 
     return new Observable((observer) => {

--- a/src/link/core/types.ts
+++ b/src/link/core/types.ts
@@ -63,33 +63,40 @@ export type ExecutionPatchResult<
   | ExecutionPatchInitialResult<TData, TExtensions>
   | ExecutionPatchIncrementalResult<TData, TExtensions>;
 
-export interface GraphQLRequest<TVariables = Record<string, any>> {
+export interface GraphQLRequest<
+  TVariables = Record<string, any>,
+  TContext extends DefaultContext = DefaultContext,
+> {
   query: DocumentNode;
   variables?: TVariables;
   operationName?: string;
-  context?: DefaultContext;
+  context?: TContext;
   extensions?: Record<string, any>;
 }
 
-export interface Operation {
+export interface Operation<
+  OperationContext extends DefaultContext = DefaultContext,
+> {
   query: DocumentNode;
   variables: Record<string, any>;
   operationName: string;
   extensions: Record<string, any>;
   setContext: {
-    (context: Partial<DefaultContext>): void;
-    (
-      updateContext: (
-        previousContext: DefaultContext
-      ) => Partial<DefaultContext>
+    <TContext extends OperationContext = OperationContext>(
+      context: Partial<TContext>
+    ): void;
+    <TContext extends OperationContext = OperationContext>(
+      updateContext: (previousContext: TContext) => Partial<TContext>
     ): void;
   };
-  getContext: () => DefaultContext;
+  getContext: <
+    TContext extends OperationContext = OperationContext,
+  >() => TContext;
 }
 
 export interface SingleExecutionResult<
   TData = Record<string, any>,
-  TContext = DefaultContext,
+  TContext extends DefaultContext = DefaultContext,
   TExtensions = Record<string, any>,
 > {
   // data might be undefined if errorPolicy was set to 'ignore'
@@ -101,7 +108,7 @@ export interface SingleExecutionResult<
 
 export type FetchResult<
   TData = Record<string, any>,
-  TContext = Record<string, any>,
+  TContext extends DefaultContext = DefaultContext,
   TExtensions = Record<string, any>,
 > =
   | SingleExecutionResult<TData, TContext, TExtensions>

--- a/src/react/query-preloader/createQueryPreloader.ts
+++ b/src/react/query-preloader/createQueryPreloader.ts
@@ -41,11 +41,12 @@ export type PreloadQueryFetchPolicy = Extract<
 
 export type PreloadQueryOptions<
   TVariables extends OperationVariables = OperationVariables,
+  TContext extends DefaultContext = DefaultContext,
 > = {
   /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#canonizeResults:member} */
   canonizeResults?: boolean;
   /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#context:member} */
-  context?: DefaultContext;
+  context?: TContext;
   /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#errorPolicy:member} */
   errorPolicy?: ErrorPolicy;
   /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#fetchPolicy:member} */

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -51,13 +51,14 @@ export type CommonOptions<TOptions> = TOptions & {
 export interface BaseQueryOptions<
   TVariables extends OperationVariables = OperationVariables,
   TData = any,
+  TContext extends DefaultContext = DefaultContext,
 > extends SharedWatchQueryOptions<TVariables, TData> {
   /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#ssr:member} */
   ssr?: boolean;
   /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#client:member} */
   client?: ApolloClient<any>;
   /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#context:member} */
-  context?: DefaultContext;
+  context?: TContext;
 }
 
 export interface QueryFunctionOptions<
@@ -202,11 +203,12 @@ export type SuspenseQueryHookFetchPolicy = Extract<
 export interface SuspenseQueryHookOptions<
   TData = unknown,
   TVariables extends OperationVariables = OperationVariables,
+  TContext extends DefaultContext = DefaultContext,
 > {
   /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#client:member} */
   client?: ApolloClient<any>;
   /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#context:member} */
-  context?: DefaultContext;
+  context?: TContext;
   /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#variables:member} */
   variables?: TVariables;
   /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#errorPolicy:member} */
@@ -274,13 +276,15 @@ export type LoadableQueryHookFetchPolicy = Extract<
   "cache-first" | "network-only" | "no-cache" | "cache-and-network"
 >;
 
-export interface LoadableQueryHookOptions {
+export interface LoadableQueryHookOptions<
+  TContext extends DefaultContext = DefaultContext,
+> {
   /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#canonizeResults:member} */
   canonizeResults?: boolean;
   /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#client:member} */
   client?: ApolloClient<any>;
   /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#context:member} */
-  context?: DefaultContext;
+  context?: TContext;
   /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#errorPolicy:member} */
   errorPolicy?: ErrorPolicy;
   /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#fetchPolicy:member} */
@@ -296,11 +300,14 @@ export interface LoadableQueryHookOptions {
 /**
  * @deprecated This type will be removed in the next major version of Apollo Client
  */
-export interface QueryLazyOptions<TVariables> {
+export interface QueryLazyOptions<
+  TVariables,
+  TContext extends DefaultContext = DefaultContext,
+> {
   /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#variables:member} */
   variables?: TVariables;
   /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#context:member} */
-  context?: DefaultContext;
+  context?: TContext;
 }
 
 /**
@@ -437,6 +444,7 @@ export interface OnSubscriptionDataOptions<TData = any> {
 export interface BaseSubscriptionOptions<
   TData = any,
   TVariables extends OperationVariables = OperationVariables,
+  TContext extends DefaultContext = DefaultContext,
 > {
   /** {@inheritDoc @apollo/client!SubscriptionOptionsDocumentation#variables:member} */
   variables?: TVariables;
@@ -453,7 +461,7 @@ export interface BaseSubscriptionOptions<
   /** {@inheritDoc @apollo/client!SubscriptionOptionsDocumentation#skip:member} */
   skip?: boolean;
   /** {@inheritDoc @apollo/client!SubscriptionOptionsDocumentation#context:member} */
-  context?: DefaultContext;
+  context?: TContext;
   /** {@inheritDoc @apollo/client!SubscriptionOptionsDocumentation#extensions:member} */
   extensions?: Record<string, any>;
   /** {@inheritDoc @apollo/client!SubscriptionOptionsDocumentation#onComplete:member} */


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:

### Checklist:
- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
-->

This PR extends the types exported by apollo client to allow users to enforce strict types for operation contexts. 


Here's a real-world situation that may server as an example of what this is trying to help.

- I have a large project that fires many requests, and some are much faster than others. 
   
   many of the critical queries are well optimized, but users can experience significant delays in load time due to to them getting batched with a collection of less critical, slow requests.

- to get around this, we implemented the following in the `BatchHttpLink`:

```ts
batchKey: (operation) => {
      const { excludeFromBatch, batchKey } = operation.getContext();
      if (excludeFromBatch) {
        return operation.operationName;
      }

      return '';
    },
```

so that I can provide `{ context: { excludeFromBatch: true }}` to the options for `useQuery` in order to take these render-critical queries and prevent them from being glued to a random batch. 

( btw - whoever added this `batchKey` field on the link - _nice_. This is a pretty cool thing and has come in clutch :) ) 

Here's the rub, though. we work with typescript, and there are a lot of us. 

Currently, there doesn't seem to be a way for me to enforce this operation context's type; `Record<string, any>` - the type that the relevant `DefaultContext` forces us to stick with, isn't something we want to stick with. 

I ended up creating a function to wrap the options object in order to provide this context and guarantee that others in my project can't accidentally provide ` context: { excludeFromBatch: false }` as a prop in args that are wrapped with it.

We'd much rather be able to have TS warn us if we do the following:

```ts
// somewhere in the app
interface OurQueryContext extends DefaultContext {
	excludeFromBatch?: boolean
}

const { data: criticalStuff } = useQuery<
VariablesType, 
DataType,
OurQueryContext
>(query, {
	variables: { ... },
	// ...
	context: {
		// TS error - excludFromBatch does not exist on type 'OurQueryContext' - did you mean 'excludeFromBatch'?
		excludFromBatch: true 
	}
})

```

since it's a pretty easy mistake to make.


So, that's what this PR attempts to do. It keeps the `DefaultContext` interface, but adjusts type signatures to make it a default, rather than effectively barring us from trying to type it out ourselves. 

Most types that have `DefaultContext` mentioned have been altered to allow consumers to provide a generic in order to enforce. On types where it's been added to existing type arguments, it's provided last so codegen tools don't break and always defaults to `DefaultContext` if nothing is provided there.

Since it's a type-level-only addition, tests were not added. The changeset proposes a patch, rather than a feature version as this should be semver-safe.

Some core types were extended with generics. I can reverse some of this to limit the scope, but included them for review here to make things easier.

This is my first PR here - please let me know if I need to change anything, or if this is something that already has a solution that I totally wooshed over.

Thank you for building this library, and for taking the time to hear this one out. I appreciate all y'all do.