### PR TITLE
docs: clean up

### DIFF
--- a/docs/source/get-started.mdx
+++ b/docs/source/get-started.mdx
@@ -2,12 +2,6 @@
 title: Get started with Apollo Client
 ---
 
-<SummitCallout
-  topic="Apollo Client"
-  workshopName="GraphQL for web: Going hands-on with Apollo Client"
-  URL="https://reg.summit.graphql.com/flow/apollo/summit24/AttendeePortal/page/catalog/session/1712947597337001S7vZ"
-/>
-
 Hello! 👋 This short tutorial gets you up and running with Apollo Client.
 
 > For an introduction to the entire Apollo platform, [check out **Odyssey**, Apollo's interactive learning platform](https://www.apollographql.com/tutorials/?utm_source=apollo_docs&utm_medium=referral).

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -2,14 +2,6 @@
 title: Introduction to Apollo Client
 ---
 
-import { Link } from 'gatsby';
-
-<SummitCallout
-  topic="Apollo Client"
-  workshopName="GraphQL for web: Going hands-on with Apollo Client"
-  URL="https://reg.summit.graphql.com/flow/apollo/summit24/AttendeePortal/page/catalog/session/1712947597337001S7vZ"
-/>
-
 **Apollo Client** is a comprehensive state management library for JavaScript. It enables you to manage both local and remote data with GraphQL. Use it to fetch, cache, and modify application data, all while automatically updating your UI.
 
 Apollo Client helps you structure code in an economical, predictable, and declarative way that's consistent with modern development practices. The core `@apollo/client` library provides built-in integration with React, and the larger Apollo community maintains [integrations for other popular view layers](#community-integrations).


### PR DESCRIPTION
Removes Summit callouts, unused Gatsby Link import, and an empty page