### PR TITLE
Alternate implementation of `UnwrapFragmentRefs`

### DIFF
--- a/src/masking/internal/types.ts
+++ b/src/masking/internal/types.ts
@@ -1,9 +1,7 @@
 export type UnwrapFragmentRefs<TData> =
   // Leave TData alone if it is Record<string, any> and not a specific shape
   string extends keyof NonNullable<TData> ? TData
-  : keyof NonNullable<TData> extends never ? TData
-  : //: TData extends Array<infer U> ? Array<UnwrapFragmentRefs<U>>
-  TData extends { " $fragmentRefs"?: object | null } ?
+  : TData extends { " $fragmentRefs"?: object | null } ?
     Combine<KeyTuples<TData>> extends infer Flattened ?
       { [K in keyof Flattened]: UnwrapFragmentRefs<Flattened[K]> }
     : never

--- a/src/masking/types.ts
+++ b/src/masking/types.ts
@@ -1,6 +1,5 @@
 import type { TypedDocumentNode } from "@graphql-typed-document-node/core";
 import type {
-  RemoveFragmentName,
   RemoveMaskedMarker,
   UnwrapFragmentRefs,
 } from "./internal/types.ts";
@@ -45,6 +44,4 @@ export type MaybeMasked<TData> =
  * Unmasks a type to provide its full result.
  */
 export type Unmasked<TData> =
-  TData extends object ?
-    UnwrapFragmentRefs<RemoveMaskedMarker<RemoveFragmentName<TData>>>
-  : TData;
+  TData extends object ? UnwrapFragmentRefs<RemoveMaskedMarker<TData>> : TData;


### PR DESCRIPTION
This is a finished version of the alternative implementation of `UnwrapFragmentRefs`, which was rolled back in [`314d87f` (#12064)](https://github.com/apollographql/apollo-client/pull/12064/commits/314d87fc2f63991c0520fa3935917e82f82b4f35).

I wouldn't immediately get this merged - we should benchmark both of these approaches to find out which one gives the better editor experience.