### PR TITLE
Fix Suspense boundary indefinitely shown when fetchMore returns error

### DIFF
--- a/.changeset/serious-cows-trade.md
+++ b/.changeset/serious-cows-trade.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix an issue where errors returned from a `fetchMore` call from a Suspense hook would cause a Suspense boundary to be shown indefinitely.

--- a/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable testing-library/render-result-naming-convention */
 import React, { Fragment, StrictMode, Suspense, useTransition } from "react";
 import {
   act,

--- a/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
@@ -9,7 +9,7 @@ import {
   RenderHookOptions,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { ErrorBoundary } from "react-error-boundary";
+import { ErrorBoundary, FallbackProps } from "react-error-boundary";
 import { GraphQLError } from "graphql";
 import { InvariantError } from "ts-invariant";
 import { equal } from "@wry/equality";
@@ -10567,6 +10567,137 @@ describe("useSuspenseQuery", () => {
           { __typename: "Letter", letter: "D", position: 4 },
         ],
       });
+    }
+
+    await expect(renderStream).not.toRerender();
+  });
+
+  // https://github.com/apollographql/apollo-client/issues/12103
+  it("does not get stuck pending when `fetchMore` rejects with an error", async () => {
+    using _ = spyOnConsole("error");
+    const { query, data } = setupPaginatedCase();
+
+    const link = new ApolloLink((operation) => {
+      const { offset = 0, limit = 2 } = operation.variables;
+      const letters = data.slice(offset, offset + limit);
+
+      return new Observable((observer) => {
+        setTimeout(() => {
+          if (offset === 2) {
+            observer.next({
+              data: null,
+              errors: [{ message: "Could not fetch letters" }],
+            });
+          } else {
+            observer.next({ data: { letters } });
+          }
+          observer.complete();
+        }, 10);
+      });
+    });
+
+    const user = userEvent.setup();
+    const client = new ApolloClient({
+      cache: new InMemoryCache(),
+      link,
+    });
+
+    const renderStream = createRenderStream({
+      initialSnapshot: {
+        result: null as UseSuspenseQueryResult<
+          PaginatedCaseData,
+          PaginatedCaseVariables
+        > | null,
+        error: null as ApolloError | null,
+      },
+    });
+
+    function SuspenseFallback() {
+      useTrackRenders();
+
+      return <div>Loading...</div>;
+    }
+
+    function ErrorFallback({ error }: FallbackProps) {
+      useTrackRenders();
+      renderStream.mergeSnapshot({ error });
+
+      return <div>Error</div>;
+    }
+
+    function App() {
+      useTrackRenders();
+      const result = useSuspenseQuery(query, {
+        variables: { offset: 0, limit: 2 },
+      });
+      const { data, fetchMore } = result;
+
+      renderStream.mergeSnapshot({ result });
+
+      return (
+        <button
+          onClick={() =>
+            fetchMore({
+              variables: {
+                offset: data.letters.length,
+                limit: data.letters.length + 1,
+              },
+            })
+          }
+        >
+          Fetch next
+        </button>
+      );
+    }
+
+    renderStream.render(
+      <Suspense fallback={<SuspenseFallback />}>
+        <ErrorBoundary FallbackComponent={ErrorFallback}>
+          <App />
+        </ErrorBoundary>
+      </Suspense>,
+      {
+        wrapper: ({ children }) => (
+          <ApolloProvider client={client}>{children}</ApolloProvider>
+        ),
+      }
+    );
+
+    {
+      const { renderedComponents } = await renderStream.takeRender();
+
+      expect(renderedComponents).toStrictEqual([SuspenseFallback]);
+    }
+
+    {
+      const { snapshot, renderedComponents } = await renderStream.takeRender();
+
+      expect(renderedComponents).toStrictEqual([App]);
+      expect(snapshot.result?.data).toEqual({
+        letters: [
+          { __typename: "Letter", letter: "A", position: 1 },
+          { __typename: "Letter", letter: "B", position: 2 },
+        ],
+      });
+    }
+
+    await act(() => user.click(screen.getByText("Fetch next")));
+
+    {
+      const { renderedComponents } = await renderStream.takeRender();
+
+      expect(renderedComponents).toStrictEqual([SuspenseFallback]);
+    }
+
+    {
+      const { snapshot, renderedComponents } = await renderStream.takeRender();
+
+      expect(renderedComponents).toStrictEqual([ErrorFallback]);
+      expect(snapshot.error).toEqual(
+        new ApolloError({
+          graphQLErrors: [{ message: "Could not fetch letters" }],
+        })
+      );
     }
 
     await expect(renderStream).not.toRerender();

--- a/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
@@ -10596,7 +10596,6 @@ describe("useSuspenseQuery", () => {
       });
     });
 
-    const user = userEvent.setup();
     const client = new ApolloClient({
       cache: new InMemoryCache(),
       link,
@@ -10630,24 +10629,10 @@ describe("useSuspenseQuery", () => {
       const result = useSuspenseQuery(query, {
         variables: { offset: 0, limit: 2 },
       });
-      const { data, fetchMore } = result;
 
       renderStream.mergeSnapshot({ result });
 
-      return (
-        <button
-          onClick={() =>
-            fetchMore({
-              variables: {
-                offset: data.letters.length,
-                limit: data.letters.length + 1,
-              },
-            })
-          }
-        >
-          Fetch next
-        </button>
-      );
+      return null;
     }
 
     renderStream.render(
@@ -10681,7 +10666,10 @@ describe("useSuspenseQuery", () => {
       });
     }
 
-    await act(() => user.click(screen.getByText("Fetch next")));
+    const { snapshot } = renderStream.getCurrentRender();
+    await act(() =>
+      snapshot.result!.fetchMore({ variables: { offset: 2 } }).catch(() => {})
+    );
 
     {
       const { renderedComponents } = await renderStream.takeRender();

--- a/src/react/internal/cache/QueryReference.ts
+++ b/src/react/internal/cache/QueryReference.ts
@@ -486,7 +486,7 @@ export class InternalQueryReference<TData = unknown> {
           }
         });
       })
-      .catch(() => {});
+      .catch((error) => this.reject?.(error));
 
     return returnedPromise;
   }


### PR DESCRIPTION
Fixes #12103

Fixes an issue where the Suspsense boundary would be shown indefinitely when `fetchMore` returned from `useSuspenseQuery` is called and an error is returned. 

When using `fetchMore`, the `handleNext` function inside `InternalQueryReference` was never called so there was no handler to resolve the promise thrown to the Suspense boundary. This small fix ensures that `reject` is called in `.catch` so that the promise does not get stuck in pending.