### PR TITLE
Fix data masking tests that depended on the old profiler utils

### DIFF
--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 41445,
+  "dist/apollo-client.min.cjs": 41459,
   "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 34213
 }

--- a/src/react/hooks/__tests__/useBackgroundQuery.test.tsx
+++ b/src/react/hooks/__tests__/useBackgroundQuery.test.tsx
@@ -4141,9 +4141,9 @@ it("masks queries when dataMasking is `true`", async () => {
     link: new MockLink(mocks),
   });
 
-  const Profiler = createDefaultProfiler<Masked<Query>>();
+  const renderStream = createDefaultProfiler<Masked<Query>>();
   const { SuspenseFallback, ReadQueryHook } =
-    createDefaultTrackedComponents(Profiler);
+    createDefaultTrackedComponents(renderStream);
 
   function App() {
     useTrackRenders();
@@ -4156,13 +4156,15 @@ it("masks queries when dataMasking is `true`", async () => {
     );
   }
 
-  renderWithClient(<App />, { client, wrapper: Profiler });
+  renderStream.render(<App />, {
+    wrapper: createClientWrapper(client),
+  });
 
   // loading
-  await Profiler.takeRender();
+  await renderStream.takeRender();
 
   {
-    const { snapshot } = await Profiler.takeRender();
+    const { snapshot } = await renderStream.takeRender();
 
     expect(snapshot.result).toEqual({
       data: {
@@ -4227,9 +4229,9 @@ it("does not mask query when dataMasking is `false`", async () => {
     link: new MockLink(mocks),
   });
 
-  const Profiler = createDefaultProfiler<Query>();
+  const renderStream = createDefaultProfiler<Query>();
   const { SuspenseFallback, ReadQueryHook } =
-    createDefaultTrackedComponents(Profiler);
+    createDefaultTrackedComponents(renderStream);
 
   function App() {
     useTrackRenders();
@@ -4242,12 +4244,12 @@ it("does not mask query when dataMasking is `false`", async () => {
     );
   }
 
-  renderWithClient(<App />, { client, wrapper: Profiler });
+  renderStream.render(<App />, { wrapper: createClientWrapper(client) });
 
   // loading
-  await Profiler.takeRender();
+  await renderStream.takeRender();
 
-  const { snapshot } = await Profiler.takeRender();
+  const { snapshot } = await renderStream.takeRender();
 
   expect(snapshot.result).toEqual({
     data: {
@@ -4311,9 +4313,9 @@ it("does not mask query by default", async () => {
     link: new MockLink(mocks),
   });
 
-  const Profiler = createDefaultProfiler<Query>();
+  const renderStream = createDefaultProfiler<Query>();
   const { SuspenseFallback, ReadQueryHook } =
-    createDefaultTrackedComponents(Profiler);
+    createDefaultTrackedComponents(renderStream);
 
   function App() {
     useTrackRenders();
@@ -4326,12 +4328,12 @@ it("does not mask query by default", async () => {
     );
   }
 
-  renderWithClient(<App />, { client, wrapper: Profiler });
+  renderStream.render(<App />, { wrapper: createClientWrapper(client) });
 
   // loading
-  await Profiler.takeRender();
+  await renderStream.takeRender();
 
-  const { snapshot } = await Profiler.takeRender();
+  const { snapshot } = await renderStream.takeRender();
 
   expect(snapshot.result).toEqual({
     data: {
@@ -4396,9 +4398,9 @@ it("masks queries updated by the cache", async () => {
     link: new MockLink(mocks),
   });
 
-  const Profiler = createDefaultProfiler<Masked<Query>>();
+  const renderStream = createDefaultProfiler<Masked<Query>>();
   const { SuspenseFallback, ReadQueryHook } =
-    createDefaultTrackedComponents(Profiler);
+    createDefaultTrackedComponents(renderStream);
 
   function App() {
     useTrackRenders();
@@ -4411,13 +4413,13 @@ it("masks queries updated by the cache", async () => {
     );
   }
 
-  renderWithClient(<App />, { client, wrapper: Profiler });
+  renderStream.render(<App />, { wrapper: createClientWrapper(client) });
 
   // loading
-  await Profiler.takeRender();
+  await renderStream.takeRender();
 
   {
-    const { snapshot } = await Profiler.takeRender();
+    const { snapshot } = await renderStream.takeRender();
 
     expect(snapshot.result).toEqual({
       data: {
@@ -4447,7 +4449,7 @@ it("masks queries updated by the cache", async () => {
   });
 
   {
-    const { snapshot } = await Profiler.takeRender();
+    const { snapshot } = await renderStream.takeRender();
 
     expect(snapshot.result).toEqual({
       data: {
@@ -4512,9 +4514,9 @@ it("does not rerender when updating field in named fragment", async () => {
     link: new MockLink(mocks),
   });
 
-  const Profiler = createDefaultProfiler<Masked<Query>>();
+  const renderStream = createDefaultProfiler<Masked<Query>>();
   const { SuspenseFallback, ReadQueryHook } =
-    createDefaultTrackedComponents(Profiler);
+    createDefaultTrackedComponents(renderStream);
 
   function App() {
     useTrackRenders();
@@ -4527,13 +4529,15 @@ it("does not rerender when updating field in named fragment", async () => {
     );
   }
 
-  renderWithClient(<App />, { client, wrapper: Profiler });
+  renderStream.render(<App />, {
+    wrapper: createClientWrapper(client),
+  });
 
   // loading
-  await Profiler.takeRender();
+  await renderStream.takeRender();
 
   {
-    const { snapshot } = await Profiler.takeRender();
+    const { snapshot } = await renderStream.takeRender();
 
     expect(snapshot.result).toEqual({
       data: {
@@ -4562,7 +4566,7 @@ it("does not rerender when updating field in named fragment", async () => {
     },
   });
 
-  await expect(Profiler).not.toRerender();
+  await expect(renderStream).not.toRerender();
 
   expect(client.readQuery({ query })).toEqual({
     currentUser: {
@@ -4635,9 +4639,9 @@ it("masks result from cache when using with cache-first fetch policy", async () 
     },
   });
 
-  const Profiler = createDefaultProfiler<Masked<Query>>();
+  const renderStream = createDefaultProfiler<Masked<Query>>();
   const { SuspenseFallback, ReadQueryHook } =
-    createDefaultTrackedComponents(Profiler);
+    createDefaultTrackedComponents(renderStream);
 
   function App() {
     useTrackRenders();
@@ -4652,9 +4656,9 @@ it("masks result from cache when using with cache-first fetch policy", async () 
     );
   }
 
-  renderWithClient(<App />, { client, wrapper: Profiler });
+  renderStream.render(<App />, { wrapper: createClientWrapper(client) });
 
-  const { snapshot } = await Profiler.takeRender();
+  const { snapshot } = await renderStream.takeRender();
 
   expect(snapshot.result).toEqual({
     data: {
@@ -4731,9 +4735,9 @@ it("masks cache and network result when using cache-and-network fetch policy", a
     },
   });
 
-  const Profiler = createDefaultProfiler<Masked<Query>>();
+  const renderStream = createDefaultProfiler<Masked<Query>>();
   const { SuspenseFallback, ReadQueryHook } =
-    createDefaultTrackedComponents(Profiler);
+    createDefaultTrackedComponents(renderStream);
 
   function App() {
     useTrackRenders();
@@ -4748,10 +4752,10 @@ it("masks cache and network result when using cache-and-network fetch policy", a
     );
   }
 
-  renderWithClient(<App />, { client, wrapper: Profiler });
+  renderStream.render(<App />, { wrapper: createClientWrapper(client) });
 
   {
-    const { snapshot } = await Profiler.takeRender();
+    const { snapshot } = await renderStream.takeRender();
 
     expect(snapshot.result).toEqual({
       data: {
@@ -4767,7 +4771,7 @@ it("masks cache and network result when using cache-and-network fetch policy", a
   }
 
   {
-    const { snapshot } = await Profiler.takeRender();
+    const { snapshot } = await renderStream.takeRender();
 
     expect(snapshot.result).toEqual({
       data: {
@@ -4848,9 +4852,9 @@ it("masks partial cache data when returnPartialData is `true`", async () => {
     });
   }
 
-  const Profiler = createDefaultProfiler<DeepPartial<Masked<Query>>>();
+  const renderStream = createDefaultProfiler<DeepPartial<Masked<Query>>>();
   const { SuspenseFallback, ReadQueryHook } =
-    createDefaultTrackedComponents(Profiler);
+    createDefaultTrackedComponents(renderStream);
 
   function App() {
     useTrackRenders();
@@ -4863,10 +4867,10 @@ it("masks partial cache data when returnPartialData is `true`", async () => {
     );
   }
 
-  renderWithClient(<App />, { client, wrapper: Profiler });
+  renderStream.render(<App />, { wrapper: createClientWrapper(client) });
 
   {
-    const { snapshot } = await Profiler.takeRender();
+    const { snapshot } = await renderStream.takeRender();
 
     expect(snapshot.result).toEqual({
       data: {
@@ -4881,7 +4885,7 @@ it("masks partial cache data when returnPartialData is `true`", async () => {
   }
 
   {
-    const { snapshot } = await Profiler.takeRender();
+    const { snapshot } = await renderStream.takeRender();
 
     expect(snapshot.result).toEqual({
       data: {
@@ -4948,9 +4952,9 @@ it("masks partial data returned from data on errors with errorPolicy `all`", asy
     link: new MockLink(mocks),
   });
 
-  const Profiler = createDefaultProfiler<Masked<Query> | undefined>();
+  const renderStream = createDefaultProfiler<Masked<Query> | undefined>();
   const { SuspenseFallback, ReadQueryHook } =
-    createDefaultTrackedComponents(Profiler);
+    createDefaultTrackedComponents(renderStream);
 
   function App() {
     useTrackRenders();
@@ -4963,13 +4967,13 @@ it("masks partial data returned from data on errors with errorPolicy `all`", asy
     );
   }
 
-  renderWithClient(<App />, { client, wrapper: Profiler });
+  renderStream.render(<App />, { wrapper: createClientWrapper(client) });
 
   // loading
-  await Profiler.takeRender();
+  await renderStream.takeRender();
 
   {
-    const { snapshot } = await Profiler.takeRender();
+    const { snapshot } = await renderStream.takeRender();
 
     expect(snapshot.result).toEqual({
       data: {

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -2051,18 +2051,19 @@ describe("useLazyQuery Hook", () => {
         link: new MockLink(mocks),
       });
 
-      const ProfiledHook = profileHook(() => useLazyQuery(query));
-
-      render(<ProfiledHook />, {
-        wrapper: ({ children }) => (
-          <ApolloProvider client={client}>{children}</ApolloProvider>
-        ),
-      });
+      const { takeSnapshot, getCurrentSnapshot } = renderHookToSnapshotStream(
+        () => useLazyQuery(query),
+        {
+          wrapper: ({ children }) => (
+            <ApolloProvider client={client}>{children}</ApolloProvider>
+          ),
+        }
+      );
 
       // initial render
-      await ProfiledHook.takeSnapshot();
+      await takeSnapshot();
 
-      const [execute] = ProfiledHook.getCurrentSnapshot();
+      const [execute] = getCurrentSnapshot();
       const result = await execute();
 
       expect(result.data).toEqual({
@@ -2074,10 +2075,10 @@ describe("useLazyQuery Hook", () => {
       });
 
       // Loading
-      await ProfiledHook.takeSnapshot();
+      await takeSnapshot();
 
       {
-        const [, { data }] = await ProfiledHook.takeSnapshot();
+        const [, { data }] = await takeSnapshot();
 
         expect(data).toEqual({
           currentUser: {
@@ -2139,18 +2140,19 @@ describe("useLazyQuery Hook", () => {
         link: new MockLink(mocks),
       });
 
-      const ProfiledHook = profileHook(() => useLazyQuery(query));
-
-      render(<ProfiledHook />, {
-        wrapper: ({ children }) => (
-          <ApolloProvider client={client}>{children}</ApolloProvider>
-        ),
-      });
+      const { takeSnapshot, getCurrentSnapshot } = renderHookToSnapshotStream(
+        () => useLazyQuery(query),
+        {
+          wrapper: ({ children }) => (
+            <ApolloProvider client={client}>{children}</ApolloProvider>
+          ),
+        }
+      );
 
       // initial render
-      await ProfiledHook.takeSnapshot();
+      await takeSnapshot();
 
-      const [execute] = ProfiledHook.getCurrentSnapshot();
+      const [execute] = getCurrentSnapshot();
       const result = await execute();
 
       expect(result.data).toEqual({
@@ -2163,10 +2165,10 @@ describe("useLazyQuery Hook", () => {
       });
 
       // Loading
-      await ProfiledHook.takeSnapshot();
+      await takeSnapshot();
 
       {
-        const [, { data }] = await ProfiledHook.takeSnapshot();
+        const [, { data }] = await takeSnapshot();
 
         expect(data).toEqual({
           currentUser: {
@@ -2228,18 +2230,19 @@ describe("useLazyQuery Hook", () => {
         link: new MockLink(mocks),
       });
 
-      const ProfiledHook = profileHook(() => useLazyQuery(query));
-
-      render(<ProfiledHook />, {
-        wrapper: ({ children }) => (
-          <ApolloProvider client={client}>{children}</ApolloProvider>
-        ),
-      });
+      const { takeSnapshot, getCurrentSnapshot } = renderHookToSnapshotStream(
+        () => useLazyQuery(query),
+        {
+          wrapper: ({ children }) => (
+            <ApolloProvider client={client}>{children}</ApolloProvider>
+          ),
+        }
+      );
 
       // initial render
-      await ProfiledHook.takeSnapshot();
+      await takeSnapshot();
 
-      const [execute] = ProfiledHook.getCurrentSnapshot();
+      const [execute] = getCurrentSnapshot();
       const result = await execute();
 
       expect(result.data).toEqual({
@@ -2252,10 +2255,10 @@ describe("useLazyQuery Hook", () => {
       });
 
       // Loading
-      await ProfiledHook.takeSnapshot();
+      await takeSnapshot();
 
       {
-        const [, { data }] = await ProfiledHook.takeSnapshot();
+        const [, { data }] = await takeSnapshot();
 
         expect(data).toEqual({
           currentUser: {
@@ -2318,25 +2321,26 @@ describe("useLazyQuery Hook", () => {
         link: new MockLink(mocks),
       });
 
-      const ProfiledHook = profileHook(() => useLazyQuery(query));
-
-      render(<ProfiledHook />, {
-        wrapper: ({ children }) => (
-          <ApolloProvider client={client}>{children}</ApolloProvider>
-        ),
-      });
+      const { takeSnapshot, getCurrentSnapshot } = renderHookToSnapshotStream(
+        () => useLazyQuery(query),
+        {
+          wrapper: ({ children }) => (
+            <ApolloProvider client={client}>{children}</ApolloProvider>
+          ),
+        }
+      );
 
       // initial render
-      await ProfiledHook.takeSnapshot();
+      await takeSnapshot();
 
-      const [execute] = ProfiledHook.getCurrentSnapshot();
+      const [execute] = getCurrentSnapshot();
       execute();
 
       // Loading
-      await ProfiledHook.takeSnapshot();
+      await takeSnapshot();
 
       {
-        const [, { data }] = await ProfiledHook.takeSnapshot();
+        const [, { data }] = await takeSnapshot();
 
         expect(data).toEqual({
           currentUser: {
@@ -2360,7 +2364,7 @@ describe("useLazyQuery Hook", () => {
       });
 
       {
-        const [, { data, previousData }] = await ProfiledHook.takeSnapshot();
+        const [, { data, previousData }] = await takeSnapshot();
 
         expect(data).toEqual({
           currentUser: {
@@ -2425,25 +2429,26 @@ describe("useLazyQuery Hook", () => {
         link: new MockLink(mocks),
       });
 
-      const ProfiledHook = profileHook(() => useLazyQuery(query));
-
-      render(<ProfiledHook />, {
-        wrapper: ({ children }) => (
-          <ApolloProvider client={client}>{children}</ApolloProvider>
-        ),
-      });
+      const { takeSnapshot, getCurrentSnapshot } = renderHookToSnapshotStream(
+        () => useLazyQuery(query),
+        {
+          wrapper: ({ children }) => (
+            <ApolloProvider client={client}>{children}</ApolloProvider>
+          ),
+        }
+      );
 
       // initial render
-      await ProfiledHook.takeSnapshot();
+      await takeSnapshot();
 
-      const [execute] = ProfiledHook.getCurrentSnapshot();
+      const [execute] = getCurrentSnapshot();
       execute();
 
       // Loading
-      await ProfiledHook.takeSnapshot();
+      await takeSnapshot();
 
       {
-        const [, { data }] = await ProfiledHook.takeSnapshot();
+        const [, { data }] = await takeSnapshot();
 
         expect(data).toEqual({
           currentUser: {
@@ -2466,7 +2471,7 @@ describe("useLazyQuery Hook", () => {
         },
       });
 
-      await expect(ProfiledHook).not.toRerender();
+      await expect(takeSnapshot).not.toRerender();
 
       expect(client.readQuery({ query })).toEqual({
         currentUser: {

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -2875,15 +2875,16 @@ describe("data masking", () => {
       link: new MockLink(mocks),
     });
 
-    const ProfiledHook = profileHook(() => useMutation(mutation));
+    const { takeSnapshot } = renderHookToSnapshotStream(
+      () => useMutation(mutation),
+      {
+        wrapper: ({ children }) => (
+          <ApolloProvider client={client}>{children}</ApolloProvider>
+        ),
+      }
+    );
 
-    render(<ProfiledHook />, {
-      wrapper: ({ children }) => (
-        <ApolloProvider client={client}>{children}</ApolloProvider>
-      ),
-    });
-
-    const [mutate, result] = await ProfiledHook.takeSnapshot();
+    const [mutate, result] = await takeSnapshot();
 
     expect(result.loading).toBe(false);
     expect(result.data).toBeUndefined();
@@ -2895,7 +2896,7 @@ describe("data masking", () => {
     });
 
     {
-      const [, result] = await ProfiledHook.takeSnapshot();
+      const [, result] = await takeSnapshot();
 
       expect(result.loading).toBe(true);
       expect(result.data).toBeUndefined();
@@ -2903,7 +2904,7 @@ describe("data masking", () => {
     }
 
     {
-      const [, result] = await ProfiledHook.takeSnapshot();
+      const [, result] = await takeSnapshot();
 
       expect(result.loading).toBe(false);
       expect(result.data).toEqual({
@@ -2929,7 +2930,7 @@ describe("data masking", () => {
       expect(errors).toBeUndefined();
     }
 
-    await expect(ProfiledHook).not.toRerender();
+    await expect(takeSnapshot).not.toRerender();
   });
 
   test("does not mask data returned from useMutation when dataMasking is `false`", async () => {
@@ -2978,15 +2979,16 @@ describe("data masking", () => {
       link: new MockLink(mocks),
     });
 
-    const ProfiledHook = profileHook(() => useMutation(mutation));
+    const { takeSnapshot } = renderHookToSnapshotStream(
+      () => useMutation(mutation),
+      {
+        wrapper: ({ children }) => (
+          <ApolloProvider client={client}>{children}</ApolloProvider>
+        ),
+      }
+    );
 
-    render(<ProfiledHook />, {
-      wrapper: ({ children }) => (
-        <ApolloProvider client={client}>{children}</ApolloProvider>
-      ),
-    });
-
-    const [mutate, result] = await ProfiledHook.takeSnapshot();
+    const [mutate, result] = await takeSnapshot();
 
     expect(result.loading).toBe(false);
     expect(result.data).toBeUndefined();
@@ -2998,7 +3000,7 @@ describe("data masking", () => {
     });
 
     {
-      const [, result] = await ProfiledHook.takeSnapshot();
+      const [, result] = await takeSnapshot();
 
       expect(result.loading).toBe(true);
       expect(result.data).toBeUndefined();
@@ -3006,7 +3008,7 @@ describe("data masking", () => {
     }
 
     {
-      const [, result] = await ProfiledHook.takeSnapshot();
+      const [, result] = await takeSnapshot();
 
       expect(result.loading).toBe(false);
       expect(result.data).toEqual({
@@ -3034,7 +3036,7 @@ describe("data masking", () => {
       expect(errors).toBeUndefined();
     }
 
-    await expect(ProfiledHook).not.toRerender();
+    await expect(takeSnapshot).not.toRerender();
   });
 
   test("passes masked data to onCompleted, does not pass masked data to update", async () => {
@@ -3086,17 +3088,16 @@ describe("data masking", () => {
 
     const update = jest.fn();
     const onCompleted = jest.fn();
-    const ProfiledHook = profileHook(() =>
-      useMutation(mutation, { onCompleted, update })
+    const { takeSnapshot } = renderHookToSnapshotStream(
+      () => useMutation(mutation, { onCompleted, update }),
+      {
+        wrapper: ({ children }) => (
+          <ApolloProvider client={client}>{children}</ApolloProvider>
+        ),
+      }
     );
 
-    render(<ProfiledHook />, {
-      wrapper: ({ children }) => (
-        <ApolloProvider client={client}>{children}</ApolloProvider>
-      ),
-    });
-
-    const [mutate] = await ProfiledHook.takeSnapshot();
+    const [mutate] = await takeSnapshot();
 
     await act(() => mutate());
 

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -10252,7 +10252,7 @@ describe("useQuery Hook", () => {
         link: new MockLink(mocks),
       });
 
-      const Profiler = createProfiler({
+      const renderStream = createRenderStream({
         initialSnapshot: {
           result: null as QueryResult<Masked<Query>, never> | null,
         },
@@ -10261,27 +10261,25 @@ describe("useQuery Hook", () => {
       function App() {
         const result = useQuery(query);
 
-        Profiler.replaceSnapshot({ result });
+        renderStream.replaceSnapshot({ result });
 
         return null;
       }
 
-      render(<App />, {
+      renderStream.render(<App />, {
         wrapper: ({ children }) => (
-          <ApolloProvider client={client}>
-            <Profiler>{children}</Profiler>
-          </ApolloProvider>
+          <ApolloProvider client={client}>{children}</ApolloProvider>
         ),
       });
 
       {
-        const { snapshot } = await Profiler.takeRender();
+        const { snapshot } = await renderStream.takeRender();
 
         expect(snapshot.result?.loading).toBe(true);
       }
 
       {
-        const { snapshot } = await Profiler.takeRender();
+        const { snapshot } = await renderStream.takeRender();
         const { result } = snapshot;
 
         expect(result?.loading).toBe(false);
@@ -10345,7 +10343,7 @@ describe("useQuery Hook", () => {
         link: new MockLink(mocks),
       });
 
-      const Profiler = createProfiler({
+      const renderStream = createRenderStream({
         initialSnapshot: {
           result: null as QueryResult<Query, never> | null,
         },
@@ -10354,23 +10352,21 @@ describe("useQuery Hook", () => {
       function App() {
         const result = useQuery(query);
 
-        Profiler.replaceSnapshot({ result });
+        renderStream.replaceSnapshot({ result });
 
         return null;
       }
 
-      render(<App />, {
+      renderStream.render(<App />, {
         wrapper: ({ children }) => (
-          <ApolloProvider client={client}>
-            <Profiler>{children}</Profiler>
-          </ApolloProvider>
+          <ApolloProvider client={client}>{children}</ApolloProvider>
         ),
       });
 
       // loading
-      await Profiler.takeRender();
+      await renderStream.takeRender();
 
-      const { snapshot } = await Profiler.takeRender();
+      const { snapshot } = await renderStream.takeRender();
 
       expect(snapshot.result?.data).toEqual({
         currentUser: {
@@ -10431,7 +10427,7 @@ describe("useQuery Hook", () => {
         link: new MockLink(mocks),
       });
 
-      const Profiler = createProfiler({
+      const renderStream = createRenderStream({
         initialSnapshot: {
           result: null as QueryResult<Query, never> | null,
         },
@@ -10440,23 +10436,21 @@ describe("useQuery Hook", () => {
       function App() {
         const result = useQuery(query);
 
-        Profiler.replaceSnapshot({ result });
+        renderStream.replaceSnapshot({ result });
 
         return null;
       }
 
-      render(<App />, {
+      renderStream.render(<App />, {
         wrapper: ({ children }) => (
-          <ApolloProvider client={client}>
-            <Profiler>{children}</Profiler>
-          </ApolloProvider>
+          <ApolloProvider client={client}>{children}</ApolloProvider>
         ),
       });
 
       // loading
-      await Profiler.takeRender();
+      await renderStream.takeRender();
 
-      const { snapshot } = await Profiler.takeRender();
+      const { snapshot } = await renderStream.takeRender();
 
       expect(snapshot.result?.data).toEqual({
         currentUser: {
@@ -10518,7 +10512,7 @@ describe("useQuery Hook", () => {
         link: new MockLink(mocks),
       });
 
-      const Profiler = createProfiler({
+      const renderStream = createRenderStream({
         initialSnapshot: {
           result: null as QueryResult<Masked<Query>, never> | null,
         },
@@ -10527,24 +10521,22 @@ describe("useQuery Hook", () => {
       function App() {
         const result = useQuery(query);
 
-        Profiler.replaceSnapshot({ result });
+        renderStream.replaceSnapshot({ result });
 
         return null;
       }
 
-      render(<App />, {
+      renderStream.render(<App />, {
         wrapper: ({ children }) => (
-          <ApolloProvider client={client}>
-            <Profiler>{children}</Profiler>
-          </ApolloProvider>
+          <ApolloProvider client={client}>{children}</ApolloProvider>
         ),
       });
 
       // loading
-      await Profiler.takeRender();
+      await renderStream.takeRender();
 
       {
-        const { snapshot } = await Profiler.takeRender();
+        const { snapshot } = await renderStream.takeRender();
 
         expect(snapshot.result?.data).toEqual({
           currentUser: {
@@ -10569,7 +10561,7 @@ describe("useQuery Hook", () => {
       });
 
       {
-        const { snapshot } = await Profiler.takeRender();
+        const { snapshot } = await renderStream.takeRender();
 
         expect(snapshot.result?.data).toEqual({
           currentUser: {
@@ -10633,7 +10625,7 @@ describe("useQuery Hook", () => {
         link: new MockLink(mocks),
       });
 
-      const Profiler = createProfiler({
+      const renderStream = createRenderStream({
         initialSnapshot: {
           result: null as QueryResult<Masked<Query>, never> | null,
         },
@@ -10642,24 +10634,22 @@ describe("useQuery Hook", () => {
       function App() {
         const result = useQuery(query);
 
-        Profiler.replaceSnapshot({ result });
+        renderStream.replaceSnapshot({ result });
 
         return null;
       }
 
-      render(<App />, {
+      renderStream.render(<App />, {
         wrapper: ({ children }) => (
-          <ApolloProvider client={client}>
-            <Profiler>{children}</Profiler>
-          </ApolloProvider>
+          <ApolloProvider client={client}>{children}</ApolloProvider>
         ),
       });
 
       // loading
-      await Profiler.takeRender();
+      await renderStream.takeRender();
 
       {
-        const { snapshot } = await Profiler.takeRender();
+        const { snapshot } = await renderStream.takeRender();
 
         expect(snapshot.result?.data).toEqual({
           currentUser: {
@@ -10683,7 +10673,7 @@ describe("useQuery Hook", () => {
         },
       });
 
-      await expect(Profiler).not.toRerender();
+      await expect(renderStream).not.toRerender();
 
       expect(client.readQuery({ query })).toEqual({
         currentUser: {
@@ -10758,7 +10748,7 @@ describe("useQuery Hook", () => {
           },
         });
 
-        const Profiler = createProfiler({
+        const renderStream = createRenderStream({
           initialSnapshot: {
             result: null as QueryResult<Masked<Query>, never> | null,
           },
@@ -10767,20 +10757,18 @@ describe("useQuery Hook", () => {
         function App() {
           const result = useQuery(query, { fetchPolicy });
 
-          Profiler.replaceSnapshot({ result });
+          renderStream.replaceSnapshot({ result });
 
           return null;
         }
 
-        render(<App />, {
+        renderStream.render(<App />, {
           wrapper: ({ children }) => (
-            <ApolloProvider client={client}>
-              <Profiler>{children}</Profiler>
-            </ApolloProvider>
+            <ApolloProvider client={client}>{children}</ApolloProvider>
           ),
         });
 
-        const { snapshot } = await Profiler.takeRender();
+        const { snapshot } = await renderStream.takeRender();
 
         expect(snapshot.result?.data).toEqual({
           currentUser: {
@@ -10855,7 +10843,7 @@ describe("useQuery Hook", () => {
         },
       });
 
-      const Profiler = createProfiler({
+      const renderStream = createRenderStream({
         initialSnapshot: {
           result: null as QueryResult<Masked<Query>, never> | null,
         },
@@ -10864,21 +10852,19 @@ describe("useQuery Hook", () => {
       function App() {
         const result = useQuery(query, { fetchPolicy: "cache-and-network" });
 
-        Profiler.replaceSnapshot({ result });
+        renderStream.replaceSnapshot({ result });
 
         return null;
       }
 
-      render(<App />, {
+      renderStream.render(<App />, {
         wrapper: ({ children }) => (
-          <ApolloProvider client={client}>
-            <Profiler>{children}</Profiler>
-          </ApolloProvider>
+          <ApolloProvider client={client}>{children}</ApolloProvider>
         ),
       });
 
       {
-        const { snapshot } = await Profiler.takeRender();
+        const { snapshot } = await renderStream.takeRender();
 
         expect(snapshot.result?.data).toEqual({
           currentUser: {
@@ -10891,7 +10877,7 @@ describe("useQuery Hook", () => {
       }
 
       {
-        const { snapshot } = await Profiler.takeRender();
+        const { snapshot } = await renderStream.takeRender();
 
         expect(snapshot.result?.data).toEqual({
           currentUser: {
@@ -10976,7 +10962,7 @@ describe("useQuery Hook", () => {
         });
       }
 
-      const Profiler = createProfiler({
+      const renderStream = createRenderStream({
         initialSnapshot: {
           result: null as QueryResult<Masked<Query>, never> | null,
         },
@@ -10985,21 +10971,19 @@ describe("useQuery Hook", () => {
       function App() {
         const result = useQuery(query, { returnPartialData: true });
 
-        Profiler.replaceSnapshot({ result });
+        renderStream.replaceSnapshot({ result });
 
         return null;
       }
 
-      render(<App />, {
+      renderStream.render(<App />, {
         wrapper: ({ children }) => (
-          <ApolloProvider client={client}>
-            <Profiler>{children}</Profiler>
-          </ApolloProvider>
+          <ApolloProvider client={client}>{children}</ApolloProvider>
         ),
       });
 
       {
-        const { snapshot } = await Profiler.takeRender();
+        const { snapshot } = await renderStream.takeRender();
 
         expect(snapshot.result?.data).toEqual({
           currentUser: {
@@ -11010,7 +10994,7 @@ describe("useQuery Hook", () => {
       }
 
       {
-        const { snapshot } = await Profiler.takeRender();
+        const { snapshot } = await renderStream.takeRender();
 
         expect(snapshot.result?.data).toEqual({
           currentUser: {
@@ -11073,7 +11057,7 @@ describe("useQuery Hook", () => {
         link: new MockLink(mocks),
       });
 
-      const Profiler = createProfiler({
+      const renderStream = createRenderStream({
         initialSnapshot: {
           result: null as QueryResult<Masked<Query>, never> | null,
         },
@@ -11082,24 +11066,22 @@ describe("useQuery Hook", () => {
       function App() {
         const result = useQuery(query, { errorPolicy: "all" });
 
-        Profiler.replaceSnapshot({ result });
+        renderStream.replaceSnapshot({ result });
 
         return null;
       }
 
-      render(<App />, {
+      renderStream.render(<App />, {
         wrapper: ({ children }) => (
-          <ApolloProvider client={client}>
-            <Profiler>{children}</Profiler>
-          </ApolloProvider>
+          <ApolloProvider client={client}>{children}</ApolloProvider>
         ),
       });
 
       // loading
-      await Profiler.takeRender();
+      await renderStream.takeRender();
 
       {
-        const { snapshot } = await Profiler.takeRender();
+        const { snapshot } = await renderStream.takeRender();
         const { result } = snapshot;
 
         expect(result?.data).toEqual({

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -2087,16 +2087,17 @@ describe("data masking", () => {
       link,
     });
 
-    const ProfiledHook = profileHook(() => useSubscription(subscription));
-
-    render(<ProfiledHook />, {
-      wrapper: ({ children }) => (
-        <ApolloProvider client={client}>{children}</ApolloProvider>
-      ),
-    });
+    const { takeSnapshot } = renderHookToSnapshotStream(
+      () => useSubscription(subscription),
+      {
+        wrapper: ({ children }) => (
+          <ApolloProvider client={client}>{children}</ApolloProvider>
+        ),
+      }
+    );
 
     {
-      const { data, loading, error } = await ProfiledHook.takeSnapshot();
+      const { data, loading, error } = await takeSnapshot();
 
       expect(loading).toBe(true);
       expect(data).toBeUndefined();
@@ -2117,7 +2118,7 @@ describe("data masking", () => {
     });
 
     {
-      const { data, loading, error } = await ProfiledHook.takeSnapshot();
+      const { data, loading, error } = await takeSnapshot();
 
       expect(loading).toBe(false);
       expect(data).toEqual({
@@ -2129,7 +2130,7 @@ describe("data masking", () => {
       expect(error).toBeUndefined();
     }
 
-    await expect(ProfiledHook).not.toRerender();
+    await expect(takeSnapshot).not.toRerender();
   });
 
   test("does not mask data returned from subscriptions when dataMasking is `false`", async () => {
@@ -2154,16 +2155,17 @@ describe("data masking", () => {
       link,
     });
 
-    const ProfiledHook = profileHook(() => useSubscription(subscription));
-
-    render(<ProfiledHook />, {
-      wrapper: ({ children }) => (
-        <ApolloProvider client={client}>{children}</ApolloProvider>
-      ),
-    });
+    const { takeSnapshot } = renderHookToSnapshotStream(
+      () => useSubscription(subscription),
+      {
+        wrapper: ({ children }) => (
+          <ApolloProvider client={client}>{children}</ApolloProvider>
+        ),
+      }
+    );
 
     {
-      const { data, loading, error } = await ProfiledHook.takeSnapshot();
+      const { data, loading, error } = await takeSnapshot();
 
       expect(loading).toBe(true);
       expect(data).toBeUndefined();
@@ -2184,7 +2186,7 @@ describe("data masking", () => {
     });
 
     {
-      const { data, loading, error } = await ProfiledHook.takeSnapshot();
+      const { data, loading, error } = await takeSnapshot();
 
       expect(loading).toBe(false);
       expect(data).toEqual({
@@ -2198,7 +2200,7 @@ describe("data masking", () => {
       expect(error).toBeUndefined();
     }
 
-    await expect(ProfiledHook).not.toRerender();
+    await expect(takeSnapshot).not.toRerender();
   });
 
   test("masks data passed to onData callback when dataMasking is `true`", async () => {
@@ -2224,18 +2226,17 @@ describe("data masking", () => {
     });
 
     const onData = jest.fn();
-    const ProfiledHook = profileHook(() =>
-      useSubscription(subscription, { onData })
+    const { takeSnapshot } = renderHookToSnapshotStream(
+      () => useSubscription(subscription, { onData }),
+      {
+        wrapper: ({ children }) => (
+          <ApolloProvider client={client}>{children}</ApolloProvider>
+        ),
+      }
     );
 
-    render(<ProfiledHook />, {
-      wrapper: ({ children }) => (
-        <ApolloProvider client={client}>{children}</ApolloProvider>
-      ),
-    });
-
     {
-      const { data, loading, error } = await ProfiledHook.takeSnapshot();
+      const { data, loading, error } = await takeSnapshot();
 
       expect(loading).toBe(true);
       expect(data).toBeUndefined();
@@ -2256,7 +2257,7 @@ describe("data masking", () => {
     });
 
     {
-      const { data, loading, error } = await ProfiledHook.takeSnapshot();
+      const { data, loading, error } = await takeSnapshot();
 
       expect(loading).toBe(false);
       expect(data).toEqual({
@@ -2279,7 +2280,7 @@ describe("data masking", () => {
       });
     }
 
-    await expect(ProfiledHook).not.toRerender();
+    await expect(takeSnapshot).not.toRerender();
   });
 
   test("uses unmasked data when using the @unmask directive", async () => {
@@ -2305,18 +2306,17 @@ describe("data masking", () => {
     });
 
     const onData = jest.fn();
-    const ProfiledHook = profileHook(() =>
-      useSubscription(subscription, { onData })
+    const { takeSnapshot } = renderHookToSnapshotStream(
+      () => useSubscription(subscription, { onData }),
+      {
+        wrapper: ({ children }) => (
+          <ApolloProvider client={client}>{children}</ApolloProvider>
+        ),
+      }
     );
 
-    render(<ProfiledHook />, {
-      wrapper: ({ children }) => (
-        <ApolloProvider client={client}>{children}</ApolloProvider>
-      ),
-    });
-
     {
-      const { data, loading, error } = await ProfiledHook.takeSnapshot();
+      const { data, loading, error } = await takeSnapshot();
 
       expect(loading).toBe(true);
       expect(data).toBeUndefined();
@@ -2337,7 +2337,7 @@ describe("data masking", () => {
     });
 
     {
-      const { data, loading, error } = await ProfiledHook.takeSnapshot();
+      const { data, loading, error } = await takeSnapshot();
 
       expect(loading).toBe(false);
       expect(data).toEqual({
@@ -2369,7 +2369,7 @@ describe("data masking", () => {
       });
     }
 
-    await expect(ProfiledHook).not.toRerender();
+    await expect(takeSnapshot).not.toRerender();
   });
 });
 

--- a/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
@@ -10796,7 +10796,7 @@ describe("useSuspenseQuery", () => {
       link: new MockLink(mocks),
     });
 
-    const Profiler = createProfiler({
+    const renderStream = createRenderStream({
       initialSnapshot: {
         result: null as UseSuspenseQueryResult<Masked<Query>, never> | null,
       },
@@ -10805,26 +10805,27 @@ describe("useSuspenseQuery", () => {
     function App() {
       const result = useSuspenseQuery(query);
 
-      Profiler.replaceSnapshot({ result });
+      renderStream.replaceSnapshot({ result });
 
       return null;
     }
 
-    render(<App />, {
-      wrapper: ({ children }) => (
-        <ApolloProvider client={client}>
-          <Profiler>
-            <Suspense fallback={<div>Loading...</div>}>{children}</Suspense>
-          </Profiler>
-        </ApolloProvider>
-      ),
-    });
+    renderStream.render(
+      <Suspense fallback={<div>Loading...</div>}>
+        <App />
+      </Suspense>,
+      {
+        wrapper: ({ children }) => (
+          <ApolloProvider client={client}>{children}</ApolloProvider>
+        ),
+      }
+    );
 
     // loading
-    await Profiler.takeRender();
+    await renderStream.takeRender();
 
     {
-      const { snapshot } = await Profiler.takeRender();
+      const { snapshot } = await renderStream.takeRender();
       const { result } = snapshot;
 
       expect(result?.data).toEqual({
@@ -10886,7 +10887,7 @@ describe("useSuspenseQuery", () => {
       link: new MockLink(mocks),
     });
 
-    const Profiler = createProfiler({
+    const renderStream = createRenderStream({
       initialSnapshot: {
         result: null as UseSuspenseQueryResult<Query, never> | null,
       },
@@ -10895,25 +10896,26 @@ describe("useSuspenseQuery", () => {
     function App() {
       const result = useSuspenseQuery(query);
 
-      Profiler.replaceSnapshot({ result });
+      renderStream.replaceSnapshot({ result });
 
       return null;
     }
 
-    render(<App />, {
-      wrapper: ({ children }) => (
-        <ApolloProvider client={client}>
-          <Profiler>
-            <Suspense fallback="Loading">{children}</Suspense>
-          </Profiler>
-        </ApolloProvider>
-      ),
-    });
+    renderStream.render(
+      <Suspense fallback="Loading">
+        <App />
+      </Suspense>,
+      {
+        wrapper: ({ children }) => (
+          <ApolloProvider client={client}>{children}</ApolloProvider>
+        ),
+      }
+    );
 
     // loading
-    await Profiler.takeRender();
+    await renderStream.takeRender();
 
-    const { snapshot } = await Profiler.takeRender();
+    const { snapshot } = await renderStream.takeRender();
 
     expect(snapshot.result?.data).toEqual({
       currentUser: {
@@ -10973,7 +10975,7 @@ describe("useSuspenseQuery", () => {
       link: new MockLink(mocks),
     });
 
-    const Profiler = createProfiler({
+    const renderStream = createRenderStream({
       initialSnapshot: {
         result: null as UseSuspenseQueryResult<Query, never> | null,
       },
@@ -10982,25 +10984,26 @@ describe("useSuspenseQuery", () => {
     function App() {
       const result = useSuspenseQuery(query);
 
-      Profiler.replaceSnapshot({ result });
+      renderStream.replaceSnapshot({ result });
 
       return null;
     }
 
-    render(<App />, {
-      wrapper: ({ children }) => (
-        <ApolloProvider client={client}>
-          <Profiler>
-            <Suspense fallback="Loading">{children}</Suspense>
-          </Profiler>
-        </ApolloProvider>
-      ),
-    });
+    renderStream.render(
+      <Suspense fallback="Loading">
+        <App />
+      </Suspense>,
+      {
+        wrapper: ({ children }) => (
+          <ApolloProvider client={client}>{children}</ApolloProvider>
+        ),
+      }
+    );
 
     // loading
-    await Profiler.takeRender();
+    await renderStream.takeRender();
 
-    const { snapshot } = await Profiler.takeRender();
+    const { snapshot } = await renderStream.takeRender();
 
     expect(snapshot.result?.data).toEqual({
       currentUser: {
@@ -11061,7 +11064,7 @@ describe("useSuspenseQuery", () => {
       link: new MockLink(mocks),
     });
 
-    const Profiler = createProfiler({
+    const renderStream = createRenderStream({
       initialSnapshot: {
         result: null as UseSuspenseQueryResult<Masked<Query>, never> | null,
       },
@@ -11070,26 +11073,27 @@ describe("useSuspenseQuery", () => {
     function App() {
       const result = useSuspenseQuery(query);
 
-      Profiler.replaceSnapshot({ result });
+      renderStream.replaceSnapshot({ result });
 
       return null;
     }
 
-    render(<App />, {
-      wrapper: ({ children }) => (
-        <ApolloProvider client={client}>
-          <Profiler>
-            <Suspense fallback="Loading">{children}</Suspense>
-          </Profiler>
-        </ApolloProvider>
-      ),
-    });
+    renderStream.render(
+      <Suspense fallback="Loading">
+        <App />
+      </Suspense>,
+      {
+        wrapper: ({ children }) => (
+          <ApolloProvider client={client}>{children}</ApolloProvider>
+        ),
+      }
+    );
 
     // loading
-    await Profiler.takeRender();
+    await renderStream.takeRender();
 
     {
-      const { snapshot } = await Profiler.takeRender();
+      const { snapshot } = await renderStream.takeRender();
 
       expect(snapshot.result?.data).toEqual({
         currentUser: {
@@ -11117,7 +11121,7 @@ describe("useSuspenseQuery", () => {
     });
 
     {
-      const { snapshot } = await Profiler.takeRender();
+      const { snapshot } = await renderStream.takeRender();
 
       expect(snapshot.result?.data).toEqual({
         currentUser: {
@@ -11178,7 +11182,7 @@ describe("useSuspenseQuery", () => {
       link: new MockLink(mocks),
     });
 
-    const Profiler = createProfiler({
+    const renderStream = createRenderStream({
       initialSnapshot: {
         result: null as UseSuspenseQueryResult<Masked<Query>, never> | null,
       },
@@ -11187,26 +11191,27 @@ describe("useSuspenseQuery", () => {
     function App() {
       const result = useSuspenseQuery(query);
 
-      Profiler.replaceSnapshot({ result });
+      renderStream.replaceSnapshot({ result });
 
       return null;
     }
 
-    render(<App />, {
-      wrapper: ({ children }) => (
-        <ApolloProvider client={client}>
-          <Profiler>
-            <Suspense fallback="Loading">{children}</Suspense>
-          </Profiler>
-        </ApolloProvider>
-      ),
-    });
+    renderStream.render(
+      <Suspense fallback="Loading">
+        <App />
+      </Suspense>,
+      {
+        wrapper: ({ children }) => (
+          <ApolloProvider client={client}>{children}</ApolloProvider>
+        ),
+      }
+    );
 
     // loading
-    await Profiler.takeRender();
+    await renderStream.takeRender();
 
     {
-      const { snapshot } = await Profiler.takeRender();
+      const { snapshot } = await renderStream.takeRender();
 
       expect(snapshot.result?.data).toEqual({
         currentUser: {
@@ -11231,7 +11236,7 @@ describe("useSuspenseQuery", () => {
       },
     });
 
-    await expect(Profiler).not.toRerender();
+    await expect(renderStream).not.toRerender();
 
     expect(client.readQuery({ query })).toEqual({
       currentUser: {
@@ -11304,7 +11309,7 @@ describe("useSuspenseQuery", () => {
       },
     });
 
-    const Profiler = createProfiler({
+    const renderStream = createRenderStream({
       initialSnapshot: {
         result: null as UseSuspenseQueryResult<Masked<Query>, never> | null,
       },
@@ -11313,22 +11318,23 @@ describe("useSuspenseQuery", () => {
     function App() {
       const result = useSuspenseQuery(query, { fetchPolicy: "cache-first" });
 
-      Profiler.replaceSnapshot({ result });
+      renderStream.replaceSnapshot({ result });
 
       return null;
     }
 
-    render(<App />, {
-      wrapper: ({ children }) => (
-        <ApolloProvider client={client}>
-          <Profiler>
-            <Suspense fallback="Loading">{children}</Suspense>
-          </Profiler>
-        </ApolloProvider>
-      ),
-    });
+    renderStream.render(
+      <Suspense fallback="Loading">
+        <App />
+      </Suspense>,
+      {
+        wrapper: ({ children }) => (
+          <ApolloProvider client={client}>{children}</ApolloProvider>
+        ),
+      }
+    );
 
-    const { snapshot } = await Profiler.takeRender();
+    const { snapshot } = await renderStream.takeRender();
 
     expect(snapshot.result?.data).toEqual({
       currentUser: {
@@ -11401,7 +11407,7 @@ describe("useSuspenseQuery", () => {
       },
     });
 
-    const Profiler = createProfiler({
+    const renderStream = createRenderStream({
       initialSnapshot: {
         result: null as UseSuspenseQueryResult<Masked<Query>, never> | null,
       },
@@ -11412,23 +11418,24 @@ describe("useSuspenseQuery", () => {
         fetchPolicy: "cache-and-network",
       });
 
-      Profiler.replaceSnapshot({ result });
+      renderStream.replaceSnapshot({ result });
 
       return null;
     }
 
-    render(<App />, {
-      wrapper: ({ children }) => (
-        <ApolloProvider client={client}>
-          <Profiler>
-            <Suspense fallback="Loading">{children}</Suspense>
-          </Profiler>
-        </ApolloProvider>
-      ),
-    });
+    renderStream.render(
+      <Suspense fallback="Loading">
+        <App />
+      </Suspense>,
+      {
+        wrapper: ({ children }) => (
+          <ApolloProvider client={client}>{children}</ApolloProvider>
+        ),
+      }
+    );
 
     {
-      const { snapshot } = await Profiler.takeRender();
+      const { snapshot } = await renderStream.takeRender();
 
       expect(snapshot.result?.data).toEqual({
         currentUser: {
@@ -11440,7 +11447,7 @@ describe("useSuspenseQuery", () => {
     }
 
     {
-      const { snapshot } = await Profiler.takeRender();
+      const { snapshot } = await renderStream.takeRender();
 
       expect(snapshot.result?.data).toEqual({
         currentUser: {
@@ -11517,7 +11524,7 @@ describe("useSuspenseQuery", () => {
       });
     }
 
-    const Profiler = createProfiler({
+    const renderStream = createRenderStream({
       initialSnapshot: {
         result: null as UseSuspenseQueryResult<
           DeepPartial<Masked<Query>>,
@@ -11529,23 +11536,24 @@ describe("useSuspenseQuery", () => {
     function App() {
       const result = useSuspenseQuery(query, { returnPartialData: true });
 
-      Profiler.replaceSnapshot({ result });
+      renderStream.replaceSnapshot({ result });
 
       return null;
     }
 
-    render(<App />, {
-      wrapper: ({ children }) => (
-        <ApolloProvider client={client}>
-          <Profiler>
-            <Suspense fallback="Loading">{children}</Suspense>
-          </Profiler>
-        </ApolloProvider>
-      ),
-    });
+    renderStream.render(
+      <Suspense fallback="Loading">
+        <App />
+      </Suspense>,
+      {
+        wrapper: ({ children }) => (
+          <ApolloProvider client={client}>{children}</ApolloProvider>
+        ),
+      }
+    );
 
     {
-      const { snapshot } = await Profiler.takeRender();
+      const { snapshot } = await renderStream.takeRender();
 
       expect(snapshot.result?.data).toEqual({
         currentUser: {
@@ -11556,7 +11564,7 @@ describe("useSuspenseQuery", () => {
     }
 
     {
-      const { snapshot } = await Profiler.takeRender();
+      const { snapshot } = await renderStream.takeRender();
 
       expect(snapshot.result?.data).toEqual({
         currentUser: {
@@ -11619,7 +11627,7 @@ describe("useSuspenseQuery", () => {
       link: new MockLink(mocks),
     });
 
-    const Profiler = createProfiler({
+    const renderStream = createRenderStream({
       initialSnapshot: {
         result: null as UseSuspenseQueryResult<
           Masked<Query> | undefined,
@@ -11631,26 +11639,27 @@ describe("useSuspenseQuery", () => {
     function App() {
       const result = useSuspenseQuery(query, { errorPolicy: "all" });
 
-      Profiler.replaceSnapshot({ result });
+      renderStream.replaceSnapshot({ result });
 
       return null;
     }
 
-    render(<App />, {
-      wrapper: ({ children }) => (
-        <ApolloProvider client={client}>
-          <Profiler>
-            <Suspense fallback="Loading">{children}</Suspense>
-          </Profiler>
-        </ApolloProvider>
-      ),
-    });
+    renderStream.render(
+      <Suspense fallback="Loading">
+        <App />
+      </Suspense>,
+      {
+        wrapper: ({ children }) => (
+          <ApolloProvider client={client}>{children}</ApolloProvider>
+        ),
+      }
+    );
 
     // loading
-    await Profiler.takeRender();
+    await renderStream.takeRender();
 
     {
-      const { snapshot } = await Profiler.takeRender();
+      const { snapshot } = await renderStream.takeRender();
       const { result } = snapshot;
 
       expect(result?.data).toEqual({

--- a/src/react/query-preloader/__tests__/createQueryPreloader.test.tsx
+++ b/src/react/query-preloader/__tests__/createQueryPreloader.test.tsx
@@ -1876,19 +1876,21 @@ test("masks result when dataMasking is `true`", async () => {
 
   const queryRef = preloadQuery(query, { variables: { id: "1" } });
 
-  const { Profiler } = renderDefaultTestApp<Masked<MaskedVariablesCaseData>>({
+  const { renderStream } = renderDefaultTestApp<
+    Masked<MaskedVariablesCaseData>
+  >({
     client,
     queryRef,
   });
 
   {
-    const { renderedComponents } = await Profiler.takeRender();
+    const { renderedComponents } = await renderStream.takeRender();
 
     expect(renderedComponents).toStrictEqual(["App", "SuspenseFallback"]);
   }
 
   {
-    const { snapshot } = await Profiler.takeRender();
+    const { snapshot } = await renderStream.takeRender();
 
     expect(snapshot.result).toEqual({
       data: {
@@ -1911,19 +1913,19 @@ test("does not mask result when dataMasking is `false`", async () => {
 
   const queryRef = preloadQuery(query, { variables: { id: "1" } });
 
-  const { Profiler } = renderDefaultTestApp<MaskedVariablesCaseData>({
+  const { renderStream } = renderDefaultTestApp<MaskedVariablesCaseData>({
     client,
     queryRef,
   });
 
   {
-    const { renderedComponents } = await Profiler.takeRender();
+    const { renderedComponents } = await renderStream.takeRender();
 
     expect(renderedComponents).toStrictEqual(["App", "SuspenseFallback"]);
   }
 
   {
-    const { snapshot } = await Profiler.takeRender();
+    const { snapshot } = await renderStream.takeRender();
 
     expect(snapshot.result).toEqual({
       data: {
@@ -1945,19 +1947,19 @@ test("does not mask results by default", async () => {
 
   const queryRef = preloadQuery(query, { variables: { id: "1" } });
 
-  const { Profiler } = renderDefaultTestApp<MaskedVariablesCaseData>({
+  const { renderStream } = renderDefaultTestApp<MaskedVariablesCaseData>({
     client,
     queryRef,
   });
 
   {
-    const { renderedComponents } = await Profiler.takeRender();
+    const { renderedComponents } = await renderStream.takeRender();
 
     expect(renderedComponents).toStrictEqual(["App", "SuspenseFallback"]);
   }
 
   {
-    const { snapshot } = await Profiler.takeRender();
+    const { snapshot } = await renderStream.takeRender();
 
     expect(snapshot.result).toEqual({
       data: {


### PR DESCRIPTION
After merging `main` into the `release-3.12` branch, many of the data masking tests began failing since they were still using the old profiler testing utilities. This PR updates the data masking tests to use the new render stream library instead.