### PR TITLE
[Data masking] Fix aggressive warnings when using objects marked with `@unmask(mode: "migrate")` with `cache.identify`

### DIFF
--- a/.api-reports/api-report-cache.api.md
+++ b/.api-reports/api-report-cache.api.md
@@ -1109,9 +1109,9 @@ interface WriteContext extends ReadMergeModifyContext {
 // Warnings were encountered during analysis:
 //
 // src/cache/core/cache.ts:92:7 - (ae-forgotten-export) The symbol "MaybeMasked" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/policies.ts:92:3 - (ae-forgotten-export) The symbol "FragmentMap" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/policies.ts:161:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/policies.ts:161:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:93:3 - (ae-forgotten-export) The symbol "FragmentMap" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:162:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:162:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/types.ts:139:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -2432,9 +2432,9 @@ interface WriteContext extends ReadMergeModifyContext {
 
 // Warnings were encountered during analysis:
 //
-// src/cache/inmemory/policies.ts:92:3 - (ae-forgotten-export) The symbol "FragmentMap" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/policies.ts:161:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/policies.ts:161:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:93:3 - (ae-forgotten-export) The symbol "FragmentMap" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:162:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:162:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/types.ts:139:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:120:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:121:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report-utilities.api.md
+++ b/.api-reports/api-report-utilities.api.md
@@ -2792,11 +2792,11 @@ interface WriteContext extends ReadMergeModifyContext {
 // Warnings were encountered during analysis:
 //
 // src/cache/core/types/DataProxy.ts:147:7 - (ae-forgotten-export) The symbol "MissingFieldError" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/policies.ts:57:3 - (ae-forgotten-export) The symbol "TypePolicy" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/policies.ts:161:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/policies.ts:161:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/policies.ts:162:3 - (ae-forgotten-export) The symbol "FieldReadFunction" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/policies.ts:163:3 - (ae-forgotten-export) The symbol "FieldMergeFunction" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:58:3 - (ae-forgotten-export) The symbol "TypePolicy" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:162:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:162:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:163:3 - (ae-forgotten-export) The symbol "FieldReadFunction" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:164:3 - (ae-forgotten-export) The symbol "FieldMergeFunction" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/types.ts:139:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/writeToStore.ts:65:7 - (ae-forgotten-export) The symbol "MergeTree" needs to be exported by the entry point index.d.ts
 // src/core/LocalState.ts:71:3 - (ae-forgotten-export) The symbol "ApolloClient" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -3143,9 +3143,9 @@ interface WriteContext extends ReadMergeModifyContext {
 
 // Warnings were encountered during analysis:
 //
-// src/cache/inmemory/policies.ts:92:3 - (ae-forgotten-export) The symbol "FragmentMap" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/policies.ts:161:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/policies.ts:161:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:93:3 - (ae-forgotten-export) The symbol "FragmentMap" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:162:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:162:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/types.ts:139:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:120:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:121:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts

--- a/.changeset/early-bobcats-eat.md
+++ b/.changeset/early-bobcats-eat.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Prevent field accessor warnings when using `@unmask(mode: "migrate")` on objects that are passed into `cache.identify`.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 41506,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 34257
+  "dist/apollo-client.min.cjs": 41516,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 34299
 }

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
   "dist/apollo-client.min.cjs": 41516,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 34299
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 34296
 }

--- a/src/__tests__/dataMasking.ts
+++ b/src/__tests__/dataMasking.ts
@@ -3149,6 +3149,18 @@ describe("client.watchFragment", () => {
       cache: new InMemoryCache(),
     });
 
+    client.writeFragment({
+      id: client.cache.identify({ __typename: "User", id: 1 }),
+      fragment,
+      fragmentName: "UserFields",
+      data: {
+        __typename: "User",
+        id: 1,
+        age: 30,
+        name: "Test User",
+      },
+    });
+
     const observable = client.watchFragment({
       fragment,
       fragmentName: "UserFields",

--- a/src/__tests__/dataMasking.ts
+++ b/src/__tests__/dataMasking.ts
@@ -3112,79 +3112,72 @@ describe("client.watchFragment", () => {
     });
   });
 
-  // FIXME: This broke with the changes in https://github.com/apollographql/apollo-client/pull/12114
-  // which ensure masking works with deferred payloads. Instead of fixing with
-  // #12114, it will be fixed with https://github.com/apollographql/apollo-client/issues/12043
-  // which will fix overagressive warnings.
-  test.failing(
-    "warns when accessing an unmasked field on a watched fragment while using @unmask with mode: 'migrate'",
-    async () => {
-      using consoleSpy = spyOnConsole("warn");
+  test("warns when accessing an unmasked field on a watched fragment while using @unmask with mode: 'migrate'", async () => {
+    using consoleSpy = spyOnConsole("warn");
 
-      type ProfileFieldsFragment = {
-        __typename: "User";
-        age: number;
-        name: string;
-      } & { " $fragmentName": "UserFieldsFragment" };
+    type ProfileFieldsFragment = {
+      __typename: "User";
+      age: number;
+      name: string;
+    } & { " $fragmentName": "UserFieldsFragment" };
 
-      type UserFieldsFragment = {
-        __typename: "User";
-        id: number;
-        name: string;
-        /** @deprecated */
-        age: number;
-      } & { " $fragmentName": "UserFieldsFragment" } & {
-        " $fragmentRefs": { ProfileFieldsFragment: ProfileFieldsFragment };
-      };
+    type UserFieldsFragment = {
+      __typename: "User";
+      id: number;
+      name: string;
+      /** @deprecated */
+      age: number;
+    } & { " $fragmentName": "UserFieldsFragment" } & {
+      " $fragmentRefs": { ProfileFieldsFragment: ProfileFieldsFragment };
+    };
 
-      const fragment: MaskedDocumentNode<UserFieldsFragment, never> = gql`
-        fragment UserFields on User {
-          id
-          name
-          ...ProfileFields @unmask(mode: "migrate")
-        }
-
-        fragment ProfileFields on User {
-          age
-          name
-        }
-      `;
-
-      const client = new ApolloClient({
-        dataMasking: true,
-        cache: new InMemoryCache(),
-      });
-
-      const observable = client.watchFragment({
-        fragment,
-        fragmentName: "UserFields",
-        from: { __typename: "User", id: 1 },
-      });
-      const stream = new ObservableStream(observable);
-
-      {
-        const { data } = await stream.takeNext();
-        data.__typename;
-        data.id;
-        data.name;
-
-        expect(consoleSpy.warn).not.toHaveBeenCalled();
-
-        data.age;
-
-        expect(consoleSpy.warn).toHaveBeenCalledTimes(1);
-        expect(consoleSpy.warn).toHaveBeenCalledWith(
-          "Accessing unmasked field on %s at path '%s'. This field will not be available when masking is enabled. Please read the field from the fragment instead.",
-          "fragment 'UserFields'",
-          "age"
-        );
-
-        // Ensure we only warn once
-        data.age;
-        expect(consoleSpy.warn).toHaveBeenCalledTimes(1);
+    const fragment: MaskedDocumentNode<UserFieldsFragment, never> = gql`
+      fragment UserFields on User {
+        id
+        name
+        ...ProfileFields @unmask(mode: "migrate")
       }
+
+      fragment ProfileFields on User {
+        age
+        name
+      }
+    `;
+
+    const client = new ApolloClient({
+      dataMasking: true,
+      cache: new InMemoryCache(),
+    });
+
+    const observable = client.watchFragment({
+      fragment,
+      fragmentName: "UserFields",
+      from: { __typename: "User", id: 1 },
+    });
+    const stream = new ObservableStream(observable);
+
+    {
+      const { data } = await stream.takeNext();
+      data.__typename;
+      data.id;
+      data.name;
+
+      expect(consoleSpy.warn).not.toHaveBeenCalled();
+
+      data.age;
+
+      expect(consoleSpy.warn).toHaveBeenCalledTimes(1);
+      expect(consoleSpy.warn).toHaveBeenCalledWith(
+        "Accessing unmasked field on %s at path '%s'. This field will not be available when masking is enabled. Please read the field from the fragment instead.",
+        "fragment 'UserFields'",
+        "age"
+      );
+
+      // Ensure we only warn once
+      data.age;
+      expect(consoleSpy.warn).toHaveBeenCalledTimes(1);
     }
-  );
+  });
 
   test("can lookup unmasked fragments from the fragment registry in watched fragments", async () => {
     const fragments = createFragmentRegistry();

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -392,17 +392,18 @@ export class Policies {
 
     const policy = typename && this.getTypePolicy(typename);
     let keyFn = (policy && policy.keyFn) || this.config.dataIdFromObject;
-    while (keyFn) {
-      const specifierOrId = disableWarningsSlot.withValue(true, () => {
-        return keyFn!({ ...object, ...storeObject }, context);
-      });
-      if (isArray(specifierOrId)) {
-        keyFn = keyFieldsFnFromSpecifier(specifierOrId);
-      } else {
-        id = specifierOrId;
-        break;
+
+    disableWarningsSlot.withValue(true, () => {
+      while (keyFn) {
+        const specifierOrId = keyFn({ ...object, ...storeObject }, context);
+        if (isArray(specifierOrId)) {
+          keyFn = keyFieldsFnFromSpecifier(specifierOrId);
+        } else {
+          id = specifierOrId;
+          break;
+        }
       }
-    }
+    });
 
     id = id ? String(id) : void 0;
     return context.keyObject ? [id, context.keyObject] : [id];

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -52,6 +52,7 @@ import {
   keyArgsFnFromSpecifier,
   keyFieldsFnFromSpecifier,
 } from "./key-extractor.js";
+import { disableWarningsSlot } from "../../core/masking.js";
 
 export type TypePolicies = {
   [__typename: string]: TypePolicy;
@@ -392,7 +393,9 @@ export class Policies {
     const policy = typename && this.getTypePolicy(typename);
     let keyFn = (policy && policy.keyFn) || this.config.dataIdFromObject;
     while (keyFn) {
-      const specifierOrId = keyFn({ ...object, ...storeObject }, context);
+      const specifierOrId = disableWarningsSlot.withValue(true, () => {
+        return keyFn!({ ...object, ...storeObject }, context);
+      });
       if (isArray(specifierOrId)) {
         keyFn = keyFieldsFnFromSpecifier(specifierOrId);
       } else {

--- a/src/core/__tests__/masking.test.ts
+++ b/src/core/__tests__/masking.test.ts
@@ -2244,7 +2244,7 @@ describe("maskFragment", () => {
 
   test("warns when accessing unmasked fields when using `@unmask` directive with mode 'migrate'", () => {
     using _ = spyOnConsole("warn");
-    const query = gql`
+    const fragment = gql`
       fragment UnmaskedFragment on User {
         id
         name
@@ -2265,7 +2265,7 @@ describe("maskFragment", () => {
           age: 30,
         },
       }),
-      query,
+      fragment,
       new InMemoryCache(),
       "UnmaskedFragment"
     );

--- a/src/core/__tests__/masking.test.ts
+++ b/src/core/__tests__/masking.test.ts
@@ -2268,6 +2268,12 @@ describe("maskFragment", () => {
       "UnmaskedFragment"
     );
 
+    data.__typename;
+    data.id;
+    data.name;
+
+    expect(console.warn).not.toHaveBeenCalled();
+
     data.age;
 
     expect(console.warn).toHaveBeenCalledTimes(1);

--- a/src/core/__tests__/masking.test.ts
+++ b/src/core/__tests__/masking.test.ts
@@ -2258,12 +2258,10 @@ describe("maskFragment", () => {
 
     const data = maskFragment(
       deepFreeze({
-        currentUser: {
-          __typename: "User",
-          id: 1,
-          name: "Test User",
-          age: 30,
-        },
+        __typename: "User",
+        id: 1,
+        name: "Test User",
+        age: 30,
       }),
       fragment,
       new InMemoryCache(),

--- a/src/core/masking.ts
+++ b/src/core/masking.ts
@@ -370,6 +370,10 @@ function addAccessorWarning(
   path: string,
   context: MaskingContext
 ) {
+  if (value === void 0) {
+    return;
+  }
+
   let getValue = () => {
     if (context.disableWarnings) {
       return value;

--- a/src/core/masking.ts
+++ b/src/core/masking.ts
@@ -11,6 +11,7 @@ import {
 import type { FragmentMap } from "../utilities/index.js";
 import type { ApolloCache, DocumentNode, TypedDocumentNode } from "./index.js";
 import { invariant } from "../utilities/globals/index.js";
+import { equal } from "@wry/equality";
 
 interface MaskingContext {
   operationType: "query" | "mutation" | "subscription" | "fragment";
@@ -107,6 +108,13 @@ export function maskFragment<TData = unknown>(
 
   if (data == null) {
     // Maintain the original `null` or `undefined` value
+    return data;
+  }
+
+  if (equal(data, {})) {
+    // Return early and skip the masking algorithm if we don't have any data
+    // yet. This can happen when cache.diff returns an empty object which is
+    // used from watchFragment.
     return data;
   }
 

--- a/src/core/masking.ts
+++ b/src/core/masking.ts
@@ -378,6 +378,11 @@ function addAccessorWarning(
   path: string,
   context: MaskingContext
 ) {
+  // In order to preserve the original shape of the data as much as possible, we
+  // want to skip adding a property with warning to the final result when the
+  // value is missing, otherwise our final result will contain additional
+  // properties that our original result did not have. This could happen with a
+  // deferred payload for example.
   if (value === void 0) {
     return;
   }


### PR DESCRIPTION
Closes #12043

When passing an unmasked object in migration mode to `cache.identify`, we'd get field accessor warnings even though the end user wasn't accessing them at all. This was due to the fact that `cache.identify` does a spread operation of the result which shallow-copies all the fields, triggering the getters.

This change adds a new `Slot` that we can use to disable field accessor warnings inside Apollo Client core for masked fields. This fixes the `cache.identify` case as this is the only known case of the issue so far. In the future we can use this `Slot` if we encounter other areas of the codebase that prematurely trigger the warnings.