### PR TITLE
[Data masking] Fix issue applying accessor warnings to interface types

### DIFF
--- a/.changeset/nice-countries-share.md
+++ b/.changeset/nice-countries-share.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix error thrown when applying unmask migrate mode warnings on interface types with selection sets that contain inline fragment conditions.

--- a/src/core/masking.ts
+++ b/src/core/masking.ts
@@ -333,6 +333,13 @@ function addFieldAccessorWarnings(
         return memo;
       }
       case Kind.INLINE_FRAGMENT: {
+        if (
+          selection.typeCondition &&
+          !context.cache.fragmentMatches!(selection, (data as any).__typename)
+        ) {
+          return memo;
+        }
+
         return addFieldAccessorWarnings(
           memo,
           data,


### PR DESCRIPTION
Fixes #12127

Fixes error thrown when trying to apply accessor warnings to selection sets with inline fragment nodes. I did not previously check the fragment condition before trying to apply the additional selection set, so `data` would be `undefined` in those conditions.
