### PR TITLE
[Data masking] Allow `null` as a valid `from` value

### DIFF
--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -2251,7 +2251,7 @@ export interface UseFragmentOptions<TData, TVars> extends Omit<Cache_2.DiffOptio
     // Warning: (ae-forgotten-export) The symbol "FragmentType" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    from: StoreObject | Reference | FragmentType<NoInfer_2<TData>> | string;
+    from: StoreObject | Reference | FragmentType<NoInfer_2<TData>> | string | null;
     // (undocumented)
     optimistic?: boolean;
 }

--- a/.api-reports/api-report-react_hooks.api.md
+++ b/.api-reports/api-report-react_hooks.api.md
@@ -2075,7 +2075,7 @@ export interface UseFragmentOptions<TData, TVars> extends Omit<Cache_2.DiffOptio
     // Warning: (ae-forgotten-export) The symbol "FragmentType" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    from: StoreObject | Reference | FragmentType<NoInfer_2<TData>> | string;
+    from: StoreObject | Reference | FragmentType<NoInfer_2<TData>> | string | null;
     // (undocumented)
     optimistic?: boolean;
 }

--- a/.api-reports/api-report-react_internal.api.md
+++ b/.api-reports/api-report-react_internal.api.md
@@ -2138,7 +2138,7 @@ interface UseFragmentOptions<TData, TVars> extends Omit<Cache_2.DiffOptions<NoIn
     // Warning: (ae-forgotten-export) The symbol "FragmentType" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    from: StoreObject | Reference | FragmentType<NoInfer_2<TData>> | string;
+    from: StoreObject | Reference | FragmentType<NoInfer_2<TData>> | string | null;
     // (undocumented)
     optimistic?: boolean;
 }

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -2924,7 +2924,7 @@ export function useFragment<TData = any, TVars = OperationVariables>(options: Us
 export interface UseFragmentOptions<TData, TVars> extends Omit<Cache_2.DiffOptions<NoInfer_2<TData>, NoInfer_2<TVars>>, "id" | "query" | "optimistic" | "previousResult" | "returnPartialData">, Omit<Cache_2.ReadFragmentOptions<TData, TVars>, "id" | "variables" | "returnPartialData"> {
     client?: ApolloClient<any>;
     // (undocumented)
-    from: StoreObject | Reference | FragmentType<NoInfer_2<TData>> | string;
+    from: StoreObject | Reference | FragmentType<NoInfer_2<TData>> | string | null;
     // (undocumented)
     optimistic?: boolean;
 }

--- a/.changeset/long-zoos-ring.md
+++ b/.changeset/long-zoos-ring.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": minor
+---
+
+Allow `null` as a valid `from` value in `useFragment`.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 41573,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 34361
+  "dist/apollo-client.min.cjs": 41601,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 34359
 }


### PR DESCRIPTION
While trying out data masking with the [Spotify showcase](https://github.com/apollographql/spotify-showcase), I discovered some cases where it was a bit difficult to adopt data masking without some significant refactors. For example, see https://github.com/apollographql/spotify-showcase/commit/a24c3ed370cf186b5285097aa8d5a42eed2bf7cb. In this component, I had to split out a fallback component and a component that renders the non-null case simply because we can't conditionally render hooks and `null` is not a valid `from` value in `useFragment`. By adding support for `null`, it should make data masking a bit easier to adopt by avoiding these types of refactors where a fallback state is perfectly valid.