### PR TITLE
[Data masking] Ensure `null` is retained when unmasking nullable objects

### DIFF
--- a/.api-reports/api-report-cache.api.md
+++ b/.api-reports/api-report-cache.api.md
@@ -445,6 +445,16 @@ export namespace EntityStore {
     }
 }
 
+// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+type ExtractFragmentRefs<TData> = TData extends {
+    " $fragmentRefs"?: infer FragmentRefs extends object;
+} ? Prettify<{
+    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
+} & CombineFragmentRefs<FragmentRefs>> : never;
+
 // @public (undocumented)
 export interface FieldFunctionOptions<TArgs = Record<string, any>, TVars = Record<string, any>> {
     // (undocumented)
@@ -730,7 +740,6 @@ export function makeReference(id: string): Reference;
 // @public (undocumented)
 export function makeVar<T>(value: T): ReactiveVar<T>;
 
-// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "DataMasking" needs to be exported by the entry point index.d.ts
 //
@@ -1041,14 +1050,10 @@ type UnionToIntersection<U> = (U extends any ? (x: U) => void : never) extends (
 // @public
 type Unmasked<TData> = TData extends object ? UnwrapFragmentRefs<RemoveMaskedMarker<RemoveFragmentName<TData>>> : TData;
 
-// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ExtractFragmentRefs" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? TData extends {
-    " $fragmentRefs"?: infer FragmentRefs extends object;
-} ? Prettify<{
-    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
-} & CombineFragmentRefs<FragmentRefs>> : never : TData extends object ? {
+type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? null extends TData ? ExtractFragmentRefs<TData> | null : ExtractFragmentRefs<TData> : TData extends object ? {
     [K in keyof TData]: UnwrapFragmentRefs<TData[K]>;
 } : TData;
 

--- a/.api-reports/api-report-cache.api.md
+++ b/.api-reports/api-report-cache.api.md
@@ -445,16 +445,6 @@ export namespace EntityStore {
     }
 }
 
-// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
-//
-// @public (undocumented)
-type ExtractFragmentRefs<TData> = TData extends {
-    " $fragmentRefs"?: infer FragmentRefs extends object;
-} ? Prettify<{
-    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
-} & CombineFragmentRefs<FragmentRefs>> : never;
-
 // @public (undocumented)
 export interface FieldFunctionOptions<TArgs = Record<string, any>, TVars = Record<string, any>> {
     // (undocumented)
@@ -740,6 +730,7 @@ export function makeReference(id: string): Reference;
 // @public (undocumented)
 export function makeVar<T>(value: T): ReactiveVar<T>;
 
+// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "DataMasking" needs to be exported by the entry point index.d.ts
 //
@@ -1050,12 +1041,16 @@ type UnionToIntersection<U> = (U extends any ? (x: U) => void : never) extends (
 // @public
 type Unmasked<TData> = TData extends object ? UnwrapFragmentRefs<RemoveMaskedMarker<RemoveFragmentName<TData>>> : TData;
 
-// Warning: (ae-forgotten-export) The symbol "ExtractFragmentRefs" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? null extends TData ? ExtractFragmentRefs<TData> | null : ExtractFragmentRefs<TData> : TData extends object ? {
+type UnwrapFragmentRefs<TData> = TData extends any ? string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? TData extends {
+    " $fragmentRefs"?: infer FragmentRefs extends object;
+} ? Prettify<{
+    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
+} & CombineFragmentRefs<FragmentRefs>> : never : TData extends object ? {
     [K in keyof TData]: UnwrapFragmentRefs<TData[K]>;
-} : TData;
+} : TData : never;
 
 // @public
 export interface WatchFragmentOptions<TData, TVars> {

--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -808,6 +808,16 @@ interface ExecutionPatchResultBase {
     hasNext?: boolean;
 }
 
+// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+type ExtractFragmentRefs<TData> = TData extends {
+    " $fragmentRefs"?: infer FragmentRefs extends object;
+} ? Prettify<{
+    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
+} & CombineFragmentRefs<FragmentRefs>> : never;
+
 // @public (undocumented)
 export const fallbackHttpConfig: {
     http: HttpQueryOptions;
@@ -1374,7 +1384,6 @@ interface MaskOperationOptions<TData> {
 // @public (undocumented)
 type MaybeAsync<T> = T | PromiseLike<T>;
 
-// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
 //
 // @public
@@ -2338,14 +2347,10 @@ type UnionToIntersection_2<U> = (U extends any ? (k: U) => void : never) extends
 // @public
 export type Unmasked<TData> = TData extends object ? UnwrapFragmentRefs<RemoveMaskedMarker<RemoveFragmentName<TData>>> : TData;
 
-// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ExtractFragmentRefs" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? TData extends {
-    " $fragmentRefs"?: infer FragmentRefs extends object;
-} ? Prettify<{
-    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
-} & CombineFragmentRefs<FragmentRefs>> : never : TData extends object ? {
+type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? null extends TData ? ExtractFragmentRefs<TData> | null : ExtractFragmentRefs<TData> : TData extends object ? {
     [K in keyof TData]: UnwrapFragmentRefs<TData[K]>;
 } : TData;
 

--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -808,16 +808,6 @@ interface ExecutionPatchResultBase {
     hasNext?: boolean;
 }
 
-// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
-//
-// @public (undocumented)
-type ExtractFragmentRefs<TData> = TData extends {
-    " $fragmentRefs"?: infer FragmentRefs extends object;
-} ? Prettify<{
-    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
-} & CombineFragmentRefs<FragmentRefs>> : never;
-
 // @public (undocumented)
 export const fallbackHttpConfig: {
     http: HttpQueryOptions;
@@ -1384,6 +1374,7 @@ interface MaskOperationOptions<TData> {
 // @public (undocumented)
 type MaybeAsync<T> = T | PromiseLike<T>;
 
+// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
 //
 // @public
@@ -2347,12 +2338,16 @@ type UnionToIntersection_2<U> = (U extends any ? (k: U) => void : never) extends
 // @public
 export type Unmasked<TData> = TData extends object ? UnwrapFragmentRefs<RemoveMaskedMarker<RemoveFragmentName<TData>>> : TData;
 
-// Warning: (ae-forgotten-export) The symbol "ExtractFragmentRefs" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? null extends TData ? ExtractFragmentRefs<TData> | null : ExtractFragmentRefs<TData> : TData extends object ? {
+type UnwrapFragmentRefs<TData> = TData extends any ? string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? TData extends {
+    " $fragmentRefs"?: infer FragmentRefs extends object;
+} ? Prettify<{
+    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
+} & CombineFragmentRefs<FragmentRefs>> : never : TData extends object ? {
     [K in keyof TData]: UnwrapFragmentRefs<TData[K]>;
-} : TData;
+} : TData : never;
 
 // @public (undocumented)
 type UpdateQueries<TData> = MutationOptions<TData, any, any>["updateQueries"];

--- a/.api-reports/api-report-masking.api.md
+++ b/.api-reports/api-report-masking.api.md
@@ -19,6 +19,16 @@ type CombineFragmentRefs<FragmentRefs extends Record<string, any>> = UnionToInte
 export interface DataMasking {
 }
 
+// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+type ExtractFragmentRefs<TData> = TData extends {
+    " $fragmentRefs"?: infer FragmentRefs extends object;
+} ? Prettify<{
+    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
+} & CombineFragmentRefs<FragmentRefs>> : never;
+
 // @public (undocumented)
 export type FragmentType<TData> = [
 TData
@@ -42,7 +52,6 @@ export type MaskedDocumentNode<TData = {
     [key: string]: any;
 }> = TypedDocumentNode<Masked<TData>, TVariables>;
 
-// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
 //
 // @public
@@ -69,14 +78,10 @@ type UnionToIntersection<U> = (U extends any ? (x: U) => void : never) extends (
 // @public
 export type Unmasked<TData> = TData extends object ? UnwrapFragmentRefs<RemoveMaskedMarker<RemoveFragmentName<TData>>> : TData;
 
-// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ExtractFragmentRefs" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? TData extends {
-    " $fragmentRefs"?: infer FragmentRefs extends object;
-} ? Prettify<{
-    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
-} & CombineFragmentRefs<FragmentRefs>> : never : TData extends object ? {
+type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? null extends TData ? ExtractFragmentRefs<TData> | null : ExtractFragmentRefs<TData> : TData extends object ? {
     [K in keyof TData]: UnwrapFragmentRefs<TData[K]>;
 } : TData;
 

--- a/.api-reports/api-report-masking.api.md
+++ b/.api-reports/api-report-masking.api.md
@@ -19,16 +19,6 @@ type CombineFragmentRefs<FragmentRefs extends Record<string, any>> = UnionToInte
 export interface DataMasking {
 }
 
-// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
-//
-// @public (undocumented)
-type ExtractFragmentRefs<TData> = TData extends {
-    " $fragmentRefs"?: infer FragmentRefs extends object;
-} ? Prettify<{
-    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
-} & CombineFragmentRefs<FragmentRefs>> : never;
-
 // @public (undocumented)
 export type FragmentType<TData> = [
 TData
@@ -52,6 +42,7 @@ export type MaskedDocumentNode<TData = {
     [key: string]: any;
 }> = TypedDocumentNode<Masked<TData>, TVariables>;
 
+// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
 //
 // @public
@@ -78,12 +69,16 @@ type UnionToIntersection<U> = (U extends any ? (x: U) => void : never) extends (
 // @public
 export type Unmasked<TData> = TData extends object ? UnwrapFragmentRefs<RemoveMaskedMarker<RemoveFragmentName<TData>>> : TData;
 
-// Warning: (ae-forgotten-export) The symbol "ExtractFragmentRefs" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? null extends TData ? ExtractFragmentRefs<TData> | null : ExtractFragmentRefs<TData> : TData extends object ? {
+type UnwrapFragmentRefs<TData> = TData extends any ? string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? TData extends {
+    " $fragmentRefs"?: infer FragmentRefs extends object;
+} ? Prettify<{
+    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
+} & CombineFragmentRefs<FragmentRefs>> : never : TData extends object ? {
     [K in keyof TData]: UnwrapFragmentRefs<TData[K]>;
-} : TData;
+} : TData : never;
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -799,6 +799,16 @@ interface ExecutionPatchResultBase {
     hasNext?: boolean;
 }
 
+// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+type ExtractFragmentRefs<TData> = TData extends {
+    " $fragmentRefs"?: infer FragmentRefs extends object;
+} ? Prettify<{
+    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
+} & CombineFragmentRefs<FragmentRefs>> : never;
+
 // Warning: (ae-forgotten-export) The symbol "FetchMoreQueryOptions" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
@@ -1119,7 +1129,6 @@ interface MaskOperationOptions<TData> {
 // @public (undocumented)
 type MaybeAsync<T> = T | PromiseLike<T>;
 
-// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "DataMasking" needs to be exported by the entry point index.d.ts
 //
@@ -2134,14 +2143,10 @@ type UnionToIntersection_2<U> = (U extends any ? (k: U) => void : never) extends
 // @public
 type Unmasked<TData> = TData extends object ? UnwrapFragmentRefs<RemoveMaskedMarker<RemoveFragmentName<TData>>> : TData;
 
-// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ExtractFragmentRefs" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? TData extends {
-    " $fragmentRefs"?: infer FragmentRefs extends object;
-} ? Prettify<{
-    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
-} & CombineFragmentRefs<FragmentRefs>> : never : TData extends object ? {
+type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? null extends TData ? ExtractFragmentRefs<TData> | null : ExtractFragmentRefs<TData> : TData extends object ? {
     [K in keyof TData]: UnwrapFragmentRefs<TData[K]>;
 } : TData;
 

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -799,16 +799,6 @@ interface ExecutionPatchResultBase {
     hasNext?: boolean;
 }
 
-// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
-//
-// @public (undocumented)
-type ExtractFragmentRefs<TData> = TData extends {
-    " $fragmentRefs"?: infer FragmentRefs extends object;
-} ? Prettify<{
-    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
-} & CombineFragmentRefs<FragmentRefs>> : never;
-
 // Warning: (ae-forgotten-export) The symbol "FetchMoreQueryOptions" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
@@ -1129,6 +1119,7 @@ interface MaskOperationOptions<TData> {
 // @public (undocumented)
 type MaybeAsync<T> = T | PromiseLike<T>;
 
+// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "DataMasking" needs to be exported by the entry point index.d.ts
 //
@@ -2143,12 +2134,16 @@ type UnionToIntersection_2<U> = (U extends any ? (k: U) => void : never) extends
 // @public
 type Unmasked<TData> = TData extends object ? UnwrapFragmentRefs<RemoveMaskedMarker<RemoveFragmentName<TData>>> : TData;
 
-// Warning: (ae-forgotten-export) The symbol "ExtractFragmentRefs" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? null extends TData ? ExtractFragmentRefs<TData> | null : ExtractFragmentRefs<TData> : TData extends object ? {
+type UnwrapFragmentRefs<TData> = TData extends any ? string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? TData extends {
+    " $fragmentRefs"?: infer FragmentRefs extends object;
+} ? Prettify<{
+    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
+} & CombineFragmentRefs<FragmentRefs>> : never : TData extends object ? {
     [K in keyof TData]: UnwrapFragmentRefs<TData[K]>;
-} : TData;
+} : TData : never;
 
 // @public (undocumented)
 type UpdateQueries<TData> = MutationOptions<TData, any, any>["updateQueries"];

--- a/.api-reports/api-report-react_components.api.md
+++ b/.api-reports/api-report-react_components.api.md
@@ -731,6 +731,16 @@ interface ExecutionPatchResultBase {
     hasNext?: boolean;
 }
 
+// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+type ExtractFragmentRefs<TData> = TData extends {
+    " $fragmentRefs"?: infer FragmentRefs extends object;
+} ? Prettify<{
+    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
+} & CombineFragmentRefs<FragmentRefs>> : never;
+
 // @public (undocumented)
 interface FetchMoreQueryOptions<TVariables, TData = any> {
     // (undocumented)
@@ -982,7 +992,6 @@ interface MaskOperationOptions<TData> {
 // @public (undocumented)
 type MaybeAsync<T> = T | PromiseLike<T>;
 
-// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "DataMasking" needs to be exported by the entry point index.d.ts
 //
@@ -1867,14 +1876,10 @@ type UnionToIntersection_2<U> = (U extends any ? (k: U) => void : never) extends
 // @public
 type Unmasked<TData> = TData extends object ? UnwrapFragmentRefs<RemoveMaskedMarker<RemoveFragmentName<TData>>> : TData;
 
-// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ExtractFragmentRefs" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? TData extends {
-    " $fragmentRefs"?: infer FragmentRefs extends object;
-} ? Prettify<{
-    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
-} & CombineFragmentRefs<FragmentRefs>> : never : TData extends object ? {
+type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? null extends TData ? ExtractFragmentRefs<TData> | null : ExtractFragmentRefs<TData> : TData extends object ? {
     [K in keyof TData]: UnwrapFragmentRefs<TData[K]>;
 } : TData;
 

--- a/.api-reports/api-report-react_components.api.md
+++ b/.api-reports/api-report-react_components.api.md
@@ -731,16 +731,6 @@ interface ExecutionPatchResultBase {
     hasNext?: boolean;
 }
 
-// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
-//
-// @public (undocumented)
-type ExtractFragmentRefs<TData> = TData extends {
-    " $fragmentRefs"?: infer FragmentRefs extends object;
-} ? Prettify<{
-    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
-} & CombineFragmentRefs<FragmentRefs>> : never;
-
 // @public (undocumented)
 interface FetchMoreQueryOptions<TVariables, TData = any> {
     // (undocumented)
@@ -992,6 +982,7 @@ interface MaskOperationOptions<TData> {
 // @public (undocumented)
 type MaybeAsync<T> = T | PromiseLike<T>;
 
+// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "DataMasking" needs to be exported by the entry point index.d.ts
 //
@@ -1876,12 +1867,16 @@ type UnionToIntersection_2<U> = (U extends any ? (k: U) => void : never) extends
 // @public
 type Unmasked<TData> = TData extends object ? UnwrapFragmentRefs<RemoveMaskedMarker<RemoveFragmentName<TData>>> : TData;
 
-// Warning: (ae-forgotten-export) The symbol "ExtractFragmentRefs" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? null extends TData ? ExtractFragmentRefs<TData> | null : ExtractFragmentRefs<TData> : TData extends object ? {
+type UnwrapFragmentRefs<TData> = TData extends any ? string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? TData extends {
+    " $fragmentRefs"?: infer FragmentRefs extends object;
+} ? Prettify<{
+    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
+} & CombineFragmentRefs<FragmentRefs>> : never : TData extends object ? {
     [K in keyof TData]: UnwrapFragmentRefs<TData[K]>;
-} : TData;
+} : TData : never;
 
 // @public (undocumented)
 type UpdateQueries<TData> = MutationOptions<TData, any, any>["updateQueries"];

--- a/.api-reports/api-report-react_context.api.md
+++ b/.api-reports/api-report-react_context.api.md
@@ -725,6 +725,16 @@ interface ExecutionPatchResultBase {
     hasNext?: boolean;
 }
 
+// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+type ExtractFragmentRefs<TData> = TData extends {
+    " $fragmentRefs"?: infer FragmentRefs extends object;
+} ? Prettify<{
+    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
+} & CombineFragmentRefs<FragmentRefs>> : never;
+
 // @public (undocumented)
 interface FetchMoreQueryOptions<TVariables, TData = any> {
     // (undocumented)
@@ -979,7 +989,6 @@ interface MaskOperationOptions<TData> {
 // @public (undocumented)
 type MaybeAsync<T> = T | PromiseLike<T>;
 
-// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "DataMasking" needs to be exported by the entry point index.d.ts
 //
@@ -1787,14 +1796,10 @@ type UnionToIntersection_2<U> = (U extends any ? (k: U) => void : never) extends
 // @public
 type Unmasked<TData> = TData extends object ? UnwrapFragmentRefs<RemoveMaskedMarker<RemoveFragmentName<TData>>> : TData;
 
-// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ExtractFragmentRefs" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? TData extends {
-    " $fragmentRefs"?: infer FragmentRefs extends object;
-} ? Prettify<{
-    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
-} & CombineFragmentRefs<FragmentRefs>> : never : TData extends object ? {
+type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? null extends TData ? ExtractFragmentRefs<TData> | null : ExtractFragmentRefs<TData> : TData extends object ? {
     [K in keyof TData]: UnwrapFragmentRefs<TData[K]>;
 } : TData;
 

--- a/.api-reports/api-report-react_context.api.md
+++ b/.api-reports/api-report-react_context.api.md
@@ -725,16 +725,6 @@ interface ExecutionPatchResultBase {
     hasNext?: boolean;
 }
 
-// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
-//
-// @public (undocumented)
-type ExtractFragmentRefs<TData> = TData extends {
-    " $fragmentRefs"?: infer FragmentRefs extends object;
-} ? Prettify<{
-    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
-} & CombineFragmentRefs<FragmentRefs>> : never;
-
 // @public (undocumented)
 interface FetchMoreQueryOptions<TVariables, TData = any> {
     // (undocumented)
@@ -989,6 +979,7 @@ interface MaskOperationOptions<TData> {
 // @public (undocumented)
 type MaybeAsync<T> = T | PromiseLike<T>;
 
+// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "DataMasking" needs to be exported by the entry point index.d.ts
 //
@@ -1796,12 +1787,16 @@ type UnionToIntersection_2<U> = (U extends any ? (k: U) => void : never) extends
 // @public
 type Unmasked<TData> = TData extends object ? UnwrapFragmentRefs<RemoveMaskedMarker<RemoveFragmentName<TData>>> : TData;
 
-// Warning: (ae-forgotten-export) The symbol "ExtractFragmentRefs" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? null extends TData ? ExtractFragmentRefs<TData> | null : ExtractFragmentRefs<TData> : TData extends object ? {
+type UnwrapFragmentRefs<TData> = TData extends any ? string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? TData extends {
+    " $fragmentRefs"?: infer FragmentRefs extends object;
+} ? Prettify<{
+    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
+} & CombineFragmentRefs<FragmentRefs>> : never : TData extends object ? {
     [K in keyof TData]: UnwrapFragmentRefs<TData[K]>;
-} : TData;
+} : TData : never;
 
 // @public (undocumented)
 type UpdateQueries<TData> = MutationOptions<TData, any, any>["updateQueries"];

--- a/.api-reports/api-report-react_hoc.api.md
+++ b/.api-reports/api-report-react_hoc.api.md
@@ -723,16 +723,6 @@ interface ExecutionPatchResultBase {
     hasNext?: boolean;
 }
 
-// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
-//
-// @public (undocumented)
-type ExtractFragmentRefs<TData> = TData extends {
-    " $fragmentRefs"?: infer FragmentRefs extends object;
-} ? Prettify<{
-    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
-} & CombineFragmentRefs<FragmentRefs>> : never;
-
 // @public (undocumented)
 interface FetchMoreOptions<TData = any, TVariables = OperationVariables> {
     // (undocumented)
@@ -996,6 +986,7 @@ interface MaskOperationOptions<TData> {
 // @public (undocumented)
 type MaybeAsync<T> = T | PromiseLike<T>;
 
+// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "DataMasking" needs to be exported by the entry point index.d.ts
 //
@@ -1800,12 +1791,16 @@ type UnionToIntersection_2<U> = (U extends any ? (k: U) => void : never) extends
 // @public
 type Unmasked<TData> = TData extends object ? UnwrapFragmentRefs<RemoveMaskedMarker<RemoveFragmentName<TData>>> : TData;
 
-// Warning: (ae-forgotten-export) The symbol "ExtractFragmentRefs" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? null extends TData ? ExtractFragmentRefs<TData> | null : ExtractFragmentRefs<TData> : TData extends object ? {
+type UnwrapFragmentRefs<TData> = TData extends any ? string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? TData extends {
+    " $fragmentRefs"?: infer FragmentRefs extends object;
+} ? Prettify<{
+    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
+} & CombineFragmentRefs<FragmentRefs>> : never : TData extends object ? {
     [K in keyof TData]: UnwrapFragmentRefs<TData[K]>;
-} : TData;
+} : TData : never;
 
 // @public (undocumented)
 type UpdateQueries<TData> = MutationOptions<TData, any, any>["updateQueries"];

--- a/.api-reports/api-report-react_hoc.api.md
+++ b/.api-reports/api-report-react_hoc.api.md
@@ -723,6 +723,16 @@ interface ExecutionPatchResultBase {
     hasNext?: boolean;
 }
 
+// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+type ExtractFragmentRefs<TData> = TData extends {
+    " $fragmentRefs"?: infer FragmentRefs extends object;
+} ? Prettify<{
+    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
+} & CombineFragmentRefs<FragmentRefs>> : never;
+
 // @public (undocumented)
 interface FetchMoreOptions<TData = any, TVariables = OperationVariables> {
     // (undocumented)
@@ -986,7 +996,6 @@ interface MaskOperationOptions<TData> {
 // @public (undocumented)
 type MaybeAsync<T> = T | PromiseLike<T>;
 
-// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "DataMasking" needs to be exported by the entry point index.d.ts
 //
@@ -1791,14 +1800,10 @@ type UnionToIntersection_2<U> = (U extends any ? (k: U) => void : never) extends
 // @public
 type Unmasked<TData> = TData extends object ? UnwrapFragmentRefs<RemoveMaskedMarker<RemoveFragmentName<TData>>> : TData;
 
-// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ExtractFragmentRefs" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? TData extends {
-    " $fragmentRefs"?: infer FragmentRefs extends object;
-} ? Prettify<{
-    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
-} & CombineFragmentRefs<FragmentRefs>> : never : TData extends object ? {
+type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? null extends TData ? ExtractFragmentRefs<TData> | null : ExtractFragmentRefs<TData> : TData extends object ? {
     [K in keyof TData]: UnwrapFragmentRefs<TData[K]>;
 } : TData;
 

--- a/.api-reports/api-report-react_hooks.api.md
+++ b/.api-reports/api-report-react_hooks.api.md
@@ -754,6 +754,16 @@ interface ExecutionPatchResultBase {
     hasNext?: boolean;
 }
 
+// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+type ExtractFragmentRefs<TData> = TData extends {
+    " $fragmentRefs"?: infer FragmentRefs extends object;
+} ? Prettify<{
+    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
+} & CombineFragmentRefs<FragmentRefs>> : never;
+
 // Warning: (ae-forgotten-export) The symbol "FetchMoreQueryOptions" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
@@ -1068,7 +1078,6 @@ interface MaskOperationOptions<TData> {
 // @public (undocumented)
 type MaybeAsync<T> = T | PromiseLike<T>;
 
-// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "DataMasking" needs to be exported by the entry point index.d.ts
 //
@@ -1957,14 +1966,10 @@ type UnionToIntersection_2<U> = (U extends any ? (k: U) => void : never) extends
 // @public
 type Unmasked<TData> = TData extends object ? UnwrapFragmentRefs<RemoveMaskedMarker<RemoveFragmentName<TData>>> : TData;
 
-// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ExtractFragmentRefs" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? TData extends {
-    " $fragmentRefs"?: infer FragmentRefs extends object;
-} ? Prettify<{
-    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
-} & CombineFragmentRefs<FragmentRefs>> : never : TData extends object ? {
+type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? null extends TData ? ExtractFragmentRefs<TData> | null : ExtractFragmentRefs<TData> : TData extends object ? {
     [K in keyof TData]: UnwrapFragmentRefs<TData[K]>;
 } : TData;
 

--- a/.api-reports/api-report-react_hooks.api.md
+++ b/.api-reports/api-report-react_hooks.api.md
@@ -754,16 +754,6 @@ interface ExecutionPatchResultBase {
     hasNext?: boolean;
 }
 
-// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
-//
-// @public (undocumented)
-type ExtractFragmentRefs<TData> = TData extends {
-    " $fragmentRefs"?: infer FragmentRefs extends object;
-} ? Prettify<{
-    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
-} & CombineFragmentRefs<FragmentRefs>> : never;
-
 // Warning: (ae-forgotten-export) The symbol "FetchMoreQueryOptions" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
@@ -1078,6 +1068,7 @@ interface MaskOperationOptions<TData> {
 // @public (undocumented)
 type MaybeAsync<T> = T | PromiseLike<T>;
 
+// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "DataMasking" needs to be exported by the entry point index.d.ts
 //
@@ -1966,12 +1957,16 @@ type UnionToIntersection_2<U> = (U extends any ? (k: U) => void : never) extends
 // @public
 type Unmasked<TData> = TData extends object ? UnwrapFragmentRefs<RemoveMaskedMarker<RemoveFragmentName<TData>>> : TData;
 
-// Warning: (ae-forgotten-export) The symbol "ExtractFragmentRefs" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? null extends TData ? ExtractFragmentRefs<TData> | null : ExtractFragmentRefs<TData> : TData extends object ? {
+type UnwrapFragmentRefs<TData> = TData extends any ? string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? TData extends {
+    " $fragmentRefs"?: infer FragmentRefs extends object;
+} ? Prettify<{
+    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
+} & CombineFragmentRefs<FragmentRefs>> : never : TData extends object ? {
     [K in keyof TData]: UnwrapFragmentRefs<TData[K]>;
-} : TData;
+} : TData : never;
 
 // @public (undocumented)
 type UpdateQueries<TData> = MutationOptions<TData, any, any>["updateQueries"];

--- a/.api-reports/api-report-react_internal.api.md
+++ b/.api-reports/api-report-react_internal.api.md
@@ -738,16 +738,6 @@ interface ExecutionPatchResultBase {
     hasNext?: boolean;
 }
 
-// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
-//
-// @public (undocumented)
-type ExtractFragmentRefs<TData> = TData extends {
-    " $fragmentRefs"?: infer FragmentRefs extends object;
-} ? Prettify<{
-    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
-} & CombineFragmentRefs<FragmentRefs>> : never;
-
 // Warning: (ae-forgotten-export) The symbol "FetchMoreQueryOptions" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
@@ -1088,6 +1078,7 @@ interface MaskOperationOptions<TData> {
 // @public (undocumented)
 type MaybeAsync<T> = T | PromiseLike<T>;
 
+// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "DataMasking" needs to be exported by the entry point index.d.ts
 //
@@ -2018,12 +2009,16 @@ type UnionToIntersection_2<U> = (U extends any ? (k: U) => void : never) extends
 // @public
 type Unmasked<TData> = TData extends object ? UnwrapFragmentRefs<RemoveMaskedMarker<RemoveFragmentName<TData>>> : TData;
 
-// Warning: (ae-forgotten-export) The symbol "ExtractFragmentRefs" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? null extends TData ? ExtractFragmentRefs<TData> | null : ExtractFragmentRefs<TData> : TData extends object ? {
+type UnwrapFragmentRefs<TData> = TData extends any ? string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? TData extends {
+    " $fragmentRefs"?: infer FragmentRefs extends object;
+} ? Prettify<{
+    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
+} & CombineFragmentRefs<FragmentRefs>> : never : TData extends object ? {
     [K in keyof TData]: UnwrapFragmentRefs<TData[K]>;
-} : TData;
+} : TData : never;
 
 // @public (undocumented)
 export function unwrapQueryRef<TData>(queryRef: WrappedQueryRef<TData>): InternalQueryReference<TData>;

--- a/.api-reports/api-report-react_internal.api.md
+++ b/.api-reports/api-report-react_internal.api.md
@@ -738,6 +738,16 @@ interface ExecutionPatchResultBase {
     hasNext?: boolean;
 }
 
+// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+type ExtractFragmentRefs<TData> = TData extends {
+    " $fragmentRefs"?: infer FragmentRefs extends object;
+} ? Prettify<{
+    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
+} & CombineFragmentRefs<FragmentRefs>> : never;
+
 // Warning: (ae-forgotten-export) The symbol "FetchMoreQueryOptions" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
@@ -1078,7 +1088,6 @@ interface MaskOperationOptions<TData> {
 // @public (undocumented)
 type MaybeAsync<T> = T | PromiseLike<T>;
 
-// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "DataMasking" needs to be exported by the entry point index.d.ts
 //
@@ -2009,14 +2018,10 @@ type UnionToIntersection_2<U> = (U extends any ? (k: U) => void : never) extends
 // @public
 type Unmasked<TData> = TData extends object ? UnwrapFragmentRefs<RemoveMaskedMarker<RemoveFragmentName<TData>>> : TData;
 
-// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ExtractFragmentRefs" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? TData extends {
-    " $fragmentRefs"?: infer FragmentRefs extends object;
-} ? Prettify<{
-    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
-} & CombineFragmentRefs<FragmentRefs>> : never : TData extends object ? {
+type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? null extends TData ? ExtractFragmentRefs<TData> | null : ExtractFragmentRefs<TData> : TData extends object ? {
     [K in keyof TData]: UnwrapFragmentRefs<TData[K]>;
 } : TData;
 

--- a/.api-reports/api-report-react_ssr.api.md
+++ b/.api-reports/api-report-react_ssr.api.md
@@ -694,16 +694,6 @@ interface ExecutionPatchResultBase {
     hasNext?: boolean;
 }
 
-// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
-//
-// @public (undocumented)
-type ExtractFragmentRefs<TData> = TData extends {
-    " $fragmentRefs"?: infer FragmentRefs extends object;
-} ? Prettify<{
-    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
-} & CombineFragmentRefs<FragmentRefs>> : never;
-
 // @public (undocumented)
 interface FetchMoreQueryOptions<TVariables, TData = any> {
     // (undocumented)
@@ -974,6 +964,7 @@ interface MaskOperationOptions<TData> {
 // @public (undocumented)
 type MaybeAsync<T> = T | PromiseLike<T>;
 
+// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "DataMasking" needs to be exported by the entry point index.d.ts
 //
@@ -1781,12 +1772,16 @@ type UnionToIntersection_2<U> = (U extends any ? (k: U) => void : never) extends
 // @public
 type Unmasked<TData> = TData extends object ? UnwrapFragmentRefs<RemoveMaskedMarker<RemoveFragmentName<TData>>> : TData;
 
-// Warning: (ae-forgotten-export) The symbol "ExtractFragmentRefs" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? null extends TData ? ExtractFragmentRefs<TData> | null : ExtractFragmentRefs<TData> : TData extends object ? {
+type UnwrapFragmentRefs<TData> = TData extends any ? string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? TData extends {
+    " $fragmentRefs"?: infer FragmentRefs extends object;
+} ? Prettify<{
+    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
+} & CombineFragmentRefs<FragmentRefs>> : never : TData extends object ? {
     [K in keyof TData]: UnwrapFragmentRefs<TData[K]>;
-} : TData;
+} : TData : never;
 
 // @public (undocumented)
 type UpdateQueries<TData> = MutationOptions<TData, any, any>["updateQueries"];

--- a/.api-reports/api-report-react_ssr.api.md
+++ b/.api-reports/api-report-react_ssr.api.md
@@ -694,6 +694,16 @@ interface ExecutionPatchResultBase {
     hasNext?: boolean;
 }
 
+// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+type ExtractFragmentRefs<TData> = TData extends {
+    " $fragmentRefs"?: infer FragmentRefs extends object;
+} ? Prettify<{
+    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
+} & CombineFragmentRefs<FragmentRefs>> : never;
+
 // @public (undocumented)
 interface FetchMoreQueryOptions<TVariables, TData = any> {
     // (undocumented)
@@ -964,7 +974,6 @@ interface MaskOperationOptions<TData> {
 // @public (undocumented)
 type MaybeAsync<T> = T | PromiseLike<T>;
 
-// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "DataMasking" needs to be exported by the entry point index.d.ts
 //
@@ -1772,14 +1781,10 @@ type UnionToIntersection_2<U> = (U extends any ? (k: U) => void : never) extends
 // @public
 type Unmasked<TData> = TData extends object ? UnwrapFragmentRefs<RemoveMaskedMarker<RemoveFragmentName<TData>>> : TData;
 
-// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ExtractFragmentRefs" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? TData extends {
-    " $fragmentRefs"?: infer FragmentRefs extends object;
-} ? Prettify<{
-    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
-} & CombineFragmentRefs<FragmentRefs>> : never : TData extends object ? {
+type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? null extends TData ? ExtractFragmentRefs<TData> | null : ExtractFragmentRefs<TData> : TData extends object ? {
     [K in keyof TData]: UnwrapFragmentRefs<TData[K]>;
 } : TData;
 

--- a/.api-reports/api-report-testing.api.md
+++ b/.api-reports/api-report-testing.api.md
@@ -695,16 +695,6 @@ interface ExecutionPatchResultBase {
     hasNext?: boolean;
 }
 
-// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
-//
-// @public (undocumented)
-type ExtractFragmentRefs<TData> = TData extends {
-    " $fragmentRefs"?: infer FragmentRefs extends object;
-} ? Prettify<{
-    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
-} & CombineFragmentRefs<FragmentRefs>> : never;
-
 // @public (undocumented)
 interface FetchMoreQueryOptions<TVariables, TData = any> {
     // (undocumented)
@@ -963,6 +953,7 @@ interface MaskOperationOptions<TData> {
 // @public (undocumented)
 type MaybeAsync<T> = T | PromiseLike<T>;
 
+// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "DataMasking" needs to be exported by the entry point index.d.ts
 //
@@ -1832,12 +1823,16 @@ type UnionToIntersection_2<U> = (U extends any ? (k: U) => void : never) extends
 // @public
 type Unmasked<TData> = TData extends object ? UnwrapFragmentRefs<RemoveMaskedMarker<RemoveFragmentName<TData>>> : TData;
 
-// Warning: (ae-forgotten-export) The symbol "ExtractFragmentRefs" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? null extends TData ? ExtractFragmentRefs<TData> | null : ExtractFragmentRefs<TData> : TData extends object ? {
+type UnwrapFragmentRefs<TData> = TData extends any ? string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? TData extends {
+    " $fragmentRefs"?: infer FragmentRefs extends object;
+} ? Prettify<{
+    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
+} & CombineFragmentRefs<FragmentRefs>> : never : TData extends object ? {
     [K in keyof TData]: UnwrapFragmentRefs<TData[K]>;
-} : TData;
+} : TData : never;
 
 // @public (undocumented)
 type UpdateQueries<TData> = MutationOptions<TData, any, any>["updateQueries"];

--- a/.api-reports/api-report-testing.api.md
+++ b/.api-reports/api-report-testing.api.md
@@ -695,6 +695,16 @@ interface ExecutionPatchResultBase {
     hasNext?: boolean;
 }
 
+// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+type ExtractFragmentRefs<TData> = TData extends {
+    " $fragmentRefs"?: infer FragmentRefs extends object;
+} ? Prettify<{
+    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
+} & CombineFragmentRefs<FragmentRefs>> : never;
+
 // @public (undocumented)
 interface FetchMoreQueryOptions<TVariables, TData = any> {
     // (undocumented)
@@ -953,7 +963,6 @@ interface MaskOperationOptions<TData> {
 // @public (undocumented)
 type MaybeAsync<T> = T | PromiseLike<T>;
 
-// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "DataMasking" needs to be exported by the entry point index.d.ts
 //
@@ -1823,14 +1832,10 @@ type UnionToIntersection_2<U> = (U extends any ? (k: U) => void : never) extends
 // @public
 type Unmasked<TData> = TData extends object ? UnwrapFragmentRefs<RemoveMaskedMarker<RemoveFragmentName<TData>>> : TData;
 
-// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ExtractFragmentRefs" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? TData extends {
-    " $fragmentRefs"?: infer FragmentRefs extends object;
-} ? Prettify<{
-    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
-} & CombineFragmentRefs<FragmentRefs>> : never : TData extends object ? {
+type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? null extends TData ? ExtractFragmentRefs<TData> | null : ExtractFragmentRefs<TData> : TData extends object ? {
     [K in keyof TData]: UnwrapFragmentRefs<TData[K]>;
 } : TData;
 

--- a/.api-reports/api-report-testing_core.api.md
+++ b/.api-reports/api-report-testing_core.api.md
@@ -694,16 +694,6 @@ interface ExecutionPatchResultBase {
     hasNext?: boolean;
 }
 
-// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
-//
-// @public (undocumented)
-type ExtractFragmentRefs<TData> = TData extends {
-    " $fragmentRefs"?: infer FragmentRefs extends object;
-} ? Prettify<{
-    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
-} & CombineFragmentRefs<FragmentRefs>> : never;
-
 // @public (undocumented)
 interface FetchMoreQueryOptions<TVariables, TData = any> {
     // (undocumented)
@@ -962,6 +952,7 @@ interface MaskOperationOptions<TData> {
 // @public (undocumented)
 type MaybeAsync<T> = T | PromiseLike<T>;
 
+// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "DataMasking" needs to be exported by the entry point index.d.ts
 //
@@ -1789,12 +1780,16 @@ type UnionToIntersection_2<U> = (U extends any ? (k: U) => void : never) extends
 // @public
 type Unmasked<TData> = TData extends object ? UnwrapFragmentRefs<RemoveMaskedMarker<RemoveFragmentName<TData>>> : TData;
 
-// Warning: (ae-forgotten-export) The symbol "ExtractFragmentRefs" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? null extends TData ? ExtractFragmentRefs<TData> | null : ExtractFragmentRefs<TData> : TData extends object ? {
+type UnwrapFragmentRefs<TData> = TData extends any ? string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? TData extends {
+    " $fragmentRefs"?: infer FragmentRefs extends object;
+} ? Prettify<{
+    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
+} & CombineFragmentRefs<FragmentRefs>> : never : TData extends object ? {
     [K in keyof TData]: UnwrapFragmentRefs<TData[K]>;
-} : TData;
+} : TData : never;
 
 // @public (undocumented)
 type UpdateQueries<TData> = MutationOptions<TData, any, any>["updateQueries"];

--- a/.api-reports/api-report-testing_core.api.md
+++ b/.api-reports/api-report-testing_core.api.md
@@ -694,6 +694,16 @@ interface ExecutionPatchResultBase {
     hasNext?: boolean;
 }
 
+// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+type ExtractFragmentRefs<TData> = TData extends {
+    " $fragmentRefs"?: infer FragmentRefs extends object;
+} ? Prettify<{
+    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
+} & CombineFragmentRefs<FragmentRefs>> : never;
+
 // @public (undocumented)
 interface FetchMoreQueryOptions<TVariables, TData = any> {
     // (undocumented)
@@ -952,7 +962,6 @@ interface MaskOperationOptions<TData> {
 // @public (undocumented)
 type MaybeAsync<T> = T | PromiseLike<T>;
 
-// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "DataMasking" needs to be exported by the entry point index.d.ts
 //
@@ -1780,14 +1789,10 @@ type UnionToIntersection_2<U> = (U extends any ? (k: U) => void : never) extends
 // @public
 type Unmasked<TData> = TData extends object ? UnwrapFragmentRefs<RemoveMaskedMarker<RemoveFragmentName<TData>>> : TData;
 
-// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ExtractFragmentRefs" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? TData extends {
-    " $fragmentRefs"?: infer FragmentRefs extends object;
-} ? Prettify<{
-    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
-} & CombineFragmentRefs<FragmentRefs>> : never : TData extends object ? {
+type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? null extends TData ? ExtractFragmentRefs<TData> | null : ExtractFragmentRefs<TData> : TData extends object ? {
     [K in keyof TData]: UnwrapFragmentRefs<TData[K]>;
 } : TData;
 

--- a/.api-reports/api-report-utilities.api.md
+++ b/.api-reports/api-report-utilities.api.md
@@ -1002,6 +1002,15 @@ interface ExecutionPatchResultBase {
     hasNext?: boolean;
 }
 
+// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+type ExtractFragmentRefs<TData> = TData extends {
+    " $fragmentRefs"?: infer FragmentRefs extends object;
+} ? Prettify<{
+    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
+} & CombineFragmentRefs<FragmentRefs>> : never;
+
 // @public (undocumented)
 interface FetchMoreQueryOptions<TVariables, TData = any> {
     // (undocumented)
@@ -2698,14 +2707,10 @@ type UnionToIntersection_2<U> = (U extends any ? (k: U) => void : never) extends
 // @public
 type Unmasked<TData> = TData extends object ? UnwrapFragmentRefs<RemoveMaskedMarker<RemoveFragmentName<TData>>> : TData;
 
-// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ExtractFragmentRefs" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? TData extends {
-    " $fragmentRefs"?: infer FragmentRefs extends object;
-} ? Prettify<{
-    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
-} & CombineFragmentRefs<FragmentRefs>> : never : TData extends object ? {
+type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? null extends TData ? ExtractFragmentRefs<TData> | null : ExtractFragmentRefs<TData> : TData extends object ? {
     [K in keyof TData]: UnwrapFragmentRefs<TData[K]>;
 } : TData;
 

--- a/.api-reports/api-report-utilities.api.md
+++ b/.api-reports/api-report-utilities.api.md
@@ -1002,15 +1002,6 @@ interface ExecutionPatchResultBase {
     hasNext?: boolean;
 }
 
-// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
-//
-// @public (undocumented)
-type ExtractFragmentRefs<TData> = TData extends {
-    " $fragmentRefs"?: infer FragmentRefs extends object;
-} ? Prettify<{
-    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
-} & CombineFragmentRefs<FragmentRefs>> : never;
-
 // @public (undocumented)
 interface FetchMoreQueryOptions<TVariables, TData = any> {
     // (undocumented)
@@ -2707,12 +2698,16 @@ type UnionToIntersection_2<U> = (U extends any ? (k: U) => void : never) extends
 // @public
 type Unmasked<TData> = TData extends object ? UnwrapFragmentRefs<RemoveMaskedMarker<RemoveFragmentName<TData>>> : TData;
 
-// Warning: (ae-forgotten-export) The symbol "ExtractFragmentRefs" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? null extends TData ? ExtractFragmentRefs<TData> | null : ExtractFragmentRefs<TData> : TData extends object ? {
+type UnwrapFragmentRefs<TData> = TData extends any ? string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? TData extends {
+    " $fragmentRefs"?: infer FragmentRefs extends object;
+} ? Prettify<{
+    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
+} & CombineFragmentRefs<FragmentRefs>> : never : TData extends object ? {
     [K in keyof TData]: UnwrapFragmentRefs<TData[K]>;
-} : TData;
+} : TData : never;
 
 // @public (undocumented)
 type UpdateQueries<TData> = MutationOptions<TData, any, any>["updateQueries"];

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -921,16 +921,6 @@ interface ExecutionPatchResultBase {
     hasNext?: boolean;
 }
 
-// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
-//
-// @public (undocumented)
-type ExtractFragmentRefs<TData> = TData extends {
-    " $fragmentRefs"?: infer FragmentRefs extends object;
-} ? Prettify<{
-    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
-} & CombineFragmentRefs<FragmentRefs>> : never;
-
 // @public (undocumented)
 export const fallbackHttpConfig: {
     http: HttpQueryOptions;
@@ -1565,6 +1555,7 @@ interface MaskOperationOptions<TData> {
 // @public (undocumented)
 type MaybeAsync<T> = T | PromiseLike<T>;
 
+// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
 //
 // @public
@@ -2812,12 +2803,16 @@ type UnionToIntersection_2<U> = (U extends any ? (k: U) => void : never) extends
 // @public
 export type Unmasked<TData> = TData extends object ? UnwrapFragmentRefs<RemoveMaskedMarker<RemoveFragmentName<TData>>> : TData;
 
-// Warning: (ae-forgotten-export) The symbol "ExtractFragmentRefs" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? null extends TData ? ExtractFragmentRefs<TData> | null : ExtractFragmentRefs<TData> : TData extends object ? {
+type UnwrapFragmentRefs<TData> = TData extends any ? string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? TData extends {
+    " $fragmentRefs"?: infer FragmentRefs extends object;
+} ? Prettify<{
+    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
+} & CombineFragmentRefs<FragmentRefs>> : never : TData extends object ? {
     [K in keyof TData]: UnwrapFragmentRefs<TData[K]>;
-} : TData;
+} : TData : never;
 
 // @public (undocumented)
 type UpdateQueries<TData> = MutationOptions<TData, any, any>["updateQueries"];

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -921,6 +921,16 @@ interface ExecutionPatchResultBase {
     hasNext?: boolean;
 }
 
+// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+type ExtractFragmentRefs<TData> = TData extends {
+    " $fragmentRefs"?: infer FragmentRefs extends object;
+} ? Prettify<{
+    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
+} & CombineFragmentRefs<FragmentRefs>> : never;
+
 // @public (undocumented)
 export const fallbackHttpConfig: {
     http: HttpQueryOptions;
@@ -1555,7 +1565,6 @@ interface MaskOperationOptions<TData> {
 // @public (undocumented)
 type MaybeAsync<T> = T | PromiseLike<T>;
 
-// Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
 //
 // @public
@@ -2803,14 +2812,10 @@ type UnionToIntersection_2<U> = (U extends any ? (k: U) => void : never) extends
 // @public
 export type Unmasked<TData> = TData extends object ? UnwrapFragmentRefs<RemoveMaskedMarker<RemoveFragmentName<TData>>> : TData;
 
-// Warning: (ae-forgotten-export) The symbol "CombineFragmentRefs" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ExtractFragmentRefs" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? TData extends {
-    " $fragmentRefs"?: infer FragmentRefs extends object;
-} ? Prettify<{
-    [K in keyof TData as K extends " $fragmentRefs" ? never : K]: UnwrapFragmentRefs<TData[K]>;
-} & CombineFragmentRefs<FragmentRefs>> : never : TData extends object ? {
+type UnwrapFragmentRefs<TData> = string extends keyof NonNullable<TData> ? TData : " $fragmentRefs" extends keyof NonNullable<TData> ? null extends TData ? ExtractFragmentRefs<TData> | null : ExtractFragmentRefs<TData> : TData extends object ? {
     [K in keyof TData]: UnwrapFragmentRefs<TData[K]>;
 } : TData;
 

--- a/.changeset/small-bears-confess.md
+++ b/.changeset/small-bears-confess.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Ensure `null` is retained in nullable types when unmasking a type with the `Unmask` helper type.

--- a/.changeset/small-bears-confess.md
+++ b/.changeset/small-bears-confess.md
@@ -2,4 +2,4 @@
 "@apollo/client": patch
 ---
 
-Ensure `null` is retained in nullable types when unmasking a type with the `Unmask` helper type.
+Ensure `null` is retained in nullable types when unmasking a type with the `Unmasked` helper type.

--- a/src/masking/__tests__/types.test.ts
+++ b/src/masking/__tests__/types.test.ts
@@ -108,6 +108,14 @@ describe.skip("Unmasked", () => {
             title: string;
           } & { " $fragmentRefs"?: { JobFieldsFragment: JobFieldsFragment } })
         | null;
+      jobs: Array<
+        | ({
+            __typename: "Job";
+            id: string;
+            title: string;
+          } & { " $fragmentRefs"?: { JobFieldsFragment: JobFieldsFragment } })
+        | null
+      >;
     } & { " $fragmentName"?: "UserFieldsFragment" } & {
       " $fragmentRefs"?: {
         NameFieldsFragment: NameFieldsFragment;
@@ -145,6 +153,13 @@ describe.skip("Unmasked", () => {
         job: string;
         position: string;
       } | null;
+      jobs: Array<{
+        __typename: "Job";
+        id: string;
+        title: string;
+        job: string;
+        position: string;
+      } | null>;
     }>();
   });
 

--- a/src/masking/__tests__/types.test.ts
+++ b/src/masking/__tests__/types.test.ts
@@ -96,6 +96,58 @@ describe.skip("Unmasked", () => {
     }>();
   });
 
+  test("unmasks deeply nested nullable fragments", () => {
+    type UserFieldsFragment = {
+      __typename: "User";
+      id: number;
+      age: number;
+      career:
+        | ({
+            __typename: "Job";
+            id: string;
+            title: string;
+          } & { " $fragmentRefs"?: { JobFieldsFragment: JobFieldsFragment } })
+        | null;
+    } & { " $fragmentName"?: "UserFieldsFragment" } & {
+      " $fragmentRefs"?: {
+        NameFieldsFragment: NameFieldsFragment;
+      };
+    };
+
+    type NameFieldsFragment = {
+      __typename: "User";
+      firstName: string;
+      lastName: string;
+    } & { " $fragmentName"?: "NameFieldsFragment" };
+
+    type JobFieldsFragment = {
+      __typename: "Job";
+      job: string;
+    } & { " $fragmentName"?: "JobFieldsFragment" } & {
+      " $fragmentRefs"?: { CareerFieldsFragment: CareerFieldsFragment };
+    };
+
+    type CareerFieldsFragment = {
+      __typename: "Job";
+      position: string;
+    } & { " $fragmentName"?: "CareerFieldsFragment" };
+
+    expectTypeOf<Unmasked<UserFieldsFragment>>().toEqualTypeOf<{
+      __typename: "User";
+      id: number;
+      age: number;
+      firstName: string;
+      lastName: string;
+      career: {
+        __typename: "Job";
+        id: string;
+        title: string;
+        job: string;
+        position: string;
+      } | null;
+    }>();
+  });
+
   test("unmasks DeepPartial types", () => {
     type UserFieldsFragment = {
       __typename: "User";

--- a/src/masking/internal/types.ts
+++ b/src/masking/internal/types.ts
@@ -1,23 +1,21 @@
 import type { Prettify, UnionToIntersection } from "../../utilities/index.js";
 
 export type UnwrapFragmentRefs<TData> =
-  // Leave TData alone if it is Record<string, any> and not a specific shape
-  string extends keyof NonNullable<TData> ? TData
-  : " $fragmentRefs" extends keyof NonNullable<TData> ?
-    null extends TData ?
-      ExtractFragmentRefs<TData> | null
-    : ExtractFragmentRefs<TData>
-  : TData extends object ? { [K in keyof TData]: UnwrapFragmentRefs<TData[K]> }
-  : TData;
-
-type ExtractFragmentRefs<TData> =
-  TData extends { " $fragmentRefs"?: infer FragmentRefs extends object } ?
-    Prettify<
-      {
-        [K in keyof TData as K extends " $fragmentRefs" ? never
-        : K]: UnwrapFragmentRefs<TData[K]>;
-      } & CombineFragmentRefs<FragmentRefs>
-    >
+  TData extends any ?
+    // Leave TData alone if it is Record<string, any> and not a specific shape
+    string extends keyof NonNullable<TData> ? TData
+    : " $fragmentRefs" extends keyof NonNullable<TData> ?
+      TData extends { " $fragmentRefs"?: infer FragmentRefs extends object } ?
+        Prettify<
+          {
+            [K in keyof TData as K extends " $fragmentRefs" ? never
+            : K]: UnwrapFragmentRefs<TData[K]>;
+          } & CombineFragmentRefs<FragmentRefs>
+        >
+      : never
+    : TData extends object ?
+      { [K in keyof TData]: UnwrapFragmentRefs<TData[K]> }
+    : TData
   : never;
 
 type CombineFragmentRefs<FragmentRefs extends Record<string, any>> =

--- a/src/masking/internal/types.ts
+++ b/src/masking/internal/types.ts
@@ -4,16 +4,21 @@ export type UnwrapFragmentRefs<TData> =
   // Leave TData alone if it is Record<string, any> and not a specific shape
   string extends keyof NonNullable<TData> ? TData
   : " $fragmentRefs" extends keyof NonNullable<TData> ?
-    TData extends { " $fragmentRefs"?: infer FragmentRefs extends object } ?
-      Prettify<
-        {
-          [K in keyof TData as K extends " $fragmentRefs" ? never
-          : K]: UnwrapFragmentRefs<TData[K]>;
-        } & CombineFragmentRefs<FragmentRefs>
-      >
-    : never
+    null extends TData ?
+      ExtractFragmentRefs<TData> | null
+    : ExtractFragmentRefs<TData>
   : TData extends object ? { [K in keyof TData]: UnwrapFragmentRefs<TData[K]> }
   : TData;
+
+type ExtractFragmentRefs<TData> =
+  TData extends { " $fragmentRefs"?: infer FragmentRefs extends object } ?
+    Prettify<
+      {
+        [K in keyof TData as K extends " $fragmentRefs" ? never
+        : K]: UnwrapFragmentRefs<TData[K]>;
+      } & CombineFragmentRefs<FragmentRefs>
+    >
+  : never;
 
 type CombineFragmentRefs<FragmentRefs extends Record<string, any>> =
   UnionToIntersection<


### PR DESCRIPTION
The `Unmasked` helper has a bug where unmasking a nullable object would return the object as a non-null type. This PR ensures the `null` is retained in the type.