### PR TITLE
[Data masking] Fix issue with `@unmask(mode: "migrate")` with nested partial objects from parent query

### DIFF
--- a/.changeset/gorgeous-zebras-confess.md
+++ b/.changeset/gorgeous-zebras-confess.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix issue where data went missing when an unmasked fragment in migrate mode selected fields that the parent did not.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 41601,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 34359
+  "dist/apollo-client.min.cjs": 41638,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 34394
 }

--- a/src/core/__tests__/masking.test.ts
+++ b/src/core/__tests__/masking.test.ts
@@ -1751,8 +1751,7 @@ describe("maskOperation", () => {
       }
 
       fragment PlaylistTitleCell on Playlist {
-        id
-        album {
+        artist {
           id
           images {
             url
@@ -1806,10 +1805,14 @@ describe("maskOperation", () => {
     data.playlist.album;
     data.playlist.album.id;
     data.playlist.album.__typename;
+    data.playlist.artist;
+    data.playlist.artist.id;
+    data.playlist.artist.__typename;
     expect(console.warn).not.toHaveBeenCalled();
 
     data.playlist.album.images;
-    expect(console.warn).toHaveBeenCalledTimes(1);
+    data.playlist.artist.images;
+    expect(console.warn).toHaveBeenCalledTimes(2);
   });
 
   test("masks fragments in subscription documents", () => {

--- a/src/core/__tests__/masking.test.ts
+++ b/src/core/__tests__/masking.test.ts
@@ -1717,6 +1717,101 @@ describe("maskOperation", () => {
     });
   });
 
+  test('handles overlapping types when subtype has accessor warnings with @unmask(mode: "migrate")', async () => {
+    using _ = spyOnConsole("warn");
+    const query = gql`
+      query PlaylistQuery {
+        playlist {
+          ...PlaylistFragment @unmask(mode: "migrate")
+          id
+          name
+          album {
+            id
+            __typename
+          }
+          artist {
+            id
+            __typename
+          }
+          __typename
+
+          ...PlaylistTitleCell @unmask(mode: "migrate")
+        }
+      }
+
+      fragment PlaylistFragment on Playlist {
+        album {
+          id
+          images {
+            url
+            __typename
+          }
+          __typename
+        }
+      }
+
+      fragment PlaylistTitleCell on Playlist {
+        id
+        album {
+          id
+          images {
+            url
+            __typename
+          }
+          __typename
+        }
+      }
+    `;
+
+    const data = maskOperation(
+      {
+        playlist: {
+          id: "1",
+          name: "Playlist",
+          album: {
+            id: "2RSIoPew2TOy41ASHpzOx3",
+            __typename: "Album",
+            images: [{ url: "https://i.scdn.co/image/1", __typename: "Image" }],
+          },
+          artist: {
+            id: "2",
+            __typename: "Artist",
+            images: [{ url: "https://i.scdn.co/image/1", __typename: "Image" }],
+          },
+        },
+      },
+      query,
+      new InMemoryCache()
+    );
+
+    expect(console.warn).not.toHaveBeenCalled();
+
+    expect(data).toEqual({
+      playlist: {
+        id: "1",
+        name: "Playlist",
+        album: {
+          id: "2RSIoPew2TOy41ASHpzOx3",
+          __typename: "Album",
+          images: [{ url: "https://i.scdn.co/image/1", __typename: "Image" }],
+        },
+        artist: {
+          id: "2",
+          __typename: "Artist",
+          images: [{ url: "https://i.scdn.co/image/1", __typename: "Image" }],
+        },
+      },
+    });
+
+    data.playlist.album;
+    data.playlist.album.id;
+    data.playlist.album.__typename;
+    expect(console.warn).not.toHaveBeenCalled();
+
+    data.playlist.album.images;
+    expect(console.warn).toHaveBeenCalledTimes(1);
+  });
+
   test("masks fragments in subscription documents", () => {
     const subscription = gql`
       subscription {

--- a/src/core/masking.ts
+++ b/src/core/masking.ts
@@ -314,7 +314,8 @@ function addFieldAccessorWarnings(
 
         if (childSelectionSet) {
           value = addFieldAccessorWarnings(
-            memo[keyName] || Object.create(null),
+            memo[keyName] ||
+              (Array.isArray(data[keyName]) ? [] : Object.create(null)),
             data[keyName] as Record<string, unknown>,
             childSelectionSet,
             `${path}.${keyName}`,

--- a/src/core/masking.ts
+++ b/src/core/masking.ts
@@ -1,5 +1,9 @@
 import { Kind } from "graphql";
-import type { FragmentDefinitionNode, SelectionSetNode } from "graphql";
+import type {
+  FragmentDefinitionNode,
+  SelectionNode,
+  SelectionSetNode,
+} from "graphql";
 import {
   createFragmentMap,
   resultKeyNameFromField,
@@ -7,7 +11,6 @@ import {
   getFragmentMaskMode,
   getOperationDefinition,
   maybeDeepFreeze,
-  isNonNullObject,
 } from "../utilities/index.js";
 import type { FragmentMap } from "../utilities/index.js";
 import type { ApolloCache, DocumentNode, TypedDocumentNode } from "./index.js";
@@ -20,7 +23,6 @@ interface MaskingContext {
   operationName: string | undefined;
   fragmentMap: FragmentMap;
   cache: ApolloCache<unknown>;
-  disableWarnings?: boolean;
 }
 
 // Contextual slot that allows us to disable accessor warnings on fields when in
@@ -170,15 +172,16 @@ function maskSelectionSet(
     return [changed ? masked : data, changed];
   }
 
-  const result = selectionSet.selections.reduce<[any, boolean]>(
-    ([memo, changed], selection) => {
-      switch (selection.kind) {
-        case Kind.FIELD: {
-          disableWarningsSlot.withValue(true, () => {
+  const result = selectionSet.selections
+    .concat()
+    .sort(sortFragmentsLast)
+    .reduce<[any, boolean]>(
+      ([memo, changed], selection) => {
+        switch (selection.kind) {
+          case Kind.FIELD: {
             const keyName = resultKeyNameFromField(selection);
             const childSelectionSet = selection.selectionSet;
 
-            const maybeValueWithWarning = memo[keyName];
             memo[keyName] = data[keyName];
 
             if (memo[keyName] === void 0) {
@@ -204,87 +207,82 @@ function maskSelectionSet(
                 // additional fields from the same child selection.
                 Object.keys(masked).length !== Object.keys(data[keyName]).length
               ) {
-                delete memo[keyName];
-                memo[keyName] =
-                  maybeValueWithWarning ?
-                    backfillFieldsWithWarnings(masked, maybeValueWithWarning)
-                  : masked;
+                memo[keyName] = masked;
                 changed = true;
               }
             }
-          });
 
-          return [memo, changed];
-        }
-        case Kind.INLINE_FRAGMENT: {
-          if (
-            selection.typeCondition &&
-            !context.cache.fragmentMatches!(selection, data.__typename)
-          ) {
             return [memo, changed];
           }
-
-          const [fragmentData, childChanged] = maskSelectionSet(
-            data,
-            selection.selectionSet,
-            context,
-            path
-          );
-
-          return [
-            {
-              ...memo,
-              ...fragmentData,
-            },
-            changed || childChanged,
-          ];
-        }
-        case Kind.FRAGMENT_SPREAD: {
-          const fragmentName = selection.name.value;
-          let fragment: FragmentDefinitionNode | null =
-            context.fragmentMap[fragmentName] ||
-            (context.fragmentMap[fragmentName] =
-              context.cache.lookupFragment(fragmentName)!);
-          invariant(
-            fragment,
-            "Could not find fragment with name '%s'.",
-            fragmentName
-          );
-
-          const mode = getFragmentMaskMode(selection);
-
-          if (mode === "mask") {
-            return [memo, true];
-          }
-
-          if (__DEV__) {
-            if (mode === "migrate") {
-              return [
-                addFieldAccessorWarnings(
-                  memo,
-                  data,
-                  fragment.selectionSet,
-                  path || "",
-                  context
-                ),
-                true,
-              ];
+          case Kind.INLINE_FRAGMENT: {
+            if (
+              selection.typeCondition &&
+              !context.cache.fragmentMatches!(selection, data.__typename)
+            ) {
+              return [memo, changed];
             }
+
+            const [fragmentData, childChanged] = maskSelectionSet(
+              data,
+              selection.selectionSet,
+              context,
+              path
+            );
+
+            return [
+              {
+                ...memo,
+                ...fragmentData,
+              },
+              changed || childChanged,
+            ];
           }
+          case Kind.FRAGMENT_SPREAD: {
+            const fragmentName = selection.name.value;
+            let fragment: FragmentDefinitionNode | null =
+              context.fragmentMap[fragmentName] ||
+              (context.fragmentMap[fragmentName] =
+                context.cache.lookupFragment(fragmentName)!);
+            invariant(
+              fragment,
+              "Could not find fragment with name '%s'.",
+              fragmentName
+            );
 
-          const [fragmentData, changed] = maskSelectionSet(
-            data,
-            fragment.selectionSet,
-            context,
-            path
-          );
+            const mode = getFragmentMaskMode(selection);
 
-          return [{ ...memo, ...fragmentData }, changed];
+            if (mode === "mask") {
+              return [memo, true];
+            }
+
+            if (__DEV__) {
+              if (mode === "migrate") {
+                return [
+                  addFieldAccessorWarnings(
+                    memo,
+                    data,
+                    fragment.selectionSet,
+                    path || "",
+                    context
+                  ),
+                  true,
+                ];
+              }
+            }
+
+            const [fragmentData, changed] = maskSelectionSet(
+              data,
+              fragment.selectionSet,
+              context,
+              path
+            );
+
+            return [{ ...memo, ...fragmentData }, changed];
+          }
         }
-      }
-    },
-    [Object.create(null), false]
-  );
+      },
+      [Object.create(null), false]
+    );
 
   if (data && "__typename" in data && !("__typename" in result[0])) {
     result[0].__typename = data.__typename;
@@ -312,84 +310,91 @@ function addFieldAccessorWarnings(
     });
   }
 
-  return selectionSetNode.selections.reduce<any>((memo, selection) => {
-    switch (selection.kind) {
-      case Kind.FIELD: {
-        const keyName = resultKeyNameFromField(selection);
-        const childSelectionSet = selection.selectionSet;
+  return selectionSetNode.selections
+    .concat()
+    .sort(sortFragmentsLast)
+    .reduce<any>((memo, selection) => {
+      switch (selection.kind) {
+        case Kind.FIELD: {
+          const keyName = resultKeyNameFromField(selection);
+          const childSelectionSet = selection.selectionSet;
 
-        if (keyName in memo && !childSelectionSet) {
+          if (keyName in memo && !childSelectionSet) {
+            return memo;
+          }
+
+          let value = data[keyName];
+
+          if (childSelectionSet) {
+            value = addFieldAccessorWarnings(
+              memo[keyName] ||
+                (Array.isArray(data[keyName]) ? [] : Object.create(null)),
+              data[keyName] as Record<string, unknown>,
+              childSelectionSet,
+              `${path}.${keyName}`,
+              context
+            );
+          }
+
+          if (__DEV__) {
+            if (keyName in memo) {
+              memo[keyName] = value;
+            } else {
+              addAccessorWarning(memo, value, keyName, path, context);
+            }
+          }
+
+          if (!__DEV__) {
+            memo[keyName] = data[keyName];
+          }
+
           return memo;
         }
+        case Kind.INLINE_FRAGMENT: {
+          if (
+            selection.typeCondition &&
+            !context.cache.fragmentMatches!(selection, (data as any).__typename)
+          ) {
+            return memo;
+          }
 
-        let value = data[keyName];
-
-        if (childSelectionSet) {
-          value = addFieldAccessorWarnings(
-            memo[keyName] ||
-              (Array.isArray(data[keyName]) ? [] : Object.create(null)),
-            data[keyName] as Record<string, unknown>,
-            childSelectionSet,
-            `${path}.${keyName}`,
+          return addFieldAccessorWarnings(
+            memo,
+            data,
+            selection.selectionSet,
+            path,
             context
           );
         }
+        case Kind.FRAGMENT_SPREAD: {
+          const fragment = context.fragmentMap[selection.name.value];
+          const mode = getFragmentMaskMode(selection);
 
-        if (__DEV__) {
-          addAccessorWarning(memo, value, keyName, path, context);
-        }
+          if (mode === "mask") {
+            return memo;
+          }
 
-        if (!__DEV__) {
-          memo[keyName] = data[keyName];
-        }
+          if (mode === "unmask") {
+            const [fragmentData] = maskSelectionSet(
+              data,
+              fragment.selectionSet,
+              context,
+              path
+            );
 
-        return memo;
-      }
-      case Kind.INLINE_FRAGMENT: {
-        if (
-          selection.typeCondition &&
-          !context.cache.fragmentMatches!(selection, (data as any).__typename)
-        ) {
-          return memo;
-        }
+            return Object.assign(memo, fragmentData);
+          }
 
-        return addFieldAccessorWarnings(
-          memo,
-          data,
-          selection.selectionSet,
-          path,
-          context
-        );
-      }
-      case Kind.FRAGMENT_SPREAD: {
-        const fragment = context.fragmentMap[selection.name.value];
-        const mode = getFragmentMaskMode(selection);
-
-        if (mode === "mask") {
-          return memo;
-        }
-
-        if (mode === "unmask") {
-          const [fragmentData] = maskSelectionSet(
+          return addFieldAccessorWarnings(
+            memo,
             data,
             fragment.selectionSet,
-            context,
-            path
+            path,
+            context
           );
-
-          return Object.assign(memo, fragmentData);
         }
-
-        return addFieldAccessorWarnings(
-          memo,
-          data,
-          fragment.selectionSet,
-          path,
-          context
-        );
       }
-    }
-  }, memo);
+    }, memo);
 }
 
 function addAccessorWarning(
@@ -448,51 +453,10 @@ function warnOnImproperCacheImplementation() {
   }
 }
 
-function backfillFieldsWithWarnings(
-  source: Record<string, unknown>,
-  unmasked: Record<string, unknown>
-): any {
-  if (Array.isArray(source)) {
-    if (Array.isArray(unmasked)) {
-      return source.map((s, idx) =>
-        backfillFieldsWithWarnings(s, unmasked[idx])
-      );
-    }
-
-    return source;
+function sortFragmentsLast(a: SelectionNode, b: SelectionNode) {
+  if (a.kind === b.kind) {
+    return 0;
   }
 
-  const keys = new Set([...Object.keys(source), ...Object.keys(unmasked)]);
-  const returnValue: Record<string, unknown> = {};
-  const { hasOwnProperty } = Object.prototype;
-
-  if (isNonNullObject(source) && isNonNullObject(unmasked)) {
-    Array.from(keys).forEach((key) => {
-      if (hasOwnProperty.call(source, key)) {
-        if (isNonNullObject(source[key]) && isNonNullObject(unmasked[key])) {
-          returnValue[key] = backfillFieldsWithWarnings(
-            source[key],
-            unmasked[key]
-          );
-        } else {
-          returnValue[key] = source[key];
-        }
-
-        return;
-      }
-
-      const descriptor = Object.getOwnPropertyDescriptor(unmasked, key);
-
-      Object.defineProperty(returnValue, key, {
-        get: descriptor?.get,
-        set: descriptor?.set,
-        enumerable: true,
-        configurable: true,
-      });
-    });
-  } else {
-    return source;
-  }
-
-  return returnValue;
+  return a.kind === Kind.FRAGMENT_SPREAD ? 1 : -1;
 }

--- a/src/core/masking.ts
+++ b/src/core/masking.ts
@@ -306,7 +306,7 @@ function addFieldAccessorWarnings(
         const keyName = resultKeyNameFromField(selection);
         const childSelectionSet = selection.selectionSet;
 
-        if (keyName in memo) {
+        if (keyName in memo && !childSelectionSet) {
           return memo;
         }
 


### PR DESCRIPTION
Fixes an issue where a query selects some fields from an object and warnings are applied to a fragment that selects from the same selection set with more fields. Currently the additional fields are masked accidentally. See the test for a reproduction.