### PR TITLE
[docs] remove all docs deployment except typegen

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,19 +1,3 @@
 [build]
   publish = "docs/public"
   command = "npm run typedoc; npm run docmodel > docs/public/log.txt || true"
-
-[context.deploy-preview.build]
-  base = "docs"
-  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../src"
-  command = """\
-  npm i
-  npm run docmodel
-  cd ../
-  rm -rf monodocs
-  git clone https://github.com/apollographql/docs --branch main --single-branch monodocs
-  cd monodocs
-  npm i
-  cp -r ../docs local
-  DOCS_LOCAL=true npm run build \
-  """
-  publish = "monodocs/public"


### PR DESCRIPTION
Removes the deploy-preview specific builds for Netlify, as that docs site is no longer used. Now all builds will just emit the typegen info.