### PR TITLE
skip unmasking for types without fragments

### DIFF
--- a/.api-reports/api-report-cache.api.md
+++ b/.api-reports/api-report-cache.api.md
@@ -226,6 +226,9 @@ type CombineFragmentRefs<FragmentRefs extends Record<string, any>> = UnionToInte
 }[keyof FragmentRefs]>;
 
 // @public (undocumented)
+type ContainsFragmentsRefs<TData> = TData extends object ? " $fragmentRefs" extends keyof TData ? true : ContainsFragmentsRefs<TData[keyof TData]> : false;
+
+// @public (undocumented)
 export function createFragmentRegistry(...fragments: DocumentNode[]): FragmentRegistryAPI;
 
 // @public (undocumented)
@@ -733,13 +736,14 @@ export function makeVar<T>(value: T): ReactiveVar<T>;
 // Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "DataMasking" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ContainsFragmentsRefs" needs to be exported by the entry point index.d.ts
 //
 // @public
 type MaybeMasked<TData> = TData extends {
     __masked?: true;
 } ? Prettify<RemoveMaskedMarker<TData>> : DataMasking extends {
     enabled: true;
-} ? TData : Unmasked<TData>;
+} ? TData : true extends ContainsFragmentsRefs<TData> ? Unmasked<TData> : TData;
 
 // @public (undocumented)
 export interface MergeInfo {

--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -469,6 +469,9 @@ type ConcastSourcesIterable<T> = Iterable<Source<T>>;
 export const concat: typeof ApolloLink.concat;
 
 // @public (undocumented)
+type ContainsFragmentsRefs<TData> = TData extends object ? " $fragmentRefs" extends keyof TData ? true : ContainsFragmentsRefs<TData[keyof TData]> : false;
+
+// @public (undocumented)
 export const createHttpLink: (linkOptions?: HttpOptions) => ApolloLink;
 
 // @public @deprecated (undocumented)
@@ -1376,13 +1379,14 @@ type MaybeAsync<T> = T | PromiseLike<T>;
 
 // Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ContainsFragmentsRefs" needs to be exported by the entry point index.d.ts
 //
 // @public
 export type MaybeMasked<TData> = TData extends {
     __masked?: true;
 } ? Prettify<RemoveMaskedMarker<TData>> : DataMasking extends {
     enabled: true;
-} ? TData : Unmasked<TData>;
+} ? TData : true extends ContainsFragmentsRefs<TData> ? Unmasked<TData> : TData;
 
 // @public (undocumented)
 export interface MergeInfo {

--- a/.api-reports/api-report-masking.api.md
+++ b/.api-reports/api-report-masking.api.md
@@ -16,6 +16,9 @@ type CombineFragmentRefs<FragmentRefs extends Record<string, any>> = UnionToInte
 }[keyof FragmentRefs]>;
 
 // @public (undocumented)
+type ContainsFragmentsRefs<TData> = TData extends object ? " $fragmentRefs" extends keyof TData ? true : ContainsFragmentsRefs<TData[keyof TData]> : false;
+
+// @public (undocumented)
 export interface DataMasking {
 }
 
@@ -44,13 +47,14 @@ export type MaskedDocumentNode<TData = {
 
 // Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ContainsFragmentsRefs" needs to be exported by the entry point index.d.ts
 //
 // @public
 export type MaybeMasked<TData> = TData extends {
     __masked?: true;
 } ? Prettify<RemoveMaskedMarker<TData>> : DataMasking extends {
     enabled: true;
-} ? TData : Unmasked<TData>;
+} ? TData : true extends ContainsFragmentsRefs<TData> ? Unmasked<TData> : TData;
 
 // @public (undocumented)
 type Prettify<T> = {

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -567,6 +567,9 @@ class Concast<T> extends Observable<T> {
 type ConcastSourcesIterable<T> = Iterable<Source<T>>;
 
 // @public (undocumented)
+type ContainsFragmentsRefs<TData> = TData extends object ? " $fragmentRefs" extends keyof TData ? true : ContainsFragmentsRefs<TData[keyof TData]> : false;
+
+// @public (undocumented)
 export interface Context extends Record<string, any> {
 }
 
@@ -1122,13 +1125,14 @@ type MaybeAsync<T> = T | PromiseLike<T>;
 // Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "DataMasking" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ContainsFragmentsRefs" needs to be exported by the entry point index.d.ts
 //
 // @public
 type MaybeMasked<TData> = TData extends {
     __masked?: true;
 } ? Prettify<RemoveMaskedMarker<TData>> : DataMasking extends {
     enabled: true;
-} ? TData : Unmasked<TData>;
+} ? TData : true extends ContainsFragmentsRefs<TData> ? Unmasked<TData> : TData;
 
 // @public (undocumented)
 class MissingFieldError extends Error {

--- a/.api-reports/api-report-react_components.api.md
+++ b/.api-reports/api-report-react_components.api.md
@@ -513,6 +513,9 @@ class Concast<T> extends Observable<T> {
 type ConcastSourcesIterable<T> = Iterable<Source<T>>;
 
 // @public (undocumented)
+type ContainsFragmentsRefs<TData> = TData extends object ? " $fragmentRefs" extends keyof TData ? true : ContainsFragmentsRefs<TData[keyof TData]> : false;
+
+// @public (undocumented)
 interface DataMasking {
 }
 
@@ -985,13 +988,14 @@ type MaybeAsync<T> = T | PromiseLike<T>;
 // Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "DataMasking" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ContainsFragmentsRefs" needs to be exported by the entry point index.d.ts
 //
 // @public
 type MaybeMasked<TData> = TData extends {
     __masked?: true;
 } ? Prettify<RemoveMaskedMarker<TData>> : DataMasking extends {
     enabled: true;
-} ? TData : Unmasked<TData>;
+} ? TData : true extends ContainsFragmentsRefs<TData> ? Unmasked<TData> : TData;
 
 // @public (undocumented)
 class MissingFieldError extends Error {

--- a/.api-reports/api-report-react_context.api.md
+++ b/.api-reports/api-report-react_context.api.md
@@ -507,6 +507,9 @@ class Concast<T> extends Observable<T> {
 type ConcastSourcesIterable<T> = Iterable<Source<T>>;
 
 // @public (undocumented)
+type ContainsFragmentsRefs<TData> = TData extends object ? " $fragmentRefs" extends keyof TData ? true : ContainsFragmentsRefs<TData[keyof TData]> : false;
+
+// @public (undocumented)
 interface DataMasking {
 }
 
@@ -982,13 +985,14 @@ type MaybeAsync<T> = T | PromiseLike<T>;
 // Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "DataMasking" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ContainsFragmentsRefs" needs to be exported by the entry point index.d.ts
 //
 // @public
 type MaybeMasked<TData> = TData extends {
     __masked?: true;
 } ? Prettify<RemoveMaskedMarker<TData>> : DataMasking extends {
     enabled: true;
-} ? TData : Unmasked<TData>;
+} ? TData : true extends ContainsFragmentsRefs<TData> ? Unmasked<TData> : TData;
 
 // @public (undocumented)
 class MissingFieldError extends Error {

--- a/.api-reports/api-report-react_hoc.api.md
+++ b/.api-reports/api-report-react_hoc.api.md
@@ -496,6 +496,9 @@ class Concast<T> extends Observable<T> {
 type ConcastSourcesIterable<T> = Iterable<Source<T>>;
 
 // @public (undocumented)
+type ContainsFragmentsRefs<TData> = TData extends object ? " $fragmentRefs" extends keyof TData ? true : ContainsFragmentsRefs<TData[keyof TData]> : false;
+
+// @public (undocumented)
 interface DataMasking {
 }
 
@@ -989,13 +992,14 @@ type MaybeAsync<T> = T | PromiseLike<T>;
 // Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "DataMasking" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ContainsFragmentsRefs" needs to be exported by the entry point index.d.ts
 //
 // @public
 type MaybeMasked<TData> = TData extends {
     __masked?: true;
 } ? Prettify<RemoveMaskedMarker<TData>> : DataMasking extends {
     enabled: true;
-} ? TData : Unmasked<TData>;
+} ? TData : true extends ContainsFragmentsRefs<TData> ? Unmasked<TData> : TData;
 
 // @public (undocumented)
 class MissingFieldError extends Error {

--- a/.api-reports/api-report-react_hooks.api.md
+++ b/.api-reports/api-report-react_hooks.api.md
@@ -536,6 +536,9 @@ class Concast<T> extends Observable<T> {
 type ConcastSourcesIterable<T> = Iterable<Source<T>>;
 
 // @public (undocumented)
+type ContainsFragmentsRefs<TData> = TData extends object ? " $fragmentRefs" extends keyof TData ? true : ContainsFragmentsRefs<TData[keyof TData]> : false;
+
+// @public (undocumented)
 interface DataMasking {
 }
 
@@ -1071,13 +1074,14 @@ type MaybeAsync<T> = T | PromiseLike<T>;
 // Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "DataMasking" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ContainsFragmentsRefs" needs to be exported by the entry point index.d.ts
 //
 // @public
 type MaybeMasked<TData> = TData extends {
     __masked?: true;
 } ? Prettify<RemoveMaskedMarker<TData>> : DataMasking extends {
     enabled: true;
-} ? TData : Unmasked<TData>;
+} ? TData : true extends ContainsFragmentsRefs<TData> ? Unmasked<TData> : TData;
 
 // @public (undocumented)
 class MissingFieldError extends Error {

--- a/.api-reports/api-report-react_internal.api.md
+++ b/.api-reports/api-report-react_internal.api.md
@@ -514,6 +514,9 @@ class Concast<T> extends Observable<T> {
 // @public (undocumented)
 type ConcastSourcesIterable<T> = Iterable<Source<T>>;
 
+// @public (undocumented)
+type ContainsFragmentsRefs<TData> = TData extends object ? " $fragmentRefs" extends keyof TData ? true : ContainsFragmentsRefs<TData[keyof TData]> : false;
+
 // Warning: (ae-forgotten-export) The symbol "PreloadQueryFunction" needs to be exported by the entry point index.d.ts
 //
 // @public
@@ -1081,13 +1084,14 @@ type MaybeAsync<T> = T | PromiseLike<T>;
 // Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "DataMasking" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ContainsFragmentsRefs" needs to be exported by the entry point index.d.ts
 //
 // @public
 type MaybeMasked<TData> = TData extends {
     __masked?: true;
 } ? Prettify<RemoveMaskedMarker<TData>> : DataMasking extends {
     enabled: true;
-} ? TData : Unmasked<TData>;
+} ? TData : true extends ContainsFragmentsRefs<TData> ? Unmasked<TData> : TData;
 
 // @public (undocumented)
 class MissingFieldError extends Error {

--- a/.api-reports/api-report-react_ssr.api.md
+++ b/.api-reports/api-report-react_ssr.api.md
@@ -476,6 +476,9 @@ class Concast<T> extends Observable<T> {
 type ConcastSourcesIterable<T> = Iterable<Source<T>>;
 
 // @public (undocumented)
+type ContainsFragmentsRefs<TData> = TData extends object ? " $fragmentRefs" extends keyof TData ? true : ContainsFragmentsRefs<TData[keyof TData]> : false;
+
+// @public (undocumented)
 interface DataMasking {
 }
 
@@ -967,13 +970,14 @@ type MaybeAsync<T> = T | PromiseLike<T>;
 // Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "DataMasking" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ContainsFragmentsRefs" needs to be exported by the entry point index.d.ts
 //
 // @public
 type MaybeMasked<TData> = TData extends {
     __masked?: true;
 } ? Prettify<RemoveMaskedMarker<TData>> : DataMasking extends {
     enabled: true;
-} ? TData : Unmasked<TData>;
+} ? TData : true extends ContainsFragmentsRefs<TData> ? Unmasked<TData> : TData;
 
 // @public (undocumented)
 class MissingFieldError extends Error {

--- a/.api-reports/api-report-testing.api.md
+++ b/.api-reports/api-report-testing.api.md
@@ -465,6 +465,9 @@ class Concast<T> extends Observable<T> {
 // @public (undocumented)
 type ConcastSourcesIterable<T> = Iterable<Source<T>>;
 
+// @public (undocumented)
+type ContainsFragmentsRefs<TData> = TData extends object ? " $fragmentRefs" extends keyof TData ? true : ContainsFragmentsRefs<TData[keyof TData]> : false;
+
 // @internal (undocumented)
 type CovariantUnaryFunction<out Arg, out Ret> = {
     fn(arg: Arg): Ret;
@@ -956,13 +959,14 @@ type MaybeAsync<T> = T | PromiseLike<T>;
 // Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "DataMasking" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ContainsFragmentsRefs" needs to be exported by the entry point index.d.ts
 //
 // @public
 type MaybeMasked<TData> = TData extends {
     __masked?: true;
 } ? Prettify<RemoveMaskedMarker<TData>> : DataMasking extends {
     enabled: true;
-} ? TData : Unmasked<TData>;
+} ? TData : true extends ContainsFragmentsRefs<TData> ? Unmasked<TData> : TData;
 
 // @public (undocumented)
 class MissingFieldError extends Error {

--- a/.api-reports/api-report-testing_core.api.md
+++ b/.api-reports/api-report-testing_core.api.md
@@ -464,6 +464,9 @@ class Concast<T> extends Observable<T> {
 // @public (undocumented)
 type ConcastSourcesIterable<T> = Iterable<Source<T>>;
 
+// @public (undocumented)
+type ContainsFragmentsRefs<TData> = TData extends object ? " $fragmentRefs" extends keyof TData ? true : ContainsFragmentsRefs<TData[keyof TData]> : false;
+
 // @internal (undocumented)
 type CovariantUnaryFunction<out Arg, out Ret> = {
     fn(arg: Arg): Ret;
@@ -955,13 +958,14 @@ type MaybeAsync<T> = T | PromiseLike<T>;
 // Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "DataMasking" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ContainsFragmentsRefs" needs to be exported by the entry point index.d.ts
 //
 // @public
 type MaybeMasked<TData> = TData extends {
     __masked?: true;
 } ? Prettify<RemoveMaskedMarker<TData>> : DataMasking extends {
     enabled: true;
-} ? TData : Unmasked<TData>;
+} ? TData : true extends ContainsFragmentsRefs<TData> ? Unmasked<TData> : TData;
 
 // @public (undocumented)
 class MissingFieldError extends Error {

--- a/.api-reports/api-report-utilities.api.md
+++ b/.api-reports/api-report-utilities.api.md
@@ -596,6 +596,9 @@ export type ConcastSourcesIterable<T> = Iterable<Source<T>>;
 export function concatPagination<T = Reference>(keyArgs?: KeyArgs): FieldPolicy<T[]>;
 
 // @public (undocumented)
+type ContainsFragmentsRefs<TData> = TData extends object ? " $fragmentRefs" extends keyof TData ? true : ContainsFragmentsRefs<TData[keyof TData]> : false;
+
+// @public (undocumented)
 export function createFragmentMap(fragments?: FragmentDefinitionNode[]): FragmentMap;
 
 // Warning: (ae-forgotten-export) The symbol "FulfilledPromise" needs to be exported by the entry point index.d.ts
@@ -1664,13 +1667,14 @@ export function maybeDeepFreeze<T>(obj: T): T;
 
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "DataMasking" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ContainsFragmentsRefs" needs to be exported by the entry point index.d.ts
 //
 // @public
 type MaybeMasked<TData> = TData extends {
     __masked?: true;
 } ? Prettify<RemoveMaskedMarker<TData>> : DataMasking extends {
     enabled: true;
-} ? TData : Unmasked<TData>;
+} ? TData : true extends ContainsFragmentsRefs<TData> ? Unmasked<TData> : TData;
 
 // @public (undocumented)
 export function mergeDeep<T extends any[]>(...sources: T): TupleToIntersection<T>;

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -566,6 +566,9 @@ type ConcastSourcesIterable<T> = Iterable<Source<T>>;
 export const concat: typeof ApolloLink.concat;
 
 // @public (undocumented)
+type ContainsFragmentsRefs<TData> = TData extends object ? " $fragmentRefs" extends keyof TData ? true : ContainsFragmentsRefs<TData[keyof TData]> : false;
+
+// @public (undocumented)
 export const createHttpLink: (linkOptions?: HttpOptions) => ApolloLink;
 
 // @public
@@ -1557,13 +1560,14 @@ type MaybeAsync<T> = T | PromiseLike<T>;
 
 // Warning: (ae-forgotten-export) The symbol "Prettify" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "RemoveMaskedMarker" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ContainsFragmentsRefs" needs to be exported by the entry point index.d.ts
 //
 // @public
 export type MaybeMasked<TData> = TData extends {
     __masked?: true;
 } ? Prettify<RemoveMaskedMarker<TData>> : DataMasking extends {
     enabled: true;
-} ? TData : Unmasked<TData>;
+} ? TData : true extends ContainsFragmentsRefs<TData> ? Unmasked<TData> : TData;
 
 // @public (undocumented)
 export interface MergeInfo {

--- a/.changeset/perfect-jobs-flow.md
+++ b/.changeset/perfect-jobs-flow.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Add a helper that will skip the TS unmasking alorithm when no fragments are present on type level

--- a/src/masking/internal/types.ts
+++ b/src/masking/internal/types.ts
@@ -31,3 +31,10 @@ export type RemoveMaskedMarker<T> = Omit<T, "__masked">;
 // force distrubution when T is a union with | undefined
 export type RemoveFragmentName<T> =
   T extends any ? Omit<T, " $fragmentName"> : T;
+
+export type ContainsFragmentsRefs<TData> =
+  TData extends object ?
+    " $fragmentRefs" extends keyof TData ?
+      true
+    : ContainsFragmentsRefs<TData[keyof TData]>
+  : false;

--- a/src/masking/types.ts
+++ b/src/masking/types.ts
@@ -44,7 +44,7 @@ export type MaybeMasked<TData> =
 
 type RecContainsFragments<T> =
   T extends object ?
-    keyof T extends " $fragmentRefs" ?
+    " $fragmentRefs" extends keyof T ?
       true
     : RecContainsFragments<T[keyof T]>
   : false;

--- a/src/masking/types.ts
+++ b/src/masking/types.ts
@@ -1,5 +1,6 @@
 import type { TypedDocumentNode } from "@graphql-typed-document-node/core";
 import type {
+  ContainsFragmentsRefs,
   RemoveFragmentName,
   RemoveMaskedMarker,
   UnwrapFragmentRefs,
@@ -39,15 +40,8 @@ export type FragmentType<TData> =
 export type MaybeMasked<TData> =
   TData extends { __masked?: true } ? Prettify<RemoveMaskedMarker<TData>>
   : DataMasking extends { enabled: true } ? TData
-  : true extends RecContainsFragments<TData> ? Unmasked<TData>
+  : true extends ContainsFragmentsRefs<TData> ? Unmasked<TData>
   : TData;
-
-type RecContainsFragments<T> =
-  T extends object ?
-    " $fragmentRefs" extends keyof T ?
-      true
-    : RecContainsFragments<T[keyof T]>
-  : false;
 
 /**
  * Unmasks a type to provide its full result.

--- a/src/masking/types.ts
+++ b/src/masking/types.ts
@@ -46,5 +46,17 @@ export type MaybeMasked<TData> =
  */
 export type Unmasked<TData> =
   TData extends object ?
-    UnwrapFragmentRefs<RemoveMaskedMarker<RemoveFragmentName<TData>>>
+    FastForwardUnmask<RemoveMaskedMarker<RemoveFragmentName<TData>>>
   : TData;
+
+/**
+ * This type will skip going through the unmasking algorithm until it reaches
+ * the first fragment reference.
+ * This is useful for types that are not code-generated.
+ */
+type FastForwardUnmask<T> =
+  T extends Record<string, any> ?
+    T extends { " $fragmentRefs"?: any } ?
+      UnwrapFragmentRefs<T>
+    : { [K in keyof T]: FastForwardUnmask<T[K]> }
+  : T;

--- a/src/masking/types.ts
+++ b/src/masking/types.ts
@@ -39,24 +39,20 @@ export type FragmentType<TData> =
 export type MaybeMasked<TData> =
   TData extends { __masked?: true } ? Prettify<RemoveMaskedMarker<TData>>
   : DataMasking extends { enabled: true } ? TData
-  : Unmasked<TData>;
+  : true extends RecContainsFragments<TData> ? Unmasked<TData>
+  : TData;
+
+type RecContainsFragments<T> =
+  T extends object ?
+    keyof T extends " $fragmentRefs" ?
+      true
+    : RecContainsFragments<T[keyof T]>
+  : false;
 
 /**
  * Unmasks a type to provide its full result.
  */
 export type Unmasked<TData> =
   TData extends object ?
-    FastForwardUnmask<RemoveMaskedMarker<RemoveFragmentName<TData>>>
+    UnwrapFragmentRefs<RemoveMaskedMarker<RemoveFragmentName<TData>>>
   : TData;
-
-/**
- * This type will skip going through the unmasking algorithm until it reaches
- * the first fragment reference.
- * This is useful for types that are not code-generated.
- */
-type FastForwardUnmask<T> =
-  T extends Record<string, any> ?
-    T extends { " $fragmentRefs"?: any } ?
-      UnwrapFragmentRefs<T>
-    : { [K in keyof T]: FastForwardUnmask<T[K]> }
-  : T;


### PR DESCRIPTION
I'm still looking into ways to make this potentially faster, but this should already enable a "safer" option for types that didn't contain fragments in the first place.
