### PR TITLE
Fix tsdoc issue

### DIFF
--- a/src/masking/internal/types.ts
+++ b/src/masking/internal/types.ts
@@ -29,20 +29,20 @@ export type UnwrapFragmentRefs<TData> =
   : never;
 
 /**
- ```ts
-  CombineIntersection<
-    | { foo: string }
+```ts
+CombineIntersection<
+  | { foo: string }
+  | { __typename: "A"; a: string }
+  | { __typename: "B"; b1: number }
+  | { __typename: "B"; b2: string }
+> =>
+  | { foo: string }
+  | CombineByTypeName<
     | { __typename: "A"; a: string }
     | { __typename: "B"; b1: number }
     | { __typename: "B"; b2: string }
-  > =>
-    | { foo: string }
-    | CombineByTypeName<
-      | { __typename: "A"; a: string }
-      | { __typename: "B"; b1: number }
-      | { __typename: "B"; b2: string }
-    >
- ```
+  >
+```
  */
 type CombineIntersection<T> =
   | Exclude<T, { __typename?: string }>


### PR DESCRIPTION
API extractor is currently failing on `release-3.12`. This PR fixes it.