### PR TITLE
Update data masking tests in React hooks to account for changes in render stream library

### DIFF
--- a/src/react/hooks/__tests__/useBackgroundQuery.test.tsx
+++ b/src/react/hooks/__tests__/useBackgroundQuery.test.tsx
@@ -4219,7 +4219,8 @@ it("masks queries when dataMasking is `true`", async () => {
     );
   }
 
-  renderStream.render(<App />, {
+  using _disabledAct = disableActEnvironment();
+  await renderStream.render(<App />, {
     wrapper: createClientWrapper(client),
   });
 
@@ -4307,7 +4308,8 @@ it("does not mask query when dataMasking is `false`", async () => {
     );
   }
 
-  renderStream.render(<App />, { wrapper: createClientWrapper(client) });
+  using _disabledAct = disableActEnvironment();
+  await renderStream.render(<App />, { wrapper: createClientWrapper(client) });
 
   // loading
   await renderStream.takeRender();
@@ -4391,7 +4393,8 @@ it("does not mask query by default", async () => {
     );
   }
 
-  renderStream.render(<App />, { wrapper: createClientWrapper(client) });
+  using _disabledAct = disableActEnvironment();
+  await renderStream.render(<App />, { wrapper: createClientWrapper(client) });
 
   // loading
   await renderStream.takeRender();
@@ -4476,7 +4479,8 @@ it("masks queries updated by the cache", async () => {
     );
   }
 
-  renderStream.render(<App />, { wrapper: createClientWrapper(client) });
+  using _disabledAct = disableActEnvironment();
+  await renderStream.render(<App />, { wrapper: createClientWrapper(client) });
 
   // loading
   await renderStream.takeRender();
@@ -4592,7 +4596,8 @@ it("does not rerender when updating field in named fragment", async () => {
     );
   }
 
-  renderStream.render(<App />, {
+  using _disabledAct = disableActEnvironment();
+  await renderStream.render(<App />, {
     wrapper: createClientWrapper(client),
   });
 
@@ -4719,7 +4724,8 @@ it("masks result from cache when using with cache-first fetch policy", async () 
     );
   }
 
-  renderStream.render(<App />, { wrapper: createClientWrapper(client) });
+  using _disabledAct = disableActEnvironment();
+  await renderStream.render(<App />, { wrapper: createClientWrapper(client) });
 
   const { snapshot } = await renderStream.takeRender();
 
@@ -4815,7 +4821,8 @@ it("masks cache and network result when using cache-and-network fetch policy", a
     );
   }
 
-  renderStream.render(<App />, { wrapper: createClientWrapper(client) });
+  using _disabledAct = disableActEnvironment();
+  await renderStream.render(<App />, { wrapper: createClientWrapper(client) });
 
   {
     const { snapshot } = await renderStream.takeRender();
@@ -4931,7 +4938,8 @@ it("masks partial cache data when returnPartialData is `true`", async () => {
     );
   }
 
-  renderStream.render(<App />, { wrapper: createClientWrapper(client) });
+  using _disabledAct = disableActEnvironment();
+  await renderStream.render(<App />, { wrapper: createClientWrapper(client) });
 
   {
     const { snapshot } = await renderStream.takeRender();
@@ -5031,7 +5039,8 @@ it("masks partial data returned from data on errors with errorPolicy `all`", asy
     );
   }
 
-  renderStream.render(<App />, { wrapper: createClientWrapper(client) });
+  using _disabledAct = disableActEnvironment();
+  await renderStream.render(<App />, { wrapper: createClientWrapper(client) });
 
   // loading
   await renderStream.takeRender();

--- a/src/react/hooks/__tests__/useFragment.test.tsx
+++ b/src/react/hooks/__tests__/useFragment.test.tsx
@@ -1635,12 +1635,6 @@ describe("useFragment", () => {
       }
     );
 
-    expect(console.warn).toHaveBeenCalledTimes(1);
-    expect(console.warn).toHaveBeenCalledWith(
-      "Could not identify object passed to `from` for '%s' fragment, either because the object is non-normalized or the key fields are missing. If you are masking this object, please ensure the key fields are requested by the parent object.",
-      "UserFields"
-    );
-
     {
       const { data, complete } = await takeSnapshot();
 
@@ -1648,6 +1642,12 @@ describe("useFragment", () => {
       // TODO: Update when https://github.com/apollographql/apollo-client/issues/12003 is fixed
       expect(complete).toBe(true);
     }
+
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenCalledWith(
+      "Could not identify object passed to `from` for '%s' fragment, either because the object is non-normalized or the key fields are missing. If you are masking this object, please ensure the key fields are requested by the parent object.",
+      "UserFields"
+    );
   });
 
   it("allows `null` as valid `from` value without warning", async () => {

--- a/src/react/hooks/__tests__/useFragment.test.tsx
+++ b/src/react/hooks/__tests__/useFragment.test.tsx
@@ -1625,7 +1625,8 @@ describe("useFragment", () => {
 
     const client = new ApolloClient({ cache: new InMemoryCache() });
 
-    const { takeSnapshot } = renderHookToSnapshotStream(
+    using _disabledAct = disableActEnvironment();
+    const { takeSnapshot } = await renderHookToSnapshotStream(
       () => useFragment({ fragment, from: { __typename: "User" } }),
       {
         wrapper: ({ children }) => (
@@ -1664,7 +1665,8 @@ describe("useFragment", () => {
 
     const client = new ApolloClient({ cache: new InMemoryCache() });
 
-    const { takeSnapshot } = renderHookToSnapshotStream(
+    using _disabledAct = disableActEnvironment();
+    const { takeSnapshot } = await renderHookToSnapshotStream(
       () => useFragment({ fragment, from: null }),
       {
         wrapper: ({ children }) => (
@@ -1711,7 +1713,8 @@ describe("useFragment", () => {
       },
     });
 
-    const { takeSnapshot, rerender } = renderHookToSnapshotStream(
+    using _disabledAct = disableActEnvironment();
+    const { takeSnapshot, rerender } = await renderHookToSnapshotStream(
       ({ from }) => useFragment({ fragment, from }),
       {
         initialProps: { from: null as UseFragmentOptions<any, never>["from"] },
@@ -1728,7 +1731,7 @@ describe("useFragment", () => {
       expect(complete).toBe(false);
     }
 
-    rerender({ from: { __typename: "User", id: "1" } });
+    await rerender({ from: { __typename: "User", id: "1" } });
 
     {
       const { data, complete } = await takeSnapshot();
@@ -1972,7 +1975,8 @@ describe("data masking", () => {
       },
     });
 
-    const { takeSnapshot } = renderHookToSnapshotStream(
+    using _disabledAct = disableActEnvironment();
+    const { takeSnapshot } = await renderHookToSnapshotStream(
       () =>
         useFragment({
           fragment,
@@ -2089,7 +2093,8 @@ describe("data masking", () => {
       return null;
     }
 
-    renderStream.render(<Parent />, {
+    using _disabledAct = disableActEnvironment();
+    await renderStream.render(<Parent />, {
       wrapper: ({ children }) => (
         <ApolloProvider client={client}>{children}</ApolloProvider>
       ),

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -2440,6 +2440,7 @@ describe("useLazyQuery Hook", () => {
               },
             },
           },
+          delay: 20,
         },
       ];
 

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -2075,14 +2075,13 @@ describe("useLazyQuery Hook", () => {
         link: new MockLink(mocks),
       });
 
-      const { takeSnapshot, getCurrentSnapshot } = renderHookToSnapshotStream(
-        () => useLazyQuery(query),
-        {
+      using _disabledAct = disableActEnvironment();
+      const { takeSnapshot, getCurrentSnapshot } =
+        await renderHookToSnapshotStream(() => useLazyQuery(query), {
           wrapper: ({ children }) => (
             <ApolloProvider client={client}>{children}</ApolloProvider>
           ),
-        }
-      );
+        });
 
       // initial render
       await takeSnapshot();
@@ -2164,14 +2163,13 @@ describe("useLazyQuery Hook", () => {
         link: new MockLink(mocks),
       });
 
-      const { takeSnapshot, getCurrentSnapshot } = renderHookToSnapshotStream(
-        () => useLazyQuery(query),
-        {
+      using _disabledAct = disableActEnvironment();
+      const { takeSnapshot, getCurrentSnapshot } =
+        await renderHookToSnapshotStream(() => useLazyQuery(query), {
           wrapper: ({ children }) => (
             <ApolloProvider client={client}>{children}</ApolloProvider>
           ),
-        }
-      );
+        });
 
       // initial render
       await takeSnapshot();
@@ -2254,14 +2252,13 @@ describe("useLazyQuery Hook", () => {
         link: new MockLink(mocks),
       });
 
-      const { takeSnapshot, getCurrentSnapshot } = renderHookToSnapshotStream(
-        () => useLazyQuery(query),
-        {
+      using _disabledAct = disableActEnvironment();
+      const { takeSnapshot, getCurrentSnapshot } =
+        await renderHookToSnapshotStream(() => useLazyQuery(query), {
           wrapper: ({ children }) => (
             <ApolloProvider client={client}>{children}</ApolloProvider>
           ),
-        }
-      );
+        });
 
       // initial render
       await takeSnapshot();
@@ -2345,20 +2342,19 @@ describe("useLazyQuery Hook", () => {
         link: new MockLink(mocks),
       });
 
-      const { takeSnapshot, getCurrentSnapshot } = renderHookToSnapshotStream(
-        () => useLazyQuery(query),
-        {
+      using _disabledAct = disableActEnvironment();
+      const { takeSnapshot, getCurrentSnapshot } =
+        await renderHookToSnapshotStream(() => useLazyQuery(query), {
           wrapper: ({ children }) => (
             <ApolloProvider client={client}>{children}</ApolloProvider>
           ),
-        }
-      );
+        });
 
       // initial render
       await takeSnapshot();
 
       const [execute] = getCurrentSnapshot();
-      execute();
+      await execute();
 
       // Loading
       await takeSnapshot();
@@ -2453,20 +2449,19 @@ describe("useLazyQuery Hook", () => {
         link: new MockLink(mocks),
       });
 
-      const { takeSnapshot, getCurrentSnapshot } = renderHookToSnapshotStream(
-        () => useLazyQuery(query),
-        {
+      using _disabledAct = disableActEnvironment();
+      const { takeSnapshot, getCurrentSnapshot } =
+        await renderHookToSnapshotStream(() => useLazyQuery(query), {
           wrapper: ({ children }) => (
             <ApolloProvider client={client}>{children}</ApolloProvider>
           ),
-        }
-      );
+        });
 
       // initial render
       await takeSnapshot();
 
       const [execute] = getCurrentSnapshot();
-      execute();
+      await execute();
 
       // Loading
       await takeSnapshot();

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -2873,7 +2873,8 @@ describe("data masking", () => {
       link: new MockLink(mocks),
     });
 
-    const { takeSnapshot } = renderHookToSnapshotStream(
+    using _disabledAct = disableActEnvironment();
+    const { takeSnapshot } = await renderHookToSnapshotStream(
       () => useMutation(mutation),
       {
         wrapper: ({ children }) => (
@@ -2888,10 +2889,18 @@ describe("data masking", () => {
     expect(result.data).toBeUndefined();
     expect(result.error).toBeUndefined();
 
-    let promise!: Promise<FetchResult<Mutation>>;
-    act(() => {
-      promise = mutate();
-    });
+    {
+      const { data, errors } = await mutate();
+
+      expect(data).toEqual({
+        updateUser: {
+          __typename: "User",
+          id: 1,
+          name: "Test User",
+        },
+      });
+      expect(errors).toBeUndefined();
+    }
 
     {
       const [, result] = await takeSnapshot();
@@ -2913,19 +2922,6 @@ describe("data masking", () => {
         },
       });
       expect(result.error).toBeUndefined();
-    }
-
-    {
-      const { data, errors } = await promise;
-
-      expect(data).toEqual({
-        updateUser: {
-          __typename: "User",
-          id: 1,
-          name: "Test User",
-        },
-      });
-      expect(errors).toBeUndefined();
     }
 
     await expect(takeSnapshot).not.toRerender();
@@ -2977,7 +2973,8 @@ describe("data masking", () => {
       link: new MockLink(mocks),
     });
 
-    const { takeSnapshot } = renderHookToSnapshotStream(
+    using _disabledAct = disableActEnvironment();
+    const { takeSnapshot } = await renderHookToSnapshotStream(
       () => useMutation(mutation),
       {
         wrapper: ({ children }) => (
@@ -2992,10 +2989,19 @@ describe("data masking", () => {
     expect(result.data).toBeUndefined();
     expect(result.error).toBeUndefined();
 
-    let promise!: Promise<FetchResult<Mutation>>;
-    act(() => {
-      promise = mutate();
-    });
+    {
+      const { data, errors } = await mutate();
+
+      expect(data).toEqual({
+        updateUser: {
+          __typename: "User",
+          id: 1,
+          name: "Test User",
+          age: 30,
+        },
+      });
+      expect(errors).toBeUndefined();
+    }
 
     {
       const [, result] = await takeSnapshot();
@@ -3018,20 +3024,6 @@ describe("data masking", () => {
         },
       });
       expect(result.error).toBeUndefined();
-    }
-
-    {
-      const { data, errors } = await promise;
-
-      expect(data).toEqual({
-        updateUser: {
-          __typename: "User",
-          id: 1,
-          name: "Test User",
-          age: 30,
-        },
-      });
-      expect(errors).toBeUndefined();
     }
 
     await expect(takeSnapshot).not.toRerender();
@@ -3086,7 +3078,9 @@ describe("data masking", () => {
 
     const update = jest.fn();
     const onCompleted = jest.fn();
-    const { takeSnapshot } = renderHookToSnapshotStream(
+
+    using _disabledAct = disableActEnvironment();
+    const { takeSnapshot } = await renderHookToSnapshotStream(
       () => useMutation(mutation, { onCompleted, update }),
       {
         wrapper: ({ children }) => (
@@ -3097,7 +3091,7 @@ describe("data masking", () => {
 
     const [mutate] = await takeSnapshot();
 
-    await act(() => mutate());
+    await mutate();
 
     expect(onCompleted).toHaveBeenCalledTimes(1);
     expect(onCompleted).toHaveBeenCalledWith(

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -10318,7 +10318,8 @@ describe("useQuery Hook", () => {
         return null;
       }
 
-      renderStream.render(<App />, {
+      using _disabledAct = disableActEnvironment();
+      await renderStream.render(<App />, {
         wrapper: ({ children }) => (
           <ApolloProvider client={client}>{children}</ApolloProvider>
         ),
@@ -10409,7 +10410,8 @@ describe("useQuery Hook", () => {
         return null;
       }
 
-      renderStream.render(<App />, {
+      using _disabledAct = disableActEnvironment();
+      await renderStream.render(<App />, {
         wrapper: ({ children }) => (
           <ApolloProvider client={client}>{children}</ApolloProvider>
         ),
@@ -10493,7 +10495,8 @@ describe("useQuery Hook", () => {
         return null;
       }
 
-      renderStream.render(<App />, {
+      using _disabledAct = disableActEnvironment();
+      await renderStream.render(<App />, {
         wrapper: ({ children }) => (
           <ApolloProvider client={client}>{children}</ApolloProvider>
         ),
@@ -10578,7 +10581,8 @@ describe("useQuery Hook", () => {
         return null;
       }
 
-      renderStream.render(<App />, {
+      using _disabledAct = disableActEnvironment();
+      await renderStream.render(<App />, {
         wrapper: ({ children }) => (
           <ApolloProvider client={client}>{children}</ApolloProvider>
         ),
@@ -10691,7 +10695,8 @@ describe("useQuery Hook", () => {
         return null;
       }
 
-      renderStream.render(<App />, {
+      using _disabledAct = disableActEnvironment();
+      await renderStream.render(<App />, {
         wrapper: ({ children }) => (
           <ApolloProvider client={client}>{children}</ApolloProvider>
         ),
@@ -10814,7 +10819,8 @@ describe("useQuery Hook", () => {
           return null;
         }
 
-        renderStream.render(<App />, {
+        using _disabledAct = disableActEnvironment();
+        await renderStream.render(<App />, {
           wrapper: ({ children }) => (
             <ApolloProvider client={client}>{children}</ApolloProvider>
           ),
@@ -10909,7 +10915,8 @@ describe("useQuery Hook", () => {
         return null;
       }
 
-      renderStream.render(<App />, {
+      using _disabledAct = disableActEnvironment();
+      await renderStream.render(<App />, {
         wrapper: ({ children }) => (
           <ApolloProvider client={client}>{children}</ApolloProvider>
         ),
@@ -11029,7 +11036,8 @@ describe("useQuery Hook", () => {
         return null;
       }
 
-      renderStream.render(<App />, {
+      using _disabledAct = disableActEnvironment();
+      await renderStream.render(<App />, {
         wrapper: ({ children }) => (
           <ApolloProvider client={client}>{children}</ApolloProvider>
         ),
@@ -11124,7 +11132,8 @@ describe("useQuery Hook", () => {
         return null;
       }
 
-      renderStream.render(<App />, {
+      using _disabledAct = disableActEnvironment();
+      await renderStream.render(<App />, {
         wrapper: ({ children }) => (
           <ApolloProvider client={client}>{children}</ApolloProvider>
         ),

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -2110,7 +2110,8 @@ describe("data masking", () => {
       link,
     });
 
-    const { takeSnapshot } = renderHookToSnapshotStream(
+    using _disabledAct = disableActEnvironment();
+    const { takeSnapshot } = await renderHookToSnapshotStream(
       () => useSubscription(subscription),
       {
         wrapper: ({ children }) => (
@@ -2178,7 +2179,8 @@ describe("data masking", () => {
       link,
     });
 
-    const { takeSnapshot } = renderHookToSnapshotStream(
+    using _disabledAct = disableActEnvironment();
+    const { takeSnapshot } = await renderHookToSnapshotStream(
       () => useSubscription(subscription),
       {
         wrapper: ({ children }) => (
@@ -2249,7 +2251,8 @@ describe("data masking", () => {
     });
 
     const onData = jest.fn();
-    const { takeSnapshot } = renderHookToSnapshotStream(
+    using _disabledAct = disableActEnvironment();
+    const { takeSnapshot } = await renderHookToSnapshotStream(
       () => useSubscription(subscription, { onData }),
       {
         wrapper: ({ children }) => (
@@ -2329,7 +2332,8 @@ describe("data masking", () => {
     });
 
     const onData = jest.fn();
-    const { takeSnapshot } = renderHookToSnapshotStream(
+    using _disabledAct = disableActEnvironment();
+    const { takeSnapshot } = await renderHookToSnapshotStream(
       () => useSubscription(subscription, { onData }),
       {
         wrapper: ({ children }) => (

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -1269,7 +1269,6 @@ followed by new in-flight setup", async () => {
           link.simulateResult(graphQlErrorResult);
           {
             const snapshot = await takeSnapshot();
-            console.dir({ graphQlErrorResult, snapshot }, { depth: 5 });
             expect(snapshot).toStrictEqual({
               loading: false,
               error: new ApolloError({

--- a/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
@@ -10897,7 +10897,8 @@ describe("useSuspenseQuery", () => {
       return null;
     }
 
-    renderStream.render(
+    using _disabledAct = disableActEnvironment();
+    await renderStream.render(
       <Suspense fallback={<div>Loading...</div>}>
         <App />
       </Suspense>,
@@ -10988,7 +10989,8 @@ describe("useSuspenseQuery", () => {
       return null;
     }
 
-    renderStream.render(
+    using _disabledAct = disableActEnvironment();
+    await renderStream.render(
       <Suspense fallback="Loading">
         <App />
       </Suspense>,
@@ -11076,7 +11078,8 @@ describe("useSuspenseQuery", () => {
       return null;
     }
 
-    renderStream.render(
+    using _disabledAct = disableActEnvironment();
+    await renderStream.render(
       <Suspense fallback="Loading">
         <App />
       </Suspense>,
@@ -11165,7 +11168,8 @@ describe("useSuspenseQuery", () => {
       return null;
     }
 
-    renderStream.render(
+    using _disabledAct = disableActEnvironment();
+    await renderStream.render(
       <Suspense fallback="Loading">
         <App />
       </Suspense>,
@@ -11283,7 +11287,8 @@ describe("useSuspenseQuery", () => {
       return null;
     }
 
-    renderStream.render(
+    using _disabledAct = disableActEnvironment();
+    await renderStream.render(
       <Suspense fallback="Loading">
         <App />
       </Suspense>,
@@ -11410,7 +11415,8 @@ describe("useSuspenseQuery", () => {
       return null;
     }
 
-    renderStream.render(
+    using _disabledAct = disableActEnvironment();
+    await renderStream.render(
       <Suspense fallback="Loading">
         <App />
       </Suspense>,
@@ -11510,7 +11516,8 @@ describe("useSuspenseQuery", () => {
       return null;
     }
 
-    renderStream.render(
+    using _disabledAct = disableActEnvironment();
+    await renderStream.render(
       <Suspense fallback="Loading">
         <App />
       </Suspense>,
@@ -11629,7 +11636,8 @@ describe("useSuspenseQuery", () => {
       return null;
     }
 
-    renderStream.render(
+    using _disabledAct = disableActEnvironment();
+    await renderStream.render(
       <Suspense fallback="Loading">
         <App />
       </Suspense>,
@@ -11732,7 +11740,8 @@ describe("useSuspenseQuery", () => {
       return null;
     }
 
-    renderStream.render(
+    using _disabledAct = disableActEnvironment();
+    await renderStream.render(
       <Suspense fallback="Loading">
         <App />
       </Suspense>,

--- a/src/react/query-preloader/__tests__/createQueryPreloader.test.tsx
+++ b/src/react/query-preloader/__tests__/createQueryPreloader.test.tsx
@@ -1899,7 +1899,8 @@ test("masks result when dataMasking is `true`", async () => {
 
   const queryRef = preloadQuery(query, { variables: { id: "1" } });
 
-  const { renderStream } = renderDefaultTestApp<
+  using _disabledAct = disableActEnvironment();
+  const { renderStream } = await renderDefaultTestApp<
     Masked<MaskedVariablesCaseData>
   >({
     client,
@@ -1936,7 +1937,8 @@ test("does not mask result when dataMasking is `false`", async () => {
 
   const queryRef = preloadQuery(query, { variables: { id: "1" } });
 
-  const { renderStream } = renderDefaultTestApp<MaskedVariablesCaseData>({
+  using _disabledAct = disableActEnvironment();
+  const { renderStream } = await renderDefaultTestApp<MaskedVariablesCaseData>({
     client,
     queryRef,
   });
@@ -1970,7 +1972,8 @@ test("does not mask results by default", async () => {
 
   const queryRef = preloadQuery(query, { variables: { id: "1" } });
 
-  const { renderStream } = renderDefaultTestApp<MaskedVariablesCaseData>({
+  using _disabledAct = disableActEnvironment();
+  const { renderStream } = await renderDefaultTestApp<MaskedVariablesCaseData>({
     client,
     queryRef,
   });


### PR DESCRIPTION
Updates the data masked tests to adjust for changes in the render stream library. 

Related: #12140