### PR TITLE
Remove `itAsync` from remaining relevant tests

### DIFF
--- a/src/__tests__/graphqlSubscriptions.ts
+++ b/src/__tests__/graphqlSubscriptions.ts
@@ -61,8 +61,6 @@ describe("GraphQL Subscriptions", () => {
     await expect(stream).toEmitValue(results[0].result);
 
     stream.unsubscribe();
-
-    await expect(stream).not.toEmitAnything();
   });
 
   it("should subscribe with default values", async () => {
@@ -80,8 +78,6 @@ describe("GraphQL Subscriptions", () => {
     await expect(stream).toEmitValue(results[0].result);
 
     stream.unsubscribe();
-
-    await expect(stream).not.toEmitAnything();
   });
 
   it("should multiplex subscriptions", async () => {

--- a/src/__tests__/graphqlSubscriptions.ts
+++ b/src/__tests__/graphqlSubscriptions.ts
@@ -4,9 +4,9 @@ import { ApolloClient, FetchResult } from "../core";
 import { InMemoryCache } from "../cache";
 import { ApolloError, PROTOCOL_ERRORS_SYMBOL } from "../errors";
 import { QueryManager } from "../core/QueryManager";
-import { itAsync, mockObservableLink } from "../testing";
+import { mockObservableLink } from "../testing";
 import { GraphQLError } from "graphql";
-import { spyOnConsole } from "../testing/internal";
+import { ObservableStream, spyOnConsole } from "../testing/internal";
 import { getDefaultOptionsForQueryManagerTests } from "../testing/core/mocking/mockQueryManager";
 
 describe("GraphQL Subscriptions", () => {
@@ -47,36 +47,7 @@ describe("GraphQL Subscriptions", () => {
     };
   });
 
-  itAsync(
-    "should start a subscription on network interface and unsubscribe",
-    (resolve, reject) => {
-      const link = mockObservableLink();
-      // This test calls directly through Apollo Client
-      const client = new ApolloClient({
-        link,
-        cache: new InMemoryCache({ addTypename: false }),
-      });
-
-      let count = 0;
-      const sub = client.subscribe(defaultOptions).subscribe({
-        next(result) {
-          count++;
-          expect(result).toEqual(results[0].result);
-
-          // Test unsubscribing
-          if (count > 1) {
-            throw new Error("next fired after unsubscribing");
-          }
-          sub.unsubscribe();
-          resolve();
-        },
-      });
-
-      link.simulateResult(results[0]);
-    }
-  );
-
-  itAsync("should subscribe with default values", (resolve, reject) => {
+  it("should start a subscription on network interface and unsubscribe", async () => {
     const link = mockObservableLink();
     // This test calls directly through Apollo Client
     const client = new ApolloClient({
@@ -84,25 +55,36 @@ describe("GraphQL Subscriptions", () => {
       cache: new InMemoryCache({ addTypename: false }),
     });
 
-    let count = 0;
-    const sub = client.subscribe(options).subscribe({
-      next(result) {
-        expect(result).toEqual(results[0].result);
-
-        // Test unsubscribing
-        if (count > 1) {
-          throw new Error("next fired after unsubscribing");
-        }
-        sub.unsubscribe();
-
-        resolve();
-      },
-    });
-
+    const stream = new ObservableStream(client.subscribe(defaultOptions));
     link.simulateResult(results[0]);
+
+    await expect(stream).toEmitValue(results[0].result);
+
+    stream.unsubscribe();
+
+    await expect(stream).not.toEmitAnything();
   });
 
-  itAsync("should multiplex subscriptions", (resolve, reject) => {
+  it("should subscribe with default values", async () => {
+    const link = mockObservableLink();
+    // This test calls directly through Apollo Client
+    const client = new ApolloClient({
+      link,
+      cache: new InMemoryCache({ addTypename: false }),
+    });
+
+    const stream = new ObservableStream(client.subscribe(options));
+
+    link.simulateResult(results[0]);
+
+    await expect(stream).toEmitValue(results[0].result);
+
+    stream.unsubscribe();
+
+    await expect(stream).not.toEmitAnything();
+  });
+
+  it("should multiplex subscriptions", async () => {
     const link = mockObservableLink();
     const queryManager = new QueryManager(
       getDefaultOptionsForQueryManagerTests({
@@ -112,88 +94,57 @@ describe("GraphQL Subscriptions", () => {
     );
 
     const obs = queryManager.startGraphQLSubscription(options);
-
-    let counter = 0;
-
-    // tslint:disable-next-line
-    obs.subscribe({
-      next(result) {
-        expect(result).toEqual(results[0].result);
-        counter++;
-        if (counter === 2) {
-          resolve();
-        }
-      },
-    }) as any;
-
-    // Subscribe again. Should also receive the same result.
-    // tslint:disable-next-line
-    obs.subscribe({
-      next(result) {
-        expect(result).toEqual(results[0].result);
-        counter++;
-        if (counter === 2) {
-          resolve();
-        }
-      },
-    }) as any;
+    const stream1 = new ObservableStream(obs);
+    const stream2 = new ObservableStream(obs);
 
     link.simulateResult(results[0]);
+
+    await expect(stream1).toEmitValue(results[0].result);
+    await expect(stream2).toEmitValue(results[0].result);
   });
 
-  itAsync(
-    "should receive multiple results for a subscription",
-    (resolve, reject) => {
-      const link = mockObservableLink();
-      let numResults = 0;
-      const queryManager = new QueryManager(
-        getDefaultOptionsForQueryManagerTests({
-          link,
-          cache: new InMemoryCache({ addTypename: false }),
-        })
-      );
-
-      // tslint:disable-next-line
-      queryManager.startGraphQLSubscription(options).subscribe({
-        next(result) {
-          expect(result).toEqual(results[numResults].result);
-          numResults++;
-          if (numResults === 4) {
-            resolve();
-          }
-        },
-      }) as any;
-
-      for (let i = 0; i < 4; i++) {
-        link.simulateResult(results[i]);
-      }
-    }
-  );
-
-  itAsync(
-    "should not cache subscription data if a `no-cache` fetch policy is used",
-    (resolve, reject) => {
-      const link = mockObservableLink();
-      const cache = new InMemoryCache({ addTypename: false });
-      const client = new ApolloClient({
+  it("should receive multiple results for a subscription", async () => {
+    const link = mockObservableLink();
+    const queryManager = new QueryManager(
+      getDefaultOptionsForQueryManagerTests({
         link,
-        cache,
-      });
+        cache: new InMemoryCache({ addTypename: false }),
+      })
+    );
 
-      expect(cache.extract()).toEqual({});
+    const stream = new ObservableStream(
+      queryManager.startGraphQLSubscription(options)
+    );
 
-      options.fetchPolicy = "no-cache";
-      const sub = client.subscribe(options).subscribe({
-        next() {
-          expect(cache.extract()).toEqual({});
-          sub.unsubscribe();
-          resolve();
-        },
-      });
-
-      link.simulateResult(results[0]);
+    for (let i = 0; i < 4; i++) {
+      link.simulateResult(results[i]);
     }
-  );
+
+    await expect(stream).toEmitValue(results[0].result);
+    await expect(stream).toEmitValue(results[1].result);
+    await expect(stream).toEmitValue(results[2].result);
+    await expect(stream).toEmitValue(results[3].result);
+    await expect(stream).not.toEmitAnything();
+  });
+
+  it("should not cache subscription data if a `no-cache` fetch policy is used", async () => {
+    const link = mockObservableLink();
+    const cache = new InMemoryCache({ addTypename: false });
+    const client = new ApolloClient({
+      link,
+      cache,
+    });
+
+    expect(cache.extract()).toEqual({});
+
+    options.fetchPolicy = "no-cache";
+    const stream = new ObservableStream(client.subscribe(options));
+
+    link.simulateResult(results[0]);
+
+    await expect(stream).toEmitNext();
+    expect(cache.extract()).toEqual({});
+  });
 
   it("should throw an error if the result has errors on it", () => {
     const link = mockObservableLink();
@@ -492,27 +443,22 @@ describe("GraphQL Subscriptions", () => {
     });
   });
 
-  itAsync(
-    "should pass a context object through the link execution chain",
-    (resolve, reject) => {
-      const link = mockObservableLink();
-      const client = new ApolloClient({
-        cache: new InMemoryCache(),
-        link,
-      });
+  it("should pass a context object through the link execution chain", async () => {
+    const link = mockObservableLink();
+    const client = new ApolloClient({
+      cache: new InMemoryCache(),
+      link,
+    });
 
-      client.subscribe(options).subscribe({
-        next() {
-          expect(link.operation?.getContext().someVar).toEqual(
-            options.context.someVar
-          );
-          resolve();
-        },
-      });
+    const stream = new ObservableStream(client.subscribe(options));
 
-      link.simulateResult(results[0]);
-    }
-  );
+    link.simulateResult(results[0]);
+
+    await expect(stream).toEmitNext();
+    expect(link.operation?.getContext().someVar).toEqual(
+      options.context.someVar
+    );
+  });
 
   it("should throw an error if the result has protocolErrors on it", async () => {
     const link = mockObservableLink();

--- a/src/__tests__/optimistic.ts
+++ b/src/__tests__/optimistic.ts
@@ -240,7 +240,7 @@ describe("optimistic mutation results", () => {
       });
 
       it("handles errors produced by one mutation in a series", async () => {
-        expect.assertions(12);
+        expect.assertions(11);
         const client = await setup(
           {
             request: { query: mutation },
@@ -303,7 +303,7 @@ describe("optimistic mutation results", () => {
       });
 
       it("can run 2 mutations concurrently and handles all intermediate states well", async () => {
-        expect.assertions(36);
+        expect.assertions(35);
         function checkBothMutationsAreApplied(
           expectedText1: any,
           expectedText2: any
@@ -466,7 +466,7 @@ describe("optimistic mutation results", () => {
       });
 
       it("handles errors produced by one mutation in a series", async () => {
-        expect.assertions(12);
+        expect.assertions(11);
         const client = await setup(
           {
             request: { query: mutation },
@@ -528,7 +528,7 @@ describe("optimistic mutation results", () => {
       });
 
       it("can run 2 mutations concurrently and handles all intermediate states well", async () => {
-        expect.assertions(36);
+        expect.assertions(35);
         function checkBothMutationsAreApplied(
           expectedText1: any,
           expectedText2: any
@@ -831,7 +831,7 @@ describe("optimistic mutation results", () => {
     });
 
     it("will use a passed variable in optimisticResponse", async () => {
-      expect.assertions(8);
+      expect.assertions(7);
       const client = await setup({
         request: { query: mutation, variables },
         result: mutationResult,
@@ -893,7 +893,7 @@ describe("optimistic mutation results", () => {
     });
 
     it("will not update optimistically if optimisticResponse returns IGNORE sentinel object", async () => {
-      expect.assertions(7);
+      expect.assertions(6);
 
       const client = await setup({
         request: { query: mutation, variables },
@@ -1068,7 +1068,7 @@ describe("optimistic mutation results", () => {
     };
 
     it("will insert a single itemAsync to the beginning", async () => {
-      expect.assertions(9);
+      expect.assertions(8);
       const client = await setup({
         request: { query: mutation },
         result: mutationResult,
@@ -1116,7 +1116,7 @@ describe("optimistic mutation results", () => {
     });
 
     it("two array insert like mutations", async () => {
-      expect.assertions(11);
+      expect.assertions(10);
       const client = await setup(
         {
           request: { query: mutation },
@@ -1198,7 +1198,7 @@ describe("optimistic mutation results", () => {
     });
 
     it("two mutations, one fails", async () => {
-      expect.assertions(12);
+      expect.assertions(11);
       const client = await setup(
         {
           request: { query: mutation },
@@ -1452,7 +1452,7 @@ describe("optimistic mutation results", () => {
     };
 
     it("will insert a single itemAsync to the beginning", async () => {
-      expect.assertions(8);
+      expect.assertions(7);
       const client = await setup({
         request: { query: mutation },
         delay: 300,
@@ -1510,7 +1510,7 @@ describe("optimistic mutation results", () => {
     });
 
     it("two array insert like mutations", async () => {
-      expect.assertions(11);
+      expect.assertions(10);
       const client = await setup(
         {
           request: { query: mutation },
@@ -1610,7 +1610,7 @@ describe("optimistic mutation results", () => {
     });
 
     it("two mutations, one fails", async () => {
-      expect.assertions(12);
+      expect.assertions(11);
       const client = await setup(
         {
           request: { query: mutation },
@@ -2299,7 +2299,7 @@ describe("optimistic mutation - githunt comments", () => {
   };
 
   it("can post a new comment", async () => {
-    expect.assertions(3);
+    expect.assertions(2);
     const mutationVariables = {
       repoFullName: "org/repo",
       commentContent: "New Comment",

--- a/src/__tests__/refetchQueries.ts
+++ b/src/__tests__/refetchQueries.ts
@@ -565,8 +565,6 @@ describe("client.refetchQueries", () => {
           expect(diff.result).toEqual({ a: "A" });
         } else if (obs === bObs) {
           expect(diff.result).toEqual({ b: "B" });
-        } else if (obs === abObs) {
-          expect(diff.result).toEqual({ a: "A", b: "B" });
         } else {
           throw new Error(
             `unexpected ObservableQuery ${obs.queryId} with name ${obs.queryName}`

--- a/src/__tests__/refetchQueries.ts
+++ b/src/__tests__/refetchQueries.ts
@@ -1,6 +1,5 @@
 import { Subscription } from "zen-observable-ts";
 
-import { itAsync } from "../testing";
 import {
   ApolloClient,
   ApolloLink,
@@ -10,29 +9,30 @@ import {
   TypedDocumentNode,
   ObservableQuery,
 } from "../core";
+import { ObservableStream } from "../testing/internal";
 
 describe("client.refetchQueries", () => {
-  itAsync("is public and callable", (resolve, reject) => {
+  it("is public and callable", async () => {
     const client = new ApolloClient({
       cache: new InMemoryCache(),
     });
     expect(typeof client.refetchQueries).toBe("function");
+    const onQueryUpdated = jest.fn();
 
     const result = client.refetchQueries({
       updateCache(cache) {
         expect(cache).toBe(client.cache);
         expect(cache.extract()).toEqual({});
       },
-      onQueryUpdated() {
-        reject("should not have called onQueryUpdated");
-        return false;
-      },
+      onQueryUpdated,
     });
 
     expect(result.queries).toEqual([]);
     expect(result.results).toEqual([]);
 
-    result.then(resolve, reject);
+    await result;
+
+    expect(onQueryUpdated).not.toHaveBeenCalled();
   });
 
   const aQuery: TypedDocumentNode<{ a: string }> = gql`
@@ -113,179 +113,569 @@ describe("client.refetchQueries", () => {
     });
   }
 
-  itAsync(
-    "includes watched queries affected by updateCache",
-    async (resolve, reject) => {
-      const client = makeClient();
-      const [aObs, bObs, abObs] = await setup(client);
+  it("includes watched queries affected by updateCache", async () => {
+    const client = makeClient();
+    const [aObs, bObs, abObs] = await setup(client);
 
-      const ayyResults = await client.refetchQueries({
-        updateCache(cache) {
-          cache.writeQuery({
-            query: aQuery,
-            data: {
-              a: "Ayy",
-            },
-          });
+    const ayyResults = await client.refetchQueries({
+      updateCache(cache) {
+        cache.writeQuery({
+          query: aQuery,
+          data: {
+            a: "Ayy",
+          },
+        });
+      },
+
+      onQueryUpdated(obs, diff) {
+        if (obs === aObs) {
+          expect(diff.result).toEqual({ a: "Ayy" });
+        } else if (obs === bObs) {
+          throw new Error("bQuery should not have been updated");
+        } else if (obs === abObs) {
+          expect(diff.result).toEqual({ a: "Ayy", b: "B" });
+        } else {
+          throw new Error(
+            `unexpected ObservableQuery ${obs.queryId} with name ${obs.queryName}`
+          );
+        }
+        return Promise.resolve(diff.result);
+      },
+    });
+
+    sortObjects(ayyResults);
+
+    expect(ayyResults).toEqual([
+      { a: "Ayy" },
+      { a: "Ayy", b: "B" },
+      // Note that no bQuery result is included here.
+    ]);
+
+    const beeResults = await client.refetchQueries({
+      updateCache(cache) {
+        cache.writeQuery({
+          query: bQuery,
+          data: {
+            b: "Bee",
+          },
+        });
+      },
+
+      onQueryUpdated(obs, diff) {
+        if (obs === aObs) {
+          throw new Error("aQuery should not have been updated");
+        } else if (obs === bObs) {
+          expect(diff.result).toEqual({ b: "Bee" });
+        } else if (obs === abObs) {
+          expect(diff.result).toEqual({ a: "Ayy", b: "Bee" });
+        } else {
+          throw new Error(
+            `unexpected ObservableQuery ${obs.queryId} with name ${obs.queryName}`
+          );
+        }
+        return diff.result;
+      },
+    });
+
+    sortObjects(beeResults);
+
+    expect(beeResults).toEqual([
+      // Note that no aQuery result is included here.
+      { a: "Ayy", b: "Bee" },
+      { b: "Bee" },
+    ]);
+
+    unsubscribe();
+  });
+
+  it("includes watched queries named in options.include", async () => {
+    const client = makeClient();
+    const [aObs, bObs, abObs] = await setup(client);
+
+    const ayyResults = await client.refetchQueries({
+      updateCache(cache) {
+        cache.writeQuery({
+          query: aQuery,
+          data: {
+            a: "Ayy",
+          },
+        });
+      },
+
+      // This is the options.include array mentioned in the test description.
+      include: ["B"],
+
+      onQueryUpdated(obs, diff) {
+        if (obs === aObs) {
+          expect(diff.result).toEqual({ a: "Ayy" });
+        } else if (obs === bObs) {
+          expect(diff.result).toEqual({ b: "B" });
+        } else if (obs === abObs) {
+          expect(diff.result).toEqual({ a: "Ayy", b: "B" });
+        } else {
+          throw new Error(
+            `unexpected ObservableQuery ${obs.queryId} with name ${obs.queryName}`
+          );
+        }
+        return Promise.resolve(diff.result);
+      },
+    });
+
+    sortObjects(ayyResults);
+
+    expect(ayyResults).toEqual([
+      { a: "Ayy" },
+      { a: "Ayy", b: "B" },
+      // Included this time!
+      { b: "B" },
+    ]);
+
+    const beeResults = await client.refetchQueries({
+      updateCache(cache) {
+        cache.writeQuery({
+          query: bQuery,
+          data: {
+            b: "Bee",
+          },
+        });
+      },
+
+      // The "A" here causes aObs to be included, but the "AB" should be
+      // redundant because that query is already included.
+      include: ["A", "AB"],
+
+      onQueryUpdated(obs, diff) {
+        if (obs === aObs) {
+          expect(diff.result).toEqual({ a: "Ayy" });
+        } else if (obs === bObs) {
+          expect(diff.result).toEqual({ b: "Bee" });
+        } else if (obs === abObs) {
+          expect(diff.result).toEqual({ a: "Ayy", b: "Bee" });
+        } else {
+          throw new Error(
+            `unexpected ObservableQuery ${obs.queryId} with name ${obs.queryName}`
+          );
+        }
+        return diff.result;
+      },
+    });
+
+    sortObjects(beeResults);
+
+    expect(beeResults).toEqual([
+      { a: "Ayy" }, // Included this time!
+      { a: "Ayy", b: "Bee" },
+      { b: "Bee" },
+    ]);
+
+    unsubscribe();
+  });
+
+  it("includes query DocumentNode objects specified in options.include", async () => {
+    const client = makeClient();
+    const [aObs, bObs, abObs] = await setup(client);
+
+    const ayyResults = await client.refetchQueries({
+      updateCache(cache) {
+        cache.writeQuery({
+          query: aQuery,
+          data: {
+            a: "Ayy",
+          },
+        });
+      },
+
+      // Note that we're passing query DocumentNode objects instead of query
+      // name strings, in this test.
+      include: [bQuery, abQuery],
+
+      onQueryUpdated(obs, diff) {
+        if (obs === aObs) {
+          expect(diff.result).toEqual({ a: "Ayy" });
+        } else if (obs === bObs) {
+          expect(diff.result).toEqual({ b: "B" });
+        } else if (obs === abObs) {
+          expect(diff.result).toEqual({ a: "Ayy", b: "B" });
+        } else {
+          throw new Error(
+            `unexpected ObservableQuery ${obs.queryId} with name ${obs.queryName}`
+          );
+        }
+        return Promise.resolve(diff.result);
+      },
+    });
+
+    sortObjects(ayyResults);
+
+    expect(ayyResults).toEqual([
+      { a: "Ayy" },
+      { a: "Ayy", b: "B" },
+      // Included this time!
+      { b: "B" },
+    ]);
+
+    const beeResults = await client.refetchQueries({
+      updateCache(cache) {
+        cache.writeQuery({
+          query: bQuery,
+          data: {
+            b: "Bee",
+          },
+        });
+      },
+
+      // The abQuery and "AB" should be redundant, but the aQuery here is
+      // important for aObs to be included.
+      include: [abQuery, "AB", aQuery],
+
+      onQueryUpdated(obs, diff) {
+        if (obs === aObs) {
+          expect(diff.result).toEqual({ a: "Ayy" });
+        } else if (obs === bObs) {
+          expect(diff.result).toEqual({ b: "Bee" });
+        } else if (obs === abObs) {
+          expect(diff.result).toEqual({ a: "Ayy", b: "Bee" });
+        } else {
+          throw new Error(
+            `unexpected ObservableQuery ${obs.queryId} with name ${obs.queryName}`
+          );
+        }
+        return diff.result;
+      },
+    });
+
+    sortObjects(beeResults);
+
+    expect(beeResults).toEqual([
+      { a: "Ayy" }, // Included this time!
+      { a: "Ayy", b: "Bee" },
+      { b: "Bee" },
+    ]);
+
+    unsubscribe();
+  });
+
+  it('includes all queries when options.include === "all"', async () => {
+    const client = makeClient();
+    const [aObs, bObs, abObs] = await setup(client);
+
+    const ayyResults = await client.refetchQueries({
+      include: "all",
+
+      updateCache(cache) {
+        cache.writeQuery({
+          query: aQuery,
+          data: {
+            a: "Ayy",
+          },
+        });
+      },
+
+      onQueryUpdated(obs, diff) {
+        if (obs === aObs) {
+          expect(diff.result).toEqual({ a: "Ayy" });
+        } else if (obs === bObs) {
+          expect(diff.result).toEqual({ b: "B" });
+        } else if (obs === abObs) {
+          expect(diff.result).toEqual({ a: "Ayy", b: "B" });
+        } else {
+          throw new Error(
+            `unexpected ObservableQuery ${obs.queryId} with name ${obs.queryName}`
+          );
+        }
+        return Promise.resolve(diff.result);
+      },
+    });
+
+    sortObjects(ayyResults);
+
+    expect(ayyResults).toEqual([
+      { a: "Ayy" },
+      { a: "Ayy", b: "B" },
+      { b: "B" },
+    ]);
+
+    const beeResults = await client.refetchQueries({
+      include: "all",
+
+      updateCache(cache) {
+        cache.writeQuery({
+          query: bQuery,
+          data: {
+            b: "Bee",
+          },
+        });
+      },
+
+      onQueryUpdated(obs, diff) {
+        if (obs === aObs) {
+          expect(diff.result).toEqual({ a: "Ayy" });
+        } else if (obs === bObs) {
+          expect(diff.result).toEqual({ b: "Bee" });
+        } else if (obs === abObs) {
+          expect(diff.result).toEqual({ a: "Ayy", b: "Bee" });
+        } else {
+          throw new Error(
+            `unexpected ObservableQuery ${obs.queryId} with name ${obs.queryName}`
+          );
+        }
+        return diff.result;
+      },
+    });
+
+    sortObjects(beeResults);
+
+    expect(beeResults).toEqual([
+      { a: "Ayy" },
+      { a: "Ayy", b: "Bee" },
+      { b: "Bee" },
+    ]);
+
+    unsubscribe();
+  });
+
+  it('includes all active queries when options.include === "active"', async () => {
+    const client = makeClient();
+    const [aObs, bObs, abObs] = await setup(client);
+
+    const extraObs = client.watchQuery({ query: abQuery });
+    expect(extraObs.hasObservers()).toBe(false);
+
+    const activeResults = await client.refetchQueries({
+      include: "active",
+
+      onQueryUpdated(obs, diff) {
+        if (obs === aObs) {
+          expect(diff.result).toEqual({ a: "A" });
+        } else if (obs === bObs) {
+          expect(diff.result).toEqual({ b: "B" });
+        } else if (obs === abObs) {
+          expect(diff.result).toEqual({ a: "A", b: "B" });
+        } else {
+          throw new Error(
+            `unexpected ObservableQuery ${obs.queryId} with name ${obs.queryName}`
+          );
+        }
+        return Promise.resolve(diff.result);
+      },
+    });
+
+    sortObjects(activeResults);
+
+    expect(activeResults).toEqual([{ a: "A" }, { a: "A", b: "B" }, { b: "B" }]);
+
+    subs.push(
+      extraObs.subscribe({
+        next(result) {
+          expect(result).toEqual({ a: "A", b: "B" });
         },
+      })
+    );
+    expect(extraObs.hasObservers()).toBe(true);
 
-        onQueryUpdated(obs, diff) {
-          if (obs === aObs) {
-            expect(diff.result).toEqual({ a: "Ayy" });
-          } else if (obs === bObs) {
-            reject("bQuery should not have been updated");
-          } else if (obs === abObs) {
-            expect(diff.result).toEqual({ a: "Ayy", b: "B" });
-          } else {
-            reject(
-              `unexpected ObservableQuery ${obs.queryId} with name ${obs.queryName}`
-            );
-          }
-          return Promise.resolve(diff.result);
-        },
-      });
+    const resultsAfterSubscribe = await client.refetchQueries({
+      include: "active",
 
-      sortObjects(ayyResults);
+      onQueryUpdated(obs, diff) {
+        if (obs === aObs) {
+          expect(diff.result).toEqual({ a: "A" });
+        } else if (obs === bObs) {
+          expect(diff.result).toEqual({ b: "B" });
+        } else if (obs === abObs) {
+          expect(diff.result).toEqual({ a: "A", b: "B" });
+        } else if (obs === extraObs) {
+          expect(diff.result).toEqual({ a: "A", b: "B" });
+        } else {
+          throw new Error(
+            `unexpected ObservableQuery ${obs.queryId} with name ${obs.queryName}`
+          );
+        }
+        return Promise.resolve(diff.result);
+      },
+    });
 
-      expect(ayyResults).toEqual([
-        { a: "Ayy" },
-        { a: "Ayy", b: "B" },
-        // Note that no bQuery result is included here.
-      ]);
+    sortObjects(resultsAfterSubscribe);
 
-      const beeResults = await client.refetchQueries({
-        updateCache(cache) {
-          cache.writeQuery({
-            query: bQuery,
-            data: {
-              b: "Bee",
-            },
-          });
-        },
+    expect(resultsAfterSubscribe).toEqual([
+      { a: "A" },
+      { a: "A", b: "B" },
+      // Included thanks to extraObs this time.
+      { a: "A", b: "B" },
+      // Sorted last by sortObjects.
+      { b: "B" },
+    ]);
 
-        onQueryUpdated(obs, diff) {
-          if (obs === aObs) {
-            reject("aQuery should not have been updated");
-          } else if (obs === bObs) {
-            expect(diff.result).toEqual({ b: "Bee" });
-          } else if (obs === abObs) {
-            expect(diff.result).toEqual({ a: "Ayy", b: "Bee" });
-          } else {
-            reject(
-              `unexpected ObservableQuery ${obs.queryId} with name ${obs.queryName}`
-            );
-          }
-          return diff.result;
-        },
-      });
+    unsubscribe();
+  });
 
-      sortObjects(beeResults);
+  it("includes queries named in refetchQueries even if they have no observers", async () => {
+    const client = makeClient();
 
-      expect(beeResults).toEqual([
-        // Note that no aQuery result is included here.
-        { a: "Ayy", b: "Bee" },
-        { b: "Bee" },
-      ]);
+    const aObs = client.watchQuery({ query: aQuery });
+    const bObs = client.watchQuery({ query: bQuery });
+    const abObs = client.watchQuery({ query: abQuery });
 
-      unsubscribe();
-      resolve();
-    }
-  );
+    // These ObservableQuery objects have no observers yet, but should
+    // nevertheless be refetched if identified explicitly in an options.include
+    // array passed to client.refetchQueries.
+    expect(aObs.hasObservers()).toBe(false);
+    expect(bObs.hasObservers()).toBe(false);
+    expect(abObs.hasObservers()).toBe(false);
 
-  itAsync(
-    "includes watched queries named in options.include",
-    async (resolve, reject) => {
-      const client = makeClient();
-      const [aObs, bObs, abObs] = await setup(client);
+    const activeResults = await client.refetchQueries({
+      include: ["A", abQuery],
 
-      const ayyResults = await client.refetchQueries({
-        updateCache(cache) {
-          cache.writeQuery({
-            query: aQuery,
-            data: {
-              a: "Ayy",
-            },
-          });
-        },
+      onQueryUpdated(obs, diff) {
+        if (obs === aObs) {
+          expect(diff.complete).toBe(false);
+          expect(diff.result).toEqual({});
+        } else if (obs === abObs) {
+          expect(diff.complete).toBe(false);
+          expect(diff.result).toEqual({});
+        } else {
+          throw new Error(
+            `unexpected ObservableQuery ${obs.queryId} with name ${obs.queryName}`
+          );
+        }
+        return Promise.resolve(diff.result);
+      },
+    });
 
-        // This is the options.include array mentioned in the test description.
+    sortObjects(activeResults);
+    expect(activeResults).toEqual([{}, {}]);
+
+    const stream = new ObservableStream(abObs);
+    subs.push(stream as unknown as Subscription);
+    expect(abObs.hasObservers()).toBe(true);
+
+    await expect(stream).toEmitMatchedValue({ data: { a: "A", b: "B" } });
+
+    const resultsAfterSubscribe = await client.refetchQueries({
+      include: [aQuery, "B"],
+
+      onQueryUpdated(obs, diff) {
+        if (obs === aObs) {
+          expect(diff.result).toEqual({ a: "A" });
+        } else if (obs === bObs) {
+          expect(diff.result).toEqual({ b: "B" });
+        } else if (obs === abObs) {
+          expect(diff.result).toEqual({ a: "A", b: "B" });
+        } else {
+          throw new Error(
+            `unexpected ObservableQuery ${obs.queryId} with name ${obs.queryName}`
+          );
+        }
+        return Promise.resolve(diff.result);
+      },
+    });
+
+    sortObjects(resultsAfterSubscribe);
+    expect(resultsAfterSubscribe).toEqual([{ a: "A" }, { b: "B" }]);
+
+    unsubscribe();
+  });
+
+  it("should not include unwatched single queries", async () => {
+    const client = makeClient();
+    const [aObs, bObs, abObs] = await setup(client);
+
+    const delayedQuery = gql`
+      query DELAYED {
+        d
+        e
+        l
+        a
+        y
+        e
+        d
+      }
+    `;
+
+    void client.query({
+      query: delayedQuery,
+      variables: {
+        // Delay this query by 10 seconds so it stays in-flight.
+        delay: 10000,
+      },
+    });
+
+    const queries = client["queryManager"]["queries"];
+    expect(queries.size).toBe(4);
+
+    queries.forEach((queryInfo, queryId) => {
+      if (queryId === "1" || queryId === "2" || queryId === "3") {
+        expect(queryInfo.observableQuery).toBeInstanceOf(ObservableQuery);
+      } else if (queryId === "4") {
+        // One-off client.query-style queries never get an ObservableQuery, so
+        // they should not be included by include: "active".
+        expect(queryInfo.observableQuery).toBe(null);
+        expect(queryInfo.document).toBe(delayedQuery);
+      }
+    });
+
+    const activeResults = await client.refetchQueries({
+      include: "active",
+
+      onQueryUpdated(obs, diff) {
+        if (obs === aObs) {
+          expect(diff.result).toEqual({ a: "A" });
+        } else if (obs === bObs) {
+          expect(diff.result).toEqual({ b: "B" });
+        } else if (obs === abObs) {
+          expect(diff.result).toEqual({ a: "A", b: "B" });
+        } else {
+          throw new Error(
+            `unexpected ObservableQuery ${obs.queryId} with name ${obs.queryName}`
+          );
+        }
+        return Promise.resolve(diff.result);
+      },
+    });
+
+    sortObjects(activeResults);
+
+    expect(activeResults).toEqual([{ a: "A" }, { a: "A", b: "B" }, { b: "B" }]);
+
+    const allResults = await client.refetchQueries({
+      include: "all",
+
+      onQueryUpdated(obs, diff) {
+        if (obs === aObs) {
+          expect(diff.result).toEqual({ a: "A" });
+        } else if (obs === bObs) {
+          expect(diff.result).toEqual({ b: "B" });
+        } else if (obs === abObs) {
+          expect(diff.result).toEqual({ a: "A", b: "B" });
+        } else {
+          throw new Error(
+            `unexpected ObservableQuery ${obs.queryId} with name ${obs.queryName}`
+          );
+        }
+        return Promise.resolve(diff.result);
+      },
+    });
+
+    sortObjects(allResults);
+
+    expect(allResults).toEqual([{ a: "A" }, { a: "A", b: "B" }, { b: "B" }]);
+
+    unsubscribe();
+    client.stop();
+
+    expect(queries.size).toBe(0);
+  });
+
+  it("refetches watched queries if onQueryUpdated not provided", async () => {
+    const client = makeClient();
+    const [aObs, bObs, abObs] = await setup(client);
+
+    const aSpy = jest.spyOn(aObs, "refetch");
+    const bSpy = jest.spyOn(bObs, "refetch");
+    const abSpy = jest.spyOn(abObs, "refetch");
+
+    const ayyResults = (
+      await client.refetchQueries({
         include: ["B"],
-
-        onQueryUpdated(obs, diff) {
-          if (obs === aObs) {
-            expect(diff.result).toEqual({ a: "Ayy" });
-          } else if (obs === bObs) {
-            expect(diff.result).toEqual({ b: "B" });
-          } else if (obs === abObs) {
-            expect(diff.result).toEqual({ a: "Ayy", b: "B" });
-          } else {
-            reject(
-              `unexpected ObservableQuery ${obs.queryId} with name ${obs.queryName}`
-            );
-          }
-          return Promise.resolve(diff.result);
-        },
-      });
-
-      sortObjects(ayyResults);
-
-      expect(ayyResults).toEqual([
-        { a: "Ayy" },
-        { a: "Ayy", b: "B" },
-        // Included this time!
-        { b: "B" },
-      ]);
-
-      const beeResults = await client.refetchQueries({
-        updateCache(cache) {
-          cache.writeQuery({
-            query: bQuery,
-            data: {
-              b: "Bee",
-            },
-          });
-        },
-
-        // The "A" here causes aObs to be included, but the "AB" should be
-        // redundant because that query is already included.
-        include: ["A", "AB"],
-
-        onQueryUpdated(obs, diff) {
-          if (obs === aObs) {
-            expect(diff.result).toEqual({ a: "Ayy" });
-          } else if (obs === bObs) {
-            expect(diff.result).toEqual({ b: "Bee" });
-          } else if (obs === abObs) {
-            expect(diff.result).toEqual({ a: "Ayy", b: "Bee" });
-          } else {
-            reject(
-              `unexpected ObservableQuery ${obs.queryId} with name ${obs.queryName}`
-            );
-          }
-          return diff.result;
-        },
-      });
-
-      sortObjects(beeResults);
-
-      expect(beeResults).toEqual([
-        { a: "Ayy" }, // Included this time!
-        { a: "Ayy", b: "Bee" },
-        { b: "Bee" },
-      ]);
-
-      unsubscribe();
-      resolve();
-    }
-  );
-
-  itAsync(
-    "includes query DocumentNode objects specified in options.include",
-    async (resolve, reject) => {
-      const client = makeClient();
-      const [aObs, bObs, abObs] = await setup(client);
-
-      const ayyResults = await client.refetchQueries({
         updateCache(cache) {
           cache.writeQuery({
             query: aQuery,
@@ -294,736 +684,277 @@ describe("client.refetchQueries", () => {
             },
           });
         },
+      })
+    ).map((result) => result.data as object);
 
-        // Note that we're passing query DocumentNode objects instead of query
-        // name strings, in this test.
-        include: [bQuery, abQuery],
+    sortObjects(ayyResults);
 
-        onQueryUpdated(obs, diff) {
-          if (obs === aObs) {
-            expect(diff.result).toEqual({ a: "Ayy" });
-          } else if (obs === bObs) {
-            expect(diff.result).toEqual({ b: "B" });
-          } else if (obs === abObs) {
-            expect(diff.result).toEqual({ a: "Ayy", b: "B" });
-          } else {
-            reject(
-              `unexpected ObservableQuery ${obs.queryId} with name ${obs.queryName}`
-            );
-          }
-          return Promise.resolve(diff.result);
-        },
-      });
+    // These results have reverted back to what the ApolloLink returns ("A"
+    // rather than "Ayy"), because we let them be refetched (by not providing
+    // an onQueryUpdated function).
+    expect(ayyResults).toEqual([{ a: "A" }, { a: "A", b: "B" }, { b: "B" }]);
 
-      sortObjects(ayyResults);
+    expect(aSpy).toHaveBeenCalledTimes(1);
+    expect(bSpy).toHaveBeenCalledTimes(1);
+    expect(abSpy).toHaveBeenCalledTimes(1);
 
-      expect(ayyResults).toEqual([
-        { a: "Ayy" },
-        { a: "Ayy", b: "B" },
-        // Included this time!
-        { b: "B" },
-      ]);
+    unsubscribe();
+  });
 
-      const beeResults = await client.refetchQueries({
-        updateCache(cache) {
-          cache.writeQuery({
-            query: bQuery,
-            data: {
-              b: "Bee",
+  it("can run updateQuery function against optimistic cache layer", async () => {
+    const client = makeClient();
+    const [aObs, bObs, abObs] = await setup(client);
+
+    client.cache.watch({
+      query: abQuery,
+      optimistic: false,
+      callback(diff) {
+        throw new Error("should not have notified non-optimistic watcher");
+      },
+    });
+
+    expect(client.cache.extract(true)).toEqual({
+      ROOT_QUERY: {
+        __typename: "Query",
+        a: "A",
+        b: "B",
+      },
+    });
+
+    const results = await client.refetchQueries({
+      // This causes the update to run against a temporary optimistic layer.
+      optimistic: true,
+
+      updateCache(cache) {
+        const modified = cache.modify({
+          fields: {
+            a(value, { DELETE }) {
+              expect(value).toEqual("A");
+              return DELETE;
             },
-          });
-        },
-
-        // The abQuery and "AB" should be redundant, but the aQuery here is
-        // important for aObs to be included.
-        include: [abQuery, "AB", aQuery],
-
-        onQueryUpdated(obs, diff) {
-          if (obs === aObs) {
-            expect(diff.result).toEqual({ a: "Ayy" });
-          } else if (obs === bObs) {
-            expect(diff.result).toEqual({ b: "Bee" });
-          } else if (obs === abObs) {
-            expect(diff.result).toEqual({ a: "Ayy", b: "Bee" });
-          } else {
-            reject(
-              `unexpected ObservableQuery ${obs.queryId} with name ${obs.queryName}`
-            );
-          }
-          return diff.result;
-        },
-      });
-
-      sortObjects(beeResults);
-
-      expect(beeResults).toEqual([
-        { a: "Ayy" }, // Included this time!
-        { a: "Ayy", b: "Bee" },
-        { b: "Bee" },
-      ]);
-
-      unsubscribe();
-      resolve();
-    }
-  );
-
-  itAsync(
-    'includes all queries when options.include === "all"',
-    async (resolve, reject) => {
-      const client = makeClient();
-      const [aObs, bObs, abObs] = await setup(client);
-
-      const ayyResults = await client.refetchQueries({
-        include: "all",
-
-        updateCache(cache) {
-          cache.writeQuery({
-            query: aQuery,
-            data: {
-              a: "Ayy",
-            },
-          });
-        },
-
-        onQueryUpdated(obs, diff) {
-          if (obs === aObs) {
-            expect(diff.result).toEqual({ a: "Ayy" });
-          } else if (obs === bObs) {
-            expect(diff.result).toEqual({ b: "B" });
-          } else if (obs === abObs) {
-            expect(diff.result).toEqual({ a: "Ayy", b: "B" });
-          } else {
-            reject(
-              `unexpected ObservableQuery ${obs.queryId} with name ${obs.queryName}`
-            );
-          }
-          return Promise.resolve(diff.result);
-        },
-      });
-
-      sortObjects(ayyResults);
-
-      expect(ayyResults).toEqual([
-        { a: "Ayy" },
-        { a: "Ayy", b: "B" },
-        { b: "B" },
-      ]);
-
-      const beeResults = await client.refetchQueries({
-        include: "all",
-
-        updateCache(cache) {
-          cache.writeQuery({
-            query: bQuery,
-            data: {
-              b: "Bee",
-            },
-          });
-        },
-
-        onQueryUpdated(obs, diff) {
-          if (obs === aObs) {
-            expect(diff.result).toEqual({ a: "Ayy" });
-          } else if (obs === bObs) {
-            expect(diff.result).toEqual({ b: "Bee" });
-          } else if (obs === abObs) {
-            expect(diff.result).toEqual({ a: "Ayy", b: "Bee" });
-          } else {
-            reject(
-              `unexpected ObservableQuery ${obs.queryId} with name ${obs.queryName}`
-            );
-          }
-          return diff.result;
-        },
-      });
-
-      sortObjects(beeResults);
-
-      expect(beeResults).toEqual([
-        { a: "Ayy" },
-        { a: "Ayy", b: "Bee" },
-        { b: "Bee" },
-      ]);
-
-      unsubscribe();
-      resolve();
-    }
-  );
-
-  itAsync(
-    'includes all active queries when options.include === "active"',
-    async (resolve, reject) => {
-      const client = makeClient();
-      const [aObs, bObs, abObs] = await setup(client);
-
-      const extraObs = client.watchQuery({ query: abQuery });
-      expect(extraObs.hasObservers()).toBe(false);
-
-      const activeResults = await client.refetchQueries({
-        include: "active",
-
-        onQueryUpdated(obs, diff) {
-          if (obs === aObs) {
-            expect(diff.result).toEqual({ a: "A" });
-          } else if (obs === bObs) {
-            expect(diff.result).toEqual({ b: "B" });
-          } else if (obs === abObs) {
-            expect(diff.result).toEqual({ a: "A", b: "B" });
-          } else {
-            reject(
-              `unexpected ObservableQuery ${obs.queryId} with name ${obs.queryName}`
-            );
-          }
-          return Promise.resolve(diff.result);
-        },
-      });
-
-      sortObjects(activeResults);
-
-      expect(activeResults).toEqual([
-        { a: "A" },
-        { a: "A", b: "B" },
-        { b: "B" },
-      ]);
-
-      subs.push(
-        extraObs.subscribe({
-          next(result) {
-            expect(result).toEqual({ a: "A", b: "B" });
           },
-        })
-      );
-      expect(extraObs.hasObservers()).toBe(true);
+        });
+        expect(modified).toBe(true);
+      },
 
-      const resultsAfterSubscribe = await client.refetchQueries({
-        include: "active",
+      onQueryUpdated(obs, diff) {
+        expect(diff.complete).toBe(true);
 
-        onQueryUpdated(obs, diff) {
-          if (obs === aObs) {
-            expect(diff.result).toEqual({ a: "A" });
-          } else if (obs === bObs) {
-            expect(diff.result).toEqual({ b: "B" });
-          } else if (obs === abObs) {
-            expect(diff.result).toEqual({ a: "A", b: "B" });
-          } else if (obs === extraObs) {
-            expect(diff.result).toEqual({ a: "A", b: "B" });
-          } else {
-            reject(
-              `unexpected ObservableQuery ${obs.queryId} with name ${obs.queryName}`
-            );
-          }
-          return Promise.resolve(diff.result);
-        },
-      });
-
-      sortObjects(resultsAfterSubscribe);
-
-      expect(resultsAfterSubscribe).toEqual([
-        { a: "A" },
-        { a: "A", b: "B" },
-        // Included thanks to extraObs this time.
-        { a: "A", b: "B" },
-        // Sorted last by sortObjects.
-        { b: "B" },
-      ]);
-
-      unsubscribe();
-      resolve();
-    }
-  );
-
-  itAsync(
-    "includes queries named in refetchQueries even if they have no observers",
-    async (resolve, reject) => {
-      const client = makeClient();
-
-      const aObs = client.watchQuery({ query: aQuery });
-      const bObs = client.watchQuery({ query: bQuery });
-      const abObs = client.watchQuery({ query: abQuery });
-
-      // These ObservableQuery objects have no observers yet, but should
-      // nevertheless be refetched if identified explicitly in an options.include
-      // array passed to client.refetchQueries.
-      expect(aObs.hasObservers()).toBe(false);
-      expect(bObs.hasObservers()).toBe(false);
-      expect(abObs.hasObservers()).toBe(false);
-
-      const activeResults = await client.refetchQueries({
-        include: ["A", abQuery],
-
-        onQueryUpdated(obs, diff) {
-          if (obs === aObs) {
-            expect(diff.complete).toBe(false);
-            expect(diff.result).toEqual({});
-          } else if (obs === abObs) {
-            expect(diff.complete).toBe(false);
-            expect(diff.result).toEqual({});
-          } else {
-            reject(
-              `unexpected ObservableQuery ${obs.queryId} with name ${obs.queryName}`
-            );
-          }
-          return Promise.resolve(diff.result);
-        },
-      });
-
-      sortObjects(activeResults);
-      expect(activeResults).toEqual([{}, {}]);
-
-      subs.push(
-        abObs.subscribe({
-          next(result) {
-            expect(result.data).toEqual({ a: "A", b: "B" });
-
-            client
-              .refetchQueries({
-                include: [aQuery, "B"],
-
-                onQueryUpdated(obs, diff) {
-                  if (obs === aObs) {
-                    expect(diff.result).toEqual({ a: "A" });
-                  } else if (obs === bObs) {
-                    expect(diff.result).toEqual({ b: "B" });
-                  } else if (obs === abObs) {
-                    expect(diff.result).toEqual({ a: "A", b: "B" });
-                  } else {
-                    reject(
-                      `unexpected ObservableQuery ${obs.queryId} with name ${obs.queryName}`
-                    );
-                  }
-                  return Promise.resolve(diff.result);
-                },
-              })
-              .then((resultsAfterSubscribe) => {
-                sortObjects(resultsAfterSubscribe);
-                expect(resultsAfterSubscribe).toEqual([{ a: "A" }, { b: "B" }]);
-
-                unsubscribe();
-              })
-              .then(resolve, reject);
-          },
-        })
-      );
-
-      expect(abObs.hasObservers()).toBe(true);
-    }
-  );
-
-  itAsync(
-    "should not include unwatched single queries",
-    async (resolve, reject) => {
-      const client = makeClient();
-      const [aObs, bObs, abObs] = await setup(client);
-
-      const delayedQuery = gql`
-        query DELAYED {
-          d
-          e
-          l
-          a
-          y
-          e
-          d
+        // Even though we evicted the Query.a field in the updateCache function,
+        // that optimistic layer was discarded before broadcasting results, so
+        // we're back to the original (non-optimistic) data.
+        if (obs === aObs) {
+          expect(diff.result).toEqual({ a: "A" });
+        } else if (obs === bObs) {
+          throw new Error("bQuery should not have been updated");
+        } else if (obs === abObs) {
+          expect(diff.result).toEqual({ a: "A", b: "B" });
+        } else {
+          throw new Error(
+            `unexpected ObservableQuery ${obs.queryId} with name ${obs.queryName}`
+          );
         }
-      `;
 
-      client
-        .query({
-          query: delayedQuery,
-          variables: {
-            // Delay this query by 10 seconds so it stays in-flight.
-            delay: 10000,
-          },
-        })
-        .catch(reject);
+        return diff.result;
+      },
+    });
 
-      const queries = client["queryManager"]["queries"];
-      expect(queries.size).toBe(4);
+    sortObjects(results);
 
-      queries.forEach((queryInfo, queryId) => {
-        if (queryId === "1" || queryId === "2" || queryId === "3") {
-          expect(queryInfo.observableQuery).toBeInstanceOf(ObservableQuery);
-        } else if (queryId === "4") {
-          // One-off client.query-style queries never get an ObservableQuery, so
-          // they should not be included by include: "active".
-          expect(queryInfo.observableQuery).toBe(null);
-          expect(queryInfo.document).toBe(delayedQuery);
+    expect(results).toEqual([{ a: "A" }, { a: "A", b: "B" }]);
+
+    expect(client.cache.extract(true)).toEqual({
+      ROOT_QUERY: {
+        __typename: "Query",
+        a: "A",
+        b: "B",
+      },
+    });
+  });
+
+  it("can return true from onQueryUpdated to choose default refetching behavior", async () => {
+    const client = makeClient();
+    const [aObs, bObs, abObs] = await setup(client);
+
+    const refetchResult = client.refetchQueries({
+      include: ["A", "B"],
+      onQueryUpdated(obs, diff) {
+        if (obs === aObs) {
+          expect(diff.result).toEqual({ a: "A" });
+        } else if (obs === bObs) {
+          expect(diff.result).toEqual({ b: "B" });
+        } else if (obs === abObs) {
+          throw new Error("abQuery should not have been updated");
+        } else {
+          throw new Error(
+            `unexpected ObservableQuery ${obs.queryId} with name ${obs.queryName}`
+          );
         }
-      });
+        return true;
+      },
+    });
 
-      const activeResults = await client.refetchQueries({
-        include: "active",
+    expect(refetchResult.results.length).toBe(2);
+    refetchResult.results.forEach((result) => {
+      expect(result).toBeInstanceOf(Promise);
+    });
 
-        onQueryUpdated(obs, diff) {
-          if (obs === aObs) {
-            expect(diff.result).toEqual({ a: "A" });
-          } else if (obs === bObs) {
-            expect(diff.result).toEqual({ b: "B" });
-          } else if (obs === abObs) {
-            expect(diff.result).toEqual({ a: "A", b: "B" });
-          } else {
-            reject(
-              `unexpected ObservableQuery ${obs.queryId} with name ${obs.queryName}`
-            );
-          }
-          return Promise.resolve(diff.result);
-        },
-      });
-
-      sortObjects(activeResults);
-
-      expect(activeResults).toEqual([
-        { a: "A" },
-        { a: "A", b: "B" },
-        { b: "B" },
-      ]);
-
-      const allResults = await client.refetchQueries({
-        include: "all",
-
-        onQueryUpdated(obs, diff) {
-          if (obs === aObs) {
-            expect(diff.result).toEqual({ a: "A" });
-          } else if (obs === bObs) {
-            expect(diff.result).toEqual({ b: "B" });
-          } else if (obs === abObs) {
-            expect(diff.result).toEqual({ a: "A", b: "B" });
-          } else {
-            reject(
-              `unexpected ObservableQuery ${obs.queryId} with name ${obs.queryName}`
-            );
-          }
-          return Promise.resolve(diff.result);
-        },
-      });
-
-      sortObjects(allResults);
-
-      expect(allResults).toEqual([{ a: "A" }, { a: "A", b: "B" }, { b: "B" }]);
-
-      unsubscribe();
-      client.stop();
-
-      expect(queries.size).toBe(0);
-
-      resolve();
-    }
-  );
-
-  itAsync(
-    "refetches watched queries if onQueryUpdated not provided",
-    async (resolve, reject) => {
-      const client = makeClient();
-      const [aObs, bObs, abObs] = await setup(client);
-
-      const aSpy = jest.spyOn(aObs, "refetch");
-      const bSpy = jest.spyOn(bObs, "refetch");
-      const abSpy = jest.spyOn(abObs, "refetch");
-
-      const ayyResults = (
-        await client.refetchQueries({
-          include: ["B"],
-          updateCache(cache) {
-            cache.writeQuery({
-              query: aQuery,
-              data: {
-                a: "Ayy",
-              },
-            });
-          },
+    expect(
+      refetchResult.queries
+        .map((obs) => {
+          expect(obs).toBeInstanceOf(ObservableQuery);
+          return obs.queryName;
         })
-      ).map((result) => result.data as object);
+        .sort()
+    ).toEqual(["A", "B"]);
 
-      sortObjects(ayyResults);
-
-      // These results have reverted back to what the ApolloLink returns ("A"
-      // rather than "Ayy"), because we let them be refetched (by not providing
-      // an onQueryUpdated function).
-      expect(ayyResults).toEqual([{ a: "A" }, { a: "A", b: "B" }, { b: "B" }]);
-
-      expect(aSpy).toHaveBeenCalledTimes(1);
-      expect(bSpy).toHaveBeenCalledTimes(1);
-      expect(abSpy).toHaveBeenCalledTimes(1);
-
-      unsubscribe();
-      resolve();
-    }
-  );
-
-  itAsync(
-    "can run updateQuery function against optimistic cache layer",
-    async (resolve, reject) => {
-      const client = makeClient();
-      const [aObs, bObs, abObs] = await setup(client);
-
-      client.cache.watch({
-        query: abQuery,
-        optimistic: false,
-        callback(diff) {
-          reject("should not have notified non-optimistic watcher");
-        },
-      });
-
-      expect(client.cache.extract(true)).toEqual({
-        ROOT_QUERY: {
-          __typename: "Query",
-          a: "A",
-          b: "B",
-        },
-      });
-
-      const results = await client.refetchQueries({
-        // This causes the update to run against a temporary optimistic layer.
-        optimistic: true,
-
-        updateCache(cache) {
-          const modified = cache.modify({
-            fields: {
-              a(value, { DELETE }) {
-                expect(value).toEqual("A");
-                return DELETE;
-              },
-            },
-          });
-          expect(modified).toBe(true);
-        },
-
-        onQueryUpdated(obs, diff) {
-          expect(diff.complete).toBe(true);
-
-          // Even though we evicted the Query.a field in the updateCache function,
-          // that optimistic layer was discarded before broadcasting results, so
-          // we're back to the original (non-optimistic) data.
-          if (obs === aObs) {
-            expect(diff.result).toEqual({ a: "A" });
-          } else if (obs === bObs) {
-            reject("bQuery should not have been updated");
-          } else if (obs === abObs) {
-            expect(diff.result).toEqual({ a: "A", b: "B" });
-          } else {
-            reject(
-              `unexpected ObservableQuery ${obs.queryId} with name ${obs.queryName}`
-            );
-          }
-
-          return diff.result;
-        },
-      });
-
-      sortObjects(results);
-
-      expect(results).toEqual([{ a: "A" }, { a: "A", b: "B" }]);
-
-      expect(client.cache.extract(true)).toEqual({
-        ROOT_QUERY: {
-          __typename: "Query",
-          a: "A",
-          b: "B",
-        },
-      });
-
-      resolve();
-    }
-  );
-
-  itAsync(
-    "can return true from onQueryUpdated to choose default refetching behavior",
-    async (resolve, reject) => {
-      const client = makeClient();
-      const [aObs, bObs, abObs] = await setup(client);
-
-      const refetchResult = client.refetchQueries({
-        include: ["A", "B"],
-        onQueryUpdated(obs, diff) {
-          if (obs === aObs) {
-            expect(diff.result).toEqual({ a: "A" });
-          } else if (obs === bObs) {
-            expect(diff.result).toEqual({ b: "B" });
-          } else if (obs === abObs) {
-            reject("abQuery should not have been updated");
-          } else {
-            reject(
-              `unexpected ObservableQuery ${obs.queryId} with name ${obs.queryName}`
-            );
-          }
-          return true;
-        },
-      });
-
-      expect(refetchResult.results.length).toBe(2);
-      refetchResult.results.forEach((result) => {
-        expect(result).toBeInstanceOf(Promise);
-      });
-
-      expect(
-        refetchResult.queries
-          .map((obs) => {
-            expect(obs).toBeInstanceOf(ObservableQuery);
-            return obs.queryName;
-          })
-          .sort()
-      ).toEqual(["A", "B"]);
-
-      const results = (await refetchResult).map((result) => {
-        // These results are ApolloQueryResult<any>, as inferred by TypeScript.
-        expect(Object.keys(result).sort()).toEqual([
-          "data",
-          "loading",
-          "networkStatus",
-        ]);
-        return result.data;
-      });
-
-      sortObjects(results);
-
-      expect(results).toEqual([{ a: "A" }, { b: "B" }]);
-
-      resolve();
-    }
-  );
-
-  itAsync(
-    "can return true from onQueryUpdated when using options.updateCache",
-    async (resolve, reject) => {
-      const client = makeClient();
-      const [aObs, bObs, abObs] = await setup(client);
-
-      const refetchResult = client.refetchQueries({
-        updateCache(cache) {
-          cache.writeQuery({
-            query: bQuery,
-            data: {
-              b: "Beetlejuice",
-            },
-          });
-        },
-
-        onQueryUpdated(obs, diff) {
-          if (obs === aObs) {
-            reject("aQuery should not have been updated");
-          } else if (obs === bObs) {
-            expect(diff.result).toEqual({ b: "Beetlejuice" });
-          } else if (obs === abObs) {
-            expect(diff.result).toEqual({ a: "A", b: "Beetlejuice" });
-          } else {
-            reject(
-              `unexpected ObservableQuery ${obs.queryId} with name ${obs.queryName}`
-            );
-          }
-
-          expect(client.cache.extract()).toEqual({
-            ROOT_QUERY: {
-              __typename: "Query",
-              a: "A",
-              b: "Beetlejuice",
-            },
-          });
-
-          return true;
-        },
-      });
-
-      expect(refetchResult.results.length).toBe(2);
-      refetchResult.results.forEach((result) => {
-        expect(result).toBeInstanceOf(Promise);
-      });
-
-      expect(
-        refetchResult.queries
-          .map((obs) => {
-            expect(obs).toBeInstanceOf(ObservableQuery);
-            return obs.queryName;
-          })
-          .sort()
-      ).toEqual(["AB", "B"]);
-
-      const results = (await refetchResult).map((result) => {
-        // These results are ApolloQueryResult<any>, as inferred by TypeScript.
-        expect(Object.keys(result).sort()).toEqual([
-          "data",
-          "loading",
-          "networkStatus",
-        ]);
-        return result.data;
-      });
-
-      sortObjects(results);
-
-      expect(results).toEqual([
-        // Since we returned true from onQueryUpdated, the results were refetched,
-        // replacing "Beetlejuice" with "B" again.
-        { a: "A", b: "B" },
-        { b: "B" },
+    const results = (await refetchResult).map((result) => {
+      // These results are ApolloQueryResult<any>, as inferred by TypeScript.
+      expect(Object.keys(result).sort()).toEqual([
+        "data",
+        "loading",
+        "networkStatus",
       ]);
+      return result.data;
+    });
 
-      expect(client.cache.extract()).toEqual({
-        ROOT_QUERY: {
-          __typename: "Query",
-          a: "A",
-          b: "B",
-        },
-      });
+    sortObjects(results);
 
-      resolve();
-    }
-  );
+    expect(results).toEqual([{ a: "A" }, { b: "B" }]);
+  });
 
-  itAsync(
-    "can return false from onQueryUpdated to skip/ignore a query",
-    async (resolve, reject) => {
-      const client = makeClient();
-      const [aObs, bObs, abObs] = await setup(client);
+  it("can return true from onQueryUpdated when using options.updateCache", async () => {
+    const client = makeClient();
+    const [aObs, bObs, abObs] = await setup(client);
 
-      const refetchResult = client.refetchQueries({
-        include: ["A", "B"],
-        onQueryUpdated(obs, diff) {
-          if (obs === aObs) {
-            expect(diff.result).toEqual({ a: "A" });
-          } else if (obs === bObs) {
-            expect(diff.result).toEqual({ b: "B" });
-          } else if (obs === abObs) {
-            reject("abQuery should not have been updated");
-          } else {
-            reject(
-              `unexpected ObservableQuery ${obs.queryId} with name ${obs.queryName}`
-            );
-          }
-          // Skip refetching all but the B query.
-          return obs.queryName === "B";
-        },
-      });
+    const refetchResult = client.refetchQueries({
+      updateCache(cache) {
+        cache.writeQuery({
+          query: bQuery,
+          data: {
+            b: "Beetlejuice",
+          },
+        });
+      },
 
-      expect(refetchResult.results.length).toBe(1);
-      refetchResult.results.forEach((result) => {
-        expect(result).toBeInstanceOf(Promise);
-      });
+      onQueryUpdated(obs, diff) {
+        if (obs === aObs) {
+          throw new Error("aQuery should not have been updated");
+        } else if (obs === bObs) {
+          expect(diff.result).toEqual({ b: "Beetlejuice" });
+        } else if (obs === abObs) {
+          expect(diff.result).toEqual({ a: "A", b: "Beetlejuice" });
+        } else {
+          throw new Error(
+            `unexpected ObservableQuery ${obs.queryId} with name ${obs.queryName}`
+          );
+        }
 
-      expect(
-        refetchResult.queries
-          .map((obs) => {
-            expect(obs).toBeInstanceOf(ObservableQuery);
-            return obs.queryName;
-          })
-          .sort()
-      ).toEqual(["B"]);
+        expect(client.cache.extract()).toEqual({
+          ROOT_QUERY: {
+            __typename: "Query",
+            a: "A",
+            b: "Beetlejuice",
+          },
+        });
 
-      const results = (await refetchResult).map((result) => {
-        // These results are ApolloQueryResult<any>, as inferred by TypeScript.
-        expect(Object.keys(result).sort()).toEqual([
-          "data",
-          "loading",
-          "networkStatus",
-        ]);
-        return result.data;
-      });
+        return true;
+      },
+    });
 
-      sortObjects(results);
+    expect(refetchResult.results.length).toBe(2);
+    refetchResult.results.forEach((result) => {
+      expect(result).toBeInstanceOf(Promise);
+    });
 
-      expect(results).toEqual([{ b: "B" }]);
+    expect(
+      refetchResult.queries
+        .map((obs) => {
+          expect(obs).toBeInstanceOf(ObservableQuery);
+          return obs.queryName;
+        })
+        .sort()
+    ).toEqual(["AB", "B"]);
 
-      resolve();
-    }
-  );
+    const results = (await refetchResult).map((result) => {
+      // These results are ApolloQueryResult<any>, as inferred by TypeScript.
+      expect(Object.keys(result).sort()).toEqual([
+        "data",
+        "loading",
+        "networkStatus",
+      ]);
+      return result.data;
+    });
+
+    sortObjects(results);
+
+    expect(results).toEqual([
+      // Since we returned true from onQueryUpdated, the results were refetched,
+      // replacing "Beetlejuice" with "B" again.
+      { a: "A", b: "B" },
+      { b: "B" },
+    ]);
+
+    expect(client.cache.extract()).toEqual({
+      ROOT_QUERY: {
+        __typename: "Query",
+        a: "A",
+        b: "B",
+      },
+    });
+  });
+
+  it("can return false from onQueryUpdated to skip/ignore a query", async () => {
+    const client = makeClient();
+    const [aObs, bObs, abObs] = await setup(client);
+
+    const refetchResult = client.refetchQueries({
+      include: ["A", "B"],
+      onQueryUpdated(obs, diff) {
+        if (obs === aObs) {
+          expect(diff.result).toEqual({ a: "A" });
+        } else if (obs === bObs) {
+          expect(diff.result).toEqual({ b: "B" });
+        } else if (obs === abObs) {
+          throw new Error("abQuery should not have been updated");
+        } else {
+          throw new Error(
+            `unexpected ObservableQuery ${obs.queryId} with name ${obs.queryName}`
+          );
+        }
+        // Skip refetching all but the B query.
+        return obs.queryName === "B";
+      },
+    });
+
+    expect(refetchResult.results.length).toBe(1);
+    refetchResult.results.forEach((result) => {
+      expect(result).toBeInstanceOf(Promise);
+    });
+
+    expect(
+      refetchResult.queries
+        .map((obs) => {
+          expect(obs).toBeInstanceOf(ObservableQuery);
+          return obs.queryName;
+        })
+        .sort()
+    ).toEqual(["B"]);
+
+    const results = (await refetchResult).map((result) => {
+      // These results are ApolloQueryResult<any>, as inferred by TypeScript.
+      expect(Object.keys(result).sort()).toEqual([
+        "data",
+        "loading",
+        "networkStatus",
+      ]);
+      return result.data;
+    });
+
+    sortObjects(results);
+
+    expect(results).toEqual([{ b: "B" }]);
+  });
 
   it("can refetch no-cache queries", () => {
     // TODO The options.updateCache function won't work for these queries, but

--- a/src/__tests__/refetchQueries.ts
+++ b/src/__tests__/refetchQueries.ts
@@ -13,6 +13,7 @@ import { ObservableStream } from "../testing/internal";
 
 describe("client.refetchQueries", () => {
   it("is public and callable", async () => {
+    expect.assertions(6);
     const client = new ApolloClient({
       cache: new InMemoryCache(),
     });
@@ -114,6 +115,7 @@ describe("client.refetchQueries", () => {
   }
 
   it("includes watched queries affected by updateCache", async () => {
+    expect.assertions(9);
     const client = makeClient();
     const [aObs, bObs, abObs] = await setup(client);
 
@@ -189,6 +191,7 @@ describe("client.refetchQueries", () => {
   });
 
   it("includes watched queries named in options.include", async () => {
+    expect.assertions(11);
     const client = makeClient();
     const [aObs, bObs, abObs] = await setup(client);
 
@@ -272,6 +275,7 @@ describe("client.refetchQueries", () => {
   });
 
   it("includes query DocumentNode objects specified in options.include", async () => {
+    expect.assertions(11);
     const client = makeClient();
     const [aObs, bObs, abObs] = await setup(client);
 
@@ -356,6 +360,7 @@ describe("client.refetchQueries", () => {
   });
 
   it('includes all queries when options.include === "all"', async () => {
+    expect.assertions(11);
     const client = makeClient();
     const [aObs, bObs, abObs] = await setup(client);
 
@@ -435,6 +440,7 @@ describe("client.refetchQueries", () => {
   });
 
   it('includes all active queries when options.include === "active"', async () => {
+    expect.assertions(15);
     const client = makeClient();
     const [aObs, bObs, abObs] = await setup(client);
 
@@ -509,6 +515,7 @@ describe("client.refetchQueries", () => {
   });
 
   it("includes queries named in refetchQueries even if they have no observers", async () => {
+    expect.assertions(13);
     const client = makeClient();
 
     const aObs = client.watchQuery({ query: aQuery });
@@ -576,6 +583,7 @@ describe("client.refetchQueries", () => {
   });
 
   it("should not include unwatched single queries", async () => {
+    expect.assertions(18);
     const client = makeClient();
     const [aObs, bObs, abObs] = await setup(client);
 
@@ -666,6 +674,7 @@ describe("client.refetchQueries", () => {
   });
 
   it("refetches watched queries if onQueryUpdated not provided", async () => {
+    expect.assertions(7);
     const client = makeClient();
     const [aObs, bObs, abObs] = await setup(client);
 
@@ -702,6 +711,7 @@ describe("client.refetchQueries", () => {
   });
 
   it("can run updateQuery function against optimistic cache layer", async () => {
+    expect.assertions(12);
     const client = makeClient();
     const [aObs, bObs, abObs] = await setup(client);
 
@@ -773,6 +783,7 @@ describe("client.refetchQueries", () => {
   });
 
   it("can return true from onQueryUpdated to choose default refetching behavior", async () => {
+    expect.assertions(14);
     const client = makeClient();
     const [aObs, bObs, abObs] = await setup(client);
 
@@ -824,6 +835,7 @@ describe("client.refetchQueries", () => {
   });
 
   it("can return true from onQueryUpdated when using options.updateCache", async () => {
+    expect.assertions(17);
     const client = makeClient();
     const [aObs, bObs, abObs] = await setup(client);
 
@@ -905,6 +917,7 @@ describe("client.refetchQueries", () => {
   });
 
   it("can return false from onQueryUpdated to skip/ignore a query", async () => {
+    expect.assertions(11);
     const client = makeClient();
     const [aObs, bObs, abObs] = await setup(client);
 

--- a/src/link/utils/__tests__/toPromise.ts
+++ b/src/link/utils/__tests__/toPromise.ts
@@ -1,5 +1,4 @@
 import { Observable } from "../../../utilities/observables/Observable";
-import { itAsync } from "../../../testing";
 import { toPromise } from "../toPromise";
 import { fromError } from "../fromError";
 
@@ -38,12 +37,11 @@ describe("toPromise", () => {
       console.warn = _warn;
     });
 
-    itAsync("return error call as Promise rejection", (resolve, reject) => {
-      toPromise(Observable.of(data, data)).then((result) => {
-        expect(data).toEqual(result);
-        expect(spy).toHaveBeenCalled();
-        resolve();
-      });
+    it("return error call as Promise rejection", async () => {
+      const result = await toPromise(Observable.of(data, data));
+
+      expect(data).toEqual(result);
+      expect(spy).toHaveBeenCalled();
     });
   });
 });

--- a/src/testing/internal/ObservableStream.ts
+++ b/src/testing/internal/ObservableStream.ts
@@ -1,3 +1,7 @@
+import type { Tester } from "@jest/expect-utils";
+import { equals, iterableEquality } from "@jest/expect-utils";
+import { expect } from "@jest/globals";
+import * as matcherUtils from "jest-matcher-utils";
 import type {
   Observable,
   ObservableSubscription,
@@ -28,17 +32,13 @@ export class ObservableStream<T> {
     }).getReader();
   }
 
-  take({ timeout = 100 }: TakeOptions = {}) {
-    return Promise.race([
-      this.reader.read().then((result) => result.value!),
-      new Promise<T>((_, reject) => {
-        setTimeout(
-          reject,
-          timeout,
-          new Error("Timeout waiting for next event")
-        );
-      }),
-    ]);
+  take<T>({ timeout = 100 }: TakeOptions = {}) {
+    return new Promise<ObservableEvent<T>>((resolve, reject) => {
+      this.reader
+        .read()
+        .then((result) => resolve(result.value! as ObservableEvent<T>));
+      setTimeout(reject, timeout, new Error("Timeout waiting for next event"));
+    });
   }
 
   unsubscribe() {
@@ -47,18 +47,58 @@ export class ObservableStream<T> {
 
   async takeNext(options?: TakeOptions): Promise<T> {
     const event = await this.take(options);
-    expect(event).toEqual({ type: "next", value: expect.anything() });
+    validateEquals(event, { type: "next", value: expect.anything() });
     return (event as ObservableEvent<T> & { type: "next" }).value;
   }
 
   async takeError(options?: TakeOptions): Promise<any> {
     const event = await this.take(options);
-    expect(event).toEqual({ type: "error", error: expect.anything() });
+    validateEquals(event, { type: "error", error: expect.anything() });
     return (event as ObservableEvent<T> & { type: "error" }).error;
   }
 
   async takeComplete(options?: TakeOptions): Promise<void> {
     const event = await this.take(options);
-    expect(event).toEqual({ type: "complete" });
+
+    validateEquals(event, { type: "complete" });
   }
+}
+
+// Lightweight expect(...).toEqual(...) check that avoids using `expect` so that
+// `expect.assertions(num)` does not double count assertions when using the take*
+// functions inside of expect(stream).toEmit* matchers.
+function validateEquals(
+  actualEvent: ObservableEvent<any>,
+  expectedEvent: ObservableEvent<any>
+) {
+  // Uses the same matchers as expect(...).toEqual(...)
+  // https://github.com/jestjs/jest/blob/611d1a4ba0008d67b5dcda485177f0813b2b573e/packages/expect/src/matchers.ts#L626-L629
+  const isEqual = equals(actualEvent, expectedEvent, [
+    ...getCustomMatchers(),
+    iterableEquality,
+  ]);
+
+  if (isEqual) {
+    return;
+  }
+
+  const hint = matcherUtils.matcherHint("toEqual", "stream", "expected");
+
+  throw new Error(
+    hint +
+      "\n\n" +
+      matcherUtils.printDiffOrStringify(
+        expectedEvent,
+        actualEvent,
+        "Expected",
+        "Received",
+        true
+      )
+  );
+}
+
+function getCustomMatchers(): Array<Tester> {
+  // https://github.com/jestjs/jest/blob/611d1a4ba0008d67b5dcda485177f0813b2b573e/packages/expect/src/jestMatchersObject.ts#L141-L143
+  const JEST_MATCHERS_OBJECT = Symbol.for("$$jest-matchers-object");
+  return (globalThis as any)[JEST_MATCHERS_OBJECT].customEqualityTesters;
 }

--- a/src/testing/internal/ObservableStream.ts
+++ b/src/testing/internal/ObservableStream.ts
@@ -32,11 +32,9 @@ export class ObservableStream<T> {
     }).getReader();
   }
 
-  take<T>({ timeout = 100 }: TakeOptions = {}) {
+  take({ timeout = 100 }: TakeOptions = {}) {
     return new Promise<ObservableEvent<T>>((resolve, reject) => {
-      this.reader
-        .read()
-        .then((result) => resolve(result.value! as ObservableEvent<T>));
+      this.reader.read().then((result) => resolve(result.value!));
       setTimeout(reject, timeout, new Error("Timeout waiting for next event"));
     });
   }


### PR DESCRIPTION
This PR completes the work to remove `itAsync` from our tests. It is still used by the hoc and component tests, but these will be deleted with 4.0 so we can ignore these for now. `itAsync` will be removed when we remove the query components and hoc on the 4.0 branch.