### PR TITLE
Fix incorrect config for data masking for client preset in docs

### DIFF
--- a/docs/source/data/fragments.mdx
+++ b/docs/source/data/fragments.mdx
@@ -1156,10 +1156,12 @@ const config: CodegenConfig = {
         // ...
         // disables the incompatible GraphQL Codegen fragment masking feature
         fragmentMasking: false,
-        inlineFragmentTypes: "mask",
         customDirectives: {
           apolloUnmask: true
         }
+      },
+      config: {
+        inlineFragmentTypes: "mask",
       }
     }
   }


### PR DESCRIPTION
Reported here: https://discord.com/channels/1022972389463687228/1316737355633135636/1316737355633135636

I have tried this myself and can confirm it works as expected.