### PR TITLE
add GH action to run tests against react@canary on a schedule

### DIFF
--- a/.github/workflows/scheduled-test-canary.yml
+++ b/.github/workflows/scheduled-test-canary.yml
@@ -1,0 +1,25 @@
+# a GitHub Action that once a day runs all tests from `main` and `release-*` branches
+# with the latest `canary` and `experimental` release of `react` and `react-dom`
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tag:
+          - canary
+          - experimental
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+      - uses: bahmutov/npm-install@v1
+      - run: npm install react@${{ matrix.tag }} react-dom@${{ matrix.tag }}
+      # tests can be flaky, this runs only once a day and we want to minimize false negatives - retry up to three times
+      - run: "parallel --line-buffer -j 1 --retries 3 'npm run test:ci -- --selectProjects ' ::: 'ReactDOM 19'"


### PR DESCRIPTION
I'll merge this immediately since I can't test it from a branch - new trigger workflows need to exist on `main` before I can run them adjusted from a branch.