### PR TITLE
fix timing problems in tests introduced by latest React canary

### DIFF
--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 41639,
+  "dist/apollo-client.min.cjs": 41640,
   "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 34381
 }

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -12,7 +12,7 @@ import {
 import { PROTOCOL_ERRORS_SYMBOL } from "../../../errors";
 import { InMemoryCache as Cache } from "../../../cache";
 import { ApolloProvider } from "../../context";
-import { MockSubscriptionLink } from "../../../testing";
+import { MockSubscriptionLink, wait } from "../../../testing";
 import { useSubscription } from "../useSubscription";
 import { spyOnConsole } from "../../../testing/internal";
 import { SubscriptionHookOptions } from "../../types/types";
@@ -1961,6 +1961,7 @@ describe("ignoreResults", () => {
       }
     );
     if (!IS_REACT_17) {
+      await wait(0);
       expect(subscriptionCreated).toHaveBeenCalledTimes(1);
     }
 
@@ -2034,6 +2035,7 @@ describe("ignoreResults", () => {
       }
     );
     if (!IS_REACT_17) {
+      await wait(0);
       expect(subscriptionCreated).toHaveBeenCalledTimes(1);
     }
 


### PR DESCRIPTION
stacked on top of #12233

CI run: https://github.com/apollographql/apollo-client/actions/runs/12394062292