### PR TITLE
Replace Discord with Discourse links

### DIFF
--- a/.github/ISSUE_TEMPLATE/question-discussion.md
+++ b/.github/ISSUE_TEMPLATE/question-discussion.md
@@ -5,7 +5,6 @@ about: Questions / discussions are best posted in our community forums or StackO
 
 Need help or want to talk all things Apollo Client? Issues here are reserved for bugs, but one of the following resources should help:
 
-* Apollo Discord server: https://discord.gg/graphos
 * Apollo GraphQL community forums: https://community.apollographql.com
 * StackOverflow (`apollo-client` tag): https://stackoverflow.com/questions/tagged/apollo-client
 * Apollo Feature Request repo: https://github.com/apollographql/apollo-feature-requests

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -25,7 +25,7 @@ jobs:
           issue-comment: >
             This issue has been automatically locked since there has not been any recent activity after it was closed. Please open a new issue for related bugs.
 
-            For general questions, we recommend using [StackOverflow](https://stackoverflow.com/questions/tagged/apollo-client) or our [discord server](https://discord.gg/graphos).
+            For general questions, we recommend using [StackOverflow](https://stackoverflow.com/questions/tagged/apollo-client) or our [Community Forum](https://community.apollographql.com/).
 
           pr-inactive-days: "30"
           exclude-any-pr-labels: "discussion"

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -25,7 +25,7 @@ jobs:
           issue-comment: >
             This issue has been automatically locked since there has not been any recent activity after it was closed. Please open a new issue for related bugs.
 
-            For general questions, we recommend using [StackOverflow](https://stackoverflow.com/questions/tagged/apollo-client) or our [Community Forum](https://community.apollographql.com/).
+            For general questions, we recommend using our [Community Forum](https://community.apollographql.com/) or [Stack Overflow](https://stackoverflow.com/questions/tagged/apollo-client).
 
           pr-inactive-days: "30"
           exclude-any-pr-labels: "discussion"

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 </p>
 <h1>Apollo Client</h1>
 
-[![npm version](https://badge.fury.io/js/%40apollo%2Fclient.svg)](https://badge.fury.io/js/%40apollo%2Fclient) [![Build Status](https://circleci.com/gh/apollographql/apollo-client.svg?style=svg)](https://circleci.com/gh/apollographql/apollo-client) [![Join the community](https://img.shields.io/discourse/status?label=Join%20the%20community&server=https%3A%2F%2Fcommunity.apollographql.com)](https://community.apollographql.com) [![Join our Discord server](https://img.shields.io/discord/1022972389463687228.svg?color=7389D8&labelColor=6A7EC2&logo=discord&logoColor=ffffff&style=flat-square)](https://discord.gg/graphos)
+[![npm version](https://badge.fury.io/js/%40apollo%2Fclient.svg)](https://badge.fury.io/js/%40apollo%2Fclient) [![Build Status](https://circleci.com/gh/apollographql/apollo-client.svg?style=svg)](https://circleci.com/gh/apollographql/apollo-client) [![Join the community](https://img.shields.io/discourse/status?label=Join%20the%20community&server=https%3A%2F%2Fcommunity.apollographql.com)](https://community.apollographql.com)
 
 </div>
 
 ---
 
-**Announcement:**   
+**Announcement:**
 Join 1000+ engineers at GraphQL Summit for talks, workshops, and office hours, Oct 8-10 in NYC. [Get your pass here ->](https://summit.graphql.com/?utm_campaign=github_federation_readme)
 
 ---


### PR DESCRIPTION
Replace Discord with Discourse links since the Discourse Community Forum there is becoming our focus.