### PR TITLE
Add new default accept header

### DIFF
--- a/.changeset/popular-games-sleep.md
+++ b/.changeset/popular-games-sleep.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": major
+---
+
+Changes the default `Accept` header to `application/graphql-response+json`.

--- a/src/link/batch-http/__tests__/batchHttpLink.ts
+++ b/src/link/batch-http/__tests__/batchHttpLink.ts
@@ -610,7 +610,7 @@ describe("SharedHttpTest", () => {
           .headers as Record<string, string>;
         expect(headers.authorization).toBe("1234");
         expect(headers["content-type"]).toBe("application/json");
-        expect(headers.accept).toBe("*/*");
+        expect(headers.accept).toBe("application/graphql-response+json");
       })
     );
   });
@@ -628,7 +628,7 @@ describe("SharedHttpTest", () => {
           .headers as Record<string, string>;
         expect(headers.authorization).toBe("1234");
         expect(headers["content-type"]).toBe("application/json");
-        expect(headers.accept).toBe("*/*");
+        expect(headers.accept).toBe("application/graphql-response+json");
       })
     );
   });
@@ -708,7 +708,7 @@ describe("SharedHttpTest", () => {
             .headers as Record<string, string>;
           expect(headers.authorization).toBe("1234");
           expect(headers["content-type"]).toBe("application/json");
-          expect(headers.accept).toBe("*/*");
+          expect(headers.accept).toBe("application/graphql-response+json");
         })
       );
     }
@@ -733,7 +733,7 @@ describe("SharedHttpTest", () => {
             .headers as Record<string, string>;
           expect(headers.authorization).toBe("1234");
           expect(headers["content-type"]).toBe("application/json");
-          expect(headers.accept).toBe("*/*");
+          expect(headers.accept).toBe("application/graphql-response+json");
         })
       );
     }
@@ -758,7 +758,7 @@ describe("SharedHttpTest", () => {
           const headers: any = fetchMock.lastCall()![1]!.headers;
           expect(headers.AUTHORIZATION).toBe("1234");
           expect(headers["CONTENT-TYPE"]).toBe("application/json");
-          expect(headers.accept).toBe("*/*");
+          expect(headers.accept).toBe("application/graphql-response+json");
         })
       );
     }
@@ -788,7 +788,7 @@ describe("SharedHttpTest", () => {
           const headers: any = fetchMock.lastCall()![1]!.headers;
           expect(headers.AUTHORIZATION).toBe("1234");
           expect(headers["content-type"]).toBe("application/json");
-          expect(headers.accept).toBe("*/*");
+          expect(headers.accept).toBe("application/graphql-response+json");
         })
       );
     }
@@ -813,7 +813,7 @@ describe("SharedHttpTest", () => {
           const headers: any = fetchMock.lastCall()![1]!.headers;
           expect(headers.AUTHORIZATION).toBe("1234");
           expect(headers["content-type"]).toBe("application/json");
-          expect(headers.accept).toBe("*/*");
+          expect(headers.accept).toBe("application/graphql-response+json");
         })
       );
     }

--- a/src/link/http/__tests__/HttpLink.ts
+++ b/src/link/http/__tests__/HttpLink.ts
@@ -710,7 +710,7 @@ describe("HttpLink", () => {
             const headers = fetchMock.lastCall()![1]!.headers as any;
             expect(headers.authorization).toBe("1234");
             expect(headers["content-type"]).toBe("application/json");
-            expect(headers.accept).toBe("*/*");
+            expect(headers.accept).toBe("application/graphql-response+json");
           })
         );
       }
@@ -728,7 +728,7 @@ describe("HttpLink", () => {
           const headers = fetchMock.lastCall()![1]!.headers as any;
           expect(headers.authorization).toBe("1234");
           expect(headers["content-type"]).toBe("application/json");
-          expect(headers.accept).toBe("*/*");
+          expect(headers.accept).toBe("application/graphql-response+json");
         })
       );
     });
@@ -752,7 +752,7 @@ describe("HttpLink", () => {
             const headers = fetchMock.lastCall()![1]!.headers as any;
             expect(headers.authorization).toBe("1234");
             expect(headers["content-type"]).toBe("application/json");
-            expect(headers.accept).toBe("*/*");
+            expect(headers.accept).toBe("application/graphql-response+json");
           })
         );
       }
@@ -776,7 +776,7 @@ describe("HttpLink", () => {
             const headers = fetchMock.lastCall()![1]!.headers as any;
             expect(headers.authorization).toBe("1234");
             expect(headers["content-type"]).toBe("application/json");
-            expect(headers.accept).toBe("*/*");
+            expect(headers.accept).toBe("application/graphql-response+json");
           })
         );
       }
@@ -1911,7 +1911,7 @@ describe("HttpLink", () => {
                 "/graphql",
                 expect.objectContaining({
                   headers: {
-                    accept: "*/*",
+                    accept: "application/graphql-response+json",
                     "content-type": "application/json",
                   },
                 })

--- a/src/link/http/__tests__/selectHttpOptionsAndBody.ts
+++ b/src/link/http/__tests__/selectHttpOptionsAndBody.ts
@@ -36,7 +36,7 @@ describe("selectHttpOptionsAndBody", () => {
 
   it("the fallbackConfig is used if no other configs are specified", () => {
     const defaultHeaders = {
-      accept: "*/*",
+      accept: "application/graphql-response+json",
       "content-type": "application/json",
     };
 

--- a/src/link/http/selectHttpOptionsAndBody.ts
+++ b/src/link/http/selectHttpOptionsAndBody.ts
@@ -105,7 +105,7 @@ const defaultHttpOptions: HttpQueryOptions = {
 
 const defaultHeaders = {
   // headers are case insensitive (https://stackoverflow.com/a/5259004)
-  accept: "*/*",
+  accept: "application/graphql-response+json",
   // The content-type header describes the type of the body of the request, and
   // so it typically only is sent with requests that actually have bodies. One
   // could imagine that Apollo Client would remove this header when constructing


### PR DESCRIPTION
Closes #12206

Changes the default `Accept` header to `application/graphql-response+json`