### PR TITLE
Update `useLazyQuery` tests for robustness

### DIFF
--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -834,6 +834,7 @@ describe("useLazyQuery Hook", () => {
 
     {
       const [, result] = await takeSnapshot();
+
       expect(result).toEqualQueryResult({
         data: undefined,
         error: undefined,
@@ -1253,7 +1254,7 @@ describe("useLazyQuery Hook", () => {
       });
     }
 
-    expect(await executeResult).toEqualQueryResult({
+    await expect(executeResult).resolves.toEqualQueryResult({
       data: { hello: "world" },
       called: true,
       loading: false,
@@ -1363,7 +1364,7 @@ describe("useLazyQuery Hook", () => {
       });
     }
 
-    expect(await executeResult).toEqualQueryResult({
+    await expect(executeResult).resolves.toEqualQueryResult({
       data: {
         countries: {
           code: "PA",
@@ -1406,7 +1407,7 @@ describe("useLazyQuery Hook", () => {
       });
     }
 
-    expect(await executeResult).toEqualQueryResult({
+    await expect(executeResult).resolves.toEqualQueryResult({
       data: { countries: { code: "BA", name: "Bahamas" } },
       called: true,
       loading: false,
@@ -1489,7 +1490,7 @@ describe("useLazyQuery Hook", () => {
       });
     }
 
-    expect(await executePromise).toEqualQueryResult({
+    await expect(executePromise).resolves.toEqualQueryResult({
       data: undefined,
       called: true,
       loading: false,
@@ -1597,7 +1598,7 @@ describe("useLazyQuery Hook", () => {
 
     link.simulateResult({ result: { data: { hello: "Greetings" } } }, true);
 
-    expect(await promise!).toEqualQueryResult({
+    await expect(promise!).resolves.toEqualQueryResult({
       data: { hello: "Greetings" },
       called: true,
       loading: false,
@@ -1639,8 +1640,8 @@ describe("useLazyQuery Hook", () => {
       variables: {},
     };
 
-    expect(await promise1!).toEqualQueryResult(expectedResult);
-    expect(await promise2!).toEqualQueryResult(expectedResult);
+    await expect(promise1!).resolves.toEqualQueryResult(expectedResult);
+    await expect(promise2!).resolves.toEqualQueryResult(expectedResult);
   });
 
   // https://github.com/apollographql/apollo-client/issues/9755
@@ -1704,7 +1705,7 @@ describe("useLazyQuery Hook", () => {
     const promise1 = execute({ variables: { id: "1" } });
     const promise2 = execute({ variables: { id: "2" } });
 
-    expect(await promise1).toEqualQueryResult({
+    await expect(promise1).resolves.toEqualQueryResult({
       data: mocks[0].result.data,
       loading: false,
       called: true,
@@ -1713,7 +1714,7 @@ describe("useLazyQuery Hook", () => {
       variables: { id: "2" },
     });
 
-    expect(await promise2).toEqualQueryResult({
+    await expect(promise2).resolves.toEqualQueryResult({
       data: mocks[1].result.data,
       loading: false,
       called: true,
@@ -1866,7 +1867,7 @@ describe("useLazyQuery Hook", () => {
       });
     }
 
-    expect(await promise).toEqualQueryResult({
+    await expect(promise).resolves.toEqualQueryResult({
       data: mocks[1].result.data,
       called: true,
       loading: false,
@@ -1961,7 +1962,7 @@ describe("useLazyQuery Hook", () => {
       });
     }
 
-    expect(await promise).toEqualQueryResult({
+    await expect(promise).resolves.toEqualQueryResult({
       data: { hello: "Greetings" },
       called: true,
       loading: false,

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -25,7 +25,7 @@ import {
 import { useLazyQuery } from "../useLazyQuery";
 import { QueryResult } from "../../types/types";
 import { InvariantError } from "../../../utilities/globals";
-import { Masked, MaskedDocumentNode } from "../../../masking";
+import { Masked, MaskedDocumentNode, Unmasked } from "../../../masking";
 import { expectTypeOf } from "expect-type";
 import {
   disableActEnvironment,
@@ -2727,6 +2727,7 @@ describe("useLazyQuery Hook", () => {
   describe("data masking", () => {
     it("masks queries when dataMasking is `true`", async () => {
       type UserFieldsFragment = {
+        __typename: "User";
         age: number;
       } & { " $fragmentName"?: "UserFieldsFragment" };
 
@@ -2829,6 +2830,7 @@ describe("useLazyQuery Hook", () => {
 
     it("does not mask queries when dataMasking is `false`", async () => {
       type UserFieldsFragment = {
+        __typename: "User";
         age: number;
       } & { " $fragmentName"?: "UserFieldsFragment" };
 
@@ -2840,7 +2842,10 @@ describe("useLazyQuery Hook", () => {
         } & { " $fragmentRefs"?: { UserFieldsFragment: UserFieldsFragment } };
       }
 
-      const query: TypedDocumentNode<Query, never> = gql`
+      const query: TypedDocumentNode<
+        Unmasked<Query>,
+        Record<string, never>
+      > = gql`
         query MaskedQuery {
           currentUser {
             id
@@ -2919,6 +2924,7 @@ describe("useLazyQuery Hook", () => {
 
     it("does not mask queries by default", async () => {
       type UserFieldsFragment = {
+        __typename: "User";
         age: number;
       } & { " $fragmentName"?: "UserFieldsFragment" };
 

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -1596,11 +1596,14 @@ describe("useLazyQuery Hook", () => {
 
     link.simulateResult({ result: { data: { hello: "Greetings" } } }, true);
 
-    const queryResult = await promise!;
-
-    expect(queryResult.data).toEqual({ hello: "Greetings" });
-    expect(queryResult.loading).toBe(false);
-    expect(queryResult.networkStatus).toBe(NetworkStatus.ready);
+    expect(await promise!).toEqualQueryResult({
+      data: { hello: "Greetings" },
+      called: true,
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      previousData: undefined,
+      variables: {},
+    });
   });
 
   it("handles resolving multiple in-flight requests when component unmounts", async () => {
@@ -1628,12 +1631,15 @@ describe("useLazyQuery Hook", () => {
 
     const expectedResult = {
       data: { hello: "Greetings" },
+      called: true,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      previousData: undefined,
+      variables: {},
     };
 
-    await expect(promise1!).resolves.toMatchObject(expectedResult);
-    await expect(promise2!).resolves.toMatchObject(expectedResult);
+    expect(await promise1!).toEqualQueryResult(expectedResult);
+    expect(await promise2!).toEqualQueryResult(expectedResult);
   });
 
   // https://github.com/apollographql/apollo-client/issues/9755

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -139,24 +139,24 @@ describe("useLazyQuery Hook", () => {
       });
 
     {
-      const [, result] = await takeSnapshot();
-      expect(result.loading).toBe(false);
-      expect(result.called).toBe(false);
+      const [, { loading, called }] = await takeSnapshot();
+      expect(loading).toBe(false);
+      expect(called).toBe(false);
     }
 
     const execute = getCurrentSnapshot()[0];
     setTimeout(() => execute());
 
     {
-      const [, result] = await takeSnapshot();
-      expect(result.loading).toBe(true);
-      expect(result.called).toBe(true);
+      const [, { loading, called }] = await takeSnapshot();
+      expect(loading).toBe(true);
+      expect(called).toBe(true);
     }
 
     {
-      const [, result] = await takeSnapshot();
-      expect(result.loading).toBe(false);
-      expect(result.called).toBe(true);
+      const [, { loading, called }] = await takeSnapshot();
+      expect(loading).toBe(false);
+      expect(called).toBe(true);
     }
   });
 

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -2738,7 +2738,7 @@ describe("useLazyQuery Hook", () => {
         } & { " $fragmentRefs"?: { UserFieldsFragment: UserFieldsFragment } };
       }
 
-      const query: MaskedDocumentNode<Query, never> = gql`
+      const query: TypedDocumentNode<Query, Record<string, never>> = gql`
         query MaskedQuery {
           currentUser {
             id
@@ -2789,26 +2789,40 @@ describe("useLazyQuery Hook", () => {
       const [execute] = getCurrentSnapshot();
       const result = await execute();
 
-      expect(result.data).toEqual({
-        currentUser: {
-          __typename: "User",
-          id: 1,
-          name: "Test User",
+      expect(result).toEqualQueryResult({
+        data: {
+          currentUser: {
+            __typename: "User",
+            id: 1,
+            name: "Test User",
+          },
         },
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: undefined,
+        variables: {},
       });
 
       // Loading
       await takeSnapshot();
 
       {
-        const [, { data }] = await takeSnapshot();
+        const [, result] = await takeSnapshot();
 
-        expect(data).toEqual({
-          currentUser: {
-            __typename: "User",
-            id: 1,
-            name: "Test User",
+        expect(result).toEqualQueryResult({
+          data: {
+            currentUser: {
+              __typename: "User",
+              id: 1,
+              name: "Test User",
+            },
           },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: undefined,
+          variables: {},
         });
       }
     });

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -2896,28 +2896,42 @@ describe("useLazyQuery Hook", () => {
       const [execute] = getCurrentSnapshot();
       const result = await execute();
 
-      expect(result.data).toEqual({
-        currentUser: {
-          __typename: "User",
-          id: 1,
-          name: "Test User",
-          age: 30,
-        },
-      });
-
-      // Loading
-      await takeSnapshot();
-
-      {
-        const [, { data }] = await takeSnapshot();
-
-        expect(data).toEqual({
+      expect(result).toEqualQueryResult({
+        data: {
           currentUser: {
             __typename: "User",
             id: 1,
             name: "Test User",
             age: 30,
           },
+        },
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: undefined,
+        variables: {},
+      });
+
+      // Loading
+      await takeSnapshot();
+
+      {
+        const [, result] = await takeSnapshot();
+
+        expect(result).toEqualQueryResult({
+          data: {
+            currentUser: {
+              __typename: "User",
+              id: 1,
+              name: "Test User",
+              age: 30,
+            },
+          },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: undefined,
+          variables: {},
         });
       }
     });
@@ -2936,7 +2950,10 @@ describe("useLazyQuery Hook", () => {
         } & { " $fragmentRefs"?: { UserFieldsFragment: UserFieldsFragment } };
       }
 
-      const query: TypedDocumentNode<Query, never> = gql`
+      const query: TypedDocumentNode<
+        Unmasked<Query>,
+        Record<string, never>
+      > = gql`
         query MaskedQuery {
           currentUser {
             id
@@ -2986,34 +3003,49 @@ describe("useLazyQuery Hook", () => {
       const [execute] = getCurrentSnapshot();
       const result = await execute();
 
-      expect(result.data).toEqual({
-        currentUser: {
-          __typename: "User",
-          id: 1,
-          name: "Test User",
-          age: 30,
-        },
-      });
-
-      // Loading
-      await takeSnapshot();
-
-      {
-        const [, { data }] = await takeSnapshot();
-
-        expect(data).toEqual({
+      expect(result).toEqualQueryResult({
+        data: {
           currentUser: {
             __typename: "User",
             id: 1,
             name: "Test User",
             age: 30,
           },
+        },
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: undefined,
+        variables: {},
+      });
+
+      // Loading
+      await takeSnapshot();
+
+      {
+        const [, result] = await takeSnapshot();
+
+        expect(result).toEqualQueryResult({
+          data: {
+            currentUser: {
+              __typename: "User",
+              id: 1,
+              name: "Test User",
+              age: 30,
+            },
+          },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: undefined,
+          variables: {},
         });
       }
     });
 
     it("masks queries updated by the cache", async () => {
       type UserFieldsFragment = {
+        __typename: "User";
         age: number;
       } & { " $fragmentName"?: "UserFieldsFragment" };
 
@@ -3025,7 +3057,7 @@ describe("useLazyQuery Hook", () => {
         } & { " $fragmentRefs"?: { UserFieldsFragment: UserFieldsFragment } };
       }
 
-      const query: MaskedDocumentNode<Query, never> = gql`
+      const query: TypedDocumentNode<Query, Record<string, never>> = gql`
         query MaskedQuery {
           currentUser {
             id
@@ -3080,14 +3112,21 @@ describe("useLazyQuery Hook", () => {
       await takeSnapshot();
 
       {
-        const [, { data }] = await takeSnapshot();
+        const [, result] = await takeSnapshot();
 
-        expect(data).toEqual({
-          currentUser: {
-            __typename: "User",
-            id: 1,
-            name: "Test User",
+        expect(result).toEqualQueryResult({
+          data: {
+            currentUser: {
+              __typename: "User",
+              id: 1,
+              name: "Test User",
+            },
           },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: undefined,
+          variables: {},
         });
       }
 
@@ -3104,24 +3143,30 @@ describe("useLazyQuery Hook", () => {
       });
 
       {
-        const [, { data, previousData }] = await takeSnapshot();
+        const [, result] = await takeSnapshot();
 
-        expect(data).toEqual({
-          currentUser: {
-            __typename: "User",
-            id: 1,
-            name: "Test User (updated)",
+        expect(result).toEqualQueryResult({
+          data: {
+            currentUser: {
+              __typename: "User",
+              id: 1,
+              name: "Test User (updated)",
+            },
           },
-        });
-
-        expect(previousData).toEqual({
-          currentUser: { __typename: "User", id: 1, name: "Test User" },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: {
+            currentUser: { __typename: "User", id: 1, name: "Test User" },
+          },
+          variables: {},
         });
       }
     });
 
     it("does not rerender when updating field in named fragment", async () => {
       type UserFieldsFragment = {
+        __typename: "User";
         age: number;
       } & { " $fragmentName"?: "UserFieldsFragment" };
 
@@ -3133,7 +3178,7 @@ describe("useLazyQuery Hook", () => {
         } & { " $fragmentRefs"?: { UserFieldsFragment: UserFieldsFragment } };
       }
 
-      const query: MaskedDocumentNode<Query, never> = gql`
+      const query: TypedDocumentNode<Query, Record<string, never>> = gql`
         query MaskedQuery {
           currentUser {
             id
@@ -3188,14 +3233,21 @@ describe("useLazyQuery Hook", () => {
       await takeSnapshot();
 
       {
-        const [, { data }] = await takeSnapshot();
+        const [, result] = await takeSnapshot();
 
-        expect(data).toEqual({
-          currentUser: {
-            __typename: "User",
-            id: 1,
-            name: "Test User",
+        expect(result).toEqualQueryResult({
+          data: {
+            currentUser: {
+              __typename: "User",
+              id: 1,
+              name: "Test User",
+            },
           },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: undefined,
+          variables: {},
         });
       }
 

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -1447,52 +1447,88 @@ describe("useLazyQuery Hook", () => {
 
     {
       const [, result] = await takeSnapshot();
-      expect(result.loading).toBe(false);
-      expect(result.data).toBeUndefined();
+
+      expect(result).toEqualQueryResult({
+        data: undefined,
+        error: undefined,
+        called: false,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: undefined,
+        variables: {},
+      });
     }
 
     const executePromise = Promise.resolve().then(() => execute());
 
     {
       const [, result] = await takeSnapshot();
-      expect(result.loading).toBe(true);
-      expect(result.data).toBeUndefined();
-      expect(result.error).toBe(undefined);
+
+      expect(result).toEqualQueryResult({
+        data: undefined,
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: undefined,
+        variables: {},
+      });
     }
 
     {
       const [, result] = await takeSnapshot();
-      expect(result.loading).toBe(false);
-      expect(result.data).toBeUndefined();
-      expect(result.error).toEqual(
-        new ApolloError({ graphQLErrors: [{ message: "error 1" }] })
-      );
+
+      expect(result).toEqualQueryResult({
+        data: undefined,
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.error,
+        previousData: undefined,
+        error: new ApolloError({ graphQLErrors: [{ message: "error 1" }] }),
+        variables: {},
+      });
     }
 
-    await executePromise.then((result) => {
-      expect(result.loading).toBe(false);
-      expect(result.data).toBeUndefined();
-      expect(result.error!.message).toBe("error 1");
+    expect(await executePromise).toEqualQueryResult({
+      data: undefined,
+      called: true,
+      loading: false,
+      networkStatus: NetworkStatus.error,
+      previousData: undefined,
+      error: new ApolloError({ graphQLErrors: [{ message: "error 1" }] }),
+      errors: [{ message: "error 1" }],
+      variables: {},
     });
 
     void execute();
 
     {
       const [, result] = await takeSnapshot();
-      expect(result.loading).toBe(true);
-      expect(result.data).toBeUndefined();
-      expect(result.error).toEqual(
-        new ApolloError({ graphQLErrors: [{ message: "error 1" }] })
-      );
+
+      expect(result).toEqualQueryResult({
+        data: undefined,
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: undefined,
+        error: new ApolloError({ graphQLErrors: [{ message: "error 1" }] }),
+        // TODO: Why is this only populated when in loading state?
+        errors: [{ message: "error 1" }],
+        variables: {},
+      });
     }
 
     {
       const [, result] = await takeSnapshot();
-      expect(result.loading).toBe(false);
-      expect(result.data).toBeUndefined();
-      expect(result.error).toEqual(
-        new ApolloError({ graphQLErrors: [{ message: "error 2" }] })
-      );
+
+      expect(result).toEqualQueryResult({
+        data: undefined,
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.error,
+        previousData: undefined,
+        error: new ApolloError({ graphQLErrors: [{ message: "error 2" }] }),
+        variables: {},
+      });
     }
   });
 

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -2539,14 +2539,14 @@ describe("useLazyQuery Hook", () => {
           (request) =>
             new Observable((observer) => {
               if (request.operationName === "GetCounter") {
-                observer.next({
-                  data: {
-                    counter: ++count,
-                  },
-                });
                 setTimeout(() => {
+                  observer.next({
+                    data: {
+                      counter: ++count,
+                    },
+                  });
                   observer.complete();
-                }, 10);
+                }, 20);
               } else {
                 observer.error(
                   new Error(

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -63,13 +63,14 @@ describe("useLazyQuery Hook", () => {
     {
       const [, result] = await takeSnapshot();
 
-      expect(result).toMatchObject({
+      expect(result).toEqualQueryResult({
         data: undefined,
         error: undefined,
         called: false,
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
+        variables: {},
       });
       expect(result).not.toHaveProperty("errors");
     }
@@ -81,12 +82,13 @@ describe("useLazyQuery Hook", () => {
     {
       const [, result] = await takeSnapshot();
 
-      expect(result).toMatchObject({
+      expect(result).toEqualQueryResult({
         data: undefined,
         called: true,
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
+        variables: {},
       });
       expect(result).not.toHaveProperty("error");
       expect(result).not.toHaveProperty("errors");
@@ -95,12 +97,13 @@ describe("useLazyQuery Hook", () => {
     {
       const [, result] = await takeSnapshot();
 
-      expect(result).toMatchObject({
+      expect(result).toEqualQueryResult({
         data: { hello: "world" },
         called: true,
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
+        variables: {},
       });
       expect(result).not.toHaveProperty("error");
       expect(result).not.toHaveProperty("errors");
@@ -194,13 +197,14 @@ describe("useLazyQuery Hook", () => {
     {
       const [, result] = await takeSnapshot();
 
-      expect(result).toMatchObject({
+      expect(result).toEqualQueryResult({
         data: undefined,
         error: undefined,
         called: false,
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
+        variables: { id: 1 },
       });
       expect(result).not.toHaveProperty("errors");
     }
@@ -211,12 +215,13 @@ describe("useLazyQuery Hook", () => {
     {
       const [, result] = await takeSnapshot();
 
-      expect(result).toMatchObject({
+      expect(result).toEqualQueryResult({
         data: undefined,
         called: true,
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
+        variables: { id: 1 },
       });
       expect(result).not.toHaveProperty("error");
       expect(result).not.toHaveProperty("errors");
@@ -224,12 +229,13 @@ describe("useLazyQuery Hook", () => {
     {
       const [, result] = await takeSnapshot();
 
-      expect(result).toMatchObject({
+      expect(result).toEqualQueryResult({
         data: { hello: "world 1" },
         called: true,
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
+        variables: { id: 1 },
       });
       expect(result).not.toHaveProperty("error");
       expect(result).not.toHaveProperty("errors");
@@ -273,13 +279,14 @@ describe("useLazyQuery Hook", () => {
     {
       const [, result] = await takeSnapshot();
 
-      expect(result).toMatchObject({
+      expect(result).toEqualQueryResult({
         data: undefined,
         error: undefined,
         called: false,
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
+        variables: { id: 1 },
       });
       expect(result).not.toHaveProperty("errors");
     }
@@ -290,12 +297,13 @@ describe("useLazyQuery Hook", () => {
     {
       const [, result] = await takeSnapshot();
 
-      expect(result).toMatchObject({
+      expect(result).toEqualQueryResult({
         data: undefined,
         called: true,
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
+        variables: { id: 2 },
       });
       expect(result).not.toHaveProperty("error");
       expect(result).not.toHaveProperty("errors");
@@ -304,12 +312,13 @@ describe("useLazyQuery Hook", () => {
     {
       const [, result] = await takeSnapshot();
 
-      expect(result).toMatchObject({
+      expect(result).toEqualQueryResult({
         data: { hello: "world 2" },
         called: true,
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
+        variables: { id: 2 },
       });
       expect(result).not.toHaveProperty("error");
       expect(result).not.toHaveProperty("errors");
@@ -320,6 +329,7 @@ describe("useLazyQuery Hook", () => {
     const counterQuery: TypedDocumentNode<
       {
         counter: number;
+        vars: Record<string, boolean>;
       },
       {
         hookVar?: boolean;
@@ -399,13 +409,18 @@ describe("useLazyQuery Hook", () => {
     {
       const [, result] = await takeSnapshot();
 
-      expect(result).toMatchObject({
+      expect(result).toEqualQueryResult({
         data: undefined,
         error: undefined,
         called: false,
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
+        variables: {
+          globalDefaultVar: true,
+          localDefaultVar: true,
+          hookVar: true,
+        },
       });
       expect(result).not.toHaveProperty("errors");
     }
@@ -427,12 +442,18 @@ describe("useLazyQuery Hook", () => {
       },
     });
 
-    expect(execResult).toMatchObject({
+    expect(execResult).toEqualQueryResult({
       data: expectedFinalData,
       called: true,
       loading: false,
       networkStatus: NetworkStatus.ready,
       previousData: undefined,
+      variables: {
+        globalDefaultVar: true,
+        localDefaultVar: true,
+        hookVar: true,
+        execVar: true,
+      },
     });
     expect(execResult).not.toHaveProperty("error");
     expect(execResult).not.toHaveProperty("errors");
@@ -440,12 +461,18 @@ describe("useLazyQuery Hook", () => {
     {
       const [, result] = await takeSnapshot();
 
-      expect(result).toMatchObject({
+      expect(result).toEqualQueryResult({
         data: undefined,
         called: true,
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
+        variables: {
+          globalDefaultVar: true,
+          localDefaultVar: true,
+          hookVar: true,
+          execVar: true,
+        },
       });
       expect(result).not.toHaveProperty("error");
       expect(result).not.toHaveProperty("errors");
@@ -454,12 +481,18 @@ describe("useLazyQuery Hook", () => {
     {
       const [, result] = await takeSnapshot();
 
-      expect(result).toMatchObject({
+      expect(result).toEqualQueryResult({
         data: expectedFinalData,
         called: true,
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
+        variables: {
+          globalDefaultVar: true,
+          localDefaultVar: true,
+          hookVar: true,
+          execVar: true,
+        },
       });
       expect(result).not.toHaveProperty("error");
       expect(result).not.toHaveProperty("errors");
@@ -484,12 +517,13 @@ describe("useLazyQuery Hook", () => {
     {
       const [, result] = await takeSnapshot();
 
-      expect(result).toMatchObject({
+      expect(result).toEqualQueryResult({
         data: expectedFinalData,
         called: true,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
         previousData: expectedFinalData,
+        variables: { execVar: false },
       });
       expect(result).not.toHaveProperty("error");
       expect(result).not.toHaveProperty("errors");
@@ -498,12 +532,13 @@ describe("useLazyQuery Hook", () => {
     {
       const [, result] = await takeSnapshot();
 
-      expect(result).toMatchObject({
+      expect(result).toEqualQueryResult({
         data: { counter: 2, vars: { execVar: false } },
         called: true,
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: expectedFinalData,
+        variables: { execVar: false },
       });
       expect(result).not.toHaveProperty("error");
       expect(result).not.toHaveProperty("errors");
@@ -517,12 +552,18 @@ describe("useLazyQuery Hook", () => {
       },
     });
 
-    expect(execResult2).toMatchObject({
+    expect(execResult2).toEqualQueryResult({
       data: { counter: 3, vars: { ...expectedFinalData.vars, execVar: true } },
       called: true,
       loading: false,
       networkStatus: NetworkStatus.ready,
       previousData: { counter: 2, vars: { execVar: false } },
+      variables: {
+        globalDefaultVar: true,
+        localDefaultVar: true,
+        hookVar: true,
+        execVar: true,
+      },
     });
     expect(execResult2).not.toHaveProperty("error");
     expect(execResult2).not.toHaveProperty("errors");
@@ -530,12 +571,18 @@ describe("useLazyQuery Hook", () => {
     {
       const [, result] = await takeSnapshot();
 
-      expect(result).toMatchObject({
+      expect(result).toEqualQueryResult({
         data: { counter: 2, vars: { execVar: false } },
         called: true,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
         previousData: { counter: 2, vars: { execVar: false } },
+        variables: {
+          globalDefaultVar: true,
+          localDefaultVar: true,
+          hookVar: true,
+          execVar: true,
+        },
       });
       expect(result).not.toHaveProperty("error");
       expect(result).not.toHaveProperty("errors");
@@ -545,12 +592,18 @@ describe("useLazyQuery Hook", () => {
     if (IS_REACT_18) {
       const [, result] = await takeSnapshot();
 
-      expect(result).toMatchObject({
+      expect(result).toEqualQueryResult({
         data: { counter: 2, vars: { execVar: false } },
         called: true,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
         previousData: { counter: 2, vars: { execVar: false } },
+        variables: {
+          globalDefaultVar: true,
+          localDefaultVar: true,
+          hookVar: true,
+          execVar: true,
+        },
       });
       expect(result).not.toHaveProperty("error");
       expect(result).not.toHaveProperty("errors");
@@ -559,7 +612,7 @@ describe("useLazyQuery Hook", () => {
     {
       const [, result] = await takeSnapshot();
 
-      expect(result).toMatchObject({
+      expect(result).toEqualQueryResult({
         data: {
           counter: 3,
           vars: { ...expectedFinalData.vars, execVar: true },
@@ -568,6 +621,12 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: { counter: 2, vars: { execVar: false } },
+        variables: {
+          globalDefaultVar: true,
+          localDefaultVar: true,
+          hookVar: true,
+          execVar: true,
+        },
       });
       expect(result).not.toHaveProperty("error");
       expect(result).not.toHaveProperty("errors");
@@ -612,13 +671,14 @@ describe("useLazyQuery Hook", () => {
     {
       const [, result] = await takeSnapshot();
 
-      expect(result).toMatchObject({
+      expect(result).toEqualQueryResult({
         data: undefined,
         error: undefined,
         called: false,
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
+        variables: {},
       });
       expect(result).not.toHaveProperty("errors");
     }
@@ -629,12 +689,13 @@ describe("useLazyQuery Hook", () => {
     {
       const [, result] = await takeSnapshot();
 
-      expect(result).toMatchObject({
+      expect(result).toEqualQueryResult({
         data: undefined,
         called: true,
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
+        variables: {},
       });
       expect(result).not.toHaveProperty("error");
       expect(result).not.toHaveProperty("errors");
@@ -642,12 +703,13 @@ describe("useLazyQuery Hook", () => {
     {
       const [, result] = await takeSnapshot();
 
-      expect(result).toMatchObject({
+      expect(result).toEqualQueryResult({
         data: { hello: "world" },
         called: true,
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
+        variables: {},
       });
       expect(result).not.toHaveProperty("error");
       expect(result).not.toHaveProperty("errors");
@@ -658,12 +720,13 @@ describe("useLazyQuery Hook", () => {
     {
       const [, result] = await takeSnapshot();
 
-      expect(result).toMatchObject({
+      expect(result).toEqualQueryResult({
         data: { hello: "world" },
         called: true,
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: { hello: "world" },
+        variables: {},
       });
       expect(result).not.toHaveProperty("error");
       expect(result).not.toHaveProperty("errors");
@@ -674,12 +737,13 @@ describe("useLazyQuery Hook", () => {
       expect(result.loading).toBe(false);
       expect(result.data).toEqual({ name: "changed" });
 
-      expect(result).toMatchObject({
+      expect(result).toEqualQueryResult({
         data: { name: "changed" },
         called: true,
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: { hello: "world" },
+        variables: {},
       });
       expect(result).not.toHaveProperty("error");
       expect(result).not.toHaveProperty("errors");

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -106,22 +106,19 @@ describe("useLazyQuery Hook", () => {
   });
 
   it("should set `called` to false by default", async () => {
-    const mocks = [
+    using _disabledAct = disableActEnvironment();
+    const { takeSnapshot } = await renderHookToSnapshotStream(
+      () => useLazyQuery(helloQuery),
       {
-        request: { query: helloQuery },
-        result: { data: { hello: "world" } },
-        delay: 20,
-      },
-    ];
-    const { result } = renderHook(() => useLazyQuery(helloQuery), {
-      wrapper: ({ children }) => (
-        <MockedProvider mocks={mocks}>{children}</MockedProvider>
-      ),
-    });
+        wrapper: ({ children }) => (
+          <MockedProvider mocks={[]}>{children}</MockedProvider>
+        ),
+      }
+    );
 
-    expect(result.current[1].loading).toBe(false);
-    expect(result.current[1].data).toBe(undefined);
-    expect(result.current[1].called).toBe(false);
+    const [, { called }] = await takeSnapshot();
+
+    expect(called).toBe(false);
   });
 
   it("should set `called` to true after calling the lazy execute function", async () => {

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -692,8 +692,6 @@ describe("useLazyQuery Hook", () => {
 
     {
       const [, result] = await takeSnapshot();
-      expect(result.loading).toBe(false);
-      expect(result.data).toEqual({ name: "changed" });
 
       expect(result).toEqualQueryResult({
         data: { name: "changed" },

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -32,6 +32,8 @@ import {
   renderHookToSnapshotStream,
 } from "@testing-library/react-render-stream";
 
+const IS_REACT_18 = React.version.startsWith("18");
+
 describe("useLazyQuery Hook", () => {
   const helloQuery: TypedDocumentNode<{
     hello: string;
@@ -359,7 +361,7 @@ describe("useLazyQuery Hook", () => {
                   },
                 });
                 observer.complete();
-              }, 10);
+              }, 50);
             } else {
               observer.error(
                 new Error(
@@ -526,6 +528,21 @@ describe("useLazyQuery Hook", () => {
     expect(execResult2).not.toHaveProperty("errors");
 
     {
+      const [, result] = await takeSnapshot();
+
+      expect(result).toMatchObject({
+        data: { counter: 2, vars: { execVar: false } },
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.setVariables,
+        previousData: { counter: 2, vars: { execVar: false } },
+      });
+      expect(result).not.toHaveProperty("error");
+      expect(result).not.toHaveProperty("errors");
+    }
+
+    // For some reason we get an extra render in React 18 of the same thing
+    if (IS_REACT_18) {
       const [, result] = await takeSnapshot();
 
       expect(result).toMatchObject({

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -594,34 +594,78 @@ describe("useLazyQuery Hook", () => {
 
     {
       const [, result] = await takeSnapshot();
-      expect(result.loading).toBe(false);
-      expect(result.data).toBe(undefined);
-    }
-    const execute = getCurrentSnapshot()[0];
 
+      expect(result).toMatchObject({
+        data: undefined,
+        error: undefined,
+        called: false,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: undefined,
+      });
+      expect(result).not.toHaveProperty("errors");
+    }
+
+    const execute = getCurrentSnapshot()[0];
     setTimeout(() => execute());
 
     {
       const [, result] = await takeSnapshot();
-      expect(result.loading).toBe(true);
+
+      expect(result).toMatchObject({
+        data: undefined,
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: undefined,
+      });
+      expect(result).not.toHaveProperty("error");
+      expect(result).not.toHaveProperty("errors");
     }
     {
       const [, result] = await takeSnapshot();
-      expect(result.loading).toBe(false);
-      expect(result.data).toEqual({ hello: "world" });
+
+      expect(result).toMatchObject({
+        data: { hello: "world" },
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: undefined,
+      });
+      expect(result).not.toHaveProperty("error");
+      expect(result).not.toHaveProperty("errors");
     }
 
     setTimeout(() => execute({ query: query2 }));
 
     {
       const [, result] = await takeSnapshot();
-      expect(result.loading).toBe(true);
+
+      expect(result).toMatchObject({
+        data: { hello: "world" },
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: { hello: "world" },
+      });
+      expect(result).not.toHaveProperty("error");
+      expect(result).not.toHaveProperty("errors");
     }
 
     {
       const [, result] = await takeSnapshot();
       expect(result.loading).toBe(false);
       expect(result.data).toEqual({ name: "changed" });
+
+      expect(result).toMatchObject({
+        data: { name: "changed" },
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: { hello: "world" },
+      });
+      expect(result).not.toHaveProperty("error");
+      expect(result).not.toHaveProperty("errors");
     }
   });
 

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -72,7 +72,6 @@ describe("useLazyQuery Hook", () => {
         previousData: undefined,
         variables: {},
       });
-      expect(result).not.toHaveProperty("errors");
     }
 
     const [execute] = getCurrentSnapshot();
@@ -90,8 +89,6 @@ describe("useLazyQuery Hook", () => {
         previousData: undefined,
         variables: {},
       });
-      expect(result).not.toHaveProperty("error");
-      expect(result).not.toHaveProperty("errors");
     }
 
     {
@@ -105,8 +102,6 @@ describe("useLazyQuery Hook", () => {
         previousData: undefined,
         variables: {},
       });
-      expect(result).not.toHaveProperty("error");
-      expect(result).not.toHaveProperty("errors");
     }
   });
 
@@ -206,7 +201,6 @@ describe("useLazyQuery Hook", () => {
         previousData: undefined,
         variables: { id: 1 },
       });
-      expect(result).not.toHaveProperty("errors");
     }
 
     const execute = getCurrentSnapshot()[0];
@@ -223,8 +217,6 @@ describe("useLazyQuery Hook", () => {
         previousData: undefined,
         variables: { id: 1 },
       });
-      expect(result).not.toHaveProperty("error");
-      expect(result).not.toHaveProperty("errors");
     }
     {
       const [, result] = await takeSnapshot();
@@ -237,8 +229,6 @@ describe("useLazyQuery Hook", () => {
         previousData: undefined,
         variables: { id: 1 },
       });
-      expect(result).not.toHaveProperty("error");
-      expect(result).not.toHaveProperty("errors");
     }
   });
 
@@ -288,7 +278,6 @@ describe("useLazyQuery Hook", () => {
         previousData: undefined,
         variables: { id: 1 },
       });
-      expect(result).not.toHaveProperty("errors");
     }
 
     const [execute] = getCurrentSnapshot();
@@ -305,8 +294,6 @@ describe("useLazyQuery Hook", () => {
         previousData: undefined,
         variables: { id: 2 },
       });
-      expect(result).not.toHaveProperty("error");
-      expect(result).not.toHaveProperty("errors");
     }
 
     {
@@ -320,8 +307,6 @@ describe("useLazyQuery Hook", () => {
         previousData: undefined,
         variables: { id: 2 },
       });
-      expect(result).not.toHaveProperty("error");
-      expect(result).not.toHaveProperty("errors");
     }
   });
 
@@ -422,7 +407,6 @@ describe("useLazyQuery Hook", () => {
           hookVar: true,
         },
       });
-      expect(result).not.toHaveProperty("errors");
     }
 
     const expectedFinalData = {
@@ -455,8 +439,6 @@ describe("useLazyQuery Hook", () => {
         execVar: true,
       },
     });
-    expect(execResult).not.toHaveProperty("error");
-    expect(execResult).not.toHaveProperty("errors");
 
     {
       const [, result] = await takeSnapshot();
@@ -474,8 +456,6 @@ describe("useLazyQuery Hook", () => {
           execVar: true,
         },
       });
-      expect(result).not.toHaveProperty("error");
-      expect(result).not.toHaveProperty("errors");
     }
 
     {
@@ -494,8 +474,6 @@ describe("useLazyQuery Hook", () => {
           execVar: true,
         },
       });
-      expect(result).not.toHaveProperty("error");
-      expect(result).not.toHaveProperty("errors");
     }
 
     const refetchResult = await getCurrentSnapshot()[1].reobserve({
@@ -511,8 +489,6 @@ describe("useLazyQuery Hook", () => {
       loading: false,
       networkStatus: NetworkStatus.ready,
     });
-    expect(refetchResult).not.toHaveProperty("error");
-    expect(refetchResult).not.toHaveProperty("errors");
 
     {
       const [, result] = await takeSnapshot();
@@ -525,8 +501,6 @@ describe("useLazyQuery Hook", () => {
         previousData: expectedFinalData,
         variables: { execVar: false },
       });
-      expect(result).not.toHaveProperty("error");
-      expect(result).not.toHaveProperty("errors");
     }
 
     {
@@ -540,8 +514,6 @@ describe("useLazyQuery Hook", () => {
         previousData: expectedFinalData,
         variables: { execVar: false },
       });
-      expect(result).not.toHaveProperty("error");
-      expect(result).not.toHaveProperty("errors");
     }
 
     const execResult2 = await getCurrentSnapshot()[0]({
@@ -565,8 +537,6 @@ describe("useLazyQuery Hook", () => {
         execVar: true,
       },
     });
-    expect(execResult2).not.toHaveProperty("error");
-    expect(execResult2).not.toHaveProperty("errors");
 
     {
       const [, result] = await takeSnapshot();
@@ -584,8 +554,6 @@ describe("useLazyQuery Hook", () => {
           execVar: true,
         },
       });
-      expect(result).not.toHaveProperty("error");
-      expect(result).not.toHaveProperty("errors");
     }
 
     // For some reason we get an extra render in React 18 of the same thing
@@ -605,8 +573,6 @@ describe("useLazyQuery Hook", () => {
           execVar: true,
         },
       });
-      expect(result).not.toHaveProperty("error");
-      expect(result).not.toHaveProperty("errors");
     }
 
     {
@@ -628,8 +594,6 @@ describe("useLazyQuery Hook", () => {
           execVar: true,
         },
       });
-      expect(result).not.toHaveProperty("error");
-      expect(result).not.toHaveProperty("errors");
     }
   });
 
@@ -680,7 +644,6 @@ describe("useLazyQuery Hook", () => {
         previousData: undefined,
         variables: {},
       });
-      expect(result).not.toHaveProperty("errors");
     }
 
     const execute = getCurrentSnapshot()[0];
@@ -697,8 +660,6 @@ describe("useLazyQuery Hook", () => {
         previousData: undefined,
         variables: {},
       });
-      expect(result).not.toHaveProperty("error");
-      expect(result).not.toHaveProperty("errors");
     }
     {
       const [, result] = await takeSnapshot();
@@ -711,8 +672,6 @@ describe("useLazyQuery Hook", () => {
         previousData: undefined,
         variables: {},
       });
-      expect(result).not.toHaveProperty("error");
-      expect(result).not.toHaveProperty("errors");
     }
 
     setTimeout(() => execute({ query: query2 }));
@@ -728,8 +687,6 @@ describe("useLazyQuery Hook", () => {
         previousData: { hello: "world" },
         variables: {},
       });
-      expect(result).not.toHaveProperty("error");
-      expect(result).not.toHaveProperty("errors");
     }
 
     {
@@ -745,8 +702,6 @@ describe("useLazyQuery Hook", () => {
         previousData: { hello: "world" },
         variables: {},
       });
-      expect(result).not.toHaveProperty("error");
-      expect(result).not.toHaveProperty("errors");
     }
   });
 
@@ -790,7 +745,6 @@ describe("useLazyQuery Hook", () => {
         previousData: undefined,
         variables: {},
       });
-      expect(result).not.toHaveProperty("errors");
     }
     const execute = getCurrentSnapshot()[0];
     setTimeout(() => execute());
@@ -806,8 +760,6 @@ describe("useLazyQuery Hook", () => {
         previousData: undefined,
         variables: {},
       });
-      expect(result).not.toHaveProperty("error");
-      expect(result).not.toHaveProperty("errors");
     }
 
     {
@@ -821,8 +773,6 @@ describe("useLazyQuery Hook", () => {
         previousData: undefined,
         variables: {},
       });
-      expect(result).not.toHaveProperty("error");
-      expect(result).not.toHaveProperty("errors");
     }
 
     setTimeout(() => execute());
@@ -850,8 +800,6 @@ describe("useLazyQuery Hook", () => {
         previousData: { hello: "world 1" },
         variables: {},
       });
-      expect(result).not.toHaveProperty("error");
-      expect(result).not.toHaveProperty("errors");
     }
   });
 

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -2032,7 +2032,7 @@ describe("useLazyQuery Hook", () => {
     "does not issue multiple network calls when calling execute again without variables with a %s fetch policy",
     async (fetchPolicy) => {
       interface Data {
-        user: { id: string; name: string };
+        user: { id: string | null; name: string };
       }
 
       interface Variables {
@@ -2088,8 +2088,13 @@ describe("useLazyQuery Hook", () => {
       expect(fetchCount).toBe(1);
 
       await waitFor(() => {
-        expect(result.current[1].data).toEqual({
-          user: { id: "2", name: "John Doe" },
+        expect(result.current[1]).toEqualQueryResult({
+          data: { user: { id: "2", name: "John Doe" } },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: undefined,
+          variables: { id: "2" },
         });
       });
 
@@ -2098,8 +2103,13 @@ describe("useLazyQuery Hook", () => {
       await act(() => result.current[0]());
 
       await waitFor(() => {
-        expect(result.current[1].data).toEqual({
-          user: { id: null, name: "John Default" },
+        expect(result.current[1]).toEqualQueryResult({
+          data: { user: { id: null, name: "John Default" } },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: { user: { id: "2", name: "John Doe" } },
+          variables: {},
         });
       });
 

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -780,33 +780,78 @@ describe("useLazyQuery Hook", () => {
 
     {
       const [, result] = await takeSnapshot();
-      expect(result.loading).toBe(false);
+
+      expect(result).toEqualQueryResult({
+        data: undefined,
+        called: false,
+        error: undefined,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: undefined,
+        variables: {},
+      });
+      expect(result).not.toHaveProperty("errors");
     }
     const execute = getCurrentSnapshot()[0];
     setTimeout(() => execute());
 
     {
       const [, result] = await takeSnapshot();
-      expect(result.loading).toBe(true);
+
+      expect(result).toEqualQueryResult({
+        data: undefined,
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: undefined,
+        variables: {},
+      });
+      expect(result).not.toHaveProperty("error");
+      expect(result).not.toHaveProperty("errors");
     }
 
     {
       const [, result] = await takeSnapshot();
-      expect(result.loading).toBe(false);
-      expect(result.data).toEqual({ hello: "world 1" });
+
+      expect(result).toEqualQueryResult({
+        data: { hello: "world 1" },
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: undefined,
+        variables: {},
+      });
+      expect(result).not.toHaveProperty("error");
+      expect(result).not.toHaveProperty("errors");
     }
 
     setTimeout(() => execute());
 
     {
       const [, result] = await takeSnapshot();
-      expect(result.loading).toBe(true);
-      expect(result.data).toEqual({ hello: "world 1" });
+
+      expect(result).toEqualQueryResult({
+        data: { hello: "world 1" },
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: { hello: "world 1" },
+        variables: {},
+      });
     }
     {
       const [, result] = await takeSnapshot();
-      expect(result.loading).toBe(false);
-      expect(result.data).toEqual({ hello: "world 2" });
+
+      expect(result).toEqualQueryResult({
+        data: { hello: "world 2" },
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: { hello: "world 1" },
+        variables: {},
+      });
+      expect(result).not.toHaveProperty("error");
+      expect(result).not.toHaveProperty("errors");
     }
   });
 

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -160,48 +160,6 @@ describe("useLazyQuery Hook", () => {
     }
   });
 
-  it("should override `skip` if lazy mode execution function is called", async () => {
-    const mocks = [
-      {
-        request: { query: helloQuery },
-        result: { data: { hello: "world" } },
-        delay: 20,
-      },
-    ];
-
-    using _disabledAct = disableActEnvironment();
-    const { takeSnapshot, getCurrentSnapshot } =
-      await renderHookToSnapshotStream(
-        // skip isn’t actually an option on the types
-        () => useLazyQuery(helloQuery, { skip: true } as any),
-        {
-          wrapper: ({ children }) => (
-            <MockedProvider mocks={mocks}>{children}</MockedProvider>
-          ),
-        }
-      );
-
-    {
-      const [, result] = await takeSnapshot();
-      expect(result.loading).toBe(false);
-      expect(result.called).toBe(false);
-    }
-    const execute = getCurrentSnapshot()[0];
-    setTimeout(() => execute());
-
-    {
-      const [, result] = await takeSnapshot();
-      expect(result.loading).toBe(true);
-      expect(result.called).toBe(true);
-    }
-
-    {
-      const [, result] = await takeSnapshot();
-      expect(result.loading).toBe(false);
-      expect(result.called).toBe(true);
-    }
-  });
-
   it("should use variables defined in hook options (if any), when running the lazy execution function", async () => {
     const query = gql`
       query ($id: number) {

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -833,40 +833,71 @@ describe("useLazyQuery Hook", () => {
 
     {
       const [, result] = await takeSnapshot();
-      expect(result.loading).toBe(false);
-      expect(result.data).toBe(undefined);
-      expect(result.previousData).toBe(undefined);
+      expect(result).toEqualQueryResult({
+        data: undefined,
+        error: undefined,
+        called: false,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: undefined,
+        variables: {},
+      });
     }
     const execute = getCurrentSnapshot()[0];
     setTimeout(() => execute());
 
     {
       const [, result] = await takeSnapshot();
-      expect(result.loading).toBe(true);
-      expect(result.data).toBe(undefined);
-      expect(result.previousData).toBe(undefined);
+
+      expect(result).toEqualQueryResult({
+        data: undefined,
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: undefined,
+        variables: {},
+      });
     }
 
     {
       const [, result] = await takeSnapshot();
-      expect(result.loading).toBe(false);
-      expect(result.data).toEqual({ hello: "world 1" });
-      expect(result.previousData).toBe(undefined);
+
+      expect(result).toEqualQueryResult({
+        data: { hello: "world 1" },
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: undefined,
+        variables: {},
+      });
     }
 
     const refetch = getCurrentSnapshot()[1].refetch;
     setTimeout(() => refetch!());
+
     {
       const [, result] = await takeSnapshot();
-      expect(result.loading).toBe(true);
-      expect(result.data).toEqual({ hello: "world 1" });
-      expect(result.previousData).toEqual({ hello: "world 1" });
+
+      expect(result).toEqualQueryResult({
+        data: { hello: "world 1" },
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.refetch,
+        previousData: { hello: "world 1" },
+        variables: {},
+      });
     }
     {
       const [, result] = await takeSnapshot();
-      expect(result.loading).toBe(false);
-      expect(result.data).toEqual({ hello: "world 2" });
-      expect(result.previousData).toEqual({ hello: "world 1" });
+
+      expect(result).toEqualQueryResult({
+        data: { hello: "world 2" },
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: { hello: "world 1" },
+        variables: {},
+      });
     }
   });
 
@@ -899,8 +930,16 @@ describe("useLazyQuery Hook", () => {
 
     {
       const [, result] = await takeSnapshot();
-      expect(result.loading).toBe(false);
-      expect(result.data).toBe(undefined);
+
+      expect(result).toEqualQueryResult({
+        data: undefined,
+        error: undefined,
+        called: false,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: undefined,
+        variables: {},
+      });
     }
 
     await tick();
@@ -908,25 +947,54 @@ describe("useLazyQuery Hook", () => {
 
     {
       const [, result] = await takeSnapshot();
-      expect(result.loading).toBe(true);
+
+      expect(result).toEqualQueryResult({
+        data: undefined,
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: undefined,
+        variables: {},
+      });
     }
 
     {
       const [, result] = await takeSnapshot();
-      expect(result.loading).toBe(false);
-      expect(result.data).toEqual({ hello: "world 1" });
+
+      expect(result).toEqualQueryResult({
+        data: { hello: "world 1" },
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: undefined,
+        variables: {},
+      });
     }
 
     {
       const [, result] = await takeSnapshot();
-      expect(result.loading).toBe(false);
-      expect(result.data).toEqual({ hello: "world 2" });
+
+      expect(result).toEqualQueryResult({
+        data: { hello: "world 2" },
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: { hello: "world 1" },
+        variables: {},
+      });
     }
 
     {
       const [, result] = await takeSnapshot();
-      expect(result.loading).toBe(false);
-      expect(result.data).toEqual({ hello: "world 3" });
+
+      expect(result).toEqualQueryResult({
+        data: { hello: "world 3" },
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: { hello: "world 2" },
+        variables: {},
+      });
     }
 
     getCurrentSnapshot()[1].stopPolling();
@@ -983,39 +1051,70 @@ describe("useLazyQuery Hook", () => {
 
     {
       const [, result] = await takeSnapshot();
-      expect(result.loading).toBe(false);
-      expect(result.data).toBe(undefined);
-      expect(result.previousData).toBe(undefined);
+
+      expect(result).toEqualQueryResult({
+        data: undefined,
+        error: undefined,
+        called: false,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: undefined,
+        variables: {},
+      });
     }
     const execute = getCurrentSnapshot()[0];
     setTimeout(() => execute({ variables: { id: 1 } }));
 
     {
       const [, result] = await takeSnapshot();
-      expect(result.loading).toBe(true);
-      expect(result.data).toBe(undefined);
-      expect(result.previousData).toBe(undefined);
+
+      expect(result).toEqualQueryResult({
+        data: undefined,
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: undefined,
+        variables: { id: 1 },
+      });
     }
     {
       const [, result] = await takeSnapshot();
-      expect(result.loading).toBe(false);
-      expect(result.data).toEqual(data1);
-      expect(result.previousData).toBe(undefined);
+
+      expect(result).toEqualQueryResult({
+        data: data1,
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: undefined,
+        variables: { id: 1 },
+      });
     }
 
     setTimeout(() => execute({ variables: { id: 2 } }));
 
     {
       const [, result] = await takeSnapshot();
-      expect(result.loading).toBe(true);
-      expect(result.data).toBe(undefined);
-      expect(result.previousData).toEqual(data1);
+
+      expect(result).toEqualQueryResult({
+        data: undefined,
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.setVariables,
+        previousData: data1,
+        variables: { id: 2 },
+      });
     }
     {
       const [, result] = await takeSnapshot();
-      expect(result.loading).toBe(false);
-      expect(result.data).toEqual(data2);
-      expect(result.previousData).toEqual(data1);
+
+      expect(result).toEqualQueryResult({
+        data: data2,
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: data1,
+        variables: { id: 2 },
+      });
     }
   });
 
@@ -1034,37 +1133,61 @@ describe("useLazyQuery Hook", () => {
 
     cache.writeQuery({ query: helloQuery, data: { hello: "from cache" } });
 
-    const { result } = renderHook(
-      () => useLazyQuery(helloQuery, { fetchPolicy: "cache-and-network" }),
-      {
-        wrapper: ({ children }) => (
-          <ApolloProvider client={client}>{children}</ApolloProvider>
-        ),
-      }
-    );
+    using _disabledAct = disableActEnvironment();
+    const { takeSnapshot, getCurrentSnapshot } =
+      await renderHookToSnapshotStream(
+        () => useLazyQuery(helloQuery, { fetchPolicy: "cache-and-network" }),
+        {
+          wrapper: ({ children }) => (
+            <ApolloProvider client={client}>{children}</ApolloProvider>
+          ),
+        }
+      );
 
-    expect(result.current[1].loading).toBe(false);
-    expect(result.current[1].data).toBe(undefined);
-    const execute = result.current[0];
+    {
+      const [, result] = await takeSnapshot();
+
+      expect(result).toEqualQueryResult({
+        data: undefined,
+        error: undefined,
+        called: false,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: undefined,
+        variables: {},
+      });
+    }
+
+    const [execute] = getCurrentSnapshot();
+
     setTimeout(() => execute());
 
-    await waitFor(
-      () => {
-        expect(result.current[1].loading).toBe(true);
-      },
-      { interval: 1 }
-    );
+    {
+      const [, result] = await takeSnapshot();
 
-    // TODO: FIXME
-    expect(result.current[1].data).toEqual({ hello: "from cache" });
+      expect(result).toEqualQueryResult({
+        // TODO: FIXME
+        data: { hello: "from cache" },
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: undefined,
+        variables: {},
+      });
+    }
 
-    await waitFor(
-      () => {
-        expect(result.current[1].loading).toBe(false);
-      },
-      { interval: 1 }
-    );
-    expect(result.current[1].data).toEqual({ hello: "from link" });
+    {
+      const [, result] = await takeSnapshot();
+
+      expect(result).toEqualQueryResult({
+        data: { hello: "from link" },
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: { hello: "from cache" },
+        variables: {},
+      });
+    }
   });
 
   it("should return a promise from the execution function which resolves with the result", async () => {

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -427,6 +427,9 @@ describe("useLazyQuery Hook", () => {
       },
     });
 
+    // TODO: Determine if the return value makes sense. Other fetching functions
+    // (`refetch`, `fetchMore`, etc.) resolve with an `ApolloQueryResult` type
+    // which contain a subset of this data.
     expect(execResult).toEqualQueryResult({
       data: expectedFinalData,
       called: true,

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -2465,25 +2465,45 @@ describe("useLazyQuery Hook", () => {
 
       {
         const [, result] = await takeSnapshot();
-        expect(result.loading).toBe(false);
-        expect(result.networkStatus).toBe(NetworkStatus.ready);
-        expect(result.data).toBeUndefined();
+
+        expect(result).toEqualQueryResult({
+          data: undefined,
+          error: undefined,
+          called: false,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: undefined,
+          variables: {},
+        });
       }
+
       const execute = getCurrentSnapshot()[0];
       setTimeout(execute);
 
       {
         const [, result] = await takeSnapshot();
-        expect(result.loading).toBe(true);
-        expect(result.networkStatus).toBe(NetworkStatus.loading);
-        expect(result.data).toBeUndefined();
+
+        expect(result).toEqualQueryResult({
+          data: undefined,
+          called: true,
+          loading: true,
+          networkStatus: NetworkStatus.loading,
+          previousData: undefined,
+          variables: {},
+        });
       }
       {
         const [, result] = await takeSnapshot();
-        expect(result.loading).toBe(false);
-        expect(result.networkStatus).toBe(NetworkStatus.error);
-        expect(result.data).toBeUndefined();
-        expect(result.error!.message).toBe("from the network");
+
+        expect(result).toEqualQueryResult({
+          data: undefined,
+          error: new ApolloError({ networkError }),
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.error,
+          previousData: undefined,
+          variables: {},
+        });
       }
     }
 

--- a/src/testing/matchers/index.d.ts
+++ b/src/testing/matchers/index.d.ts
@@ -71,6 +71,8 @@ interface ApolloCustomMatchers<R = void, T = {}> {
 
   toEqualQueryResult: T extends QueryResult<infer TData, infer TVariables> ?
     (expected: Pick<QueryResult<TData, TVariables>, CheckedKeys>) => R
+  : T extends Promise<QueryResult<infer TData, infer TVariables>> ?
+    (expected: Pick<QueryResult<TData, TVariables>, CheckedKeys>) => R
   : { error: "matchers needs to be called on a QueryResult" };
 }
 

--- a/src/testing/matchers/index.d.ts
+++ b/src/testing/matchers/index.d.ts
@@ -3,10 +3,11 @@ import type {
   DocumentNode,
   OperationVariables,
 } from "../../core/index.js";
-import type { QueryRef } from "../../react/index.js";
+import type { QueryRef, QueryResult } from "../../react/index.js";
 import { NextRenderOptions, ObservableStream } from "../internal/index.js";
 import { RenderStreamMatchers } from "@testing-library/react-render-stream/expect";
 import { TakeOptions } from "../internal/ObservableStream.js";
+import { CheckedKeys } from "./toEqualQueryResult.js";
 
 interface ApolloCustomMatchers<R = void, T = {}> {
   /**
@@ -67,6 +68,10 @@ interface ApolloCustomMatchers<R = void, T = {}> {
   toEmitMatchedValue: T extends ObservableStream<any> ?
     (value: any, options?: TakeOptions) => Promise<R>
   : { error: "matcher needs to be called on an ObservableStream instance" };
+
+  toEqualQueryResult: T extends QueryResult<infer TData, infer TVariables> ?
+    (expected: Pick<QueryResult<TData, TVariables>, CheckedKeys>) => R
+  : { error: "matchers needs to be called on a QueryResult" };
 }
 
 declare global {

--- a/src/testing/matchers/index.ts
+++ b/src/testing/matchers/index.ts
@@ -10,6 +10,7 @@ import { toEmitMatchedValue } from "./toEmitMatchedValue.js";
 import { toEmitNext } from "./toEmitNext.js";
 import { toEmitValue } from "./toEmitValue.js";
 import { toEmitValueStrict } from "./toEmitValueStrict.js";
+import { toEqualQueryResult } from "./toEqualQueryResult.js";
 
 expect.extend({
   toComplete,
@@ -19,6 +20,7 @@ expect.extend({
   toEmitNext,
   toEmitValue,
   toEmitValueStrict,
+  toEqualQueryResult,
   toBeDisposed,
   toHaveSuspenseCacheEntryUsing,
   toMatchDocument,

--- a/src/testing/matchers/toEqualQueryResult.ts
+++ b/src/testing/matchers/toEqualQueryResult.ts
@@ -1,0 +1,71 @@
+import { iterableEquality } from "@jest/expect-utils";
+import type { MatcherFunction } from "expect";
+import type { QueryResult } from "../../react/index.js";
+
+const CHECKED_KEYS = [
+  "loading",
+  "error",
+  "errors",
+  "data",
+  "variables",
+  "networkStatus",
+  "errors",
+  "called",
+  "previousData",
+] as const;
+
+export type CheckedKeys = (typeof CHECKED_KEYS)[number];
+
+const hasOwnProperty = (obj: Record<string, any>, key: string) =>
+  Object.prototype.hasOwnProperty.call(obj, key);
+
+export const toEqualQueryResult: MatcherFunction<
+  [queryResult: Pick<QueryResult<any, any>, CheckedKeys>]
+> = function (actual, expected) {
+  const queryResult = actual as QueryResult<any, any>;
+  const hint = this.utils.matcherHint(
+    this.isNot ? ".not.toEqualQueryResult" : "toEqualQueryResult",
+    "queryResult",
+    "expected"
+  );
+
+  const checkedQueryResult = CHECKED_KEYS.reduce(
+    (memo, key) => {
+      if (hasOwnProperty(queryResult, key)) {
+        memo[key] = queryResult[key];
+      }
+
+      return memo;
+    },
+    {} as Partial<QueryResult<any, any>>
+  );
+
+  const pass = this.equals(
+    checkedQueryResult,
+    expected,
+    // https://github.com/jestjs/jest/blob/22029ba06b69716699254bb9397f2b3bc7b3cf3b/packages/expect/src/matchers.ts#L62-L67
+    [...this.customTesters, iterableEquality],
+    true
+  );
+
+  return {
+    pass,
+    message: () => {
+      if (pass) {
+        return hint + `\n\nExpected: not ${this.utils.printExpected(expected)}`;
+      }
+
+      return (
+        hint +
+        "\n\n" +
+        this.utils.printDiffOrStringify(
+          expected,
+          checkedQueryResult,
+          "Expected",
+          "Received",
+          true
+        )
+      );
+    },
+  };
+};

--- a/src/testing/matchers/toEqualQueryResult.ts
+++ b/src/testing/matchers/toEqualQueryResult.ts
@@ -26,7 +26,8 @@ export const toEqualQueryResult: MatcherFunction<
   const hint = this.utils.matcherHint(
     this.isNot ? ".not.toEqualQueryResult" : "toEqualQueryResult",
     "queryResult",
-    "expected"
+    "expected",
+    { isNot: this.isNot, promise: this.promise }
   );
 
   const checkedQueryResult = CHECKED_KEYS.reduce(


### PR DESCRIPTION
In preparation for changes to `useLazyQuery` in v4, I'm doing some work to update the `useLazyQuery` test suite. The goals of this refactor are to:

* Switch to render stream checks
* More robust checks on properties returned by the hook (not just the usual `loading`, `data`, etc)