### PR TITLE
Refactor `useQuery` tests to use `toEqualQueryResult` - Part 1

### DIFF
--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -1008,6 +1008,7 @@ describe("useQuery Hook", () => {
     });
 
     // TODO: Rewrite this test
+    // Context: https://legacy.reactjs.org/blog/2020/02/26/react-v16.13.0.html#warnings-for-some-updates-during-render
     it("should not error when forcing an update with React >= 16.13.0", async () => {
       const CAR_QUERY: DocumentNode = gql`
         query {

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -1582,22 +1582,43 @@ describe("useQuery Hook", () => {
         ssrMode: true,
       });
 
-      const { result } = renderHook(() => useQuery(query), {
-        wrapper: ({ children }) => (
-          <ApolloProvider client={client}>{children}</ApolloProvider>
-        ),
-      });
-
-      expect(result.current.loading).toBe(true);
-      expect(result.current.data).toBeUndefined();
-
-      await waitFor(
-        () => {
-          expect(result.current.loading).toBe(false);
-        },
-        { interval: 1 }
+      using _disabledAct = disableActEnvironment();
+      const { takeSnapshot } = await renderHookToSnapshotStream(
+        () => useQuery(query),
+        {
+          wrapper: ({ children }) => (
+            <ApolloProvider client={client}>{children}</ApolloProvider>
+          ),
+        }
       );
-      expect(result.current.data).toEqual({ hello: "from link" });
+
+      {
+        const result = await takeSnapshot();
+
+        expect(result).toEqualQueryResult({
+          data: undefined,
+          called: true,
+          loading: true,
+          networkStatus: NetworkStatus.loading,
+          previousData: undefined,
+          variables: {},
+        });
+      }
+
+      {
+        const result = await takeSnapshot();
+
+        expect(result).toEqualQueryResult({
+          data: { hello: "from link" },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: undefined,
+          variables: {},
+        });
+      }
+
+      await expect(takeSnapshot).not.toRerender();
     });
   });
 

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -1844,7 +1844,7 @@ describe("useQuery Hook", () => {
         },
       });
 
-      expect(finalResult).toEqual({
+      expect(finalResult).toEqualApolloQueryResult({
         data: {
           vars: {
             sourceOfVar: "reobserve",
@@ -1899,7 +1899,7 @@ describe("useQuery Hook", () => {
           },
         });
 
-      expect(finalResultNoVarMerge).toEqual({
+      expect(finalResultNoVarMerge).toEqualApolloQueryResult({
         // Since we didn't merge in result.current.observable.variables, we
         // don't see these variables anymore:
         // isGlobal: false,
@@ -2263,7 +2263,7 @@ describe("useQuery Hook", () => {
 
       await expect(
         getCurrentSnapshot().observable.reobserve()
-      ).resolves.toEqual({
+      ).resolves.toEqualApolloQueryResult({
         data: { linkCount: 2 },
         loading: false,
         networkStatus: NetworkStatus.ready,

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -865,6 +865,21 @@ describe("useQuery Hook", () => {
       let setName: any;
 
       using _disabledAct = disableActEnvironment();
+      // TODO: Take a deeper look into this to better understand what this is
+      // trying to test. There are a few problems with this:
+      //
+      // 1. We execute the mutation and a setState at the same time. What is
+      //    that meant to accomplish?
+      // 2. The update callback in the useMutation is writing data for none of
+      //    the results in the mocks. The mutation returns `updateName: true`,
+      //    yet the callback is trying to set a value from `data.updateGreeting`
+      // 3. The update callback in `useMutation` does not use `variables`, so
+      //    the written cache result does not affect any of the queries from the
+      //    `useQuery` returned here.
+      //
+      // My recommendation is to just delete the `useMutation` as part of this
+      // render callback as it doesn't seem to serve much of a purpose for this
+      // test.
       const { takeSnapshot, getCurrentSnapshot } =
         await renderHookToSnapshotStream(
           () => {

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -1518,6 +1518,7 @@ describe("useQuery Hook", () => {
       await expect(takeSnapshot).not.toRerender();
     });
 
+    // TODO: Move this to ssr useQuery tests
     it("should use the cache when in ssrMode and fetchPolicy is `network-only`", async () => {
       const query = gql`
         query {
@@ -1563,6 +1564,7 @@ describe("useQuery Hook", () => {
       await expect(takeSnapshot).not.toRerender();
     });
 
+    // TODO: Move this to ssr useQuery tests
     it("should not hang when ssrMode is true but the cache is not populated for some reason", async () => {
       const query = gql`
         query {

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -482,12 +482,15 @@ describe("useQuery Hook", () => {
         </MockedProvider>
       );
 
-      const { result, unmount } = renderHook(() => useQuery(query), {
-        wrapper,
-      });
+      using _disabledAct = disableActEnvironment();
+      const { takeSnapshot } = await renderHookToSnapshotStream(
+        () => useQuery(query),
+        { wrapper }
+      );
 
-      expect(result.current.called).toBe(true);
-      unmount();
+      const { called } = await takeSnapshot();
+
+      expect(called).toBe(true);
     });
 
     it("should set called to false when skip option is true", async () => {
@@ -510,13 +513,15 @@ describe("useQuery Hook", () => {
         </MockedProvider>
       );
 
-      const { result, unmount } = renderHook(
+      using _disabledAct = disableActEnvironment();
+      const { takeSnapshot } = await renderHookToSnapshotStream(
         () => useQuery(query, { skip: true }),
         { wrapper }
       );
 
-      expect(result.current.called).toBe(false);
-      unmount();
+      const { called } = await takeSnapshot();
+
+      expect(called).toBe(false);
     });
 
     it("should work with variables", async () => {

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -1336,6 +1336,11 @@ describe("useQuery Hook", () => {
 
       using _disabledAct = disableActEnvironment();
       const { takeSnapshot, rerender } = await renderHookToSnapshotStream(
+        // TODO: I don't think this needs to be a polling query as it has
+        // nothing to do with this test. This test checks to ensure that
+        // changing queries executes the new query and returns the right value.
+        // We should consider removing the pollling from this test and save it
+        // for a polling-specific test instead.
         ({ query }) => useQuery(query, { pollInterval: 10 }),
         {
           wrapper: ({ children }) => (
@@ -1387,6 +1392,9 @@ describe("useQuery Hook", () => {
           variables: {},
         });
       }
+
+      // We do not include expect(takeSnapshot).not.toRerender() here because
+      // this is a polling query.
     });
 
     it("`cache-and-network` fetch policy", async () => {

--- a/src/testing/matchers/index.d.ts
+++ b/src/testing/matchers/index.d.ts
@@ -1,5 +1,6 @@
 import type {
   ApolloClient,
+  ApolloQueryResult,
   DocumentNode,
   OperationVariables,
 } from "../../core/index.js";
@@ -68,6 +69,12 @@ interface ApolloCustomMatchers<R = void, T = {}> {
   toEmitMatchedValue: T extends ObservableStream<any> ?
     (value: any, options?: TakeOptions) => Promise<R>
   : { error: "matcher needs to be called on an ObservableStream instance" };
+
+  toEqualApolloQueryResult: T extends ApolloQueryResult<infer TData> ?
+    (expected: ApolloQueryResult<TData>) => R
+  : T extends Promise<ApolloQueryResult<infer TData>> ?
+    (expected: ApolloQueryResult<TData>) => R
+  : { error: "matchers needs to be called on an ApolloQueryResult" };
 
   toEqualQueryResult: T extends QueryResult<infer TData, infer TVariables> ?
     (expected: Pick<QueryResult<TData, TVariables>, CheckedKeys>) => R

--- a/src/testing/matchers/index.ts
+++ b/src/testing/matchers/index.ts
@@ -10,6 +10,7 @@ import { toEmitMatchedValue } from "./toEmitMatchedValue.js";
 import { toEmitNext } from "./toEmitNext.js";
 import { toEmitValue } from "./toEmitValue.js";
 import { toEmitValueStrict } from "./toEmitValueStrict.js";
+import { toEqualApolloQueryResult } from "./toEqualApolloQueryResult.js";
 import { toEqualQueryResult } from "./toEqualQueryResult.js";
 
 expect.extend({
@@ -20,6 +21,7 @@ expect.extend({
   toEmitNext,
   toEmitValue,
   toEmitValueStrict,
+  toEqualApolloQueryResult,
   toEqualQueryResult,
   toBeDisposed,
   toHaveSuspenseCacheEntryUsing,

--- a/src/testing/matchers/toEqualApolloQueryResult.ts
+++ b/src/testing/matchers/toEqualApolloQueryResult.ts
@@ -1,0 +1,44 @@
+import { iterableEquality } from "@jest/expect-utils";
+import type { MatcherFunction } from "expect";
+import type { ApolloQueryResult } from "../../core/index.js";
+
+export const toEqualApolloQueryResult: MatcherFunction<
+  [queryResult: ApolloQueryResult<any>]
+> = function (actual, expected) {
+  const queryResult = actual as ApolloQueryResult<any>;
+  const hint = this.utils.matcherHint(
+    this.isNot ? ".not.toEqualApolloQueryResult" : "toEqualApolloQueryResult",
+    "queryResult",
+    "expected",
+    { isNot: this.isNot, promise: this.promise }
+  );
+
+  const pass = this.equals(
+    queryResult,
+    expected,
+    // https://github.com/jestjs/jest/blob/22029ba06b69716699254bb9397f2b3bc7b3cf3b/packages/expect/src/matchers.ts#L62-L67
+    [...this.customTesters, iterableEquality],
+    true
+  );
+
+  return {
+    pass,
+    message: () => {
+      if (pass) {
+        return hint + `\n\nExpected: not ${this.utils.printExpected(expected)}`;
+      }
+
+      return (
+        hint +
+        "\n\n" +
+        this.utils.printDiffOrStringify(
+          expected,
+          queryResult,
+          "Expected",
+          "Received",
+          true
+        )
+      );
+    },
+  };
+};


### PR DESCRIPTION
Similar to #12260, this refactors `useQuery` tests to use the new `toEqualQueryResult` matcher. There are many tests in this suite, so this is the first of a series of PRs to make PR review a bit more digestable.