### PR TITLE
Refactor `useQuery` tests to use `toEqualQueryResult` - Part 2

### DIFF
--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -4291,6 +4291,7 @@ describe("useQuery Hook", () => {
       await expect(takeSnapshot).not.toRerender();
     });
 
+    // TODO: Rewrite this test using renderHookToSnapshotStream
     it("should not return partial data from cache on refetch with errorPolicy: none (default) and notifyOnNetworkStatusChange: true", async () => {
       const query = gql`
         {
@@ -4434,6 +4435,7 @@ describe("useQuery Hook", () => {
       expect(screen.queryByText(/partial data rendered/i)).toBeNull();
     });
 
+    // TODO: Rewrite this test using renderHookToSnapshotStream
     it("should return partial data from cache on refetch", async () => {
       const GET_DOG_DETAILS = gql`
         query dog($breed: String!) {

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -2824,21 +2824,37 @@ describe("useQuery Hook", () => {
         </React.StrictMode>
       );
 
-      const { result, unmount } = renderHook(
+      using _disabledAct = disableActEnvironment();
+      const { takeSnapshot, unmount } = await renderHookToSnapshotStream(
         () => useQuery(query, { pollInterval: 10 }),
         { wrapper }
       );
 
-      expect(result.current.loading).toBe(true);
-      expect(result.current.data).toBe(undefined);
+      {
+        const result = await takeSnapshot();
 
-      await waitFor(
-        () => {
-          expect(result.current.loading).toBe(false);
-        },
-        { interval: 1 }
-      );
-      expect(result.current.data).toEqual({ hello: "world 1" });
+        expect(result).toEqualQueryResult({
+          data: undefined,
+          called: true,
+          loading: true,
+          networkStatus: NetworkStatus.loading,
+          previousData: undefined,
+          variables: {},
+        });
+      }
+
+      {
+        const result = await takeSnapshot();
+
+        expect(result).toEqualQueryResult({
+          data: { hello: "world 1" },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: undefined,
+          variables: {},
+        });
+      }
 
       const requestSpyCallCount = requestSpy.mock.calls.length;
       expect(requestSpy).toHaveBeenCalledTimes(requestSpyCallCount);

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -4239,44 +4239,56 @@ describe("useQuery Hook", () => {
         </MockedProvider>
       );
 
-      let updates = 0;
-      const { result, rerender } = renderHook(
-        () => (updates++, useQuery(query)),
+      using _disabledAct = disableActEnvironment();
+      const { takeSnapshot, rerender } = await renderHookToSnapshotStream(
+        () => useQuery(query),
         { wrapper }
       );
 
-      expect(result.current.loading).toBe(true);
-      expect(result.current.data).toBe(undefined);
-      expect(result.current.error).toBe(undefined);
+      {
+        const result = await takeSnapshot();
 
-      await waitFor(
-        () => {
-          expect(result.current.loading).toBe(false);
-        },
-        { interval: 1 }
-      );
+        expect(result).toEqualQueryResult({
+          data: undefined,
+          called: true,
+          loading: true,
+          networkStatus: NetworkStatus.loading,
+          previousData: undefined,
+          variables: {},
+        });
+      }
 
-      expect(result.current.loading).toBe(false);
-      expect(result.current.data).toBe(undefined);
-      expect(result.current.error).toBeInstanceOf(ApolloError);
-      expect(result.current.error!.message).toBe("error");
+      {
+        const result = await takeSnapshot();
 
-      rerender();
+        expect(result).toEqualQueryResult({
+          data: undefined,
+          error: new ApolloError({ graphQLErrors: [{ message: "error" }] }),
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.error,
+          previousData: undefined,
+          variables: {},
+        });
+      }
 
-      expect(result.current.loading).toBe(false);
-      expect(result.current.data).toBe(undefined);
-      expect(result.current.error).toBeInstanceOf(ApolloError);
-      expect(result.current.error!.message).toBe("error");
+      await rerender(undefined);
 
-      let previousUpdates = updates;
-      await expect(
-        waitFor(
-          () => {
-            expect(updates).not.toEqual(previousUpdates);
-          },
-          { interval: 1, timeout: 20 }
-        )
-      ).rejects.toThrow();
+      {
+        const result = await takeSnapshot();
+
+        expect(result).toEqualQueryResult({
+          data: undefined,
+          error: new ApolloError({ graphQLErrors: [{ message: "error" }] }),
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.error,
+          previousData: undefined,
+          variables: {},
+        });
+      }
+
+      await expect(takeSnapshot).not.toRerender();
     });
 
     it("should not return partial data from cache on refetch with errorPolicy: none (default) and notifyOnNetworkStatusChange: true", async () => {

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -4002,27 +4002,43 @@ describe("useQuery Hook", () => {
       );
 
       const onError = jest.fn();
-      const { result } = renderHook(
+      using _disabledAct = disableActEnvironment();
+      const { takeSnapshot } = await renderHookToSnapshotStream(
         () => useQuery(query, { onError, errorPolicy: "all" }),
         { wrapper }
       );
 
-      expect(result.current.loading).toBe(true);
-      expect(result.current.data).toBe(undefined);
+      {
+        const result = await takeSnapshot();
 
-      await waitFor(
-        () => {
-          expect(result.current.loading).toBe(false);
-        },
-        { interval: 1 }
-      );
+        expect(result).toEqualQueryResult({
+          data: undefined,
+          called: true,
+          loading: true,
+          networkStatus: NetworkStatus.loading,
+          previousData: undefined,
+          variables: {},
+        });
+      }
 
-      expect(result.current.data).toEqual({ hello: null });
-      expect(result.current.error).toBeInstanceOf(ApolloError);
-      expect(result.current.error!.message).toBe('Could not fetch "hello"');
-      expect(result.current.error!.graphQLErrors).toEqual([
-        new GraphQLError('Could not fetch "hello"'),
-      ]);
+      {
+        const result = await takeSnapshot();
+
+        expect(result).toEqualQueryResult({
+          data: { hello: null },
+          error: new ApolloError({
+            graphQLErrors: [{ message: 'Could not fetch "hello"' }],
+          }),
+          errors: [{ message: 'Could not fetch "hello"' }],
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: undefined,
+          variables: {},
+        });
+      }
+
+      await expect(takeSnapshot).not.toRerender();
     });
 
     it('calls `onError` but not `onCompleted` when returning partial data with GraphQL errors while using an `errorPolicy` set to "all"', async () => {

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -3747,37 +3747,47 @@ describe("useQuery Hook", () => {
       );
 
       const onError = jest.fn();
-      const { result } = renderHook(
+      using _disabledAct = disableActEnvironment();
+      const { takeSnapshot } = await renderHookToSnapshotStream(
         () => useQuery(query, { onError, errorPolicy: "ignore" }),
         { wrapper }
       );
 
-      expect(result.current.loading).toBe(true);
-      expect(result.current.data).toBe(undefined);
-      expect(result.current.error).toBe(undefined);
+      {
+        const result = await takeSnapshot();
 
-      await waitFor(
-        () => {
-          expect(result.current.loading).toBe(false);
-        },
-        { interval: 1 }
+        expect(result).toEqualQueryResult({
+          data: undefined,
+          called: true,
+          loading: true,
+          networkStatus: NetworkStatus.loading,
+          previousData: undefined,
+          variables: {},
+        });
+      }
+
+      {
+        const result = await takeSnapshot();
+
+        expect(result).toEqualQueryResult({
+          data: undefined,
+          error: new ApolloError({
+            networkError: new Error("Could not fetch"),
+          }),
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.error,
+          previousData: undefined,
+          variables: {},
+        });
+      }
+
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledWith(
+        new ApolloError({ networkError: new Error("Could not fetch") })
       );
 
-      expect(result.current.data).toBeUndefined();
-      expect(result.current.error).toBeInstanceOf(ApolloError);
-      expect(result.current.error!.message).toBe("Could not fetch");
-      expect(result.current.error!.networkError).toEqual(
-        new Error("Could not fetch")
-      );
-
-      await waitFor(() => {
-        expect(onError).toHaveBeenCalledTimes(1);
-      });
-      await waitFor(() => {
-        expect(onError).toHaveBeenCalledWith(
-          new ApolloError({ networkError: new Error("Could not fetch") })
-        );
-      });
+      await expect(takeSnapshot).not.toRerender();
     });
 
     it('returns partial data and discards GraphQL errors when using an `errorPolicy` set to "ignore"', async () => {

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -2394,6 +2394,9 @@ describe("useQuery Hook", () => {
       await expect(takeSnapshot).not.toRerender();
     });
 
+    // TODO: Refactor the initial state of this test. This test states that
+    // `skip` goes from `true` -> `false`, but it starts out unskipped before
+    // enabling it.
     it("should start polling when skip goes from true to false", async () => {
       const query = gql`
         {

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -4971,53 +4971,90 @@ describe("useQuery Hook", () => {
 
       {
         const result = await takeSnapshot();
-        expect(result.loading).toBe(true);
-        expect(result.data).toBe(undefined);
-        expect(result.error).toBe(undefined);
+
+        expect(result).toEqualQueryResult({
+          data: undefined,
+          called: true,
+          loading: true,
+          networkStatus: NetworkStatus.loading,
+          previousData: undefined,
+          variables: {},
+        });
       }
       {
         const result = await takeSnapshot();
-        expect(result.loading).toBe(false);
-        expect(result.data).toBe(undefined);
-        expect(result.error).toBeInstanceOf(ApolloError);
-        expect(result.error!.message).toBe("same error");
+
+        expect(result).toEqualQueryResult({
+          data: undefined,
+          error: new ApolloError({
+            graphQLErrors: [{ message: "same error" }],
+          }),
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.error,
+          previousData: undefined,
+          variables: {},
+        });
       }
+
       await getCurrentSnapshot().refetch();
 
       {
         const result = await takeSnapshot();
-        expect(result.loading).toBe(true);
-        expect(result.data).toBe(undefined);
-        expect(result.error).toBe(undefined);
+
+        expect(result).toEqualQueryResult({
+          data: undefined,
+          called: true,
+          loading: true,
+          networkStatus: NetworkStatus.refetch,
+          previousData: undefined,
+          variables: {},
+        });
       }
       {
         const result = await takeSnapshot();
-        expect(result.loading).toBe(false);
-        expect(result.data).toEqual({ hello: "world" });
-        expect(result.error).toBe(undefined);
+
+        expect(result).toEqualQueryResult({
+          data: { hello: "world" },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: undefined,
+          variables: {},
+        });
       }
-      const catchFn = jest.fn();
-      getCurrentSnapshot().refetch().catch(catchFn);
+
+      await expect(getCurrentSnapshot().refetch()).rejects.toEqual(
+        new ApolloError({ graphQLErrors: [{ message: "same error" }] })
+      );
 
       {
         const result = await takeSnapshot();
-        expect(result.loading).toBe(true);
-        expect(result.data).toEqual({ hello: "world" });
-        expect(result.error).toBe(undefined);
+        expect(result).toEqualQueryResult({
+          data: { hello: "world" },
+          called: true,
+          loading: true,
+          networkStatus: NetworkStatus.refetch,
+          previousData: { hello: "world" },
+          variables: {},
+        });
       }
       {
         const result = await takeSnapshot();
-        expect(result.loading).toBe(false);
-        // TODO: Is this correct behavior here?
-        expect(result.data).toEqual({ hello: "world" });
-        expect(result.error).toBeInstanceOf(ApolloError);
-        expect(result.error!.message).toBe("same error");
-      }
 
-      expect(catchFn.mock.calls.length).toBe(1);
-      expect(catchFn.mock.calls[0].length).toBe(1);
-      expect(catchFn.mock.calls[0][0]).toBeInstanceOf(ApolloError);
-      expect(catchFn.mock.calls[0][0].message).toBe("same error");
+        expect(result).toEqualQueryResult({
+          // TODO: Is this correct behavior here?
+          data: { hello: "world" },
+          error: new ApolloError({
+            graphQLErrors: [{ message: "same error" }],
+          }),
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.error,
+          previousData: { hello: "world" },
+          variables: {},
+        });
+      }
     });
 
     it("should call onCompleted when variables change", async () => {

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -2429,43 +2429,93 @@ describe("useQuery Hook", () => {
           ),
         }
       );
+
       {
         const result = await takeSnapshot();
-        expect(result.loading).toBe(true);
-        expect(result.data).toBe(undefined);
+
+        expect(result).toEqualQueryResult({
+          data: undefined,
+          called: true,
+          loading: true,
+          networkStatus: NetworkStatus.loading,
+          previousData: undefined,
+          variables: {},
+        });
       }
+
       {
         const result = await takeSnapshot();
-        expect(result.loading).toBe(false);
-        expect(result.data).toEqual({ hello: "world 1" });
+
+        expect(result).toEqualQueryResult({
+          data: { hello: "world 1" },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: undefined,
+          variables: {},
+        });
       }
 
       await rerender({ skip: true });
+
       {
-        const snapshot = await takeSnapshot();
-        expect(snapshot.loading).toBe(false);
-        expect(snapshot.data).toEqual(undefined);
+        const result = await takeSnapshot();
+
+        expect(result).toEqualQueryResult({
+          // TODO: wut?
+          data: undefined,
+          // TODO: wut?
+          called: false,
+          // TODO: wut?
+          error: undefined,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: { hello: "world 1" },
+          variables: {},
+        });
       }
 
       await expect(takeSnapshot).not.toRerender({ timeout: 100 });
 
       await rerender({ skip: false });
+
       {
         const result = await takeSnapshot();
-        expect(result.loading).toBe(false);
-        expect(result.data).toEqual({ hello: "world 1" });
+
+        expect(result).toEqualQueryResult({
+          data: { hello: "world 1" },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: { hello: "world 1" },
+          variables: {},
+        });
       }
 
       {
         const result = await takeSnapshot();
-        expect(result.loading).toBe(false);
-        expect(result.data).toEqual({ hello: "world 2" });
+
+        expect(result).toEqualQueryResult({
+          data: { hello: "world 2" },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: { hello: "world 1" },
+          variables: {},
+        });
       }
 
       {
         const result = await takeSnapshot();
-        expect(result.loading).toBe(false);
-        expect(result.data).toEqual({ hello: "world 3" });
+
+        expect(result).toEqualQueryResult({
+          data: { hello: "world 3" },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: { hello: "world 2" },
+          variables: {},
+        });
       }
     });
 

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -2736,27 +2736,45 @@ describe("useQuery Hook", () => {
       );
 
       {
-        const snapshot = await takeSnapshot();
+        const result = await takeSnapshot();
 
-        expect(snapshot.loading).toBe(true);
-        expect(snapshot.data).toBeUndefined();
+        expect(result).toEqualQueryResult({
+          data: undefined,
+          called: true,
+          loading: true,
+          networkStatus: NetworkStatus.loading,
+          previousData: undefined,
+          variables: {},
+        });
       }
 
       {
-        const snapshot = await takeSnapshot();
+        const result = await takeSnapshot();
 
-        expect(snapshot.loading).toBe(false);
-        expect(snapshot.data).toEqual({ hello: "world 1" });
+        expect(result).toEqualQueryResult({
+          data: { hello: "world 1" },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: undefined,
+          variables: {},
+        });
         expect(requestSpy).toHaveBeenCalledTimes(1);
       }
 
       await wait(10);
 
       {
-        const snapshot = await takeSnapshot();
+        const result = await takeSnapshot();
 
-        expect(snapshot.loading).toBe(false);
-        expect(snapshot.data).toEqual({ hello: "world 2" });
+        expect(result).toEqualQueryResult({
+          data: { hello: "world 2" },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: { hello: "world 1" },
+          variables: {},
+        });
         expect(requestSpy).toHaveBeenCalledTimes(2);
       }
 

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -3687,28 +3687,43 @@ describe("useQuery Hook", () => {
       );
 
       const onError = jest.fn();
-      const { result } = renderHook(
+      using _disabledAct = disableActEnvironment();
+      const { takeSnapshot } = await renderHookToSnapshotStream(
         () => useQuery(query, { onError, errorPolicy: "ignore" }),
         { wrapper }
       );
 
-      expect(result.current.loading).toBe(true);
-      expect(result.current.data).toBe(undefined);
-      expect(result.current.error).toBe(undefined);
+      {
+        const result = await takeSnapshot();
 
-      await waitFor(
-        () => {
-          expect(result.current.loading).toBe(false);
-        },
-        { interval: 1 }
-      );
+        expect(result).toEqualQueryResult({
+          data: undefined,
+          called: true,
+          loading: true,
+          networkStatus: NetworkStatus.loading,
+          previousData: undefined,
+          variables: {},
+        });
+      }
 
-      expect(result.current.data).toBeUndefined();
-      expect(result.current.error).toBeUndefined();
+      {
+        const result = await takeSnapshot();
+
+        expect(result).toEqualQueryResult({
+          data: undefined,
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: undefined,
+          variables: {},
+        });
+      }
 
       await tick();
 
       expect(onError).not.toHaveBeenCalled();
+
+      await expect(takeSnapshot).not.toRerender();
     });
 
     it('calls `onError` when a network error has occurred while using an `errorPolicy` set to "ignore"', async () => {

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -3217,55 +3217,82 @@ describe("useQuery Hook", () => {
           { wrapper }
         );
 
-        expect(result.current.loading).toBe(true);
-        expect(result.current.data).toBe(undefined);
+        expect(result.current).toEqualQueryResult({
+          data: undefined,
+          called: true,
+          loading: true,
+          networkStatus: NetworkStatus.loading,
+          previousData: undefined,
+          variables: {},
+        });
 
         await waitFor(
           () => {
-            expect(result.current.data).toEqual({ hello: "world 1" });
+            expect(result.current).toEqualQueryResult({
+              data: { hello: "world 1" },
+              called: true,
+              loading: false,
+              networkStatus: NetworkStatus.ready,
+              previousData: undefined,
+              variables: {},
+            });
           },
           { interval: 1 }
         );
 
-        expect(result.current.loading).toBe(false);
-
-        await waitFor(
-          () => {
-            expect(result.current.data).toEqual({ hello: "world 2" });
-          },
-          { interval: 1 }
-        );
+        await jest.advanceTimersByTimeAsync(12);
+        expect(result.current).toEqualQueryResult({
+          data: { hello: "world 2" },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: { hello: "world 1" },
+          variables: {},
+        });
 
         skipPollAttempt.mockImplementation(() => true);
-        expect(result.current.loading).toBe(false);
 
-        await jest.advanceTimersByTime(12);
-        await waitFor(
-          () => expect(result.current.data).toEqual({ hello: "world 2" }),
-          { interval: 1 }
-        );
+        await jest.advanceTimersByTimeAsync(12);
+        expect(result.current).toEqualQueryResult({
+          data: { hello: "world 2" },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: { hello: "world 1" },
+          variables: {},
+        });
 
-        await jest.advanceTimersByTime(12);
-        await waitFor(
-          () => expect(result.current.data).toEqual({ hello: "world 2" }),
-          { interval: 1 }
-        );
+        await jest.advanceTimersByTimeAsync(12);
+        expect(result.current).toEqualQueryResult({
+          data: { hello: "world 2" },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: { hello: "world 1" },
+          variables: {},
+        });
 
-        await jest.advanceTimersByTime(12);
-        await waitFor(
-          () => expect(result.current.data).toEqual({ hello: "world 2" }),
-          { interval: 1 }
-        );
+        await jest.advanceTimersByTimeAsync(12);
+        expect(result.current).toEqualQueryResult({
+          data: { hello: "world 2" },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: { hello: "world 1" },
+          variables: {},
+        });
 
         skipPollAttempt.mockImplementation(() => false);
-        expect(result.current.loading).toBe(false);
 
-        await waitFor(
-          () => {
-            expect(result.current.data).toEqual({ hello: "world 3" });
-          },
-          { interval: 1 }
-        );
+        await jest.advanceTimersByTimeAsync(12);
+        expect(result.current).toEqualQueryResult({
+          data: { hello: "world 3" },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: { hello: "world 2" },
+          variables: {},
+        });
       });
 
       it("when defined for a single query", async () => {

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -2929,27 +2929,45 @@ describe("useQuery Hook", () => {
       );
 
       {
-        const snapshot = await takeSnapshot();
+        const result = await takeSnapshot();
 
-        expect(snapshot.loading).toBe(true);
-        expect(snapshot.data).toBeUndefined();
+        expect(result).toEqualQueryResult({
+          data: undefined,
+          called: true,
+          loading: true,
+          networkStatus: NetworkStatus.loading,
+          previousData: undefined,
+          variables: {},
+        });
       }
 
       {
-        const snapshot = await takeSnapshot();
+        const result = await takeSnapshot();
 
-        expect(snapshot.loading).toBe(false);
-        expect(snapshot.data).toEqual({ hello: "world 1" });
+        expect(result).toEqualQueryResult({
+          data: { hello: "world 1" },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: undefined,
+          variables: {},
+        });
         expect(requestSpy).toHaveBeenCalledTimes(1);
       }
 
       await wait(10);
 
       {
-        const snapshot = await takeSnapshot();
+        const result = await takeSnapshot();
 
-        expect(snapshot.loading).toBe(false);
-        expect(snapshot.data).toEqual({ hello: "world 2" });
+        expect(result).toEqualQueryResult({
+          data: { hello: "world 2" },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: { hello: "world 1" },
+          variables: {},
+        });
         expect(requestSpy).toHaveBeenCalledTimes(2);
       }
 

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -2522,6 +2522,7 @@ describe("useQuery Hook", () => {
       }
     });
 
+    // TODO: Move out of "polling" query tests since this doesn't test polling
     it("should return data from network when clients default fetch policy set to network-only", async () => {
       const query = gql`
         {

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -3334,55 +3334,82 @@ describe("useQuery Hook", () => {
           { wrapper }
         );
 
-        expect(result.current.loading).toBe(true);
-        expect(result.current.data).toBe(undefined);
+        expect(result.current).toEqualQueryResult({
+          data: undefined,
+          called: true,
+          loading: true,
+          networkStatus: NetworkStatus.loading,
+          previousData: undefined,
+          variables: {},
+        });
 
         await waitFor(
           () => {
-            expect(result.current.data).toEqual({ hello: "world 1" });
+            expect(result.current).toEqualQueryResult({
+              data: { hello: "world 1" },
+              called: true,
+              loading: false,
+              networkStatus: NetworkStatus.ready,
+              previousData: undefined,
+              variables: {},
+            });
           },
           { interval: 1 }
         );
 
-        expect(result.current.loading).toBe(false);
-
-        await waitFor(
-          () => {
-            expect(result.current.data).toEqual({ hello: "world 2" });
-          },
-          { interval: 1 }
-        );
+        await jest.advanceTimersByTimeAsync(12);
+        expect(result.current).toEqualQueryResult({
+          data: { hello: "world 2" },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: { hello: "world 1" },
+          variables: {},
+        });
 
         skipPollAttempt.mockImplementation(() => true);
-        expect(result.current.loading).toBe(false);
 
-        await jest.advanceTimersByTime(12);
-        await waitFor(
-          () => expect(result.current.data).toEqual({ hello: "world 2" }),
-          { interval: 1 }
-        );
+        await jest.advanceTimersByTimeAsync(12);
+        expect(result.current).toEqualQueryResult({
+          data: { hello: "world 2" },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: { hello: "world 1" },
+          variables: {},
+        });
 
-        await jest.advanceTimersByTime(12);
-        await waitFor(
-          () => expect(result.current.data).toEqual({ hello: "world 2" }),
-          { interval: 1 }
-        );
+        await jest.advanceTimersByTimeAsync(12);
+        expect(result.current).toEqualQueryResult({
+          data: { hello: "world 2" },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: { hello: "world 1" },
+          variables: {},
+        });
 
-        await jest.advanceTimersByTime(12);
-        await waitFor(
-          () => expect(result.current.data).toEqual({ hello: "world 2" }),
-          { interval: 1 }
-        );
+        await jest.advanceTimersByTimeAsync(12);
+        expect(result.current).toEqualQueryResult({
+          data: { hello: "world 2" },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: { hello: "world 1" },
+          variables: {},
+        });
 
         skipPollAttempt.mockImplementation(() => false);
-        expect(result.current.loading).toBe(false);
 
-        await waitFor(
-          () => {
-            expect(result.current.data).toEqual({ hello: "world 3" });
-          },
-          { interval: 1 }
-        );
+        await jest.advanceTimersByTimeAsync(12);
+        expect(result.current).toEqualQueryResult({
+          data: { hello: "world 3" },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: { hello: "world 2" },
+          variables: {},
+        });
       });
     });
   });

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -4766,39 +4766,63 @@ describe("useQuery Hook", () => {
 
       {
         const result = await takeSnapshot();
-        expect(result.loading).toBe(true);
-        expect(result.data).toBe(undefined);
-        expect(result.error).toBe(undefined);
+
+        expect(result).toEqualQueryResult({
+          data: undefined,
+          called: true,
+          loading: true,
+          networkStatus: NetworkStatus.loading,
+          previousData: undefined,
+          variables: {},
+        });
       }
 
       {
         const result = await takeSnapshot();
-        expect(result.loading).toBe(false);
-        expect(result.data).toBe(undefined);
-        expect(result.error).toBeInstanceOf(ApolloError);
-        expect(result.error!.message).toBe("error 1");
+
+        expect(result).toEqualQueryResult({
+          data: undefined,
+          error: new ApolloError({ graphQLErrors: [{ message: "error 1" }] }),
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.error,
+          previousData: undefined,
+          variables: {},
+        });
       }
 
-      const catchFn = jest.fn();
-      getCurrentSnapshot().refetch().catch(catchFn);
+      await expect(getCurrentSnapshot().refetch()).rejects.toEqual(
+        new ApolloError({ graphQLErrors: [{ message: "error 2" }] })
+      );
+
       {
         const result = await takeSnapshot();
-        expect(result.loading).toBe(true);
-        expect(result.data).toBe(undefined);
-        expect(result.error).toBe(undefined);
+
+        expect(result).toEqualQueryResult({
+          data: undefined,
+          called: true,
+          loading: true,
+          networkStatus: NetworkStatus.refetch,
+          previousData: undefined,
+          variables: {},
+        });
       }
 
       {
         const result = await takeSnapshot();
-        expect(result.loading).toBe(false);
-        expect(result.data).toBe(undefined);
-        expect(result.error).toBeInstanceOf(ApolloError);
-        expect(result.error!.message).toBe("error 2");
+
+        expect(result).toEqualQueryResult({
+          data: undefined,
+          error: new ApolloError({ graphQLErrors: [{ message: "error 2" }] }),
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.error,
+          previousData: undefined,
+          variables: {},
+        });
       }
-      expect(catchFn.mock.calls.length).toBe(1);
-      expect(catchFn.mock.calls[0].length).toBe(1);
-      expect(catchFn.mock.calls[0][0]).toBeInstanceOf(ApolloError);
-      expect(catchFn.mock.calls[0][0].message).toBe("error 2");
+
+      await expect(takeSnapshot).not.toRerender();
     });
 
     it("should render the same error on refetch", async () => {

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -2632,14 +2632,28 @@ describe("useQuery Hook", () => {
 
       {
         const result = await takeSnapshot();
-        expect(result.loading).toBe(true);
-        expect(result.data).toBe(undefined);
+
+        expect(result).toEqualQueryResult({
+          data: undefined,
+          called: true,
+          loading: true,
+          networkStatus: NetworkStatus.loading,
+          previousData: undefined,
+          variables: {},
+        });
       }
 
       {
         const result = await takeSnapshot();
-        expect(result.loading).toBe(false);
-        expect(result.data).toEqual({ hello: "world 1" });
+
+        expect(result).toEqualQueryResult({
+          data: { hello: "world 1" },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: undefined,
+          variables: {},
+        });
         expect(requestSpy).toHaveBeenCalled();
       }
 


### PR DESCRIPTION
Continuation of #12260