### PR TITLE
Refactor `useQuery` tests to use `toEqualQueryResult` - Part 3

### DIFF
--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -9520,18 +9520,17 @@ describe("useQuery Hook", () => {
           expect.any(Number)
         );
       };
-      let nextFetchPolicy: WatchQueryOptions<
+      const nextFetchPolicy: WatchQueryOptions<
         OperationVariables,
         any
-      >["nextFetchPolicy"] = (_, context) => {
+      >["nextFetchPolicy"] = jest.fn((_, context) => {
         if (context.reason === "variables-changed") {
           return "cache-and-network";
         } else if (context.reason === "after-fetch") {
           return "cache-only";
         }
         throw new Error("should never happen");
-      };
-      nextFetchPolicy = jest.fn(nextFetchPolicy);
+      });
 
       const { result, rerender } = renderHook<
         QueryResult,

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -10955,6 +10955,8 @@ describe("useQuery Hook", () => {
   });
 
   describe("regression test issue #9204", () => {
+    // TODO: See if we can rewrite this with renderHookToSnapshotStream and
+    // check output of hook to ensure its a stable object
     it("should handle a simple query", async () => {
       const query = gql`
         {

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -8118,7 +8118,9 @@ describe("useQuery Hook", () => {
 
       const cache = new InMemoryCache();
       const onCompleted = jest.fn();
-      const { result } = renderHook(
+
+      using _disabledAct = disableActEnvironment();
+      const { takeSnapshot } = await renderHookToSnapshotStream(
         () =>
           useQuery(query, {
             onCompleted,
@@ -8133,33 +8135,46 @@ describe("useQuery Hook", () => {
         }
       );
 
-      expect(result.current.loading).toBe(true);
+      await expect(takeSnapshot()).resolves.toEqualQueryResult({
+        data: undefined,
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: undefined,
+        variables: {},
+      });
 
-      await waitFor(
-        () => {
-          expect(result.current.data).toEqual({ hello: "world 1" });
-        },
-        { interval: 1 }
-      );
-      expect(result.current.loading).toBe(false);
+      await expect(takeSnapshot()).resolves.toEqualQueryResult({
+        data: { hello: "world 1" },
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: undefined,
+        variables: {},
+      });
+
       expect(onCompleted).toHaveBeenCalledTimes(1);
 
-      await waitFor(
-        () => {
-          expect(result.current.data).toEqual({ hello: "world 2" });
-        },
-        { interval: 1 }
-      );
-      expect(result.current.loading).toBe(false);
+      await expect(takeSnapshot()).resolves.toEqualQueryResult({
+        data: { hello: "world 2" },
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: { hello: "world 1" },
+        variables: {},
+      });
+
       expect(onCompleted).toHaveBeenCalledTimes(1);
 
-      await waitFor(
-        () => {
-          expect(result.current.data).toEqual({ hello: "world 3" });
-        },
-        { interval: 1 }
-      );
-      expect(result.current.loading).toBe(false);
+      await expect(takeSnapshot()).resolves.toEqualQueryResult({
+        data: { hello: "world 3" },
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: { hello: "world 2" },
+        variables: {},
+      });
+
       expect(onCompleted).toHaveBeenCalledTimes(1);
     });
 

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -10199,7 +10199,7 @@ describe("useQuery Hook", () => {
         variables: { vin: "ABCDEFG0123456789" },
       });
 
-      await expect(takeSnapshot).not.toRerender()
+      await expect(takeSnapshot).not.toRerender();
     });
 
     it("should persist result.previousData even if query changes", async () => {

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -10023,40 +10023,51 @@ describe("useQuery Hook", () => {
       );
 
       using _disabledAct = disableActEnvironment();
-      const { takeSnapshot } = await renderHookToSnapshotStream(
-        () => useQuery(query, { notifyOnNetworkStatusChange: true }),
-        { wrapper }
-      );
+      const { takeSnapshot, getCurrentSnapshot } =
+        await renderHookToSnapshotStream(
+          () => useQuery(query, { notifyOnNetworkStatusChange: true }),
+          { wrapper }
+        );
 
-      {
-        const result = await takeSnapshot();
-        expect(result.loading).toBe(true);
-        expect(result.data).toBe(undefined);
-        expect(result.previousData).toBe(undefined);
-      }
+      await expect(takeSnapshot()).resolves.toEqualQueryResult({
+        data: undefined,
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: undefined,
+        variables: {},
+      });
 
-      {
-        const result = await takeSnapshot();
-        expect(result.loading).toBe(false);
-        expect(result.data).toEqual(data1);
-        expect(result.previousData).toBe(undefined);
+      await expect(takeSnapshot()).resolves.toEqualQueryResult({
+        data: data1,
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: undefined,
+        variables: {},
+      });
 
-        await result.refetch();
-      }
+      await getCurrentSnapshot().refetch();
 
-      {
-        const result = await takeSnapshot();
-        expect(result.loading).toBe(true);
-        expect(result.data).toEqual(data1);
-        expect(result.previousData).toEqual(data1);
-      }
+      await expect(takeSnapshot()).resolves.toEqualQueryResult({
+        data: data1,
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.refetch,
+        previousData: data1,
+        variables: {},
+      });
 
-      {
-        const result = await takeSnapshot();
-        expect(result.loading).toBe(false);
-        expect(result.data).toEqual(data2);
-        expect(result.previousData).toEqual(data1);
-      }
+      await expect(takeSnapshot()).resolves.toEqualQueryResult({
+        data: data2,
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: data1,
+        variables: {},
+      });
+
+      await expect(takeSnapshot).not.toRerender();
     });
 
     it("should persist result.previousData across multiple results", async () => {

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -8325,6 +8325,9 @@ describe("useQuery Hook", () => {
       }
 
       expect(onCompleted).toHaveBeenCalledTimes(3);
+
+      jest.runOnlyPendingTimers();
+      jest.useRealTimers();
     });
 
     // This test was added for issue https://github.com/apollographql/apollo-client/issues/9794

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -7131,25 +7131,57 @@ describe("useQuery Hook", () => {
         );
       {
         const result = await takeSnapshot();
-        expect(result.loading).toBe(true);
-        expect(result.data).toBe(undefined);
+
+        expect(result).toEqualQueryResult({
+          data: undefined,
+          called: true,
+          loading: true,
+          networkStatus: NetworkStatus.loading,
+          previousData: undefined,
+          variables: { id: 1 },
+        });
       }
       {
         const result = await takeSnapshot();
-        expect(result.loading).toBe(false);
-        expect(result.data).toEqual({ hello: "world 1" });
+
+        expect(result).toEqualQueryResult({
+          data: { hello: "world 1" },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: undefined,
+          variables: { id: 1 },
+        });
       }
+
       await getCurrentSnapshot().refetch({ id: 2 });
+
       {
         const result = await takeSnapshot();
-        expect(result.loading).toBe(true);
-        expect(result.data).toBe(undefined);
+
+        expect(result).toEqualQueryResult({
+          data: undefined,
+          called: true,
+          loading: true,
+          networkStatus: NetworkStatus.setVariables,
+          previousData: { hello: "world 1" },
+          variables: { id: 2 },
+        });
       }
       {
         const result = await takeSnapshot();
-        expect(result.loading).toBe(false);
-        expect(result.data).toEqual({ hello: "world 2" });
+
+        expect(result).toEqualQueryResult({
+          data: { hello: "world 2" },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: { hello: "world 1" },
+          variables: { id: 2 },
+        });
       }
+
+      await expect(takeSnapshot).not.toRerender();
     });
 
     it("refetching after an error", async () => {

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -8204,6 +8204,7 @@ describe("useQuery Hook", () => {
 
       const cache = new InMemoryCache();
       const onCompleted = jest.fn();
+
       using _disabledAct = disableActEnvironment();
       const { takeSnapshot } = await renderHookToSnapshotStream(
         () =>
@@ -8221,41 +8222,71 @@ describe("useQuery Hook", () => {
         }
       );
 
-      {
-        const result = await takeSnapshot();
-        expect(result.data).toEqual(undefined);
-        expect(result.loading).toBe(true);
-      }
-      {
-        const result = await takeSnapshot();
-        expect(result.data).toEqual({ hello: "world 1" });
-        expect(result.loading).toBe(false);
-        expect(onCompleted).toHaveBeenCalledTimes(1);
-      }
-      {
-        const result = await takeSnapshot();
-        expect(result.data).toEqual({ hello: "world 1" });
-        expect(result.loading).toBe(true);
-        expect(onCompleted).toHaveBeenCalledTimes(1);
-      }
-      {
-        const result = await takeSnapshot();
-        expect(result.data).toEqual({ hello: "world 2" });
-        expect(result.loading).toBe(false);
-        expect(onCompleted).toHaveBeenCalledTimes(2);
-      }
-      {
-        const result = await takeSnapshot();
-        expect(result.data).toEqual({ hello: "world 2" });
-        expect(result.loading).toBe(true);
-        expect(onCompleted).toHaveBeenCalledTimes(2);
-      }
-      {
-        const result = await takeSnapshot();
-        expect(result.data).toEqual({ hello: "world 3" });
-        expect(result.loading).toBe(false);
-        expect(onCompleted).toHaveBeenCalledTimes(3);
-      }
+      await expect(takeSnapshot()).resolves.toEqualQueryResult({
+        data: undefined,
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: undefined,
+        variables: {},
+      });
+
+      expect(onCompleted).toHaveBeenCalledTimes(0);
+
+      await expect(takeSnapshot()).resolves.toEqualQueryResult({
+        data: { hello: "world 1" },
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: undefined,
+        variables: {},
+      });
+
+      expect(onCompleted).toHaveBeenCalledTimes(1);
+
+      await expect(takeSnapshot()).resolves.toEqualQueryResult({
+        data: { hello: "world 1" },
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.poll,
+        previousData: { hello: "world 1" },
+        variables: {},
+      });
+
+      expect(onCompleted).toHaveBeenCalledTimes(1);
+
+      await expect(takeSnapshot()).resolves.toEqualQueryResult({
+        data: { hello: "world 2" },
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: { hello: "world 1" },
+        variables: {},
+      });
+
+      expect(onCompleted).toHaveBeenCalledTimes(2);
+
+      await expect(takeSnapshot()).resolves.toEqualQueryResult({
+        data: { hello: "world 2" },
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.poll,
+        previousData: { hello: "world 2" },
+        variables: {},
+      });
+
+      expect(onCompleted).toHaveBeenCalledTimes(2);
+
+      await expect(takeSnapshot()).resolves.toEqualQueryResult({
+        data: { hello: "world 3" },
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: { hello: "world 2" },
+        variables: {},
+      });
+
+      expect(onCompleted).toHaveBeenCalledTimes(3);
     });
 
     // This test was added for issue https://github.com/apollographql/apollo-client/issues/9794

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -9774,7 +9774,8 @@ describe("useQuery Hook", () => {
         }
       `;
 
-      const { result } = renderHook(
+      using _disabledAct = disableActEnvironment();
+      const { takeSnapshot } = await renderHookToSnapshotStream(
         () => useQuery(partialQuery, { returnPartialData: true }),
         {
           wrapper: ({ children }) => (
@@ -9783,19 +9784,25 @@ describe("useQuery Hook", () => {
         }
       );
 
-      expect(result.current.loading).toBe(true);
-      expect(result.current.data).toEqual({
-        cars: [
-          {
-            __typename: "Car",
-            repairs: [
-              {
-                __typename: "Repair",
-                date: "2019-05-08",
-              },
-            ],
-          },
-        ],
+      await expect(takeSnapshot()).resolves.toEqualQueryResult({
+        data: {
+          cars: [
+            {
+              __typename: "Car",
+              repairs: [
+                {
+                  __typename: "Repair",
+                  date: "2019-05-08",
+                },
+              ],
+            },
+          ],
+        },
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: undefined,
+        variables: {},
       });
     });
 

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -6989,17 +6989,20 @@ describe("useQuery Hook", () => {
     {
       const { snapshot } = await renderStream.takeRender();
 
-      expect(snapshot.useQueryResult).toMatchObject({
+      expect(snapshot.useQueryResult!).toEqualQueryResult({
         data: undefined,
+        called: true,
         loading: true,
         networkStatus: NetworkStatus.loading,
+        previousData: undefined,
+        variables: {},
       });
     }
 
     {
       const { snapshot } = await renderStream.takeRender();
 
-      expect(snapshot.useQueryResult).toMatchObject({
+      expect(snapshot.useQueryResult!).toEqualQueryResult({
         data: {
           author: {
             __typename: "Author",
@@ -7007,12 +7010,16 @@ describe("useQuery Hook", () => {
             name: "Author Lee",
             post: {
               __typename: "Post",
+              id: 1,
               title: "Title",
             },
           },
         },
+        called: true,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        previousData: undefined,
+        variables: {},
       });
     }
 
@@ -7022,7 +7029,7 @@ describe("useQuery Hook", () => {
     {
       const { snapshot } = await renderStream.takeRender();
 
-      expect(snapshot.useQueryResult).toMatchObject({
+      expect(snapshot.useQueryResult!).toEqualQueryResult({
         data: {
           author: {
             __typename: "Author",
@@ -7030,19 +7037,23 @@ describe("useQuery Hook", () => {
             name: "Author Lee",
             post: {
               __typename: "Post",
+              id: 1,
               title: "Title",
             },
           },
         },
+        called: true,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        previousData: undefined,
+        variables: {},
       });
     }
 
     {
       const { snapshot } = await renderStream.takeRender();
 
-      expect(snapshot.useQueryResult).toMatchObject({
+      expect(snapshot.useQueryResult!).toEqualQueryResult({
         data: {
           author: {
             __typename: "Author",
@@ -7054,12 +7065,27 @@ describe("useQuery Hook", () => {
             name: "Author Lee (refetch)",
             post: {
               __typename: "Post",
+              id: 1,
               title: "Title",
             },
           },
         },
+        called: true,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        previousData: {
+          author: {
+            __typename: "Author",
+            id: 1,
+            name: "Author Lee",
+            post: {
+              __typename: "Post",
+              id: 1,
+              title: "Title",
+            },
+          },
+        },
+        variables: {},
       });
     }
 

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -11060,14 +11060,28 @@ describe("useQuery Hook", () => {
         }
       );
 
-      expect(result.current.loading).toBe(true);
-      expect(result.current.data).toBeUndefined();
+      expect(result.current).toEqualQueryResult({
+        data: undefined,
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: undefined,
+        variables: {},
+      });
 
       await waitFor(() => {
         expect(result.current.loading).toBe(false);
       });
 
-      expect(result.current.data).toEqual({ hello: "hello 1" });
+      expect(result.current).toEqualQueryResult({
+        data: { hello: "hello 1" },
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: undefined,
+        variables: {},
+      });
+
       expect(cache.readQuery({ query })).toEqual({ hello: "hello 1" });
 
       act(() => {
@@ -11078,14 +11092,28 @@ describe("useQuery Hook", () => {
         setShow(true);
       });
 
-      expect(result.current.loading).toBe(true);
-      expect(result.current.data).toBeUndefined();
+      expect(result.current).toEqualQueryResult({
+        data: undefined,
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: undefined,
+        variables: {},
+      });
 
       await waitFor(() => {
         expect(result.current.loading).toBe(false);
       });
 
-      expect(result.current.data).toEqual({ hello: "hello 2" });
+      expect(result.current).toEqualQueryResult({
+        data: { hello: "hello 2" },
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: undefined,
+        variables: {},
+      });
+
       expect(cache.readQuery({ query })).toEqual({ hello: "hello 2" });
     });
   });

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -10901,6 +10901,8 @@ describe("useQuery Hook", () => {
       expect(result.current.b.data).toEqual(bData);
     }
 
+    // TODO: Eventually move the "check" code back into these test so we can
+    // check them render-by-render with renderHookToSnapshotStream
     it("cache-first for both", () => check("cache-first", "cache-first"));
 
     it("cache-first first, cache-and-network second", () =>

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -8388,51 +8388,66 @@ describe("useQuery Hook", () => {
           result: { data: { hello: "bar" } },
         },
       ];
-      const link = new MockLink(mocks);
-      const cache = new InMemoryCache();
+      const client = new ApolloClient({
+        cache: new InMemoryCache(),
+        link: new MockLink(mocks),
+      });
       const onCompleted = jest.fn();
 
-      const ChildComponent: React.FC = () => {
-        const { data, client } = useQuery(query, { onCompleted });
-        function refetchQueries() {
-          void client.refetchQueries({ include: "active" });
+      using _disabledAct = disableActEnvironment();
+      const { takeSnapshot } = await renderHookToSnapshotStream(
+        () => useQuery(query, { onCompleted }),
+        {
+          wrapper: ({ children }) => (
+            <ApolloProvider client={client}>{children}</ApolloProvider>
+          ),
         }
-        function writeQuery() {
-          client.writeQuery({ query, data: { hello: "baz" } });
-        }
-        return (
-          <div>
-            <span>Data: {data?.hello}</span>
-            <button onClick={() => refetchQueries()}>Refetch queries</button>
-            <button onClick={() => writeQuery()}>Update word</button>
-          </div>
-        );
-      };
-
-      const ParentComponent: React.FC = () => {
-        return (
-          <MockedProvider link={link} cache={cache}>
-            <div>
-              <ChildComponent />
-            </div>
-          </MockedProvider>
-        );
-      };
-
-      render(<ParentComponent />);
-
-      await screen.findByText("Data: foo");
-      await userEvent.click(
-        screen.getByRole("button", { name: /refetch queries/i })
       );
-      expect(onCompleted).toBeCalledTimes(1);
-      await screen.findByText("Data: bar");
-      await userEvent.click(
-        screen.getByRole("button", { name: /update word/i })
-      );
-      expect(onCompleted).toBeCalledTimes(1);
-      await screen.findByText("Data: baz");
-      expect(onCompleted).toBeCalledTimes(1);
+
+      await expect(takeSnapshot()).resolves.toEqualQueryResult({
+        data: undefined,
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: undefined,
+        variables: {},
+      });
+
+      await expect(takeSnapshot()).resolves.toEqualQueryResult({
+        data: { hello: "foo" },
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: undefined,
+        variables: {},
+      });
+      expect(onCompleted).toHaveBeenCalledTimes(1);
+
+      void client.refetchQueries({ include: "active" });
+
+      await expect(takeSnapshot()).resolves.toEqualQueryResult({
+        data: { hello: "bar" },
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: { hello: "foo" },
+        variables: {},
+      });
+      expect(onCompleted).toHaveBeenCalledTimes(1);
+
+      client.writeQuery({ query, data: { hello: "baz" } });
+
+      await expect(takeSnapshot()).resolves.toEqualQueryResult({
+        data: { hello: "baz" },
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: { hello: "bar" },
+        variables: {},
+      });
+      expect(onCompleted).toHaveBeenCalledTimes(1);
+
+      await expect(takeSnapshot).not.toRerender();
     });
 
     it("onCompleted should execute on cache writes after initial query execution with notifyOnNetworkStatusChange: true", async () => {

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -7786,31 +7786,82 @@ describe("useQuery Hook", () => {
         expect(hookResponse).toHaveBeenCalledTimes(5);
       });
 
-      expect(hookResponse.mock.calls.map((call) => call[0].data)).toEqual([
-        undefined,
-        {
+      expect(hookResponse.mock.calls[0][0] as QueryResult).toEqualQueryResult({
+        data: undefined,
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: undefined,
+        variables: { id: 1 },
+      });
+      expect(hookResponse.mock.calls[1][0] as QueryResult).toEqualQueryResult({
+        data: {
           car: {
             __typename: "Car",
             make: "Audi",
             model: "A4",
           },
         },
-        {
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: undefined,
+        variables: { id: 1 },
+      });
+      expect(hookResponse.mock.calls[2][0] as QueryResult).toEqualQueryResult({
+        data: {
           car: {
             __typename: "Car",
             make: "Audi",
             model: "A4",
           },
         },
-        undefined,
-        {
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.refetch,
+        previousData: {
+          car: {
+            __typename: "Car",
+            make: "Audi",
+            model: "A4",
+          },
+        },
+        variables: { id: 1 },
+      });
+      expect(hookResponse.mock.calls[3][0] as QueryResult).toEqualQueryResult({
+        data: undefined,
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.setVariables,
+        previousData: {
+          car: {
+            __typename: "Car",
+            make: "Audi",
+            model: "A4",
+          },
+        },
+        variables: { id: 2 },
+      });
+      expect(hookResponse.mock.calls[4][0] as QueryResult).toEqualQueryResult({
+        data: {
           car: {
             __typename: "Car",
             make: "Audi",
             model: "RS8",
           },
         },
-      ]);
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: {
+          car: {
+            __typename: "Car",
+            make: "Audi",
+            model: "A4",
+          },
+        },
+        variables: { id: 2 },
+      });
     });
   });
 

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -8463,10 +8463,12 @@ describe("useQuery Hook", () => {
         {
           request: { query },
           result: { data: { hello: "foo" } },
+          delay: 20,
         },
         {
           request: { query },
           result: { data: { hello: "bar" } },
+          delay: 20,
         },
       ];
       const client = new ApolloClient({

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -8652,16 +8652,31 @@ describe("useQuery Hook", () => {
 
       {
         const { query } = await takeSnapshot();
-        expect(query.loading).toBe(true);
-      }
-      const mutate = getCurrentSnapshot().mutation[0];
-      {
-        const { query } = await takeSnapshot();
-        expect(query.loading).toBe(false);
-        expect(query.loading).toBe(false);
-        expect(query.data).toEqual(carsData);
+
+        expect(query).toEqualQueryResult({
+          data: undefined,
+          called: true,
+          loading: true,
+          networkStatus: NetworkStatus.loading,
+          previousData: undefined,
+          variables: {},
+        });
       }
 
+      {
+        const { query } = await takeSnapshot();
+
+        expect(query).toEqualQueryResult({
+          data: carsData,
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: undefined,
+          variables: {},
+        });
+      }
+
+      const mutate = getCurrentSnapshot().mutation[0];
       void mutate();
 
       {
@@ -8677,8 +8692,14 @@ describe("useQuery Hook", () => {
           ({ query, mutation } = await takeSnapshot());
         }
         expect(mutation[1].loading).toBe(true);
-        expect(query.loading).toBe(false);
-        expect(query.data).toEqual(allCarsData);
+        expect(query).toEqualQueryResult({
+          data: allCarsData,
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: carsData,
+          variables: {},
+        });
       }
 
       expect(onError).toHaveBeenCalledTimes(0);
@@ -8687,7 +8708,14 @@ describe("useQuery Hook", () => {
         // The mutation ran and is loading the result. The query stays at
         // not loading as nothing has changed for the query.
         expect(mutation[1].loading).toBe(true);
-        expect(query.loading).toBe(false);
+        expect(query).toEqualQueryResult({
+          data: carsData,
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: allCarsData,
+          variables: {},
+        });
       }
 
       {
@@ -8695,8 +8723,14 @@ describe("useQuery Hook", () => {
         // The mutation has completely finished, leaving the query with access to
         // the original cache data.
         expect(mutation[1].loading).toBe(false);
-        expect(query.loading).toBe(false);
-        expect(query.data).toEqual(carsData);
+        expect(query).toEqualQueryResult({
+          data: carsData,
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: allCarsData,
+          variables: {},
+        });
       }
 
       expect(onError).toHaveBeenCalledTimes(1);

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -12695,15 +12695,23 @@ describe("useQuery Hook", () => {
 
       const { snapshot } = await renderStream.takeRender();
 
-      expect(snapshot.result?.data).toEqual({
-        currentUser: {
-          __typename: "User",
-          id: 1,
-          name: "Test User",
-          age: 30,
+      expect(snapshot.result).toEqualQueryResult({
+        data: {
+          currentUser: {
+            __typename: "User",
+            id: 1,
+            name: "Test User",
+            age: 30,
+          },
         },
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: undefined,
+        variables: {},
       });
-      expect(snapshot.result?.previousData).toBeUndefined();
+
+      await expect(renderStream).not.toRerender();
     });
 
     it("does not mask query by default", async () => {

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -12590,22 +12590,33 @@ describe("useQuery Hook", () => {
       {
         const { snapshot } = await renderStream.takeRender();
 
-        expect(snapshot.result?.loading).toBe(true);
+        expect(snapshot.result).toEqualQueryResult({
+          data: undefined,
+          called: true,
+          loading: true,
+          networkStatus: NetworkStatus.loading,
+          previousData: undefined,
+          variables: {},
+        });
       }
 
       {
         const { snapshot } = await renderStream.takeRender();
-        const { result } = snapshot;
 
-        expect(result?.loading).toBe(false);
-        expect(result?.data).toEqual({
-          currentUser: {
-            __typename: "User",
-            id: 1,
-            name: "Test User",
+        expect(snapshot.result).toEqualQueryResult({
+          data: {
+            currentUser: {
+              __typename: "User",
+              id: 1,
+              name: "Test User",
+            },
           },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: undefined,
+          variables: {},
         });
-        expect(result?.previousData).toBeUndefined();
       }
     });
 

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -10704,6 +10704,8 @@ describe("useQuery Hook", () => {
     });
   });
 
+  // TODO: Delete this test after PR review since this is a duplicate of the
+  // previous one
   describe("canonical cache results", () => {
     it("can be disabled via useQuery options", async () => {
       const cache = new InMemoryCache({

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -8014,7 +8014,9 @@ describe("useQuery Hook", () => {
       );
 
       const onCompleted = jest.fn();
-      const { result } = renderHook(
+
+      using _disabledAct = disableActEnvironment();
+      const { takeSnapshot } = await renderHookToSnapshotStream(
         () =>
           useQuery(query, {
             skip: true,
@@ -8023,20 +8025,18 @@ describe("useQuery Hook", () => {
         { wrapper }
       );
 
-      expect(result.current.loading).toBe(false);
-      expect(result.current.data).toBe(undefined);
+      await expect(takeSnapshot()).resolves.toEqualQueryResult({
+        data: undefined,
+        error: undefined,
+        called: false,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: undefined,
+        variables: {},
+      });
 
       expect(onCompleted).toHaveBeenCalledTimes(0);
-
-      await expect(
-        waitFor(
-          () => {
-            expect(onCompleted).toHaveBeenCalledTimes(1);
-          },
-          { interval: 1, timeout: 20 }
-        )
-      ).rejects.toThrow();
-
+      await expect(takeSnapshot).not.toRerender();
       expect(onCompleted).toHaveBeenCalledTimes(0);
     });
 

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -9930,12 +9930,9 @@ describe("useQuery Hook", () => {
         },
       });
 
-      let setId: any;
       using _disabledAct = disableActEnvironment();
-      const { takeSnapshot } = await renderHookToSnapshotStream(
-        () => {
-          const [id, setId1] = React.useState(2);
-          setId = setId1;
+      const { takeSnapshot, rerender } = await renderHookToSnapshotStream(
+        ({ id }) => {
           return useQuery(partialQuery, {
             variables: { id },
             returnPartialData: false,
@@ -9943,6 +9940,7 @@ describe("useQuery Hook", () => {
           });
         },
         {
+          initialProps: { id: 2 },
           wrapper: ({ children }) => (
             <ApolloProvider client={client}>{children}</ApolloProvider>
           ),
@@ -9965,9 +9963,7 @@ describe("useQuery Hook", () => {
         variables: { id: 2 },
       });
 
-      setTimeout(() => {
-        setId(1);
-      });
+      await rerender({ id: 1 });
 
       await expect(takeSnapshot()).resolves.toEqualQueryResult({
         data: undefined,

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -12470,44 +12470,48 @@ describe("useQuery Hook", () => {
         }
       );
 
-    {
-      const { loading, data, error } = await takeSnapshot();
+    await expect(takeSnapshot()).resolves.toEqualQueryResult({
+      data: undefined,
+      called: true,
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      previousData: undefined,
+      variables: {},
+    });
 
-      expect(loading).toBe(true);
-      expect(data).toBeUndefined();
-      expect(error).toBeUndefined();
-    }
-
-    {
-      const { loading, data, error } = await takeSnapshot();
-
-      expect(loading).toBe(false);
-      expect(data).toBeUndefined();
-      expect(error).toEqual(new ApolloError({ graphQLErrors: [graphQLError] }));
-    }
+    await expect(takeSnapshot()).resolves.toEqualQueryResult({
+      data: undefined,
+      error: new ApolloError({ graphQLErrors: [graphQLError] }),
+      called: true,
+      loading: false,
+      networkStatus: NetworkStatus.error,
+      previousData: undefined,
+      variables: {},
+    });
 
     const { refetch } = getCurrentSnapshot();
 
     refetch().catch(() => {});
     refetch().catch(() => {});
 
-    {
-      const { loading, networkStatus, data, error } = await takeSnapshot();
+    await expect(takeSnapshot()).resolves.toEqualQueryResult({
+      data: undefined,
+      called: true,
+      loading: true,
+      networkStatus: NetworkStatus.refetch,
+      previousData: undefined,
+      variables: {},
+    });
 
-      expect(loading).toBe(true);
-      expect(data).toBeUndefined();
-      expect(networkStatus).toBe(NetworkStatus.refetch);
-      expect(error).toBeUndefined();
-    }
-
-    {
-      const { loading, networkStatus, data, error } = await takeSnapshot();
-
-      expect(loading).toBe(false);
-      expect(data).toBeUndefined();
-      expect(networkStatus).toBe(NetworkStatus.error);
-      expect(error).toEqual(new ApolloError({ graphQLErrors: [graphQLError] }));
-    }
+    await expect(takeSnapshot()).resolves.toEqualQueryResult({
+      data: undefined,
+      error: new ApolloError({ graphQLErrors: [graphQLError] }),
+      called: true,
+      loading: false,
+      networkStatus: NetworkStatus.error,
+      previousData: undefined,
+      variables: {},
+    });
 
     await expect(takeSnapshot).not.toRerender({ timeout: 200 });
   });

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -12805,8 +12805,8 @@ describe("useQuery Hook", () => {
           },
         },
         called: true,
-        loading: true,
-        networkStatus: NetworkStatus.loading,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
         previousData: undefined,
         variables: {},
       });
@@ -12886,14 +12886,20 @@ describe("useQuery Hook", () => {
       {
         const { snapshot } = await renderStream.takeRender();
 
-        expect(snapshot.data).toEqual({
-          currentUser: {
-            __typename: "User",
-            id: 1,
-            name: "Test User",
+        expect(snapshot).toEqualQueryResult({
+          data: {
+            currentUser: {
+              __typename: "User",
+              id: 1,
+              name: "Test User",
+            },
           },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: undefined,
+          variables: {},
         });
-        expect(snapshot.previousData).toBeUndefined();
       }
 
       client.writeQuery({
@@ -12911,15 +12917,25 @@ describe("useQuery Hook", () => {
       {
         const { snapshot } = await renderStream.takeRender();
 
-        expect(snapshot.data).toEqual({
-          currentUser: {
-            __typename: "User",
-            id: 1,
-            name: "Test User (updated)",
+        expect(snapshot).toEqualQueryResult({
+          data: {
+            currentUser: {
+              __typename: "User",
+              id: 1,
+              name: "Test User (updated)",
+            },
           },
-        });
-        expect(snapshot.previousData).toEqual({
-          currentUser: { __typename: "User", id: 1, name: "Test User" },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: {
+            currentUser: {
+              __typename: "User",
+              id: 1,
+              name: "Test User",
+            },
+          },
+          variables: {},
         });
       }
     });
@@ -12998,14 +13014,20 @@ describe("useQuery Hook", () => {
       {
         const { snapshot } = await renderStream.takeRender();
 
-        expect(snapshot.data).toEqual({
-          currentUser: {
-            __typename: "User",
-            id: 1,
-            name: "Test User",
+        expect(snapshot).toEqualQueryResult({
+          data: {
+            currentUser: {
+              __typename: "User",
+              id: 1,
+              name: "Test User",
+            },
           },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: undefined,
+          variables: {},
         });
-        expect(snapshot.previousData).toBeUndefined();
       }
 
       client.writeQuery({
@@ -13116,14 +13138,20 @@ describe("useQuery Hook", () => {
 
         const { snapshot } = await renderStream.takeRender();
 
-        expect(snapshot.data).toEqual({
-          currentUser: {
-            __typename: "User",
-            id: 1,
-            name: "Test User",
+        expect(snapshot).toEqualQueryResult({
+          data: {
+            currentUser: {
+              __typename: "User",
+              id: 1,
+              name: "Test User",
+            },
           },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: undefined,
+          variables: {},
         });
-        expect(snapshot.previousData).toBeUndefined();
       }
     );
 
@@ -13211,32 +13239,44 @@ describe("useQuery Hook", () => {
       {
         const { snapshot } = await renderStream.takeRender();
 
-        expect(snapshot.data).toEqual({
-          currentUser: {
-            __typename: "User",
-            id: 1,
-            name: "Test User",
+        expect(snapshot).toEqualQueryResult({
+          data: {
+            currentUser: {
+              __typename: "User",
+              id: 1,
+              name: "Test User",
+            },
           },
+          called: true,
+          loading: true,
+          networkStatus: NetworkStatus.loading,
+          previousData: undefined,
+          variables: {},
         });
-        expect(snapshot.previousData).toBeUndefined();
       }
 
       {
         const { snapshot } = await renderStream.takeRender();
 
-        expect(snapshot.data).toEqual({
-          currentUser: {
-            __typename: "User",
-            id: 1,
-            name: "Test User (server)",
+        expect(snapshot).toEqualQueryResult({
+          data: {
+            currentUser: {
+              __typename: "User",
+              id: 1,
+              name: "Test User (server)",
+            },
           },
-        });
-        expect(snapshot.previousData).toEqual({
-          currentUser: {
-            __typename: "User",
-            id: 1,
-            name: "Test User",
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: {
+            currentUser: {
+              __typename: "User",
+              id: 1,
+              name: "Test User",
+            },
           },
+          variables: {},
         });
       }
     });
@@ -13329,23 +13369,42 @@ describe("useQuery Hook", () => {
       {
         const { snapshot } = await renderStream.takeRender();
 
-        expect(snapshot.data).toEqual({
-          currentUser: {
-            __typename: "User",
-            id: 1,
-          },
+        expect(snapshot).toEqualQueryResult({
+          data: {
+            currentUser: {
+              __typename: "User",
+              id: 1,
+            },
+          } as Query,
+          called: true,
+          loading: true,
+          networkStatus: NetworkStatus.loading,
+          previousData: undefined,
+          variables: {},
         });
       }
 
       {
         const { snapshot } = await renderStream.takeRender();
 
-        expect(snapshot.data).toEqual({
-          currentUser: {
-            __typename: "User",
-            id: 1,
-            name: "Test User (server)",
+        expect(snapshot).toEqualQueryResult({
+          data: {
+            currentUser: {
+              __typename: "User",
+              id: 1,
+              name: "Test User (server)",
+            },
           },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: {
+            currentUser: {
+              __typename: "User",
+              id: 1,
+            },
+          } as Query,
+          variables: {},
         });
       }
     });
@@ -13360,7 +13419,7 @@ describe("useQuery Hook", () => {
         currentUser: {
           __typename: "User";
           id: number;
-          name: string;
+          name: string | null;
         } & { " $fragmentRefs"?: { UserFieldsFragment: UserFieldsFragment } };
       }
 
@@ -13426,19 +13485,24 @@ describe("useQuery Hook", () => {
       {
         const { snapshot } = await renderStream.takeRender();
 
-        expect(snapshot.data).toEqual({
-          currentUser: {
-            __typename: "User",
-            id: 1,
-            name: null,
+        expect(snapshot).toEqualQueryResult({
+          data: {
+            currentUser: {
+              __typename: "User",
+              id: 1,
+              name: null,
+            },
           },
-        });
-
-        expect(snapshot.error).toEqual(
-          new ApolloError({
+          error: new ApolloError({
             graphQLErrors: [new GraphQLError("Couldn't get name")],
-          })
-        );
+          }),
+          errors: [{ message: "Couldn't get name" }],
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: undefined,
+          variables: {},
+        });
       }
     });
   });

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -10270,204 +10270,144 @@ describe("useQuery Hook", () => {
         ),
       });
 
-      const { result } = renderHook(
-        () => {
-          const [query, setQuery] = useState<DocumentNode>(aQuery);
-          return {
-            query,
-            setQuery,
-            useQueryResult: useQuery(query, {
-              fetchPolicy: "cache-and-network",
-              notifyOnNetworkStatusChange: true,
-            }),
-          };
-        },
-        {
-          wrapper: ({ children }: any) => (
-            <ApolloProvider client={client}>{children}</ApolloProvider>
-          ),
-        }
-      );
-
-      await waitFor(
-        () => {
-          const { loading } = result.current.useQueryResult;
-          expect(loading).toBe(true);
-        },
-        { interval: 1 }
-      );
-      await waitFor(
-        () => {
-          const { data } = result.current.useQueryResult;
-          expect(data).toEqual({ a: "a" });
-        },
-        { interval: 1 }
-      );
-      await waitFor(
-        () => {
-          const { previousData } = result.current.useQueryResult;
-          expect(previousData).toBeUndefined();
-        },
-        { interval: 1 }
-      );
-
-      await waitFor(
-        () => {
-          const { loading } = result.current.useQueryResult;
-          expect(loading).toBe(false);
-        },
-        { interval: 1 }
-      );
-      await waitFor(
-        () => {
-          const { data } = result.current.useQueryResult;
-          expect(data).toEqual({ a: "a" });
-        },
-        { interval: 1 }
-      );
-      await waitFor(
-        () => {
-          const { previousData } = result.current.useQueryResult;
-          expect(previousData).toBe(undefined);
-        },
-        { interval: 1 }
-      );
-
-      await expect(
-        await waitFor(
+      using _disabledAct = disableActEnvironment();
+      const { takeSnapshot, getCurrentSnapshot } =
+        await renderHookToSnapshotStream(
           () => {
-            result.current.setQuery(abQuery);
+            const [query, setQuery] = useState<DocumentNode>(aQuery);
+            return {
+              query,
+              setQuery,
+              useQueryResult: useQuery(query, {
+                fetchPolicy: "cache-and-network",
+                notifyOnNetworkStatusChange: true,
+              }),
+            };
           },
-          { interval: 1 }
-        )
-      );
+          {
+            wrapper: ({ children }: any) => (
+              <ApolloProvider client={client}>{children}</ApolloProvider>
+            ),
+          }
+        );
 
-      await waitFor(
-        () => {
-          const { loading } = result.current.useQueryResult;
-          expect(loading).toBe(false);
-        },
-        { interval: 1 }
-      );
-      await waitFor(
-        () => {
-          const { data } = result.current.useQueryResult;
-          expect(data).toEqual({ a: "aa", b: 1 });
-        },
-        { interval: 1 }
-      );
-      await waitFor(
-        () => {
-          const { previousData } = result.current.useQueryResult;
-          expect(previousData).toEqual({ a: "a" });
-        },
-        { interval: 1 }
-      );
+      {
+        const { useQueryResult } = await takeSnapshot();
 
-      await waitFor(
-        () => {
-          const { loading } = result.current.useQueryResult;
-          expect(loading).toBe(false);
-        },
-        { interval: 1 }
-      );
-      await waitFor(
-        () => {
-          const { data } = result.current.useQueryResult;
-          expect(data).toEqual({ a: "aa", b: 1 });
-        },
-        { interval: 1 }
-      );
-      await waitFor(
-        () => {
-          const { previousData } = result.current.useQueryResult;
-          expect(previousData).toEqual({ a: "a" });
-        },
-        { interval: 1 }
-      );
+        expect(useQueryResult).toEqualQueryResult({
+          data: undefined,
+          called: true,
+          loading: true,
+          networkStatus: NetworkStatus.loading,
+          previousData: undefined,
+          variables: {},
+        });
+      }
 
-      await waitFor(
-        () => {
-          // TODO investigate why do we call `reobserve` in a very quick loop here?
-          void result.current.useQueryResult.reobserve().then((result) => {
-            expect(result.loading).toBe(false);
-            expect(result.data).toEqual({ a: "aaa", b: 2 });
-          });
-        },
-        { interval: 1 }
-      );
+      {
+        const { useQueryResult } = await takeSnapshot();
 
-      await waitFor(
-        () => {
-          const { loading } = result.current.useQueryResult;
-          expect(loading).toBe(false);
-        },
-        { interval: 1 }
-      );
-      await waitFor(
-        () => {
-          const { data } = result.current.useQueryResult;
-          expect(data).toEqual({ a: "aaa", b: 2 });
-        },
-        { interval: 1 }
-      );
-      await waitFor(
-        () => {
-          const { previousData } = result.current.useQueryResult;
-          expect(previousData).toEqual({ a: "aa", b: 1 });
-        },
-        { interval: 1 }
-      );
+        expect(useQueryResult).toEqualQueryResult({
+          data: { a: "a" },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: undefined,
+          variables: {},
+        });
+      }
 
-      await waitFor(
-        () => {
-          result.current.setQuery(bQuery);
-        },
-        { interval: 1 }
-      );
+      getCurrentSnapshot().setQuery(abQuery);
 
-      await waitFor(
-        () => {
-          const { loading } = result.current.useQueryResult;
-          expect(loading).toBe(false);
-        },
-        { interval: 1 }
-      );
-      await waitFor(
-        () => {
-          const { data } = result.current.useQueryResult;
-          expect(data).toEqual({ b: 3 });
-        },
-        { interval: 1 }
-      );
-      await waitFor(
-        () => {
-          const { previousData } = result.current.useQueryResult;
-          expect(previousData).toEqual({ b: 2 });
-        },
-        { interval: 1 }
-      );
-      await waitFor(
-        () => {
-          const { loading } = result.current.useQueryResult;
-          expect(loading).toBe(false);
-        },
-        { interval: 1 }
-      );
-      await waitFor(
-        () => {
-          const { data } = result.current.useQueryResult;
-          expect(data).toEqual({ b: 3 });
-        },
-        { interval: 1 }
-      );
-      await waitFor(
-        () => {
-          const { previousData } = result.current.useQueryResult;
-          expect(previousData).toEqual({ b: 2 });
-        },
-        { interval: 1 }
-      );
+      {
+        const { useQueryResult } = await takeSnapshot();
+
+        expect(useQueryResult).toEqualQueryResult({
+          data: undefined,
+          called: true,
+          loading: true,
+          networkStatus: NetworkStatus.loading,
+          previousData: { a: "a" },
+          variables: {},
+        });
+      }
+
+      {
+        const { useQueryResult } = await takeSnapshot();
+
+        expect(useQueryResult).toEqualQueryResult({
+          data: { a: "aa", b: 1 },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: { a: "a" },
+          variables: {},
+        });
+      }
+
+      const result = await getCurrentSnapshot().useQueryResult.reobserve();
+
+      expect(result).toEqualApolloQueryResult({
+        data: { a: "aaa", b: 2 },
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+      });
+
+      {
+        const { useQueryResult } = await takeSnapshot();
+
+        expect(useQueryResult).toEqualQueryResult({
+          data: { a: "aa", b: 1 },
+          called: true,
+          loading: true,
+          networkStatus: NetworkStatus.loading,
+          previousData: { a: "aa", b: 1 },
+          variables: {},
+        });
+      }
+
+      {
+        const { useQueryResult } = await takeSnapshot();
+
+        expect(useQueryResult).toEqualQueryResult({
+          data: { a: "aaa", b: 2 },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: { a: "aa", b: 1 },
+          variables: {},
+        });
+      }
+
+      getCurrentSnapshot().setQuery(bQuery);
+
+      {
+        const { useQueryResult } = await takeSnapshot();
+
+        expect(useQueryResult).toEqualQueryResult({
+          data: { b: 2 },
+          called: true,
+          loading: true,
+          networkStatus: NetworkStatus.loading,
+          previousData: { a: "aaa", b: 2 },
+          variables: {},
+        });
+      }
+
+      {
+        const { useQueryResult } = await takeSnapshot();
+
+        expect(useQueryResult).toEqualQueryResult({
+          data: { b: 3 },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: { b: 2 },
+          variables: {},
+        });
+      }
+
+      await expect(takeSnapshot).not.toRerender();
     });
 
     it("should be cleared when variables change causes cache miss", async () => {

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -9806,7 +9806,7 @@ describe("useQuery Hook", () => {
       });
     });
 
-    it("should not return partial cache data when `returnPartialData` is false", () => {
+    it("should not return partial cache data when `returnPartialData` is false", async () => {
       const cache = new InMemoryCache();
       const client = new ApolloClient({
         cache,
@@ -9858,7 +9858,8 @@ describe("useQuery Hook", () => {
         }
       `;
 
-      const { result } = renderHook(
+      using _disabledAct = disableActEnvironment();
+      const { takeSnapshot } = await renderHookToSnapshotStream(
         () => useQuery(partialQuery, { returnPartialData: false }),
         {
           wrapper: ({ children }) => (
@@ -9867,8 +9868,14 @@ describe("useQuery Hook", () => {
         }
       );
 
-      expect(result.current.loading).toBe(true);
-      expect(result.current.data).toBe(undefined);
+      await expect(takeSnapshot()).resolves.toEqualQueryResult({
+        data: undefined,
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: undefined,
+        variables: {},
+      });
     });
 
     it("should not return partial cache data when `returnPartialData` is false and new variables are passed in", async () => {

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -10074,8 +10074,9 @@ describe("useQuery Hook", () => {
       const query: TypedDocumentNode<
         {
           car: {
-            id: string;
+            id: number;
             make: string;
+            __typename: "Car";
           };
         },
         {
@@ -10094,7 +10095,7 @@ describe("useQuery Hook", () => {
         car: {
           id: 1,
           make: "Venturi",
-          __typename: "Car",
+          __typename: "Car" as const,
         },
       };
 
@@ -10102,7 +10103,7 @@ describe("useQuery Hook", () => {
         car: {
           id: 2,
           make: "Wiesmann",
-          __typename: "Car",
+          __typename: "Car" as const,
         },
       };
 
@@ -10110,7 +10111,7 @@ describe("useQuery Hook", () => {
         car: {
           id: 3,
           make: "Beetle",
-          __typename: "Car",
+          __typename: "Car" as const,
         },
       };
 

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -10374,6 +10374,9 @@ describe("useQuery Hook", () => {
       await expect(takeSnapshot).not.toRerender();
     });
 
+    // TODO: Determine if this test is needed or is already covered by other
+    // tests such as changing variables (since those tests check all returned
+    // hook properties)
     it("should be cleared when variables change causes cache miss", async () => {
       const peopleData = [
         { id: 1, name: "John Smith", gender: "male", __typename: "Person" },

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -10886,19 +10886,44 @@ describe("useQuery Hook", () => {
         }
       );
 
-      expect(result.current.a.loading).toBe(true);
-      expect(result.current.b.loading).toBe(true);
-      expect(result.current.a.data).toBe(undefined);
-      expect(result.current.b.data).toBe(undefined);
+      expect(result.current.a).toEqualQueryResult({
+        data: undefined,
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: undefined,
+        variables: {},
+      });
+      expect(result.current.b).toEqualQueryResult({
+        data: undefined,
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: undefined,
+        variables: {},
+      });
 
       await waitFor(() => {
         expect(result.current.a.loading).toBe(false);
-      });
-      await waitFor(() => {
         expect(result.current.b.loading).toBe(false);
       });
-      expect(result.current.a.data).toEqual(aData);
-      expect(result.current.b.data).toEqual(bData);
+
+      expect(result.current.a).toEqualQueryResult({
+        data: aData,
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: undefined,
+        variables: {},
+      });
+      expect(result.current.b).toEqualQueryResult({
+        data: bData,
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: undefined,
+        variables: {},
+      });
     }
 
     // TODO: Eventually move the "check" code back into these test so we can

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -7486,87 +7486,92 @@ describe("useQuery Hook", () => {
           </MockedProvider>
         );
 
-        const { result } = renderHook(
-          () =>
-            useQuery(query, {
-              variables: { min: 0, max: 12 },
-              notifyOnNetworkStatusChange: true,
-              // This is the key line in this test.
-              refetchWritePolicy: "merge",
-            }),
-          { wrapper }
-        );
+        using _disabledAct = disableActEnvironment();
+        const { takeSnapshot, getCurrentSnapshot } =
+          await renderHookToSnapshotStream(
+            () =>
+              useQuery(query, {
+                variables: { min: 0, max: 12 },
+                notifyOnNetworkStatusChange: true,
+                // This is the key line in this test.
+                refetchWritePolicy: "merge",
+              }),
+            { wrapper }
+          );
 
-        expect(result.current.loading).toBe(true);
-        expect(result.current.error).toBe(undefined);
-        expect(result.current.data).toBe(undefined);
-        expect(typeof result.current.refetch).toBe("function");
+        {
+          const result = await takeSnapshot();
 
-        await waitFor(
-          () => {
-            expect(result.current.loading).toBe(false);
-          },
-          { interval: 1 }
-        );
-        expect(result.current.error).toBeUndefined();
-        expect(result.current.data).toEqual({ primes: [2, 3, 5, 7, 11] });
+          expect(result).toEqualQueryResult({
+            data: undefined,
+            called: true,
+            loading: true,
+            networkStatus: NetworkStatus.loading,
+            previousData: undefined,
+            variables: { min: 0, max: 12 },
+          });
+        }
+
+        {
+          const result = await takeSnapshot();
+
+          expect(result).toEqualQueryResult({
+            data: { primes: [2, 3, 5, 7, 11] },
+            called: true,
+            loading: false,
+            networkStatus: NetworkStatus.ready,
+            previousData: undefined,
+            variables: { min: 0, max: 12 },
+          });
+        }
+
         expect(mergeParams).toEqual([[undefined, [2, 3, 5, 7, 11]]]);
 
-        const thenFn = jest.fn();
-        await act(
-          async () =>
-            void result.current.refetch({ min: 12, max: 30 }).then(thenFn)
-        );
-
-        await waitFor(
-          () => {
-            expect(result.current.loading).toBe(true);
-          },
-          { interval: 1 }
-        );
-        expect(result.current.error).toBe(undefined);
-        expect(result.current.data).toEqual({
-          // We get the stale data because we configured keyArgs: false.
-          primes: [2, 3, 5, 7, 11],
+        await expect(
+          getCurrentSnapshot().refetch({ min: 12, max: 30 })
+        ).resolves.toEqualApolloQueryResult({
+          data: { primes: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29] },
+          loading: false,
+          networkStatus: NetworkStatus.ready,
         });
-        // This networkStatus is setVariables instead of refetch because we
-        // called refetch with new variables.
-        expect(result.current.networkStatus).toBe(NetworkStatus.setVariables);
-        await waitFor(
-          () => {
-            expect(result.current.loading).toBe(false);
-          },
-          { interval: 1 }
-        );
 
-        expect(result.current.error).toBe(undefined);
-        expect(result.current.data).toEqual({
-          primes: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29],
-        });
+        {
+          const result = await takeSnapshot();
+
+          expect(result).toEqualQueryResult({
+            // We get the stale data because we configured keyArgs: false.
+            data: { primes: [2, 3, 5, 7, 11] },
+            called: true,
+            loading: true,
+            // This networkStatus is setVariables instead of refetch because we
+            // called refetch with new variables.
+            networkStatus: NetworkStatus.setVariables,
+            previousData: { primes: [2, 3, 5, 7, 11] },
+            variables: { min: 12, max: 30 },
+          });
+        }
+
+        {
+          const result = await takeSnapshot();
+
+          expect(result).toEqualQueryResult({
+            data: { primes: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29] },
+            called: true,
+            loading: false,
+            networkStatus: NetworkStatus.ready,
+            previousData: { primes: [2, 3, 5, 7, 11] },
+            variables: { min: 12, max: 30 },
+          });
+        }
+
         expect(mergeParams).toEqual([
-          [void 0, [2, 3, 5, 7, 11]],
+          [undefined, [2, 3, 5, 7, 11]],
           // This indicates concatenation happened.
           [
             [2, 3, 5, 7, 11],
             [13, 17, 19, 23, 29],
           ],
         ]);
-        expect(mergeParams).toEqual([
-          [undefined, [2, 3, 5, 7, 11]],
-          // Without refetchWritePolicy: "overwrite", this array will be
-          // all 10 primes (2 through 29) together.
-          [
-            [2, 3, 5, 7, 11],
-            [13, 17, 19, 23, 29],
-          ],
-        ]);
-
-        expect(thenFn).toHaveBeenCalledTimes(1);
-        expect(thenFn).toHaveBeenCalledWith({
-          loading: false,
-          networkStatus: NetworkStatus.ready,
-          data: { primes: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29] },
-        });
       });
 
       it('should assume default refetchWritePolicy value is "overwrite"', async () => {

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -12795,15 +12795,21 @@ describe("useQuery Hook", () => {
 
       const { snapshot } = await renderStream.takeRender();
 
-      expect(snapshot.data).toEqual({
-        currentUser: {
-          __typename: "User",
-          id: 1,
-          name: "Test User",
-          age: 30,
+      expect(snapshot).toEqualQueryResult({
+        data: {
+          currentUser: {
+            __typename: "User",
+            id: 1,
+            name: "Test User",
+            age: 30,
+          },
         },
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: undefined,
+        variables: {},
       });
-      expect(snapshot.previousData).toBeUndefined();
     });
 
     it("masks queries updated by the cache", async () => {

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -12403,26 +12403,31 @@ describe("useQuery Hook", () => {
 
     await wait(10);
     expect(requests).toBe(1);
-    {
-      const result = await takeSnapshot();
-      expect(result.loading).toBe(true);
-      expect(result.data).toBeUndefined();
-    }
+
+    await expect(takeSnapshot()).resolves.toEqualQueryResult({
+      data: undefined,
+      called: true,
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      previousData: undefined,
+      variables: {},
+    });
 
     await client.clearStore();
 
-    {
-      const result = await takeSnapshot();
-      expect(result.loading).toBe(false);
-      expect(result.data).toBeUndefined();
-      expect(result.error).toEqual(
-        new ApolloError({
-          networkError: new InvariantError(
-            "Store reset while query was in flight (not completed in link chain)"
-          ),
-        })
-      );
-    }
+    await expect(takeSnapshot()).resolves.toEqualQueryResult({
+      data: undefined,
+      error: new ApolloError({
+        networkError: new InvariantError(
+          "Store reset while query was in flight (not completed in link chain)"
+        ),
+      }),
+      called: true,
+      loading: false,
+      networkStatus: NetworkStatus.error,
+      previousData: undefined,
+      variables: {},
+    });
 
     link.simulateResult({ result: { data: { hello: "Greetings" } } }, true);
     await expect(takeSnapshot).not.toRerender({ timeout: 50 });

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -10528,53 +10528,51 @@ describe("useQuery Hook", () => {
         link,
       });
 
-      const { result } = renderHook(() => useQuery(query), {
-        wrapper: ({ children }) => (
-          <ApolloProvider client={client}>{children}</ApolloProvider>
-        ),
+      using _disabledAct = disableActEnvironment();
+      const { takeSnapshot } = await renderHookToSnapshotStream(
+        () => useQuery(query),
+        {
+          wrapper: ({ children }) => (
+            <ApolloProvider client={client}>{children}</ApolloProvider>
+          ),
+        }
+      );
+
+      await expect(takeSnapshot()).resolves.toEqualQueryResult({
+        data: undefined,
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: undefined,
+        variables: {},
       });
 
-      expect(result.current.loading).toBe(true);
-      expect(result.current.data).toBe(undefined);
+      await expect(takeSnapshot()).resolves.toEqualQueryResult({
+        data: { hello: "world 1" },
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: undefined,
+        variables: {},
+      });
 
-      await waitFor(
-        () => {
-          expect(result.current.loading).toBe(false);
-        },
-        { interval: 1 }
-      );
-      await waitFor(
-        () => {
-          expect(result.current.data).toEqual({ hello: "world 1" });
-        },
-        { interval: 1 }
-      );
+      await expect(takeSnapshot()).resolves.toEqualQueryResult({
+        data: { hello: "world 2" },
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: { hello: "world 1" },
+        variables: {},
+      });
 
-      await waitFor(
-        () => {
-          expect(result.current.loading).toBe(false);
-        },
-        { interval: 1 }
-      );
-      await waitFor(
-        () => {
-          expect(result.current.data).toEqual({ hello: "world 2" });
-        },
-        { interval: 1 }
-      );
-
-      await waitFor(
-        () => {
-          expect(result.current.loading).toBe(false);
-        },
-        { interval: 1 }
-      );
-      await waitFor(
-        () => {
-          expect(result.current.data).toEqual({ hello: "world 3" });
-        },
-        { interval: 1 }
-      );
+      await expect(takeSnapshot()).resolves.toEqualQueryResult({
+        data: { hello: "world 3" },
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: { hello: "world 2" },
+        variables: {},
+      });
     });
   });
 

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -8179,6 +8179,7 @@ describe("useQuery Hook", () => {
     });
 
     it("onCompleted should fire when polling with notifyOnNetworkStatusChange: true", async () => {
+      jest.useFakeTimers();
       const query = gql`
         {
           hello
@@ -8188,17 +8189,17 @@ describe("useQuery Hook", () => {
         {
           request: { query },
           result: { data: { hello: "world 1" } },
-          delay: 3,
+          delay: 20,
         },
         {
           request: { query },
           result: { data: { hello: "world 2" } },
-          delay: 3,
+          delay: 20,
         },
         {
           request: { query },
           result: { data: { hello: "world 3" } },
-          delay: 3,
+          delay: 20,
         },
       ];
 
@@ -8222,69 +8223,106 @@ describe("useQuery Hook", () => {
         }
       );
 
-      await expect(takeSnapshot()).resolves.toEqualQueryResult({
-        data: undefined,
-        called: true,
-        loading: true,
-        networkStatus: NetworkStatus.loading,
-        previousData: undefined,
-        variables: {},
-      });
+      {
+        const promise = takeSnapshot();
+        await jest.advanceTimersByTimeAsync(0);
+
+        await expect(promise).resolves.toEqualQueryResult({
+          data: undefined,
+          called: true,
+          loading: true,
+          networkStatus: NetworkStatus.loading,
+          previousData: undefined,
+          variables: {},
+        });
+      }
 
       expect(onCompleted).toHaveBeenCalledTimes(0);
+      jest.advanceTimersByTime(20);
 
-      await expect(takeSnapshot()).resolves.toEqualQueryResult({
-        data: { hello: "world 1" },
-        called: true,
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        previousData: undefined,
-        variables: {},
-      });
+      {
+        const promise = takeSnapshot();
+        await jest.advanceTimersByTimeAsync(0);
 
-      expect(onCompleted).toHaveBeenCalledTimes(1);
-
-      await expect(takeSnapshot()).resolves.toEqualQueryResult({
-        data: { hello: "world 1" },
-        called: true,
-        loading: true,
-        networkStatus: NetworkStatus.poll,
-        previousData: { hello: "world 1" },
-        variables: {},
-      });
+        await expect(promise).resolves.toEqualQueryResult({
+          data: { hello: "world 1" },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: undefined,
+          variables: {},
+        });
+      }
 
       expect(onCompleted).toHaveBeenCalledTimes(1);
+      // Polling is started with the first request, so we only need to advance
+      // the timer by 180 (200 poll time - 20 result delay)
+      jest.advanceTimersByTime(180);
 
-      await expect(takeSnapshot()).resolves.toEqualQueryResult({
-        data: { hello: "world 2" },
-        called: true,
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        previousData: { hello: "world 1" },
-        variables: {},
-      });
+      {
+        const promise = takeSnapshot();
+        await jest.advanceTimersByTimeAsync(0);
+
+        await expect(promise).resolves.toEqualQueryResult({
+          data: { hello: "world 1" },
+          called: true,
+          loading: true,
+          networkStatus: NetworkStatus.poll,
+          previousData: { hello: "world 1" },
+          variables: {},
+        });
+      }
+
+      expect(onCompleted).toHaveBeenCalledTimes(1);
+      jest.advanceTimersByTime(20);
+
+      {
+        const promise = takeSnapshot();
+        await jest.advanceTimersByTimeAsync(0);
+
+        await expect(promise).resolves.toEqualQueryResult({
+          data: { hello: "world 2" },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: { hello: "world 1" },
+          variables: {},
+        });
+      }
 
       expect(onCompleted).toHaveBeenCalledTimes(2);
+      jest.advanceTimersByTime(200);
 
-      await expect(takeSnapshot()).resolves.toEqualQueryResult({
-        data: { hello: "world 2" },
-        called: true,
-        loading: true,
-        networkStatus: NetworkStatus.poll,
-        previousData: { hello: "world 2" },
-        variables: {},
-      });
+      {
+        const promise = takeSnapshot();
+        await jest.advanceTimersByTimeAsync(0);
+
+        await expect(promise).resolves.toEqualQueryResult({
+          data: { hello: "world 2" },
+          called: true,
+          loading: true,
+          networkStatus: NetworkStatus.poll,
+          previousData: { hello: "world 2" },
+          variables: {},
+        });
+      }
 
       expect(onCompleted).toHaveBeenCalledTimes(2);
+      jest.advanceTimersByTime(20);
 
-      await expect(takeSnapshot()).resolves.toEqualQueryResult({
-        data: { hello: "world 3" },
-        called: true,
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        previousData: { hello: "world 2" },
-        variables: {},
-      });
+      {
+        const promise = takeSnapshot();
+        await jest.advanceTimersByTimeAsync(0);
+
+        await expect(promise).resolves.toEqualQueryResult({
+          data: { hello: "world 3" },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: { hello: "world 2" },
+          variables: {},
+        });
+      }
 
       expect(onCompleted).toHaveBeenCalledTimes(3);
     });


### PR DESCRIPTION
Continuation of #12274