### PR TITLE
Changed return type of useMutation when ignoreResult is explicitly set to true to hide unset result

### DIFF
--- a/.changeset/tasty-steaks-think.md
+++ b/.changeset/tasty-steaks-think.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Changed return type of useMutation when ignoreResult is explicitly set to true to avoid using unset values of the result

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -3414,19 +3414,19 @@ describe.skip("Type Tests", () => {
       expectTypeOf(result).toMatchTypeOf<{ reset: () => void }>();
       expectTypeOf(result).not.toMatchTypeOf<MutationResult<Mutation>>();
       expectTypeOf(mutate()).toMatchTypeOf<Promise<FetchResult<Mutation>>>();
-      const {
-        reset,
-        // @ts-expect-error
-        data,
-        // @ts-expect-error
-        loading,
-        // @ts-expect-error
-        error,
-      } = result;
-      reset;
-      data;
-      loading;
-      error;
+      // Available and reliable in the result
+      result.reset;
+
+      // @ts-expect-error
+      result.called;
+      // @ts-expect-error
+      result.client;
+      // @ts-expect-error
+      result.data;
+      // @ts-expect-error
+      result.error;
+      // @ts-expect-error
+      result.loading;
     }
 
     // Explicit `false`

--- a/src/react/hooks/useMutation.ts
+++ b/src/react/hooks/useMutation.ts
@@ -218,6 +218,7 @@ export function useMutation<
           return response;
         })
         .catch((error) => {
+          // TODO: Should this be checking for ignoreResults?
           if (mutationId === ref.current.mutationId && ref.current.isMounted) {
             const result = {
               loading: false,

--- a/src/react/hooks/useMutation.ts
+++ b/src/react/hooks/useMutation.ts
@@ -2,6 +2,7 @@ import * as React from "rehackt";
 import type { DocumentNode } from "graphql";
 import type { TypedDocumentNode } from "@graphql-typed-document-node/core";
 import type {
+  MutationFunction,
   MutationFunctionOptions,
   MutationHookOptions,
   MutationResult,
@@ -69,6 +70,38 @@ import { useIsomorphicLayoutEffect } from "./internal/useIsomorphicLayoutEffect.
  * @param options - Options to control how the mutation is executed.
  * @returns A tuple in the form of `[mutate, result]`
  */
+export function useMutation<
+  TData = any,
+  TVariables = OperationVariables,
+  TContext = DefaultContext,
+  TCache extends ApolloCache<any> = ApolloCache<any>,
+>(
+  mutation: DocumentNode | TypedDocumentNode<TData, TVariables>,
+  options: { ignoreResults: true } & MutationHookOptions<
+    NoInfer<TData>,
+    NoInfer<TVariables>,
+    TContext,
+    TCache
+  >
+): [
+  MutationFunction<TData, TVariables, TContext, TCache>,
+  // result is not reliable when ignoreResults is true
+  Pick<MutationResult<TData>, "reset">,
+];
+export function useMutation<
+  TData = any,
+  TVariables = OperationVariables,
+  TContext = DefaultContext,
+  TCache extends ApolloCache<any> = ApolloCache<any>,
+>(
+  mutation: DocumentNode | TypedDocumentNode<TData, TVariables>,
+  options?: MutationHookOptions<
+    NoInfer<TData>,
+    NoInfer<TVariables>,
+    TContext,
+    TCache
+  >
+): MutationTuple<TData, TVariables, TContext, TCache>;
 export function useMutation<
   TData = any,
   TVariables = OperationVariables,

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -394,6 +394,8 @@ export declare type MutationFunction<
   TCache extends ApolloCache<any> = ApolloCache<any>,
 > = (
   options?: MutationFunctionOptions<TData, TVariables, TContext, TCache>
+  // TODO This FetchResult<TData> seems strange here, as opposed to an
+  // ApolloQueryResult<TData>
 ) => Promise<FetchResult<MaybeMasked<TData>>>;
 
 export interface MutationHookOptions<
@@ -418,11 +420,7 @@ export type MutationTuple<
   TContext = DefaultContext,
   TCache extends ApolloCache<any> = ApolloCache<any>,
 > = [
-  mutate: (
-    options?: MutationFunctionOptions<TData, TVariables, TContext, TCache>
-    // TODO This FetchResult<TData> seems strange here, as opposed to an
-    // ApolloQueryResult<TData>
-  ) => Promise<FetchResult<MaybeMasked<TData>>>,
+  mutate: MutationFunction<TData, TVariables, TContext, TCache>,
   result: MutationResult<TData>,
 ];
 


### PR DESCRIPTION
We've encountered numerous bugs around this where the default (somehow) was to set `ignoreResult: true` when calling `useMutation`
Then devs would try to use `data` or `loading` from the tuple without realizing it would never be set.
I've been using this patch for a while and it does help avoid bugs

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:

### Checklist:
- [X] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [X] Make sure all of the significant new logic is covered by tests
-->
