### PR TITLE
Remove unused dependency `response-iterator`

### DIFF
--- a/.changeset/lemon-singers-pay.md
+++ b/.changeset/lemon-singers-pay.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Remove unused dependency `response-iterator`

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "optimism": "^0.18.0",
         "prop-types": "^15.7.2",
         "rehackt": "^0.1.0",
-        "response-iterator": "^0.2.6",
         "symbol-observable": "^4.0.0",
         "ts-invariant": "^0.10.3",
         "tslib": "^2.3.0",
@@ -11410,14 +11409,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/response-iterator": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/response-iterator/-/response-iterator-0.2.6.tgz",
-      "integrity": "sha512-pVzEEzrsg23Sh053rmDUvLSkGXluZio0qu8VT6ukrYuvtjVfCbDZH9d6PGXb8HZfzdNZt8feXv/jvUzlhRgLnw==",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/reusify": {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     "optimism": "^0.18.0",
     "prop-types": "^15.7.2",
     "rehackt": "^0.1.0",
-    "response-iterator": "^0.2.6",
     "symbol-observable": "^4.0.0",
     "ts-invariant": "^0.10.3",
     "tslib": "^2.3.0",


### PR DESCRIPTION
This came up in #12291 and we don't need to wait for 4.0 to do it.