### PR TITLE
Deprecate ignoreResults in useMutation

### DIFF
--- a/.changeset/khaki-cars-develop.md
+++ b/.changeset/khaki-cars-develop.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Deprecate option `ignoreResults` in `useMutation`.

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -358,7 +358,10 @@ export interface BaseMutationOptions<
   ) => void;
   /** {@inheritDoc @apollo/client!MutationOptionsDocumentation#onError:member} */
   onError?: (error: ApolloError, clientOptions?: BaseMutationOptions) => void;
-  /** {@inheritDoc @apollo/client!MutationOptionsDocumentation#ignoreResults:member} */
+  /**
+   * {@inheritDoc @apollo/client!MutationOptionsDocumentation#ignoreResults:member}
+   * @deprecated This property will be removed in the next major version of Apollo Client
+   */
   ignoreResults?: boolean;
 }
 


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:

### Checklist:
- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
-->

From discussion in https://github.com/apollographql/apollo-client/pull/12277
`ignoreResults` is more likely to cause confusion than actually help since the results are always returned.
The option potentially reduces the number of rerenders where the mutation is hooked, but I'm skeptical of the necessity and effectiveness of this.
If there's really a need for performance around state management in `useMutation` then there could be a separate hook more specialized for this that has a clear contract and expected behavior instead of a somewhat unused state that doesn't always gets refreshed

@jerelmiller I was wondering if we want to also deprecate `ignoreResults` in `useSubscription`. I admit I didn't even know that was an option there so I didn't dig
