### PR TITLE
Add more information about deprecation of useMutation ignoreResults option

### DIFF
--- a/.changeset/khaki-cars-develop.md
+++ b/.changeset/khaki-cars-develop.md
@@ -4,4 +4,4 @@
 
 Deprecate option `ignoreResults` in `useMutation`.
 Once this option is removed, existing code still using it might see increase in re-renders.
-Instead, please use `useApolloClient` to get your ApolloClient instance and call `client.mutate` directly.
+If you don't want to synchronize your component state with the mutation, please use `useApolloClient` to get your ApolloClient instance and call `client.mutate` directly.

--- a/.changeset/khaki-cars-develop.md
+++ b/.changeset/khaki-cars-develop.md
@@ -3,3 +3,5 @@
 ---
 
 Deprecate option `ignoreResults` in `useMutation`.
+Once this option is removed, existing code still using it might see increase in re-renders.
+Instead, please use `useApolloClient` to get your ApolloClient instance and call `client.mutate` directly.

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -361,7 +361,7 @@ export interface BaseMutationOptions<
   /**
    * {@inheritDoc @apollo/client!MutationOptionsDocumentation#ignoreResults:member}
    *
-   * @deprecated This property will be removed in the next major version of Apollo Client.
+   * @deprecated This option will be removed in the next major version of Apollo Client.
    * If you don't want to synchronize your component state with the mutation, please use `useApolloClient` to get your ApolloClient instance and call `client.mutate` directly.
    */
   ignoreResults?: boolean;

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -360,7 +360,10 @@ export interface BaseMutationOptions<
   onError?: (error: ApolloError, clientOptions?: BaseMutationOptions) => void;
   /**
    * {@inheritDoc @apollo/client!MutationOptionsDocumentation#ignoreResults:member}
-   * @deprecated This property will be removed in the next major version of Apollo Client
+   *
+   * @deprecated This property will be removed in the next major version of Apollo Client.
+   * Once this option is removed, existing code still using it might see increase in re-renders.
+   * Instead, please use `useApolloClient` to get your ApolloClient instance and call `client.mutate` directly.
    */
   ignoreResults?: boolean;
 }

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -362,8 +362,7 @@ export interface BaseMutationOptions<
    * {@inheritDoc @apollo/client!MutationOptionsDocumentation#ignoreResults:member}
    *
    * @deprecated This property will be removed in the next major version of Apollo Client.
-   * Once this option is removed, existing code still using it might see increase in re-renders.
-   * Instead, please use `useApolloClient` to get your ApolloClient instance and call `client.mutate` directly.
+   * If you don't want to synchronize your component state with the mutation, please use `useApolloClient` to get your ApolloClient instance and call `client.mutate` directly.
    */
   ignoreResults?: boolean;
 }


### PR DESCRIPTION
Following-up on discussion in https://github.com/apollographql/apollo-client/pull/12296
Added more information about impact once the option will be removed and possible alternative to retain similar behavior

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:

### Checklist:
- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
-->
