### PR TITLE
Remove `wait-for-observables` in favor of `ObservableStream`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -115,7 +115,6 @@
         "tsx": "4.19.2",
         "typedoc": "0.25.0",
         "typescript": "5.7.3",
-        "wait-for-observables": "1.0.3",
         "web-streams-polyfill": "4.0.0",
         "whatwg-fetch": "3.6.20"
       },
@@ -13563,21 +13562,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/wait-for-observables": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/wait-for-observables/-/wait-for-observables-1.0.3.tgz",
-      "integrity": "sha1-Oz3vX1VrS2QR9giJl0bdOc/cw/M=",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^1.8.0"
-      }
-    },
-    "node_modules/wait-for-observables/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
     },
     "node_modules/walker": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -198,7 +198,6 @@
     "tsx": "4.19.2",
     "typedoc": "0.25.0",
     "typescript": "5.7.3",
-    "wait-for-observables": "1.0.3",
     "web-streams-polyfill": "4.0.0",
     "whatwg-fetch": "3.6.20"
   },

--- a/src/link/retry/__tests__/retryLink.ts
+++ b/src/link/retry/__tests__/retryLink.ts
@@ -1,11 +1,11 @@
 import gql from "graphql-tag";
-import waitFor from "wait-for-observables";
 
 import { ApolloLink } from "../../core/ApolloLink";
 import { execute } from "../../core/execute";
 import { Observable } from "../../../utilities/observables/Observable";
 import { fromError } from "../../utils/fromError";
 import { RetryLink } from "../retryLink";
+import { ObservableStream } from "../../../testing/internal";
 
 const query = gql`
   {
@@ -23,9 +23,10 @@ describe("RetryLink", () => {
     const retry = new RetryLink({ delay: { initial: 1 }, attempts: { max } });
     const stub = jest.fn(() => fromError(standardError)) as any;
     const link = ApolloLink.from([retry, stub]);
+    const stream = new ObservableStream(execute(link, { query }));
 
-    const [{ error }] = (await waitFor(execute(link, { query }))) as any;
-    expect(error).toEqual(standardError);
+    await expect(stream).toEmitError(standardError, { timeout: 1000 });
+
     expect(stub).toHaveBeenCalledTimes(max);
   });
 
@@ -34,9 +35,11 @@ describe("RetryLink", () => {
     const data = { data: { hello: "world" } };
     const stub = jest.fn(() => Observable.of(data));
     const link = ApolloLink.from([retry, stub]);
+    const stream = new ObservableStream(execute(link, { query }));
 
-    const [{ values }] = (await waitFor(execute(link, { query }))) as any;
-    expect(values).toEqual([data]);
+    await expect(stream).toEmitValue(data);
+    await expect(stream).toComplete();
+
     expect(stub).toHaveBeenCalledTimes(1);
   });
 
@@ -50,9 +53,11 @@ describe("RetryLink", () => {
     stub.mockReturnValueOnce(fromError(standardError));
     stub.mockReturnValueOnce(Observable.of(data));
     const link = ApolloLink.from([retry, stub]);
+    const stream = new ObservableStream(execute(link, { query }));
 
-    const [{ values }] = (await waitFor(execute(link, { query }))) as any;
-    expect(values).toEqual([data]);
+    await expect(stream).toEmitValue(data);
+    await expect(stream).toComplete();
+
     expect(stub).toHaveBeenCalledTimes(2);
   });
 
@@ -129,13 +134,14 @@ describe("RetryLink", () => {
     });
     const stub = jest.fn(() => fromError(standardError)) as any;
     const link = ApolloLink.from([retry, stub]);
+    const stream1 = new ObservableStream(execute(link, { query }));
+    const stream2 = new ObservableStream(execute(link, { query }));
 
-    const [result1, result2] = (await waitFor(
-      execute(link, { query }),
-      execute(link, { query })
-    )) as any;
-    expect(result1.error).toEqual(standardError);
-    expect(result2.error).toEqual(standardError);
+    await Promise.all([
+      expect(stream1).toEmitError(standardError),
+      expect(stream2).toEmitError(standardError),
+    ]);
+
     expect(stub).toHaveBeenCalledTimes(10);
   });
 
@@ -144,9 +150,10 @@ describe("RetryLink", () => {
     const retry = new RetryLink({ delay: delayStub, attempts: { max: 3 } });
     const linkStub = jest.fn(() => fromError(standardError)) as any;
     const link = ApolloLink.from([retry, linkStub]);
-    const [{ error }] = (await waitFor(execute(link, { query }))) as any;
+    const stream = new ObservableStream(execute(link, { query }));
 
-    expect(error).toEqual(standardError);
+    await expect(stream).toEmitError(standardError);
+
     const operation = (delayStub.mock.calls[0] as any)[1];
     expect(delayStub.mock.calls).toEqual([
       [1, operation, standardError],
@@ -166,9 +173,10 @@ describe("RetryLink", () => {
     });
     const linkStub = jest.fn(() => fromError(standardError)) as any;
     const link = ApolloLink.from([retry, linkStub]);
-    const [{ error }] = (await waitFor(execute(link, { query }))) as any;
+    const stream = new ObservableStream(execute(link, { query }));
 
-    expect(error).toEqual(standardError);
+    await expect(stream).toEmitError(standardError);
+
     const operation = attemptStub.mock.calls[0][1];
     expect(attemptStub.mock.calls).toEqual([
       [1, operation, standardError],
@@ -191,9 +199,10 @@ describe("RetryLink", () => {
       () => new Observable((o) => o.error(standardError))
     ) as any;
     const link = ApolloLink.from([retry, linkStub]);
-    const [{ error }] = (await waitFor(execute(link, { query }))) as any;
+    const stream = new ObservableStream(execute(link, { query }));
 
-    expect(error).toEqual(standardError);
+    await expect(stream).toEmitError(standardError);
+
     const operation = attemptStub.mock.calls[0][1];
     expect(attemptStub.mock.calls).toEqual([
       [1, operation, standardError],


### PR DESCRIPTION
I noticed an opportunity to remove a dependency by switching our `RetryLink` tests over to `ObservableStream`.