### PR TITLE
Fix type of `extensions` in `protocolErrors`

### DIFF
--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -200,10 +200,7 @@ export class ApolloError extends Error {
     // (undocumented)
     networkError: Error | ServerParseError | ServerError | null;
     // (undocumented)
-    protocolErrors: ReadonlyArray<{
-        message: string;
-        extensions?: GraphQLErrorExtensions[];
-    }>;
+    protocolErrors: ReadonlyArray<GraphQLFormattedError>;
 }
 
 // @public (undocumented)
@@ -219,10 +216,7 @@ interface ApolloErrorOptions {
     // (undocumented)
     networkError?: Error | ServerParseError | ServerError | null;
     // (undocumented)
-    protocolErrors?: ReadonlyArray<{
-        message: string;
-        extensions?: GraphQLErrorExtensions[];
-    }>;
+    protocolErrors?: ReadonlyArray<GraphQLFormattedError>;
 }
 
 // @public (undocumented)

--- a/.api-reports/api-report-errors.api.md
+++ b/.api-reports/api-report-errors.api.md
@@ -31,10 +31,7 @@ export class ApolloError extends Error {
     // (undocumented)
     networkError: Error | ServerParseError | ServerError | null;
     // (undocumented)
-    protocolErrors: ReadonlyArray<{
-        message: string;
-        extensions?: GraphQLErrorExtensions[];
-    }>;
+    protocolErrors: ReadonlyArray<GraphQLFormattedError>;
 }
 
 // @public (undocumented)
@@ -50,10 +47,7 @@ export interface ApolloErrorOptions {
     // (undocumented)
     networkError?: Error | ServerParseError | ServerError | null;
     // (undocumented)
-    protocolErrors?: ReadonlyArray<{
-        message: string;
-        extensions?: GraphQLErrorExtensions[];
-    }>;
+    protocolErrors?: ReadonlyArray<GraphQLFormattedError>;
 }
 
 // @public (undocumented)

--- a/.api-reports/api-report-link_error.api.md
+++ b/.api-reports/api-report-link_error.api.md
@@ -6,7 +6,6 @@
 
 import type { DocumentNode } from 'graphql';
 import type { FormattedExecutionResult } from 'graphql';
-import type { GraphQLErrorExtensions } from 'graphql';
 import type { GraphQLFormattedError } from 'graphql';
 import { Observable } from 'zen-observable-ts';
 import type { Observer } from 'zen-observable-ts';
@@ -86,10 +85,7 @@ export interface ErrorResponse {
     networkError?: NetworkError;
     // (undocumented)
     operation: Operation;
-    protocolErrors?: ReadonlyArray<{
-        message: string;
-        extensions?: GraphQLErrorExtensions[];
-    }>;
+    protocolErrors?: ReadonlyArray<GraphQLFormattedError>;
     // (undocumented)
     response?: FormattedExecutionResult;
 }

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -257,10 +257,7 @@ class ApolloError extends Error {
     // (undocumented)
     networkError: Error | ServerParseError | ServerError | null;
     // (undocumented)
-    protocolErrors: ReadonlyArray<{
-        message: string;
-        extensions?: GraphQLErrorExtensions[];
-    }>;
+    protocolErrors: ReadonlyArray<GraphQLFormattedError>;
 }
 
 // @public (undocumented)
@@ -276,10 +273,7 @@ interface ApolloErrorOptions {
     // (undocumented)
     networkError?: Error | ServerParseError | ServerError | null;
     // (undocumented)
-    protocolErrors?: ReadonlyArray<{
-        message: string;
-        extensions?: GraphQLErrorExtensions[];
-    }>;
+    protocolErrors?: ReadonlyArray<GraphQLFormattedError>;
 }
 
 // @public (undocumented)

--- a/.api-reports/api-report-react_components.api.md
+++ b/.api-reports/api-report-react_components.api.md
@@ -235,10 +235,7 @@ class ApolloError extends Error {
     // (undocumented)
     networkError: Error | ServerParseError | ServerError | null;
     // (undocumented)
-    protocolErrors: ReadonlyArray<{
-        message: string;
-        extensions?: GraphQLErrorExtensions[];
-    }>;
+    protocolErrors: ReadonlyArray<GraphQLFormattedError>;
 }
 
 // @public (undocumented)
@@ -254,10 +251,7 @@ interface ApolloErrorOptions {
     // (undocumented)
     networkError?: Error | ServerParseError | ServerError | null;
     // (undocumented)
-    protocolErrors?: ReadonlyArray<{
-        message: string;
-        extensions?: GraphQLErrorExtensions[];
-    }>;
+    protocolErrors?: ReadonlyArray<GraphQLFormattedError>;
 }
 
 // @public (undocumented)

--- a/.api-reports/api-report-react_context.api.md
+++ b/.api-reports/api-report-react_context.api.md
@@ -255,10 +255,7 @@ class ApolloError extends Error {
     // (undocumented)
     networkError: Error | ServerParseError | ServerError | null;
     // (undocumented)
-    protocolErrors: ReadonlyArray<{
-        message: string;
-        extensions?: GraphQLErrorExtensions[];
-    }>;
+    protocolErrors: ReadonlyArray<GraphQLFormattedError>;
 }
 
 // @public (undocumented)
@@ -274,10 +271,7 @@ interface ApolloErrorOptions {
     // (undocumented)
     networkError?: Error | ServerParseError | ServerError | null;
     // (undocumented)
-    protocolErrors?: ReadonlyArray<{
-        message: string;
-        extensions?: GraphQLErrorExtensions[];
-    }>;
+    protocolErrors?: ReadonlyArray<GraphQLFormattedError>;
 }
 
 // @public (undocumented)

--- a/.api-reports/api-report-react_hoc.api.md
+++ b/.api-reports/api-report-react_hoc.api.md
@@ -234,10 +234,7 @@ class ApolloError extends Error {
     // (undocumented)
     networkError: Error | ServerParseError | ServerError | null;
     // (undocumented)
-    protocolErrors: ReadonlyArray<{
-        message: string;
-        extensions?: GraphQLErrorExtensions[];
-    }>;
+    protocolErrors: ReadonlyArray<GraphQLFormattedError>;
 }
 
 // @public (undocumented)
@@ -253,10 +250,7 @@ interface ApolloErrorOptions {
     // (undocumented)
     networkError?: Error | ServerParseError | ServerError | null;
     // (undocumented)
-    protocolErrors?: ReadonlyArray<{
-        message: string;
-        extensions?: GraphQLErrorExtensions[];
-    }>;
+    protocolErrors?: ReadonlyArray<GraphQLFormattedError>;
 }
 
 // @public (undocumented)

--- a/.api-reports/api-report-react_hooks.api.md
+++ b/.api-reports/api-report-react_hooks.api.md
@@ -233,10 +233,7 @@ class ApolloError extends Error {
     // (undocumented)
     networkError: Error | ServerParseError | ServerError | null;
     // (undocumented)
-    protocolErrors: ReadonlyArray<{
-        message: string;
-        extensions?: GraphQLErrorExtensions[];
-    }>;
+    protocolErrors: ReadonlyArray<GraphQLFormattedError>;
 }
 
 // @public (undocumented)
@@ -252,10 +249,7 @@ interface ApolloErrorOptions {
     // (undocumented)
     networkError?: Error | ServerParseError | ServerError | null;
     // (undocumented)
-    protocolErrors?: ReadonlyArray<{
-        message: string;
-        extensions?: GraphQLErrorExtensions[];
-    }>;
+    protocolErrors?: ReadonlyArray<GraphQLFormattedError>;
 }
 
 // @public (undocumented)

--- a/.api-reports/api-report-react_internal.api.md
+++ b/.api-reports/api-report-react_internal.api.md
@@ -233,10 +233,7 @@ class ApolloError extends Error {
     // (undocumented)
     networkError: Error | ServerParseError | ServerError | null;
     // (undocumented)
-    protocolErrors: ReadonlyArray<{
-        message: string;
-        extensions?: GraphQLErrorExtensions[];
-    }>;
+    protocolErrors: ReadonlyArray<GraphQLFormattedError>;
 }
 
 // @public (undocumented)
@@ -252,10 +249,7 @@ interface ApolloErrorOptions {
     // (undocumented)
     networkError?: Error | ServerParseError | ServerError | null;
     // (undocumented)
-    protocolErrors?: ReadonlyArray<{
-        message: string;
-        extensions?: GraphQLErrorExtensions[];
-    }>;
+    protocolErrors?: ReadonlyArray<GraphQLFormattedError>;
 }
 
 // @public (undocumented)

--- a/.api-reports/api-report-react_ssr.api.md
+++ b/.api-reports/api-report-react_ssr.api.md
@@ -234,10 +234,7 @@ class ApolloError extends Error {
     // (undocumented)
     networkError: Error | ServerParseError | ServerError | null;
     // (undocumented)
-    protocolErrors: ReadonlyArray<{
-        message: string;
-        extensions?: GraphQLErrorExtensions[];
-    }>;
+    protocolErrors: ReadonlyArray<GraphQLFormattedError>;
 }
 
 // @public (undocumented)
@@ -253,10 +250,7 @@ interface ApolloErrorOptions {
     // (undocumented)
     networkError?: Error | ServerParseError | ServerError | null;
     // (undocumented)
-    protocolErrors?: ReadonlyArray<{
-        message: string;
-        extensions?: GraphQLErrorExtensions[];
-    }>;
+    protocolErrors?: ReadonlyArray<GraphQLFormattedError>;
 }
 
 // @public (undocumented)

--- a/.api-reports/api-report-testing.api.md
+++ b/.api-reports/api-report-testing.api.md
@@ -234,10 +234,7 @@ class ApolloError extends Error {
     // (undocumented)
     networkError: Error | ServerParseError | ServerError | null;
     // (undocumented)
-    protocolErrors: ReadonlyArray<{
-        message: string;
-        extensions?: GraphQLErrorExtensions[];
-    }>;
+    protocolErrors: ReadonlyArray<GraphQLFormattedError>;
 }
 
 // @public (undocumented)
@@ -253,10 +250,7 @@ interface ApolloErrorOptions {
     // (undocumented)
     networkError?: Error | ServerParseError | ServerError | null;
     // (undocumented)
-    protocolErrors?: ReadonlyArray<{
-        message: string;
-        extensions?: GraphQLErrorExtensions[];
-    }>;
+    protocolErrors?: ReadonlyArray<GraphQLFormattedError>;
 }
 
 // @public (undocumented)

--- a/.api-reports/api-report-testing_core.api.md
+++ b/.api-reports/api-report-testing_core.api.md
@@ -233,10 +233,7 @@ class ApolloError extends Error {
     // (undocumented)
     networkError: Error | ServerParseError | ServerError | null;
     // (undocumented)
-    protocolErrors: ReadonlyArray<{
-        message: string;
-        extensions?: GraphQLErrorExtensions[];
-    }>;
+    protocolErrors: ReadonlyArray<GraphQLFormattedError>;
 }
 
 // @public (undocumented)
@@ -252,10 +249,7 @@ interface ApolloErrorOptions {
     // (undocumented)
     networkError?: Error | ServerParseError | ServerError | null;
     // (undocumented)
-    protocolErrors?: ReadonlyArray<{
-        message: string;
-        extensions?: GraphQLErrorExtensions[];
-    }>;
+    protocolErrors?: ReadonlyArray<GraphQLFormattedError>;
 }
 
 // @public (undocumented)

--- a/.api-reports/api-report-utilities.api.md
+++ b/.api-reports/api-report-utilities.api.md
@@ -248,10 +248,7 @@ class ApolloError extends Error {
     // (undocumented)
     networkError: Error | ServerParseError | ServerError | null;
     // (undocumented)
-    protocolErrors: ReadonlyArray<{
-        message: string;
-        extensions?: GraphQLErrorExtensions[];
-    }>;
+    protocolErrors: ReadonlyArray<GraphQLFormattedError>;
 }
 
 // @public (undocumented)
@@ -267,10 +264,7 @@ interface ApolloErrorOptions {
     // (undocumented)
     networkError?: Error | ServerParseError | ServerError | null;
     // (undocumented)
-    protocolErrors?: ReadonlyArray<{
-        message: string;
-        extensions?: GraphQLErrorExtensions[];
-    }>;
+    protocolErrors?: ReadonlyArray<GraphQLFormattedError>;
 }
 
 // @public (undocumented)

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -223,10 +223,7 @@ export class ApolloError extends Error {
     // (undocumented)
     networkError: Error | ServerParseError | ServerError | null;
     // (undocumented)
-    protocolErrors: ReadonlyArray<{
-        message: string;
-        extensions?: GraphQLErrorExtensions[];
-    }>;
+    protocolErrors: ReadonlyArray<GraphQLFormattedError>;
 }
 
 // @public (undocumented)
@@ -242,10 +239,7 @@ interface ApolloErrorOptions {
     // (undocumented)
     networkError?: Error | ServerParseError | ServerError | null;
     // (undocumented)
-    protocolErrors?: ReadonlyArray<{
-        message: string;
-        extensions?: GraphQLErrorExtensions[];
-    }>;
+    protocolErrors?: ReadonlyArray<GraphQLFormattedError>;
 }
 
 // @public (undocumented)

--- a/.changeset/curvy-seahorses-walk.md
+++ b/.changeset/curvy-seahorses-walk.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix type of `extensions` in `protocolErrors` for `ApolloError` and the `onError` link. According to the [multipart HTTP subscription protocol](https://www.apollographql.com/docs/graphos/routing/operations/subscriptions/multipart-protocol), fatal tranport errors follow the [GraphQL error format](https://spec.graphql.org/draft/#sec-Errors.Error-Result-Format) which require `extensions` to be a map as its value instead of an array.

--- a/src/__tests__/__snapshots__/graphqlSubscriptions.ts.snap
+++ b/src/__tests__/__snapshots__/graphqlSubscriptions.ts.snap
@@ -40,11 +40,9 @@ ApolloError {
 exports[`GraphQL Subscriptions should throw an error if the result has protocolErrors on it 1`] = `
 ApolloError {
   "cause": Object {
-    "extensions": Array [
-      Object {
-        "code": "WEBSOCKET_MESSAGE_ERROR",
-      },
-    ],
+    "extensions": Object {
+      "code": "WEBSOCKET_MESSAGE_ERROR",
+    },
     "message": "cannot read message from websocket",
   },
   "clientErrors": Array [],
@@ -55,11 +53,9 @@ ApolloError {
   "networkError": null,
   "protocolErrors": Array [
     Object {
-      "extensions": Array [
-        Object {
-          "code": "WEBSOCKET_MESSAGE_ERROR",
-        },
-      ],
+      "extensions": Object {
+        "code": "WEBSOCKET_MESSAGE_ERROR",
+      },
       "message": "cannot read message from websocket",
     },
   ],

--- a/src/__tests__/graphqlSubscriptions.ts
+++ b/src/__tests__/graphqlSubscriptions.ts
@@ -296,11 +296,9 @@ describe("GraphQL Subscriptions", () => {
         protocolErrors: [
           {
             message: "cannot read message from websocket",
-            extensions: [
-              {
-                code: "WEBSOCKET_MESSAGE_ERROR",
-              },
-            ],
+            extensions: {
+              code: "WEBSOCKET_MESSAGE_ERROR",
+            },
           },
         ],
       })
@@ -411,11 +409,9 @@ describe("GraphQL Subscriptions", () => {
         protocolErrors: [
           {
             message: "cannot read message from websocket",
-            extensions: [
-              {
-                code: "WEBSOCKET_MESSAGE_ERROR",
-              },
-            ],
+            extensions: {
+              code: "WEBSOCKET_MESSAGE_ERROR",
+            },
           },
         ],
       })

--- a/src/__tests__/graphqlSubscriptions.ts
+++ b/src/__tests__/graphqlSubscriptions.ts
@@ -275,11 +275,9 @@ describe("GraphQL Subscriptions", () => {
           [PROTOCOL_ERRORS_SYMBOL]: [
             {
               message: "cannot read message from websocket",
-              extensions: [
-                {
-                  code: "WEBSOCKET_MESSAGE_ERROR",
-                },
-              ],
+              extensions: {
+                code: "WEBSOCKET_MESSAGE_ERROR",
+              },
             } as any,
           ],
         },
@@ -388,12 +386,10 @@ describe("GraphQL Subscriptions", () => {
           [PROTOCOL_ERRORS_SYMBOL]: [
             {
               message: "cannot read message from websocket",
-              extensions: [
-                {
-                  code: "WEBSOCKET_MESSAGE_ERROR",
-                },
-              ],
-            } as any,
+              extensions: {
+                code: "WEBSOCKET_MESSAGE_ERROR",
+              },
+            },
           ],
         },
       },
@@ -482,12 +478,10 @@ describe("GraphQL Subscriptions", () => {
           [PROTOCOL_ERRORS_SYMBOL]: [
             {
               message: "cannot read message from websocket",
-              extensions: [
-                {
-                  code: "WEBSOCKET_MESSAGE_ERROR",
-                },
-              ],
-            } as any,
+              extensions: {
+                code: "WEBSOCKET_MESSAGE_ERROR",
+              },
+            },
           ],
         },
       },

--- a/src/errors/__tests__/ApolloError.ts
+++ b/src/errors/__tests__/ApolloError.ts
@@ -9,11 +9,9 @@ describe("ApolloError", () => {
     const protocolErrors = [
       {
         message: "cannot read message from websocket",
-        extensions: [
-          {
-            code: "WEBSOCKET_MESSAGE_ERROR",
-          },
-        ],
+        extensions: {
+          code: "WEBSOCKET_MESSAGE_ERROR",
+        },
       },
     ];
     const networkError = new Error("Network error");
@@ -80,11 +78,9 @@ describe("ApolloError", () => {
     const protocolErrors = [
       {
         message: "cannot read message from websocket",
-        extensions: [
-          {
-            code: "WEBSOCKET_MESSAGE_ERROR",
-          },
-        ],
+        extensions: {
+          code: "WEBSOCKET_MESSAGE_ERROR",
+        },
       },
     ];
     const apolloError = new ApolloError({

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -22,10 +22,7 @@ type FetchResultWithSymbolExtensions<T> = FetchResult<T> & {
 
 export interface ApolloErrorOptions {
   graphQLErrors?: ReadonlyArray<GraphQLFormattedError>;
-  protocolErrors?: ReadonlyArray<{
-    message: string;
-    extensions?: GraphQLErrorExtensions[];
-  }>;
+  protocolErrors?: ReadonlyArray<GraphQLFormattedError>;
   clientErrors?: ReadonlyArray<Error>;
   networkError?: Error | ServerParseError | ServerError | null;
   errorMessage?: string;
@@ -86,10 +83,7 @@ export class ApolloError extends Error {
   public name: string;
   public message: string;
   public graphQLErrors: ReadonlyArray<GraphQLFormattedError>;
-  public protocolErrors: ReadonlyArray<{
-    message: string;
-    extensions?: GraphQLErrorExtensions[];
-  }>;
+  public protocolErrors: ReadonlyArray<GraphQLFormattedError>;
   public clientErrors: ReadonlyArray<Error>;
   public networkError: Error | ServerParseError | ServerError | null;
   /**

--- a/src/link/error/index.ts
+++ b/src/link/error/index.ts
@@ -28,10 +28,7 @@ export interface ErrorResponse {
    * Fatal transport-level errors from multipart subscriptions.
    * See the [multipart subscription protocol](https://www.apollographql.com/docs/graphos/routing/operations/subscriptions/multipart-protocol#message-and-error-format) for more information.
    */
-  protocolErrors?: ReadonlyArray<{
-    message: string;
-    extensions?: GraphQLErrorExtensions[];
-  }>;
+  protocolErrors?: ReadonlyArray<GraphQLFormattedError>;
   response?: FormattedExecutionResult;
   operation: Operation;
   forward: NextLink;

--- a/src/link/error/index.ts
+++ b/src/link/error/index.ts
@@ -1,8 +1,4 @@
-import type {
-  FormattedExecutionResult,
-  GraphQLErrorExtensions,
-  GraphQLFormattedError,
-} from "graphql";
+import type { FormattedExecutionResult, GraphQLFormattedError } from "graphql";
 
 import {
   graphQLResultHasProtocolErrors,


### PR DESCRIPTION
According to the [multipart HTTP subscription protocol](https://www.apollographql.com/docs/graphos/routing/operations/subscriptions/multipart-protocol), fatal tranport errors follow the [GraphQL error format](https://spec.graphql.org/draft/#sec-Errors.Error-Result-Format) which require `extensions` to be a map as its value instead of an array. This PR fixes this by using `GraphQLFormattedError` as its type.