### PR TITLE
enable `verbatimModuleSyntax` tsconfig option

### DIFF
--- a/config/build.ts
+++ b/config/build.ts
@@ -15,7 +15,7 @@ $.cwd = join(import.meta.dirname, "..");
 $.verbose = true;
 
 const buildSteps = {
-  typescript: () => $`npx tsc`,
+  typescript: () => $`npx tsc --verbatimModuleSyntax false`,
   updateVersion,
   inlineInheritDoc,
   processInvariants,

--- a/config/jest.config.ts
+++ b/config/jest.config.ts
@@ -24,6 +24,7 @@ const defaults = {
         diagnostics: {
           warnOnly: process.env.TEST_ENV !== "ci",
         },
+        tsconfig: import.meta.dirname + "/../tsconfig.tests.json",
       },
     ],
   },

--- a/src/__tests__/__snapshots__/exports.ts.snap
+++ b/src/__tests__/__snapshots__/exports.ts.snap
@@ -6,7 +6,6 @@ Array [
   "ApolloClient",
   "ApolloError",
   "ApolloLink",
-  "Cache",
   "DocumentTransform",
   "HttpLink",
   "InMemoryCache",
@@ -53,7 +52,6 @@ Array [
 exports[`exports of public entry points @apollo/client/cache 1`] = `
 Array [
   "ApolloCache",
-  "Cache",
   "EntityStore",
   "InMemoryCache",
   "MissingFieldError",
@@ -75,7 +73,6 @@ Array [
   "ApolloClient",
   "ApolloError",
   "ApolloLink",
-  "Cache",
   "DocumentTransform",
   "HttpLink",
   "InMemoryCache",

--- a/src/cache/core/types/Cache.ts
+++ b/src/cache/core/types/Cache.ts
@@ -1,4 +1,4 @@
-import { DataProxy } from "./DataProxy.js";
+import type { DataProxy } from "./DataProxy.js";
 import type { AllFieldsModifier, Modifiers } from "./common.js";
 import type { ApolloCache } from "../cache.js";
 import type { Unmasked } from "../../../masking/index.js";
@@ -105,12 +105,23 @@ export namespace Cache {
     ) => any;
   }
 
-  export import DiffResult = DataProxy.DiffResult;
-  export import ReadQueryOptions = DataProxy.ReadQueryOptions;
-  export import ReadFragmentOptions = DataProxy.ReadFragmentOptions;
-  export import WriteQueryOptions = DataProxy.WriteQueryOptions;
-  export import WriteFragmentOptions = DataProxy.WriteFragmentOptions;
-  export import UpdateQueryOptions = DataProxy.UpdateQueryOptions;
-  export import UpdateFragmentOptions = DataProxy.UpdateFragmentOptions;
-  export import Fragment = DataProxy.Fragment;
+  export type DiffResult<T> = DataProxy.DiffResult<T>;
+  export type ReadQueryOptions<TData, TVariables> = DataProxy.ReadQueryOptions<
+    TData,
+    TVariables
+  >;
+  export type ReadFragmentOptions<TData, TVariables> =
+    DataProxy.ReadFragmentOptions<TData, TVariables>;
+  export type WriteQueryOptions<TData, TVariables> =
+    DataProxy.WriteQueryOptions<TData, TVariables>;
+  export type WriteFragmentOptions<TData, TVariables> =
+    DataProxy.WriteFragmentOptions<TData, TVariables>;
+  export type UpdateQueryOptions<TData, TVariables> =
+    DataProxy.UpdateQueryOptions<TData, TVariables>;
+  export type UpdateFragmentOptions<TData, TVariables> =
+    DataProxy.UpdateFragmentOptions<TData, TVariables>;
+  export type Fragment<TVariables, TData> = DataProxy.Fragment<
+    TVariables,
+    TData
+  >;
 }

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -6,7 +6,7 @@ export type {
   WatchFragmentResult,
 } from "./core/cache.js";
 export { ApolloCache } from "./core/cache.js";
-export { Cache } from "./core/types/Cache.js";
+export type { Cache } from "./core/types/Cache.js";
 export type { DataProxy } from "./core/types/DataProxy.js";
 export type {
   MissingTree,

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -601,7 +601,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
    * information to the DevTools.
    * Use at your own risk!
    */
-  public getMemoryInternals?: typeof getInMemoryCacheMemoryInternals;
+  public declare getMemoryInternals?: typeof getInMemoryCacheMemoryInternals;
 }
 
 if (__DEV__) {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -44,7 +44,7 @@ export type {
   WatchFragmentResult,
 } from "../cache/index.js";
 export {
-  Cache,
+  type Cache,
   ApolloCache,
   InMemoryCache,
   MissingFieldError,

--- a/src/link/error/index.ts
+++ b/src/link/error/index.ts
@@ -47,7 +47,7 @@ export namespace ErrorLink {
 }
 
 // For backwards compatibility.
-export import ErrorHandler = ErrorLink.ErrorHandler;
+export type ErrorHandler = ErrorLink.ErrorHandler;
 
 export function onError(errorHandler: ErrorHandler): ApolloLink {
   return new ApolloLink((operation, forward) => {

--- a/src/link/ws/index.ts
+++ b/src/link/ws/index.ts
@@ -28,7 +28,7 @@ export namespace WebSocketLink {
 }
 
 // For backwards compatibility.
-export import WebSocketParams = WebSocketLink.Configuration;
+export type WebSocketParams = WebSocketLink.Configuration;
 
 export class WebSocketLink extends ApolloLink {
   private subscriptionClient: SubscriptionClient;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,9 @@
     "outDir": "./dist",
     "lib": ["es2015", "esnext.asynciterable"],
     "jsx": "react",
-    "strict": true
+    "strict": true,
+    "useDefineForClassFields": true,
+    "verbatimModuleSyntax": true
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["src/**/__tests__/**/*"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,6 @@
     "lib": ["es2015", "esnext.asynciterable"],
     "jsx": "react",
     "strict": true,
-    "useDefineForClassFields": true,
     "verbatimModuleSyntax": true
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,3 +1,7 @@
 {
-  "extends": "./src/tsconfig.json"
+  "extends": "./src/tsconfig.json",
+  "compilerOptions": {
+    "useDefineForClassFields": false,
+    "verbatimModuleSyntax": false
+  }
 }

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,7 +1,6 @@
 {
   "extends": "./src/tsconfig.json",
   "compilerOptions": {
-    "useDefineForClassFields": false,
     "verbatimModuleSyntax": false
   }
 }


### PR DESCRIPTION
Just a small one to prepare for more bundling changes and get rid of *some* Typescript weirdness that might confuse other bundling tools.