### PR TITLE
Fix tests affected by change to cache

### DIFF
--- a/.api-reports/api-report-testing_react.api.md
+++ b/.api-reports/api-report-testing_react.api.md
@@ -233,10 +233,7 @@ class ApolloError extends Error {
     // (undocumented)
     networkError: Error | ServerParseError | ServerError | null;
     // (undocumented)
-    protocolErrors: ReadonlyArray<{
-        message: string;
-        extensions?: GraphQLErrorExtensions[];
-    }>;
+    protocolErrors: ReadonlyArray<GraphQLFormattedError>;
 }
 
 // @public (undocumented)
@@ -252,10 +249,7 @@ interface ApolloErrorOptions {
     // (undocumented)
     networkError?: Error | ServerParseError | ServerError | null;
     // (undocumented)
-    protocolErrors?: ReadonlyArray<{
-        message: string;
-        extensions?: GraphQLErrorExtensions[];
-    }>;
+    protocolErrors?: ReadonlyArray<GraphQLFormattedError>;
 }
 
 // @public (undocumented)

--- a/knip.config.js
+++ b/knip.config.js
@@ -41,6 +41,7 @@ const config = {
   ],
   ignoreBinaries: ["jq"],
   ignoreDependencies: [
+    /@actions\/.*/,
     /@size-limit\/.*/,
     /eslint-.*/,
     // used by `recast`

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -124,7 +124,7 @@ interface MaskOperationOptions<TData> {
   fetchPolicy?: WatchQueryFetchPolicy;
 }
 
-export interface QueryManagerOptions<TStore> {
+interface QueryManagerOptions<TStore> {
   cache: ApolloCache<TStore>;
   link: ApolloLink;
   defaultOptions: DefaultOptions;

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -274,8 +274,7 @@ describe("ObservableQuery", () => {
       await observable.refetch(variables2);
 
       await expect(stream).toEmitApolloQueryResult({
-        // TODO: Ensure this value is undefined instead of an empty object
-        data: {},
+        data: undefined,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
         partial: true,
@@ -404,7 +403,7 @@ describe("ObservableQuery", () => {
       });
 
       await expect(stream).toEmitApolloQueryResult({
-        data: {},
+        data: undefined,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
         partial: true,
@@ -561,7 +560,7 @@ describe("ObservableQuery", () => {
       await client.resetStore();
 
       await expect(stream).toEmitApolloQueryResult({
-        data: {},
+        data: undefined,
         loading: false,
         networkStatus: NetworkStatus.ready,
         partial: true,
@@ -825,7 +824,7 @@ describe("ObservableQuery", () => {
       await expect(stream).toEmitApolloQueryResult({
         // TODO: Fix this error
         // @ts-expect-error `ApolloQueryResult` needs to be updated to allow for `undefined` and this value needs to emit undefined instead of empty object
-        data: {},
+        data: undefined,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
         partial: true,
@@ -1069,7 +1068,7 @@ describe("ObservableQuery", () => {
       await expect(stream).toEmitApolloQueryResult({
         // TODO: Fix this error
         // @ts-expect-error Ensure ApolloQueryResult allows for undefined and fix this value to match
-        data: {},
+        data: undefined,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
         partial: true,
@@ -1120,7 +1119,7 @@ describe("ObservableQuery", () => {
       await expect(stream).toEmitApolloQueryResult({
         // TODO: Fix this error
         // @ts-expect-error Need to update ApolloQueryResult to allow undefined and fix this value
-        data: {},
+        data: undefined,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
         partial: true,
@@ -1452,7 +1451,7 @@ describe("ObservableQuery", () => {
       await observable.refetch(variables2);
 
       await expect(stream).toEmitApolloQueryResult({
-        data: {},
+        data: undefined,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
         partial: true,
@@ -1566,7 +1565,7 @@ describe("ObservableQuery", () => {
       await observable.refetch(variables2);
 
       await expect(stream).toEmitApolloQueryResult({
-        data: {},
+        data: undefined,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
         partial: true,


### PR DESCRIPTION
Fixes tests changed by #12327 that now check for the `data` property and not caught when doing the `cache.diff` change in #12304