### PR TITLE
Deprecate `partial` and ensure its correctness. Fix type of `data` in `ApolloQueryResult`

### DIFF
--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -259,7 +259,7 @@ export interface ApolloPayloadResult<TData = Record<string, any>, TExtensions = 
 
 // @public (undocumented)
 export interface ApolloQueryResult<T> {
-    complete?: boolean;
+    complete: boolean;
     // (undocumented)
     data: T | undefined;
     error?: ApolloError;
@@ -268,6 +268,8 @@ export interface ApolloQueryResult<T> {
     loading: boolean;
     // (undocumented)
     networkStatus: NetworkStatus;
+    // @deprecated
+    partial: boolean;
 }
 
 // @public (undocumented)

--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -259,7 +259,6 @@ export interface ApolloPayloadResult<TData = Record<string, any>, TExtensions = 
 
 // @public (undocumented)
 export interface ApolloQueryResult<T> {
-    complete: boolean;
     // (undocumented)
     data: T | undefined;
     error?: ApolloError;

--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -259,16 +259,15 @@ export interface ApolloPayloadResult<TData = Record<string, any>, TExtensions = 
 
 // @public (undocumented)
 export interface ApolloQueryResult<T> {
+    complete?: boolean;
     // (undocumented)
-    data: T;
+    data: T | undefined;
     error?: ApolloError;
     errors?: ReadonlyArray<GraphQLFormattedError>;
     // (undocumented)
     loading: boolean;
     // (undocumented)
     networkStatus: NetworkStatus;
-    // (undocumented)
-    partial?: boolean;
 }
 
 // @public (undocumented)

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -327,7 +327,6 @@ interface ApolloProviderProps<TCache> {
 
 // @public (undocumented)
 interface ApolloQueryResult<T> {
-    complete: boolean;
     // (undocumented)
     data: T | undefined;
     // Warning: (ae-forgotten-export) The symbol "ApolloError" needs to be exported by the entry point index.d.ts
@@ -2520,8 +2519,8 @@ interface WatchQueryOptions<TVariables extends OperationVariables = OperationVar
 // src/core/ObservableQuery.ts:121:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:159:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:414:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:184:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:213:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:178:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:207:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:271:2 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:38:3 - (ae-forgotten-export) The symbol "SubscribeToMoreFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:54:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -327,7 +327,7 @@ interface ApolloProviderProps<TCache> {
 
 // @public (undocumented)
 interface ApolloQueryResult<T> {
-    complete?: boolean;
+    complete: boolean;
     // (undocumented)
     data: T | undefined;
     // Warning: (ae-forgotten-export) The symbol "ApolloError" needs to be exported by the entry point index.d.ts
@@ -339,6 +339,8 @@ interface ApolloQueryResult<T> {
     //
     // (undocumented)
     networkStatus: NetworkStatus;
+    // @deprecated
+    partial: boolean;
 }
 
 // @public
@@ -2518,8 +2520,8 @@ interface WatchQueryOptions<TVariables extends OperationVariables = OperationVar
 // src/core/ObservableQuery.ts:121:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:159:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:414:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:176:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:205:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:184:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:213:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:271:2 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:38:3 - (ae-forgotten-export) The symbol "SubscribeToMoreFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:54:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -327,8 +327,9 @@ interface ApolloProviderProps<TCache> {
 
 // @public (undocumented)
 interface ApolloQueryResult<T> {
+    complete?: boolean;
     // (undocumented)
-    data: T;
+    data: T | undefined;
     // Warning: (ae-forgotten-export) The symbol "ApolloError" needs to be exported by the entry point index.d.ts
     error?: ApolloError;
     errors?: ReadonlyArray<GraphQLFormattedError>;
@@ -338,8 +339,6 @@ interface ApolloQueryResult<T> {
     //
     // (undocumented)
     networkStatus: NetworkStatus;
-    // (undocumented)
-    partial?: boolean;
 }
 
 // @public
@@ -2519,8 +2518,8 @@ interface WatchQueryOptions<TVariables extends OperationVariables = OperationVar
 // src/core/ObservableQuery.ts:121:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:159:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:414:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:175:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:204:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:176:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:205:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:271:2 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:38:3 - (ae-forgotten-export) The symbol "SubscribeToMoreFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:54:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report-react_context.api.md
+++ b/.api-reports/api-report-react_context.api.md
@@ -323,7 +323,7 @@ export interface ApolloProviderProps<TCache> {
 
 // @public (undocumented)
 interface ApolloQueryResult<T> {
-    complete?: boolean;
+    complete: boolean;
     // (undocumented)
     data: T | undefined;
     // Warning: (ae-forgotten-export) The symbol "ApolloError" needs to be exported by the entry point index.d.ts
@@ -335,6 +335,8 @@ interface ApolloQueryResult<T> {
     //
     // (undocumented)
     networkStatus: NetworkStatus;
+    // @deprecated
+    partial: boolean;
 }
 
 // @public
@@ -1920,8 +1922,8 @@ interface WatchQueryOptions<TVariables extends OperationVariables = OperationVar
 // src/core/ObservableQuery.ts:121:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:159:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:414:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:176:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:205:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:184:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:213:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:271:2 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-react_context.api.md
+++ b/.api-reports/api-report-react_context.api.md
@@ -323,7 +323,6 @@ export interface ApolloProviderProps<TCache> {
 
 // @public (undocumented)
 interface ApolloQueryResult<T> {
-    complete: boolean;
     // (undocumented)
     data: T | undefined;
     // Warning: (ae-forgotten-export) The symbol "ApolloError" needs to be exported by the entry point index.d.ts
@@ -1922,8 +1921,8 @@ interface WatchQueryOptions<TVariables extends OperationVariables = OperationVar
 // src/core/ObservableQuery.ts:121:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:159:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:414:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:184:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:213:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:178:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:207:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:271:2 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-react_context.api.md
+++ b/.api-reports/api-report-react_context.api.md
@@ -323,8 +323,9 @@ export interface ApolloProviderProps<TCache> {
 
 // @public (undocumented)
 interface ApolloQueryResult<T> {
+    complete?: boolean;
     // (undocumented)
-    data: T;
+    data: T | undefined;
     // Warning: (ae-forgotten-export) The symbol "ApolloError" needs to be exported by the entry point index.d.ts
     error?: ApolloError;
     errors?: ReadonlyArray<GraphQLFormattedError>;
@@ -334,8 +335,6 @@ interface ApolloQueryResult<T> {
     //
     // (undocumented)
     networkStatus: NetworkStatus;
-    // (undocumented)
-    partial?: boolean;
 }
 
 // @public
@@ -1921,8 +1920,8 @@ interface WatchQueryOptions<TVariables extends OperationVariables = OperationVar
 // src/core/ObservableQuery.ts:121:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:159:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:414:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:175:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:204:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:176:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:205:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:271:2 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-react_hooks.api.md
+++ b/.api-reports/api-report-react_hooks.api.md
@@ -290,8 +290,9 @@ class ApolloLink {
 
 // @public (undocumented)
 interface ApolloQueryResult<T> {
+    complete?: boolean;
     // (undocumented)
-    data: T;
+    data: T | undefined;
     // Warning: (ae-forgotten-export) The symbol "ApolloError" needs to be exported by the entry point index.d.ts
     error?: ApolloError;
     errors?: ReadonlyArray<GraphQLFormattedError>;
@@ -301,8 +302,6 @@ interface ApolloQueryResult<T> {
     //
     // (undocumented)
     networkStatus: NetworkStatus;
-    // (undocumented)
-    partial?: boolean;
 }
 
 // @public
@@ -2346,8 +2345,8 @@ interface WatchQueryOptions<TVariables extends OperationVariables = OperationVar
 // src/core/ObservableQuery.ts:121:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:159:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:414:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:175:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:204:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:176:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:205:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:271:2 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:38:3 - (ae-forgotten-export) The symbol "SubscribeToMoreFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:54:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report-react_hooks.api.md
+++ b/.api-reports/api-report-react_hooks.api.md
@@ -290,7 +290,7 @@ class ApolloLink {
 
 // @public (undocumented)
 interface ApolloQueryResult<T> {
-    complete?: boolean;
+    complete: boolean;
     // (undocumented)
     data: T | undefined;
     // Warning: (ae-forgotten-export) The symbol "ApolloError" needs to be exported by the entry point index.d.ts
@@ -302,6 +302,8 @@ interface ApolloQueryResult<T> {
     //
     // (undocumented)
     networkStatus: NetworkStatus;
+    // @deprecated
+    partial: boolean;
 }
 
 // @public
@@ -2345,8 +2347,8 @@ interface WatchQueryOptions<TVariables extends OperationVariables = OperationVar
 // src/core/ObservableQuery.ts:121:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:159:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:414:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:176:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:205:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:184:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:213:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:271:2 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:38:3 - (ae-forgotten-export) The symbol "SubscribeToMoreFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:54:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report-react_hooks.api.md
+++ b/.api-reports/api-report-react_hooks.api.md
@@ -290,7 +290,6 @@ class ApolloLink {
 
 // @public (undocumented)
 interface ApolloQueryResult<T> {
-    complete: boolean;
     // (undocumented)
     data: T | undefined;
     // Warning: (ae-forgotten-export) The symbol "ApolloError" needs to be exported by the entry point index.d.ts
@@ -2347,8 +2346,8 @@ interface WatchQueryOptions<TVariables extends OperationVariables = OperationVar
 // src/core/ObservableQuery.ts:121:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:159:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:414:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:184:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:213:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:178:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:207:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:271:2 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:38:3 - (ae-forgotten-export) The symbol "SubscribeToMoreFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:54:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report-react_internal.api.md
+++ b/.api-reports/api-report-react_internal.api.md
@@ -290,7 +290,6 @@ class ApolloLink {
 
 // @public (undocumented)
 interface ApolloQueryResult<T> {
-    complete: boolean;
     // (undocumented)
     data: T | undefined;
     // Warning: (ae-forgotten-export) The symbol "ApolloError" needs to be exported by the entry point index.d.ts
@@ -2410,8 +2409,8 @@ export function wrapQueryRef<TData, TVariables extends OperationVariables>(inter
 // src/core/ObservableQuery.ts:121:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:159:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:414:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:184:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:213:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:178:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:207:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:271:2 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:38:3 - (ae-forgotten-export) The symbol "SubscribeToMoreFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:54:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report-react_internal.api.md
+++ b/.api-reports/api-report-react_internal.api.md
@@ -290,8 +290,9 @@ class ApolloLink {
 
 // @public (undocumented)
 interface ApolloQueryResult<T> {
+    complete?: boolean;
     // (undocumented)
-    data: T;
+    data: T | undefined;
     // Warning: (ae-forgotten-export) The symbol "ApolloError" needs to be exported by the entry point index.d.ts
     error?: ApolloError;
     errors?: ReadonlyArray<GraphQLFormattedError>;
@@ -301,8 +302,6 @@ interface ApolloQueryResult<T> {
     //
     // (undocumented)
     networkStatus: NetworkStatus;
-    // (undocumented)
-    partial?: boolean;
 }
 
 // Warning: (ae-forgotten-export) The symbol "WrappedQueryRef" needs to be exported by the entry point index.d.ts
@@ -2409,8 +2408,8 @@ export function wrapQueryRef<TData, TVariables extends OperationVariables>(inter
 // src/core/ObservableQuery.ts:121:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:159:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:414:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:175:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:204:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:176:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:205:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:271:2 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:38:3 - (ae-forgotten-export) The symbol "SubscribeToMoreFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:54:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report-react_internal.api.md
+++ b/.api-reports/api-report-react_internal.api.md
@@ -290,7 +290,7 @@ class ApolloLink {
 
 // @public (undocumented)
 interface ApolloQueryResult<T> {
-    complete?: boolean;
+    complete: boolean;
     // (undocumented)
     data: T | undefined;
     // Warning: (ae-forgotten-export) The symbol "ApolloError" needs to be exported by the entry point index.d.ts
@@ -302,6 +302,8 @@ interface ApolloQueryResult<T> {
     //
     // (undocumented)
     networkStatus: NetworkStatus;
+    // @deprecated
+    partial: boolean;
 }
 
 // Warning: (ae-forgotten-export) The symbol "WrappedQueryRef" needs to be exported by the entry point index.d.ts
@@ -2408,8 +2410,8 @@ export function wrapQueryRef<TData, TVariables extends OperationVariables>(inter
 // src/core/ObservableQuery.ts:121:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:159:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:414:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:176:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:205:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:184:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:213:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:271:2 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:38:3 - (ae-forgotten-export) The symbol "SubscribeToMoreFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:54:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report-react_ssr.api.md
+++ b/.api-reports/api-report-react_ssr.api.md
@@ -291,7 +291,7 @@ class ApolloLink {
 
 // @public (undocumented)
 interface ApolloQueryResult<T> {
-    complete?: boolean;
+    complete: boolean;
     // (undocumented)
     data: T | undefined;
     // Warning: (ae-forgotten-export) The symbol "ApolloError" needs to be exported by the entry point index.d.ts
@@ -303,6 +303,8 @@ interface ApolloQueryResult<T> {
     //
     // (undocumented)
     networkStatus: NetworkStatus;
+    // @deprecated
+    partial: boolean;
 }
 
 // @public
@@ -1908,8 +1910,8 @@ interface WatchQueryOptions<TVariables extends OperationVariables = OperationVar
 // src/core/ObservableQuery.ts:121:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:159:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:414:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:176:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:205:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:184:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:213:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:271:2 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-react_ssr.api.md
+++ b/.api-reports/api-report-react_ssr.api.md
@@ -291,8 +291,9 @@ class ApolloLink {
 
 // @public (undocumented)
 interface ApolloQueryResult<T> {
+    complete?: boolean;
     // (undocumented)
-    data: T;
+    data: T | undefined;
     // Warning: (ae-forgotten-export) The symbol "ApolloError" needs to be exported by the entry point index.d.ts
     error?: ApolloError;
     errors?: ReadonlyArray<GraphQLFormattedError>;
@@ -302,8 +303,6 @@ interface ApolloQueryResult<T> {
     //
     // (undocumented)
     networkStatus: NetworkStatus;
-    // (undocumented)
-    partial?: boolean;
 }
 
 // @public
@@ -1909,8 +1908,8 @@ interface WatchQueryOptions<TVariables extends OperationVariables = OperationVar
 // src/core/ObservableQuery.ts:121:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:159:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:414:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:175:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:204:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:176:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:205:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:271:2 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-react_ssr.api.md
+++ b/.api-reports/api-report-react_ssr.api.md
@@ -291,7 +291,6 @@ class ApolloLink {
 
 // @public (undocumented)
 interface ApolloQueryResult<T> {
-    complete: boolean;
     // (undocumented)
     data: T | undefined;
     // Warning: (ae-forgotten-export) The symbol "ApolloError" needs to be exported by the entry point index.d.ts
@@ -1910,8 +1909,8 @@ interface WatchQueryOptions<TVariables extends OperationVariables = OperationVar
 // src/core/ObservableQuery.ts:121:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:159:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:414:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:184:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:213:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:178:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:207:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:271:2 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-testing.api.md
+++ b/.api-reports/api-report-testing.api.md
@@ -290,7 +290,6 @@ class ApolloLink {
 
 // @public (undocumented)
 interface ApolloQueryResult<T> {
-    complete: boolean;
     // (undocumented)
     data: T | undefined;
     // Warning: (ae-forgotten-export) The symbol "ApolloError" needs to be exported by the entry point index.d.ts
@@ -1925,8 +1924,8 @@ export function withWarningSpy<TArgs extends any[], TResult>(it: (...args: TArgs
 // src/core/ObservableQuery.ts:121:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:159:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:414:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:184:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:213:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:178:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:207:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:271:2 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-testing.api.md
+++ b/.api-reports/api-report-testing.api.md
@@ -290,8 +290,9 @@ class ApolloLink {
 
 // @public (undocumented)
 interface ApolloQueryResult<T> {
+    complete?: boolean;
     // (undocumented)
-    data: T;
+    data: T | undefined;
     // Warning: (ae-forgotten-export) The symbol "ApolloError" needs to be exported by the entry point index.d.ts
     error?: ApolloError;
     errors?: ReadonlyArray<GraphQLFormattedError>;
@@ -301,8 +302,6 @@ interface ApolloQueryResult<T> {
     //
     // (undocumented)
     networkStatus: NetworkStatus;
-    // (undocumented)
-    partial?: boolean;
 }
 
 // @public
@@ -1924,8 +1923,8 @@ export function withWarningSpy<TArgs extends any[], TResult>(it: (...args: TArgs
 // src/core/ObservableQuery.ts:121:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:159:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:414:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:175:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:204:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:176:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:205:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:271:2 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-testing.api.md
+++ b/.api-reports/api-report-testing.api.md
@@ -290,7 +290,7 @@ class ApolloLink {
 
 // @public (undocumented)
 interface ApolloQueryResult<T> {
-    complete?: boolean;
+    complete: boolean;
     // (undocumented)
     data: T | undefined;
     // Warning: (ae-forgotten-export) The symbol "ApolloError" needs to be exported by the entry point index.d.ts
@@ -302,6 +302,8 @@ interface ApolloQueryResult<T> {
     //
     // (undocumented)
     networkStatus: NetworkStatus;
+    // @deprecated
+    partial: boolean;
 }
 
 // @public
@@ -1923,8 +1925,8 @@ export function withWarningSpy<TArgs extends any[], TResult>(it: (...args: TArgs
 // src/core/ObservableQuery.ts:121:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:159:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:414:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:176:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:205:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:184:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:213:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:271:2 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-testing_core.api.md
+++ b/.api-reports/api-report-testing_core.api.md
@@ -290,7 +290,6 @@ class ApolloLink {
 
 // @public (undocumented)
 interface ApolloQueryResult<T> {
-    complete: boolean;
     // (undocumented)
     data: T | undefined;
     // Warning: (ae-forgotten-export) The symbol "ApolloError" needs to be exported by the entry point index.d.ts
@@ -1925,8 +1924,8 @@ export function withWarningSpy<TArgs extends any[], TResult>(it: (...args: TArgs
 // src/core/ObservableQuery.ts:121:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:159:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:414:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:184:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:213:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:178:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:207:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:271:2 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-testing_core.api.md
+++ b/.api-reports/api-report-testing_core.api.md
@@ -290,8 +290,9 @@ class ApolloLink {
 
 // @public (undocumented)
 interface ApolloQueryResult<T> {
+    complete?: boolean;
     // (undocumented)
-    data: T;
+    data: T | undefined;
     // Warning: (ae-forgotten-export) The symbol "ApolloError" needs to be exported by the entry point index.d.ts
     error?: ApolloError;
     errors?: ReadonlyArray<GraphQLFormattedError>;
@@ -301,8 +302,6 @@ interface ApolloQueryResult<T> {
     //
     // (undocumented)
     networkStatus: NetworkStatus;
-    // (undocumented)
-    partial?: boolean;
 }
 
 // @public
@@ -1924,8 +1923,8 @@ export function withWarningSpy<TArgs extends any[], TResult>(it: (...args: TArgs
 // src/core/ObservableQuery.ts:121:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:159:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:414:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:175:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:204:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:176:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:205:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:271:2 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-testing_core.api.md
+++ b/.api-reports/api-report-testing_core.api.md
@@ -290,7 +290,7 @@ class ApolloLink {
 
 // @public (undocumented)
 interface ApolloQueryResult<T> {
-    complete?: boolean;
+    complete: boolean;
     // (undocumented)
     data: T | undefined;
     // Warning: (ae-forgotten-export) The symbol "ApolloError" needs to be exported by the entry point index.d.ts
@@ -302,6 +302,8 @@ interface ApolloQueryResult<T> {
     //
     // (undocumented)
     networkStatus: NetworkStatus;
+    // @deprecated
+    partial: boolean;
 }
 
 // @public
@@ -1923,8 +1925,8 @@ export function withWarningSpy<TArgs extends any[], TResult>(it: (...args: TArgs
 // src/core/ObservableQuery.ts:121:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:159:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:414:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:176:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:205:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:184:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:213:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:271:2 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-testing_experimental.api.md
+++ b/.api-reports/api-report-testing_experimental.api.md
@@ -79,7 +79,7 @@ interface TestSchemaOptions {
 // Warnings were encountered during analysis:
 //
 // src/core/LocalState.ts:46:5 - (ae-forgotten-export) The symbol "FragmentMap" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:204:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:205:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/testing/experimental/createTestSchema.ts:10:23 - (ae-forgotten-export) The symbol "Resolvers" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-testing_experimental.api.md
+++ b/.api-reports/api-report-testing_experimental.api.md
@@ -79,7 +79,7 @@ interface TestSchemaOptions {
 // Warnings were encountered during analysis:
 //
 // src/core/LocalState.ts:46:5 - (ae-forgotten-export) The symbol "FragmentMap" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:213:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:207:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/testing/experimental/createTestSchema.ts:10:23 - (ae-forgotten-export) The symbol "Resolvers" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-testing_experimental.api.md
+++ b/.api-reports/api-report-testing_experimental.api.md
@@ -79,7 +79,7 @@ interface TestSchemaOptions {
 // Warnings were encountered during analysis:
 //
 // src/core/LocalState.ts:46:5 - (ae-forgotten-export) The symbol "FragmentMap" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:205:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:213:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/testing/experimental/createTestSchema.ts:10:23 - (ae-forgotten-export) The symbol "Resolvers" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-testing_react.api.md
+++ b/.api-reports/api-report-testing_react.api.md
@@ -291,7 +291,6 @@ class ApolloLink {
 
 // @public (undocumented)
 interface ApolloQueryResult<T> {
-    complete: boolean;
     // (undocumented)
     data: T | undefined;
     // Warning: (ae-forgotten-export) The symbol "ApolloError" needs to be exported by the entry point index.d.ts
@@ -1874,8 +1873,8 @@ interface WatchQueryOptions<TVariables extends OperationVariables = OperationVar
 // src/core/ObservableQuery.ts:121:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:159:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:414:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:184:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:213:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:178:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:207:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:271:2 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-testing_react.api.md
+++ b/.api-reports/api-report-testing_react.api.md
@@ -291,8 +291,9 @@ class ApolloLink {
 
 // @public (undocumented)
 interface ApolloQueryResult<T> {
+    complete?: boolean;
     // (undocumented)
-    data: T;
+    data: T | undefined;
     // Warning: (ae-forgotten-export) The symbol "ApolloError" needs to be exported by the entry point index.d.ts
     error?: ApolloError;
     errors?: ReadonlyArray<GraphQLFormattedError>;
@@ -302,8 +303,6 @@ interface ApolloQueryResult<T> {
     //
     // (undocumented)
     networkStatus: NetworkStatus;
-    // (undocumented)
-    partial?: boolean;
 }
 
 // @public
@@ -1873,8 +1872,8 @@ interface WatchQueryOptions<TVariables extends OperationVariables = OperationVar
 // src/core/ObservableQuery.ts:121:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:159:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:414:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:175:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:204:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:176:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:205:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:271:2 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-testing_react.api.md
+++ b/.api-reports/api-report-testing_react.api.md
@@ -291,7 +291,7 @@ class ApolloLink {
 
 // @public (undocumented)
 interface ApolloQueryResult<T> {
-    complete?: boolean;
+    complete: boolean;
     // (undocumented)
     data: T | undefined;
     // Warning: (ae-forgotten-export) The symbol "ApolloError" needs to be exported by the entry point index.d.ts
@@ -303,6 +303,8 @@ interface ApolloQueryResult<T> {
     //
     // (undocumented)
     networkStatus: NetworkStatus;
+    // @deprecated
+    partial: boolean;
 }
 
 // @public
@@ -1872,8 +1874,8 @@ interface WatchQueryOptions<TVariables extends OperationVariables = OperationVar
 // src/core/ObservableQuery.ts:121:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:159:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:414:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:176:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:205:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:184:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:213:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:271:2 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-utilities.api.md
+++ b/.api-reports/api-report-utilities.api.md
@@ -316,8 +316,9 @@ interface ApolloPayloadResult<TData = Record<string, any>, TExtensions = Record<
 
 // @public (undocumented)
 interface ApolloQueryResult<T> {
+    complete?: boolean;
     // (undocumented)
-    data: T;
+    data: T | undefined;
     // Warning: (ae-forgotten-export) The symbol "ApolloError" needs to be exported by the entry point index.d.ts
     error?: ApolloError;
     errors?: ReadonlyArray<GraphQLFormattedError>;
@@ -327,8 +328,6 @@ interface ApolloQueryResult<T> {
     //
     // (undocumented)
     networkStatus: NetworkStatus;
-    // (undocumented)
-    partial?: boolean;
 }
 
 // @public (undocumented)
@@ -2884,8 +2883,8 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/core/ObservableQuery.ts:121:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:159:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:414:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:175:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:204:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:176:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:205:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:271:2 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
 // src/utilities/graphql/storeUtils.ts:226:12 - (ae-forgotten-export) The symbol "storeKeyNameStringify" needs to be exported by the entry point index.d.ts
 // src/utilities/policies/pagination.ts:76:3 - (ae-forgotten-export) The symbol "TRelayEdge" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report-utilities.api.md
+++ b/.api-reports/api-report-utilities.api.md
@@ -316,7 +316,6 @@ interface ApolloPayloadResult<TData = Record<string, any>, TExtensions = Record<
 
 // @public (undocumented)
 interface ApolloQueryResult<T> {
-    complete: boolean;
     // (undocumented)
     data: T | undefined;
     // Warning: (ae-forgotten-export) The symbol "ApolloError" needs to be exported by the entry point index.d.ts
@@ -2885,8 +2884,8 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/core/ObservableQuery.ts:121:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:159:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:414:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:184:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:213:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:178:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:207:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:271:2 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
 // src/utilities/graphql/storeUtils.ts:226:12 - (ae-forgotten-export) The symbol "storeKeyNameStringify" needs to be exported by the entry point index.d.ts
 // src/utilities/policies/pagination.ts:76:3 - (ae-forgotten-export) The symbol "TRelayEdge" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report-utilities.api.md
+++ b/.api-reports/api-report-utilities.api.md
@@ -316,7 +316,7 @@ interface ApolloPayloadResult<TData = Record<string, any>, TExtensions = Record<
 
 // @public (undocumented)
 interface ApolloQueryResult<T> {
-    complete?: boolean;
+    complete: boolean;
     // (undocumented)
     data: T | undefined;
     // Warning: (ae-forgotten-export) The symbol "ApolloError" needs to be exported by the entry point index.d.ts
@@ -328,6 +328,8 @@ interface ApolloQueryResult<T> {
     //
     // (undocumented)
     networkStatus: NetworkStatus;
+    // @deprecated
+    partial: boolean;
 }
 
 // @public (undocumented)
@@ -2883,8 +2885,8 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/core/ObservableQuery.ts:121:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:159:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:414:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:176:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:205:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:184:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:213:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:271:2 - (ae-forgotten-export) The symbol "UpdateQueryFn" needs to be exported by the entry point index.d.ts
 // src/utilities/graphql/storeUtils.ts:226:12 - (ae-forgotten-export) The symbol "storeKeyNameStringify" needs to be exported by the entry point index.d.ts
 // src/utilities/policies/pagination.ts:76:3 - (ae-forgotten-export) The symbol "TRelayEdge" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -259,7 +259,7 @@ export interface ApolloPayloadResult<TData = Record<string, any>, TExtensions = 
 
 // @public (undocumented)
 export interface ApolloQueryResult<T> {
-    complete?: boolean;
+    complete: boolean;
     // (undocumented)
     data: T | undefined;
     error?: ApolloError;
@@ -268,6 +268,8 @@ export interface ApolloQueryResult<T> {
     loading: boolean;
     // (undocumented)
     networkStatus: NetworkStatus;
+    // @deprecated
+    partial: boolean;
 }
 
 // @public (undocumented)

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -259,7 +259,6 @@ export interface ApolloPayloadResult<TData = Record<string, any>, TExtensions = 
 
 // @public (undocumented)
 export interface ApolloQueryResult<T> {
-    complete: boolean;
     // (undocumented)
     data: T | undefined;
     error?: ApolloError;

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -259,16 +259,15 @@ export interface ApolloPayloadResult<TData = Record<string, any>, TExtensions = 
 
 // @public (undocumented)
 export interface ApolloQueryResult<T> {
+    complete?: boolean;
     // (undocumented)
-    data: T;
+    data: T | undefined;
     error?: ApolloError;
     errors?: ReadonlyArray<GraphQLFormattedError>;
     // (undocumented)
     loading: boolean;
     // (undocumented)
     networkStatus: NetworkStatus;
-    // (undocumented)
-    partial?: boolean;
 }
 
 // @public (undocumented)

--- a/.changeset/rich-kids-carry.md
+++ b/.changeset/rich-kids-carry.md
@@ -3,3 +3,7 @@
 ---
 
 Fix type of `data` property on `ApolloQueryResult`. Previously this field was non-optional, non-null `TData`, however at runtime this value could be set to `undefined`. This field is now reported as `TData | undefined`.
+
+This will affect you in a handful of places:
+- The `data` property emitted from the result passed to the `next` callback from `client.watchQuery`
+- Fetch-based APIs that return an `ApolloQueryResult` type such as `observableQuery.refetch`, `observableQuery.fetchMore`, etc.

--- a/.changeset/rich-kids-carry.md
+++ b/.changeset/rich-kids-carry.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": major
+---
+
+Fix type of `data` property on `ApolloQueryResult`. Previously this field was non-optional, non-null `TData`, however at runtime this value could be set to `undefined`. This field is now reported as `TData | undefined`.

--- a/.changeset/rude-fans-study.md
+++ b/.changeset/rude-fans-study.md
@@ -1,0 +1,7 @@
+---
+"@apollo/client": major
+---
+
+Remove the `partial` flag on `ApolloQueryResult` in favor of a `complete` flag. The `complete` flag is now only set when `returnPartialData` is `true` as a means to determine if the returned result is a complete or partial result.
+
+If you use `result.partial`, you can migrate to use `!result.complete` to achieve the same result for any query that uses `returnPartialData: true`. All queries where `returnPartialData` is not set or set to `false`, you will need to remove this check and instead check if `data` is `undefined` or not.

--- a/.changeset/rude-fans-study.md
+++ b/.changeset/rude-fans-study.md
@@ -2,6 +2,4 @@
 "@apollo/client": major
 ---
 
-Remove the `partial` flag on `ApolloQueryResult` in favor of a `complete` flag. The `complete` flag is now only set when `returnPartialData` is `true` as a means to determine if the returned result is a complete or partial result.
-
-If you use `result.partial`, you can migrate to use `!result.complete` to achieve the same result for any query that uses `returnPartialData: true`. All queries where `returnPartialData` is not set or set to `false`, you will need to remove this check and instead check if `data` is `undefined` or not.
+Deprecate the `partial` flag on `ApolloQueryResult` and make it a non-optional property. Previously `partial` was only set conditionally if the result emitted was partial. This value is now available with all results that return an `ApolloQueryResult`.

--- a/.changeset/rude-fans-study.md
+++ b/.changeset/rude-fans-study.md
@@ -1,5 +1,5 @@
 ---
-"@apollo/client": major
+"@apollo/client": minor
 ---
 
 Deprecate the `partial` flag on `ApolloQueryResult` and make it a non-optional property. Previously `partial` was only set conditionally if the result emitted was partial. This value is now available with all results that return an `ApolloQueryResult`.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 34298,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 34387
+  "dist/apollo-client.min.cjs": 34276,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 39524
 }

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 34271,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 34359
+  "dist/apollo-client.min.cjs": 34284,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 34370
 }

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 34284,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 34370
+  "dist/apollo-client.min.cjs": 34298,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 34387
 }

--- a/src/__tests__/ApolloClient.ts
+++ b/src/__tests__/ApolloClient.ts
@@ -3167,7 +3167,7 @@ describe("ApolloClient", () => {
 
       observableQuery.subscribe({
         next: (result) => {
-          expectTypeOf(result.data).toMatchTypeOf<Query>();
+          expectTypeOf(result.data).toMatchTypeOf<Query | undefined>();
           expectTypeOf(result.data).not.toMatchTypeOf<UnmaskedQuery>();
         },
       });
@@ -3191,12 +3191,12 @@ describe("ApolloClient", () => {
         },
       });
 
-      expectTypeOf(fetchMoreResult.data).toMatchTypeOf<Query>();
+      expectTypeOf(fetchMoreResult.data).toMatchTypeOf<Query | undefined>();
       expectTypeOf(fetchMoreResult.data).not.toMatchTypeOf<UnmaskedQuery>();
 
       const refetchResult = await observableQuery.refetch();
 
-      expectTypeOf(refetchResult.data).toMatchTypeOf<Query>();
+      expectTypeOf(refetchResult.data).toMatchTypeOf<Query | undefined>();
       expectTypeOf(refetchResult.data).not.toMatchTypeOf<UnmaskedQuery>();
 
       const setVariablesResult = await observableQuery.setVariables({

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -1865,10 +1865,12 @@ describe("client", () => {
       });
       const stream = new ObservableStream(obs);
 
-      await expect(stream).toEmitValue({
+      await expect(stream).toEmitApolloQueryResult({
         loading: true,
         data: initialData,
         networkStatus: 1,
+        complete: true,
+        partial: false,
       });
 
       const error = await stream.takeError();
@@ -2543,19 +2545,23 @@ describe("client", () => {
 
     let stream = new ObservableStream(observable);
 
-    await expect(stream).toEmitValue({
+    await expect(stream).toEmitApolloQueryResult({
       loading: false,
       networkStatus: NetworkStatus.ready,
       data,
+      complete: true,
+      partial: false,
     });
 
     await wait(0);
     await expect(observable.refetch()).rejects.toThrow();
 
-    await expect(stream).toEmitValue({
+    await expect(stream).toEmitApolloQueryResult({
       loading: true,
       networkStatus: NetworkStatus.refetch,
       data,
+      complete: true,
+      partial: false,
     });
 
     const error = await stream.takeError();
@@ -2576,26 +2582,31 @@ describe("client", () => {
     observable.resetLastResults();
     stream = new ObservableStream(observable);
 
-    await expect(stream).toEmitValue({
+    await expect(stream).toEmitApolloQueryResult({
       loading: false,
       networkStatus: NetworkStatus.ready,
       data,
+      complete: true,
+      partial: false,
     });
 
     await wait(0);
     await expect(observable.refetch()).resolves.toBeTruthy();
 
-    await expect(stream).toEmitValue({
+    await expect(stream).toEmitApolloQueryResult({
       loading: true,
       networkStatus: NetworkStatus.refetch,
       data,
+      complete: true,
+      partial: false,
     });
 
-    await expect(stream).toEmitValue({
+    await expect(stream).toEmitApolloQueryResult({
       loading: false,
       networkStatus: NetworkStatus.ready,
-      errors: undefined,
       data: dataTwo,
+      complete: true,
+      partial: false,
     });
 
     await expect(stream).not.toEmitAnything();
@@ -3003,18 +3014,24 @@ describe("@connection", () => {
       data: { a: 123 },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     await expect(bStream).toEmitApolloQueryResult({
       data: { b: "asdf" },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     await expect(abStream).toEmitApolloQueryResult({
       data: { a: 123, b: "asdf" },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     aVar(aVar() + 111);
@@ -3023,6 +3040,8 @@ describe("@connection", () => {
       data: { a: 234 },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     await expect(bStream).not.toEmitAnything({ timeout: 10 });
@@ -3031,6 +3050,8 @@ describe("@connection", () => {
       data: { a: 234, b: "asdf" },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     bVar(bVar().toUpperCase());
@@ -3041,12 +3062,16 @@ describe("@connection", () => {
       data: { b: "ASDF" },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     await expect(abStream).toEmitApolloQueryResult({
       data: { a: 234, b: "ASDF" },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     aVar(aVar() + 222);
@@ -3056,18 +3081,24 @@ describe("@connection", () => {
       data: { a: 456 },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     await expect(bStream).toEmitApolloQueryResult({
       data: { b: "oyez" },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     await expect(abStream).toEmitApolloQueryResult({
       data: { a: 456, b: "oyez" },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     // Since the ObservableQuery skips results that are the same as the
@@ -3102,6 +3133,8 @@ describe("@connection", () => {
       data: undefined,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: false,
+      partial: true,
     });
 
     // Now try writing directly to the cache, rather than calling
@@ -3120,6 +3153,8 @@ describe("@connection", () => {
       data: { c: "see" },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     cache.modify({
@@ -3138,6 +3173,8 @@ describe("@connection", () => {
       data: { c: "saw" },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     client.cache.evict({ fieldName: "c" });
@@ -3149,6 +3186,8 @@ describe("@connection", () => {
       data: undefined,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: false,
+      partial: true,
     });
   });
 
@@ -4585,6 +4624,8 @@ describe("custom document transforms", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       expect(document).toMatchDocument(transformedQuery);
@@ -4736,6 +4777,8 @@ describe("custom document transforms", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
     });
   });
@@ -4826,6 +4869,8 @@ describe("custom document transforms", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       expect(document).toMatchDocument(enabledQuery);
@@ -4851,6 +4896,8 @@ describe("custom document transforms", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
   });
 
@@ -4948,6 +4995,8 @@ describe("custom document transforms", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       expect(document).toMatchDocument(enabledQuery);
@@ -4976,6 +5025,8 @@ describe("custom document transforms", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
   });
 
@@ -5112,6 +5163,8 @@ describe("custom document transforms", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       expect(handleNext).toHaveBeenCalledTimes(1);
@@ -5156,6 +5209,8 @@ describe("custom document transforms", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
   });
 
@@ -5245,6 +5300,8 @@ describe("custom document transforms", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       expect(document).toMatchDocument(enabledQuery);
@@ -5270,6 +5327,8 @@ describe("custom document transforms", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
   });
 
@@ -5359,6 +5418,8 @@ describe("custom document transforms", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       expect(document).toMatchDocument(enabledQuery);
@@ -5384,6 +5445,8 @@ describe("custom document transforms", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
   });
 
@@ -5482,6 +5545,8 @@ describe("custom document transforms", () => {
         data: mocks[0].result.data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       expect(document).toMatchDocument(transformedQuery);
@@ -5501,6 +5566,8 @@ describe("custom document transforms", () => {
       data: mocks[1].result.data,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
   });
 

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -2999,19 +2999,19 @@ describe("@connection", () => {
       }
     `);
 
-    await expect(aStream).toEmitValue({
+    await expect(aStream).toEmitApolloQueryResult({
       data: { a: 123 },
       loading: false,
       networkStatus: NetworkStatus.ready,
     });
 
-    await expect(bStream).toEmitValue({
+    await expect(bStream).toEmitApolloQueryResult({
       data: { b: "asdf" },
       loading: false,
       networkStatus: NetworkStatus.ready,
     });
 
-    await expect(abStream).toEmitValue({
+    await expect(abStream).toEmitApolloQueryResult({
       data: { a: 123, b: "asdf" },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -3019,7 +3019,7 @@ describe("@connection", () => {
 
     aVar(aVar() + 111);
 
-    await expect(aStream).toEmitValue({
+    await expect(aStream).toEmitApolloQueryResult({
       data: { a: 234 },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -3027,7 +3027,7 @@ describe("@connection", () => {
 
     await expect(bStream).not.toEmitAnything({ timeout: 10 });
 
-    await expect(abStream).toEmitValue({
+    await expect(abStream).toEmitApolloQueryResult({
       data: { a: 234, b: "asdf" },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -3037,13 +3037,13 @@ describe("@connection", () => {
 
     await expect(aStream).not.toEmitAnything({ timeout: 10 });
 
-    await expect(bStream).toEmitValue({
+    await expect(bStream).toEmitApolloQueryResult({
       data: { b: "ASDF" },
       loading: false,
       networkStatus: NetworkStatus.ready,
     });
 
-    await expect(abStream).toEmitValue({
+    await expect(abStream).toEmitApolloQueryResult({
       data: { a: 234, b: "ASDF" },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -3052,19 +3052,19 @@ describe("@connection", () => {
     aVar(aVar() + 222);
     bVar("oyez");
 
-    await expect(aStream).toEmitValue({
+    await expect(aStream).toEmitApolloQueryResult({
       data: { a: 456 },
       loading: false,
       networkStatus: NetworkStatus.ready,
     });
 
-    await expect(bStream).toEmitValue({
+    await expect(bStream).toEmitApolloQueryResult({
       data: { b: "oyez" },
       loading: false,
       networkStatus: NetworkStatus.ready,
     });
 
-    await expect(abStream).toEmitValue({
+    await expect(abStream).toEmitApolloQueryResult({
       data: { a: 456, b: "oyez" },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -3098,11 +3098,10 @@ describe("@connection", () => {
     // result to be delivered even though networkStatus is still loading.
     const cStream = watch(cQuery, "cache-only");
 
-    await expect(cStream).toEmitValue({
+    await expect(cStream).toEmitApolloQueryResult({
       data: undefined,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      partial: true,
     });
 
     // Now try writing directly to the cache, rather than calling
@@ -3117,7 +3116,7 @@ describe("@connection", () => {
     await expect(aStream).not.toEmitAnything();
     await expect(bStream).not.toEmitAnything();
     await expect(abStream).not.toEmitAnything();
-    await expect(cStream).toEmitValue({
+    await expect(cStream).toEmitApolloQueryResult({
       data: { c: "see" },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -3135,7 +3134,7 @@ describe("@connection", () => {
     await expect(aStream).not.toEmitAnything();
     await expect(bStream).not.toEmitAnything();
     await expect(abStream).not.toEmitAnything();
-    await expect(cStream).toEmitValue({
+    await expect(cStream).toEmitApolloQueryResult({
       data: { c: "saw" },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -3146,11 +3145,10 @@ describe("@connection", () => {
     await expect(aStream).not.toEmitAnything();
     await expect(bStream).not.toEmitAnything();
     await expect(abStream).not.toEmitAnything();
-    await expect(cStream).toEmitValue({
+    await expect(cStream).toEmitApolloQueryResult({
       data: undefined,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      partial: true,
     });
   });
 

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -1869,7 +1869,6 @@ describe("client", () => {
         loading: true,
         data: initialData,
         networkStatus: 1,
-        complete: true,
         partial: false,
       });
 
@@ -2549,7 +2548,6 @@ describe("client", () => {
       loading: false,
       networkStatus: NetworkStatus.ready,
       data,
-      complete: true,
       partial: false,
     });
 
@@ -2560,7 +2558,6 @@ describe("client", () => {
       loading: true,
       networkStatus: NetworkStatus.refetch,
       data,
-      complete: true,
       partial: false,
     });
 
@@ -2586,7 +2583,6 @@ describe("client", () => {
       loading: false,
       networkStatus: NetworkStatus.ready,
       data,
-      complete: true,
       partial: false,
     });
 
@@ -2597,7 +2593,6 @@ describe("client", () => {
       loading: true,
       networkStatus: NetworkStatus.refetch,
       data,
-      complete: true,
       partial: false,
     });
 
@@ -2605,7 +2600,6 @@ describe("client", () => {
       loading: false,
       networkStatus: NetworkStatus.ready,
       data: dataTwo,
-      complete: true,
       partial: false,
     });
 
@@ -3014,7 +3008,6 @@ describe("@connection", () => {
       data: { a: 123 },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -3022,7 +3015,6 @@ describe("@connection", () => {
       data: { b: "asdf" },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -3030,7 +3022,6 @@ describe("@connection", () => {
       data: { a: 123, b: "asdf" },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -3040,7 +3031,6 @@ describe("@connection", () => {
       data: { a: 234 },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -3050,7 +3040,6 @@ describe("@connection", () => {
       data: { a: 234, b: "asdf" },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -3062,7 +3051,6 @@ describe("@connection", () => {
       data: { b: "ASDF" },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -3070,7 +3058,6 @@ describe("@connection", () => {
       data: { a: 234, b: "ASDF" },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -3081,7 +3068,6 @@ describe("@connection", () => {
       data: { a: 456 },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -3089,7 +3075,6 @@ describe("@connection", () => {
       data: { b: "oyez" },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -3097,7 +3082,6 @@ describe("@connection", () => {
       data: { a: 456, b: "oyez" },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -3133,7 +3117,6 @@ describe("@connection", () => {
       data: undefined,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: false,
       partial: true,
     });
 
@@ -3153,7 +3136,6 @@ describe("@connection", () => {
       data: { c: "see" },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -3173,7 +3155,6 @@ describe("@connection", () => {
       data: { c: "saw" },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -3186,7 +3167,6 @@ describe("@connection", () => {
       data: undefined,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: false,
       partial: true,
     });
   });
@@ -4624,7 +4604,6 @@ describe("custom document transforms", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -4777,7 +4756,6 @@ describe("custom document transforms", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
     });
@@ -4869,7 +4847,6 @@ describe("custom document transforms", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -4896,7 +4873,6 @@ describe("custom document transforms", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
   });
@@ -4995,7 +4971,6 @@ describe("custom document transforms", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -5025,7 +5000,6 @@ describe("custom document transforms", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
   });
@@ -5163,7 +5137,6 @@ describe("custom document transforms", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -5209,7 +5182,6 @@ describe("custom document transforms", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
   });
@@ -5300,7 +5272,6 @@ describe("custom document transforms", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -5327,7 +5298,6 @@ describe("custom document transforms", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
   });
@@ -5418,7 +5388,6 @@ describe("custom document transforms", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -5445,7 +5414,6 @@ describe("custom document transforms", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
   });
@@ -5545,7 +5513,6 @@ describe("custom document transforms", () => {
         data: mocks[0].result.data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -5566,7 +5533,6 @@ describe("custom document transforms", () => {
       data: mocks[1].result.data,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
   });

--- a/src/__tests__/dataMasking.ts
+++ b/src/__tests__/dataMasking.ts
@@ -1126,13 +1126,13 @@ describe("client.watchQuery", () => {
 
     {
       const { data } = await stream.takeNext();
-      data.currentUser.__typename;
-      data.currentUser.id;
-      data.currentUser.name;
+      data!.currentUser.__typename;
+      data!.currentUser.id;
+      data!.currentUser.name;
 
       expect(consoleSpy.warn).not.toHaveBeenCalled();
 
-      data.currentUser.age;
+      data!.currentUser.age;
 
       expect(consoleSpy.warn).toHaveBeenCalledTimes(1);
       expect(consoleSpy.warn).toHaveBeenCalledWith(
@@ -1142,7 +1142,7 @@ describe("client.watchQuery", () => {
       );
 
       // Ensure we only warn once
-      data.currentUser.age;
+      data!.currentUser.age;
       expect(consoleSpy.warn).toHaveBeenCalledTimes(1);
     }
   });
@@ -1208,7 +1208,7 @@ describe("client.watchQuery", () => {
 
     const { data } = await stream.takeNext();
 
-    const id = client.cache.identify(data.currentUser);
+    const id = client.cache.identify(data!.currentUser);
 
     expect(consoleSpy.warn).not.toHaveBeenCalled();
     expect(id).toEqual("User:1");
@@ -1272,7 +1272,7 @@ describe("client.watchQuery", () => {
     const { data } = await queryStream.takeNext();
     const fragmentObservable = client.watchFragment({
       fragment,
-      from: data.currentUser,
+      from: data!.currentUser,
     });
 
     const fragmentStream = new ObservableStream(fragmentObservable);
@@ -1345,7 +1345,7 @@ describe("client.watchQuery", () => {
     const { data } = await queryStream.takeNext();
     const fragmentObservable = client.watchFragment({
       fragment,
-      from: data.currentUser,
+      from: data!.currentUser,
     });
 
     expect(console.warn).toHaveBeenCalledTimes(1);
@@ -1422,7 +1422,7 @@ describe("client.watchQuery", () => {
     const { data } = await queryStream.takeNext();
     const fragmentObservable = client.watchFragment({
       fragment,
-      from: data.currentUser,
+      from: data!.currentUser,
     });
 
     expect(console.warn).toHaveBeenCalledTimes(1);

--- a/src/__tests__/fetchMore.ts
+++ b/src/__tests__/fetchMore.ts
@@ -612,12 +612,14 @@ describe("fetchMore on an observable query", () => {
 
       const stream = new ObservableStream(observable);
 
-      await expect(stream).toEmitValue({
+      await expect(stream).toEmitApolloQueryResult({
         loading: false,
         networkStatus: NetworkStatus.ready,
         data: {
           TODO: tasks.slice(0, 2),
         },
+        complete: true,
+        partial: false,
       });
 
       expect(linkRequests).toEqual([
@@ -631,21 +633,25 @@ describe("fetchMore on an observable query", () => {
           },
         });
 
-        expect(fetchMoreResult).toEqual({
+        expect(fetchMoreResult).toEqualApolloQueryResult({
           loading: false,
           networkStatus: NetworkStatus.ready,
           data: {
             TODO: tasks.slice(2, 4),
           },
+          complete: true,
+          partial: false,
         });
       }
 
-      await expect(stream).toEmitValue({
+      await expect(stream).toEmitApolloQueryResult({
         loading: false,
         networkStatus: NetworkStatus.ready,
         data: {
           TODO: tasks.slice(0, 4),
         },
+        complete: true,
+        partial: false,
       });
 
       expect(linkRequests).toEqual([
@@ -661,21 +667,25 @@ describe("fetchMore on an observable query", () => {
           },
         });
 
-        expect(fetchMoreResult).toEqual({
+        expect(fetchMoreResult).toEqualApolloQueryResult({
           loading: false,
           networkStatus: NetworkStatus.ready,
           data: {
             TODO: tasks.slice(5, 8),
           },
+          complete: true,
+          partial: false,
         });
       }
 
-      await expect(stream).toEmitValue({
+      await expect(stream).toEmitApolloQueryResult({
         loading: false,
         networkStatus: NetworkStatus.ready,
         data: {
           TODO: [...tasks.slice(0, 4), ...tasks.slice(5, 8)],
         },
+        complete: true,
+        partial: false,
       });
 
       expect(linkRequests).toEqual([
@@ -706,12 +716,14 @@ describe("fetchMore on an observable query", () => {
 
       const stream = new ObservableStream(observable);
 
-      await expect(stream).toEmitValue({
+      await expect(stream).toEmitApolloQueryResult({
         loading: false,
         networkStatus: NetworkStatus.ready,
         data: {
           TODO: tasks.slice(0, 2),
         },
+        complete: true,
+        partial: false,
       });
 
       expect(linkRequests).toEqual([
@@ -725,29 +737,35 @@ describe("fetchMore on an observable query", () => {
           },
         });
 
-        expect(fetchMoreResult).toEqual({
+        expect(fetchMoreResult).toEqualApolloQueryResult({
           loading: false,
           networkStatus: NetworkStatus.ready,
           data: {
             TODO: tasks.slice(2, 4),
           },
+          complete: true,
+          partial: false,
         });
       }
 
-      await expect(stream).toEmitValue({
+      await expect(stream).toEmitApolloQueryResult({
         loading: true,
         networkStatus: NetworkStatus.fetchMore,
         data: {
           TODO: tasks.slice(0, 2),
         },
+        complete: true,
+        partial: false,
       });
 
-      await expect(stream).toEmitValue({
+      await expect(stream).toEmitApolloQueryResult({
         loading: false,
         networkStatus: NetworkStatus.ready,
         data: {
           TODO: tasks.slice(0, 4),
         },
+        complete: true,
+        partial: false,
       });
 
       expect(linkRequests).toEqual([
@@ -763,29 +781,35 @@ describe("fetchMore on an observable query", () => {
           },
         });
 
-        expect(fetchMoreResult).toEqual({
+        expect(fetchMoreResult).toEqualApolloQueryResult({
           loading: false,
           networkStatus: NetworkStatus.ready,
           data: {
             TODO: tasks.slice(5, 8),
           },
+          complete: true,
+          partial: false,
         });
       }
 
-      await expect(stream).toEmitValue({
+      await expect(stream).toEmitApolloQueryResult({
         loading: true,
         networkStatus: NetworkStatus.fetchMore,
         data: {
           TODO: tasks.slice(0, 4),
         },
+        complete: true,
+        partial: false,
       });
 
-      await expect(stream).toEmitValue({
+      await expect(stream).toEmitApolloQueryResult({
         loading: false,
         networkStatus: NetworkStatus.ready,
         data: {
           TODO: [...tasks.slice(0, 4), ...tasks.slice(5, 8)],
         },
+        complete: true,
+        partial: false,
       });
 
       expect(linkRequests).toEqual([
@@ -815,12 +839,14 @@ describe("fetchMore on an observable query", () => {
 
       const stream = new ObservableStream(observable);
 
-      await expect(stream).toEmitValue({
+      await expect(stream).toEmitApolloQueryResult({
         loading: false,
         networkStatus: NetworkStatus.ready,
         data: {
           TODO: tasks.slice(0, 2),
         },
+        complete: true,
+        partial: false,
       });
 
       expect(linkRequests).toEqual([
@@ -834,21 +860,25 @@ describe("fetchMore on an observable query", () => {
           },
         });
 
-        expect(fetchMoreResult).toEqual({
+        expect(fetchMoreResult).toEqualApolloQueryResult({
           loading: false,
           networkStatus: NetworkStatus.ready,
           data: {
             TODO: tasks.slice(2, 4),
           },
+          complete: true,
+          partial: false,
         });
       }
 
-      await expect(stream).toEmitValue({
+      await expect(stream).toEmitApolloQueryResult({
         loading: false,
         networkStatus: NetworkStatus.ready,
         data: {
           TODO: tasks.slice(0, 4),
         },
+        complete: true,
+        partial: false,
       });
 
       expect(linkRequests).toEqual([
@@ -864,21 +894,25 @@ describe("fetchMore on an observable query", () => {
           },
         });
 
-        expect(fetchMoreResult).toEqual({
+        expect(fetchMoreResult).toEqualApolloQueryResult({
           loading: false,
           networkStatus: NetworkStatus.ready,
           data: {
             TODO: tasks.slice(5, 8),
           },
+          complete: true,
+          partial: false,
         });
       }
 
-      await expect(stream).toEmitValue({
+      await expect(stream).toEmitApolloQueryResult({
         loading: false,
         networkStatus: NetworkStatus.ready,
         data: {
           TODO: [...tasks.slice(0, 4), ...tasks.slice(5, 8)],
         },
+        complete: true,
+        partial: false,
       });
 
       expect(linkRequests).toEqual([
@@ -908,12 +942,14 @@ describe("fetchMore on an observable query", () => {
 
       const stream = new ObservableStream(observable);
 
-      await expect(stream).toEmitValue({
+      await expect(stream).toEmitApolloQueryResult({
         loading: false,
         networkStatus: NetworkStatus.ready,
         data: {
           TODO: tasks.slice(0, 2),
         },
+        complete: true,
+        partial: false,
       });
 
       expect(linkRequests).toEqual([
@@ -927,29 +963,35 @@ describe("fetchMore on an observable query", () => {
           },
         });
 
-        expect(fetchMoreResult).toEqual({
+        expect(fetchMoreResult).toEqualApolloQueryResult({
           loading: false,
           networkStatus: NetworkStatus.ready,
           data: {
             TODO: tasks.slice(2, 4),
           },
+          complete: true,
+          partial: false,
         });
       }
 
-      await expect(stream).toEmitValue({
+      await expect(stream).toEmitApolloQueryResult({
         loading: true,
         networkStatus: NetworkStatus.fetchMore,
         data: {
           TODO: tasks.slice(0, 2),
         },
+        complete: true,
+        partial: false,
       });
 
-      await expect(stream).toEmitValue({
+      await expect(stream).toEmitApolloQueryResult({
         loading: false,
         networkStatus: NetworkStatus.ready,
         data: {
           TODO: tasks.slice(0, 4),
         },
+        complete: true,
+        partial: false,
       });
 
       expect(linkRequests).toEqual([
@@ -965,29 +1007,35 @@ describe("fetchMore on an observable query", () => {
           },
         });
 
-        expect(fetchMoreResult).toEqual({
+        expect(fetchMoreResult).toEqualApolloQueryResult({
           loading: false,
           networkStatus: NetworkStatus.ready,
           data: {
             TODO: tasks.slice(5, 8),
           },
+          complete: true,
+          partial: false,
         });
       }
 
-      await expect(stream).toEmitValue({
+      await expect(stream).toEmitApolloQueryResult({
         loading: true,
         networkStatus: NetworkStatus.fetchMore,
         data: {
           TODO: tasks.slice(0, 4),
         },
+        complete: true,
+        partial: false,
       });
 
-      await expect(stream).toEmitValue({
+      await expect(stream).toEmitApolloQueryResult({
         loading: false,
         networkStatus: NetworkStatus.ready,
         data: {
           TODO: [...tasks.slice(0, 4), ...tasks.slice(5, 8)],
         },
+        complete: true,
+        partial: false,
       });
 
       expect(linkRequests).toEqual([
@@ -1118,12 +1166,14 @@ describe("fetchMore on an observable query", () => {
 
     const stream = new ObservableStream(observable);
 
-    await expect(stream).toEmitValue({
+    await expect(stream).toEmitApolloQueryResult({
       loading: false,
       networkStatus: NetworkStatus.ready,
       data: {
         groceries: initialGroceries,
       },
+      complete: true,
+      partial: false,
     });
 
     expect(mergeArgsHistory).toEqual([{ offset: 0, limit: 2 }]);
@@ -1136,12 +1186,14 @@ describe("fetchMore on an observable query", () => {
         },
       });
 
-      expect(fetchMoreResult).toEqual({
+      expect(fetchMoreResult).toEqualApolloQueryResult({
         loading: false,
         networkStatus: NetworkStatus.ready,
         data: {
           groceries: additionalGroceries,
         },
+        complete: true,
+        partial: false,
       });
 
       expect(observable.options.fetchPolicy).toBe("cache-first");
@@ -1150,12 +1202,14 @@ describe("fetchMore on an observable query", () => {
     // This result comes entirely from the cache, without updating the
     // original variables for the ObservableQuery, because the
     // offsetLimitPagination field policy has keyArgs:false.
-    await expect(stream).toEmitValue({
+    await expect(stream).toEmitApolloQueryResult({
       loading: false,
       networkStatus: NetworkStatus.ready,
       data: {
         groceries: finalGroceries,
       },
+      complete: true,
+      partial: false,
     });
 
     expect(mergeArgsHistory).toEqual([
@@ -1393,38 +1447,46 @@ describe("fetchMore on an observable query", () => {
 
     const stream = new ObservableStream(observable);
 
-    await expect(stream).toEmitValue({
+    await expect(stream).toEmitApolloQueryResult({
       loading: false,
       networkStatus: NetworkStatus.ready,
       data: {
         emptyItems: [],
       },
+      complete: true,
+      partial: false,
     });
 
     const fetchMoreResult = await observable.fetchMore({
       variables,
     });
 
-    expect(fetchMoreResult).toEqual({
+    expect(fetchMoreResult).toEqualApolloQueryResult({
       loading: false,
       networkStatus: NetworkStatus.ready,
       data: { emptyItems: [] },
+      complete: true,
+      partial: false,
     });
 
-    await expect(stream).toEmitValue({
+    await expect(stream).toEmitApolloQueryResult({
       loading: true,
       networkStatus: NetworkStatus.fetchMore,
       data: {
         emptyItems: [],
       },
+      complete: true,
+      partial: false,
     });
 
-    await expect(stream).toEmitValue({
+    await expect(stream).toEmitApolloQueryResult({
       loading: false,
       networkStatus: NetworkStatus.ready,
       data: {
         emptyItems: [],
       },
+      complete: true,
+      partial: false,
     });
 
     await expect(stream).not.toEmitAnything();

--- a/src/__tests__/fetchMore.ts
+++ b/src/__tests__/fetchMore.ts
@@ -293,7 +293,7 @@ describe("fetchMore on an observable query", () => {
         const result = await stream.takeNext();
 
         expect(result.loading).toBe(false);
-        expect(result.data.entry.comments).toHaveLength(10);
+        expect(result.data!.entry.comments).toHaveLength(10);
       }
 
       {
@@ -314,12 +314,12 @@ describe("fetchMore on an observable query", () => {
 
         // This is the server result
         expect(fetchMoreResult.loading).toBe(false);
-        expect(fetchMoreResult.data.entry.comments).toHaveLength(10);
+        expect(fetchMoreResult.data!.entry.comments).toHaveLength(10);
       }
 
       {
         const result = await stream.takeNext();
-        const combinedComments = result.data.entry.comments;
+        const combinedComments = result.data!.entry.comments;
 
         expect(combinedComments).toHaveLength(20);
 
@@ -354,7 +354,7 @@ describe("fetchMore on an observable query", () => {
         const result = await stream.takeNext();
 
         expect(result.loading).toBe(false);
-        expect(result.data.entry.comments).toHaveLength(10);
+        expect(result.data!.entry.comments).toHaveLength(10);
       }
 
       {
@@ -365,12 +365,12 @@ describe("fetchMore on an observable query", () => {
 
         // This is the server result
         expect(fetchMoreResult.loading).toBe(false);
-        expect(fetchMoreResult.data.entry.comments).toHaveLength(10);
+        expect(fetchMoreResult.data!.entry.comments).toHaveLength(10);
       }
 
       {
         const result = await stream.takeNext();
-        const combinedComments = result.data.entry.comments;
+        const combinedComments = result.data!.entry.comments;
 
         expect(result.loading).toBe(false);
         expect(combinedComments).toHaveLength(20);
@@ -400,7 +400,7 @@ describe("fetchMore on an observable query", () => {
         const result = await stream.takeNext();
 
         expect(result.loading).toBe(false);
-        expect(result.data.entry.comments).toHaveLength(10);
+        expect(result.data!.entry.comments).toHaveLength(10);
       }
 
       {
@@ -417,7 +417,7 @@ describe("fetchMore on an observable query", () => {
           },
         });
 
-        const fetchMoreComments = fetchMoreResult.data.entry.comments;
+        const fetchMoreComments = fetchMoreResult.data!.entry.comments;
 
         expect(fetchMoreResult.loading).toBe(false);
         expect(fetchMoreComments).toHaveLength(10);
@@ -428,7 +428,7 @@ describe("fetchMore on an observable query", () => {
 
       {
         const result = await stream.takeNext();
-        const combinedComments = result.data.entry.comments;
+        const combinedComments = result.data!.entry.comments;
 
         expect(result.loading).toBe(false);
         expect(combinedComments).toHaveLength(20);
@@ -467,7 +467,7 @@ describe("fetchMore on an observable query", () => {
         const result = await stream.takeNext();
 
         expect(result.loading).toBe(false);
-        expect(result.data.entry.comments).toHaveLength(10);
+        expect(result.data!.entry.comments).toHaveLength(10);
       }
 
       {
@@ -477,12 +477,12 @@ describe("fetchMore on an observable query", () => {
         });
 
         expect(fetchMoreResult.loading).toBe(false);
-        expect(fetchMoreResult.data.entry.comments).toHaveLength(10); // this is the server result
+        expect(fetchMoreResult.data!.entry.comments).toHaveLength(10); // this is the server result
       }
 
       {
         const result = await stream.takeNext();
-        const combinedComments = result.data.entry.comments;
+        const combinedComments = result.data!.entry.comments;
 
         expect(result.loading).toBe(false);
         expect(combinedComments).toHaveLength(20);
@@ -1181,7 +1181,7 @@ describe("fetchMore on an observable query", () => {
       const result = await stream.takeNext();
 
       expect(result.loading).toBe(false);
-      expect(result.data.entry.comments).toHaveLength(10);
+      expect(result.data!.entry.comments).toHaveLength(10);
     }
 
     {
@@ -1199,12 +1199,12 @@ describe("fetchMore on an observable query", () => {
       });
 
       expect(fetchMoreResult.loading).toBe(false);
-      expect(fetchMoreResult.data.comments).toHaveLength(10);
+      expect(fetchMoreResult.data!.comments).toHaveLength(10);
     }
 
     {
       const result = await stream.takeNext();
-      const combinedComments = result.data.entry.comments;
+      const combinedComments = result.data!.entry.comments;
 
       expect(result.loading).toBe(false);
       expect(combinedComments).toHaveLength(20);
@@ -1252,7 +1252,7 @@ describe("fetchMore on an observable query", () => {
       const { data, networkStatus } = await stream.takeNext();
 
       expect(networkStatus).toBe(NetworkStatus.ready);
-      expect(data.entry.comments.length).toBe(10);
+      expect(data!.entry.comments.length).toBe(10);
 
       const error = await observable
         .fetchMore({
@@ -1315,7 +1315,7 @@ describe("fetchMore on an observable query", () => {
       const { data, networkStatus } = await stream.takeNext();
 
       expect(networkStatus).toBe(NetworkStatus.ready);
-      expect(data.entry.comments.length).toBe(10);
+      expect(data!.entry.comments.length).toBe(10);
 
       const error = await observable
         .fetchMore({
@@ -1574,7 +1574,7 @@ describe("fetchMore on an observable query with connection", () => {
         const result = await stream.takeNext();
 
         expect(result.loading).toBe(false);
-        expect(result.data.entry.comments).toHaveLength(10);
+        expect(result.data!.entry.comments).toHaveLength(10);
       }
 
       {
@@ -1590,13 +1590,13 @@ describe("fetchMore on an observable query with connection", () => {
           },
         });
 
-        expect(fetchMoreResult.data.entry.comments).toHaveLength(10);
+        expect(fetchMoreResult.data!.entry.comments).toHaveLength(10);
         expect(fetchMoreResult.loading).toBe(false);
       }
 
       {
         const result = await stream.takeNext();
-        const combinedComments = result.data.entry.comments;
+        const combinedComments = result.data!.entry.comments;
 
         expect(combinedComments).toHaveLength(20);
         combinedComments.forEach((comment, i) => {
@@ -1633,7 +1633,7 @@ describe("fetchMore on an observable query with connection", () => {
         const result = await stream.takeNext();
 
         expect(result.loading).toBe(false);
-        expect(result.data.entry.comments).toHaveLength(10);
+        expect(result.data!.entry.comments).toHaveLength(10);
       }
 
       {
@@ -1644,13 +1644,13 @@ describe("fetchMore on an observable query with connection", () => {
 
         // this is the server result
         expect(fetchMoreResult.loading).toBe(false);
-        expect(fetchMoreResult.data.entry.comments).toHaveLength(10);
+        expect(fetchMoreResult.data!.entry.comments).toHaveLength(10);
       }
 
       {
         const result = await stream.takeNext();
 
-        const combinedComments = result.data.entry.comments;
+        const combinedComments = result.data!.entry.comments;
         expect(combinedComments).toHaveLength(20);
         combinedComments.forEach((comment, i) => {
           expect(comment.text).toBe(`comment ${i + 1}`);
@@ -1693,7 +1693,7 @@ describe("fetchMore on an observable query with connection", () => {
         const { data, networkStatus } = await stream.takeNext();
 
         expect(networkStatus).toBe(NetworkStatus.ready);
-        expect(data.entry.comments.length).toBe(10);
+        expect(data!.entry.comments.length).toBe(10);
       }
 
       void observable.fetchMore({
@@ -1712,7 +1712,7 @@ describe("fetchMore on an observable query with connection", () => {
         const { data, networkStatus } = await stream.takeNext();
 
         expect(networkStatus).toBe(NetworkStatus.fetchMore);
-        expect(data.entry.comments.length).toBe(10);
+        expect(data!.entry.comments.length).toBe(10);
       }
 
       {
@@ -1775,14 +1775,14 @@ describe("fetchMore on an observable query with connection", () => {
         const { data, networkStatus } = await stream.takeNext();
 
         expect(networkStatus).toBe(NetworkStatus.fetchMore);
-        expect(data.entry.comments.length).toBe(10);
+        expect(data!.entry.comments.length).toBe(10);
       }
 
       {
         const { data, networkStatus } = await stream.takeNext();
 
         expect(networkStatus).toBe(NetworkStatus.ready);
-        expect(data.entry.comments.length).toBe(20);
+        expect(data!.entry.comments.length).toBe(20);
       }
 
       await expect(stream).not.toEmitAnything();

--- a/src/__tests__/fetchMore.ts
+++ b/src/__tests__/fetchMore.ts
@@ -618,7 +618,6 @@ describe("fetchMore on an observable query", () => {
         data: {
           TODO: tasks.slice(0, 2),
         },
-        complete: true,
         partial: false,
       });
 
@@ -639,7 +638,6 @@ describe("fetchMore on an observable query", () => {
           data: {
             TODO: tasks.slice(2, 4),
           },
-          complete: true,
           partial: false,
         });
       }
@@ -650,7 +648,6 @@ describe("fetchMore on an observable query", () => {
         data: {
           TODO: tasks.slice(0, 4),
         },
-        complete: true,
         partial: false,
       });
 
@@ -673,7 +670,6 @@ describe("fetchMore on an observable query", () => {
           data: {
             TODO: tasks.slice(5, 8),
           },
-          complete: true,
           partial: false,
         });
       }
@@ -684,7 +680,6 @@ describe("fetchMore on an observable query", () => {
         data: {
           TODO: [...tasks.slice(0, 4), ...tasks.slice(5, 8)],
         },
-        complete: true,
         partial: false,
       });
 
@@ -722,7 +717,6 @@ describe("fetchMore on an observable query", () => {
         data: {
           TODO: tasks.slice(0, 2),
         },
-        complete: true,
         partial: false,
       });
 
@@ -743,7 +737,6 @@ describe("fetchMore on an observable query", () => {
           data: {
             TODO: tasks.slice(2, 4),
           },
-          complete: true,
           partial: false,
         });
       }
@@ -754,7 +747,6 @@ describe("fetchMore on an observable query", () => {
         data: {
           TODO: tasks.slice(0, 2),
         },
-        complete: true,
         partial: false,
       });
 
@@ -764,7 +756,6 @@ describe("fetchMore on an observable query", () => {
         data: {
           TODO: tasks.slice(0, 4),
         },
-        complete: true,
         partial: false,
       });
 
@@ -787,7 +778,6 @@ describe("fetchMore on an observable query", () => {
           data: {
             TODO: tasks.slice(5, 8),
           },
-          complete: true,
           partial: false,
         });
       }
@@ -798,7 +788,6 @@ describe("fetchMore on an observable query", () => {
         data: {
           TODO: tasks.slice(0, 4),
         },
-        complete: true,
         partial: false,
       });
 
@@ -808,7 +797,6 @@ describe("fetchMore on an observable query", () => {
         data: {
           TODO: [...tasks.slice(0, 4), ...tasks.slice(5, 8)],
         },
-        complete: true,
         partial: false,
       });
 
@@ -845,7 +833,6 @@ describe("fetchMore on an observable query", () => {
         data: {
           TODO: tasks.slice(0, 2),
         },
-        complete: true,
         partial: false,
       });
 
@@ -866,7 +853,6 @@ describe("fetchMore on an observable query", () => {
           data: {
             TODO: tasks.slice(2, 4),
           },
-          complete: true,
           partial: false,
         });
       }
@@ -877,7 +863,6 @@ describe("fetchMore on an observable query", () => {
         data: {
           TODO: tasks.slice(0, 4),
         },
-        complete: true,
         partial: false,
       });
 
@@ -900,7 +885,6 @@ describe("fetchMore on an observable query", () => {
           data: {
             TODO: tasks.slice(5, 8),
           },
-          complete: true,
           partial: false,
         });
       }
@@ -911,7 +895,6 @@ describe("fetchMore on an observable query", () => {
         data: {
           TODO: [...tasks.slice(0, 4), ...tasks.slice(5, 8)],
         },
-        complete: true,
         partial: false,
       });
 
@@ -948,7 +931,6 @@ describe("fetchMore on an observable query", () => {
         data: {
           TODO: tasks.slice(0, 2),
         },
-        complete: true,
         partial: false,
       });
 
@@ -969,7 +951,6 @@ describe("fetchMore on an observable query", () => {
           data: {
             TODO: tasks.slice(2, 4),
           },
-          complete: true,
           partial: false,
         });
       }
@@ -980,7 +961,6 @@ describe("fetchMore on an observable query", () => {
         data: {
           TODO: tasks.slice(0, 2),
         },
-        complete: true,
         partial: false,
       });
 
@@ -990,7 +970,6 @@ describe("fetchMore on an observable query", () => {
         data: {
           TODO: tasks.slice(0, 4),
         },
-        complete: true,
         partial: false,
       });
 
@@ -1013,7 +992,6 @@ describe("fetchMore on an observable query", () => {
           data: {
             TODO: tasks.slice(5, 8),
           },
-          complete: true,
           partial: false,
         });
       }
@@ -1024,7 +1002,6 @@ describe("fetchMore on an observable query", () => {
         data: {
           TODO: tasks.slice(0, 4),
         },
-        complete: true,
         partial: false,
       });
 
@@ -1034,7 +1011,6 @@ describe("fetchMore on an observable query", () => {
         data: {
           TODO: [...tasks.slice(0, 4), ...tasks.slice(5, 8)],
         },
-        complete: true,
         partial: false,
       });
 
@@ -1172,7 +1148,6 @@ describe("fetchMore on an observable query", () => {
       data: {
         groceries: initialGroceries,
       },
-      complete: true,
       partial: false,
     });
 
@@ -1192,7 +1167,6 @@ describe("fetchMore on an observable query", () => {
         data: {
           groceries: additionalGroceries,
         },
-        complete: true,
         partial: false,
       });
 
@@ -1208,7 +1182,6 @@ describe("fetchMore on an observable query", () => {
       data: {
         groceries: finalGroceries,
       },
-      complete: true,
       partial: false,
     });
 
@@ -1453,7 +1426,6 @@ describe("fetchMore on an observable query", () => {
       data: {
         emptyItems: [],
       },
-      complete: true,
       partial: false,
     });
 
@@ -1465,7 +1437,6 @@ describe("fetchMore on an observable query", () => {
       loading: false,
       networkStatus: NetworkStatus.ready,
       data: { emptyItems: [] },
-      complete: true,
       partial: false,
     });
 
@@ -1475,7 +1446,6 @@ describe("fetchMore on an observable query", () => {
       data: {
         emptyItems: [],
       },
-      complete: true,
       partial: false,
     });
 
@@ -1485,7 +1455,6 @@ describe("fetchMore on an observable query", () => {
       data: {
         emptyItems: [],
       },
-      complete: true,
       partial: false,
     });
 

--- a/src/__tests__/local-state/general.ts
+++ b/src/__tests__/local-state/general.ts
@@ -409,13 +409,15 @@ describe("Cache manipulation", () => {
 
     const stream = new ObservableStream(client.watchQuery({ query }));
 
-    await expect(stream).toEmitValue({
+    await expect(stream).toEmitApolloQueryResult({
       data: {
         serverData,
         selectedItemId: -1,
       },
       loading: false,
       networkStatus: 7,
+      complete: true,
+      partial: false,
     });
 
     await client.mutate({
@@ -424,13 +426,15 @@ describe("Cache manipulation", () => {
       refetchQueries: ["FetchInitialData"],
     });
 
-    await expect(stream).toEmitValue({
+    await expect(stream).toEmitApolloQueryResult({
       data: {
         serverData,
         selectedItemId: 123,
       },
       loading: false,
       networkStatus: 7,
+      complete: true,
+      partial: false,
     });
   });
 

--- a/src/__tests__/local-state/general.ts
+++ b/src/__tests__/local-state/general.ts
@@ -416,7 +416,6 @@ describe("Cache manipulation", () => {
       },
       loading: false,
       networkStatus: 7,
-      complete: true,
       partial: false,
     });
 
@@ -433,7 +432,6 @@ describe("Cache manipulation", () => {
       },
       loading: false,
       networkStatus: 7,
-      complete: true,
       partial: false,
     });
   });

--- a/src/__tests__/local-state/resolvers.ts
+++ b/src/__tests__/local-state/resolvers.ts
@@ -76,6 +76,8 @@ describe("Basic resolver capabilities", () => {
       data: { foo: { bar: true } },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     await expect(stream).not.toEmitAnything();
@@ -121,6 +123,8 @@ describe("Basic resolver capabilities", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     await expect(stream).not.toEmitAnything();
@@ -171,6 +175,8 @@ describe("Basic resolver capabilities", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     await expect(stream).not.toEmitAnything();
@@ -232,6 +238,8 @@ describe("Basic resolver capabilities", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     await expect(stream).not.toEmitAnything();
@@ -265,6 +273,8 @@ describe("Basic resolver capabilities", () => {
       data: { foo: { bar: 1 } },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     await expect(stream).not.toEmitAnything();
@@ -298,6 +308,8 @@ describe("Basic resolver capabilities", () => {
       data: { foo: { bar: 1 } },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     await expect(stream).not.toEmitAnything();
@@ -363,6 +375,8 @@ describe("Basic resolver capabilities", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     await expect(stream).not.toEmitAnything();
@@ -393,6 +407,8 @@ describe("Basic resolver capabilities", () => {
       data: { isInCart: false },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
   });
 
@@ -558,6 +574,8 @@ describe("Basic resolver capabilities", () => {
       data: { foo: { bar: true }, bar: { baz: true } },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
     expect(barResolver).not.toHaveBeenCalled();
   });
@@ -597,6 +615,8 @@ describe("Writing cache data from resolvers", () => {
       data: { field: 1 },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
   });
 
@@ -654,6 +674,8 @@ describe("Writing cache data from resolvers", () => {
       data: { obj: { __typename: "Object", field: 2 } },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
   });
 
@@ -724,6 +746,8 @@ describe("Writing cache data from resolvers", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
   });
 });
@@ -766,6 +790,8 @@ describe("Resolving field aliases", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
   });
 
@@ -796,6 +822,8 @@ describe("Resolving field aliases", () => {
       data: { fie: { bar: true, __typename: "Foo" } },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
     expect(fie).not.toHaveBeenCalled();
   });
@@ -837,6 +865,8 @@ describe("Resolving field aliases", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
     expect(fie).not.toHaveBeenCalled();
   });
@@ -879,6 +909,8 @@ describe("Resolving field aliases", () => {
       data: { fie: { bar: "yo", __typename: "Foo" } },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
   });
 
@@ -941,6 +973,8 @@ describe("Resolving field aliases", () => {
       data: { launch: { __typename: "Launch", id: 1, isInCart: true } },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     // When the same query fires again, `isInCart` should be pulled from
@@ -949,6 +983,8 @@ describe("Resolving field aliases", () => {
       data: { launch: { __typename: "Launch", id: 1, isInCart: true } },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
   });
 });
@@ -990,6 +1026,8 @@ describe("Force local resolvers", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     client.addResolvers({
@@ -1009,6 +1047,8 @@ describe("Force local resolvers", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
   });
 
@@ -1057,6 +1097,8 @@ describe("Force local resolvers", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
     expect(count).toEqual(1);
   });
@@ -1195,6 +1237,8 @@ describe("Force local resolvers", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
   });
 });
@@ -1224,6 +1268,8 @@ describe("Async resolvers", () => {
       data: { isLoggedIn: true },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
   });
 
@@ -1283,6 +1329,8 @@ describe("Async resolvers", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
   });
 });

--- a/src/__tests__/local-state/resolvers.ts
+++ b/src/__tests__/local-state/resolvers.ts
@@ -76,7 +76,6 @@ describe("Basic resolver capabilities", () => {
       data: { foo: { bar: true } },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -123,7 +122,6 @@ describe("Basic resolver capabilities", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -175,7 +173,6 @@ describe("Basic resolver capabilities", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -238,7 +235,6 @@ describe("Basic resolver capabilities", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -273,7 +269,6 @@ describe("Basic resolver capabilities", () => {
       data: { foo: { bar: 1 } },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -308,7 +303,6 @@ describe("Basic resolver capabilities", () => {
       data: { foo: { bar: 1 } },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -375,7 +369,6 @@ describe("Basic resolver capabilities", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -407,7 +400,6 @@ describe("Basic resolver capabilities", () => {
       data: { isInCart: false },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
   });
@@ -574,7 +566,6 @@ describe("Basic resolver capabilities", () => {
       data: { foo: { bar: true }, bar: { baz: true } },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
     expect(barResolver).not.toHaveBeenCalled();
@@ -615,7 +606,6 @@ describe("Writing cache data from resolvers", () => {
       data: { field: 1 },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
   });
@@ -674,7 +664,6 @@ describe("Writing cache data from resolvers", () => {
       data: { obj: { __typename: "Object", field: 2 } },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
   });
@@ -746,7 +735,6 @@ describe("Writing cache data from resolvers", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
   });
@@ -790,7 +778,6 @@ describe("Resolving field aliases", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
   });
@@ -822,7 +809,6 @@ describe("Resolving field aliases", () => {
       data: { fie: { bar: true, __typename: "Foo" } },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
     expect(fie).not.toHaveBeenCalled();
@@ -865,7 +851,6 @@ describe("Resolving field aliases", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
     expect(fie).not.toHaveBeenCalled();
@@ -909,7 +894,6 @@ describe("Resolving field aliases", () => {
       data: { fie: { bar: "yo", __typename: "Foo" } },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
   });
@@ -973,7 +957,6 @@ describe("Resolving field aliases", () => {
       data: { launch: { __typename: "Launch", id: 1, isInCart: true } },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -983,7 +966,6 @@ describe("Resolving field aliases", () => {
       data: { launch: { __typename: "Launch", id: 1, isInCart: true } },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
   });
@@ -1026,7 +1008,6 @@ describe("Force local resolvers", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -1047,7 +1028,6 @@ describe("Force local resolvers", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
   });
@@ -1097,7 +1077,6 @@ describe("Force local resolvers", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
     expect(count).toEqual(1);
@@ -1237,7 +1216,6 @@ describe("Force local resolvers", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
   });
@@ -1268,7 +1246,6 @@ describe("Async resolvers", () => {
       data: { isLoggedIn: true },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
   });
@@ -1329,7 +1306,6 @@ describe("Async resolvers", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
   });

--- a/src/__tests__/refetchQueries.ts
+++ b/src/__tests__/refetchQueries.ts
@@ -819,9 +819,11 @@ describe("client.refetchQueries", () => {
     const results = (await refetchResult).map((result) => {
       // These results are ApolloQueryResult<any>, as inferred by TypeScript.
       expect(Object.keys(result).sort()).toEqual([
+        "complete",
         "data",
         "loading",
         "networkStatus",
+        "partial",
       ]);
       return result.data;
     });
@@ -888,9 +890,11 @@ describe("client.refetchQueries", () => {
     const results = (await refetchResult).map((result) => {
       // These results are ApolloQueryResult<any>, as inferred by TypeScript.
       expect(Object.keys(result).sort()).toEqual([
+        "complete",
         "data",
         "loading",
         "networkStatus",
+        "partial",
       ]);
       return result.data;
     });
@@ -954,9 +958,11 @@ describe("client.refetchQueries", () => {
     const results = (await refetchResult).map((result) => {
       // These results are ApolloQueryResult<any>, as inferred by TypeScript.
       expect(Object.keys(result).sort()).toEqual([
+        "complete",
         "data",
         "loading",
         "networkStatus",
+        "partial",
       ]);
       return result.data;
     });

--- a/src/__tests__/refetchQueries.ts
+++ b/src/__tests__/refetchQueries.ts
@@ -819,7 +819,6 @@ describe("client.refetchQueries", () => {
     const results = (await refetchResult).map((result) => {
       // These results are ApolloQueryResult<any>, as inferred by TypeScript.
       expect(Object.keys(result).sort()).toEqual([
-        "complete",
         "data",
         "loading",
         "networkStatus",
@@ -890,7 +889,6 @@ describe("client.refetchQueries", () => {
     const results = (await refetchResult).map((result) => {
       // These results are ApolloQueryResult<any>, as inferred by TypeScript.
       expect(Object.keys(result).sort()).toEqual([
-        "complete",
         "data",
         "loading",
         "networkStatus",
@@ -958,7 +956,6 @@ describe("client.refetchQueries", () => {
     const results = (await refetchResult).map((result) => {
       // These results are ApolloQueryResult<any>, as inferred by TypeScript.
       expect(Object.keys(result).sort()).toEqual([
-        "complete",
         "data",
         "loading",
         "networkStatus",

--- a/src/__tests__/subscribeToMore.ts
+++ b/src/__tests__/subscribeToMore.ts
@@ -87,7 +87,6 @@ describe("subscribeToMore", () => {
       data: { entry: { value: "1" } },
       loading: false,
       networkStatus: 7,
-      complete: true,
       partial: false,
     });
 
@@ -97,7 +96,6 @@ describe("subscribeToMore", () => {
       data: { entry: { value: "Dahivat Pandya" } },
       loading: false,
       networkStatus: 7,
-      complete: true,
       partial: false,
     });
 
@@ -108,7 +106,6 @@ describe("subscribeToMore", () => {
       data: { entry: { value: "Amanda Liu" } },
       loading: false,
       networkStatus: 7,
-      complete: true,
       partial: false,
     });
   });
@@ -150,7 +147,6 @@ describe("subscribeToMore", () => {
       data: { entry: { value: "1" } },
       loading: false,
       networkStatus: 7,
-      complete: true,
       partial: false,
     });
 
@@ -158,7 +154,6 @@ describe("subscribeToMore", () => {
       data: { entry: { value: "Amanda Liu" } },
       loading: false,
       networkStatus: 7,
-      complete: true,
       partial: false,
     });
 
@@ -204,7 +199,6 @@ describe("subscribeToMore", () => {
       data: { entry: { value: "1" } },
       loading: false,
       networkStatus: 7,
-      complete: true,
       partial: false,
     });
 
@@ -285,7 +279,6 @@ describe("subscribeToMore", () => {
       data: { entry: [{ value: "1" }, { value: "2" }] },
       loading: false,
       networkStatus: 7,
-      complete: true,
       partial: false,
     });
 
@@ -295,7 +288,6 @@ describe("subscribeToMore", () => {
       },
       loading: false,
       networkStatus: 7,
-      complete: true,
       partial: false,
     });
 
@@ -310,7 +302,6 @@ describe("subscribeToMore", () => {
       },
       loading: false,
       networkStatus: 7,
-      complete: true,
       partial: false,
     });
 
@@ -367,7 +358,6 @@ describe("subscribeToMore", () => {
       data: { entry: { value: "1" } },
       loading: false,
       networkStatus: 7,
-      complete: true,
       partial: false,
     });
 
@@ -377,7 +367,6 @@ describe("subscribeToMore", () => {
       data: { entry: { value: "Dahivat Pandya" } },
       loading: false,
       networkStatus: 7,
-      complete: true,
       partial: false,
     });
 
@@ -388,7 +377,6 @@ describe("subscribeToMore", () => {
       data: { entry: { value: "Amanda Liu" } },
       loading: false,
       networkStatus: 7,
-      complete: true,
       partial: false,
     });
   });

--- a/src/__tests__/subscribeToMore.ts
+++ b/src/__tests__/subscribeToMore.ts
@@ -83,27 +83,33 @@ describe("subscribeToMore", () => {
       },
     });
 
-    await expect(stream).toEmitValue({
+    await expect(stream).toEmitApolloQueryResult({
       data: { entry: { value: "1" } },
       loading: false,
       networkStatus: 7,
+      complete: true,
+      partial: false,
     });
 
     wSLink.simulateResult(results[0]);
 
-    await expect(stream).toEmitValue({
+    await expect(stream).toEmitApolloQueryResult({
       data: { entry: { value: "Dahivat Pandya" } },
       loading: false,
       networkStatus: 7,
+      complete: true,
+      partial: false,
     });
 
     await wait(10);
     wSLink.simulateResult(results[1]);
 
-    await expect(stream).toEmitValue({
+    await expect(stream).toEmitApolloQueryResult({
       data: { entry: { value: "Amanda Liu" } },
       loading: false,
       networkStatus: 7,
+      complete: true,
+      partial: false,
     });
   });
 
@@ -140,16 +146,20 @@ describe("subscribeToMore", () => {
       wSLink.simulateResult(result);
     }
 
-    await expect(stream).toEmitValue({
+    await expect(stream).toEmitApolloQueryResult({
       data: { entry: { value: "1" } },
       loading: false,
       networkStatus: 7,
+      complete: true,
+      partial: false,
     });
 
-    await expect(stream).toEmitValue({
+    await expect(stream).toEmitApolloQueryResult({
       data: { entry: { value: "Amanda Liu" } },
       loading: false,
       networkStatus: 7,
+      complete: true,
+      partial: false,
     });
 
     await wait(15);
@@ -190,10 +200,12 @@ describe("subscribeToMore", () => {
       wSLink.simulateResult(result);
     }
 
-    await expect(stream).toEmitValue({
+    await expect(stream).toEmitApolloQueryResult({
       data: { entry: { value: "1" } },
       loading: false,
       networkStatus: 7,
+      complete: true,
+      partial: false,
     });
 
     await wait(15);
@@ -217,10 +229,10 @@ describe("subscribeToMore", () => {
         ROOT_QUERY: {
           entry: [
             {
-              value: 1,
+              value: "1",
             },
             {
-              value: 2,
+              value: "2",
             },
           ],
         },
@@ -269,31 +281,37 @@ describe("subscribeToMore", () => {
       // note: we don't complete mutation with performTransaction because a real example would detect duplicates
     }
 
-    await expect(stream).toEmitValue({
-      data: { entry: [{ value: 1 }, { value: 2 }] },
+    await expect(stream).toEmitApolloQueryResult({
+      data: { entry: [{ value: "1" }, { value: "2" }] },
       loading: false,
       networkStatus: 7,
+      complete: true,
+      partial: false,
     });
 
-    await expect(stream).toEmitValue({
+    await expect(stream).toEmitApolloQueryResult({
       data: {
-        entry: [{ value: 1 }, { value: 2 }, { value: "Dahivat Pandya" }],
+        entry: [{ value: "1" }, { value: "2" }, { value: "Dahivat Pandya" }],
       },
       loading: false,
       networkStatus: 7,
+      complete: true,
+      partial: false,
     });
 
-    await expect(stream).toEmitValue({
+    await expect(stream).toEmitApolloQueryResult({
       data: {
         entry: [
-          { value: 1 },
-          { value: 2 },
+          { value: "1" },
+          { value: "2" },
           { value: "Dahivat Pandya" },
           { value: "Amanda Liu" },
         ],
       },
       loading: false,
       networkStatus: 7,
+      complete: true,
+      partial: false,
     });
 
     await expect(stream).not.toEmitAnything();
@@ -345,27 +363,33 @@ describe("subscribeToMore", () => {
       },
     });
 
-    await expect(stream).toEmitValue({
+    await expect(stream).toEmitApolloQueryResult({
       data: { entry: { value: "1" } },
       loading: false,
       networkStatus: 7,
+      complete: true,
+      partial: false,
     });
 
     wSLink.simulateResult(results[0]);
 
-    await expect(stream).toEmitValue({
+    await expect(stream).toEmitApolloQueryResult({
       data: { entry: { value: "Dahivat Pandya" } },
       loading: false,
       networkStatus: 7,
+      complete: true,
+      partial: false,
     });
 
     await wait(10);
     wSLink.simulateResult(results[1]);
 
-    await expect(stream).toEmitValue({
+    await expect(stream).toEmitApolloQueryResult({
       data: { entry: { value: "Amanda Liu" } },
       loading: false,
       networkStatus: 7,
+      complete: true,
+      partial: false,
     });
   });
 });

--- a/src/cache/inmemory/__tests__/fragmentRegistry.ts
+++ b/src/cache/inmemory/__tests__/fragmentRegistry.ts
@@ -97,7 +97,6 @@ describe("FragmentRegistry", () => {
         __typename: "Query",
         source: "local",
       },
-      complete: true,
       partial: false,
     });
 
@@ -108,7 +107,6 @@ describe("FragmentRegistry", () => {
         __typename: "Query",
         source: "link",
       },
-      complete: true,
       partial: false,
     });
 

--- a/src/cache/inmemory/__tests__/fragmentRegistry.ts
+++ b/src/cache/inmemory/__tests__/fragmentRegistry.ts
@@ -90,22 +90,26 @@ describe("FragmentRegistry", () => {
       client.watchQuery({ query, fetchPolicy: "cache-and-network" })
     );
 
-    await expect(stream).toEmitValue({
+    await expect(stream).toEmitApolloQueryResult({
       loading: true,
       networkStatus: NetworkStatus.loading,
       data: {
         __typename: "Query",
         source: "local",
       },
+      complete: true,
+      partial: false,
     });
 
-    await expect(stream).toEmitValue({
+    await expect(stream).toEmitApolloQueryResult({
       loading: false,
       networkStatus: NetworkStatus.ready,
       data: {
         __typename: "Query",
         source: "link",
       },
+      complete: true,
+      partial: false,
     });
 
     expect(cache.readQuery({ query })).toEqual({

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -3655,7 +3655,6 @@ describe("type policies", function () {
             totalCount: 1292,
           },
         },
-        complete: true,
         partial: false,
       });
 
@@ -3690,7 +3689,6 @@ describe("type policies", function () {
             totalCount: 1292,
           },
         },
-        complete: true,
         partial: false,
       });
 
@@ -3706,7 +3704,6 @@ describe("type policies", function () {
             extraMetaData: "extra",
           },
         },
-        complete: true,
         partial: false,
       });
       expect(cache.extract()).toMatchSnapshot();
@@ -4124,7 +4121,6 @@ describe("type policies", function () {
             totalCount: 1292,
           },
         },
-        complete: true,
         partial: false,
       });
       expect(cache.extract()).toMatchSnapshot();
@@ -4150,7 +4146,6 @@ describe("type policies", function () {
               totalCount: 1292,
             },
           },
-          complete: true,
           partial: false,
         });
         expect(cache.extract()).toMatchSnapshot();
@@ -4179,7 +4174,6 @@ describe("type policies", function () {
               totalCount: 1292,
             },
           },
-          complete: true,
           partial: false,
         });
 
@@ -4207,7 +4201,6 @@ describe("type policies", function () {
               totalCount: 1292,
             },
           },
-          complete: true,
           partial: false,
         });
 
@@ -4242,7 +4235,6 @@ describe("type policies", function () {
               totalCount: 1292,
             },
           },
-          complete: true,
           partial: false,
         });
 
@@ -4272,7 +4264,6 @@ describe("type policies", function () {
               totalCount: 13531,
             },
           },
-          complete: true,
           partial: false,
         });
 
@@ -4342,7 +4333,6 @@ describe("type policies", function () {
               totalCount: 1292,
             },
           },
-          complete: true,
           partial: false,
         });
 
@@ -4371,7 +4361,6 @@ describe("type policies", function () {
               totalCount: 13531,
             },
           },
-          complete: true,
           partial: false,
         });
 

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -3647,7 +3647,7 @@ describe("type policies", function () {
 
       let result = await client.query({ query: firstQuery });
 
-      expect(result).toEqual({
+      expect(result).toEqualApolloQueryResult({
         loading: false,
         networkStatus: NetworkStatus.ready,
         data: {
@@ -3655,6 +3655,8 @@ describe("type policies", function () {
             totalCount: 1292,
           },
         },
+        complete: true,
+        partial: false,
       });
 
       expect(cache.extract()).toEqual({
@@ -3678,7 +3680,7 @@ describe("type policies", function () {
         variables: secondVariables,
       });
 
-      expect(result).toEqual({
+      expect(result).toEqualApolloQueryResult({
         loading: false,
         networkStatus: NetworkStatus.ready,
         data: {
@@ -3688,12 +3690,14 @@ describe("type policies", function () {
             totalCount: 1292,
           },
         },
+        complete: true,
+        partial: false,
       });
 
       expect(cache.extract()).toMatchSnapshot();
 
       result = await client.query({ query: thirdQuery });
-      expect(result).toEqual({
+      expect(result).toEqualApolloQueryResult({
         loading: false,
         networkStatus: NetworkStatus.ready,
         data: {
@@ -3702,6 +3706,8 @@ describe("type policies", function () {
             extraMetaData: "extra",
           },
         },
+        complete: true,
+        partial: false,
       });
       expect(cache.extract()).toMatchSnapshot();
     });
@@ -4108,7 +4114,7 @@ describe("type policies", function () {
 
       const stream = new ObservableStream(observable);
 
-      await expect(stream).toEmitValue({
+      await expect(stream).toEmitApolloQueryResult({
         loading: false,
         networkStatus: NetworkStatus.ready,
         data: {
@@ -4118,6 +4124,8 @@ describe("type policies", function () {
             totalCount: 1292,
           },
         },
+        complete: true,
+        partial: false,
       });
       expect(cache.extract()).toMatchSnapshot();
 
@@ -4126,7 +4134,7 @@ describe("type policies", function () {
       {
         const result = await stream.takeNext();
 
-        expect(result).toEqual({
+        expect(result).toEqualApolloQueryResult({
           loading: false,
           networkStatus: NetworkStatus.ready,
           data: {
@@ -4142,6 +4150,8 @@ describe("type policies", function () {
               totalCount: 1292,
             },
           },
+          complete: true,
+          partial: false,
         });
         expect(cache.extract()).toMatchSnapshot();
       }
@@ -4153,7 +4163,7 @@ describe("type policies", function () {
 
         expect(result.data.search.edges.length).toBe(5);
 
-        expect(result).toEqual({
+        expect(result).toEqualApolloQueryResult({
           loading: false,
           networkStatus: NetworkStatus.ready,
           data: {
@@ -4169,6 +4179,8 @@ describe("type policies", function () {
               totalCount: 1292,
             },
           },
+          complete: true,
+          partial: false,
         });
 
         expect(cache.extract()).toMatchSnapshot();
@@ -4179,7 +4191,7 @@ describe("type policies", function () {
       {
         const result = await stream.takeNext();
 
-        expect(result).toEqual({
+        expect(result).toEqualApolloQueryResult({
           loading: false,
           networkStatus: NetworkStatus.ready,
           data: {
@@ -4195,6 +4207,8 @@ describe("type policies", function () {
               totalCount: 1292,
             },
           },
+          complete: true,
+          partial: false,
         });
 
         expect(result.data.search.edges).toEqual([
@@ -4212,7 +4226,7 @@ describe("type policies", function () {
 
         expect(result.data.search.edges.length).toBe(7);
 
-        expect(result).toEqual({
+        expect(result).toEqualApolloQueryResult({
           loading: false,
           networkStatus: NetworkStatus.ready,
           data: {
@@ -4228,6 +4242,8 @@ describe("type policies", function () {
               totalCount: 1292,
             },
           },
+          complete: true,
+          partial: false,
         });
 
         expect(cache.extract()).toMatchSnapshot();
@@ -4246,7 +4262,7 @@ describe("type policies", function () {
         });
         const snapshot = cache.extract();
 
-        expect(result).toEqual({
+        expect(result).toEqualApolloQueryResult({
           loading: false,
           networkStatus: NetworkStatus.ready,
           data: {
@@ -4256,6 +4272,8 @@ describe("type policies", function () {
               totalCount: 13531,
             },
           },
+          complete: true,
+          partial: false,
         });
 
         expect(snapshot).toMatchSnapshot();
@@ -4308,7 +4326,7 @@ describe("type policies", function () {
           },
         });
 
-        expect(result).toEqual({
+        expect(result).toEqualApolloQueryResult({
           loading: false,
           networkStatus: NetworkStatus.ready,
           data: {
@@ -4324,6 +4342,8 @@ describe("type policies", function () {
               totalCount: 1292,
             },
           },
+          complete: true,
+          partial: false,
         });
 
         expect(cache.extract()).toMatchSnapshot();
@@ -4341,7 +4361,7 @@ describe("type policies", function () {
         });
         const snapshot = cache.extract();
 
-        expect(result).toEqual({
+        expect(result).toEqualApolloQueryResult({
           loading: false,
           networkStatus: NetworkStatus.ready,
           data: {
@@ -4351,6 +4371,8 @@ describe("type policies", function () {
               totalCount: 13531,
             },
           },
+          complete: true,
+          partial: false,
         });
 
         expect(snapshot).toMatchSnapshot();

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -253,6 +253,7 @@ export class ObservableQuery<
 
     const result: ApolloQueryResult<TData> = {
       data: undefined,
+      complete: false,
       ...lastResult,
       loading: isNetworkRequestInFlight(networkStatus),
       networkStatus,
@@ -278,16 +279,14 @@ export class ObservableQuery<
     } else {
       const diff = this.queryInfo.getDiff();
 
+      result.complete = diff.complete;
+
       if (diff.complete || this.options.returnPartialData) {
         result.data = diff.result;
       }
 
       if (result.data === null) {
         result.data = void 0 as any;
-      }
-
-      if (this.options.returnPartialData) {
-        result.complete = diff.complete;
       }
 
       if (diff.complete) {

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1080,9 +1080,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     // because the query may be using the @nonreactive directive, and we want to
     // save the the latest version of any nonreactive subtrees (in case
     // getCurrentResult is called), even though we skip broadcasting changes.
-    if (lastError || !result.partial || this.options.returnPartialData) {
-      this.updateLastResult(result, variables);
-    }
+    this.updateLastResult(result, variables);
     if (lastError || isDifferent) {
       iterateObserversSafely(this.observers, "next", this.maskResult(result));
     }

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -253,7 +253,6 @@ export class ObservableQuery<
 
     const result: ApolloQueryResult<TData> = {
       data: undefined,
-      complete: false,
       partial: true,
       ...lastResult,
       loading: isNetworkRequestInFlight(networkStatus),
@@ -280,7 +279,6 @@ export class ObservableQuery<
     } else {
       const diff = this.queryInfo.getDiff();
 
-      result.complete = diff.complete;
       result.partial = !diff.complete;
 
       if (diff.complete || this.options.returnPartialData) {
@@ -1092,7 +1090,6 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     // must mirror the updates that occur in QueryStore.markQueryError here
     const errorResult: ApolloQueryResult<TData> = {
       data: undefined,
-      complete: false,
       partial: true,
       ...this.getLastResult(),
       error,

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -251,11 +251,12 @@ export class ObservableQuery<
       (lastResult && lastResult.networkStatus) ||
       NetworkStatus.ready;
 
-    const result = {
+    const result: ApolloQueryResult<TData> = {
+      data: undefined,
       ...lastResult,
       loading: isNetworkRequestInFlight(networkStatus),
       networkStatus,
-    } as ApolloQueryResult<TData>;
+    };
 
     const { fetchPolicy = "cache-first" } = this.options;
     if (

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1090,13 +1090,16 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
   private reportError(error: ApolloError, variables: TVariables | undefined) {
     // Since we don't get the current result on errors, only the error, we
     // must mirror the updates that occur in QueryStore.markQueryError here
-    const errorResult = {
+    const errorResult: ApolloQueryResult<TData> = {
+      data: undefined,
+      complete: false,
+      partial: true,
       ...this.getLastResult(),
       error,
       errors: error.graphQLErrors,
       networkStatus: NetworkStatus.error,
       loading: false,
-    } as ApolloQueryResult<TData>;
+    };
 
     this.updateLastResult(errorResult, variables);
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -285,11 +285,11 @@ export class ObservableQuery<
         result.data = void 0 as any;
       }
 
-      if (diff.complete) {
-        // Similar to setting result.partial to false, but taking advantage of the
-        // falsiness of missing fields.
-        delete result.partial;
+      if (this.options.returnPartialData) {
+        result.complete = diff.complete;
+      }
 
+      if (diff.complete) {
         // If the diff is complete, and we're using a FetchPolicy that
         // terminates after a complete cache read, we can assume the next result
         // we receive will have NetworkStatus.ready and !loading.
@@ -301,8 +301,6 @@ export class ObservableQuery<
           result.networkStatus = NetworkStatus.ready;
           result.loading = false;
         }
-      } else {
-        result.partial = true;
       }
 
       if (

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -254,6 +254,7 @@ export class ObservableQuery<
     const result: ApolloQueryResult<TData> = {
       data: undefined,
       complete: false,
+      partial: true,
       ...lastResult,
       loading: isNetworkRequestInFlight(networkStatus),
       networkStatus,
@@ -280,6 +281,7 @@ export class ObservableQuery<
       const diff = this.queryInfo.getDiff();
 
       result.complete = diff.complete;
+      result.partial = !diff.complete;
 
       if (diff.complete || this.options.returnPartialData) {
         result.data = diff.result;

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1260,12 +1260,14 @@ export class QueryManager<TStore> {
           queryInfo.markReady();
         }
 
+        const complete = !!result.data;
+
         const aqr: ApolloQueryResult<TData> = {
           data: result.data,
           loading: false,
           networkStatus: NetworkStatus.ready,
-          complete: true,
-          partial: false,
+          complete,
+          partial: !complete,
         };
 
         // In the case we start multiple network requests simulatenously, we
@@ -1279,8 +1281,6 @@ export class QueryManager<TStore> {
         if (hasErrors && errorPolicy !== "ignore") {
           aqr.errors = graphQLErrors;
           aqr.networkStatus = NetworkStatus.error;
-          aqr.complete = !!aqr.data;
-          aqr.partial = !aqr.complete;
         }
 
         return aqr;

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1264,6 +1264,7 @@ export class QueryManager<TStore> {
           data: result.data,
           loading: false,
           networkStatus: NetworkStatus.ready,
+          complete: true,
         };
 
         // In the case we start multiple network requests simulatenously, we
@@ -1660,11 +1661,8 @@ export class QueryManager<TStore> {
           data: data as TData | undefined,
           loading: isNetworkRequestInFlight(networkStatus),
           networkStatus,
+          complete: diff.complete,
         };
-
-        if (returnPartialData) {
-          result.complete = diff.complete;
-        }
 
         return Observable.of(result);
       };
@@ -1721,12 +1719,6 @@ export class QueryManager<TStore> {
         context,
         fetchPolicy,
         errorPolicy,
-      }).map((result) => {
-        if (returnPartialData) {
-          result.complete = true;
-        }
-
-        return result;
       });
 
     const shouldNotify =

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1654,13 +1654,19 @@ export class QueryManager<TStore> {
         logMissingFieldErrors(diff.missing);
       }
 
-      const fromData = (data: TData | DeepPartial<TData> | undefined) =>
-        Observable.of({
-          data,
+      const fromData = (data: TData | DeepPartial<TData> | undefined) => {
+        const result: ApolloQueryResult<TData> = {
+          data: data as TData | undefined,
           loading: isNetworkRequestInFlight(networkStatus),
           networkStatus,
-          ...(diff.complete ? null : { partial: true }),
-        } as ApolloQueryResult<TData>);
+        };
+
+        if (returnPartialData) {
+          result.complete = diff.complete;
+        }
+
+        return Observable.of(result);
+      };
 
       if (this.getDocumentInfo(query).hasForcedResolvers) {
         return this.localState

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1656,6 +1656,7 @@ export class QueryManager<TStore> {
 
       const fromData = (data: TData | DeepPartial<TData> | undefined) => {
         const result: ApolloQueryResult<TData> = {
+          // TODO: Handle partial data
           data: data as TData | undefined,
           loading: isNetworkRequestInFlight(networkStatus),
           networkStatus,

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1721,6 +1721,12 @@ export class QueryManager<TStore> {
         context,
         fetchPolicy,
         errorPolicy,
+      }).map((result) => {
+        if (returnPartialData) {
+          result.complete = true;
+        }
+
+        return result;
       });
 
     const shouldNotify =

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1279,6 +1279,8 @@ export class QueryManager<TStore> {
         if (hasErrors && errorPolicy !== "ignore") {
           aqr.errors = graphQLErrors;
           aqr.networkStatus = NetworkStatus.error;
+          aqr.complete = !!aqr.data;
+          aqr.partial = !aqr.complete;
         }
 
         return aqr;

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1265,6 +1265,7 @@ export class QueryManager<TStore> {
           loading: false,
           networkStatus: NetworkStatus.ready,
           complete: true,
+          partial: false,
         };
 
         // In the case we start multiple network requests simulatenously, we
@@ -1662,6 +1663,7 @@ export class QueryManager<TStore> {
           loading: isNetworkRequestInFlight(networkStatus),
           networkStatus,
           complete: diff.complete,
+          partial: !diff.complete,
         };
 
         return Observable.of(result);

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1260,14 +1260,11 @@ export class QueryManager<TStore> {
           queryInfo.markReady();
         }
 
-        const complete = !!result.data;
-
         const aqr: ApolloQueryResult<TData> = {
           data: result.data,
           loading: false,
           networkStatus: NetworkStatus.ready,
-          complete,
-          partial: !complete,
+          partial: !result.data,
         };
 
         // In the case we start multiple network requests simulatenously, we
@@ -1664,7 +1661,6 @@ export class QueryManager<TStore> {
           data: data as TData | undefined,
           loading: isNetworkRequestInFlight(networkStatus),
           networkStatus,
-          complete: diff.complete,
           partial: !diff.complete,
         };
 

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -110,6 +110,8 @@ describe("ApolloClient", () => {
       loading: false,
       networkStatus: 8,
       errors: [{ message: "This is an error message." }],
+      complete: false,
+      partial: true,
     });
   });
 
@@ -176,6 +178,8 @@ describe("ApolloClient", () => {
       },
       networkStatus: NetworkStatus.ready,
       loading: false,
+      complete: true,
+      partial: false,
     });
   });
 
@@ -498,6 +502,8 @@ describe("ApolloClient", () => {
       fromRx: true,
       loading: false,
       networkStatus: 7,
+      complete: true,
+      partial: false,
       ...expResult,
     });
   });
@@ -566,11 +572,15 @@ describe("ApolloClient", () => {
       data: data1,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
     await expect(stream2).toEmitApolloQueryResult({
       data: data1,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     void observable.refetch();
@@ -579,11 +589,15 @@ describe("ApolloClient", () => {
       data: data2,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
     await expect(stream2).toEmitApolloQueryResult({
       data: data2,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     stream1.unsubscribe();
@@ -593,6 +607,8 @@ describe("ApolloClient", () => {
       data: data3,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
   });
 
@@ -687,16 +703,22 @@ describe("ApolloClient", () => {
       data: data1,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
     await expect(stream2).toEmitApolloQueryResult({
       data: data2,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
     await expect(stream3).toEmitApolloQueryResult({
       data: data3,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
   });
 
@@ -741,12 +763,16 @@ describe("ApolloClient", () => {
       data: data1,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
     void observable.refetch();
     await expect(stream).toEmitApolloQueryResult({
       data: data2,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
   });
 
@@ -908,6 +934,8 @@ describe("ApolloClient", () => {
       data: data1,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     void observable.refetch();
@@ -916,11 +944,15 @@ describe("ApolloClient", () => {
       data: data1,
       loading: true,
       networkStatus: NetworkStatus.refetch,
+      complete: true,
+      partial: false,
     });
     await expect(stream).toEmitApolloQueryResult({
       data: data2,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
   });
 
@@ -961,6 +993,8 @@ describe("ApolloClient", () => {
       data: data1,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     const result = await observable.refetch();
@@ -969,6 +1003,8 @@ describe("ApolloClient", () => {
       data: data2,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
   });
 
@@ -1045,6 +1081,8 @@ describe("ApolloClient", () => {
       data: data1,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     void observable.refetch();
@@ -1053,6 +1091,8 @@ describe("ApolloClient", () => {
       data: data2,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     void observable.refetch(variables1);
@@ -1061,6 +1101,8 @@ describe("ApolloClient", () => {
       data: data3,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     void observable.refetch(variables2);
@@ -1069,6 +1111,8 @@ describe("ApolloClient", () => {
       data: data4,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
   });
 
@@ -1118,6 +1162,8 @@ describe("ApolloClient", () => {
       data: data1,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     void observable.refetch();
@@ -1126,6 +1172,8 @@ describe("ApolloClient", () => {
       data: data2,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     const updatedOptions = { ...observable.options };
@@ -1190,6 +1238,8 @@ describe("ApolloClient", () => {
       data: data1,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     void observable.refetch();
@@ -1198,6 +1248,8 @@ describe("ApolloClient", () => {
       data: data2,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     await expect(stream).toEmitApolloQueryResult(
@@ -1205,6 +1257,8 @@ describe("ApolloClient", () => {
         data: data3,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       },
       { timeout: 250 }
     );
@@ -1268,12 +1322,16 @@ describe("ApolloClient", () => {
       data: data1,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     await expect(stream).toEmitApolloQueryResult({
       data: data1,
       loading: true,
       networkStatus: NetworkStatus.poll,
+      complete: true,
+      partial: false,
     });
 
     stream.unsubscribe();
@@ -1299,6 +1357,8 @@ describe("ApolloClient", () => {
       data,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
     expect(observable.getCurrentResult().data).toEqual(data);
   });
@@ -1346,10 +1406,14 @@ describe("ApolloClient", () => {
 
     const stream = new ObservableStream(observable);
 
+    // TODO: We should not emit a partial result for cache-only unless
+    // returnPartialData is `true`
     await expect(stream).toEmitApolloQueryResult({
       data: { luke: { name: "Luke Skywalker" } },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: false,
+      partial: true,
     });
   });
 
@@ -1624,11 +1688,15 @@ describe("ApolloClient", () => {
       data: data1,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
     await expect(stream2).toEmitApolloQueryResult({
       data: data2,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
   });
 
@@ -1697,6 +1765,8 @@ describe("ApolloClient", () => {
       data: data1,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     await client.query({ query: query2 });
@@ -1712,6 +1782,8 @@ describe("ApolloClient", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     await expect(stream).not.toEmitAnything();
@@ -1786,6 +1858,8 @@ describe("ApolloClient", () => {
       data: transformedQueryResult,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
   });
 
@@ -1905,6 +1979,8 @@ describe("ApolloClient", () => {
       data,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     await expect(
@@ -1951,6 +2027,8 @@ describe("ApolloClient", () => {
       data,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     stream.unsubscribe();
@@ -1998,6 +2076,8 @@ describe("ApolloClient", () => {
       data,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
     expect(client.cache.extract().ROOT_QUERY!.author).toEqual(data.author);
 
@@ -2041,12 +2121,16 @@ describe("ApolloClient", () => {
       data,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     await expect(client.query({ query })).resolves.toEqualApolloQueryResult({
       data,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     await expect(stream).not.toEmitAnything();
@@ -2133,11 +2217,15 @@ describe("ApolloClient", () => {
       data: data1,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
     await expect(stream2).toEmitApolloQueryResult({
       data: data2,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
   });
 
@@ -2215,17 +2303,21 @@ describe("ApolloClient", () => {
       loading: true,
       networkStatus: NetworkStatus.loading,
       complete: false,
+      partial: true,
     });
     await expect(stream2).toEmitApolloQueryResult({
       data: data2,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
     await expect(stream1).toEmitApolloQueryResult({
       data: data1,
       loading: false,
       networkStatus: NetworkStatus.ready,
       complete: true,
+      partial: false,
     });
   });
 
@@ -2293,6 +2385,7 @@ describe("ApolloClient", () => {
       networkStatus: NetworkStatus.loading,
       data: undefined,
       complete: false,
+      partial: true,
     });
 
     await expect(bStream).toEmitApolloQueryResult({
@@ -2300,6 +2393,7 @@ describe("ApolloClient", () => {
       networkStatus: NetworkStatus.loading,
       data: undefined,
       complete: false,
+      partial: true,
     });
 
     await expect(aStream).toEmitApolloQueryResult({
@@ -2311,6 +2405,7 @@ describe("ApolloClient", () => {
         },
       },
       complete: true,
+      partial: false,
     });
 
     await expect(bStream).toEmitApolloQueryResult({
@@ -2322,6 +2417,7 @@ describe("ApolloClient", () => {
         },
       },
       complete: true,
+      partial: false,
     });
 
     await expect(aStream).toEmitApolloQueryResult({
@@ -2331,6 +2427,7 @@ describe("ApolloClient", () => {
         info: {},
       },
       complete: false,
+      partial: true,
     });
 
     await expect(aStream).toEmitApolloQueryResult({
@@ -2342,6 +2439,7 @@ describe("ApolloClient", () => {
         },
       },
       complete: true,
+      partial: false,
     });
 
     await expect(aStream).not.toEmitAnything();
@@ -2392,6 +2490,7 @@ describe("ApolloClient", () => {
       networkStatus: NetworkStatus.loading,
       data: undefined,
       complete: false,
+      partial: true,
     });
 
     await expect(stream).toEmitApolloQueryResult({
@@ -2403,6 +2502,7 @@ describe("ApolloClient", () => {
         },
       },
       complete: true,
+      partial: false,
     });
 
     cache.evict({ fieldName: "info" });
@@ -2412,6 +2512,7 @@ describe("ApolloClient", () => {
       networkStatus: NetworkStatus.loading,
       data: undefined,
       complete: false,
+      partial: true,
     });
 
     await expect(stream).toEmitApolloQueryResult({
@@ -2423,6 +2524,7 @@ describe("ApolloClient", () => {
         },
       },
       complete: true,
+      partial: false,
     });
 
     cache.modify({
@@ -2438,6 +2540,7 @@ describe("ApolloClient", () => {
       networkStatus: NetworkStatus.loading,
       data: undefined,
       complete: false,
+      partial: true,
     });
 
     await expect(stream).toEmitApolloQueryResult({
@@ -2449,6 +2552,7 @@ describe("ApolloClient", () => {
         },
       },
       complete: true,
+      partial: false,
     });
 
     await expect(stream).not.toEmitAnything();
@@ -2556,11 +2660,15 @@ describe("ApolloClient", () => {
       data: dataWithoutId,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
     await expect(stream2).toEmitApolloQueryResult({
       data: dataWithId,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
   });
 
@@ -2600,6 +2708,8 @@ describe("ApolloClient", () => {
       data: firstResult.data,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     const expectedError = new ApolloError({
@@ -2666,11 +2776,15 @@ describe("ApolloClient", () => {
       data: dataA,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
     expect(observableB.getCurrentResult()).toEqualApolloQueryResult({
       data: undefined,
       loading: true,
       networkStatus: NetworkStatus.loading,
+      complete: false,
+      partial: true,
     });
 
     await expect(streamB).toEmitNext();
@@ -2678,11 +2792,15 @@ describe("ApolloClient", () => {
       data: dataA,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
     expect(observableB.getCurrentResult()).toEqualApolloQueryResult({
       data: dataB,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
   });
 
@@ -2804,11 +2922,15 @@ describe("ApolloClient", () => {
         data: data1,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       await expect(stream).toEmitApolloQueryResult({
         data: data2,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
     });
 
@@ -2868,6 +2990,8 @@ describe("ApolloClient", () => {
         data: data1,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       await expect(stream).not.toEmitAnything();
     });
@@ -3045,11 +3169,15 @@ describe("ApolloClient", () => {
         data: data1,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       await expect(stream).toEmitApolloQueryResult({
         data: data2,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       stream.unsubscribe();
@@ -3119,6 +3247,8 @@ describe("ApolloClient", () => {
         data: data1,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       await expect(stream).toEmitError(
         new ApolloError({ networkError: new Error("Network error") })
@@ -3181,11 +3311,15 @@ describe("ApolloClient", () => {
         data: data1,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       await expect(stream).toEmitApolloQueryResult({
         data: data2,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
     });
 
@@ -3238,6 +3372,8 @@ describe("ApolloClient", () => {
         data: data1,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       observable.stopPolling();
@@ -3295,6 +3431,8 @@ describe("ApolloClient", () => {
         data: data1,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       const result = await client.query({
@@ -3307,11 +3445,15 @@ describe("ApolloClient", () => {
         data: data2,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       await expect(stream).toEmitApolloQueryResult({
         data: data2,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
     });
   });
@@ -3396,11 +3538,15 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       await expect(stream2).toEmitApolloQueryResult({
         data: data2,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await client.resetStore();
@@ -3409,11 +3555,15 @@ describe("ApolloClient", () => {
         data: dataChanged,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(observable2.getCurrentResult()).toEqualApolloQueryResult({
         data: data2Changed,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
     });
 
@@ -3480,6 +3630,8 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(timesFired).toBe(1);
 
@@ -3491,6 +3643,8 @@ describe("ApolloClient", () => {
         data: data2,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(timesFired).toBe(2);
 
@@ -3533,6 +3687,8 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       stream.unsubscribe();
@@ -3589,6 +3745,8 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(timesFired).toBe(1);
 
@@ -3598,6 +3756,8 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(timesFired).toBe(2);
     });
@@ -3942,11 +4102,15 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       await expect(stream2).toEmitApolloQueryResult({
         data: data2,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await client.reFetchObservableQueries();
@@ -3955,11 +4119,15 @@ describe("ApolloClient", () => {
         data: dataChanged,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(observable2.getCurrentResult()).toEqualApolloQueryResult({
         data: data2Changed,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
     });
 
@@ -4011,6 +4179,8 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(timesFired).toBe(1);
 
@@ -4021,6 +4191,8 @@ describe("ApolloClient", () => {
         data: data2,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(timesFired).toBe(2);
     });
@@ -4062,6 +4234,8 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(timesFired).toBe(1);
 
@@ -4114,6 +4288,8 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(timesFired).toBe(1);
 
@@ -4123,6 +4299,8 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(timesFired).toBe(2);
 
@@ -4457,11 +4635,15 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       await expect(stream2).toEmitApolloQueryResult({
         data: data2,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await client.refetchQueries({
@@ -4472,11 +4654,15 @@ describe("ApolloClient", () => {
         data: dataChanged,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(observable2.getCurrentResult()).toEqualApolloQueryResult({
         data: data2Changed,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
     });
   });
@@ -4505,6 +4691,8 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
     });
 
@@ -4557,12 +4745,14 @@ describe("ApolloClient", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         complete: false,
+        partial: true,
       });
       await expect(stream).toEmitApolloQueryResult({
         data: fullData,
         loading: false,
         networkStatus: NetworkStatus.ready,
         complete: true,
+        partial: false,
       });
     });
 
@@ -4590,6 +4780,8 @@ describe("ApolloClient", () => {
         data: { author: { firstName: "John", lastName: "Smith" } },
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
     });
 
@@ -4635,19 +4827,23 @@ describe("ApolloClient", () => {
         })
       );
 
-      await expect(stream).toEmitValue({
+      await expect(stream).toEmitApolloQueryResult({
         data: data1,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await wait(0);
       void client.resetStore();
 
-      await expect(stream).toEmitValue({
+      await expect(stream).toEmitApolloQueryResult({
         data: data2,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await expect(stream).not.toEmitAnything();
@@ -4704,6 +4900,8 @@ describe("ApolloClient", () => {
         data: data1,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       const observable = client.watchQuery({
@@ -4717,12 +4915,14 @@ describe("ApolloClient", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         complete: false,
+        partial: true,
       });
       await expect(stream).toEmitApolloQueryResult({
         data: data2,
         loading: false,
         networkStatus: NetworkStatus.ready,
         complete: true,
+        partial: false,
       });
 
       await expect(stream).not.toEmitAnything();
@@ -4802,6 +5002,8 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       void client.mutate({ mutation, refetchQueries: ["getAuthors"] });
@@ -4810,11 +5012,15 @@ describe("ApolloClient", () => {
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
     });
 
@@ -4880,6 +5086,8 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       void client.mutate({
@@ -4891,6 +5099,8 @@ describe("ApolloClient", () => {
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(consoleWarnSpy).toHaveBeenLastCalledWith(
         'Unknown query named "%s" requested in refetchQueries options.include array',
@@ -4958,6 +5168,8 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       stream.unsubscribe();
@@ -5032,6 +5244,8 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       stream.unsubscribe();
 
@@ -5107,6 +5321,8 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       stream.unsubscribe();
 
@@ -5186,6 +5402,8 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await client.mutate({
@@ -5199,6 +5417,8 @@ describe("ApolloClient", () => {
           data: secondReqData,
           loading: false,
           networkStatus: NetworkStatus.ready,
+          complete: true,
+          partial: false,
         },
         { timeout: 150 }
       );
@@ -5206,6 +5426,8 @@ describe("ApolloClient", () => {
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await expect(stream).not.toEmitAnything();
@@ -5276,6 +5498,8 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await client.mutate({
@@ -5289,6 +5513,8 @@ describe("ApolloClient", () => {
           data: secondReqData,
           loading: false,
           networkStatus: NetworkStatus.ready,
+          complete: true,
+          partial: false,
         },
         { timeout: 150 }
       );
@@ -5296,6 +5522,8 @@ describe("ApolloClient", () => {
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await expect(stream).not.toEmitAnything();
@@ -5366,6 +5594,8 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await client.mutate({
@@ -5380,6 +5610,8 @@ describe("ApolloClient", () => {
           data: secondReqData,
           loading: false,
           networkStatus: NetworkStatus.ready,
+          complete: true,
+          partial: false,
         },
         { timeout: 150 }
       );
@@ -5387,6 +5619,8 @@ describe("ApolloClient", () => {
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await expect(stream).not.toEmitAnything();
@@ -5451,6 +5685,8 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       const conditional = jest.fn(() => []);
@@ -5521,6 +5757,8 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       const conditional = jest.fn(() => [{ query }]);
@@ -5535,6 +5773,8 @@ describe("ApolloClient", () => {
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
     });
 
@@ -5785,6 +6025,8 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await client.mutate({
@@ -5817,11 +6059,15 @@ describe("ApolloClient", () => {
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
     });
 
@@ -5846,6 +6092,8 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       void client.mutate({
@@ -5871,6 +6119,8 @@ describe("ApolloClient", () => {
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       const context = (client.link as MockApolloLink).operation!.getContext();
@@ -5896,6 +6146,8 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       void client.mutate({
@@ -5921,6 +6173,8 @@ describe("ApolloClient", () => {
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       const context = (client.link as MockApolloLink).operation!.getContext();
@@ -6002,6 +6256,8 @@ describe("ApolloClient", () => {
         data: queryData,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       void client
@@ -6018,11 +6274,15 @@ describe("ApolloClient", () => {
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(mutationComplete).toBe(true);
     });
@@ -6099,6 +6359,8 @@ describe("ApolloClient", () => {
         data: queryData,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       void client
@@ -6111,11 +6373,15 @@ describe("ApolloClient", () => {
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(mutationComplete).toBe(true);
     });
@@ -6192,6 +6458,8 @@ describe("ApolloClient", () => {
         data: queryData,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       void client
@@ -6208,11 +6476,15 @@ describe("ApolloClient", () => {
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(mutationComplete).toBe(false);
     });
@@ -6291,6 +6563,8 @@ describe("ApolloClient", () => {
         data: queryData,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       void client
@@ -6392,12 +6666,16 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
     });
   });
@@ -6595,6 +6873,8 @@ describe("ApolloClient", () => {
         data: data1,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       stream1.unsubscribe();
@@ -6605,6 +6885,8 @@ describe("ApolloClient", () => {
         data: data1,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: false,
+        partial: true,
       });
       expect(spy).toHaveBeenCalledTimes(1);
     });
@@ -6665,6 +6947,8 @@ describe("ApolloClient", () => {
         data: data1,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       stream1.unsubscribe();
@@ -6676,6 +6960,7 @@ describe("ApolloClient", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         complete: false,
+        partial: true,
       });
       expect(spy).toHaveBeenCalledTimes(0);
     });

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -1346,13 +1346,10 @@ describe("ApolloClient", () => {
 
     const stream = new ObservableStream(observable);
 
-    // TODO: We should only return partial data when returnPartialData is true
-    // for cache-only queries, otherwise return `undefined`. Update for v4.
     await expect(stream).toEmitApolloQueryResult({
       data: { luke: { name: "Luke Skywalker" } },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      partial: true,
     });
   });
 
@@ -2217,7 +2214,7 @@ describe("ApolloClient", () => {
       data: undefined,
       loading: true,
       networkStatus: NetworkStatus.loading,
-      partial: true,
+      complete: false,
     });
     await expect(stream2).toEmitApolloQueryResult({
       data: data2,
@@ -2228,6 +2225,7 @@ describe("ApolloClient", () => {
       data: data1,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
     });
   });
 
@@ -2294,14 +2292,14 @@ describe("ApolloClient", () => {
       loading: true,
       networkStatus: NetworkStatus.loading,
       data: undefined,
-      partial: true,
+      complete: false,
     });
 
     await expect(bStream).toEmitApolloQueryResult({
       loading: true,
       networkStatus: NetworkStatus.loading,
       data: undefined,
-      partial: true,
+      complete: false,
     });
 
     await expect(aStream).toEmitApolloQueryResult({
@@ -2312,6 +2310,7 @@ describe("ApolloClient", () => {
           a: "ay",
         },
       },
+      complete: true,
     });
 
     await expect(bStream).toEmitApolloQueryResult({
@@ -2322,6 +2321,7 @@ describe("ApolloClient", () => {
           b: "bee",
         },
       },
+      complete: true,
     });
 
     await expect(aStream).toEmitApolloQueryResult({
@@ -2330,7 +2330,7 @@ describe("ApolloClient", () => {
       data: {
         info: {},
       },
-      partial: true,
+      complete: false,
     });
 
     await expect(aStream).toEmitApolloQueryResult({
@@ -2341,6 +2341,7 @@ describe("ApolloClient", () => {
           a: "ay",
         },
       },
+      complete: true,
     });
 
     await expect(aStream).not.toEmitAnything();
@@ -2390,7 +2391,7 @@ describe("ApolloClient", () => {
       loading: true,
       networkStatus: NetworkStatus.loading,
       data: undefined,
-      partial: true,
+      complete: false,
     });
 
     await expect(stream).toEmitApolloQueryResult({
@@ -2401,6 +2402,7 @@ describe("ApolloClient", () => {
           c: "see",
         },
       },
+      complete: true,
     });
 
     cache.evict({ fieldName: "info" });
@@ -2409,7 +2411,7 @@ describe("ApolloClient", () => {
       loading: true,
       networkStatus: NetworkStatus.loading,
       data: undefined,
-      partial: true,
+      complete: false,
     });
 
     await expect(stream).toEmitApolloQueryResult({
@@ -2420,6 +2422,7 @@ describe("ApolloClient", () => {
           c: "see",
         },
       },
+      complete: true,
     });
 
     cache.modify({
@@ -2434,7 +2437,7 @@ describe("ApolloClient", () => {
       loading: true,
       networkStatus: NetworkStatus.loading,
       data: undefined,
-      partial: true,
+      complete: false,
     });
 
     await expect(stream).toEmitApolloQueryResult({
@@ -2445,6 +2448,7 @@ describe("ApolloClient", () => {
           c: "see",
         },
       },
+      complete: true,
     });
 
     await expect(stream).not.toEmitAnything();
@@ -2663,13 +2667,10 @@ describe("ApolloClient", () => {
       loading: false,
       networkStatus: NetworkStatus.ready,
     });
-    // @ts-ignore ApolloQueryResult expects `data` key to be available, but the
-    // runtime behavior does not provide it. This test fails by including a
-    // check for the data key.
     expect(observableB.getCurrentResult()).toEqualApolloQueryResult({
+      data: undefined,
       loading: true,
       networkStatus: NetworkStatus.loading,
-      partial: true,
     });
 
     await expect(streamB).toEmitNext();
@@ -4555,12 +4556,13 @@ describe("ApolloClient", () => {
         data: primeData,
         loading: true,
         networkStatus: NetworkStatus.loading,
-        partial: true,
+        complete: false,
       });
       await expect(stream).toEmitApolloQueryResult({
         data: fullData,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
       });
     });
 
@@ -4714,12 +4716,13 @@ describe("ApolloClient", () => {
         data: data1,
         loading: true,
         networkStatus: NetworkStatus.loading,
-        partial: true,
+        complete: false,
       });
       await expect(stream).toEmitApolloQueryResult({
         data: data2,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
       });
 
       await expect(stream).not.toEmitAnything();

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -110,7 +110,6 @@ describe("ApolloClient", () => {
       loading: false,
       networkStatus: 8,
       errors: [{ message: "This is an error message." }],
-      complete: false,
       partial: true,
     });
   });
@@ -178,7 +177,6 @@ describe("ApolloClient", () => {
       },
       networkStatus: NetworkStatus.ready,
       loading: false,
-      complete: true,
       partial: false,
     });
   });
@@ -502,7 +500,6 @@ describe("ApolloClient", () => {
       fromRx: true,
       loading: false,
       networkStatus: 7,
-      complete: true,
       partial: false,
       ...expResult,
     });
@@ -572,14 +569,12 @@ describe("ApolloClient", () => {
       data: data1,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
     await expect(stream2).toEmitApolloQueryResult({
       data: data1,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -589,14 +584,12 @@ describe("ApolloClient", () => {
       data: data2,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
     await expect(stream2).toEmitApolloQueryResult({
       data: data2,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -607,7 +600,6 @@ describe("ApolloClient", () => {
       data: data3,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
   });
@@ -703,21 +695,18 @@ describe("ApolloClient", () => {
       data: data1,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
     await expect(stream2).toEmitApolloQueryResult({
       data: data2,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
     await expect(stream3).toEmitApolloQueryResult({
       data: data3,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
   });
@@ -763,7 +752,6 @@ describe("ApolloClient", () => {
       data: data1,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
     void observable.refetch();
@@ -771,7 +759,6 @@ describe("ApolloClient", () => {
       data: data2,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
   });
@@ -934,7 +921,6 @@ describe("ApolloClient", () => {
       data: data1,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -944,14 +930,12 @@ describe("ApolloClient", () => {
       data: data1,
       loading: true,
       networkStatus: NetworkStatus.refetch,
-      complete: true,
       partial: false,
     });
     await expect(stream).toEmitApolloQueryResult({
       data: data2,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
   });
@@ -993,7 +977,6 @@ describe("ApolloClient", () => {
       data: data1,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -1003,7 +986,6 @@ describe("ApolloClient", () => {
       data: data2,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
   });
@@ -1081,7 +1063,6 @@ describe("ApolloClient", () => {
       data: data1,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -1091,7 +1072,6 @@ describe("ApolloClient", () => {
       data: data2,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -1101,7 +1081,6 @@ describe("ApolloClient", () => {
       data: data3,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -1111,7 +1090,6 @@ describe("ApolloClient", () => {
       data: data4,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
   });
@@ -1162,7 +1140,6 @@ describe("ApolloClient", () => {
       data: data1,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -1172,7 +1149,6 @@ describe("ApolloClient", () => {
       data: data2,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -1238,7 +1214,6 @@ describe("ApolloClient", () => {
       data: data1,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -1248,7 +1223,6 @@ describe("ApolloClient", () => {
       data: data2,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -1257,7 +1231,6 @@ describe("ApolloClient", () => {
         data: data3,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       },
       { timeout: 250 }
@@ -1322,7 +1295,6 @@ describe("ApolloClient", () => {
       data: data1,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -1330,7 +1302,6 @@ describe("ApolloClient", () => {
       data: data1,
       loading: true,
       networkStatus: NetworkStatus.poll,
-      complete: true,
       partial: false,
     });
 
@@ -1357,7 +1328,6 @@ describe("ApolloClient", () => {
       data,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
     expect(observable.getCurrentResult().data).toEqual(data);
@@ -1412,7 +1382,6 @@ describe("ApolloClient", () => {
       data: { luke: { name: "Luke Skywalker" } },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: false,
       partial: true,
     });
   });
@@ -1688,14 +1657,12 @@ describe("ApolloClient", () => {
       data: data1,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
     await expect(stream2).toEmitApolloQueryResult({
       data: data2,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
   });
@@ -1765,7 +1732,6 @@ describe("ApolloClient", () => {
       data: data1,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -1782,7 +1748,6 @@ describe("ApolloClient", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -1858,7 +1823,6 @@ describe("ApolloClient", () => {
       data: transformedQueryResult,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
   });
@@ -1979,7 +1943,6 @@ describe("ApolloClient", () => {
       data,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -2027,7 +1990,6 @@ describe("ApolloClient", () => {
       data,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -2076,7 +2038,6 @@ describe("ApolloClient", () => {
       data,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
     expect(client.cache.extract().ROOT_QUERY!.author).toEqual(data.author);
@@ -2121,7 +2082,6 @@ describe("ApolloClient", () => {
       data,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -2129,7 +2089,6 @@ describe("ApolloClient", () => {
       data,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -2217,14 +2176,12 @@ describe("ApolloClient", () => {
       data: data1,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
     await expect(stream2).toEmitApolloQueryResult({
       data: data2,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
   });
@@ -2302,21 +2259,18 @@ describe("ApolloClient", () => {
       data: undefined,
       loading: true,
       networkStatus: NetworkStatus.loading,
-      complete: false,
       partial: true,
     });
     await expect(stream2).toEmitApolloQueryResult({
       data: data2,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
     await expect(stream1).toEmitApolloQueryResult({
       data: data1,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
   });
@@ -2384,7 +2338,6 @@ describe("ApolloClient", () => {
       loading: true,
       networkStatus: NetworkStatus.loading,
       data: undefined,
-      complete: false,
       partial: true,
     });
 
@@ -2392,7 +2345,6 @@ describe("ApolloClient", () => {
       loading: true,
       networkStatus: NetworkStatus.loading,
       data: undefined,
-      complete: false,
       partial: true,
     });
 
@@ -2404,7 +2356,6 @@ describe("ApolloClient", () => {
           a: "ay",
         },
       },
-      complete: true,
       partial: false,
     });
 
@@ -2416,7 +2367,6 @@ describe("ApolloClient", () => {
           b: "bee",
         },
       },
-      complete: true,
       partial: false,
     });
 
@@ -2426,7 +2376,6 @@ describe("ApolloClient", () => {
       data: {
         info: {},
       },
-      complete: false,
       partial: true,
     });
 
@@ -2438,7 +2387,6 @@ describe("ApolloClient", () => {
           a: "ay",
         },
       },
-      complete: true,
       partial: false,
     });
 
@@ -2489,7 +2437,6 @@ describe("ApolloClient", () => {
       loading: true,
       networkStatus: NetworkStatus.loading,
       data: undefined,
-      complete: false,
       partial: true,
     });
 
@@ -2501,7 +2448,6 @@ describe("ApolloClient", () => {
           c: "see",
         },
       },
-      complete: true,
       partial: false,
     });
 
@@ -2511,7 +2457,6 @@ describe("ApolloClient", () => {
       loading: true,
       networkStatus: NetworkStatus.loading,
       data: undefined,
-      complete: false,
       partial: true,
     });
 
@@ -2523,7 +2468,6 @@ describe("ApolloClient", () => {
           c: "see",
         },
       },
-      complete: true,
       partial: false,
     });
 
@@ -2539,7 +2483,6 @@ describe("ApolloClient", () => {
       loading: true,
       networkStatus: NetworkStatus.loading,
       data: undefined,
-      complete: false,
       partial: true,
     });
 
@@ -2551,7 +2494,6 @@ describe("ApolloClient", () => {
           c: "see",
         },
       },
-      complete: true,
       partial: false,
     });
 
@@ -2660,14 +2602,12 @@ describe("ApolloClient", () => {
       data: dataWithoutId,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
     await expect(stream2).toEmitApolloQueryResult({
       data: dataWithId,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
   });
@@ -2708,7 +2648,6 @@ describe("ApolloClient", () => {
       data: firstResult.data,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -2776,14 +2715,12 @@ describe("ApolloClient", () => {
       data: dataA,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
     expect(observableB.getCurrentResult()).toEqualApolloQueryResult({
       data: undefined,
       loading: true,
       networkStatus: NetworkStatus.loading,
-      complete: false,
       partial: true,
     });
 
@@ -2792,14 +2729,12 @@ describe("ApolloClient", () => {
       data: dataA,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
     expect(observableB.getCurrentResult()).toEqualApolloQueryResult({
       data: dataB,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
   });
@@ -2922,14 +2857,12 @@ describe("ApolloClient", () => {
         data: data1,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       await expect(stream).toEmitApolloQueryResult({
         data: data2,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
     });
@@ -2990,7 +2923,6 @@ describe("ApolloClient", () => {
         data: data1,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       await expect(stream).not.toEmitAnything();
@@ -3169,14 +3101,12 @@ describe("ApolloClient", () => {
         data: data1,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       await expect(stream).toEmitApolloQueryResult({
         data: data2,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -3247,7 +3177,6 @@ describe("ApolloClient", () => {
         data: data1,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       await expect(stream).toEmitError(
@@ -3311,14 +3240,12 @@ describe("ApolloClient", () => {
         data: data1,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       await expect(stream).toEmitApolloQueryResult({
         data: data2,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
     });
@@ -3372,7 +3299,6 @@ describe("ApolloClient", () => {
         data: data1,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -3431,7 +3357,6 @@ describe("ApolloClient", () => {
         data: data1,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -3445,14 +3370,12 @@ describe("ApolloClient", () => {
         data: data2,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       await expect(stream).toEmitApolloQueryResult({
         data: data2,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
     });
@@ -3538,14 +3461,12 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       await expect(stream2).toEmitApolloQueryResult({
         data: data2,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -3555,14 +3476,12 @@ describe("ApolloClient", () => {
         data: dataChanged,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(observable2.getCurrentResult()).toEqualApolloQueryResult({
         data: data2Changed,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
     });
@@ -3630,7 +3549,6 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(timesFired).toBe(1);
@@ -3643,7 +3561,6 @@ describe("ApolloClient", () => {
         data: data2,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(timesFired).toBe(2);
@@ -3687,7 +3604,6 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -3745,7 +3661,6 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(timesFired).toBe(1);
@@ -3756,7 +3671,6 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(timesFired).toBe(2);
@@ -4102,14 +4016,12 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       await expect(stream2).toEmitApolloQueryResult({
         data: data2,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -4119,14 +4031,12 @@ describe("ApolloClient", () => {
         data: dataChanged,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(observable2.getCurrentResult()).toEqualApolloQueryResult({
         data: data2Changed,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
     });
@@ -4179,7 +4089,6 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(timesFired).toBe(1);
@@ -4191,7 +4100,6 @@ describe("ApolloClient", () => {
         data: data2,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(timesFired).toBe(2);
@@ -4234,7 +4142,6 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(timesFired).toBe(1);
@@ -4288,7 +4195,6 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(timesFired).toBe(1);
@@ -4299,7 +4205,6 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(timesFired).toBe(2);
@@ -4635,14 +4540,12 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       await expect(stream2).toEmitApolloQueryResult({
         data: data2,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -4654,14 +4557,12 @@ describe("ApolloClient", () => {
         data: dataChanged,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(observable2.getCurrentResult()).toEqualApolloQueryResult({
         data: data2Changed,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
     });
@@ -4691,7 +4592,6 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
     });
@@ -4744,14 +4644,12 @@ describe("ApolloClient", () => {
         data: primeData,
         loading: true,
         networkStatus: NetworkStatus.loading,
-        complete: false,
         partial: true,
       });
       await expect(stream).toEmitApolloQueryResult({
         data: fullData,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
     });
@@ -4780,7 +4678,6 @@ describe("ApolloClient", () => {
         data: { author: { firstName: "John", lastName: "Smith" } },
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
     });
@@ -4831,7 +4728,6 @@ describe("ApolloClient", () => {
         data: data1,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -4842,7 +4738,6 @@ describe("ApolloClient", () => {
         data: data2,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -4900,7 +4795,6 @@ describe("ApolloClient", () => {
         data: data1,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -4914,14 +4808,12 @@ describe("ApolloClient", () => {
         data: data1,
         loading: true,
         networkStatus: NetworkStatus.loading,
-        complete: false,
         partial: true,
       });
       await expect(stream).toEmitApolloQueryResult({
         data: data2,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -5002,7 +4894,6 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -5012,14 +4903,12 @@ describe("ApolloClient", () => {
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
     });
@@ -5086,7 +4975,6 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -5099,7 +4987,6 @@ describe("ApolloClient", () => {
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(consoleWarnSpy).toHaveBeenLastCalledWith(
@@ -5168,7 +5055,6 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -5244,7 +5130,6 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       stream.unsubscribe();
@@ -5321,7 +5206,6 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       stream.unsubscribe();
@@ -5402,7 +5286,6 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -5417,7 +5300,6 @@ describe("ApolloClient", () => {
           data: secondReqData,
           loading: false,
           networkStatus: NetworkStatus.ready,
-          complete: true,
           partial: false,
         },
         { timeout: 150 }
@@ -5426,7 +5308,6 @@ describe("ApolloClient", () => {
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -5498,7 +5379,6 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -5513,7 +5393,6 @@ describe("ApolloClient", () => {
           data: secondReqData,
           loading: false,
           networkStatus: NetworkStatus.ready,
-          complete: true,
           partial: false,
         },
         { timeout: 150 }
@@ -5522,7 +5401,6 @@ describe("ApolloClient", () => {
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -5594,7 +5472,6 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -5610,7 +5487,6 @@ describe("ApolloClient", () => {
           data: secondReqData,
           loading: false,
           networkStatus: NetworkStatus.ready,
-          complete: true,
           partial: false,
         },
         { timeout: 150 }
@@ -5619,7 +5495,6 @@ describe("ApolloClient", () => {
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -5685,7 +5560,6 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -5757,7 +5631,6 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -5773,7 +5646,6 @@ describe("ApolloClient", () => {
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
     });
@@ -6025,7 +5897,6 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -6059,14 +5930,12 @@ describe("ApolloClient", () => {
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
     });
@@ -6092,7 +5961,6 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -6119,7 +5987,6 @@ describe("ApolloClient", () => {
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -6146,7 +6013,6 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -6173,7 +6039,6 @@ describe("ApolloClient", () => {
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -6256,7 +6121,6 @@ describe("ApolloClient", () => {
         data: queryData,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -6274,14 +6138,12 @@ describe("ApolloClient", () => {
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(mutationComplete).toBe(true);
@@ -6359,7 +6221,6 @@ describe("ApolloClient", () => {
         data: queryData,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -6373,14 +6234,12 @@ describe("ApolloClient", () => {
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(mutationComplete).toBe(true);
@@ -6458,7 +6317,6 @@ describe("ApolloClient", () => {
         data: queryData,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -6476,14 +6334,12 @@ describe("ApolloClient", () => {
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(mutationComplete).toBe(false);
@@ -6563,7 +6419,6 @@ describe("ApolloClient", () => {
         data: queryData,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -6666,7 +6521,6 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -6674,7 +6528,6 @@ describe("ApolloClient", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
     });
@@ -6873,7 +6726,6 @@ describe("ApolloClient", () => {
         data: data1,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -6885,7 +6737,6 @@ describe("ApolloClient", () => {
         data: data1,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: false,
         partial: true,
       });
       expect(spy).toHaveBeenCalledTimes(1);
@@ -6947,7 +6798,6 @@ describe("ApolloClient", () => {
         data: data1,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -6959,7 +6809,6 @@ describe("ApolloClient", () => {
         data: data1,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: false,
         partial: true,
       });
       expect(spy).toHaveBeenCalledTimes(0);

--- a/src/core/__tests__/ApolloClient/multiple-results.test.ts
+++ b/src/core/__tests__/ApolloClient/multiple-results.test.ts
@@ -52,6 +52,8 @@ describe("mutiple results", () => {
       data: initialData,
       loading: false,
       networkStatus: 7,
+      complete: true,
+      partial: false,
     });
 
     link.simulateResult({ result: { data: laterData } });
@@ -60,6 +62,8 @@ describe("mutiple results", () => {
       data: laterData,
       loading: false,
       networkStatus: 7,
+      complete: true,
+      partial: false,
     });
   });
 
@@ -109,6 +113,8 @@ describe("mutiple results", () => {
       data: initialData,
       loading: false,
       networkStatus: 7,
+      complete: true,
+      partial: false,
     });
 
     link.simulateResult({
@@ -119,6 +125,8 @@ describe("mutiple results", () => {
       data: undefined,
       loading: false,
       networkStatus: 7,
+      complete: false,
+      partial: true,
     });
 
     await wait(20);
@@ -128,6 +136,8 @@ describe("mutiple results", () => {
       data: laterData,
       loading: false,
       networkStatus: 7,
+      complete: true,
+      partial: false,
     });
   });
 
@@ -177,6 +187,8 @@ describe("mutiple results", () => {
       data: initialData,
       loading: false,
       networkStatus: 7,
+      complete: true,
+      partial: false,
     });
 
     // this should fire the `next` event without this error
@@ -191,6 +203,8 @@ describe("mutiple results", () => {
       data: laterData,
       loading: false,
       networkStatus: 7,
+      complete: true,
+      partial: false,
     });
   });
 
@@ -240,6 +254,8 @@ describe("mutiple results", () => {
       data: initialData,
       loading: false,
       networkStatus: 7,
+      complete: true,
+      partial: false,
     });
 
     // this should fire the next event again
@@ -252,6 +268,8 @@ describe("mutiple results", () => {
       loading: false,
       networkStatus: 7,
       errors: [new Error("defer failed")],
+      complete: true,
+      partial: false,
     });
 
     link.simulateResult({ result: { data: laterData } });
@@ -260,6 +278,8 @@ describe("mutiple results", () => {
       data: laterData,
       loading: false,
       networkStatus: 7,
+      complete: true,
+      partial: false,
     });
   });
 
@@ -320,6 +340,8 @@ describe("mutiple results", () => {
       data: initialData,
       loading: false,
       networkStatus: 7,
+      complete: true,
+      partial: false,
     });
 
     link.simulateResult({ error: new Error("defer failed") });

--- a/src/core/__tests__/ApolloClient/multiple-results.test.ts
+++ b/src/core/__tests__/ApolloClient/multiple-results.test.ts
@@ -52,7 +52,6 @@ describe("mutiple results", () => {
       data: initialData,
       loading: false,
       networkStatus: 7,
-      complete: true,
       partial: false,
     });
 
@@ -62,7 +61,6 @@ describe("mutiple results", () => {
       data: laterData,
       loading: false,
       networkStatus: 7,
-      complete: true,
       partial: false,
     });
   });
@@ -113,7 +111,6 @@ describe("mutiple results", () => {
       data: initialData,
       loading: false,
       networkStatus: 7,
-      complete: true,
       partial: false,
     });
 
@@ -125,7 +122,6 @@ describe("mutiple results", () => {
       data: undefined,
       loading: false,
       networkStatus: 7,
-      complete: false,
       partial: true,
     });
 
@@ -136,7 +132,6 @@ describe("mutiple results", () => {
       data: laterData,
       loading: false,
       networkStatus: 7,
-      complete: true,
       partial: false,
     });
   });
@@ -187,7 +182,6 @@ describe("mutiple results", () => {
       data: initialData,
       loading: false,
       networkStatus: 7,
-      complete: true,
       partial: false,
     });
 
@@ -203,7 +197,6 @@ describe("mutiple results", () => {
       data: laterData,
       loading: false,
       networkStatus: 7,
-      complete: true,
       partial: false,
     });
   });
@@ -254,7 +247,6 @@ describe("mutiple results", () => {
       data: initialData,
       loading: false,
       networkStatus: 7,
-      complete: true,
       partial: false,
     });
 
@@ -268,7 +260,6 @@ describe("mutiple results", () => {
       loading: false,
       networkStatus: 7,
       errors: [new Error("defer failed")],
-      complete: true,
       partial: false,
     });
 
@@ -278,7 +269,6 @@ describe("mutiple results", () => {
       data: laterData,
       loading: false,
       networkStatus: 7,
-      complete: true,
       partial: false,
     });
   });
@@ -340,7 +330,6 @@ describe("mutiple results", () => {
       data: initialData,
       loading: false,
       networkStatus: 7,
-      complete: true,
       partial: false,
     });
 

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -118,7 +118,6 @@ describe("ObservableQuery", () => {
           data: dataOne,
           loading: false,
           networkStatus: NetworkStatus.ready,
-          complete: true,
           partial: false,
         });
 
@@ -128,7 +127,6 @@ describe("ObservableQuery", () => {
           data: dataTwo,
           loading: false,
           networkStatus: NetworkStatus.ready,
-          complete: true,
           partial: false,
         });
 
@@ -168,7 +166,6 @@ describe("ObservableQuery", () => {
           data: dataOne,
           loading: false,
           networkStatus: NetworkStatus.ready,
-          complete: true,
           partial: false,
         });
 
@@ -209,7 +206,6 @@ describe("ObservableQuery", () => {
           data: dataOne,
           loading: false,
           networkStatus: NetworkStatus.ready,
-          complete: true,
           partial: false,
         });
 
@@ -219,7 +215,6 @@ describe("ObservableQuery", () => {
           data: dataTwo,
           loading: false,
           networkStatus: NetworkStatus.ready,
-          complete: true,
           partial: false,
         });
 
@@ -279,7 +274,6 @@ describe("ObservableQuery", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -289,7 +283,6 @@ describe("ObservableQuery", () => {
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
-        complete: false,
         partial: true,
       });
 
@@ -297,7 +290,6 @@ describe("ObservableQuery", () => {
         data: data2,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -353,7 +345,6 @@ describe("ObservableQuery", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -363,7 +354,6 @@ describe("ObservableQuery", () => {
         data,
         loading: true,
         networkStatus: NetworkStatus.refetch,
-        complete: true,
         partial: false,
       });
 
@@ -371,7 +361,6 @@ describe("ObservableQuery", () => {
         data: data2,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -416,7 +405,6 @@ describe("ObservableQuery", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -429,7 +417,6 @@ describe("ObservableQuery", () => {
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
-        complete: false,
         partial: true,
       });
 
@@ -437,7 +424,6 @@ describe("ObservableQuery", () => {
         data: data2,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -447,7 +433,6 @@ describe("ObservableQuery", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -455,7 +440,6 @@ describe("ObservableQuery", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -487,7 +471,6 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -503,7 +486,6 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -532,7 +514,6 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -542,7 +523,6 @@ describe("ObservableQuery", () => {
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -590,7 +570,6 @@ describe("ObservableQuery", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -603,7 +582,6 @@ describe("ObservableQuery", () => {
         data: undefined,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: false,
         partial: true,
       });
 
@@ -656,7 +634,6 @@ describe("ObservableQuery", () => {
         data: undefined,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: false,
         partial: true,
       });
       expect(timesFired).toBe(0);
@@ -667,7 +644,6 @@ describe("ObservableQuery", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(timesFired).toBe(1);
@@ -717,7 +693,6 @@ describe("ObservableQuery", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(timesFired).toBe(1);
@@ -775,7 +750,6 @@ describe("ObservableQuery", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -809,7 +783,6 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -821,7 +794,6 @@ describe("ObservableQuery", () => {
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -829,7 +801,6 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: true,
         networkStatus: NetworkStatus.loading,
-        complete: true,
         partial: false,
       });
 
@@ -837,7 +808,6 @@ describe("ObservableQuery", () => {
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -873,7 +843,6 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -883,7 +852,6 @@ describe("ObservableQuery", () => {
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
-        complete: false,
         partial: true,
       });
 
@@ -891,7 +859,6 @@ describe("ObservableQuery", () => {
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -920,14 +887,12 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -937,14 +902,12 @@ describe("ObservableQuery", () => {
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -1007,14 +970,12 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -1024,14 +985,12 @@ describe("ObservableQuery", () => {
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -1066,7 +1025,6 @@ describe("ObservableQuery", () => {
         errors: [error],
         loading: false,
         networkStatus: NetworkStatus.error,
-        complete: false,
         partial: true,
       });
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
@@ -1074,7 +1032,6 @@ describe("ObservableQuery", () => {
         errors: [error],
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: false,
         partial: true,
       });
 
@@ -1084,14 +1041,12 @@ describe("ObservableQuery", () => {
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -1138,7 +1093,6 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -1148,7 +1102,6 @@ describe("ObservableQuery", () => {
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
-        complete: false,
         partial: true,
       });
 
@@ -1156,7 +1109,6 @@ describe("ObservableQuery", () => {
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -1192,7 +1144,6 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -1202,7 +1153,6 @@ describe("ObservableQuery", () => {
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
-        complete: false,
         partial: true,
       });
 
@@ -1210,7 +1160,6 @@ describe("ObservableQuery", () => {
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -1238,7 +1187,6 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -1275,7 +1223,6 @@ describe("ObservableQuery", () => {
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -1316,7 +1263,6 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -1326,7 +1272,6 @@ describe("ObservableQuery", () => {
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -1377,7 +1322,6 @@ describe("ObservableQuery", () => {
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -1407,7 +1351,6 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -1434,7 +1377,6 @@ describe("ObservableQuery", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -1543,7 +1485,6 @@ describe("ObservableQuery", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -1553,7 +1494,6 @@ describe("ObservableQuery", () => {
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
-        complete: false,
         partial: true,
       });
 
@@ -1561,7 +1501,6 @@ describe("ObservableQuery", () => {
         data: data2,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -1571,7 +1510,6 @@ describe("ObservableQuery", () => {
         data,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
-        complete: true,
         partial: false,
       });
 
@@ -1579,7 +1517,6 @@ describe("ObservableQuery", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -1665,7 +1602,6 @@ describe("ObservableQuery", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(observable.options.fetchPolicy).toBe("cache-first");
@@ -1676,7 +1612,6 @@ describe("ObservableQuery", () => {
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
-        complete: false,
         partial: true,
       });
       expect(observable.options.fetchPolicy).toBe("cache-first");
@@ -1685,7 +1620,6 @@ describe("ObservableQuery", () => {
         data: data2,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(observable.options.fetchPolicy).toBe("cache-first");
@@ -1697,7 +1631,6 @@ describe("ObservableQuery", () => {
           data,
           loading: false,
           networkStatus: NetworkStatus.ready,
-          complete: true,
           partial: false,
         });
         expect(observable.options.fetchPolicy).toBe("cache-first");
@@ -1707,7 +1640,6 @@ describe("ObservableQuery", () => {
         data,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
-        complete: true,
         partial: false,
       });
       expect(observable.options.fetchPolicy).toBe("cache-first");
@@ -1716,7 +1648,6 @@ describe("ObservableQuery", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(observable.options.fetchPolicy).toBe("cache-first");
@@ -1728,7 +1659,6 @@ describe("ObservableQuery", () => {
           data: data2,
           loading: false,
           networkStatus: NetworkStatus.ready,
-          complete: true,
           partial: false,
         });
         expect(observable.options.fetchPolicy).toBe("cache-first");
@@ -1738,7 +1668,6 @@ describe("ObservableQuery", () => {
         data: data2,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
-        complete: true,
         partial: false,
       });
       expect(observable.options.fetchPolicy).toBe("cache-first");
@@ -1747,7 +1676,6 @@ describe("ObservableQuery", () => {
         data: data2,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(observable.options.fetchPolicy).toBe("cache-first");
@@ -1812,7 +1740,6 @@ describe("ObservableQuery", () => {
         data: { counter: 1 },
         loading: true,
         networkStatus: NetworkStatus.loading,
-        complete: false,
         partial: true,
       });
 
@@ -1820,7 +1747,6 @@ describe("ObservableQuery", () => {
         data: { counter: 2, name: "Ben" },
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -1836,7 +1762,6 @@ describe("ObservableQuery", () => {
         data: { counter: 3, name: "Ben" },
         loading: true,
         networkStatus: NetworkStatus.refetch,
-        complete: true,
         partial: false,
       });
 
@@ -1854,7 +1779,6 @@ describe("ObservableQuery", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -1918,7 +1842,6 @@ describe("ObservableQuery", () => {
           },
           loading: false,
           networkStatus: NetworkStatus.ready,
-          complete: true,
           partial: false,
         });
 
@@ -1935,7 +1858,6 @@ describe("ObservableQuery", () => {
           },
           loading: false,
           networkStatus: NetworkStatus.ready,
-          complete: true,
           partial: false,
         });
 
@@ -2010,7 +1932,6 @@ describe("ObservableQuery", () => {
           },
           loading: false,
           networkStatus: NetworkStatus.ready,
-          complete: true,
           partial: false,
         });
 
@@ -2106,7 +2027,6 @@ describe("ObservableQuery", () => {
           },
           loading: false,
           networkStatus: NetworkStatus.ready,
-          complete: true,
           partial: false,
         });
 
@@ -2121,7 +2041,6 @@ describe("ObservableQuery", () => {
           },
           loading: false,
           networkStatus: NetworkStatus.ready,
-          complete: true,
           partial: false,
         });
 
@@ -2231,7 +2150,6 @@ describe("ObservableQuery", () => {
         data: dataOneWithTypename,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -2239,7 +2157,6 @@ describe("ObservableQuery", () => {
         data: dataOneWithTypename,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -2249,14 +2166,12 @@ describe("ObservableQuery", () => {
         data: dataOneWithTypename,
         loading: true,
         networkStatus: NetworkStatus.refetch,
-        complete: true,
         partial: false,
       });
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: dataOneWithTypename,
         loading: true,
         networkStatus: NetworkStatus.refetch,
-        complete: true,
         partial: false,
       });
 
@@ -2264,14 +2179,12 @@ describe("ObservableQuery", () => {
         data: dataTwoWithTypename,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: dataTwoWithTypename,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -2296,7 +2209,6 @@ describe("ObservableQuery", () => {
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.loading,
-        complete: false,
         partial: true,
       });
 
@@ -2306,7 +2218,6 @@ describe("ObservableQuery", () => {
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.loading,
-        complete: false,
         partial: true,
       });
 
@@ -2316,7 +2227,6 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: false,
         networkStatus: 7,
-        complete: true,
         partial: false,
       });
     });
@@ -2338,7 +2248,6 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: false,
         networkStatus: 7,
-        complete: true,
         partial: false,
       });
 
@@ -2348,7 +2257,6 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
     });
@@ -2376,7 +2284,6 @@ describe("ObservableQuery", () => {
         errors: [error],
         loading: false,
         networkStatus: NetworkStatus.error,
-        complete: false,
         partial: true,
       });
     });
@@ -2407,7 +2314,6 @@ describe("ObservableQuery", () => {
         errors: [error],
         loading: false,
         networkStatus: NetworkStatus.error,
-        complete: false,
         partial: true,
       });
 
@@ -2439,7 +2345,6 @@ describe("ObservableQuery", () => {
         errors: [error],
         loading: false,
         networkStatus: NetworkStatus.error,
-        complete: true,
         partial: false,
       });
       expect(currentResult).toEqualApolloQueryResult({
@@ -2449,7 +2354,6 @@ describe("ObservableQuery", () => {
         // TODO: The networkStatus returned here is different than the one
         // returned from `observable.result()`. These should match
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
     });
@@ -2523,14 +2427,12 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(currentResult).toEqualApolloQueryResult({
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
     });
@@ -2578,7 +2480,6 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: true,
         networkStatus: NetworkStatus.loading,
-        complete: false,
         partial: true,
       });
 
@@ -2588,14 +2489,12 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: true,
         networkStatus: NetworkStatus.loading,
-        complete: false,
         partial: true,
       });
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: dataOne,
         loading: true,
         networkStatus: NetworkStatus.loading,
-        complete: false,
         partial: true,
       });
 
@@ -2603,14 +2502,12 @@ describe("ObservableQuery", () => {
         data: superDataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: superDataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -2638,7 +2535,6 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -2652,7 +2548,6 @@ describe("ObservableQuery", () => {
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.loading,
-        complete: false,
         partial: true,
       });
 
@@ -2662,7 +2557,6 @@ describe("ObservableQuery", () => {
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.loading,
-        complete: false,
         partial: true,
       });
 
@@ -2670,7 +2564,6 @@ describe("ObservableQuery", () => {
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -2704,7 +2597,6 @@ describe("ObservableQuery", () => {
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.loading,
-        complete: false,
         partial: true,
       });
 
@@ -2714,14 +2606,12 @@ describe("ObservableQuery", () => {
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.loading,
-        complete: false,
         partial: true,
       });
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.loading,
-        complete: false,
         partial: true,
       });
 
@@ -2729,14 +2619,12 @@ describe("ObservableQuery", () => {
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -2788,9 +2676,8 @@ describe("ObservableQuery", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
-        // TODO: This should be false since there are still outstanding chunks
+        // TODO: This should be true since there are still outstanding chunks
         // that haven't been processed.
-        complete: true,
         partial: false,
       });
 
@@ -2803,7 +2690,6 @@ describe("ObservableQuery", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: false,
         partial: true,
       });
 
@@ -2841,7 +2727,6 @@ describe("ObservableQuery", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -2858,7 +2743,6 @@ describe("ObservableQuery", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -2877,7 +2761,6 @@ describe("ObservableQuery", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -2936,49 +2819,41 @@ describe("ObservableQuery", () => {
         resultBeforeSubscribe: {
           ...loadingStates.loading,
           data: cacheValues.initial,
-          complete: true,
           partial: false,
         },
         resultAfterSubscribe: {
           ...loadingStates.loading,
           data: cacheValues.initial,
-          complete: true,
           partial: false,
         },
         resultAfterCacheUpdate1: {
           ...loadingStates.loading,
           data: cacheValues.update1,
-          complete: true,
           partial: false,
         },
         resultAfterLinkNext: {
           ...loadingStates.done,
           data: cacheValues.link,
-          complete: true,
           partial: false,
         },
         resultAfterCacheUpdate2: {
           ...loadingStates.done,
           data: cacheValues.update2,
-          complete: true,
           partial: false,
         },
         resultAfterCacheUpdate3: {
           ...loadingStates.refetching,
           data: cacheValues.update3,
-          complete: true,
           partial: false,
         },
         resultAfterRefetchNext: {
           ...loadingStates.done,
           data: cacheValues.refetch,
-          complete: true,
           partial: false,
         },
         resultAfterCacheUpdate4: {
           ...loadingStates.done,
           data: cacheValues.update4,
-          complete: true,
           partial: false,
         },
       };
@@ -2987,49 +2862,41 @@ describe("ObservableQuery", () => {
         resultBeforeSubscribe: {
           ...loadingStates.loading,
           data: undefined,
-          complete: false,
           partial: true,
         },
         resultAfterSubscribe: {
           ...loadingStates.loading,
           data: undefined,
-          complete: false,
           partial: true,
         },
         resultAfterCacheUpdate1: {
           ...loadingStates.loading,
           data: undefined,
-          complete: false,
           partial: true,
         },
         resultAfterLinkNext: {
           ...loadingStates.done,
           data: cacheValues.link,
-          complete: true,
           partial: false,
         },
         resultAfterCacheUpdate2: {
           ...loadingStates.done,
           data: cacheValues.link,
-          complete: true,
           partial: false,
         },
         resultAfterCacheUpdate3: {
           ...loadingStates.refetching,
           data: cacheValues.link,
-          complete: true,
           partial: false,
         },
         resultAfterRefetchNext: {
           ...loadingStates.done,
           data: cacheValues.refetch,
-          complete: true,
           partial: false,
         },
         resultAfterCacheUpdate4: {
           ...loadingStates.done,
           data: cacheValues.refetch,
-          complete: true,
           partial: false,
         },
       };
@@ -3039,37 +2906,31 @@ describe("ObservableQuery", () => {
         resultBeforeSubscribe: {
           ...loadingStates.loading,
           data: undefined,
-          complete: false,
           partial: true,
         },
         resultAfterSubscribe: {
           ...loadingStates.loading,
           data: undefined,
-          complete: false,
           partial: true,
         },
         resultAfterCacheUpdate1: {
           ...loadingStates.loading,
           data: undefined,
-          complete: false,
           partial: true,
         },
         resultAfterLinkNext: {
           ...loadingStates.loading,
           data: undefined,
-          complete: false,
           partial: true,
         },
         resultAfterCacheUpdate2: {
           ...loadingStates.loading,
           data: undefined,
-          complete: false,
           partial: true,
         },
         resultAfterCacheUpdate3: {
           ...loadingStates.refetching,
           data: undefined,
-          complete: false,
           partial: true,
         },
         // like linkOnly:
@@ -3082,19 +2943,16 @@ describe("ObservableQuery", () => {
         resultBeforeSubscribe: {
           ...loadingStates.loading,
           data: undefined,
-          complete: false,
           partial: true,
         },
         resultAfterSubscribe: {
           ...loadingStates.loading,
           data: undefined,
-          complete: false,
           partial: true,
         },
         resultAfterCacheUpdate1: {
           ...loadingStates.loading,
           data: undefined,
-          complete: false,
           partial: true,
         },
         // like cacheAndLink:
@@ -3110,25 +2968,21 @@ describe("ObservableQuery", () => {
         resultBeforeSubscribe: {
           ...loadingStates.done,
           data: cacheValues.initial,
-          complete: true,
           partial: false,
         },
         resultAfterSubscribe: {
           ...loadingStates.done,
           data: cacheValues.initial,
-          complete: true,
           partial: false,
         },
         resultAfterCacheUpdate1: {
           ...loadingStates.done,
           data: cacheValues.update1,
-          complete: true,
           partial: false,
         },
         resultAfterLinkNext: {
           ...loadingStates.done,
           data: cacheValues.update1,
-          complete: true,
           partial: false,
         },
         // like cacheAndLink:
@@ -3298,14 +3152,12 @@ describe("ObservableQuery", () => {
           data: dataOne,
           loading: false,
           networkStatus: NetworkStatus.ready,
-          complete: true,
           partial: false,
         });
         expect(observable.getCurrentResult()).toEqualApolloQueryResult({
           data: dataOne,
           loading: false,
           networkStatus: NetworkStatus.ready,
-          complete: true,
           partial: false,
         });
 
@@ -3321,7 +3173,6 @@ describe("ObservableQuery", () => {
           },
           loading: false,
           networkStatus: NetworkStatus.ready,
-          complete: true,
           partial: false,
         });
         expect(observable.getCurrentResult()).toEqualApolloQueryResult({
@@ -3330,7 +3181,6 @@ describe("ObservableQuery", () => {
           },
           loading: false,
           networkStatus: NetworkStatus.ready,
-          complete: true,
           partial: false,
         });
 
@@ -3340,7 +3190,6 @@ describe("ObservableQuery", () => {
           },
           loading: false,
           networkStatus: NetworkStatus.ready,
-          complete: true,
           partial: false,
         });
         expect(observable.getCurrentResult()).toEqualApolloQueryResult({
@@ -3349,7 +3198,6 @@ describe("ObservableQuery", () => {
           },
           loading: false,
           networkStatus: NetworkStatus.ready,
-          complete: true,
           partial: false,
         });
 
@@ -3659,7 +3507,6 @@ describe("ObservableQuery", () => {
       data: dataOne,
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -3724,7 +3571,6 @@ describe("ObservableQuery", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         data: dataOne,
-        complete: true,
         partial: false,
       });
       return {
@@ -3741,7 +3587,6 @@ describe("ObservableQuery", () => {
       loading: false,
       networkStatus: NetworkStatus.ready,
       data: { mapped: true },
-      complete: true,
       partial: false,
     });
 
@@ -3816,7 +3661,6 @@ test("regression test for #10587", async () => {
           },
           loading: true,
           networkStatus: 1,
-          complete: true,
           partial: false,
         },
       ],
@@ -3830,7 +3674,6 @@ test("regression test for #10587", async () => {
           },
           loading: false,
           networkStatus: 7,
-          complete: true,
           partial: false,
         },
       ],
@@ -3847,7 +3690,6 @@ test("regression test for #10587", async () => {
           },
           loading: true,
           networkStatus: 1,
-          complete: true,
           partial: false,
         },
       ],
@@ -3863,7 +3705,6 @@ test("regression test for #10587", async () => {
           // TODO: this should be `true`, but that seems to be a separate bug!
           loading: false,
           networkStatus: 7,
-          complete: true,
           partial: false,
         },
       ],
@@ -3878,7 +3719,6 @@ test("regression test for #10587", async () => {
           },
           loading: false,
           networkStatus: 7,
-          complete: true,
           partial: false,
         },
       ],
@@ -3954,7 +3794,6 @@ test("handles changing variables in rapid succession before other request is com
       data: { userCount: 10 },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
   });
@@ -3971,7 +3810,6 @@ test("handles changing variables in rapid succession before other request is com
     data: { userCount: 10 },
     loading: false,
     networkStatus: NetworkStatus.ready,
-    complete: true,
     partial: false,
   });
 });

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -277,7 +277,6 @@ describe("ObservableQuery", () => {
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
-        partial: true,
       });
 
       await expect(stream).toEmitApolloQueryResult({
@@ -406,7 +405,6 @@ describe("ObservableQuery", () => {
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
-        partial: true,
       });
 
       await expect(stream).toEmitApolloQueryResult({
@@ -563,7 +561,6 @@ describe("ObservableQuery", () => {
         data: undefined,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        partial: true,
       });
 
       expect(timesFired).toBe(1);
@@ -615,7 +612,6 @@ describe("ObservableQuery", () => {
         data: undefined,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        partial: true,
       });
       expect(timesFired).toBe(0);
 
@@ -822,12 +818,9 @@ describe("ObservableQuery", () => {
       await observable.setVariables(differentVariables);
 
       await expect(stream).toEmitApolloQueryResult({
-        // TODO: Fix this error
-        // @ts-expect-error `ApolloQueryResult` needs to be updated to allow for `undefined` and this value needs to emit undefined instead of empty object
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
-        partial: true,
       });
 
       await expect(stream).toEmitApolloQueryResult({
@@ -987,22 +980,16 @@ describe("ObservableQuery", () => {
       const stream = new ObservableStream(observable);
 
       await expect(stream).toEmitApolloQueryResult({
-        // TODO: Fix this error
-        // @ts-expect-error Need to update ApolloQueryResult type to allow for undefined
         data: undefined,
         errors: [error],
         loading: false,
         networkStatus: NetworkStatus.error,
       });
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
-        // TODO: Fix this error
-        // @ts-expect-error Need to update ApolloQueryResult type to allow for undefined
         data: undefined,
         errors: [error],
         loading: false,
         networkStatus: NetworkStatus.ready,
-        // TODO: This is not present on the emitted result so this should match
-        partial: true,
       });
 
       await observable.setVariables(differentVariables);
@@ -1066,12 +1053,9 @@ describe("ObservableQuery", () => {
       await observable.setVariables(differentVariables);
 
       await expect(stream).toEmitApolloQueryResult({
-        // TODO: Fix this error
-        // @ts-expect-error Ensure ApolloQueryResult allows for undefined and fix this value to match
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
-        partial: true,
       });
 
       await expect(stream).toEmitApolloQueryResult({
@@ -1117,12 +1101,9 @@ describe("ObservableQuery", () => {
       await observable.refetch(differentVariables);
 
       await expect(stream).toEmitApolloQueryResult({
-        // TODO: Fix this error
-        // @ts-expect-error Need to update ApolloQueryResult to allow undefined and fix this value
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
-        partial: true,
       });
 
       await expect(stream).toEmitApolloQueryResult({
@@ -1454,7 +1435,6 @@ describe("ObservableQuery", () => {
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
-        partial: true,
       });
 
       await expect(stream).toEmitApolloQueryResult({
@@ -1568,7 +1548,6 @@ describe("ObservableQuery", () => {
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
-        partial: true,
       });
       expect(observable.options.fetchPolicy).toBe("cache-first");
 
@@ -1689,13 +1668,14 @@ describe("ObservableQuery", () => {
         data: { counter: 1 },
         loading: true,
         networkStatus: NetworkStatus.loading,
-        partial: true,
+        complete: false,
       });
 
       await expect(stream).toEmitApolloQueryResult({
         data: { counter: 2, name: "Ben" },
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
       });
 
       const oldLinkObs = linkObservable;
@@ -1710,6 +1690,7 @@ describe("ObservableQuery", () => {
         data: { counter: 3, name: "Ben" },
         loading: true,
         networkStatus: NetworkStatus.refetch,
+        complete: true,
       });
 
       await expect(stream).toEmitError(intentionalNetworkFailure);
@@ -1726,6 +1707,7 @@ describe("ObservableQuery", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
       });
 
       await expect(stream).not.toEmitAnything();
@@ -2140,22 +2122,18 @@ describe("ObservableQuery", () => {
       const observable = client.watchQuery({ query, variables });
       const stream = new ObservableStream(observable);
 
-      // TODO: Fix this error
-      // @ts-expect-error ApolloQueryResult expects a `data` property, but the value returned from `getCurrentResult` does not include it
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+        data: undefined,
         loading: true,
         networkStatus: NetworkStatus.loading,
-        partial: true,
       });
 
       await tick();
 
-      // TODO: Fix this error
-      // @ts-expect-error ApolloQueryResult expects a `data` property, but the value returned from `getCurrentResult` does not include it
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+        data: undefined,
         loading: true,
         networkStatus: NetworkStatus.loading,
-        partial: true,
       });
 
       await stream.takeNext();
@@ -2212,14 +2190,12 @@ describe("ObservableQuery", () => {
       await expect(stream).toEmitError(
         new ApolloError({ graphQLErrors: [error] })
       );
-      // TODO: Fix this error
-      // @ts-expect-error ApolloQueryResult expects `data` property to be defined but it is not returned here
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+        data: undefined,
         error: new ApolloError({ graphQLErrors: [error] }),
         errors: [error],
         loading: false,
         networkStatus: NetworkStatus.error,
-        partial: true,
       });
     });
 
@@ -2243,13 +2219,12 @@ describe("ObservableQuery", () => {
       const currentResult = observable.getCurrentResult();
       const currentResult2 = observable.getCurrentResult();
 
-      // @ts-expect-error ApolloQueryResult expects a `data` property to be returned
       expect(currentResult).toEqualApolloQueryResult({
+        data: undefined,
         error: new ApolloError({ graphQLErrors: [error] }),
         errors: [error],
         loading: false,
         networkStatus: NetworkStatus.error,
-        partial: true,
       });
 
       expect(currentResult.error === currentResult2.error).toBe(true);
@@ -2411,7 +2386,7 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: true,
         networkStatus: NetworkStatus.loading,
-        partial: true,
+        complete: false,
       });
 
       const stream = new ObservableStream(observable);
@@ -2420,24 +2395,26 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: true,
         networkStatus: NetworkStatus.loading,
-        partial: true,
+        complete: false,
       });
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: dataOne,
         loading: true,
         networkStatus: NetworkStatus.loading,
-        partial: true,
+        complete: false,
       });
 
       await expect(stream).toEmitApolloQueryResult({
         data: superDataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
       });
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: superDataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
       });
 
       await expect(stream).not.toEmitAnything();
@@ -2472,18 +2449,16 @@ describe("ObservableQuery", () => {
         fetchPolicy: "network-only",
       });
 
-      // TODO: Fix this issue
-      // @ts-expect-error `ApolloQueryResult` expects a `data` property
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+        data: undefined,
         loading: true,
         networkStatus: NetworkStatus.loading,
       });
 
       const stream = new ObservableStream(observable);
 
-      // TODO: Fix this issue
-      // @ts-expect-error `ApolloQueryResult` expects a `data` property
       await expect(stream).toEmitApolloQueryResult({
+        data: undefined,
         loading: true,
         networkStatus: NetworkStatus.loading,
       });
@@ -2520,24 +2495,21 @@ describe("ObservableQuery", () => {
         fetchPolicy: "no-cache",
       });
 
-      // TODO: Fix this issue
-      // @ts-expect-error `ApolloQueryResult` expects a `data` property
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+        data: undefined,
         loading: true,
         networkStatus: NetworkStatus.loading,
       });
 
       const stream = new ObservableStream(observable);
 
-      // TODO: Fix this issue
-      // @ts-expect-error `ApolloQueryResult` expects a `data` property
       await expect(stream).toEmitApolloQueryResult({
+        data: undefined,
         loading: true,
         networkStatus: NetworkStatus.loading,
       });
-      // TODO: Fix this issue
-      // @ts-expect-error `ApolloQueryResult` expects a `data` property
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+        data: undefined,
         loading: true,
         networkStatus: NetworkStatus.loading,
       });
@@ -2612,9 +2584,6 @@ describe("ObservableQuery", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
-        // TODO: This should not be there since the observable did not emit this
-        // property.
-        partial: true,
       });
 
       link.simulateResult(
@@ -2689,7 +2658,7 @@ describe("ObservableQuery", () => {
     });
 
     {
-      type Result = Partial<ApolloQueryResult<{ hello: string }>>;
+      type Result = ApolloQueryResult<{ hello: string }>;
 
       const cacheValues = {
         initial: { hello: "world (initial)" },
@@ -2774,12 +2743,15 @@ describe("ObservableQuery", () => {
       const linkOnly: TestDetails = {
         resultBeforeSubscribe: {
           ...loadingStates.loading,
+          data: undefined,
         },
         resultAfterSubscribe: {
           ...loadingStates.loading,
+          data: undefined,
         },
         resultAfterCacheUpdate1: {
           ...loadingStates.loading,
+          data: undefined,
         },
         resultAfterLinkNext: {
           ...loadingStates.done,
@@ -2807,21 +2779,27 @@ describe("ObservableQuery", () => {
         ...linkOnly,
         resultBeforeSubscribe: {
           ...loadingStates.loading,
+          data: undefined,
         },
         resultAfterSubscribe: {
           ...loadingStates.loading,
+          data: undefined,
         },
         resultAfterCacheUpdate1: {
           ...loadingStates.loading,
+          data: undefined,
         },
         resultAfterLinkNext: {
           ...loadingStates.loading,
+          data: undefined,
         },
         resultAfterCacheUpdate2: {
           ...loadingStates.loading,
+          data: undefined,
         },
         resultAfterCacheUpdate3: {
           ...loadingStates.refetching,
+          data: undefined,
         },
         // like linkOnly:
         // resultAfterRefetchNext
@@ -2832,12 +2810,15 @@ describe("ObservableQuery", () => {
         ...cacheAndLink,
         resultBeforeSubscribe: {
           ...loadingStates.loading,
+          data: undefined,
         },
         resultAfterSubscribe: {
           ...loadingStates.loading,
+          data: undefined,
         },
         resultAfterCacheUpdate1: {
           ...loadingStates.loading,
+          data: undefined,
         },
         // like cacheAndLink:
         // resultAfterLinkNext

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -297,8 +297,8 @@ describe("ObservableQuery", () => {
         data: data2,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: false,
-        partial: true,
+        complete: true,
+        partial: false,
       });
 
       await expect(stream).not.toEmitAnything();
@@ -1192,8 +1192,8 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: false,
-        partial: true,
+        complete: true,
+        partial: false,
       });
 
       await observable.refetch(differentVariables);
@@ -1210,8 +1210,8 @@ describe("ObservableQuery", () => {
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: false,
-        partial: true,
+        complete: true,
+        partial: false,
       });
 
       await expect(stream).not.toEmitAnything();
@@ -1238,8 +1238,8 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: false,
-        partial: true,
+        complete: true,
+        partial: false,
       });
 
       await observable.setVariables(variables);
@@ -2252,10 +2252,12 @@ describe("ObservableQuery", () => {
         complete: true,
         partial: false,
       });
-      expect(observable.getCurrentResult()).toEqual({
+      expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: dataOneWithTypename,
         loading: true,
         networkStatus: NetworkStatus.refetch,
+        complete: true,
+        partial: false,
       });
 
       await expect(stream).toEmitApolloQueryResult({
@@ -2265,10 +2267,12 @@ describe("ObservableQuery", () => {
         complete: true,
         partial: false,
       });
-      expect(observable.getCurrentResult()).toEqual({
+      expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: dataTwoWithTypename,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await expect(stream).not.toEmitAnything();
@@ -2435,8 +2439,8 @@ describe("ObservableQuery", () => {
         errors: [error],
         loading: false,
         networkStatus: NetworkStatus.error,
-        complete: false,
-        partial: true,
+        complete: true,
+        partial: false,
       });
       expect(currentResult).toEqualApolloQueryResult({
         data: dataOne,
@@ -2445,8 +2449,8 @@ describe("ObservableQuery", () => {
         // TODO: The networkStatus returned here is different than the one
         // returned from `observable.result()`. These should match
         networkStatus: NetworkStatus.ready,
-        complete: false,
-        partial: true,
+        complete: true,
+        partial: false,
       });
     });
 
@@ -2784,6 +2788,8 @@ describe("ObservableQuery", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
+        // TODO: This should be false since there are still outstanding chunks
+        // that haven't been processed.
         complete: true,
         partial: false,
       });
@@ -2797,8 +2803,8 @@ describe("ObservableQuery", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
-        partial: false,
+        complete: false,
+        partial: true,
       });
 
       link.simulateResult(
@@ -2999,32 +3005,32 @@ describe("ObservableQuery", () => {
         resultAfterLinkNext: {
           ...loadingStates.done,
           data: cacheValues.link,
-          complete: false,
-          partial: true,
+          complete: true,
+          partial: false,
         },
         resultAfterCacheUpdate2: {
           ...loadingStates.done,
           data: cacheValues.link,
-          complete: false,
-          partial: true,
+          complete: true,
+          partial: false,
         },
         resultAfterCacheUpdate3: {
           ...loadingStates.refetching,
           data: cacheValues.link,
-          complete: false,
-          partial: true,
+          complete: true,
+          partial: false,
         },
         resultAfterRefetchNext: {
           ...loadingStates.done,
           data: cacheValues.refetch,
-          complete: false,
-          partial: true,
+          complete: true,
+          partial: false,
         },
         resultAfterCacheUpdate4: {
           ...loadingStates.done,
           data: cacheValues.refetch,
-          complete: false,
-          partial: true,
+          complete: true,
+          partial: false,
         },
       };
 
@@ -3110,20 +3116,20 @@ describe("ObservableQuery", () => {
         resultAfterSubscribe: {
           ...loadingStates.done,
           data: cacheValues.initial,
-          complete: false,
-          partial: true,
+          complete: true,
+          partial: false,
         },
         resultAfterCacheUpdate1: {
           ...loadingStates.done,
           data: cacheValues.update1,
-          complete: false,
-          partial: true,
+          complete: true,
+          partial: false,
         },
         resultAfterLinkNext: {
           ...loadingStates.done,
           data: cacheValues.update1,
-          complete: false,
-          partial: true,
+          complete: true,
+          partial: false,
         },
         // like cacheAndLink:
         // resultAfterCacheUpdate2
@@ -3810,6 +3816,8 @@ test("regression test for #10587", async () => {
           },
           loading: true,
           networkStatus: 1,
+          complete: true,
+          partial: false,
         },
       ],
       [
@@ -3822,6 +3830,8 @@ test("regression test for #10587", async () => {
           },
           loading: false,
           networkStatus: 7,
+          complete: true,
+          partial: false,
         },
       ],
     ],
@@ -3837,6 +3847,8 @@ test("regression test for #10587", async () => {
           },
           loading: true,
           networkStatus: 1,
+          complete: true,
+          partial: false,
         },
       ],
       [
@@ -3851,6 +3863,8 @@ test("regression test for #10587", async () => {
           // TODO: this should be `true`, but that seems to be a separate bug!
           loading: false,
           networkStatus: 7,
+          complete: true,
+          partial: false,
         },
       ],
       [
@@ -3864,6 +3878,8 @@ test("regression test for #10587", async () => {
           },
           loading: false,
           networkStatus: 7,
+          complete: true,
+          partial: false,
         },
       ],
     ],

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -2925,17 +2925,17 @@ describe("ObservableQuery", () => {
             nextFetchPolicy,
           });
 
-          expect(observableQuery.getCurrentResult()).toStrictEqual(
+          expect(observableQuery.getCurrentResult()).toEqualApolloQueryResult(
             resultBeforeSubscribe
           );
 
           observableQuery.subscribe({});
-          expect(observableQuery.getCurrentResult()).toStrictEqual(
+          expect(observableQuery.getCurrentResult()).toEqualApolloQueryResult(
             resultAfterSubscribe
           );
 
           cache.writeQuery({ query, data: cacheValues.update1 });
-          expect(observableQuery.getCurrentResult()).toStrictEqual(
+          expect(observableQuery.getCurrentResult()).toEqualApolloQueryResult(
             resultAfterCacheUpdate1
           );
 
@@ -2945,21 +2945,21 @@ describe("ObservableQuery", () => {
           }
           await waitFor(
             () =>
-              void expect(observableQuery.getCurrentResult()).toStrictEqual(
-                resultAfterLinkNext
-              ),
+              void expect(
+                observableQuery.getCurrentResult()
+              ).toEqualApolloQueryResult(resultAfterLinkNext),
             { interval: 1 }
           );
 
           cache.writeQuery({ query, data: cacheValues.update2 });
-          expect(observableQuery.getCurrentResult()).toStrictEqual(
+          expect(observableQuery.getCurrentResult()).toEqualApolloQueryResult(
             resultAfterCacheUpdate2
           );
 
           void observableQuery.refetch();
 
           cache.writeQuery({ query, data: cacheValues.update3 });
-          expect(observableQuery.getCurrentResult()).toStrictEqual(
+          expect(observableQuery.getCurrentResult()).toEqualApolloQueryResult(
             resultAfterCacheUpdate3
           );
 
@@ -2969,14 +2969,14 @@ describe("ObservableQuery", () => {
           }
           await waitFor(
             () =>
-              void expect(observableQuery.getCurrentResult()).toStrictEqual(
-                resultAfterRefetchNext
-              ),
+              void expect(
+                observableQuery.getCurrentResult()
+              ).toEqualApolloQueryResult(resultAfterRefetchNext),
             { interval: 1 }
           );
 
           cache.writeQuery({ query, data: cacheValues.update4 });
-          expect(observableQuery.getCurrentResult()).toStrictEqual(
+          expect(observableQuery.getCurrentResult()).toEqualApolloQueryResult(
             resultAfterCacheUpdate4
           );
         }

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -118,6 +118,8 @@ describe("ObservableQuery", () => {
           data: dataOne,
           loading: false,
           networkStatus: NetworkStatus.ready,
+          complete: true,
+          partial: false,
         });
 
         await observable.setOptions({ query, pollInterval: 10 });
@@ -126,6 +128,8 @@ describe("ObservableQuery", () => {
           data: dataTwo,
           loading: false,
           networkStatus: NetworkStatus.ready,
+          complete: true,
+          partial: false,
         });
 
         observable.stopPolling();
@@ -164,6 +168,8 @@ describe("ObservableQuery", () => {
           data: dataOne,
           loading: false,
           networkStatus: NetworkStatus.ready,
+          complete: true,
+          partial: false,
         });
 
         await observable.setOptions({ query, pollInterval: 0 });
@@ -203,6 +209,8 @@ describe("ObservableQuery", () => {
           data: dataOne,
           loading: false,
           networkStatus: NetworkStatus.ready,
+          complete: true,
+          partial: false,
         });
 
         await observable.setOptions({ query, pollInterval: 10 });
@@ -211,6 +219,8 @@ describe("ObservableQuery", () => {
           data: dataTwo,
           loading: false,
           networkStatus: NetworkStatus.ready,
+          complete: true,
+          partial: false,
         });
 
         observable.stopPolling();
@@ -269,6 +279,8 @@ describe("ObservableQuery", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await observable.refetch(variables2);
@@ -277,12 +289,16 @@ describe("ObservableQuery", () => {
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
+        complete: false,
+        partial: true,
       });
 
       await expect(stream).toEmitApolloQueryResult({
         data: data2,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: false,
+        partial: true,
       });
 
       await expect(stream).not.toEmitAnything();
@@ -337,6 +353,8 @@ describe("ObservableQuery", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await observable.refetch();
@@ -345,12 +363,16 @@ describe("ObservableQuery", () => {
         data,
         loading: true,
         networkStatus: NetworkStatus.refetch,
+        complete: true,
+        partial: false,
       });
 
       await expect(stream).toEmitApolloQueryResult({
         data: data2,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await expect(stream).not.toEmitAnything();
@@ -394,6 +416,8 @@ describe("ObservableQuery", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await observable.setOptions({
@@ -405,12 +429,16 @@ describe("ObservableQuery", () => {
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
+        complete: false,
+        partial: true,
       });
 
       await expect(stream).toEmitApolloQueryResult({
         data: data2,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       // go back to first set of variables
@@ -419,12 +447,16 @@ describe("ObservableQuery", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await expect(stream).toEmitApolloQueryResult({
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await expect(stream).not.toEmitAnything();
@@ -455,6 +487,8 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await expect(observable.refetch()).rejects.toThrow(
@@ -469,6 +503,8 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await expect(stream).not.toEmitAnything();
@@ -496,6 +532,8 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await observable.setOptions({ fetchPolicy: "network-only" });
@@ -504,6 +542,8 @@ describe("ObservableQuery", () => {
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await expect(stream).not.toEmitAnything();
@@ -550,6 +590,8 @@ describe("ObservableQuery", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       expect(timesFired).toBe(1);
@@ -561,6 +603,8 @@ describe("ObservableQuery", () => {
         data: undefined,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: false,
+        partial: true,
       });
 
       expect(timesFired).toBe(1);
@@ -612,6 +656,8 @@ describe("ObservableQuery", () => {
         data: undefined,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: false,
+        partial: true,
       });
       expect(timesFired).toBe(0);
 
@@ -621,6 +667,8 @@ describe("ObservableQuery", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(timesFired).toBe(1);
       await expect(stream).not.toEmitAnything();
@@ -669,6 +717,8 @@ describe("ObservableQuery", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(timesFired).toBe(1);
 
@@ -725,6 +775,8 @@ describe("ObservableQuery", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       expect(timesFired).toBe(1);
@@ -757,6 +809,8 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       const res = await observable.setOptions({
@@ -767,18 +821,24 @@ describe("ObservableQuery", () => {
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await expect(stream).toEmitApolloQueryResult({
         data: dataOne,
         loading: true,
         networkStatus: NetworkStatus.loading,
+        complete: true,
+        partial: false,
       });
 
       await expect(stream).toEmitApolloQueryResult({
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await expect(stream).not.toEmitAnything();
@@ -813,6 +873,8 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await observable.setVariables(differentVariables);
@@ -821,12 +883,16 @@ describe("ObservableQuery", () => {
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
+        complete: false,
+        partial: true,
       });
 
       await expect(stream).toEmitApolloQueryResult({
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await expect(stream).not.toEmitAnything();
@@ -854,11 +920,15 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await observable.setVariables(differentVariables);
@@ -867,11 +937,15 @@ describe("ObservableQuery", () => {
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await expect(stream).not.toEmitAnything();
@@ -933,11 +1007,15 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await observable.setVariables(differentVariables);
@@ -946,11 +1024,15 @@ describe("ObservableQuery", () => {
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await expect(stream).not.toEmitAnything();
@@ -984,12 +1066,16 @@ describe("ObservableQuery", () => {
         errors: [error],
         loading: false,
         networkStatus: NetworkStatus.error,
+        complete: false,
+        partial: true,
       });
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: undefined,
         errors: [error],
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: false,
+        partial: true,
       });
 
       await observable.setVariables(differentVariables);
@@ -998,11 +1084,15 @@ describe("ObservableQuery", () => {
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await expect(stream).not.toEmitAnything();
@@ -1048,6 +1138,8 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await observable.setVariables(differentVariables);
@@ -1056,12 +1148,16 @@ describe("ObservableQuery", () => {
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
+        complete: false,
+        partial: true,
       });
 
       await expect(stream).toEmitApolloQueryResult({
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await expect(stream).not.toEmitAnything();
@@ -1096,6 +1192,8 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: false,
+        partial: true,
       });
 
       await observable.refetch(differentVariables);
@@ -1104,12 +1202,16 @@ describe("ObservableQuery", () => {
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
+        complete: false,
+        partial: true,
       });
 
       await expect(stream).toEmitApolloQueryResult({
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: false,
+        partial: true,
       });
 
       await expect(stream).not.toEmitAnything();
@@ -1136,6 +1238,8 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: false,
+        partial: true,
       });
 
       await observable.setVariables(variables);
@@ -1171,6 +1275,8 @@ describe("ObservableQuery", () => {
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await expect(stream).not.toEmitAnything();
@@ -1210,6 +1316,8 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await observable.refetch(differentVariables);
@@ -1218,6 +1326,8 @@ describe("ObservableQuery", () => {
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       const fqbpCalls = mocks.fetchQueryByPolicy.mock.calls;
@@ -1267,6 +1377,8 @@ describe("ObservableQuery", () => {
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await expect(stream).not.toEmitAnything();
@@ -1295,6 +1407,8 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       void observableQuery.refetch({ id: 2 });
@@ -1320,6 +1434,8 @@ describe("ObservableQuery", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await expect(stream).not.toEmitAnything();
@@ -1427,6 +1543,8 @@ describe("ObservableQuery", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await observable.refetch(variables2);
@@ -1435,12 +1553,16 @@ describe("ObservableQuery", () => {
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
+        complete: false,
+        partial: true,
       });
 
       await expect(stream).toEmitApolloQueryResult({
         data: data2,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await observable.refetch(variables1);
@@ -1449,12 +1571,16 @@ describe("ObservableQuery", () => {
         data,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
+        complete: true,
+        partial: false,
       });
 
       await expect(stream).toEmitApolloQueryResult({
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await expect(stream).not.toEmitAnything();
@@ -1539,6 +1665,8 @@ describe("ObservableQuery", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(observable.options.fetchPolicy).toBe("cache-first");
 
@@ -1548,6 +1676,8 @@ describe("ObservableQuery", () => {
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
+        complete: false,
+        partial: true,
       });
       expect(observable.options.fetchPolicy).toBe("cache-first");
 
@@ -1555,6 +1685,8 @@ describe("ObservableQuery", () => {
         data: data2,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(observable.options.fetchPolicy).toBe("cache-first");
 
@@ -1565,6 +1697,8 @@ describe("ObservableQuery", () => {
           data,
           loading: false,
           networkStatus: NetworkStatus.ready,
+          complete: true,
+          partial: false,
         });
         expect(observable.options.fetchPolicy).toBe("cache-first");
       }
@@ -1573,6 +1707,8 @@ describe("ObservableQuery", () => {
         data,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
+        complete: true,
+        partial: false,
       });
       expect(observable.options.fetchPolicy).toBe("cache-first");
 
@@ -1580,6 +1716,8 @@ describe("ObservableQuery", () => {
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(observable.options.fetchPolicy).toBe("cache-first");
 
@@ -1590,6 +1728,8 @@ describe("ObservableQuery", () => {
           data: data2,
           loading: false,
           networkStatus: NetworkStatus.ready,
+          complete: true,
+          partial: false,
         });
         expect(observable.options.fetchPolicy).toBe("cache-first");
       }
@@ -1598,6 +1738,8 @@ describe("ObservableQuery", () => {
         data: data2,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
+        complete: true,
+        partial: false,
       });
       expect(observable.options.fetchPolicy).toBe("cache-first");
 
@@ -1605,6 +1747,8 @@ describe("ObservableQuery", () => {
         data: data2,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(observable.options.fetchPolicy).toBe("cache-first");
 
@@ -1669,6 +1813,7 @@ describe("ObservableQuery", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         complete: false,
+        partial: true,
       });
 
       await expect(stream).toEmitApolloQueryResult({
@@ -1676,6 +1821,7 @@ describe("ObservableQuery", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         complete: true,
+        partial: false,
       });
 
       const oldLinkObs = linkObservable;
@@ -1691,6 +1837,7 @@ describe("ObservableQuery", () => {
         loading: true,
         networkStatus: NetworkStatus.refetch,
         complete: true,
+        partial: false,
       });
 
       await expect(stream).toEmitError(intentionalNetworkFailure);
@@ -1708,6 +1855,7 @@ describe("ObservableQuery", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         complete: true,
+        partial: false,
       });
 
       await expect(stream).not.toEmitAnything();
@@ -1770,6 +1918,8 @@ describe("ObservableQuery", () => {
           },
           loading: false,
           networkStatus: NetworkStatus.ready,
+          complete: true,
+          partial: false,
         });
 
         await observableWithoutVariables.refetch({
@@ -1785,6 +1935,8 @@ describe("ObservableQuery", () => {
           },
           loading: false,
           networkStatus: NetworkStatus.ready,
+          complete: true,
+          partial: false,
         });
 
         expect(console.warn).toHaveBeenCalledTimes(1);
@@ -1858,6 +2010,8 @@ describe("ObservableQuery", () => {
           },
           loading: false,
           networkStatus: NetworkStatus.ready,
+          complete: true,
+          partial: false,
         });
 
         // It's a common mistake to call refetch({ variables }) when you meant
@@ -1952,6 +2106,8 @@ describe("ObservableQuery", () => {
           },
           loading: false,
           networkStatus: NetworkStatus.ready,
+          complete: true,
+          partial: false,
         });
 
         await observableWithVariablesVar.refetch({ variables: ["d", "e"] });
@@ -1965,6 +2121,8 @@ describe("ObservableQuery", () => {
           },
           loading: false,
           networkStatus: NetworkStatus.ready,
+          complete: true,
+          partial: false,
         });
 
         expect(console.warn).not.toHaveBeenCalled();
@@ -2073,12 +2231,16 @@ describe("ObservableQuery", () => {
         data: dataOneWithTypename,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: dataOneWithTypename,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       void observable.refetch();
@@ -2087,6 +2249,8 @@ describe("ObservableQuery", () => {
         data: dataOneWithTypename,
         loading: true,
         networkStatus: NetworkStatus.refetch,
+        complete: true,
+        partial: false,
       });
       expect(observable.getCurrentResult()).toEqual({
         data: dataOneWithTypename,
@@ -2098,6 +2262,8 @@ describe("ObservableQuery", () => {
         data: dataTwoWithTypename,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(observable.getCurrentResult()).toEqual({
         data: dataTwoWithTypename,
@@ -2126,6 +2292,8 @@ describe("ObservableQuery", () => {
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.loading,
+        complete: false,
+        partial: true,
       });
 
       await tick();
@@ -2134,6 +2302,8 @@ describe("ObservableQuery", () => {
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.loading,
+        complete: false,
+        partial: true,
       });
 
       await stream.takeNext();
@@ -2142,6 +2312,8 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: false,
         networkStatus: 7,
+        complete: true,
+        partial: false,
       });
     });
 
@@ -2162,6 +2334,8 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: false,
         networkStatus: 7,
+        complete: true,
+        partial: false,
       });
 
       const observable = client.watchQuery({ query, variables });
@@ -2170,6 +2344,8 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
     });
 
@@ -2196,6 +2372,8 @@ describe("ObservableQuery", () => {
         errors: [error],
         loading: false,
         networkStatus: NetworkStatus.error,
+        complete: false,
+        partial: true,
       });
     });
 
@@ -2225,6 +2403,8 @@ describe("ObservableQuery", () => {
         errors: [error],
         loading: false,
         networkStatus: NetworkStatus.error,
+        complete: false,
+        partial: true,
       });
 
       expect(currentResult.error === currentResult2.error).toBe(true);
@@ -2255,6 +2435,8 @@ describe("ObservableQuery", () => {
         errors: [error],
         loading: false,
         networkStatus: NetworkStatus.error,
+        complete: false,
+        partial: true,
       });
       expect(currentResult).toEqualApolloQueryResult({
         data: dataOne,
@@ -2263,6 +2445,8 @@ describe("ObservableQuery", () => {
         // TODO: The networkStatus returned here is different than the one
         // returned from `observable.result()`. These should match
         networkStatus: NetworkStatus.ready,
+        complete: false,
+        partial: true,
       });
     });
 
@@ -2335,11 +2519,15 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(currentResult).toEqualApolloQueryResult({
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
     });
 
@@ -2387,6 +2575,7 @@ describe("ObservableQuery", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         complete: false,
+        partial: true,
       });
 
       const stream = new ObservableStream(observable);
@@ -2396,12 +2585,14 @@ describe("ObservableQuery", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         complete: false,
+        partial: true,
       });
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: dataOne,
         loading: true,
         networkStatus: NetworkStatus.loading,
         complete: false,
+        partial: true,
       });
 
       await expect(stream).toEmitApolloQueryResult({
@@ -2409,12 +2600,14 @@ describe("ObservableQuery", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         complete: true,
+        partial: false,
       });
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: superDataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
         complete: true,
+        partial: false,
       });
 
       await expect(stream).not.toEmitAnything();
@@ -2441,6 +2634,8 @@ describe("ObservableQuery", () => {
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       const observable = client.watchQuery({
@@ -2453,6 +2648,8 @@ describe("ObservableQuery", () => {
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.loading,
+        complete: false,
+        partial: true,
       });
 
       const stream = new ObservableStream(observable);
@@ -2461,12 +2658,16 @@ describe("ObservableQuery", () => {
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.loading,
+        complete: false,
+        partial: true,
       });
 
       await expect(stream).toEmitApolloQueryResult({
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await expect(stream).not.toEmitAnything();
@@ -2499,6 +2700,8 @@ describe("ObservableQuery", () => {
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.loading,
+        complete: false,
+        partial: true,
       });
 
       const stream = new ObservableStream(observable);
@@ -2507,22 +2710,30 @@ describe("ObservableQuery", () => {
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.loading,
+        complete: false,
+        partial: true,
       });
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.loading,
+        complete: false,
+        partial: true,
       });
 
       await expect(stream).toEmitApolloQueryResult({
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await expect(stream).not.toEmitAnything();
@@ -2573,6 +2784,8 @@ describe("ObservableQuery", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       expect(obs.getCurrentResult()).toEqualApolloQueryResult({
@@ -2584,6 +2797,8 @@ describe("ObservableQuery", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       link.simulateResult(
@@ -2620,6 +2835,8 @@ describe("ObservableQuery", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       expect(obs.getCurrentResult()).toEqualApolloQueryResult({
@@ -2635,6 +2852,8 @@ describe("ObservableQuery", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       // This 2nd identical check is intentional to ensure calling this function
@@ -2652,6 +2871,8 @@ describe("ObservableQuery", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await expect(stream).not.toEmitAnything();
@@ -2709,34 +2930,50 @@ describe("ObservableQuery", () => {
         resultBeforeSubscribe: {
           ...loadingStates.loading,
           data: cacheValues.initial,
+          complete: true,
+          partial: false,
         },
         resultAfterSubscribe: {
           ...loadingStates.loading,
           data: cacheValues.initial,
+          complete: true,
+          partial: false,
         },
         resultAfterCacheUpdate1: {
           ...loadingStates.loading,
           data: cacheValues.update1,
+          complete: true,
+          partial: false,
         },
         resultAfterLinkNext: {
           ...loadingStates.done,
           data: cacheValues.link,
+          complete: true,
+          partial: false,
         },
         resultAfterCacheUpdate2: {
           ...loadingStates.done,
           data: cacheValues.update2,
+          complete: true,
+          partial: false,
         },
         resultAfterCacheUpdate3: {
           ...loadingStates.refetching,
           data: cacheValues.update3,
+          complete: true,
+          partial: false,
         },
         resultAfterRefetchNext: {
           ...loadingStates.done,
           data: cacheValues.refetch,
+          complete: true,
+          partial: false,
         },
         resultAfterCacheUpdate4: {
           ...loadingStates.done,
           data: cacheValues.update4,
+          complete: true,
+          partial: false,
         },
       };
 
@@ -2744,34 +2981,50 @@ describe("ObservableQuery", () => {
         resultBeforeSubscribe: {
           ...loadingStates.loading,
           data: undefined,
+          complete: false,
+          partial: true,
         },
         resultAfterSubscribe: {
           ...loadingStates.loading,
           data: undefined,
+          complete: false,
+          partial: true,
         },
         resultAfterCacheUpdate1: {
           ...loadingStates.loading,
           data: undefined,
+          complete: false,
+          partial: true,
         },
         resultAfterLinkNext: {
           ...loadingStates.done,
           data: cacheValues.link,
+          complete: false,
+          partial: true,
         },
         resultAfterCacheUpdate2: {
           ...loadingStates.done,
           data: cacheValues.link,
+          complete: false,
+          partial: true,
         },
         resultAfterCacheUpdate3: {
           ...loadingStates.refetching,
           data: cacheValues.link,
+          complete: false,
+          partial: true,
         },
         resultAfterRefetchNext: {
           ...loadingStates.done,
           data: cacheValues.refetch,
+          complete: false,
+          partial: true,
         },
         resultAfterCacheUpdate4: {
           ...loadingStates.done,
           data: cacheValues.refetch,
+          complete: false,
+          partial: true,
         },
       };
 
@@ -2780,26 +3033,38 @@ describe("ObservableQuery", () => {
         resultBeforeSubscribe: {
           ...loadingStates.loading,
           data: undefined,
+          complete: false,
+          partial: true,
         },
         resultAfterSubscribe: {
           ...loadingStates.loading,
           data: undefined,
+          complete: false,
+          partial: true,
         },
         resultAfterCacheUpdate1: {
           ...loadingStates.loading,
           data: undefined,
+          complete: false,
+          partial: true,
         },
         resultAfterLinkNext: {
           ...loadingStates.loading,
           data: undefined,
+          complete: false,
+          partial: true,
         },
         resultAfterCacheUpdate2: {
           ...loadingStates.loading,
           data: undefined,
+          complete: false,
+          partial: true,
         },
         resultAfterCacheUpdate3: {
           ...loadingStates.refetching,
           data: undefined,
+          complete: false,
+          partial: true,
         },
         // like linkOnly:
         // resultAfterRefetchNext
@@ -2811,14 +3076,20 @@ describe("ObservableQuery", () => {
         resultBeforeSubscribe: {
           ...loadingStates.loading,
           data: undefined,
+          complete: false,
+          partial: true,
         },
         resultAfterSubscribe: {
           ...loadingStates.loading,
           data: undefined,
+          complete: false,
+          partial: true,
         },
         resultAfterCacheUpdate1: {
           ...loadingStates.loading,
           data: undefined,
+          complete: false,
+          partial: true,
         },
         // like cacheAndLink:
         // resultAfterLinkNext
@@ -2833,18 +3104,26 @@ describe("ObservableQuery", () => {
         resultBeforeSubscribe: {
           ...loadingStates.done,
           data: cacheValues.initial,
+          complete: true,
+          partial: false,
         },
         resultAfterSubscribe: {
           ...loadingStates.done,
           data: cacheValues.initial,
+          complete: false,
+          partial: true,
         },
         resultAfterCacheUpdate1: {
           ...loadingStates.done,
           data: cacheValues.update1,
+          complete: false,
+          partial: true,
         },
         resultAfterLinkNext: {
           ...loadingStates.done,
           data: cacheValues.update1,
+          complete: false,
+          partial: true,
         },
         // like cacheAndLink:
         // resultAfterCacheUpdate2
@@ -3013,11 +3292,15 @@ describe("ObservableQuery", () => {
           data: dataOne,
           loading: false,
           networkStatus: NetworkStatus.ready,
+          complete: true,
+          partial: false,
         });
         expect(observable.getCurrentResult()).toEqualApolloQueryResult({
           data: dataOne,
           loading: false,
           networkStatus: NetworkStatus.ready,
+          complete: true,
+          partial: false,
         });
 
         void client.mutate({
@@ -3032,6 +3315,8 @@ describe("ObservableQuery", () => {
           },
           loading: false,
           networkStatus: NetworkStatus.ready,
+          complete: true,
+          partial: false,
         });
         expect(observable.getCurrentResult()).toEqualApolloQueryResult({
           data: {
@@ -3039,6 +3324,8 @@ describe("ObservableQuery", () => {
           },
           loading: false,
           networkStatus: NetworkStatus.ready,
+          complete: true,
+          partial: false,
         });
 
         await expect(stream).toEmitApolloQueryResult({
@@ -3047,6 +3334,8 @@ describe("ObservableQuery", () => {
           },
           loading: false,
           networkStatus: NetworkStatus.ready,
+          complete: true,
+          partial: false,
         });
         expect(observable.getCurrentResult()).toEqualApolloQueryResult({
           data: {
@@ -3054,6 +3343,8 @@ describe("ObservableQuery", () => {
           },
           loading: false,
           networkStatus: NetworkStatus.ready,
+          complete: true,
+          partial: false,
         });
 
         await expect(stream).not.toEmitAnything();
@@ -3362,6 +3653,8 @@ describe("ObservableQuery", () => {
       data: dataOne,
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     let invalidateCount = 0;
@@ -3425,6 +3718,8 @@ describe("ObservableQuery", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         data: dataOne,
+        complete: true,
+        partial: false,
       });
       return {
         ...result,
@@ -3440,6 +3735,8 @@ describe("ObservableQuery", () => {
       loading: false,
       networkStatus: NetworkStatus.ready,
       data: { mapped: true },
+      complete: true,
+      partial: false,
     });
 
     await expect(stream).not.toEmitAnything();
@@ -3637,10 +3934,12 @@ test("handles changing variables in rapid succession before other request is com
   observable.subscribe(jest.fn());
 
   await waitFor(() => {
-    expect(observable.getCurrentResult(false)).toEqual({
+    expect(observable.getCurrentResult(false)).toEqualApolloQueryResult({
       data: { userCount: 10 },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
   });
 
@@ -3652,9 +3951,11 @@ test("handles changing variables in rapid succession before other request is com
   await wait(50);
 
   expect(observable.options.variables).toEqual({ department: null });
-  expect(observable.getCurrentResult(false)).toEqual({
+  expect(observable.getCurrentResult(false)).toEqualApolloQueryResult({
     data: { userCount: 10 },
     loading: false,
     networkStatus: NetworkStatus.ready,
+    complete: true,
+    partial: false,
   });
 });

--- a/src/core/__tests__/fetchPolicies.ts
+++ b/src/core/__tests__/fetchPolicies.ts
@@ -418,10 +418,12 @@ describe("no-cache", () => {
         };
       }
 
-      await expect(stream).toEmitValue({
+      await expect(stream).toEmitApolloQueryResult({
         data: dataWithId(1),
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(client.cache.extract(true)).toEqual({});
 
@@ -431,12 +433,16 @@ describe("no-cache", () => {
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
+        complete: false,
+        partial: true,
       });
 
       await expect(stream).toEmitApolloQueryResult({
         data: dataWithId(2),
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(client.cache.extract(true)).toEqual({});
 
@@ -446,6 +452,8 @@ describe("no-cache", () => {
         data: dataWithId(2),
         loading: true,
         networkStatus: NetworkStatus.refetch,
+        complete: true,
+        partial: false,
       });
       expect(client.cache.extract(true)).toEqual({});
 
@@ -453,6 +461,8 @@ describe("no-cache", () => {
         data: dataWithId(2),
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(client.cache.extract(true)).toEqual({});
 
@@ -462,6 +472,8 @@ describe("no-cache", () => {
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
+        complete: false,
+        partial: true,
       });
       expect(client.cache.extract(true)).toEqual({});
 
@@ -469,6 +481,8 @@ describe("no-cache", () => {
         data: dataWithId(3),
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(client.cache.extract(true)).toEqual({});
 
@@ -505,6 +519,7 @@ describe("cache-first", () => {
       loading: true,
       networkStatus: NetworkStatus.loading,
       complete: false,
+      partial: true,
     });
     expect(results).toHaveLength(0);
 
@@ -520,6 +535,7 @@ describe("cache-first", () => {
       loading: false,
       networkStatus: NetworkStatus.ready,
       complete: true,
+      partial: false,
     });
     expect(results).toHaveLength(1);
 
@@ -546,6 +562,7 @@ describe("cache-first", () => {
       loading: false,
       networkStatus: NetworkStatus.ready,
       complete: false,
+      partial: true,
     });
     expect(results).toHaveLength(1);
 
@@ -566,6 +583,7 @@ describe("cache-first", () => {
       loading: false,
       networkStatus: NetworkStatus.ready,
       complete: true,
+      partial: false,
     });
     // A network request should not be triggered until after the bogus
     // optimistic transaction has been removed.
@@ -596,6 +614,7 @@ describe("cache-first", () => {
       loading: false,
       networkStatus: NetworkStatus.ready,
       complete: true,
+      partial: false,
     });
     expect(inOptimisticTransaction).toBe(false);
     expect(results).toHaveLength(1);
@@ -635,23 +654,27 @@ describe("cache-only", () => {
 
     const stream = new ObservableStream(observable);
 
-    await expect(stream).toEmitValue({
+    await expect(stream).toEmitApolloQueryResult({
       loading: false,
       networkStatus: NetworkStatus.ready,
       data: {
         count: 1,
       },
+      complete: true,
+      partial: false,
     });
     expect(observable.options.fetchPolicy).toBe("cache-only");
 
     await observable.refetch();
 
-    await expect(stream).toEmitValue({
+    await expect(stream).toEmitApolloQueryResult({
       loading: false,
       networkStatus: NetworkStatus.ready,
       data: {
         count: 2,
       },
+      complete: true,
+      partial: false,
     });
 
     expect(observable.options.fetchPolicy).toBe("cache-only");
@@ -704,10 +727,12 @@ describe("cache-and-network", function () {
       };
     }
 
-    await expect(stream).toEmitValue({
+    await expect(stream).toEmitApolloQueryResult({
       data: dataWithId(1),
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     await observable.setVariables({ id: "2" });
@@ -716,12 +741,16 @@ describe("cache-and-network", function () {
       data: undefined,
       loading: true,
       networkStatus: NetworkStatus.setVariables,
+      complete: false,
+      partial: true,
     });
 
     await expect(stream).toEmitApolloQueryResult({
       data: dataWithId(2),
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     await observable.refetch();
@@ -730,12 +759,16 @@ describe("cache-and-network", function () {
       data: dataWithId(2),
       loading: true,
       networkStatus: NetworkStatus.refetch,
+      complete: true,
+      partial: false,
     });
 
     await expect(stream).toEmitApolloQueryResult({
       data: dataWithId(2),
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     await observable.refetch({ id: "3" });
@@ -744,12 +777,16 @@ describe("cache-and-network", function () {
       data: undefined,
       loading: true,
       networkStatus: NetworkStatus.setVariables,
+      complete: false,
+      partial: true,
     });
 
     await expect(stream).toEmitApolloQueryResult({
       data: dataWithId(3),
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     await expect(stream).not.toEmitAnything();
@@ -890,6 +927,8 @@ describe("nextFetchPolicy", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
     }
 
@@ -906,6 +945,8 @@ describe("nextFetchPolicy", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     expect(observable.options.fetchPolicy).toBe("cache-first");
@@ -930,6 +971,8 @@ describe("nextFetchPolicy", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       // Changing variables resets the fetchPolicy to its initial value.
@@ -949,6 +992,8 @@ describe("nextFetchPolicy", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     // But nextFetchPolicy is applied again after the first request.
@@ -1035,6 +1080,8 @@ describe("nextFetchPolicy", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
     }
 
@@ -1051,6 +1098,8 @@ describe("nextFetchPolicy", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
     // Changing variables resets the fetchPolicy to its initial value.
     // expect(observable.options.fetchPolicy).toBe("cache-and-network");
@@ -1076,6 +1125,8 @@ describe("nextFetchPolicy", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
     }
 
@@ -1092,6 +1143,8 @@ describe("nextFetchPolicy", () => {
       },
       loading: true,
       networkStatus: NetworkStatus.setVariables,
+      complete: true,
+      partial: false,
     });
     // But nextFetchPolicy is applied again after the first request.
     expect(observable.options.fetchPolicy).toBe("cache-first");
@@ -1109,6 +1162,8 @@ describe("nextFetchPolicy", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
     expect(observable.options.fetchPolicy).toBe("cache-first");
 
@@ -1202,6 +1257,8 @@ describe("nextFetchPolicy", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
     }
 
@@ -1218,6 +1275,8 @@ describe("nextFetchPolicy", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
     expect(observable.options.fetchPolicy).toBe("cache-first");
 
@@ -1241,6 +1300,8 @@ describe("nextFetchPolicy", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       // The nextFetchPolicy function we provided always returnes cache-first,
@@ -1263,6 +1324,8 @@ describe("nextFetchPolicy", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
     expect(observable.options.fetchPolicy).toBe("cache-first");
 

--- a/src/core/__tests__/fetchPolicies.ts
+++ b/src/core/__tests__/fetchPolicies.ts
@@ -422,7 +422,6 @@ describe("no-cache", () => {
         data: dataWithId(1),
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(client.cache.extract(true)).toEqual({});
@@ -433,7 +432,6 @@ describe("no-cache", () => {
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
-        complete: false,
         partial: true,
       });
 
@@ -441,7 +439,6 @@ describe("no-cache", () => {
         data: dataWithId(2),
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(client.cache.extract(true)).toEqual({});
@@ -452,7 +449,6 @@ describe("no-cache", () => {
         data: dataWithId(2),
         loading: true,
         networkStatus: NetworkStatus.refetch,
-        complete: true,
         partial: false,
       });
       expect(client.cache.extract(true)).toEqual({});
@@ -461,7 +457,6 @@ describe("no-cache", () => {
         data: dataWithId(2),
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(client.cache.extract(true)).toEqual({});
@@ -472,7 +467,6 @@ describe("no-cache", () => {
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.setVariables,
-        complete: false,
         partial: true,
       });
       expect(client.cache.extract(true)).toEqual({});
@@ -481,7 +475,6 @@ describe("no-cache", () => {
         data: dataWithId(3),
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(client.cache.extract(true)).toEqual({});
@@ -518,7 +511,6 @@ describe("cache-first", () => {
       data: undefined,
       loading: true,
       networkStatus: NetworkStatus.loading,
-      complete: false,
       partial: true,
     });
     expect(results).toHaveLength(0);
@@ -534,7 +526,6 @@ describe("cache-first", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
     expect(results).toHaveLength(1);
@@ -561,7 +552,6 @@ describe("cache-first", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: false,
       partial: true,
     });
     expect(results).toHaveLength(1);
@@ -582,7 +572,6 @@ describe("cache-first", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
     // A network request should not be triggered until after the bogus
@@ -613,7 +602,6 @@ describe("cache-first", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
     expect(inOptimisticTransaction).toBe(false);
@@ -660,7 +648,6 @@ describe("cache-only", () => {
       data: {
         count: 1,
       },
-      complete: true,
       partial: false,
     });
     expect(observable.options.fetchPolicy).toBe("cache-only");
@@ -673,7 +660,6 @@ describe("cache-only", () => {
       data: {
         count: 2,
       },
-      complete: true,
       partial: false,
     });
 
@@ -731,7 +717,6 @@ describe("cache-and-network", function () {
       data: dataWithId(1),
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -741,7 +726,6 @@ describe("cache-and-network", function () {
       data: undefined,
       loading: true,
       networkStatus: NetworkStatus.setVariables,
-      complete: false,
       partial: true,
     });
 
@@ -749,7 +733,6 @@ describe("cache-and-network", function () {
       data: dataWithId(2),
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -759,7 +742,6 @@ describe("cache-and-network", function () {
       data: dataWithId(2),
       loading: true,
       networkStatus: NetworkStatus.refetch,
-      complete: true,
       partial: false,
     });
 
@@ -767,7 +749,6 @@ describe("cache-and-network", function () {
       data: dataWithId(2),
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -777,7 +758,6 @@ describe("cache-and-network", function () {
       data: undefined,
       loading: true,
       networkStatus: NetworkStatus.setVariables,
-      complete: false,
       partial: true,
     });
 
@@ -785,7 +765,6 @@ describe("cache-and-network", function () {
       data: dataWithId(3),
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -927,7 +906,6 @@ describe("nextFetchPolicy", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
     }
@@ -945,7 +923,6 @@ describe("nextFetchPolicy", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -971,7 +948,6 @@ describe("nextFetchPolicy", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -992,7 +968,6 @@ describe("nextFetchPolicy", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -1080,7 +1055,6 @@ describe("nextFetchPolicy", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
     }
@@ -1098,7 +1072,6 @@ describe("nextFetchPolicy", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
     // Changing variables resets the fetchPolicy to its initial value.
@@ -1125,7 +1098,6 @@ describe("nextFetchPolicy", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
     }
@@ -1143,7 +1115,6 @@ describe("nextFetchPolicy", () => {
       },
       loading: true,
       networkStatus: NetworkStatus.setVariables,
-      complete: true,
       partial: false,
     });
     // But nextFetchPolicy is applied again after the first request.
@@ -1162,7 +1133,6 @@ describe("nextFetchPolicy", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
     expect(observable.options.fetchPolicy).toBe("cache-first");
@@ -1257,7 +1227,6 @@ describe("nextFetchPolicy", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
     }
@@ -1275,7 +1244,6 @@ describe("nextFetchPolicy", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
     expect(observable.options.fetchPolicy).toBe("cache-first");
@@ -1300,7 +1268,6 @@ describe("nextFetchPolicy", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -1324,7 +1291,6 @@ describe("nextFetchPolicy", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
     expect(observable.options.fetchPolicy).toBe("cache-first");

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -160,6 +160,14 @@ export interface ApolloQueryResult<T> {
    * set when `returnPartialData` is `true` in query options.
    */
   complete: boolean;
+  /**
+   * Describes whether `data` is a complete or partial result. This flag is only
+   * set when `returnPartialData` is `true` in query options.
+   *
+   * @deprecated Please use the `complete` flag on the result instead. This
+   * field will be removed in a future version of Apollo Client.
+   */
+  partial: boolean;
 }
 
 // This is part of the public API, people write these functions in `updateQueries`.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -155,10 +155,11 @@ export interface ApolloQueryResult<T> {
   error?: ApolloError;
   loading: boolean;
   networkStatus: NetworkStatus;
-  // If result.data was read from the cache with missing fields,
-  // result.partial will be true. Otherwise, result.partial will be falsy
-  // (usually because the property is absent from the result object).
-  partial?: boolean;
+  /**
+   * Describes whether `data` is a complete or partial result. This flag is only
+   * set when `returnPartialData` is `true` in query options.
+   */
+  complete?: boolean;
 }
 
 // This is part of the public API, people write these functions in `updateQueries`.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -141,7 +141,7 @@ export type { QueryOptions as PureQueryOptions };
 export type OperationVariables = Record<string, any>;
 
 export interface ApolloQueryResult<T> {
-  data: T;
+  data: T | undefined;
   /**
    * A list of any errors that occurred during server-side execution of a GraphQL operation.
    * See https://www.apollographql.com/docs/react/data/error-handling/ for more information.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -158,14 +158,8 @@ export interface ApolloQueryResult<T> {
   /**
    * Describes whether `data` is a complete or partial result. This flag is only
    * set when `returnPartialData` is `true` in query options.
-   */
-  complete: boolean;
-  /**
-   * Describes whether `data` is a complete or partial result. This flag is only
-   * set when `returnPartialData` is `true` in query options.
    *
-   * @deprecated Please use the `complete` flag on the result instead. This
-   * field will be removed in a future version of Apollo Client.
+   * @deprecated This field will be removed in a future version of Apollo Client.
    */
   partial: boolean;
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -159,7 +159,7 @@ export interface ApolloQueryResult<T> {
    * Describes whether `data` is a complete or partial result. This flag is only
    * set when `returnPartialData` is `true` in query options.
    */
-  complete?: boolean;
+  complete: boolean;
 }
 
 // This is part of the public API, people write these functions in `updateQueries`.

--- a/src/react/hooks/__tests__/useBackgroundQuery.test.tsx
+++ b/src/react/hooks/__tests__/useBackgroundQuery.test.tsx
@@ -8271,7 +8271,7 @@ describe.skip("type tests", () => {
       const result = await refetch();
 
       expectTypeOf(result.data).toEqualTypeOf<
-        Masked<MaskedVariablesCaseData>
+        Masked<MaskedVariablesCaseData> | undefined
       >();
       expectTypeOf(result.data).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
     }
@@ -8281,7 +8281,9 @@ describe.skip("type tests", () => {
 
       const result = await refetch();
 
-      expectTypeOf(result.data).toEqualTypeOf<MaskedVariablesCaseData>();
+      expectTypeOf(result.data).toEqualTypeOf<
+        MaskedVariablesCaseData | undefined
+      >();
       expectTypeOf(result.data).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
     }
   });
@@ -8309,7 +8311,7 @@ describe.skip("type tests", () => {
       });
 
       expectTypeOf(result.data).toEqualTypeOf<
-        Masked<MaskedVariablesCaseData>
+        Masked<MaskedVariablesCaseData> | undefined
       >();
       expectTypeOf(result.data).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
     }
@@ -8333,7 +8335,9 @@ describe.skip("type tests", () => {
         },
       });
 
-      expectTypeOf(result.data).toEqualTypeOf<MaskedVariablesCaseData>();
+      expectTypeOf(result.data).toEqualTypeOf<
+        MaskedVariablesCaseData | undefined
+      >();
       expectTypeOf(result.data).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
     }
   });

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -3384,13 +3384,13 @@ describe.skip("Type Tests", () => {
         },
       });
 
-      expectTypeOf(data).toEqualTypeOf<Masked<Query>>();
+      expectTypeOf(data).toEqualTypeOf<Masked<Query> | undefined>();
     }
 
     {
       const { data } = await refetch();
 
-      expectTypeOf(data).toEqualTypeOf<Masked<Query>>();
+      expectTypeOf(data).toEqualTypeOf<Masked<Query> | undefined>();
     }
   });
 
@@ -3483,13 +3483,13 @@ describe.skip("Type Tests", () => {
         },
       });
 
-      expectTypeOf(data).toEqualTypeOf<Query>();
+      expectTypeOf(data).toEqualTypeOf<Query | undefined>();
     }
 
     {
       const { data } = await refetch();
 
-      expectTypeOf(data).toEqualTypeOf<Query>();
+      expectTypeOf(data).toEqualTypeOf<Query | undefined>();
     }
   });
 });

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -492,7 +492,6 @@ describe("useLazyQuery Hook", () => {
       data: { counter: 2, vars: { execVar: false } },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -488,10 +488,12 @@ describe("useLazyQuery Hook", () => {
       },
     });
 
-    expect(refetchResult).toEqual({
+    expect(refetchResult).toEqualApolloQueryResult({
       data: { counter: 2, vars: { execVar: false } },
       loading: false,
       networkStatus: NetworkStatus.ready,
+      complete: true,
+      partial: false,
     });
 
     {

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -1845,12 +1845,14 @@ describe("useMutation Hook", () => {
             todoCount: 1,
           },
         });
-        expect(onUpdateResult.result).toEqual({
+        expect(onUpdateResult.result).toEqualApolloQueryResult({
           loading: false,
           networkStatus: NetworkStatus.ready,
           data: {
             todoCount: 1,
           },
+          complete: true,
+          partial: false,
         });
       });
 

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -1851,7 +1851,6 @@ describe("useMutation Hook", () => {
           data: {
             todoCount: 1,
           },
-          complete: true,
           partial: false,
         });
       });

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -7,7 +7,6 @@ import { render, screen, waitFor, renderHook } from "@testing-library/react";
 import {
   ApolloClient,
   ApolloError,
-  ApolloQueryResult,
   FetchPolicy,
   NetworkStatus,
   OperationVariables,
@@ -6214,17 +6213,14 @@ describe("useQuery Hook", () => {
       expect(
         snapshot.useQueryResult?.observable.getCurrentResult(false)!
       ).toEqualApolloQueryResult({
+        data: undefined,
         error: new ApolloError({
           graphQLErrors: [new GraphQLError("Intentional error")],
         }),
         errors: [new GraphQLError("Intentional error")],
         loading: false,
         networkStatus: NetworkStatus.error,
-        partial: true,
-        // TODO: Fix ApolloQueryResult type to allow `data` to be an optional property.
-        // This fails without the type case for now even though the runtime
-        // code doesn't include a `data` property.
-      } as unknown as ApolloQueryResult<Query1>);
+      });
 
       expect(snapshot.useLazyQueryResult!).toEqualQueryResult({
         data: { person: { __typename: "Person", id: 1, lastName: "Doe" } },
@@ -6280,15 +6276,13 @@ describe("useQuery Hook", () => {
       expect(
         snapshot.useQueryResult?.observable.getCurrentResult(false)!
       ).toEqualApolloQueryResult({
-        // TODO: Fix TypeScript types to allow for `data` to be `undefined`
-        data: undefined as unknown as Query1,
+        data: undefined,
         error: new ApolloError({
           graphQLErrors: [new GraphQLError("Intentional error")],
         }),
         errors: [new GraphQLError("Intentional error")],
         loading: false,
         networkStatus: NetworkStatus.error,
-        partial: true,
       });
 
       expect(snapshot.useLazyQueryResult!).toEqualQueryResult({

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -1853,7 +1853,6 @@ describe("useQuery Hook", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -1908,7 +1907,6 @@ describe("useQuery Hook", () => {
         data: { vars: { sourceOfVar: "reobserve without variable merge" } },
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -2252,7 +2250,6 @@ describe("useQuery Hook", () => {
               data: {
                 linkCount: expectedLinkCount,
               },
-              complete: true,
               partial: false,
             });
           } else {
@@ -2272,7 +2269,6 @@ describe("useQuery Hook", () => {
         data: { linkCount: 2 },
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -5281,7 +5277,6 @@ describe("useQuery Hook", () => {
         data: { letters: cd },
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -5354,7 +5349,6 @@ describe("useQuery Hook", () => {
         data: { letters: cd },
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -5445,7 +5439,6 @@ describe("useQuery Hook", () => {
         data: { letters: cd },
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -5527,7 +5520,6 @@ describe("useQuery Hook", () => {
         data: { letters: cd },
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -5744,7 +5736,6 @@ describe("useQuery Hook", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -5823,7 +5814,6 @@ describe("useQuery Hook", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -6240,7 +6230,6 @@ describe("useQuery Hook", () => {
         errors: [new GraphQLError("Intentional error")],
         loading: false,
         networkStatus: NetworkStatus.error,
-        complete: false,
         partial: true,
       });
 
@@ -6305,7 +6294,6 @@ describe("useQuery Hook", () => {
         errors: [new GraphQLError("Intentional error")],
         loading: false,
         networkStatus: NetworkStatus.error,
-        complete: false,
         partial: true,
       });
 
@@ -7313,7 +7301,6 @@ describe("useQuery Hook", () => {
         data: { hello: "world 2" },
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -7449,7 +7436,6 @@ describe("useQuery Hook", () => {
           data: { primes: [13, 17, 19, 23, 29] },
           loading: false,
           networkStatus: NetworkStatus.ready,
-          complete: true,
           partial: false,
         });
 
@@ -7561,7 +7547,6 @@ describe("useQuery Hook", () => {
           data: { primes: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29] },
           loading: false,
           networkStatus: NetworkStatus.ready,
-          complete: true,
           partial: false,
         });
 
@@ -7671,7 +7656,6 @@ describe("useQuery Hook", () => {
           data: { primes: [13, 17, 19, 23, 29] },
           loading: false,
           networkStatus: NetworkStatus.ready,
-          complete: true,
           partial: false,
         });
 
@@ -9169,7 +9153,6 @@ describe("useQuery Hook", () => {
         data: { hello: "world" },
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 
@@ -9284,7 +9267,6 @@ describe("useQuery Hook", () => {
         data: { hello: 2 },
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
       expect(reasons).toEqual(["variables-changed", "after-fetch"]);
@@ -10159,7 +10141,6 @@ describe("useQuery Hook", () => {
         data: { a: "aaa", b: 2 },
         loading: false,
         networkStatus: NetworkStatus.ready,
-        complete: true,
         partial: false,
       });
 

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -1853,6 +1853,8 @@ describe("useQuery Hook", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       {
@@ -1906,6 +1908,8 @@ describe("useQuery Hook", () => {
         data: { vars: { sourceOfVar: "reobserve without variable merge" } },
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       {
@@ -2242,12 +2246,14 @@ describe("useQuery Hook", () => {
           if (obsQuery.hasObservers()) {
             expect(inactiveSet.has(obsQuery)).toBe(false);
             activeSet.add(obsQuery);
-            expect(obsQuery.getCurrentResult()).toEqual({
+            expect(obsQuery.getCurrentResult()).toEqualApolloQueryResult({
               loading: false,
               networkStatus: NetworkStatus.ready,
               data: {
                 linkCount: expectedLinkCount,
               },
+              complete: true,
+              partial: false,
             });
           } else {
             expect(activeSet.has(obsQuery)).toBe(false);
@@ -2266,6 +2272,8 @@ describe("useQuery Hook", () => {
         data: { linkCount: 2 },
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       {
@@ -5273,6 +5281,8 @@ describe("useQuery Hook", () => {
         data: { letters: cd },
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       {
@@ -5344,6 +5354,8 @@ describe("useQuery Hook", () => {
         data: { letters: cd },
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       {
@@ -5433,6 +5445,8 @@ describe("useQuery Hook", () => {
         data: { letters: cd },
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       {
@@ -5513,6 +5527,8 @@ describe("useQuery Hook", () => {
         data: { letters: cd },
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       {
@@ -5728,6 +5744,8 @@ describe("useQuery Hook", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await expect(takeSnapshot).not.toRerender();
@@ -5805,6 +5823,8 @@ describe("useQuery Hook", () => {
         },
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await expect(takeSnapshot).not.toRerender();
@@ -6220,6 +6240,8 @@ describe("useQuery Hook", () => {
         errors: [new GraphQLError("Intentional error")],
         loading: false,
         networkStatus: NetworkStatus.error,
+        complete: false,
+        partial: true,
       });
 
       expect(snapshot.useLazyQueryResult!).toEqualQueryResult({
@@ -6283,6 +6305,8 @@ describe("useQuery Hook", () => {
         errors: [new GraphQLError("Intentional error")],
         loading: false,
         networkStatus: NetworkStatus.error,
+        complete: false,
+        partial: true,
       });
 
       expect(snapshot.useLazyQueryResult!).toEqualQueryResult({
@@ -7289,6 +7313,8 @@ describe("useQuery Hook", () => {
         data: { hello: "world 2" },
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       {
@@ -7423,6 +7449,8 @@ describe("useQuery Hook", () => {
           data: { primes: [13, 17, 19, 23, 29] },
           loading: false,
           networkStatus: NetworkStatus.ready,
+          complete: true,
+          partial: false,
         });
 
         {
@@ -7533,6 +7561,8 @@ describe("useQuery Hook", () => {
           data: { primes: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29] },
           loading: false,
           networkStatus: NetworkStatus.ready,
+          complete: true,
+          partial: false,
         });
 
         {
@@ -7641,6 +7671,8 @@ describe("useQuery Hook", () => {
           data: { primes: [13, 17, 19, 23, 29] },
           loading: false,
           networkStatus: NetworkStatus.ready,
+          complete: true,
+          partial: false,
         });
 
         {
@@ -9137,6 +9169,8 @@ describe("useQuery Hook", () => {
         data: { hello: "world" },
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       expect(requestSpy).toHaveBeenCalledTimes(1);
@@ -9250,6 +9284,8 @@ describe("useQuery Hook", () => {
         data: { hello: 2 },
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
       expect(reasons).toEqual(["variables-changed", "after-fetch"]);
 
@@ -10123,6 +10159,8 @@ describe("useQuery Hook", () => {
         data: { a: "aaa", b: 2 },
         loading: false,
         networkStatus: NetworkStatus.ready,
+        complete: true,
+        partial: false,
       });
 
       await expect(takeSnapshot()).resolves.toEqualQueryResult({

--- a/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
@@ -7901,7 +7901,6 @@ describe("useSuspenseQuery", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -8285,7 +8284,6 @@ describe("useSuspenseQuery", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 
@@ -9456,7 +9454,6 @@ describe("useSuspenseQuery", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      complete: true,
       partial: false,
     });
 

--- a/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
@@ -7888,7 +7888,7 @@ describe("useSuspenseQuery", () => {
       });
     });
 
-    await expect(refetchPromise!).resolves.toEqual({
+    await expect(refetchPromise!).resolves.toEqualApolloQueryResult({
       data: {
         greeting: {
           __typename: "Greeting",
@@ -7901,7 +7901,8 @@ describe("useSuspenseQuery", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      error: undefined,
+      complete: true,
+      partial: false,
     });
 
     expect(renders.count).toBe(6 + (IS_REACT_19 ? renders.suspenseCount : 0));
@@ -8269,7 +8270,7 @@ describe("useSuspenseQuery", () => {
       });
     });
 
-    await expect(fetchMorePromise!).resolves.toEqual({
+    await expect(fetchMorePromise!).resolves.toEqualApolloQueryResult({
       data: {
         greetings: [
           {
@@ -8284,7 +8285,8 @@ describe("useSuspenseQuery", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      error: undefined,
+      complete: true,
+      partial: false,
     });
 
     expect(renders.count).toBe(5 + (IS_REACT_19 ? renders.suspenseCount : 0));
@@ -9442,7 +9444,7 @@ describe("useSuspenseQuery", () => {
       });
     });
 
-    await expect(refetchPromise!).resolves.toEqual({
+    await expect(refetchPromise!).resolves.toEqualApolloQueryResult({
       data: {
         hero: {
           heroFriends: [
@@ -9454,7 +9456,8 @@ describe("useSuspenseQuery", () => {
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
-      error: undefined,
+      complete: true,
+      partial: false,
     });
 
     cache.updateQuery({ query }, (data) => ({

--- a/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
@@ -12783,7 +12783,7 @@ describe("useSuspenseQuery", () => {
         const result = await refetch();
 
         expectTypeOf(result.data).toEqualTypeOf<
-          Masked<MaskedVariablesCaseData>
+          Masked<MaskedVariablesCaseData> | undefined
         >();
         expectTypeOf(
           result.data
@@ -12795,7 +12795,9 @@ describe("useSuspenseQuery", () => {
 
         const result = await refetch();
 
-        expectTypeOf(result.data).toEqualTypeOf<MaskedVariablesCaseData>();
+        expectTypeOf(result.data).toEqualTypeOf<
+          MaskedVariablesCaseData | undefined
+        >();
         expectTypeOf(
           result.data
         ).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
@@ -12827,7 +12829,7 @@ describe("useSuspenseQuery", () => {
         });
 
         expectTypeOf(result.data).toEqualTypeOf<
-          Masked<MaskedVariablesCaseData>
+          Masked<MaskedVariablesCaseData> | undefined
         >();
         expectTypeOf(
           result.data
@@ -12855,7 +12857,9 @@ describe("useSuspenseQuery", () => {
           },
         });
 
-        expectTypeOf(result.data).toEqualTypeOf<MaskedVariablesCaseData>();
+        expectTypeOf(result.data).toEqualTypeOf<
+          MaskedVariablesCaseData | undefined
+        >();
         expectTypeOf(
           result.data
         ).not.toEqualTypeOf<UnmaskedVariablesCaseData>();

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -733,7 +733,7 @@ export function toQueryResult<TData, TVariables extends OperationVariables>(
   observable: ObservableQuery<TData, TVariables>,
   client: ApolloClient<object>
 ): InternalQueryResult<TData, TVariables> {
-  const { data, partial, ...resultWithoutPartial } = result;
+  const { data, complete, ...resultWithoutPartial } = result;
   const queryResult: InternalQueryResult<TData, TVariables> = {
     data, // Ensure always defined, even if result.data is missing.
     ...resultWithoutPartial,

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -733,7 +733,7 @@ export function toQueryResult<TData, TVariables extends OperationVariables>(
   observable: ObservableQuery<TData, TVariables>,
   client: ApolloClient<object>
 ): InternalQueryResult<TData, TVariables> {
-  const { data, complete, ...resultWithoutPartial } = result;
+  const { data, complete, partial, ...resultWithoutPartial } = result;
   const queryResult: InternalQueryResult<TData, TVariables> = {
     data, // Ensure always defined, even if result.data is missing.
     ...resultWithoutPartial,

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -426,6 +426,7 @@ function useObservableSubscriptionResult<
             (previousResult && previousResult.loading) ||
             !equal(error, previousResult.error)
           ) {
+            const complete = !!previousResult?.data;
             setResult(
               {
                 data: (previousResult &&
@@ -433,6 +434,8 @@ function useObservableSubscriptionResult<
                 error: error as ApolloError,
                 loading: false,
                 networkStatus: NetworkStatus.error,
+                complete,
+                partial: !complete,
               },
               resultData,
               observable,
@@ -751,6 +754,8 @@ const ssrDisabledResult = maybeDeepFreeze({
   data: void 0 as any,
   error: void 0,
   networkStatus: NetworkStatus.loading,
+  complete: false,
+  partial: true,
 });
 
 const skipStandbyResult = maybeDeepFreeze({
@@ -758,6 +763,8 @@ const skipStandbyResult = maybeDeepFreeze({
   data: void 0 as any,
   error: void 0,
   networkStatus: NetworkStatus.ready,
+  complete: false,
+  partial: true,
 });
 
 function bindObservableMethods<TData, TVariables extends OperationVariables>(

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -426,7 +426,6 @@ function useObservableSubscriptionResult<
             (previousResult && previousResult.loading) ||
             !equal(error, previousResult.error)
           ) {
-            const complete = !!previousResult?.data;
             setResult(
               {
                 data: (previousResult &&
@@ -434,8 +433,7 @@ function useObservableSubscriptionResult<
                 error: error as ApolloError,
                 loading: false,
                 networkStatus: NetworkStatus.error,
-                complete,
-                partial: !complete,
+                partial: !previousResult?.data,
               },
               resultData,
               observable,
@@ -736,7 +734,7 @@ export function toQueryResult<TData, TVariables extends OperationVariables>(
   observable: ObservableQuery<TData, TVariables>,
   client: ApolloClient<object>
 ): InternalQueryResult<TData, TVariables> {
-  const { data, complete, partial, ...resultWithoutPartial } = result;
+  const { data, partial, ...resultWithoutPartial } = result;
   const queryResult: InternalQueryResult<TData, TVariables> = {
     data, // Ensure always defined, even if result.data is missing.
     ...resultWithoutPartial,
@@ -754,7 +752,6 @@ const ssrDisabledResult = maybeDeepFreeze({
   data: void 0 as any,
   error: void 0,
   networkStatus: NetworkStatus.loading,
-  complete: false,
   partial: true,
 });
 
@@ -763,7 +760,6 @@ const skipStandbyResult = maybeDeepFreeze({
   data: void 0 as any,
   error: void 0,
   networkStatus: NetworkStatus.ready,
-  complete: false,
   partial: true,
 });
 

--- a/src/react/hooks/useReadQuery.ts
+++ b/src/react/hooks/useReadQuery.ts
@@ -100,7 +100,7 @@ function useReadQuery_<TData>(
 
   return React.useMemo(() => {
     return {
-      data: result.data,
+      data: result.data!,
       networkStatus: result.networkStatus,
       error: toApolloError(result),
     };

--- a/src/react/hooks/useSuspenseQuery.ts
+++ b/src/react/hooks/useSuspenseQuery.ts
@@ -242,14 +242,17 @@ function useSuspenseQuery_<
     };
   }, [queryRef]);
 
-  const skipResult = React.useMemo(() => {
+  const skipResult = React.useMemo<ApolloQueryResult<TData>>(() => {
     const error = toApolloError(queryRef.result);
+    const complete = !!queryRef.result.data;
 
     return {
       loading: false,
       data: queryRef.result.data,
       networkStatus: error ? NetworkStatus.error : NetworkStatus.ready,
       error,
+      complete,
+      partial: !complete,
     };
   }, [queryRef.result]);
 

--- a/src/react/internal/cache/QueryReference.ts
+++ b/src/react/internal/cache/QueryReference.ts
@@ -517,10 +517,7 @@ export class InternalQueryReference<TData = unknown> {
 
     this.result = result;
     this.promise =
-      (
-        result.data &&
-        (!result.partial || this.watchQueryOptions.returnPartialData)
-      ) ?
+      result.data ?
         createFulfilledPromise(result)
       : this.createPendingPromise();
   }


### PR DESCRIPTION
Closes #12332

This change aims to bring more consistency to the emitted results from the core API with the following changes:

- Makes the `partial` flag a non-optional property that is now emitted with every `ApolloQueryResult`
- Deprecates the `partial` flag. A followup solution will be provided with #12344
- Always sets a `data` property on the emitted result instead of omitting it when it would otherwise be `undefined`. This aligns the runtime behavior with the TypeScript type which specifies `data` as a non-optional property.
- Updates `ApolloQueryResult` to specify `data` as `TData | undefined` to align it with the runtime behavior where an undefined result can be emitted from the core API.

