### PR TITLE
Fix `watchFragment` reports `complete=false` when from object is not identifiable

### DIFF
--- a/src/__tests__/ApolloClient.ts
+++ b/src/__tests__/ApolloClient.ts
@@ -2542,6 +2542,7 @@ describe("ApolloClient", () => {
         expect(result).toStrictEqual({
           data: {},
           complete: false,
+          missing: "Unable to identify object",
         });
       }
     });

--- a/src/__tests__/ApolloClient.ts
+++ b/src/__tests__/ApolloClient.ts
@@ -2515,6 +2515,36 @@ describe("ApolloClient", () => {
         });
       }
     });
+
+    it("reports complete as false when `from` is not identifiable", async () => {
+      const cache = new InMemoryCache();
+      const client = new ApolloClient({
+        cache,
+        link: ApolloLink.empty(),
+      });
+      const ItemFragment = gql`
+        fragment ItemFragment on Item {
+          id
+          text
+        }
+      `;
+
+      const observable = client.watchFragment({
+        fragment: ItemFragment,
+        from: {},
+      });
+
+      const stream = new ObservableStream(observable);
+
+      {
+        const result = await stream.takeNext();
+
+        expect(result).toStrictEqual({
+          data: {},
+          complete: false,
+        });
+      }
+    });
   });
 
   describe("defaultOptions", () => {

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -226,10 +226,23 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
     } = options;
     const query = this.getFragmentDoc(fragment, fragmentName);
 
+    const id = typeof from === "string" ? from : this.identify(from);
+
+    if (!id) {
+      return new Observable((observer) => {
+        observer.next({
+          data: {} as DeepPartial<TData>,
+          complete: false,
+          missing: "Unable to identify object",
+        });
+        return () => {};
+      });
+    }
+
     const diffOptions: Cache.DiffOptions<TData, TVars> = {
       ...otherOptions,
       returnPartialData: true,
-      id: typeof from === "string" ? from : this.identify(from),
+      id,
       query,
       optimistic,
     };


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:

### Checklist:
- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
-->
