### PR TITLE
keep deferred inFlightLinkObservables until the response is finished

### DIFF
--- a/.changeset/quiet-apricots-reply.md
+++ b/.changeset/quiet-apricots-reply.md
@@ -2,4 +2,5 @@
 "@apollo/client": patch
 ---
 
-keep deferred `inFlightLinkObservables` until the response is finished
+In case of a multipart response (e.g. with `@defer`), query deduplication will
+now keep going until the final chunk has been received.

--- a/.changeset/quiet-apricots-reply.md
+++ b/.changeset/quiet-apricots-reply.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+keep deferred `inFlightLinkObservables` until the response is finished

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 42196,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 34405
+  "dist/apollo-client.min.cjs": 42225,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 34432
 }

--- a/src/config/jest/setup.ts
+++ b/src/config/jest/setup.ts
@@ -36,3 +36,6 @@ if (!Symbol.asyncDispose) {
 
 // @ts-ignore
 expect.addEqualityTesters([areApolloErrorsEqual, areGraphQLErrorsEqual]);
+
+// not available in JSDOM 🙄
+global.structuredClone = (val) => JSON.parse(JSON.stringify(val));

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1182,8 +1182,12 @@ export class QueryManager<TStore> {
           ]);
           observable = entry.observable = concast;
 
-          concast.beforeNext(() => {
-            inFlightLinkObservables.remove(printedServerQuery, varJson);
+          concast.beforeNext(function cb(method, arg: FetchResult) {
+            if (method === "next" && "hasNext" in arg && arg.hasNext) {
+              concast.beforeNext(cb);
+            } else {
+              inFlightLinkObservables.remove(printedServerQuery, varJson);
+            }
           });
         }
       } else {


### PR DESCRIPTION
An experiment. This might be required for query streaming with `@defer` and `useSuspenseQuery`.