### PR TITLE
remove cci-based security scans

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,4 +180,3 @@ workflows:
                 - "@types/react@18 @types/react-dom@18"
                 - "@types/react@19 @types/react-dom@19"
                 - "typescript@next"
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,5 @@
 version: 2.1
 
-orbs:
-  secops: apollo/circleci-secops-orb@2.0.7
-
 jobs:
   # Filesize:
   #   docker:
@@ -183,17 +180,4 @@ workflows:
                 - "@types/react@18 @types/react-dom@18"
                 - "@types/react@19 @types/react-dom@19"
                 - "typescript@next"
-  security-scans:
-    jobs:
-      - secops/gitleaks:
-          context:
-            - platform-docker-ro
-            - github-orb
-            - secops-oidc
-          git-base-revision: <<#pipeline.git.base_revision>><<pipeline.git.base_revision>><</pipeline.git.base_revision >>
-          git-revision: << pipeline.git.revision >>
-      - secops/semgrep:
-          context:
-            - secops-oidc
-            - github-orb
-          git-base-revision: <<#pipeline.git.base_revision>><<pipeline.git.base_revision>><</pipeline.git.base_revision >>
+

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 41642,
+  "dist/apollo-client.min.cjs": 41643,
   "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 34384
 }

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 41643,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 34384
+  "dist/apollo-client.min.cjs": 41642,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 34385
 }


### PR DESCRIPTION
## Motivation / Implements

Removes the security scans run in CircleCI. We have replaced these with a github app implementation that fixes some of the issues we've seen with CCI / fetching credentials for the pipelines. These issues have been especially noticeable on PRs from forks.

The updated scans write output to the "Checks" tab in Github rather than using Github comments. Additionally they run faster. 