### PR TITLE
Add `graphql-ws` `^6.0.3` as a valid `peerDependency`

### DIFF
--- a/.changeset/lazy-clocks-sip.md
+++ b/.changeset/lazy-clocks-sip.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Add `graphql-ws` `^6.0.3` as a valid `peerDependency`

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,7 @@
         "globals": "15.14.0",
         "graphql": "16.9.0",
         "graphql-17-alpha2": "npm:graphql@17.0.0-alpha.2",
-        "graphql-ws": "5.16.0",
+        "graphql-ws": "6.0.3",
         "jest": "29.7.0",
         "jest-environment-jsdom": "29.7.0",
         "jest-junit": "16.0.0",
@@ -124,7 +124,7 @@
       },
       "peerDependencies": {
         "graphql": "^15.0.0 || ^16.0.0",
-        "graphql-ws": "^5.5.5",
+        "graphql-ws": "^5.5.5 || ^6.0.3",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc",
         "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
@@ -7997,18 +7997,30 @@
       }
     },
     "node_modules/graphql-ws": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.16.0.tgz",
-      "integrity": "sha512-Ju2RCU2dQMgSKtArPbEtsK5gNLnsQyTNIo/T7cZNp96niC1x0KdJNZV0TIoilceBPQwfb5itrGl8pkFeOUMl4A==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-6.0.3.tgz",
+      "integrity": "sha512-mvLRHihMg0llF74vo16063HufZHMGaiMxAjzyj0ARYueIikGzj1khlbPNl7vUc2h9rxbq9pGpQYbqypgq1fAXA==",
       "dev": true,
-      "workspaces": [
-        "website"
-      ],
+      "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=20"
       },
       "peerDependencies": {
-        "graphql": ">=0.11 <=16"
+        "@fastify/websocket": "^10 || ^11",
+        "graphql": "^15.10.1 || ^16",
+        "uWebSockets.js": "^20",
+        "ws": "^8"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/websocket": {
+          "optional": true
+        },
+        "uWebSockets.js": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
       }
     },
     "node_modules/has": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "graphql": "^15.0.0 || ^16.0.0",
-    "graphql-ws": "^5.5.5",
+    "graphql-ws": "^5.5.5 || ^6.0.3",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc",
     "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
@@ -166,7 +166,7 @@
     "globals": "15.14.0",
     "graphql": "16.9.0",
     "graphql-17-alpha2": "npm:graphql@17.0.0-alpha.2",
-    "graphql-ws": "5.16.0",
+    "graphql-ws": "6.0.3",
     "jest": "29.7.0",
     "jest-environment-jsdom": "29.7.0",
     "jest-junit": "16.0.0",


### PR DESCRIPTION
With the [6.0.3 release](https://github.com/enisdenjo/graphql-ws/releases/tag/v6.0.3), the incorrect alternative response format that was introduced on the `Client.prototype.subscribe` `sink` argument in v6 has been removed, so it can now safely be used as a valid `peerDependency`.