### PR TITLE
Fix emitted `fetchMore` result from `observableQuery` for no-cache queries

### DIFF
--- a/.changeset/curvy-ads-matter.md
+++ b/.changeset/curvy-ads-matter.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fixes an issue where the wrong `networkStatus` and `loading` value was emitted from `observableQuery` when calling `fetchMore` with a `no-cache` fetch policy. The `networkStatus` now properly reports as `ready` and `loading` as `false` after the result is returned.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 41642,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 34385
+  "dist/apollo-client.min.cjs": 41649,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 34394
 }

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -585,7 +585,12 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
           });
 
           this.reportResult(
-            { ...lastResult, data: data as TData },
+            {
+              ...lastResult,
+              networkStatus: originalNetworkStatus!,
+              loading: isNetworkRequestInFlight(originalNetworkStatus),
+              data: data as TData,
+            },
             this.variables
           );
         }


### PR DESCRIPTION
I discovered this issue when working on some updates for 4.0. When `fetchMore` is executed for a `no-cache` query, the wrong `networkStatus` and `loading` value is emitted for the final result in the observable. This doesn't currently affect `useQuery` because `useQuery` uses `getCurrentResult()` which returns the right values.