### PR TITLE
use `WeakCache` for `executeSelectionSet` et al wrappers

### DIFF
--- a/.changeset/hungry-pens-rule.md
+++ b/.changeset/hungry-pens-rule.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Use a WeakCache as backend for `executeSelectionSet`, `executeSubSelectedArray` and `maybeBroadcastWatch`.

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -34,6 +34,7 @@ import { Policies } from "./policies.js";
 import { hasOwn, normalizeConfig, shouldCanonizeResults } from "./helpers.js";
 import type { OperationVariables } from "../../core/index.js";
 import { getInMemoryCacheMemoryInternals } from "../../utilities/caching/getMemoryInternals.js";
+import { WeakCache } from "@wry/caches";
 
 type BroadcastOptions = Pick<
   Cache.BatchOptions<InMemoryCache>,
@@ -131,6 +132,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
         return this.broadcastWatch(c, options);
       },
       {
+        cache: WeakCache,
         max:
           this.config.resultCacheMaxSize ||
           cacheSizes["inMemoryCache.maybeBroadcastWatch"] ||

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -4,6 +4,7 @@ import type { DocumentNode, FieldNode, SelectionSetNode } from "graphql";
 import { Kind } from "graphql";
 import type { OptimisticWrapperFunction } from "optimism";
 import { wrap } from "optimism";
+import { WeakCache } from "@wry/caches";
 
 import type {
   Reference,
@@ -195,6 +196,7 @@ export class StoreReader {
         return this.execSelectionSetImpl(options);
       },
       {
+        cache: WeakCache,
         max:
           this.config.resultCacheMaxSize ||
           cacheSizes["inMemoryCache.executeSelectionSet"] ||
@@ -224,6 +226,7 @@ export class StoreReader {
         return this.execSubSelectedArrayImpl(options);
       },
       {
+        cache: WeakCache,
         max:
           this.config.resultCacheMaxSize ||
           cacheSizes["inMemoryCache.executeSubSelectedArray"] ||


### PR DESCRIPTION
This would address #12360 and ensure that `optimism`-wrapped caclulations that can't possibly be re-executed because the arguments have left memory are cache-collected.

That said, I am pretty sure that I excluded these three methods intentionally while doing my cache collection analysis ([internal link](https://github.com/apollographql/team-clients/issues/196)). I've reread my documentation from back then and don't really find a reason why I did that, but we should probably discuss this more before merging this.