### PR TITLE
Require `variables` option in `useSuspenseFragment` when there are required variables

### DIFF
--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -1547,8 +1547,6 @@ export interface PreloadQueryFunction {
     <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, ...[options]: PreloadQueryOptionsArg<NoInfer_2<TVariables>>): PreloadedQueryRef<TData, TVariables>;
 }
 
-// Warning: (ae-forgotten-export) The symbol "VariablesOption" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
 export type PreloadQueryOptions<TVariables extends OperationVariables = OperationVariables> = {
     canonizeResults?: boolean;
@@ -2472,16 +2470,14 @@ export function useSuspenseFragment<TData, TVariables extends OperationVariables
 // @public (undocumented)
 export function useSuspenseFragment<TData, TVariables extends OperationVariables = OperationVariables>(options: UseSuspenseFragmentOptions<TData, TVariables>): UseSuspenseFragmentResult<TData>;
 
-// Warning: (ae-forgotten-export) The symbol "VariablesOption_2" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
-type UseSuspenseFragmentOptions<TData, TVars> = {
-    fragment: DocumentNode | TypedDocumentNode<TData, TVars>;
+type UseSuspenseFragmentOptions<TData, TVariables extends OperationVariables> = {
+    fragment: DocumentNode | TypedDocumentNode<TData, TVariables>;
     fragmentName?: string;
     from: From<TData>;
     optimistic?: boolean;
     client?: ApolloClient<any>;
-} & VariablesOption_2<NoInfer_2<TVars>>;
+} & VariablesOption<NoInfer_2<TVariables>>;
 
 // @public (undocumented)
 export type UseSuspenseFragmentResult<TData> = {
@@ -2548,21 +2544,10 @@ export interface UseSuspenseQueryResult<TData = unknown, TVariables extends Oper
 }
 
 // @public (undocumented)
-type VariablesOption<TVariables extends OperationVariables> = [
+export type VariablesOption<TVariables extends OperationVariables> = [
 TVariables
 ] extends [never] ? {
     variables?: Record<string, never>;
-} : {} extends OnlyRequiredProperties<TVariables> ? {
-    variables?: TVariables;
-} : {
-    variables: TVariables;
-};
-
-// @public (undocumented)
-type VariablesOption_2<TVariables> = [
-TVariables
-] extends [never] ? {
-    variables?: never;
 } : Record<string, never> extends OnlyRequiredProperties<TVariables> ? {
     variables?: TVariables;
 } : {
@@ -2616,7 +2601,7 @@ interface WatchQueryOptions<TVariables extends OperationVariables = OperationVar
 // src/react/hooks/useBackgroundQuery.ts:51:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:75:4 - (ae-forgotten-export) The symbol "RefetchFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useLoadableQuery.ts:120:9 - (ae-forgotten-export) The symbol "ResetFunction" needs to be exported by the entry point index.d.ts
-// src/react/hooks/useSuspenseFragment.ts:74:5 - (ae-forgotten-export) The symbol "From" needs to be exported by the entry point index.d.ts
+// src/react/hooks/useSuspenseFragment.ts:70:5 - (ae-forgotten-export) The symbol "From" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -2472,14 +2472,16 @@ export function useSuspenseFragment<TData, TVariables extends OperationVariables
 // @public (undocumented)
 export function useSuspenseFragment<TData, TVariables extends OperationVariables = OperationVariables>(options: UseSuspenseFragmentOptions<TData, TVariables>): UseSuspenseFragmentResult<TData>;
 
+// Warning: (ae-forgotten-export) The symbol "VariablesOption_2" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
-interface UseSuspenseFragmentOptions<TData, TVars> extends Omit<Cache_2.DiffOptions<NoInfer_2<TData>, NoInfer_2<TVars>>, "id" | "query" | "optimistic" | "previousResult" | "returnPartialData">, Omit<Cache_2.ReadFragmentOptions<TData, TVars>, "id" | "variables" | "returnPartialData"> {
-    client?: ApolloClient<any>;
-    // (undocumented)
+type UseSuspenseFragmentOptions<TData, TVars> = {
+    fragment: DocumentNode | TypedDocumentNode<TData, TVars>;
+    fragmentName?: string;
     from: From<TData>;
-    // (undocumented)
     optimistic?: boolean;
-}
+    client?: ApolloClient<any>;
+} & VariablesOption_2<NoInfer_2<TVars>>;
 
 // @public (undocumented)
 export type UseSuspenseFragmentResult<TData> = {
@@ -2556,6 +2558,17 @@ TVariables
     variables: TVariables;
 };
 
+// @public (undocumented)
+type VariablesOption_2<TVariables> = [
+TVariables
+] extends [never] ? {
+    variables?: never;
+} : Record<string, never> extends OnlyRequiredProperties<TVariables> ? {
+    variables?: TVariables;
+} : {
+    variables: TVariables;
+};
+
 // @public
 interface WatchFragmentOptions<TData, TVars> {
     fragment: DocumentNode | TypedDocumentNode<TData, TVars>;
@@ -2603,7 +2616,7 @@ interface WatchQueryOptions<TVariables extends OperationVariables = OperationVar
 // src/react/hooks/useBackgroundQuery.ts:51:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:75:4 - (ae-forgotten-export) The symbol "RefetchFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useLoadableQuery.ts:120:9 - (ae-forgotten-export) The symbol "ResetFunction" needs to be exported by the entry point index.d.ts
-// src/react/hooks/useSuspenseFragment.ts:60:5 - (ae-forgotten-export) The symbol "From" needs to be exported by the entry point index.d.ts
+// src/react/hooks/useSuspenseFragment.ts:74:5 - (ae-forgotten-export) The symbol "From" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report-react_hooks.api.md
+++ b/.api-reports/api-report-react_hooks.api.md
@@ -2305,14 +2305,16 @@ export function useSuspenseFragment<TData, TVariables extends OperationVariables
 // @public (undocumented)
 export function useSuspenseFragment<TData, TVariables extends OperationVariables = OperationVariables>(options: UseSuspenseFragmentOptions<TData, TVariables>): UseSuspenseFragmentResult<TData>;
 
+// Warning: (ae-forgotten-export) The symbol "VariablesOption" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
-interface UseSuspenseFragmentOptions<TData, TVars> extends Omit<Cache_2.DiffOptions<NoInfer_2<TData>, NoInfer_2<TVars>>, "id" | "query" | "optimistic" | "previousResult" | "returnPartialData">, Omit<Cache_2.ReadFragmentOptions<TData, TVars>, "id" | "variables" | "returnPartialData"> {
-    client?: ApolloClient<any>;
-    // (undocumented)
+type UseSuspenseFragmentOptions<TData, TVars> = {
+    fragment: DocumentNode | TypedDocumentNode<TData, TVars>;
+    fragmentName?: string;
     from: From<TData>;
-    // (undocumented)
     optimistic?: boolean;
-}
+    client?: ApolloClient<any>;
+} & VariablesOption<NoInfer_2<TVars>>;
 
 // @public (undocumented)
 export type UseSuspenseFragmentResult<TData> = {
@@ -2380,6 +2382,17 @@ export interface UseSuspenseQueryResult<TData = unknown, TVariables extends Oper
     subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
 }
 
+// @public (undocumented)
+type VariablesOption<TVariables> = [
+TVariables
+] extends [never] ? {
+    variables?: never;
+} : Record<string, never> extends OnlyRequiredProperties<TVariables> ? {
+    variables?: TVariables;
+} : {
+    variables: TVariables;
+};
+
 // @public
 interface WatchFragmentOptions<TData, TVars> {
     fragment: DocumentNode | TypedDocumentNode<TData, TVars>;
@@ -2427,7 +2440,7 @@ interface WatchQueryOptions<TVariables extends OperationVariables = OperationVar
 // src/react/hooks/useBackgroundQuery.ts:51:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:75:4 - (ae-forgotten-export) The symbol "RefetchFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useLoadableQuery.ts:120:9 - (ae-forgotten-export) The symbol "ResetFunction" needs to be exported by the entry point index.d.ts
-// src/react/hooks/useSuspenseFragment.ts:60:5 - (ae-forgotten-export) The symbol "From" needs to be exported by the entry point index.d.ts
+// src/react/hooks/useSuspenseFragment.ts:74:5 - (ae-forgotten-export) The symbol "From" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report-react_hooks.api.md
+++ b/.api-reports/api-report-react_hooks.api.md
@@ -2308,13 +2308,13 @@ export function useSuspenseFragment<TData, TVariables extends OperationVariables
 // Warning: (ae-forgotten-export) The symbol "VariablesOption" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-type UseSuspenseFragmentOptions<TData, TVars> = {
-    fragment: DocumentNode | TypedDocumentNode<TData, TVars>;
+type UseSuspenseFragmentOptions<TData, TVariables extends OperationVariables> = {
+    fragment: DocumentNode | TypedDocumentNode<TData, TVariables>;
     fragmentName?: string;
     from: From<TData>;
     optimistic?: boolean;
     client?: ApolloClient<any>;
-} & VariablesOption<NoInfer_2<TVars>>;
+} & VariablesOption<NoInfer_2<TVariables>>;
 
 // @public (undocumented)
 export type UseSuspenseFragmentResult<TData> = {
@@ -2383,10 +2383,10 @@ export interface UseSuspenseQueryResult<TData = unknown, TVariables extends Oper
 }
 
 // @public (undocumented)
-type VariablesOption<TVariables> = [
+type VariablesOption<TVariables extends OperationVariables> = [
 TVariables
 ] extends [never] ? {
-    variables?: never;
+    variables?: Record<string, never>;
 } : Record<string, never> extends OnlyRequiredProperties<TVariables> ? {
     variables?: TVariables;
 } : {
@@ -2440,7 +2440,7 @@ interface WatchQueryOptions<TVariables extends OperationVariables = OperationVar
 // src/react/hooks/useBackgroundQuery.ts:51:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:75:4 - (ae-forgotten-export) The symbol "RefetchFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useLoadableQuery.ts:120:9 - (ae-forgotten-export) The symbol "ResetFunction" needs to be exported by the entry point index.d.ts
-// src/react/hooks/useSuspenseFragment.ts:74:5 - (ae-forgotten-export) The symbol "From" needs to be exported by the entry point index.d.ts
+// src/react/hooks/useSuspenseFragment.ts:70:5 - (ae-forgotten-export) The symbol "From" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report-react_internal.api.md
+++ b/.api-reports/api-report-react_internal.api.md
@@ -2367,14 +2367,16 @@ function useSuspenseFragment<TData, TVariables extends OperationVariables = Oper
 // @public (undocumented)
 function useSuspenseFragment<TData, TVariables extends OperationVariables = OperationVariables>(options: UseSuspenseFragmentOptions<TData, TVariables>): UseSuspenseFragmentResult<TData>;
 
+// Warning: (ae-forgotten-export) The symbol "VariablesOption_2" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
-interface UseSuspenseFragmentOptions<TData, TVars> extends Omit<Cache_2.DiffOptions<NoInfer_2<TData>, NoInfer_2<TVars>>, "id" | "query" | "optimistic" | "previousResult" | "returnPartialData">, Omit<Cache_2.ReadFragmentOptions<TData, TVars>, "id" | "variables" | "returnPartialData"> {
-    client?: ApolloClient<any>;
-    // (undocumented)
+type UseSuspenseFragmentOptions<TData, TVars> = {
+    fragment: DocumentNode | TypedDocumentNode<TData, TVars>;
+    fragmentName?: string;
     from: From<TData>;
-    // (undocumented)
     optimistic?: boolean;
-}
+    client?: ApolloClient<any>;
+} & VariablesOption_2<NoInfer_2<TVars>>;
 
 // @public (undocumented)
 type UseSuspenseFragmentResult<TData> = {
@@ -2449,6 +2451,17 @@ TVariables
 ] extends [never] ? {
     variables?: Record<string, never>;
 } : {} extends OnlyRequiredProperties<TVariables> ? {
+    variables?: TVariables;
+} : {
+    variables: TVariables;
+};
+
+// @public (undocumented)
+type VariablesOption_2<TVariables> = [
+TVariables
+] extends [never] ? {
+    variables?: never;
+} : Record<string, never> extends OnlyRequiredProperties<TVariables> ? {
     variables?: TVariables;
 } : {
     variables: TVariables;
@@ -2549,7 +2562,7 @@ export function wrapQueryRef<TData, TVariables extends OperationVariables>(inter
 // src/core/watchQueryOptions.ts:357:2 - (ae-forgotten-export) The symbol "UpdateQueryOptions" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:51:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:75:4 - (ae-forgotten-export) The symbol "RefetchFunction" needs to be exported by the entry point index.d.ts
-// src/react/hooks/useSuspenseFragment.ts:60:5 - (ae-forgotten-export) The symbol "From" needs to be exported by the entry point index.d.ts
+// src/react/hooks/useSuspenseFragment.ts:74:5 - (ae-forgotten-export) The symbol "From" needs to be exported by the entry point index.d.ts
 // src/react/query-preloader/createQueryPreloader.ts:145:3 - (ae-forgotten-export) The symbol "PreloadQueryFetchPolicy" needs to be exported by the entry point index.d.ts
 // src/react/query-preloader/createQueryPreloader.ts:167:5 - (ae-forgotten-export) The symbol "RefetchWritePolicy" needs to be exported by the entry point index.d.ts
 

--- a/.api-reports/api-report-react_internal.api.md
+++ b/.api-reports/api-report-react_internal.api.md
@@ -2367,16 +2367,14 @@ function useSuspenseFragment<TData, TVariables extends OperationVariables = Oper
 // @public (undocumented)
 function useSuspenseFragment<TData, TVariables extends OperationVariables = OperationVariables>(options: UseSuspenseFragmentOptions<TData, TVariables>): UseSuspenseFragmentResult<TData>;
 
-// Warning: (ae-forgotten-export) The symbol "VariablesOption_2" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
-type UseSuspenseFragmentOptions<TData, TVars> = {
-    fragment: DocumentNode | TypedDocumentNode<TData, TVars>;
+type UseSuspenseFragmentOptions<TData, TVariables extends OperationVariables> = {
+    fragment: DocumentNode | TypedDocumentNode<TData, TVariables>;
     fragmentName?: string;
     from: From<TData>;
     optimistic?: boolean;
     client?: ApolloClient<any>;
-} & VariablesOption_2<NoInfer_2<TVars>>;
+} & VariablesOption<NoInfer_2<TVariables>>;
 
 // @public (undocumented)
 type UseSuspenseFragmentResult<TData> = {
@@ -2450,17 +2448,6 @@ type VariablesOption<TVariables extends OperationVariables> = [
 TVariables
 ] extends [never] ? {
     variables?: Record<string, never>;
-} : {} extends OnlyRequiredProperties<TVariables> ? {
-    variables?: TVariables;
-} : {
-    variables: TVariables;
-};
-
-// @public (undocumented)
-type VariablesOption_2<TVariables> = [
-TVariables
-] extends [never] ? {
-    variables?: never;
 } : Record<string, never> extends OnlyRequiredProperties<TVariables> ? {
     variables?: TVariables;
 } : {
@@ -2562,9 +2549,9 @@ export function wrapQueryRef<TData, TVariables extends OperationVariables>(inter
 // src/core/watchQueryOptions.ts:357:2 - (ae-forgotten-export) The symbol "UpdateQueryOptions" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:51:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:75:4 - (ae-forgotten-export) The symbol "RefetchFunction" needs to be exported by the entry point index.d.ts
-// src/react/hooks/useSuspenseFragment.ts:74:5 - (ae-forgotten-export) The symbol "From" needs to be exported by the entry point index.d.ts
-// src/react/query-preloader/createQueryPreloader.ts:145:3 - (ae-forgotten-export) The symbol "PreloadQueryFetchPolicy" needs to be exported by the entry point index.d.ts
-// src/react/query-preloader/createQueryPreloader.ts:167:5 - (ae-forgotten-export) The symbol "RefetchWritePolicy" needs to be exported by the entry point index.d.ts
+// src/react/hooks/useSuspenseFragment.ts:70:5 - (ae-forgotten-export) The symbol "From" needs to be exported by the entry point index.d.ts
+// src/react/query-preloader/createQueryPreloader.ts:77:5 - (ae-forgotten-export) The symbol "PreloadQueryFetchPolicy" needs to be exported by the entry point index.d.ts
+// src/react/query-preloader/createQueryPreloader.ts:117:3 - (ae-forgotten-export) The symbol "RefetchWritePolicy" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -2118,8 +2118,6 @@ export interface PreloadQueryFunction {
     <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, ...[options]: PreloadQueryOptionsArg<NoInfer_2<TVariables>>): PreloadedQueryRef<TData, TVariables>;
 }
 
-// Warning: (ae-forgotten-export) The symbol "VariablesOption" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
 export type PreloadQueryOptions<TVariables extends OperationVariables = OperationVariables> = {
     canonizeResults?: boolean;
@@ -3133,16 +3131,14 @@ export function useSuspenseFragment<TData, TVariables extends OperationVariables
 // @public (undocumented)
 export function useSuspenseFragment<TData, TVariables extends OperationVariables = OperationVariables>(options: UseSuspenseFragmentOptions<TData, TVariables>): UseSuspenseFragmentResult<TData>;
 
-// Warning: (ae-forgotten-export) The symbol "VariablesOption_2" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
-type UseSuspenseFragmentOptions<TData, TVars> = {
-    fragment: DocumentNode | TypedDocumentNode<TData, TVars>;
+type UseSuspenseFragmentOptions<TData, TVariables extends OperationVariables> = {
+    fragment: DocumentNode | TypedDocumentNode<TData, TVariables>;
     fragmentName?: string;
     from: From<TData>;
     optimistic?: boolean;
     client?: ApolloClient<any>;
-} & VariablesOption_2<NoInfer_2<TVars>>;
+} & VariablesOption<NoInfer_2<TVariables>>;
 
 // @public (undocumented)
 export type UseSuspenseFragmentResult<TData> = {
@@ -3209,21 +3205,10 @@ export interface UseSuspenseQueryResult<TData = unknown, TVariables extends Oper
 }
 
 // @public (undocumented)
-type VariablesOption<TVariables extends OperationVariables> = [
+export type VariablesOption<TVariables extends OperationVariables> = [
 TVariables
 ] extends [never] ? {
     variables?: Record<string, never>;
-} : {} extends OnlyRequiredProperties<TVariables> ? {
-    variables?: TVariables;
-} : {
-    variables: TVariables;
-};
-
-// @public (undocumented)
-type VariablesOption_2<TVariables> = [
-TVariables
-] extends [never] ? {
-    variables?: never;
 } : Record<string, never> extends OnlyRequiredProperties<TVariables> ? {
     variables?: TVariables;
 } : {
@@ -3304,7 +3289,7 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/react/hooks/useBackgroundQuery.ts:51:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:75:4 - (ae-forgotten-export) The symbol "RefetchFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useLoadableQuery.ts:120:9 - (ae-forgotten-export) The symbol "ResetFunction" needs to be exported by the entry point index.d.ts
-// src/react/hooks/useSuspenseFragment.ts:74:5 - (ae-forgotten-export) The symbol "From" needs to be exported by the entry point index.d.ts
+// src/react/hooks/useSuspenseFragment.ts:70:5 - (ae-forgotten-export) The symbol "From" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -3133,14 +3133,16 @@ export function useSuspenseFragment<TData, TVariables extends OperationVariables
 // @public (undocumented)
 export function useSuspenseFragment<TData, TVariables extends OperationVariables = OperationVariables>(options: UseSuspenseFragmentOptions<TData, TVariables>): UseSuspenseFragmentResult<TData>;
 
+// Warning: (ae-forgotten-export) The symbol "VariablesOption_2" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
-interface UseSuspenseFragmentOptions<TData, TVars> extends Omit<Cache_2.DiffOptions<NoInfer_2<TData>, NoInfer_2<TVars>>, "id" | "query" | "optimistic" | "previousResult" | "returnPartialData">, Omit<Cache_2.ReadFragmentOptions<TData, TVars>, "id" | "variables" | "returnPartialData"> {
-    client?: ApolloClient<any>;
-    // (undocumented)
+type UseSuspenseFragmentOptions<TData, TVars> = {
+    fragment: DocumentNode | TypedDocumentNode<TData, TVars>;
+    fragmentName?: string;
     from: From<TData>;
-    // (undocumented)
     optimistic?: boolean;
-}
+    client?: ApolloClient<any>;
+} & VariablesOption_2<NoInfer_2<TVars>>;
 
 // @public (undocumented)
 export type UseSuspenseFragmentResult<TData> = {
@@ -3212,6 +3214,17 @@ TVariables
 ] extends [never] ? {
     variables?: Record<string, never>;
 } : {} extends OnlyRequiredProperties<TVariables> ? {
+    variables?: TVariables;
+} : {
+    variables: TVariables;
+};
+
+// @public (undocumented)
+type VariablesOption_2<TVariables> = [
+TVariables
+] extends [never] ? {
+    variables?: never;
+} : Record<string, never> extends OnlyRequiredProperties<TVariables> ? {
     variables?: TVariables;
 } : {
     variables: TVariables;
@@ -3291,7 +3304,7 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/react/hooks/useBackgroundQuery.ts:51:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:75:4 - (ae-forgotten-export) The symbol "RefetchFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useLoadableQuery.ts:120:9 - (ae-forgotten-export) The symbol "ResetFunction" needs to be exported by the entry point index.d.ts
-// src/react/hooks/useSuspenseFragment.ts:60:5 - (ae-forgotten-export) The symbol "From" needs to be exported by the entry point index.d.ts
+// src/react/hooks/useSuspenseFragment.ts:74:5 - (ae-forgotten-export) The symbol "From" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.changeset/swift-turtles-clap.md
+++ b/.changeset/swift-turtles-clap.md
@@ -1,5 +1,0 @@
----
-"@apollo/client": patch
----
-
-Ensure `variables` option passed to `useSuspenseFragment` is required when there are required variables in `TVariables`.

--- a/.changeset/swift-turtles-clap.md
+++ b/.changeset/swift-turtles-clap.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Ensure `variables` option passed to `useSuspenseFragment` is required when there are required variables in `TVariables`.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 42235,
+  "dist/apollo-client.min.cjs": 42240,
   "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 34448
 }

--- a/src/react/hooks/__tests__/useSuspenseFragment.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseFragment.test.tsx
@@ -1895,7 +1895,6 @@ describe.skip("type tests", () => {
     const fragment: TypedDocumentNode<{ greeting: string }, never> = gql``;
 
     useSuspenseFragment({ fragment, from: null });
-    // @ts-expect-error no variables argument allowed
     useSuspenseFragment({ fragment, from: null, variables: {} });
     // @ts-expect-error no variables argument allowed
     useSuspenseFragment({ fragment, from: null, variables: { foo: "bar" } });

--- a/src/react/hooks/__tests__/useSuspenseFragment.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseFragment.test.tsx
@@ -1881,8 +1881,6 @@ describe.skip("type tests", () => {
   it("does not allow variables when TVariables is `never`", () => {
     const fragment: TypedDocumentNode<{ greeting: string }, never> = gql``;
 
-    const [useSuspenseFragment] = useLoadableQuery(query);
-
     useSuspenseFragment({ fragment, from: null });
     // @ts-expect-error no variables argument allowed
     useSuspenseFragment({ fragment, from: null, variables: {} });

--- a/src/react/hooks/__tests__/useSuspenseFragment.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseFragment.test.tsx
@@ -10,6 +10,7 @@ import {
   Masked,
   MaskedDocumentNode,
   MaybeMasked,
+  OperationVariables,
   TypedDocumentNode,
 } from "../../../core";
 import React, { Suspense } from "react";
@@ -1859,6 +1860,18 @@ describe.skip("type tests", () => {
 
   it("variables are optional and can be anything with unspecified TVariables on a TypedDocumentNode", () => {
     const fragment: TypedDocumentNode<{ greeting: string }> = gql``;
+
+    useSuspenseFragment({ fragment, from: null });
+    useSuspenseFragment({ fragment, from: null, variables: {} });
+    useSuspenseFragment({ fragment, from: null, variables: { foo: "bar" } });
+    useSuspenseFragment({ fragment, from: null, variables: { bar: "baz" } });
+  });
+
+  it("variables are optional and can be anything with OperationVariables on a TypedDocumentNode", () => {
+    const fragment: TypedDocumentNode<
+      { greeting: string },
+      OperationVariables
+    > = gql``;
 
     useSuspenseFragment({ fragment, from: null });
     useSuspenseFragment({ fragment, from: null, variables: {} });

--- a/src/react/hooks/useSuspenseFragment.ts
+++ b/src/react/hooks/useSuspenseFragment.ts
@@ -23,14 +23,17 @@ type From<TData> =
   | string
   | null;
 
-export type UseSuspenseFragmentOptions<TData, TVars> = {
+export type UseSuspenseFragmentOptions<
+  TData,
+  TVariables extends OperationVariables,
+> = {
   /**
    * A GraphQL document created using the `gql` template string tag from
    * `graphql-tag` with one or more fragments which will be used to determine
    * the shape of data to read. If you provide more than one fragment in this
    * document then you must also specify `fragmentName` to select a single.
    */
-  fragment: DocumentNode | TypedDocumentNode<TData, TVars>;
+  fragment: DocumentNode | TypedDocumentNode<TData, TVariables>;
 
   /**
    * The name of the fragment in your GraphQL document to be used. If you do
@@ -50,7 +53,7 @@ export type UseSuspenseFragmentOptions<TData, TVars> = {
    * @docGroup 1. Operation options
    */
   client?: ApolloClient<any>;
-} & VariablesOption<NoInfer<TVars>>;
+} & VariablesOption<NoInfer<TVariables>>;
 
 export type UseSuspenseFragmentResult<TData> = { data: MaybeMasked<TData> };
 

--- a/src/react/hooks/useSuspenseFragment.ts
+++ b/src/react/hooks/useSuspenseFragment.ts
@@ -15,7 +15,7 @@ import { __use } from "./internal/__use.js";
 import { wrapHook } from "./internal/index.js";
 import type { FragmentType, MaybeMasked } from "../../masking/index.js";
 import type { NoInfer } from "../types/types.js";
-import { OnlyRequiredProperties } from "../../utilities/index.js";
+import type { OnlyRequiredProperties } from "../../utilities/index.js";
 
 type From<TData> =
   | StoreObject

--- a/src/react/hooks/useSuspenseFragment.ts
+++ b/src/react/hooks/useSuspenseFragment.ts
@@ -1,8 +1,10 @@
 import type {
   ApolloClient,
+  DocumentNode,
   OperationVariables,
   Reference,
   StoreObject,
+  TypedDocumentNode,
 } from "../../core/index.js";
 import { canonicalStringify } from "../../cache/index.js";
 import type { Cache } from "../../cache/index.js";
@@ -22,15 +24,25 @@ type From<TData> =
   | string
   | null;
 
-export interface UseSuspenseFragmentOptions<TData, TVars>
-  extends Omit<
-      Cache.DiffOptions<NoInfer<TData>, NoInfer<TVars>>,
-      "id" | "query" | "optimistic" | "previousResult" | "returnPartialData"
-    >,
-    Omit<
-      Cache.ReadFragmentOptions<TData, TVars>,
-      "id" | "variables" | "returnPartialData"
-    > {
+export interface UseSuspenseFragmentOptions<TData, TVars> {
+  /**
+   * A GraphQL document created using the `gql` template string tag from
+   * `graphql-tag` with one or more fragments which will be used to determine
+   * the shape of data to read. If you provide more than one fragment in this
+   * document then you must also specify `fragmentName` to select a single.
+   */
+  fragment: DocumentNode | TypedDocumentNode<TData, TVars>;
+
+  /**
+   * The name of the fragment in your GraphQL document to be used. If you do
+   * not provide a `fragmentName` and there is only one fragment in your
+   * `fragment` document then that fragment will be used.
+   */
+  fragmentName?: string;
+  /**
+   * Any variables that the GraphQL query may depend on.
+   */
+  variables?: NoInfer<TVars>;
   from: From<TData>;
   // Override this field to make it optional (default: true).
   optimistic?: boolean;

--- a/src/react/hooks/useSuspenseFragment.ts
+++ b/src/react/hooks/useSuspenseFragment.ts
@@ -7,7 +7,6 @@ import type {
   TypedDocumentNode,
 } from "../../core/index.js";
 import { canonicalStringify } from "../../cache/index.js";
-import type { Cache } from "../../cache/index.js";
 import { useApolloClient } from "./useApolloClient.js";
 import { getSuspenseCache } from "../internal/index.js";
 import React, { useMemo } from "rehackt";
@@ -16,6 +15,7 @@ import { __use } from "./internal/__use.js";
 import { wrapHook } from "./internal/index.js";
 import type { FragmentType, MaybeMasked } from "../../masking/index.js";
 import type { NoInfer } from "../types/types.js";
+import { OnlyRequiredProperties } from "../../utilities/index.js";
 
 type From<TData> =
   | StoreObject
@@ -24,7 +24,13 @@ type From<TData> =
   | string
   | null;
 
-export interface UseSuspenseFragmentOptions<TData, TVars> {
+type VariablesOption<TVariables> =
+  [TVariables] extends [never] ? { variables?: never }
+  : Record<string, never> extends OnlyRequiredProperties<TVariables> ?
+    { variables?: TVariables }
+  : { variables: TVariables };
+
+export type UseSuspenseFragmentOptions<TData, TVars> = {
   /**
    * A GraphQL document created using the `gql` template string tag from
    * `graphql-tag` with one or more fragments which will be used to determine
@@ -39,10 +45,6 @@ export interface UseSuspenseFragmentOptions<TData, TVars> {
    * `fragment` document then that fragment will be used.
    */
   fragmentName?: string;
-  /**
-   * Any variables that the GraphQL query may depend on.
-   */
-  variables?: NoInfer<TVars>;
   from: From<TData>;
   // Override this field to make it optional (default: true).
   optimistic?: boolean;
@@ -55,7 +57,7 @@ export interface UseSuspenseFragmentOptions<TData, TVars> {
    * @docGroup 1. Operation options
    */
   client?: ApolloClient<any>;
-}
+} & VariablesOption<NoInfer<TVars>>;
 
 export type UseSuspenseFragmentResult<TData> = { data: MaybeMasked<TData> };
 

--- a/src/react/hooks/useSuspenseFragment.ts
+++ b/src/react/hooks/useSuspenseFragment.ts
@@ -14,8 +14,7 @@ import type { FragmentKey } from "../internal/cache/types.js";
 import { __use } from "./internal/__use.js";
 import { wrapHook } from "./internal/index.js";
 import type { FragmentType, MaybeMasked } from "../../masking/index.js";
-import type { NoInfer } from "../types/types.js";
-import type { OnlyRequiredProperties } from "../../utilities/index.js";
+import type { NoInfer, VariablesOption } from "../types/types.js";
 
 type From<TData> =
   | StoreObject
@@ -23,12 +22,6 @@ type From<TData> =
   | FragmentType<NoInfer<TData>>
   | string
   | null;
-
-type VariablesOption<TVariables> =
-  [TVariables] extends [never] ? { variables?: never }
-  : Record<string, never> extends OnlyRequiredProperties<TVariables> ?
-    { variables?: TVariables }
-  : { variables: TVariables };
 
 export type UseSuspenseFragmentOptions<TData, TVars> = {
   /**

--- a/src/react/hooks/useSuspenseFragment.ts
+++ b/src/react/hooks/useSuspenseFragment.ts
@@ -117,7 +117,7 @@ function useSuspenseFragment_<
   options: UseSuspenseFragmentOptions<TData, TVariables>
 ): UseSuspenseFragmentResult<TData | null> {
   const client = useApolloClient(options.client);
-  const { from } = options;
+  const { from, variables } = options;
   const { cache } = client;
 
   const id = useMemo(
@@ -130,10 +130,10 @@ function useSuspenseFragment_<
 
   const fragmentRef =
     id === null ? null : (
-      getSuspenseCache(client).getFragmentRef<TData, TVariables>(
-        [id, options.fragment, canonicalStringify(options.variables)],
+      getSuspenseCache(client).getFragmentRef(
+        [id, options.fragment, canonicalStringify(variables)],
         client,
-        { ...options, from: id }
+        { ...options, variables: variables as TVariables, from: id }
       )
     );
 

--- a/src/react/query-preloader/createQueryPreloader.ts
+++ b/src/react/query-preloader/createQueryPreloader.ts
@@ -15,24 +15,8 @@ import type {
 } from "../../utilities/index.js";
 import { InternalQueryReference, wrapQueryRef } from "../internal/index.js";
 import type { PreloadedQueryRef } from "../internal/index.js";
-import type { NoInfer } from "../index.js";
+import type { NoInfer, VariablesOption } from "../index.js";
 import { wrapHook } from "../hooks/internal/index.js";
-
-type VariablesOption<TVariables extends OperationVariables> =
-  [TVariables] extends [never] ?
-    {
-      /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#variables:member} */
-      variables?: Record<string, never>;
-    }
-  : {} extends OnlyRequiredProperties<TVariables> ?
-    {
-      /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#variables:member} */
-      variables?: TVariables;
-    }
-  : {
-      /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#variables:member} */
-      variables: TVariables;
-    };
 
 export type PreloadQueryFetchPolicy = Extract<
   WatchQueryFetchPolicy,

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -5,6 +5,7 @@ import type { TypedDocumentNode } from "@graphql-typed-document-node/core";
 import type {
   Observable,
   ObservableSubscription,
+  OnlyRequiredProperties,
 } from "../../utilities/index.js";
 import type { FetchResult } from "../../link/core/index.js";
 import type { ApolloError } from "../../errors/index.js";
@@ -526,5 +527,21 @@ export interface SubscriptionCurrentObservable {
   query?: Observable<any>;
   subscription?: ObservableSubscription;
 }
+
+export type VariablesOption<TVariables> =
+  [TVariables] extends [never] ?
+    {
+      /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#variables:member} */
+      variables?: Record<string, never>;
+    }
+  : Record<string, never> extends OnlyRequiredProperties<TVariables> ?
+    {
+      /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#variables:member} */
+      variables?: TVariables;
+    }
+  : {
+      /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#variables:member} */
+      variables: TVariables;
+    };
 
 export type { NoInfer } from "../../utilities/index.js";

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -528,7 +528,7 @@ export interface SubscriptionCurrentObservable {
   subscription?: ObservableSubscription;
 }
 
-export type VariablesOption<TVariables> =
+export type VariablesOption<TVariables extends OperationVariables> =
   [TVariables] extends [never] ?
     {
       /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#variables:member} */


### PR DESCRIPTION
Discovered this when working in the Next.js streaming package. When the fragment contains required variables, ensure the `variables` option for `useSuspenseFragment` is required as well.