### PR TITLE
Export `UseSuspenseFragmentOptions`

### DIFF
--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -2450,8 +2450,6 @@ export function useSubscription<TData = any, TVariables extends OperationVariabl
     variables?: TVariables | undefined;
 };
 
-// Warning: (ae-forgotten-export) The symbol "UseSuspenseFragmentOptions" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
 export function useSuspenseFragment<TData, TVariables extends OperationVariables = OperationVariables>(options: UseSuspenseFragmentOptions<TData, TVariables> & {
     from: NonNullable<From<TData>>;
@@ -2471,7 +2469,7 @@ export function useSuspenseFragment<TData, TVariables extends OperationVariables
 export function useSuspenseFragment<TData, TVariables extends OperationVariables = OperationVariables>(options: UseSuspenseFragmentOptions<TData, TVariables>): UseSuspenseFragmentResult<TData>;
 
 // @public (undocumented)
-type UseSuspenseFragmentOptions<TData, TVariables extends OperationVariables> = {
+export type UseSuspenseFragmentOptions<TData, TVariables extends OperationVariables> = {
     fragment: DocumentNode | TypedDocumentNode<TData, TVariables>;
     fragmentName?: string;
     from: From<TData>;

--- a/.api-reports/api-report-react_hooks.api.md
+++ b/.api-reports/api-report-react_hooks.api.md
@@ -2285,8 +2285,6 @@ export function useSubscription<TData = any, TVariables extends OperationVariabl
     variables?: TVariables | undefined;
 };
 
-// Warning: (ae-forgotten-export) The symbol "UseSuspenseFragmentOptions" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
 export function useSuspenseFragment<TData, TVariables extends OperationVariables = OperationVariables>(options: UseSuspenseFragmentOptions<TData, TVariables> & {
     from: NonNullable<From<TData>>;
@@ -2308,7 +2306,7 @@ export function useSuspenseFragment<TData, TVariables extends OperationVariables
 // Warning: (ae-forgotten-export) The symbol "VariablesOption" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-type UseSuspenseFragmentOptions<TData, TVariables extends OperationVariables> = {
+export type UseSuspenseFragmentOptions<TData, TVariables extends OperationVariables> = {
     fragment: DocumentNode | TypedDocumentNode<TData, TVariables>;
     fragmentName?: string;
     from: From<TData>;

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -3111,8 +3111,6 @@ export function useSubscription<TData = any, TVariables extends OperationVariabl
     variables?: TVariables | undefined;
 };
 
-// Warning: (ae-forgotten-export) The symbol "UseSuspenseFragmentOptions" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
 export function useSuspenseFragment<TData, TVariables extends OperationVariables = OperationVariables>(options: UseSuspenseFragmentOptions<TData, TVariables> & {
     from: NonNullable<From<TData>>;
@@ -3132,7 +3130,7 @@ export function useSuspenseFragment<TData, TVariables extends OperationVariables
 export function useSuspenseFragment<TData, TVariables extends OperationVariables = OperationVariables>(options: UseSuspenseFragmentOptions<TData, TVariables>): UseSuspenseFragmentResult<TData>;
 
 // @public (undocumented)
-type UseSuspenseFragmentOptions<TData, TVariables extends OperationVariables> = {
+export type UseSuspenseFragmentOptions<TData, TVariables extends OperationVariables> = {
     fragment: DocumentNode | TypedDocumentNode<TData, TVariables>;
     fragmentName?: string;
     from: From<TData>;

--- a/.changeset/shiny-sheep-behave.md
+++ b/.changeset/shiny-sheep-behave.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Export the `UseSuspenseFragmentOptions` type.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 42232,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 34438
+  "dist/apollo-client.min.cjs": 42231,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 34437
 }

--- a/src/react/hooks/index.ts
+++ b/src/react/hooks/index.ts
@@ -11,7 +11,10 @@ export type { UseSuspenseQueryResult } from "./useSuspenseQuery.js";
 export { useSuspenseQuery } from "./useSuspenseQuery.js";
 export type { UseBackgroundQueryResult } from "./useBackgroundQuery.js";
 export { useBackgroundQuery } from "./useBackgroundQuery.js";
-export type { UseSuspenseFragmentResult } from "./useSuspenseFragment.js";
+export type {
+  UseSuspenseFragmentResult,
+  UseSuspenseFragmentOptions,
+} from "./useSuspenseFragment.js";
 export { useSuspenseFragment } from "./useSuspenseFragment.js";
 export type {
   LoadQueryFunction,


### PR DESCRIPTION
This should fix https://github.com/apollographql/apollo-client/actions/runs/13318196502/job/37197223428?pr=12201 in the 4.0 branch. This should have been exported in 3.13.0, but I forgot to include this 🤦‍♂️ 