### PR TITLE
Remove deprecated `ignoreResults` option from `useMutation`

### DIFF
--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -372,8 +372,6 @@ type BackgroundQueryHookOptionsNoInfer<TData, TVariables extends OperationVariab
 // @public (undocumented)
 export interface BaseMutationOptions<TData = any, TVariables = OperationVariables, TContext = Context, TCache extends ApolloCache<any> = ApolloCache<any>> extends MutationSharedOptions<TData, TVariables, TContext, TCache> {
     client?: ApolloClient<object>;
-    // @deprecated
-    ignoreResults?: boolean;
     notifyOnNetworkStatusChange?: boolean;
     onCompleted?: (data: MaybeMasked<TData>, clientOptions?: BaseMutationOptions) => void;
     onError?: (error: ApolloError, clientOptions?: BaseMutationOptions) => void;

--- a/.api-reports/api-report-react_hooks.api.md
+++ b/.api-reports/api-report-react_hooks.api.md
@@ -343,8 +343,6 @@ type BackgroundQueryHookOptionsNoInfer<TData, TVariables extends OperationVariab
 interface BaseMutationOptions<TData = any, TVariables = OperationVariables, TContext = DefaultContext, TCache extends ApolloCache<any> = ApolloCache<any>> extends MutationSharedOptions<TData, TVariables, TContext, TCache> {
     // Warning: (ae-forgotten-export) The symbol "ApolloClient" needs to be exported by the entry point index.d.ts
     client?: ApolloClient<object>;
-    // @deprecated
-    ignoreResults?: boolean;
     notifyOnNetworkStatusChange?: boolean;
     onCompleted?: (data: MaybeMasked<TData>, clientOptions?: BaseMutationOptions) => void;
     onError?: (error: ApolloError, clientOptions?: BaseMutationOptions) => void;

--- a/.changeset/curvy-pianos-count.md
+++ b/.changeset/curvy-pianos-count.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": major
+---
+
+Remove deprecated `ignoreResults` option from `useMutation`. If you don't want to synchronize component state with the mutation, use `useApolloClient` to access your client instance and use `client.mutate` directly.

--- a/src/react/hooks/useMutation.ts
+++ b/src/react/hooks/useMutation.ts
@@ -117,11 +117,7 @@ export function useMutation<
       const baseOptions = { ...options, mutation };
       const client = executeOptions.client || ref.current.client;
 
-      if (
-        !ref.current.result.loading &&
-        !baseOptions.ignoreResults &&
-        ref.current.isMounted
-      ) {
+      if (!ref.current.result.loading && ref.current.isMounted) {
         setResult(
           (ref.current.result = {
             loading: true,
@@ -156,10 +152,7 @@ export function useMutation<
               );
             }
 
-            if (
-              mutationId === ref.current.mutationId &&
-              !clientOptions.ignoreResults
-            ) {
+            if (mutationId === ref.current.mutationId) {
               const result = {
                 called: true,
                 loading: false,

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -336,13 +336,6 @@ export interface BaseMutationOptions<
   ) => void;
   /** {@inheritDoc @apollo/client!MutationOptionsDocumentation#onError:member} */
   onError?: (error: ApolloError, clientOptions?: BaseMutationOptions) => void;
-  /**
-   * {@inheritDoc @apollo/client!MutationOptionsDocumentation#ignoreResults:member}
-   *
-   * @deprecated This option will be removed in the next major version of Apollo Client.
-   * If you don't want to synchronize your component state with the mutation, please use `useApolloClient` to get your ApolloClient instance and call `client.mutate` directly.
-   */
-  ignoreResults?: boolean;
 }
 
 export interface MutationFunctionOptions<


### PR DESCRIPTION
Closes #12299

Removes the deprecated `ignoreResults` option from `useMutation`.