### PR TITLE
Remove `addTypename` option from `InMemoryCache` and `MockedProvider`

### DIFF
--- a/.api-reports/api-report-cache.api.md
+++ b/.api-reports/api-report-cache.api.md
@@ -82,7 +82,6 @@ export abstract class ApolloCache<TSerialized> implements DataProxy {
 // @public (undocumented)
 export type ApolloReducerConfig = {
     dataIdFromObject?: KeyFieldsFunction;
-    addTypename?: boolean;
 };
 
 // @public

--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -274,7 +274,6 @@ export interface ApolloQueryResult<T> {
 // @public (undocumented)
 export type ApolloReducerConfig = {
     dataIdFromObject?: KeyFieldsFunction;
-    addTypename?: boolean;
 };
 
 // @public

--- a/.api-reports/api-report-testing.api.md
+++ b/.api-reports/api-report-testing.api.md
@@ -1076,11 +1076,9 @@ interface MockedSubscriptionResult {
 
 // @public (undocumented)
 export class MockLink extends ApolloLink {
-    constructor(mockedResponses: ReadonlyArray<MockedResponse<any, any>>, addTypename?: Boolean, options?: MockLinkOptions);
+    constructor(mockedResponses: ReadonlyArray<MockedResponse<any, any>>, options?: MockLinkOptions);
     // (undocumented)
     addMockedResponse(mockedResponse: MockedResponse): void;
-    // (undocumented)
-    addTypename: Boolean;
     // (undocumented)
     operation: Operation;
     // (undocumented)
@@ -1101,7 +1099,7 @@ export function mockObservableLink(): MockSubscriptionLink;
 // Warning: (ae-forgotten-export) The symbol "MockApolloLink" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export function mockSingleLink(...mockedResponses: Array<any>): MockApolloLink;
+export function mockSingleLink(...mockedResponses: Array<MockedResponse<any, any>>): MockApolloLink;
 
 // @public (undocumented)
 export class MockSubscriptionLink extends ApolloLink {

--- a/.api-reports/api-report-testing_core.api.md
+++ b/.api-reports/api-report-testing_core.api.md
@@ -1076,11 +1076,9 @@ interface MockedSubscriptionResult {
 
 // @public (undocumented)
 export class MockLink extends ApolloLink {
-    constructor(mockedResponses: ReadonlyArray<MockedResponse<any, any>>, addTypename?: Boolean, options?: MockLinkOptions);
+    constructor(mockedResponses: ReadonlyArray<MockedResponse<any, any>>, options?: MockLinkOptions);
     // (undocumented)
     addMockedResponse(mockedResponse: MockedResponse): void;
-    // (undocumented)
-    addTypename: Boolean;
     // (undocumented)
     operation: Operation;
     // (undocumented)
@@ -1101,7 +1099,7 @@ export function mockObservableLink(): MockSubscriptionLink;
 // Warning: (ae-forgotten-export) The symbol "MockApolloLink" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export function mockSingleLink(...mockedResponses: Array<any>): MockApolloLink;
+export function mockSingleLink(...mockedResponses: Array<MockedResponse<any, any>>): MockApolloLink;
 
 // @public (undocumented)
 export class MockSubscriptionLink extends ApolloLink {

--- a/.api-reports/api-report-testing_react.api.md
+++ b/.api-reports/api-report-testing_react.api.md
@@ -1041,15 +1041,11 @@ export class MockedProvider extends React_2.Component<MockedProviderProps, Mocke
     // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
-    static defaultProps: MockedProviderProps;
-    // (undocumented)
     render(): React_2.JSX.Element | null;
 }
 
 // @public (undocumented)
 export interface MockedProviderProps<TSerializedCache = {}> {
-    // (undocumented)
-    addTypename?: boolean;
     // (undocumented)
     cache?: ApolloCache<TSerializedCache>;
     // (undocumented)

--- a/.api-reports/api-report-utilities.api.md
+++ b/.api-reports/api-report-utilities.api.md
@@ -334,7 +334,6 @@ interface ApolloQueryResult<T> {
 // @public (undocumented)
 type ApolloReducerConfig = {
     dataIdFromObject?: KeyFieldsFunction;
-    addTypename?: boolean;
 };
 
 // @public (undocumented)

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -274,7 +274,6 @@ export interface ApolloQueryResult<T> {
 // @public (undocumented)
 export type ApolloReducerConfig = {
     dataIdFromObject?: KeyFieldsFunction;
-    addTypename?: boolean;
 };
 
 // @public

--- a/.changeset/calm-frogs-remain.md
+++ b/.changeset/calm-frogs-remain.md
@@ -1,0 +1,7 @@
+---
+"@apollo/client": major
+---
+
+Removes the `addTypename` option from `InMemoryCache` and `MockedProvider`. `__typename` is now always added to the outgoing query document when using `InMemoryCache` and cannot be disabled.
+
+If you are using `<MockedProvider />` with `addTypename={false}`, ensure that your mocked responses include a `__typename` field. This will ensure cache normalization kicks in and behaves more like production.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 34321,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 39583
+  "dist/apollo-client.min.cjs": 34276,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"dist/index.js\" (production)": 39535
 }

--- a/src/__tests__/ApolloClient.ts
+++ b/src/__tests__/ApolloClient.ts
@@ -1178,7 +1178,6 @@ describe("ApolloClient", () => {
                 return result.__typename + result.id;
               }
             },
-            addTypename: true,
           }),
         });
       }
@@ -1612,9 +1611,7 @@ describe("ApolloClient", () => {
     it("will not use a default id getter if __typename is not present", () => {
       const client = new ApolloClient({
         link: ApolloLink.empty(),
-        cache: new InMemoryCache({
-          addTypename: false,
-        }),
+        cache: new InMemoryCache(),
       });
 
       client.writeQuery({
@@ -1832,9 +1829,7 @@ describe("ApolloClient", () => {
     it("will not use a default id getter if id is present and __typename is not present", () => {
       const client = new ApolloClient({
         link: ApolloLink.empty(),
-        cache: new InMemoryCache({
-          addTypename: false,
-        }),
+        cache: new InMemoryCache(),
       });
 
       client.writeQuery({
@@ -1881,9 +1876,7 @@ describe("ApolloClient", () => {
     it("will not use a default id getter if _id is present but __typename is not present", () => {
       const client = new ApolloClient({
         link: ApolloLink.empty(),
-        cache: new InMemoryCache({
-          addTypename: false,
-        }),
+        cache: new InMemoryCache(),
       });
 
       client.writeQuery({
@@ -1930,9 +1923,7 @@ describe("ApolloClient", () => {
     it("will not use a default id getter if either _id or id is present when __typename is not also present", () => {
       const client = new ApolloClient({
         link: ApolloLink.empty(),
-        cache: new InMemoryCache({
-          addTypename: false,
-        }),
+        cache: new InMemoryCache(),
       });
 
       client.writeQuery({

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -165,7 +165,7 @@ describe("client", () => {
 
     const client = new ApolloClient({
       link,
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     const actualResult = await client.query({ query, variables });
@@ -210,7 +210,7 @@ describe("client", () => {
 
     const client = new ApolloClient({
       link,
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     {
@@ -276,7 +276,7 @@ describe("client", () => {
 
     const client = new ApolloClient({
       link,
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     {
@@ -434,9 +434,7 @@ describe("client", () => {
 
     const client = new ApolloClient({
       link,
-      cache: new InMemoryCache({ addTypename: false }).restore(
-        initialState.data
-      ),
+      cache: new InMemoryCache().restore(initialState.data),
     });
 
     const result = await client.query({ query });
@@ -490,9 +488,7 @@ describe("client", () => {
 
     const client = new ApolloClient({
       link,
-      cache: new InMemoryCache({ addTypename: false }).restore(
-        initialState.data
-      ),
+      cache: new InMemoryCache().restore(initialState.data),
     });
 
     const result = await client.query({ query });
@@ -554,9 +550,7 @@ describe("client", () => {
 
     const client = new ApolloClient({
       link,
-      cache: new InMemoryCache({ addTypename: false }).restore(
-        initialState.data
-      ),
+      cache: new InMemoryCache().restore(initialState.data),
     });
 
     expect(client.restore(initialState.data)).toEqual(
@@ -588,7 +582,7 @@ describe("client", () => {
 
     const client = new ApolloClient({
       link,
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     await expect(client.query({ query })).rejects.toEqual(
@@ -633,7 +627,7 @@ describe("client", () => {
 
     const client = new ApolloClient({
       link,
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     await expect(client.query({ query })).rejects.toEqual(
@@ -664,7 +658,7 @@ describe("client", () => {
 
     const client = new ApolloClient({
       link,
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     await expect(client.query({ query })).rejects.toThrow(
@@ -697,7 +691,7 @@ describe("client", () => {
 
     const client = new ApolloClient({
       link,
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     return client.query({ query }).then((result: FormattedExecutionResult) => {
@@ -748,7 +742,7 @@ describe("client", () => {
 
     const client = new ApolloClient({
       link,
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     const handle = client.watchQuery({ query });
@@ -791,7 +785,7 @@ describe("client", () => {
 
     const client = new ApolloClient({
       link,
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     const handle = client.watchQuery({ query });
@@ -833,7 +827,7 @@ describe("client", () => {
 
     const client = new ApolloClient({
       link,
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     const handle = client.watchQuery({ query });
@@ -861,12 +855,6 @@ describe("client", () => {
       }
     `;
 
-    const result = {
-      author: {
-        firstName: "John",
-        lastName: "Smith",
-      },
-    };
     const transformedResult = {
       author: {
         firstName: "John",
@@ -875,21 +863,14 @@ describe("client", () => {
       },
     };
 
-    const link = mockSingleLink(
-      {
-        request: { query },
-        result: { data: result },
-      },
-      {
-        request: { query: transformedQuery },
-        result: { data: transformedResult },
-      },
-      false
-    );
+    const link = mockSingleLink({
+      request: { query: transformedQuery },
+      result: { data: transformedResult },
+    });
 
     const client = new ApolloClient({
       link,
-      cache: new InMemoryCache({ addTypename: true }),
+      cache: new InMemoryCache(),
     });
 
     const actualResult = await client.query({ query });
@@ -915,12 +896,6 @@ describe("client", () => {
         }
       }
     `;
-    const result = {
-      author: {
-        firstName: "John",
-        lastName: "Smith",
-      },
-    };
     const transformedResult = {
       author: {
         firstName: "John",
@@ -928,21 +903,14 @@ describe("client", () => {
         __typename: "Author",
       },
     };
-    const link = mockSingleLink(
-      {
-        request: { query },
-        result: { data: result },
-      },
-      {
-        request: { query: transformedQuery },
-        result: { data: transformedResult },
-      },
-      false
-    );
+    const link = mockSingleLink({
+      request: { query: transformedQuery },
+      result: { data: transformedResult },
+    });
 
     const client = new ApolloClient({
       link,
-      cache: new InMemoryCache({ addTypename: true }),
+      cache: new InMemoryCache(),
     });
 
     const actualResult = await client.query({
@@ -973,6 +941,7 @@ describe("client", () => {
         author {
           firstName
           lastName
+          __typename
         }
       }
     `;
@@ -993,7 +962,7 @@ describe("client", () => {
 
     const client = new ApolloClient({
       link,
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     await client.query({ query });
@@ -1032,7 +1001,7 @@ describe("client", () => {
     });
     const client = new ApolloClient({
       link,
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     const actualResult = await client.mutate({ mutation });
@@ -1069,7 +1038,7 @@ describe("client", () => {
 
     const client = new ApolloClient({
       link,
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     const actualResult = await client.query({
@@ -1114,7 +1083,7 @@ describe("client", () => {
     });
     const client = new ApolloClient({
       link,
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     const actualResult = await client.query({ query });
@@ -1150,7 +1119,7 @@ describe("client", () => {
     });
     const client = new ApolloClient({
       link,
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     const actualResult = await client.query({ query });
@@ -1357,7 +1326,7 @@ describe("client", () => {
     ]);
     const client = new ApolloClient({
       link,
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     return client.query({ query }).then((actualResult) => {
@@ -1382,7 +1351,7 @@ describe("client", () => {
     ]);
     const client = new ApolloClient({
       link,
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     return client.mutate({ mutation }).then((actualResult) => {
@@ -1425,7 +1394,7 @@ describe("client", () => {
 
     const client = new ApolloClient({
       link,
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       queryDeduplication: false,
     });
 
@@ -1473,7 +1442,7 @@ describe("client", () => {
     );
     const client = new ApolloClient({
       link,
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     const q1 = client.query({ query: queryDoc });
@@ -1519,7 +1488,7 @@ describe("client", () => {
     );
     const client = new ApolloClient({
       link,
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       queryDeduplication: false,
     });
 
@@ -1574,7 +1543,7 @@ describe("client", () => {
     );
     const client = new ApolloClient({
       link,
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     // The first query gets tracked in the dedup logic, the second one ignores it and runs anyways
@@ -1701,7 +1670,6 @@ describe("client", () => {
 
         cache: new InMemoryCache({
           dataIdFromObject: (obj: any) => obj.id,
-          addTypename: false,
         }),
       });
 
@@ -1786,7 +1754,7 @@ describe("client", () => {
 
       const client = new ApolloClient({
         link,
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
       });
 
       client.writeQuery({ query, data: initialData });
@@ -1811,7 +1779,7 @@ describe("client", () => {
       });
       const client = new ApolloClient({
         link,
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
       });
 
       const obs = client.watchQuery({
@@ -1832,7 +1800,7 @@ describe("client", () => {
       const link = mockSingleLink(); // no queries = no replies.
       const client = new ApolloClient({
         link,
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
       });
 
       const obs = client.watchQuery({
@@ -1854,7 +1822,7 @@ describe("client", () => {
 
       const client = new ApolloClient({
         link,
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
       });
 
       client.writeQuery({ query, data: initialData });
@@ -1974,7 +1942,7 @@ describe("client", () => {
     it("forces the query to rerun", async () => {
       const client = new ApolloClient({
         link: makeLink(),
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
       });
 
       // Run a query first to initialize the store
@@ -1989,7 +1957,7 @@ describe("client", () => {
       const client = new ApolloClient({
         link: makeLink(),
         ssrMode: true,
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
       });
 
       const options: QueryOptions = { query, fetchPolicy: "network-only" };
@@ -2011,7 +1979,7 @@ describe("client", () => {
       const client = new ApolloClient({
         link: makeLink(),
         ssrForceFetchDelay: 100,
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
       });
 
       // Run a query first to initialize the store
@@ -2056,7 +2024,7 @@ describe("client", () => {
         result: { data },
         error: networkError,
       }),
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     await expect(client.mutate({ mutation })).rejects.toThrow(
@@ -2087,7 +2055,7 @@ describe("client", () => {
         request: { query: mutation },
         result: { data, errors },
       }),
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     await expect(client.mutate({ mutation })).rejects.toEqual(
@@ -2123,7 +2091,7 @@ describe("client", () => {
           },
         },
       }),
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     const result = await client.mutate({ mutation, errorPolicy: "all" });
@@ -2161,7 +2129,7 @@ describe("client", () => {
         request: { query: mutation },
         result: { data, errors },
       }),
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     const result = await client.mutate({ mutation, errorPolicy: "ignore" });
@@ -2195,7 +2163,7 @@ describe("client", () => {
         request: { query: mutation },
         result: { data, errors },
       }),
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
     const mutatePromise = client.mutate({
       mutation,
@@ -2494,7 +2462,7 @@ describe("client", () => {
 
     const client = new ApolloClient({
       link,
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     const handle = client.watchQuery({
@@ -2534,7 +2502,7 @@ describe("client", () => {
     );
     const client = new ApolloClient({
       link,
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     const observable = client.watchQuery({
@@ -3305,7 +3273,7 @@ describe("@connection", () => {
       });
       const client = new ApolloClient({
         link,
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         defaultOptions: {
           watchQuery: {
             fetchPolicy: "cache-and-network",
@@ -3530,7 +3498,7 @@ describe("@connection", () => {
       });
       const client = new ApolloClient({
         link,
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         defaultOptions: {
           query: { errorPolicy: "all" },
         },
@@ -3561,7 +3529,7 @@ describe("@connection", () => {
 
       const client = new ApolloClient({
         link,
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         defaultOptions: {
           mutate: { variables: { id: 1 } },
         },

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -458,6 +458,7 @@ describe("client", () => {
       allPeople: {
         people: [
           {
+            __typename: "Person",
             name: "Luke Skywalker",
           },
         ],
@@ -475,6 +476,7 @@ describe("client", () => {
           'allPeople({"first":1})': {
             people: [
               {
+                __typename: "Person",
                 name: "Luke Skywalker",
               },
             ],

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -486,7 +486,7 @@ describe("client", () => {
       },
     };
 
-    const finalState = assign({}, initialState, {});
+    const finalState = assign({}, initialState);
 
     const client = new ApolloClient({
       link,

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -486,7 +486,7 @@ describe("client", () => {
       },
     };
 
-    const finalState = assign({}, initialState);
+    const finalState = Object.assign({}, initialState);
 
     const client = new ApolloClient({
       link,

--- a/src/__tests__/graphqlSubscriptions.ts
+++ b/src/__tests__/graphqlSubscriptions.ts
@@ -50,7 +50,7 @@ describe("GraphQL Subscriptions", () => {
     // This test calls directly through Apollo Client
     const client = new ApolloClient({
       link,
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     const stream = new ObservableStream(client.subscribe(defaultOptions));
@@ -66,7 +66,7 @@ describe("GraphQL Subscriptions", () => {
     // This test calls directly through Apollo Client
     const client = new ApolloClient({
       link,
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     const stream = new ObservableStream(client.subscribe(options));
@@ -82,7 +82,7 @@ describe("GraphQL Subscriptions", () => {
     const link = mockObservableLink();
     const client = new ApolloClient({
       link,
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     const obs = client.subscribe(options);
@@ -99,7 +99,7 @@ describe("GraphQL Subscriptions", () => {
     const link = mockObservableLink();
     const client = new ApolloClient({
       link,
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     const stream = new ObservableStream(client.subscribe(options));
@@ -117,7 +117,7 @@ describe("GraphQL Subscriptions", () => {
 
   it("should not cache subscription data if a `no-cache` fetch policy is used", async () => {
     const link = mockObservableLink();
-    const cache = new InMemoryCache({ addTypename: false });
+    const cache = new InMemoryCache();
     const client = new ApolloClient({
       link,
       cache,
@@ -138,7 +138,7 @@ describe("GraphQL Subscriptions", () => {
     const link = mockObservableLink();
     const client = new ApolloClient({
       link,
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     const obs = client.subscribe(options);
@@ -372,7 +372,7 @@ describe("GraphQL Subscriptions", () => {
     const link = mockObservableLink();
     const client = new ApolloClient({
       link,
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     const stream = new ObservableStream(client.subscribe(defaultOptions));
@@ -404,7 +404,7 @@ describe("GraphQL Subscriptions", () => {
     const link = mockObservableLink();
     const client = new ApolloClient({
       link,
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     const obs = client.subscribe(options);

--- a/src/__tests__/local-state/export.ts
+++ b/src/__tests__/local-state/export.ts
@@ -616,9 +616,7 @@ describe("@client @export tests", () => {
         expect(print(request.query)).toBe(print(expectedServerQuery));
         return Observable.of({ data });
       }),
-      cache: new InMemoryCache({
-        addTypename: true,
-      }),
+      cache: new InMemoryCache(),
       resolvers: {
         Query: {
           currentFilter() {

--- a/src/__tests__/local-state/resolvers.ts
+++ b/src/__tests__/local-state/resolvers.ts
@@ -36,7 +36,7 @@ const setupTestWithResolvers = ({
   delay?: number;
 }) => {
   const client = new ApolloClient({
-    cache: new InMemoryCache({ addTypename: false }),
+    cache: new InMemoryCache(),
     link: new MockLink([
       {
         request: { query: serverQuery || query, variables },
@@ -169,7 +169,7 @@ describe("Basic resolver capabilities", () => {
     await expect(stream).toEmitApolloQueryResult({
       data: {
         foo: { bar: true, __typename: "ClientData" },
-        bar: { baz: true },
+        bar: { baz: true, __typename: "Bar" },
       },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -266,7 +266,7 @@ describe("Basic resolver capabilities", () => {
     });
 
     await expect(stream).toEmitApolloQueryResult({
-      data: { foo: { bar: 1 } },
+      data: { foo: { __typename: "Foo", bar: 1 } },
       loading: false,
       networkStatus: NetworkStatus.ready,
       partial: false,
@@ -300,7 +300,7 @@ describe("Basic resolver capabilities", () => {
     });
 
     await expect(stream).toEmitApolloQueryResult({
-      data: { foo: { bar: 1 } },
+      data: { foo: { __typename: "Foo", bar: 1 } },
       loading: false,
       networkStatus: NetworkStatus.ready,
       partial: false,
@@ -360,8 +360,10 @@ describe("Basic resolver capabilities", () => {
     await expect(stream).toEmitApolloQueryResult({
       data: {
         author: {
+          __typename: "Author",
           name: "John Smith",
           stats: {
+            __typename: "Stats",
             totalPosts: 100,
             postsToday: 10,
           },
@@ -559,11 +561,14 @@ describe("Basic resolver capabilities", () => {
       resolvers,
       query,
       serverQuery,
-      serverResult: { data: { bar: { baz: true } } },
+      serverResult: { data: { bar: { __typename: "Bar", baz: true } } },
     });
 
     await expect(stream).toEmitApolloQueryResult({
-      data: { foo: { bar: true }, bar: { baz: true } },
+      data: {
+        foo: { __typename: "Foo", bar: true },
+        bar: { __typename: "Bar", baz: true },
+      },
       loading: false,
       networkStatus: NetworkStatus.ready,
       partial: false,

--- a/src/__tests__/mutationResults.ts
+++ b/src/__tests__/mutationResults.ts
@@ -1073,7 +1073,7 @@ describe("mutation results", () => {
           result: resetMutationResult,
         }
       ),
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     const watchedQuery = client.watchQuery({
@@ -1121,7 +1121,7 @@ describe("mutation results", () => {
     let count = 0;
 
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link: ApolloLink.from([
         ({ variables }: any) =>
           new Observable((observer) => {
@@ -1198,7 +1198,7 @@ describe("mutation results", () => {
     let count = 0;
 
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link: ApolloLink.from([
         ({ variables }: any) =>
           new Observable((observer) => {
@@ -1273,7 +1273,7 @@ describe("mutation results", () => {
     let count = 0;
 
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link: ApolloLink.from([
         ({ variables }: any) =>
           new Observable((observer) => {
@@ -1643,7 +1643,7 @@ describe("mutation results", () => {
           request: { query: mutation } as any,
           result: result1,
         }),
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
       });
 
       const result = await client.mutate<{ foo: { bar: string } }>({

--- a/src/__tests__/subscribeToMore.ts
+++ b/src/__tests__/subscribeToMore.ts
@@ -65,7 +65,7 @@ describe("subscribeToMore", () => {
     const link = ApolloLink.split(isSub, wSLink, httpLink);
 
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link,
     });
 
@@ -117,7 +117,7 @@ describe("subscribeToMore", () => {
 
     const client = new ApolloClient({
       link,
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     const obsHandle = client.watchQuery<(typeof req1)["result"]["data"]>({
@@ -172,7 +172,7 @@ describe("subscribeToMore", () => {
 
     const client = new ApolloClient({
       link,
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     const obsHandle = client.watchQuery({
@@ -219,7 +219,7 @@ describe("subscribeToMore", () => {
     const link = ApolloLink.split(isSub, wSLink, httpLink);
 
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }).restore({
+      cache: new InMemoryCache().restore({
         ROOT_QUERY: {
           entry: [
             {
@@ -335,7 +335,7 @@ describe("subscribeToMore", () => {
     const link = ApolloLink.split(isSub, wSLink, httpLink);
 
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link,
     });
 

--- a/src/cache/inmemory/__tests__/__snapshots__/policies.ts.snap
+++ b/src/cache/inmemory/__tests__/__snapshots__/policies.ts.snap
@@ -818,6 +818,7 @@ Object {
   "ROOT_QUERY": Object {
     "__typename": "Query",
     "todos": Object {
+      "__typename": "TodosConnection",
       "edges": Array [
         Object {
           "__ref": "TodoEdge:edge1",
@@ -854,6 +855,7 @@ Object {
   "ROOT_QUERY": Object {
     "__typename": "Query",
     "todos": Object {
+      "__typename": "TodosConnection",
       "edges": Array [
         Object {
           "__ref": "TodoEdge:edge1",

--- a/src/cache/inmemory/__tests__/cache.ts
+++ b/src/cache/inmemory/__tests__/cache.ts
@@ -31,13 +31,10 @@ describe("Cache", () => {
   ) {
     const cachesList: InMemoryCache[][] = [
       initialDataForCaches.map((data) =>
-        new InMemoryCache({
-          addTypename: false,
-        }).restore(cloneDeep(data))
+        new InMemoryCache().restore(cloneDeep(data))
       ),
       initialDataForCaches.map((data) =>
         new InMemoryCache({
-          addTypename: false,
           resultCaching: false,
         }).restore(cloneDeep(data))
       ),
@@ -56,12 +53,10 @@ describe("Cache", () => {
   ) {
     const caches = [
       new InMemoryCache({
-        addTypename: false,
         ...config,
         resultCaching: true,
       }),
       new InMemoryCache({
-        addTypename: false,
         ...config,
         resultCaching: false,
       }),
@@ -402,7 +397,7 @@ describe("Cache", () => {
               }
             `,
           })
-        ).toEqual({ e: 4, h: { i: 7 } });
+        ).toEqual({ __typename: "Foo", e: 4, h: { __typename: "Bar", i: 7 } });
         expect(
           proxy.readFragment({
             id: "foo",
@@ -419,7 +414,13 @@ describe("Cache", () => {
               }
             `,
           })
-        ).toEqual({ e: 4, f: 5, g: 6, h: { i: 7, j: 8, k: 9 } });
+        ).toEqual({
+          __typename: "Foo",
+          e: 4,
+          f: 5,
+          g: 6,
+          h: { __typename: "Bar", i: 7, j: 8, k: 9 },
+        });
         expect(
           proxy.readFragment({
             id: "bar",
@@ -429,7 +430,7 @@ describe("Cache", () => {
               }
             `,
           })
-        ).toEqual({ i: 7 });
+        ).toEqual({ __typename: "Bar", i: 7 });
         expect(
           proxy.readFragment({
             id: "bar",
@@ -441,7 +442,7 @@ describe("Cache", () => {
               }
             `,
           })
-        ).toEqual({ i: 7, j: 8, k: 9 });
+        ).toEqual({ __typename: "Bar", i: 7, j: 8, k: 9 });
         expect(
           proxy.readFragment({
             id: "foo",
@@ -465,7 +466,13 @@ describe("Cache", () => {
             `,
             fragmentName: "fragmentFoo",
           })
-        ).toEqual({ e: 4, f: 5, g: 6, h: { i: 7, j: 8, k: 9 } });
+        ).toEqual({
+          __typename: "Foo",
+          e: 4,
+          f: 5,
+          g: 6,
+          h: { __typename: "Bar", i: 7, j: 8, k: 9 },
+        });
         expect(
           proxy.readFragment({
             id: "bar",
@@ -489,7 +496,7 @@ describe("Cache", () => {
             `,
             fragmentName: "fragmentBar",
           })
-        ).toEqual({ i: 7, j: 8, k: 9 });
+        ).toEqual({ __typename: "Bar", i: 7, j: 8, k: 9 });
       }
     );
 
@@ -519,7 +526,7 @@ describe("Cache", () => {
               value: 42,
             },
           })
-        ).toEqual({ a: 1, b: 2 });
+        ).toEqual({ __typename: "Foo", a: 1, b: 2 });
       }
     );
 
@@ -573,7 +580,7 @@ describe("Cache", () => {
               }
             `,
           })
-        ).toEqual({ a: 1, b: 2, c: 3 });
+        ).toEqual({ __typename: "Foo", a: 1, b: 2, c: 3 });
       }
     );
 
@@ -1129,7 +1136,6 @@ describe("Cache", () => {
       "will write some deeply nested data into the store at any id",
       {
         dataIdFromObject: (o: any) => o.id,
-        addTypename: false,
       },
       (proxy) => {
         proxy.writeFragment({
@@ -1248,42 +1254,34 @@ describe("Cache", () => {
       }
     );
 
-    itWithCacheConfig(
-      "writes data that can be read back",
-      {
-        addTypename: true,
-      },
-      (proxy) => {
-        const readWriteFragment = gql`
-          fragment aFragment on query {
-            getSomething {
-              id
-            }
+    itWithCacheConfig("writes data that can be read back", {}, (proxy) => {
+      const readWriteFragment = gql`
+        fragment aFragment on query {
+          getSomething {
+            id
           }
-        `;
-        const data = {
-          __typename: "query",
-          getSomething: { id: "123", __typename: "Something" },
-        };
-        proxy.writeFragment({
-          data,
-          id: "query",
-          fragment: readWriteFragment,
-        });
+        }
+      `;
+      const data = {
+        __typename: "query",
+        getSomething: { id: "123", __typename: "Something" },
+      };
+      proxy.writeFragment({
+        data,
+        id: "query",
+        fragment: readWriteFragment,
+      });
 
-        const result = proxy.readFragment({
-          fragment: readWriteFragment,
-          id: "query",
-        });
-        expect(result).toEqual(data);
-      }
-    );
+      const result = proxy.readFragment({
+        fragment: readWriteFragment,
+        id: "query",
+      });
+      expect(result).toEqual(data);
+    });
 
     itWithCacheConfig(
       "will write some data to the store with variables",
-      {
-        addTypename: true,
-      },
+      {},
       (proxy) => {
         proxy.writeFragment({
           data: {

--- a/src/cache/inmemory/__tests__/fragmentMatcher.ts
+++ b/src/cache/inmemory/__tests__/fragmentMatcher.ts
@@ -6,12 +6,9 @@ import { hasOwn } from "../helpers";
 
 describe("fragment matching", () => {
   it("can match exact types with or without possibleTypes", () => {
-    const cacheWithoutPossibleTypes = new InMemoryCache({
-      addTypename: true,
-    });
+    const cacheWithoutPossibleTypes = new InMemoryCache();
 
     const cacheWithPossibleTypes = new InMemoryCache({
-      addTypename: true,
       possibleTypes: {
         Animal: ["Cat", "Dog"],
       },
@@ -57,7 +54,6 @@ describe("fragment matching", () => {
 
   it("can match interface subtypes", () => {
     const cache = new InMemoryCache({
-      addTypename: true,
       possibleTypes: {
         Animal: ["Cat", "Dog"],
       },
@@ -89,7 +85,6 @@ describe("fragment matching", () => {
 
   it("can match union member types", () => {
     const cache = new InMemoryCache({
-      addTypename: true,
       possibleTypes: {
         Status: ["PASSING", "FAILING", "SKIPPED"],
       },
@@ -139,7 +134,6 @@ describe("fragment matching", () => {
 
   it("can match indirect subtypes while avoiding cycles", () => {
     const cache = new InMemoryCache({
-      addTypename: true,
       possibleTypes: {
         Animal: ["Animal", "Bug", "Mammal"],
         Bug: ["Ant", "Spider", "RolyPoly"],
@@ -186,9 +180,7 @@ describe("fragment matching", () => {
   });
 
   it("can match against the root Query", () => {
-    const cache = new InMemoryCache({
-      addTypename: true,
-    });
+    const cache = new InMemoryCache();
 
     const query = gql`
       query AllPeople {

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -3527,7 +3527,6 @@ describe("type policies", function () {
 
     it("can handle Relay-style pagination without args", async () => {
       const cache = new InMemoryCache({
-        addTypename: false,
         typePolicies: {
           Query: {
             fields: {
@@ -3711,7 +3710,6 @@ describe("type policies", function () {
 
     it("can handle Relay-style pagination", async () => {
       const cache = new InMemoryCache({
-        addTypename: false,
         typePolicies: {
           Query: {
             fields: {

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -3605,6 +3605,7 @@ describe("type policies", function () {
           result: {
             data: {
               todos: {
+                __typename: "TodosConnection",
                 totalCount: 1292,
               },
             },
@@ -3618,6 +3619,7 @@ describe("type policies", function () {
           result: {
             data: {
               todos: {
+                __typename: "TodosConnection",
                 edges: secondEdges,
                 pageInfo: secondPageInfo,
                 totalCount: 1292,
@@ -3632,6 +3634,7 @@ describe("type policies", function () {
           result: {
             data: {
               todos: {
+                __typename: "TodosConnection",
                 totalCount: 1293,
                 extraMetaData: "extra",
               },
@@ -3651,6 +3654,7 @@ describe("type policies", function () {
         networkStatus: NetworkStatus.ready,
         data: {
           todos: {
+            __typename: "TodosConnection",
             totalCount: 1292,
           },
         },
@@ -3661,6 +3665,7 @@ describe("type policies", function () {
         ROOT_QUERY: {
           __typename: "Query",
           todos: {
+            __typename: "TodosConnection",
             edges: [],
             pageInfo: {
               endCursor: "",
@@ -3683,6 +3688,7 @@ describe("type policies", function () {
         networkStatus: NetworkStatus.ready,
         data: {
           todos: {
+            __typename: "TodosConnection",
             edges: secondEdges,
             pageInfo: secondPageInfo,
             totalCount: 1292,
@@ -3699,6 +3705,7 @@ describe("type policies", function () {
         networkStatus: NetworkStatus.ready,
         data: {
           todos: {
+            __typename: "TodosConnection",
             totalCount: 1293,
             extraMetaData: "extra",
           },

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -49,7 +49,6 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
 
   protected config: InMemoryCacheConfig;
   private watches = new Set<Cache.WatchOptions>();
-  private addTypename: boolean;
 
   private storeReader!: StoreReader;
   private storeWriter!: StoreWriter;
@@ -75,7 +74,6 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
   constructor(config: InMemoryCacheConfig = {}) {
     super();
     this.config = normalizeConfig(config);
-    this.addTypename = !!this.config.addTypename;
 
     this.policies = new Policies({
       cache: this,
@@ -117,7 +115,6 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
       this,
       (this.storeReader = new StoreReader({
         cache: this,
-        addTypename: this.addTypename,
         resultCacheMaxSize: this.config.resultCacheMaxSize,
         canonizeResults: shouldCanonizeResults(this.config),
         canon:
@@ -551,10 +548,7 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
   }
 
   private addTypenameToDocument(document: DocumentNode) {
-    if (this.addTypename) {
-      return this.addTypenameTransform.transformDocument(document);
-    }
-    return document;
+    return this.addTypenameTransform.transformDocument(document);
   }
 
   // This method is wrapped by maybeBroadcastWatch, which is called by

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -522,7 +522,9 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
   }
 
   public transformDocument(document: DocumentNode): DocumentNode {
-    return this.addTypenameToDocument(this.addFragmentsToDocument(document));
+    return this.addTypenameTransform.transformDocument(
+      this.addFragmentsToDocument(document)
+    );
   }
 
   public fragmentMatches(
@@ -545,10 +547,6 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
   private addFragmentsToDocument(document: DocumentNode) {
     const { fragments } = this.config;
     return fragments ? fragments.transform(document) : document;
-  }
-
-  private addTypenameToDocument(document: DocumentNode) {
-    return this.addTypenameTransform.transformDocument(document);
   }
 
   // This method is wrapped by maybeBroadcastWatch, which is called by

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -84,7 +84,6 @@ type ExecSubSelectedArrayOptions = {
 
 interface StoreReaderConfig {
   cache: InMemoryCache;
-  addTypename?: boolean;
   resultCacheMaxSize?: number;
   canonizeResults?: boolean;
   canon?: ObjectCanon;
@@ -129,7 +128,6 @@ export class StoreReader {
 
   private config: {
     cache: InMemoryCache;
-    addTypename: boolean;
     resultCacheMaxSize?: number;
     canonizeResults: boolean;
     fragments?: InMemoryCacheConfig["fragments"];
@@ -147,7 +145,6 @@ export class StoreReader {
 
   constructor(config: StoreReaderConfig) {
     this.config = compact(config, {
-      addTypename: config.addTypename !== false,
       canonizeResults: shouldCanonizeResults(config),
     });
 
@@ -349,11 +346,7 @@ export class StoreReader {
     let missing: MissingTree | undefined;
     const missingMerger = new DeepMerger();
 
-    if (
-      this.config.addTypename &&
-      typeof typename === "string" &&
-      !policies.rootIdsByTypename[typename]
-    ) {
+    if (typeof typename === "string" && !policies.rootIdsByTypename[typename]) {
       // Ensure we always include a default value for the __typename
       // field, if we have one, and this.config.addTypename is true. Note
       // that this field can be overridden by other merged objects.

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -348,8 +348,8 @@ export class StoreReader {
 
     if (typeof typename === "string" && !policies.rootIdsByTypename[typename]) {
       // Ensure we always include a default value for the __typename
-      // field, if we have one, and this.config.addTypename is true. Note
-      // that this field can be overridden by other merged objects.
+      // field, if we have one. Note that this field can be overridden by other
+      // merged objects.
       objectsToMerge.push({ __typename: typename });
     }
 

--- a/src/cache/inmemory/types.ts
+++ b/src/cache/inmemory/types.ts
@@ -137,7 +137,6 @@ export type DiffQueryAgainstStoreOptions = ReadQueryOptions & {
 
 export type ApolloReducerConfig = {
   dataIdFromObject?: KeyFieldsFunction;
-  addTypename?: boolean;
 };
 
 export interface InMemoryCacheConfig extends ApolloReducerConfig {

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -37,7 +37,7 @@ import { waitFor } from "@testing-library/react";
 import { wait } from "../../../testing/core";
 import { ApolloClient, ApolloQueryResult } from "../../../core";
 import { mockFetchQuery } from "../ObservableQuery";
-import { Concast, print } from "../../../utilities";
+import { addTypenameToDocument, Concast, print } from "../../../utilities";
 import {
   mockDeferStream,
   ObservableStream,
@@ -61,7 +61,7 @@ describe("ApolloClient", () => {
     delay?: number;
   }) => {
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link: new MockLink([
         { request: { query, variables }, result, error, delay },
       ]),
@@ -253,7 +253,7 @@ describe("ApolloClient", () => {
 
     const client = new ApolloClient({
       link: new MockLink([{ request: { query }, error }]),
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     const observable = client.watchQuery({ query });
@@ -347,7 +347,7 @@ describe("ApolloClient", () => {
 
     const client = new ApolloClient({
       link: mockedSingleLink,
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     const observableQuery = client.watchQuery({
@@ -420,7 +420,7 @@ describe("ApolloClient", () => {
 
     const client = new ApolloClient({
       link: mockedSingleLink,
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       defaultOptions: {
         watchQuery: {
           fetchPolicy: "cache-and-network",
@@ -487,7 +487,7 @@ describe("ApolloClient", () => {
     `;
 
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link: new MockLink([{ request: { query }, result: expResult }]),
     });
     const handle = client.watchQuery({
@@ -548,7 +548,7 @@ describe("ApolloClient", () => {
     };
 
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link: new MockLink([
         {
           request,
@@ -673,7 +673,7 @@ describe("ApolloClient", () => {
     };
 
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link: new MockLink([
         {
           request,
@@ -749,7 +749,7 @@ describe("ApolloClient", () => {
     };
 
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link: new MockLink([
         { request, result: { data: data1 } },
         { request, result: { data: data2 } },
@@ -813,7 +813,7 @@ describe("ApolloClient", () => {
     };
 
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link: new MockLink([
         { request, result: { data: data1 } },
         { request, result: { data: data2 } },
@@ -875,7 +875,7 @@ describe("ApolloClient", () => {
     };
 
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link: new MockLink([{ request, result: { data: data1 } }]),
     });
 
@@ -1076,7 +1076,7 @@ describe("ApolloClient", () => {
         };
 
         const client = new ApolloClient({
-          cache: new InMemoryCache({ addTypename: false }),
+          cache: new InMemoryCache(),
           link: new MockLink([
             { request, result: { data: data1 } },
             { request, result: { data: data2 } },
@@ -1120,7 +1120,7 @@ describe("ApolloClient", () => {
     };
 
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link: new MockLink([
         { request, result: { data: data1 } },
         { request, result: { data: data2 } },
@@ -1189,7 +1189,7 @@ describe("ApolloClient", () => {
     };
 
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link: new MockLink([
         {
           request: { query: query },
@@ -1273,7 +1273,7 @@ describe("ApolloClient", () => {
     };
 
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link: new MockLink([
         {
           request: { query: query },
@@ -1343,7 +1343,7 @@ describe("ApolloClient", () => {
     };
 
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link: new MockLink([
         {
           request: { query },
@@ -1424,7 +1424,7 @@ describe("ApolloClient", () => {
     };
 
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link: new MockLink([
         {
           request: { query },
@@ -1475,7 +1475,7 @@ describe("ApolloClient", () => {
     `;
     const data = { list: [null, { value: 1 }] };
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link: new MockLink([{ request: { query }, result: { data } }]),
     });
     const observable = client.watchQuery({ query });
@@ -1517,7 +1517,7 @@ describe("ApolloClient", () => {
     };
 
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link: new MockLink([
         { request: { query: primeQuery }, result: { data: data1 } },
       ]),
@@ -1551,7 +1551,7 @@ describe("ApolloClient", () => {
     `;
 
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link: new MockLink([
         {
           request: { query: mutation },
@@ -1573,7 +1573,7 @@ describe("ApolloClient", () => {
     `;
 
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link: new MockLink([
         {
           request: { query: mutation },
@@ -1599,7 +1599,7 @@ describe("ApolloClient", () => {
     const errors = [new GraphQLError("foo")];
 
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link: new MockLink([
         {
           request: { query: mutation },
@@ -1621,7 +1621,7 @@ describe("ApolloClient", () => {
     `;
 
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link: new MockLink([
         {
           request: { query: mutation, variables: { listId: "1" } },
@@ -1659,7 +1659,6 @@ describe("ApolloClient", () => {
     const client = new ApolloClient({
       cache: new InMemoryCache({
         dataIdFromObject: getIdField,
-        addTypename: false,
       }),
       link: new MockLink([
         {
@@ -1697,7 +1696,6 @@ describe("ApolloClient", () => {
     };
     const client = new ApolloClient({
       cache: new InMemoryCache({
-        addTypename: false,
         dataIdFromObject: getIdField,
       }),
       link: new MockLink([
@@ -1738,7 +1736,6 @@ describe("ApolloClient", () => {
 
     const client = new ApolloClient({
       cache: new InMemoryCache({
-        addTypename: false,
         dataIdFromObject: getIdField,
       }),
       link: new MockLink([
@@ -1790,7 +1787,7 @@ describe("ApolloClient", () => {
     };
 
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link: new MockLink([
         {
           request: { query: query1 },
@@ -1868,7 +1865,7 @@ describe("ApolloClient", () => {
     };
 
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link: new MockLink([
         {
           request: { query: query1 },
@@ -1913,7 +1910,7 @@ describe("ApolloClient", () => {
 
   it("warns if you forget the template literal tag", async () => {
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
     expect(() => {
       void client.query({
@@ -2037,7 +2034,7 @@ describe("ApolloClient", () => {
 
     await expect(
       new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([{ request: { query }, error: networkError }]),
       }).query({ query })
     ).rejects.toEqual(new ApolloError({ networkError }));
@@ -2055,7 +2052,7 @@ describe("ApolloClient", () => {
     const graphQLErrors = [new GraphQLError("GraphQL error")];
     await expect(
       new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query },
@@ -2082,7 +2079,7 @@ describe("ApolloClient", () => {
       },
     };
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link: new MockLink([
         {
           request: { query },
@@ -2127,7 +2124,7 @@ describe("ApolloClient", () => {
     };
 
     const observable = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link: new MockLink([
         {
           request: { query },
@@ -2172,7 +2169,7 @@ describe("ApolloClient", () => {
       },
     };
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link: new MockLink([
         {
           request: { query },
@@ -2222,7 +2219,7 @@ describe("ApolloClient", () => {
       },
     };
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link: new MockLink([
         {
           request: { query },
@@ -2299,7 +2296,6 @@ describe("ApolloClient", () => {
     };
     const client = new ApolloClient({
       cache: new InMemoryCache({
-        addTypename: false,
         dataIdFromObject: (object) => {
           if (object.__typename && object.id) {
             return object.__typename + "__" + object.id;
@@ -2390,7 +2386,7 @@ describe("ApolloClient", () => {
     };
 
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link: new MockLink([
         {
           request: { query: query1 },
@@ -2707,7 +2703,6 @@ describe("ApolloClient", () => {
     let mergeCount = 0;
     const client = new ApolloClient({
       cache: new InMemoryCache({
-        addTypename: false,
         typePolicies: {
           Query: {
             fields: {
@@ -2791,7 +2786,7 @@ describe("ApolloClient", () => {
     };
 
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link: new MockLink([
         { request, result: firstResult },
         { request, result: secondResult },
@@ -2921,7 +2916,7 @@ describe("ApolloClient", () => {
     ];
 
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link: new MockLink(mockedResponses),
     });
     const queryManager = client["queryManager"];
@@ -2990,7 +2985,7 @@ describe("ApolloClient", () => {
       };
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -3051,7 +3046,7 @@ describe("ApolloClient", () => {
 
       const client = new ApolloClient({
         ssrMode: true,
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -3136,7 +3131,7 @@ describe("ApolloClient", () => {
         },
       };
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query: query1 },
@@ -3228,7 +3223,7 @@ describe("ApolloClient", () => {
       };
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -3299,7 +3294,7 @@ describe("ApolloClient", () => {
       };
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -3372,7 +3367,7 @@ describe("ApolloClient", () => {
       };
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -3433,7 +3428,7 @@ describe("ApolloClient", () => {
       };
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -3490,7 +3485,7 @@ describe("ApolloClient", () => {
       };
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -3587,7 +3582,7 @@ describe("ApolloClient", () => {
       };
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query },
@@ -3645,7 +3640,7 @@ describe("ApolloClient", () => {
 
     it("should change the store state to an empty state", () => {
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([]),
       });
 
@@ -3696,7 +3691,7 @@ describe("ApolloClient", () => {
           })
       );
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link,
       });
       const observable = client.watchQuery({ query });
@@ -3751,7 +3746,7 @@ describe("ApolloClient", () => {
       ]);
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link,
       });
       const observable = client.watchQuery({ query });
@@ -3804,7 +3799,7 @@ describe("ApolloClient", () => {
       ]);
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link,
       });
 
@@ -3858,7 +3853,7 @@ describe("ApolloClient", () => {
       );
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link,
       });
 
@@ -3890,7 +3885,7 @@ describe("ApolloClient", () => {
         },
       };
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query },
@@ -3932,7 +3927,7 @@ describe("ApolloClient", () => {
         },
       };
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query },
@@ -3962,7 +3957,7 @@ describe("ApolloClient", () => {
       `;
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([]),
       });
 
@@ -3998,7 +3993,7 @@ describe("ApolloClient", () => {
       `;
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([]),
       });
 
@@ -4034,7 +4029,7 @@ describe("ApolloClient", () => {
       `;
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([]),
       });
 
@@ -4142,7 +4137,7 @@ describe("ApolloClient", () => {
       };
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query },
@@ -4236,7 +4231,7 @@ describe("ApolloClient", () => {
           })
       );
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link,
       });
       const observable = client.watchQuery({ query });
@@ -4289,7 +4284,7 @@ describe("ApolloClient", () => {
       ]);
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link,
       });
       const observable = client.watchQuery({ query });
@@ -4338,7 +4333,7 @@ describe("ApolloClient", () => {
       ]);
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link,
       });
 
@@ -4385,7 +4380,7 @@ describe("ApolloClient", () => {
         },
       };
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query },
@@ -4419,7 +4414,7 @@ describe("ApolloClient", () => {
         },
       };
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query },
@@ -4450,7 +4445,7 @@ describe("ApolloClient", () => {
       `;
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([]),
       });
 
@@ -4486,7 +4481,7 @@ describe("ApolloClient", () => {
       `;
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([]),
       });
 
@@ -4522,7 +4517,7 @@ describe("ApolloClient", () => {
       `;
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([]),
       });
 
@@ -4559,7 +4554,7 @@ describe("ApolloClient", () => {
       `;
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([]),
       });
 
@@ -4609,7 +4604,7 @@ describe("ApolloClient", () => {
       );
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link,
       });
 
@@ -4666,7 +4661,7 @@ describe("ApolloClient", () => {
       };
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query },
@@ -4736,7 +4731,7 @@ describe("ApolloClient", () => {
         fortuneCookie: "Buy it",
       };
       const result = await new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query },
@@ -4775,7 +4770,7 @@ describe("ApolloClient", () => {
       const fullData = { fortuneCookie, author };
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query },
@@ -4861,7 +4856,7 @@ describe("ApolloClient", () => {
         },
       };
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query: testQuery },
@@ -4933,7 +4928,7 @@ describe("ApolloClient", () => {
         b: { x2: 3, y2: 2, z2: 1 },
       };
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query: query1 },
@@ -5024,7 +5019,7 @@ describe("ApolloClient", () => {
       };
       const variables = { id: "1234" };
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -5106,7 +5101,7 @@ describe("ApolloClient", () => {
         },
       };
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query },
@@ -5188,7 +5183,7 @@ describe("ApolloClient", () => {
         },
       };
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query },
@@ -5263,7 +5258,7 @@ describe("ApolloClient", () => {
         },
       };
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query },
@@ -5339,7 +5334,7 @@ describe("ApolloClient", () => {
         },
       };
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query },
@@ -5417,7 +5412,7 @@ describe("ApolloClient", () => {
       const variables = { id: "1234" };
       const mutationVariables = { id: "2345" };
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -5510,7 +5505,7 @@ describe("ApolloClient", () => {
       const variables = { id: "1234" };
       const mutationVariables = { id: "2345" };
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -5603,7 +5598,7 @@ describe("ApolloClient", () => {
       const variables = { id: "1234" };
       const mutationVariables = { id: "2345" };
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -5694,7 +5689,7 @@ describe("ApolloClient", () => {
         },
       };
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query },
@@ -5765,7 +5760,7 @@ describe("ApolloClient", () => {
         },
       };
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query },
@@ -5844,7 +5839,7 @@ describe("ApolloClient", () => {
       };
       const variables = { id: "1234" };
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -5925,7 +5920,7 @@ describe("ApolloClient", () => {
       };
       const variables = { id: "1234" };
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -6020,7 +6015,7 @@ describe("ApolloClient", () => {
 
     function makeClient() {
       return new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -6249,7 +6244,7 @@ describe("ApolloClient", () => {
       const variables = { id: "1234" };
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -6349,7 +6344,7 @@ describe("ApolloClient", () => {
       const variables = { id: "1234" };
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -6445,7 +6440,7 @@ describe("ApolloClient", () => {
       const variables = { id: "1234" };
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -6546,7 +6541,7 @@ describe("ApolloClient", () => {
       const refetchError = new Error("Refetch failed");
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -6659,7 +6654,7 @@ describe("ApolloClient", () => {
       };
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query },
@@ -6721,7 +6716,7 @@ describe("ApolloClient", () => {
       };
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link,
         ...clientAwareness,
       });
@@ -6750,13 +6745,13 @@ describe("ApolloClient", () => {
         }
       `;
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query },
             result: {
               data: {
-                author: { firstName: "John" },
+                author: { __typename: "Author", firstName: "John" },
               },
             },
           },
@@ -6769,7 +6764,7 @@ describe("ApolloClient", () => {
       // without reaching into internal state
       expect(
         client["queryManager"]["inFlightLinkObservables"].peek(
-          print(query),
+          print(addTypenameToDocument(query)),
           "{}"
         )
       ).toEqual({
@@ -6787,7 +6782,7 @@ describe("ApolloClient", () => {
       `;
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query },
@@ -6807,7 +6802,7 @@ describe("ApolloClient", () => {
       // without checking internal state
       expect(
         client["queryManager"]["inFlightLinkObservables"].peek(
-          print(query),
+          print(addTypenameToDocument(query)),
           "{}"
         )
       ).toBeUndefined();
@@ -6985,7 +6980,7 @@ describe("ApolloClient", () => {
       };
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query: query1 },
@@ -7057,7 +7052,7 @@ describe("ApolloClient", () => {
       };
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query: query1 },

--- a/src/core/__tests__/ApolloClient/links.test.ts
+++ b/src/core/__tests__/ApolloClient/links.test.ts
@@ -49,7 +49,7 @@ describe("Link interactions", () => {
     const mockLink = new MockSubscriptionLink();
     const link = ApolloLink.from([evictionLink, mockLink]);
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link,
     });
 
@@ -93,7 +93,7 @@ describe("Link interactions", () => {
 
     const link = new MockSubscriptionLink();
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link,
     });
 
@@ -165,7 +165,7 @@ describe("Link interactions", () => {
 
     const link = new MockSubscriptionLink();
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link,
     });
 
@@ -236,7 +236,7 @@ describe("Link interactions", () => {
     const mockLink = new MockSubscriptionLink();
     const link = ApolloLink.from([evictionLink, mockLink]);
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link,
     });
 
@@ -265,7 +265,7 @@ describe("Link interactions", () => {
     const mockLink = new MockSubscriptionLink();
     const link = ApolloLink.from([evictionLink, mockLink]);
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link,
     });
 
@@ -361,6 +361,7 @@ describe("Link interactions", () => {
         books {
           id
           title
+          __typename
         }
       }
     `;
@@ -380,7 +381,7 @@ describe("Link interactions", () => {
 
     const client = new ApolloClient({
       link,
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     await client.query({ query });

--- a/src/core/__tests__/ApolloClient/multiple-results.test.ts
+++ b/src/core/__tests__/ApolloClient/multiple-results.test.ts
@@ -35,7 +35,7 @@ describe("mutiple results", () => {
     };
     const link = new MockSubscriptionLink();
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link,
     });
 
@@ -93,7 +93,7 @@ describe("mutiple results", () => {
     };
     const link = new MockSubscriptionLink();
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link,
     });
 
@@ -164,7 +164,7 @@ describe("mutiple results", () => {
     };
     const link = new MockSubscriptionLink();
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link,
     });
 
@@ -229,7 +229,7 @@ describe("mutiple results", () => {
     };
     const link = new MockSubscriptionLink();
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link,
     });
 
@@ -294,7 +294,7 @@ describe("mutiple results", () => {
 
     const link = new MockSubscriptionLink();
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link,
     });
 

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -91,7 +91,7 @@ describe("ObservableQuery", () => {
     describe("to change pollInterval", () => {
       it("starts polling if goes from 0 -> something", async () => {
         const client = new ApolloClient({
-          cache: new InMemoryCache({ addTypename: false }),
+          cache: new InMemoryCache(),
           link: new MockLink([
             {
               request: { query, variables },
@@ -139,7 +139,7 @@ describe("ObservableQuery", () => {
 
       it("stops polling if goes from something -> 0", async () => {
         const client = new ApolloClient({
-          cache: new InMemoryCache({ addTypename: false }),
+          cache: new InMemoryCache(),
           link: new MockLink([
             {
               request: { query, variables },
@@ -178,7 +178,7 @@ describe("ObservableQuery", () => {
 
       it("can change from x>0 to y>0", async () => {
         const client = new ApolloClient({
-          cache: new InMemoryCache({ addTypename: false }),
+          cache: new InMemoryCache(),
           link: new MockLink([
             {
               request: { query, variables },
@@ -245,7 +245,7 @@ describe("ObservableQuery", () => {
       const variables2 = { first: 1 };
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: {
@@ -316,7 +316,7 @@ describe("ObservableQuery", () => {
       const data2 = { allPeople: { people: [{ name: "Leia Skywalker" }] } };
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: {
@@ -388,7 +388,7 @@ describe("ObservableQuery", () => {
       const variables2 = { first: 1 };
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -450,7 +450,7 @@ describe("ObservableQuery", () => {
 
     it("if query is refetched, and an error is returned, no other observer callbacks will be called", async () => {
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -496,7 +496,7 @@ describe("ObservableQuery", () => {
 
     it("does a network request if fetchPolicy becomes networkOnly", async () => {
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -558,7 +558,7 @@ describe("ObservableQuery", () => {
       ]);
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link,
       });
       // fetch first data from server
@@ -620,7 +620,7 @@ describe("ObservableQuery", () => {
       ]);
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link,
       });
 
@@ -680,7 +680,7 @@ describe("ObservableQuery", () => {
         },
       ]);
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link,
       });
       const observable = client.watchQuery({
@@ -734,7 +734,7 @@ describe("ObservableQuery", () => {
         },
       ]);
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link,
       });
 
@@ -766,7 +766,7 @@ describe("ObservableQuery", () => {
 
     it("returns a promise which eventually returns data", async () => {
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -820,7 +820,7 @@ describe("ObservableQuery", () => {
   describe("setVariables", () => {
     it("reruns query if the variables change", async () => {
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -869,7 +869,7 @@ describe("ObservableQuery", () => {
 
     it("does invalidate the currentResult data if the variables change", async () => {
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -952,7 +952,7 @@ describe("ObservableQuery", () => {
       };
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -1001,7 +1001,7 @@ describe("ObservableQuery", () => {
 
     it("does not invalidate the currentResult errors if the variables change", async () => {
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -1058,7 +1058,7 @@ describe("ObservableQuery", () => {
     it("does not perform a query when unsubscribed if variables change", async () => {
       // Note: no responses, will throw if a query is made
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([]),
       });
       const observable = client.watchQuery({ query, variables });
@@ -1079,7 +1079,7 @@ describe("ObservableQuery", () => {
       ];
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink(mockedResponses),
       });
       const firstRequest = mockedResponses[0].request;
@@ -1130,7 +1130,7 @@ describe("ObservableQuery", () => {
       ];
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink(mockedResponses),
       });
       const firstRequest = mockedResponses[0].request;
@@ -1170,7 +1170,7 @@ describe("ObservableQuery", () => {
 
     it("does not rerun query if variables do not change", async () => {
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -1199,7 +1199,7 @@ describe("ObservableQuery", () => {
 
     it("handles variables changing while a query is in-flight", async () => {
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -1246,7 +1246,7 @@ describe("ObservableQuery", () => {
       ];
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink(mockedResponses),
       });
       const firstRequest = mockedResponses[0].request;
@@ -1398,7 +1398,7 @@ describe("ObservableQuery", () => {
       ];
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink(mockedResponses),
       });
       const firstRequest = mockedResponses[0].request;
@@ -1448,7 +1448,7 @@ describe("ObservableQuery", () => {
       const variables2 = { first: 1 };
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: {
@@ -1544,7 +1544,7 @@ describe("ObservableQuery", () => {
       const variables2 = { first: 1 };
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: {
@@ -1825,7 +1825,7 @@ describe("ObservableQuery", () => {
         }
 
         const client = new ApolloClient({
-          cache: new InMemoryCache({ addTypename: false }),
+          cache: new InMemoryCache(),
           link: new MockLink([makeMock("a", "b", "c"), makeMock("d", "e")]),
         });
         const observableWithoutVariables = client.watchQuery({
@@ -1913,8 +1913,8 @@ describe("ObservableQuery", () => {
         const mocks = [makeMock("a", "b", "c"), makeMock("d", "e")];
         const firstRequest = mocks[0].request;
         const client = new ApolloClient({
-          cache: new InMemoryCache({ addTypename: false }),
-          link: new MockLink(mocks, true, { showWarnings: false }),
+          cache: new InMemoryCache(),
+          link: new MockLink(mocks, { showWarnings: false }),
         });
 
         const observableWithVarsVar = client.watchQuery({
@@ -2009,7 +2009,7 @@ describe("ObservableQuery", () => {
         }
 
         const client = new ApolloClient({
-          cache: new InMemoryCache({ addTypename: false }),
+          cache: new InMemoryCache(),
           link: new MockLink([makeMock("a", "b", "c"), makeMock("d", "e")]),
         });
 
@@ -2196,7 +2196,7 @@ describe("ObservableQuery", () => {
 
     it("returns the current query status immediately", async () => {
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -2236,7 +2236,7 @@ describe("ObservableQuery", () => {
 
     it("returns results from the store immediately", async () => {
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -2266,7 +2266,7 @@ describe("ObservableQuery", () => {
 
     it("returns errors from the store immediately", async () => {
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -2293,7 +2293,7 @@ describe("ObservableQuery", () => {
 
     it("returns referentially equal errors", async () => {
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -2325,7 +2325,7 @@ describe("ObservableQuery", () => {
 
     it("returns errors with data if errorPolicy is all", async () => {
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -2363,7 +2363,7 @@ describe("ObservableQuery", () => {
 
     it("errors out if errorPolicy is none", async () => {
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -2385,7 +2385,7 @@ describe("ObservableQuery", () => {
 
     it("errors out if errorPolicy is none and the observable has completed", async () => {
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -2408,7 +2408,7 @@ describe("ObservableQuery", () => {
 
     it("ignores errors with data if errorPolicy is ignore", async () => {
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -2458,7 +2458,7 @@ describe("ObservableQuery", () => {
       };
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -2519,7 +2519,7 @@ describe("ObservableQuery", () => {
 
     it("returns loading even if full data is available when using network-only fetchPolicy", async () => {
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -2575,7 +2575,7 @@ describe("ObservableQuery", () => {
 
     it("returns loading on no-cache fetchPolicy queries when calling getCurrentResult", async () => {
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -3131,7 +3131,7 @@ describe("ObservableQuery", () => {
 
       it("returns optimistic mutation results from the store", async () => {
         const client = new ApolloClient({
-          cache: new InMemoryCache({ addTypename: false }),
+          cache: new InMemoryCache(),
           link: new MockLink([
             {
               request: { query, variables },
@@ -3300,7 +3300,7 @@ describe("ObservableQuery", () => {
       const graphQLError = new GraphQLError("oh no!");
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -3330,7 +3330,7 @@ describe("ObservableQuery", () => {
       const networkError = new Error("oh no!");
 
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -3481,7 +3481,7 @@ describe("ObservableQuery", () => {
   describe("updateQuery", () => {
     it("should be able to determine if the previous result is complete", async () => {
       const client = new ApolloClient({
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
         link: new MockLink([
           {
             request: { query, variables },
@@ -3543,7 +3543,7 @@ describe("ObservableQuery", () => {
 
   it("QueryInfo does not notify for !== but deep-equal results", async () => {
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link: new MockLink([
         {
           request: { query, variables },
@@ -3620,7 +3620,7 @@ describe("ObservableQuery", () => {
 
   it("ObservableQuery#map respects Symbol.species", async () => {
     const client = new ApolloClient({
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
       link: new MockLink([
         {
           request: { query, variables },

--- a/src/core/__tests__/fetchPolicies.ts
+++ b/src/core/__tests__/fetchPolicies.ts
@@ -110,7 +110,7 @@ describe("network-only", () => {
 
     const client = new ApolloClient({
       link: inspector.concat(createLink()),
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     await client.query({ query });
@@ -135,7 +135,7 @@ describe("network-only", () => {
 
     const client = new ApolloClient({
       link: inspector.concat(createLink()),
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     await client.query({ query, fetchPolicy: "network-only" });
@@ -157,7 +157,7 @@ describe("network-only", () => {
 
     const client = new ApolloClient({
       link: inspector.concat(createFailureLink()),
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     let didFail = false;
@@ -183,7 +183,7 @@ describe("network-only", () => {
 
     const client = new ApolloClient({
       link: inspector.concat(createMutationLink()),
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     await client.query({ query });
@@ -210,7 +210,7 @@ describe("no-cache", () => {
 
     const client = new ApolloClient({
       link: inspector.concat(createLink()),
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     const actualResult = await client.query({ fetchPolicy: "no-cache", query });
@@ -231,7 +231,7 @@ describe("no-cache", () => {
 
     const client = new ApolloClient({
       link: inspector.concat(createLink()),
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     await client.query({ query });
@@ -253,7 +253,7 @@ describe("no-cache", () => {
 
     const client = new ApolloClient({
       link: inspector.concat(createLink()),
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     await client.query({ query, fetchPolicy: "no-cache" });
@@ -276,7 +276,7 @@ describe("no-cache", () => {
 
     const client = new ApolloClient({
       link: inspector.concat(createFailureLink()),
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     let didFail = false;
@@ -302,7 +302,7 @@ describe("no-cache", () => {
 
     const client = new ApolloClient({
       link: inspector.concat(createMutationLink()),
-      cache: new InMemoryCache({ addTypename: false }),
+      cache: new InMemoryCache(),
     });
 
     await client.query({ query });
@@ -325,7 +325,7 @@ describe("no-cache", () => {
 
       const client = new ApolloClient({
         link: inspector.concat(createLink()),
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
       });
 
       await client.query({
@@ -352,7 +352,7 @@ describe("no-cache", () => {
 
       const client = new ApolloClient({
         link: inspector.concat(createFailureLink()),
-        cache: new InMemoryCache({ addTypename: false }),
+        cache: new InMemoryCache(),
       });
 
       let didFail = false;
@@ -834,9 +834,7 @@ describe("nextFetchPolicy", () => {
     } (${args.useDefaultOptions ? "" : "not "}using defaults)`, async () => {
       const client = new ApolloClient({
         link: makeLink(),
-        cache: new InMemoryCache({
-          addTypename: true,
-        }),
+        cache: new InMemoryCache(),
         defaultOptions: {
           watchQuery:
             args.useDefaultOptions ?

--- a/src/link/persisted-queries/__tests__/react.test.tsx
+++ b/src/link/persisted-queries/__tests__/react.test.tsx
@@ -14,6 +14,7 @@ import { getDataFromTree } from "../../../react/ssr/getDataFromTree";
 import { createPersistedQueryLink as createPersistedQuery, VERSION } from "..";
 import { useQuery } from "../../../react";
 import { OperationVariables } from "../../../core";
+import { addTypenameToDocument } from "../../../utilities";
 
 function sha256(data: string) {
   const hash = crypto.createHash("sha256");
@@ -54,7 +55,7 @@ const data2 = {
 };
 const response = JSON.stringify({ data });
 const response2 = JSON.stringify({ data: data2 });
-const queryString = print(query);
+const queryString = print(addTypenameToDocument(query));
 
 const hash = sha256(queryString);
 
@@ -85,7 +86,7 @@ describe("react application", () => {
 
     const client = new ApolloClient({
       link,
-      cache: new Cache({ addTypename: false }),
+      cache: new Cache(),
       ssrMode: true,
     });
 
@@ -134,7 +135,7 @@ describe("react application", () => {
     // reset client and try with different input object
     const client2 = new ApolloClient({
       link,
-      cache: new Cache({ addTypename: false }),
+      cache: new Cache(),
       ssrMode: true,
     });
 

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -46,7 +46,7 @@ describe("useSubscription Hook", () => {
     const link = new MockSubscriptionLink();
     const client = new ApolloClient({
       link,
-      cache: new Cache({ addTypename: false }),
+      cache: new Cache(),
     });
 
     const { result } = renderHook(() => useSubscription(subscription), {
@@ -113,7 +113,7 @@ describe("useSubscription Hook", () => {
     const link = new MockSubscriptionLink();
     const client = new ApolloClient({
       link,
-      cache: new Cache({ addTypename: false }),
+      cache: new Cache(),
     });
 
     const onError = jest.fn();
@@ -165,7 +165,7 @@ describe("useSubscription Hook", () => {
     const link = new MockSubscriptionLink();
     const client = new ApolloClient({
       link,
-      cache: new Cache({ addTypename: false }),
+      cache: new Cache(),
     });
 
     const onComplete = jest.fn();
@@ -204,7 +204,7 @@ describe("useSubscription Hook", () => {
     const link = new MockSubscriptionLink();
     const client = new ApolloClient({
       link,
-      cache: new Cache({ addTypename: false }),
+      cache: new Cache(),
     });
 
     const onData = jest.fn();
@@ -260,7 +260,7 @@ describe("useSubscription Hook", () => {
     link.onSetup(onSetup);
     const client = new ApolloClient({
       link,
-      cache: new Cache({ addTypename: false }),
+      cache: new Cache(),
     });
 
     const onData = jest.fn();
@@ -324,7 +324,7 @@ describe("useSubscription Hook", () => {
     const link = new MockSubscriptionLink();
     const client = new ApolloClient({
       link,
-      cache: new Cache({ addTypename: false }),
+      cache: new Cache(),
     });
     const { result, rerender } = renderHook(
       ({ skip }) => useSubscription(subscription, { skip }),
@@ -420,7 +420,7 @@ describe("useSubscription Hook", () => {
     });
     const client = new ApolloClient({
       link: concat(contextLink, link),
-      cache: new Cache({ addTypename: false }),
+      cache: new Cache(),
     });
 
     const { result } = renderHook(
@@ -488,7 +488,7 @@ describe("useSubscription Hook", () => {
     });
     const client = new ApolloClient({
       link: concat(extensionsLink, link),
-      cache: new Cache({ addTypename: false }),
+      cache: new Cache(),
     });
 
     const { result } = renderHook(
@@ -551,7 +551,7 @@ describe("useSubscription Hook", () => {
     const link = new MockSubscriptionLink();
     const client = new ApolloClient({
       link,
-      cache: new Cache({ addTypename: false }),
+      cache: new Cache(),
     });
 
     const { result } = renderHook(
@@ -620,7 +620,7 @@ describe("useSubscription Hook", () => {
     const link = new MockSubscriptionLink();
     const client = new ApolloClient({
       link,
-      cache: new Cache({ addTypename: false }),
+      cache: new Cache(),
     });
 
     const { result } = renderHook(() => useSubscription(subscription), {
@@ -668,7 +668,7 @@ describe("useSubscription Hook", () => {
     const link = new MockSubscriptionLink();
     const client = new ApolloClient({
       link,
-      cache: new Cache({ addTypename: false }),
+      cache: new Cache(),
     });
 
     const { result } = renderHook(
@@ -746,7 +746,7 @@ describe("useSubscription Hook", () => {
     const link = new MockSubscriptionLink();
     const client = new ApolloClient({
       link,
-      cache: new Cache({ addTypename: false }),
+      cache: new Cache(),
     });
 
     renderHook(
@@ -789,7 +789,7 @@ describe("useSubscription Hook", () => {
     const link = new MockSubscriptionLink();
     const client = new ApolloClient({
       link,
-      cache: new Cache({ addTypename: false }),
+      cache: new Cache(),
     });
 
     const onData = jest.fn();
@@ -837,7 +837,7 @@ describe("useSubscription Hook", () => {
     const link = new MockSubscriptionLink();
     const client = new ApolloClient({
       link,
-      cache: new Cache({ addTypename: false }),
+      cache: new Cache(),
     });
 
     const onSubscriptionData = jest.fn();
@@ -876,7 +876,7 @@ describe("useSubscription Hook", () => {
     const link = new MockSubscriptionLink();
     const client = new ApolloClient({
       link,
-      cache: new Cache({ addTypename: false }),
+      cache: new Cache(),
     });
 
     const { rerender } = renderHook(
@@ -909,7 +909,7 @@ describe("useSubscription Hook", () => {
     const link = new MockSubscriptionLink();
     const client = new ApolloClient({
       link,
-      cache: new Cache({ addTypename: false }),
+      cache: new Cache(),
     });
 
     renderHook(
@@ -952,7 +952,7 @@ describe("useSubscription Hook", () => {
     const link = new MockSubscriptionLink();
     const client = new ApolloClient({
       link,
-      cache: new Cache({ addTypename: false }),
+      cache: new Cache(),
     });
 
     const onComplete = jest.fn();
@@ -1002,7 +1002,7 @@ describe("useSubscription Hook", () => {
     const link = new MockSubscriptionLink();
     const client = new ApolloClient({
       link,
-      cache: new Cache({ addTypename: false }),
+      cache: new Cache(),
     });
 
     const onSubscriptionComplete = jest.fn();
@@ -1043,7 +1043,7 @@ describe("useSubscription Hook", () => {
     const link = new MockSubscriptionLink();
     const client = new ApolloClient({
       link,
-      cache: new Cache({ addTypename: false }),
+      cache: new Cache(),
     });
 
     const { rerender } = renderHook(
@@ -1098,7 +1098,7 @@ describe("useSubscription Hook", () => {
       const link = new MockSubscriptionLink();
       const client = new ApolloClient({
         link,
-        cache: new Cache({ addTypename: false }),
+        cache: new Cache(),
       });
       let renderCount = 0;
 
@@ -1147,7 +1147,7 @@ followed by new in-flight setup", async () => {
     const link = new MockSubscriptionLink();
     const client = new ApolloClient({
       link,
-      cache: new Cache({ addTypename: false }),
+      cache: new Cache(),
     });
 
     const { result, unmount, rerender } = renderHook(
@@ -1798,7 +1798,7 @@ describe("ignoreResults", () => {
     const link = new MockSubscriptionLink();
     const client = new ApolloClient({
       link,
-      cache: new Cache({ addTypename: false }),
+      cache: new Cache(),
     });
 
     const onData = jest.fn((() => {}) as SubscriptionHookOptions["onData"]);
@@ -1872,7 +1872,7 @@ describe("ignoreResults", () => {
     const link = new MockSubscriptionLink();
     const client = new ApolloClient({
       link,
-      cache: new Cache({ addTypename: false }),
+      cache: new Cache(),
     });
 
     const onData = jest.fn((() => {}) as SubscriptionHookOptions["onData"]);
@@ -1942,7 +1942,7 @@ describe("ignoreResults", () => {
     link.onSetup(subscriptionCreated);
     const client = new ApolloClient({
       link,
-      cache: new Cache({ addTypename: false }),
+      cache: new Cache(),
     });
 
     const onData = jest.fn((() => {}) as SubscriptionHookOptions["onData"]);
@@ -2016,7 +2016,7 @@ describe("ignoreResults", () => {
     link.onSetup(subscriptionCreated);
     const client = new ApolloClient({
       link,
-      cache: new Cache({ addTypename: false }),
+      cache: new Cache(),
     });
 
     const onData = jest.fn((() => {}) as SubscriptionHookOptions["onData"]);

--- a/src/react/ssr/__tests__/getDataFromTree.test.tsx
+++ b/src/react/ssr/__tests__/getDataFromTree.test.tsx
@@ -48,7 +48,7 @@ describe("SSR", () => {
       });
       const apolloClient = new ApolloClient({
         link,
-        cache: new Cache({ addTypename: false }),
+        cache: new Cache(),
       });
 
       interface Data {
@@ -103,7 +103,7 @@ describe("SSR", () => {
 
       const client = new ApolloClient({
         link,
-        cache: new Cache({ addTypename: false }),
+        cache: new Cache(),
       });
 
       function App() {

--- a/src/react/ssr/__tests__/useQuery.test.tsx
+++ b/src/react/ssr/__tests__/useQuery.test.tsx
@@ -324,7 +324,7 @@ describe("useQuery Hook SSR", () => {
     };
 
     const app = (
-      <MockedProvider addTypename cache={cache}>
+      <MockedProvider cache={cache}>
         <Component />
       </MockedProvider>
     );

--- a/src/testing/core/mocking/__tests__/mockLink.ts
+++ b/src/testing/core/mocking/__tests__/mockLink.ts
@@ -164,7 +164,7 @@ describe("mockLink", () => {
     // in the operation before calling the Link, so we have to do the same here
     // when we call `execute`
     const defaults = { done: true };
-    const link = new MockLink(mocks, false, { showWarnings: false });
+    const link = new MockLink(mocks, { showWarnings: false });
     {
       // Non-optional variable is missing, should not match.
       const stream = new ObservableStream(

--- a/src/testing/core/mocking/mockClient.ts
+++ b/src/testing/core/mocking/mockClient.ts
@@ -17,6 +17,6 @@ export function createMockClient<TData>(
     }).setOnError((error) => {
       throw error;
     }),
-    cache: new InMemoryCache({ addTypename: false }),
+    cache: new InMemoryCache(),
   });
 }

--- a/src/testing/core/mocking/mockLink.ts
+++ b/src/testing/core/mocking/mockLink.ts
@@ -259,6 +259,8 @@ export interface MockApolloLink extends ApolloLink {
 
 // Pass in multiple mocked responses, so that you can test flows that end up
 // making multiple queries to the server.
-export function mockSingleLink(...mockedResponses: Array<any>): MockApolloLink {
+export function mockSingleLink(
+  ...mockedResponses: Array<MockedResponse<any, any>>
+): MockApolloLink {
   return new MockLink(mockedResponses);
 }

--- a/src/testing/core/mocking/mockLink.ts
+++ b/src/testing/core/mocking/mockLink.ts
@@ -56,27 +56,23 @@ export interface MockLinkOptions {
   showWarnings?: boolean;
 }
 
-function requestToKey(request: GraphQLRequest, addTypename: Boolean): string {
+function requestToKey(request: GraphQLRequest): string {
   const queryString =
-    request.query &&
-    print(addTypename ? addTypenameToDocument(request.query) : request.query);
+    request.query && print(addTypenameToDocument(request.query));
   const requestKey = { query: queryString };
   return JSON.stringify(requestKey);
 }
 
 export class MockLink extends ApolloLink {
   public operation!: Operation;
-  public addTypename: Boolean = true;
   public showWarnings: boolean = true;
   private mockedResponsesByKey: { [key: string]: MockedResponse[] } = {};
 
   constructor(
     mockedResponses: ReadonlyArray<MockedResponse<any, any>>,
-    addTypename: Boolean = true,
     options: MockLinkOptions = Object.create(null)
   ) {
     super();
-    this.addTypename = addTypename;
     this.showWarnings = options.showWarnings ?? true;
 
     if (mockedResponses) {
@@ -89,10 +85,7 @@ export class MockLink extends ApolloLink {
   public addMockedResponse(mockedResponse: MockedResponse) {
     const normalizedMockedResponse =
       this.normalizeMockedResponse(mockedResponse);
-    const key = requestToKey(
-      normalizedMockedResponse.request,
-      this.addTypename
-    );
+    const key = requestToKey(normalizedMockedResponse.request);
     let mockedResponses = this.mockedResponsesByKey[key];
     if (!mockedResponses) {
       mockedResponses = [];
@@ -103,7 +96,7 @@ export class MockLink extends ApolloLink {
 
   public request(operation: Operation): Observable<FetchResult> | null {
     this.operation = operation;
-    const key = requestToKey(operation, this.addTypename);
+    const key = requestToKey(operation);
     const unmatchedVars: Array<Record<string, any>> = [];
     const requestVariables = operation.variables || {};
     const mockedResponses = this.mockedResponsesByKey[key];
@@ -266,17 +259,6 @@ export interface MockApolloLink extends ApolloLink {
 
 // Pass in multiple mocked responses, so that you can test flows that end up
 // making multiple queries to the server.
-// NOTE: The last arg can optionally be an `addTypename` arg.
 export function mockSingleLink(...mockedResponses: Array<any>): MockApolloLink {
-  // To pull off the potential typename. If this isn't a boolean, we'll just
-  // set it true later.
-  let maybeTypename = mockedResponses[mockedResponses.length - 1];
-  let mocks = mockedResponses.slice(0, mockedResponses.length - 1);
-
-  if (typeof maybeTypename !== "boolean") {
-    mocks = mockedResponses;
-    maybeTypename = true;
-  }
-
-  return new MockLink(mocks, maybeTypename);
+  return new MockLink(mockedResponses);
 }

--- a/src/testing/react/MockedProvider.tsx
+++ b/src/testing/react/MockedProvider.tsx
@@ -12,7 +12,6 @@ import type { ApolloCache } from "../../cache/index.js";
 
 export interface MockedProviderProps<TSerializedCache = {}> {
   mocks?: ReadonlyArray<MockedResponse<any, any>>;
-  addTypename?: boolean;
   defaultOptions?: DefaultOptions;
   cache?: ApolloCache<TSerializedCache>;
   resolvers?: Resolvers;
@@ -35,16 +34,11 @@ export class MockedProvider extends React.Component<
   MockedProviderProps,
   MockedProviderState
 > {
-  public static defaultProps: MockedProviderProps = {
-    addTypename: true,
-  };
-
   constructor(props: MockedProviderProps) {
     super(props);
 
     const {
       mocks,
-      addTypename,
       defaultOptions,
       cache,
       resolvers,
@@ -53,7 +47,7 @@ export class MockedProvider extends React.Component<
       connectToDevTools = false,
     } = this.props;
     const client = new ApolloClient({
-      cache: cache || new Cache({ addTypename }),
+      cache: cache || new Cache(),
       defaultOptions,
       connectToDevTools,
       link: link || new MockLink(mocks || [], { showWarnings }),

--- a/src/testing/react/MockedProvider.tsx
+++ b/src/testing/react/MockedProvider.tsx
@@ -56,7 +56,7 @@ export class MockedProvider extends React.Component<
       cache: cache || new Cache({ addTypename }),
       defaultOptions,
       connectToDevTools,
-      link: link || new MockLink(mocks || [], addTypename, { showWarnings }),
+      link: link || new MockLink(mocks || [], { showWarnings }),
       resolvers,
     });
 

--- a/src/testing/react/__tests__/MockedProvider.test.tsx
+++ b/src/testing/react/__tests__/MockedProvider.test.tsx
@@ -575,7 +575,7 @@ describe("General use", () => {
 
     const link = ApolloLink.from([
       errorLink,
-      new MockLink([], true, { showWarnings: false }),
+      new MockLink([], { showWarnings: false }),
     ]);
 
     render(
@@ -637,7 +637,7 @@ describe("General use", () => {
       },
     ];
 
-    const mockLink = new MockLink(mocks, true, { showWarnings: false });
+    const mockLink = new MockLink(mocks, { showWarnings: false });
     const link = ApolloLink.from([errorLink, mockLink]);
     const Wrapper = ({ children }: { children: React.ReactNode }) => (
       <MockedProvider link={link}>{children}</MockedProvider>
@@ -688,7 +688,7 @@ describe("General use", () => {
       },
     ];
 
-    const mockLink = new MockLink(mocks, true, { showWarnings: false });
+    const mockLink = new MockLink(mocks, { showWarnings: false });
     const link = ApolloLink.from([errorLink, mockLink]);
     const Wrapper = ({ children }: { children: React.ReactNode }) => (
       <MockedProvider link={link}>{children}</MockedProvider>
@@ -746,7 +746,7 @@ describe("General use", () => {
       },
     ];
 
-    const mockLink = new MockLink(mocks, true, { showWarnings: false });
+    const mockLink = new MockLink(mocks, { showWarnings: false });
     const link = ApolloLink.from([errorLink, mockLink]);
     const Wrapper = ({ children }: { children: React.ReactNode }) => (
       <MockedProvider link={link}>{children}</MockedProvider>
@@ -811,7 +811,7 @@ describe("General use", () => {
       },
     ];
 
-    const mockLink = new MockLink(mocks, true, { showWarnings: false });
+    const mockLink = new MockLink(mocks, { showWarnings: false });
     const link = ApolloLink.from([errorLink, mockLink]);
     const Wrapper = ({ children }: { children: React.ReactNode }) => (
       <MockedProvider link={link}>{children}</MockedProvider>
@@ -982,7 +982,7 @@ describe("General use", () => {
       },
     ];
 
-    const link = new MockLink(mocksDifferentQuery, false, {
+    const link = new MockLink(mocksDifferentQuery, {
       showWarnings: false,
     });
 
@@ -1008,7 +1008,7 @@ describe("General use", () => {
       return null;
     }
 
-    const mockLink = new MockLink([], true, { showWarnings: false });
+    const mockLink = new MockLink([], { showWarnings: false });
     mockLink.setOnError((error) => {
       expect(error).toMatchSnapshot();
       finished = true;
@@ -1039,7 +1039,7 @@ describe("General use", () => {
       return null;
     }
 
-    const mockLink = new MockLink([], true, { showWarnings: false });
+    const mockLink = new MockLink([], { showWarnings: false });
     mockLink.setOnError(() => {
       throw new Error("oh no!");
     });

--- a/src/testing/react/__tests__/mockSubscriptionLink.test.tsx
+++ b/src/testing/react/__tests__/mockSubscriptionLink.test.tsx
@@ -21,7 +21,7 @@ describe("mockSubscriptionLink", () => {
     const link = new MockSubscriptionLink();
     const client = new ApolloClient({
       link,
-      cache: new Cache({ addTypename: false }),
+      cache: new Cache(),
     });
 
     let renderCountA = 0;


### PR DESCRIPTION
Closes #12184

Removes the `addTypename` option from `InMemoryCache` and all functionality associated with it. 