### PR TITLE
Docs: simplify subscribeToMore example

### DIFF
--- a/docs/source/data/subscriptions.mdx
+++ b/docs/source/data/subscriptions.mdx
@@ -473,7 +473,7 @@ function CommentsPageWithData({ params }: CommentsPageWithDataProps) {
 
   useEffect(() => {
     if (result.data) {
-      subscribeToMore({
+      const unsubscribe = subscribeToMore({
         document: COMMENTS_SUBSCRIPTION,
         variables: { postID: params.postID },
         updateQuery: (prev, { subscriptionData }) => {
@@ -487,8 +487,10 @@ function CommentsPageWithData({ params }: CommentsPageWithDataProps) {
           });
         }
       });
+
+      return () => { unsubscribe(); };
     }
-  }, [result.data]);
+  }, [result.data, params.postID]);
 
   return (
     <CommentsPage {...result} />
@@ -505,7 +507,7 @@ function CommentsPageWithData({ params }) {
 
   useEffect(() => {
     if (result.data) {
-      subscribeToMore({
+      const unsubscribe = subscribeToMore({
         document: COMMENTS_SUBSCRIPTION,
         variables: { postID: params.postID },
         updateQuery: (prev, { subscriptionData }) => {
@@ -519,8 +521,10 @@ function CommentsPageWithData({ params }) {
           });
         }
       });
+
+      return () => { unsubscribe(); };
     }
-  }, [result.data]);
+  }, [result.data, params.postID]);
 
   return (
     <CommentsPage {...result} />

--- a/docs/source/data/subscriptions.mdx
+++ b/docs/source/data/subscriptions.mdx
@@ -472,6 +472,8 @@ function CommentsPageWithData({ params }: CommentsPageWithDataProps) {
   );
 
   useEffect(() => {
+    // This assumes you want to wait to start the subscription
+    // after the query has loaded.
     if (result.data) {
       const unsubscribe = subscribeToMore({
         document: COMMENTS_SUBSCRIPTION,

--- a/docs/source/data/subscriptions.mdx
+++ b/docs/source/data/subscriptions.mdx
@@ -466,10 +466,9 @@ Next, we modify our `CommentsPageWithData` component to call `subscribeToMore` a
 
 ```tsx {10-25}
 function CommentsPageWithData({ params }: CommentsPageWithDataProps) {
-  const { subscribeToMore, ...result } = useQuery(
-    COMMENTS_QUERY,
-    { variables: { postID: params.postID } }
-  );
+  const { subscribeToMore, ...result } = useQuery(COMMENTS_QUERY, {
+    variables: { postID: params.postID },
+  });
 
   useEffect(() => {
     // This assumes you want to wait to start the subscription
@@ -484,28 +483,27 @@ function CommentsPageWithData({ params }: CommentsPageWithDataProps) {
 
           return Object.assign({}, prev, {
             post: {
-              comments: [newFeedItem, ...prev.post.comments]
-            }
+              comments: [newFeedItem, ...prev.post.comments],
+            },
           });
-        }
+        },
       });
 
-      return () => { unsubscribe(); };
+      return () => {
+        unsubscribe();
+      };
     }
   }, [result.data, params.postID, subscribeToMore]);
 
-  return (
-    <CommentsPage {...result} />
-  );
+  return <CommentsPage {...result} />;
 }
 ```
 
 ```jsx {10-25}
 function CommentsPageWithData({ params }) {
-  const { subscribeToMore, ...result } = useQuery(
-    COMMENTS_QUERY,
-    { variables: { postID: params.postID } }
-  );
+  const { subscribeToMore, ...result } = useQuery(COMMENTS_QUERY, {
+    variables: { postID: params.postID },
+  });
 
   useEffect(() => {
     if (result.data) {
@@ -518,19 +516,19 @@ function CommentsPageWithData({ params }) {
 
           return Object.assign({}, prev, {
             post: {
-              comments: [newFeedItem, ...prev.post.comments]
-            }
+              comments: [newFeedItem, ...prev.post.comments],
+            },
           });
-        }
+        },
       });
 
-      return () => { unsubscribe(); };
+      return () => {
+        unsubscribe();
+      };
     }
   }, [result.data, params.postID]);
 
-  return (
-    <CommentsPage {...result} />
-  );
+  return <CommentsPage {...result} />;
 }
 ```
 

--- a/docs/source/data/subscriptions.mdx
+++ b/docs/source/data/subscriptions.mdx
@@ -460,7 +460,7 @@ const COMMENTS_SUBSCRIPTION = gql`
 
 </MultiCodeBlock>
 
-Next, we modify our `CommentsPageWithData` function to add a `subscribeToNewComments` property to the `CommentsPage` component it returns. This property is a function that will be responsible for calling `subscribeToMore` after the component mounts.
+Next, we modify our `CommentsPageWithData` function call `subscribeToMore` the comments query loads:
 
 <MultiCodeBlock>
 
@@ -471,26 +471,27 @@ function CommentsPageWithData({ params }: CommentsPageWithDataProps) {
     { variables: { postID: params.postID } }
   );
 
-  return (
-    <CommentsPage
-      {...result}
-      subscribeToNewComments={() =>
-        subscribeToMore({
-          document: COMMENTS_SUBSCRIPTION,
-          variables: { postID: params.postID },
-          updateQuery: (prev, { subscriptionData }) => {
-            if (!subscriptionData.data) return prev;
-            const newFeedItem = subscriptionData.data.commentAdded;
+  useEffect(() => {
+    if (result.data) {
+      subscribeToMore({
+        document: COMMENTS_SUBSCRIPTION,
+        variables: { postID: params.postID },
+        updateQuery: (prev, { subscriptionData }) => {
+          if (!subscriptionData.data) return prev;
+          const newFeedItem = subscriptionData.data.commentAdded;
 
-            return Object.assign({}, prev, {
-              post: {
-                comments: [newFeedItem, ...prev.post.comments]
-              }
-            });
-          }
-        })
-      }
-    />
+          return Object.assign({}, prev, {
+            post: {
+              comments: [newFeedItem, ...prev.post.comments]
+            }
+          });
+        }
+      });
+    }
+  }, [result.data]);
+
+  return (
+    <CommentsPage {...result} />
   );
 }
 ```
@@ -502,26 +503,27 @@ function CommentsPageWithData({ params }) {
     { variables: { postID: params.postID } }
   );
 
-  return (
-    <CommentsPage
-      {...result}
-      subscribeToNewComments={() =>
-        subscribeToMore({
-          document: COMMENTS_SUBSCRIPTION,
-          variables: { postID: params.postID },
-          updateQuery: (prev, { subscriptionData }) => {
-            if (!subscriptionData.data) return prev;
-            const newFeedItem = subscriptionData.data.commentAdded;
+  useEffect(() => {
+    if (result.data) {
+      subscribeToMore({
+        document: COMMENTS_SUBSCRIPTION,
+        variables: { postID: params.postID },
+        updateQuery: (prev, { subscriptionData }) => {
+          if (!subscriptionData.data) return prev;
+          const newFeedItem = subscriptionData.data.commentAdded;
 
-            return Object.assign({}, prev, {
-              post: {
-                comments: [newFeedItem, ...prev.post.comments]
-              }
-            });
-          }
-        })
-      }
-    />
+          return Object.assign({}, prev, {
+            post: {
+              comments: [newFeedItem, ...prev.post.comments]
+            }
+          });
+        }
+      });
+    }
+  }, [result.data]);
+
+  return (
+    <CommentsPage {...result} />
   );
 }
 ```
@@ -533,28 +535,6 @@ In the example above, we pass three options to `subscribeToMore`:
 * `document` indicates the subscription to execute.
 * `variables` indicates the variables to include when executing the subscription.
 * `updateQuery` is a function that tells Apollo Client how to combine the query's currently cached result (`prev`) with the `subscriptionData` that's pushed by our GraphQL server. The return value of this function **completely replaces** the current cached result for the query.
-
-Finally, in our definition of `CommentsPage`, we tell the component to `subscribeToNewComments` when it mounts:
-
-<MultiCodeBlock>
-
-```tsx
-export function CommentsPage({ subscribeToNewComments }: CommentsPageProps) {
-  useEffect(() => subscribeToNewComments(), []);
-
-  return <>...</>
-}
-```
-
-```jsx
-export function CommentsPage({ subscribeToNewComments }) {
-  useEffect(() => subscribeToNewComments(), []);
-
-  return <>...</>
-}
-```
-
-</MultiCodeBlock>
 
 ## `useSubscription` API reference
 

--- a/docs/source/data/subscriptions.mdx
+++ b/docs/source/data/subscriptions.mdx
@@ -492,7 +492,7 @@ function CommentsPageWithData({ params }: CommentsPageWithDataProps) {
 
       return () => { unsubscribe(); };
     }
-  }, [result.data, params.postID]);
+  }, [result.data, params.postID, subscribeToMore]);
 
   return (
     <CommentsPage {...result} />

--- a/docs/source/data/subscriptions.mdx
+++ b/docs/source/data/subscriptions.mdx
@@ -460,7 +460,7 @@ const COMMENTS_SUBSCRIPTION = gql`
 
 </MultiCodeBlock>
 
-Next, we modify our `CommentsPageWithData` function call `subscribeToMore` the comments query loads:
+Next, we modify our `CommentsPageWithData` component to call `subscribeToMore` after the comments query loads.
 
 <MultiCodeBlock>
 


### PR DESCRIPTION
This is a proposed simplification to the `subscribeToMore` example, to remove a level of indirection that seemed unjustified. If the original approach is more correct, I suggest explaining why the `useEffect` should be in `CommentsPage`, rather than calling it directly in `CommentsPageWithData`.

I am assuming the need to wait until the query data has arrived before executing the subscription.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:

### Checklist:
- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
-->
