### PR TITLE
Allowed DeepOmit to support partial

### DIFF
--- a/.changeset/grumpy-donuts-smoke.md
+++ b/.changeset/grumpy-donuts-smoke.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fixes an issue where the DeepOmit type would turn optional properties into required properties. This should only affect you if you were using the omitDeep or stripTypename utilities exported by Apollo Client.

--- a/src/utilities/types/DeepOmit.ts
+++ b/src/utilities/types/DeepOmit.ts
@@ -28,19 +28,15 @@ export type MandatoryKeysOf<Obj> = Omit<Obj, keyof OptionalKeysOf<Obj>>;
 export type DeepOmit<T, K> =
   T extends DeepOmitPrimitive ? T
   : {
-    [P in Exclude<keyof MandatoryKeysOf<T>, K>]: T[P] extends infer TP
-      ? TP extends DeepOmitPrimitive
-        ? TP
-        : TP extends any[]
-          ? DeepOmitArray<TP, K>
-          : DeepOmit<TP, K>
+      [P in Exclude<keyof MandatoryKeysOf<T>, K>]: T[P] extends infer TP ?
+        TP extends DeepOmitPrimitive ? TP
+        : TP extends any[] ? DeepOmitArray<TP, K>
+        : DeepOmit<TP, K>
       : never;
-  } & Partial<{
-    [P in Exclude<keyof OptionalKeysOf<T>, K>]: T[P] extends infer TP
-      ? TP extends DeepOmitPrimitive
-        ? TP
-        : TP extends any[]
-          ? DeepOmitArray<TP, K>
-          : DeepOmit<TP, K>
+    } & Partial<{
+      [P in Exclude<keyof OptionalKeysOf<T>, K>]: T[P] extends infer TP ?
+        TP extends DeepOmitPrimitive ? TP
+        : TP extends any[] ? DeepOmitArray<TP, K>
+        : DeepOmit<TP, K>
       : never;
-  }>;
+    }>;

--- a/src/utilities/types/DeepOmit.ts
+++ b/src/utilities/types/DeepOmit.ts
@@ -7,12 +7,6 @@ export type DeepOmitArray<T extends any[], K> = {
   [P in keyof T]: DeepOmit<T[P], K>;
 };
 
-export type OptionalKeysOf<Obj> = {
-  [Key in keyof Obj as Omit<Obj, Key> extends Obj ? Key : never]: Obj[Key];
-};
-
-export type MandatoryKeysOf<Obj> = Omit<Obj, keyof OptionalKeysOf<Obj>>;
-
 // Unfortunately there is one major flaw in this type: This will omit properties
 // from class instances in the return type even though our omitDeep helper
 // ignores class instances, therefore resulting in a type mismatch between
@@ -28,15 +22,9 @@ export type MandatoryKeysOf<Obj> = Omit<Obj, keyof OptionalKeysOf<Obj>>;
 export type DeepOmit<T, K> =
   T extends DeepOmitPrimitive ? T
   : {
-      [P in Exclude<keyof MandatoryKeysOf<T>, K>]: T[P] extends infer TP ?
+      [P in keyof T as P extends K ? never : P]: T[P] extends infer TP ?
         TP extends DeepOmitPrimitive ? TP
         : TP extends any[] ? DeepOmitArray<TP, K>
         : DeepOmit<TP, K>
       : never;
-    } & Partial<{
-      [P in Exclude<keyof OptionalKeysOf<T>, K>]: T[P] extends infer TP ?
-        TP extends DeepOmitPrimitive ? TP
-        : TP extends any[] ? DeepOmitArray<TP, K>
-        : DeepOmit<TP, K>
-      : never;
-    }>;
+    };


### PR DESCRIPTION
Linked to issue: [https://github.com/apollographql/apollo-client/issues/12391](https://github.com/apollographql/apollo-client/issues/12391)

Proposed solution to bug in DeepOmit function.

When deep commit is used on a type with optional keys, the optional key(s) is removed and replaced with the orignial type union `undefined`.

This leads to situations like:
```
type OptionalString = {
  maybeString?: string;
  __typename: 'X-type';
};
```
becoming
```
{
    maybeString: string | undefined;
}
```
when DeepOmit is used to remove `___typename`

To solve this I've added logic to deal with Optional and Required keys seperately.
