### PR TITLE
Consolidate error properties

### DIFF
--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -261,7 +261,6 @@ export interface ApolloQueryResult<T> {
     // (undocumented)
     data: T | undefined;
     error?: ApolloError;
-    errors?: ReadonlyArray<GraphQLFormattedError>;
     // (undocumented)
     loading: boolean;
     // (undocumented)

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -332,7 +332,6 @@ interface ApolloQueryResult<T> {
     data: T | undefined;
     // Warning: (ae-forgotten-export) The symbol "ApolloError" needs to be exported by the entry point index.d.ts
     error?: ApolloError;
-    errors?: ReadonlyArray<GraphQLFormattedError>;
     // (undocumented)
     loading: boolean;
     // Warning: (ae-forgotten-export) The symbol "NetworkStatus" needs to be exported by the entry point index.d.ts
@@ -1805,8 +1804,6 @@ export interface QueryResult<TData = any, TVariables extends OperationVariables 
     client: ApolloClient<any>;
     data: MaybeMasked<TData> | undefined;
     error?: ApolloError;
-    // @deprecated (undocumented)
-    errors?: ReadonlyArray<GraphQLFormattedError>;
     loading: boolean;
     networkStatus: NetworkStatus;
     observable: ObservableQuery<TData, TVariables>;
@@ -2518,8 +2515,8 @@ interface WatchQueryOptions<TVariables extends OperationVariables = OperationVar
 // src/core/ObservableQuery.ts:117:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:172:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:430:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:179:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:208:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:174:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:203:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:203:3 - (ae-forgotten-export) The symbol "UpdateQueryOptions" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:35:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:37:3 - (ae-forgotten-export) The symbol "RefetchFunction" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report-react_context.api.md
+++ b/.api-reports/api-report-react_context.api.md
@@ -328,7 +328,6 @@ interface ApolloQueryResult<T> {
     data: T | undefined;
     // Warning: (ae-forgotten-export) The symbol "ApolloError" needs to be exported by the entry point index.d.ts
     error?: ApolloError;
-    errors?: ReadonlyArray<GraphQLFormattedError>;
     // (undocumented)
     loading: boolean;
     // Warning: (ae-forgotten-export) The symbol "NetworkStatus" needs to be exported by the entry point index.d.ts
@@ -1541,8 +1540,6 @@ interface QueryResult<TData = any, TVariables extends OperationVariables = Opera
     client: ApolloClient<any>;
     data: MaybeMasked<TData> | undefined;
     error?: ApolloError;
-    // @deprecated (undocumented)
-    errors?: ReadonlyArray<GraphQLFormattedError>;
     loading: boolean;
     networkStatus: NetworkStatus;
     observable: ObservableQuery<TData, TVariables>;
@@ -1901,8 +1898,8 @@ interface WatchQueryOptions<TVariables extends OperationVariables = OperationVar
 // src/core/ObservableQuery.ts:117:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:172:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:430:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:179:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:208:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:174:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:203:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:203:3 - (ae-forgotten-export) The symbol "UpdateQueryOptions" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-react_hooks.api.md
+++ b/.api-reports/api-report-react_hooks.api.md
@@ -295,7 +295,6 @@ interface ApolloQueryResult<T> {
     data: T | undefined;
     // Warning: (ae-forgotten-export) The symbol "ApolloError" needs to be exported by the entry point index.d.ts
     error?: ApolloError;
-    errors?: ReadonlyArray<GraphQLFormattedError>;
     // (undocumented)
     loading: boolean;
     // Warning: (ae-forgotten-export) The symbol "NetworkStatus" needs to be exported by the entry point index.d.ts
@@ -1672,8 +1671,6 @@ interface QueryResult<TData = any, TVariables extends OperationVariables = Opera
     client: ApolloClient<any>;
     data: MaybeMasked<TData> | undefined;
     error?: ApolloError;
-    // @deprecated (undocumented)
-    errors?: ReadonlyArray<GraphQLFormattedError>;
     loading: boolean;
     networkStatus: NetworkStatus;
     observable: ObservableQuery<TData, TVariables>;
@@ -2368,8 +2365,8 @@ interface WatchQueryOptions<TVariables extends OperationVariables = OperationVar
 // src/core/ObservableQuery.ts:117:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:172:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:430:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:179:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:208:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:174:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:203:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:203:3 - (ae-forgotten-export) The symbol "UpdateQueryOptions" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:35:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:37:3 - (ae-forgotten-export) The symbol "RefetchFunction" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report-react_internal.api.md
+++ b/.api-reports/api-report-react_internal.api.md
@@ -295,7 +295,6 @@ interface ApolloQueryResult<T> {
     data: T | undefined;
     // Warning: (ae-forgotten-export) The symbol "ApolloError" needs to be exported by the entry point index.d.ts
     error?: ApolloError;
-    errors?: ReadonlyArray<GraphQLFormattedError>;
     // (undocumented)
     loading: boolean;
     // Warning: (ae-forgotten-export) The symbol "NetworkStatus" needs to be exported by the entry point index.d.ts
@@ -1788,8 +1787,6 @@ interface QueryResult<TData = any, TVariables extends OperationVariables = Opera
     client: ApolloClient<any>;
     data: MaybeMasked<TData> | undefined;
     error?: ApolloError;
-    // @deprecated (undocumented)
-    errors?: ReadonlyArray<GraphQLFormattedError>;
     loading: boolean;
     networkStatus: NetworkStatus;
     observable: ObservableQuery<TData, TVariables>;
@@ -2486,8 +2483,8 @@ export function wrapQueryRef<TData, TVariables extends OperationVariables>(inter
 // src/core/ObservableQuery.ts:117:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:172:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:430:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:179:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:208:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:174:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:203:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:203:3 - (ae-forgotten-export) The symbol "UpdateQueryOptions" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:35:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:37:3 - (ae-forgotten-export) The symbol "RefetchFunction" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report-react_ssr.api.md
+++ b/.api-reports/api-report-react_ssr.api.md
@@ -296,7 +296,6 @@ interface ApolloQueryResult<T> {
     data: T | undefined;
     // Warning: (ae-forgotten-export) The symbol "ApolloError" needs to be exported by the entry point index.d.ts
     error?: ApolloError;
-    errors?: ReadonlyArray<GraphQLFormattedError>;
     // (undocumented)
     loading: boolean;
     // Warning: (ae-forgotten-export) The symbol "NetworkStatus" needs to be exported by the entry point index.d.ts
@@ -1526,8 +1525,6 @@ interface QueryResult<TData = any, TVariables extends OperationVariables = Opera
     client: ApolloClient<any>;
     data: MaybeMasked<TData> | undefined;
     error?: ApolloError;
-    // @deprecated (undocumented)
-    errors?: ReadonlyArray<GraphQLFormattedError>;
     loading: boolean;
     networkStatus: NetworkStatus;
     observable: ObservableQuery<TData, TVariables>;
@@ -1889,8 +1886,8 @@ interface WatchQueryOptions<TVariables extends OperationVariables = OperationVar
 // src/core/ObservableQuery.ts:117:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:172:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:430:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:179:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:208:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:174:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:203:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:203:3 - (ae-forgotten-export) The symbol "UpdateQueryOptions" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-testing.api.md
+++ b/.api-reports/api-report-testing.api.md
@@ -295,7 +295,6 @@ interface ApolloQueryResult<T> {
     data: T | undefined;
     // Warning: (ae-forgotten-export) The symbol "ApolloError" needs to be exported by the entry point index.d.ts
     error?: ApolloError;
-    errors?: ReadonlyArray<GraphQLFormattedError>;
     // (undocumented)
     loading: boolean;
     // Warning: (ae-forgotten-export) The symbol "NetworkStatus" needs to be exported by the entry point index.d.ts
@@ -1897,8 +1896,8 @@ export function withWarningSpy<TArgs extends any[], TResult>(it: (...args: TArgs
 // src/core/ObservableQuery.ts:117:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:172:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:430:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:179:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:208:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:174:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:203:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:203:3 - (ae-forgotten-export) The symbol "UpdateQueryOptions" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-testing_core.api.md
+++ b/.api-reports/api-report-testing_core.api.md
@@ -295,7 +295,6 @@ interface ApolloQueryResult<T> {
     data: T | undefined;
     // Warning: (ae-forgotten-export) The symbol "ApolloError" needs to be exported by the entry point index.d.ts
     error?: ApolloError;
-    errors?: ReadonlyArray<GraphQLFormattedError>;
     // (undocumented)
     loading: boolean;
     // Warning: (ae-forgotten-export) The symbol "NetworkStatus" needs to be exported by the entry point index.d.ts
@@ -1897,8 +1896,8 @@ export function withWarningSpy<TArgs extends any[], TResult>(it: (...args: TArgs
 // src/core/ObservableQuery.ts:117:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:172:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:430:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:179:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:208:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:174:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:203:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:203:3 - (ae-forgotten-export) The symbol "UpdateQueryOptions" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-testing_experimental.api.md
+++ b/.api-reports/api-report-testing_experimental.api.md
@@ -79,7 +79,7 @@ interface TestSchemaOptions {
 // Warnings were encountered during analysis:
 //
 // src/core/LocalState.ts:46:5 - (ae-forgotten-export) The symbol "FragmentMap" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:208:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:203:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/testing/experimental/createTestSchema.ts:12:23 - (ae-forgotten-export) The symbol "Resolvers" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-testing_react.api.md
+++ b/.api-reports/api-report-testing_react.api.md
@@ -296,7 +296,6 @@ interface ApolloQueryResult<T> {
     data: T | undefined;
     // Warning: (ae-forgotten-export) The symbol "ApolloError" needs to be exported by the entry point index.d.ts
     error?: ApolloError;
-    errors?: ReadonlyArray<GraphQLFormattedError>;
     // (undocumented)
     loading: boolean;
     // Warning: (ae-forgotten-export) The symbol "NetworkStatus" needs to be exported by the entry point index.d.ts
@@ -1844,8 +1843,8 @@ interface WatchQueryOptions<TVariables extends OperationVariables = OperationVar
 // src/core/ObservableQuery.ts:117:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:172:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:430:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:179:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:208:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:174:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:203:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:203:3 - (ae-forgotten-export) The symbol "UpdateQueryOptions" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-utilities.api.md
+++ b/.api-reports/api-report-utilities.api.md
@@ -321,7 +321,6 @@ interface ApolloQueryResult<T> {
     data: T | undefined;
     // Warning: (ae-forgotten-export) The symbol "ApolloError" needs to be exported by the entry point index.d.ts
     error?: ApolloError;
-    errors?: ReadonlyArray<GraphQLFormattedError>;
     // (undocumented)
     loading: boolean;
     // Warning: (ae-forgotten-export) The symbol "NetworkStatus" needs to be exported by the entry point index.d.ts
@@ -2842,8 +2841,8 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/core/ObservableQuery.ts:117:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:172:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:430:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:179:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:208:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:174:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:203:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:203:3 - (ae-forgotten-export) The symbol "UpdateQueryOptions" needs to be exported by the entry point index.d.ts
 // src/utilities/graphql/storeUtils.ts:283:1 - (ae-forgotten-export) The symbol "storeKeyNameStringify" needs to be exported by the entry point index.d.ts
 // src/utilities/policies/pagination.ts:77:3 - (ae-forgotten-export) The symbol "TRelayEdge" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -261,7 +261,6 @@ export interface ApolloQueryResult<T> {
     // (undocumented)
     data: T | undefined;
     error?: ApolloError;
-    errors?: ReadonlyArray<GraphQLFormattedError>;
     // (undocumented)
     loading: boolean;
     // (undocumented)

--- a/.changeset/calm-seals-relate.md
+++ b/.changeset/calm-seals-relate.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": major
+---
+
+Remove the deprecated `errors` property from `useQuery` and `useLazyQuery`. Read errors from the `error` property instead.

--- a/.changeset/nice-donkeys-reflect.md
+++ b/.changeset/nice-donkeys-reflect.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": major
+---
+
+Remove the `errors` property from the results emitted from `ObservableQuery` or returned from `client.query`. Read errors from the `error` property instead.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 41078,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 40593,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 31579,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 31052
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 41069,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 40606,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 31564,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 31017
 }

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -1822,7 +1822,6 @@ describe("client", () => {
       await expect(stream).toEmitApolloQueryResult({
         data: undefined,
         error: new ApolloError({ networkError: new Error("Oops") }),
-        errors: [],
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: true,
@@ -1862,7 +1861,6 @@ describe("client", () => {
         error: new ApolloError({
           graphQLErrors: [{ message: "network failure" }],
         }),
-        errors: [{ message: "network failure" }],
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: false,
@@ -2512,7 +2510,6 @@ describe("client", () => {
     await expect(stream).toEmitApolloQueryResult({
       data: undefined,
       error: new ApolloError({ networkError: new Error("Uh oh!") }),
-      errors: [],
       loading: false,
       networkStatus: NetworkStatus.error,
       partial: true,
@@ -2569,7 +2566,6 @@ describe("client", () => {
     await expect(stream).toEmitApolloQueryResult({
       data,
       error: new ApolloError({ networkError: new Error("This is an error!") }),
-      errors: [],
       loading: false,
       networkStatus: NetworkStatus.error,
       partial: false,
@@ -3548,7 +3544,13 @@ describe("@connection", () => {
 
       const result = await client.query({ query });
 
-      expect(result.errors).toEqual(errors);
+      expect(result).toEqualApolloQueryResult({
+        data: undefined,
+        error: new ApolloError({ graphQLErrors: errors }),
+        loading: false,
+        networkStatus: NetworkStatus.error,
+        partial: true,
+      });
     });
 
     it("allows setting default options for mutation", async () => {

--- a/src/__tests__/local-state/general.ts
+++ b/src/__tests__/local-state/general.ts
@@ -1179,7 +1179,6 @@ describe("Combining client and server state/operations", () => {
     await expect(stream).toEmitApolloQueryResult({
       data: undefined,
       error: new ApolloError({ graphQLErrors: [error] }),
-      errors: [error],
       loading: false,
       networkStatus: NetworkStatus.error,
       partial: true,

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -328,10 +328,7 @@ export class ObservableQuery<
       // are cases where sometimes `error` is set, but not `errors` and
       // vice-versa. This will be updated in the next major version when
       // `errors` is deprecated in favor of `error`.
-      if (
-        result.networkStatus === NetworkStatus.ready &&
-        (result.error || result.errors)
-      ) {
+      if (result.networkStatus === NetworkStatus.ready && result.error) {
         result.networkStatus = NetworkStatus.error;
       }
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1103,7 +1103,6 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
       partial: true,
       ...this.getLastResult(),
       error,
-      errors: error.graphQLErrors,
       networkStatus: NetworkStatus.error,
       loading: false,
     };

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1276,6 +1276,7 @@ export class QueryManager<TStore> {
         }
 
         if (hasErrors && errorPolicy !== "ignore") {
+          aqr.error = new ApolloError({ graphQLErrors });
           aqr.networkStatus = NetworkStatus.error;
         }
 

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1276,7 +1276,6 @@ export class QueryManager<TStore> {
         }
 
         if (hasErrors && errorPolicy !== "ignore") {
-          aqr.errors = graphQLErrors;
           aqr.networkStatus = NetworkStatus.error;
         }
 

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -5165,14 +5165,6 @@ describe("ApolloClient", () => {
   });
 
   describe("refetchQueries", () => {
-    let consoleWarnSpy: jest.SpyInstance;
-    beforeEach(() => {
-      consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation();
-    });
-    afterEach(() => {
-      consoleWarnSpy.mockRestore();
-    });
-
     it("should refetch the right query when a result is successfully returned", async () => {
       const mutation = gql`
         mutation changeAuthorName {
@@ -5257,6 +5249,7 @@ describe("ApolloClient", () => {
     });
 
     it("should not warn and continue when an unknown query name is asked to refetch", async () => {
+      using _ = spyOnConsole("warn");
       const mutation = gql`
         mutation changeAuthorName {
           changeAuthorName(newName: "Jack Smith") {
@@ -5332,13 +5325,14 @@ describe("ApolloClient", () => {
         networkStatus: NetworkStatus.ready,
         partial: false,
       });
-      expect(consoleWarnSpy).toHaveBeenLastCalledWith(
+      expect(console.warn).toHaveBeenLastCalledWith(
         'Unknown query named "%s" requested in refetchQueries options.include array',
         "fakeQuery"
       );
     });
 
     it("should ignore (with warning) a query named in refetchQueries that has no active subscriptions", async () => {
+      using _ = spyOnConsole("warn");
       const mutation = gql`
         mutation changeAuthorName {
           changeAuthorName(newName: "Jack Smith") {
@@ -5407,13 +5401,14 @@ describe("ApolloClient", () => {
         refetchQueries: ["getAuthors"],
       });
 
-      expect(consoleWarnSpy).toHaveBeenLastCalledWith(
+      expect(console.warn).toHaveBeenLastCalledWith(
         'Unknown query named "%s" requested in refetchQueries options.include array',
         "getAuthors"
       );
     });
 
     it("should ignore (with warning) a document node in refetchQueries that has no active subscriptions", async () => {
+      using _ = spyOnConsole("warn");
       const mutation = gql`
         mutation changeAuthorName {
           changeAuthorName(newName: "Jack Smith") {
@@ -5483,13 +5478,14 @@ describe("ApolloClient", () => {
         refetchQueries: [query],
       });
 
-      expect(consoleWarnSpy).toHaveBeenLastCalledWith(
+      expect(console.warn).toHaveBeenLastCalledWith(
         'Unknown query named "%s" requested in refetchQueries options.include array',
         "getAuthors"
       );
     });
 
     it("should ignore (with warning) a document node containing an anonymous query in refetchQueries that has no active subscriptions", async () => {
+      using _ = spyOnConsole("warn");
       const mutation = gql`
         mutation changeAuthorName {
           changeAuthorName(newName: "Jack Smith") {
@@ -5559,7 +5555,7 @@ describe("ApolloClient", () => {
         refetchQueries: [query],
       });
 
-      expect(consoleWarnSpy).toHaveBeenLastCalledWith(
+      expect(console.warn).toHaveBeenLastCalledWith(
         "Unknown anonymous query requested in refetchQueries options.include array"
       );
     });

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -145,6 +145,9 @@ describe("ApolloClient", () => {
     await expect(stream).toEmitApolloQueryResult({
       data: undefined,
       loading: false,
+      error: new ApolloError({
+        graphQLErrors: [{ message: "This is an error message." }],
+      }),
       networkStatus: 8,
       partial: true,
     });

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -114,7 +114,6 @@ describe("ApolloClient", () => {
       error: new ApolloError({
         graphQLErrors: [{ message: "This is an error message." }],
       }),
-      errors: [{ message: "This is an error message." }],
       loading: false,
       networkStatus: NetworkStatus.error,
       partial: true,
@@ -147,7 +146,6 @@ describe("ApolloClient", () => {
       data: undefined,
       loading: false,
       networkStatus: 8,
-      errors: [{ message: "This is an error message." }],
       partial: true,
     });
   });
@@ -180,7 +178,6 @@ describe("ApolloClient", () => {
       error: new ApolloError({
         graphQLErrors: [{ message: "This is an error message." }],
       }),
-      errors: [{ message: "This is an error message." }],
       loading: false,
       networkStatus: NetworkStatus.error,
       partial: true,
@@ -249,7 +246,6 @@ describe("ApolloClient", () => {
       error: new ApolloError({
         graphQLErrors: [null as any],
       }),
-      errors: [null as any],
       loading: false,
       networkStatus: NetworkStatus.error,
       partial: true,
@@ -277,7 +273,6 @@ describe("ApolloClient", () => {
       error: new ApolloError({
         networkError: new Error("Network error"),
       }),
-      errors: [],
       loading: false,
       networkStatus: NetworkStatus.error,
       partial: true,
@@ -2374,7 +2369,6 @@ describe("ApolloClient", () => {
       error: new ApolloError({
         networkError: new Error("Network error occurred."),
       }),
-      errors: [],
       loading: false,
       networkStatus: NetworkStatus.error,
       partial: false,
@@ -2996,7 +2990,6 @@ describe("ApolloClient", () => {
     await expect(stream).toEmitApolloQueryResult({
       data: firstResult.data,
       error: expectedError,
-      errors: [{ message: expectedError.graphQLErrors[0].message }],
       loading: false,
       networkStatus: NetworkStatus.error,
       partial: false,
@@ -3526,7 +3519,6 @@ describe("ApolloClient", () => {
       await expect(stream).toEmitApolloQueryResult({
         data: data1,
         error: new ApolloError({ networkError: new Error("Network error") }),
-        errors: [],
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: false,
@@ -6748,7 +6740,6 @@ describe("ApolloClient", () => {
       await expect(stream).toEmitApolloQueryResult({
         data: queryData,
         error: new ApolloError({ networkError: refetchError }),
-        errors: [],
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: false,

--- a/src/core/__tests__/ApolloClient/multiple-results.test.ts
+++ b/src/core/__tests__/ApolloClient/multiple-results.test.ts
@@ -262,7 +262,7 @@ describe("mutiple results", () => {
       data: initialData,
       loading: false,
       networkStatus: 7,
-      errors: [new Error("defer failed")],
+      error: new ApolloError({ networkError: new Error("defer failed") }),
       partial: false,
     });
 
@@ -314,7 +314,7 @@ describe("mutiple results", () => {
         // errors should never be passed since they are ignored
         count++;
         if (count === 1) {
-          expect(result.errors).toBeUndefined();
+          expect(result.error).toBeUndefined();
         }
         if (count === 2) {
           expect(result.error).toBeDefined();
@@ -337,7 +337,6 @@ describe("mutiple results", () => {
     await expect(stream).toEmitApolloQueryResult({
       data: initialData,
       error: new ApolloError({ networkError: new Error("defer failed") }),
-      errors: [],
       loading: false,
       networkStatus: NetworkStatus.error,
       partial: false,

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -480,7 +480,6 @@ describe("ObservableQuery", () => {
       await expect(stream).toEmitApolloQueryResult({
         data: dataOne,
         error: new ApolloError({ graphQLErrors: [error] }),
-        errors: [error],
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: false,
@@ -1040,14 +1039,12 @@ describe("ObservableQuery", () => {
 
       await expect(stream).toEmitApolloQueryResult({
         data: undefined,
-        errors: [error],
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: true,
       });
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: undefined,
-        errors: [error],
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: true,
@@ -1787,7 +1784,6 @@ describe("ObservableQuery", () => {
       await expect(stream).toEmitApolloQueryResult({
         data: { counter: 3, name: "Ben" },
         error: intentionalNetworkFailure,
-        errors: [],
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: false,
@@ -2318,7 +2314,6 @@ describe("ObservableQuery", () => {
       await expect(stream).toEmitApolloQueryResult({
         data: undefined,
         error: new ApolloError({ graphQLErrors: [error] }),
-        errors: [error],
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: true,
@@ -2327,7 +2322,6 @@ describe("ObservableQuery", () => {
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: undefined,
         error: new ApolloError({ graphQLErrors: [error] }),
-        errors: [error],
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: true,
@@ -2357,7 +2351,6 @@ describe("ObservableQuery", () => {
       expect(currentResult).toEqualApolloQueryResult({
         data: undefined,
         error: new ApolloError({ graphQLErrors: [error] }),
-        errors: [error],
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: true,
@@ -2389,14 +2382,12 @@ describe("ObservableQuery", () => {
       // TODO: This should include an `error` property, not just `errors`
       expect(result).toEqualApolloQueryResult({
         data: dataOne,
-        errors: [error],
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: false,
       });
       expect(currentResult).toEqualApolloQueryResult({
         data: dataOne,
-        errors: [error],
         loading: false,
         // TODO: The networkStatus returned here is different than the one
         // returned from `observable.result()`. These should match

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -1039,12 +1039,14 @@ describe("ObservableQuery", () => {
 
       await expect(stream).toEmitApolloQueryResult({
         data: undefined,
+        error: new ApolloError({ graphQLErrors: [error] }),
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: true,
       });
       expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: undefined,
+        error: new ApolloError({ graphQLErrors: [error] }),
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: true,
@@ -2382,12 +2384,14 @@ describe("ObservableQuery", () => {
       // TODO: This should include an `error` property, not just `errors`
       expect(result).toEqualApolloQueryResult({
         data: dataOne,
+        error: new ApolloError({ graphQLErrors: [error] }),
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: false,
       });
       expect(currentResult).toEqualApolloQueryResult({
         data: dataOne,
+        error: new ApolloError({ graphQLErrors: [error] }),
         loading: false,
         // TODO: The networkStatus returned here is different than the one
         // returned from `observable.result()`. These should match

--- a/src/core/__tests__/equalByQuery.ts
+++ b/src/core/__tests__/equalByQuery.ts
@@ -1,6 +1,6 @@
 import { GraphQLError } from "graphql";
 
-import { gql, TypedDocumentNode } from "@apollo/client/core";
+import { ApolloError, gql, TypedDocumentNode } from "@apollo/client/core";
 
 import { equalByQuery } from "../equalByQuery.js";
 
@@ -284,14 +284,20 @@ describe("equalByQuery", () => {
       equalByQuery(
         query,
         { data: data123 },
-        { data: data123, errors: [oopsError] }
+        {
+          data: data123,
+          error: new ApolloError({ graphQLErrors: [oopsError] }),
+        }
       )
     ).toBe(false);
 
     expect(
       equalByQuery(
         query,
-        { data: data123, errors: [oopsError] },
+        {
+          data: data123,
+          error: new ApolloError({ graphQLErrors: [oopsError] }),
+        },
         { data: data123 }
       )
     ).toBe(false);
@@ -299,48 +305,75 @@ describe("equalByQuery", () => {
     expect(
       equalByQuery(
         query,
-        { data: data123, errors: [oopsError] },
-        { data: data123, errors: [oopsError] }
+        {
+          data: data123,
+          error: new ApolloError({ graphQLErrors: [oopsError] }),
+        },
+        {
+          data: data123,
+          error: new ApolloError({ graphQLErrors: [oopsError] }),
+        }
       )
     ).toBe(true);
 
     expect(
       equalByQuery(
         query,
-        { data: data123, errors: [oopsError] },
-        { data: data123, errors: [differentError] }
+        {
+          data: data123,
+          error: new ApolloError({ graphQLErrors: [oopsError] }),
+        },
+        {
+          data: data123,
+          error: new ApolloError({ graphQLErrors: [differentError] }),
+        }
       )
     ).toBe(false);
 
     expect(
       equalByQuery(
         query,
-        { data: data123, errors: [oopsError] },
-        { data: data123, errors: [oopsError] }
+        {
+          data: data123,
+          error: new ApolloError({ graphQLErrors: [oopsError] }),
+        },
+        {
+          data: data123,
+          error: new ApolloError({ graphQLErrors: [oopsError] }),
+        }
       )
     ).toBe(true);
 
     expect(
       equalByQuery(
         query,
-        { data: data123, errors: [oopsError] },
-        { data: { ...data123, b: 100 }, errors: [oopsError] }
+        {
+          data: data123,
+          error: new ApolloError({ graphQLErrors: [oopsError] }),
+        },
+        {
+          data: { ...data123, b: 100 },
+          error: new ApolloError({ graphQLErrors: [oopsError] }),
+        }
       )
     ).toBe(true);
 
     expect(
       equalByQuery(
         query,
-        { data: data123, errors: [] },
-        { data: data123, errors: [] }
+        { data: data123, error: new ApolloError({ graphQLErrors: [] }) },
+        { data: data123, error: new ApolloError({ graphQLErrors: [] }) }
       )
     ).toBe(true);
 
     expect(
       equalByQuery(
         query,
-        { data: data123, errors: [] },
-        { data: { ...data123, b: 100 }, errors: [] }
+        { data: data123, error: new ApolloError({ graphQLErrors: [] }) },
+        {
+          data: { ...data123, b: 100 },
+          error: new ApolloError({ graphQLErrors: [] }),
+        }
       )
     ).toBe(true);
   });

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,4 +1,4 @@
-import type { DocumentNode, GraphQLFormattedError } from "graphql";
+import type { DocumentNode } from "graphql";
 
 import type { ApolloCache } from "@apollo/client/cache";
 import type { Cache } from "@apollo/client/cache";

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -144,11 +144,6 @@ export type OperationVariables = Record<string, any>;
 export interface ApolloQueryResult<T> {
   data: T | undefined;
   /**
-   * A list of any errors that occurred during server-side execution of a GraphQL operation.
-   * See https://www.apollographql.com/docs/react/data/error-handling/ for more information.
-   */
-  errors?: ReadonlyArray<GraphQLFormattedError>;
-  /**
    * The single Error object that is passed to onError and useQuery hooks, and is often thrown during manual `client.query` calls.
    * This will contain both a NetworkError field and any GraphQLErrors.
    * See https://www.apollographql.com/docs/react/data/error-handling/ for more information.

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -1490,7 +1490,6 @@ describe("useLazyQuery Hook", () => {
         networkStatus: NetworkStatus.error,
         previousData: undefined,
         error: new ApolloError({ graphQLErrors: [{ message: "error 1" }] }),
-        errors: [{ message: "error 1" }],
         variables: {},
       });
     }
@@ -1502,7 +1501,6 @@ describe("useLazyQuery Hook", () => {
       networkStatus: NetworkStatus.error,
       previousData: undefined,
       error: new ApolloError({ graphQLErrors: [{ message: "error 1" }] }),
-      errors: [{ message: "error 1" }],
       variables: {},
     });
 
@@ -1518,7 +1516,6 @@ describe("useLazyQuery Hook", () => {
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
         error: new ApolloError({ graphQLErrors: [{ message: "error 1" }] }),
-        errors: [{ message: "error 1" }],
         variables: {},
       });
     }
@@ -1533,7 +1530,6 @@ describe("useLazyQuery Hook", () => {
         networkStatus: NetworkStatus.error,
         previousData: undefined,
         error: new ApolloError({ graphQLErrors: [{ message: "error 2" }] }),
-        errors: [{ message: "error 2" }],
         variables: {},
       });
     }
@@ -2306,7 +2302,6 @@ describe("useLazyQuery Hook", () => {
       expect(result).toEqualQueryResult({
         data: undefined,
         error: new ApolloError({ graphQLErrors: [{ message: "Oops" }] }),
-        errors: [{ message: "Oops" }],
         called: true,
         loading: false,
         networkStatus: NetworkStatus.error,
@@ -2336,7 +2331,6 @@ describe("useLazyQuery Hook", () => {
       expect(result).toEqualQueryResult({
         data: undefined,
         error: new ApolloError({ graphQLErrors: [{ message: "Oops" }] }),
-        errors: [{ message: "Oops" }],
         called: true,
         loading: false,
         networkStatus: NetworkStatus.error,
@@ -2498,7 +2492,6 @@ describe("useLazyQuery Hook", () => {
         expect(result).toEqualQueryResult({
           data: undefined,
           error: new ApolloError({ networkError }),
-          errors: [],
           called: true,
           loading: false,
           networkStatus: NetworkStatus.error,
@@ -2694,7 +2687,6 @@ describe("useLazyQuery Hook", () => {
           "Store reset while query was in flight (not completed in link chain)"
         ),
       }),
-      errors: [],
       loading: true,
       networkStatus: NetworkStatus.loading,
       called: true,
@@ -2712,7 +2704,6 @@ describe("useLazyQuery Hook", () => {
             "Store reset while query was in flight (not completed in link chain)"
           ),
         }),
-        errors: [],
         called: true,
         loading: false,
         networkStatus: NetworkStatus.error,

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -4259,7 +4259,6 @@ describe("useQuery Hook", () => {
         expect(result).toEqualQueryResult({
           data: undefined,
           error: new ApolloError({ graphQLErrors: [{ message: "error 1" }] }),
-          errors: [{ message: "error 1" }],
           called: true,
           loading: false,
           networkStatus: NetworkStatus.error,
@@ -4278,7 +4277,6 @@ describe("useQuery Hook", () => {
         expect(result).toEqualQueryResult({
           data: undefined,
           error: new ApolloError({ graphQLErrors: [{ message: "error 2" }] }),
-          errors: [{ message: "error 2" }],
           called: true,
           loading: false,
           networkStatus: NetworkStatus.error,

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -3485,7 +3485,6 @@ describe("useQuery Hook", () => {
         expect(result).toEqualQueryResult({
           data: undefined,
           error: new ApolloError({ graphQLErrors: [{ message: "error" }] }),
-          errors: [{ message: "error" }],
           called: true,
           loading: false,
           networkStatus: NetworkStatus.error,
@@ -3545,7 +3544,6 @@ describe("useQuery Hook", () => {
           error: new ApolloError({
             graphQLErrors: [{ message: 'Could not fetch "hello"' }],
           }),
-          errors: [{ message: 'Could not fetch "hello"' }],
           called: true,
           loading: false,
           networkStatus: NetworkStatus.error,
@@ -3665,7 +3663,6 @@ describe("useQuery Hook", () => {
           error: new ApolloError({
             graphQLErrors: [{ message: 'Could not fetch "hello"' }],
           }),
-          errors: [{ message: 'Could not fetch "hello"' }],
           called: true,
           loading: false,
           networkStatus: NetworkStatus.error,
@@ -3725,7 +3722,6 @@ describe("useQuery Hook", () => {
         expect(result).toEqualQueryResult({
           data: undefined,
           error: new ApolloError({ graphQLErrors: [{ message: "error" }] }),
-          errors: [{ message: "error" }],
           called: true,
           loading: false,
           networkStatus: NetworkStatus.error,
@@ -3742,7 +3738,6 @@ describe("useQuery Hook", () => {
         expect(result).toEqualQueryResult({
           data: undefined,
           error: new ApolloError({ graphQLErrors: [{ message: "error" }] }),
-          errors: [{ message: "error" }],
           called: true,
           loading: false,
           networkStatus: NetworkStatus.error,
@@ -4045,7 +4040,6 @@ describe("useQuery Hook", () => {
         expect(result).toEqualQueryResult({
           data: undefined,
           error: new ApolloError({ graphQLErrors: [{ message: "error" }] }),
-          errors: [{ message: "error" }],
           called: true,
           loading: false,
           networkStatus: NetworkStatus.error,
@@ -4168,7 +4162,6 @@ describe("useQuery Hook", () => {
         expect(result).toEqualQueryResult({
           data: undefined,
           error: new ApolloError({ graphQLErrors: [{ message: "error 1" }] }),
-          errors: [{ message: "error 1" }],
           called: true,
           loading: false,
           networkStatus: NetworkStatus.error,
@@ -4200,7 +4193,6 @@ describe("useQuery Hook", () => {
         expect(result).toEqualQueryResult({
           data: undefined,
           error: new ApolloError({ graphQLErrors: [{ message: "error 2" }] }),
-          errors: [{ message: "error 2" }],
           called: true,
           loading: false,
           networkStatus: NetworkStatus.error,
@@ -4355,7 +4347,6 @@ describe("useQuery Hook", () => {
           error: new ApolloError({
             graphQLErrors: [{ message: "same error" }],
           }),
-          errors: [{ message: "same error" }],
           called: true,
           loading: false,
           networkStatus: NetworkStatus.error,
@@ -4389,7 +4380,6 @@ describe("useQuery Hook", () => {
           error: new ApolloError({
             graphQLErrors: [{ message: "same error" }],
           }),
-          errors: [{ message: "same error" }],
           called: true,
           loading: false,
           networkStatus: NetworkStatus.error,
@@ -4464,7 +4454,6 @@ describe("useQuery Hook", () => {
           error: new ApolloError({
             graphQLErrors: [{ message: "same error" }],
           }),
-          errors: [{ message: "same error" }],
           called: true,
           loading: false,
           networkStatus: NetworkStatus.error,
@@ -4524,7 +4513,6 @@ describe("useQuery Hook", () => {
           error: new ApolloError({
             graphQLErrors: [{ message: "same error" }],
           }),
-          errors: [{ message: "same error" }],
           called: true,
           loading: false,
           networkStatus: NetworkStatus.error,
@@ -5507,7 +5495,6 @@ describe("useQuery Hook", () => {
         error: new ApolloError({
           graphQLErrors: [new GraphQLError("Intentional error")],
         }),
-        errors: [{ message: "Intentional error" }],
         called: true,
         loading: false,
         networkStatus: NetworkStatus.error,
@@ -5536,7 +5523,6 @@ describe("useQuery Hook", () => {
         error: new ApolloError({
           graphQLErrors: [new GraphQLError("Intentional error")],
         }),
-        errors: [{ message: "Intentional error" }],
         called: true,
         loading: false,
         networkStatus: NetworkStatus.error,
@@ -5562,7 +5548,6 @@ describe("useQuery Hook", () => {
         error: new ApolloError({
           graphQLErrors: [new GraphQLError("Intentional error")],
         }),
-        errors: [{ message: "Intentional error" }],
         called: true,
         loading: false,
         networkStatus: NetworkStatus.error,
@@ -5579,7 +5564,6 @@ describe("useQuery Hook", () => {
         error: new ApolloError({
           graphQLErrors: [new GraphQLError("Intentional error")],
         }),
-        errors: [new GraphQLError("Intentional error")],
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: true,
@@ -5627,7 +5611,6 @@ describe("useQuery Hook", () => {
         error: new ApolloError({
           graphQLErrors: [new GraphQLError("Intentional error")],
         }),
-        errors: [{ message: "Intentional error" }],
         called: true,
         loading: false,
         networkStatus: NetworkStatus.error,
@@ -5644,7 +5627,6 @@ describe("useQuery Hook", () => {
         error: new ApolloError({
           graphQLErrors: [new GraphQLError("Intentional error")],
         }),
-        errors: [new GraphQLError("Intentional error")],
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: true,
@@ -5795,7 +5777,6 @@ describe("useQuery Hook", () => {
         error: new ApolloError({
           graphQLErrors: [new GraphQLError("Intentional error")],
         }),
-        errors: [{ message: "Intentional error" }],
         called: true,
         loading: false,
         networkStatus: NetworkStatus.error,
@@ -5824,7 +5805,6 @@ describe("useQuery Hook", () => {
         error: new ApolloError({
           graphQLErrors: [new GraphQLError("Intentional error")],
         }),
-        errors: [{ message: "Intentional error" }],
         called: true,
         loading: false,
         networkStatus: NetworkStatus.error,
@@ -5853,7 +5833,6 @@ describe("useQuery Hook", () => {
         error: new ApolloError({
           graphQLErrors: [new GraphQLError("Intentional error")],
         }),
-        errors: [{ message: "Intentional error" }],
         called: true,
         loading: false,
         networkStatus: NetworkStatus.error,
@@ -6048,7 +6027,6 @@ describe("useQuery Hook", () => {
         error: new ApolloError({
           graphQLErrors: [new GraphQLError("Intentional error")],
         }),
-        errors: [{ message: "Intentional error" }],
         called: true,
         loading: false,
         networkStatus: NetworkStatus.error,
@@ -6077,7 +6055,6 @@ describe("useQuery Hook", () => {
         error: new ApolloError({
           graphQLErrors: [new GraphQLError("Intentional error")],
         }),
-        errors: [{ message: "Intentional error" }],
         called: true,
         loading: false,
         networkStatus: NetworkStatus.error,
@@ -6103,7 +6080,6 @@ describe("useQuery Hook", () => {
         error: new ApolloError({
           graphQLErrors: [new GraphQLError("Intentional error")],
         }),
-        errors: [{ message: "Intentional error" }],
         called: true,
         loading: false,
         networkStatus: NetworkStatus.error,
@@ -6646,7 +6622,6 @@ describe("useQuery Hook", () => {
           error: new ApolloError({
             networkError: new Error("This is an error!"),
           }),
-          errors: [],
           called: true,
           loading: false,
           networkStatus: NetworkStatus.error,
@@ -10324,13 +10299,6 @@ describe("useQuery Hook", () => {
             },
           ],
         }),
-        errors: [
-          {
-            message:
-              "homeWorld for character with ID 1000 could not be fetched.",
-            path: ["hero", "heroFriends", 0, "homeWorld"],
-          },
-        ],
         called: true,
         loading: false,
         networkStatus: NetworkStatus.error,
@@ -10510,13 +10478,6 @@ describe("useQuery Hook", () => {
             },
           ],
         }),
-        errors: [
-          {
-            message:
-              "homeWorld for character with ID 1000 could not be fetched.",
-            path: ["hero", "heroFriends", 0, "homeWorld"],
-          },
-        ],
         called: true,
         loading: false,
         networkStatus: NetworkStatus.error,
@@ -10923,7 +10884,6 @@ describe("useQuery Hook", () => {
           "Store reset while query was in flight (not completed in link chain)"
         ),
       }),
-      errors: [],
       called: true,
       loading: false,
       networkStatus: NetworkStatus.error,
@@ -10984,7 +10944,6 @@ describe("useQuery Hook", () => {
     await expect(takeSnapshot()).resolves.toEqualQueryResult({
       data: undefined,
       error: new ApolloError({ graphQLErrors: [graphQLError] }),
-      errors: [graphQLError],
       called: true,
       loading: false,
       networkStatus: NetworkStatus.error,
@@ -11009,7 +10968,6 @@ describe("useQuery Hook", () => {
     await expect(takeSnapshot()).resolves.toEqualQueryResult({
       data: undefined,
       error: new ApolloError({ graphQLErrors: [graphQLError] }),
-      errors: [graphQLError],
       called: true,
       loading: false,
       networkStatus: NetworkStatus.error,
@@ -12000,7 +11958,6 @@ describe("useQuery Hook", () => {
           error: new ApolloError({
             graphQLErrors: [new GraphQLError("Couldn't get name")],
           }),
-          errors: [{ message: "Couldn't get name" }],
           called: true,
           loading: false,
           networkStatus: NetworkStatus.error,

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -558,14 +558,6 @@ function setResult<TData, TVariables extends OperationVariables>(
     resultData.previousData = previousResult.data;
   }
 
-  if (!nextResult.error && isNonEmptyArray(nextResult.errors)) {
-    // Until a set naming convention for networkError and graphQLErrors is
-    // decided upon, we map errors (graphQLErrors) to the error options.
-    // TODO: Is it possible for both result.error and result.errors to be
-    // defined here?
-    nextResult.error = new ApolloError({ graphQLErrors: nextResult.errors });
-  }
-
   resultData.current = toQueryResult(
     nextResult,
     resultData.previousData,

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -33,7 +33,6 @@ import type {
   WatchQueryOptions,
 } from "@apollo/client/core";
 import { NetworkStatus } from "@apollo/client/core";
-import { ApolloError } from "@apollo/client/errors";
 import type { MaybeMasked } from "@apollo/client/masking";
 import type {
   NoInfer,
@@ -44,11 +43,7 @@ import type {
 import { getApolloContext } from "@apollo/client/react/context";
 import { DocumentType, verifyDocumentType } from "@apollo/client/react/parser";
 import type { RenderPromises } from "@apollo/client/react/ssr";
-import {
-  compact,
-  isNonEmptyArray,
-  maybeDeepFreeze,
-} from "@apollo/client/utilities";
+import { compact, maybeDeepFreeze } from "@apollo/client/utilities";
 import { mergeOptions } from "@apollo/client/utilities";
 
 import { wrapHook } from "./internal/index.js";
@@ -601,14 +596,6 @@ export function getDefaultFetchPolicy<
     clientDefaultOptions?.watchQuery?.fetchPolicy ||
     "cache-first"
   );
-}
-
-export function toApolloError<TData>(
-  result: Pick<ApolloQueryResult<TData>, "errors" | "error">
-): ApolloError | undefined {
-  return isNonEmptyArray(result.errors) ?
-      new ApolloError({ graphQLErrors: result.errors })
-    : result.error;
 }
 
 export function toQueryResult<TData, TVariables extends OperationVariables>(

--- a/src/react/hooks/useReadQuery.ts
+++ b/src/react/hooks/useReadQuery.ts
@@ -17,7 +17,6 @@ import {
 
 import { __use, wrapHook } from "./internal/index.js";
 import { useApolloClient } from "./useApolloClient.js";
-import { toApolloError } from "./useSuspenseQuery.js";
 import { useSyncExternalStore } from "./useSyncExternalStore.js";
 
 export interface UseReadQueryResult<TData = unknown> {
@@ -106,7 +105,7 @@ function useReadQuery_<TData>(
     return {
       data: result.data!,
       networkStatus: result.networkStatus,
-      error: toApolloError(result),
+      error: result.error,
     };
   }, [result]);
 }

--- a/src/react/hooks/useSubscription.ts
+++ b/src/react/hooks/useSubscription.ts
@@ -25,7 +25,6 @@ import { invariant } from "@apollo/client/utilities/invariant";
 import { useDeepMemo } from "./internal/useDeepMemo.js";
 import { useIsomorphicLayoutEffect } from "./internal/useIsomorphicLayoutEffect.js";
 import { useApolloClient } from "./useApolloClient.js";
-import { toApolloError } from "./useQuery.js";
 import { useSyncExternalStore } from "./useSyncExternalStore.js";
 
 /**
@@ -240,7 +239,10 @@ export function useSubscription<
               // TODO: fetchResult.data can be null but SubscriptionResult.data
               // expects TData | undefined only
               data: fetchResult.data!,
-              error: toApolloError(fetchResult),
+              error:
+                fetchResult.errors ?
+                  new ApolloError({ graphQLErrors: fetchResult.errors })
+                : undefined,
               variables,
             };
             observable.__.setResult(result);

--- a/src/react/hooks/useSuspenseQuery.ts
+++ b/src/react/hooks/useSuspenseQuery.ts
@@ -3,6 +3,7 @@ import * as React from "rehackt";
 import { canonicalStringify } from "@apollo/client/cache";
 import type {
   ApolloClient,
+  ApolloError,
   ApolloQueryResult,
   DocumentNode,
   FetchMoreQueryOptions,
@@ -12,7 +13,7 @@ import type {
   WatchQueryOptions,
 } from "@apollo/client/core";
 import type { SubscribeToMoreFunction } from "@apollo/client/core";
-import { ApolloError, NetworkStatus } from "@apollo/client/core";
+import { NetworkStatus } from "@apollo/client/core";
 import type { MaybeMasked, Unmasked } from "@apollo/client/masking";
 import type {
   NoInfer,
@@ -23,7 +24,6 @@ import type { CacheKey, QueryKey } from "@apollo/client/react/internal";
 import { getSuspenseCache } from "@apollo/client/react/internal";
 import { DocumentType, verifyDocumentType } from "@apollo/client/react/parser";
 import type { DeepPartial } from "@apollo/client/utilities";
-import { isNonEmptyArray } from "@apollo/client/utilities";
 import { __DEV__ } from "@apollo/client/utilities/environment";
 import { invariant } from "@apollo/client/utilities/invariant";
 
@@ -242,7 +242,7 @@ function useSuspenseQuery_<
   }, [queryRef]);
 
   const skipResult = React.useMemo<ApolloQueryResult<TData>>(() => {
-    const error = toApolloError(queryRef.result);
+    const error = queryRef.result.error;
     const complete = !!queryRef.result.data;
 
     return {
@@ -289,7 +289,7 @@ function useSuspenseQuery_<
     return {
       client,
       data: result.data,
-      error: toApolloError(result),
+      error: result.error,
       networkStatus: result.networkStatus,
       fetchMore,
       refetch,
@@ -332,12 +332,6 @@ function validatePartialDataReturn(
       "Using `returnPartialData` with a `no-cache` fetch policy has no effect. To read partial data from the cache, consider using an alternate fetch policy."
     );
   }
-}
-
-export function toApolloError(result: ApolloQueryResult<any>) {
-  return isNonEmptyArray(result.errors) ?
-      new ApolloError({ graphQLErrors: result.errors })
-    : result.error;
 }
 
 interface UseWatchQueryOptionsHookOptions<

--- a/src/react/internal/cache/QueryReference.ts
+++ b/src/react/internal/cache/QueryReference.ts
@@ -405,7 +405,12 @@ export class InternalQueryReference<TData = unknown> {
           result.data = this.result.data;
         }
 
-        if (result.error) {
+        if (
+          result.error &&
+          (result.error?.networkError ||
+            this.watchQueryOptions.errorPolicy === "none" ||
+            this.watchQueryOptions.errorPolicy === undefined)
+        ) {
           this.reject?.(result.error);
         } else {
           this.result = result;

--- a/src/react/internal/cache/QueryReference.ts
+++ b/src/react/internal/cache/QueryReference.ts
@@ -405,12 +405,7 @@ export class InternalQueryReference<TData = unknown> {
           result.data = this.result.data;
         }
 
-        if (
-          result.error &&
-          (result.error?.networkError ||
-            this.watchQueryOptions.errorPolicy === "none" ||
-            this.watchQueryOptions.errorPolicy === undefined)
-        ) {
+        if (this.shouldReject(result)) {
           this.reject?.(result.error);
         } else {
           this.result = result;
@@ -435,12 +430,7 @@ export class InternalQueryReference<TData = unknown> {
           result.data = this.result.data;
         }
 
-        if (
-          result.error &&
-          (result.error?.networkError ||
-            this.watchQueryOptions.errorPolicy === "none" ||
-            this.watchQueryOptions.errorPolicy === undefined)
-        ) {
+        if (this.shouldReject(result)) {
           this.promise = createRejectedPromise(result.error);
           this.deliver(this.promise);
         } else {
@@ -520,6 +510,17 @@ export class InternalQueryReference<TData = unknown> {
       result.data ?
         createFulfilledPromise(result)
       : this.createPendingPromise();
+  }
+
+  private shouldReject(result: ApolloQueryResult<any>) {
+    const { errorPolicy } = this.watchQueryOptions;
+
+    return (
+      result.error &&
+      (result.error.networkError ||
+        errorPolicy === "none" ||
+        errorPolicy === undefined)
+    );
   }
 
   private createPendingPromise() {

--- a/src/react/internal/cache/QueryReference.ts
+++ b/src/react/internal/cache/QueryReference.ts
@@ -435,7 +435,12 @@ export class InternalQueryReference<TData = unknown> {
           result.data = this.result.data;
         }
 
-        if (result.error) {
+        if (
+          result.error &&
+          (result.error?.networkError ||
+            this.watchQueryOptions.errorPolicy === "none" ||
+            this.watchQueryOptions.errorPolicy === undefined)
+        ) {
           this.promise = createRejectedPromise(result.error);
           this.deliver(this.promise);
         } else {

--- a/src/react/query-preloader/__tests__/createQueryPreloader.test.tsx
+++ b/src/react/query-preloader/__tests__/createQueryPreloader.test.tsx
@@ -1472,7 +1472,11 @@ test("throws when error is returned", async () => {
   using _consoleSpy = spyOnConsole("error");
   const { query } = setupSimpleCase();
   const mocks = [
-    { request: { query }, result: { errors: [new GraphQLError("Oops")] } },
+    {
+      request: { query },
+      result: { errors: [new GraphQLError("Oops")] },
+      delay: 20,
+    },
   ];
   const client = createDefaultClient(mocks);
 

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -1,5 +1,5 @@
 import type { TypedDocumentNode } from "@graphql-typed-document-node/core";
-import type { DocumentNode, GraphQLFormattedError } from "graphql";
+import type { DocumentNode } from "graphql";
 import type * as ReactTypes from "react";
 
 import type {

--- a/src/react/types/types.ts
+++ b/src/react/types/types.ts
@@ -129,11 +129,6 @@ export interface QueryResult<
   previousData?: MaybeMasked<TData>;
   /** {@inheritDoc @apollo/client!QueryResultDocumentation#error:member} */
   error?: ApolloError;
-  /**
-   * @deprecated This property will be removed in a future version of Apollo Client.
-   * Please use `error.graphQLErrors` instead.
-   */
-  errors?: ReadonlyArray<GraphQLFormattedError>;
   /** {@inheritDoc @apollo/client!QueryResultDocumentation#loading:member} */
   loading: boolean;
   /** {@inheritDoc @apollo/client!QueryResultDocumentation#networkStatus:member} */

--- a/src/testing/matchers/toEqualQueryResult.ts
+++ b/src/testing/matchers/toEqualQueryResult.ts
@@ -6,11 +6,9 @@ import type { QueryResult } from "@apollo/client/react";
 const CHECKED_KEYS = [
   "loading",
   "error",
-  "errors",
   "data",
   "variables",
   "networkStatus",
-  "errors",
   "called",
   "previousData",
 ] as const;


### PR DESCRIPTION
Removes the `errors` from all derived result types and consolidates on the `error` property thoughout the client. This is a precursor to #12200 which will do work to split up `ApolloError` into separate types.

