### PR TITLE
feat: add package entrypoints

### DIFF
--- a/.changeset/dry-gorillas-remember.md
+++ b/.changeset/dry-gorillas-remember.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": minor
+---
+
+Add an export map (NodeJS Package Entrypoints) to the `package.json`, which will allow ESM Node projects to correctly load the ESM exports.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,16 @@
   "main": "./dist/main.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/main.cjs"
+      }
+    },
+    "./*": "./*"
+  },
   "sideEffects": false,
   "react-native": {
     "./dist/cache/inmemory/fixPolyfills.js": "./dist/cache/inmemory/fixPolyfills.native.js",


### PR DESCRIPTION
I noticed that https://github.com/apollographql/apollo-client/pull/12385 is also adding package entrypoints, which is great, but I was wondering if we could accept an interim solution by adding the proposed package entrypoints, and using the `"./*": "./*"` for backwards compatibility / ensuring this is not a breaking change. It allows users to do direct file imports from the package, which package entrypoints would otherwise restrict (defining/restricting your public API is great, but would be a breaking change).

It's a little tough to test this change, because in order to create a failing test to begin with, we'd have to set up a dummy ESM project with "type" "module" to show that importing from the built & packaged Apollo client is problematic in ESM projects.
