### PR TITLE
Use `{}` instead of `Object.create(null)`

### DIFF
--- a/.changeset/itchy-roses-accept.md
+++ b/.changeset/itchy-roses-accept.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Use an an empty object (`{}`) rather than an object with `null` prototype (`Object.create(null)`) in all areas that instantiate objects.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 42017,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 41559,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 32122,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 31594
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 41947,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 41483,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 32072,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 31589
 }

--- a/docs/source/caching/cache-field-behavior.mdx
+++ b/docs/source/caching/cache-field-behavior.mdx
@@ -365,7 +365,7 @@ const cache = new InMemoryCache({
         authors: {
           merge(existing: any[], incoming: any[], { readField, mergeObjects }) {
             const merged: any[] = existing ? existing.slice(0) : [];
-            const authorNameToIndex: Record<string, number> = Object.create(null);
+            const authorNameToIndex: Record<string, number> = {};
             if (existing) {
               existing.forEach((author, index) => {
                 authorNameToIndex[readField<string>("name", author)] = index;

--- a/src/cache/inmemory/__tests__/cache.ts
+++ b/src/cache/inmemory/__tests__/cache.ts
@@ -2328,7 +2328,7 @@ describe("InMemoryCache#broadcastWatches", function () {
         name: string;
       };
     }>;
-    const diffs: Record<string, Diff[]> = Object.create(null);
+    const diffs: Record<string, Diff[]> = {};
     function addDiff(name: string, diff: Diff) {
       (diffs[name] || (diffs[name] = [])).push(diff);
     }
@@ -3844,8 +3844,8 @@ describe("ReactiveVar and makeVar", () => {
 
   it("should remove all watchers when cache.reset() called", () => {
     const { cache, query, nameVar } = makeCacheAndVar(false);
-    const unwatchers: Record<string, Array<() => void>> = Object.create(null);
-    const diffCounts: Record<string, number> = Object.create(null);
+    const unwatchers: Record<string, Array<() => void>> = {};
+    const diffCounts: Record<string, number> = {};
 
     function watch(id: string) {
       const fns = unwatchers[id] || (unwatchers[id] = []);

--- a/src/cache/inmemory/__tests__/entityStore.ts
+++ b/src/cache/inmemory/__tests__/entityStore.ts
@@ -1005,7 +1005,7 @@ describe("EntityStore", () => {
     // Hacky way of injecting a stray __ref field into the Will Smith Person
     // object, clearing store.refs (which was populated by the previous GC).
     storeRootData[willId]!.__ref = willId;
-    store["refs"] = Object.create(null);
+    store["refs"] = {};
 
     expect(cache.extract()).toEqual({
       'Person:{"name":"Jaden Smith"}': {

--- a/src/cache/inmemory/__tests__/writeToStore.ts
+++ b/src/cache/inmemory/__tests__/writeToStore.ts
@@ -2815,7 +2815,7 @@ describe("writing to the store", () => {
       },
     });
 
-    const mergeCounts: Record<string, number> = Object.create(null);
+    const mergeCounts: Record<string, number> = {};
 
     const query = gql`
       query {

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -35,12 +35,12 @@ import type {
 } from "../core/types/common.js";
 import type { DocumentNode, FieldNode, SelectionSetNode } from "graphql";
 
-const DELETE: DeleteModifier = Object.create(null);
+const DELETE = {} as DeleteModifier;
 const delModifier: Modifier<any> = () => DELETE;
-const INVALIDATE: InvalidateModifier = Object.create(null);
+const INVALIDATE = {} as InvalidateModifier;
 
 export abstract class EntityStore implements NormalizedCache {
-  protected data: NormalizedCacheObject = Object.create(null);
+  protected data: NormalizedCacheObject = {};
 
   constructor(
     public readonly policies: Policies,
@@ -105,7 +105,7 @@ export abstract class EntityStore implements NormalizedCache {
     }
 
     if (this.policies.rootTypenamesById[dataId]) {
-      return Object.create(null);
+      return {};
     }
   }
 
@@ -140,7 +140,7 @@ export abstract class EntityStore implements NormalizedCache {
     if (merged !== existing) {
       delete this.refs[dataId];
       if (this.group.caching) {
-        const fieldsToDirty: Record<string, 1> = Object.create(null);
+        const fieldsToDirty: Record<string, 1> = {};
 
         // If we added a new StoreObject where there was previously none, dirty
         // anything that depended on the existence of this dataId, such as the
@@ -208,7 +208,7 @@ export abstract class EntityStore implements NormalizedCache {
     const storeObject = this.lookup(dataId);
 
     if (storeObject) {
-      const changedFields: Record<string, any> = Object.create(null);
+      const changedFields: Record<string, any> = {};
       let needToMerge = false;
       let allDeleted = true;
 
@@ -426,7 +426,7 @@ export abstract class EntityStore implements NormalizedCache {
   // entities they reference (even indirectly) from being garbage collected.
   private rootIds: {
     [rootId: string]: number;
-  } = Object.create(null);
+  } = {};
 
   public retain(rootId: string): number {
     return (this.rootIds[rootId] = (this.rootIds[rootId] || 0) + 1);
@@ -486,11 +486,11 @@ export abstract class EntityStore implements NormalizedCache {
   // Lazily tracks { __ref: <dataId> } strings contained by this.data[dataId].
   private refs: {
     [dataId: string]: Record<string, true>;
-  } = Object.create(null);
+  } = {};
 
   public findChildRefIds(dataId: string): Record<string, true> {
     if (!hasOwn.call(this.refs, dataId)) {
-      const found = (this.refs[dataId] = Object.create(null));
+      const found = (this.refs[dataId] = {} as Record<string, true>);
       const root = this.data[dataId];
       if (!root) return found;
 

--- a/src/cache/inmemory/fragmentRegistry.ts
+++ b/src/cache/inmemory/fragmentRegistry.ts
@@ -36,7 +36,7 @@ export function createFragmentRegistry(
 }
 
 class FragmentRegistry implements FragmentRegistryAPI {
-  private registry: FragmentMap = Object.create(null);
+  private registry: FragmentMap = {};
 
   // Call `createFragmentRegistry` instead of invoking the
   // FragmentRegistry constructor directly. This reserves the constructor for
@@ -119,7 +119,7 @@ class FragmentRegistry implements FragmentRegistryAPI {
     enqueueChildSpreads(document);
 
     const missing: string[] = [];
-    const map: FragmentMap = Object.create(null);
+    const map: FragmentMap = {};
 
     // This Set forEach loop can be extended during iteration by adding
     // additional strings to the unbound set.
@@ -157,7 +157,7 @@ class FragmentRegistry implements FragmentRegistryAPI {
   }
 
   public findFragmentSpreads(root: ASTNode): FragmentSpreadMap {
-    const spreads: FragmentSpreadMap = Object.create(null);
+    const spreads: FragmentSpreadMap = {};
 
     visit(root, {
       FragmentSpread(node) {

--- a/src/cache/inmemory/key-extractor.ts
+++ b/src/cache/inmemory/key-extractor.ts
@@ -22,17 +22,14 @@ const specifierInfoCache: Record<
     keyFieldsFn?: KeyFieldsFunction;
     keyArgsFn?: KeyArgsFunction;
   }
-> = Object.create(null);
+> = {};
 
 function lookupSpecifierInfo(spec: KeySpecifier) {
   // It's safe to encode KeySpecifier arrays with JSON.stringify, since they're
   // just arrays of strings or nested KeySpecifier arrays, and the order of the
   // array elements is important (and suitably preserved by JSON.stringify).
   const cacheKey = JSON.stringify(spec);
-  return (
-    specifierInfoCache[cacheKey] ||
-    (specifierInfoCache[cacheKey] = Object.create(null))
-  );
+  return specifierInfoCache[cacheKey] || (specifierInfoCache[cacheKey] = {});
 }
 
 export function keyFieldsFnFromSpecifier(
@@ -197,7 +194,7 @@ export function collectSpecifierPaths(
       collected = merger.merge(collected, toMerge);
     }
     return collected;
-  }, Object.create(null));
+  }, {});
 }
 
 export function getSpecifierPaths(spec: KeySpecifier): string[][] {

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -298,11 +298,11 @@ export class Policies {
         };
       };
     };
-  } = Object.create(null);
+  } = {};
 
   private toBeAdded: {
     [__typename: string]: TypePolicy[];
-  } = Object.create(null);
+  } = {};
 
   // Map from subtype names to sets of supertype names. Note that this
   // representation inverts the structure of possibleTypes (whose keys are
@@ -318,10 +318,8 @@ export class Policies {
 
   public readonly cache: InMemoryCache;
 
-  public readonly rootIdsByTypename: Record<string, string> =
-    Object.create(null);
-  public readonly rootTypenamesById: Record<string, string> =
-    Object.create(null);
+  public readonly rootIdsByTypename: Record<string, string> = {};
+  public readonly rootTypenamesById: Record<string, string> = {};
 
   public readonly usingPossibleTypes = false;
 
@@ -564,8 +562,8 @@ export class Policies {
     if (!hasOwn.call(this.typePolicies, typename)) {
       const policy: Policies["typePolicies"][string] = (this.typePolicies[
         typename
-      ] = Object.create(null));
-      policy.fields = Object.create(null);
+      ] = {} as any);
+      policy.fields = {};
 
       // When the TypePolicy for typename is first accessed, instead of
       // starting with an empty policy object, inherit any properties or
@@ -649,7 +647,7 @@ export class Policies {
       const fieldPolicies = this.getTypePolicy(typename).fields;
       return (
         fieldPolicies[fieldName] ||
-        (createIfMissing && (fieldPolicies[fieldName] = Object.create(null)))
+        (createIfMissing && (fieldPolicies[fieldName] = {}))
       );
     }
   }
@@ -945,7 +943,7 @@ export class Policies {
           variables: context.variables,
         },
         context,
-        storage || Object.create(null)
+        storage || {}
       )
     );
   }

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -140,7 +140,7 @@ export class StoreWriter {
 
     const context: WriteContext = {
       store,
-      written: Object.create(null),
+      written: {},
       merge<T>(existing: T, incoming: T) {
         return merger.merge(existing, incoming) as T;
       },
@@ -155,7 +155,7 @@ export class StoreWriter {
     };
 
     const ref = this.processSelectionSet({
-      result: result || Object.create(null),
+      result: result || {},
       dataId,
       selectionSet: operationDefinition.selectionSet,
       mergeTree: { map: new Map() },
@@ -191,8 +191,7 @@ export class StoreWriter {
         }
 
         if (__DEV__ && !context.overwrite) {
-          const fieldsWithSelectionSets: Record<string, true> =
-            Object.create(null);
+          const fieldsWithSelectionSets: Record<string, true> = {};
           fieldNodeSet.forEach((field) => {
             if (field.selectionSet) {
               fieldsWithSelectionSets[field.name.value] = true;
@@ -254,7 +253,7 @@ export class StoreWriter {
 
     // This variable will be repeatedly updated using context.merge to
     // accumulate all fields that need to be written into the store.
-    let incoming: StoreObject = Object.create(null);
+    let incoming: StoreObject = {};
 
     // If typename was not passed in, infer it. Note that typename is
     // always passed in for tricky-to-infer cases such as "Query" for

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -264,7 +264,7 @@ export class ApolloClient<TCacheShape> implements DataProxy {
     this.cache = cache;
     this.disableNetworkFetches = ssrMode || ssrForceFetchDelay > 0;
     this.queryDeduplication = queryDeduplication;
-    this.defaultOptions = defaultOptions || Object.create(null);
+    this.defaultOptions = defaultOptions || {};
     this.typeDefs = typeDefs;
     this.devtoolsConfig = {
       ...devtools,

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -86,7 +86,7 @@ import type { TODO } from "../utilities/types/TODO.js";
 
 const { hasOwnProperty } = Object.prototype;
 
-const IGNORE: IgnoreModifier = Object.create(null);
+const IGNORE = {} as IgnoreModifier;
 
 interface MutationStoreValue {
   mutation: DocumentNode;
@@ -199,10 +199,10 @@ export class QueryManager<TStore> {
           // selections and fragments from the fragment registry.
           .concat(defaultDocumentTransform)
       : defaultDocumentTransform;
-    this.defaultContext = options.defaultContext || Object.create(null);
+    this.defaultContext = options.defaultContext || {};
 
     if ((this.onBroadcast = options.onBroadcast)) {
-      this.mutationStore = Object.create(null);
+      this.mutationStore = {};
     }
   }
 
@@ -870,7 +870,7 @@ export class QueryManager<TStore> {
     });
 
     if (this.mutationStore) {
-      this.mutationStore = Object.create(null);
+      this.mutationStore = {};
     }
 
     // begin removing data from the store

--- a/src/link/persisted-queries/index.ts
+++ b/src/link/persisted-queries/index.ts
@@ -69,8 +69,8 @@ function processErrors(
     | ReadonlyArray<GraphQLFormattedError>
     | undefined
 ): ErrorMeta {
-  const byMessage = Object.create(null),
-    byCode = Object.create(null);
+  const byMessage: Record<string, GraphQLFormattedError> = {},
+    byCode: Record<string, GraphQLFormattedError> = {};
 
   if (isNonEmptyArray(graphQLErrors)) {
     graphQLErrors.forEach((error) => {

--- a/src/link/remove-typename/removeTypenameFromVariables.ts
+++ b/src/link/remove-typename/removeTypenameFromVariables.ts
@@ -23,7 +23,7 @@ export interface RemoveTypenameFromVariablesOptions {
 }
 
 export function removeTypenameFromVariables(
-  options: RemoveTypenameFromVariablesOptions = Object.create(null)
+  options: RemoveTypenameFromVariablesOptions = {}
 ) {
   return Object.assign(
     new ApolloLink((operation, forward) => {

--- a/src/masking/maskDefinition.ts
+++ b/src/masking/maskDefinition.ts
@@ -43,7 +43,7 @@ function getMutableTarget(
     return mutableTargets.get(data);
   }
 
-  const mutableTarget = Array.isArray(data) ? [] : Object.create(null);
+  const mutableTarget = Array.isArray(data) ? [] : {};
   mutableTargets.set(data, mutableTarget);
   return mutableTarget;
 }

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -651,7 +651,7 @@ describe("useSubscription Hook", () => {
     expect(consoleSpy.error.mock.calls[0]).toStrictEqual([
       "Missing field '%s' while writing result %o",
       "car",
-      Object.create(null),
+      {},
     ]);
   });
 
@@ -719,17 +719,17 @@ describe("useSubscription Hook", () => {
     expect(consoleSpy.error.mock.calls[0]).toStrictEqual([
       "Missing field '%s' while writing result %o",
       "car",
-      Object.create(null),
+      {},
     ]);
     expect(consoleSpy.error.mock.calls[1]).toStrictEqual([
       "Missing field '%s' while writing result %o",
       "car",
-      Object.create(null),
+      {},
     ]);
     expect(consoleSpy.error.mock.calls[2]).toStrictEqual([
       "Missing field '%s' while writing result %o",
       "car",
-      Object.create(null),
+      {},
     ]);
   });
 

--- a/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
@@ -104,7 +104,7 @@ interface SimpleQueryData {
 
 async function renderSuspenseHook<Result, Props>(
   render: (initialProps: Props) => Result,
-  options: RenderSuspenseHookOptions<Props> = Object.create(null)
+  options: RenderSuspenseHookOptions<Props> = {}
 ) {
   function SuspenseFallback() {
     renders.suspenseCount++;
@@ -239,17 +239,15 @@ interface ErrorCaseData {
   };
 }
 
-function useErrorCase<TData extends ErrorCaseData>(
-  {
-    data,
-    networkError,
-    graphQLErrors,
-  }: {
-    data?: Unmasked<TData>;
-    networkError?: Error;
-    graphQLErrors?: GraphQLError[];
-  } = Object.create(null)
-) {
+function useErrorCase<TData extends ErrorCaseData>({
+  data,
+  networkError,
+  graphQLErrors,
+}: {
+  data?: Unmasked<TData>;
+  networkError?: Error;
+  graphQLErrors?: GraphQLError[];
+} = {}) {
   const query: TypedDocumentNode<TData, never> = gql`
     query MyQuery {
       currentUser {

--- a/src/react/hooks/useBackgroundQuery.ts
+++ b/src/react/hooks/useBackgroundQuery.ts
@@ -180,7 +180,7 @@ export function useBackgroundQuery<
   options:
     | (SkipToken &
         Partial<BackgroundQueryHookOptionsNoInfer<TData, TVariables>>)
-    | BackgroundQueryHookOptionsNoInfer<TData, TVariables> = Object.create(null)
+    | BackgroundQueryHookOptionsNoInfer<TData, TVariables> = {}
 ): [
   QueryRef<TData, TVariables> | undefined,
   UseBackgroundQueryResult<TData, TVariables>,

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -124,7 +124,7 @@ export function useLazyQuery<
       const method = obsQueryFields[key];
       eagerMethods[key] = function () {
         if (!execOptionsRef.current) {
-          execOptionsRef.current = Object.create(null);
+          execOptionsRef.current = {};
           // Only the first time populating execOptionsRef.current matters here.
           forceUpdateState();
         }

--- a/src/react/hooks/useLoadableQuery.ts
+++ b/src/react/hooks/useLoadableQuery.ts
@@ -168,7 +168,7 @@ export function useLoadableQuery<
   TVariables extends OperationVariables = OperationVariables,
 >(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  options: LoadableQueryHookOptions = Object.create(null)
+  options: LoadableQueryHookOptions = {}
 ): UseLoadableQueryResult<TData, TVariables> {
   const client = useApolloClient(options.client);
   const suspenseCache = getSuspenseCache(client);

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -123,10 +123,7 @@ export function useQuery<
   TVariables extends OperationVariables = OperationVariables,
 >(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  options: QueryHookOptions<
-    NoInfer<TData>,
-    NoInfer<TVariables>
-  > = Object.create(null)
+  options: QueryHookOptions<NoInfer<TData>, NoInfer<TVariables>> = {}
 ): QueryResult<TData, TVariables> {
   return wrapHook(
     "useQuery",

--- a/src/react/hooks/useSubscription.ts
+++ b/src/react/hooks/useSubscription.ts
@@ -112,10 +112,7 @@ export function useSubscription<
   TVariables extends OperationVariables = OperationVariables,
 >(
   subscription: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  options: SubscriptionHookOptions<
-    NoInfer<TData>,
-    NoInfer<TVariables>
-  > = Object.create(null)
+  options: SubscriptionHookOptions<NoInfer<TData>, NoInfer<TVariables>> = {}
 ) {
   const hasIssuedDeprecationWarningRef = React.useRef(false);
   const client = useApolloClient(options.client);

--- a/src/react/hooks/useSuspenseQuery.ts
+++ b/src/react/hooks/useSuspenseQuery.ts
@@ -171,7 +171,7 @@ export function useSuspenseQuery<
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
   options:
     | (SkipToken & Partial<SuspenseQueryHookOptions<TData, TVariables>>)
-    | SuspenseQueryHookOptions<TData, TVariables> = Object.create(null)
+    | SuspenseQueryHookOptions<TData, TVariables> = {}
 ): UseSuspenseQueryResult<TData | undefined, TVariables> {
   return wrapHook(
     "useSuspenseQuery",

--- a/src/react/internal/cache/SuspenseCache.ts
+++ b/src/react/internal/cache/SuspenseCache.ts
@@ -33,7 +33,7 @@ export class SuspenseCache {
 
   private options: SuspenseCacheOptions;
 
-  constructor(options: SuspenseCacheOptions = Object.create(null)) {
+  constructor(options: SuspenseCacheOptions = {}) {
     this.options = options;
   }
 

--- a/src/react/query-preloader/createQueryPreloader.ts
+++ b/src/react/query-preloader/createQueryPreloader.ts
@@ -170,7 +170,7 @@ const _createQueryPreloader: typeof createQueryPreloader = (client) => {
   >(
     query: DocumentNode | TypedDocumentNode<TData, TVariables>,
     options: PreloadQueryOptions<NoInfer<TVariables>> &
-      VariablesOption<TVariables> = Object.create(null)
+      VariablesOption<TVariables> = {} as any
   ): PreloadedQueryRef<TData, TVariables> {
     const queryRef = new InternalQueryReference(
       client.watchQuery({

--- a/src/testing/core/mocking/mockLink.ts
+++ b/src/testing/core/mocking/mockLink.ts
@@ -70,7 +70,7 @@ export class MockLink extends ApolloLink {
 
   constructor(
     mockedResponses: ReadonlyArray<MockedResponse<any, any>>,
-    options: MockLinkOptions = Object.create(null)
+    options: MockLinkOptions = {}
   ) {
     super();
     this.showWarnings = options.showWarnings ?? true;

--- a/src/testing/matchers/toHaveSuspenseCacheEntryUsing.ts
+++ b/src/testing/matchers/toHaveSuspenseCacheEntryUsing.ts
@@ -14,11 +14,7 @@ export const toHaveSuspenseCacheEntryUsing: MatcherFunction<
       queryKey?: string | number | any[];
     },
   ]
-> = function (
-  client,
-  query,
-  { variables, queryKey = [] } = Object.create(null)
-) {
+> = function (client, query, { variables, queryKey = [] } = {}) {
   if (!(client instanceof ApolloClient)) {
     throw new Error("Actual must be an instance of `ApolloClient`");
   }

--- a/src/utilities/common/__tests__/maybeDeepFeeze.ts
+++ b/src/utilities/common/__tests__/maybeDeepFeeze.ts
@@ -9,7 +9,7 @@ describe("maybeDeepFreeze", () => {
   });
 
   it("should properly freeze objects without hasOwnProperty", () => {
-    const foo = Object.create(null);
+    const foo: Record<string, any> = {};
     foo.bar = undefined;
     maybeDeepFreeze(foo);
     expect(() => (foo.bar = 1)).toThrow();

--- a/src/utilities/common/__tests__/mergeDeep.ts
+++ b/src/utilities/common/__tests__/mergeDeep.ts
@@ -8,7 +8,7 @@ describe("mergeDeep", function () {
   });
 
   it("should preserve identity for single arguments", function () {
-    const arg = Object.create(null);
+    const arg = {};
     expect(mergeDeep(arg)).toBe(arg);
   });
 

--- a/src/utilities/common/compact.ts
+++ b/src/utilities/common/compact.ts
@@ -7,7 +7,7 @@ import type { TupleToIntersection } from "./mergeDeep.js";
 export function compact<TArgs extends any[]>(
   ...objects: TArgs
 ): TupleToIntersection<TArgs> {
-  const result = Object.create(null);
+  const result = {} as TupleToIntersection<TArgs>;
 
   objects.forEach((obj) => {
     if (!obj) return;

--- a/src/utilities/graphql/DocumentTransform.ts
+++ b/src/utilities/graphql/DocumentTransform.ts
@@ -78,10 +78,7 @@ export class DocumentTransform {
     );
   }
 
-  constructor(
-    transform: TransformFn,
-    options: DocumentTransformOptions = Object.create(null)
-  ) {
+  constructor(transform: TransformFn, options: DocumentTransformOptions = {}) {
     this.transform = transform;
 
     if (options.getCacheKey) {

--- a/src/utilities/graphql/getFromAST.ts
+++ b/src/utilities/graphql/getFromAST.ts
@@ -153,7 +153,7 @@ export function getMainDefinition(
 export function getDefaultValues(
   definition: OperationDefinitionNode | undefined
 ): Record<string, any> {
-  const defaultValues = Object.create(null);
+  const defaultValues = {};
   const defs = definition && definition.variableDefinitions;
   if (defs && defs.length) {
     defs.forEach((def) => {

--- a/src/utilities/types/NoInfer.ts
+++ b/src/utilities/types/NoInfer.ts
@@ -10,7 +10,7 @@ export function useQuery<
   TVariables extends OperationVariables = OperationVariables,
 >(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  options: QueryHookOptions<NoInfer<TData>, NoInfer<TVariables>> = Object.create(null),
+  options: QueryHookOptions<NoInfer<TData>, NoInfer<TVariables>> = {},
 )
 ```
 In this case, `TData` and `TVariables` should be inferred from `query`, but never widened from something in `options`.


### PR DESCRIPTION
Closes #12199

Converts all `Object.create(null)` statements to `{}`.