### PR TITLE
Remove leftover of `addTypename`

### DIFF
--- a/docs/source/api/react/testing.md
+++ b/docs/source/api/react/testing.md
@@ -44,23 +44,6 @@ An array containing GraphQL operation definitions and their corresponding mocked
 <tr>
 <td>
 
-###### `addTypename`
-
-`Boolean`
-</td>
-<td>
-
-If `true`, the `MockedProvider` automatically adds the `__typename` field to every object type included in every executed query. Set this to `false` if the responses in your `mocks` array do _not_ include `__typename` fields. See [Setting `addTypename`](../../development-testing/testing/#setting-addtypename).
-
-The default value is `true`.
-
-</td>
-</tr>
-
-
-<tr>
-<td>
-
 ###### `defaultOptions`
 
 `DefaultOptions`

--- a/docs/source/caching/cache-configuration.mdx
+++ b/docs/source/caching/cache-configuration.mdx
@@ -43,25 +43,6 @@ To customize cache behavior, you provide a configuration object to the `InMemory
 <tr>
 <td>
 
-###### `addTypename`
-
-`Boolean`
-
-</td>
-<td>
-
-If `true`, the cache automatically requests the `__typename` field for every object in your outgoing operations, which means you can omit `__typename` from your operation definitions.
-
-By default, the cache uses the `__typename` field as part of the cache ID for every cached object, so it's helpful to guarantee that the field is always fetched.
-
-The default value is `true`.
-
-</td>
-</tr>
-
-<tr>
-<td>
-
 ###### `resultCaching`
 
 `Boolean`

--- a/docs/source/development-testing/testing.mdx
+++ b/docs/source/development-testing/testing.mdx
@@ -464,7 +464,6 @@ In order to properly test local state using `MockedProvider`, you'll need to pas
 ```jsx
 const {
   mocks,
-  addTypename,
   defaultOptions,
   cache,
   resolvers,
@@ -472,9 +471,9 @@ const {
   showWarnings,
 } = this.props;
 const client = new ApolloClient({
-  cache: cache || new Cache({ addTypename }),
+  cache: cache || new Cache(),
   defaultOptions,
-  link: link || new MockLink(mocks || [], addTypename, { showWarnings }),
+  link: link || new MockLink(mocks || [], { showWarnings }),
   resolvers,
 });
 ```

--- a/src/cache/inmemory/helpers.ts
+++ b/src/cache/inmemory/helpers.ts
@@ -60,9 +60,8 @@ export function defaultDataIdFromObject(
   }
 }
 
-const defaultConfig = {
+const defaultConfig: InMemoryCacheConfig = {
   dataIdFromObject: defaultDataIdFromObject,
-  addTypename: true,
   resultCaching: true,
   // Thanks to the shouldCanonizeResults helper, this should be the only line
   // you have to change to reenable canonization by default in the future.
@@ -77,7 +76,7 @@ export function shouldCanonizeResults(
   config: Pick<InMemoryCacheConfig, "canonizeResults">
 ): boolean {
   const value = config.canonizeResults;
-  return value === void 0 ? defaultConfig.canonizeResults : value;
+  return value === void 0 ? !!defaultConfig.canonizeResults : value;
 }
 
 export function getTypenameFromStoreObject(


### PR DESCRIPTION
Removing `addTypename` was started in ef892b4dc505, but we still have a few leftovers.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:

### Checklist:
- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
-->
