### PR TITLE
Remove `ObservableQuery.result`

### DIFF
--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -1671,10 +1671,8 @@ export class ObservableQuery<TData = any, TVariables extends OperationVariables 
     // (undocumented)
     resetLastResults(): void;
     // (undocumented)
-    result(): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
-    // (undocumented)
     setOptions(newOptions: Partial<WatchQueryOptions<TVariables, TData>>): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
-    setVariables(variables: TVariables): Promise<ApolloQueryResult<MaybeMasked<TData>> | void>;
+    setVariables(variables: TVariables): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
     // (undocumented)
     silentSetOptions(newOptions: Partial<WatchQueryOptions<TVariables, TData>>): void;
     startPolling(pollInterval: number): void;

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -1396,10 +1396,8 @@ class ObservableQuery<TData = any, TVariables extends OperationVariables = Opera
     // (undocumented)
     resetLastResults(): void;
     // (undocumented)
-    result(): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
-    // (undocumented)
     setOptions(newOptions: Partial<WatchQueryOptions<TVariables, TData>>): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
-    setVariables(variables: TVariables): Promise<ApolloQueryResult<MaybeMasked<TData>> | void>;
+    setVariables(variables: TVariables): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
     // (undocumented)
     silentSetOptions(newOptions: Partial<WatchQueryOptions<TVariables, TData>>): void;
     startPolling(pollInterval: number): void;

--- a/.api-reports/api-report-react_context.api.md
+++ b/.api-reports/api-report-react_context.api.md
@@ -1189,10 +1189,8 @@ class ObservableQuery<TData = any, TVariables extends OperationVariables = Opera
     // (undocumented)
     resetLastResults(): void;
     // (undocumented)
-    result(): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
-    // (undocumented)
     setOptions(newOptions: Partial<WatchQueryOptions<TVariables, TData>>): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
-    setVariables(variables: TVariables): Promise<ApolloQueryResult<MaybeMasked<TData>> | void>;
+    setVariables(variables: TVariables): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
     // (undocumented)
     silentSetOptions(newOptions: Partial<WatchQueryOptions<TVariables, TData>>): void;
     startPolling(pollInterval: number): void;

--- a/.api-reports/api-report-react_hooks.api.md
+++ b/.api-reports/api-report-react_hooks.api.md
@@ -1336,10 +1336,8 @@ class ObservableQuery<TData = any, TVariables extends OperationVariables = Opera
     // (undocumented)
     resetLastResults(): void;
     // (undocumented)
-    result(): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
-    // (undocumented)
     setOptions(newOptions: Partial<WatchQueryOptions<TVariables, TData>>): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
-    setVariables(variables: TVariables): Promise<ApolloQueryResult<MaybeMasked<TData>> | void>;
+    setVariables(variables: TVariables): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
     // (undocumented)
     silentSetOptions(newOptions: Partial<WatchQueryOptions<TVariables, TData>>): void;
     startPolling(pollInterval: number): void;

--- a/.api-reports/api-report-react_internal.api.md
+++ b/.api-reports/api-report-react_internal.api.md
@@ -1344,10 +1344,8 @@ class ObservableQuery<TData = any, TVariables extends OperationVariables = Opera
     // (undocumented)
     resetLastResults(): void;
     // (undocumented)
-    result(): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
-    // (undocumented)
     setOptions(newOptions: Partial<WatchQueryOptions<TVariables, TData>>): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
-    setVariables(variables: TVariables): Promise<ApolloQueryResult<MaybeMasked<TData>> | void>;
+    setVariables(variables: TVariables): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
     // (undocumented)
     silentSetOptions(newOptions: Partial<WatchQueryOptions<TVariables, TData>>): void;
     startPolling(pollInterval: number): void;

--- a/.api-reports/api-report-react_ssr.api.md
+++ b/.api-reports/api-report-react_ssr.api.md
@@ -1174,10 +1174,8 @@ class ObservableQuery<TData = any, TVariables extends OperationVariables = Opera
     // (undocumented)
     resetLastResults(): void;
     // (undocumented)
-    result(): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
-    // (undocumented)
     setOptions(newOptions: Partial<WatchQueryOptions<TVariables, TData>>): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
-    setVariables(variables: TVariables): Promise<ApolloQueryResult<MaybeMasked<TData>> | void>;
+    setVariables(variables: TVariables): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
     // (undocumented)
     silentSetOptions(newOptions: Partial<WatchQueryOptions<TVariables, TData>>): void;
     startPolling(pollInterval: number): void;

--- a/.api-reports/api-report-testing.api.md
+++ b/.api-reports/api-report-testing.api.md
@@ -1251,10 +1251,8 @@ class ObservableQuery<TData = any, TVariables extends OperationVariables = Opera
     // (undocumented)
     resetLastResults(): void;
     // (undocumented)
-    result(): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
-    // (undocumented)
     setOptions(newOptions: Partial<WatchQueryOptions<TVariables, TData>>): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
-    setVariables(variables: TVariables): Promise<ApolloQueryResult<MaybeMasked<TData>> | void>;
+    setVariables(variables: TVariables): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
     // (undocumented)
     silentSetOptions(newOptions: Partial<WatchQueryOptions<TVariables, TData>>): void;
     startPolling(pollInterval: number): void;

--- a/.api-reports/api-report-testing_core.api.md
+++ b/.api-reports/api-report-testing_core.api.md
@@ -1251,10 +1251,8 @@ class ObservableQuery<TData = any, TVariables extends OperationVariables = Opera
     // (undocumented)
     resetLastResults(): void;
     // (undocumented)
-    result(): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
-    // (undocumented)
     setOptions(newOptions: Partial<WatchQueryOptions<TVariables, TData>>): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
-    setVariables(variables: TVariables): Promise<ApolloQueryResult<MaybeMasked<TData>> | void>;
+    setVariables(variables: TVariables): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
     // (undocumented)
     silentSetOptions(newOptions: Partial<WatchQueryOptions<TVariables, TData>>): void;
     startPolling(pollInterval: number): void;

--- a/.api-reports/api-report-testing_react.api.md
+++ b/.api-reports/api-report-testing_react.api.md
@@ -1214,10 +1214,8 @@ class ObservableQuery<TData = any, TVariables extends OperationVariables = Opera
     // (undocumented)
     resetLastResults(): void;
     // (undocumented)
-    result(): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
-    // (undocumented)
     setOptions(newOptions: Partial<WatchQueryOptions<TVariables, TData>>): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
-    setVariables(variables: TVariables): Promise<ApolloQueryResult<MaybeMasked<TData>> | void>;
+    setVariables(variables: TVariables): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
     // (undocumented)
     silentSetOptions(newOptions: Partial<WatchQueryOptions<TVariables, TData>>): void;
     startPolling(pollInterval: number): void;

--- a/.api-reports/api-report-utilities.api.md
+++ b/.api-reports/api-report-utilities.api.md
@@ -1942,10 +1942,8 @@ class ObservableQuery<TData = any, TVariables extends OperationVariables = Opera
     // (undocumented)
     resetLastResults(): void;
     // (undocumented)
-    result(): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
-    // (undocumented)
     setOptions(newOptions: Partial<WatchQueryOptions<TVariables, TData>>): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
-    setVariables(variables: TVariables): Promise<ApolloQueryResult<MaybeMasked<TData>> | void>;
+    setVariables(variables: TVariables): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
     // (undocumented)
     silentSetOptions(newOptions: Partial<WatchQueryOptions<TVariables, TData>>): void;
     startPolling(pollInterval: number): void;

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -1671,10 +1671,8 @@ export class ObservableQuery<TData = any, TVariables extends OperationVariables 
     // (undocumented)
     resetLastResults(): void;
     // (undocumented)
-    result(): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
-    // (undocumented)
     setOptions(newOptions: Partial<WatchQueryOptions<TVariables, TData>>): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
-    setVariables(variables: TVariables): Promise<ApolloQueryResult<MaybeMasked<TData>> | void>;
+    setVariables(variables: TVariables): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
     // (undocumented)
     silentSetOptions(newOptions: Partial<WatchQueryOptions<TVariables, TData>>): void;
     startPolling(pollInterval: number): void;

--- a/.changeset/purple-lions-cough.md
+++ b/.changeset/purple-lions-cough.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": major
+---
+
+`ObservableQuery.setVariables` will now resolve with the last emitted result instead of `undefined` when either the variables match the current variables or there are no subscribers to the query.

--- a/.changeset/tidy-squids-poke.md
+++ b/.changeset/tidy-squids-poke.md
@@ -1,0 +1,14 @@
+---
+"@apollo/client": major
+---
+
+Removes `ObservableQuery.result()` method. If you use this method and need similar functionality, create and resolve a promise with the first value emitted from the observable instead.
+
+```ts
+const result = await new Promise((resolve) => {
+  const subscription = observableQuery.subscribe((value) => {
+    resolve(value);
+    subscription.unsubscribe();
+  });
+});
+```

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 41080,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 40600,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 31450,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 30986
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43289,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38712,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33512,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 28913
 }

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43328,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38754,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33565,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 28963
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43289,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38712,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33512,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 28913
 }

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43289,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38712,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33512,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 28913
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 41080,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 40600,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 31450,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 30986
 }

--- a/src/__tests__/mutationResults.ts
+++ b/src/__tests__/mutationResults.ts
@@ -182,12 +182,6 @@ describe("mutation results", () => {
     };
   }
 
-  it("correctly primes cache for tests", async () => {
-    const { client, obsQuery } = setupObsQuery();
-
-    await obsQuery.result().then(() => client.query({ query }));
-  });
-
   it("correctly integrates field changes by default", async () => {
     const mutation = gql`
       mutation setCompleted {

--- a/src/__tests__/optimistic.ts
+++ b/src/__tests__/optimistic.ts
@@ -142,7 +142,12 @@ describe("optimistic mutation results", () => {
     });
 
     const obsHandle = client.watchQuery({ query });
-    await obsHandle.result();
+    await new Promise((resolve) => {
+      const subscription = obsHandle.subscribe((value) => {
+        resolve(value);
+        setTimeout(() => subscription.unsubscribe());
+      });
+    });
 
     return client;
   }
@@ -2267,7 +2272,12 @@ describe("optimistic mutation - githunt comments", () => {
       variables,
     });
 
-    await obsHandle.result();
+    await new Promise((resolve) => {
+      const subscription = obsHandle.subscribe((value) => {
+        resolve(value);
+        setTimeout(() => subscription.unsubscribe());
+      });
+    });
 
     return client;
   }

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -220,45 +220,6 @@ export class ObservableQuery<
 
   public pipe: Observable<ApolloQueryResult<MaybeMasked<TData>>>["pipe"];
 
-  // TODO: Consider deprecating this method. If not, use firstValueFrom helper
-  // instead.
-  public result(): Promise<ApolloQueryResult<MaybeMasked<TData>>> {
-    return new Promise((resolve, reject) => {
-      // TODO: this code doesn’t actually make sense insofar as the observer
-      // will never exist in this.observers due how zen-observable wraps observables.
-      // https://github.com/zenparsing/zen-observable/blob/master/src/Observable.js#L169
-      const observer: Partial<Observer<ApolloQueryResult<MaybeMasked<TData>>>> =
-        {
-          next: (result) => {
-            resolve(result);
-
-            // Stop the query within the QueryManager if we can before
-            // this function returns.
-            //
-            // We do this in order to prevent observers piling up within
-            // the QueryManager. Notice that we only fully unsubscribe
-            // from the subscription in a setTimeout(..., 0)  call. This call can
-            // actually be handled by the browser at a much later time. If queries
-            // are fired in the meantime, observers that should have been removed
-            // from the QueryManager will continue to fire, causing an unnecessary
-            // performance hit.
-            if (!this.hasObservers()) {
-              // TODO: I think this can be removed, especially when we do the work to
-              // emit a `complete` notification once this instance is torn down.
-              // This was added in https://github.com/apollographql/apollo-client/pull/1567/commits/f9219c399a86e82db709e48cef64468bfd1056fe
-              this.queryManager.removeQuery(this.queryId);
-            }
-
-            setTimeout(() => {
-              subscription.unsubscribe();
-            }, 0);
-          },
-          error: reject,
-        };
-      const subscription = this.subscribe(observer);
-    });
-  }
-
   /** @internal */
   public resetDiff() {
     this.queryInfo.resetDiff();

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -720,21 +720,21 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
    * @param variables - The new set of variables. If there are missing variables,
    * the previous values of those variables will be used.
    */
-  public setVariables(
+  public async setVariables(
     variables: TVariables
-  ): Promise<ApolloQueryResult<MaybeMasked<TData>> | void> {
+  ): Promise<ApolloQueryResult<MaybeMasked<TData>>> {
     if (equal(this.variables, variables)) {
       // If we have no observers, then we don't actually want to make a network
       // request. As soon as someone observes the query, the request will kick
       // off. For now, we just store any changes. (See #1077)
-      return this.hasObservers() ? this.result() : Promise.resolve();
+      return this.subject.getValue();
     }
 
     this.options.variables = variables;
 
     // See comment above
     if (!this.hasObservers()) {
-      return Promise.resolve();
+      return this.subject.getValue();
     }
 
     return this.reobserve(

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -714,7 +714,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
    * Note: the promise will return the old results immediately if the variables
    * have not changed.
    *
-   * Note: the promise will return null immediately if the query is not active
+   * Note: the promise will return the last result immediately if the query is not active
    * (there are no subscribers).
    *
    * @param variables - The new set of variables. If there are missing variables,

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -2403,9 +2403,14 @@ describe("ObservableQuery", () => {
       });
 
       const observable = client.watchQuery({ query, variables });
+      const stream = new ObservableStream(observable);
 
-      await expect(observable.result()).resolves.toMatchObject({
+      await expect(stream).toEmitApolloQueryResult({
+        data: undefined,
         error: new CombinedGraphQLErrors([error]),
+        loading: false,
+        networkStatus: NetworkStatus.error,
+        partial: true,
       });
 
       const currentResult = observable.getCurrentResult();
@@ -2438,19 +2443,16 @@ describe("ObservableQuery", () => {
         variables,
         errorPolicy: "all",
       });
+      const stream = new ObservableStream(observable);
 
-      const result = await observable.result();
-      const currentResult = observable.getCurrentResult();
-
-      // TODO: This should include an `error` property, not just `errors`
-      expect(result).toEqualApolloQueryResult({
+      await expect(stream).toEmitApolloQueryResult({
         data: dataOne,
         error: new CombinedGraphQLErrors([error]),
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: false,
       });
-      expect(currentResult).toEqualApolloQueryResult({
+      expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: dataOne,
         error: new CombinedGraphQLErrors([error]),
         loading: false,
@@ -2476,8 +2478,14 @@ describe("ObservableQuery", () => {
         errorPolicy: "none",
       });
 
-      await expect(observable.result()).resolves.toMatchObject({
+      const stream = new ObservableStream(observable);
+
+      await expect(stream).toEmitApolloQueryResult({
+        data: undefined,
         error: wrappedError,
+        loading: false,
+        networkStatus: NetworkStatus.error,
+        partial: true,
       });
 
       expect(observable.getLastError()).toEqual(wrappedError);
@@ -2499,11 +2507,20 @@ describe("ObservableQuery", () => {
         variables,
         errorPolicy: "none",
       });
+      const stream = new ObservableStream(observable);
 
-      await expect(observable.result()).resolves.toMatchObject({
+      await expect(stream).toEmitApolloQueryResult({
+        data: undefined,
+        error: new CombinedGraphQLErrors([error]),
+        loading: false,
+        networkStatus: NetworkStatus.error,
+        partial: true,
+      });
+
+      expect(observable.getCurrentResult()).toMatchObject({
         error: wrappedError,
       });
-      await expect(observable.result()).resolves.toMatchObject({
+      expect(observable.getCurrentResult()).toMatchObject({
         error: wrappedError,
       });
 
@@ -2527,16 +2544,15 @@ describe("ObservableQuery", () => {
         errorPolicy: "ignore",
       });
 
-      const result = await observable.result();
-      const currentResult = observable.getCurrentResult();
+      const stream = new ObservableStream(observable);
 
-      expect(result).toEqualApolloQueryResult({
+      await expect(stream).toEmitApolloQueryResult({
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
         partial: false,
       });
-      expect(currentResult).toEqualApolloQueryResult({
+      expect(observable.getCurrentResult()).toEqualApolloQueryResult({
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -861,7 +861,14 @@ describe("ObservableQuery", () => {
         partial: false,
       });
 
-      await observable.setVariables(differentVariables);
+      await expect(
+        observable.setVariables(differentVariables)
+      ).resolves.toEqualApolloQueryResult({
+        data: dataTwo,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        partial: false,
+      });
 
       await expect(stream).toEmitApolloQueryResult({
         data: undefined,
@@ -911,7 +918,14 @@ describe("ObservableQuery", () => {
         partial: false,
       });
 
-      await observable.setVariables(differentVariables);
+      await expect(
+        observable.setVariables(differentVariables)
+      ).resolves.toEqualApolloQueryResult({
+        data: dataTwo,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        partial: false,
+      });
 
       await expect(stream).toEmitApolloQueryResult({
         data: dataTwo,
@@ -994,7 +1008,14 @@ describe("ObservableQuery", () => {
         partial: false,
       });
 
-      await observable.setVariables(differentVariables);
+      await expect(
+        observable.setVariables(differentVariables)
+      ).resolves.toEqualApolloQueryResult({
+        data: dataTwo,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        partial: false,
+      });
 
       await expect(stream).toEmitApolloQueryResult({
         data: dataTwo,
@@ -1050,7 +1071,14 @@ describe("ObservableQuery", () => {
         partial: true,
       });
 
-      await observable.setVariables(differentVariables);
+      await expect(
+        observable.setVariables(differentVariables)
+      ).resolves.toEqualApolloQueryResult({
+        data: dataTwo,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        partial: false,
+      });
 
       await expect(stream).toEmitApolloQueryResult({
         data: dataTwo,
@@ -1076,7 +1104,14 @@ describe("ObservableQuery", () => {
       });
       const observable = client.watchQuery({ query, variables });
 
-      await observable.setVariables(differentVariables);
+      await expect(
+        observable.setVariables(differentVariables)
+      ).resolves.toEqualApolloQueryResult({
+        data: undefined,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        partial: true,
+      });
     });
 
     it("sets networkStatus to `setVariables` when fetching", async () => {
@@ -1111,7 +1146,14 @@ describe("ObservableQuery", () => {
         partial: false,
       });
 
-      await observable.setVariables(differentVariables);
+      await expect(
+        observable.setVariables(differentVariables)
+      ).resolves.toEqualApolloQueryResult({
+        data: dataTwo,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        partial: false,
+      });
 
       await expect(stream).toEmitApolloQueryResult({
         data: undefined,
@@ -1130,7 +1172,7 @@ describe("ObservableQuery", () => {
       await expect(stream).not.toEmitAnything();
     });
 
-    it("sets networkStatus to `setVariables` when calling refetch with new variables", async () => {
+    it("sets networkStatus to `refetch` when calling refetch with new variables", async () => {
       const mockedResponses = [
         {
           request: { query, variables },
@@ -1162,7 +1204,14 @@ describe("ObservableQuery", () => {
         partial: false,
       });
 
-      await observable.refetch(differentVariables);
+      await expect(
+        observable.refetch(differentVariables)
+      ).resolves.toEqualApolloQueryResult({
+        data: dataTwo,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        partial: false,
+      });
 
       await expect(stream).toEmitApolloQueryResult({
         data: undefined,
@@ -1205,7 +1254,14 @@ describe("ObservableQuery", () => {
         partial: false,
       });
 
-      await observable.setVariables(variables);
+      await expect(
+        observable.setVariables(variables)
+      ).resolves.toEqualApolloQueryResult({
+        data: dataOne,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        partial: false,
+      });
 
       await expect(stream).not.toEmitAnything();
     });
@@ -1232,7 +1288,14 @@ describe("ObservableQuery", () => {
       const observable = client.watchQuery({ query, variables });
       const stream = new ObservableStream(observable);
 
-      await observable.setVariables(differentVariables);
+      await expect(
+        observable.setVariables(differentVariables)
+      ).resolves.toEqualApolloQueryResult({
+        data: dataTwo,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        partial: false,
+      });
 
       await expect(stream).toEmitApolloQueryResult({
         data: dataTwo,


### PR DESCRIPTION
Removes the `ObservableQuery.result()` method. This method was not super useful and made it too easy to remove the query from the list of active queries if nothing was subscribed to the observable.

The only other place that used this function was the `setVariables` API. This has been updated to always return a result in the case the variables remain the same or there are no subscribers.