### PR TITLE
Move build before size limits

### DIFF
--- a/.github/workflows/cleanup-checks.yml
+++ b/.github/workflows/cleanup-checks.yml
@@ -41,9 +41,6 @@ jobs:
       - name: Install dependencies (with cache)
         uses: bahmutov/npm-install@v1
 
-      - name: Run build
-        run: npm run build
-
       - name: Run Api-Extractor
         run: npm run extract-api
         env:
@@ -51,6 +48,9 @@ jobs:
 
       - name: Run prettier
         run: npm run format
+
+      - name: Run build
+        run: npm run build
 
       - name: Update size-limit
         run: npm run update-size-limits


### PR DESCRIPTION
Since the `extract-api` script was updated, I think the build artifact isn't quite what it needs to be for the `update-size-limits` script to work properly. This moves the `build` command right before we update size limits for a more accurate value.