### PR TITLE
Use `firstValueFrom(from(observableQuery))` where appropriate

### DIFF
--- a/.changeset/tidy-squids-poke.md
+++ b/.changeset/tidy-squids-poke.md
@@ -2,13 +2,11 @@
 "@apollo/client": major
 ---
 
-Removes `ObservableQuery.result()` method. If you use this method and need similar functionality, create and resolve a promise with the first value emitted from the observable instead.
+Removes `ObservableQuery.result()` method. If you use this method and need similar functionality, use the `firstValueFrom` helper in RxJS.
 
 ```ts
-const result = await new Promise((resolve) => {
-  const subscription = observableQuery.subscribe((value) => {
-    resolve(value);
-    subscription.unsubscribe();
-  });
-});
+import { firstValueFrom, from } from "rxjs";
+
+// The `from` is necessary to turn `observableQuery` into an RxJS observable
+const result = await firstValueFrom(from(observableQuery))
 ```

--- a/src/__tests__/optimistic.ts
+++ b/src/__tests__/optimistic.ts
@@ -1,6 +1,6 @@
 import { gql } from "graphql-tag";
 import { assign, cloneDeep } from "lodash";
-import { lastValueFrom, Observable } from "rxjs";
+import { firstValueFrom, from, lastValueFrom, Observable } from "rxjs";
 import { map, take, toArray } from "rxjs/operators";
 
 import { Cache, InMemoryCache } from "@apollo/client/cache";
@@ -142,6 +142,8 @@ describe("optimistic mutation results", () => {
     });
 
     const obsHandle = client.watchQuery({ query });
+    // We can't use firstValueFrom here because we need to unsubscribe in the
+    // setTimeout
     await new Promise((resolve) => {
       const subscription = obsHandle.subscribe((value) => {
         resolve(value);
@@ -2272,12 +2274,7 @@ describe("optimistic mutation - githunt comments", () => {
       variables,
     });
 
-    await new Promise((resolve) => {
-      const subscription = obsHandle.subscribe((value) => {
-        resolve(value);
-        setTimeout(() => subscription.unsubscribe());
-      });
-    });
+    await firstValueFrom(from(obsHandle));
 
     return client;
   }


### PR DESCRIPTION
As a result of #12432, we can now use `from(observableQuery)` to turn `ObservableQuery` into an RxJS observable which means we can use the `firstValueFrom` as a proper replacement for the removed `result` function (#12430). This PR updates the tests from #12430 to use this pattern and update the changeset with the updated recommendation.