### PR TITLE
Disable warnings in mocks to fix flaky test

### DIFF
--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -5278,20 +5278,23 @@ describe("ApolloClient", () => {
       };
       const client = new ApolloClient({
         cache: new InMemoryCache(),
-        link: new MockLink([
-          {
-            request: { query },
-            result: { data },
-          },
-          {
-            request: { query },
-            result: { data: secondReqData },
-          },
-          {
-            request: { query: mutation },
-            result: { data: mutationData },
-          },
-        ]),
+        link: new MockLink(
+          [
+            {
+              request: { query },
+              result: { data },
+            },
+            {
+              request: { query },
+              result: { data: secondReqData },
+            },
+            {
+              request: { query: mutation },
+              result: { data: mutationData },
+            },
+          ],
+          { showWarnings: false }
+        ),
       });
       const observable = client.watchQuery({
         query,


### PR DESCRIPTION
We have a pretty flaky core test that checks against warnings emitted to the console. `MockLink` causes the test to fail from time to time as it is emitting warnings on unmatched mocks. This disables warnings in `MockLink` which don't affect the test anyways.