### PR TITLE
Fix an issue where incorrect results are returned when changing variables and skipping

### DIFF
--- a/.changeset/little-trainers-compare.md
+++ b/.changeset/little-trainers-compare.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix an issue where a `cache-first` query would return the result for previous variables when a cache update is issued after simultaneously changing variables and skipping the query.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 42244,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 34450
+  "dist/apollo-client.min.cjs": 42263,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 34469
 }

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -86,6 +86,7 @@ export class QueryInfo {
   graphQLErrors?: ReadonlyArray<GraphQLFormattedError>;
   stopped = false;
 
+  private cancelWatch?: () => void;
   private cache: ApolloCache<any>;
 
   constructor(
@@ -128,6 +129,8 @@ export class QueryInfo {
 
     if (!equal(query.variables, this.variables)) {
       this.lastDiff = void 0;
+      // Ensure we don't continue to receive cache updates for old variables
+      this.cancel();
     }
 
     Object.assign(this, {
@@ -308,20 +311,17 @@ export class QueryInfo {
 
       // Cancel the pending notify timeout
       this.reset();
-
       this.cancel();
-      // Revert back to the no-op version of cancel inherited from
-      // QueryInfo.prototype.
-      this.cancel = QueryInfo.prototype.cancel;
 
       const oq = this.observableQuery;
       if (oq) oq.stopPolling();
     }
   }
 
-  // This method is a no-op by default, until/unless overridden by the
-  // updateWatch method.
-  private cancel() {}
+  private cancel() {
+    this.cancelWatch?.();
+    this.cancelWatch = void 0;
+  }
 
   private lastWatch?: Cache.WatchOptions;
 
@@ -342,7 +342,7 @@ export class QueryInfo {
 
     if (!this.lastWatch || !equal(watchOptions, this.lastWatch)) {
       this.cancel();
-      this.cancel = this.cache.watch((this.lastWatch = watchOptions));
+      this.cancelWatch = this.cache.watch((this.lastWatch = watchOptions));
     }
   }
 

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -1656,19 +1656,15 @@ describe("useQuery Hook", () => {
         }
       );
 
-      {
-        const result = await takeSnapshot();
-
-        expect(result).toEqualQueryResult({
-          data: undefined,
-          error: undefined,
-          called: false,
-          loading: false,
-          networkStatus: NetworkStatus.ready,
-          previousData: undefined,
-          variables: { id: 1 },
-        });
-      }
+      await expect(takeSnapshot()).resolves.toEqualQueryResult({
+        data: undefined,
+        error: undefined,
+        called: false,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: undefined,
+        variables: { id: 1 },
+      });
 
       client.writeQuery({
         query,
@@ -1677,34 +1673,26 @@ describe("useQuery Hook", () => {
       });
       await rerender({ id: 1, skip: false });
 
-      {
-        const result2 = await takeSnapshot();
-
-        expect(result2).toEqualQueryResult({
-          data: { user: { __typename: "User", id: 1, name: "User 1" } },
-          called: true,
-          loading: false,
-          networkStatus: NetworkStatus.ready,
-          previousData: undefined,
-          variables: { id: 1 },
-        });
-      }
+      await expect(takeSnapshot()).resolves.toEqualQueryResult({
+        data: { user: { __typename: "User", id: 1, name: "User 1" } },
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: undefined,
+        variables: { id: 1 },
+      });
 
       await rerender({ id: 2, skip: true });
 
-      {
-        const result = await takeSnapshot();
-
-        expect(result).toEqualQueryResult({
-          data: undefined,
-          error: undefined,
-          called: false,
-          loading: false,
-          networkStatus: NetworkStatus.ready,
-          previousData: { user: { __typename: "User", id: 1, name: "User 1" } },
-          variables: { id: 2 },
-        });
-      }
+      await expect(takeSnapshot()).resolves.toEqualQueryResult({
+        data: undefined,
+        error: undefined,
+        called: false,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: { user: { __typename: "User", id: 1, name: "User 1" } },
+        variables: { id: 2 },
+      });
 
       client.writeQuery({
         query,
@@ -1714,18 +1702,14 @@ describe("useQuery Hook", () => {
 
       await rerender({ id: 2, skip: false });
 
-      {
-        const result = await takeSnapshot();
-
-        expect(result).toEqualQueryResult({
-          data: { user: { __typename: "User", id: 2, name: "User 2" } },
-          called: true,
-          loading: false,
-          networkStatus: NetworkStatus.ready,
-          previousData: { user: { __typename: "User", id: 1, name: "User 1" } },
-          variables: { id: 2 },
-        });
-      }
+      await expect(takeSnapshot()).resolves.toEqualQueryResult({
+        data: { user: { __typename: "User", id: 2, name: "User 2" } },
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: { user: { __typename: "User", id: 1, name: "User 1" } },
+        variables: { id: 2 },
+      });
 
       await expect(takeSnapshot).not.toRerender();
     });


### PR DESCRIPTION
Fixes #12458

If a query changed variables and simultaneously skipped a query, `QueryInfo` would get updated with the right `variables`, but the previous `cache.watch` was active. This was a problem when the `fetchPolicy` changed to `standby` as a result of skipping the query while changing variables. If something else cache a cache update during the period while the query was in standby, the diff was updated to the result from the previous variables which meant the next time `queryInfo.getDiff()` was called, it used the already stored wrong result.

This change cancels a `cache.watch` if variables change so that cache updates while a query is skipped don't update `QueryInfo`.

