### PR TITLE
doc: add defer to sidebar

### DIFF
--- a/docs/source/_sidebar.yaml
+++ b/docs/source/_sidebar.yaml
@@ -35,6 +35,8 @@ items:
         href: ./data/error-handling
       - label: Document transforms
         href: ./data/document-transforms
+      - label: Deferring response data
+        href: ./data/defer
       - label: Best practices
         href: ./data/operation-best-practices
   - label: Caching

--- a/docs/source/data/defer.mdx
+++ b/docs/source/data/defer.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Using the @defer directive in Apollo Client"
 description: Receive query response data incrementally
+minVersion: 3.7.0
 ---
 
 > **The `@defer` directive is currently at the [General Availability stage](/resources/product-launch-stages/#general-availability) in Apollo Client, and is available by installing `@apollo/client@latest`.** If you have feedback on it, please let us know via [GitHub issues](https://github.com/apollographql/apollo-client/issues/new?assignees=&labels=&template=bug.md).


### PR DESCRIPTION
Adds the defer page to the sidebar and adds a `minVersion` to the defer page