### PR TITLE
Refactor `useMutation` tests to use full result matchers and snapshot streams

### DIFF
--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -182,9 +182,7 @@ export class ApolloClient implements DataProxy {
    * @deprecated `disableNetworkFetches` has been renamed to `prioritizeCacheValues`.
    */
   public disableNetworkFetches!: never;
-  /**
-   * {@inheritDoc @apollo/client!ApolloClient#prioritizeCacheValues:member}
-   */
+
   public set prioritizeCacheValues(value: boolean) {
     this.queryManager.prioritizeCacheValues = value;
   }

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -1638,37 +1638,78 @@ describe("useMutation Hook", () => {
           result: {
             data: CREATE_TODO_DATA,
           },
+          delay: 20,
         },
       ];
 
       const onCompleted = jest.fn();
-      const { result, rerender } = renderHook(
-        ({ onCompleted }) => {
-          return useMutation<
-            { createTodo: Todo },
-            { priority: string; description: string }
-          >(CREATE_TODO_MUTATION, { onCompleted });
-        },
-        {
-          wrapper: ({ children }) => (
-            <MockedProvider mocks={mocks}>{children}</MockedProvider>
-          ),
-          initialProps: { onCompleted },
-        }
-      );
+      using _disabledAct = disableActEnvironment();
+      const { takeSnapshot, getCurrentSnapshot, rerender } =
+        await renderHookToSnapshotStream(
+          ({ onCompleted }) => {
+            return useMutation<
+              { createTodo: Todo },
+              { priority: string; description: string }
+            >(CREATE_TODO_MUTATION, { onCompleted });
+          },
+          {
+            wrapper: ({ children }) => (
+              <MockedProvider mocks={mocks}>{children}</MockedProvider>
+            ),
+            initialProps: { onCompleted },
+          }
+        );
+
+      {
+        const [, result] = await takeSnapshot();
+
+        expect(result).toEqualStrictTyped({
+          loading: false,
+          called: false,
+        });
+      }
 
       const onCompleted1 = jest.fn();
-      rerender({ onCompleted: onCompleted1 });
-      const createTodo = result.current[0];
-      let fetchResult: any;
-      await act(async () => {
-        fetchResult = await createTodo({
-          variables,
+      await rerender({ onCompleted: onCompleted1 });
+
+      {
+        const [, result] = await takeSnapshot();
+
+        expect(result).toEqualStrictTyped({
+          loading: false,
+          called: false,
         });
+      }
+
+      const [createTodo] = getCurrentSnapshot();
+      await expect(createTodo({ variables })).resolves.toEqualStrictTyped({
+        data: CREATE_TODO_DATA,
       });
 
-      expect(fetchResult).toEqual({ data: CREATE_TODO_DATA });
-      expect(result.current[1].data).toEqual(CREATE_TODO_DATA);
+      {
+        const [, result] = await takeSnapshot();
+
+        expect(result).toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
+          loading: true,
+          called: true,
+        });
+      }
+
+      {
+        const [, result] = await takeSnapshot();
+
+        expect(result).toEqualStrictTyped({
+          data: CREATE_TODO_DATA,
+          error: undefined,
+          loading: false,
+          called: true,
+        });
+      }
+
+      await expect(takeSnapshot).not.toRerender();
+
       expect(onCompleted).toHaveBeenCalledTimes(0);
       expect(onCompleted1).toHaveBeenCalledTimes(1);
       expect(onCompleted1).toHaveBeenCalledWith(

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -881,10 +881,14 @@ describe("useMutation Hook", () => {
   });
 
   it("should return the current client instance in the result object", async () => {
+    const client = new ApolloClient({ cache: new InMemoryCache() });
+
     const { result } = renderHook(() => useMutation(CREATE_TODO_MUTATION), {
-      wrapper: ({ children }) => <MockedProvider>{children}</MockedProvider>,
+      wrapper: ({ children }) => (
+        <ApolloProvider client={client}>{children}</ApolloProvider>
+      ),
     });
-    expect(result.current[1].client).toBeInstanceOf(ApolloClient);
+    expect(result.current[1].client).toBe(client);
   });
 
   it("should call client passed to execute function", async () => {

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -967,6 +967,7 @@ describe("useMutation Hook", () => {
     await expect(takeSnapshot).not.toRerender();
   });
 
+  // TODO: Do we want to keep this variable merge behavior?
   it("should merge provided variables", async () => {
     const CREATE_TODO_DATA = {
       createTodo: {

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -1447,6 +1447,30 @@ describe("useMutation Hook", () => {
         errors: new CombinedGraphQLErrors(errors),
       });
 
+      {
+        const [, result] = await takeSnapshot();
+
+        expect(result).toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
+          loading: true,
+          called: true,
+        });
+      }
+
+      {
+        const [, result] = await takeSnapshot();
+
+        expect(result).toEqualStrictTyped({
+          data: undefined,
+          error: new CombinedGraphQLErrors(errors),
+          loading: false,
+          called: true,
+        });
+      }
+
+      await expect(takeSnapshot).not.toRerender();
+
       expect(onCompleted).toHaveBeenCalledTimes(0);
       expect(onError).toHaveBeenCalledTimes(1);
       expect(onError).toHaveBeenCalledWith(
@@ -1469,6 +1493,7 @@ describe("useMutation Hook", () => {
           result: {
             errors: [{ message: CREATE_TODO_ERROR }],
           },
+          delay: 20,
         },
       ];
 
@@ -1504,6 +1529,28 @@ describe("useMutation Hook", () => {
         // @ts-expect-error
         errors: new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }]),
       });
+
+      {
+        const [, result] = await takeSnapshot();
+
+        expect(result).toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
+          loading: true,
+          called: true,
+        });
+      }
+
+      {
+        const [, result] = await takeSnapshot();
+
+        expect(result).toEqualStrictTyped({
+          data: undefined,
+          error: new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }]),
+          loading: false,
+          called: true,
+        });
+      }
 
       expect(onError).toHaveBeenCalledTimes(1);
       expect(onError).toHaveBeenCalledWith(

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -371,7 +371,7 @@ describe("useMutation Hook", () => {
 
     await act(async () => {
       await result.current.createTodo({ variables });
-      await result.current.reset();
+      result.current.reset();
     });
 
     expect(consoleSpies.error).not.toHaveBeenCalled();

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -1742,40 +1742,80 @@ describe("useMutation Hook", () => {
           result: {
             data: CREATE_TODO_DATA,
           },
+          delay: 20,
         },
       ];
 
       const onCompleted = jest.fn();
 
-      const { result, rerender } = renderHook(
-        ({ onCompleted }) => {
-          return useMutation<
-            { createTodo: Todo },
-            { priority: string; description: string }
-          >(CREATE_TODO_MUTATION, { onCompleted });
-        },
-        {
-          wrapper: ({ children }) => (
-            <MockedProvider mocks={mocks}>{children}</MockedProvider>
-          ),
-          initialProps: { onCompleted },
-        }
-      );
+      using _disabledAct = disableActEnvironment();
+      const { takeSnapshot, getCurrentSnapshot, rerender } =
+        await renderHookToSnapshotStream(
+          ({ onCompleted }) => {
+            return useMutation<
+              { createTodo: Todo },
+              { priority: string; description: string }
+            >(CREATE_TODO_MUTATION, { onCompleted });
+          },
+          {
+            wrapper: ({ children }) => (
+              <MockedProvider mocks={mocks}>{children}</MockedProvider>
+            ),
+            initialProps: { onCompleted },
+          }
+        );
 
-      const createTodo = result.current[0];
-      let fetchResult: any;
+      {
+        const [, result] = await takeSnapshot();
+
+        expect(result).toEqualStrictTyped({
+          loading: false,
+          called: false,
+        });
+      }
+
+      const [createTodo] = getCurrentSnapshot();
 
       const onCompleted1 = jest.fn();
-      rerender({ onCompleted: onCompleted1 });
+      await rerender({ onCompleted: onCompleted1 });
 
-      await act(async () => {
-        fetchResult = await createTodo({
-          variables,
+      {
+        const [, result] = await takeSnapshot();
+
+        expect(result).toEqualStrictTyped({
+          loading: false,
+          called: false,
         });
+      }
+
+      await expect(createTodo({ variables })).resolves.toEqualStrictTyped({
+        data: CREATE_TODO_DATA,
       });
 
-      expect(fetchResult).toEqual({ data: CREATE_TODO_DATA });
-      expect(result.current[1].data).toEqual(CREATE_TODO_DATA);
+      {
+        const [, result] = await takeSnapshot();
+
+        expect(result).toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
+          loading: true,
+          called: true,
+        });
+      }
+
+      {
+        const [, result] = await takeSnapshot();
+
+        expect(result).toEqualStrictTyped({
+          data: CREATE_TODO_DATA,
+          error: undefined,
+          loading: false,
+          called: true,
+        });
+      }
+
+      await expect(takeSnapshot).not.toRerender();
+
       expect(onCompleted).toHaveBeenCalledTimes(0);
       expect(onCompleted1).toHaveBeenCalledTimes(1);
       expect(onCompleted1).toHaveBeenCalledWith(

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -1932,16 +1932,18 @@ describe("useMutation Hook", () => {
     const link = new ApolloLink(
       (operation) =>
         new Observable((observer) => {
-          observer.next({
-            data: {
-              __typename: "Mutation",
-              doSomething: {
-                __typename: "MutationPayload",
-                time: startTime,
+          setTimeout(() => {
+            observer.next({
+              data: {
+                __typename: "Mutation",
+                doSomething: {
+                  __typename: "MutationPayload",
+                  time: startTime,
+                },
               },
-            },
-          });
-          observer.complete();
+            });
+            observer.complete();
+          }, 20);
         })
     );
 
@@ -1979,31 +1981,35 @@ describe("useMutation Hook", () => {
         }),
       });
 
-      const { result } = renderHook(() => useMutation(mutation), {
-        wrapper: ({ children }) => (
-          <ApolloProvider client={client}>{children}</ApolloProvider>
-        ),
-      });
+      using _disabledAct = disableActEnvironment();
+      const { takeSnapshot, getCurrentSnapshot } =
+        await renderHookToSnapshotStream(() => useMutation(mutation), {
+          wrapper: ({ children }) => (
+            <ApolloProvider client={client}>{children}</ApolloProvider>
+          ),
+        });
 
-      expect(result.current[1].loading).toBe(false);
-      expect(result.current[1].called).toBe(false);
-      expect(result.current[1].data).toBe(undefined);
-      const mutate = result.current[0];
+      {
+        const [, result] = await takeSnapshot();
 
-      let mutationResult: any;
-      act(() => {
-        mutationResult = mutate({
-          update(
-            cache,
-            {
-              data: {
-                doSomething: { __typename, time },
+        expect(result).toEqualStrictTyped({
+          loading: false,
+          called: false,
+        });
+      }
+
+      const [mutate] = getCurrentSnapshot();
+
+      await expect(
+        mutate({
+          update(cache, { data }) {
+            expect(data).toEqualStrictTyped({
+              doSomething: {
+                __typename: "MutationPayload",
+                time: new Date(startTime),
               },
-            }
-          ) {
-            expect(__typename).toBe("MutationPayload");
-            expect(time).toBeInstanceOf(Date);
-            expect(time.getTime()).toBe(startTime);
+            });
+
             expect(timeReadCount).toBe(1);
             expect(timeMergeCount).toBe(1);
             // The contents of the ROOT_MUTATION object exist only briefly,
@@ -2019,48 +2025,55 @@ describe("useMutation Hook", () => {
               },
             });
           },
-        }).then(
-          ({
-            data: {
-              doSomething: { __typename, time },
+        })
+      ).resolves.toEqualStrictTyped({
+        data: {
+          doSomething: {
+            __typename: "MutationPayload",
+            time: new Date(startTime),
+          },
+        },
+      });
+
+      expect(timeReadCount).toBe(1);
+      expect(timeMergeCount).toBe(1);
+      // The contents of the ROOT_MUTATION object exist only briefly,
+      // for the duration of the mutation update, and are removed after
+      // the mutation write is finished.
+      expect(client.cache.extract()).toEqual({
+        ROOT_MUTATION: {
+          __typename: "Mutation",
+        },
+      });
+
+      {
+        const [, result] = await takeSnapshot();
+
+        expect(result).toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
+          loading: true,
+          called: true,
+        });
+      }
+
+      {
+        const [, result] = await takeSnapshot();
+
+        expect(result).toEqualStrictTyped({
+          data: {
+            doSomething: {
+              __typename: "MutationPayload",
+              time: new Date(startTime),
             },
-          }) => {
-            expect(__typename).toBe("MutationPayload");
-            expect(time).toBeInstanceOf(Date);
-            expect(time.getTime()).toBe(startTime);
-            expect(timeReadCount).toBe(1);
-            expect(timeMergeCount).toBe(1);
-            // The contents of the ROOT_MUTATION object exist only briefly,
-            // for the duration of the mutation update, and are removed after
-            // the mutation write is finished.
-            expect(client.cache.extract()).toEqual({
-              ROOT_MUTATION: {
-                __typename: "Mutation",
-              },
-            });
-          }
-        );
-        mutationResult.catch(() => {});
-      });
+          },
+          error: undefined,
+          loading: false,
+          called: true,
+        });
+      }
 
-      expect(result.current[1].loading).toBe(true);
-      expect(result.current[1].called).toBe(true);
-      expect(result.current[1].data).toBe(undefined);
-
-      await waitFor(() => {
-        expect(result.current[1].loading).toBe(false);
-      });
-      expect(result.current[1].called).toBe(true);
-      expect(result.current[1].data).toBeDefined();
-
-      const {
-        doSomething: { __typename, time },
-      } = result.current[1].data;
-      expect(__typename).toBe("MutationPayload");
-      expect(time).toBeInstanceOf(Date);
-      expect(time.getTime()).toBe(startTime);
-
-      await expect(mutationResult).resolves.toBe(undefined);
+      await expect(takeSnapshot).not.toRerender();
     });
 
     it("can be preserved by passing keepRootFields: true", async () => {

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -1194,34 +1194,43 @@ describe("useMutation Hook", () => {
       createTodo = mutate;
       reset = result.reset;
       //initial value
-      expect(result.data).toBe(undefined);
-      expect(result.loading).toBe(false);
-      expect(result.called).toBe(false);
+      expect(result).toEqualStrictTyped({
+        loading: false,
+        called: false,
+      });
     }
 
-    let fetchResult = createTodo({
+    const fetchResult = createTodo({
       variables: { priority: "Low", description: "Get milk." },
     });
 
     {
       const [, result] = await takeSnapshot();
+
       // started loading
-      expect(result.data).toBe(undefined);
-      expect(result.loading).toBe(true);
-      expect(result.called).toBe(true);
+      expect(result).toEqualStrictTyped({
+        data: undefined,
+        error: undefined,
+        loading: true,
+        called: true,
+      });
     }
 
     reset();
 
     {
       const [, result] = await takeSnapshot();
+
       // reset to initial value
-      expect(result.data).toBe(undefined);
-      expect(result.loading).toBe(false);
-      expect(result.called).toBe(false);
+      expect(result).toEqualStrictTyped({
+        loading: false,
+        called: false,
+      });
     }
 
-    expect(await fetchResult).toEqual({ data: CREATE_TODO_DATA });
+    await expect(fetchResult).resolves.toEqualStrictTyped({
+      data: CREATE_TODO_DATA,
+    });
 
     await expect(takeSnapshot).not.toRerender();
   });

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -150,6 +150,7 @@ describe("useMutation Hook", () => {
           variables,
         },
         result: { data: CREATE_TODO_RESULT },
+        delay: 20,
       },
     ];
 
@@ -162,22 +163,32 @@ describe("useMutation Hook", () => {
       return { loading, data };
     };
 
-    const { result } = renderHook(() => useCreateTodo(), {
-      wrapper: ({ children }) => (
-        <MockedProvider mocks={mocks}>{children}</MockedProvider>
-      ),
+    using _disabledAct = disableActEnvironment();
+    const { takeSnapshot } = await renderHookToSnapshotStream(
+      () => useCreateTodo(),
+      {
+        wrapper: ({ children }) => (
+          <MockedProvider mocks={mocks}>{children}</MockedProvider>
+        ),
+      }
+    );
+
+    await expect(takeSnapshot()).resolves.toEqualStrictTyped({
+      data: undefined,
+      loading: false,
     });
 
-    expect(result.current.loading).toBe(true);
-    expect(result.current.data).toBe(undefined);
+    await expect(takeSnapshot()).resolves.toEqualStrictTyped({
+      data: undefined,
+      loading: true,
+    });
 
-    await waitFor(
-      () => {
-        expect(result.current.loading).toBe(false);
-      },
-      { interval: 1 }
-    );
-    expect(result.current.data).toEqual(CREATE_TODO_RESULT);
+    await expect(takeSnapshot()).resolves.toEqualStrictTyped({
+      data: CREATE_TODO_RESULT,
+      loading: false,
+    });
+
+    await expect(takeSnapshot).not.toRerender();
   });
 
   it("should ensure the mutation callback function has a stable identity no matter what", async () => {

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -2716,7 +2716,7 @@ describe("useMutation Hook", () => {
         }
       }
 
-      {
+      if (IS_REACT_19) {
         const {
           query,
           mutation: [, mutation],
@@ -2729,12 +2729,57 @@ describe("useMutation Hook", () => {
           previousData: { todoCount: 0 },
           variables: {},
         });
+
         expect(mutation).toEqualStrictTyped({
           data: CREATE_TODO_RESULT,
           error: undefined,
           loading: false,
           called: true,
         });
+      } else {
+        {
+          const {
+            query,
+            mutation: [, mutation],
+          } = await takeSnapshot();
+
+          expect(query).toEqualStrictTyped({
+            data: { todoCount: 1 },
+            networkStatus: NetworkStatus.ready,
+            loading: false,
+            previousData: { todoCount: 0 },
+            variables: {},
+          });
+
+          expect(mutation).toEqualStrictTyped({
+            data: undefined,
+            error: undefined,
+            loading: true,
+            called: true,
+          });
+        }
+
+        {
+          const {
+            query,
+            mutation: [, mutation],
+          } = await takeSnapshot();
+
+          expect(query).toEqualStrictTyped({
+            data: { todoCount: 1 },
+            networkStatus: NetworkStatus.ready,
+            loading: false,
+            previousData: { todoCount: 0 },
+            variables: {},
+          });
+
+          expect(mutation).toEqualStrictTyped({
+            data: CREATE_TODO_RESULT,
+            error: undefined,
+            loading: false,
+            called: true,
+          });
+        }
       }
 
       await expect(takeSnapshot).not.toRerender();

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -377,34 +377,6 @@ describe("useMutation Hook", () => {
     expect(consoleSpies.error).not.toHaveBeenCalled();
   });
 
-  it("should resolve mutate function promise with mutation results", async () => {
-    const variables = {
-      description: "Get milk!",
-    };
-
-    const mocks = [
-      {
-        request: {
-          query: CREATE_TODO_MUTATION,
-          variables,
-        },
-        result: { data: CREATE_TODO_RESULT },
-      },
-    ];
-
-    const { result } = renderHook(() => useMutation(CREATE_TODO_MUTATION), {
-      wrapper: ({ children }) => (
-        <MockedProvider mocks={mocks}>{children}</MockedProvider>
-      ),
-    });
-
-    await act(async () => {
-      await expect(result.current[0]({ variables })).resolves.toEqual({
-        data: CREATE_TODO_RESULT,
-      });
-    });
-  });
-
   describe("mutate function upon error", () => {
     it("resolves with the resulting data and errors", async () => {
       const variables = {

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -589,29 +589,62 @@ describe("useMutation Hook", () => {
           },
           result: {
             data: CREATE_TODO_RESULT,
-            errors: [new GraphQLError(CREATE_TODO_ERROR)],
+            errors: [{ message: CREATE_TODO_ERROR }],
           },
+          delay: 20,
         },
       ];
 
-      const { result } = renderHook(
-        () => useMutation(CREATE_TODO_MUTATION, { errorPolicy: "all" }),
-        {
-          wrapper: ({ children }) => (
-            <MockedProvider mocks={mocks}>{children}</MockedProvider>
-          ),
-        }
-      );
+      using _disabledAct = disableActEnvironment();
+      const { takeSnapshot, getCurrentSnapshot } =
+        await renderHookToSnapshotStream(
+          () => useMutation(CREATE_TODO_MUTATION, { errorPolicy: "all" }),
+          {
+            wrapper: ({ children }) => (
+              <MockedProvider mocks={mocks}>{children}</MockedProvider>
+            ),
+          }
+        );
 
-      const createTodo = result.current[0];
+      {
+        const [, result] = await takeSnapshot();
 
-      let fetchResult: any;
-      await act(async () => {
-        fetchResult = await createTodo({ variables });
+        expect(result).toEqualStrictTyped({
+          loading: false,
+          called: false,
+        });
+      }
+
+      const [createTodo] = getCurrentSnapshot();
+
+      await expect(createTodo({ variables })).resolves.toEqualStrictTyped({
+        data: CREATE_TODO_RESULT,
+        errors: [{ message: CREATE_TODO_ERROR }],
       });
 
-      expect(fetchResult.data).toEqual(CREATE_TODO_RESULT);
-      expect(fetchResult.errors[0].message).toEqual(CREATE_TODO_ERROR);
+      {
+        const [, result] = await takeSnapshot();
+
+        expect(result).toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
+          loading: true,
+          called: true,
+        });
+      }
+
+      {
+        const [, result] = await takeSnapshot();
+
+        expect(result).toEqualStrictTyped({
+          data: CREATE_TODO_RESULT,
+          error: new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }]),
+          loading: false,
+          called: true,
+        });
+      }
+
+      await expect(takeSnapshot).not.toRerender();
     });
 
     it(`should call onError when errorPolicy is 'all'`, async () => {

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -744,27 +744,62 @@ describe("useMutation Hook", () => {
             variables,
           },
           result: {
-            errors: [new GraphQLError(CREATE_TODO_ERROR)],
+            errors: [{ message: CREATE_TODO_ERROR }],
           },
+          delay: 20,
         },
       ];
 
-      const { result } = renderHook(
-        () => useMutation(CREATE_TODO_MUTATION, { errorPolicy: "ignore" }),
-        {
-          wrapper: ({ children }) => (
-            <MockedProvider mocks={mocks}>{children}</MockedProvider>
-          ),
-        }
-      );
+      using _disabledAct = disableActEnvironment();
+      const { takeSnapshot, getCurrentSnapshot } =
+        await renderHookToSnapshotStream(
+          () => useMutation(CREATE_TODO_MUTATION, { errorPolicy: "ignore" }),
+          {
+            wrapper: ({ children }) => (
+              <MockedProvider mocks={mocks}>{children}</MockedProvider>
+            ),
+          }
+        );
 
-      const createTodo = result.current[0];
-      let fetchResult: any;
-      await act(async () => {
-        fetchResult = await createTodo({ variables });
+      {
+        const [, result] = await takeSnapshot();
+
+        expect(result).toEqualStrictTyped({
+          loading: false,
+          called: false,
+        });
+      }
+
+      const [createTodo] = getCurrentSnapshot();
+
+      await expect(createTodo({ variables })).resolves.toEqualStrictTyped({
+        data: undefined,
       });
 
-      expect(fetchResult).toEqual({});
+      {
+        const [, result] = await takeSnapshot();
+
+        expect(result).toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
+          loading: true,
+          called: true,
+        });
+      }
+
+      {
+        const [, result] = await takeSnapshot();
+
+        expect(result).toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
+          loading: false,
+          called: true,
+        });
+      }
+
+      await expect(takeSnapshot).not.toRerender();
+
       expect(consoleSpy.error).toHaveBeenCalledTimes(1);
       expect(consoleSpy.error.mock.calls[0][0]).toMatch("Missing field");
     });

--- a/src/testing/matchers/index.d.ts
+++ b/src/testing/matchers/index.d.ts
@@ -95,12 +95,14 @@ interface ApolloCustomMatchers<R = void, T = {}> {
     (value: any, options?: TakeOptions) => Promise<R>
   : { error: "matcher needs to be called on an ObservableStream instance" };
 
+  /** @deprecated Use `toEqualStrictTyped` instead */
   toEqualApolloQueryResult: T extends ApolloQueryResult<infer TData> ?
     (expected: ApolloQueryResult<TData>) => R
   : T extends Promise<ApolloQueryResult<infer TData>> ?
     (expected: ApolloQueryResult<TData>) => R
   : { error: "matchers needs to be called on an ApolloQueryResult" };
 
+  /** @deprecated Use `toEqualStrictTyped` instead */
   toEqualLazyQueryResult: T extends (
     useLazyQuery.Result<infer TData, infer TVariables>
   ) ?
@@ -109,12 +111,14 @@ interface ApolloCustomMatchers<R = void, T = {}> {
     (expected: CheckedLazyQueryResult<TData, TVariables>) => R
   : { error: "matchers needs to be called on a LazyQueryResult" };
 
+  /** @deprecated Use `toEqualStrictTyped` instead */
   toEqualQueryResult: T extends useQuery.Result<infer TData, infer TVariables> ?
     (expected: Pick<useQuery.Result<TData, TVariables>, CheckedKeys>) => R
   : T extends Promise<useQuery.Result<infer TData, infer TVariables>> ?
     (expected: Pick<useQuery.Result<TData, TVariables>, CheckedKeys>) => R
   : { error: "matchers needs to be called on a QueryResult" };
 
+  /** @deprecated Use `toEqualStrictTyped` instead */
   toEqualFetchResult: T extends (
     FetchResult<infer TData, infer TContext, infer TExtensions>
   ) ?

--- a/src/testing/matchers/index.d.ts
+++ b/src/testing/matchers/index.d.ts
@@ -16,7 +16,7 @@ import { CheckedLazyQueryResult } from "./toEqualLazyQueryResult.js";
 // Unfortunately TypeScript does not have a way to determine if a generic
 // argument is a class or not, so we need to manually keep track of known class
 // intances that we filter out.
-type KnownClassInstances = ApolloClient | ObservableQuery;
+type KnownClassInstances = ApolloClient | ObservableQuery<any, any>;
 type FilterUnserializableProperties<T extends Record<string, any>> = {
   [K in keyof T as T[K] extends (...args: any[]) => any ? never
   : T[K] extends KnownClassInstances ? never

--- a/src/testing/matchers/index.ts
+++ b/src/testing/matchers/index.ts
@@ -15,6 +15,7 @@ import { toEqualApolloQueryResult } from "./toEqualApolloQueryResult.js";
 import { toEqualFetchResult } from "./toEqualFetchResult.js";
 import { toEqualLazyQueryResult } from "./toEqualLazyQueryResult.js";
 import { toEqualQueryResult } from "./toEqualQueryResult.js";
+import { toEqualStrictTyped } from "./toEqualStrictTyped.js";
 import { toHaveSuspenseCacheEntryUsing } from "./toHaveSuspenseCacheEntryUsing.js";
 import { toMatchDocument } from "./toMatchDocument.js";
 
@@ -32,6 +33,7 @@ expect.extend({
   toEqualFetchResult,
   toEqualLazyQueryResult,
   toEqualQueryResult,
+  toEqualStrictTyped,
   toBeDisposed,
   toHaveSuspenseCacheEntryUsing,
   toMatchDocument,

--- a/src/testing/matchers/toEqualStrictTyped.ts
+++ b/src/testing/matchers/toEqualStrictTyped.ts
@@ -1,0 +1,61 @@
+import { iterableEquality } from "@jest/expect-utils";
+import type { MatcherFunction } from "expect";
+
+import { ApolloClient, ObservableQuery } from "@apollo/client/core";
+
+function isKnownClassInstance(value: unknown) {
+  return [ApolloClient, ObservableQuery].some((c) => value instanceof c);
+}
+
+export const toEqualStrictTyped: MatcherFunction<[value: any]> = function (
+  actual,
+  expected
+) {
+  const value = actual as Record<string, any>;
+  const hint = this.utils.matcherHint(
+    this.isNot ? ".not.toEqualStrictTyped" : "toEqualStrictTyped",
+    "value",
+    "expected",
+    { isNot: this.isNot, promise: this.promise }
+  );
+
+  const serializableProperties = Object.entries(value).reduce(
+    (memo, [key, value]) => {
+      if (typeof value === "function" || isKnownClassInstance(value)) {
+        return memo;
+      }
+
+      return { ...memo, [key]: value };
+    },
+    {} as Record<string, any>
+  );
+
+  const pass = this.equals(
+    serializableProperties,
+    expected,
+    // https://github.com/jestjs/jest/blob/22029ba06b69716699254bb9397f2b3bc7b3cf3b/packages/expect/src/matchers.ts#L62-L67
+    [...this.customTesters, iterableEquality],
+    true
+  );
+
+  return {
+    pass,
+    message: () => {
+      if (pass) {
+        return hint + `\n\nExpected: not ${this.utils.printExpected(expected)}`;
+      }
+
+      return (
+        hint +
+        "\n\n" +
+        this.utils.printDiffOrStringify(
+          expected,
+          serializableProperties,
+          "Expected",
+          "Received",
+          true
+        )
+      );
+    },
+  };
+};


### PR DESCRIPTION
While in the process of updating the mutation types, I found it difficult to fully ensure `useMutation` worked as expected since it only checked individual properties. This PR refactors all tests to use snapshot streams and full result matchers to ensure the return values match what is expected. As a result, we've discovered some inconsistencies that we will follow up with later.