### PR TITLE
 Unify error behavior of `client.mutate` and update its type

### DIFF
--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -155,7 +155,7 @@ export class ApolloClient implements DataProxy_2 {
     getResolvers(): Resolvers;
     // (undocumented)
     link: ApolloLink_2;
-    mutate<TData = unknown, TVariables extends OperationVariables = OperationVariables, TContext extends Record<string, any> = DefaultContext, TCache extends ApolloCache_2 = ApolloCache_2>(options: MutationOptions<TData, TVariables, TContext>): Promise<FetchResult_2<MaybeMasked_2<TData>>>;
+    mutate<TData = unknown, TVariables extends OperationVariables = OperationVariables, TContext extends Record<string, any> = DefaultContext, TCache extends ApolloCache_2 = ApolloCache_2>(options: MutationOptions<TData, TVariables, TContext>): Promise<MutateResult<MaybeMasked_2<TData>>>;
     onClearStore(cb: () => Promise<any>): () => void;
     onResetStore(cb: () => Promise<any>): () => void;
     set prioritizeCacheValues(value: boolean);
@@ -1377,6 +1377,13 @@ type Modifiers<T extends Record<string, any> = Record<string, unknown>> = Partia
 }>;
 
 // @public (undocumented)
+export interface MutateResult<TData = unknown> {
+    data: TData | undefined;
+    error?: ErrorLike;
+    extensions?: Record<string, unknown>;
+}
+
+// @public (undocumented)
 export type MutationFetchPolicy = Extract<FetchPolicy, "network-only" | "no-cache">;
 
 // @public (undocumented)
@@ -1797,7 +1804,7 @@ class QueryManager {
     // (undocumented)
     maskOperation<TData = unknown>(options: MaskOperationOptions<TData>): MaybeMasked_2<TData>;
     // (undocumented)
-    mutate<TData, TVariables extends OperationVariables, TContext extends Record<string, any>, TCache extends ApolloCache_2>({ mutation, variables, optimisticResponse, updateQueries, refetchQueries, awaitRefetchQueries, update: updateWithProxyFn, onQueryUpdated, fetchPolicy, errorPolicy, keepRootFields, context, }: MutationOptions<TData, TVariables, TContext>): Promise<FetchResult_2<MaybeMasked_2<TData>>>;
+    mutate<TData, TVariables extends OperationVariables, TContext extends Record<string, any>, TCache extends ApolloCache_2>({ mutation, variables, optimisticResponse, updateQueries, refetchQueries, awaitRefetchQueries, update: updateWithProxyFn, onQueryUpdated, fetchPolicy, errorPolicy, keepRootFields, context, }: MutationOptions<TData, TVariables, TContext>): Promise<MutateResult<MaybeMasked_2<TData>>>;
     // (undocumented)
     mutationStore?: {
         [mutationId: string]: MutationStoreValue;
@@ -2321,8 +2328,8 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/cache/inmemory/types.ts:133:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:128:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:129:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:184:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:438:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:185:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:456:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
 // src/link/http/selectHttpOptionsAndBody.ts:128:1 - (ae-forgotten-export) The symbol "HttpQueryOptions" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -37,6 +37,7 @@ import type { IsStrictlyAny } from '@apollo/client/utilities';
 import type { MaybeMasked } from '@apollo/client/masking';
 import type { MaybeMasked as MaybeMasked_2 } from '@apollo/client/core';
 import type { MissingTree } from '@apollo/client/cache';
+import type { MutateResult as MutateResult_2 } from '@apollo/client/core';
 import type { MutationFetchPolicy as MutationFetchPolicy_2 } from '@apollo/client/core';
 import type { MutationQueryReducersMap as MutationQueryReducersMap_2 } from '@apollo/client/core';
 import type { MutationUpdaterFunction as MutationUpdaterFunction_2 } from '@apollo/client/core';
@@ -120,7 +121,8 @@ class ApolloClient_2 implements DataProxy {
     link: ApolloLink;
     // Warning: (ae-forgotten-export) The symbol "DefaultContext_2" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "MutationOptions" needs to be exported by the entry point index.d.ts
-    mutate<TData = unknown, TVariables extends OperationVariables_2 = OperationVariables_2, TContext extends Record<string, any> = DefaultContext_2, TCache extends ApolloCache = ApolloCache>(options: MutationOptions<TData, TVariables, TContext>): Promise<FetchResult<MaybeMasked<TData>>>;
+    // Warning: (ae-forgotten-export) The symbol "MutateResult" needs to be exported by the entry point index.d.ts
+    mutate<TData = unknown, TVariables extends OperationVariables_2 = OperationVariables_2, TContext extends Record<string, any> = DefaultContext_2, TCache extends ApolloCache = ApolloCache>(options: MutationOptions<TData, TVariables, TContext>): Promise<MutateResult<MaybeMasked<TData>>>;
     onClearStore(cb: () => Promise<any>): () => void;
     onResetStore(cb: () => Promise<any>): () => void;
     set prioritizeCacheValues(value: boolean);
@@ -461,6 +463,13 @@ interface MaskOperationOptions<TData> {
     fetchPolicy?: WatchQueryFetchPolicy_2;
     // (undocumented)
     id: string;
+}
+
+// @public (undocumented)
+interface MutateResult<TData = unknown> {
+    data: TData | undefined;
+    error?: ErrorLike;
+    extensions?: Record<string, unknown>;
 }
 
 // Warning: (ae-forgotten-export) The symbol "FetchPolicy" needs to be exported by the entry point index.d.ts
@@ -839,7 +848,7 @@ class QueryManager {
     // (undocumented)
     maskOperation<TData = unknown>(options: MaskOperationOptions<TData>): MaybeMasked<TData>;
     // (undocumented)
-    mutate<TData, TVariables extends OperationVariables_2, TContext extends Record<string, any>, TCache extends ApolloCache>({ mutation, variables, optimisticResponse, updateQueries, refetchQueries, awaitRefetchQueries, update: updateWithProxyFn, onQueryUpdated, fetchPolicy, errorPolicy, keepRootFields, context, }: MutationOptions<TData, TVariables, TContext>): Promise<FetchResult<MaybeMasked<TData>>>;
+    mutate<TData, TVariables extends OperationVariables_2, TContext extends Record<string, any>, TCache extends ApolloCache>({ mutation, variables, optimisticResponse, updateQueries, refetchQueries, awaitRefetchQueries, update: updateWithProxyFn, onQueryUpdated, fetchPolicy, errorPolicy, keepRootFields, context, }: MutationOptions<TData, TVariables, TContext>): Promise<MutateResult<MaybeMasked<TData>>>;
     // (undocumented)
     mutationStore?: {
         [mutationId: string]: MutationStoreValue;
@@ -1353,14 +1362,14 @@ export namespace useMutation {
     export interface Result<TData = unknown> {
         called: boolean;
         client: ApolloClient;
-        data?: MaybeMasked_2<TData> | null;
-        error?: ErrorLike_2;
+        data: MaybeMasked_2<TData> | null | undefined;
+        error: ErrorLike_2 | undefined;
         loading: boolean;
         reset: () => void;
     }
     // (undocumented)
     export type ResultTuple<TData, TVariables, TContext = DefaultContext, TCache extends ApolloCache_2 = ApolloCache_2> = [
-    mutate: (options?: MutationFunctionOptions<TData, TVariables, TContext, TCache>) => Promise<FetchResult_2<MaybeMasked_2<TData>>>,
+    mutate: (options?: MutationFunctionOptions<TData, TVariables, TContext, TCache>) => Promise<MutateResult_2<MaybeMasked_2<TData>>>,
     result: Result<TData>
     ];
 }
@@ -1646,8 +1655,8 @@ interface WatchQueryOptions_2<TVariables extends OperationVariables_2 = Operatio
 // src/core/LocalState.ts:71:3 - (ae-forgotten-export) The symbol "ApolloClient_2" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:128:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:129:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:184:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:438:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:185:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:456:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:204:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:233:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:195:3 - (ae-forgotten-export) The symbol "UpdateQueryOptions" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report-react_hooks.api.md
+++ b/.api-reports/api-report-react_hooks.api.md
@@ -36,6 +36,7 @@ import type { IsStrictlyAny } from '@apollo/client/utilities';
 import type { MaybeMasked } from '@apollo/client/masking';
 import type { MaybeMasked as MaybeMasked_2 } from '@apollo/client/core';
 import type { MissingTree } from '@apollo/client/cache';
+import type { MutateResult as MutateResult_2 } from '@apollo/client/core';
 import type { MutationFetchPolicy as MutationFetchPolicy_2 } from '@apollo/client/core';
 import type { MutationQueryReducersMap as MutationQueryReducersMap_2 } from '@apollo/client/core';
 import type { MutationUpdaterFunction as MutationUpdaterFunction_2 } from '@apollo/client/core';
@@ -104,7 +105,8 @@ class ApolloClient_2 implements DataProxy {
     link: ApolloLink;
     // Warning: (ae-forgotten-export) The symbol "DefaultContext" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "MutationOptions" needs to be exported by the entry point index.d.ts
-    mutate<TData = unknown, TVariables extends OperationVariables_2 = OperationVariables_2, TContext extends Record<string, any> = DefaultContext, TCache extends ApolloCache = ApolloCache>(options: MutationOptions<TData, TVariables, TContext>): Promise<FetchResult<MaybeMasked<TData>>>;
+    // Warning: (ae-forgotten-export) The symbol "MutateResult" needs to be exported by the entry point index.d.ts
+    mutate<TData = unknown, TVariables extends OperationVariables_2 = OperationVariables_2, TContext extends Record<string, any> = DefaultContext, TCache extends ApolloCache = ApolloCache>(options: MutationOptions<TData, TVariables, TContext>): Promise<MutateResult<MaybeMasked<TData>>>;
     onClearStore(cb: () => Promise<any>): () => void;
     onResetStore(cb: () => Promise<any>): () => void;
     set prioritizeCacheValues(value: boolean);
@@ -356,6 +358,13 @@ interface MaskOperationOptions<TData> {
     fetchPolicy?: WatchQueryFetchPolicy_2;
     // (undocumented)
     id: string;
+}
+
+// @public (undocumented)
+interface MutateResult<TData = unknown> {
+    data: TData | undefined;
+    error?: ErrorLike;
+    extensions?: Record<string, unknown>;
 }
 
 // Warning: (ae-forgotten-export) The symbol "FetchPolicy" needs to be exported by the entry point index.d.ts
@@ -655,7 +664,7 @@ class QueryManager {
     // (undocumented)
     maskOperation<TData = unknown>(options: MaskOperationOptions<TData>): MaybeMasked<TData>;
     // (undocumented)
-    mutate<TData, TVariables extends OperationVariables_2, TContext extends Record<string, any>, TCache extends ApolloCache>({ mutation, variables, optimisticResponse, updateQueries, refetchQueries, awaitRefetchQueries, update: updateWithProxyFn, onQueryUpdated, fetchPolicy, errorPolicy, keepRootFields, context, }: MutationOptions<TData, TVariables, TContext>): Promise<FetchResult<MaybeMasked<TData>>>;
+    mutate<TData, TVariables extends OperationVariables_2, TContext extends Record<string, any>, TCache extends ApolloCache>({ mutation, variables, optimisticResponse, updateQueries, refetchQueries, awaitRefetchQueries, update: updateWithProxyFn, onQueryUpdated, fetchPolicy, errorPolicy, keepRootFields, context, }: MutationOptions<TData, TVariables, TContext>): Promise<MutateResult<MaybeMasked<TData>>>;
     // (undocumented)
     mutationStore?: {
         [mutationId: string]: MutationStoreValue;
@@ -1130,14 +1139,14 @@ export namespace useMutation {
     export interface Result<TData = unknown> {
         called: boolean;
         client: ApolloClient;
-        data?: MaybeMasked_2<TData> | null;
-        error?: ErrorLike_2;
+        data: MaybeMasked_2<TData> | null | undefined;
+        error: ErrorLike_2 | undefined;
         loading: boolean;
         reset: () => void;
     }
     // (undocumented)
     export type ResultTuple<TData, TVariables, TContext = DefaultContext_2, TCache extends ApolloCache_2 = ApolloCache_2> = [
-    mutate: (options?: MutationFunctionOptions<TData, TVariables, TContext, TCache>) => Promise<FetchResult_2<MaybeMasked_2<TData>>>,
+    mutate: (options?: MutationFunctionOptions<TData, TVariables, TContext, TCache>) => Promise<MutateResult_2<MaybeMasked_2<TData>>>,
     result: Result<TData>
     ];
 }
@@ -1408,8 +1417,8 @@ interface WatchQueryOptions_2<TVariables extends OperationVariables_2 = Operatio
 // src/core/LocalState.ts:71:3 - (ae-forgotten-export) The symbol "ApolloClient_2" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:128:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:129:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:184:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:438:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:185:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:456:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:204:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:233:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:195:3 - (ae-forgotten-export) The symbol "UpdateQueryOptions" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -119,7 +119,7 @@ export class ApolloClient implements DataProxy {
     getResolvers(): Resolvers;
     // (undocumented)
     link: ApolloLink;
-    mutate<TData = unknown, TVariables extends OperationVariables = OperationVariables, TContext extends Record<string, any> = DefaultContext, TCache extends ApolloCache = ApolloCache>(options: MutationOptions<TData, TVariables, TContext>): Promise<FetchResult<MaybeMasked<TData>>>;
+    mutate<TData = unknown, TVariables extends OperationVariables = OperationVariables, TContext extends Record<string, any> = DefaultContext, TCache extends ApolloCache = ApolloCache>(options: MutationOptions<TData, TVariables, TContext>): Promise<MutateResult<MaybeMasked<TData>>>;
     onClearStore(cb: () => Promise<any>): () => void;
     onResetStore(cb: () => Promise<any>): () => void;
     set prioritizeCacheValues(value: boolean);
@@ -1471,6 +1471,13 @@ type Modifiers<T extends Record<string, any> = Record<string, unknown>> = Partia
 }>;
 
 // @public (undocumented)
+export interface MutateResult<TData = unknown> {
+    data: TData | undefined;
+    error?: ErrorLike;
+    extensions?: Record<string, unknown>;
+}
+
+// @public (undocumented)
 export type MutationFetchPolicy = Extract<FetchPolicy, "network-only" | "no-cache">;
 
 // @public (undocumented)
@@ -1913,7 +1920,7 @@ class QueryManager {
     // (undocumented)
     maskOperation<TData = unknown>(options: MaskOperationOptions<TData>): MaybeMasked<TData>;
     // (undocumented)
-    mutate<TData, TVariables extends OperationVariables, TContext extends Record<string, any>, TCache extends ApolloCache>({ mutation, variables, optimisticResponse, updateQueries, refetchQueries, awaitRefetchQueries, update: updateWithProxyFn, onQueryUpdated, fetchPolicy, errorPolicy, keepRootFields, context, }: MutationOptions<TData, TVariables, TContext>): Promise<FetchResult<MaybeMasked<TData>>>;
+    mutate<TData, TVariables extends OperationVariables, TContext extends Record<string, any>, TCache extends ApolloCache>({ mutation, variables, optimisticResponse, updateQueries, refetchQueries, awaitRefetchQueries, update: updateWithProxyFn, onQueryUpdated, fetchPolicy, errorPolicy, keepRootFields, context, }: MutationOptions<TData, TVariables, TContext>): Promise<MutateResult<MaybeMasked<TData>>>;
     // (undocumented)
     mutationStore?: {
         [mutationId: string]: MutationStoreValue;
@@ -2463,8 +2470,8 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/cache/inmemory/types.ts:133:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:128:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:129:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:184:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:438:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:185:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:456:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
 // src/link/http/selectHttpOptionsAndBody.ts:128:1 - (ae-forgotten-export) The symbol "HttpQueryOptions" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.changeset/grumpy-vans-type.md
+++ b/.changeset/grumpy-vans-type.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": major
+---
+
+Unify error behavior on mutations for GraphQL errors and network errors by ensuring network errors are subject to the `errorPolicy`. Network errors created when using an `errorPolicy` of `all` will now resolve the promise and be returned on the `error` property of the result, or stripped away when the `errorPolicy` is `none`.

--- a/.changeset/little-spoons-kick.md
+++ b/.changeset/little-spoons-kick.md
@@ -1,0 +1,7 @@
+---
+"@apollo/client": major
+---
+
+`client.mutate` now returns a `MutateResult` instead of `FetchResult`. As a result, the `errors` property has been removed in favor of `error` which is set if either a network error occured or GraphQL errors are returned from the server.
+
+`useMutation` now also returns a `MutateResult` instead of a `FetchResult`.

--- a/.changeset/many-buses-allow.md
+++ b/.changeset/many-buses-allow.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix an issue where passing `onError` to `useMutation` would resolve the promise returned by the `mutate` function instead of rejecting when using an `errorPolicy` of `none`.

--- a/.changeset/poor-eels-punch.md
+++ b/.changeset/poor-eels-punch.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": major
+---
+
+Mutations no longer report errors if the GraphQL result from the server contains an empty array of errors.

--- a/.changeset/tough-rockets-allow.md
+++ b/.changeset/tough-rockets-allow.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix an issue where additional response properties were returned on the result returned from `client.mutate`, such as `@defer` payload fields. These properties are now stripped out to correspond to the TypeScript type.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 42208,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 37572,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 32599,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27503
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 42184,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 37665,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 32637,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27537
 }

--- a/src/__tests__/ApolloClient.ts
+++ b/src/__tests__/ApolloClient.ts
@@ -10,11 +10,12 @@ import {
   ApolloQueryResult,
   DefaultOptions,
   makeReference,
+  MutateResult,
   NetworkStatus,
   ObservableQuery,
   QueryOptions,
 } from "@apollo/client/core";
-import { ApolloLink, FetchResult } from "@apollo/client/link/core";
+import { ApolloLink } from "@apollo/client/link/core";
 import { HttpLink } from "@apollo/client/link/http";
 import { Masked } from "@apollo/client/masking";
 import { MockLink } from "@apollo/client/testing";
@@ -3019,7 +3020,7 @@ describe("ApolloClient", () => {
         },
       });
 
-      expectTypeOf(promise).toMatchTypeOf<Promise<FetchResult<any>>>();
+      expectTypeOf(promise).branded.toEqualTypeOf<Promise<MutateResult<any>>>();
     });
 
     test("client.mutate uses TData type when using plain TypedDocumentNode", () => {
@@ -3079,7 +3080,9 @@ describe("ApolloClient", () => {
         },
       });
 
-      expectTypeOf(promise).toMatchTypeOf<Promise<FetchResult<Mutation>>>();
+      expectTypeOf(promise).branded.toEqualTypeOf<
+        Promise<MutateResult<Mutation>>
+      >();
     });
 
     test("client.mutate uses masked/unmasked type when using Masked<TData>", async () => {
@@ -3151,7 +3154,7 @@ describe("ApolloClient", () => {
         },
       });
 
-      expectTypeOf(result.data).toMatchTypeOf<Mutation | null | undefined>();
+      expectTypeOf(result.data).toEqualTypeOf<Masked<Mutation> | undefined>();
     });
 
     test("client.query uses correct masked/unmasked types", async () => {

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -2109,7 +2109,7 @@ describe("client", () => {
         lastName: "Smith",
       },
     };
-    const errors = [new Error("Some kind of GraphQL error.")];
+    const errors = [{ message: "Some kind of GraphQL error." }];
     const client = new ApolloClient({
       link: mockSingleLink({
         request: { query: mutation },
@@ -2123,13 +2123,11 @@ describe("client", () => {
       cache: new InMemoryCache(),
     });
 
-    const result = await client.mutate({ mutation, errorPolicy: "all" });
-
-    expect(result.errors).toBeDefined();
-    expect(result.errors!.length).toBe(1);
-    expect(result.errors![0].message).toBe(errors[0].message);
-    expect(result.data).toEqual({
-      newPerson: data,
+    await expect(
+      client.mutate({ mutation, errorPolicy: "all" })
+    ).resolves.toEqualStrictTyped({
+      data: { newPerson: data },
+      error: new CombinedGraphQLErrors(errors),
     });
   });
 
@@ -2161,10 +2159,9 @@ describe("client", () => {
       cache: new InMemoryCache(),
     });
 
-    const result = await client.mutate({ mutation, errorPolicy: "ignore" });
-
-    expect(result.errors).toBeUndefined();
-    expect(result.data).toEqual(data);
+    await expect(
+      client.mutate({ mutation, errorPolicy: "ignore" })
+    ).resolves.toEqualStrictTyped({ data });
   });
 
   it("should rollback optimistic after mutation got a GraphQL error", async () => {

--- a/src/__tests__/dataMasking.ts
+++ b/src/__tests__/dataMasking.ts
@@ -5529,13 +5529,15 @@ describe("client.mutate", () => {
       link: new MockLink(mocks),
     });
 
-    const { data, errors } = await client.mutate({
-      mutation,
-      errorPolicy: "all",
+    await expect(
+      client.mutate({
+        mutation,
+        errorPolicy: "all",
+      })
+    ).resolves.toEqualStrictTyped({
+      data: { updateUser: null },
+      error: new CombinedGraphQLErrors([{ message: "User not logged in" }]),
     });
-
-    expect(data).toEqual({ updateUser: null });
-    expect(errors).toEqual([{ message: "User not logged in" }]);
   });
 
   test("masks fragment data in fields nulled by errors when using errorPolicy `all`", async () => {
@@ -5590,20 +5592,23 @@ describe("client.mutate", () => {
       link: new MockLink(mocks),
     });
 
-    const { data, errors } = await client.mutate({
-      mutation,
-      errorPolicy: "all",
-    });
-
-    expect(data).toEqual({
-      updateUser: {
-        __typename: "User",
-        id: 1,
-        name: "Test User",
+    await expect(
+      client.mutate({
+        mutation,
+        errorPolicy: "all",
+      })
+    ).resolves.toEqualStrictTyped({
+      data: {
+        updateUser: {
+          __typename: "User",
+          id: 1,
+          name: "Test User",
+        },
       },
+      error: new CombinedGraphQLErrors([
+        { message: "Could not determine age" },
+      ]),
     });
-
-    expect(errors).toEqual([{ message: "Could not determine age" }]);
   });
 
   test("warns and returns masked result when used with no-cache fetch policy", async () => {

--- a/src/__tests__/mutationResults.ts
+++ b/src/__tests__/mutationResults.ts
@@ -358,7 +358,7 @@ describe("mutation results", () => {
       },
     });
 
-    expect(ignoreErrorsResult).toEqual({
+    expect(ignoreErrorsResult).toEqualStrictTyped({
       data: {
         newPerson: {
           __typename: "Person",
@@ -377,14 +377,14 @@ describe("mutation results", () => {
       },
     });
 
-    expect(allErrorsResult).toEqual({
+    expect(allErrorsResult).toEqualStrictTyped({
       data: {
         newPerson: {
           __typename: "Person",
           name: "Ellen Shapiro",
         },
       },
-      errors: [expectedFakeError],
+      error: new CombinedGraphQLErrors([expectedFakeError]),
     });
 
     expect(client.cache.extract()).toMatchSnapshot();

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -31,6 +31,7 @@ import type {
   ApolloQueryResult,
   DefaultContext,
   InternalRefetchQueriesResult,
+  MutateResult,
   OperationVariables,
   RefetchQueriesInclude,
   RefetchQueriesOptions,
@@ -492,7 +493,7 @@ export class ApolloClient implements DataProxy {
     TCache extends ApolloCache = ApolloCache,
   >(
     options: MutationOptions<TData, TVariables, TContext>
-  ): Promise<FetchResult<MaybeMasked<TData>>> {
+  ): Promise<MutateResult<MaybeMasked<TData>>> {
     if (this.defaultOptions.mutate) {
       options = mergeOptions(this.defaultOptions.mutate, options);
     }

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -397,8 +397,10 @@ export class QueryManager {
                 }) as any,
               };
 
-              if (storeResult.errors) {
-                result.error = new CombinedGraphQLErrors(storeResult.errors);
+              if (graphQLResultHasError(storeResult)) {
+                result.error = new CombinedGraphQLErrors(
+                  getGraphQLErrorsFromResult(storeResult)
+                );
               }
 
               resolve(result);

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -390,15 +390,20 @@ export class QueryManager {
             // ExecutionPatchResult has arrived and we have assembled the
             // multipart response into a single result.
             if (!("hasNext" in storeResult) || storeResult.hasNext === false) {
-              resolve({
-                ...storeResult,
+              const result: MutateResult<TData> = {
                 data: this.maskOperation({
                   document: mutation,
                   data: storeResult.data,
                   fetchPolicy,
                   id: mutationId,
                 }) as any,
-              });
+              };
+
+              if (storeResult.errors) {
+                result.error = new CombinedGraphQLErrors(storeResult.errors);
+              }
+
+              resolve(result);
             }
           },
 

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -83,6 +83,7 @@ import type {
   InternalRefetchQueriesMap,
   InternalRefetchQueriesOptions,
   InternalRefetchQueriesResult,
+  MutateResult,
   MutationUpdaterFunction,
   OnQueryUpdated,
   OperationVariables,
@@ -266,7 +267,7 @@ export class QueryManager {
     keepRootFields,
     context,
   }: MutationOptions<TData, TVariables, TContext>): Promise<
-    FetchResult<MaybeMasked<TData>>
+    MutateResult<MaybeMasked<TData>>
   > {
     invariant(
       mutation,

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -403,6 +403,10 @@ export class QueryManager {
                 );
               }
 
+              if (storeResult.extensions) {
+                result.extensions = storeResult.extensions;
+              }
+
               resolve(result);
             }
           },

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -1731,10 +1731,7 @@ describe("ApolloClient", () => {
 
     const result = await client.mutate({ mutation });
 
-    expect(result).toEqualFetchResult({
-      data: { makeListPrivate: true },
-      errors: [],
-    });
+    expect(result).toEqualStrictTyped({ data: { makeListPrivate: true } });
   });
 
   it('runs a mutation with default errorPolicy equal to "none"', async () => {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -233,3 +233,14 @@ export interface Resolvers {
     [field: string]: Resolver;
   };
 }
+
+export interface MutateResult<TData = unknown> {
+  /** {@inheritDoc @apollo/client!MutationResultDocumentation#data:member} */
+  data: TData | undefined;
+
+  /** {@inheritDoc @apollo/client!MutationResultDocumentation#error:member} */
+  error?: ErrorLike;
+
+  /** {@inheritDoc @apollo/client!MutationResultDocumentation#extensions:member} */
+  extensions?: Record<string, unknown>;
+}

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -424,15 +424,9 @@ describe("useMutation Hook", () => {
 
       const [createTodo] = getCurrentSnapshot();
 
-      // TODO: This should either be an `error` property or it should be the
-      // raw error array. This value is a lie against the TypeScript type.
-      // This will be fixed by https://github.com/apollographql/apollo-client/issues/7167
-      // when we address the issue with onError.
-      await expect(createTodo({ variables })).resolves.toEqualStrictTyped({
-        data: undefined,
-        // @ts-expect-error
-        errors: new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }]),
-      });
+      await expect(createTodo({ variables })).rejects.toThrow(
+        new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }])
+      );
 
       expect(onError).toHaveBeenCalledTimes(1);
       expect(onError).toHaveBeenLastCalledWith(
@@ -1442,14 +1436,9 @@ describe("useMutation Hook", () => {
       const onCompleted = jest.fn();
       const onError = jest.fn();
 
-      // TODO: Ensure this rejects when fixing issue with onError
       await expect(
         createTodo({ variables, onCompleted, onError })
-      ).resolves.toEqualStrictTyped({
-        data: undefined,
-        // @ts-expect-error needs to be fixed
-        errors: new CombinedGraphQLErrors(errors),
-      });
+      ).rejects.toThrow(new CombinedGraphQLErrors(errors));
 
       {
         const [, result] = await takeSnapshot();
@@ -1525,14 +1514,9 @@ describe("useMutation Hook", () => {
 
       const [createTodo] = getCurrentSnapshot();
       const onError = jest.fn();
-      // TODO: Fix this when fixing issue with onError
-      await expect(
-        createTodo({ variables, onError })
-      ).resolves.toEqualStrictTyped({
-        data: undefined,
-        // @ts-expect-error
-        errors: new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }]),
-      });
+      await expect(createTodo({ variables, onError })).rejects.toThrow(
+        new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }])
+      );
 
       {
         const [, result] = await takeSnapshot();
@@ -1626,11 +1610,9 @@ describe("useMutation Hook", () => {
         });
       }
 
-      await expect(createTodo({ variables })).resolves.toEqualStrictTyped({
-        data: undefined,
-        // @ts-expect-error
-        errors: new CombinedGraphQLErrors(errors),
-      });
+      await expect(createTodo({ variables })).rejects.toThrow(
+        new CombinedGraphQLErrors(errors)
+      );
 
       {
         const [, result] = await takeSnapshot();
@@ -3947,11 +3929,9 @@ describe("useMutation Hook", () => {
         true
       );
 
-      await expect(promise).resolves.toEqualStrictTyped({
-        data: undefined,
-        // @ts-expect-error
-        errors: new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }]),
-      });
+      await expect(promise).rejects.toThrow(
+        new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }])
+      );
 
       {
         const [, result] = await takeSnapshot();

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -623,7 +623,7 @@ describe("useMutation Hook", () => {
 
       await expect(createTodo({ variables })).resolves.toEqualStrictTyped({
         data: CREATE_TODO_RESULT,
-        errors: [{ message: CREATE_TODO_ERROR }],
+        error: new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }]),
       });
 
       {
@@ -702,7 +702,7 @@ describe("useMutation Hook", () => {
 
       await expect(createTodo({ variables })).resolves.toEqualStrictTyped({
         data: CREATE_TODO_RESULT,
-        errors: [{ message: CREATE_TODO_ERROR }],
+        error: new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }]),
       });
 
       {

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -104,7 +104,8 @@ describe("useMutation Hook", () => {
       const [, result] = await takeSnapshot();
 
       expect(result).toEqualStrictTyped({
-        // TODO: Include data and make it a required property
+        data: undefined,
+        error: undefined,
         loading: false,
         called: false,
       });
@@ -259,6 +260,8 @@ describe("useMutation Hook", () => {
       const [, result] = await takeSnapshot();
 
       expect(result).toEqualStrictTyped({
+        data: undefined,
+        error: undefined,
         loading: false,
         called: false,
       });
@@ -417,6 +420,8 @@ describe("useMutation Hook", () => {
         const [, result] = await takeSnapshot();
 
         expect(result).toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
           loading: false,
           called: false,
         });
@@ -468,6 +473,8 @@ describe("useMutation Hook", () => {
         const [, result] = await takeSnapshot();
 
         expect(result).toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
           loading: false,
           called: false,
         });
@@ -538,6 +545,8 @@ describe("useMutation Hook", () => {
         const [, result] = await takeSnapshot();
 
         expect(result).toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
           loading: false,
           called: false,
         });
@@ -608,6 +617,8 @@ describe("useMutation Hook", () => {
         const [, result] = await takeSnapshot();
 
         expect(result).toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
           loading: false,
           called: false,
         });
@@ -687,6 +698,8 @@ describe("useMutation Hook", () => {
         const [, result] = await takeSnapshot();
 
         expect(result).toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
           loading: false,
           called: false,
         });
@@ -763,6 +776,8 @@ describe("useMutation Hook", () => {
         const [, result] = await takeSnapshot();
 
         expect(result).toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
           loading: false,
           called: false,
         });
@@ -841,6 +856,8 @@ describe("useMutation Hook", () => {
         const [, result] = await takeSnapshot();
 
         expect(result).toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
           loading: false,
           called: false,
         });
@@ -929,6 +946,8 @@ describe("useMutation Hook", () => {
       const [, result] = await takeSnapshot();
 
       expect(result).toEqualStrictTyped({
+        data: undefined,
+        error: undefined,
         loading: false,
         called: false,
       });
@@ -1012,6 +1031,8 @@ describe("useMutation Hook", () => {
       const [, result] = await takeSnapshot();
 
       expect(result).toEqualStrictTyped({
+        data: undefined,
+        error: undefined,
         loading: false,
         called: false,
       });
@@ -1095,6 +1116,8 @@ describe("useMutation Hook", () => {
       const [, result] = await takeSnapshot();
 
       expect(result).toEqualStrictTyped({
+        data: undefined,
+        error: undefined,
         loading: false,
         called: false,
       });
@@ -1136,6 +1159,8 @@ describe("useMutation Hook", () => {
       const [, result] = await takeSnapshot();
 
       expect(result).toEqualStrictTyped({
+        data: undefined,
+        error: undefined,
         loading: false,
         called: false,
       });
@@ -1193,6 +1218,8 @@ describe("useMutation Hook", () => {
       reset = result.reset;
       //initial value
       expect(result).toEqualStrictTyped({
+        data: undefined,
+        error: undefined,
         loading: false,
         called: false,
       });
@@ -1221,6 +1248,8 @@ describe("useMutation Hook", () => {
 
       // reset to initial value
       expect(result).toEqualStrictTyped({
+        data: undefined,
+        error: undefined,
         loading: false,
         called: false,
       });
@@ -1281,6 +1310,8 @@ describe("useMutation Hook", () => {
         const [, result] = await takeSnapshot();
 
         expect(result).toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
           loading: false,
           called: false,
         });
@@ -1372,6 +1403,8 @@ describe("useMutation Hook", () => {
         const [, result] = await takeSnapshot();
 
         expect(result).toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
           loading: false,
           called: false,
         });
@@ -1426,6 +1459,8 @@ describe("useMutation Hook", () => {
         const [, result] = await takeSnapshot();
 
         expect(result).toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
           loading: false,
           called: false,
         });
@@ -1507,6 +1542,8 @@ describe("useMutation Hook", () => {
         const [, result] = await takeSnapshot();
 
         expect(result).toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
           loading: false,
           called: false,
         });
@@ -1591,6 +1628,8 @@ describe("useMutation Hook", () => {
         const [, result] = await takeSnapshot();
 
         expect(result).toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
           loading: false,
           called: false,
         });
@@ -1605,6 +1644,8 @@ describe("useMutation Hook", () => {
         const [, result] = await takeSnapshot();
 
         expect(result).toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
           loading: false,
           called: false,
         });
@@ -1697,6 +1738,8 @@ describe("useMutation Hook", () => {
         const [, result] = await takeSnapshot();
 
         expect(result).toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
           loading: false,
           called: false,
         });
@@ -1709,6 +1752,8 @@ describe("useMutation Hook", () => {
         const [, result] = await takeSnapshot();
 
         expect(result).toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
           loading: false,
           called: false,
         });
@@ -1802,6 +1847,8 @@ describe("useMutation Hook", () => {
         const [, result] = await takeSnapshot();
 
         expect(result).toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
           loading: false,
           called: false,
         });
@@ -1816,6 +1863,8 @@ describe("useMutation Hook", () => {
         const [, result] = await takeSnapshot();
 
         expect(result).toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
           loading: false,
           called: false,
         });
@@ -1979,6 +2028,8 @@ describe("useMutation Hook", () => {
         const [, result] = await takeSnapshot();
 
         expect(result).toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
           loading: false,
           called: false,
         });
@@ -2107,6 +2158,8 @@ describe("useMutation Hook", () => {
         const [, result] = await takeSnapshot();
 
         expect(result).toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
           loading: false,
           called: false,
         });
@@ -2366,6 +2419,8 @@ describe("useMutation Hook", () => {
         const [, result] = await takeSnapshot();
 
         expect(result).toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
           loading: false,
           called: false,
         });
@@ -2632,6 +2687,8 @@ describe("useMutation Hook", () => {
           variables: {},
         });
         expect(mutation).toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
           loading: false,
           called: false,
         });
@@ -2685,6 +2742,8 @@ describe("useMutation Hook", () => {
 
         if (IS_REACT_18) {
           expect(mutation).toEqualStrictTyped({
+            data: undefined,
+            error: undefined,
             loading: false,
             called: false,
           });
@@ -2832,6 +2891,8 @@ describe("useMutation Hook", () => {
         });
 
         expect(mutation).toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
           loading: false,
           called: false,
         });
@@ -2852,6 +2913,8 @@ describe("useMutation Hook", () => {
         });
 
         expect(mutation).toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
           loading: false,
           called: false,
         });
@@ -3005,6 +3068,8 @@ describe("useMutation Hook", () => {
         });
 
         expect(mutation).toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
           loading: false,
           called: false,
         });
@@ -3025,6 +3090,8 @@ describe("useMutation Hook", () => {
         });
 
         expect(mutation).toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
           loading: false,
           called: false,
         });
@@ -3178,6 +3245,8 @@ describe("useMutation Hook", () => {
         });
 
         expect(mutation).toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
           loading: false,
           called: false,
         });
@@ -3198,6 +3267,8 @@ describe("useMutation Hook", () => {
         });
 
         expect(mutation).toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
           loading: false,
           called: false,
         });
@@ -3765,6 +3836,8 @@ describe("useMutation Hook", () => {
         const [, mutation] = await takeSnapshot();
 
         expect(mutation).toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
           loading: false,
           called: false,
         });
@@ -3879,6 +3952,8 @@ describe("useMutation Hook", () => {
         const [, result] = await takeSnapshot();
 
         expect(result).toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
           loading: false,
           called: false,
         });
@@ -3978,6 +4053,8 @@ describe("useMutation Hook", () => {
         const [, result] = await takeSnapshot();
 
         expect(result).toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
           loading: false,
           called: false,
         });
@@ -4147,6 +4224,8 @@ describe("data masking", () => {
       const [, result] = await takeSnapshot();
 
       expect(result).toEqualStrictTyped({
+        data: undefined,
+        error: undefined,
         loading: false,
         called: false,
       });
@@ -4254,6 +4333,8 @@ describe("data masking", () => {
       const [, result] = await takeSnapshot();
 
       expect(result).toEqualStrictTyped({
+        data: undefined,
+        error: undefined,
         loading: false,
         called: false,
       });

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -3858,7 +3858,6 @@ describe("useMutation Hook", () => {
         });
       }
 
-      // @ts-expect-error `incremental` should be stripped out
       await expect(promise).resolves.toEqualStrictTyped({
         data: {
           createTodo: {
@@ -3868,17 +3867,6 @@ describe("useMutation Hook", () => {
             __typename: "Todo",
           },
         },
-        hasNext: false,
-        incremental: [
-          {
-            data: {
-              description: "Get milk!",
-              priority: "High",
-              __typename: "Todo",
-            },
-            path: ["createTodo"],
-          },
-        ],
       });
 
       expect(consoleSpies.error).not.toHaveBeenCalled();

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -6775,7 +6775,7 @@ describe("useQuery Hook", () => {
       }
 
       const mutate = getCurrentSnapshot().mutation[0];
-      void mutate();
+      void mutate().catch(() => {});
 
       {
         // The mutation ran and is loading the result. The query stays at not

--- a/src/react/hooks/useMutation.ts
+++ b/src/react/hooks/useMutation.ts
@@ -21,7 +21,6 @@ import type {
   OperationVariables,
   Unmasked,
 } from "@apollo/client/core";
-import { CombinedGraphQLErrors } from "@apollo/client/errors";
 import { DocumentType, verifyDocumentType } from "@apollo/client/react/parser";
 import type { NoInfer } from "@apollo/client/utilities";
 import { mergeOptions } from "@apollo/client/utilities";

--- a/src/react/hooks/useMutation.ts
+++ b/src/react/hooks/useMutation.ts
@@ -260,11 +260,7 @@ export function useMutation<
         .mutate(clientOptions as MutationOptions<TData, OperationVariables>)
         .then(
           (response) => {
-            const { data, errors } = response;
-            const error =
-              errors && errors.length > 0 ?
-                new CombinedGraphQLErrors(errors)
-              : void 0;
+            const { data, error } = response;
 
             const onError =
               executeOptions.onError || ref.current.options?.onError;

--- a/src/react/hooks/useMutation.ts
+++ b/src/react/hooks/useMutation.ts
@@ -315,9 +315,6 @@ export function useMutation<
 
             if (onError) {
               onError(error, clientOptions);
-
-              // TODO(brian): why are we returning this here???
-              return { data: void 0, errors: error };
             }
 
             throw error;

--- a/src/react/hooks/useMutation.ts
+++ b/src/react/hooks/useMutation.ts
@@ -12,6 +12,7 @@ import type {
   FetchResult,
   InternalRefetchQueriesInclude,
   MaybeMasked,
+  MutateResult,
   MutationFetchPolicy,
   MutationOptions,
   MutationQueryReducersMap,
@@ -126,9 +127,7 @@ export declare namespace useMutation {
   > = [
     mutate: (
       options?: MutationFunctionOptions<TData, TVariables, TContext, TCache>
-      // TODO This FetchResult<TData> seems strange here, as opposed to an
-      // ApolloQueryResult<TData>
-    ) => Promise<FetchResult<MaybeMasked<TData>>>,
+    ) => Promise<MutateResult<MaybeMasked<TData>>>,
     result: Result<TData>,
   ];
 

--- a/src/react/hooks/useMutation.ts
+++ b/src/react/hooks/useMutation.ts
@@ -100,10 +100,10 @@ export declare namespace useMutation {
 
   export interface Result<TData = unknown> {
     /** {@inheritDoc @apollo/client!MutationResultDocumentation#data:member} */
-    data?: MaybeMasked<TData> | null;
+    data: MaybeMasked<TData> | null | undefined;
 
     /** {@inheritDoc @apollo/client!MutationResultDocumentation#error:member} */
-    error?: ErrorLike;
+    error: ErrorLike | undefined;
 
     /** {@inheritDoc @apollo/client!MutationResultDocumentation#loading:member} */
     loading: boolean;
@@ -208,11 +208,7 @@ export function useMutation<
   verifyDocumentType(mutation, DocumentType.Mutation);
   const [result, setResult] = React.useState<
     Omit<useMutation.Result<TData>, "reset">
-  >({
-    called: false,
-    loading: false,
-    client,
-  });
+  >(() => createInitialResult(client));
 
   const ref = React.useRef({
     result,
@@ -244,8 +240,8 @@ export function useMutation<
         setResult(
           (ref.current.result = {
             loading: true,
-            error: void 0,
-            data: void 0,
+            error: undefined,
+            data: undefined,
             called: true,
             client,
           })
@@ -325,11 +321,7 @@ export function useMutation<
 
   const reset = React.useCallback(() => {
     if (ref.current.isMounted) {
-      const result = {
-        called: false,
-        loading: false,
-        client: ref.current.client,
-      };
+      const result = createInitialResult(ref.current.client);
       Object.assign(ref.current, { mutationId: 0, result });
       setResult(result);
     }
@@ -345,4 +337,14 @@ export function useMutation<
   }, []);
 
   return [execute, { reset, ...result }];
+}
+
+function createInitialResult(client: ApolloClient) {
+  return {
+    data: undefined,
+    error: undefined,
+    called: false,
+    loading: false,
+    client,
+  };
 }

--- a/src/react/types/types.documentation.ts
+++ b/src/react/types/types.documentation.ts
@@ -461,6 +461,10 @@ export interface MutationResultDocumentation {
    * A function that you can call to reset the mutation's result to its initial, uncalled state.
    */
   reset: unknown;
+  /**
+   * Custom extensions returned from the GraphQL server
+   */
+  extensions: unknown;
 }
 
 export interface SubscriptionOptionsDocumentation {


### PR DESCRIPTION
Closes #12455
Fixes #9065
Fixes #7167
Partially addresses #12427

Updates `client.mutate` to return a `MutateResult` type instead of a `FetchResult`. `FetchResult` is the raw response type we expect from the link chain. Because of this, we were not able to apply error unification to mutations since there is no `error` property on this type.

This change swaps `errors` for `error` and applies the same error unification behavior to mutations as was done to queries in #12457. Network errors are now subject to the `errorPolicy` and will resolve the mutation promise if the `errorPolicy` is not `none`.

This change also fixes a long-standing bug with `useMutation` where passing an `onError` callback would resolve the promise returned from the mutation when `errorPolicy` was `none`. These errors are now rejected to ensure the mutation behaves the same whether or not `onError` was provided.