### PR TITLE
Unify subscription error behavior and update emitted type

### DIFF
--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -173,7 +173,7 @@ export class ApolloClient implements DataProxy_2 {
     setLocalStateFragmentMatcher(fragmentMatcher: FragmentMatcher): void;
     setResolvers(resolvers: Resolvers | Resolvers[]): void;
     stop(): void;
-    subscribe<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: SubscriptionOptions<TVariables, TData>): Observable<FetchResult_2<MaybeMasked_2<TData>>>;
+    subscribe<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: SubscriptionOptions<TVariables, TData>): Observable<SubscribeResult<MaybeMasked_2<TData>>>;
     // (undocumented)
     readonly typeDefs: ApolloClientOptions["typeDefs"];
     // (undocumented)
@@ -1823,7 +1823,7 @@ class QueryManager {
     // (undocumented)
     readonly ssrMode: boolean;
     // (undocumented)
-    startGraphQLSubscription<TData = unknown>(options: SubscriptionOptions): Observable<FetchResult_2<TData>>;
+    startGraphQLSubscription<TData = unknown>(options: SubscriptionOptions): Observable<SubscribeResult<TData>>;
     stop(): void;
     // (undocumented)
     stopQuery(queryId: string): void;
@@ -2110,6 +2110,13 @@ class Stump extends Layer {
 }
 
 // @public (undocumented)
+export interface SubscribeResult<TData = unknown> {
+    data: TData | undefined;
+    error?: ErrorLike;
+    extensions?: Record<string, unknown>;
+}
+
+// @public (undocumented)
 export interface SubscribeToMoreFunction<TData, TVariables extends OperationVariables = OperationVariables> {
     // (undocumented)
     <TSubscriptionData = TData, TSubscriptionVariables extends OperationVariables = TVariables>(options: SubscribeToMoreOptions<TData, TSubscriptionVariables, TSubscriptionData, TVariables>): () => void;
@@ -2328,8 +2335,8 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/cache/inmemory/types.ts:133:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:128:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:129:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:185:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:456:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:187:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:458:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
 // src/link/http/selectHttpOptionsAndBody.ts:128:1 - (ae-forgotten-export) The symbol "HttpQueryOptions" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -146,7 +146,8 @@ class ApolloClient_2 implements DataProxy {
     setResolvers(resolvers: Resolvers | Resolvers[]): void;
     stop(): void;
     // Warning: (ae-forgotten-export) The symbol "SubscriptionOptions" needs to be exported by the entry point index.d.ts
-    subscribe<TData = unknown, TVariables extends OperationVariables_2 = OperationVariables_2>(options: SubscriptionOptions<TVariables, TData>): Observable<FetchResult<MaybeMasked<TData>>>;
+    // Warning: (ae-forgotten-export) The symbol "SubscribeResult" needs to be exported by the entry point index.d.ts
+    subscribe<TData = unknown, TVariables extends OperationVariables_2 = OperationVariables_2>(options: SubscriptionOptions<TVariables, TData>): Observable<SubscribeResult<MaybeMasked<TData>>>;
     // Warning: (ae-forgotten-export) The symbol "ApolloClientOptions" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
@@ -870,7 +871,7 @@ class QueryManager {
     // (undocumented)
     readonly ssrMode: boolean;
     // (undocumented)
-    startGraphQLSubscription<TData = unknown>(options: SubscriptionOptions): Observable<FetchResult<TData>>;
+    startGraphQLSubscription<TData = unknown>(options: SubscriptionOptions): Observable<SubscribeResult<TData>>;
     stop(): void;
     // (undocumented)
     stopQuery(queryId: string): void;
@@ -994,6 +995,13 @@ export type SkipToken = typeof skipToken;
 
 // @public (undocumented)
 export const skipToken: unique symbol;
+
+// @public (undocumented)
+interface SubscribeResult<TData = unknown> {
+    data: TData | undefined;
+    error?: ErrorLike;
+    extensions?: Record<string, unknown>;
+}
 
 // @public (undocumented)
 interface SubscribeToMoreOptions<TData = unknown, TSubscriptionVariables extends OperationVariables_2 = OperationVariables_2, TSubscriptionData = TData, TVariables extends OperationVariables_2 = TSubscriptionVariables> {
@@ -1655,8 +1663,8 @@ interface WatchQueryOptions_2<TVariables extends OperationVariables_2 = Operatio
 // src/core/LocalState.ts:71:3 - (ae-forgotten-export) The symbol "ApolloClient_2" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:128:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:129:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:185:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:456:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:187:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:458:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:204:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:233:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:195:3 - (ae-forgotten-export) The symbol "UpdateQueryOptions" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -1472,13 +1472,7 @@ export namespace useReadQuery {
 export type UseReadQueryResult<TData = unknown> = useReadQuery_2.Result<TData>;
 
 // @public
-export function useSubscription<TData = unknown, TVariables extends OperationVariables = OperationVariables>(subscription: DocumentNode | TypedDocumentNode_2<TData, TVariables>, options?: useSubscription.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>): {
-    restart: () => void;
-    loading: boolean;
-    data?: TData | undefined;
-    error?: ErrorLike_2;
-    variables?: TVariables | undefined;
-};
+export function useSubscription<TData = unknown, TVariables extends OperationVariables = OperationVariables>(subscription: DocumentNode | TypedDocumentNode_2<TData, TVariables>, options?: useSubscription.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>): useSubscription.Result<TData, TVariables>;
 
 // @public (undocumented)
 export namespace useSubscription {
@@ -1487,14 +1481,16 @@ export namespace useSubscription {
         // (undocumented)
         client: ApolloClient;
         // (undocumented)
-        data: Result<TData>;
+        data: OnDataResult<TData>;
     }
+    // (undocumented)
+    export type OnDataResult<TData = unknown> = Omit<Result<TData>, "restart">;
     // (undocumented)
     export interface OnSubscriptionDataOptions<TData = unknown> {
         // (undocumented)
         client: ApolloClient;
         // (undocumented)
-        subscriptionData: Result<TData>;
+        subscriptionData: OnDataResult<TData>;
     }
     // (undocumented)
     export interface Options<TData = unknown, TVariables extends OperationVariables = OperationVariables> {
@@ -1520,6 +1516,8 @@ export namespace useSubscription {
         data?: MaybeMasked<TData>;
         error?: ErrorLike_2;
         loading: boolean;
+        // (undocumented)
+        restart: () => void;
         // @internal (undocumented)
         variables?: TVariables;
     }

--- a/.api-reports/api-report-react_hooks.api.md
+++ b/.api-reports/api-report-react_hooks.api.md
@@ -130,7 +130,8 @@ class ApolloClient_2 implements DataProxy {
     setResolvers(resolvers: Resolvers | Resolvers[]): void;
     stop(): void;
     // Warning: (ae-forgotten-export) The symbol "SubscriptionOptions" needs to be exported by the entry point index.d.ts
-    subscribe<TData = unknown, TVariables extends OperationVariables_2 = OperationVariables_2>(options: SubscriptionOptions<TVariables, TData>): Observable<FetchResult<MaybeMasked<TData>>>;
+    // Warning: (ae-forgotten-export) The symbol "SubscribeResult" needs to be exported by the entry point index.d.ts
+    subscribe<TData = unknown, TVariables extends OperationVariables_2 = OperationVariables_2>(options: SubscriptionOptions<TVariables, TData>): Observable<SubscribeResult<MaybeMasked<TData>>>;
     // Warning: (ae-forgotten-export) The symbol "ApolloClientOptions" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
@@ -686,7 +687,7 @@ class QueryManager {
     // (undocumented)
     readonly ssrMode: boolean;
     // (undocumented)
-    startGraphQLSubscription<TData = unknown>(options: SubscriptionOptions): Observable<FetchResult<TData>>;
+    startGraphQLSubscription<TData = unknown>(options: SubscriptionOptions): Observable<SubscribeResult<TData>>;
     stop(): void;
     // (undocumented)
     stopQuery(queryId: string): void;
@@ -795,6 +796,13 @@ export type SkipToken = typeof skipToken;
 
 // @public (undocumented)
 export const skipToken: unique symbol;
+
+// @public (undocumented)
+interface SubscribeResult<TData = unknown> {
+    data: TData | undefined;
+    error?: ErrorLike;
+    extensions?: Record<string, unknown>;
+}
 
 // @public (undocumented)
 interface SubscribeToMoreOptions<TData = unknown, TSubscriptionVariables extends OperationVariables_2 = OperationVariables_2, TSubscriptionData = TData, TVariables extends OperationVariables_2 = TSubscriptionVariables> {
@@ -1417,8 +1425,8 @@ interface WatchQueryOptions_2<TVariables extends OperationVariables_2 = Operatio
 // src/core/LocalState.ts:71:3 - (ae-forgotten-export) The symbol "ApolloClient_2" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:128:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:129:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:185:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:456:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:187:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:458:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:204:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:233:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:195:3 - (ae-forgotten-export) The symbol "UpdateQueryOptions" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report-react_hooks.api.md
+++ b/.api-reports/api-report-react_hooks.api.md
@@ -1243,13 +1243,7 @@ export namespace useReadQuery {
 }
 
 // @public
-export function useSubscription<TData = unknown, TVariables extends OperationVariables = OperationVariables>(subscription: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: useSubscription.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>): {
-    restart: () => void;
-    loading: boolean;
-    data?: TData | undefined;
-    error?: ErrorLike_2;
-    variables?: TVariables | undefined;
-};
+export function useSubscription<TData = unknown, TVariables extends OperationVariables = OperationVariables>(subscription: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: useSubscription.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>): useSubscription.Result<TData, TVariables>;
 
 // @public (undocumented)
 export namespace useSubscription {
@@ -1258,14 +1252,16 @@ export namespace useSubscription {
         // (undocumented)
         client: ApolloClient;
         // (undocumented)
-        data: Result<TData>;
+        data: OnDataResult<TData>;
     }
+    // (undocumented)
+    export type OnDataResult<TData = unknown> = Omit<Result<TData>, "restart">;
     // (undocumented)
     export interface OnSubscriptionDataOptions<TData = unknown> {
         // (undocumented)
         client: ApolloClient;
         // (undocumented)
-        subscriptionData: Result<TData>;
+        subscriptionData: OnDataResult<TData>;
     }
     // (undocumented)
     export interface Options<TData = unknown, TVariables extends OperationVariables = OperationVariables> {
@@ -1291,6 +1287,8 @@ export namespace useSubscription {
         data?: MaybeMasked<TData>;
         error?: ErrorLike_2;
         loading: boolean;
+        // (undocumented)
+        restart: () => void;
         // @internal (undocumented)
         variables?: TVariables;
     }

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -137,7 +137,7 @@ export class ApolloClient implements DataProxy {
     setLocalStateFragmentMatcher(fragmentMatcher: FragmentMatcher): void;
     setResolvers(resolvers: Resolvers | Resolvers[]): void;
     stop(): void;
-    subscribe<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: SubscriptionOptions<TVariables, TData>): Observable<FetchResult<MaybeMasked<TData>>>;
+    subscribe<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: SubscriptionOptions<TVariables, TData>): Observable<SubscribeResult<MaybeMasked<TData>>>;
     // (undocumented)
     readonly typeDefs: ApolloClientOptions["typeDefs"];
     // (undocumented)
@@ -1939,7 +1939,7 @@ class QueryManager {
     // (undocumented)
     readonly ssrMode: boolean;
     // (undocumented)
-    startGraphQLSubscription<TData = unknown>(options: SubscriptionOptions): Observable<FetchResult<TData>>;
+    startGraphQLSubscription<TData = unknown>(options: SubscriptionOptions): Observable<SubscribeResult<TData>>;
     stop(): void;
     // (undocumented)
     stopQuery(queryId: string): void;
@@ -2234,6 +2234,13 @@ class Stump extends Layer {
 }
 
 // @public (undocumented)
+export interface SubscribeResult<TData = unknown> {
+    data: TData | undefined;
+    error?: ErrorLike;
+    extensions?: Record<string, unknown>;
+}
+
+// @public (undocumented)
 export interface SubscribeToMoreFunction<TData, TVariables extends OperationVariables = OperationVariables> {
     // (undocumented)
     <TSubscriptionData = TData, TSubscriptionVariables extends OperationVariables = TVariables>(options: SubscribeToMoreOptions<TData, TSubscriptionVariables, TSubscriptionData, TVariables>): () => void;
@@ -2470,8 +2477,8 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/cache/inmemory/types.ts:133:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:128:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:129:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:185:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:456:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:187:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:458:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
 // src/link/http/selectHttpOptionsAndBody.ts:128:1 - (ae-forgotten-export) The symbol "HttpQueryOptions" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.changeset/forty-shrimps-fry.md
+++ b/.changeset/forty-shrimps-fry.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": major
+---
+
+Subscriptions now emit a `SubscribeResult` instead of a `FetchResult`. As a result, the `errors` field has been removed in favor of `error`.

--- a/.changeset/real-teachers-peel.md
+++ b/.changeset/real-teachers-peel.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": major
+---
+
+Unify error behavior on subscriptions for GraphQL errors and network errors by ensuring network errors are subject to the `errorPolicy`. Network errors that terminate the connection will now be emitted on the `error` property passed to the `next` callback followed by a call to the `complete` callback.

--- a/.changeset/tricky-tables-shave.md
+++ b/.changeset/tricky-tables-shave.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": major
+---
+
+GraphQL errors or network errors emitted while using an `errorPolicy` of `ignore` in subscriptions will no longer emit a result if there is no `data` emitted along with the error.

--- a/.changeset/warm-ties-sit.md
+++ b/.changeset/warm-ties-sit.md
@@ -1,0 +1,7 @@
+---
+"@apollo/client": major
+---
+
+Subscriptions no longer emit errors in the `error` callback and instead provide errors on the `error` property on the result passed to the `next` callback. As a result, errors will no longer automatically terminate the connection allowing additional results to be emitted when the connection stays open.
+
+When an error terminates the downstream connection, a `next` event will be emitted with an `error` property followed by a `complete` event instead.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 42184,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 37665,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 32637,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27537
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 42313,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 37697,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 32739,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27589
 }

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -6277,7 +6277,7 @@ describe("unconventional errors", () => {
 
     const stream = new ObservableStream(client.watchQuery({ query }));
 
-    await expect(stream).toEmitApolloQueryResult({
+    await expect(stream).toEmitStrictTyped({
       data: undefined,
       error: expectedError,
       loading: false,
@@ -6332,7 +6332,7 @@ describe("unconventional errors", () => {
 
       const stream = new ObservableStream(client.watchQuery({ query }));
 
-      await expect(stream).toEmitApolloQueryResult({
+      await expect(stream).toEmitStrictTyped({
         data: undefined,
         error: expectedError,
         loading: false,

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -6253,7 +6253,7 @@ describe("custom document transforms", () => {
 });
 
 describe("unconventional errors", () => {
-  test("wraps error mesage in Error type when erroring with a string", async () => {
+  test("wraps error message in Error type when erroring with a string", async () => {
     const query = gql`
       query {
         hello
@@ -6304,7 +6304,10 @@ describe("unconventional errors", () => {
     });
     const subscriptionStream = new ObservableStream(subscription);
 
-    await expect(subscriptionStream).toEmitError(expectedError);
+    await expect(subscriptionStream).toEmitStrictTyped({
+      data: undefined,
+      error: expectedError,
+    });
   });
 
   test("wraps unconventional types in UnconventionalError", async () => {
@@ -6359,7 +6362,10 @@ describe("unconventional errors", () => {
       });
       const subscriptionStream = new ObservableStream(subscription);
 
-      await expect(subscriptionStream).toEmitError(expectedError);
+      await expect(subscriptionStream).toEmitStrictTyped({
+        data: undefined,
+        error: expectedError,
+      });
     }
   });
 });

--- a/src/__tests__/dataMasking.ts
+++ b/src/__tests__/dataMasking.ts
@@ -4388,11 +4388,10 @@ describe("client.subscribe", () => {
       },
     });
 
-    const error = await stream.takeError();
-
-    expect(error).toEqual(
-      new CombinedGraphQLErrors([{ message: "Something went wrong" }])
-    );
+    await expect(stream).toEmitStrictTyped({
+      data: undefined,
+      error: new CombinedGraphQLErrors([{ message: "Something went wrong" }]),
+    });
   });
 
   test("handles errors returned from the subscription when errorPolicy is `all`", async () => {
@@ -4433,10 +4432,10 @@ describe("client.subscribe", () => {
       },
     });
 
-    const { data, errors } = await stream.takeNext();
-
-    expect(data).toEqual({ addedComment: null });
-    expect(errors).toEqual([{ message: "Something went wrong" }]);
+    await expect(stream).toEmitStrictTyped({
+      data: { addedComment: null },
+      error: new CombinedGraphQLErrors([{ message: "Something went wrong" }]),
+    });
   });
 
   test("masks partial data for errors returned from the subscription when errorPolicy is `all`", async () => {
@@ -4482,10 +4481,10 @@ describe("client.subscribe", () => {
       },
     });
 
-    const { data, errors } = await stream.takeNext();
-
-    expect(data).toEqual({ addedComment: { __typename: "Comment", id: 1 } });
-    expect(errors).toEqual([{ message: "Could not get author" }]);
+    await expect(stream).toEmitStrictTyped({
+      data: { addedComment: { __typename: "Comment", id: 1 } },
+      error: new CombinedGraphQLErrors([{ message: "Could not get author" }]),
+    });
   });
 
   test("warns and returns masked result when used with no-cache fetch policy", async () => {

--- a/src/__tests__/graphqlSubscriptions.ts
+++ b/src/__tests__/graphqlSubscriptions.ts
@@ -186,7 +186,7 @@ describe("GraphQL Subscriptions", () => {
     });
   });
 
-  it("emits an error if the result has network errors", async () => {
+  it("emits a result with error if the result has network errors", async () => {
     const link = new MockSubscriptionLink();
     const client = new ApolloClient({
       link,
@@ -198,7 +198,12 @@ describe("GraphQL Subscriptions", () => {
 
     link.simulateResult({ error: new Error("Oops") });
 
-    await expect(stream).toEmitError(new Error("Oops"));
+    await expect(stream).toEmitStrictTyped({
+      data: undefined,
+      error: new Error("Oops"),
+    });
+
+    await expect(stream).toComplete();
   });
 
   it('returns errors in next result when `errorPolicy` is "all"', async () => {

--- a/src/__tests__/graphqlSubscriptions.ts
+++ b/src/__tests__/graphqlSubscriptions.ts
@@ -61,7 +61,7 @@ describe("GraphQL Subscriptions", () => {
     const stream = new ObservableStream(client.subscribe(defaultOptions));
     link.simulateResult(results[0]);
 
-    await expect(stream).toEmitFetchResult(results[0].result);
+    await expect(stream).toEmitStrictTyped(results[0].result);
 
     stream.unsubscribe();
   });
@@ -78,7 +78,7 @@ describe("GraphQL Subscriptions", () => {
 
     link.simulateResult(results[0]);
 
-    await expect(stream).toEmitFetchResult(results[0].result);
+    await expect(stream).toEmitStrictTyped(results[0].result);
 
     stream.unsubscribe();
   });
@@ -96,8 +96,8 @@ describe("GraphQL Subscriptions", () => {
 
     link.simulateResult(results[0]);
 
-    await expect(stream1).toEmitFetchResult(results[0].result);
-    await expect(stream2).toEmitFetchResult(results[0].result);
+    await expect(stream1).toEmitStrictTyped(results[0].result);
+    await expect(stream2).toEmitStrictTyped(results[0].result);
   });
 
   it("should receive multiple results for a subscription", async () => {
@@ -113,10 +113,10 @@ describe("GraphQL Subscriptions", () => {
       link.simulateResult(results[i]);
     }
 
-    await expect(stream).toEmitFetchResult(results[0].result);
-    await expect(stream).toEmitFetchResult(results[1].result);
-    await expect(stream).toEmitFetchResult(results[2].result);
-    await expect(stream).toEmitFetchResult(results[3].result);
+    await expect(stream).toEmitStrictTyped(results[0].result);
+    await expect(stream).toEmitStrictTyped(results[1].result);
+    await expect(stream).toEmitStrictTyped(results[2].result);
+    await expect(stream).toEmitStrictTyped(results[3].result);
     await expect(stream).not.toEmitAnything();
   });
 
@@ -214,7 +214,7 @@ describe("GraphQL Subscriptions", () => {
       true
     );
 
-    await expect(stream).toEmitFetchResult({
+    await expect(stream).toEmitStrictTyped({
       data: null,
       errors: [new GraphQLError("This is an error")],
     });
@@ -308,7 +308,7 @@ describe("GraphQL Subscriptions", () => {
       true
     );
 
-    await expect(stream).toEmitFetchResult({ data: null });
+    await expect(stream).toEmitStrictTyped({ data: null });
     await expect(stream).toComplete();
   });
 
@@ -392,7 +392,7 @@ describe("GraphQL Subscriptions", () => {
 
     link.simulateResult(results[0]);
 
-    await expect(stream).toEmitFetchResult(results[0].result);
+    await expect(stream).toEmitStrictTyped(results[0].result);
 
     expect(link.operation?.getContext().someVar).toEqual(
       options.context.someVar

--- a/src/__tests__/graphqlSubscriptions.ts
+++ b/src/__tests__/graphqlSubscriptions.ts
@@ -8,7 +8,7 @@ import {
   CombinedProtocolErrors,
   PROTOCOL_ERRORS_SYMBOL,
 } from "@apollo/client/errors";
-import { mockObservableLink } from "@apollo/client/testing";
+import { MockSubscriptionLink } from "@apollo/client/testing";
 
 import { ObservableStream, spyOnConsole } from "../testing/internal/index.js";
 
@@ -51,7 +51,7 @@ describe("GraphQL Subscriptions", () => {
   });
 
   it("should start a subscription on network interface and unsubscribe", async () => {
-    const link = mockObservableLink();
+    const link = new MockSubscriptionLink();
     // This test calls directly through Apollo Client
     const client = new ApolloClient({
       link,
@@ -67,7 +67,7 @@ describe("GraphQL Subscriptions", () => {
   });
 
   it("should subscribe with default values", async () => {
-    const link = mockObservableLink();
+    const link = new MockSubscriptionLink();
     // This test calls directly through Apollo Client
     const client = new ApolloClient({
       link,
@@ -84,7 +84,7 @@ describe("GraphQL Subscriptions", () => {
   });
 
   it("should multiplex subscriptions", async () => {
-    const link = mockObservableLink();
+    const link = new MockSubscriptionLink();
     const client = new ApolloClient({
       link,
       cache: new InMemoryCache(),
@@ -101,7 +101,7 @@ describe("GraphQL Subscriptions", () => {
   });
 
   it("should receive multiple results for a subscription", async () => {
-    const link = mockObservableLink();
+    const link = new MockSubscriptionLink();
     const client = new ApolloClient({
       link,
       cache: new InMemoryCache(),
@@ -121,7 +121,7 @@ describe("GraphQL Subscriptions", () => {
   });
 
   it("should not cache subscription data if a `no-cache` fetch policy is used", async () => {
-    const link = mockObservableLink();
+    const link = new MockSubscriptionLink();
     const cache = new InMemoryCache();
     const client = new ApolloClient({
       link,
@@ -140,7 +140,7 @@ describe("GraphQL Subscriptions", () => {
   });
 
   it("should throw an error if the result has errors on it", async () => {
-    const link = mockObservableLink();
+    const link = new MockSubscriptionLink();
     const client = new ApolloClient({
       link,
       cache: new InMemoryCache(),
@@ -191,7 +191,7 @@ describe("GraphQL Subscriptions", () => {
         }
       }
     `;
-    const link = mockObservableLink();
+    const link = new MockSubscriptionLink();
     const client = new ApolloClient({
       link,
       cache: new InMemoryCache(),
@@ -230,7 +230,7 @@ describe("GraphQL Subscriptions", () => {
         }
       }
     `;
-    const link = mockObservableLink();
+    const link = new MockSubscriptionLink();
     const client = new ApolloClient({
       link,
       cache: new InMemoryCache(),
@@ -285,7 +285,7 @@ describe("GraphQL Subscriptions", () => {
         }
       }
     `;
-    const link = mockObservableLink();
+    const link = new MockSubscriptionLink();
     const client = new ApolloClient({
       link,
       cache: new InMemoryCache(),
@@ -320,7 +320,7 @@ describe("GraphQL Subscriptions", () => {
         }
       }
     `;
-    const link = mockObservableLink();
+    const link = new MockSubscriptionLink();
     const client = new ApolloClient({
       link,
       cache: new InMemoryCache(),
@@ -368,7 +368,7 @@ describe("GraphQL Subscriptions", () => {
   });
 
   it("should call complete handler when the subscription completes", async () => {
-    const link = mockObservableLink();
+    const link = new MockSubscriptionLink();
     const client = new ApolloClient({
       link,
       cache: new InMemoryCache(),
@@ -382,7 +382,7 @@ describe("GraphQL Subscriptions", () => {
   });
 
   it("should pass a context object through the link execution chain", async () => {
-    const link = mockObservableLink();
+    const link = new MockSubscriptionLink();
     const client = new ApolloClient({
       cache: new InMemoryCache(),
       link,
@@ -400,7 +400,7 @@ describe("GraphQL Subscriptions", () => {
   });
 
   it("should throw an error if the result has protocolErrors on it", async () => {
-    const link = mockObservableLink();
+    const link = new MockSubscriptionLink();
     const client = new ApolloClient({
       link,
       cache: new InMemoryCache(),

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -37,6 +37,7 @@ import type {
   RefetchQueriesOptions,
   RefetchQueriesResult,
   Resolvers,
+  SubscribeResult,
 } from "./types.js";
 import type {
   MutationOptions,
@@ -511,7 +512,7 @@ export class ApolloClient implements DataProxy {
     TVariables extends OperationVariables = OperationVariables,
   >(
     options: SubscriptionOptions<TVariables, TData>
-  ): Observable<FetchResult<MaybeMasked<TData>>> {
+  ): Observable<SubscribeResult<MaybeMasked<TData>>> {
     const id = this.queryManager.generateQueryId();
 
     return this.queryManager.startGraphQLSubscription<TData>(options).pipe(

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -7,7 +7,7 @@ import type {
   WatchFragmentOptions,
   WatchFragmentResult,
 } from "@apollo/client/cache";
-import type { FetchResult, GraphQLRequest } from "@apollo/client/link/core";
+import type { GraphQLRequest } from "@apollo/client/link/core";
 import { ApolloLink, execute } from "@apollo/client/link/core";
 import type { UriFunction } from "@apollo/client/link/http";
 import { HttpLink } from "@apollo/client/link/http";

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -649,7 +649,19 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
       })
       .subscribe({
         next: (subscriptionData) => {
-          const { updateQuery } = options;
+          const { updateQuery, onError } = options;
+          const { error } = subscriptionData;
+
+          if (error) {
+            if (onError) {
+              onError(error);
+            } else {
+              invariant.error("Unhandled GraphQL subscription error", error);
+            }
+
+            return;
+          }
+
           if (updateQuery) {
             this.updateQuery((previous, updateOptions) =>
               updateQuery(previous, {
@@ -660,13 +672,6 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
               })
             );
           }
-        },
-        error: (err: any) => {
-          if (options.onError) {
-            options.onError(err);
-            return;
-          }
-          invariant.error("Unhandled GraphQL subscription error", err);
         },
       });
 

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1106,10 +1106,10 @@ export class QueryManager {
 
           return result;
         }),
-        filter((result) => !!(result.data || result.error)),
         catchError((error) => {
           throw maybeWrapError(error);
-        })
+        }),
+        filter((result) => !!(result.data || result.error))
       );
 
     if (this.getDocumentInfo(query).hasClientExports) {

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1107,17 +1107,11 @@ export class QueryManager {
           return result;
         }),
         catchError((error) => {
-          error = maybeWrapError(error);
-
-          if (errorPolicy === "none") {
-            throw error;
-          }
-
           if (errorPolicy === "ignore") {
             return of({ data: undefined } as SubscribeResult<TData>);
           }
 
-          return of({ data: undefined, error });
+          return of({ data: undefined, error: maybeWrapError(error) });
         }),
         filter((result) => !!(result.data || result.error))
       );

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1080,14 +1080,19 @@ export class QueryManager {
             data: rawResult.data ?? undefined,
           };
 
-          if (rawResult.extensions) {
-            result.extensions = rawResult.extensions;
-          }
-
           if (graphQLResultHasError(rawResult)) {
             result.error = new CombinedGraphQLErrors(rawResult.errors!);
           } else if (graphQLResultHasProtocolErrors(rawResult)) {
             result.error = rawResult.extensions[PROTOCOL_ERRORS_SYMBOL];
+            // Don't emit protocol errors added by HttpLink
+            delete rawResult.extensions[PROTOCOL_ERRORS_SYMBOL];
+          }
+
+          if (
+            rawResult.extensions &&
+            Object.keys(rawResult.extensions).length
+          ) {
+            result.extensions = rawResult.extensions;
           }
 
           if (result.error && errorPolicy === "none") {

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1107,7 +1107,17 @@ export class QueryManager {
           return result;
         }),
         catchError((error) => {
-          throw maybeWrapError(error);
+          error = maybeWrapError(error);
+
+          if (errorPolicy === "none") {
+            throw error;
+          }
+
+          if (errorPolicy === "ignore") {
+            return of({ data: undefined } as SubscribeResult<TData>);
+          }
+
+          return of({ data: undefined, error });
         }),
         filter((result) => !!(result.data || result.error))
       );

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -5,6 +5,7 @@ import {
   catchError,
   concat,
   EMPTY,
+  filter,
   from,
   lastValueFrom,
   map,
@@ -1105,6 +1106,7 @@ export class QueryManager {
 
           return result;
         }),
+        filter((result) => !!(result.data || result.error)),
         catchError((error) => {
           throw maybeWrapError(error);
         })

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -244,3 +244,14 @@ export interface MutateResult<TData = unknown> {
   /** {@inheritDoc @apollo/client!MutationResultDocumentation#extensions:member} */
   extensions?: Record<string, unknown>;
 }
+
+export interface SubscribeResult<TData = unknown> {
+  /** {@inheritDoc @apollo/client!MutationResultDocumentation#data:member} */
+  data: TData | undefined;
+
+  /** {@inheritDoc @apollo/client!MutationResultDocumentation#error:member} */
+  error?: ErrorLike;
+
+  /** {@inheritDoc @apollo/client!MutationResultDocumentation#extensions:member} */
+  extensions?: Record<string, unknown>;
+}

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -4,7 +4,7 @@ import {
   renderHookToSnapshotStream,
 } from "@testing-library/react-render-stream";
 import { expectTypeOf } from "expect-type";
-import { GraphQLError, GraphQLFormattedError } from "graphql";
+import { GraphQLFormattedError } from "graphql";
 import { gql } from "graphql-tag";
 import React from "react";
 import { ErrorBoundary } from "react-error-boundary";

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -2138,38 +2138,36 @@ describe("ignoreResults", () => {
     });
 
     link.simulateResult(results[0]);
+    await tick();
 
-    await waitFor(() => {
-      expect(onData).toHaveBeenCalledTimes(1);
-      expect(onData).toHaveBeenLastCalledWith({
-        client,
-        data: {
-          data: results[0].result.data,
-          error: undefined,
-          loading: false,
-          variables: undefined,
-        },
-      });
-      expect(onError).toHaveBeenCalledTimes(0);
-      expect(onComplete).toHaveBeenCalledTimes(0);
+    expect(onData).toHaveBeenCalledTimes(1);
+    expect(onData).toHaveBeenLastCalledWith({
+      client,
+      data: {
+        data: results[0].result.data,
+        error: undefined,
+        loading: false,
+        variables: undefined,
+      },
     });
+    expect(onError).toHaveBeenCalledTimes(0);
+    expect(onComplete).toHaveBeenCalledTimes(0);
 
     link.simulateResult(results[1], true);
+    await tick();
 
-    await waitFor(() => {
-      expect(onData).toHaveBeenCalledTimes(2);
-      expect(onData).toHaveBeenLastCalledWith({
-        client,
-        data: {
-          data: results[1].result.data,
-          error: undefined,
-          loading: false,
-          variables: undefined,
-        },
-      });
-      expect(onError).toHaveBeenCalledTimes(0);
-      expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onData).toHaveBeenCalledTimes(2);
+    expect(onData).toHaveBeenLastCalledWith({
+      client,
+      data: {
+        data: results[1].result.data,
+        error: undefined,
+        loading: false,
+        variables: undefined,
+      },
     });
+    expect(onError).toHaveBeenCalledTimes(0);
+    expect(onComplete).toHaveBeenCalledTimes(1);
 
     await expect(takeSnapshot).not.toRerender();
   });
@@ -2211,31 +2209,29 @@ describe("ignoreResults", () => {
     });
 
     link.simulateResult(results[0]);
+    await tick();
 
-    await waitFor(() => {
-      expect(onData).toHaveBeenCalledTimes(1);
-      expect(onData).toHaveBeenLastCalledWith({
-        client,
-        data: {
-          data: results[0].result.data,
-          error: undefined,
-          loading: false,
-          variables: undefined,
-        },
-      });
-      expect(onError).toHaveBeenCalledTimes(0);
-      expect(onComplete).toHaveBeenCalledTimes(0);
+    expect(onData).toHaveBeenCalledTimes(1);
+    expect(onData).toHaveBeenLastCalledWith({
+      client,
+      data: {
+        data: results[0].result.data,
+        error: undefined,
+        loading: false,
+        variables: undefined,
+      },
     });
+    expect(onError).toHaveBeenCalledTimes(0);
+    expect(onComplete).toHaveBeenCalledTimes(0);
 
     const error = new Error("test");
     link.simulateResult({ error });
+    await tick();
 
-    await waitFor(() => {
-      expect(onData).toHaveBeenCalledTimes(1);
-      expect(onError).toHaveBeenCalledTimes(1);
-      expect(onError).toHaveBeenLastCalledWith(error);
-      expect(onComplete).toHaveBeenCalledTimes(0);
-    });
+    expect(onData).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenLastCalledWith(error);
+    expect(onComplete).toHaveBeenCalledTimes(0);
 
     await expect(takeSnapshot).not.toRerender();
   });

--- a/src/react/hooks/useSubscription.ts
+++ b/src/react/hooks/useSubscription.ts
@@ -13,7 +13,6 @@ import type {
   OperationVariables,
   SubscribeResult,
 } from "@apollo/client/core";
-import { CombinedGraphQLErrors } from "@apollo/client/errors";
 import type { MaybeMasked } from "@apollo/client/masking";
 import { DocumentType, verifyDocumentType } from "@apollo/client/react/parser";
 import type { NoInfer } from "@apollo/client/utilities";
@@ -312,22 +311,18 @@ export function useSubscription<
         const variables = observable.__.variables;
         const client = observable.__.client;
         const subscription = observable.subscribe({
-          next(fetchResult) {
+          next(value) {
             if (subscriptionStopped) {
               return;
             }
 
-            const result = {
+            const result: useSubscription.Result<TData, TVariables> = {
               loading: false,
-              // TODO: fetchResult.data can be null but SubscriptionResult.data
-              // expects TData | undefined only
-              data: fetchResult.data!,
-              error:
-                fetchResult.errors ?
-                  new CombinedGraphQLErrors(fetchResult.errors)
-                : undefined,
+              data: value.data,
+              error: value.error,
               variables,
             };
+
             observable.__.setResult(result);
             if (!ignoreResultsRef.current) update();
 

--- a/src/react/hooks/useSubscription.ts
+++ b/src/react/hooks/useSubscription.ts
@@ -10,8 +10,8 @@ import type {
   ErrorLike,
   ErrorPolicy,
   FetchPolicy,
-  FetchResult,
   OperationVariables,
+  SubscribeResult,
 } from "@apollo/client/core";
 import { CombinedGraphQLErrors } from "@apollo/client/errors";
 import type { MaybeMasked } from "@apollo/client/masking";
@@ -432,9 +432,9 @@ function createSubscription<
     },
   };
 
-  let observable: Observable<FetchResult<MaybeMasked<TData>>> | null = null;
+  let observable: Observable<SubscribeResult<MaybeMasked<TData>>> | null = null;
   return Object.assign(
-    new Observable<FetchResult<MaybeMasked<TData>>>((observer) => {
+    new Observable<SubscribeResult<MaybeMasked<TData>>>((observer) => {
       // lazily start the subscription when the first observer subscribes
       // to get around strict mode
       if (!observable) {

--- a/src/react/hooks/useSubscription.ts
+++ b/src/react/hooks/useSubscription.ts
@@ -97,14 +97,16 @@ export declare namespace useSubscription {
     variables?: TVariables;
   }
 
+  export type OnDataResult<TData = unknown> = Omit<Result<TData>, "restart">;
+
   export interface OnDataOptions<TData = unknown> {
     client: ApolloClient;
-    data: Omit<Result<TData>, "restart">;
+    data: OnDataResult<TData>;
   }
 
   export interface OnSubscriptionDataOptions<TData = unknown> {
     client: ApolloClient;
-    subscriptionData: Omit<Result<TData>, "restart">;
+    subscriptionData: OnDataResult<TData>;
   }
 }
 

--- a/src/react/hooks/useSubscription.ts
+++ b/src/react/hooks/useSubscription.ts
@@ -340,18 +340,6 @@ export function useSubscription<
               });
             }
           },
-          error(error) {
-            if (!subscriptionStopped) {
-              observable.__.setResult({
-                loading: false,
-                data: void 0,
-                error,
-                variables,
-              });
-              if (!ignoreResultsRef.current) update();
-              optionsRef.current.onError?.(error);
-            }
-          },
           complete() {
             if (!subscriptionStopped) {
               if (optionsRef.current.onComplete) {

--- a/src/testing/matchers/index.d.ts
+++ b/src/testing/matchers/index.d.ts
@@ -59,6 +59,7 @@ interface ApolloCustomMatchers<R = void, T = {}> {
     (options?: TakeOptions) => Promise<R>
   : { error: "matcher needs to be called on an ObservableStream instance" };
 
+  /** @deprecated Use `toEmitStrictTyped` instead */
   toEmitApolloQueryResult: T extends ObservableStream<infer QueryResult> ?
     QueryResult extends ApolloQueryResult<infer TData> ?
       (value: ApolloQueryResult<TData>, options?: TakeOptions) => Promise<R>
@@ -73,6 +74,7 @@ interface ApolloCustomMatchers<R = void, T = {}> {
     (error?: any, options?: TakeOptions) => Promise<R>
   : { error: "matcher needs to be called on an ObservableStream instance" };
 
+  /** @deprecated Use `toEmitStrictTyped` instead */
   toEmitFetchResult: T extends ObservableStream<FetchResult<infer TData>> ?
     (value: FetchResult<TData>, options?: TakeOptions) => Promise<R>
   : {
@@ -87,14 +89,17 @@ interface ApolloCustomMatchers<R = void, T = {}> {
     (options?: TakeOptions) => Promise<R>
   : { error: "matcher needs to be called on an ObservableStream instance" };
 
+  /** @deprecated Use `toEmitStrictTyped` instead */
   toEmitValue: T extends ObservableStream<any> ?
     (value: any, options?: TakeOptions) => Promise<R>
   : { error: "matcher needs to be called on an ObservableStream instance" };
 
+  /** @deprecated Use `toEmitStrictTyped` instead */
   toEmitValueStrict: T extends ObservableStream<any> ?
     (value: any, options?: TakeOptions) => Promise<R>
   : { error: "matcher needs to be called on an ObservableStream instance" };
 
+  /** @deprecated Use `toEmitStrictTyped` instead */
   toEmitMatchedValue: T extends ObservableStream<any> ?
     (value: any, options?: TakeOptions) => Promise<R>
   : { error: "matcher needs to be called on an ObservableStream instance" };

--- a/src/testing/matchers/index.d.ts
+++ b/src/testing/matchers/index.d.ts
@@ -133,6 +133,13 @@ interface ApolloCustomMatchers<R = void, T = {}> {
     (expected: FetchResult<TData, TContext, TExtensions>) => R
   : { error: "matchers needs to be called on a FetchResult" };
 
+  toEmitStrictTyped: T extends ObservableStream<infer TResult> ?
+    (
+      expected: FilterUnserializableProperties<TResult>,
+      options?: TakeOptions
+    ) => Promise<R>
+  : { error: "toEmitStrictTyped needs to be called on an ObservableStream" };
+
   toEqualStrictTyped: T extends Promise<infer TResult> ?
     (expected: FilterUnserializableProperties<TResult>) => R
   : (expected: FilterUnserializableProperties<T>) => R;

--- a/src/testing/matchers/index.ts
+++ b/src/testing/matchers/index.ts
@@ -9,6 +9,7 @@ import { toEmitError } from "./toEmitError.js";
 import { toEmitFetchResult } from "./toEmitFetchResult.js";
 import { toEmitMatchedValue } from "./toEmitMatchedValue.js";
 import { toEmitNext } from "./toEmitNext.js";
+import { toEmitStrictTyped } from "./toEmitStrictTyped.js";
 import { toEmitValue } from "./toEmitValue.js";
 import { toEmitValueStrict } from "./toEmitValueStrict.js";
 import { toEqualApolloQueryResult } from "./toEqualApolloQueryResult.js";
@@ -27,6 +28,7 @@ expect.extend({
   toEmitFetchResult,
   toEmitMatchedValue,
   toEmitNext,
+  toEmitStrictTyped,
   toEmitValue,
   toEmitValueStrict,
   toEqualApolloQueryResult,

--- a/src/testing/matchers/toEmitStrictTyped.ts
+++ b/src/testing/matchers/toEmitStrictTyped.ts
@@ -1,0 +1,69 @@
+import { iterableEquality } from "@jest/expect-utils";
+import type { MatcherFunction } from "expect";
+
+import type { ObservableStream } from "../internal/index.js";
+import type { TakeOptions } from "../internal/ObservableStream.js";
+
+import { getSerializableProperties } from "./utils/getSerializableProperties.js";
+
+export const toEmitStrictTyped: MatcherFunction<
+  [value: any, options?: TakeOptions]
+> = async function (actual, expected, options) {
+  const stream = actual as ObservableStream<any>;
+  const hint = this.utils.matcherHint(
+    this.isNot ? ".not.toEmitStrictTyped" : "toEmitStrictTyped",
+    "stream",
+    "expected",
+    { isNot: this.isNot }
+  );
+
+  try {
+    const value = await stream.takeNext(options);
+    const serializableProperties = getSerializableProperties(value);
+
+    const pass = this.equals(
+      serializableProperties,
+      expected,
+      // https://github.com/jestjs/jest/blob/22029ba06b69716699254bb9397f2b3bc7b3cf3b/packages/expect/src/matchers.ts#L62-L67
+      [...this.customTesters, iterableEquality],
+      true
+    );
+
+    return {
+      pass,
+      message: () => {
+        if (pass) {
+          return (
+            hint +
+            "\n\nExpected stream not to emit a fetch result equal to expected but it did."
+          );
+        }
+
+        return (
+          hint +
+          "\n\n" +
+          this.utils.printDiffOrStringify(
+            expected,
+            serializableProperties,
+            "Expected",
+            "Received",
+            true
+          )
+        );
+      },
+    };
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message === "Timeout waiting for next event"
+    ) {
+      return {
+        pass: false,
+        message: () =>
+          hint + "\n\nExpected stream to emit a value but it did not.",
+      };
+    } else {
+      throw error;
+    }
+  }
+};

--- a/src/testing/matchers/toEqualStrictTyped.ts
+++ b/src/testing/matchers/toEqualStrictTyped.ts
@@ -1,33 +1,7 @@
 import { iterableEquality } from "@jest/expect-utils";
 import type { MatcherFunction } from "expect";
 
-import { ApolloClient, ObservableQuery } from "@apollo/client/core";
-import { isPlainObject } from "@apollo/client/utilities";
-
-function isKnownClassInstance(value: unknown) {
-  return [ApolloClient, ObservableQuery].some((c) => value instanceof c);
-}
-
-function getSerializableProperties(obj: unknown): any {
-  if (Array.isArray(obj)) {
-    return obj.map((item) => getSerializableProperties(item));
-  }
-
-  if (isPlainObject(obj)) {
-    return Object.entries(obj).reduce(
-      (memo, [key, value]) => {
-        if (typeof value === "function" || isKnownClassInstance(value)) {
-          return memo;
-        }
-
-        return { ...memo, [key]: value };
-      },
-      {} as Record<string, any>
-    );
-  }
-
-  return obj;
-}
+import { getSerializableProperties } from "./utils/getSerializableProperties.js";
 
 export const toEqualStrictTyped: MatcherFunction<[value: any]> = function (
   actual,

--- a/src/testing/matchers/utils/getSerializableProperties.ts
+++ b/src/testing/matchers/utils/getSerializableProperties.ts
@@ -1,0 +1,27 @@
+import { ApolloClient, ObservableQuery } from "@apollo/client/core";
+import { isPlainObject } from "@apollo/client/utilities";
+
+function isKnownClassInstance(value: unknown) {
+  return [ApolloClient, ObservableQuery].some((c) => value instanceof c);
+}
+
+export function getSerializableProperties(obj: unknown): any {
+  if (Array.isArray(obj)) {
+    return obj.map((item) => getSerializableProperties(item));
+  }
+
+  if (isPlainObject(obj)) {
+    return Object.entries(obj).reduce(
+      (memo, [key, value]) => {
+        if (typeof value === "function" || isKnownClassInstance(value)) {
+          return memo;
+        }
+
+        return { ...memo, [key]: value };
+      },
+      {} as Record<string, any>
+    );
+  }
+
+  return obj;
+}


### PR DESCRIPTION
Closes #12456
Closes #12422
Closes #12427

Changes the type emitted from subscriptions to a `SubscribeResult`, which uses `error` instead of `errors`. This change also unifies the error behavior between GraphQL errors and network errors so that network errors adhere to the configured `errorPolicy`. This change means that results are no longer emitted when using `errorPolicy: 'ignore'` if there is no associated `data` as well so that we avoid emitting an empty value.

This change also no longer terminates the downstream connection when encountering an error. If the downstream connection closes as a result of the error, a `next` event will be followed by a `complete` event instead. This change essentially means that using the `error` callback is useless and no longer needed. This change allows for additional results to be emitted from the subscription if the subscription remains open after errors are emitted.