### PR TITLE
Refactor `useSubscription` tests to use render stream and more strict type matcher

### DIFF
--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
 import {
   disableActEnvironment,
   renderHookToSnapshotStream,
@@ -19,7 +19,6 @@ import {
 import {
   CombinedGraphQLErrors,
   CombinedProtocolErrors,
-  PROTOCOL_ERRORS_SYMBOL,
 } from "@apollo/client/errors";
 import { Masked, MaskedDocumentNode } from "@apollo/client/masking";
 import { ApolloProvider } from "@apollo/client/react/context";

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -52,47 +52,60 @@ describe("useSubscription Hook", () => {
       cache: new Cache(),
     });
 
-    const { result } = renderHook(() => useSubscription(subscription), {
-      wrapper: ({ children }) => (
-        <ApolloProvider client={client}>{children}</ApolloProvider>
-      ),
+    using _disabledAct = disableActEnvironment();
+    const { takeSnapshot } = await renderHookToSnapshotStream(
+      () => useSubscription(subscription),
+      {
+        wrapper: ({ children }) => (
+          <ApolloProvider client={client}>{children}</ApolloProvider>
+        ),
+      }
+    );
+
+    await expect(takeSnapshot()).resolves.toEqualStrictTyped({
+      data: undefined,
+      error: undefined,
+      loading: true,
+      variables: undefined,
     });
 
-    expect(result.current.loading).toBe(true);
-    expect(result.current.error).toBe(undefined);
-    expect(result.current.data).toBe(undefined);
-    setTimeout(() => link.simulateResult(results[0]));
-    await waitFor(
-      () => {
-        expect(result.current.data).toEqual(results[0].result.data);
-      },
-      { interval: 1 }
-    );
-    expect(result.current.loading).toBe(false);
-    setTimeout(() => link.simulateResult(results[1]));
-    await waitFor(
-      () => {
-        expect(result.current.data).toEqual(results[1].result.data);
-      },
-      { interval: 1 }
-    );
-    expect(result.current.loading).toBe(false);
-    setTimeout(() => link.simulateResult(results[2]));
-    await waitFor(
-      () => {
-        expect(result.current.data).toEqual(results[2].result.data);
-      },
-      { interval: 1 }
-    );
-    expect(result.current.loading).toBe(false);
-    setTimeout(() => link.simulateResult(results[3]));
-    await waitFor(
-      () => {
-        expect(result.current.data).toEqual(results[3].result.data);
-      },
-      { interval: 1 }
-    );
-    expect(result.current.loading).toBe(false);
+    link.simulateResult(results[0]);
+
+    await expect(takeSnapshot()).resolves.toEqualStrictTyped({
+      data: results[0].result.data,
+      error: undefined,
+      loading: false,
+      variables: undefined,
+    });
+
+    link.simulateResult(results[1]);
+
+    await expect(takeSnapshot()).resolves.toEqualStrictTyped({
+      data: results[1].result.data,
+      error: undefined,
+      loading: false,
+      variables: undefined,
+    });
+
+    link.simulateResult(results[2]);
+
+    await expect(takeSnapshot()).resolves.toEqualStrictTyped({
+      data: results[2].result.data,
+      error: undefined,
+      loading: false,
+      variables: undefined,
+    });
+
+    link.simulateResult(results[3]);
+
+    await expect(takeSnapshot()).resolves.toEqualStrictTyped({
+      data: results[3].result.data,
+      error: undefined,
+      loading: false,
+      variables: undefined,
+    });
+
+    await expect(takeSnapshot).not.toRerender();
   });
 
   it("should call onError after error results", async () => {

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -2203,33 +2203,33 @@ describe("ignoreResults", () => {
     );
 
     const snapshot = await takeSnapshot();
-    expect(snapshot).toStrictEqual({
+    expect(snapshot).toEqualStrictTyped({
       loading: false,
       error: undefined,
       data: undefined,
       variables: undefined,
-      restart: expect.any(Function),
     });
+
     link.simulateResult(results[0]);
 
     await waitFor(() => {
       expect(onData).toHaveBeenCalledTimes(1);
-      expect(onData).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          data: {
-            data: results[0].result.data,
-            error: undefined,
-            loading: false,
-            variables: undefined,
-          },
-        })
-      );
+      expect(onData).toHaveBeenLastCalledWith({
+        client,
+        data: {
+          data: results[0].result.data,
+          error: undefined,
+          loading: false,
+          variables: undefined,
+        },
+      });
       expect(onError).toHaveBeenCalledTimes(0);
       expect(onComplete).toHaveBeenCalledTimes(0);
     });
 
     const error = new Error("test");
     link.simulateResult({ error });
+
     await waitFor(() => {
       expect(onData).toHaveBeenCalledTimes(1);
       expect(onError).toHaveBeenCalledTimes(1);

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -2566,13 +2566,12 @@ describe("data masking", () => {
       }
     );
 
-    {
-      const { data, loading, error } = await takeSnapshot();
-
-      expect(loading).toBe(true);
-      expect(data).toBeUndefined();
-      expect(error).toBeUndefined();
-    }
+    await expect(takeSnapshot()).resolves.toEqualStrictTyped({
+      data: undefined,
+      error: undefined,
+      loading: true,
+      variables: undefined,
+    });
 
     link.simulateResult({
       result: {
@@ -2587,29 +2586,28 @@ describe("data masking", () => {
       },
     });
 
-    {
-      const { data, loading, error } = await takeSnapshot();
-
-      expect(loading).toBe(false);
-      expect(data).toEqual({
+    await expect(takeSnapshot()).resolves.toEqualStrictTyped({
+      data: {
         addedComment: {
           __typename: "Comment",
           id: 1,
         },
-      });
-      expect(error).toBeUndefined();
+      },
+      error: undefined,
+      loading: false,
+      variables: undefined,
+    });
 
-      expect(onData).toHaveBeenCalledTimes(1);
-      expect(onData).toHaveBeenCalledWith({
-        client: expect.anything(),
-        data: {
-          data: { addedComment: { __typename: "Comment", id: 1 } },
-          loading: false,
-          error: undefined,
-          variables: undefined,
-        },
-      });
-    }
+    expect(onData).toHaveBeenCalledTimes(1);
+    expect(onData).toHaveBeenCalledWith({
+      client,
+      data: {
+        data: { addedComment: { __typename: "Comment", id: 1 } },
+        loading: false,
+        error: undefined,
+        variables: undefined,
+      },
+    });
 
     await expect(takeSnapshot).not.toRerender();
   });

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -488,7 +488,8 @@ describe("useSubscription Hook", () => {
       cache: new Cache(),
     });
 
-    const { result } = renderHook(
+    using _disabledAct = disableActEnvironment();
+    const { takeSnapshot } = await renderHookToSnapshotStream(
       () =>
         useSubscription(subscription, {
           context: { make: "Audi" },
@@ -500,34 +501,32 @@ describe("useSubscription Hook", () => {
       }
     );
 
-    expect(result.current.loading).toBe(true);
-    expect(result.current.error).toBe(undefined);
-    expect(result.current.data).toBe(undefined);
-    setTimeout(() => {
-      link.simulateResult(results[0]);
-    }, 100);
-
-    await waitFor(
-      () => {
-        expect(result.current.data).toEqual(results[0].result.data);
-      },
-      { interval: 1 }
-    );
-    expect(result.current.loading).toBe(false);
-    expect(result.current.error).toBe(undefined);
-
-    setTimeout(() => {
-      link.simulateResult(results[1]);
+    await expect(takeSnapshot()).resolves.toEqualStrictTyped({
+      data: undefined,
+      error: undefined,
+      loading: true,
+      variables: undefined,
     });
 
-    await waitFor(
-      () => {
-        expect(result.current.data).toEqual(results[1].result.data);
-      },
-      { interval: 1 }
-    );
-    expect(result.current.loading).toBe(false);
-    expect(result.current.error).toBe(undefined);
+    link.simulateResult(results[0]);
+
+    await expect(takeSnapshot()).resolves.toEqualStrictTyped({
+      data: results[0].result.data,
+      error: undefined,
+      loading: false,
+      variables: undefined,
+    });
+
+    link.simulateResult(results[1]);
+
+    await expect(takeSnapshot()).resolves.toEqualStrictTyped({
+      data: results[1].result.data,
+      error: undefined,
+      loading: false,
+      variables: undefined,
+    });
+
+    await expect(takeSnapshot).not.toRerender();
 
     expect(context!).toBe("Audi");
   });

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -2429,13 +2429,12 @@ describe("data masking", () => {
       }
     );
 
-    {
-      const { data, loading, error } = await takeSnapshot();
-
-      expect(loading).toBe(true);
-      expect(data).toBeUndefined();
-      expect(error).toBeUndefined();
-    }
+    await expect(takeSnapshot()).resolves.toEqualStrictTyped({
+      data: undefined,
+      error: undefined,
+      loading: true,
+      variables: undefined,
+    });
 
     link.simulateResult({
       result: {
@@ -2450,18 +2449,17 @@ describe("data masking", () => {
       },
     });
 
-    {
-      const { data, loading, error } = await takeSnapshot();
-
-      expect(loading).toBe(false);
-      expect(data).toEqual({
+    await expect(takeSnapshot()).resolves.toEqualStrictTyped({
+      data: {
         addedComment: {
           __typename: "Comment",
           id: 1,
         },
-      });
-      expect(error).toBeUndefined();
-    }
+      },
+      error: undefined,
+      loading: false,
+      variables: undefined,
+    });
 
     await expect(takeSnapshot).not.toRerender();
   });

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -2330,11 +2330,8 @@ describe("ignoreResults", () => {
     const onData = jest.fn((() => {}) as useSubscription.Options["onData"]);
     using _disabledAct = disableActEnvironment();
     const { takeSnapshot, rerender } = await renderHookToSnapshotStream(
-      ({ ignoreResults }: { ignoreResults: boolean }) =>
-        useSubscription(subscription, {
-          ignoreResults,
-          onData,
-        }),
+      ({ ignoreResults }) =>
+        useSubscription(subscription, { ignoreResults, onData }),
       {
         initialProps: { ignoreResults: false },
         wrapper: ({ children }) => (
@@ -2342,6 +2339,7 @@ describe("ignoreResults", () => {
         ),
       }
     );
+
     if (!IS_REACT_17) {
       await wait(0);
       expect(subscriptionCreated).toHaveBeenCalledTimes(1);
@@ -2349,45 +2347,47 @@ describe("ignoreResults", () => {
 
     {
       const snapshot = await takeSnapshot();
-      expect(snapshot).toStrictEqual({
+      expect(snapshot).toEqualStrictTyped({
         loading: true,
         error: undefined,
         data: undefined,
         variables: undefined,
-        restart: expect.any(Function),
       });
       expect(onData).toHaveBeenCalledTimes(0);
     }
+
     link.simulateResult(results[0]);
+
     {
       const snapshot = await takeSnapshot();
-      expect(snapshot).toStrictEqual({
+      expect(snapshot).toEqualStrictTyped({
         loading: false,
         error: undefined,
         data: results[0].result.data,
         variables: undefined,
-        restart: expect.any(Function),
       });
       expect(onData).toHaveBeenCalledTimes(1);
     }
+
     await expect(takeSnapshot).not.toRerender({ timeout: 20 });
 
     await rerender({ ignoreResults: true });
+
     {
       const snapshot = await takeSnapshot();
-      expect(snapshot).toStrictEqual({
+      expect(snapshot).toEqualStrictTyped({
         loading: false,
         error: undefined,
         // switching back to the default `ignoreResults: true` return value
         data: undefined,
         variables: undefined,
-        restart: expect.any(Function),
       });
       // `onData` should not be called again
       expect(onData).toHaveBeenCalledTimes(1);
     }
 
     link.simulateResult(results[1]);
+
     await expect(takeSnapshot).not.toRerender({ timeout: 20 });
     expect(onData).toHaveBeenCalledTimes(2);
 

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -2645,13 +2645,12 @@ describe("data masking", () => {
       }
     );
 
-    {
-      const { data, loading, error } = await takeSnapshot();
-
-      expect(loading).toBe(true);
-      expect(data).toBeUndefined();
-      expect(error).toBeUndefined();
-    }
+    await expect(takeSnapshot()).resolves.toEqualStrictTyped({
+      data: undefined,
+      error: undefined,
+      loading: true,
+      variables: undefined,
+    });
 
     link.simulateResult({
       result: {
@@ -2666,38 +2665,37 @@ describe("data masking", () => {
       },
     });
 
-    {
-      const { data, loading, error } = await takeSnapshot();
-
-      expect(loading).toBe(false);
-      expect(data).toEqual({
+    await expect(takeSnapshot()).resolves.toEqualStrictTyped({
+      data: {
         addedComment: {
           __typename: "Comment",
           id: 1,
           comment: "Test comment",
           author: "Test User",
         },
-      });
-      expect(error).toBeUndefined();
+      },
+      error: undefined,
+      loading: false,
+      variables: undefined,
+    });
 
-      expect(onData).toHaveBeenCalledTimes(1);
-      expect(onData).toHaveBeenCalledWith({
-        client: expect.anything(),
+    expect(onData).toHaveBeenCalledTimes(1);
+    expect(onData).toHaveBeenCalledWith({
+      client: expect.anything(),
+      data: {
         data: {
-          data: {
-            addedComment: {
-              __typename: "Comment",
-              id: 1,
-              comment: "Test comment",
-              author: "Test User",
-            },
+          addedComment: {
+            __typename: "Comment",
+            id: 1,
+            comment: "Test comment",
+            author: "Test User",
           },
-          loading: false,
-          error: undefined,
-          variables: undefined,
         },
-      });
-    }
+        loading: false,
+        error: undefined,
+        variables: undefined,
+      },
+    });
 
     await expect(takeSnapshot).not.toRerender();
   });

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -1564,17 +1564,23 @@ followed by new in-flight setup", async () => {
         const { takeSnapshot, link, graphQlErrorResult, errorBoundaryOnError } =
           await setup({ errorPolicy: "all", onError, onData });
 
-        await takeSnapshot();
+        await expect(takeSnapshot()).resolves.toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
+          loading: true,
+          variables: undefined,
+        });
+
         link.simulateResult(graphQlErrorResult);
+
         {
           const snapshot = await takeSnapshot();
-          expect(snapshot).toStrictEqual({
+          expect(snapshot).toEqualStrictTyped({
             loading: false,
             error: new CombinedGraphQLErrors(
               graphQlErrorResult.result!.errors!
             ),
             data: { totalLikes: 42 },
-            restart: expect.any(Function),
             variables: undefined,
           });
         }

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -2264,6 +2264,7 @@ describe("ignoreResults", () => {
         ),
       }
     );
+
     if (!IS_REACT_17) {
       await wait(0);
       expect(subscriptionCreated).toHaveBeenCalledTimes(1);
@@ -2271,49 +2272,52 @@ describe("ignoreResults", () => {
 
     {
       const snapshot = await takeSnapshot();
-      expect(snapshot).toStrictEqual({
+      expect(snapshot).toEqualStrictTyped({
         loading: false,
         error: undefined,
         data: undefined,
         variables: undefined,
-        restart: expect.any(Function),
       });
       expect(onData).toHaveBeenCalledTimes(0);
     }
+
     link.simulateResult(results[0]);
+
     await expect(takeSnapshot).not.toRerender({ timeout: 20 });
     expect(onData).toHaveBeenCalledTimes(1);
 
     await rerender({ ignoreResults: false });
+
     {
       const snapshot = await takeSnapshot();
-      expect(snapshot).toStrictEqual({
+      expect(snapshot).toEqualStrictTyped({
         loading: false,
         error: undefined,
         // `data` appears immediately after changing to `ignoreResults: false`
         data: results[0].result.data,
         variables: undefined,
-        restart: expect.any(Function),
       });
       // `onData` should not be called again for the same result
       expect(onData).toHaveBeenCalledTimes(1);
     }
 
     link.simulateResult(results[1]);
+
     {
       const snapshot = await takeSnapshot();
-      expect(snapshot).toStrictEqual({
+      expect(snapshot).toEqualStrictTyped({
         loading: false,
         error: undefined,
         data: results[1].result.data,
         variables: undefined,
-        restart: expect.any(Function),
       });
       expect(onData).toHaveBeenCalledTimes(2);
     }
+
     // a second subscription should not have been started
     expect(subscriptionCreated).toHaveBeenCalledTimes(1);
   });
+
   it("can switch from `ignoreResults: false` to `ignoreResults: true` and will stop rerendering, without creating a new subscription", async () => {
     const subscriptionCreated = jest.fn();
     const link = new MockSubscriptionLink();

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -2130,44 +2130,43 @@ describe("ignoreResults", () => {
     );
 
     const snapshot = await takeSnapshot();
-    expect(snapshot).toStrictEqual({
+    expect(snapshot).toEqualStrictTyped({
       loading: false,
       error: undefined,
       data: undefined,
       variables: undefined,
-      restart: expect.any(Function),
     });
+
     link.simulateResult(results[0]);
 
     await waitFor(() => {
       expect(onData).toHaveBeenCalledTimes(1);
-      expect(onData).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          data: {
-            data: results[0].result.data,
-            error: undefined,
-            loading: false,
-            variables: undefined,
-          },
-        })
-      );
+      expect(onData).toHaveBeenLastCalledWith({
+        client,
+        data: {
+          data: results[0].result.data,
+          error: undefined,
+          loading: false,
+          variables: undefined,
+        },
+      });
       expect(onError).toHaveBeenCalledTimes(0);
       expect(onComplete).toHaveBeenCalledTimes(0);
     });
 
     link.simulateResult(results[1], true);
+
     await waitFor(() => {
       expect(onData).toHaveBeenCalledTimes(2);
-      expect(onData).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          data: {
-            data: results[1].result.data,
-            error: undefined,
-            loading: false,
-            variables: undefined,
-          },
-        })
-      );
+      expect(onData).toHaveBeenLastCalledWith({
+        client,
+        data: {
+          data: results[1].result.data,
+          error: undefined,
+          loading: false,
+          variables: undefined,
+        },
+      });
       expect(onError).toHaveBeenCalledTimes(0);
       expect(onComplete).toHaveBeenCalledTimes(1);
     });

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -2064,16 +2064,17 @@ describe("`restart` callback", () => {
         variables: { id: "1" },
         skip: true,
       });
+
     {
       const snapshot = await takeSnapshot();
-      expect(snapshot).toStrictEqual({
+      expect(snapshot).toEqualStrictTyped({
         loading: false,
         data: undefined,
         error: undefined,
-        restart: expect.any(Function),
         variables: { id: "1" },
       });
     }
+
     expect(onUnsubscribe).toHaveBeenCalledTimes(0);
     expect(onSubscribe).toHaveBeenCalledTimes(0);
 

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -1999,30 +1999,32 @@ describe("`restart` callback", () => {
     } = await setup({
       variables: { id: "1" },
     });
+
     {
       const snapshot = await takeSnapshot();
-      expect(snapshot).toStrictEqual({
+      expect(snapshot).toEqualStrictTyped({
         loading: true,
         data: undefined,
         error: undefined,
-        restart: expect.any(Function),
         variables: { id: "1" },
       });
     }
+
     const error = new GraphQLError("error");
     link.simulateResult({
       result: { errors: [error] },
     });
+
     {
       const snapshot = await takeSnapshot();
-      expect(snapshot).toStrictEqual({
+      expect(snapshot).toEqualStrictTyped({
         loading: false,
         data: undefined,
         error: new CombinedGraphQLErrors([error]),
-        restart: expect.any(Function),
         variables: { id: "1" },
       });
     }
+
     await expect(takeSnapshot).not.toRerender({ timeout: 20 });
     expect(onUnsubscribe).toHaveBeenCalledTimes(1);
     expect(onSubscribe).toHaveBeenCalledTimes(1);
@@ -2031,29 +2033,30 @@ describe("`restart` callback", () => {
 
     {
       const snapshot = await takeSnapshot();
-      expect(snapshot).toStrictEqual({
+      expect(snapshot).toEqualStrictTyped({
         loading: true,
         data: undefined,
         error: undefined,
-        restart: expect.any(Function),
         variables: { id: "1" },
       });
     }
+
     await waitFor(() => expect(onSubscribe).toHaveBeenCalledTimes(2));
     expect(onUnsubscribe).toHaveBeenCalledTimes(1);
 
     link.simulateResult({ result: { data: { totalLikes: 2 } } });
+
     {
       const snapshot = await takeSnapshot();
-      expect(snapshot).toStrictEqual({
+      expect(snapshot).toEqualStrictTyped({
         loading: false,
         data: { totalLikes: 2 },
         error: undefined,
-        restart: expect.any(Function),
         variables: { id: "1" },
       });
     }
   });
+
   it("will not restart a subscription that has been `skip`ped", async () => {
     using _disabledAct = disableActEnvironment();
     const { takeSnapshot, getCurrentSnapshot, onSubscribe, onUnsubscribe } =

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -1592,6 +1592,7 @@ followed by new in-flight setup", async () => {
         expect(onData).toHaveBeenCalledTimes(0);
         expect(errorBoundaryOnError).toHaveBeenCalledTimes(0);
       });
+
       it("`errorPolicy: 'ignore'`: returns `{ data }`, calls `onData`", async () => {
         const onData = jest.fn();
         const onError = jest.fn();
@@ -1603,15 +1604,21 @@ followed by new in-flight setup", async () => {
             onData,
           });
 
-        await takeSnapshot();
+        await expect(takeSnapshot()).resolves.toEqualStrictTyped({
+          data: undefined,
+          error: undefined,
+          loading: true,
+          variables: undefined,
+        });
+
         link.simulateResult(graphQlErrorResult);
+
         {
           const snapshot = await takeSnapshot();
-          expect(snapshot).toStrictEqual({
+          expect(snapshot).toEqualStrictTyped({
             loading: false,
             error: undefined,
             data: { totalLikes: 42 },
-            restart: expect.any(Function),
             variables: undefined,
           });
         }

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -2496,13 +2496,12 @@ describe("data masking", () => {
       }
     );
 
-    {
-      const { data, loading, error } = await takeSnapshot();
-
-      expect(loading).toBe(true);
-      expect(data).toBeUndefined();
-      expect(error).toBeUndefined();
-    }
+    await expect(takeSnapshot()).resolves.toEqualStrictTyped({
+      data: undefined,
+      error: undefined,
+      loading: true,
+      variables: undefined,
+    });
 
     link.simulateResult({
       result: {
@@ -2517,20 +2516,19 @@ describe("data masking", () => {
       },
     });
 
-    {
-      const { data, loading, error } = await takeSnapshot();
-
-      expect(loading).toBe(false);
-      expect(data).toEqual({
+    await expect(takeSnapshot()).resolves.toEqualStrictTyped({
+      data: {
         addedComment: {
           __typename: "Comment",
           id: 1,
           comment: "Test comment",
           author: "Test User",
         },
-      });
-      expect(error).toBeUndefined();
-    }
+      },
+      error: undefined,
+      loading: false,
+      variables: undefined,
+    });
 
     await expect(takeSnapshot).not.toRerender();
   });

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -1765,25 +1765,26 @@ describe("`restart` callback", () => {
 
     {
       const snapshot = await takeSnapshot();
-      expect(snapshot).toStrictEqual({
+      expect(snapshot).toEqualStrictTyped({
         loading: true,
         data: undefined,
         error: undefined,
-        restart: expect.any(Function),
         variables: { id: "1" },
       });
     }
+
     link.simulateResult({ result: { data: { totalLikes: 1 } } });
+
     {
       const snapshot = await takeSnapshot();
-      expect(snapshot).toStrictEqual({
+      expect(snapshot).toEqualStrictTyped({
         loading: false,
         data: { totalLikes: 1 },
         error: undefined,
-        restart: expect.any(Function),
         variables: { id: "1" },
       });
     }
+
     await expect(takeSnapshot).not.toRerender({ timeout: 20 });
     expect(onUnsubscribe).toHaveBeenCalledTimes(0);
     expect(onSubscribe).toHaveBeenCalledTimes(1);
@@ -1792,29 +1793,30 @@ describe("`restart` callback", () => {
 
     {
       const snapshot = await takeSnapshot();
-      expect(snapshot).toStrictEqual({
+      expect(snapshot).toEqualStrictTyped({
         loading: true,
         data: undefined,
         error: undefined,
-        restart: expect.any(Function),
         variables: { id: "1" },
       });
     }
+
     await waitFor(() => expect(onUnsubscribe).toHaveBeenCalledTimes(1));
     expect(onSubscribe).toHaveBeenCalledTimes(2);
 
     link.simulateResult({ result: { data: { totalLikes: 2 } } });
+
     {
       const snapshot = await takeSnapshot();
-      expect(snapshot).toStrictEqual({
+      expect(snapshot).toEqualStrictTyped({
         loading: false,
         data: { totalLikes: 2 },
         error: undefined,
-        restart: expect.any(Function),
         variables: { id: "1" },
       });
     }
   });
+
   it("will use the most recently passed in options", async () => {
     using _disabledAct = disableActEnvironment();
     const {

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -1829,20 +1829,22 @@ describe("`restart` callback", () => {
     } = await setup({
       variables: { id: "1" },
     });
+
     {
       const snapshot = await takeSnapshot();
-      expect(snapshot).toStrictEqual({
+      expect(snapshot).toEqualStrictTyped({
         loading: true,
         data: undefined,
         error: undefined,
-        restart: expect.any(Function),
         variables: { id: "1" },
       });
     }
+
     // deliberately keeping a reference to a very old `restart` function
     // to show that the most recent options are used even with that
     const restart = getCurrentSnapshot().restart;
     link.simulateResult({ result: { data: { totalLikes: 1 } } });
+
     {
       const snapshot = await takeSnapshot();
       expect(snapshot).toStrictEqual({
@@ -1853,33 +1855,35 @@ describe("`restart` callback", () => {
         variables: { id: "1" },
       });
     }
+
     await expect(takeSnapshot).not.toRerender({ timeout: 20 });
     expect(onUnsubscribe).toHaveBeenCalledTimes(0);
     expect(onSubscribe).toHaveBeenCalledTimes(1);
 
     void rerender({ variables: { id: "2" } });
+
     await waitFor(() => expect(onUnsubscribe).toHaveBeenCalledTimes(1));
     expect(onSubscribe).toHaveBeenCalledTimes(2);
     expect(link.operation?.variables).toStrictEqual({ id: "2" });
 
     {
       const snapshot = await takeSnapshot();
-      expect(snapshot).toStrictEqual({
+      expect(snapshot).toEqualStrictTyped({
         loading: true,
         data: undefined,
         error: undefined,
-        restart: expect.any(Function),
         variables: { id: "2" },
       });
     }
+
     link.simulateResult({ result: { data: { totalLikes: 1000 } } });
+
     {
       const snapshot = await takeSnapshot();
-      expect(snapshot).toStrictEqual({
+      expect(snapshot).toEqualStrictTyped({
         loading: false,
         data: { totalLikes: 1000 },
         error: undefined,
-        restart: expect.any(Function),
         variables: { id: "2" },
       });
     }
@@ -1896,26 +1900,27 @@ describe("`restart` callback", () => {
 
     {
       const snapshot = await takeSnapshot();
-      expect(snapshot).toStrictEqual({
+      expect(snapshot).toEqualStrictTyped({
         loading: true,
         data: undefined,
         error: undefined,
-        restart: expect.any(Function),
         variables: { id: "2" },
       });
     }
+
     link.simulateResult({ result: { data: { totalLikes: 1005 } } });
+
     {
       const snapshot = await takeSnapshot();
-      expect(snapshot).toStrictEqual({
+      expect(snapshot).toEqualStrictTyped({
         loading: false,
         data: { totalLikes: 1005 },
         error: undefined,
-        restart: expect.any(Function),
         variables: { id: "2" },
       });
     }
   });
+
   it("can restart a subscription that has completed", async () => {
     using _disabledAct = disableActEnvironment();
     const {

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -23,7 +23,7 @@ import {
 } from "@apollo/client/errors";
 import { Masked, MaskedDocumentNode } from "@apollo/client/masking";
 import { ApolloProvider } from "@apollo/client/react/context";
-import { MockSubscriptionLink, wait } from "@apollo/client/testing";
+import { MockSubscriptionLink, tick, wait } from "@apollo/client/testing";
 import { InvariantError } from "@apollo/client/utilities/invariant";
 
 import { MockedSubscriptionResult } from "../../../testing/core/mocking/mockSubscriptionLink.js";
@@ -1011,13 +1011,10 @@ describe("useSubscription Hook", () => {
       }
     );
 
-    setTimeout(() => link.simulateResult(results[0]));
-    await waitFor(
-      () => {
-        expect(onData).toHaveBeenCalledTimes(1);
-      },
-      { interval: 1 }
-    );
+    link.simulateResult(results[0]);
+    await tick();
+
+    expect(onData).toHaveBeenCalledTimes(1);
     expect(onSubscriptionData).toHaveBeenCalledTimes(0);
   });
 
@@ -1057,13 +1054,10 @@ describe("useSubscription Hook", () => {
       }
     );
 
-    setTimeout(() => link.simulateResult(results[0]));
-    await waitFor(
-      () => {
-        expect(onSubscriptionData).toHaveBeenCalledTimes(1);
-      },
-      { interval: 1 }
-    );
+    link.simulateResult(results[0]);
+    await tick();
+
+    expect(onSubscriptionData).toHaveBeenCalledTimes(1);
   });
 
   test("only warns once using `onSubscriptionData`", () => {
@@ -1174,15 +1168,10 @@ describe("useSubscription Hook", () => {
       }
     );
 
-    link.simulateResult(results[0]);
+    link.simulateResult(results[0], true);
+    await tick();
 
-    setTimeout(() => link.simulateComplete());
-    await waitFor(
-      () => {
-        expect(onComplete).toHaveBeenCalledTimes(1);
-      },
-      { interval: 1 }
-    );
+    expect(onComplete).toHaveBeenCalledTimes(1);
     expect(onSubscriptionComplete).toHaveBeenCalledTimes(0);
   });
 
@@ -1222,15 +1211,10 @@ describe("useSubscription Hook", () => {
       }
     );
 
-    link.simulateResult(results[0]);
+    link.simulateResult(results[0], true);
+    await tick();
 
-    setTimeout(() => link.simulateComplete());
-    await waitFor(
-      () => {
-        expect(onSubscriptionComplete).toHaveBeenCalledTimes(1);
-      },
-      { interval: 1 }
-    );
+    expect(onSubscriptionComplete).toHaveBeenCalledTimes(1);
   });
 
   test("only warns once using `onSubscriptionComplete`", () => {

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -1528,23 +1528,30 @@ followed by new in-flight setup", async () => {
             errorBoundaryOnError,
           } = await setup({ errorPolicy, onError, onData });
 
-          await takeSnapshot();
+          await expect(takeSnapshot()).resolves.toEqualStrictTyped({
+            data: undefined,
+            error: undefined,
+            loading: true,
+            variables: undefined,
+          });
+
           link.simulateResult(graphQlErrorResult);
+
           {
             const snapshot = await takeSnapshot();
-            expect(snapshot).toStrictEqual({
+            expect(snapshot).toEqualStrictTyped({
               loading: false,
               error: new CombinedGraphQLErrors(
                 graphQlErrorResult.result!.errors as any
               ),
               data: undefined,
-              restart: expect.any(Function),
               variables: undefined,
             });
           }
+
           expect(onError).toHaveBeenCalledTimes(1);
           expect(onError).toHaveBeenCalledWith(
-            new CombinedGraphQLErrors(graphQlErrorResult.result!.errors as any)
+            new CombinedGraphQLErrors(graphQlErrorResult.result!.errors!)
           );
           expect(onData).toHaveBeenCalledTimes(0);
           expect(errorBoundaryOnError).toHaveBeenCalledTimes(0);

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -1932,27 +1932,29 @@ describe("`restart` callback", () => {
     } = await setup({
       variables: { id: "1" },
     });
+
     {
       const snapshot = await takeSnapshot();
-      expect(snapshot).toStrictEqual({
+      expect(snapshot).toEqualStrictTyped({
         loading: true,
         data: undefined,
         error: undefined,
-        restart: expect.any(Function),
         variables: { id: "1" },
       });
     }
+
     link.simulateResult({ result: { data: { totalLikes: 1 } } }, true);
+
     {
       const snapshot = await takeSnapshot();
-      expect(snapshot).toStrictEqual({
+      expect(snapshot).toEqualStrictTyped({
         loading: false,
         data: { totalLikes: 1 },
         error: undefined,
-        restart: expect.any(Function),
         variables: { id: "1" },
       });
     }
+
     await expect(takeSnapshot).not.toRerender({ timeout: 20 });
     expect(onUnsubscribe).toHaveBeenCalledTimes(1);
     expect(onSubscribe).toHaveBeenCalledTimes(1);
@@ -1969,21 +1971,23 @@ describe("`restart` callback", () => {
         variables: { id: "1" },
       });
     }
+
     await waitFor(() => expect(onSubscribe).toHaveBeenCalledTimes(2));
     expect(onUnsubscribe).toHaveBeenCalledTimes(1);
 
     link.simulateResult({ result: { data: { totalLikes: 2 } } });
+
     {
       const snapshot = await takeSnapshot();
-      expect(snapshot).toStrictEqual({
+      expect(snapshot).toEqualStrictTyped({
         loading: false,
         data: { totalLikes: 2 },
         error: undefined,
-        restart: expect.any(Function),
         variables: { id: "1" },
       });
     }
   });
+
   it("can restart a subscription that has errored", async () => {
     using _disabledAct = disableActEnvironment();
     const {


### PR DESCRIPTION
These changes will be used as the base to test changes for the subscription type in #12456