### PR TITLE
Remove deprecated `onSubscriptionData`, `onSubscriptionComplete` callbacks and returned `variables` from `useSubscripton`

### DIFF
--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -1043,7 +1043,7 @@ interface SubscriptionOptions<TVariables = OperationVariables_2, TData = unknown
 }
 
 // @public @deprecated (undocumented)
-export type SubscriptionResult<TData = unknown, TVariables extends OperationVariables = OperationVariables> = useSubscription_2.Result<TData, TVariables>;
+export type SubscriptionResult<TData = unknown, TVariables extends OperationVariables = OperationVariables> = useSubscription_2.Result<TData>;
 
 // @public @deprecated (undocumented)
 export type SuspenseQueryHookFetchPolicy = useSuspenseQuery_2.FetchPolicy;
@@ -1472,7 +1472,7 @@ export namespace useReadQuery {
 export type UseReadQueryResult<TData = unknown> = useReadQuery_2.Result<TData>;
 
 // @public
-export function useSubscription<TData = unknown, TVariables extends OperationVariables = OperationVariables>(subscription: DocumentNode | TypedDocumentNode_2<TData, TVariables>, options?: useSubscription.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>): useSubscription.Result<TData, TVariables>;
+export function useSubscription<TData = unknown, TVariables extends OperationVariables = OperationVariables>(subscription: DocumentNode | TypedDocumentNode_2<TData, TVariables>, options?: useSubscription.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>): useSubscription.Result<TData>;
 
 // @public (undocumented)
 export namespace useSubscription {
@@ -1503,23 +1503,17 @@ export namespace useSubscription {
         onComplete?: () => void;
         onData?: (options: OnDataOptions<TData>) => any;
         onError?: (error: ErrorLike_2) => void;
-        // @deprecated
-        onSubscriptionComplete?: () => void;
-        // @deprecated
-        onSubscriptionData?: (options: OnSubscriptionDataOptions<TData>) => any;
         shouldResubscribe?: boolean | ((options: Options<TData, TVariables>) => boolean);
         skip?: boolean;
         variables?: TVariables;
     }
     // (undocumented)
-    export interface Result<TData = unknown, TVariables = OperationVariables> {
+    export interface Result<TData = unknown> {
         data?: MaybeMasked<TData>;
         error?: ErrorLike_2;
         loading: boolean;
         // (undocumented)
         restart: () => void;
-        // @internal (undocumented)
-        variables?: TVariables;
     }
 }
 

--- a/.api-reports/api-report-react_hooks.api.md
+++ b/.api-reports/api-report-react_hooks.api.md
@@ -1243,7 +1243,7 @@ export namespace useReadQuery {
 }
 
 // @public
-export function useSubscription<TData = unknown, TVariables extends OperationVariables = OperationVariables>(subscription: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: useSubscription.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>): useSubscription.Result<TData, TVariables>;
+export function useSubscription<TData = unknown, TVariables extends OperationVariables = OperationVariables>(subscription: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: useSubscription.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>): useSubscription.Result<TData>;
 
 // @public (undocumented)
 export namespace useSubscription {
@@ -1274,23 +1274,17 @@ export namespace useSubscription {
         onComplete?: () => void;
         onData?: (options: OnDataOptions<TData>) => any;
         onError?: (error: ErrorLike_2) => void;
-        // @deprecated
-        onSubscriptionComplete?: () => void;
-        // @deprecated
-        onSubscriptionData?: (options: OnSubscriptionDataOptions<TData>) => any;
         shouldResubscribe?: boolean | ((options: Options<TData, TVariables>) => boolean);
         skip?: boolean;
         variables?: TVariables;
     }
     // (undocumented)
-    export interface Result<TData = unknown, TVariables = OperationVariables> {
+    export interface Result<TData = unknown> {
         data?: MaybeMasked<TData>;
         error?: ErrorLike_2;
         loading: boolean;
         // (undocumented)
         restart: () => void;
-        // @internal (undocumented)
-        variables?: TVariables;
     }
 }
 

--- a/.changeset/eleven-kangaroos-jump.md
+++ b/.changeset/eleven-kangaroos-jump.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": major
+---
+
+Remove `variables` from the result returned from `useSubscription`.

--- a/.changeset/slimy-chicken-melt.md
+++ b/.changeset/slimy-chicken-melt.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": major
+---
+
+Remove deprecated `onSubscriptionData` and `onSubscriptionComplete` callbacks from `useSubscription`. Use `onData` and `onComplete` instead.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 42313,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 37697,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 32739,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27589
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 42188,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 37688,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 32591,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27597
 }

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -68,7 +68,6 @@ describe("useSubscription Hook", () => {
       data: undefined,
       error: undefined,
       loading: true,
-      variables: undefined,
     });
 
     link.simulateResult(results[0]);
@@ -77,7 +76,6 @@ describe("useSubscription Hook", () => {
       data: results[0].result.data,
       error: undefined,
       loading: false,
-      variables: undefined,
     });
 
     link.simulateResult(results[1]);
@@ -86,7 +84,6 @@ describe("useSubscription Hook", () => {
       data: results[1].result.data,
       error: undefined,
       loading: false,
-      variables: undefined,
     });
 
     link.simulateResult(results[2]);
@@ -95,7 +92,6 @@ describe("useSubscription Hook", () => {
       data: results[2].result.data,
       error: undefined,
       loading: false,
-      variables: undefined,
     });
 
     link.simulateResult(results[3]);
@@ -104,7 +100,6 @@ describe("useSubscription Hook", () => {
       data: results[3].result.data,
       error: undefined,
       loading: false,
-      variables: undefined,
     });
 
     await expect(takeSnapshot).not.toRerender();
@@ -148,7 +143,6 @@ describe("useSubscription Hook", () => {
       data: undefined,
       error: undefined,
       loading: true,
-      variables: undefined,
     });
 
     link.simulateResult(results[0]);
@@ -157,7 +151,6 @@ describe("useSubscription Hook", () => {
       data: results[0].result.data,
       error: undefined,
       loading: false,
-      variables: undefined,
     });
 
     link.simulateResult(errorResult);
@@ -166,7 +159,6 @@ describe("useSubscription Hook", () => {
       data: undefined,
       error: new CombinedGraphQLErrors([{ message: "test" }]),
       loading: false,
-      variables: undefined,
     });
 
     await expect(takeSnapshot).not.toRerender();
@@ -217,7 +209,6 @@ describe("useSubscription Hook", () => {
       data: undefined,
       error: undefined,
       loading: true,
-      variables: undefined,
     });
 
     link.simulateResult(results[0]);
@@ -226,7 +217,6 @@ describe("useSubscription Hook", () => {
       data: results[0].result.data,
       error: undefined,
       loading: false,
-      variables: undefined,
     });
 
     expect(onData).toHaveBeenCalledTimes(1);
@@ -248,7 +238,6 @@ describe("useSubscription Hook", () => {
       data: undefined,
       error: new CombinedGraphQLErrors([{ message: "test" }]),
       loading: false,
-      variables: undefined,
     });
 
     expect(onData).toHaveBeenCalledTimes(1);
@@ -264,7 +253,6 @@ describe("useSubscription Hook", () => {
       data: results[1].result.data,
       error: undefined,
       loading: false,
-      variables: undefined,
     });
 
     expect(onData).toHaveBeenCalledTimes(2);
@@ -319,7 +307,6 @@ describe("useSubscription Hook", () => {
       data: undefined,
       error: undefined,
       loading: true,
-      variables: undefined,
     });
 
     link.simulateResult(results[0]);
@@ -328,7 +315,6 @@ describe("useSubscription Hook", () => {
       data: results[0].result.data,
       error: undefined,
       loading: false,
-      variables: undefined,
     });
 
     link.simulateComplete();
@@ -376,7 +362,6 @@ describe("useSubscription Hook", () => {
       data: undefined,
       error: undefined,
       loading: true,
-      variables: undefined,
     });
 
     link.simulateResult(results[0]);
@@ -385,7 +370,6 @@ describe("useSubscription Hook", () => {
       data: results[0].result.data,
       error: undefined,
       loading: false,
-      variables: undefined,
     });
 
     expect(onData).toHaveBeenCalledTimes(1);
@@ -450,7 +434,6 @@ describe("useSubscription Hook", () => {
       data: undefined,
       error: undefined,
       loading: false,
-      variables: { foo: "bar" },
     });
 
     await rerender({ variables: { foo: "bar2" } });
@@ -459,7 +442,6 @@ describe("useSubscription Hook", () => {
       data: undefined,
       error: undefined,
       loading: false,
-      variables: { foo: "bar2" },
     });
 
     await expect(takeSnapshot).not.toRerender();
@@ -508,7 +490,6 @@ describe("useSubscription Hook", () => {
       data: undefined,
       error: undefined,
       loading: false,
-      variables: undefined,
     });
 
     await rerender({ skip: false });
@@ -517,7 +498,6 @@ describe("useSubscription Hook", () => {
       data: undefined,
       error: undefined,
       loading: true,
-      variables: undefined,
     });
 
     link.simulateResult(results[0]);
@@ -526,7 +506,6 @@ describe("useSubscription Hook", () => {
       data: results[0].result.data,
       error: undefined,
       loading: false,
-      variables: undefined,
     });
 
     await rerender({ skip: true });
@@ -535,7 +514,6 @@ describe("useSubscription Hook", () => {
       data: undefined,
       error: undefined,
       loading: false,
-      variables: undefined,
     });
 
     // ensure state persists across rerenders
@@ -545,7 +523,6 @@ describe("useSubscription Hook", () => {
       data: undefined,
       error: undefined,
       loading: false,
-      variables: undefined,
     });
 
     await expect(takeSnapshot).not.toRerender();
@@ -557,7 +534,6 @@ describe("useSubscription Hook", () => {
       data: undefined,
       error: undefined,
       loading: true,
-      variables: undefined,
     });
 
     link.simulateResult(results[1]);
@@ -566,7 +542,6 @@ describe("useSubscription Hook", () => {
       data: results[1].result.data,
       error: undefined,
       loading: false,
-      variables: undefined,
     });
 
     await expect(takeSnapshot).not.toRerender();
@@ -613,7 +588,6 @@ describe("useSubscription Hook", () => {
       data: undefined,
       error: undefined,
       loading: true,
-      variables: undefined,
     });
 
     link.simulateResult(results[0]);
@@ -622,7 +596,6 @@ describe("useSubscription Hook", () => {
       data: results[0].result.data,
       error: undefined,
       loading: false,
-      variables: undefined,
     });
 
     link.simulateResult(results[1]);
@@ -631,7 +604,6 @@ describe("useSubscription Hook", () => {
       data: results[1].result.data,
       error: undefined,
       loading: false,
-      variables: undefined,
     });
 
     await expect(takeSnapshot).not.toRerender();
@@ -680,7 +652,6 @@ describe("useSubscription Hook", () => {
       data: undefined,
       error: undefined,
       loading: true,
-      variables: undefined,
     });
 
     link.simulateResult(results[0]);
@@ -689,7 +660,6 @@ describe("useSubscription Hook", () => {
       data: results[0].result.data,
       error: undefined,
       loading: false,
-      variables: undefined,
     });
 
     link.simulateResult(results[1]);
@@ -698,7 +668,6 @@ describe("useSubscription Hook", () => {
       data: results[1].result.data,
       error: undefined,
       loading: false,
-      variables: undefined,
     });
 
     await expect(takeSnapshot).not.toRerender();
@@ -745,14 +714,12 @@ describe("useSubscription Hook", () => {
         data: undefined,
         error: undefined,
         loading: true,
-        variables: undefined,
       });
 
       expect(sub2).toEqualStrictTyped({
         data: undefined,
         error: undefined,
         loading: true,
-        variables: undefined,
       });
     }
 
@@ -765,14 +732,12 @@ describe("useSubscription Hook", () => {
         data: results[0].result.data,
         error: undefined,
         loading: false,
-        variables: undefined,
       });
 
       expect(sub2).toEqualStrictTyped({
         data: undefined,
         error: undefined,
         loading: true,
-        variables: undefined,
       });
     }
 
@@ -783,14 +748,12 @@ describe("useSubscription Hook", () => {
         data: results[0].result.data,
         error: undefined,
         loading: false,
-        variables: undefined,
       });
 
       expect(sub2).toEqualStrictTyped({
         data: results[0].result.data,
         error: undefined,
         loading: false,
-        variables: undefined,
       });
     }
 
@@ -803,14 +766,12 @@ describe("useSubscription Hook", () => {
         data: results[1].result.data,
         error: undefined,
         loading: false,
-        variables: undefined,
       });
 
       expect(sub2).toEqualStrictTyped({
         data: results[0].result.data,
         error: undefined,
         loading: false,
-        variables: undefined,
       });
     }
 
@@ -821,14 +782,12 @@ describe("useSubscription Hook", () => {
         data: results[1].result.data,
         error: undefined,
         loading: false,
-        variables: undefined,
       });
 
       expect(sub2).toEqualStrictTyped({
         data: results[1].result.data,
         error: undefined,
         loading: false,
-        variables: undefined,
       });
     }
 
@@ -864,7 +823,6 @@ describe("useSubscription Hook", () => {
       data: undefined,
       error: undefined,
       loading: true,
-      variables: undefined,
     });
 
     // Simulating the behavior of HttpLink, which calls next and complete in sequence.
@@ -877,7 +835,6 @@ describe("useSubscription Hook", () => {
       data: { car: { __typename: "Car", make: "Audi" } },
       error: undefined,
       loading: false,
-      variables: undefined,
     });
 
     await expect(takeSnapshot).not.toRerender();
@@ -919,21 +876,18 @@ describe("useSubscription Hook", () => {
         data: undefined,
         error: undefined,
         loading: true,
-        variables: undefined,
       });
 
       expect(sub2).toEqualStrictTyped({
         data: undefined,
         error: undefined,
         loading: true,
-        variables: undefined,
       });
 
       expect(sub3).toEqualStrictTyped({
         data: undefined,
         error: undefined,
         loading: true,
-        variables: undefined,
       });
     }
 
@@ -951,21 +905,18 @@ describe("useSubscription Hook", () => {
           data: { car: { __typename: "Car", make: "Audi" } },
           error: undefined,
           loading: false,
-          variables: undefined,
         });
 
         expect(sub2).toEqualStrictTyped({
           data: undefined,
           error: undefined,
           loading: true,
-          variables: undefined,
         });
 
         expect(sub3).toEqualStrictTyped({
           data: undefined,
           error: undefined,
           loading: true,
-          variables: undefined,
         });
       }
 
@@ -976,21 +927,18 @@ describe("useSubscription Hook", () => {
           data: { car: { __typename: "Car", make: "Audi" } },
           error: undefined,
           loading: false,
-          variables: undefined,
         });
 
         expect(sub2).toEqualStrictTyped({
           data: { car: { __typename: "Car", make: "Audi" } },
           error: undefined,
           loading: false,
-          variables: undefined,
         });
 
         expect(sub3).toEqualStrictTyped({
           data: undefined,
           error: undefined,
           loading: true,
-          variables: undefined,
         });
       }
     }
@@ -1002,21 +950,18 @@ describe("useSubscription Hook", () => {
         data: { car: { __typename: "Car", make: "Audi" } },
         error: undefined,
         loading: false,
-        variables: undefined,
       });
 
       expect(sub2).toEqualStrictTyped({
         data: { car: { __typename: "Car", make: "Audi" } },
         error: undefined,
         loading: false,
-        variables: undefined,
       });
 
       expect(sub3).toEqualStrictTyped({
         data: { car: { __typename: "Car", make: "Audi" } },
         error: undefined,
         loading: false,
-        variables: undefined,
       });
     }
 
@@ -1373,7 +1318,6 @@ describe("useSubscription Hook", () => {
         data: undefined,
         error: undefined,
         loading: true,
-        variables: undefined,
       });
 
       enqueueProtocolErrors([
@@ -1396,7 +1340,6 @@ describe("useSubscription Hook", () => {
           },
         ]),
         loading: false,
-        variables: undefined,
       });
 
       await expect(takeSnapshot).not.toRerender();
@@ -1455,14 +1398,12 @@ followed by new in-flight setup", async () => {
         data: undefined,
         error: undefined,
         loading: true,
-        variables: {},
       });
 
       expect(tails).toEqualStrictTyped({
         data: undefined,
         error: undefined,
         loading: false,
-        variables: {},
       });
     }
 
@@ -1475,14 +1416,12 @@ followed by new in-flight setup", async () => {
         data: undefined,
         error: undefined,
         loading: false,
-        variables: {},
       });
 
       expect(tails).toEqualStrictTyped({
         data: undefined,
         error: undefined,
         loading: true,
-        variables: {},
       });
     }
 
@@ -1497,14 +1436,12 @@ followed by new in-flight setup", async () => {
         data: undefined,
         error: undefined,
         loading: false,
-        variables: {},
       });
 
       expect(tails).toEqualStrictTyped({
         data: results[0].result.data,
         error: undefined,
         loading: false,
-        variables: {},
       });
     }
 
@@ -1517,14 +1454,12 @@ followed by new in-flight setup", async () => {
         data: undefined,
         error: undefined,
         loading: true,
-        variables: {},
       });
 
       expect(tails).toEqualStrictTyped({
         data: undefined,
         error: undefined,
         loading: false,
-        variables: {},
       });
     }
 
@@ -1537,14 +1472,12 @@ followed by new in-flight setup", async () => {
         data: results[1].result.data,
         error: undefined,
         loading: false,
-        variables: {},
       });
 
       expect(tails).toEqualStrictTyped({
         data: undefined,
         error: undefined,
         loading: false,
-        variables: {},
       });
     }
 
@@ -1617,7 +1550,6 @@ followed by new in-flight setup", async () => {
             data: undefined,
             error: undefined,
             loading: true,
-            variables: undefined,
           });
 
           link.simulateResult(graphQlErrorResult);
@@ -1630,7 +1562,6 @@ followed by new in-flight setup", async () => {
                 graphQlErrorResult.result!.errors as any
               ),
               data: undefined,
-              variables: undefined,
             });
           }
 
@@ -1653,7 +1584,6 @@ followed by new in-flight setup", async () => {
           data: undefined,
           error: undefined,
           loading: true,
-          variables: undefined,
         });
 
         link.simulateResult(graphQlErrorResult);
@@ -1666,7 +1596,6 @@ followed by new in-flight setup", async () => {
               graphQlErrorResult.result!.errors!
             ),
             data: { totalLikes: 42 },
-            variables: undefined,
           });
         }
 
@@ -1693,7 +1622,6 @@ followed by new in-flight setup", async () => {
           data: undefined,
           error: undefined,
           loading: true,
-          variables: undefined,
         });
 
         link.simulateResult(graphQlErrorResult);
@@ -1704,7 +1632,6 @@ followed by new in-flight setup", async () => {
             loading: false,
             error: undefined,
             data: { totalLikes: 42 },
-            variables: undefined,
           });
         }
 
@@ -1766,7 +1693,6 @@ followed by new in-flight setup", async () => {
             data: undefined,
             error: undefined,
             loading: true,
-            variables: undefined,
           });
 
           enqueueProtocolErrors([
@@ -1781,7 +1707,6 @@ followed by new in-flight setup", async () => {
             data: undefined,
             error: expectedError,
             loading: false,
-            variables: undefined,
           });
 
           expect(onError).toHaveBeenCalledTimes(1);
@@ -1829,7 +1754,6 @@ followed by new in-flight setup", async () => {
           data: undefined,
           error: undefined,
           loading: true,
-          variables: undefined,
         });
 
         enqueueProtocolErrors([
@@ -1913,7 +1837,6 @@ describe("`restart` callback", () => {
         loading: true,
         data: undefined,
         error: undefined,
-        variables: { id: "1" },
       });
     }
 
@@ -1925,7 +1848,6 @@ describe("`restart` callback", () => {
         loading: false,
         data: { totalLikes: 1 },
         error: undefined,
-        variables: { id: "1" },
       });
     }
 
@@ -1941,7 +1863,6 @@ describe("`restart` callback", () => {
         loading: true,
         data: undefined,
         error: undefined,
-        variables: { id: "1" },
       });
     }
 
@@ -1956,7 +1877,6 @@ describe("`restart` callback", () => {
         loading: false,
         data: { totalLikes: 2 },
         error: undefined,
-        variables: { id: "1" },
       });
     }
   });
@@ -1980,7 +1900,6 @@ describe("`restart` callback", () => {
         loading: true,
         data: undefined,
         error: undefined,
-        variables: { id: "1" },
       });
     }
 
@@ -1991,12 +1910,10 @@ describe("`restart` callback", () => {
 
     {
       const snapshot = await takeSnapshot();
-      expect(snapshot).toStrictEqual({
+      expect(snapshot).toEqualStrictTyped({
         loading: false,
         data: { totalLikes: 1 },
         error: undefined,
-        restart: expect.any(Function),
-        variables: { id: "1" },
       });
     }
 
@@ -2016,7 +1933,6 @@ describe("`restart` callback", () => {
         loading: true,
         data: undefined,
         error: undefined,
-        variables: { id: "2" },
       });
     }
 
@@ -2028,7 +1944,6 @@ describe("`restart` callback", () => {
         loading: false,
         data: { totalLikes: 1000 },
         error: undefined,
-        variables: { id: "2" },
       });
     }
 
@@ -2048,7 +1963,6 @@ describe("`restart` callback", () => {
         loading: true,
         data: undefined,
         error: undefined,
-        variables: { id: "2" },
       });
     }
 
@@ -2060,7 +1974,6 @@ describe("`restart` callback", () => {
         loading: false,
         data: { totalLikes: 1005 },
         error: undefined,
-        variables: { id: "2" },
       });
     }
   });
@@ -2083,7 +1996,6 @@ describe("`restart` callback", () => {
         loading: true,
         data: undefined,
         error: undefined,
-        variables: { id: "1" },
       });
     }
 
@@ -2095,7 +2007,6 @@ describe("`restart` callback", () => {
         loading: false,
         data: { totalLikes: 1 },
         error: undefined,
-        variables: { id: "1" },
       });
     }
 
@@ -2107,12 +2018,10 @@ describe("`restart` callback", () => {
 
     {
       const snapshot = await takeSnapshot();
-      expect(snapshot).toStrictEqual({
+      expect(snapshot).toEqualStrictTyped({
         loading: true,
         data: undefined,
         error: undefined,
-        restart: expect.any(Function),
-        variables: { id: "1" },
       });
     }
 
@@ -2127,7 +2036,6 @@ describe("`restart` callback", () => {
         loading: false,
         data: { totalLikes: 2 },
         error: undefined,
-        variables: { id: "1" },
       });
     }
   });
@@ -2150,7 +2058,6 @@ describe("`restart` callback", () => {
         loading: true,
         data: undefined,
         error: undefined,
-        variables: { id: "1" },
       });
     }
 
@@ -2165,7 +2072,6 @@ describe("`restart` callback", () => {
         loading: false,
         data: undefined,
         error: new CombinedGraphQLErrors([error]),
-        variables: { id: "1" },
       });
     }
 
@@ -2181,7 +2087,6 @@ describe("`restart` callback", () => {
         loading: true,
         data: undefined,
         error: undefined,
-        variables: { id: "1" },
       });
     }
 
@@ -2197,7 +2102,6 @@ describe("`restart` callback", () => {
         loading: false,
         data: { totalLikes: 2 },
         error: undefined,
-        variables: { id: "1" },
       });
     }
   });
@@ -2216,7 +2120,6 @@ describe("`restart` callback", () => {
         loading: false,
         data: undefined,
         error: undefined,
-        variables: { id: "1" },
       });
     }
 
@@ -2279,7 +2182,6 @@ describe("ignoreResults", () => {
       loading: false,
       error: undefined,
       data: undefined,
-      variables: undefined,
     });
 
     link.simulateResult(results[0]);
@@ -2350,7 +2252,6 @@ describe("ignoreResults", () => {
       loading: false,
       error: undefined,
       data: undefined,
-      variables: undefined,
     });
 
     link.simulateResult(results[0]);
@@ -2417,7 +2318,6 @@ describe("ignoreResults", () => {
         loading: false,
         error: undefined,
         data: undefined,
-        variables: undefined,
       });
       expect(onData).toHaveBeenCalledTimes(0);
     }
@@ -2436,7 +2336,6 @@ describe("ignoreResults", () => {
         error: undefined,
         // `data` appears immediately after changing to `ignoreResults: false`
         data: results[0].result.data,
-        variables: undefined,
       });
       // `onData` should not be called again for the same result
       expect(onData).toHaveBeenCalledTimes(1);
@@ -2450,7 +2349,6 @@ describe("ignoreResults", () => {
         loading: false,
         error: undefined,
         data: results[1].result.data,
-        variables: undefined,
       });
       expect(onData).toHaveBeenCalledTimes(2);
     }
@@ -2492,7 +2390,6 @@ describe("ignoreResults", () => {
         loading: true,
         error: undefined,
         data: undefined,
-        variables: undefined,
       });
       expect(onData).toHaveBeenCalledTimes(0);
     }
@@ -2505,7 +2402,6 @@ describe("ignoreResults", () => {
         loading: false,
         error: undefined,
         data: results[0].result.data,
-        variables: undefined,
       });
       expect(onData).toHaveBeenCalledTimes(1);
     }
@@ -2521,7 +2417,6 @@ describe("ignoreResults", () => {
         error: undefined,
         // switching back to the default `ignoreResults: true` return value
         data: undefined,
-        variables: undefined,
       });
       // `onData` should not be called again
       expect(onData).toHaveBeenCalledTimes(1);
@@ -2574,7 +2469,6 @@ describe("data masking", () => {
       data: undefined,
       error: undefined,
       loading: true,
-      variables: undefined,
     });
 
     link.simulateResult({
@@ -2599,7 +2493,6 @@ describe("data masking", () => {
       },
       error: undefined,
       loading: false,
-      variables: undefined,
     });
 
     await expect(takeSnapshot).not.toRerender();
@@ -2641,7 +2534,6 @@ describe("data masking", () => {
       data: undefined,
       error: undefined,
       loading: true,
-      variables: undefined,
     });
 
     link.simulateResult({
@@ -2668,7 +2560,6 @@ describe("data masking", () => {
       },
       error: undefined,
       loading: false,
-      variables: undefined,
     });
 
     await expect(takeSnapshot).not.toRerender();
@@ -2711,7 +2602,6 @@ describe("data masking", () => {
       data: undefined,
       error: undefined,
       loading: true,
-      variables: undefined,
     });
 
     link.simulateResult({
@@ -2736,7 +2626,6 @@ describe("data masking", () => {
       },
       error: undefined,
       loading: false,
-      variables: undefined,
     });
 
     expect(onData).toHaveBeenCalledTimes(1);
@@ -2790,7 +2679,6 @@ describe("data masking", () => {
       data: undefined,
       error: undefined,
       loading: true,
-      variables: undefined,
     });
 
     link.simulateResult({
@@ -2817,7 +2705,6 @@ describe("data masking", () => {
       },
       error: undefined,
       loading: false,
-      variables: undefined,
     });
 
     expect(onData).toHaveBeenCalledTimes(1);
@@ -2843,20 +2730,6 @@ describe("data masking", () => {
 });
 
 describe.skip("Type Tests", () => {
-  test("NoInfer prevents adding arbitrary additional variables", () => {
-    const typedNode = {} as TypedDocumentNode<{ foo: string }, { bar: number }>;
-    const { variables } = useSubscription(typedNode, {
-      variables: {
-        bar: 4,
-        // @ts-expect-error
-        nonExistingVariable: "string",
-      },
-    });
-    variables?.bar;
-    // @ts-expect-error
-    variables?.nonExistingVariable;
-  });
-
   test("uses masked types when using masked document", async () => {
     type UserFieldsFragment = {
       age: number;

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -968,163 +968,6 @@ describe("useSubscription Hook", () => {
     await expect(takeSnapshot).not.toRerender();
   });
 
-  test("should warn when using 'onSubscriptionData' and 'onData' together", () => {
-    using consoleSpy = spyOnConsole("warn");
-    const subscription = gql`
-      subscription {
-        car {
-          make
-        }
-      }
-    `;
-
-    const link = new MockSubscriptionLink();
-    const client = new ApolloClient({
-      link,
-      cache: new Cache(),
-    });
-
-    renderHook(
-      () =>
-        useSubscription(subscription, {
-          onData: jest.fn(),
-          onSubscriptionData: jest.fn(),
-        }),
-      {
-        wrapper: ({ children }) => (
-          <ApolloProvider client={client}>{children}</ApolloProvider>
-        ),
-      }
-    );
-
-    expect(consoleSpy.warn).toHaveBeenCalledTimes(1);
-    expect(consoleSpy.warn).toHaveBeenCalledWith(
-      expect.stringContaining(
-        "supports only the 'onSubscriptionData' or 'onData' option"
-      )
-    );
-  });
-
-  test("prefers 'onData' when using 'onSubscriptionData' and 'onData' together", async () => {
-    jest.spyOn(console, "warn").mockImplementation(() => {});
-    const subscription = gql`
-      subscription {
-        car {
-          make
-        }
-      }
-    `;
-
-    const results = [
-      {
-        result: { data: { car: { make: "Pagani" } } },
-      },
-    ];
-
-    const link = new MockSubscriptionLink();
-    const client = new ApolloClient({
-      link,
-      cache: new Cache(),
-    });
-
-    const onData = jest.fn();
-    const onSubscriptionData = jest.fn();
-
-    renderHook(
-      () =>
-        useSubscription(subscription, {
-          onData,
-          onSubscriptionData,
-        }),
-      {
-        wrapper: ({ children }) => (
-          <ApolloProvider client={client}>{children}</ApolloProvider>
-        ),
-      }
-    );
-
-    link.simulateResult(results[0]);
-    await tick();
-
-    expect(onData).toHaveBeenCalledTimes(1);
-    expect(onSubscriptionData).toHaveBeenCalledTimes(0);
-  });
-
-  test("uses 'onSubscriptionData' when 'onData' is absent", async () => {
-    using _consoleSpy = spyOnConsole("warn");
-    const subscription = gql`
-      subscription {
-        car {
-          make
-        }
-      }
-    `;
-
-    const results = [
-      {
-        result: { data: { car: { make: "Pagani" } } },
-      },
-    ];
-
-    const link = new MockSubscriptionLink();
-    const client = new ApolloClient({
-      link,
-      cache: new Cache(),
-    });
-
-    const onSubscriptionData = jest.fn();
-
-    renderHook(
-      () =>
-        useSubscription(subscription, {
-          onSubscriptionData,
-        }),
-      {
-        wrapper: ({ children }) => (
-          <ApolloProvider client={client}>{children}</ApolloProvider>
-        ),
-      }
-    );
-
-    link.simulateResult(results[0]);
-    await tick();
-
-    expect(onSubscriptionData).toHaveBeenCalledTimes(1);
-  });
-
-  test("only warns once using `onSubscriptionData`", () => {
-    using consoleSpy = spyOnConsole("warn");
-    const subscription = gql`
-      subscription {
-        car {
-          make
-        }
-      }
-    `;
-
-    const link = new MockSubscriptionLink();
-    const client = new ApolloClient({
-      link,
-      cache: new Cache(),
-    });
-
-    const { rerender } = renderHook(
-      () =>
-        useSubscription(subscription, {
-          onSubscriptionData: jest.fn(),
-        }),
-      {
-        wrapper: ({ children }) => (
-          <ApolloProvider client={client}>{children}</ApolloProvider>
-        ),
-      }
-    );
-
-    rerender();
-
-    expect(consoleSpy.warn).toHaveBeenCalledTimes(1);
-  });
-
   test("should warn when using 'onComplete' and 'onSubscriptionComplete' together", () => {
     using consoleSpy = spyOnConsole("warn");
     const subscription = gql`
@@ -2751,11 +2594,6 @@ describe.skip("Type Tests", () => {
           Masked<Subscription> | undefined
         >();
       },
-      onSubscriptionData: ({ subscriptionData }) => {
-        expectTypeOf(subscriptionData.data).toEqualTypeOf<
-          Masked<Subscription> | undefined
-        >();
-      },
     });
 
     expectTypeOf(data).toEqualTypeOf<Masked<Subscription> | undefined>();
@@ -2780,11 +2618,6 @@ describe.skip("Type Tests", () => {
     const { data } = useSubscription(subscription, {
       onData: ({ data }) => {
         expectTypeOf(data.data).toEqualTypeOf<Subscription | undefined>();
-      },
-      onSubscriptionData: ({ subscriptionData }) => {
-        expectTypeOf(subscriptionData.data).toEqualTypeOf<
-          Subscription | undefined
-        >();
       },
     });
 

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { waitFor } from "@testing-library/react";
 import {
   disableActEnvironment,
   renderHookToSnapshotStream,
@@ -26,10 +26,7 @@ import { MockSubscriptionLink, tick, wait } from "@apollo/client/testing";
 import { InvariantError } from "@apollo/client/utilities/invariant";
 
 import { MockedSubscriptionResult } from "../../../testing/core/mocking/mockSubscriptionLink.js";
-import {
-  mockMultipartSubscriptionStream,
-  spyOnConsole,
-} from "../../../testing/internal/index.js";
+import { mockMultipartSubscriptionStream } from "../../../testing/internal/index.js";
 import { useSubscription } from "../useSubscription.js";
 
 const IS_REACT_17 = React.version.startsWith("17");
@@ -966,163 +963,6 @@ describe("useSubscription Hook", () => {
     }
 
     await expect(takeSnapshot).not.toRerender();
-  });
-
-  test("should warn when using 'onComplete' and 'onSubscriptionComplete' together", () => {
-    using consoleSpy = spyOnConsole("warn");
-    const subscription = gql`
-      subscription {
-        car {
-          make
-        }
-      }
-    `;
-
-    const link = new MockSubscriptionLink();
-    const client = new ApolloClient({
-      link,
-      cache: new Cache(),
-    });
-
-    renderHook(
-      () =>
-        useSubscription(subscription, {
-          onComplete: jest.fn(),
-          onSubscriptionComplete: jest.fn(),
-        }),
-      {
-        wrapper: ({ children }) => (
-          <ApolloProvider client={client}>{children}</ApolloProvider>
-        ),
-      }
-    );
-
-    expect(consoleSpy.warn).toHaveBeenCalledTimes(1);
-    expect(consoleSpy.warn).toHaveBeenCalledWith(
-      expect.stringContaining(
-        "supports only the 'onSubscriptionComplete' or 'onComplete' option"
-      )
-    );
-  });
-
-  test("prefers 'onComplete' when using 'onComplete' and 'onSubscriptionComplete' together", async () => {
-    using _consoleSpy = spyOnConsole("warn");
-    const subscription = gql`
-      subscription {
-        car {
-          make
-        }
-      }
-    `;
-
-    const results = [
-      {
-        result: { data: { car: { make: "Audi" } } },
-      },
-    ];
-
-    const link = new MockSubscriptionLink();
-    const client = new ApolloClient({
-      link,
-      cache: new Cache(),
-    });
-
-    const onComplete = jest.fn();
-    const onSubscriptionComplete = jest.fn();
-
-    renderHook(
-      () =>
-        useSubscription(subscription, {
-          onComplete,
-          onSubscriptionComplete,
-        }),
-      {
-        wrapper: ({ children }) => (
-          <ApolloProvider client={client}>{children}</ApolloProvider>
-        ),
-      }
-    );
-
-    link.simulateResult(results[0], true);
-    await tick();
-
-    expect(onComplete).toHaveBeenCalledTimes(1);
-    expect(onSubscriptionComplete).toHaveBeenCalledTimes(0);
-  });
-
-  test("uses 'onSubscriptionComplete' when 'onComplete' is absent", async () => {
-    using _consoleSpy = spyOnConsole("warn");
-    const subscription = gql`
-      subscription {
-        car {
-          make
-        }
-      }
-    `;
-
-    const results = [
-      {
-        result: { data: { car: { make: "Audi" } } },
-      },
-    ];
-
-    const link = new MockSubscriptionLink();
-    const client = new ApolloClient({
-      link,
-      cache: new Cache(),
-    });
-
-    const onSubscriptionComplete = jest.fn();
-
-    renderHook(
-      () =>
-        useSubscription(subscription, {
-          onSubscriptionComplete,
-        }),
-      {
-        wrapper: ({ children }) => (
-          <ApolloProvider client={client}>{children}</ApolloProvider>
-        ),
-      }
-    );
-
-    link.simulateResult(results[0], true);
-    await tick();
-
-    expect(onSubscriptionComplete).toHaveBeenCalledTimes(1);
-  });
-
-  test("only warns once using `onSubscriptionComplete`", () => {
-    using consoleSpy = spyOnConsole("warn");
-    const subscription = gql`
-      subscription {
-        car {
-          make
-        }
-      }
-    `;
-
-    const link = new MockSubscriptionLink();
-    const client = new ApolloClient({
-      link,
-      cache: new Cache(),
-    });
-
-    const { rerender } = renderHook(
-      () =>
-        useSubscription(subscription, {
-          onSubscriptionComplete: jest.fn(),
-        }),
-      {
-        wrapper: ({ children }) => (
-          <ApolloProvider client={client}>{children}</ApolloProvider>
-        ),
-      }
-    );
-
-    rerender();
-
-    expect(consoleSpy.warn).toHaveBeenCalledTimes(1);
   });
 
   describe("multipart subscriptions", () => {

--- a/src/react/hooks/useSubscription.ts
+++ b/src/react/hooks/useSubscription.ts
@@ -63,9 +63,6 @@ export declare namespace useSubscription {
     /** {@inheritDoc @apollo/client!SubscriptionOptionsDocumentation#onError:member} */
     onError?: (error: ErrorLike) => void;
 
-    /** {@inheritDoc @apollo/client!SubscriptionOptionsDocumentation#onSubscriptionComplete:member} */
-    onSubscriptionComplete?: () => void;
-
     /**
      * {@inheritDoc @apollo/client!SubscriptionOptionsDocumentation#ignoreResults:member}
      * @defaultValue `false`
@@ -189,23 +186,8 @@ export function useSubscription<
   subscription: DocumentNode | TypedDocumentNode<TData, TVariables>,
   options: useSubscription.Options<NoInfer<TData>, NoInfer<TVariables>> = {}
 ): useSubscription.Result<TData> {
-  const hasIssuedDeprecationWarningRef = React.useRef(false);
   const client = useApolloClient(options.client);
   verifyDocumentType(subscription, DocumentType.Subscription);
-
-  // eslint-disable-next-line react-compiler/react-compiler
-  if (!hasIssuedDeprecationWarningRef.current) {
-    // eslint-disable-next-line react-compiler/react-compiler
-    hasIssuedDeprecationWarningRef.current = true;
-
-    if (options.onSubscriptionComplete) {
-      invariant.warn(
-        options.onComplete ?
-          "'useSubscription' supports only the 'onSubscriptionComplete' or 'onComplete' option, but not both. Only the 'onComplete' option will be used."
-        : "'onSubscriptionComplete' is deprecated and will be removed in a future major version. Please use the 'onComplete' option instead."
-      );
-    }
-  }
 
   const {
     skip,
@@ -318,12 +300,8 @@ export function useSubscription<
             }
           },
           complete() {
-            if (!subscriptionStopped) {
-              if (optionsRef.current.onComplete) {
-                optionsRef.current.onComplete();
-              } else if (optionsRef.current.onSubscriptionComplete) {
-                optionsRef.current.onSubscriptionComplete();
-              }
+            if (!subscriptionStopped && optionsRef.current.onComplete) {
+              optionsRef.current.onComplete();
             }
           },
         });

--- a/src/react/hooks/useSubscription.ts
+++ b/src/react/hooks/useSubscription.ts
@@ -96,8 +96,6 @@ export declare namespace useSubscription {
   }
 }
 
-type StateResult<TData> = Omit<useSubscription.Result<TData>, "restart">;
-
 /**
  * > Refer to the [Subscriptions](https://www.apollographql.com/docs/react/data/subscriptions/) section for a more in-depth overview of `useSubscription`.
  *
@@ -244,7 +242,7 @@ export function useSubscription<
   });
 
   const fallbackLoading = !skip && !ignoreResults;
-  const fallbackResult = React.useMemo<StateResult<TData>>(
+  const fallbackResult = React.useMemo(
     () => ({
       loading: fallbackLoading,
       error: void 0,
@@ -266,7 +264,7 @@ export function useSubscription<
     ignoreResultsRef.current = ignoreResults;
   });
 
-  const ret = useSyncExternalStore<StateResult<TData>>(
+  const ret = useSyncExternalStore(
     React.useCallback(
       (update) => {
         if (!observable) {
@@ -281,7 +279,7 @@ export function useSubscription<
               return;
             }
 
-            const result: StateResult<TData> = {
+            const result = {
               loading: false,
               data: value.data,
               error: value.error,
@@ -336,6 +334,8 @@ export function useSubscription<
   return React.useMemo(() => ({ ...ret, restart }), [ret, restart]);
 }
 
+type SubscriptionResult<TData> = Omit<useSubscription.Result<TData>, "restart">;
+
 function createSubscription<
   TData = unknown,
   TVariables extends OperationVariables = OperationVariables,
@@ -363,8 +363,8 @@ function createSubscription<
       loading: true,
       data: void 0,
       error: void 0,
-    } as StateResult<TData>,
-    setResult(result: StateResult<TData>) {
+    } as SubscriptionResult<TData>,
+    setResult(result: SubscriptionResult<TData>) {
       __.result = result;
     },
   };

--- a/src/react/hooks/useSubscription.ts
+++ b/src/react/hooks/useSubscription.ts
@@ -60,9 +60,6 @@ export declare namespace useSubscription {
     /** {@inheritDoc @apollo/client!SubscriptionOptionsDocumentation#onData:member} */
     onData?: (options: OnDataOptions<TData>) => any;
 
-    /** {@inheritDoc @apollo/client!SubscriptionOptionsDocumentation#onSubscriptionData:member} */
-    onSubscriptionData?: (options: OnSubscriptionDataOptions<TData>) => any;
-
     /** {@inheritDoc @apollo/client!SubscriptionOptionsDocumentation#onError:member} */
     onError?: (error: ErrorLike) => void;
 
@@ -201,14 +198,6 @@ export function useSubscription<
     // eslint-disable-next-line react-compiler/react-compiler
     hasIssuedDeprecationWarningRef.current = true;
 
-    if (options.onSubscriptionData) {
-      invariant.warn(
-        options.onData ?
-          "'useSubscription' supports only the 'onSubscriptionData' or 'onData' option, but not both. Only the 'onData' option will be used."
-        : "'onSubscriptionData' is deprecated and will be removed in a future major version. Please use the 'onData' option instead."
-      );
-    }
-
     if (options.onSubscriptionComplete) {
       invariant.warn(
         options.onComplete ?
@@ -325,11 +314,6 @@ export function useSubscription<
               optionsRef.current.onData({
                 client,
                 data: result,
-              });
-            } else if (optionsRef.current.onSubscriptionData) {
-              optionsRef.current.onSubscriptionData({
-                client,
-                subscriptionData: result,
               });
             }
           },

--- a/src/react/types/deprecated.ts
+++ b/src/react/types/deprecated.ts
@@ -89,7 +89,7 @@ export type MutationTuple<
 export type SubscriptionResult<
   TData = unknown,
   TVariables extends OperationVariables = OperationVariables,
-> = useSubscription.Result<TData, TVariables>;
+> = useSubscription.Result<TData>;
 
 /** @deprecated Use `useSubscription.Options` instead */
 export type SubscriptionHookOptions<

--- a/src/react/types/types.documentation.ts
+++ b/src/react/types/types.documentation.ts
@@ -534,13 +534,6 @@ export interface SubscriptionOptionsDocumentation {
   onData: unknown;
 
   /**
-   * Allows the registration of a callback function that will be triggered each time the `useSubscription` Hook / `Subscription` component receives data. The callback `options` object param consists of the current Apollo Client instance in `client`, and the received subscription data in `subscriptionData`.
-   *
-   * @deprecated Use `onData` instead
-   */
-  onSubscriptionData: unknown;
-
-  /**
    * Allows the registration of a callback function that will be triggered each time the `useSubscription` Hook / `Subscription` component receives an error.
    *
    * @since 3.7.0

--- a/src/react/types/types.documentation.ts
+++ b/src/react/types/types.documentation.ts
@@ -539,13 +539,6 @@ export interface SubscriptionOptionsDocumentation {
    * @since 3.7.0
    */
   onError: unknown;
-
-  /**
-   * Allows the registration of a callback function that will be triggered when the `useSubscription` Hook / `Subscription` component completes the subscription.
-   *
-   * @deprecated Use `onComplete` instead
-   */
-  onSubscriptionComplete: unknown;
 }
 
 export interface SubscriptionResultDocumentation {


### PR DESCRIPTION
Removes the deprecated `onSubscriptionData`, `onSubscriptionComplete` callbacks from `useSubscription` as well as the returned `variables` value.