### PR TITLE
Remove unnecessary properties from promise-based query APIs

### DIFF
--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -160,14 +160,14 @@ export class ApolloClient implements DataProxy_2 {
     onResetStore(cb: () => Promise<any>): () => void;
     set prioritizeCacheValues(value: boolean);
     get prioritizeCacheValues(): boolean;
-    query<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: QueryOptions<TVariables, TData>): Promise<ApolloQueryResult<MaybeMasked_2<TData>>>;
+    query<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: QueryOptions<TVariables, TData>): Promise<QueryResult<MaybeMasked_2<TData>>>;
     // (undocumented)
     queryDeduplication: boolean;
     readFragment<T = unknown, TVariables = OperationVariables>(options: DataProxy_2.Fragment<TVariables, T>, optimistic?: boolean): Unmasked_2<T> | null;
     readQuery<TData = unknown, TVariables = OperationVariables>(options: DataProxy_2.Query<TVariables, TData>, optimistic?: boolean): Unmasked_2<TData> | null;
-    reFetchObservableQueries(includeStandby?: boolean): Promise<ApolloQueryResult<any>[]>;
-    refetchQueries<TCache extends ApolloCache_2 = ApolloCache_2, TResult = Promise<ApolloQueryResult<any>>>(options: RefetchQueriesOptions<TCache, TResult>): RefetchQueriesResult<TResult>;
-    resetStore(): Promise<ApolloQueryResult<any>[] | null>;
+    reFetchObservableQueries(includeStandby?: boolean): Promise<QueryResult<any>[]>;
+    refetchQueries<TCache extends ApolloCache_2 = ApolloCache_2, TResult = Promise<QueryResult<any>>>(options: RefetchQueriesOptions<TCache, TResult>): RefetchQueriesResult<TResult>;
+    resetStore(): Promise<QueryResult<any>[] | null>;
     restore(serializedState: unknown): ApolloCache_2;
     setLink(newLink: ApolloLink_2): void;
     setLocalStateFragmentMatcher(fragmentMatcher: FragmentMatcher): void;
@@ -1106,7 +1106,7 @@ export interface InternalRefetchQueriesOptions<TCache extends ApolloCache_2, TRe
 }
 
 // @public (undocumented)
-export type InternalRefetchQueriesResult<TResult> = TResult extends boolean ? Promise<ApolloQueryResult<any>> : TResult;
+export type InternalRefetchQueriesResult<TResult> = TResult extends boolean ? Promise<QueryResult<any>> : TResult;
 
 // @public (undocumented)
 export type InternalRefetchQueryDescriptor = RefetchQueryDescriptor | QueryOptions;
@@ -1537,7 +1537,7 @@ export class ObservableQuery<TData = unknown, TVariables extends OperationVariab
             fetchMoreResult: Unmasked_2<TFetchData>;
             variables: TFetchVars;
         }) => Unmasked_2<TData>;
-    }): Promise<ApolloQueryResult<MaybeMasked_2<TFetchData>>>;
+    }): Promise<QueryResult<TFetchData>>;
     // (undocumented)
     getCurrentResult(saveAsLastResult?: boolean): ApolloQueryResult<MaybeMasked_2<TData>>;
     // (undocumented)
@@ -1558,13 +1558,13 @@ export class ObservableQuery<TData = unknown, TVariables extends OperationVariab
     readonly queryId: string;
     // (undocumented)
     readonly queryName?: string;
-    refetch(variables?: Partial<TVariables>): Promise<ApolloQueryResult<MaybeMasked_2<TData>>>;
-    reobserve(newOptions?: Partial<WatchQueryOptions<TVariables, TData>>): Promise<ApolloQueryResult<MaybeMasked_2<TData>>>;
+    refetch(variables?: Partial<TVariables>): Promise<QueryResult<TData>>;
+    reobserve(newOptions?: Partial<WatchQueryOptions<TVariables, TData>>): Promise<QueryResult<MaybeMasked_2<TData>>>;
     // @internal (undocumented)
     resetDiff(): void;
     // (undocumented)
     resetLastResults(): void;
-    setVariables(variables: TVariables): Promise<ApolloQueryResult<MaybeMasked_2<TData>>>;
+    setVariables(variables: TVariables): Promise<QueryResult<TData>>;
     // @internal (undocumented)
     silentSetOptions(newOptions: Partial<WatchQueryOptions<TVariables, TData>>): void;
     startPolling(pollInterval: number): void;
@@ -1811,9 +1811,9 @@ class QueryManager {
     };
     prioritizeCacheValues: boolean;
     // (undocumented)
-    query<TData, TVars extends OperationVariables = OperationVariables>(options: QueryOptions<TVars, TData>, queryId?: string): Promise<ApolloQueryResult<MaybeMasked_2<TData>>>;
+    query<TData, TVars extends OperationVariables = OperationVariables>(options: QueryOptions<TVars, TData>, queryId?: string): Promise<QueryResult<MaybeMasked_2<TData>>>;
     // (undocumented)
-    reFetchObservableQueries(includeStandby?: boolean): Promise<ApolloQueryResult<any>[]>;
+    reFetchObservableQueries(includeStandby?: boolean): Promise<QueryResult<any>[]>;
     // (undocumented)
     refetchQueries<TResult>({ updateCache, include, optimistic, removeOptimistic, onQueryUpdated, }: InternalRefetchQueriesOptions<ApolloCache_2, TResult>): InternalRefetchQueriesMap<TResult>;
     // (undocumented)
@@ -1874,6 +1874,12 @@ interface QueryOptions<TVariables = OperationVariables, TData = unknown> {
 }
 export { QueryOptions as PureQueryOptions }
 export { QueryOptions }
+
+// @public (undocumented)
+export interface QueryResult<TData = unknown> {
+    data: TData | undefined;
+    error?: ErrorLike;
+}
 
 // @public (undocumented)
 type ReactiveListener<T> = (value: T) => any;
@@ -1951,7 +1957,7 @@ export interface RefetchQueriesOptions<TCache extends ApolloCache_2, TResult> {
 }
 
 // @public (undocumented)
-export type RefetchQueriesPromiseResults<TResult> = IsStrictlyAny<TResult> extends true ? any[] : TResult extends boolean ? ApolloQueryResult<any>[] : TResult extends PromiseLike<infer U> ? U[] : TResult[];
+export type RefetchQueriesPromiseResults<TResult> = IsStrictlyAny<TResult> extends true ? any[] : TResult extends boolean ? QueryResult<any>[] : TResult extends PromiseLike<infer U> ? U[] : TResult[];
 
 // @public (undocumented)
 export interface RefetchQueriesResult<TResult> extends Promise<RefetchQueriesPromiseResults<TResult>> {
@@ -2333,10 +2339,10 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/cache/inmemory/policies.ts:166:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/policies.ts:166:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/types.ts:133:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:128:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:129:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:187:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:458:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:131:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:132:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:188:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:459:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
 // src/link/http/selectHttpOptionsAndBody.ts:128:1 - (ae-forgotten-export) The symbol "HttpQueryOptions" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -2339,8 +2339,8 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/cache/inmemory/policies.ts:166:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/policies.ts:166:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/types.ts:133:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:131:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:132:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:130:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:131:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:188:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:459:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
 // src/link/http/selectHttpOptionsAndBody.ts:128:1 - (ae-forgotten-export) The symbol "HttpQueryOptions" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -51,6 +51,7 @@ import type { OnQueryUpdated as OnQueryUpdated_2 } from '@apollo/client/core';
 import type { OperationVariables } from '@apollo/client/core';
 import type { PreloadedQueryRef as PreloadedQueryRef_2 } from '@apollo/client/react/internal';
 import type { QueryRef as QueryRef_2 } from '@apollo/client/react/internal';
+import type { QueryResult as QueryResult_3 } from '@apollo/client/core';
 import type { ReactiveVar } from '@apollo/client/core';
 import type * as ReactTypes from 'react';
 import type { Reference } from '@apollo/client/cache';
@@ -128,17 +129,17 @@ class ApolloClient_2 implements DataProxy {
     set prioritizeCacheValues(value: boolean);
     get prioritizeCacheValues(): boolean;
     // Warning: (ae-forgotten-export) The symbol "QueryOptions" needs to be exported by the entry point index.d.ts
-    // Warning: (ae-forgotten-export) The symbol "ApolloQueryResult" needs to be exported by the entry point index.d.ts
-    query<TData = unknown, TVariables extends OperationVariables_2 = OperationVariables_2>(options: QueryOptions<TVariables, TData>): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
+    // Warning: (ae-forgotten-export) The symbol "QueryResult_2" needs to be exported by the entry point index.d.ts
+    query<TData = unknown, TVariables extends OperationVariables_2 = OperationVariables_2>(options: QueryOptions<TVariables, TData>): Promise<QueryResult_2<MaybeMasked<TData>>>;
     // (undocumented)
     queryDeduplication: boolean;
     readFragment<T = unknown, TVariables = OperationVariables_2>(options: DataProxy.Fragment<TVariables, T>, optimistic?: boolean): Unmasked<T> | null;
     readQuery<TData = unknown, TVariables = OperationVariables_2>(options: DataProxy.Query<TVariables, TData>, optimistic?: boolean): Unmasked<TData> | null;
-    reFetchObservableQueries(includeStandby?: boolean): Promise<ApolloQueryResult<any>[]>;
+    reFetchObservableQueries(includeStandby?: boolean): Promise<QueryResult_2<any>[]>;
     // Warning: (ae-forgotten-export) The symbol "RefetchQueriesOptions" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "RefetchQueriesResult" needs to be exported by the entry point index.d.ts
-    refetchQueries<TCache extends ApolloCache = ApolloCache, TResult = Promise<ApolloQueryResult<any>>>(options: RefetchQueriesOptions<TCache, TResult>): RefetchQueriesResult<TResult>;
-    resetStore(): Promise<ApolloQueryResult<any>[] | null>;
+    refetchQueries<TCache extends ApolloCache = ApolloCache, TResult = Promise<QueryResult_2<any>>>(options: RefetchQueriesOptions<TCache, TResult>): RefetchQueriesResult<TResult>;
+    resetStore(): Promise<QueryResult_2<any>[] | null>;
     restore(serializedState: unknown): ApolloCache;
     setLink(newLink: ApolloLink): void;
     // Warning: (ae-forgotten-export) The symbol "FragmentMatcher" needs to be exported by the entry point index.d.ts
@@ -366,7 +367,7 @@ interface InternalRefetchQueriesOptions<TCache extends ApolloCache, TResult> ext
 }
 
 // @public (undocumented)
-type InternalRefetchQueriesResult<TResult> = TResult extends boolean ? Promise<ApolloQueryResult<any>> : TResult;
+type InternalRefetchQueriesResult<TResult> = TResult extends boolean ? Promise<QueryResult_2<any>> : TResult;
 
 // Warning: (ae-forgotten-export) The symbol "RefetchQueryDescriptor" needs to be exported by the entry point index.d.ts
 //
@@ -573,6 +574,8 @@ interface NextFetchPolicyContext<TData, TVariables extends OperationVariables_2>
 interface ObservableAndInfo<TData> {
     // (undocumented)
     fromLink: boolean;
+    // Warning: (ae-forgotten-export) The symbol "ApolloQueryResult" needs to be exported by the entry point index.d.ts
+    //
     // (undocumented)
     observable: Observable<ApolloQueryResult<TData>>;
 }
@@ -594,7 +597,7 @@ class ObservableQuery<TData = unknown, TVariables extends OperationVariables_2 =
             fetchMoreResult: Unmasked<TFetchData>;
             variables: TFetchVars;
         }) => Unmasked<TData>;
-    }): Promise<ApolloQueryResult<MaybeMasked<TFetchData>>>;
+    }): Promise<QueryResult_2<TFetchData>>;
     // (undocumented)
     getCurrentResult(saveAsLastResult?: boolean): ApolloQueryResult<MaybeMasked<TData>>;
     // (undocumented)
@@ -615,13 +618,13 @@ class ObservableQuery<TData = unknown, TVariables extends OperationVariables_2 =
     readonly queryId: string;
     // (undocumented)
     readonly queryName?: string;
-    refetch(variables?: Partial<TVariables>): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
-    reobserve(newOptions?: Partial<WatchQueryOptions_2<TVariables, TData>>): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
+    refetch(variables?: Partial<TVariables>): Promise<QueryResult_2<TData>>;
+    reobserve(newOptions?: Partial<WatchQueryOptions_2<TVariables, TData>>): Promise<QueryResult_2<MaybeMasked<TData>>>;
     // @internal (undocumented)
     resetDiff(): void;
     // (undocumented)
     resetLastResults(): void;
-    setVariables(variables: TVariables): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
+    setVariables(variables: TVariables): Promise<QueryResult_2<TData>>;
     // @internal (undocumented)
     silentSetOptions(newOptions: Partial<WatchQueryOptions_2<TVariables, TData>>): void;
     startPolling(pollInterval: number): void;
@@ -856,9 +859,9 @@ class QueryManager {
     };
     prioritizeCacheValues: boolean;
     // (undocumented)
-    query<TData, TVars extends OperationVariables_2 = OperationVariables_2>(options: QueryOptions<TVars, TData>, queryId?: string): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
+    query<TData, TVars extends OperationVariables_2 = OperationVariables_2>(options: QueryOptions<TVars, TData>, queryId?: string): Promise<QueryResult_2<MaybeMasked<TData>>>;
     // (undocumented)
-    reFetchObservableQueries(includeStandby?: boolean): Promise<ApolloQueryResult<any>[]>;
+    reFetchObservableQueries(includeStandby?: boolean): Promise<QueryResult_2<any>[]>;
     // Warning: (ae-forgotten-export) The symbol "InternalRefetchQueriesOptions" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "InternalRefetchQueriesMap" needs to be exported by the entry point index.d.ts
     //
@@ -937,6 +940,12 @@ export interface QueryReference<TData = unknown, TVariables = unknown> extends Q
 export type QueryResult<TData = unknown, TVariables extends OperationVariables = OperationVariables> = useQuery_2.Result<TData, TVariables>;
 
 // @public (undocumented)
+interface QueryResult_2<TData = unknown> {
+    data: TData | undefined;
+    error?: ErrorLike;
+}
+
+// @public (undocumented)
 type RefetchQueriesInclude = RefetchQueryDescriptor[] | RefetchQueriesIncludeShorthand;
 
 // @public (undocumented)
@@ -955,7 +964,7 @@ interface RefetchQueriesOptions<TCache extends ApolloCache, TResult> {
 }
 
 // @public (undocumented)
-type RefetchQueriesPromiseResults<TResult> = IsStrictlyAny<TResult> extends true ? any[] : TResult extends boolean ? ApolloQueryResult<any>[] : TResult extends PromiseLike<infer U> ? U[] : TResult[];
+type RefetchQueriesPromiseResults<TResult> = IsStrictlyAny<TResult> extends true ? any[] : TResult extends boolean ? QueryResult_2<any>[] : TResult extends PromiseLike<infer U> ? U[] : TResult[];
 
 // Warning: (ae-forgotten-export) The symbol "RefetchQueriesPromiseResults" needs to be exported by the entry point index.d.ts
 //
@@ -1234,7 +1243,7 @@ export namespace useLazyQuery {
     options?: useLazyQuery.ExecOptions<TVariables>
     ] : Record<string, never> extends OnlyRequiredProperties<TVariables> ? [
     options?: useLazyQuery.ExecOptions<TVariables>
-    ] : [options: useLazyQuery.ExecOptions<TVariables>]) => Promise<ApolloQueryResult_2<TData>>;
+    ] : [options: useLazyQuery.ExecOptions<TVariables>]) => Promise<QueryResult_3<TData>>;
     // (undocumented)
     export type ExecOptions<TVariables extends OperationVariables = OperationVariables> = {
         context?: DefaultContext;
@@ -1264,12 +1273,12 @@ export namespace useLazyQuery {
                 fetchMoreResult: Unmasked_2<TFetchData>;
                 variables: TFetchVars;
             }) => Unmasked_2<TData>;
-        }) => Promise<ApolloQueryResult_2<MaybeMasked_2<TFetchData>>>;
+        }) => Promise<QueryResult_3<MaybeMasked_2<TFetchData>>>;
         loading: boolean;
         networkStatus: NetworkStatus_2;
         observable: ObservableQuery_2<TData, TVariables>;
         previousData?: MaybeMasked_2<TData>;
-        refetch: (variables?: Partial<TVariables>) => Promise<ApolloQueryResult_2<MaybeMasked_2<TData>>>;
+        refetch: (variables?: Partial<TVariables>) => Promise<QueryResult_3<MaybeMasked_2<TData>>>;
         startPolling: (pollInterval: number) => void;
         stopPolling: () => void;
         subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
@@ -1414,12 +1423,12 @@ export namespace useQuery {
                 fetchMoreResult: Unmasked<TFetchData>;
                 variables: TFetchVars;
             }) => Unmasked<TData>;
-        }) => Promise<ApolloQueryResult_2<MaybeMasked<TFetchData>>>;
+        }) => Promise<QueryResult_3<MaybeMasked<TFetchData>>>;
         loading: boolean;
         networkStatus: NetworkStatus_2;
         observable: ObservableQuery_2<TData, TVariables>;
         previousData?: MaybeMasked<TData>;
-        refetch: (variables?: Partial<TVariables>) => Promise<ApolloQueryResult_2<MaybeMasked<TData>>>;
+        refetch: (variables?: Partial<TVariables>) => Promise<QueryResult_3<MaybeMasked<TData>>>;
         startPolling: (pollInterval: number) => void;
         stopPolling: () => void;
         subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
@@ -1653,10 +1662,10 @@ interface WatchQueryOptions_2<TVariables extends OperationVariables_2 = Operatio
 // Warnings were encountered during analysis:
 //
 // src/core/LocalState.ts:71:3 - (ae-forgotten-export) The symbol "ApolloClient_2" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:128:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:129:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:187:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:458:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:131:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:132:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:188:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:459:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:204:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:233:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:195:3 - (ae-forgotten-export) The symbol "UpdateQueryOptions" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -1662,8 +1662,8 @@ interface WatchQueryOptions_2<TVariables extends OperationVariables_2 = Operatio
 // Warnings were encountered during analysis:
 //
 // src/core/LocalState.ts:71:3 - (ae-forgotten-export) The symbol "ApolloClient_2" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:131:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:132:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:130:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:131:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:188:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:459:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:204:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report-react_hooks.api.md
+++ b/.api-reports/api-report-react_hooks.api.md
@@ -1424,8 +1424,8 @@ interface WatchQueryOptions_2<TVariables extends OperationVariables_2 = Operatio
 // Warnings were encountered during analysis:
 //
 // src/core/LocalState.ts:71:3 - (ae-forgotten-export) The symbol "ApolloClient_2" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:131:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:132:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:130:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:131:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:188:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:459:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:204:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report-react_hooks.api.md
+++ b/.api-reports/api-report-react_hooks.api.md
@@ -49,6 +49,7 @@ import type { OnlyRequiredProperties } from '@apollo/client/utilities';
 import type { OnQueryUpdated as OnQueryUpdated_2 } from '@apollo/client/core';
 import type { OperationVariables } from '@apollo/client/core';
 import type { QueryRef } from '@apollo/client/react/internal';
+import type { QueryResult as QueryResult_2 } from '@apollo/client/core';
 import type { ReactiveVar } from '@apollo/client/core';
 import type { Reference } from '@apollo/client/cache';
 import type { Reference as Reference_2 } from '@apollo/client/core';
@@ -112,17 +113,17 @@ class ApolloClient_2 implements DataProxy {
     set prioritizeCacheValues(value: boolean);
     get prioritizeCacheValues(): boolean;
     // Warning: (ae-forgotten-export) The symbol "QueryOptions" needs to be exported by the entry point index.d.ts
-    // Warning: (ae-forgotten-export) The symbol "ApolloQueryResult" needs to be exported by the entry point index.d.ts
-    query<TData = unknown, TVariables extends OperationVariables_2 = OperationVariables_2>(options: QueryOptions<TVariables, TData>): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
+    // Warning: (ae-forgotten-export) The symbol "QueryResult" needs to be exported by the entry point index.d.ts
+    query<TData = unknown, TVariables extends OperationVariables_2 = OperationVariables_2>(options: QueryOptions<TVariables, TData>): Promise<QueryResult<MaybeMasked<TData>>>;
     // (undocumented)
     queryDeduplication: boolean;
     readFragment<T = unknown, TVariables = OperationVariables_2>(options: DataProxy.Fragment<TVariables, T>, optimistic?: boolean): Unmasked<T> | null;
     readQuery<TData = unknown, TVariables = OperationVariables_2>(options: DataProxy.Query<TVariables, TData>, optimistic?: boolean): Unmasked<TData> | null;
-    reFetchObservableQueries(includeStandby?: boolean): Promise<ApolloQueryResult<any>[]>;
+    reFetchObservableQueries(includeStandby?: boolean): Promise<QueryResult<any>[]>;
     // Warning: (ae-forgotten-export) The symbol "RefetchQueriesOptions" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "RefetchQueriesResult" needs to be exported by the entry point index.d.ts
-    refetchQueries<TCache extends ApolloCache = ApolloCache, TResult = Promise<ApolloQueryResult<any>>>(options: RefetchQueriesOptions<TCache, TResult>): RefetchQueriesResult<TResult>;
-    resetStore(): Promise<ApolloQueryResult<any>[] | null>;
+    refetchQueries<TCache extends ApolloCache = ApolloCache, TResult = Promise<QueryResult<any>>>(options: RefetchQueriesOptions<TCache, TResult>): RefetchQueriesResult<TResult>;
+    resetStore(): Promise<QueryResult<any>[] | null>;
     restore(serializedState: unknown): ApolloCache;
     setLink(newLink: ApolloLink): void;
     // Warning: (ae-forgotten-export) The symbol "FragmentMatcher" needs to be exported by the entry point index.d.ts
@@ -285,7 +286,7 @@ interface InternalRefetchQueriesOptions<TCache extends ApolloCache, TResult> ext
 }
 
 // @public (undocumented)
-type InternalRefetchQueriesResult<TResult> = TResult extends boolean ? Promise<ApolloQueryResult<any>> : TResult;
+type InternalRefetchQueriesResult<TResult> = TResult extends boolean ? Promise<QueryResult<any>> : TResult;
 
 // Warning: (ae-forgotten-export) The symbol "RefetchQueryDescriptor" needs to be exported by the entry point index.d.ts
 //
@@ -456,6 +457,8 @@ interface NextFetchPolicyContext<TData, TVariables extends OperationVariables_2>
 interface ObservableAndInfo<TData> {
     // (undocumented)
     fromLink: boolean;
+    // Warning: (ae-forgotten-export) The symbol "ApolloQueryResult" needs to be exported by the entry point index.d.ts
+    //
     // (undocumented)
     observable: Observable<ApolloQueryResult<TData>>;
 }
@@ -477,7 +480,7 @@ class ObservableQuery<TData = unknown, TVariables extends OperationVariables_2 =
             fetchMoreResult: Unmasked<TFetchData>;
             variables: TFetchVars;
         }) => Unmasked<TData>;
-    }): Promise<ApolloQueryResult<MaybeMasked<TFetchData>>>;
+    }): Promise<QueryResult<TFetchData>>;
     // (undocumented)
     getCurrentResult(saveAsLastResult?: boolean): ApolloQueryResult<MaybeMasked<TData>>;
     // (undocumented)
@@ -498,13 +501,13 @@ class ObservableQuery<TData = unknown, TVariables extends OperationVariables_2 =
     readonly queryId: string;
     // (undocumented)
     readonly queryName?: string;
-    refetch(variables?: Partial<TVariables>): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
-    reobserve(newOptions?: Partial<WatchQueryOptions_2<TVariables, TData>>): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
+    refetch(variables?: Partial<TVariables>): Promise<QueryResult<TData>>;
+    reobserve(newOptions?: Partial<WatchQueryOptions_2<TVariables, TData>>): Promise<QueryResult<MaybeMasked<TData>>>;
     // @internal (undocumented)
     resetDiff(): void;
     // (undocumented)
     resetLastResults(): void;
-    setVariables(variables: TVariables): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
+    setVariables(variables: TVariables): Promise<QueryResult<TData>>;
     // @internal (undocumented)
     silentSetOptions(newOptions: Partial<WatchQueryOptions_2<TVariables, TData>>): void;
     startPolling(pollInterval: number): void;
@@ -672,9 +675,9 @@ class QueryManager {
     };
     prioritizeCacheValues: boolean;
     // (undocumented)
-    query<TData, TVars extends OperationVariables_2 = OperationVariables_2>(options: QueryOptions<TVars, TData>, queryId?: string): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
+    query<TData, TVars extends OperationVariables_2 = OperationVariables_2>(options: QueryOptions<TVars, TData>, queryId?: string): Promise<QueryResult<MaybeMasked<TData>>>;
     // (undocumented)
-    reFetchObservableQueries(includeStandby?: boolean): Promise<ApolloQueryResult<any>[]>;
+    reFetchObservableQueries(includeStandby?: boolean): Promise<QueryResult<any>[]>;
     // Warning: (ae-forgotten-export) The symbol "InternalRefetchQueriesOptions" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "InternalRefetchQueriesMap" needs to be exported by the entry point index.d.ts
     //
@@ -738,6 +741,12 @@ interface QueryOptions<TVariables = OperationVariables_2, TData = unknown> {
 }
 
 // @public (undocumented)
+interface QueryResult<TData = unknown> {
+    data: TData | undefined;
+    error?: ErrorLike;
+}
+
+// @public (undocumented)
 type RefetchQueriesInclude = RefetchQueryDescriptor[] | RefetchQueriesIncludeShorthand;
 
 // @public (undocumented)
@@ -756,7 +765,7 @@ interface RefetchQueriesOptions<TCache extends ApolloCache, TResult> {
 }
 
 // @public (undocumented)
-type RefetchQueriesPromiseResults<TResult> = IsStrictlyAny<TResult> extends true ? any[] : TResult extends boolean ? ApolloQueryResult<any>[] : TResult extends PromiseLike<infer U> ? U[] : TResult[];
+type RefetchQueriesPromiseResults<TResult> = IsStrictlyAny<TResult> extends true ? any[] : TResult extends boolean ? QueryResult<any>[] : TResult extends PromiseLike<infer U> ? U[] : TResult[];
 
 // Warning: (ae-forgotten-export) The symbol "RefetchQueriesPromiseResults" needs to be exported by the entry point index.d.ts
 //
@@ -1014,7 +1023,7 @@ export namespace useLazyQuery {
     options?: useLazyQuery.ExecOptions<TVariables>
     ] : Record<string, never> extends OnlyRequiredProperties<TVariables> ? [
     options?: useLazyQuery.ExecOptions<TVariables>
-    ] : [options: useLazyQuery.ExecOptions<TVariables>]) => Promise<ApolloQueryResult_2<TData>>;
+    ] : [options: useLazyQuery.ExecOptions<TVariables>]) => Promise<QueryResult_2<TData>>;
     // (undocumented)
     export type ExecOptions<TVariables extends OperationVariables = OperationVariables> = {
         context?: DefaultContext_2;
@@ -1044,12 +1053,12 @@ export namespace useLazyQuery {
                 fetchMoreResult: Unmasked_2<TFetchData>;
                 variables: TFetchVars;
             }) => Unmasked_2<TData>;
-        }) => Promise<ApolloQueryResult_2<MaybeMasked_2<TFetchData>>>;
+        }) => Promise<QueryResult_2<MaybeMasked_2<TFetchData>>>;
         loading: boolean;
         networkStatus: NetworkStatus_2;
         observable: ObservableQuery_2<TData, TVariables>;
         previousData?: MaybeMasked_2<TData>;
-        refetch: (variables?: Partial<TVariables>) => Promise<ApolloQueryResult_2<MaybeMasked_2<TData>>>;
+        refetch: (variables?: Partial<TVariables>) => Promise<QueryResult_2<MaybeMasked_2<TData>>>;
         startPolling: (pollInterval: number) => void;
         stopPolling: () => void;
         subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
@@ -1191,12 +1200,12 @@ export namespace useQuery {
                 fetchMoreResult: Unmasked<TFetchData>;
                 variables: TFetchVars;
             }) => Unmasked<TData>;
-        }) => Promise<ApolloQueryResult_2<MaybeMasked<TFetchData>>>;
+        }) => Promise<QueryResult_2<MaybeMasked<TFetchData>>>;
         loading: boolean;
         networkStatus: NetworkStatus_2;
         observable: ObservableQuery_2<TData, TVariables>;
         previousData?: MaybeMasked<TData>;
-        refetch: (variables?: Partial<TVariables>) => Promise<ApolloQueryResult_2<MaybeMasked<TData>>>;
+        refetch: (variables?: Partial<TVariables>) => Promise<QueryResult_2<MaybeMasked<TData>>>;
         startPolling: (pollInterval: number) => void;
         stopPolling: () => void;
         subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
@@ -1415,10 +1424,10 @@ interface WatchQueryOptions_2<TVariables extends OperationVariables_2 = Operatio
 // Warnings were encountered during analysis:
 //
 // src/core/LocalState.ts:71:3 - (ae-forgotten-export) The symbol "ApolloClient_2" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:128:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:129:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:187:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:458:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:131:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:132:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:188:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:459:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:204:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:233:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:195:3 - (ae-forgotten-export) The symbol "UpdateQueryOptions" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report-react_internal.api.md
+++ b/.api-reports/api-report-react_internal.api.md
@@ -16,6 +16,7 @@ import type { ObservableQuery } from '@apollo/client/core';
 import type { OnlyRequiredProperties } from '@apollo/client/utilities';
 import type { OperationVariables } from '@apollo/client/core';
 import type { PromiseWithState } from '@apollo/client/utilities';
+import type { QueryResult } from '@apollo/client/core';
 import type { Unmasked } from '@apollo/client/core';
 import type { useBackgroundQuery } from '@apollo/client/react/hooks';
 import type { useFragment } from '@apollo/client/react/hooks';
@@ -50,7 +51,7 @@ export type FetchMoreFunction<TData, TVariables extends OperationVariables> = (f
         fetchMoreResult: Unmasked<TData>;
         variables: TVariables;
     }) => Unmasked<TData>;
-}) => Promise<ApolloQueryResult<MaybeMasked_2<TData>>>;
+}) => Promise<QueryResult<MaybeMasked_2<TData>>>;
 
 // @public (undocumented)
 type FetchMoreOptions<TData> = Parameters<ObservableQuery<TData>["fetchMore"]>[0];
@@ -140,7 +141,7 @@ export class InternalQueryReference<TData = unknown> {
     // Warning: (ae-forgotten-export) The symbol "FetchMoreOptions" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    fetchMore(options: FetchMoreOptions<TData>): Promise<ApolloQueryResult<TData>>;
+    fetchMore(options: FetchMoreOptions<TData>): Promise<QueryResult<TData>>;
     // (undocumented)
     readonly key: QueryKey;
     // Warning: (ae-forgotten-export) The symbol "Listener" needs to be exported by the entry point index.d.ts
@@ -152,7 +153,7 @@ export class InternalQueryReference<TData = unknown> {
     // (undocumented)
     promise: QueryRefPromise<TData>;
     // (undocumented)
-    refetch(variables: OperationVariables | undefined): Promise<ApolloQueryResult<TData>>;
+    refetch(variables: OperationVariables | undefined): Promise<QueryResult<TData>>;
     // (undocumented)
     reinitialize(): void;
     // (undocumented)

--- a/.api-reports/api-report-utilities_internal.api.md
+++ b/.api-reports/api-report-utilities_internal.api.md
@@ -4,7 +4,9 @@
 
 ```ts
 
+import type { ApolloQueryResult } from '@apollo/client/core';
 import { Observable } from 'rxjs';
+import type { QueryResult } from '@apollo/client/core';
 
 // @internal
 export const getApolloCacheMemoryInternals: (() => {
@@ -95,6 +97,9 @@ export function onAnyEvent<T>(handleEvent: (event: ObservableEvent<T>) => void):
 //
 // @public (undocumented)
 export function registerGlobalCache(name: keyof typeof globalCaches, getSize: () => number): void;
+
+// @public (undocumented)
+export function toQueryResult<TData = unknown>(value: ApolloQueryResult<TData>): QueryResult<TData>;
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -2481,8 +2481,8 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/cache/inmemory/policies.ts:166:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/policies.ts:166:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/types.ts:133:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:131:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:132:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:130:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:131:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:188:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:459:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
 // src/link/http/selectHttpOptionsAndBody.ts:128:1 - (ae-forgotten-export) The symbol "HttpQueryOptions" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -124,14 +124,14 @@ export class ApolloClient implements DataProxy {
     onResetStore(cb: () => Promise<any>): () => void;
     set prioritizeCacheValues(value: boolean);
     get prioritizeCacheValues(): boolean;
-    query<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: QueryOptions<TVariables, TData>): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
+    query<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: QueryOptions<TVariables, TData>): Promise<QueryResult<MaybeMasked<TData>>>;
     // (undocumented)
     queryDeduplication: boolean;
     readFragment<T = unknown, TVariables = OperationVariables>(options: DataProxy.Fragment<TVariables, T>, optimistic?: boolean): Unmasked<T> | null;
     readQuery<TData = unknown, TVariables = OperationVariables>(options: DataProxy.Query<TVariables, TData>, optimistic?: boolean): Unmasked<TData> | null;
-    reFetchObservableQueries(includeStandby?: boolean): Promise<ApolloQueryResult<any>[]>;
-    refetchQueries<TCache extends ApolloCache = ApolloCache, TResult = Promise<ApolloQueryResult<any>>>(options: RefetchQueriesOptions<TCache, TResult>): RefetchQueriesResult<TResult>;
-    resetStore(): Promise<ApolloQueryResult<any>[] | null>;
+    reFetchObservableQueries(includeStandby?: boolean): Promise<QueryResult<any>[]>;
+    refetchQueries<TCache extends ApolloCache = ApolloCache, TResult = Promise<QueryResult<any>>>(options: RefetchQueriesOptions<TCache, TResult>): RefetchQueriesResult<TResult>;
+    resetStore(): Promise<QueryResult<any>[] | null>;
     restore(serializedState: unknown): ApolloCache;
     setLink(newLink: ApolloLink): void;
     setLocalStateFragmentMatcher(fragmentMatcher: FragmentMatcher): void;
@@ -1186,7 +1186,7 @@ export interface InternalRefetchQueriesOptions<TCache extends ApolloCache, TResu
 }
 
 // @public (undocumented)
-export type InternalRefetchQueriesResult<TResult> = TResult extends boolean ? Promise<ApolloQueryResult<any>> : TResult;
+export type InternalRefetchQueriesResult<TResult> = TResult extends boolean ? Promise<QueryResult<any>> : TResult;
 
 // @public (undocumented)
 export type InternalRefetchQueryDescriptor = RefetchQueryDescriptor | QueryOptions;
@@ -1635,7 +1635,7 @@ export class ObservableQuery<TData = unknown, TVariables extends OperationVariab
             fetchMoreResult: Unmasked<TFetchData>;
             variables: TFetchVars;
         }) => Unmasked<TData>;
-    }): Promise<ApolloQueryResult<MaybeMasked<TFetchData>>>;
+    }): Promise<QueryResult<TFetchData>>;
     // (undocumented)
     getCurrentResult(saveAsLastResult?: boolean): ApolloQueryResult<MaybeMasked<TData>>;
     // (undocumented)
@@ -1656,13 +1656,13 @@ export class ObservableQuery<TData = unknown, TVariables extends OperationVariab
     readonly queryId: string;
     // (undocumented)
     readonly queryName?: string;
-    refetch(variables?: Partial<TVariables>): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
-    reobserve(newOptions?: Partial<WatchQueryOptions<TVariables, TData>>): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
+    refetch(variables?: Partial<TVariables>): Promise<QueryResult<TData>>;
+    reobserve(newOptions?: Partial<WatchQueryOptions<TVariables, TData>>): Promise<QueryResult<MaybeMasked<TData>>>;
     // @internal (undocumented)
     resetDiff(): void;
     // (undocumented)
     resetLastResults(): void;
-    setVariables(variables: TVariables): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
+    setVariables(variables: TVariables): Promise<QueryResult<TData>>;
     // @internal (undocumented)
     silentSetOptions(newOptions: Partial<WatchQueryOptions<TVariables, TData>>): void;
     startPolling(pollInterval: number): void;
@@ -1927,9 +1927,9 @@ class QueryManager {
     };
     prioritizeCacheValues: boolean;
     // (undocumented)
-    query<TData, TVars extends OperationVariables = OperationVariables>(options: QueryOptions<TVars, TData>, queryId?: string): Promise<ApolloQueryResult<MaybeMasked<TData>>>;
+    query<TData, TVars extends OperationVariables = OperationVariables>(options: QueryOptions<TVars, TData>, queryId?: string): Promise<QueryResult<MaybeMasked<TData>>>;
     // (undocumented)
-    reFetchObservableQueries(includeStandby?: boolean): Promise<ApolloQueryResult<any>[]>;
+    reFetchObservableQueries(includeStandby?: boolean): Promise<QueryResult<any>[]>;
     // (undocumented)
     refetchQueries<TResult>({ updateCache, include, optimistic, removeOptimistic, onQueryUpdated, }: InternalRefetchQueriesOptions<ApolloCache, TResult>): InternalRefetchQueriesMap<TResult>;
     // (undocumented)
@@ -1990,6 +1990,12 @@ interface QueryOptions<TVariables = OperationVariables, TData = unknown> {
 }
 export { QueryOptions as PureQueryOptions }
 export { QueryOptions }
+
+// @public (undocumented)
+export interface QueryResult<TData = unknown> {
+    data: TData | undefined;
+    error?: ErrorLike;
+}
 
 // @public (undocumented)
 type ReactiveListener<T> = (value: T) => any;
@@ -2069,7 +2075,7 @@ export interface RefetchQueriesOptions<TCache extends ApolloCache, TResult> {
 // Warning: (ae-forgotten-export) The symbol "IsStrictlyAny" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export type RefetchQueriesPromiseResults<TResult> = IsStrictlyAny<TResult> extends true ? any[] : TResult extends boolean ? ApolloQueryResult<any>[] : TResult extends PromiseLike<infer U> ? U[] : TResult[];
+export type RefetchQueriesPromiseResults<TResult> = IsStrictlyAny<TResult> extends true ? any[] : TResult extends boolean ? QueryResult<any>[] : TResult extends PromiseLike<infer U> ? U[] : TResult[];
 
 // @public (undocumented)
 export interface RefetchQueriesResult<TResult> extends Promise<RefetchQueriesPromiseResults<TResult>> {
@@ -2475,10 +2481,10 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/cache/inmemory/policies.ts:166:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/policies.ts:166:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/types.ts:133:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:128:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:129:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:187:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:458:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:131:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:132:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:188:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:459:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
 // src/link/http/selectHttpOptionsAndBody.ts:128:1 - (ae-forgotten-export) The symbol "HttpQueryOptions" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.changeset/tender-swans-flash.md
+++ b/.changeset/tender-swans-flash.md
@@ -1,0 +1,16 @@
+---
+"@apollo/client": major
+---
+
+Remove `loading`, `networkStatus`, and `partial` properties on all promise-based query APIs. These properties were mostly static and were unnecessary since promise resolution guaranteed that the query was not longer loading.
+
+This affects the following APIs:
+- `client.query`
+- `client.refetchQueries`
+- `client.reFetchObservableQueries`
+- `client.resetStore`
+- `observableQuery.fetchMore`
+- `observableQuery.refetch`
+- `observableQuery.reobserve`
+- `observableQuery.setVariables`
+- The `useLazyQuery` `execute` function

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 42383,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 37682,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 32715,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27593
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 42468,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 37846,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 32772,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27643
 }

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 42468,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 37846,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 32772,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27643
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 42421,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 37823,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 32791,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27591
 }

--- a/src/__tests__/__snapshots__/exports.ts.snap
+++ b/src/__tests__/__snapshots__/exports.ts.snap
@@ -504,6 +504,7 @@ Array [
   "getInMemoryCacheMemoryInternals",
   "onAnyEvent",
   "registerGlobalCache",
+  "toQueryResult",
 ]
 `;
 

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -2679,7 +2679,7 @@ describe("client", () => {
 
     await expect(
       client.query({ query, errorPolicy: "all" })
-    ).resolves.toEqualApolloQueryResult({
+    ).resolves.toEqualStrictTyped({
       data: { posts: null },
       error: new CombinedGraphQLErrors([
         { message: 'Cannot query field "foo" on type "Post".' },
@@ -2711,7 +2711,7 @@ describe("client", () => {
 
     await expect(
       client.query({ query, errorPolicy: "all" })
-    ).resolves.toEqualApolloQueryResult({
+    ).resolves.toEqualStrictTyped({
       data: undefined,
       error,
       loading: false,
@@ -2743,7 +2743,7 @@ describe("client", () => {
 
     await expect(
       client.query({ query, errorPolicy: "ignore" })
-    ).resolves.toEqualApolloQueryResult({
+    ).resolves.toEqualStrictTyped({
       data: { posts: null },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -2772,7 +2772,7 @@ describe("client", () => {
 
     await expect(
       client.query({ query, errorPolicy: "ignore" })
-    ).resolves.toEqualApolloQueryResult({
+    ).resolves.toEqualStrictTyped({
       data: undefined,
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -3686,7 +3686,7 @@ describe("@connection", () => {
 
       const result = await client.query({ query });
 
-      expect(result).toEqualApolloQueryResult({
+      expect(result).toEqualStrictTyped({
         data: undefined,
         error: new CombinedGraphQLErrors(errors),
         loading: false,

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -3627,7 +3627,6 @@ describe("@connection", () => {
         data: { linkCount: 3 },
       });
 
-      expect(finalResult.data).toEqual({ linkCount: 3 });
       expect(fetchPolicyRecord).toEqual([
         "cache-first",
         "network-only",

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -3604,8 +3604,7 @@ describe("@connection", () => {
       });
 
       expect(results).toHaveLength(1);
-      expect(results[0]).toMatchObject({
-        loading: false,
+      expect(results[0]).toEqualStrictTyped({
         data: { linkCount: 2 },
       });
 
@@ -3624,7 +3623,10 @@ describe("@connection", () => {
         fetchPolicy: "cache-and-network",
       });
 
-      expect(finalResult.loading).toBe(false);
+      expect(finalResult).toEqualStrictTyped({
+        data: { linkCount: 3 },
+      });
+
       expect(finalResult.data).toEqual({ linkCount: 3 });
       expect(fetchPolicyRecord).toEqual([
         "cache-first",

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -2684,9 +2684,6 @@ describe("client", () => {
       error: new CombinedGraphQLErrors([
         { message: 'Cannot query field "foo" on type "Post".' },
       ]),
-      loading: false,
-      networkStatus: NetworkStatus.error,
-      partial: false,
     });
   });
 
@@ -2711,13 +2708,7 @@ describe("client", () => {
 
     await expect(
       client.query({ query, errorPolicy: "all" })
-    ).resolves.toEqualStrictTyped({
-      data: undefined,
-      error,
-      loading: false,
-      networkStatus: NetworkStatus.error,
-      partial: true,
-    });
+    ).resolves.toEqualStrictTyped({ data: undefined, error });
   });
 
   it("resolves partial data and strips errors when errorPolicy is 'ignore'", async () => {
@@ -2743,12 +2734,7 @@ describe("client", () => {
 
     await expect(
       client.query({ query, errorPolicy: "ignore" })
-    ).resolves.toEqualStrictTyped({
-      data: { posts: null },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
-    });
+    ).resolves.toEqualStrictTyped({ data: { posts: null } });
   });
 
   it("resolves with no data or errors for network error when errorPolicy is 'ignore'", async () => {
@@ -2772,12 +2758,7 @@ describe("client", () => {
 
     await expect(
       client.query({ query, errorPolicy: "ignore" })
-    ).resolves.toEqualStrictTyped({
-      data: undefined,
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: true,
-    });
+    ).resolves.toEqualStrictTyped({ data: undefined });
   });
 
   it("should warn if server returns wrong data", async () => {
@@ -3689,9 +3670,6 @@ describe("@connection", () => {
       expect(result).toEqualStrictTyped({
         data: undefined,
         error: new CombinedGraphQLErrors(errors),
-        loading: false,
-        networkStatus: NetworkStatus.error,
-        partial: true,
       });
     });
 

--- a/src/__tests__/dataMasking.ts
+++ b/src/__tests__/dataMasking.ts
@@ -3872,9 +3872,6 @@ describe("client.query", () => {
     expect(result).toEqualStrictTyped({
       data: { currentUser: null },
       error: new CombinedGraphQLErrors([{ message: "User not logged in" }]),
-      loading: false,
-      networkStatus: NetworkStatus.error,
-      partial: false,
     });
   });
 
@@ -3929,9 +3926,6 @@ describe("client.query", () => {
       error: new CombinedGraphQLErrors([
         { message: "Could not determine age" },
       ]),
-      loading: false,
-      networkStatus: NetworkStatus.error,
-      partial: false,
     });
   });
 

--- a/src/__tests__/dataMasking.ts
+++ b/src/__tests__/dataMasking.ts
@@ -3869,7 +3869,7 @@ describe("client.query", () => {
 
     const result = await client.query({ query, errorPolicy: "all" });
 
-    expect(result).toEqualApolloQueryResult({
+    expect(result).toEqualStrictTyped({
       data: { currentUser: null },
       error: new CombinedGraphQLErrors([{ message: "User not logged in" }]),
       loading: false,
@@ -3918,7 +3918,7 @@ describe("client.query", () => {
 
     const result = await client.query({ query, errorPolicy: "all" });
 
-    expect(result).toEqualApolloQueryResult({
+    expect(result).toEqualStrictTyped({
       data: {
         currentUser: {
           __typename: "User",

--- a/src/__tests__/fetchMore.ts
+++ b/src/__tests__/fetchMore.ts
@@ -633,7 +633,7 @@ describe("fetchMore on an observable query", () => {
           },
         });
 
-        expect(fetchMoreResult).toEqualApolloQueryResult({
+        expect(fetchMoreResult).toEqualStrictTyped({
           loading: false,
           networkStatus: NetworkStatus.ready,
           data: {
@@ -665,7 +665,7 @@ describe("fetchMore on an observable query", () => {
           },
         });
 
-        expect(fetchMoreResult).toEqualApolloQueryResult({
+        expect(fetchMoreResult).toEqualStrictTyped({
           loading: false,
           networkStatus: NetworkStatus.ready,
           data: {
@@ -732,7 +732,7 @@ describe("fetchMore on an observable query", () => {
           },
         });
 
-        expect(fetchMoreResult).toEqualApolloQueryResult({
+        expect(fetchMoreResult).toEqualStrictTyped({
           loading: false,
           networkStatus: NetworkStatus.ready,
           data: {
@@ -773,7 +773,7 @@ describe("fetchMore on an observable query", () => {
           },
         });
 
-        expect(fetchMoreResult).toEqualApolloQueryResult({
+        expect(fetchMoreResult).toEqualStrictTyped({
           loading: false,
           networkStatus: NetworkStatus.ready,
           data: {
@@ -848,7 +848,7 @@ describe("fetchMore on an observable query", () => {
           },
         });
 
-        expect(fetchMoreResult).toEqualApolloQueryResult({
+        expect(fetchMoreResult).toEqualStrictTyped({
           loading: false,
           networkStatus: NetworkStatus.ready,
           data: {
@@ -880,7 +880,7 @@ describe("fetchMore on an observable query", () => {
           },
         });
 
-        expect(fetchMoreResult).toEqualApolloQueryResult({
+        expect(fetchMoreResult).toEqualStrictTyped({
           loading: false,
           networkStatus: NetworkStatus.ready,
           data: {
@@ -946,7 +946,7 @@ describe("fetchMore on an observable query", () => {
           },
         });
 
-        expect(fetchMoreResult).toEqualApolloQueryResult({
+        expect(fetchMoreResult).toEqualStrictTyped({
           loading: false,
           networkStatus: NetworkStatus.ready,
           data: {
@@ -987,7 +987,7 @@ describe("fetchMore on an observable query", () => {
           },
         });
 
-        expect(fetchMoreResult).toEqualApolloQueryResult({
+        expect(fetchMoreResult).toEqualStrictTyped({
           loading: false,
           networkStatus: NetworkStatus.ready,
           data: {
@@ -1162,7 +1162,7 @@ describe("fetchMore on an observable query", () => {
         },
       });
 
-      expect(fetchMoreResult).toEqualApolloQueryResult({
+      expect(fetchMoreResult).toEqualStrictTyped({
         loading: false,
         networkStatus: NetworkStatus.ready,
         data: {
@@ -1434,7 +1434,7 @@ describe("fetchMore on an observable query", () => {
       variables,
     });
 
-    expect(fetchMoreResult).toEqualApolloQueryResult({
+    expect(fetchMoreResult).toEqualStrictTyped({
       loading: false,
       networkStatus: NetworkStatus.ready,
       data: { emptyItems: [] },
@@ -1868,7 +1868,7 @@ test("uses updateQuery to update the result of the query with no-cache queries",
     }),
   });
 
-  expect(fetchMoreResult).toEqualApolloQueryResult({
+  expect(fetchMoreResult).toEqualStrictTyped({
     data: {
       letters: [
         { __typename: "Letter", letter: "C", position: 3 },
@@ -1907,7 +1907,7 @@ test("uses updateQuery to update the result of the query with no-cache queries",
   });
 
   // Ensure we store the merged result as the last result
-  expect(observable.getCurrentResult(false)).toEqualApolloQueryResult({
+  expect(observable.getCurrentResult(false)).toEqualStrictTyped({
     data: {
       letters: [
         { __typename: "Letter", letter: "A", position: 1 },
@@ -1928,7 +1928,7 @@ test("uses updateQuery to update the result of the query with no-cache queries",
     updateQuery: (_, { fetchMoreResult }) => fetchMoreResult,
   });
 
-  expect(fetchMoreResult).toEqualApolloQueryResult({
+  expect(fetchMoreResult).toEqualStrictTyped({
     data: {
       letters: [
         { __typename: "Letter", letter: "E", position: 5 },
@@ -1966,7 +1966,7 @@ test("uses updateQuery to update the result of the query with no-cache queries",
     partial: false,
   });
 
-  expect(observable.getCurrentResult(false)).toEqualApolloQueryResult({
+  expect(observable.getCurrentResult(false)).toEqualStrictTyped({
     data: {
       letters: [
         { __typename: "Letter", letter: "E", position: 5 },

--- a/src/__tests__/fetchMore.ts
+++ b/src/__tests__/fetchMore.ts
@@ -314,7 +314,6 @@ describe("fetchMore on an observable query", () => {
         });
 
         // This is the server result
-        expect(fetchMoreResult.loading).toBe(false);
         expect(fetchMoreResult.data!.entry.comments).toHaveLength(10);
       }
 
@@ -365,7 +364,6 @@ describe("fetchMore on an observable query", () => {
         });
 
         // This is the server result
-        expect(fetchMoreResult.loading).toBe(false);
         expect(fetchMoreResult.data!.entry.comments).toHaveLength(10);
       }
 
@@ -420,7 +418,6 @@ describe("fetchMore on an observable query", () => {
 
         const fetchMoreComments = fetchMoreResult.data!.entry.comments;
 
-        expect(fetchMoreResult.loading).toBe(false);
         expect(fetchMoreComments).toHaveLength(10);
         fetchMoreComments.forEach((comment, i) => {
           expect(comment.text).toEqual(`comment ${i + 11}`);
@@ -477,7 +474,6 @@ describe("fetchMore on an observable query", () => {
           variables: { start: 10 },
         });
 
-        expect(fetchMoreResult.loading).toBe(false);
         expect(fetchMoreResult.data!.entry.comments).toHaveLength(10); // this is the server result
       }
 
@@ -634,12 +630,7 @@ describe("fetchMore on an observable query", () => {
         });
 
         expect(fetchMoreResult).toEqualStrictTyped({
-          loading: false,
-          networkStatus: NetworkStatus.ready,
-          data: {
-            TODO: tasks.slice(2, 4),
-          },
-          partial: false,
+          data: { TODO: tasks.slice(2, 4) },
         });
       }
 
@@ -666,12 +657,9 @@ describe("fetchMore on an observable query", () => {
         });
 
         expect(fetchMoreResult).toEqualStrictTyped({
-          loading: false,
-          networkStatus: NetworkStatus.ready,
           data: {
             TODO: tasks.slice(5, 8),
           },
-          partial: false,
         });
       }
 
@@ -733,12 +721,9 @@ describe("fetchMore on an observable query", () => {
         });
 
         expect(fetchMoreResult).toEqualStrictTyped({
-          loading: false,
-          networkStatus: NetworkStatus.ready,
           data: {
             TODO: tasks.slice(2, 4),
           },
-          partial: false,
         });
       }
 
@@ -774,12 +759,9 @@ describe("fetchMore on an observable query", () => {
         });
 
         expect(fetchMoreResult).toEqualStrictTyped({
-          loading: false,
-          networkStatus: NetworkStatus.ready,
           data: {
             TODO: tasks.slice(5, 8),
           },
-          partial: false,
         });
       }
 
@@ -849,12 +831,9 @@ describe("fetchMore on an observable query", () => {
         });
 
         expect(fetchMoreResult).toEqualStrictTyped({
-          loading: false,
-          networkStatus: NetworkStatus.ready,
           data: {
             TODO: tasks.slice(2, 4),
           },
-          partial: false,
         });
       }
 
@@ -881,12 +860,9 @@ describe("fetchMore on an observable query", () => {
         });
 
         expect(fetchMoreResult).toEqualStrictTyped({
-          loading: false,
-          networkStatus: NetworkStatus.ready,
           data: {
             TODO: tasks.slice(5, 8),
           },
-          partial: false,
         });
       }
 
@@ -947,12 +923,9 @@ describe("fetchMore on an observable query", () => {
         });
 
         expect(fetchMoreResult).toEqualStrictTyped({
-          loading: false,
-          networkStatus: NetworkStatus.ready,
           data: {
             TODO: tasks.slice(2, 4),
           },
-          partial: false,
         });
       }
 
@@ -988,12 +961,9 @@ describe("fetchMore on an observable query", () => {
         });
 
         expect(fetchMoreResult).toEqualStrictTyped({
-          loading: false,
-          networkStatus: NetworkStatus.ready,
           data: {
             TODO: tasks.slice(5, 8),
           },
-          partial: false,
         });
       }
 
@@ -1163,12 +1133,9 @@ describe("fetchMore on an observable query", () => {
       });
 
       expect(fetchMoreResult).toEqualStrictTyped({
-        loading: false,
-        networkStatus: NetworkStatus.ready,
         data: {
           groceries: additionalGroceries,
         },
-        partial: false,
       });
 
       expect(observable.options.fetchPolicy).toBe("cache-first");
@@ -1226,7 +1193,6 @@ describe("fetchMore on an observable query", () => {
         },
       });
 
-      expect(fetchMoreResult.loading).toBe(false);
       expect(fetchMoreResult.data!.comments).toHaveLength(10);
     }
 
@@ -1435,10 +1401,7 @@ describe("fetchMore on an observable query", () => {
     });
 
     expect(fetchMoreResult).toEqualStrictTyped({
-      loading: false,
-      networkStatus: NetworkStatus.ready,
       data: { emptyItems: [] },
-      partial: false,
     });
 
     await expect(stream).toEmitApolloQueryResult({
@@ -1623,7 +1586,6 @@ describe("fetchMore on an observable query with connection", () => {
         });
 
         expect(fetchMoreResult.data!.entry.comments).toHaveLength(10);
-        expect(fetchMoreResult.loading).toBe(false);
       }
 
       {
@@ -1675,7 +1637,6 @@ describe("fetchMore on an observable query with connection", () => {
         });
 
         // this is the server result
-        expect(fetchMoreResult.loading).toBe(false);
         expect(fetchMoreResult.data!.entry.comments).toHaveLength(10);
       }
 
@@ -1875,9 +1836,6 @@ test("uses updateQuery to update the result of the query with no-cache queries",
         { __typename: "Letter", letter: "D", position: 4 },
       ],
     },
-    loading: false,
-    networkStatus: NetworkStatus.ready,
-    partial: false,
   });
 
   await expect(stream).toEmitApolloQueryResult({
@@ -1935,9 +1893,6 @@ test("uses updateQuery to update the result of the query with no-cache queries",
         { __typename: "Letter", letter: "F", position: 6 },
       ],
     },
-    loading: false,
-    networkStatus: NetworkStatus.ready,
-    partial: false,
   });
 
   await expect(stream).toEmitApolloQueryResult({

--- a/src/__tests__/local-state/resolvers.ts
+++ b/src/__tests__/local-state/resolvers.ts
@@ -5,8 +5,8 @@ import { of } from "rxjs";
 import { InMemoryCache, isReference } from "@apollo/client/cache";
 import {
   ApolloClient,
-  ApolloQueryResult,
   NetworkStatus,
+  QueryResult,
   Resolvers,
 } from "@apollo/client/core";
 import { ApolloLink } from "@apollo/client/link/core";
@@ -397,12 +397,7 @@ describe("Basic resolver capabilities", () => {
 
     const result = await client.query({ query, fetchPolicy: "network-only" });
 
-    expect(result).toEqualStrictTyped({
-      data: { isInCart: false },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
-    });
+    expect(result).toEqualStrictTyped({ data: { isInCart: false } });
   });
 
   it("should handle nested asynchronous @client resolvers (issue #4841)", () => {
@@ -481,7 +476,7 @@ describe("Basic resolver capabilities", () => {
       },
     });
 
-    function check(result: ApolloQueryResult<any>) {
+    function check(result: QueryResult<any>) {
       return new Promise<void>((resolve) => {
         expect(result.data.developer.id).toBe(developerId);
         expect(result.data.developer.handle).toBe("@benjamn");
@@ -606,12 +601,7 @@ describe("Writing cache data from resolvers", () => {
     await client.mutate({ mutation });
     const result = await client.query({ query });
 
-    expect(result).toEqualStrictTyped({
-      data: { field: 1 },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
-    });
+    expect(result).toEqualStrictTyped({ data: { field: 1 } });
   });
 
   it("should let you write to the cache with a mutation using an ID", async () => {
@@ -666,9 +656,6 @@ describe("Writing cache data from resolvers", () => {
 
     expect(result).toEqualStrictTyped({
       data: { obj: { __typename: "Object", field: 2 } },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
   });
 
@@ -737,9 +724,6 @@ describe("Writing cache data from resolvers", () => {
           id: "uniqueId",
         },
       },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
   });
 });
@@ -780,9 +764,6 @@ describe("Resolving field aliases", () => {
         foo: { bar: true, __typename: "Foo" },
         baz: { foo: true, __typename: "Baz" },
       },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
   });
 
@@ -811,9 +792,6 @@ describe("Resolving field aliases", () => {
 
     expect(result).toEqualStrictTyped({
       data: { fie: { bar: true, __typename: "Foo" } },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
     expect(fie).not.toHaveBeenCalled();
   });
@@ -853,9 +831,6 @@ describe("Resolving field aliases", () => {
         fie: { fum: true, __typename: "Foo" },
         baz: { foo: true, __typename: "Baz" },
       },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
     expect(fie).not.toHaveBeenCalled();
   });
@@ -896,9 +871,6 @@ describe("Resolving field aliases", () => {
 
     expect(result).toEqualStrictTyped({
       data: { fie: { bar: "yo", __typename: "Foo" } },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
   });
 
@@ -959,18 +931,12 @@ describe("Resolving field aliases", () => {
     // stored in the cache).
     await expect(client.query({ query })).resolves.toEqualStrictTyped({
       data: { launch: { __typename: "Launch", id: 1, isInCart: true } },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
 
     // When the same query fires again, `isInCart` should be pulled from
     // the cache and have a value of `true`.
     await expect(client.query({ query })).resolves.toEqualStrictTyped({
       data: { launch: { __typename: "Launch", id: 1, isInCart: true } },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
   });
 });
@@ -1010,9 +976,6 @@ describe("Force local resolvers", () => {
       data: {
         author: { __typename: "Author", isLoggedIn: false, name: "John Smith" },
       },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
 
     client.addResolvers({
@@ -1030,9 +993,6 @@ describe("Force local resolvers", () => {
       data: {
         author: { __typename: "Author", isLoggedIn: true, name: "John Smith" },
       },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
   });
 
@@ -1079,9 +1039,6 @@ describe("Force local resolvers", () => {
           name: "John Smith",
         },
       },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
     expect(count).toEqual(1);
   });
@@ -1218,9 +1175,6 @@ describe("Force local resolvers", () => {
           fullName: "Ben Newman",
         },
       },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
   });
 });
@@ -1248,9 +1202,6 @@ describe("Async resolvers", () => {
 
     expect(result).toEqualStrictTyped({
       data: { isLoggedIn: true },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
   });
 
@@ -1308,9 +1259,6 @@ describe("Async resolvers", () => {
           __typename: "Member",
         },
       },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
   });
 });

--- a/src/__tests__/local-state/resolvers.ts
+++ b/src/__tests__/local-state/resolvers.ts
@@ -397,7 +397,7 @@ describe("Basic resolver capabilities", () => {
 
     const result = await client.query({ query, fetchPolicy: "network-only" });
 
-    expect(result).toEqualApolloQueryResult({
+    expect(result).toEqualStrictTyped({
       data: { isInCart: false },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -606,7 +606,7 @@ describe("Writing cache data from resolvers", () => {
     await client.mutate({ mutation });
     const result = await client.query({ query });
 
-    expect(result).toEqualApolloQueryResult({
+    expect(result).toEqualStrictTyped({
       data: { field: 1 },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -664,7 +664,7 @@ describe("Writing cache data from resolvers", () => {
 
     const result = await client.query({ query });
 
-    expect(result).toEqualApolloQueryResult({
+    expect(result).toEqualStrictTyped({
       data: { obj: { __typename: "Object", field: 2 } },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -729,7 +729,7 @@ describe("Writing cache data from resolvers", () => {
     await client.mutate({ mutation });
     const result = await client.query({ query });
 
-    expect(result).toEqualApolloQueryResult({
+    expect(result).toEqualStrictTyped({
       data: {
         obj: {
           __typename: "Object",
@@ -775,7 +775,7 @@ describe("Resolving field aliases", () => {
 
     const result = await client.query({ query });
 
-    expect(result).toEqualApolloQueryResult({
+    expect(result).toEqualStrictTyped({
       data: {
         foo: { bar: true, __typename: "Foo" },
         baz: { foo: true, __typename: "Baz" },
@@ -809,7 +809,7 @@ describe("Resolving field aliases", () => {
 
     const result = await client.query({ query: aliasedQuery });
 
-    expect(result).toEqualApolloQueryResult({
+    expect(result).toEqualStrictTyped({
       data: { fie: { bar: true, __typename: "Foo" } },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -848,7 +848,7 @@ describe("Resolving field aliases", () => {
 
     const result = await client.query({ query: aliasedQuery });
 
-    expect(result).toEqualApolloQueryResult({
+    expect(result).toEqualStrictTyped({
       data: {
         fie: { fum: true, __typename: "Foo" },
         baz: { foo: true, __typename: "Baz" },
@@ -894,7 +894,7 @@ describe("Resolving field aliases", () => {
 
     const result = await client.query({ query });
 
-    expect(result).toEqualApolloQueryResult({
+    expect(result).toEqualStrictTyped({
       data: { fie: { bar: "yo", __typename: "Foo" } },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -957,7 +957,7 @@ describe("Resolving field aliases", () => {
 
     // `isInCart` resolver is fired, returning `true` (which is then
     // stored in the cache).
-    await expect(client.query({ query })).resolves.toEqualApolloQueryResult({
+    await expect(client.query({ query })).resolves.toEqualStrictTyped({
       data: { launch: { __typename: "Launch", id: 1, isInCart: true } },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -966,7 +966,7 @@ describe("Resolving field aliases", () => {
 
     // When the same query fires again, `isInCart` should be pulled from
     // the cache and have a value of `true`.
-    await expect(client.query({ query })).resolves.toEqualApolloQueryResult({
+    await expect(client.query({ query })).resolves.toEqualStrictTyped({
       data: { launch: { __typename: "Launch", id: 1, isInCart: true } },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -1006,7 +1006,7 @@ describe("Force local resolvers", () => {
 
     // When the resolver isn't defined, there isn't anything to force, so
     // make sure the query resolves from the cache properly.
-    await expect(client.query({ query })).resolves.toEqualApolloQueryResult({
+    await expect(client.query({ query })).resolves.toEqualStrictTyped({
       data: {
         author: { __typename: "Author", isLoggedIn: false, name: "John Smith" },
       },
@@ -1026,7 +1026,7 @@ describe("Force local resolvers", () => {
     // A resolver is defined, so make sure it's forced, and the result
     // resolves properly as a combination of cache and local resolver
     // data.
-    await expect(client.query({ query })).resolves.toEqualApolloQueryResult({
+    await expect(client.query({ query })).resolves.toEqualStrictTyped({
       data: {
         author: { __typename: "Author", isLoggedIn: true, name: "John Smith" },
       },
@@ -1071,7 +1071,7 @@ describe("Force local resolvers", () => {
       },
     });
 
-    await expect(client.query({ query })).resolves.toEqualApolloQueryResult({
+    await expect(client.query({ query })).resolves.toEqualStrictTyped({
       data: {
         author: {
           __typename: "Author",
@@ -1209,7 +1209,7 @@ describe("Force local resolvers", () => {
 
     const result = await client.query({ query });
 
-    expect(result).toEqualApolloQueryResult({
+    expect(result).toEqualStrictTyped({
       data: {
         userData: {
           __typename: "User",
@@ -1246,7 +1246,7 @@ describe("Async resolvers", () => {
 
     const result = await client.query({ query })!;
 
-    expect(result).toEqualApolloQueryResult({
+    expect(result).toEqualStrictTyped({
       data: { isLoggedIn: true },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -1299,7 +1299,7 @@ describe("Async resolvers", () => {
 
     const result = await client.query({ query })!;
 
-    expect(result).toEqualApolloQueryResult({
+    expect(result).toEqualStrictTyped({
       data: {
         member: {
           name: testMember.name,

--- a/src/__tests__/refetchQueries.ts
+++ b/src/__tests__/refetchQueries.ts
@@ -829,12 +829,7 @@ describe("client.refetchQueries", () => {
 
     const results = (await refetchResult).map((result) => {
       // These results are ApolloQueryResult<any>, as inferred by TypeScript.
-      expect(Object.keys(result).sort()).toEqual([
-        "data",
-        "loading",
-        "networkStatus",
-        "partial",
-      ]);
+      expect(Object.keys(result).sort()).toEqual(["data"]);
       return result.data;
     });
 
@@ -898,13 +893,8 @@ describe("client.refetchQueries", () => {
     ).toEqual(["AB", "B"]);
 
     const results = (await refetchResult).map((result) => {
-      // These results are ApolloQueryResult<any>, as inferred by TypeScript.
-      expect(Object.keys(result).sort()).toEqual([
-        "data",
-        "loading",
-        "networkStatus",
-        "partial",
-      ]);
+      // These results are QueryResult<any>, as inferred by TypeScript.
+      expect(Object.keys(result).sort()).toEqual(["data"]);
       return result.data;
     });
 
@@ -966,12 +956,7 @@ describe("client.refetchQueries", () => {
 
     const results = (await refetchResult).map((result) => {
       // These results are ApolloQueryResult<any>, as inferred by TypeScript.
-      expect(Object.keys(result).sort()).toEqual([
-        "data",
-        "loading",
-        "networkStatus",
-        "partial",
-      ]);
+      expect(Object.keys(result).sort()).toEqual(["data"]);
       return result.data;
     });
 

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -3660,7 +3660,7 @@ describe("type policies", function () {
 
       let result = await client.query({ query: firstQuery });
 
-      expect(result).toEqualApolloQueryResult({
+      expect(result).toEqualStrictTyped({
         loading: false,
         networkStatus: NetworkStatus.ready,
         data: {
@@ -3694,7 +3694,7 @@ describe("type policies", function () {
         variables: secondVariables,
       });
 
-      expect(result).toEqualApolloQueryResult({
+      expect(result).toEqualStrictTyped({
         loading: false,
         networkStatus: NetworkStatus.ready,
         data: {
@@ -3711,7 +3711,7 @@ describe("type policies", function () {
       expect(cache.extract()).toMatchSnapshot();
 
       result = await client.query({ query: thirdQuery });
-      expect(result).toEqualApolloQueryResult({
+      expect(result).toEqualStrictTyped({
         loading: false,
         networkStatus: NetworkStatus.ready,
         data: {
@@ -4146,7 +4146,7 @@ describe("type policies", function () {
       {
         const result = await stream.takeNext();
 
-        expect(result).toEqualApolloQueryResult({
+        expect(result).toEqualStrictTyped({
           loading: false,
           networkStatus: NetworkStatus.ready,
           data: {
@@ -4174,7 +4174,7 @@ describe("type policies", function () {
 
         expect(result.data.search.edges.length).toBe(5);
 
-        expect(result).toEqualApolloQueryResult({
+        expect(result).toEqualStrictTyped({
           loading: false,
           networkStatus: NetworkStatus.ready,
           data: {
@@ -4201,7 +4201,7 @@ describe("type policies", function () {
       {
         const result = await stream.takeNext();
 
-        expect(result).toEqualApolloQueryResult({
+        expect(result).toEqualStrictTyped({
           loading: false,
           networkStatus: NetworkStatus.ready,
           data: {
@@ -4235,7 +4235,7 @@ describe("type policies", function () {
 
         expect(result.data.search.edges.length).toBe(7);
 
-        expect(result).toEqualApolloQueryResult({
+        expect(result).toEqualStrictTyped({
           loading: false,
           networkStatus: NetworkStatus.ready,
           data: {
@@ -4270,7 +4270,7 @@ describe("type policies", function () {
         });
         const snapshot = cache.extract();
 
-        expect(result).toEqualApolloQueryResult({
+        expect(result).toEqualStrictTyped({
           loading: false,
           networkStatus: NetworkStatus.ready,
           data: {
@@ -4333,7 +4333,7 @@ describe("type policies", function () {
           },
         });
 
-        expect(result).toEqualApolloQueryResult({
+        expect(result).toEqualStrictTyped({
           loading: false,
           networkStatus: NetworkStatus.ready,
           data: {
@@ -4367,7 +4367,7 @@ describe("type policies", function () {
         });
         const snapshot = cache.extract();
 
-        expect(result).toEqualApolloQueryResult({
+        expect(result).toEqualStrictTyped({
           loading: false,
           networkStatus: NetworkStatus.ready,
           data: {

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -3661,15 +3661,12 @@ describe("type policies", function () {
       let result = await client.query({ query: firstQuery });
 
       expect(result).toEqualStrictTyped({
-        loading: false,
-        networkStatus: NetworkStatus.ready,
         data: {
           todos: {
             __typename: "TodosConnection",
             totalCount: 1292,
           },
         },
-        partial: false,
       });
 
       expect(cache.extract()).toEqual({
@@ -3695,8 +3692,6 @@ describe("type policies", function () {
       });
 
       expect(result).toEqualStrictTyped({
-        loading: false,
-        networkStatus: NetworkStatus.ready,
         data: {
           todos: {
             __typename: "TodosConnection",
@@ -3705,15 +3700,12 @@ describe("type policies", function () {
             totalCount: 1292,
           },
         },
-        partial: false,
       });
 
       expect(cache.extract()).toMatchSnapshot();
 
       result = await client.query({ query: thirdQuery });
       expect(result).toEqualStrictTyped({
-        loading: false,
-        networkStatus: NetworkStatus.ready,
         data: {
           todos: {
             __typename: "TodosConnection",
@@ -3721,7 +3713,6 @@ describe("type policies", function () {
             extraMetaData: "extra",
           },
         },
-        partial: false,
       });
       expect(cache.extract()).toMatchSnapshot();
     });
@@ -4271,8 +4262,6 @@ describe("type policies", function () {
         const snapshot = cache.extract();
 
         expect(result).toEqualStrictTyped({
-          loading: false,
-          networkStatus: NetworkStatus.ready,
           data: {
             search: {
               edges: turrellEdges.slice(0, 1),
@@ -4280,7 +4269,6 @@ describe("type policies", function () {
               totalCount: 13531,
             },
           },
-          partial: false,
         });
 
         expect(snapshot).toMatchSnapshot();
@@ -4368,8 +4356,6 @@ describe("type policies", function () {
         const snapshot = cache.extract();
 
         expect(result).toEqualStrictTyped({
-          loading: false,
-          networkStatus: NetworkStatus.ready,
           data: {
             search: {
               edges: turrellEdges,
@@ -4377,7 +4363,6 @@ describe("type policies", function () {
               totalCount: 13531,
             },
           },
-          partial: false,
         });
 
         expect(snapshot).toMatchSnapshot();

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -477,6 +477,27 @@ export class ApolloClient implements DataProxy {
         "using a different fetchPolicy, such as cache-first or network-only."
     );
 
+    invariant(
+      options.query,
+      "query option is required. You must specify your GraphQL document " +
+        "in the query option."
+    );
+
+    invariant(
+      options.query.kind === "Document",
+      'You must wrap the query string in a "gql" tag.'
+    );
+
+    invariant(
+      !options.returnPartialData,
+      "returnPartialData option only supported on watchQuery."
+    );
+
+    invariant(
+      !options.pollInterval,
+      "pollInterval option only supported on watchQuery."
+    );
+
     return this.queryManager.query<TData, TVariables>(options);
   }
 

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -33,6 +33,7 @@ import type {
   InternalRefetchQueriesResult,
   MutateResult,
   OperationVariables,
+  QueryResult,
   RefetchQueriesInclude,
   RefetchQueriesOptions,
   RefetchQueriesResult,
@@ -463,7 +464,7 @@ export class ApolloClient implements DataProxy {
     TVariables extends OperationVariables = OperationVariables,
   >(
     options: QueryOptions<TVariables, TData>
-  ): Promise<ApolloQueryResult<MaybeMasked<TData>>> {
+  ): Promise<QueryResult<MaybeMasked<TData>>> {
     if (this.defaultOptions.query) {
       options = mergeOptions(this.defaultOptions.query, options);
     }

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -658,7 +658,7 @@ export class ApolloClient implements DataProxy {
    * re-execute any queries then you should make sure to stop watching any
    * active queries.
    */
-  public resetStore(): Promise<ApolloQueryResult<any>[] | null> {
+  public resetStore(): Promise<QueryResult<any>[] | null> {
     return Promise.resolve()
       .then(() =>
         this.queryManager.clearStore({
@@ -725,7 +725,7 @@ export class ApolloClient implements DataProxy {
    */
   public reFetchObservableQueries(
     includeStandby?: boolean
-  ): Promise<ApolloQueryResult<any>[]> {
+  ): Promise<QueryResult<any>[]> {
     return this.queryManager.reFetchObservableQueries(includeStandby);
   }
 

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -28,7 +28,6 @@ import { LocalState } from "./LocalState.js";
 import type { ObservableQuery } from "./ObservableQuery.js";
 import { QueryManager } from "./QueryManager.js";
 import type {
-  ApolloQueryResult,
   DefaultContext,
   InternalRefetchQueriesResult,
   MutateResult,
@@ -765,7 +764,7 @@ export class ApolloClient implements DataProxy {
    */
   public refetchQueries<
     TCache extends ApolloCache = ApolloCache,
-    TResult = Promise<ApolloQueryResult<any>>,
+    TResult = Promise<QueryResult<any>>,
   >(
     options: RefetchQueriesOptions<TCache, TResult>
   ): RefetchQueriesResult<TResult> {

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -488,11 +488,13 @@ export class ApolloClient implements DataProxy {
       'You must wrap the query string in a "gql" tag.'
     );
 
+    // TODO: Remove returnPartialData as valid option from QueryOptions type
     invariant(
       !options.returnPartialData,
       "returnPartialData option only supported on watchQuery."
     );
 
+    // TODO: Remove pollInterval as valid option from QueryOptions type
     invariant(
       !options.pollInterval,
       "pollInterval option only supported on watchQuery."

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -409,7 +409,7 @@ export class ObservableQuery<
    * @param variables - The new set of variables. If there are missing variables,
    * the previous values of those variables will be used.
    */
-  public refetch(variables?: Partial<TVariables>) {
+  public refetch(variables?: Partial<TVariables>): Promise<QueryResult<TData>> {
     const reobserveOptions: Partial<WatchQueryOptions<TVariables, TData>> = {
       // Always disable polling for refetches.
       pollInterval: 0,
@@ -469,7 +469,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
         }
       ) => Unmasked<TData>;
     }
-  ) {
+  ): Promise<QueryResult<TFetchData>> {
     const combinedOptions = {
       ...(fetchMoreOptions.query ? fetchMoreOptions : (
         {
@@ -710,7 +710,9 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
    * @param variables - The new set of variables. If there are missing variables,
    * the previous values of those variables will be used.
    */
-  public async setVariables(variables: TVariables) {
+  public async setVariables(
+    variables: TVariables
+  ): Promise<QueryResult<TData>> {
     if (equal(this.variables, variables)) {
       // If we have no observers, then we don't actually want to make a network
       // request. As soon as someone observes the query, the request will kick

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -726,14 +726,14 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
       // If we have no observers, then we don't actually want to make a network
       // request. As soon as someone observes the query, the request will kick
       // off. For now, we just store any changes. (See #1077)
-      return this.subject.getValue();
+      return toQueryResult(this.subject.getValue());
     }
 
     this.options.variables = variables;
 
     // See comment above
     if (!this.hasObservers()) {
-      return this.subject.getValue();
+      return toQueryResult(this.subject.getValue());
     }
 
     return this.reobserve({

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -30,6 +30,7 @@ import type {
   ApolloQueryResult,
   ErrorLike,
   OperationVariables,
+  QueryResult,
   TypedDocumentNode,
 } from "./types.js";
 import type {
@@ -409,7 +410,7 @@ export class ObservableQuery<
    */
   public refetch(
     variables?: Partial<TVariables>
-  ): Promise<ApolloQueryResult<MaybeMasked<TData>>> {
+  ): Promise<QueryResult<MaybeMasked<TData>>> {
     const reobserveOptions: Partial<WatchQueryOptions<TVariables, TData>> = {
       // Always disable polling for refetches.
       pollInterval: 0,
@@ -450,6 +451,16 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     return this.reobserve({
       ...reobserveOptions,
       [newNetworkStatusSymbol]: NetworkStatus.refetch,
+    }).then((value) => {
+      const result: QueryResult<MaybeMasked<TData>> = {
+        data: value.data,
+      };
+
+      if (value.error) {
+        result.error = value.error;
+      }
+
+      return result;
     });
   }
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -20,9 +20,9 @@ import {
   preventUnhandledRejection,
 } from "@apollo/client/utilities";
 import { __DEV__ } from "@apollo/client/utilities/environment";
+import { toQueryResult } from "@apollo/client/utilities/internal";
 import { invariant } from "@apollo/client/utilities/invariant";
 
-import { toQueryResult } from "../utilities/internal/toQueryResult.js";
 
 import { equalByQuery } from "./equalByQuery.js";
 import { isNetworkRequestInFlight, NetworkStatus } from "./networkStatus.js";

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -451,16 +451,6 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     return this.reobserve({
       ...reobserveOptions,
       [newNetworkStatusSymbol]: NetworkStatus.refetch,
-    }).then((value) => {
-      const result: QueryResult<MaybeMasked<TData>> = {
-        data: value.data,
-      };
-
-      if (value.error) {
-        result.error = value.error;
-      }
-
-      return result;
     });
   }
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -23,7 +23,6 @@ import { __DEV__ } from "@apollo/client/utilities/environment";
 import { toQueryResult } from "@apollo/client/utilities/internal";
 import { invariant } from "@apollo/client/utilities/invariant";
 
-
 import { equalByQuery } from "./equalByQuery.js";
 import { isNetworkRequestInFlight, NetworkStatus } from "./networkStatus.js";
 import type { QueryInfo } from "./QueryInfo.js";
@@ -1067,7 +1066,9 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
       // Note: lastValueFrom will create a separate subscription to the
       // observable which means that terminating this ObservableQuery will not
       // cancel the request from the link chain.
-      lastValueFrom(observable).then(this.maskResult).then(toQueryResult)
+      lastValueFrom(observable).then((result) =>
+        toQueryResult(this.maskResult(result))
+      )
     );
   }
 

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -88,6 +88,7 @@ import type {
   MutationUpdaterFunction,
   OnQueryUpdated,
   OperationVariables,
+  QueryResult,
   SubscribeResult,
 } from "./types.js";
 import type {
@@ -823,7 +824,7 @@ export class QueryManager {
   public query<TData, TVars extends OperationVariables = OperationVariables>(
     options: QueryOptions<TVars, TData>,
     queryId = this.generateQueryId()
-  ): Promise<ApolloQueryResult<MaybeMasked<TData>>> {
+  ): Promise<QueryResult<MaybeMasked<TData>>> {
     invariant(
       options.query,
       "query option is required. You must specify your GraphQL document " +

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -867,10 +867,6 @@ export class QueryManager {
           result.error = value.error;
         }
 
-        if ((value as any)?.extensions) {
-          result.extensions = (value as any).extensions;
-        }
-
         return result;
       })
       .finally(() => this.stopQuery(queryId));

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1022,8 +1022,8 @@ export class QueryManager {
 
   public reFetchObservableQueries(
     includeStandby: boolean = false
-  ): Promise<ApolloQueryResult<any>[]> {
-    const observableQueryPromises: Promise<ApolloQueryResult<any>>[] = [];
+  ): Promise<QueryResult<any>[]> {
+    const observableQueryPromises: Promise<QueryResult<any>>[] = [];
 
     this.getObservableQueries(includeStandby ? "all" : "active").forEach(
       (observableQuery, queryId) => {
@@ -1556,7 +1556,7 @@ export class QueryManager {
               // options.include.
               includedQueriesById.delete(oq.queryId);
 
-              let result: TResult | boolean | Promise<ApolloQueryResult<any>> =
+              let result: TResult | boolean | Promise<QueryResult<any>> =
                 onQueryUpdated(oq, diff, lastDiff);
 
               if (result === true) {
@@ -1592,11 +1592,7 @@ export class QueryManager {
 
     if (includedQueriesById.size) {
       includedQueriesById.forEach(({ oq, lastDiff, diff }, queryId) => {
-        let result:
-          | TResult
-          | boolean
-          | Promise<ApolloQueryResult<any>>
-          | undefined;
+        let result: TResult | boolean | Promise<QueryResult<any>> | undefined;
 
         // If onQueryUpdated is provided, we want to use it for all included
         // queries, even the QueryOptions ones.

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -825,27 +825,6 @@ export class QueryManager {
     options: QueryOptions<TVars, TData>,
     queryId = this.generateQueryId()
   ): Promise<QueryResult<MaybeMasked<TData>>> {
-    invariant(
-      options.query,
-      "query option is required. You must specify your GraphQL document " +
-        "in the query option."
-    );
-
-    invariant(
-      options.query.kind === "Document",
-      'You must wrap the query string in a "gql" tag.'
-    );
-
-    invariant(
-      !(options as any).returnPartialData,
-      "returnPartialData option only supported on watchQuery."
-    );
-
-    invariant(
-      !(options as any).pollInterval,
-      "pollInterval option only supported on watchQuery."
-    );
-
     const query = this.transform(options.query);
 
     return this.fetchQuery<TData, TVars>(queryId, { ...options, query })

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -58,7 +58,7 @@ import {
 } from "@apollo/client/utilities";
 import { mergeIncrementalData } from "@apollo/client/utilities";
 import { __DEV__ } from "@apollo/client/utilities/environment";
-import { onAnyEvent } from "@apollo/client/utilities/internal";
+import { onAnyEvent, toQueryResult } from "@apollo/client/utilities/internal";
 import {
   invariant,
   newInvariantError,
@@ -854,20 +854,19 @@ export class QueryManager {
         // `value` can be `undefined` when the link chain only emits a complete
         // event with no value which should be an error.
         // https://github.com/apollographql/apollo-client/issues/12482
-        const result: QueryResult<TData> = {
+        if (!value) {
+          return { data: undefined };
+        }
+
+        return toQueryResult({
+          ...value,
           data: this.maskOperation({
             document: query,
             data: value?.data,
             fetchPolicy: options.fetchPolicy,
             id: queryId,
           }),
-        };
-
-        if (value?.error) {
-          result.error = value.error;
-        }
-
-        return result;
+        });
       })
       .finally(() => this.stopQuery(queryId));
   }

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -1184,12 +1184,7 @@ describe("ApolloClient", () => {
 
     const result = await observable.refetch();
 
-    expect(result).toEqualStrictTyped({
-      data: data2,
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
-    });
+    expect(result).toEqualStrictTyped({ data: data2 });
   });
 
   it("allows you to refetch queries with new variables", async () => {

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -2121,12 +2121,7 @@ describe("ApolloClient", () => {
       ]),
     }).query({ query });
 
-    expect(result).toEqualStrictTyped({
-      data: transformedQueryResult,
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
-    });
+    expect(result).toEqualStrictTyped({ data: transformedQueryResult });
   });
 
   it("should transform mutations correctly", async () => {
@@ -2242,12 +2237,7 @@ describe("ApolloClient", () => {
     });
     const result = await client.query({ query });
 
-    expect(result).toEqualStrictTyped({
-      data,
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
-    });
+    expect(result).toEqualStrictTyped({ data });
 
     await expect(
       client.query({ query, fetchPolicy: "network-only" })
@@ -2395,12 +2385,7 @@ describe("ApolloClient", () => {
       partial: false,
     });
 
-    await expect(client.query({ query })).resolves.toEqualStrictTyped({
-      data,
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
-    });
+    await expect(client.query({ query })).resolves.toEqualStrictTyped({ data });
 
     await expect(stream).not.toEmitAnything();
   });
@@ -3693,12 +3678,7 @@ describe("ApolloClient", () => {
         fetchPolicy: "network-only",
       });
 
-      expect(result).toEqualStrictTyped({
-        data: data2,
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
-      });
+      expect(result).toEqualStrictTyped({ data: data2 });
       await expect(stream).toEmitApolloQueryResult({
         data: data2,
         loading: false,
@@ -4914,12 +4894,7 @@ describe("ApolloClient", () => {
         ]),
       }).query({ query });
 
-      expect(result).toEqualStrictTyped({
-        data,
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
-      });
+      expect(result).toEqualStrictTyped({ data });
     });
 
     it("should be passed to the observer as true if we are returning partial data", async () => {
@@ -5117,12 +5092,7 @@ describe("ApolloClient", () => {
       });
 
       const result1 = await client.query({ query: query1 });
-      expect(result1).toEqualStrictTyped({
-        data: data1,
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
-      });
+      expect(result1).toEqualStrictTyped({ data: data1 });
 
       const observable = client.watchQuery({
         query: query2,

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -6667,7 +6667,6 @@ describe("ApolloClient", () => {
         notifyOnNetworkStatusChange: false,
       });
       const stream = new ObservableStream(observable);
-      let isRefetchErrorCaught = false;
 
       await expect(stream).toEmitApolloQueryResult({
         data: queryData,
@@ -6676,16 +6675,13 @@ describe("ApolloClient", () => {
         partial: false,
       });
 
-      void client
-        .mutate({
+      await expect(
+        client.mutate({
           mutation,
           refetchQueries: ["getAuthors"],
           awaitRefetchQueries: true,
         })
-        .catch((error) => {
-          expect(error).toBeDefined();
-          isRefetchErrorCaught = true;
-        });
+      ).rejects.toThrow(refetchError);
 
       await expect(stream).toEmitApolloQueryResult({
         data: queryData,
@@ -6694,7 +6690,6 @@ describe("ApolloClient", () => {
         networkStatus: NetworkStatus.error,
         partial: false,
       });
-      expect(isRefetchErrorCaught).toBe(true);
     });
   });
 

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -1184,7 +1184,7 @@ describe("ApolloClient", () => {
 
     const result = await observable.refetch();
 
-    expect(result).toEqualApolloQueryResult({
+    expect(result).toEqualStrictTyped({
       data: data2,
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -2121,7 +2121,7 @@ describe("ApolloClient", () => {
       ]),
     }).query({ query });
 
-    expect(result).toEqualApolloQueryResult({
+    expect(result).toEqualStrictTyped({
       data: transformedQueryResult,
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -2242,7 +2242,7 @@ describe("ApolloClient", () => {
     });
     const result = await client.query({ query });
 
-    expect(result).toEqualApolloQueryResult({
+    expect(result).toEqualStrictTyped({
       data,
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -2395,7 +2395,7 @@ describe("ApolloClient", () => {
       partial: false,
     });
 
-    await expect(client.query({ query })).resolves.toEqualApolloQueryResult({
+    await expect(client.query({ query })).resolves.toEqualStrictTyped({
       data,
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -3028,13 +3028,13 @@ describe("ApolloClient", () => {
     const streamB = new ObservableStream(observableB);
 
     await expect(streamA).toEmitNext();
-    expect(observableA.getCurrentResult()).toEqualApolloQueryResult({
+    expect(observableA.getCurrentResult()).toEqualStrictTyped({
       data: dataA,
       loading: false,
       networkStatus: NetworkStatus.ready,
       partial: false,
     });
-    expect(observableB.getCurrentResult()).toEqualApolloQueryResult({
+    expect(observableB.getCurrentResult()).toEqualStrictTyped({
       data: undefined,
       loading: true,
       networkStatus: NetworkStatus.loading,
@@ -3042,13 +3042,13 @@ describe("ApolloClient", () => {
     });
 
     await expect(streamB).toEmitNext();
-    expect(observableA.getCurrentResult()).toEqualApolloQueryResult({
+    expect(observableA.getCurrentResult()).toEqualStrictTyped({
       data: dataA,
       loading: false,
       networkStatus: NetworkStatus.ready,
       partial: false,
     });
-    expect(observableB.getCurrentResult()).toEqualApolloQueryResult({
+    expect(observableB.getCurrentResult()).toEqualStrictTyped({
       data: dataB,
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -3693,7 +3693,7 @@ describe("ApolloClient", () => {
         fetchPolicy: "network-only",
       });
 
-      expect(result).toEqualApolloQueryResult({
+      expect(result).toEqualStrictTyped({
         data: data2,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -3799,13 +3799,13 @@ describe("ApolloClient", () => {
 
       await client.resetStore();
 
-      expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+      expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: dataChanged,
         loading: false,
         networkStatus: NetworkStatus.ready,
         partial: false,
       });
-      expect(observable2.getCurrentResult()).toEqualApolloQueryResult({
+      expect(observable2.getCurrentResult()).toEqualStrictTyped({
         data: data2Changed,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -4353,13 +4353,13 @@ describe("ApolloClient", () => {
 
       await client.reFetchObservableQueries();
 
-      expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+      expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: dataChanged,
         loading: false,
         networkStatus: NetworkStatus.ready,
         partial: false,
       });
-      expect(observable2.getCurrentResult()).toEqualApolloQueryResult({
+      expect(observable2.getCurrentResult()).toEqualStrictTyped({
         data: data2Changed,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -4879,13 +4879,13 @@ describe("ApolloClient", () => {
         include: ["GetAuthor", "GetAuthor2"],
       });
 
-      expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+      expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: dataChanged,
         loading: false,
         networkStatus: NetworkStatus.ready,
         partial: false,
       });
-      expect(observable2.getCurrentResult()).toEqualApolloQueryResult({
+      expect(observable2.getCurrentResult()).toEqualStrictTyped({
         data: data2Changed,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -4914,7 +4914,7 @@ describe("ApolloClient", () => {
         ]),
       }).query({ query });
 
-      expect(result).toEqualApolloQueryResult({
+      expect(result).toEqualStrictTyped({
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -5117,7 +5117,7 @@ describe("ApolloClient", () => {
       });
 
       const result1 = await client.query({ query: query1 });
-      expect(result1).toEqualApolloQueryResult({
+      expect(result1).toEqualStrictTyped({
         data: data1,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -5223,7 +5223,7 @@ describe("ApolloClient", () => {
         networkStatus: NetworkStatus.ready,
         partial: false,
       });
-      expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+      expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -5629,7 +5629,7 @@ describe("ApolloClient", () => {
         },
         { timeout: 150 }
       );
-      expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+      expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -5722,7 +5722,7 @@ describe("ApolloClient", () => {
         },
         { timeout: 150 }
       );
-      expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+      expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -5816,7 +5816,7 @@ describe("ApolloClient", () => {
         },
         { timeout: 150 }
       );
-      expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+      expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -6257,7 +6257,7 @@ describe("ApolloClient", () => {
         networkStatus: NetworkStatus.ready,
         partial: false,
       });
-      expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+      expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -6450,7 +6450,7 @@ describe("ApolloClient", () => {
 
       await client.mutate({ mutation, refetchQueries: ["getAuthors"] });
 
-      expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+      expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: queryData,
         loading: true,
         networkStatus: NetworkStatus.refetch,
@@ -6538,7 +6538,7 @@ describe("ApolloClient", () => {
         awaitRefetchQueries: false,
       });
 
-      expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+      expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: queryData,
         loading: true,
         networkStatus: NetworkStatus.refetch,
@@ -6626,7 +6626,7 @@ describe("ApolloClient", () => {
         awaitRefetchQueries: true,
       });
 
-      expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+      expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: secondReqData,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -6817,7 +6817,7 @@ describe("ApolloClient", () => {
         partial: false,
       });
 
-      expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+      expect(observable.getCurrentResult()).toEqualStrictTyped({
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -434,12 +434,7 @@ describe("ObservableQuery", () => {
 
       // go back to first set of variables
       const current = await observable.reobserve({ variables });
-      expect(current).toEqualStrictTyped({
-        data,
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
-      });
+      expect(current).toEqualStrictTyped({ data });
 
       await expect(stream).toEmitApolloQueryResult({
         data,
@@ -810,12 +805,7 @@ describe("ObservableQuery", () => {
         fetchPolicy: "cache-and-network",
       });
 
-      expect(res).toEqualStrictTyped({
-        data: dataTwo,
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
-      });
+      expect(res).toEqualStrictTyped({ data: dataTwo });
 
       await expect(stream).toEmitApolloQueryResult({
         data: dataOne,
@@ -868,12 +858,7 @@ describe("ObservableQuery", () => {
 
       await expect(
         observable.setVariables(differentVariables)
-      ).resolves.toEqualStrictTyped({
-        data: dataTwo,
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
-      });
+      ).resolves.toEqualStrictTyped({ data: dataTwo });
 
       await expect(stream).toEmitApolloQueryResult({
         data: undefined,
@@ -925,12 +910,7 @@ describe("ObservableQuery", () => {
 
       await expect(
         observable.setVariables(differentVariables)
-      ).resolves.toEqualStrictTyped({
-        data: dataTwo,
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
-      });
+      ).resolves.toEqualStrictTyped({ data: dataTwo });
 
       await expect(stream).toEmitApolloQueryResult({
         data: dataTwo,
@@ -1015,12 +995,7 @@ describe("ObservableQuery", () => {
 
       await expect(
         observable.setVariables(differentVariables)
-      ).resolves.toEqualStrictTyped({
-        data: dataTwo,
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
-      });
+      ).resolves.toEqualStrictTyped({ data: dataTwo });
 
       await expect(stream).toEmitApolloQueryResult({
         data: dataTwo,
@@ -1078,12 +1053,7 @@ describe("ObservableQuery", () => {
 
       await expect(
         observable.setVariables(differentVariables)
-      ).resolves.toEqualStrictTyped({
-        data: dataTwo,
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
-      });
+      ).resolves.toEqualStrictTyped({ data: dataTwo });
 
       await expect(stream).toEmitApolloQueryResult({
         data: dataTwo,
@@ -1111,12 +1081,7 @@ describe("ObservableQuery", () => {
 
       await expect(
         observable.setVariables(differentVariables)
-      ).resolves.toEqualStrictTyped({
-        data: undefined,
-        loading: true,
-        networkStatus: NetworkStatus.loading,
-        partial: true,
-      });
+      ).resolves.toEqualStrictTyped({ data: undefined });
     });
 
     it("sets networkStatus to `setVariables` when fetching", async () => {
@@ -1153,12 +1118,7 @@ describe("ObservableQuery", () => {
 
       await expect(
         observable.setVariables(differentVariables)
-      ).resolves.toEqualStrictTyped({
-        data: dataTwo,
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
-      });
+      ).resolves.toEqualStrictTyped({ data: dataTwo });
 
       await expect(stream).toEmitApolloQueryResult({
         data: undefined,
@@ -1258,12 +1218,7 @@ describe("ObservableQuery", () => {
 
       await expect(
         observable.setVariables(variables)
-      ).resolves.toEqualStrictTyped({
-        data: dataOne,
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
-      });
+      ).resolves.toEqualStrictTyped({ data: dataOne });
 
       await expect(stream).not.toEmitAnything();
     });
@@ -1292,12 +1247,7 @@ describe("ObservableQuery", () => {
 
       await expect(
         observable.setVariables(differentVariables)
-      ).resolves.toEqualStrictTyped({
-        data: dataTwo,
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
-      });
+      ).resolves.toEqualStrictTyped({ data: dataTwo });
 
       await expect(stream).toEmitApolloQueryResult({
         data: dataTwo,
@@ -1707,12 +1657,7 @@ describe("ObservableQuery", () => {
       {
         const result = await observable.reobserve({ variables: variables1 });
 
-        expect(result).toEqualStrictTyped({
-          data,
-          loading: false,
-          networkStatus: NetworkStatus.ready,
-          partial: false,
-        });
+        expect(result).toEqualStrictTyped({ data });
         expect(observable.options.fetchPolicy).toBe("cache-first");
       }
 
@@ -1735,12 +1680,7 @@ describe("ObservableQuery", () => {
       {
         const result = await observable.reobserve({ variables: variables2 });
 
-        expect(result).toEqualStrictTyped({
-          data: data2,
-          loading: false,
-          networkStatus: NetworkStatus.ready,
-          partial: false,
-        });
+        expect(result).toEqualStrictTyped({ data: data2 });
         expect(observable.options.fetchPolicy).toBe("cache-first");
       }
 

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -434,7 +434,7 @@ describe("ObservableQuery", () => {
 
       // go back to first set of variables
       const current = await observable.reobserve({ variables });
-      expect(current).toEqualApolloQueryResult({
+      expect(current).toEqualStrictTyped({
         data,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -491,7 +491,7 @@ describe("ObservableQuery", () => {
         partial: false,
       });
 
-      await expect(observable.refetch()).resolves.toEqualApolloQueryResult({
+      await expect(observable.refetch()).resolves.toEqualStrictTyped({
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -813,7 +813,7 @@ describe("ObservableQuery", () => {
         fetchPolicy: "cache-and-network",
       });
 
-      expect(res).toEqualApolloQueryResult({
+      expect(res).toEqualStrictTyped({
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -871,7 +871,7 @@ describe("ObservableQuery", () => {
 
       await expect(
         observable.setVariables(differentVariables)
-      ).resolves.toEqualApolloQueryResult({
+      ).resolves.toEqualStrictTyped({
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -919,7 +919,7 @@ describe("ObservableQuery", () => {
         networkStatus: NetworkStatus.ready,
         partial: false,
       });
-      expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+      expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -928,7 +928,7 @@ describe("ObservableQuery", () => {
 
       await expect(
         observable.setVariables(differentVariables)
-      ).resolves.toEqualApolloQueryResult({
+      ).resolves.toEqualStrictTyped({
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -941,7 +941,7 @@ describe("ObservableQuery", () => {
         networkStatus: NetworkStatus.ready,
         partial: false,
       });
-      expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+      expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -1009,7 +1009,7 @@ describe("ObservableQuery", () => {
         networkStatus: NetworkStatus.ready,
         partial: false,
       });
-      expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+      expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -1018,7 +1018,7 @@ describe("ObservableQuery", () => {
 
       await expect(
         observable.setVariables(differentVariables)
-      ).resolves.toEqualApolloQueryResult({
+      ).resolves.toEqualStrictTyped({
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -1031,7 +1031,7 @@ describe("ObservableQuery", () => {
         networkStatus: NetworkStatus.ready,
         partial: false,
       });
-      expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+      expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -1071,7 +1071,7 @@ describe("ObservableQuery", () => {
         networkStatus: NetworkStatus.error,
         partial: true,
       });
-      expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+      expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: undefined,
         error: new CombinedGraphQLErrors([error]),
         loading: false,
@@ -1081,7 +1081,7 @@ describe("ObservableQuery", () => {
 
       await expect(
         observable.setVariables(differentVariables)
-      ).resolves.toEqualApolloQueryResult({
+      ).resolves.toEqualStrictTyped({
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -1094,7 +1094,7 @@ describe("ObservableQuery", () => {
         networkStatus: NetworkStatus.ready,
         partial: false,
       });
-      expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+      expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -1114,7 +1114,7 @@ describe("ObservableQuery", () => {
 
       await expect(
         observable.setVariables(differentVariables)
-      ).resolves.toEqualApolloQueryResult({
+      ).resolves.toEqualStrictTyped({
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.loading,
@@ -1156,7 +1156,7 @@ describe("ObservableQuery", () => {
 
       await expect(
         observable.setVariables(differentVariables)
-      ).resolves.toEqualApolloQueryResult({
+      ).resolves.toEqualStrictTyped({
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -1214,7 +1214,7 @@ describe("ObservableQuery", () => {
 
       await expect(
         observable.refetch(differentVariables)
-      ).resolves.toEqualApolloQueryResult({
+      ).resolves.toEqualStrictTyped({
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -1264,7 +1264,7 @@ describe("ObservableQuery", () => {
 
       await expect(
         observable.setVariables(variables)
-      ).resolves.toEqualApolloQueryResult({
+      ).resolves.toEqualStrictTyped({
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -1298,7 +1298,7 @@ describe("ObservableQuery", () => {
 
       await expect(
         observable.setVariables(differentVariables)
-      ).resolves.toEqualApolloQueryResult({
+      ).resolves.toEqualStrictTyped({
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -1713,7 +1713,7 @@ describe("ObservableQuery", () => {
       {
         const result = await observable.reobserve({ variables: variables1 });
 
-        expect(result).toEqualApolloQueryResult({
+        expect(result).toEqualStrictTyped({
           data,
           loading: false,
           networkStatus: NetworkStatus.ready,
@@ -1741,7 +1741,7 @@ describe("ObservableQuery", () => {
       {
         const result = await observable.reobserve({ variables: variables2 });
 
-        expect(result).toEqualApolloQueryResult({
+        expect(result).toEqualStrictTyped({
           data: data2,
           loading: false,
           networkStatus: NetworkStatus.ready,
@@ -1865,7 +1865,7 @@ describe("ObservableQuery", () => {
 
       const result = await observable.refetch();
 
-      expect(result).toEqualApolloQueryResult({
+      expect(result).toEqualStrictTyped({
         data: {
           counter: 5,
           name: "Ben",
@@ -2260,7 +2260,7 @@ describe("ObservableQuery", () => {
         partial: false,
       });
 
-      expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+      expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: dataOneWithTypename,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -2275,7 +2275,7 @@ describe("ObservableQuery", () => {
         networkStatus: NetworkStatus.refetch,
         partial: false,
       });
-      expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+      expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: dataOneWithTypename,
         loading: true,
         networkStatus: NetworkStatus.refetch,
@@ -2288,7 +2288,7 @@ describe("ObservableQuery", () => {
         networkStatus: NetworkStatus.ready,
         partial: false,
       });
-      expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+      expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: dataTwoWithTypename,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -2312,7 +2312,7 @@ describe("ObservableQuery", () => {
       const observable = client.watchQuery({ query, variables });
       const stream = new ObservableStream(observable);
 
-      expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+      expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.loading,
@@ -2321,7 +2321,7 @@ describe("ObservableQuery", () => {
 
       await tick();
 
-      expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+      expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.loading,
@@ -2330,7 +2330,7 @@ describe("ObservableQuery", () => {
 
       await stream.takeNext();
 
-      expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+      expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: dataOne,
         loading: false,
         networkStatus: 7,
@@ -2351,7 +2351,7 @@ describe("ObservableQuery", () => {
 
       const result = await client.query({ query, variables });
 
-      expect(result).toEqualApolloQueryResult({
+      expect(result).toEqualStrictTyped({
         data: dataOne,
         loading: false,
         networkStatus: 7,
@@ -2360,7 +2360,7 @@ describe("ObservableQuery", () => {
 
       const observable = client.watchQuery({ query, variables });
 
-      expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+      expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -2390,7 +2390,7 @@ describe("ObservableQuery", () => {
         partial: true,
       });
 
-      expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+      expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: undefined,
         error: new CombinedGraphQLErrors([error]),
         loading: false,
@@ -2424,7 +2424,7 @@ describe("ObservableQuery", () => {
       const currentResult = observable.getCurrentResult();
       const currentResult2 = observable.getCurrentResult();
 
-      expect(currentResult).toEqualApolloQueryResult({
+      expect(currentResult).toEqualStrictTyped({
         data: undefined,
         error: new CombinedGraphQLErrors([error]),
         loading: false,
@@ -2460,7 +2460,7 @@ describe("ObservableQuery", () => {
         networkStatus: NetworkStatus.error,
         partial: false,
       });
-      expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+      expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: dataOne,
         error: new CombinedGraphQLErrors([error]),
         loading: false,
@@ -2560,7 +2560,7 @@ describe("ObservableQuery", () => {
         networkStatus: NetworkStatus.ready,
         partial: false,
       });
-      expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+      expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -2609,7 +2609,7 @@ describe("ObservableQuery", () => {
 
       // TODO: Determine why this worked without the `false` argument before
       // since this updates the last value to be equal to the partial result.
-      expect(observable.getCurrentResult(false)).toEqualApolloQueryResult({
+      expect(observable.getCurrentResult(false)).toEqualStrictTyped({
         data: dataOne,
         loading: true,
         networkStatus: NetworkStatus.loading,
@@ -2624,7 +2624,7 @@ describe("ObservableQuery", () => {
         networkStatus: NetworkStatus.loading,
         partial: true,
       });
-      expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+      expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: dataOne,
         loading: true,
         networkStatus: NetworkStatus.loading,
@@ -2637,7 +2637,7 @@ describe("ObservableQuery", () => {
         networkStatus: NetworkStatus.ready,
         partial: false,
       });
-      expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+      expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: superDataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -2665,7 +2665,7 @@ describe("ObservableQuery", () => {
 
       const result = await client.query({ query, variables });
 
-      expect(result).toEqualApolloQueryResult({
+      expect(result).toEqualStrictTyped({
         data: dataOne,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -2678,7 +2678,7 @@ describe("ObservableQuery", () => {
         fetchPolicy: "network-only",
       });
 
-      expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+      expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.loading,
@@ -2700,7 +2700,7 @@ describe("ObservableQuery", () => {
         networkStatus: NetworkStatus.ready,
         partial: false,
       });
-      expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+      expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -2738,7 +2738,7 @@ describe("ObservableQuery", () => {
         fetchPolicy: "no-cache",
       });
 
-      expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+      expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.loading,
@@ -2753,7 +2753,7 @@ describe("ObservableQuery", () => {
         networkStatus: NetworkStatus.loading,
         partial: true,
       });
-      expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+      expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.loading,
@@ -2766,7 +2766,7 @@ describe("ObservableQuery", () => {
         networkStatus: NetworkStatus.ready,
         partial: false,
       });
-      expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+      expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -2826,7 +2826,7 @@ describe("ObservableQuery", () => {
         partial: false,
       });
 
-      expect(obs.getCurrentResult()).toEqualApolloQueryResult({
+      expect(obs.getCurrentResult()).toEqualStrictTyped({
         data: {
           greeting: {
             message: "Hello world",
@@ -2875,7 +2875,7 @@ describe("ObservableQuery", () => {
         partial: false,
       });
 
-      expect(obs.getCurrentResult()).toEqualApolloQueryResult({
+      expect(obs.getCurrentResult()).toEqualStrictTyped({
         data: {
           greeting: {
             message: "Hello world",
@@ -2893,7 +2893,7 @@ describe("ObservableQuery", () => {
 
       // This 2nd identical check is intentional to ensure calling this function
       // more than once returns the right value.
-      expect(obs.getCurrentResult()).toEqualApolloQueryResult({
+      expect(obs.getCurrentResult()).toEqualStrictTyped({
         data: {
           greeting: {
             message: "Hello world",
@@ -3186,17 +3186,17 @@ describe("ObservableQuery", () => {
             nextFetchPolicy,
           });
 
-          expect(observableQuery.getCurrentResult()).toEqualApolloQueryResult(
+          expect(observableQuery.getCurrentResult()).toEqualStrictTyped(
             resultBeforeSubscribe
           );
 
           observableQuery.subscribe({});
-          expect(observableQuery.getCurrentResult()).toEqualApolloQueryResult(
+          expect(observableQuery.getCurrentResult()).toEqualStrictTyped(
             resultAfterSubscribe
           );
 
           cache.writeQuery({ query, data: cacheValues.update1 });
-          expect(observableQuery.getCurrentResult()).toEqualApolloQueryResult(
+          expect(observableQuery.getCurrentResult()).toEqualStrictTyped(
             resultAfterCacheUpdate1
           );
 
@@ -3210,19 +3210,19 @@ describe("ObservableQuery", () => {
             () =>
               void expect(
                 observableQuery.getCurrentResult()
-              ).toEqualApolloQueryResult(resultAfterLinkNext),
+              ).toEqualStrictTyped(resultAfterLinkNext),
             { interval: 1 }
           );
 
           cache.writeQuery({ query, data: cacheValues.update2 });
-          expect(observableQuery.getCurrentResult()).toEqualApolloQueryResult(
+          expect(observableQuery.getCurrentResult()).toEqualStrictTyped(
             resultAfterCacheUpdate2
           );
 
           void observableQuery.refetch();
 
           cache.writeQuery({ query, data: cacheValues.update3 });
-          expect(observableQuery.getCurrentResult()).toEqualApolloQueryResult(
+          expect(observableQuery.getCurrentResult()).toEqualStrictTyped(
             resultAfterCacheUpdate3
           );
 
@@ -3235,12 +3235,12 @@ describe("ObservableQuery", () => {
             () =>
               void expect(
                 observableQuery.getCurrentResult()
-              ).toEqualApolloQueryResult(resultAfterRefetchNext),
+              ).toEqualStrictTyped(resultAfterRefetchNext),
             { interval: 1 }
           );
 
           cache.writeQuery({ query, data: cacheValues.update4 });
-          expect(observableQuery.getCurrentResult()).toEqualApolloQueryResult(
+          expect(observableQuery.getCurrentResult()).toEqualStrictTyped(
             resultAfterCacheUpdate4
           );
         }
@@ -3298,7 +3298,7 @@ describe("ObservableQuery", () => {
           networkStatus: NetworkStatus.ready,
           partial: false,
         });
-        expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+        expect(observable.getCurrentResult()).toEqualStrictTyped({
           data: dataOne,
           loading: false,
           networkStatus: NetworkStatus.ready,
@@ -3319,7 +3319,7 @@ describe("ObservableQuery", () => {
           networkStatus: NetworkStatus.ready,
           partial: false,
         });
-        expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+        expect(observable.getCurrentResult()).toEqualStrictTyped({
           data: {
             people_one: optimisticResponse,
           },
@@ -3336,7 +3336,7 @@ describe("ObservableQuery", () => {
           networkStatus: NetworkStatus.ready,
           partial: false,
         });
-        expect(observable.getCurrentResult()).toEqualApolloQueryResult({
+        expect(observable.getCurrentResult()).toEqualStrictTyped({
           data: {
             people_one: mutationData,
           },
@@ -3889,7 +3889,7 @@ test("handles changing variables in rapid succession before other request is com
   observable.subscribe(jest.fn());
 
   await waitFor(() => {
-    expect(observable.getCurrentResult(false)).toEqualApolloQueryResult({
+    expect(observable.getCurrentResult(false)).toEqualStrictTyped({
       data: { userCount: 10 },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -3905,7 +3905,7 @@ test("handles changing variables in rapid succession before other request is com
   await wait(50);
 
   expect(observable.options.variables).toEqual({ department: null });
-  expect(observable.getCurrentResult(false)).toEqualApolloQueryResult({
+  expect(observable.getCurrentResult(false)).toEqualStrictTyped({
     data: { userCount: 10 },
     loading: false,
     networkStatus: NetworkStatus.ready,
@@ -3939,7 +3939,7 @@ test("works with `from`", async () => {
   const observable = from(observableQuery);
   const stream = new ObservableStream(observable);
   const result = await stream.takeNext();
-  expect(result).toEqualApolloQueryResult({
+  expect(result).toEqualStrictTyped({
     data,
     loading: false,
     networkStatus: NetworkStatus.ready,

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -493,9 +493,6 @@ describe("ObservableQuery", () => {
 
       await expect(observable.refetch()).resolves.toEqualStrictTyped({
         data: dataOne,
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
       });
 
       await expect(stream).toEmitApolloQueryResult({
@@ -1216,9 +1213,6 @@ describe("ObservableQuery", () => {
         observable.refetch(differentVariables)
       ).resolves.toEqualStrictTyped({
         data: dataTwo,
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
       });
 
       await expect(stream).toEmitApolloQueryResult({
@@ -1870,9 +1864,6 @@ describe("ObservableQuery", () => {
           counter: 5,
           name: "Ben",
         },
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
       });
 
       await expect(stream).toEmitApolloQueryResult({

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -2351,12 +2351,7 @@ describe("ObservableQuery", () => {
 
       const result = await client.query({ query, variables });
 
-      expect(result).toEqualStrictTyped({
-        data: dataOne,
-        loading: false,
-        networkStatus: 7,
-        partial: false,
-      });
+      expect(result).toEqualStrictTyped({ data: dataOne });
 
       const observable = client.watchQuery({ query, variables });
 
@@ -2665,12 +2660,7 @@ describe("ObservableQuery", () => {
 
       const result = await client.query({ query, variables });
 
-      expect(result).toEqualStrictTyped({
-        data: dataOne,
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
-      });
+      expect(result).toEqualStrictTyped({ data: dataOne });
 
       const observable = client.watchQuery({
         query,

--- a/src/core/__tests__/fetchPolicies.ts
+++ b/src/core/__tests__/fetchPolicies.ts
@@ -940,9 +940,6 @@ describe("nextFetchPolicy", () => {
             },
           },
         },
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
       });
     }
 
@@ -982,9 +979,6 @@ describe("nextFetchPolicy", () => {
             },
           },
         },
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
       });
 
       // Changing variables resets the fetchPolicy to its initial value.
@@ -1089,9 +1083,6 @@ describe("nextFetchPolicy", () => {
             },
           },
         },
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
       });
     }
 
@@ -1132,9 +1123,6 @@ describe("nextFetchPolicy", () => {
             },
           },
         },
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
       });
     }
 
@@ -1261,9 +1249,6 @@ describe("nextFetchPolicy", () => {
             },
           },
         },
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
       });
     }
 
@@ -1302,9 +1287,6 @@ describe("nextFetchPolicy", () => {
             },
           },
         },
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
       });
 
       // The nextFetchPolicy function we provided always returnes cache-first,

--- a/src/core/__tests__/fetchPolicies.ts
+++ b/src/core/__tests__/fetchPolicies.ts
@@ -929,7 +929,7 @@ describe("nextFetchPolicy", () => {
     {
       const result = await observable.refetch({ refetching: true });
 
-      expect(result).toEqualApolloQueryResult({
+      expect(result).toEqualStrictTyped({
         data: {
           echo: {
             __typename: "Echo",
@@ -971,7 +971,7 @@ describe("nextFetchPolicy", () => {
         },
       });
 
-      expect(result).toEqualApolloQueryResult({
+      expect(result).toEqualStrictTyped({
         data: {
           echo: {
             __typename: "Echo",
@@ -1078,7 +1078,7 @@ describe("nextFetchPolicy", () => {
     {
       const result = await observable.refetch({ refetching: true });
 
-      expect(result).toEqualApolloQueryResult({
+      expect(result).toEqualStrictTyped({
         data: {
           echo: {
             __typename: "Echo",
@@ -1121,7 +1121,7 @@ describe("nextFetchPolicy", () => {
         },
       });
 
-      expect(result).toEqualApolloQueryResult({
+      expect(result).toEqualStrictTyped({
         data: {
           echo: {
             __typename: "Echo",
@@ -1250,7 +1250,7 @@ describe("nextFetchPolicy", () => {
     {
       const result = await observable.refetch({ refetching: true });
 
-      expect(result).toEqualApolloQueryResult({
+      expect(result).toEqualStrictTyped({
         data: {
           echo: {
             __typename: "Echo",
@@ -1291,7 +1291,7 @@ describe("nextFetchPolicy", () => {
         },
       });
 
-      expect(result).toEqualApolloQueryResult({
+      expect(result).toEqualStrictTyped({
         data: {
           echo: {
             __typename: "Echo",

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -262,7 +262,4 @@ export interface QueryResult<TData = unknown> {
 
   /** {@inheritDoc @apollo/client!QueryResultDocumentation#error:member} */
   error?: ErrorLike;
-
-  /** {@inheritDoc @apollo/client!QueryResultDocumentation#extensions:member} */
-  extensions?: Record<string, unknown>;
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -112,7 +112,7 @@ export type RefetchQueriesPromiseResults<TResult> =
   // query (false). Since refetching produces an ApolloQueryResult<any>, and
   // skipping produces nothing, the fully-resolved array of all results produced
   // will be an ApolloQueryResult<any>[], when TResult extends boolean.
-  TResult extends boolean ? ApolloQueryResult<any>[]
+  TResult extends boolean ? QueryResult<any>[]
   : // If onQueryUpdated returns a PromiseLike<U>, that thenable will be passed as
   // an array element to Promise.all, so we infer/unwrap the array type U here.
   TResult extends PromiseLike<infer U> ? U[]
@@ -155,7 +155,7 @@ export type InternalRefetchQueriesResult<TResult> =
   // If onQueryUpdated returns a boolean, that's equivalent to refetching the
   // query when the boolean is true and skipping the query when false, so the
   // internal type of refetched results is Promise<ApolloQueryResult<any>>.
-  TResult extends boolean ? Promise<ApolloQueryResult<any>>
+  TResult extends boolean ? Promise<QueryResult<any>>
   : // Otherwise, onQueryUpdated returns whatever it returns. If onQueryUpdated is
     // not provided, TResult defaults to Promise<ApolloQueryResult<any>> (see the
     // generic type parameters of client.refetchQueries).

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -255,3 +255,14 @@ export interface SubscribeResult<TData = unknown> {
   /** {@inheritDoc @apollo/client!MutationResultDocumentation#extensions:member} */
   extensions?: Record<string, unknown>;
 }
+
+export interface QueryResult<TData = unknown> {
+  /** {@inheritDoc @apollo/client!QueryResultDocumentation#data:member} */
+  data: TData | undefined;
+
+  /** {@inheritDoc @apollo/client!QueryResultDocumentation#error:member} */
+  error?: ErrorLike;
+
+  /** {@inheritDoc @apollo/client!QueryResultDocumentation#extensions:member} */
+  extensions?: Record<string, unknown>;
+}

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -86,7 +86,7 @@ describe("useLazyQuery Hook", () => {
     const [execute] = getCurrentSnapshot();
     const result = await execute();
 
-    expect(result).toEqualApolloQueryResult({
+    expect(result).toEqualStrictTyped({
       data: { hello: "world" },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -148,7 +148,7 @@ describe("useLazyQuery Hook", () => {
     const [execute] = getCurrentSnapshot();
     const result = await execute({ variables: { id: 1 } });
 
-    expect(result).toEqualApolloQueryResult({
+    expect(result).toEqualStrictTyped({
       data: { hello: "world 1" },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -207,7 +207,7 @@ describe("useLazyQuery Hook", () => {
     const [execute] = getCurrentSnapshot();
     const result = await execute();
 
-    expect(result).toEqualApolloQueryResult({
+    expect(result).toEqualStrictTyped({
       data: { hello: "world" },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -294,7 +294,7 @@ describe("useLazyQuery Hook", () => {
 
     const [execute] = getCurrentSnapshot();
 
-    await expect(execute()).resolves.toEqualApolloQueryResult({
+    await expect(execute()).resolves.toEqualStrictTyped({
       data: { hello: "world" },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -329,7 +329,7 @@ describe("useLazyQuery Hook", () => {
       });
     }
 
-    await expect(execute()).resolves.toEqualApolloQueryResult({
+    await expect(execute()).resolves.toEqualStrictTyped({
       data: { name: "changed" },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -403,7 +403,7 @@ describe("useLazyQuery Hook", () => {
 
     const [execute] = getCurrentSnapshot();
 
-    await expect(execute()).resolves.toEqualApolloQueryResult({
+    await expect(execute()).resolves.toEqualStrictTyped({
       data: { hello: "world" },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -440,7 +440,7 @@ describe("useLazyQuery Hook", () => {
 
     const [, { refetch }] = getCurrentSnapshot();
 
-    await expect(refetch()).resolves.toEqualApolloQueryResult({
+    await expect(refetch()).resolves.toEqualStrictTyped({
       data: { name: "changed" },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -518,7 +518,7 @@ describe("useLazyQuery Hook", () => {
 
     const [execute] = getCurrentSnapshot();
 
-    await expect(execute()).resolves.toEqualApolloQueryResult({
+    await expect(execute()).resolves.toEqualStrictTyped({
       data: { hello: "world" },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -565,7 +565,7 @@ describe("useLazyQuery Hook", () => {
       });
     }
 
-    await expect(execute()).resolves.toEqualApolloQueryResult({
+    await expect(execute()).resolves.toEqualStrictTyped({
       data: { name: "changed" },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -644,7 +644,7 @@ describe("useLazyQuery Hook", () => {
 
     const [execute] = getCurrentSnapshot();
 
-    await expect(execute()).resolves.toEqualApolloQueryResult({
+    await expect(execute()).resolves.toEqualStrictTyped({
       data: { hello: "world 1" },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -664,7 +664,7 @@ describe("useLazyQuery Hook", () => {
       });
     }
 
-    await expect(execute()).resolves.toEqualApolloQueryResult({
+    await expect(execute()).resolves.toEqualStrictTyped({
       data: { hello: "world 2" },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -731,7 +731,7 @@ describe("useLazyQuery Hook", () => {
 
     const [execute] = getCurrentSnapshot();
 
-    await expect(execute()).resolves.toEqualApolloQueryResult({
+    await expect(execute()).resolves.toEqualStrictTyped({
       data: { hello: "world 1" },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -764,7 +764,7 @@ describe("useLazyQuery Hook", () => {
       });
     }
 
-    await expect(execute()).resolves.toEqualApolloQueryResult({
+    await expect(execute()).resolves.toEqualStrictTyped({
       data: { hello: "world 2" },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -843,7 +843,7 @@ describe("useLazyQuery Hook", () => {
 
     const [execute] = getCurrentSnapshot();
 
-    await expect(execute()).resolves.toEqualApolloQueryResult({
+    await expect(execute()).resolves.toEqualStrictTyped({
       data: { hello: "world 1" },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -878,7 +878,7 @@ describe("useLazyQuery Hook", () => {
 
     const [, { refetch }] = getCurrentSnapshot();
 
-    await expect(refetch()).resolves.toEqualApolloQueryResult({
+    await expect(refetch()).resolves.toEqualStrictTyped({
       data: { hello: "world 2" },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -958,7 +958,7 @@ describe("useLazyQuery Hook", () => {
 
     const [execute] = getCurrentSnapshot();
 
-    await expect(execute()).resolves.toEqualApolloQueryResult({
+    await expect(execute()).resolves.toEqualStrictTyped({
       data: { hello: "world 1" },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -1073,14 +1073,14 @@ describe("useLazyQuery Hook", () => {
 
     const [execute] = getCurrentSnapshot();
 
-    await expect(
-      execute({ variables: { id: 1 } })
-    ).resolves.toEqualApolloQueryResult({
-      data: data1,
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
-    });
+    await expect(execute({ variables: { id: 1 } })).resolves.toEqualStrictTyped(
+      {
+        data: data1,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        partial: false,
+      }
+    );
 
     {
       const [, result] = await takeSnapshot();
@@ -1095,14 +1095,14 @@ describe("useLazyQuery Hook", () => {
       });
     }
 
-    await expect(
-      execute({ variables: { id: 2 } })
-    ).resolves.toEqualApolloQueryResult({
-      data: data2,
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
-    });
+    await expect(execute({ variables: { id: 2 } })).resolves.toEqualStrictTyped(
+      {
+        data: data2,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        partial: false,
+      }
+    );
 
     {
       const [, result] = await takeSnapshot();
@@ -1186,14 +1186,14 @@ describe("useLazyQuery Hook", () => {
 
     const [execute] = getCurrentSnapshot();
 
-    await expect(
-      execute({ variables: { id: 1 } })
-    ).resolves.toEqualApolloQueryResult({
-      data: data1,
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
-    });
+    await expect(execute({ variables: { id: 1 } })).resolves.toEqualStrictTyped(
+      {
+        data: data1,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        partial: false,
+      }
+    );
 
     {
       const [, result] = await takeSnapshot();
@@ -1221,14 +1221,14 @@ describe("useLazyQuery Hook", () => {
       });
     }
 
-    await expect(
-      execute({ variables: { id: 2 } })
-    ).resolves.toEqualApolloQueryResult({
-      data: data2,
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
-    });
+    await expect(execute({ variables: { id: 2 } })).resolves.toEqualStrictTyped(
+      {
+        data: data2,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        partial: false,
+      }
+    );
 
     {
       const [, result] = await takeSnapshot();
@@ -1299,7 +1299,7 @@ describe("useLazyQuery Hook", () => {
 
     const [execute] = getCurrentSnapshot();
 
-    await expect(execute()).resolves.toEqualApolloQueryResult({
+    await expect(execute()).resolves.toEqualStrictTyped({
       data: { hello: "from link" },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -1383,7 +1383,7 @@ describe("useLazyQuery Hook", () => {
 
     const [execute] = getCurrentSnapshot();
 
-    await expect(execute()).resolves.toEqualApolloQueryResult({
+    await expect(execute()).resolves.toEqualStrictTyped({
       data: { hello: "from link" },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -1416,7 +1416,7 @@ describe("useLazyQuery Hook", () => {
       });
     }
 
-    await expect(execute()).resolves.toEqualApolloQueryResult({
+    await expect(execute()).resolves.toEqualStrictTyped({
       data: { hello: "from link 2" },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -1505,7 +1505,7 @@ describe("useLazyQuery Hook", () => {
 
     await expect(
       execute({ variables: { id: "1" } })
-    ).resolves.toEqualApolloQueryResult({
+    ).resolves.toEqualStrictTyped({
       data: {
         character: { __typename: "Character", id: "1", name: "Spider-Man" },
       },
@@ -1548,7 +1548,7 @@ describe("useLazyQuery Hook", () => {
 
     await expect(
       execute({ variables: { id: "2" } })
-    ).resolves.toEqualApolloQueryResult({
+    ).resolves.toEqualStrictTyped({
       data: {
         character: { __typename: "Character", id: "2", name: "Black Widow" },
       },
@@ -1651,7 +1651,7 @@ describe("useLazyQuery Hook", () => {
 
     await expect(
       execute({ variables: { id: "1" } })
-    ).resolves.toEqualApolloQueryResult({
+    ).resolves.toEqualStrictTyped({
       data: {
         character: { __typename: "Character", id: "1", name: "Spider-Man" },
       },
@@ -1694,7 +1694,7 @@ describe("useLazyQuery Hook", () => {
 
     await expect(
       execute({ variables: { id: "2" } })
-    ).resolves.toEqualApolloQueryResult({
+    ).resolves.toEqualStrictTyped({
       data: {
         character: { __typename: "Character", id: "2", name: "Black Widow" },
       },
@@ -1875,7 +1875,7 @@ describe("useLazyQuery Hook", () => {
       });
     }
 
-    await expect(execute()).resolves.toEqualApolloQueryResult({
+    await expect(execute()).resolves.toEqualStrictTyped({
       data: { currentUser: null },
       error: new CombinedGraphQLErrors([{ message: "Not logged in" }]),
       loading: false,
@@ -1897,7 +1897,7 @@ describe("useLazyQuery Hook", () => {
       });
     }
 
-    await expect(execute()).resolves.toEqualApolloQueryResult({
+    await expect(execute()).resolves.toEqualStrictTyped({
       data: { currentUser: null },
       error: new CombinedGraphQLErrors([{ message: "Not logged in 2" }]),
       loading: false,
@@ -1975,7 +1975,7 @@ describe("useLazyQuery Hook", () => {
       });
     }
 
-    await expect(execute()).resolves.toEqualApolloQueryResult({
+    await expect(execute()).resolves.toEqualStrictTyped({
       data: { currentUser: null },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -2028,7 +2028,7 @@ describe("useLazyQuery Hook", () => {
 
     link.simulateResult({ result: { data: { hello: "Greetings" } } }, true);
 
-    await expect(promise!).resolves.toEqualApolloQueryResult({
+    await expect(promise!).resolves.toEqualStrictTyped({
       data: { hello: "Greetings" },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -2066,8 +2066,8 @@ describe("useLazyQuery Hook", () => {
       partial: false,
     };
 
-    await expect(promise1!).resolves.toEqualApolloQueryResult(expectedResult);
-    await expect(promise2!).resolves.toEqualApolloQueryResult(expectedResult);
+    await expect(promise1!).resolves.toEqualStrictTyped(expectedResult);
+    await expect(promise2!).resolves.toEqualStrictTyped(expectedResult);
   });
 
   // https://github.com/apollographql/apollo-client/issues/9755
@@ -2130,14 +2130,14 @@ describe("useLazyQuery Hook", () => {
     const promise1 = execute({ variables: { id: "1" } });
     const promise2 = execute({ variables: { id: "2" } });
 
-    await expect(promise1).resolves.toEqualApolloQueryResult({
+    await expect(promise1).resolves.toEqualStrictTyped({
       data: mocks[0].result.data,
       loading: false,
       networkStatus: NetworkStatus.ready,
       partial: false,
     });
 
-    await expect(promise2).resolves.toEqualApolloQueryResult({
+    await expect(promise2).resolves.toEqualStrictTyped({
       data: mocks[1].result.data,
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -2215,7 +2215,7 @@ describe("useLazyQuery Hook", () => {
 
     const [execute] = getCurrentSnapshot();
 
-    await expect(execute()).resolves.toEqualApolloQueryResult({
+    await expect(execute()).resolves.toEqualStrictTyped({
       data: { hello: "Greetings" },
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -2759,7 +2759,7 @@ describe("useLazyQuery Hook", () => {
 
       const [execute] = getCurrentSnapshot();
 
-      await expect(execute()).resolves.toEqualApolloQueryResult({
+      await expect(execute()).resolves.toEqualStrictTyped({
         data: undefined,
         error: networkError,
         loading: false,
@@ -2828,7 +2828,7 @@ describe("useLazyQuery Hook", () => {
 
       const [execute] = getCurrentSnapshot();
 
-      await expect(execute()).resolves.toEqualApolloQueryResult({
+      await expect(execute()).resolves.toEqualStrictTyped({
         data: undefined,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -2982,7 +2982,7 @@ describe("useLazyQuery Hook", () => {
       const [execute] = getCurrentSnapshot();
       const result = await execute();
 
-      expect(result).toEqualApolloQueryResult({
+      expect(result).toEqualStrictTyped({
         data: {
           currentUser: {
             __typename: "User",
@@ -3085,7 +3085,7 @@ describe("useLazyQuery Hook", () => {
       const [execute] = getCurrentSnapshot();
       const result = await execute();
 
-      expect(result).toEqualApolloQueryResult({
+      expect(result).toEqualStrictTyped({
         data: {
           currentUser: {
             __typename: "User",
@@ -3189,7 +3189,7 @@ describe("useLazyQuery Hook", () => {
       const [execute] = getCurrentSnapshot();
       const result = await execute();
 
-      expect(result).toEqualApolloQueryResult({
+      expect(result).toEqualStrictTyped({
         data: {
           currentUser: {
             __typename: "User",
@@ -3745,7 +3745,7 @@ test("uses the updated client when executing the function after changing clients
 
   const [execute] = getCurrentSnapshot();
 
-  await expect(execute()).resolves.toEqualApolloQueryResult({
+  await expect(execute()).resolves.toEqualStrictTyped({
     data: { greeting: "Hello client 1" },
     loading: false,
     networkStatus: NetworkStatus.ready,
@@ -3780,7 +3780,7 @@ test("uses the updated client when executing the function after changing clients
     });
   }
 
-  await expect(execute()).resolves.toEqualApolloQueryResult({
+  await expect(execute()).resolves.toEqualStrictTyped({
     data: { greeting: "Hello client 2" },
     loading: false,
     networkStatus: NetworkStatus.ready,
@@ -3842,7 +3842,7 @@ test("responds to cache updates after executing query", async () => {
 
   const [execute] = getCurrentSnapshot();
 
-  await expect(execute()).resolves.toEqualApolloQueryResult({
+  await expect(execute()).resolves.toEqualStrictTyped({
     data: { greeting: "Hello" },
     loading: false,
     networkStatus: NetworkStatus.ready,
@@ -3921,16 +3921,16 @@ test("responds to cache updates after changing variables", async () => {
 
   const [execute] = getCurrentSnapshot();
 
-  await expect(
-    execute({ variables: { id: "1" } })
-  ).resolves.toEqualApolloQueryResult({
-    data: {
-      character: { __typename: "Character", id: "1", name: "Spider-Man" },
-    },
-    loading: false,
-    networkStatus: NetworkStatus.ready,
-    partial: false,
-  });
+  await expect(execute({ variables: { id: "1" } })).resolves.toEqualStrictTyped(
+    {
+      data: {
+        character: { __typename: "Character", id: "1", name: "Spider-Man" },
+      },
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    }
+  );
 
   {
     const [, result] = await takeSnapshot();
@@ -3947,16 +3947,16 @@ test("responds to cache updates after changing variables", async () => {
     });
   }
 
-  await expect(
-    execute({ variables: { id: "2" } })
-  ).resolves.toEqualApolloQueryResult({
-    data: {
-      character: { __typename: "Character", id: "2", name: "Black Widow" },
-    },
-    loading: false,
-    networkStatus: NetworkStatus.ready,
-    partial: false,
-  });
+  await expect(execute({ variables: { id: "2" } })).resolves.toEqualStrictTyped(
+    {
+      data: {
+        character: { __typename: "Character", id: "2", name: "Black Widow" },
+      },
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    }
+  );
 
   {
     const [, result] = await takeSnapshot();
@@ -4069,16 +4069,16 @@ test("uses cached result when switching to variables already written to the cach
 
   const [execute] = getCurrentSnapshot();
 
-  await expect(
-    execute({ variables: { id: "1" } })
-  ).resolves.toEqualApolloQueryResult({
-    data: {
-      character: { __typename: "Character", id: "1", name: "Spider-Man" },
-    },
-    loading: false,
-    networkStatus: NetworkStatus.ready,
-    partial: false,
-  });
+  await expect(execute({ variables: { id: "1" } })).resolves.toEqualStrictTyped(
+    {
+      data: {
+        character: { __typename: "Character", id: "1", name: "Spider-Man" },
+      },
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    }
+  );
 
   {
     const [, result] = await takeSnapshot();
@@ -4095,20 +4095,20 @@ test("uses cached result when switching to variables already written to the cach
     });
   }
 
-  await expect(
-    execute({ variables: { id: "2" } })
-  ).resolves.toEqualApolloQueryResult({
-    data: {
-      character: {
-        __typename: "Character",
-        id: "2",
-        name: "Cached Character",
+  await expect(execute({ variables: { id: "2" } })).resolves.toEqualStrictTyped(
+    {
+      data: {
+        character: {
+          __typename: "Character",
+          id: "2",
+          name: "Cached Character",
+        },
       },
-    },
-    loading: false,
-    networkStatus: NetworkStatus.ready,
-    partial: false,
-  });
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    }
+  );
 
   {
     const [, result] = await takeSnapshot();
@@ -4176,16 +4176,16 @@ test("renders loading states where necessary when switching to variables maybe w
 
   const [execute] = getCurrentSnapshot();
 
-  await expect(
-    execute({ variables: { id: "1" } })
-  ).resolves.toEqualApolloQueryResult({
-    data: {
-      character: { __typename: "Character", id: "1", name: "Spider-Man" },
-    },
-    loading: false,
-    networkStatus: NetworkStatus.ready,
-    partial: false,
-  });
+  await expect(execute({ variables: { id: "1" } })).resolves.toEqualStrictTyped(
+    {
+      data: {
+        character: { __typename: "Character", id: "1", name: "Spider-Man" },
+      },
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    }
+  );
 
   {
     const [, result] = await takeSnapshot();
@@ -4215,20 +4215,20 @@ test("renders loading states where necessary when switching to variables maybe w
     });
   }
 
-  await expect(
-    execute({ variables: { id: "2" } })
-  ).resolves.toEqualApolloQueryResult({
-    data: {
-      character: {
-        __typename: "Character",
-        id: "2",
-        name: "Cached Character",
+  await expect(execute({ variables: { id: "2" } })).resolves.toEqualStrictTyped(
+    {
+      data: {
+        character: {
+          __typename: "Character",
+          id: "2",
+          name: "Cached Character",
+        },
       },
-    },
-    loading: false,
-    networkStatus: NetworkStatus.ready,
-    partial: false,
-  });
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    }
+  );
 
   {
     const [, result] = await takeSnapshot();
@@ -4251,20 +4251,20 @@ test("renders loading states where necessary when switching to variables maybe w
     });
   }
 
-  await expect(
-    execute({ variables: { id: "3" } })
-  ).resolves.toEqualApolloQueryResult({
-    data: {
-      character: {
-        __typename: "Character",
-        id: "3",
-        name: "Iron Man",
+  await expect(execute({ variables: { id: "3" } })).resolves.toEqualStrictTyped(
+    {
+      data: {
+        character: {
+          __typename: "Character",
+          id: "3",
+          name: "Iron Man",
+        },
       },
-    },
-    loading: false,
-    networkStatus: NetworkStatus.ready,
-    partial: false,
-  });
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    }
+  );
 
   {
     const [, result] = await takeSnapshot();
@@ -4384,16 +4384,16 @@ test("applies `errorPolicy` on next fetch when it changes between renders", asyn
 
   const [execute] = getCurrentSnapshot();
 
-  await expect(
-    execute({ variables: { id: "1" } })
-  ).resolves.toEqualApolloQueryResult({
-    data: {
-      character: { __typename: "Character", id: "1", name: "Spider-Man" },
-    },
-    loading: false,
-    networkStatus: NetworkStatus.ready,
-    partial: false,
-  });
+  await expect(execute({ variables: { id: "1" } })).resolves.toEqualStrictTyped(
+    {
+      data: {
+        character: { __typename: "Character", id: "1", name: "Spider-Man" },
+      },
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    }
+  );
 
   {
     const [, result] = await takeSnapshot();
@@ -4502,7 +4502,7 @@ test("applies `context` on next fetch when it changes between renders", async ()
 
   const [execute] = getCurrentSnapshot();
 
-  await expect(execute()).resolves.toEqualApolloQueryResult({
+  await expect(execute()).resolves.toEqualStrictTyped({
     data: { context: { source: "initialHookValue" } },
     loading: false,
     networkStatus: NetworkStatus.ready,
@@ -4537,7 +4537,7 @@ test("applies `context` on next fetch when it changes between renders", async ()
     });
   }
 
-  await expect(execute()).resolves.toEqualApolloQueryResult({
+  await expect(execute()).resolves.toEqualStrictTyped({
     data: { context: { source: "rerender" } },
     loading: false,
     networkStatus: NetworkStatus.ready,
@@ -4590,7 +4590,7 @@ test("applies `context` on next fetch when it changes between renders", async ()
 
   await expect(
     execute({ context: { source: "execute" } })
-  ).resolves.toEqualApolloQueryResult({
+  ).resolves.toEqualStrictTyped({
     data: { context: { source: "execute" } },
     loading: false,
     networkStatus: NetworkStatus.ready,
@@ -4693,7 +4693,7 @@ test("applies `refetchWritePolicy` on next fetch when it changes between renders
 
   await expect(
     execute({ variables: { min: 0, max: 12 } })
-  ).resolves.toEqualApolloQueryResult({
+  ).resolves.toEqualStrictTyped({
     data: mocks[0].result.data,
     loading: false,
     networkStatus: NetworkStatus.ready,
@@ -4873,16 +4873,16 @@ test("applies `returnPartialData` on next fetch when it changes between renders"
 
   const [execute] = getCurrentSnapshot();
 
-  await expect(
-    execute({ variables: { id: "1" } })
-  ).resolves.toEqualApolloQueryResult({
-    data: {
-      character: { __typename: "Character", id: "1", name: "Doctor Strange" },
-    },
-    loading: false,
-    networkStatus: NetworkStatus.ready,
-    partial: false,
-  });
+  await expect(execute({ variables: { id: "1" } })).resolves.toEqualStrictTyped(
+    {
+      data: {
+        character: { __typename: "Character", id: "1", name: "Doctor Strange" },
+      },
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    }
+  );
 
   {
     const [, result] = await takeSnapshot();
@@ -4916,16 +4916,16 @@ test("applies `returnPartialData` on next fetch when it changes between renders"
     });
   }
 
-  await expect(
-    execute({ variables: { id: "2" } })
-  ).resolves.toEqualApolloQueryResult({
-    data: {
-      character: { __typename: "Character", id: "2", name: "Hulk" },
-    },
-    loading: false,
-    networkStatus: NetworkStatus.ready,
-    partial: false,
-  });
+  await expect(execute({ variables: { id: "2" } })).resolves.toEqualStrictTyped(
+    {
+      data: {
+        character: { __typename: "Character", id: "2", name: "Hulk" },
+      },
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    }
+  );
 
   {
     const [, result] = await takeSnapshot();
@@ -5012,16 +5012,16 @@ test("applies updated `fetchPolicy` on next fetch when it changes between render
 
   const [execute] = getCurrentSnapshot();
 
-  await expect(
-    execute({ variables: { id: "1" } })
-  ).resolves.toEqualApolloQueryResult({
-    data: {
-      character: { __typename: "Character", id: "1", name: "Spider-Cache" },
-    },
-    loading: false,
-    networkStatus: NetworkStatus.ready,
-    partial: false,
-  });
+  await expect(execute({ variables: { id: "1" } })).resolves.toEqualStrictTyped(
+    {
+      data: {
+        character: { __typename: "Character", id: "1", name: "Spider-Cache" },
+      },
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    }
+  );
 
   {
     const [, result] = await takeSnapshot();
@@ -5055,16 +5055,16 @@ test("applies updated `fetchPolicy` on next fetch when it changes between render
     });
   }
 
-  await expect(
-    execute({ variables: { id: "2" } })
-  ).resolves.toEqualApolloQueryResult({
-    data: {
-      character: { __typename: "Character", id: "2", name: "Black Widow" },
-    },
-    loading: false,
-    networkStatus: NetworkStatus.ready,
-    partial: false,
-  });
+  await expect(execute({ variables: { id: "2" } })).resolves.toEqualStrictTyped(
+    {
+      data: {
+        character: { __typename: "Character", id: "2", name: "Black Widow" },
+      },
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    }
+  );
 
   {
     const [, result] = await takeSnapshot();
@@ -5146,7 +5146,7 @@ test("renders loading states at appropriate times on next fetch after updating `
 
   const [execute] = getCurrentSnapshot();
 
-  await expect(execute()).resolves.toEqualApolloQueryResult({
+  await expect(execute()).resolves.toEqualStrictTyped({
     data: { greeting: "Hello 1" },
     loading: false,
     networkStatus: NetworkStatus.ready,
@@ -5181,7 +5181,7 @@ test("renders loading states at appropriate times on next fetch after updating `
     });
   }
 
-  await expect(execute()).resolves.toEqualApolloQueryResult({
+  await expect(execute()).resolves.toEqualStrictTyped({
     data: { greeting: "Hello 2" },
     loading: false,
     networkStatus: NetworkStatus.ready,
@@ -5229,7 +5229,7 @@ test("renders loading states at appropriate times on next fetch after updating `
     });
   }
 
-  await expect(execute()).resolves.toEqualApolloQueryResult({
+  await expect(execute()).resolves.toEqualStrictTyped({
     data: { greeting: "Hello 3" },
     loading: false,
     networkStatus: NetworkStatus.ready,

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -14,11 +14,11 @@ import { Observable } from "rxjs";
 import {
   ApolloClient,
   ApolloLink,
-  ApolloQueryResult,
   CombinedGraphQLErrors,
   ErrorPolicy,
   InMemoryCache,
   NetworkStatus,
+  QueryResult,
   RefetchWritePolicy,
   TypedDocumentNode,
   WatchQueryFetchPolicy,
@@ -88,9 +88,6 @@ describe("useLazyQuery Hook", () => {
 
     expect(result).toEqualStrictTyped({
       data: { hello: "world" },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
 
     {
@@ -150,9 +147,6 @@ describe("useLazyQuery Hook", () => {
 
     expect(result).toEqualStrictTyped({
       data: { hello: "world 1" },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
 
     {
@@ -209,9 +203,6 @@ describe("useLazyQuery Hook", () => {
 
     expect(result).toEqualStrictTyped({
       data: { hello: "world" },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
 
     {
@@ -296,9 +287,6 @@ describe("useLazyQuery Hook", () => {
 
     await expect(execute()).resolves.toEqualStrictTyped({
       data: { hello: "world" },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
 
     {
@@ -331,9 +319,6 @@ describe("useLazyQuery Hook", () => {
 
     await expect(execute()).resolves.toEqualStrictTyped({
       data: { name: "changed" },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
 
     {
@@ -405,9 +390,6 @@ describe("useLazyQuery Hook", () => {
 
     await expect(execute()).resolves.toEqualStrictTyped({
       data: { hello: "world" },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
 
     {
@@ -442,9 +424,6 @@ describe("useLazyQuery Hook", () => {
 
     await expect(refetch()).resolves.toEqualStrictTyped({
       data: { name: "changed" },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
 
     {
@@ -520,9 +499,6 @@ describe("useLazyQuery Hook", () => {
 
     await expect(execute()).resolves.toEqualStrictTyped({
       data: { hello: "world" },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
 
     {
@@ -567,9 +543,6 @@ describe("useLazyQuery Hook", () => {
 
     await expect(execute()).resolves.toEqualStrictTyped({
       data: { name: "changed" },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
 
     {
@@ -646,9 +619,6 @@ describe("useLazyQuery Hook", () => {
 
     await expect(execute()).resolves.toEqualStrictTyped({
       data: { hello: "world 1" },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
 
     {
@@ -666,9 +636,6 @@ describe("useLazyQuery Hook", () => {
 
     await expect(execute()).resolves.toEqualStrictTyped({
       data: { hello: "world 2" },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
 
     {
@@ -733,9 +700,6 @@ describe("useLazyQuery Hook", () => {
 
     await expect(execute()).resolves.toEqualStrictTyped({
       data: { hello: "world 1" },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
 
     {
@@ -766,9 +730,6 @@ describe("useLazyQuery Hook", () => {
 
     await expect(execute()).resolves.toEqualStrictTyped({
       data: { hello: "world 2" },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
 
     {
@@ -845,9 +806,6 @@ describe("useLazyQuery Hook", () => {
 
     await expect(execute()).resolves.toEqualStrictTyped({
       data: { hello: "world 1" },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
 
     {
@@ -880,9 +838,6 @@ describe("useLazyQuery Hook", () => {
 
     await expect(refetch()).resolves.toEqualStrictTyped({
       data: { hello: "world 2" },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
 
     {
@@ -960,9 +915,6 @@ describe("useLazyQuery Hook", () => {
 
     await expect(execute()).resolves.toEqualStrictTyped({
       data: { hello: "world 1" },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
 
     {
@@ -1074,12 +1026,7 @@ describe("useLazyQuery Hook", () => {
     const [execute] = getCurrentSnapshot();
 
     await expect(execute({ variables: { id: 1 } })).resolves.toEqualStrictTyped(
-      {
-        data: data1,
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
-      }
+      { data: data1 }
     );
 
     {
@@ -1096,12 +1043,7 @@ describe("useLazyQuery Hook", () => {
     }
 
     await expect(execute({ variables: { id: 2 } })).resolves.toEqualStrictTyped(
-      {
-        data: data2,
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
-      }
+      { data: data2 }
     );
 
     {
@@ -1187,12 +1129,7 @@ describe("useLazyQuery Hook", () => {
     const [execute] = getCurrentSnapshot();
 
     await expect(execute({ variables: { id: 1 } })).resolves.toEqualStrictTyped(
-      {
-        data: data1,
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
-      }
+      { data: data1 }
     );
 
     {
@@ -1222,12 +1159,7 @@ describe("useLazyQuery Hook", () => {
     }
 
     await expect(execute({ variables: { id: 2 } })).resolves.toEqualStrictTyped(
-      {
-        data: data2,
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
-      }
+      { data: data2 }
     );
 
     {
@@ -1301,9 +1233,6 @@ describe("useLazyQuery Hook", () => {
 
     await expect(execute()).resolves.toEqualStrictTyped({
       data: { hello: "from link" },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
 
     {
@@ -1385,9 +1314,6 @@ describe("useLazyQuery Hook", () => {
 
     await expect(execute()).resolves.toEqualStrictTyped({
       data: { hello: "from link" },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
 
     {
@@ -1418,9 +1344,6 @@ describe("useLazyQuery Hook", () => {
 
     await expect(execute()).resolves.toEqualStrictTyped({
       data: { hello: "from link 2" },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
 
     {
@@ -1509,9 +1432,6 @@ describe("useLazyQuery Hook", () => {
       data: {
         character: { __typename: "Character", id: "1", name: "Spider-Man" },
       },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
 
     {
@@ -1552,9 +1472,6 @@ describe("useLazyQuery Hook", () => {
       data: {
         character: { __typename: "Character", id: "2", name: "Black Widow" },
       },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
 
     {
@@ -1655,9 +1572,6 @@ describe("useLazyQuery Hook", () => {
       data: {
         character: { __typename: "Character", id: "1", name: "Spider-Man" },
       },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
 
     {
@@ -1698,9 +1612,6 @@ describe("useLazyQuery Hook", () => {
       data: {
         character: { __typename: "Character", id: "2", name: "Black Widow" },
       },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
 
     {
@@ -1878,9 +1789,6 @@ describe("useLazyQuery Hook", () => {
     await expect(execute()).resolves.toEqualStrictTyped({
       data: { currentUser: null },
       error: new CombinedGraphQLErrors([{ message: "Not logged in" }]),
-      loading: false,
-      networkStatus: NetworkStatus.error,
-      partial: false,
     });
 
     {
@@ -1900,9 +1808,6 @@ describe("useLazyQuery Hook", () => {
     await expect(execute()).resolves.toEqualStrictTyped({
       data: { currentUser: null },
       error: new CombinedGraphQLErrors([{ message: "Not logged in 2" }]),
-      loading: false,
-      networkStatus: NetworkStatus.error,
-      partial: false,
     });
 
     {
@@ -1977,9 +1882,6 @@ describe("useLazyQuery Hook", () => {
 
     await expect(execute()).resolves.toEqualStrictTyped({
       data: { currentUser: null },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
 
     {
@@ -1995,11 +1897,8 @@ describe("useLazyQuery Hook", () => {
       });
     }
 
-    await expect(execute()).resolves.toEqual({
+    await expect(execute()).resolves.toEqualStrictTyped({
       data: { currentUser: null },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
 
     // We don't see an extra render here since the result is deeply equal to the
@@ -2019,7 +1918,7 @@ describe("useLazyQuery Hook", () => {
 
     const [execute] = result.current;
 
-    let promise: Promise<ApolloQueryResult<{ hello: string }>>;
+    let promise: Promise<QueryResult<{ hello: string }>>;
     act(() => {
       promise = execute();
     });
@@ -2030,9 +1929,6 @@ describe("useLazyQuery Hook", () => {
 
     await expect(promise!).resolves.toEqualStrictTyped({
       data: { hello: "Greetings" },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
   });
 
@@ -2048,8 +1944,8 @@ describe("useLazyQuery Hook", () => {
 
     const [execute] = result.current;
 
-    let promise1: Promise<ApolloQueryResult<{ hello: string }>>;
-    let promise2: Promise<ApolloQueryResult<{ hello: string }>>;
+    let promise1: Promise<QueryResult<{ hello: string }>>;
+    let promise2: Promise<QueryResult<{ hello: string }>>;
     act(() => {
       promise1 = execute();
       promise2 = execute();
@@ -2059,11 +1955,8 @@ describe("useLazyQuery Hook", () => {
 
     link.simulateResult({ result: { data: { hello: "Greetings" } } }, true);
 
-    const expectedResult = {
+    const expectedResult: QueryResult<{ hello: string }> = {
       data: { hello: "Greetings" },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     };
 
     await expect(promise1!).resolves.toEqualStrictTyped(expectedResult);
@@ -2132,16 +2025,10 @@ describe("useLazyQuery Hook", () => {
 
     await expect(promise1).resolves.toEqualStrictTyped({
       data: mocks[0].result.data,
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
 
     await expect(promise2).resolves.toEqualStrictTyped({
       data: mocks[1].result.data,
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
 
     {
@@ -2217,9 +2104,6 @@ describe("useLazyQuery Hook", () => {
 
     await expect(execute()).resolves.toEqualStrictTyped({
       data: { hello: "Greetings" },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
 
     {
@@ -2762,9 +2646,6 @@ describe("useLazyQuery Hook", () => {
       await expect(execute()).resolves.toEqualStrictTyped({
         data: undefined,
         error: networkError,
-        loading: false,
-        networkStatus: NetworkStatus.error,
-        partial: true,
       });
 
       {
@@ -2828,12 +2709,7 @@ describe("useLazyQuery Hook", () => {
 
       const [execute] = getCurrentSnapshot();
 
-      await expect(execute()).resolves.toEqualStrictTyped({
-        data: undefined,
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: true,
-      });
+      await expect(execute()).resolves.toEqualStrictTyped({ data: undefined });
 
       {
         const [, result] = await takeSnapshot();
@@ -2990,9 +2866,6 @@ describe("useLazyQuery Hook", () => {
             name: "Test User",
           },
         },
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
       });
 
       {
@@ -3094,9 +2967,6 @@ describe("useLazyQuery Hook", () => {
             age: 30,
           },
         },
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
       });
 
       {
@@ -3198,9 +3068,6 @@ describe("useLazyQuery Hook", () => {
             age: 30,
           },
         },
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
       });
 
       {
@@ -3747,9 +3614,6 @@ test("uses the updated client when executing the function after changing clients
 
   await expect(execute()).resolves.toEqualStrictTyped({
     data: { greeting: "Hello client 1" },
-    loading: false,
-    networkStatus: NetworkStatus.ready,
-    partial: false,
   });
 
   {
@@ -3782,9 +3646,6 @@ test("uses the updated client when executing the function after changing clients
 
   await expect(execute()).resolves.toEqualStrictTyped({
     data: { greeting: "Hello client 2" },
-    loading: false,
-    networkStatus: NetworkStatus.ready,
-    partial: false,
   });
 
   {
@@ -3844,9 +3705,6 @@ test("responds to cache updates after executing query", async () => {
 
   await expect(execute()).resolves.toEqualStrictTyped({
     data: { greeting: "Hello" },
-    loading: false,
-    networkStatus: NetworkStatus.ready,
-    partial: false,
   });
 
   {
@@ -3926,9 +3784,6 @@ test("responds to cache updates after changing variables", async () => {
       data: {
         character: { __typename: "Character", id: "1", name: "Spider-Man" },
       },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     }
   );
 
@@ -3952,9 +3807,6 @@ test("responds to cache updates after changing variables", async () => {
       data: {
         character: { __typename: "Character", id: "2", name: "Black Widow" },
       },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     }
   );
 
@@ -4074,9 +3926,6 @@ test("uses cached result when switching to variables already written to the cach
       data: {
         character: { __typename: "Character", id: "1", name: "Spider-Man" },
       },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     }
   );
 
@@ -4104,9 +3953,6 @@ test("uses cached result when switching to variables already written to the cach
           name: "Cached Character",
         },
       },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     }
   );
 
@@ -4181,9 +4027,6 @@ test("renders loading states where necessary when switching to variables maybe w
       data: {
         character: { __typename: "Character", id: "1", name: "Spider-Man" },
       },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     }
   );
 
@@ -4224,9 +4067,6 @@ test("renders loading states where necessary when switching to variables maybe w
           name: "Cached Character",
         },
       },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     }
   );
 
@@ -4260,9 +4100,6 @@ test("renders loading states where necessary when switching to variables maybe w
           name: "Iron Man",
         },
       },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     }
   );
 
@@ -4389,9 +4226,6 @@ test("applies `errorPolicy` on next fetch when it changes between renders", asyn
       data: {
         character: { __typename: "Character", id: "1", name: "Spider-Man" },
       },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     }
   );
 
@@ -4504,9 +4338,6 @@ test("applies `context` on next fetch when it changes between renders", async ()
 
   await expect(execute()).resolves.toEqualStrictTyped({
     data: { context: { source: "initialHookValue" } },
-    loading: false,
-    networkStatus: NetworkStatus.ready,
-    partial: false,
   });
 
   {
@@ -4539,9 +4370,6 @@ test("applies `context` on next fetch when it changes between renders", async ()
 
   await expect(execute()).resolves.toEqualStrictTyped({
     data: { context: { source: "rerender" } },
-    loading: false,
-    networkStatus: NetworkStatus.ready,
-    partial: false,
   });
 
   {
@@ -4592,9 +4420,6 @@ test("applies `context` on next fetch when it changes between renders", async ()
     execute({ context: { source: "execute" } })
   ).resolves.toEqualStrictTyped({
     data: { context: { source: "execute" } },
-    loading: false,
-    networkStatus: NetworkStatus.ready,
-    partial: false,
   });
 
   {
@@ -4693,12 +4518,7 @@ test("applies `refetchWritePolicy` on next fetch when it changes between renders
 
   await expect(
     execute({ variables: { min: 0, max: 12 } })
-  ).resolves.toEqualStrictTyped({
-    data: mocks[0].result.data,
-    loading: false,
-    networkStatus: NetworkStatus.ready,
-    partial: false,
-  });
+  ).resolves.toEqualStrictTyped({ data: mocks[0].result.data });
 
   {
     const [, result] = await takeSnapshot();
@@ -4878,9 +4698,6 @@ test("applies `returnPartialData` on next fetch when it changes between renders"
       data: {
         character: { __typename: "Character", id: "1", name: "Doctor Strange" },
       },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     }
   );
 
@@ -4921,9 +4738,6 @@ test("applies `returnPartialData` on next fetch when it changes between renders"
       data: {
         character: { __typename: "Character", id: "2", name: "Hulk" },
       },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     }
   );
 
@@ -5017,9 +4831,6 @@ test("applies updated `fetchPolicy` on next fetch when it changes between render
       data: {
         character: { __typename: "Character", id: "1", name: "Spider-Cache" },
       },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     }
   );
 
@@ -5060,9 +4871,6 @@ test("applies updated `fetchPolicy` on next fetch when it changes between render
       data: {
         character: { __typename: "Character", id: "2", name: "Black Widow" },
       },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     }
   );
 
@@ -5148,9 +4956,6 @@ test("renders loading states at appropriate times on next fetch after updating `
 
   await expect(execute()).resolves.toEqualStrictTyped({
     data: { greeting: "Hello 1" },
-    loading: false,
-    networkStatus: NetworkStatus.ready,
-    partial: false,
   });
 
   {
@@ -5183,9 +4988,6 @@ test("renders loading states at appropriate times on next fetch after updating `
 
   await expect(execute()).resolves.toEqualStrictTyped({
     data: { greeting: "Hello 2" },
-    loading: false,
-    networkStatus: NetworkStatus.ready,
-    partial: false,
   });
 
   {
@@ -5231,9 +5033,6 @@ test("renders loading states at appropriate times on next fetch after updating `
 
   await expect(execute()).resolves.toEqualStrictTyped({
     data: { greeting: "Hello 3" },
-    loading: false,
-    networkStatus: NetworkStatus.ready,
-    partial: false,
   });
 
   {

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -17,11 +17,11 @@ import { InMemoryCache } from "@apollo/client/cache";
 import {
   ApolloClient,
   ApolloLink,
-  ApolloQueryResult,
   Cache,
   CombinedGraphQLErrors,
   NetworkStatus,
   ObservableQuery,
+  QueryResult,
   TypedDocumentNode,
 } from "@apollo/client/core";
 import { BatchHttpLink } from "@apollo/client/link/batch-http";
@@ -2625,7 +2625,7 @@ describe("useMutation Hook", () => {
       interface OnQueryUpdatedResults {
         obsQuery: ObservableQuery;
         diff: Cache.DiffResult<TData>;
-        result: ApolloQueryResult<TData>;
+        result: QueryResult<TData>;
       }
       let resolveOnUpdate: (results: OnQueryUpdatedResults) => any;
       const onUpdatePromise = new Promise<OnQueryUpdatedResults>((resolve) => {
@@ -2638,12 +2638,7 @@ describe("useMutation Hook", () => {
           },
         });
         expect(onUpdateResult.result).toEqualStrictTyped({
-          loading: false,
-          networkStatus: NetworkStatus.ready,
-          data: {
-            todoCount: 1,
-          },
-          partial: false,
+          data: { todoCount: 1 },
         });
       });
 

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -1755,12 +1755,7 @@ describe("useQuery Hook", () => {
 
       await expect(
         getCurrentSnapshot().observable.reobserve()
-      ).resolves.toEqualStrictTyped({
-        data: { linkCount: 2 },
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
-      });
+      ).resolves.toEqualStrictTyped({ data: { linkCount: 2 } });
 
       {
         const result = await takeSnapshot();
@@ -4106,9 +4101,6 @@ describe("useQuery Hook", () => {
 
       expect(fetchMoreResult).toEqualStrictTyped({
         data: { letters: cd },
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
       });
 
       {
@@ -4175,9 +4167,6 @@ describe("useQuery Hook", () => {
 
       expect(fetchMoreResult).toEqualStrictTyped({
         data: { letters: cd },
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
       });
 
       {
@@ -4261,9 +4250,6 @@ describe("useQuery Hook", () => {
 
       expect(fetchMoreResult).toEqualStrictTyped({
         data: { letters: cd },
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
       });
 
       {
@@ -4339,9 +4325,6 @@ describe("useQuery Hook", () => {
 
       expect(fetchMoreResult).toEqualStrictTyped({
         data: { letters: cd },
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
       });
 
       {
@@ -4549,9 +4532,6 @@ describe("useQuery Hook", () => {
             { __typename: "Letter", letter: "D", position: 4 },
           ],
         },
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
       });
 
       await expect(takeSnapshot).not.toRerender();
@@ -4625,9 +4605,6 @@ describe("useQuery Hook", () => {
             { __typename: "Letter", letter: "F", position: 6 },
           ],
         },
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
       });
 
       await expect(takeSnapshot).not.toRerender();
@@ -6070,9 +6047,6 @@ describe("useQuery Hook", () => {
 
       await expect(getCurrentSnapshot().refetch()).resolves.toEqualStrictTyped({
         data: { hello: "world 2" },
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
       });
 
       {
@@ -6201,9 +6175,6 @@ describe("useQuery Hook", () => {
           getCurrentSnapshot().refetch({ min: 12, max: 30 })
         ).resolves.toEqualStrictTyped({
           data: { primes: [13, 17, 19, 23, 29] },
-          loading: false,
-          networkStatus: NetworkStatus.ready,
-          partial: false,
         });
 
         {
@@ -6308,9 +6279,6 @@ describe("useQuery Hook", () => {
           getCurrentSnapshot().refetch({ min: 12, max: 30 })
         ).resolves.toEqualStrictTyped({
           data: { primes: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29] },
-          loading: false,
-          networkStatus: NetworkStatus.ready,
-          partial: false,
         });
 
         {
@@ -6413,9 +6381,6 @@ describe("useQuery Hook", () => {
           getCurrentSnapshot().refetch({ min: 12, max: 30 })
         ).resolves.toEqualStrictTyped({
           data: { primes: [13, 17, 19, 23, 29] },
-          loading: false,
-          networkStatus: NetworkStatus.ready,
-          partial: false,
         });
 
         {
@@ -7207,9 +7172,6 @@ describe("useQuery Hook", () => {
 
       expect(refetchResult).toEqualStrictTyped({
         data: { hello: "world" },
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
       });
 
       expect(requestSpy).toHaveBeenCalledTimes(1);
@@ -7315,12 +7277,7 @@ describe("useQuery Hook", () => {
         },
       });
 
-      expect(result).toEqualStrictTyped({
-        data: { hello: 2 },
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
-      });
+      expect(result).toEqualStrictTyped({ data: { hello: 2 } });
       expect(reasons).toEqual(["variables-changed", "after-fetch"]);
 
       await expect(takeSnapshot()).resolves.toEqualQueryResult({
@@ -8166,9 +8123,6 @@ describe("useQuery Hook", () => {
 
       expect(result).toEqualStrictTyped({
         data: { a: "aaa", b: 2 },
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        partial: false,
       });
 
       await expect(takeSnapshot()).resolves.toEqualQueryResult({

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -1734,7 +1734,7 @@ describe("useQuery Hook", () => {
           if (obsQuery.hasObservers()) {
             expect(inactiveSet.has(obsQuery)).toBe(false);
             activeSet.add(obsQuery);
-            expect(obsQuery.getCurrentResult()).toEqualApolloQueryResult({
+            expect(obsQuery.getCurrentResult()).toEqualStrictTyped({
               loading: false,
               networkStatus: NetworkStatus.ready,
               data: {
@@ -1755,7 +1755,7 @@ describe("useQuery Hook", () => {
 
       await expect(
         getCurrentSnapshot().observable.reobserve()
-      ).resolves.toEqualApolloQueryResult({
+      ).resolves.toEqualStrictTyped({
         data: { linkCount: 2 },
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -4104,7 +4104,7 @@ describe("useQuery Hook", () => {
         }),
       });
 
-      expect(fetchMoreResult).toEqualApolloQueryResult({
+      expect(fetchMoreResult).toEqualStrictTyped({
         data: { letters: cd },
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -4173,7 +4173,7 @@ describe("useQuery Hook", () => {
         }),
       });
 
-      expect(fetchMoreResult).toEqualApolloQueryResult({
+      expect(fetchMoreResult).toEqualStrictTyped({
         data: { letters: cd },
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -4259,7 +4259,7 @@ describe("useQuery Hook", () => {
         variables: { limit: 2 },
       });
 
-      expect(fetchMoreResult).toEqualApolloQueryResult({
+      expect(fetchMoreResult).toEqualStrictTyped({
         data: { letters: cd },
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -4337,7 +4337,7 @@ describe("useQuery Hook", () => {
         variables: { limit: 2 },
       });
 
-      expect(fetchMoreResult).toEqualApolloQueryResult({
+      expect(fetchMoreResult).toEqualStrictTyped({
         data: { letters: cd },
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -4542,7 +4542,7 @@ describe("useQuery Hook", () => {
         });
       }
 
-      await expect(fetchMorePromise).resolves.toEqualApolloQueryResult({
+      await expect(fetchMorePromise).resolves.toEqualStrictTyped({
         data: {
           letters: [
             { __typename: "Letter", letter: "C", position: 3 },
@@ -4618,7 +4618,7 @@ describe("useQuery Hook", () => {
         });
       }
 
-      await expect(fetchMorePromise).resolves.toEqualApolloQueryResult({
+      await expect(fetchMorePromise).resolves.toEqualStrictTyped({
         data: {
           letters: [
             { __typename: "Letter", letter: "E", position: 5 },
@@ -5028,7 +5028,7 @@ describe("useQuery Hook", () => {
       // the partial result
       expect(
         snapshot.useQueryResult?.observable.getCurrentResult(false)!
-      ).toEqualApolloQueryResult({
+      ).toEqualStrictTyped({
         data: undefined,
         error: new CombinedGraphQLErrors([{ message: "Intentional error" }]),
         loading: false,
@@ -5085,7 +5085,7 @@ describe("useQuery Hook", () => {
       // the partial result
       expect(
         snapshot.useQueryResult?.observable.getCurrentResult(false)!
-      ).toEqualApolloQueryResult({
+      ).toEqualStrictTyped({
         data: undefined,
         error: new CombinedGraphQLErrors([{ message: "Intentional error" }]),
         loading: false,
@@ -6068,9 +6068,7 @@ describe("useQuery Hook", () => {
         });
       }
 
-      await expect(
-        getCurrentSnapshot().refetch()
-      ).resolves.toEqualApolloQueryResult({
+      await expect(getCurrentSnapshot().refetch()).resolves.toEqualStrictTyped({
         data: { hello: "world 2" },
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -6201,7 +6199,7 @@ describe("useQuery Hook", () => {
 
         await expect(
           getCurrentSnapshot().refetch({ min: 12, max: 30 })
-        ).resolves.toEqualApolloQueryResult({
+        ).resolves.toEqualStrictTyped({
           data: { primes: [13, 17, 19, 23, 29] },
           loading: false,
           networkStatus: NetworkStatus.ready,
@@ -6308,7 +6306,7 @@ describe("useQuery Hook", () => {
 
         await expect(
           getCurrentSnapshot().refetch({ min: 12, max: 30 })
-        ).resolves.toEqualApolloQueryResult({
+        ).resolves.toEqualStrictTyped({
           data: { primes: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29] },
           loading: false,
           networkStatus: NetworkStatus.ready,
@@ -6413,7 +6411,7 @@ describe("useQuery Hook", () => {
 
         await expect(
           getCurrentSnapshot().refetch({ min: 12, max: 30 })
-        ).resolves.toEqualApolloQueryResult({
+        ).resolves.toEqualStrictTyped({
           data: { primes: [13, 17, 19, 23, 29] },
           loading: false,
           networkStatus: NetworkStatus.ready,
@@ -7207,7 +7205,7 @@ describe("useQuery Hook", () => {
 
       const refetchResult = await getCurrentSnapshot().refetch();
 
-      expect(refetchResult).toEqualApolloQueryResult({
+      expect(refetchResult).toEqualStrictTyped({
         data: { hello: "world" },
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -7317,7 +7315,7 @@ describe("useQuery Hook", () => {
         },
       });
 
-      expect(result).toEqualApolloQueryResult({
+      expect(result).toEqualStrictTyped({
         data: { hello: 2 },
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -8166,7 +8164,7 @@ describe("useQuery Hook", () => {
 
       const result = await getCurrentSnapshot().observable.reobserve();
 
-      expect(result).toEqualApolloQueryResult({
+      expect(result).toEqualStrictTyped({
         data: { a: "aaa", b: 2 },
         loading: false,
         networkStatus: NetworkStatus.ready,

--- a/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
@@ -7740,7 +7740,7 @@ describe("useSuspenseQuery", () => {
       });
     });
 
-    await expect(refetchPromise!).resolves.toEqualApolloQueryResult({
+    await expect(refetchPromise!).resolves.toEqualStrictTyped({
       data: {
         greeting: {
           __typename: "Greeting",
@@ -8121,7 +8121,7 @@ describe("useSuspenseQuery", () => {
       });
     });
 
-    await expect(fetchMorePromise!).resolves.toEqualApolloQueryResult({
+    await expect(fetchMorePromise!).resolves.toEqualStrictTyped({
       data: {
         greetings: [
           {
@@ -9289,7 +9289,7 @@ describe("useSuspenseQuery", () => {
       });
     });
 
-    await expect(refetchPromise!).resolves.toEqualApolloQueryResult({
+    await expect(refetchPromise!).resolves.toEqualStrictTyped({
       data: {
         hero: {
           heroFriends: [

--- a/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
@@ -22,7 +22,6 @@ import {
   ApolloCache,
   ApolloClient,
   ApolloLink,
-  ApolloQueryResult,
   CombinedGraphQLErrors,
   DocumentNode,
   ErrorPolicy,
@@ -30,6 +29,7 @@ import {
   InMemoryCache,
   NetworkStatus,
   OperationVariables,
+  QueryResult,
   split,
   SubscribeToMoreOptions,
   TypedDocumentNode,
@@ -7672,7 +7672,7 @@ describe("useSuspenseQuery", () => {
       });
     });
 
-    let refetchPromise: Promise<ApolloQueryResult<unknown>>;
+    let refetchPromise: Promise<QueryResult<unknown>>;
     await actAsync(async () => {
       refetchPromise = result.current.refetch();
     });
@@ -7751,9 +7751,6 @@ describe("useSuspenseQuery", () => {
           },
         },
       },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
 
     expect(renders.count).toBe(6 + (IS_REACT_19 ? renders.suspenseCount : 0));
@@ -8034,7 +8031,7 @@ describe("useSuspenseQuery", () => {
       });
     });
 
-    let fetchMorePromise: Promise<ApolloQueryResult<unknown>>;
+    let fetchMorePromise: Promise<QueryResult<unknown>>;
     await actAsync(() => {
       fetchMorePromise = result.current.fetchMore({ variables: { offset: 1 } });
     });
@@ -8134,9 +8131,6 @@ describe("useSuspenseQuery", () => {
           },
         ],
       },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
 
     expect(renders.count).toBe(5 + (IS_REACT_19 ? renders.suspenseCount : 0));
@@ -8316,7 +8310,7 @@ describe("useSuspenseQuery", () => {
         });
       });
 
-      let fetchMorePromise: Promise<ApolloQueryResult<unknown>>;
+      let fetchMorePromise: Promise<QueryResult<unknown>>;
       await actAsync(() => {
         fetchMorePromise = result.current.fetchMore({
           variables: { offset: 1 },
@@ -9214,7 +9208,7 @@ describe("useSuspenseQuery", () => {
       });
     });
 
-    let refetchPromise: Promise<ApolloQueryResult<unknown>>;
+    let refetchPromise: Promise<QueryResult<unknown>>;
     await actAsync(async () => {
       refetchPromise = result.current.refetch();
     });
@@ -9299,9 +9293,6 @@ describe("useSuspenseQuery", () => {
           name: "R2-D2",
         },
       },
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
     });
 
     cache.updateQuery<any>({ query }, (data) => ({

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -13,6 +13,7 @@ import type {
   MaybeMasked,
   ObservableQuery,
   OperationVariables,
+  QueryResult,
   RefetchWritePolicy,
   SubscribeToMoreFunction,
   Unmasked,
@@ -92,7 +93,7 @@ export declare namespace useLazyQuery {
     /** {@inheritDoc @apollo/client!QueryResultDocumentation#refetch:member} */
     refetch: (
       variables?: Partial<TVariables>
-    ) => Promise<ApolloQueryResult<MaybeMasked<TData>>>;
+    ) => Promise<QueryResult<MaybeMasked<TData>>>;
 
     /** {@inheritDoc @apollo/client!QueryResultDocumentation#variables:member} */
     variables: TVariables | undefined;
@@ -111,7 +112,7 @@ export declare namespace useLazyQuery {
           }
         ) => Unmasked<TData>;
       }
-    ) => Promise<ApolloQueryResult<MaybeMasked<TFetchData>>>;
+    ) => Promise<QueryResult<MaybeMasked<TFetchData>>>;
 
     /** {@inheritDoc @apollo/client!QueryResultDocumentation#client:member} */
     client: ApolloClient;
@@ -160,7 +161,7 @@ export declare namespace useLazyQuery {
     : Record<string, never> extends OnlyRequiredProperties<TVariables> ?
       [options?: useLazyQuery.ExecOptions<TVariables>]
     : [options: useLazyQuery.ExecOptions<TVariables>]
-  ) => Promise<ApolloQueryResult<TData>>;
+  ) => Promise<QueryResult<TData>>;
 }
 
 // The following methods, when called will execute the query, regardless of

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -160,7 +160,7 @@ export declare namespace useQuery {
           }
         ) => Unmasked<TData>;
       }
-    ) => Promise<ApolloQueryResult<MaybeMasked<TFetchData>>>;
+    ) => Promise<QueryResult<MaybeMasked<TFetchData>>>;
   }
 }
 

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -22,6 +22,7 @@ import type {
   ErrorPolicy,
   FetchMoreQueryOptions,
   OperationVariables,
+  QueryResult,
   RefetchWritePolicy,
   SubscribeToMoreFunction,
   UpdateQueryMapFn,
@@ -140,7 +141,7 @@ export declare namespace useQuery {
     /** {@inheritDoc @apollo/client!QueryResultDocumentation#refetch:member} */
     refetch: (
       variables?: Partial<TVariables>
-    ) => Promise<ApolloQueryResult<MaybeMasked<TData>>>;
+    ) => Promise<QueryResult<MaybeMasked<TData>>>;
 
     /** {@inheritDoc @apollo/client!QueryResultDocumentation#variables:member} */
     variables: TVariables | undefined;

--- a/src/react/internal/cache/QueryReference.ts
+++ b/src/react/internal/cache/QueryReference.ts
@@ -6,6 +6,7 @@ import type {
   ApolloQueryResult,
   ObservableQuery,
   OperationVariables,
+  QueryResult,
   WatchQueryOptions,
 } from "@apollo/client/core";
 import type { MaybeMasked } from "@apollo/client/masking";
@@ -439,7 +440,7 @@ export class InternalQueryReference<TData = unknown> {
   }
 
   private initiateFetch(
-    returnedPromise: Promise<ApolloQueryResult<MaybeMasked<TData>>>
+    returnedPromise: Promise<QueryResult<MaybeMasked<TData>>>
   ) {
     this.promise = this.createPendingPromise();
     this.promise.catch(() => {});

--- a/src/react/internal/types.ts
+++ b/src/react/internal/types.ts
@@ -1,9 +1,9 @@
 import type {
-  ApolloQueryResult,
   FetchMoreQueryOptions,
   MaybeMasked,
   ObservableQuery,
   OperationVariables,
+  QueryResult,
   Unmasked,
 } from "@apollo/client/core";
 import type { OnlyRequiredProperties } from "@apollo/client/utilities";
@@ -39,4 +39,4 @@ export type FetchMoreFunction<TData, TVariables extends OperationVariables> = (
       }
     ) => Unmasked<TData>;
   }
-) => Promise<ApolloQueryResult<MaybeMasked<TData>>>;
+) => Promise<QueryResult<MaybeMasked<TData>>>;

--- a/src/utilities/internal/index.ts
+++ b/src/utilities/internal/index.ts
@@ -5,3 +5,4 @@ export {
   getInMemoryCacheMemoryInternals,
   registerGlobalCache,
 } from "../internal/getMemoryInternals.js";
+export { toQueryResult } from "./toQueryResult.js";

--- a/src/utilities/internal/toQueryResult.ts
+++ b/src/utilities/internal/toQueryResult.ts
@@ -1,0 +1,15 @@
+import type { ApolloQueryResult, QueryResult } from "@apollo/client/core";
+
+export function toQueryResult<TData = unknown>(
+  value: ApolloQueryResult<TData>
+) {
+  const result: QueryResult<TData> = {
+    data: value.data,
+  };
+
+  if (value.error) {
+    result.error = value.error;
+  }
+
+  return result;
+}


### PR DESCRIPTION
Closes #12481

Removes `loading`, `networkStatus`, and `partial` from all promise-based query APIs. These never made sense since the promise resolution means that the query has finished loading, so these were mostly static properties (with the exception of `networkStatus` would could be either `error` or `ready`).

I've removed those properties to simplify the return type. These extend to `refetch`, `fetchMore`, etc. as well.