### PR TITLE
Throw an error if the link chain completes without emitting a value

### DIFF
--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -1743,7 +1743,7 @@ class QueryManager {
     // (undocumented)
     fetchObservableWithInfo<TData, TVars extends OperationVariables>(queryId: string, options: WatchQueryOptions<TVars, TData>, networkStatus?: NetworkStatus, query?: DocumentNode | TypedDocumentNode<TData, TVars>, emitLoadingState?: boolean): ObservableAndInfo<TData>;
     // (undocumented)
-    fetchQuery<TData, TVars extends OperationVariables>(queryId: string, options: WatchQueryOptions<TVars, TData>, networkStatus?: NetworkStatus): Promise<ApolloQueryResult<TData>>;
+    fetchQuery<TData, TVars extends OperationVariables>(queryId: string, options: WatchQueryOptions<TVars, TData>, networkStatus?: NetworkStatus): Promise<QueryResult<TData>>;
     // (undocumented)
     generateMutationId(): string;
     // (undocumented)
@@ -2341,7 +2341,7 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/cache/inmemory/types.ts:133:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:130:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:131:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:188:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:187:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:459:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
 // src/link/http/selectHttpOptionsAndBody.ts:128:1 - (ae-forgotten-export) The symbol "HttpQueryOptions" needs to be exported by the entry point index.d.ts
 

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -791,7 +791,7 @@ class QueryManager {
     // (undocumented)
     fetchObservableWithInfo<TData, TVars extends OperationVariables_2>(queryId: string, options: WatchQueryOptions_2<TVars, TData>, networkStatus?: NetworkStatus, query?: DocumentNode | TypedDocumentNode_2<TData, TVars>, emitLoadingState?: boolean): ObservableAndInfo<TData>;
     // (undocumented)
-    fetchQuery<TData, TVars extends OperationVariables_2>(queryId: string, options: WatchQueryOptions_2<TVars, TData>, networkStatus?: NetworkStatus): Promise<ApolloQueryResult<TData>>;
+    fetchQuery<TData, TVars extends OperationVariables_2>(queryId: string, options: WatchQueryOptions_2<TVars, TData>, networkStatus?: NetworkStatus): Promise<QueryResult_2<TData>>;
     // (undocumented)
     generateMutationId(): string;
     // (undocumented)
@@ -1664,7 +1664,7 @@ interface WatchQueryOptions_2<TVariables extends OperationVariables_2 = Operatio
 // src/core/LocalState.ts:71:3 - (ae-forgotten-export) The symbol "ApolloClient_2" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:130:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:131:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:188:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:187:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:459:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:204:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:233:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report-react_hooks.api.md
+++ b/.api-reports/api-report-react_hooks.api.md
@@ -607,7 +607,7 @@ class QueryManager {
     // (undocumented)
     fetchObservableWithInfo<TData, TVars extends OperationVariables_2>(queryId: string, options: WatchQueryOptions_2<TVars, TData>, networkStatus?: NetworkStatus, query?: DocumentNode | TypedDocumentNode<TData, TVars>, emitLoadingState?: boolean): ObservableAndInfo<TData>;
     // (undocumented)
-    fetchQuery<TData, TVars extends OperationVariables_2>(queryId: string, options: WatchQueryOptions_2<TVars, TData>, networkStatus?: NetworkStatus): Promise<ApolloQueryResult<TData>>;
+    fetchQuery<TData, TVars extends OperationVariables_2>(queryId: string, options: WatchQueryOptions_2<TVars, TData>, networkStatus?: NetworkStatus): Promise<QueryResult<TData>>;
     // (undocumented)
     generateMutationId(): string;
     // (undocumented)
@@ -1426,7 +1426,7 @@ interface WatchQueryOptions_2<TVariables extends OperationVariables_2 = Operatio
 // src/core/LocalState.ts:71:3 - (ae-forgotten-export) The symbol "ApolloClient_2" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:130:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:131:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:188:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:187:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:459:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:204:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:233:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -1859,7 +1859,7 @@ class QueryManager {
     // (undocumented)
     fetchObservableWithInfo<TData, TVars extends OperationVariables>(queryId: string, options: WatchQueryOptions<TVars, TData>, networkStatus?: NetworkStatus, query?: DocumentNode | TypedDocumentNode<TData, TVars>, emitLoadingState?: boolean): ObservableAndInfo<TData>;
     // (undocumented)
-    fetchQuery<TData, TVars extends OperationVariables>(queryId: string, options: WatchQueryOptions<TVars, TData>, networkStatus?: NetworkStatus): Promise<ApolloQueryResult<TData>>;
+    fetchQuery<TData, TVars extends OperationVariables>(queryId: string, options: WatchQueryOptions<TVars, TData>, networkStatus?: NetworkStatus): Promise<QueryResult<TData>>;
     // (undocumented)
     generateMutationId(): string;
     // (undocumented)
@@ -2483,7 +2483,7 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/cache/inmemory/types.ts:133:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:130:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:131:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:188:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:187:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:459:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
 // src/link/http/selectHttpOptionsAndBody.ts:128:1 - (ae-forgotten-export) The symbol "HttpQueryOptions" needs to be exported by the entry point index.d.ts
 

--- a/.changeset/giant-bags-share.md
+++ b/.changeset/giant-bags-share.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": major
+---
+
+Throw an error for queries and mutations if the link chain completes without emitting a value.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 42421,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 37823,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 32791,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27591
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 42584,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 37830,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 32883,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27676
 }

--- a/src/__tests__/ApolloClient.ts
+++ b/src/__tests__/ApolloClient.ts
@@ -2,7 +2,7 @@ import { TypedDocumentNode } from "@graphql-typed-document-node/core";
 import { expectTypeOf } from "expect-type";
 import { Kind } from "graphql";
 import { gql } from "graphql-tag";
-import { EMPTY, Observable, of } from "rxjs";
+import { Observable, of } from "rxjs";
 
 import { createFragmentRegistry, InMemoryCache } from "@apollo/client/cache";
 import {
@@ -2930,7 +2930,7 @@ describe("ApolloClient", () => {
         )
         .mockImplementationOnce(() => {
           setTimeout(refetchQueries);
-          return EMPTY;
+          return of({ data: null });
         });
 
       const client = new ApolloClient({

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -10,7 +10,7 @@ import {
 import { GraphQLFormattedError } from "graphql";
 import { gql } from "graphql-tag";
 import { assign, cloneDeep } from "lodash";
-import { EmptyError, Observable, of, Subscription } from "rxjs";
+import { Observable, of, Subscription } from "rxjs";
 
 import {
   createFragmentRegistry,
@@ -1983,8 +1983,7 @@ describe("client", () => {
 
       await expect(
         obs.reobserve({ query, fetchPolicy: "standby" })
-        // TODO: Update this behavior
-      ).rejects.toThrow(new EmptyError());
+      ).resolves.toEqualStrictTyped({ data: undefined });
       // this write should be completely ignored by the standby query
       client.writeQuery({ query, data: data2 });
 
@@ -2013,8 +2012,7 @@ describe("client", () => {
 
       await expect(
         obs.reobserve({ query, fetchPolicy: "standby" })
-        // TODO: Update this behavior
-      ).rejects.toThrow(new EmptyError());
+      ).resolves.toEqualStrictTyped({ data: undefined });
       // this write should be completely ignored by the standby query
       client.writeQuery({ query, data: data2 });
       setTimeout(() => {

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -770,6 +770,27 @@ describe("client", () => {
     await expect(stream).toEmitStrictTyped(emittedValue);
   });
 
+  it("allows subscriptions to to terminate without emitting results", async () => {
+    const link = new ApolloLink(() => {
+      return new Observable((observer) => {
+        setTimeout(() => observer.complete(), 10);
+      });
+    });
+
+    const client = new ApolloClient({ link, cache: new InMemoryCache() });
+    const subscription = client.subscribe({
+      query: gql`
+        subscription {
+          hello
+        }
+      `,
+    });
+
+    const stream = new ObservableStream(subscription);
+
+    await expect(stream).toComplete();
+  });
+
   it.skip("should surface errors in observer.next as uncaught", async () => {
     const expectedError = new Error("this error should not reach the store");
     const listeners = process.listeners("uncaughtException");

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -770,7 +770,7 @@ describe("client", () => {
     await expect(stream).toEmitStrictTyped(emittedValue);
   });
 
-  it("allows subscriptions to to terminate without emitting results", async () => {
+  it("allows subscriptions to terminate without emitting results", async () => {
     const link = new ApolloLink(() => {
       return new Observable((observer) => {
         setTimeout(() => observer.complete(), 10);

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -2022,6 +2022,20 @@ describe("client", () => {
       await expect(stream).toEmitMatchedValue({ data: data2 });
       await expect(stream).not.toEmitAnything();
     });
+
+    it("resolves client.query with default value", async () => {
+      const query = gql`
+        query {
+          test
+        }
+      `;
+
+      const client = new ApolloClient({ cache: new InMemoryCache() });
+
+      await expect(
+        client.query({ query, fetchPolicy: "standby" })
+      ).resolves.toEqualStrictTyped({ data: undefined });
+    });
   });
 
   describe("network-only fetchPolicy", () => {

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -10,7 +10,7 @@ import {
 import { GraphQLFormattedError } from "graphql";
 import { gql } from "graphql-tag";
 import { assign, cloneDeep } from "lodash";
-import { EMPTY, EmptyError, Observable, of, Subscription } from "rxjs";
+import { EmptyError, Observable, of, Subscription } from "rxjs";
 
 import {
   createFragmentRegistry,
@@ -4165,7 +4165,7 @@ describe("custom document transforms", () => {
     const link = new ApolloLink((operation) => {
       document = operation.query;
 
-      return EMPTY;
+      return of({ data: null });
     });
 
     const client = new ApolloClient({

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -712,9 +712,8 @@ describe("client", () => {
     });
 
     const client = new ApolloClient({ link, cache: new InMemoryCache() });
-
     const expectedError = new InvariantError(
-      "The link chain completed without emitting a value"
+      "The link chain completed without emitting a value. This is likely unintentional and should be updated to emit a value before completing."
     );
 
     await expect(

--- a/src/__tests__/optimistic.ts
+++ b/src/__tests__/optimistic.ts
@@ -1011,10 +1011,12 @@ describe("optimistic mutation results", () => {
         cache: new InMemoryCache(),
       });
 
-      client.mutate({
-        mutation,
-        optimisticResponse: (vars, { IGNORE }) => IGNORE,
-      });
+      client
+        .mutate({
+          mutation,
+          optimisticResponse: (vars, { IGNORE }) => IGNORE,
+        })
+        .catch(() => {});
     });
   });
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1068,9 +1068,13 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
       // Note: lastValueFrom will create a separate subscription to the
       // observable which means that terminating this ObservableQuery will not
       // cancel the request from the link chain.
-      lastValueFrom(observable).then((result) =>
-        toQueryResult(this.maskResult(result))
-      )
+      lastValueFrom(observable, {
+        // This default value should only be used when using a `fetchPolicy` of
+        // `standby` since that fetch policy completes without emitting a
+        // result. Since we are converting this to a QueryResult type, we
+        // omit the extra fields from ApolloQueryResult in the default value.
+        defaultValue: { data: undefined } as ApolloQueryResult<TData>,
+      }).then((result) => toQueryResult(this.maskResult(result)))
     );
   }
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -608,7 +608,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
           );
         }
 
-        return toQueryResult(this.maskResult(fetchMoreResult));
+        return this.maskResult(fetchMoreResult);
       })
       .finally(() => {
         // In case the cache writes above did not generate a broadcast
@@ -1150,9 +1150,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     return this.queryManager.transform(document);
   }
 
-  private maskResult<T = TData>(
-    result: ApolloQueryResult<T>
-  ): ApolloQueryResult<MaybeMasked<T>> {
+  private maskResult<T extends { data: any }>(result: T): T {
     return result && "data" in result ?
         {
           ...result,

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -934,8 +934,6 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
    * Reevaluate the query, optionally against new options. New options will be
    * merged with the current options when given.
    */
-  // TODO: catch `EmptyError` and rethrow as network error if `complete`
-  // notification is emitted without a value.
   public reobserve(
     newOptions?: Partial<WatchQueryOptions<TVariables, TData>>
   ): Promise<QueryResult<MaybeMasked<TData>>> {

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1231,21 +1231,7 @@ export class QueryManager {
       );
     }
 
-    let didEmitValue = false;
-
-    return observable.pipe(
-      tap({
-        next: () => {
-          didEmitValue = true;
-        },
-        complete: () => {
-          invariant(
-            didEmitValue,
-            "The link chain completed without emitting a value"
-          );
-        },
-      })
-    );
+    return observable;
   }
 
   private getResultsFromLink<TData, TVars extends OperationVariables>(
@@ -1781,7 +1767,7 @@ export class QueryManager {
         context,
         fetchPolicy,
         errorPolicy,
-      });
+      }).pipe(validateDidEmitValue());
 
     switch (fetchPolicy) {
       default:
@@ -1898,6 +1884,22 @@ function maybeWrapError(error: unknown) {
   }
 
   return new UnconventionalError(error);
+}
+
+function validateDidEmitValue<T>() {
+  let didEmitValue = false;
+
+  return tap<T>({
+    next() {
+      didEmitValue = true;
+    },
+    complete() {
+      invariant(
+        didEmitValue,
+        "The link chain completed without emitting a value. This is likely unintentional and should be updated to emit a value before completing."
+      );
+    },
+  });
 }
 
 // Return types used by fetchQueryByPolicy and other private methods above.

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -706,8 +706,17 @@ export class QueryManager {
   ): Promise<ApolloQueryResult<TData>> {
     return lastValueFrom(
       this.fetchObservableWithInfo(queryId, options, networkStatus).observable,
-      { defaultValue: undefined }
-    ) as TODO;
+      {
+        // This default is needed when a `standby` fetch policy is used to avoid
+        // an EmptyError from rejecting this promise.
+        defaultValue: {
+          data: undefined,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          partial: true,
+        },
+      }
+    );
   }
 
   public transform(document: DocumentNode) {

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -839,14 +839,6 @@ export class QueryManager {
 
     return this.fetchQuery<TData, TVars>(queryId, { ...options, query })
       .then((value) => {
-        // TODO: Update this when we handle emitting errors for empty results.
-        // `value` can be `undefined` when the link chain only emits a complete
-        // event with no value which should be an error.
-        // https://github.com/apollographql/apollo-client/issues/12482
-        if (!value) {
-          return { data: undefined };
-        }
-
         return toQueryResult({
           ...value,
           data: this.maskOperation({

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -827,8 +827,6 @@ export class QueryManager {
     return observable;
   }
 
-  // TODO: catch `EmptyError` and rethrow as network error if `complete`
-  // notification is emitted without a value.
   public query<TData, TVars extends OperationVariables = OperationVariables>(
     options: QueryOptions<TVars, TData>,
     queryId = this.generateQueryId()

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1231,7 +1231,21 @@ export class QueryManager {
       );
     }
 
-    return observable;
+    let didEmitValue = false;
+
+    return observable.pipe(
+      tap({
+        next: () => {
+          didEmitValue = true;
+        },
+        complete: () => {
+          invariant(
+            didEmitValue,
+            "The link chain completed without emitting a value"
+          );
+        },
+      })
+    );
   }
 
   private getResultsFromLink<TData, TVars extends OperationVariables>(

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -65,7 +65,6 @@ import {
 } from "@apollo/client/utilities/invariant";
 
 import type { IgnoreModifier } from "../cache/core/types/common.js";
-import type { TODO } from "../utilities/types/TODO.js";
 
 import type { DefaultOptions } from "./ApolloClient.js";
 import type { LocalState } from "./LocalState.js";

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -336,6 +336,7 @@ export class QueryManager {
         false
       )
         .pipe(
+          validateDidEmitValue(),
           mergeMap((result) => {
             const hasErrors = graphQLResultHasError(result);
             if (hasErrors && errorPolicy === "none") {

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -7278,7 +7278,7 @@ describe("ApolloClient", () => {
         });
 
         // @ts-ignore a bit too generic for TS
-        client[method]({ [option]: document });
+        client[method]({ [option]: document }).catch(() => {});
 
         expect(context.foo).toBe("bar");
       }

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -7321,6 +7321,7 @@ describe("ApolloClient", () => {
           (operation) =>
             new Observable((observer) => {
               ({ cache: _, ...context } = operation.getContext());
+              observer.next({ data: null });
               observer.complete();
             })
         ),
@@ -7362,6 +7363,7 @@ describe("ApolloClient", () => {
           (operation) =>
             new Observable((observer) => {
               ({ cache: _, ...context } = operation.getContext());
+              observer.next({ data: null });
               observer.complete();
             })
         ),
@@ -7398,6 +7400,7 @@ describe("ApolloClient", () => {
           (operation) =>
             new Observable((observer) => {
               ({ cache: _, ...context } = operation.getContext());
+              observer.next({ data: null });
               observer.complete();
             })
         ),
@@ -7437,6 +7440,7 @@ describe("ApolloClient", () => {
             (operation) =>
               new Observable((observer) => {
                 ({ cache: _, ...context } = operation.getContext());
+                observer.next({ data: null });
                 observer.complete();
               })
           ),

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -3,14 +3,7 @@ import { waitFor } from "@testing-library/react";
 import { expectTypeOf } from "expect-type";
 import { GraphQLError } from "graphql";
 import { gql } from "graphql-tag";
-import {
-  EmptyError,
-  from,
-  Observable,
-  ObservedValueOf,
-  of,
-  Subject,
-} from "rxjs";
+import { from, Observable, ObservedValueOf, of, Subject } from "rxjs";
 import { Observer } from "rxjs";
 
 import { InMemoryCache } from "@apollo/client/cache";
@@ -707,7 +700,7 @@ describe("ObservableQuery", () => {
 
       await expect(
         observable.reobserve({ query, fetchPolicy: "standby" })
-      ).rejects.toThrow(new EmptyError());
+      ).resolves.toEqualStrictTyped({ data: undefined });
 
       // make sure the query didn't get fired again.
       await expect(stream).not.toEmitAnything();
@@ -767,10 +760,7 @@ describe("ObservableQuery", () => {
 
       await expect(
         observable.reobserve({ query, fetchPolicy: "standby" })
-        // TODO: Dertermine how we want to handle this. We likely should swallow
-        // the error since standby currently does not emit a value but completes
-        // instead.
-      ).rejects.toThrow(new EmptyError());
+      ).resolves.toEqualStrictTyped({ data: undefined });
 
       // make sure the query didn't get fired again.
       await expect(stream).not.toEmitAnything();

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -7692,7 +7692,14 @@ describe("useQuery Hook", () => {
       const cache = new InMemoryCache();
       const client = new ApolloClient({
         cache,
-        link: ApolloLink.empty(),
+        link: new ApolloLink(() => {
+          return new Observable((observer) => {
+            setTimeout(() => {
+              observer.next({ data: null });
+              observer.complete();
+            }, 10);
+          });
+        }),
       });
 
       const query = gql`

--- a/src/utilities/caching/__tests__/getMemoryInternals.ts
+++ b/src/utilities/caching/__tests__/getMemoryInternals.ts
@@ -134,13 +134,15 @@ it("returns information about cache usage (some query triggered)", () => {
       .concat(ApolloLink.empty()),
   });
 
-  client.query({
-    query: gql`
-      query {
-        hello
-      }
-    `,
-  });
+  client
+    .query({
+      query: gql`
+        query {
+          hello
+        }
+      `,
+    })
+    .catch(() => {});
   expect(client.getMemoryInternals?.()).toStrictEqual({
     limits: defaultCacheSizesAsObject,
     sizes: {

--- a/src/utilities/types/TODO.ts
+++ b/src/utilities/types/TODO.ts
@@ -1,2 +1,0 @@
-/** @internal */
-export type TODO = any;


### PR DESCRIPTION
Closes #12482

Throws an error if a query or mutation does not emit a value before the link chain completes. This is usually a bug in the user's link chain and can have unintended consequences. By throwing, this makes the issue more visible and lets us clean up some areas of the codebase that would otherwise not be able to handle this situation.

This also addresses the issue where issuing a query with a `standby` fetch policy would throw an `EmptyError` and instead will resolve the query with `data: undefined`.