### PR TITLE
Another attempt at fixing test flake

### DIFF
--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -5306,7 +5306,7 @@ describe("ApolloClient", () => {
         networkStatus: NetworkStatus.ready,
         partial: false,
       });
-      expect(console.warn).toHaveBeenLastCalledWith(
+      expect(console.warn).toHaveBeenCalledWith(
         'Unknown query named "%s" requested in refetchQueries options.include array',
         "fakeQuery"
       );


### PR DESCRIPTION
There is a [test flake](https://app.circleci.com/pipelines/github/apollographql/apollo-client/27149/workflows/818a22dc-d2ee-4132-b3ab-444c6cac043e/jobs/240675) that has been plaguing the core tests for some time. I've tried various fixes, but it appears that this flakes out with different queries at different times. I am fairly certain there is a race condition in other tests that happen to conflict with the timing which cause this to fail.

As such, I'm trying this fix to switch from `toHaveBeenLastCalledWith` to `toHaveBeenCalledWith` just to check to make sure that at least one call to the console has been made, that way even if the race condition occurs, this shouldn't happen. This is the only test that checks this specific message, so we shouldn't get any false positives as a result of this change.