### PR TITLE
Reduce console noise in `ApolloClient/general` tests

### DIFF
--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -3226,10 +3226,7 @@ describe("ApolloClient", () => {
           {
             request: { query, variables },
             result: { data: data2 },
-          },
-          {
-            request: { query, variables },
-            result: { data: data2 },
+            maxUsageCount: Number.POSITIVE_INFINITY,
           },
         ]),
       });

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -3540,16 +3540,19 @@ describe("ApolloClient", () => {
 
       const client = new ApolloClient({
         cache: new InMemoryCache(),
-        link: new MockLink([
-          {
-            request: { query, variables },
-            result: { data: data1 },
-          },
-          {
-            request: { query, variables },
-            result: { data: data2 },
-          },
-        ]),
+        link: new MockLink(
+          [
+            {
+              request: { query, variables },
+              result: { data: data1 },
+            },
+            {
+              request: { query, variables },
+              result: { data: data2 },
+            },
+          ],
+          { showWarnings: false }
+        ),
       });
 
       const observable = client.watchQuery({
@@ -3658,16 +3661,19 @@ describe("ApolloClient", () => {
 
       const client = new ApolloClient({
         cache: new InMemoryCache(),
-        link: new MockLink([
-          {
-            request: { query, variables },
-            result: { data: data1 },
-          },
-          {
-            request: { query, variables },
-            result: { data: data2 },
-          },
-        ]),
+        link: new MockLink(
+          [
+            {
+              request: { query, variables },
+              result: { data: data1 },
+            },
+            {
+              request: { query, variables },
+              result: { data: data2 },
+            },
+          ],
+          { showWarnings: false }
+        ),
       });
 
       const observable = client.watchQuery({

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -3154,16 +3154,19 @@ describe("ApolloClient", () => {
 
       const client = new ApolloClient({
         cache: new InMemoryCache(),
-        link: new MockLink([
-          {
-            request: { query, variables },
-            result: { data: data1 },
-          },
-          {
-            request: { query, variables },
-            result: { data: data2 },
-          },
-        ]),
+        link: new MockLink(
+          [
+            {
+              request: { query, variables },
+              result: { data: data1 },
+            },
+            {
+              request: { query, variables },
+              result: { data: data2 },
+            },
+          ],
+          { showWarnings: false }
+        ),
       });
       const observable = client.watchQuery({
         query,

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -2357,6 +2357,8 @@ describe("ApolloClient", () => {
       partial: false,
     });
     expect(cache.extract().ROOT_QUERY!.author).toEqual(data.author);
+
+    observable.stopPolling();
   });
 
   it("should not fire next on an observer if there is no change in the result", async () => {

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -1296,7 +1296,7 @@ describe("ApolloClient", () => {
     });
   });
 
-  it("only modifies varaibles when refetching", async () => {
+  it("only modifies variables when refetching", async () => {
     const query = gql`
       {
         people_one(id: 1) {

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -2466,14 +2466,11 @@ describe("ApolloClient", () => {
         {
           request: { query: query1 },
           result: { data: data1 },
+          maxUsageCount: Number.POSITIVE_INFINITY,
         },
         {
           request: { query: query2 },
           result: { data: data2 },
-        },
-        {
-          request: { query: query1 },
-          result: { data: data1 },
         },
       ]),
     });
@@ -2550,6 +2547,7 @@ describe("ApolloClient", () => {
         {
           request: { query: query1 },
           result: { data: data1 },
+          maxUsageCount: Number.POSITIVE_INFINITY,
         },
         {
           request: { query: query2 },
@@ -2900,10 +2898,12 @@ describe("ApolloClient", () => {
         {
           request: { query: queryWithoutId },
           result: { data: dataWithoutId },
+          maxUsageCount: Number.POSITIVE_INFINITY,
         },
         {
           request: { query: queryWithId },
           result: { data: dataWithId },
+          maxUsageCount: Number.POSITIVE_INFINITY,
         },
       ]),
     });


### PR DESCRIPTION
This one gets a lot of updates with our changes in 4.0, but its super noisy and difficult to trace back errors and logs. This tries to eliminate the warnings emitted from `MockLink` so that its much quieter and easier to debug against.