### PR TITLE
Refactor away `createMakeWatchQueryOptions`

### DIFF
--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -337,6 +337,7 @@ function useQueryInternals<TData, TVariables extends OperationVariables>(
   );
 
   if (!watchQueryOptions.fetchPolicy) {
+    // eslint-disable-next-line react-compiler/react-compiler
     watchQueryOptions.fetchPolicy = observable.options.initialFetchPolicy;
   }
 

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -320,10 +320,6 @@ function useQueryInternals<TData, TVariables extends OperationVariables>(
     { query }
   );
 
-  if (!watchQueryOptions.variables) {
-    watchQueryOptions.variables = {} as TVariables;
-  }
-
   if (skip) {
     // When skipping, we set watchQueryOptions.fetchPolicy initially to
     // "standby", but we also need/want to preserve the initial non-standby

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -312,11 +312,7 @@ function useQueryInternals<TData, TVariables extends OperationVariables>(
 ) {
   const client = useApolloClient(options.client);
 
-  const watchQueryOptions = createMakeWatchQueryOptions(
-    client,
-    query,
-    options
-  )();
+  const watchQueryOptions = createMakeWatchQueryOptions(client, query, options);
 
   const { observable, resultData } = useInternalState(
     client,
@@ -497,30 +493,30 @@ function createMakeWatchQueryOptions<
     ...otherOptions
   }: useQuery.Options<TData, TVariables> = {}
 ) {
-  return (): WatchQueryOptions<TVariables, TData> => {
-    // This Object.assign is safe because otherOptions is a fresh ...rest object
-    // that did not exist until just now, so modifications are still allowed.
-    const watchQueryOptions: WatchQueryOptions<TVariables, TData> =
-      Object.assign(otherOptions, { query });
+  // This Object.assign is safe because otherOptions is a fresh ...rest object
+  // that did not exist until just now, so modifications are still allowed.
+  const watchQueryOptions: WatchQueryOptions<TVariables, TData> = Object.assign(
+    otherOptions,
+    { query }
+  );
 
-    if (!watchQueryOptions.variables) {
-      watchQueryOptions.variables = {} as TVariables;
-    }
+  if (!watchQueryOptions.variables) {
+    watchQueryOptions.variables = {} as TVariables;
+  }
 
-    if (skip) {
-      // When skipping, we set watchQueryOptions.fetchPolicy initially to
-      // "standby", but we also need/want to preserve the initial non-standby
-      // fetchPolicy that would have been used if not skipping.
-      watchQueryOptions.initialFetchPolicy =
-        watchQueryOptions.initialFetchPolicy ||
-        watchQueryOptions.fetchPolicy ||
-        client.defaultOptions?.watchQuery?.fetchPolicy ||
-        "cache-first";
-      watchQueryOptions.fetchPolicy = "standby";
-    }
+  if (skip) {
+    // When skipping, we set watchQueryOptions.fetchPolicy initially to
+    // "standby", but we also need/want to preserve the initial non-standby
+    // fetchPolicy that would have been used if not skipping.
+    watchQueryOptions.initialFetchPolicy =
+      watchQueryOptions.initialFetchPolicy ||
+      watchQueryOptions.fetchPolicy ||
+      client.defaultOptions?.watchQuery?.fetchPolicy ||
+      "cache-first";
+    watchQueryOptions.fetchPolicy = "standby";
+  }
 
-    return watchQueryOptions;
-  };
+  return watchQueryOptions;
 }
 
 function getObsQueryOptions<TData, TVariables extends OperationVariables>(

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -500,9 +500,7 @@ function createMakeWatchQueryOptions<
     ...otherOptions
   }: useQuery.Options<TData, TVariables> = {}
 ) {
-  return (
-    initialFetchPolicy?: WatchQueryFetchPolicy
-  ): WatchQueryOptions<TVariables, TData> => {
+  return (): WatchQueryOptions<TVariables, TData> => {
     // This Object.assign is safe because otherOptions is a fresh ...rest object
     // that did not exist until just now, so modifications are still allowed.
     const watchQueryOptions: WatchQueryOptions<TVariables, TData> =
@@ -522,8 +520,6 @@ function createMakeWatchQueryOptions<
         client.defaultOptions?.watchQuery?.fetchPolicy ||
         "cache-first";
       watchQueryOptions.fetchPolicy = "standby";
-    } else if (!watchQueryOptions.fetchPolicy) {
-      watchQueryOptions.fetchPolicy = initialFetchPolicy;
     }
 
     return watchQueryOptions;

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -323,9 +323,7 @@ function useQueryInternals<TData, TVariables extends OperationVariables>(
     // "standby", but we also need/want to preserve the initial non-standby
     // fetchPolicy that would have been used if not skipping.
     watchQueryOptions.initialFetchPolicy =
-      options.initialFetchPolicy ||
-      options.fetchPolicy ||
-      client.defaultOptions?.watchQuery?.fetchPolicy;
+      options.initialFetchPolicy || options.fetchPolicy;
     watchQueryOptions.fetchPolicy = "standby";
   }
 

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -267,7 +267,7 @@ function useQuery_<TData, TVariables extends OperationVariables>(
 function useInternalState<TData, TVariables extends OperationVariables>(
   client: ApolloClient,
   query: DocumentNode | TypedDocumentNode<any, any>,
-  makeWatchQueryOptions: () => WatchQueryOptions<TVariables, TData>
+  watchQueryOptions: WatchQueryOptions<TVariables, TData>
 ) {
   function createInternalState(previous?: InternalState<TData, TVariables>) {
     verifyDocumentType(query, DocumentType.Query);
@@ -276,7 +276,7 @@ function useInternalState<TData, TVariables extends OperationVariables>(
       client,
       query,
       observable: client.watchQuery(
-        getObsQueryOptions(void 0, client, makeWatchQueryOptions())
+        getObsQueryOptions(void 0, client, watchQueryOptions)
       ),
       resultData: {
         // Reuse previousData from previous InternalState (if any) to provide
@@ -321,7 +321,7 @@ function useQueryInternals<TData, TVariables extends OperationVariables>(
   const { observable, resultData } = useInternalState(
     client,
     query,
-    makeWatchQueryOptions
+    makeWatchQueryOptions()
   );
 
   const watchQueryOptions: WatchQueryOptions<TVariables, TData> =

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -325,7 +325,7 @@ function useQueryInternals<TData, TVariables extends OperationVariables>(
   );
 
   const watchQueryOptions: Readonly<WatchQueryOptions<TVariables, TData>> =
-    makeWatchQueryOptions(observable);
+    makeWatchQueryOptions(observable.options.initialFetchPolicy);
 
   useResubscribeIfNecessary<TData, TVariables>(
     resultData, // might get mutated during render
@@ -497,7 +497,7 @@ function createMakeWatchQueryOptions<
   }: useQuery.Options<TData, TVariables> = {}
 ) {
   return (
-    observable?: ObservableQuery<TData, TVariables>
+    initialFetchPolicy?: WatchQueryFetchPolicy
   ): WatchQueryOptions<TVariables, TData> => {
     // This Object.assign is safe because otherOptions is a fresh ...rest object
     // that did not exist until just now, so modifications are still allowed.
@@ -519,7 +519,7 @@ function createMakeWatchQueryOptions<
         "cache-first";
       watchQueryOptions.fetchPolicy = "standby";
     } else if (!watchQueryOptions.fetchPolicy) {
-      watchQueryOptions.fetchPolicy = observable?.options.initialFetchPolicy;
+      watchQueryOptions.fetchPolicy = initialFetchPolicy;
     }
 
     return watchQueryOptions;

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -474,11 +474,6 @@ function useResubscribeIfNecessary<
   observable[lastWatchOptions] = watchQueryOptions;
 }
 
-/*
- * A function to massage options before passing them to ObservableQuery.
- * This is two-step curried because we want to reuse the `make` function,
- * but the `observable` might differ between calls to `make`.
- */
 function getWatchQueryOptions<TData, TVariables extends OperationVariables>(
   client: ApolloClient,
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -323,8 +323,8 @@ function useQueryInternals<TData, TVariables extends OperationVariables>(
     // "standby", but we also need/want to preserve the initial non-standby
     // fetchPolicy that would have been used if not skipping.
     watchQueryOptions.initialFetchPolicy =
-      watchQueryOptions.initialFetchPolicy ||
-      watchQueryOptions.fetchPolicy ||
+      options.initialFetchPolicy ||
+      options.fetchPolicy ||
       client.defaultOptions?.watchQuery?.fetchPolicy ||
       "cache-first";
     watchQueryOptions.fetchPolicy = "standby";

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -325,8 +325,7 @@ function useQueryInternals<TData, TVariables extends OperationVariables>(
     watchQueryOptions.initialFetchPolicy =
       options.initialFetchPolicy ||
       options.fetchPolicy ||
-      client.defaultOptions?.watchQuery?.fetchPolicy ||
-      "cache-first";
+      client.defaultOptions?.watchQuery?.fetchPolicy;
     watchQueryOptions.fetchPolicy = "standby";
   }
 

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -313,12 +313,10 @@ function useQueryInternals<TData, TVariables extends OperationVariables>(
   const client = useApolloClient(options.client);
   const { skip, ...otherOptions } = options;
 
-  // This Object.assign is safe because otherOptions is a fresh ...rest object
-  // that did not exist until just now, so modifications are still allowed.
-  const watchQueryOptions: WatchQueryOptions<TVariables, TData> = Object.assign(
-    otherOptions,
-    { query }
-  );
+  const watchQueryOptions: WatchQueryOptions<TVariables, TData> = {
+    ...otherOptions,
+    query,
+  };
 
   if (skip) {
     // When skipping, we set watchQueryOptions.fetchPolicy initially to

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -311,8 +311,30 @@ function useQueryInternals<TData, TVariables extends OperationVariables>(
   options: useQuery.Options<NoInfer<TData>, NoInfer<TVariables>>
 ) {
   const client = useApolloClient(options.client);
+  const { skip, ...otherOptions } = options;
 
-  const watchQueryOptions = getWatchQueryOptions(client, query, options);
+  // This Object.assign is safe because otherOptions is a fresh ...rest object
+  // that did not exist until just now, so modifications are still allowed.
+  const watchQueryOptions: WatchQueryOptions<TVariables, TData> = Object.assign(
+    otherOptions,
+    { query }
+  );
+
+  if (!watchQueryOptions.variables) {
+    watchQueryOptions.variables = {} as TVariables;
+  }
+
+  if (skip) {
+    // When skipping, we set watchQueryOptions.fetchPolicy initially to
+    // "standby", but we also need/want to preserve the initial non-standby
+    // fetchPolicy that would have been used if not skipping.
+    watchQueryOptions.initialFetchPolicy =
+      watchQueryOptions.initialFetchPolicy ||
+      watchQueryOptions.fetchPolicy ||
+      client.defaultOptions?.watchQuery?.fetchPolicy ||
+      "cache-first";
+    watchQueryOptions.fetchPolicy = "standby";
+  }
 
   const { observable, resultData } = useInternalState(
     client,
@@ -472,43 +494,6 @@ function useResubscribeIfNecessary<
     resultData.current = void 0;
   }
   observable[lastWatchOptions] = watchQueryOptions;
-}
-
-function getWatchQueryOptions<TData, TVariables extends OperationVariables>(
-  client: ApolloClient,
-  query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  {
-    skip,
-    // The above options are useQuery-specific, so this ...otherOptions spread
-    // makes otherOptions almost a WatchQueryOptions object, except for the
-    // query property that we add below.
-    ...otherOptions
-  }: useQuery.Options<TData, TVariables> = {}
-) {
-  // This Object.assign is safe because otherOptions is a fresh ...rest object
-  // that did not exist until just now, so modifications are still allowed.
-  const watchQueryOptions: WatchQueryOptions<TVariables, TData> = Object.assign(
-    otherOptions,
-    { query }
-  );
-
-  if (!watchQueryOptions.variables) {
-    watchQueryOptions.variables = {} as TVariables;
-  }
-
-  if (skip) {
-    // When skipping, we set watchQueryOptions.fetchPolicy initially to
-    // "standby", but we also need/want to preserve the initial non-standby
-    // fetchPolicy that would have been used if not skipping.
-    watchQueryOptions.initialFetchPolicy =
-      watchQueryOptions.initialFetchPolicy ||
-      watchQueryOptions.fetchPolicy ||
-      client.defaultOptions?.watchQuery?.fetchPolicy ||
-      "cache-first";
-    watchQueryOptions.fetchPolicy = "standby";
-  }
-
-  return watchQueryOptions;
 }
 
 function getObsQueryOptions<TData, TVariables extends OperationVariables>(

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -324,8 +324,12 @@ function useQueryInternals<TData, TVariables extends OperationVariables>(
     makeWatchQueryOptions
   );
 
-  const watchQueryOptions: Readonly<WatchQueryOptions<TVariables, TData>> =
-    makeWatchQueryOptions(observable.options.initialFetchPolicy);
+  const watchQueryOptions: WatchQueryOptions<TVariables, TData> =
+    makeWatchQueryOptions();
+
+  if (!watchQueryOptions.fetchPolicy) {
+    watchQueryOptions.fetchPolicy = observable.options.initialFetchPolicy;
+  }
 
   useResubscribeIfNecessary<TData, TVariables>(
     resultData, // might get mutated during render

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -312,7 +312,7 @@ function useQueryInternals<TData, TVariables extends OperationVariables>(
 ) {
   const client = useApolloClient(options.client);
 
-  const watchQueryOptions = createMakeWatchQueryOptions(client, query, options);
+  const watchQueryOptions = getWatchQueryOptions(client, query, options);
 
   const { observable, resultData } = useInternalState(
     client,
@@ -479,10 +479,7 @@ function useResubscribeIfNecessary<
  * This is two-step curried because we want to reuse the `make` function,
  * but the `observable` might differ between calls to `make`.
  */
-function createMakeWatchQueryOptions<
-  TData,
-  TVariables extends OperationVariables,
->(
+function getWatchQueryOptions<TData, TVariables extends OperationVariables>(
   client: ApolloClient,
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
   {

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -312,20 +312,17 @@ function useQueryInternals<TData, TVariables extends OperationVariables>(
 ) {
   const client = useApolloClient(options.client);
 
-  const makeWatchQueryOptions = createMakeWatchQueryOptions(
+  const watchQueryOptions = createMakeWatchQueryOptions(
     client,
     query,
     options
-  );
+  )();
 
   const { observable, resultData } = useInternalState(
     client,
     query,
-    makeWatchQueryOptions()
+    watchQueryOptions
   );
-
-  const watchQueryOptions: WatchQueryOptions<TVariables, TData> =
-    makeWatchQueryOptions();
 
   if (!watchQueryOptions.fetchPolicy) {
     watchQueryOptions.fetchPolicy = observable.options.initialFetchPolicy;


### PR DESCRIPTION
This is part 1 of a series of small refactors to try and make `useQuery` a bit more sane.

This one focuses on the `createMakeWatchQueryOptions` function to eliminate the need for the curried function. This one is best reviewed by stepping through the commits to see how I got from the starting point to here.