### PR TITLE
Refactor away `getObsQueryOptions`

### DIFF
--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -312,10 +312,10 @@ function useQueryInternals<TData, TVariables extends OperationVariables>(
   const client = useApolloClient(options.client);
   const { skip, ...otherOptions } = options;
 
-  const watchQueryOptions: WatchQueryOptions<TVariables, TData> = {
-    ...otherOptions,
-    query,
-  };
+  const watchQueryOptions: WatchQueryOptions<TVariables, TData> = mergeOptions(
+    client.defaultOptions.watchQuery,
+    { ...otherOptions, query }
+  );
 
   if (skip) {
     // When skipping, we set watchQueryOptions.fetchPolicy initially to

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -481,7 +481,7 @@ function useResubscribeIfNecessary<
     // (if provided) should be merged, to ensure individual defaulted
     // variables always have values, if not otherwise defined in
     // observable.options or watchQueryOptions.
-    toMerge.push(compact(watchQueryOptions));
+    toMerge.push(watchQueryOptions);
 
     const opts = toMerge.reduce(mergeOptions) as WatchQueryOptions<
       TVariables,

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -38,11 +38,7 @@ import { NetworkStatus } from "@apollo/client/core";
 import type { MaybeMasked, Unmasked } from "@apollo/client/masking";
 import { DocumentType, verifyDocumentType } from "@apollo/client/react/parser";
 import type { NoInfer } from "@apollo/client/utilities";
-import {
-  compact,
-  maybeDeepFreeze,
-  mergeOptions,
-} from "@apollo/client/utilities";
+import { maybeDeepFreeze, mergeOptions } from "@apollo/client/utilities";
 
 import type { NextFetchPolicyContext } from "../../core/watchQueryOptions.js";
 
@@ -287,7 +283,7 @@ function useInternalState<TData, TVariables extends OperationVariables>(
     // (if provided) should be merged, to ensure individual defaulted
     // variables always have values, if not otherwise defined in
     // observable.options or watchQueryOptions.
-    toMerge.push(compact(watchQueryOptions));
+    toMerge.push(watchQueryOptions);
 
     const opts = toMerge.reduce(mergeOptions) as WatchQueryOptions<
       TVariables,

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -511,31 +511,6 @@ function useResubscribeIfNecessary<
   observable[lastWatchOptions] = watchQueryOptions;
 }
 
-function getObsQueryOptions<TData, TVariables extends OperationVariables>(
-  observable: ObservableQuery<TData, TVariables> | undefined,
-  client: ApolloClient,
-  watchQueryOptions: Partial<WatchQueryOptions<TVariables, TData>>
-): WatchQueryOptions<TVariables, TData> {
-  const toMerge: Array<Partial<WatchQueryOptions<TVariables, TData>>> = [];
-
-  const globalDefaults = client.defaultOptions.watchQuery;
-  if (globalDefaults) toMerge.push(globalDefaults);
-
-  // We use compact rather than mergeOptions for this part of the merge,
-  // because we want watchQueryOptions.variables (if defined) to replace
-  // this.observable.options.variables whole. This replacement allows
-  // removing variables by removing them from the variables input to
-  // useQuery. If the variables were always merged together (rather than
-  // replaced), there would be no way to remove existing variables.
-  // However, the variables from options.defaultOptions and globalDefaults
-  // (if provided) should be merged, to ensure individual defaulted
-  // variables always have values, if not otherwise defined in
-  // observable.options or watchQueryOptions.
-  toMerge.push(compact(observable && observable.options, watchQueryOptions));
-
-  return toMerge.reduce(mergeOptions) as WatchQueryOptions<TVariables, TData>;
-}
-
 function setResult<TData, TVariables extends OperationVariables>(
   nextResult: ApolloQueryResult<MaybeMasked<TData>>,
   resultData: InternalResult<TData, TVariables>,

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -268,17 +268,10 @@ function useInternalState<TData, TVariables extends OperationVariables>(
   function createInternalState(previous?: InternalState<TData, TVariables>) {
     verifyDocumentType(query, DocumentType.Query);
 
-    const toMerge: Array<Partial<WatchQueryOptions<TVariables, TData>>> = [];
-
-    const globalDefaults = client.defaultOptions.watchQuery;
-    if (globalDefaults) toMerge.push(globalDefaults);
-
-    toMerge.push(watchQueryOptions);
-
-    const opts = toMerge.reduce(mergeOptions) as WatchQueryOptions<
-      TVariables,
-      TData
-    >;
+    const opts = mergeOptions(
+      client.defaultOptions.watchQuery,
+      watchQueryOptions
+    );
 
     const internalState: InternalState<TData, TVariables> = {
       client,

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -481,7 +481,7 @@ function useResubscribeIfNecessary<
     // (if provided) should be merged, to ensure individual defaulted
     // variables always have values, if not otherwise defined in
     // observable.options or watchQueryOptions.
-    toMerge.push(compact(observable.options, watchQueryOptions));
+    toMerge.push(compact(watchQueryOptions));
 
     const opts = toMerge.reduce(mergeOptions) as WatchQueryOptions<
       TVariables,

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -466,17 +466,11 @@ function useResubscribeIfNecessary<
     observable[lastWatchOptions] &&
     !equal(observable[lastWatchOptions], watchQueryOptions)
   ) {
-    const toMerge: Array<Partial<WatchQueryOptions<TVariables, TData>>> = [];
+    const opts = mergeOptions(
+      client.defaultOptions.watchQuery,
+      watchQueryOptions
+    );
 
-    const globalDefaults = client.defaultOptions.watchQuery;
-    if (globalDefaults) toMerge.push(globalDefaults);
-
-    toMerge.push(watchQueryOptions);
-
-    const opts = toMerge.reduce(mergeOptions) as WatchQueryOptions<
-      TVariables,
-      TData
-    >;
     // Though it might be tempting to postpone this reobserve call to the
     // useEffect block, we need getCurrentResult to return an appropriate
     // loading:true result synchronously (later within the same call to

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -471,16 +471,6 @@ function useResubscribeIfNecessary<
     const globalDefaults = client.defaultOptions.watchQuery;
     if (globalDefaults) toMerge.push(globalDefaults);
 
-    // We use compact rather than mergeOptions for this part of the merge,
-    // because we want watchQueryOptions.variables (if defined) to replace
-    // this.observable.options.variables whole. This replacement allows
-    // removing variables by removing them from the variables input to
-    // useQuery. If the variables were always merged together (rather than
-    // replaced), there would be no way to remove existing variables.
-    // However, the variables from options.defaultOptions and globalDefaults
-    // (if provided) should be merged, to ensure individual defaulted
-    // variables always have values, if not otherwise defined in
-    // observable.options or watchQueryOptions.
     toMerge.push(watchQueryOptions);
 
     const opts = toMerge.reduce(mergeOptions) as WatchQueryOptions<

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -38,7 +38,7 @@ import { NetworkStatus } from "@apollo/client/core";
 import type { MaybeMasked, Unmasked } from "@apollo/client/masking";
 import { DocumentType, verifyDocumentType } from "@apollo/client/react/parser";
 import type { NoInfer } from "@apollo/client/utilities";
-import { maybeDeepFreeze } from "@apollo/client/utilities";
+import { maybeDeepFreeze, mergeOptions } from "@apollo/client/utilities";
 
 import type { NextFetchPolicyContext } from "../../core/watchQueryOptions.js";
 
@@ -307,10 +307,10 @@ function useQueryInternals<TData, TVariables extends OperationVariables>(
   const client = useApolloClient(options.client);
   const { skip, ...otherOptions } = options;
 
-  const watchQueryOptions: WatchQueryOptions<TVariables, TData> = {
-    ...otherOptions,
-    query,
-  };
+  const watchQueryOptions: WatchQueryOptions<TVariables, TData> = mergeOptions(
+    client.defaultOptions.watchQuery,
+    { ...otherOptions, query }
+  );
 
   if (skip) {
     // When skipping, we set watchQueryOptions.fetchPolicy initially to

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -335,7 +335,6 @@ function useQueryInternals<TData, TVariables extends OperationVariables>(
   useResubscribeIfNecessary<TData, TVariables>(
     resultData, // might get mutated during render
     observable, // might get mutated during render
-    client,
     watchQueryOptions
   );
 
@@ -453,7 +452,6 @@ function useResubscribeIfNecessary<
   resultData: InternalResult<TData, TVariables>,
   /** this hook will mutate properties on `observable` */
   observable: ObsQueryWithMeta<TData, TVariables>,
-  client: ApolloClient,
   watchQueryOptions: Readonly<WatchQueryOptions<TVariables, TData>>
 ) {
   if (

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -273,16 +273,6 @@ function useInternalState<TData, TVariables extends OperationVariables>(
     const globalDefaults = client.defaultOptions.watchQuery;
     if (globalDefaults) toMerge.push(globalDefaults);
 
-    // We use compact rather than mergeOptions for this part of the merge,
-    // because we want watchQueryOptions.variables (if defined) to replace
-    // this.observable.options.variables whole. This replacement allows
-    // removing variables by removing them from the variables input to
-    // useQuery. If the variables were always merged together (rather than
-    // replaced), there would be no way to remove existing variables.
-    // However, the variables from options.defaultOptions and globalDefaults
-    // (if provided) should be merged, to ensure individual defaulted
-    // variables always have values, if not otherwise defined in
-    // observable.options or watchQueryOptions.
     toMerge.push(watchQueryOptions);
 
     const opts = toMerge.reduce(mergeOptions) as WatchQueryOptions<

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -38,7 +38,7 @@ import { NetworkStatus } from "@apollo/client/core";
 import type { MaybeMasked, Unmasked } from "@apollo/client/masking";
 import { DocumentType, verifyDocumentType } from "@apollo/client/react/parser";
 import type { NoInfer } from "@apollo/client/utilities";
-import { maybeDeepFreeze, mergeOptions } from "@apollo/client/utilities";
+import { maybeDeepFreeze } from "@apollo/client/utilities";
 
 import type { NextFetchPolicyContext } from "../../core/watchQueryOptions.js";
 
@@ -307,10 +307,10 @@ function useQueryInternals<TData, TVariables extends OperationVariables>(
   const client = useApolloClient(options.client);
   const { skip, ...otherOptions } = options;
 
-  const watchQueryOptions: WatchQueryOptions<TVariables, TData> = mergeOptions(
-    client.defaultOptions.watchQuery,
-    { ...otherOptions, query }
-  );
+  const watchQueryOptions: WatchQueryOptions<TVariables, TData> = {
+    ...otherOptions,
+    query,
+  };
 
   if (skip) {
     // When skipping, we set watchQueryOptions.fetchPolicy initially to

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -268,15 +268,10 @@ function useInternalState<TData, TVariables extends OperationVariables>(
   function createInternalState(previous?: InternalState<TData, TVariables>) {
     verifyDocumentType(query, DocumentType.Query);
 
-    const opts = mergeOptions(
-      client.defaultOptions.watchQuery,
-      watchQueryOptions
-    );
-
     const internalState: InternalState<TData, TVariables> = {
       client,
       query,
-      observable: client.watchQuery(opts),
+      observable: client.watchQuery(watchQueryOptions),
       resultData: {
         // Reuse previousData from previous InternalState (if any) to provide
         // continuity of previousData even if/when the query or client changes.
@@ -465,11 +460,6 @@ function useResubscribeIfNecessary<
     observable[lastWatchOptions] &&
     !equal(observable[lastWatchOptions], watchQueryOptions)
   ) {
-    const opts = mergeOptions(
-      client.defaultOptions.watchQuery,
-      watchQueryOptions
-    );
-
     // Though it might be tempting to postpone this reobserve call to the
     // useEffect block, we need getCurrentResult to return an appropriate
     // loading:true result synchronously (later within the same call to
@@ -478,7 +468,7 @@ function useResubscribeIfNecessary<
     // subscriptions, though it does feel less than ideal that reobserve
     // (potentially) kicks off a network request (for example, when the
     // variables have changed), which is technically a side-effect.
-    observable.reobserve(opts);
+    observable.reobserve(watchQueryOptions);
 
     // Make sure getCurrentResult returns a fresh ApolloQueryResult<TData>,
     // but save the current data as this.previousData, just like setResult

--- a/src/testing/react/__tests__/__snapshots__/MockedProvider.test.tsx.snap
+++ b/src/testing/react/__tests__/__snapshots__/MockedProvider.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`General use should error if the variables in the mock and component do 
     __typename
   }
 }
-Expected variables: {"username":"other_user","age":<undefined>}
+Expected variables: {"username":"other_user"}
 
 Failed to match 1 mock for this query. The mocked response had the following variables:
   {"username":"mock_username"}


### PR DESCRIPTION
Part 2 of refactoring `useQuery`.

This one works to remove `getObsQueryOptions` by merging the global defaults right away rather than doing it each time `watchQueryOptions` are about to get used. This simplifies and removes the need for `getObsQueryOptions`.

Best to review this one commit by commit