### PR TITLE
Refactor `useQuery`: Combine hooks

### DIFF
--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -1414,21 +1414,9 @@ export namespace useQuery {
 // @public (undocumented)
 export namespace useQuery {
     var // (undocumented)
-    ssrDisabledResult: {
-        loading: boolean;
-        data: any;
-        error: undefined;
-        networkStatus: NetworkStatus_2;
-        partial: boolean;
-    };
+    ssrDisabledResult: ApolloQueryResult_2<any>;
     var // (undocumented)
-    skipStandbyResult: {
-        loading: boolean;
-        data: any;
-        error: undefined;
-        networkStatus: NetworkStatus_2;
-        partial: boolean;
-    };
+    skipStandbyResult: ApolloQueryResult_2<any>;
 }
 
 // @public

--- a/.api-reports/api-report-react_hooks.api.md
+++ b/.api-reports/api-report-react_hooks.api.md
@@ -1191,21 +1191,9 @@ export namespace useQuery {
 // @public (undocumented)
 export namespace useQuery {
     var // (undocumented)
-    ssrDisabledResult: {
-        loading: boolean;
-        data: any;
-        error: undefined;
-        networkStatus: NetworkStatus_2;
-        partial: boolean;
-    };
+    ssrDisabledResult: ApolloQueryResult_2<any>;
     var // (undocumented)
-    skipStandbyResult: {
-        loading: boolean;
-        data: any;
-        error: undefined;
-        networkStatus: NetworkStatus_2;
-        partial: boolean;
-    };
+    skipStandbyResult: ApolloQueryResult_2<any>;
 }
 
 // @public

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "eslint-import-resolver-typescript": "3.7.0",
         "eslint-plugin-import": "2.31.0",
         "eslint-plugin-local-rules": "3.0.2",
-        "eslint-plugin-react-compiler": "19.0.0-beta-decd7b8-20250118",
+        "eslint-plugin-react-compiler": "19.0.0-beta-aeaed83-20250323",
         "eslint-plugin-react-hooks": "5.1.0",
         "eslint-plugin-testing-library": "7.1.1",
         "expect": "29.7.0",
@@ -7808,7 +7808,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-react-compiler": {
-      "version": "19.0.0-beta-decd7b8-20250118",
+      "version": "19.0.0-beta-aeaed83-20250323",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-compiler/-/eslint-plugin-react-compiler-19.0.0-beta-aeaed83-20250323.tgz",
+      "integrity": "sha512-zkz1RlYTt3zzo7u/O1+5GCXFf75Qwo6guOJQVqjANagc+UoiV4RHyH+HGHQ39h7Nq/QsZG8atCiUS81RMre0UQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
     "eslint-import-resolver-typescript": "3.7.0",
     "eslint-plugin-import": "2.31.0",
     "eslint-plugin-local-rules": "3.0.2",
-    "eslint-plugin-react-compiler": "19.0.0-beta-decd7b8-20250118",
+    "eslint-plugin-react-compiler": "19.0.0-beta-aeaed83-20250323",
     "eslint-plugin-react-hooks": "5.1.0",
     "eslint-plugin-testing-library": "7.1.1",
     "expect": "29.7.0",

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -416,7 +416,6 @@ function useObservableSubscriptionResult<
             }
 
             const nextResult = result;
-            const previousResult = resultData.current;
             if (previousResult && previousResult.data) {
               resultData.previousData = previousResult.data;
             }

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -319,17 +319,14 @@ function useQuery_<TData, TVariables extends OperationVariables>(
 
   return React.useMemo(() => {
     const { data, partial, ...resultWithoutPartial } = result;
-    const queryResult: InternalQueryResult<TData, TVariables> = {
+
+    return {
       data, // Ensure always defined, even if result.data is missing.
       ...resultWithoutPartial,
       client: client,
       observable: observable,
       variables: observable.variables,
       previousData,
-    };
-
-    return {
-      ...queryResult,
       ...obsQueryFields,
     };
   }, [result, client, observable, previousData, obsQueryFields]);

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -426,8 +426,8 @@ function useObservableSubscriptionResult<
 
       [observable, resultData]
     ),
-    () => resultOverride || getCurrentResult(resultData, observable, client),
-    () => resultOverride || getCurrentResult(resultData, observable, client)
+    () => resultOverride || getCurrentResult(resultData, observable),
+    () => resultOverride || getCurrentResult(resultData, observable)
   );
 
   return result;
@@ -471,8 +471,7 @@ function useResubscribeIfNecessary<
 
 function getCurrentResult<TData, TVariables extends OperationVariables>(
   resultData: InternalResult<TData, TVariables>,
-  observable: ObservableQuery<TData, TVariables>,
-  client: ApolloClient
+  observable: ObservableQuery<TData, TVariables>
 ) {
   // Using this.result as a cache ensures getCurrentResult continues returning
   // the same (===) result object, unless state.setResult has been called, or

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -261,7 +261,7 @@ function useQuery_<TData, TVariables extends OperationVariables>(
 
     const observable = client.watchQuery(watchQueryOptions);
 
-    const internalState = {
+    return {
       client,
       query,
       observable,
@@ -272,8 +272,6 @@ function useQuery_<TData, TVariables extends OperationVariables>(
         previousData: previous?.resultData.current.data,
       },
     };
-
-    return internalState;
   }
 
   let [internalState, updateInternalState] =

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -292,8 +292,6 @@ function useQuery_<TData, TVariables extends OperationVariables>(
       useQuery.skipStandbyResult
     : ssrDisabledOverride;
 
-  const previousData = resultData.previousData;
-
   const result = useSyncExternalStore(
     React.useCallback(
       (handleStoreChange) => {
@@ -356,6 +354,7 @@ function useQuery_<TData, TVariables extends OperationVariables>(
     [observable]
   );
 
+  const previousData = resultData.previousData;
   return React.useMemo(() => {
     const { data, partial, ...resultWithoutPartial } = result;
 

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -468,7 +468,7 @@ useQuery.ssrDisabledResult = maybeDeepFreeze({
   error: void 0,
   networkStatus: NetworkStatus.loading,
   partial: true,
-}) as ApolloQueryResult<any>;
+}) satisfies ApolloQueryResult<any> as ApolloQueryResult<any>;
 
 useQuery.skipStandbyResult = maybeDeepFreeze({
   loading: false,
@@ -476,4 +476,4 @@ useQuery.skipStandbyResult = maybeDeepFreeze({
   error: void 0,
   networkStatus: NetworkStatus.ready,
   partial: true,
-}) as ApolloQueryResult<any>;
+}) satisfies ApolloQueryResult<any> as ApolloQueryResult<any>;

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -312,19 +312,17 @@ function useQuery_<TData, TVariables extends OperationVariables>(
     resultOverride
   );
 
-  const queryResult = React.useMemo(
-    () => toQueryResult(result, previousData, observable, client),
-    [client, observable, result, previousData]
-  );
-
   const obsQueryFields = React.useMemo(
     () => bindObservableMethods(observable),
     [observable]
   );
 
   return React.useMemo(
-    () => ({ ...queryResult, ...obsQueryFields }),
-    [queryResult, obsQueryFields]
+    () => ({
+      ...toQueryResult(result, previousData, observable, client),
+      ...obsQueryFields,
+    }),
+    [result, client, observable, previousData, obsQueryFields]
   );
 }
 

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -305,6 +305,13 @@ function useQuery_<TData, TVariables extends OperationVariables>(
 
   const previousData = resultData.previousData;
 
+  // Using this.result as a cache ensures getCurrentResult continues returning
+  // the same (===) result object, unless state.setResult has been called, or
+  // we're doing server rendering and therefore override the result below.
+  if (!resultData.current) {
+    resultData.current = observable.getCurrentResult();
+  }
+
   const result = useSyncExternalStore(
     React.useCallback(
       (handleStoreChange) => {
@@ -454,13 +461,6 @@ function getCurrentResult<TData, TVariables extends OperationVariables>(
   resultData: InternalResult<TData, TVariables>,
   observable: ObservableQuery<TData, TVariables>
 ) {
-  // Using this.result as a cache ensures getCurrentResult continues returning
-  // the same (===) result object, unless state.setResult has been called, or
-  // we're doing server rendering and therefore override the result below.
-  if (!resultData.current) {
-    resultData.current = observable.getCurrentResult();
-  }
-
   return resultData.current;
 }
 

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -291,8 +291,8 @@ function useQuery_<TData, TVariables extends OperationVariables>(
   );
 
   const obsQueryFields = React.useMemo(
-    () => bindObservableMethods(result.observable),
-    [result.observable]
+    () => bindObservableMethods(observable),
+    [observable]
   );
 
   return React.useMemo(

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -501,7 +501,18 @@ function getCurrentResult<TData, TVariables extends OperationVariables>(
   // the same (===) result object, unless state.setResult has been called, or
   // we're doing server rendering and therefore override the result below.
   if (!resultData.current) {
-    setResult(observable.getCurrentResult(), resultData, observable, client);
+    const nextResult = observable.getCurrentResult();
+    const previousResult = resultData.current;
+    if (previousResult && previousResult.data) {
+      resultData.previousData = previousResult.data;
+    }
+
+    resultData.current = toQueryResult(
+      nextResult,
+      resultData.previousData,
+      observable,
+      client
+    );
   }
   return resultData.current!;
 }

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -163,17 +163,6 @@ export declare namespace useQuery {
   }
 }
 
-type InternalQueryResult<TData, TVariables extends OperationVariables> = Omit<
-  useQuery.Result<TData, TVariables>,
-  | "startPolling"
-  | "stopPolling"
-  | "subscribeToMore"
-  | "updateQuery"
-  | "refetch"
-  | "reobserve"
-  | "fetchMore"
->;
-
 const lastWatchOptions = Symbol();
 
 interface ObsQueryWithMeta<TData, TVariables extends OperationVariables>

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -389,10 +389,12 @@ function useInternalState<TData, TVariables extends OperationVariables>(
   function createInternalState(previous?: InternalState<TData, TVariables>) {
     verifyDocumentType(query, DocumentType.Query);
 
+    const observable = client.watchQuery(watchQueryOptions);
+
     const internalState: InternalState<TData, TVariables> = {
       client,
       query,
-      observable: client.watchQuery(watchQueryOptions),
+      observable,
       resultData: {
         // Reuse previousData from previous InternalState (if any) to provide
         // continuity of previousData even if/when the query or client changes.

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -254,12 +254,14 @@ function useQuery_<TData, TVariables extends OperationVariables>(
     watchQueryOptions.fetchPolicy = "standby";
   }
 
-  function createInternalState(previous?: InternalState<TData, TVariables>) {
+  function createInternalState(
+    previous?: InternalState<TData, TVariables>
+  ): InternalState<TData, TVariables> {
     verifyDocumentType(query, DocumentType.Query);
 
     const observable = client.watchQuery(watchQueryOptions);
 
-    const internalState: InternalState<TData, TVariables> = {
+    const internalState = {
       client,
       query,
       observable,
@@ -271,7 +273,7 @@ function useQuery_<TData, TVariables extends OperationVariables>(
       },
     };
 
-    return internalState as InternalState<TData, TVariables>;
+    return internalState;
   }
 
   let [internalState, updateInternalState] =

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -284,9 +284,7 @@ function useQuery_<TData, TVariables extends OperationVariables>(
     // Since we sometimes trigger some side-effects in the render function, we
     // re-assign `state` to the new state to ensure that those side-effects are
     // triggered with the new state.
-    const newInternalState = createInternalState(internalState);
-    updateInternalState(newInternalState);
-    internalState = newInternalState;
+    updateInternalState((internalState = createInternalState(internalState)));
   }
 
   const { observable, resultData } = internalState;

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -456,7 +456,7 @@ useQuery.ssrDisabledResult = maybeDeepFreeze({
   error: void 0,
   networkStatus: NetworkStatus.loading,
   partial: true,
-});
+}) as ApolloQueryResult<any>;
 
 useQuery.skipStandbyResult = maybeDeepFreeze({
   loading: false,
@@ -464,4 +464,4 @@ useQuery.skipStandbyResult = maybeDeepFreeze({
   error: void 0,
   networkStatus: NetworkStatus.ready,
   partial: true,
-});
+}) as ApolloQueryResult<any>;

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -384,11 +384,11 @@ function useQuery_<TData, TVariables extends OperationVariables>(
 
   const previousData = resultData.previousData;
   return React.useMemo(() => {
-    const { data, partial, ...resultWithoutPartial } = result;
+    const { data, partial, ...rest } = result;
 
     return {
       data, // Ensure always defined, even if result.data is missing.
-      ...resultWithoutPartial,
+      ...rest,
       client: client,
       observable: observable,
       variables: observable.variables,

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -308,7 +308,6 @@ function useQuery_<TData, TVariables extends OperationVariables>(
   const result = useObservableSubscriptionResult<TData, TVariables>(
     resultData,
     observable,
-    client,
     resultOverride
   );
 
@@ -378,7 +377,6 @@ function useObservableSubscriptionResult<
 >(
   resultData: InternalResult<TData, TVariables>,
   observable: ObservableQuery<TData, TVariables>,
-  client: ApolloClient,
   resultOverride: ApolloQueryResult<TData> | undefined
 ) {
   const result = useSyncExternalStore(

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -248,16 +248,7 @@ function useQuery_<TData, TVariables extends OperationVariables>(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
   options: useQuery.Options<NoInfer<TData>, NoInfer<TVariables>>
 ) {
-  const result = useQueryInternals(query, options);
-  const obsQueryFields = React.useMemo(
-    () => bindObservableMethods(result.observable),
-    [result.observable]
-  );
-
-  return React.useMemo(
-    () => ({ ...result, ...obsQueryFields }),
-    [result, obsQueryFields]
-  );
+  return useQueryInternals(query, options);
 }
 
 function useInternalState<TData, TVariables extends OperationVariables>(
@@ -346,7 +337,15 @@ function useQueryInternals<TData, TVariables extends OperationVariables>(
     watchQueryOptions
   );
 
-  return result;
+  const obsQueryFields = React.useMemo(
+    () => bindObservableMethods(result.observable),
+    [result.observable]
+  );
+
+  return React.useMemo(
+    () => ({ ...result, ...obsQueryFields }),
+    [result, obsQueryFields]
+  );
 }
 
 function useObservableSubscriptionResult<

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -415,13 +415,12 @@ function useObservableSubscriptionResult<
               return;
             }
 
-            const nextResult = result;
             if (previousResult && previousResult.data) {
               resultData.previousData = previousResult.data;
             }
 
             resultData.current = toQueryResult(
-              nextResult,
+              result,
               resultData.previousData,
               observable,
               client

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -414,66 +414,6 @@ function useInternalState<TData, TVariables extends OperationVariables>(
   return internalState;
 }
 
-function useObservableSubscriptionResult<
-  TData,
-  TVariables extends OperationVariables,
->(
-  resultData: InternalResult<TData, TVariables>,
-  observable: ObservableQuery<TData, TVariables>,
-  resultOverride: ApolloQueryResult<TData> | undefined
-) {
-  const result = useSyncExternalStore(
-    React.useCallback(
-      (handleStoreChange) => {
-        const subscription = observable
-          // We use the asapScheduler here to prevent issues with trying to
-          // update in the middle of a render. `reobserve` is kicked off in the
-          // middle of a render and because RxJS emits values synchronously,
-          // its possible for this `handleStoreChange` to be called in that same
-          // render. This allows the render to complete before trying to emit a
-          // new value.
-          .pipe(observeOn(asapScheduler))
-          .subscribe((result) => {
-            const previousResult = resultData.current;
-            // Make sure we're not attempting to re-render similar results
-            // TODO: Eventually move this check inside ObservableQuery. We should
-            // probably not emit a new result if the result is the same.
-            if (
-              previousResult &&
-              previousResult.loading === result.loading &&
-              previousResult.networkStatus === result.networkStatus &&
-              equal(previousResult.data, result.data) &&
-              equal(previousResult.error, result.error)
-            ) {
-              return;
-            }
-
-            if (previousResult && previousResult.data) {
-              resultData.previousData = previousResult.data;
-            }
-
-            resultData.current = result;
-            handleStoreChange();
-          });
-
-        // Do the "unsubscribe" with a short delay.
-        // This way, an existing subscription can be reused without an additional
-        // request if "unsubscribe"  and "resubscribe" to the same ObservableQuery
-        // happen in very fast succession.
-        return () => {
-          setTimeout(() => subscription.unsubscribe());
-        };
-      },
-
-      [observable, resultData]
-    ),
-    () => resultOverride || getCurrentResult(resultData, observable),
-    () => resultOverride || getCurrentResult(resultData, observable)
-  );
-
-  return result;
-}
-
 // this hook is not compatible with any rules of React, and there's no good way to rewrite it.
 // it should stay a separate hook that will not be optimized by the compiler
 function useResubscribeIfNecessary<

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -401,49 +401,6 @@ function useQuery_<TData, TVariables extends OperationVariables>(
   }, [result, client, observable, previousData, obsQueryFields]);
 }
 
-function useInternalState<TData, TVariables extends OperationVariables>(
-  client: ApolloClient,
-  query: DocumentNode | TypedDocumentNode<any, any>,
-  watchQueryOptions: WatchQueryOptions<TVariables, TData>
-) {
-  function createInternalState(previous?: InternalState<TData, TVariables>) {
-    verifyDocumentType(query, DocumentType.Query);
-
-    const observable = client.watchQuery(watchQueryOptions);
-
-    const internalState: InternalState<TData, TVariables> = {
-      client,
-      query,
-      observable,
-      resultData: {
-        current: observable.getCurrentResult(),
-        // Reuse previousData from previous InternalState (if any) to provide
-        // continuity of previousData even if/when the query or client changes.
-        previousData: previous?.resultData.current.data,
-      },
-    };
-
-    return internalState as InternalState<TData, TVariables>;
-  }
-
-  let [internalState, updateInternalState] =
-    React.useState(createInternalState);
-
-  if (client !== internalState.client || query !== internalState.query) {
-    // If the client or query have changed, we need to create a new InternalState.
-    // This will trigger a re-render with the new state, but it will also continue
-    // to run the current render function to completion.
-    // Since we sometimes trigger some side-effects in the render function, we
-    // re-assign `state` to the new state to ensure that those side-effects are
-    // triggered with the new state.
-    const newInternalState = createInternalState(internalState);
-    updateInternalState(newInternalState);
-    return newInternalState;
-  }
-
-  return internalState;
-}
-
 // this hook is not compatible with any rules of React, and there's no good way to rewrite it.
 // it should stay a separate hook that will not be optimized by the compiler
 function useResubscribeIfNecessary<

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -294,13 +294,6 @@ function useQuery_<TData, TVariables extends OperationVariables>(
 
   const previousData = resultData.previousData;
 
-  // Using this.result as a cache ensures getCurrentResult continues returning
-  // the same (===) result object, unless state.setResult has been called, or
-  // we're doing server rendering and therefore override the result below.
-  if (!resultData.current) {
-    resultData.current = observable.getCurrentResult();
-  }
-
   const result = useSyncExternalStore(
     React.useCallback(
       (handleStoreChange) => {

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -173,7 +173,7 @@ interface ObsQueryWithMeta<TData, TVariables extends OperationVariables>
 interface InternalResult<TData, TVariables extends OperationVariables> {
   // These members are populated by getCurrentResult and setResult, and it's
   // okay/normal for them to be initially undefined.
-  current?: undefined | ApolloQueryResult<TData>;
+  current: ApolloQueryResult<TData>;
   previousData?: undefined | MaybeMasked<TData>;
 }
 

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -415,7 +415,18 @@ function useObservableSubscriptionResult<
               return;
             }
 
-            setResult(result, resultData, observable, client);
+            const nextResult = result;
+            const previousResult = resultData.current;
+            if (previousResult && previousResult.data) {
+              resultData.previousData = previousResult.data;
+            }
+
+            resultData.current = toQueryResult(
+              nextResult,
+              resultData.previousData,
+              observable,
+              client
+            );
             handleStoreChange();
           });
 

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -487,24 +487,6 @@ function getCurrentResult<TData, TVariables extends OperationVariables>(
   return resultData.current;
 }
 
-function toQueryResult<TData, TVariables extends OperationVariables>(
-  result: ApolloQueryResult<MaybeMasked<TData>>,
-  previousData: MaybeMasked<TData> | undefined,
-  observable: ObservableQuery<TData, TVariables>,
-  client: ApolloClient
-): InternalQueryResult<TData, TVariables> {
-  const { data, partial, ...resultWithoutPartial } = result;
-  const queryResult: InternalQueryResult<TData, TVariables> = {
-    data, // Ensure always defined, even if result.data is missing.
-    ...resultWithoutPartial,
-    client: client,
-    observable: observable,
-    variables: observable.variables,
-    previousData,
-  };
-  return queryResult;
-}
-
 useQuery.ssrDisabledResult = maybeDeepFreeze({
   loading: true,
   data: void 0 as any,

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -184,7 +184,7 @@ interface ObsQueryWithMeta<TData, TVariables extends OperationVariables>
 interface InternalResult<TData, TVariables extends OperationVariables> {
   // These members are populated by getCurrentResult and setResult, and it's
   // okay/normal for them to be initially undefined.
-  current?: undefined | InternalQueryResult<TData, TVariables>;
+  current?: undefined | ApolloQueryResult<TData>;
   previousData?: undefined | MaybeMasked<TData>;
 }
 
@@ -408,12 +408,7 @@ function useObservableSubscriptionResult<
               resultData.previousData = previousResult.data;
             }
 
-            resultData.current = toQueryResult(
-              result,
-              resultData.previousData,
-              observable,
-              client
-            );
+            resultData.current = result;
             handleStoreChange();
           });
 
@@ -426,7 +421,7 @@ function useObservableSubscriptionResult<
         };
       },
 
-      [observable, resultData, client]
+      [observable, resultData]
     ),
     () => resultOverride || getCurrentResult(resultData, observable, client),
     () => resultOverride || getCurrentResult(resultData, observable, client)
@@ -475,18 +470,14 @@ function getCurrentResult<TData, TVariables extends OperationVariables>(
   resultData: InternalResult<TData, TVariables>,
   observable: ObservableQuery<TData, TVariables>,
   client: ApolloClient
-): InternalQueryResult<TData, TVariables> {
+) {
   // Using this.result as a cache ensures getCurrentResult continues returning
   // the same (===) result object, unless state.setResult has been called, or
   // we're doing server rendering and therefore override the result below.
   if (!resultData.current) {
-    resultData.current = toQueryResult(
-      observable.getCurrentResult(),
-      resultData.previousData,
-      observable,
-      client
-    );
+    resultData.current = observable.getCurrentResult();
   }
+
   return resultData.current;
 }
 

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -303,11 +303,19 @@ function useQuery_<TData, TVariables extends OperationVariables>(
       useQuery.skipStandbyResult
     : ssrDisabledOverride;
 
+  const previousData = resultData.previousData;
+  const currentResultOverride = React.useMemo(
+    () =>
+      resultOverride &&
+      toQueryResult(resultOverride, previousData, observable, client),
+    [client, observable, resultOverride, previousData]
+  );
+
   const result = useObservableSubscriptionResult<TData, TVariables>(
     resultData,
     observable,
     client,
-    resultOverride
+    currentResultOverride
   );
 
   const obsQueryFields = React.useMemo(
@@ -368,16 +376,8 @@ function useObservableSubscriptionResult<
   resultData: InternalResult<TData, TVariables>,
   observable: ObservableQuery<TData, TVariables>,
   client: ApolloClient,
-  resultOverride: ApolloQueryResult<any> | undefined
+  resultOverride: InternalQueryResult<TData, TVariables> | undefined
 ) {
-  const previousData = resultData.previousData;
-  const currentResultOverride = React.useMemo(
-    () =>
-      resultOverride &&
-      toQueryResult(resultOverride, previousData, observable, client),
-    [client, observable, resultOverride, previousData]
-  );
-
   const result = useSyncExternalStore(
     React.useCallback(
       (handleStoreChange) => {
@@ -428,10 +428,8 @@ function useObservableSubscriptionResult<
 
       [observable, resultData, client]
     ),
-    () =>
-      currentResultOverride || getCurrentResult(resultData, observable, client),
-    () =>
-      currentResultOverride || getCurrentResult(resultData, observable, client)
+    () => resultOverride || getCurrentResult(resultData, observable, client),
+    () => resultOverride || getCurrentResult(resultData, observable, client)
   );
 
   return result;

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -317,13 +317,22 @@ function useQuery_<TData, TVariables extends OperationVariables>(
     [observable]
   );
 
-  return React.useMemo(
-    () => ({
-      ...toQueryResult(result, previousData, observable, client),
+  return React.useMemo(() => {
+    const { data, partial, ...resultWithoutPartial } = result;
+    const queryResult: InternalQueryResult<TData, TVariables> = {
+      data, // Ensure always defined, even if result.data is missing.
+      ...resultWithoutPartial,
+      client: client,
+      observable: observable,
+      variables: observable.variables,
+      previousData,
+    };
+
+    return {
+      ...queryResult,
       ...obsQueryFields,
-    }),
-    [result, client, observable, previousData, obsQueryFields]
-  );
+    };
+  }, [result, client, observable, previousData, obsQueryFields]);
 }
 
 function useInternalState<TData, TVariables extends OperationVariables>(

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -339,8 +339,8 @@ function useQuery_<TData, TVariables extends OperationVariables>(
 
       [observable, resultData]
     ),
-    () => resultOverride || resultData.current!,
-    () => resultOverride || resultData.current!
+    () => resultOverride || resultData.current,
+    () => resultOverride || resultData.current
   );
 
   const obsQueryFields = React.useMemo(
@@ -381,7 +381,7 @@ function useInternalState<TData, TVariables extends OperationVariables>(
         current: observable.getCurrentResult(),
         // Reuse previousData from previous InternalState (if any) to provide
         // continuity of previousData even if/when the query or client changes.
-        previousData: previous?.resultData.current?.data,
+        previousData: previous?.resultData.current.data,
       },
     };
 
@@ -436,7 +436,7 @@ function useResubscribeIfNecessary<
     // but save the current data as this.previousData, just like setResult
     // usually does.
     resultData.previousData =
-      resultData.current?.data || resultData.previousData;
+      resultData.current.data || resultData.previousData;
     resultData.current = observable.getCurrentResult();
   }
   observable[lastWatchOptions] = watchQueryOptions;

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -289,7 +289,7 @@ function useQuery_<TData, TVariables extends OperationVariables>(
   );
 
   const resultOverride =
-    options.skip || watchQueryOptions.fetchPolicy === "standby" ?
+    skip || watchQueryOptions.fetchPolicy === "standby" ?
       // When skipping a query (ie. we're not querying for data but still want to
       // render children), make sure the `data` is cleared out and `loading` is
       // set to `false` (since we aren't loading anything).

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -307,8 +307,6 @@ function useQuery_<TData, TVariables extends OperationVariables>(
     resultData,
     observable,
     client,
-    options,
-    watchQueryOptions,
     resultOverride
   );
 
@@ -370,8 +368,6 @@ function useObservableSubscriptionResult<
   resultData: InternalResult<TData, TVariables>,
   observable: ObservableQuery<TData, TVariables>,
   client: ApolloClient,
-  options: useQuery.Options<NoInfer<TData>, NoInfer<TVariables>>,
-  watchQueryOptions: Readonly<WatchQueryOptions<TVariables, TData>>,
   resultOverride: ApolloQueryResult<any> | undefined
 ) {
   const previousData = resultData.previousData;

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -502,10 +502,6 @@ function getCurrentResult<TData, TVariables extends OperationVariables>(
   // we're doing server rendering and therefore override the result below.
   if (!resultData.current) {
     const nextResult = observable.getCurrentResult();
-    const previousResult = resultData.current;
-    if (previousResult && previousResult.data) {
-      resultData.previousData = previousResult.data;
-    }
 
     resultData.current = toQueryResult(
       nextResult,

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -482,25 +482,6 @@ function useResubscribeIfNecessary<
   observable[lastWatchOptions] = watchQueryOptions;
 }
 
-function setResult<TData, TVariables extends OperationVariables>(
-  nextResult: ApolloQueryResult<MaybeMasked<TData>>,
-  resultData: InternalResult<TData, TVariables>,
-  observable: ObservableQuery<TData, TVariables>,
-  client: ApolloClient
-) {
-  const previousResult = resultData.current;
-  if (previousResult && previousResult.data) {
-    resultData.previousData = previousResult.data;
-  }
-
-  resultData.current = toQueryResult(
-    nextResult,
-    resultData.previousData,
-    observable,
-    client
-  );
-}
-
 function getCurrentResult<TData, TVariables extends OperationVariables>(
   resultData: InternalResult<TData, TVariables>,
   observable: ObservableQuery<TData, TVariables>,

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -508,7 +508,7 @@ function getCurrentResult<TData, TVariables extends OperationVariables>(
       client
     );
   }
-  return resultData.current!;
+  return resultData.current;
 }
 
 function toQueryResult<TData, TVariables extends OperationVariables>(

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -396,6 +396,7 @@ function useInternalState<TData, TVariables extends OperationVariables>(
       query,
       observable,
       resultData: {
+        current: observable.getCurrentResult(),
         // Reuse previousData from previous InternalState (if any) to provide
         // continuity of previousData even if/when the query or client changes.
         previousData: previous?.resultData.current?.data,

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -344,7 +344,15 @@ function useQuery_<TData, TVariables extends OperationVariables>(
   );
 
   const obsQueryFields = React.useMemo(
-    () => bindObservableMethods(observable),
+    () => ({
+      refetch: observable.refetch.bind(observable),
+      fetchMore: observable.fetchMore.bind(observable),
+      updateQuery: observable.updateQuery.bind(observable),
+      startPolling: observable.startPolling.bind(observable),
+      stopPolling: observable.stopPolling.bind(observable),
+      subscribeToMore: observable.subscribeToMore.bind(observable),
+    }),
+
     [observable]
   );
 
@@ -457,16 +465,3 @@ useQuery.skipStandbyResult = maybeDeepFreeze({
   networkStatus: NetworkStatus.ready,
   partial: true,
 });
-
-function bindObservableMethods<TData, TVariables extends OperationVariables>(
-  observable: ObservableQuery<TData, TVariables>
-) {
-  return {
-    refetch: observable.refetch.bind(observable),
-    fetchMore: observable.fetchMore.bind(observable),
-    updateQuery: observable.updateQuery.bind(observable),
-    startPolling: observable.startPolling.bind(observable),
-    stopPolling: observable.stopPolling.bind(observable),
-    subscribeToMore: observable.subscribeToMore.bind(observable),
-  };
-}

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -415,13 +415,8 @@ function useObservableSubscriptionResult<
               return;
             }
 
-            setResult(
-              result,
-              resultData,
-              observable,
-              client,
-              handleStoreChange
-            );
+            setResult(result, resultData, observable, client);
+            handleStoreChange();
           });
 
         // Do the "unsubscribe" with a short delay.
@@ -482,8 +477,7 @@ function setResult<TData, TVariables extends OperationVariables>(
   nextResult: ApolloQueryResult<MaybeMasked<TData>>,
   resultData: InternalResult<TData, TVariables>,
   observable: ObservableQuery<TData, TVariables>,
-  client: ApolloClient,
-  forceUpdate: () => void
+  client: ApolloClient
 ) {
   const previousResult = resultData.current;
   if (previousResult && previousResult.data) {
@@ -496,9 +490,6 @@ function setResult<TData, TVariables extends OperationVariables>(
     observable,
     client
   );
-  // Calling state.setResult always triggers an update, though some call sites
-  // perform additional equality checks before committing to an update.
-  forceUpdate();
 }
 
 function getCurrentResult<TData, TVariables extends OperationVariables>(
@@ -510,13 +501,7 @@ function getCurrentResult<TData, TVariables extends OperationVariables>(
   // the same (===) result object, unless state.setResult has been called, or
   // we're doing server rendering and therefore override the result below.
   if (!resultData.current) {
-    setResult(
-      observable.getCurrentResult(),
-      resultData,
-      observable,
-      client,
-      () => {}
-    );
+    setResult(observable.getCurrentResult(), resultData, observable, client);
   }
   return resultData.current!;
 }

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -389,7 +389,7 @@ function useObservableSubscriptionResult<
     [client, observable, resultOverride, previousData]
   );
 
-  return useSyncExternalStore(
+  const result = useSyncExternalStore(
     React.useCallback(
       (handleStoreChange) => {
         const subscription = observable
@@ -444,6 +444,8 @@ function useObservableSubscriptionResult<
     () =>
       currentResultOverride || getCurrentResult(resultData, observable, client)
   );
+
+  return result;
 }
 
 // this hook is not compatible with any rules of React, and there's no good way to rewrite it.

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -254,7 +254,7 @@ function useQuery_<TData, TVariables extends OperationVariables>(
     watchQueryOptions.fetchPolicy = "standby";
   }
 
-  function createInternalState(
+  function createState(
     previous?: InternalState<TData, TVariables>
   ): InternalState<TData, TVariables> {
     verifyDocumentType(query, DocumentType.Query);
@@ -274,20 +274,19 @@ function useQuery_<TData, TVariables extends OperationVariables>(
     };
   }
 
-  let [internalState, updateInternalState] =
-    React.useState(createInternalState);
+  let [state, setState] = React.useState(createState);
 
-  if (client !== internalState.client || query !== internalState.query) {
+  if (client !== state.client || query !== state.query) {
     // If the client or query have changed, we need to create a new InternalState.
     // This will trigger a re-render with the new state, but it will also continue
     // to run the current render function to completion.
     // Since we sometimes trigger some side-effects in the render function, we
     // re-assign `state` to the new state to ensure that those side-effects are
     // triggered with the new state.
-    updateInternalState((internalState = createInternalState(internalState)));
+    setState((state = createState(state)));
   }
 
-  const { observable, resultData } = internalState;
+  const { observable, resultData } = state;
 
   if (!watchQueryOptions.fetchPolicy) {
     // eslint-disable-next-line react-compiler/react-compiler

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -353,8 +353,8 @@ function useObservableSubscriptionResult<
 ) {
   const ssrDisabledOverride = useSyncExternalStore(
     () => () => {},
-    () => false,
-    () => options.ssr === false
+    () => void 0,
+    () => (options.ssr === false ? useQuery.ssrDisabledResult : void 0)
   );
 
   const resultOverride =
@@ -370,8 +370,7 @@ function useObservableSubscriptionResult<
       // changing this is breaking, so we'll have to wait until Apollo Client 4.0
       // to address this.
       useQuery.skipStandbyResult
-    : ssrDisabledOverride ? useQuery.ssrDisabledResult
-    : void 0;
+    : ssrDisabledOverride;
 
   const previousData = resultData.previousData;
   const currentResultOverride = React.useMemo(

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -501,10 +501,8 @@ function getCurrentResult<TData, TVariables extends OperationVariables>(
   // the same (===) result object, unless state.setResult has been called, or
   // we're doing server rendering and therefore override the result below.
   if (!resultData.current) {
-    const nextResult = observable.getCurrentResult();
-
     resultData.current = toQueryResult(
-      nextResult,
+      observable.getCurrentResult(),
       resultData.previousData,
       observable,
       client

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -378,7 +378,6 @@ function useQuery_<TData, TVariables extends OperationVariables>(
       stopPolling: observable.stopPolling.bind(observable),
       subscribeToMore: observable.subscribeToMore.bind(observable),
     }),
-
     [observable]
   );
 

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -315,7 +315,7 @@ function useQuery_<TData, TVariables extends OperationVariables>(
     resultData,
     observable,
     client,
-    currentResultOverride
+    resultOverride
   );
 
   const obsQueryFields = React.useMemo(
@@ -376,7 +376,7 @@ function useObservableSubscriptionResult<
   resultData: InternalResult<TData, TVariables>,
   observable: ObservableQuery<TData, TVariables>,
   client: ApolloClient,
-  resultOverride: InternalQueryResult<TData, TVariables> | undefined
+  resultOverride: ApolloQueryResult<TData> | undefined
 ) {
   const result = useSyncExternalStore(
     React.useCallback(

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -238,11 +238,11 @@ function useQuery_<TData, TVariables extends OperationVariables>(
   options: useQuery.Options<NoInfer<TData>, NoInfer<TVariables>>
 ) {
   const client = useApolloClient(options.client);
-  const { skip, ssr, ...otherOptions } = options;
+  const { skip, ssr, ...opts } = options;
 
   const watchQueryOptions: WatchQueryOptions<TVariables, TData> = mergeOptions(
     client.defaultOptions.watchQuery,
-    { ...otherOptions, query }
+    { ...opts, query }
   );
 
   if (skip) {

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -238,7 +238,7 @@ function useQuery_<TData, TVariables extends OperationVariables>(
   options: useQuery.Options<NoInfer<TData>, NoInfer<TVariables>>
 ) {
   const client = useApolloClient(options.client);
-  const { skip, ...otherOptions } = options;
+  const { skip, ssr, ...otherOptions } = options;
 
   const watchQueryOptions: WatchQueryOptions<TVariables, TData> = mergeOptions(
     client.defaultOptions.watchQuery,
@@ -302,7 +302,7 @@ function useQuery_<TData, TVariables extends OperationVariables>(
   const ssrDisabledOverride = useSyncExternalStore(
     () => () => {},
     () => void 0,
-    () => (options.ssr === false ? useQuery.ssrDisabledResult : void 0)
+    () => (ssr === false ? useQuery.ssrDisabledResult : void 0)
   );
 
   const resultOverride =

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -455,7 +455,7 @@ function useResubscribeIfNecessary<
     // usually does.
     resultData.previousData =
       resultData.current?.data || resultData.previousData;
-    resultData.current = void 0;
+    resultData.current = observable.getCurrentResult();
   }
   observable[lastWatchOptions] = watchQueryOptions;
 }

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -357,8 +357,8 @@ function useQuery_<TData, TVariables extends OperationVariables>(
 
       [observable, resultData]
     ),
-    () => resultOverride || getCurrentResult(resultData, observable),
-    () => resultOverride || getCurrentResult(resultData, observable)
+    () => resultOverride || resultData.current!,
+    () => resultOverride || resultData.current!
   );
 
   const obsQueryFields = React.useMemo(
@@ -455,13 +455,6 @@ function useResubscribeIfNecessary<
     resultData.current = void 0;
   }
   observable[lastWatchOptions] = watchQueryOptions;
-}
-
-function getCurrentResult<TData, TVariables extends OperationVariables>(
-  resultData: InternalResult<TData, TVariables>,
-  observable: ObservableQuery<TData, TVariables>
-) {
-  return resultData.current;
 }
 
 useQuery.ssrDisabledResult = maybeDeepFreeze({

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -282,12 +282,34 @@ function useQuery_<TData, TVariables extends OperationVariables>(
     watchQueryOptions
   );
 
+  const ssrDisabledOverride = useSyncExternalStore(
+    () => () => {},
+    () => void 0,
+    () => (options.ssr === false ? useQuery.ssrDisabledResult : void 0)
+  );
+
+  const resultOverride =
+    options.skip || watchQueryOptions.fetchPolicy === "standby" ?
+      // When skipping a query (ie. we're not querying for data but still want to
+      // render children), make sure the `data` is cleared out and `loading` is
+      // set to `false` (since we aren't loading anything).
+      //
+      // NOTE: We no longer think this is the correct behavior. Skipping should
+      // not automatically set `data` to `undefined`, but instead leave the
+      // previous data in place. In other words, skipping should not mandate that
+      // previously received data is all of a sudden removed. Unfortunately,
+      // changing this is breaking, so we'll have to wait until Apollo Client 4.0
+      // to address this.
+      useQuery.skipStandbyResult
+    : ssrDisabledOverride;
+
   const result = useObservableSubscriptionResult<TData, TVariables>(
     resultData,
     observable,
     client,
     options,
-    watchQueryOptions
+    watchQueryOptions,
+    resultOverride
   );
 
   const obsQueryFields = React.useMemo(
@@ -349,29 +371,9 @@ function useObservableSubscriptionResult<
   observable: ObservableQuery<TData, TVariables>,
   client: ApolloClient,
   options: useQuery.Options<NoInfer<TData>, NoInfer<TVariables>>,
-  watchQueryOptions: Readonly<WatchQueryOptions<TVariables, TData>>
+  watchQueryOptions: Readonly<WatchQueryOptions<TVariables, TData>>,
+  resultOverride: ApolloQueryResult<any> | undefined
 ) {
-  const ssrDisabledOverride = useSyncExternalStore(
-    () => () => {},
-    () => void 0,
-    () => (options.ssr === false ? useQuery.ssrDisabledResult : void 0)
-  );
-
-  const resultOverride =
-    options.skip || watchQueryOptions.fetchPolicy === "standby" ?
-      // When skipping a query (ie. we're not querying for data but still want to
-      // render children), make sure the `data` is cleared out and `loading` is
-      // set to `false` (since we aren't loading anything).
-      //
-      // NOTE: We no longer think this is the correct behavior. Skipping should
-      // not automatically set `data` to `undefined`, but instead leave the
-      // previous data in place. In other words, skipping should not mandate that
-      // previously received data is all of a sudden removed. Unfortunately,
-      // changing this is breaking, so we'll have to wait until Apollo Client 4.0
-      // to address this.
-      useQuery.skipStandbyResult
-    : ssrDisabledOverride;
-
   const previousData = resultData.previousData;
   const currentResultOverride = React.useMemo(
     () =>

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -304,12 +304,6 @@ function useQuery_<TData, TVariables extends OperationVariables>(
     : ssrDisabledOverride;
 
   const previousData = resultData.previousData;
-  const currentResultOverride = React.useMemo(
-    () =>
-      resultOverride &&
-      toQueryResult(resultOverride, previousData, observable, client),
-    [client, observable, resultOverride, previousData]
-  );
 
   const result = useObservableSubscriptionResult<TData, TVariables>(
     resultData,
@@ -318,14 +312,19 @@ function useQuery_<TData, TVariables extends OperationVariables>(
     resultOverride
   );
 
+  const queryResult = React.useMemo(
+    () => toQueryResult(result, previousData, observable, client),
+    [client, observable, result, previousData]
+  );
+
   const obsQueryFields = React.useMemo(
     () => bindObservableMethods(observable),
     [observable]
   );
 
   return React.useMemo(
-    () => ({ ...result, ...obsQueryFields }),
-    [result, obsQueryFields]
+    () => ({ ...queryResult, ...obsQueryFields }),
+    [queryResult, obsQueryFields]
   );
 }
 


### PR DESCRIPTION
This focuses on inlining some of the extracted hooks. This enables additional refactoring where there might have been duplicated logic, or logic that was completely unused in some places.

This one is best to review commit by commit if possible to see the progression.