### PR TITLE
Add `data` property to `CombinedGraphQLErrors`

### DIFF
--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -19,6 +19,7 @@ import type { DocumentNode } from 'graphql';
 import { DocumentTransform as DocumentTransform_2 } from '@apollo/client/utilities';
 import { enableExperimentalFragmentVariables } from 'graphql-tag';
 import type { FetchResult as FetchResult_2 } from '@apollo/client/link/core';
+import type { FetchResult as FetchResult_3 } from '@apollo/client/core';
 import type { FieldNode } from 'graphql';
 import type { FormattedExecutionResult } from 'graphql';
 import type { FragmentDefinitionNode } from 'graphql';
@@ -423,11 +424,9 @@ type CombineByTypeName<T extends {
 
 // @public
 export class CombinedGraphQLErrors extends Error {
-    constructor(errors: Array<GraphQLFormattedError> | ReadonlyArray<GraphQLFormattedError>, options: {
-        data: Record<string, unknown> | null | undefined;
-    });
-    data: Record<string, unknown> | null | undefined;
-    errors: ReadonlyArray<GraphQLFormattedError>;
+    constructor(result: FetchResult_3<unknown>);
+    readonly data: Record<string, unknown> | null | undefined;
+    readonly errors: ReadonlyArray<GraphQLFormattedError>;
 }
 
 // @public
@@ -2345,7 +2344,7 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/core/ObservableQuery.ts:130:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:131:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:187:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:461:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:455:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
 // src/link/http/selectHttpOptionsAndBody.ts:128:1 - (ae-forgotten-export) The symbol "HttpQueryOptions" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -423,7 +423,10 @@ type CombineByTypeName<T extends {
 
 // @public
 export class CombinedGraphQLErrors extends Error {
-    constructor(errors: Array<GraphQLFormattedError> | ReadonlyArray<GraphQLFormattedError>);
+    constructor(errors: Array<GraphQLFormattedError> | ReadonlyArray<GraphQLFormattedError>, options: {
+        data: Record<string, unknown> | null | undefined;
+    });
+    data: Record<string, unknown> | null | undefined;
     errors: ReadonlyArray<GraphQLFormattedError>;
 }
 
@@ -2342,7 +2345,7 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/core/ObservableQuery.ts:130:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:131:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:187:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:459:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:461:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
 // src/link/http/selectHttpOptionsAndBody.ts:128:1 - (ae-forgotten-export) The symbol "HttpQueryOptions" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-errors.api.md
+++ b/.api-reports/api-report-errors.api.md
@@ -5,15 +5,14 @@
 ```ts
 
 import type { FetchResult } from '@apollo/client/link/core';
+import type { FetchResult as FetchResult_2 } from '@apollo/client/core';
 import type { GraphQLFormattedError } from 'graphql';
 
 // @public
 export class CombinedGraphQLErrors extends Error {
-    constructor(errors: Array<GraphQLFormattedError> | ReadonlyArray<GraphQLFormattedError>, options: {
-        data: Record<string, unknown> | null | undefined;
-    });
-    data: Record<string, unknown> | null | undefined;
-    errors: ReadonlyArray<GraphQLFormattedError>;
+    constructor(result: FetchResult_2<unknown>);
+    readonly data: Record<string, unknown> | null | undefined;
+    readonly errors: ReadonlyArray<GraphQLFormattedError>;
 }
 
 // @public

--- a/.api-reports/api-report-errors.api.md
+++ b/.api-reports/api-report-errors.api.md
@@ -9,7 +9,10 @@ import type { GraphQLFormattedError } from 'graphql';
 
 // @public
 export class CombinedGraphQLErrors extends Error {
-    constructor(errors: Array<GraphQLFormattedError> | ReadonlyArray<GraphQLFormattedError>);
+    constructor(errors: Array<GraphQLFormattedError> | ReadonlyArray<GraphQLFormattedError>, options: {
+        data: Record<string, unknown> | null | undefined;
+    });
+    data: Record<string, unknown> | null | undefined;
     errors: ReadonlyArray<GraphQLFormattedError>;
 }
 

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -1665,7 +1665,7 @@ interface WatchQueryOptions_2<TVariables extends OperationVariables_2 = Operatio
 // src/core/ObservableQuery.ts:130:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:131:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:187:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:459:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:461:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:204:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:233:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:195:3 - (ae-forgotten-export) The symbol "UpdateQueryOptions" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -1665,7 +1665,7 @@ interface WatchQueryOptions_2<TVariables extends OperationVariables_2 = Operatio
 // src/core/ObservableQuery.ts:130:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:131:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:187:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:461:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:455:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:204:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:233:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:195:3 - (ae-forgotten-export) The symbol "UpdateQueryOptions" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report-react_hooks.api.md
+++ b/.api-reports/api-report-react_hooks.api.md
@@ -1427,7 +1427,7 @@ interface WatchQueryOptions_2<TVariables extends OperationVariables_2 = Operatio
 // src/core/ObservableQuery.ts:130:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:131:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:187:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:461:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:455:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:204:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:233:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:195:3 - (ae-forgotten-export) The symbol "UpdateQueryOptions" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report-react_hooks.api.md
+++ b/.api-reports/api-report-react_hooks.api.md
@@ -1427,7 +1427,7 @@ interface WatchQueryOptions_2<TVariables extends OperationVariables_2 = Operatio
 // src/core/ObservableQuery.ts:130:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:131:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:187:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:459:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:461:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:204:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:233:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:195:3 - (ae-forgotten-export) The symbol "UpdateQueryOptions" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -397,11 +397,9 @@ type CombineByTypeName<T extends {
 
 // @public
 export class CombinedGraphQLErrors extends Error {
-    constructor(errors: Array<GraphQLFormattedError> | ReadonlyArray<GraphQLFormattedError>, options: {
-        data: Record<string, unknown> | null | undefined;
-    });
-    data: Record<string, unknown> | null | undefined;
-    errors: ReadonlyArray<GraphQLFormattedError>;
+    constructor(result: FetchResult<unknown>);
+    readonly data: Record<string, unknown> | null | undefined;
+    readonly errors: ReadonlyArray<GraphQLFormattedError>;
 }
 
 // @public
@@ -2487,7 +2485,7 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/core/ObservableQuery.ts:130:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:131:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:187:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:461:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:455:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
 // src/link/http/selectHttpOptionsAndBody.ts:128:1 - (ae-forgotten-export) The symbol "HttpQueryOptions" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -397,7 +397,10 @@ type CombineByTypeName<T extends {
 
 // @public
 export class CombinedGraphQLErrors extends Error {
-    constructor(errors: Array<GraphQLFormattedError> | ReadonlyArray<GraphQLFormattedError>);
+    constructor(errors: Array<GraphQLFormattedError> | ReadonlyArray<GraphQLFormattedError>, options: {
+        data: Record<string, unknown> | null | undefined;
+    });
+    data: Record<string, unknown> | null | undefined;
     errors: ReadonlyArray<GraphQLFormattedError>;
 }
 
@@ -2484,7 +2487,7 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/core/ObservableQuery.ts:130:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:131:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:187:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:459:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:461:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
 // src/link/http/selectHttpOptionsAndBody.ts:128:1 - (ae-forgotten-export) The symbol "HttpQueryOptions" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.changeset/nervous-fireants-bow.md
+++ b/.changeset/nervous-fireants-bow.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": minor
+---
+
+Add a `data` property to `CombinedGraphQLErrors` that captures any partial data returned by the GraphQL response when `errors` are also returned.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 42584,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 37830,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 32883,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27676
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 42585,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 37897,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 32939,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27654
 }

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 42585,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 37897,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 32939,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27654
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 42563,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 37833,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 32930,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27693
 }

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -593,7 +593,7 @@ describe("client", () => {
     });
 
     await expect(client.query({ query })).rejects.toEqual(
-      new CombinedGraphQLErrors(errors, { data: undefined })
+      new CombinedGraphQLErrors({ errors })
     );
   });
 
@@ -638,7 +638,7 @@ describe("client", () => {
     });
 
     await expect(client.query({ query })).rejects.toEqual(
-      new CombinedGraphQLErrors(errors, { data })
+      new CombinedGraphQLErrors({ data, errors })
     );
   });
 
@@ -1950,8 +1950,8 @@ describe("client", () => {
 
       await expect(stream).toEmitApolloQueryResult({
         data: initialData,
-        error: new CombinedGraphQLErrors([{ message: "network failure" }], {
-          data: undefined,
+        error: new CombinedGraphQLErrors({
+          errors: [{ message: "network failure" }],
         }),
         loading: false,
         networkStatus: NetworkStatus.error,
@@ -2191,7 +2191,7 @@ describe("client", () => {
     });
 
     await expect(client.mutate({ mutation })).rejects.toEqual(
-      new CombinedGraphQLErrors(errors, { data })
+      new CombinedGraphQLErrors({ data, errors })
     );
   });
 
@@ -2230,7 +2230,7 @@ describe("client", () => {
       client.mutate({ mutation, errorPolicy: "all" })
     ).resolves.toEqualStrictTyped({
       data,
-      error: new CombinedGraphQLErrors(errors, { data }),
+      error: new CombinedGraphQLErrors({ data, errors }),
     });
   });
 
@@ -2784,10 +2784,10 @@ describe("client", () => {
       client.query({ query, errorPolicy: "all" })
     ).resolves.toEqualStrictTyped({
       data: { posts: null },
-      error: new CombinedGraphQLErrors(
-        [{ message: 'Cannot query field "foo" on type "Post".' }],
-        { data: { posts: null } }
-      ),
+      error: new CombinedGraphQLErrors({
+        data: { posts: null },
+        errors: [{ message: 'Cannot query field "foo" on type "Post".' }],
+      }),
     });
   });
 
@@ -3774,7 +3774,7 @@ describe("@connection", () => {
 
       expect(result).toEqualStrictTyped({
         data: undefined,
-        error: new CombinedGraphQLErrors(errors, { data: undefined }),
+        error: new CombinedGraphQLErrors({ errors }),
       });
     });
 

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -593,7 +593,7 @@ describe("client", () => {
     });
 
     await expect(client.query({ query })).rejects.toEqual(
-      new CombinedGraphQLErrors(errors)
+      new CombinedGraphQLErrors(errors, { data: undefined })
     );
   });
 
@@ -638,7 +638,7 @@ describe("client", () => {
     });
 
     await expect(client.query({ query })).rejects.toEqual(
-      new CombinedGraphQLErrors(errors)
+      new CombinedGraphQLErrors(errors, { data })
     );
   });
 
@@ -1950,7 +1950,9 @@ describe("client", () => {
 
       await expect(stream).toEmitApolloQueryResult({
         data: initialData,
-        error: new CombinedGraphQLErrors([{ message: "network failure" }]),
+        error: new CombinedGraphQLErrors([{ message: "network failure" }], {
+          data: undefined,
+        }),
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: false,
@@ -2189,7 +2191,7 @@ describe("client", () => {
     });
 
     await expect(client.mutate({ mutation })).rejects.toEqual(
-      new CombinedGraphQLErrors(errors)
+      new CombinedGraphQLErrors(errors, { data })
     );
   });
 
@@ -2205,9 +2207,11 @@ describe("client", () => {
       }
     `;
     const data = {
-      person: {
-        firstName: "John",
-        lastName: "Smith",
+      newPerson: {
+        person: {
+          firstName: "John",
+          lastName: "Smith",
+        },
       },
     };
     const errors = [{ message: "Some kind of GraphQL error." }];
@@ -2216,9 +2220,7 @@ describe("client", () => {
         request: { query: mutation },
         result: {
           errors,
-          data: {
-            newPerson: data,
-          },
+          data,
         },
       }),
       cache: new InMemoryCache(),
@@ -2227,8 +2229,8 @@ describe("client", () => {
     await expect(
       client.mutate({ mutation, errorPolicy: "all" })
     ).resolves.toEqualStrictTyped({
-      data: { newPerson: data },
-      error: new CombinedGraphQLErrors(errors),
+      data,
+      error: new CombinedGraphQLErrors(errors, { data }),
     });
   });
 
@@ -2782,9 +2784,10 @@ describe("client", () => {
       client.query({ query, errorPolicy: "all" })
     ).resolves.toEqualStrictTyped({
       data: { posts: null },
-      error: new CombinedGraphQLErrors([
-        { message: 'Cannot query field "foo" on type "Post".' },
-      ]),
+      error: new CombinedGraphQLErrors(
+        [{ message: 'Cannot query field "foo" on type "Post".' }],
+        { data: { posts: null } }
+      ),
     });
   });
 
@@ -3771,7 +3774,7 @@ describe("@connection", () => {
 
       expect(result).toEqualStrictTyped({
         data: undefined,
-        error: new CombinedGraphQLErrors(errors),
+        error: new CombinedGraphQLErrors(errors, { data: undefined }),
       });
     });
 

--- a/src/__tests__/dataMasking.ts
+++ b/src/__tests__/dataMasking.ts
@@ -978,7 +978,16 @@ describe("client.watchQuery", () => {
           name: null,
         },
       },
-      error: new CombinedGraphQLErrors([{ message: "Couldn't get name" }]),
+      error: new CombinedGraphQLErrors([{ message: "Couldn't get name" }], {
+        data: {
+          currentUser: {
+            __typename: "User",
+            id: 1,
+            name: null,
+            age: 34,
+          },
+        },
+      }),
       loading: false,
       networkStatus: NetworkStatus.error,
       partial: false,
@@ -3832,7 +3841,9 @@ describe("client.query", () => {
     });
 
     await expect(client.query({ query, errorPolicy: "none" })).rejects.toEqual(
-      new CombinedGraphQLErrors([{ message: "User not logged in" }])
+      new CombinedGraphQLErrors([{ message: "User not logged in" }], {
+        data: undefined,
+      })
     );
   });
 
@@ -3871,7 +3882,9 @@ describe("client.query", () => {
 
     expect(result).toEqualStrictTyped({
       data: { currentUser: null },
-      error: new CombinedGraphQLErrors([{ message: "User not logged in" }]),
+      error: new CombinedGraphQLErrors([{ message: "User not logged in" }], {
+        data: { currentUser: null },
+      }),
     });
   });
 
@@ -3923,9 +3936,19 @@ describe("client.query", () => {
           name: "Test User",
         },
       },
-      error: new CombinedGraphQLErrors([
-        { message: "Could not determine age" },
-      ]),
+      error: new CombinedGraphQLErrors(
+        [{ message: "Could not determine age" }],
+        {
+          data: {
+            currentUser: {
+              __typename: "User",
+              id: 1,
+              name: "Test User",
+              age: null,
+            },
+          },
+        }
+      ),
     });
   });
 
@@ -4384,7 +4407,9 @@ describe("client.subscribe", () => {
 
     await expect(stream).toEmitStrictTyped({
       data: undefined,
-      error: new CombinedGraphQLErrors([{ message: "Something went wrong" }]),
+      error: new CombinedGraphQLErrors([{ message: "Something went wrong" }], {
+        data: { addedComment: null },
+      }),
     });
   });
 
@@ -4428,7 +4453,9 @@ describe("client.subscribe", () => {
 
     await expect(stream).toEmitStrictTyped({
       data: { addedComment: null },
-      error: new CombinedGraphQLErrors([{ message: "Something went wrong" }]),
+      error: new CombinedGraphQLErrors([{ message: "Something went wrong" }], {
+        data: { addedComment: null },
+      }),
     });
   });
 
@@ -4477,7 +4504,16 @@ describe("client.subscribe", () => {
 
     await expect(stream).toEmitStrictTyped({
       data: { addedComment: { __typename: "Comment", id: 1 } },
-      error: new CombinedGraphQLErrors([{ message: "Could not get author" }]),
+      error: new CombinedGraphQLErrors([{ message: "Could not get author" }], {
+        data: {
+          addedComment: {
+            __typename: "Comment",
+            id: 1,
+            comment: "Test comment",
+            author: null,
+          },
+        },
+      }),
     });
   });
 
@@ -5471,7 +5507,9 @@ describe("client.mutate", () => {
     await expect(
       client.mutate({ mutation, errorPolicy: "none" })
     ).rejects.toEqual(
-      new CombinedGraphQLErrors([{ message: "User not logged in" }])
+      new CombinedGraphQLErrors([{ message: "User not logged in" }], {
+        data: undefined,
+      })
     );
   });
 
@@ -5529,7 +5567,9 @@ describe("client.mutate", () => {
       })
     ).resolves.toEqualStrictTyped({
       data: { updateUser: null },
-      error: new CombinedGraphQLErrors([{ message: "User not logged in" }]),
+      error: new CombinedGraphQLErrors([{ message: "User not logged in" }], {
+        data: { updateUser: null },
+      }),
     });
   });
 
@@ -5598,9 +5638,19 @@ describe("client.mutate", () => {
           name: "Test User",
         },
       },
-      error: new CombinedGraphQLErrors([
-        { message: "Could not determine age" },
-      ]),
+      error: new CombinedGraphQLErrors(
+        [{ message: "Could not determine age" }],
+        {
+          data: {
+            updateUser: {
+              __typename: "User",
+              id: 1,
+              name: "Test User",
+              age: null,
+            },
+          },
+        }
+      ),
     });
   });
 

--- a/src/__tests__/dataMasking.ts
+++ b/src/__tests__/dataMasking.ts
@@ -978,7 +978,7 @@ describe("client.watchQuery", () => {
           name: null,
         },
       },
-      error: new CombinedGraphQLErrors([{ message: "Couldn't get name" }], {
+      error: new CombinedGraphQLErrors({
         data: {
           currentUser: {
             __typename: "User",
@@ -987,6 +987,7 @@ describe("client.watchQuery", () => {
             age: 34,
           },
         },
+        errors: [{ message: "Couldn't get name" }],
       }),
       loading: false,
       networkStatus: NetworkStatus.error,
@@ -3841,9 +3842,7 @@ describe("client.query", () => {
     });
 
     await expect(client.query({ query, errorPolicy: "none" })).rejects.toEqual(
-      new CombinedGraphQLErrors([{ message: "User not logged in" }], {
-        data: undefined,
-      })
+      new CombinedGraphQLErrors({ errors: [{ message: "User not logged in" }] })
     );
   });
 
@@ -3882,8 +3881,9 @@ describe("client.query", () => {
 
     expect(result).toEqualStrictTyped({
       data: { currentUser: null },
-      error: new CombinedGraphQLErrors([{ message: "User not logged in" }], {
+      error: new CombinedGraphQLErrors({
         data: { currentUser: null },
+        errors: [{ message: "User not logged in" }],
       }),
     });
   });
@@ -3936,19 +3936,17 @@ describe("client.query", () => {
           name: "Test User",
         },
       },
-      error: new CombinedGraphQLErrors(
-        [{ message: "Could not determine age" }],
-        {
-          data: {
-            currentUser: {
-              __typename: "User",
-              id: 1,
-              name: "Test User",
-              age: null,
-            },
+      error: new CombinedGraphQLErrors({
+        data: {
+          currentUser: {
+            __typename: "User",
+            id: 1,
+            name: "Test User",
+            age: null,
           },
-        }
-      ),
+        },
+        errors: [{ message: "Could not determine age" }],
+      }),
     });
   });
 
@@ -4407,8 +4405,9 @@ describe("client.subscribe", () => {
 
     await expect(stream).toEmitStrictTyped({
       data: undefined,
-      error: new CombinedGraphQLErrors([{ message: "Something went wrong" }], {
+      error: new CombinedGraphQLErrors({
         data: { addedComment: null },
+        errors: [{ message: "Something went wrong" }],
       }),
     });
   });
@@ -4453,8 +4452,9 @@ describe("client.subscribe", () => {
 
     await expect(stream).toEmitStrictTyped({
       data: { addedComment: null },
-      error: new CombinedGraphQLErrors([{ message: "Something went wrong" }], {
+      error: new CombinedGraphQLErrors({
         data: { addedComment: null },
+        errors: [{ message: "Something went wrong" }],
       }),
     });
   });
@@ -4504,7 +4504,7 @@ describe("client.subscribe", () => {
 
     await expect(stream).toEmitStrictTyped({
       data: { addedComment: { __typename: "Comment", id: 1 } },
-      error: new CombinedGraphQLErrors([{ message: "Could not get author" }], {
+      error: new CombinedGraphQLErrors({
         data: {
           addedComment: {
             __typename: "Comment",
@@ -4513,6 +4513,7 @@ describe("client.subscribe", () => {
             author: null,
           },
         },
+        errors: [{ message: "Could not get author" }],
       }),
     });
   });
@@ -5507,9 +5508,7 @@ describe("client.mutate", () => {
     await expect(
       client.mutate({ mutation, errorPolicy: "none" })
     ).rejects.toEqual(
-      new CombinedGraphQLErrors([{ message: "User not logged in" }], {
-        data: undefined,
-      })
+      new CombinedGraphQLErrors({ errors: [{ message: "User not logged in" }] })
     );
   });
 
@@ -5567,8 +5566,9 @@ describe("client.mutate", () => {
       })
     ).resolves.toEqualStrictTyped({
       data: { updateUser: null },
-      error: new CombinedGraphQLErrors([{ message: "User not logged in" }], {
+      error: new CombinedGraphQLErrors({
         data: { updateUser: null },
+        errors: [{ message: "User not logged in" }],
       }),
     });
   });
@@ -5638,19 +5638,17 @@ describe("client.mutate", () => {
           name: "Test User",
         },
       },
-      error: new CombinedGraphQLErrors(
-        [{ message: "Could not determine age" }],
-        {
-          data: {
-            updateUser: {
-              __typename: "User",
-              id: 1,
-              name: "Test User",
-              age: null,
-            },
+      error: new CombinedGraphQLErrors({
+        data: {
+          updateUser: {
+            __typename: "User",
+            id: 1,
+            name: "Test User",
+            age: null,
           },
-        }
-      ),
+        },
+        errors: [{ message: "Could not determine age" }],
+      }),
     });
   });
 

--- a/src/__tests__/graphqlSubscriptions.ts
+++ b/src/__tests__/graphqlSubscriptions.ts
@@ -171,18 +171,21 @@ describe("GraphQL Subscriptions", () => {
 
     await expect(stream).toEmitStrictTyped({
       data: undefined,
-      error: new CombinedGraphQLErrors([
-        {
-          message: "This is an error",
-          locations: [
-            {
-              column: 3,
-              line: 2,
-            },
-          ],
-          path: ["result"],
-        },
-      ]),
+      error: new CombinedGraphQLErrors(
+        [
+          {
+            message: "This is an error",
+            locations: [
+              {
+                column: 3,
+                line: 2,
+              },
+            ],
+            path: ["result"],
+          },
+        ],
+        { data: null }
+      ),
     });
   });
 
@@ -216,18 +219,21 @@ describe("GraphQL Subscriptions", () => {
 
     await expect(stream).toEmitStrictTyped({
       data: undefined,
-      error: new CombinedGraphQLErrors([
-        {
-          message: "This is an error",
-          locations: [
-            {
-              column: 3,
-              line: 2,
-            },
-          ],
-          path: ["result"],
-        },
-      ]),
+      error: new CombinedGraphQLErrors(
+        [
+          {
+            message: "This is an error",
+            locations: [
+              {
+                column: 3,
+                line: 2,
+              },
+            ],
+            path: ["result"],
+          },
+        ],
+        { data: null }
+      ),
     });
 
     link.simulateResult(results[0]);
@@ -288,7 +294,9 @@ describe("GraphQL Subscriptions", () => {
 
     await expect(stream).toEmitStrictTyped({
       data: undefined,
-      error: new CombinedGraphQLErrors([{ message: "This is an error" }]),
+      error: new CombinedGraphQLErrors([{ message: "This is an error" }], {
+        data: null,
+      }),
     });
 
     await expect(stream).toComplete();

--- a/src/__tests__/graphqlSubscriptions.ts
+++ b/src/__tests__/graphqlSubscriptions.ts
@@ -171,8 +171,9 @@ describe("GraphQL Subscriptions", () => {
 
     await expect(stream).toEmitStrictTyped({
       data: undefined,
-      error: new CombinedGraphQLErrors(
-        [
+      error: new CombinedGraphQLErrors({
+        data: null,
+        errors: [
           {
             message: "This is an error",
             locations: [
@@ -184,8 +185,7 @@ describe("GraphQL Subscriptions", () => {
             path: ["result"],
           },
         ],
-        { data: null }
-      ),
+      }),
     });
   });
 
@@ -219,8 +219,9 @@ describe("GraphQL Subscriptions", () => {
 
     await expect(stream).toEmitStrictTyped({
       data: undefined,
-      error: new CombinedGraphQLErrors(
-        [
+      error: new CombinedGraphQLErrors({
+        data: null,
+        errors: [
           {
             message: "This is an error",
             locations: [
@@ -232,8 +233,7 @@ describe("GraphQL Subscriptions", () => {
             path: ["result"],
           },
         ],
-        { data: null }
-      ),
+      }),
     });
 
     link.simulateResult(results[0]);
@@ -294,8 +294,9 @@ describe("GraphQL Subscriptions", () => {
 
     await expect(stream).toEmitStrictTyped({
       data: undefined,
-      error: new CombinedGraphQLErrors([{ message: "This is an error" }], {
+      error: new CombinedGraphQLErrors({
         data: null,
+        errors: [{ message: "This is an error" }],
       }),
     });
 

--- a/src/__tests__/local-state/general.ts
+++ b/src/__tests__/local-state/general.ts
@@ -1179,7 +1179,7 @@ describe("Combining client and server state/operations", () => {
 
     await expect(stream).toEmitApolloQueryResult({
       data: undefined,
-      error: new CombinedGraphQLErrors([error]),
+      error: new CombinedGraphQLErrors([error], { data: { user: null } }),
       loading: false,
       networkStatus: NetworkStatus.error,
       partial: true,

--- a/src/__tests__/local-state/general.ts
+++ b/src/__tests__/local-state/general.ts
@@ -1179,7 +1179,10 @@ describe("Combining client and server state/operations", () => {
 
     await expect(stream).toEmitApolloQueryResult({
       data: undefined,
-      error: new CombinedGraphQLErrors([error], { data: { user: null } }),
+      error: new CombinedGraphQLErrors({
+        data: { user: null },
+        errors: [error],
+      }),
       loading: false,
       networkStatus: NetworkStatus.error,
       partial: true,

--- a/src/__tests__/mutationResults.ts
+++ b/src/__tests__/mutationResults.ts
@@ -347,8 +347,9 @@ describe("mutation results", () => {
         },
       })
     ).rejects.toThrow(
-      new CombinedGraphQLErrors([expectedFakeError], {
+      new CombinedGraphQLErrors({
         data: { newPerson: { __typename: "Person", name: "Hugh Willson" } },
+        errors: [expectedFakeError],
       })
     );
 
@@ -388,8 +389,9 @@ describe("mutation results", () => {
           name: "Ellen Shapiro",
         },
       },
-      error: new CombinedGraphQLErrors([expectedFakeError], {
+      error: new CombinedGraphQLErrors({
         data: { newPerson: { __typename: "Person", name: "Ellen Shapiro" } },
+        errors: [expectedFakeError],
       }),
     });
 
@@ -535,8 +537,9 @@ describe("mutation results", () => {
       })
     ).resolves.toEqualStrictTyped({
       data: { newPerson: null },
-      error: new CombinedGraphQLErrors([{ message: "Oops" }], {
+      error: new CombinedGraphQLErrors({
         data: { newPerson: null },
+        errors: [{ message: "Oops" }],
       }),
       extensions: {
         requestLimit: 10,
@@ -1152,9 +1155,7 @@ describe("mutation results", () => {
           },
         })
       ).rejects.toThrow(
-        new CombinedGraphQLErrors([{ message: "mock error" }], {
-          data: undefined,
-        })
+        new CombinedGraphQLErrors({ errors: [{ message: "mock error" }] })
       );
 
       await expect(
@@ -1170,9 +1171,7 @@ describe("mutation results", () => {
           },
         })
       ).rejects.toThrow(
-        new CombinedGraphQLErrors([{ message: "mock error" }], {
-          data: undefined,
-        })
+        new CombinedGraphQLErrors({ errors: [{ message: "mock error" }] })
       );
       await obsQuery.refetch();
     });
@@ -1756,9 +1755,7 @@ describe("mutation results", () => {
           },
         })
       ).rejects.toThrow(
-        new CombinedGraphQLErrors([{ message: "mock error" }], {
-          data: undefined,
-        })
+        new CombinedGraphQLErrors({ errors: [{ message: "mock error" }] })
       );
 
       await expect(
@@ -1795,9 +1792,7 @@ describe("mutation results", () => {
           },
         })
       ).rejects.toThrow(
-        new CombinedGraphQLErrors([{ message: "mock error" }], {
-          data: undefined,
-        })
+        new CombinedGraphQLErrors({ errors: [{ message: "mock error" }] })
       );
 
       await obsQuery.refetch();

--- a/src/__tests__/mutationResults.ts
+++ b/src/__tests__/mutationResults.ts
@@ -346,7 +346,11 @@ describe("mutation results", () => {
           newName: "Hugh Willson",
         },
       })
-    ).rejects.toThrow(new CombinedGraphQLErrors([expectedFakeError]));
+    ).rejects.toThrow(
+      new CombinedGraphQLErrors([expectedFakeError], {
+        data: { newPerson: { __typename: "Person", name: "Hugh Willson" } },
+      })
+    );
 
     expect(client.cache.extract()).toMatchSnapshot();
 
@@ -384,7 +388,9 @@ describe("mutation results", () => {
           name: "Ellen Shapiro",
         },
       },
-      error: new CombinedGraphQLErrors([expectedFakeError]),
+      error: new CombinedGraphQLErrors([expectedFakeError], {
+        data: { newPerson: { __typename: "Person", name: "Ellen Shapiro" } },
+      }),
     });
 
     expect(client.cache.extract()).toMatchSnapshot();
@@ -529,7 +535,9 @@ describe("mutation results", () => {
       })
     ).resolves.toEqualStrictTyped({
       data: { newPerson: null },
-      error: new CombinedGraphQLErrors([{ message: "Oops" }]),
+      error: new CombinedGraphQLErrors([{ message: "Oops" }], {
+        data: { newPerson: null },
+      }),
       extensions: {
         requestLimit: 10,
       },
@@ -1143,7 +1151,11 @@ describe("mutation results", () => {
             },
           },
         })
-      ).rejects.toThrow(new CombinedGraphQLErrors([{ message: "mock error" }]));
+      ).rejects.toThrow(
+        new CombinedGraphQLErrors([{ message: "mock error" }], {
+          data: undefined,
+        })
+      );
 
       await expect(
         client.mutate({
@@ -1157,7 +1169,11 @@ describe("mutation results", () => {
             },
           },
         })
-      ).rejects.toThrow(new CombinedGraphQLErrors([{ message: "mock error" }]));
+      ).rejects.toThrow(
+        new CombinedGraphQLErrors([{ message: "mock error" }], {
+          data: undefined,
+        })
+      );
       await obsQuery.refetch();
     });
 
@@ -1739,7 +1755,11 @@ describe("mutation results", () => {
             });
           },
         })
-      ).rejects.toThrow(new CombinedGraphQLErrors([{ message: "mock error" }]));
+      ).rejects.toThrow(
+        new CombinedGraphQLErrors([{ message: "mock error" }], {
+          data: undefined,
+        })
+      );
 
       await expect(
         client.mutate({
@@ -1774,7 +1794,11 @@ describe("mutation results", () => {
             });
           },
         })
-      ).rejects.toThrow(new CombinedGraphQLErrors([{ message: "mock error" }]));
+      ).rejects.toThrow(
+        new CombinedGraphQLErrors([{ message: "mock error" }], {
+          data: undefined,
+        })
+      );
 
       await obsQuery.refetch();
     });

--- a/src/config/jest/areCombinedGraphQLErrorsEqual.ts
+++ b/src/config/jest/areCombinedGraphQLErrorsEqual.ts
@@ -12,7 +12,9 @@ export const areCombinedGraphQLErrorsEqual: Tester = function (
 
   if (isACombinedGraphQLErrors && isBCombinedGraphQLErrors) {
     return (
-      a.message === b.message && this.equals(a.errors, b.errors, customTesters)
+      a.message === b.message &&
+      this.equals(a.errors, b.errors, customTesters) &&
+      this.equals(a.data, b.data)
     );
   } else if (isACombinedGraphQLErrors === isBCombinedGraphQLErrors) {
     return undefined;

--- a/src/config/jest/areCombinedGraphQLErrorsEqual.ts
+++ b/src/config/jest/areCombinedGraphQLErrorsEqual.ts
@@ -14,7 +14,7 @@ export const areCombinedGraphQLErrorsEqual: Tester = function (
     return (
       a.message === b.message &&
       this.equals(a.errors, b.errors, customTesters) &&
-      this.equals(a.data, b.data)
+      this.equals(a.data, b.data, customTesters)
     );
   } else if (isACombinedGraphQLErrors === isBCombinedGraphQLErrors) {
     return undefined;

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -399,7 +399,7 @@ export class QueryManager {
               };
 
               if (graphQLResultHasError(storeResult)) {
-                result.error = new CombinedGraphQLErrors(result);
+                result.error = new CombinedGraphQLErrors(storeResult);
               }
 
               if (storeResult.extensions) {

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -340,7 +340,8 @@ export class QueryManager {
             const hasErrors = graphQLResultHasError(result);
             if (hasErrors && errorPolicy === "none") {
               throw new CombinedGraphQLErrors(
-                getGraphQLErrorsFromResult(result)
+                getGraphQLErrorsFromResult(result),
+                { data: result.data as Record<string, unknown> }
               );
             }
 
@@ -402,7 +403,8 @@ export class QueryManager {
 
               if (graphQLResultHasError(storeResult)) {
                 result.error = new CombinedGraphQLErrors(
-                  getGraphQLErrorsFromResult(storeResult)
+                  getGraphQLErrorsFromResult(storeResult),
+                  { data: storeResult.data as Record<string, unknown> }
                 );
               }
 
@@ -1065,7 +1067,9 @@ export class QueryManager {
           };
 
           if (graphQLResultHasError(rawResult)) {
-            result.error = new CombinedGraphQLErrors(rawResult.errors!);
+            result.error = new CombinedGraphQLErrors(rawResult.errors!, {
+              data: rawResult.data as Record<string, unknown>,
+            });
           } else if (graphQLResultHasProtocolErrors(rawResult)) {
             result.error = rawResult.extensions[PROTOCOL_ERRORS_SYMBOL];
             // Don't emit protocol errors added by HttpLink
@@ -1262,7 +1266,9 @@ export class QueryManager {
             queryInfo.resetLastWrite();
             queryInfo.reset();
             // Throwing here effectively calls observer.error.
-            throw new CombinedGraphQLErrors(graphQLErrors);
+            throw new CombinedGraphQLErrors(graphQLErrors, {
+              data: result.data as Record<string, unknown>,
+            });
           }
           // Use linkDocument rather than queryInfo.document so the
           // operation/fragments used to write the result are the same as the
@@ -1291,7 +1297,9 @@ export class QueryManager {
         }
 
         if (hasErrors && errorPolicy !== "ignore") {
-          aqr.error = new CombinedGraphQLErrors(graphQLErrors);
+          aqr.error = new CombinedGraphQLErrors(graphQLErrors, {
+            data: result.data as Record<string, unknown>,
+          });
           aqr.networkStatus = NetworkStatus.error;
         }
 

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -339,10 +339,7 @@ export class QueryManager {
           mergeMap((result) => {
             const hasErrors = graphQLResultHasError(result);
             if (hasErrors && errorPolicy === "none") {
-              throw new CombinedGraphQLErrors(
-                getGraphQLErrorsFromResult(result),
-                { data: result.data as Record<string, unknown> }
-              );
+              throw new CombinedGraphQLErrors(result);
             }
 
             if (mutationStoreValue) {
@@ -402,10 +399,7 @@ export class QueryManager {
               };
 
               if (graphQLResultHasError(storeResult)) {
-                result.error = new CombinedGraphQLErrors(
-                  getGraphQLErrorsFromResult(storeResult),
-                  { data: storeResult.data as Record<string, unknown> }
-                );
+                result.error = new CombinedGraphQLErrors(result);
               }
 
               if (storeResult.extensions) {
@@ -1067,9 +1061,7 @@ export class QueryManager {
           };
 
           if (graphQLResultHasError(rawResult)) {
-            result.error = new CombinedGraphQLErrors(rawResult.errors!, {
-              data: rawResult.data as Record<string, unknown>,
-            });
+            result.error = new CombinedGraphQLErrors(rawResult);
           } else if (graphQLResultHasProtocolErrors(rawResult)) {
             result.error = rawResult.extensions[PROTOCOL_ERRORS_SYMBOL];
             // Don't emit protocol errors added by HttpLink
@@ -1266,9 +1258,7 @@ export class QueryManager {
             queryInfo.resetLastWrite();
             queryInfo.reset();
             // Throwing here effectively calls observer.error.
-            throw new CombinedGraphQLErrors(graphQLErrors, {
-              data: result.data as Record<string, unknown>,
-            });
+            throw new CombinedGraphQLErrors(result);
           }
           // Use linkDocument rather than queryInfo.document so the
           // operation/fragments used to write the result are the same as the
@@ -1297,9 +1287,7 @@ export class QueryManager {
         }
 
         if (hasErrors && errorPolicy !== "ignore") {
-          aqr.error = new CombinedGraphQLErrors(graphQLErrors, {
-            data: result.data as Record<string, unknown>,
-          });
+          aqr.error = new CombinedGraphQLErrors(result);
           aqr.networkStatus = NetworkStatus.error;
         }
 

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -111,10 +111,9 @@ describe("ApolloClient", () => {
 
     await expect(stream).toEmitApolloQueryResult({
       data: undefined,
-      error: new CombinedGraphQLErrors(
-        [{ message: "This is an error message." }],
-        { data: undefined }
-      ),
+      error: new CombinedGraphQLErrors({
+        errors: [{ message: "This is an error message." }],
+      }),
       loading: false,
       networkStatus: NetworkStatus.error,
       partial: true,
@@ -146,10 +145,9 @@ describe("ApolloClient", () => {
     await expect(stream).toEmitApolloQueryResult({
       data: undefined,
       loading: false,
-      error: new CombinedGraphQLErrors(
-        [{ message: "This is an error message." }],
-        { data: undefined }
-      ),
+      error: new CombinedGraphQLErrors({
+        errors: [{ message: "This is an error message." }],
+      }),
       networkStatus: 8,
       partial: true,
     });
@@ -180,10 +178,10 @@ describe("ApolloClient", () => {
 
     await expect(stream).toEmitApolloQueryResult({
       data: undefined,
-      error: new CombinedGraphQLErrors(
-        [{ message: "This is an error message." }],
-        { data: { allPeople: { people: { name: "Ada Lovelace" } } } }
-      ),
+      error: new CombinedGraphQLErrors({
+        data: { allPeople: { people: { name: "Ada Lovelace" } } },
+        errors: [{ message: "This is an error message." }],
+      }),
       loading: false,
       networkStatus: NetworkStatus.error,
       partial: true,
@@ -249,7 +247,7 @@ describe("ApolloClient", () => {
 
     await expect(stream).toEmitApolloQueryResult({
       data: undefined,
-      error: new CombinedGraphQLErrors([null as any], { data: undefined }),
+      error: new CombinedGraphQLErrors({ errors: [null as any] }),
       loading: false,
       networkStatus: NetworkStatus.error,
       partial: true,
@@ -1751,7 +1749,7 @@ describe("ApolloClient", () => {
     });
 
     await expect(client.mutate({ mutation })).rejects.toThrow(
-      new CombinedGraphQLErrors(errors, { data: undefined })
+      new CombinedGraphQLErrors({ errors })
     );
   });
 
@@ -2201,9 +2199,7 @@ describe("ApolloClient", () => {
           },
         ]),
       }).query({ query })
-    ).rejects.toEqual(
-      new CombinedGraphQLErrors(graphQLErrors, { data: undefined })
-    );
+    ).rejects.toEqual(new CombinedGraphQLErrors({ errors: graphQLErrors }));
   });
 
   it("should not empty the store when a non-polling query fails due to a network error", async () => {
@@ -2949,8 +2945,8 @@ describe("ApolloClient", () => {
       partial: false,
     });
 
-    const expectedError = new CombinedGraphQLErrors(secondResult.errors, {
-      data: undefined,
+    const expectedError = new CombinedGraphQLErrors({
+      errors: secondResult.errors,
     });
 
     await expect(handle.refetch()).rejects.toThrow(expectedError);

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -111,9 +111,10 @@ describe("ApolloClient", () => {
 
     await expect(stream).toEmitApolloQueryResult({
       data: undefined,
-      error: new CombinedGraphQLErrors([
-        { message: "This is an error message." },
-      ]),
+      error: new CombinedGraphQLErrors(
+        [{ message: "This is an error message." }],
+        { data: undefined }
+      ),
       loading: false,
       networkStatus: NetworkStatus.error,
       partial: true,
@@ -145,9 +146,10 @@ describe("ApolloClient", () => {
     await expect(stream).toEmitApolloQueryResult({
       data: undefined,
       loading: false,
-      error: new CombinedGraphQLErrors([
-        { message: "This is an error message." },
-      ]),
+      error: new CombinedGraphQLErrors(
+        [{ message: "This is an error message." }],
+        { data: undefined }
+      ),
       networkStatus: 8,
       partial: true,
     });
@@ -178,9 +180,10 @@ describe("ApolloClient", () => {
 
     await expect(stream).toEmitApolloQueryResult({
       data: undefined,
-      error: new CombinedGraphQLErrors([
-        { message: "This is an error message." },
-      ]),
+      error: new CombinedGraphQLErrors(
+        [{ message: "This is an error message." }],
+        { data: { allPeople: { people: { name: "Ada Lovelace" } } } }
+      ),
       loading: false,
       networkStatus: NetworkStatus.error,
       partial: true,
@@ -246,7 +249,7 @@ describe("ApolloClient", () => {
 
     await expect(stream).toEmitApolloQueryResult({
       data: undefined,
-      error: new CombinedGraphQLErrors([null as any]),
+      error: new CombinedGraphQLErrors([null as any], { data: undefined }),
       loading: false,
       networkStatus: NetworkStatus.error,
       partial: true,
@@ -1748,7 +1751,7 @@ describe("ApolloClient", () => {
     });
 
     await expect(client.mutate({ mutation })).rejects.toThrow(
-      new CombinedGraphQLErrors(errors)
+      new CombinedGraphQLErrors(errors, { data: undefined })
     );
   });
 
@@ -2198,7 +2201,9 @@ describe("ApolloClient", () => {
           },
         ]),
       }).query({ query })
-    ).rejects.toEqual(new CombinedGraphQLErrors(graphQLErrors));
+    ).rejects.toEqual(
+      new CombinedGraphQLErrors(graphQLErrors, { data: undefined })
+    );
   });
 
   it("should not empty the store when a non-polling query fails due to a network error", async () => {
@@ -2944,7 +2949,9 @@ describe("ApolloClient", () => {
       partial: false,
     });
 
-    const expectedError = new CombinedGraphQLErrors(secondResult.errors);
+    const expectedError = new CombinedGraphQLErrors(secondResult.errors, {
+      data: undefined,
+    });
 
     await expect(handle.refetch()).rejects.toThrow(expectedError);
     await expect(stream).toEmitApolloQueryResult({

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -81,7 +81,7 @@ describe("ObservableQuery", () => {
   const error = new GraphQLError("is offline.", undefined, null, null, [
     "people_one",
   ]);
-  const wrappedError = new CombinedGraphQLErrors([error]);
+  const wrappedError = new CombinedGraphQLErrors([error], { data: dataOne });
 
   describe("reobserve", () => {
     describe("to change pollInterval", () => {
@@ -449,7 +449,7 @@ describe("ObservableQuery", () => {
           },
           {
             request: { query, variables },
-            result: { errors: [error] },
+            result: { data: dataOne, errors: [error] },
           },
           {
             request: { query, variables },
@@ -468,12 +468,12 @@ describe("ObservableQuery", () => {
       });
 
       await expect(observable.refetch()).rejects.toThrow(
-        new CombinedGraphQLErrors([error])
+        new CombinedGraphQLErrors([error], { data: dataOne })
       );
 
       await expect(stream).toEmitApolloQueryResult({
         data: dataOne,
-        error: new CombinedGraphQLErrors([error]),
+        error: new CombinedGraphQLErrors([error], { data: dataOne }),
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: false,
@@ -1028,14 +1028,14 @@ describe("ObservableQuery", () => {
 
       await expect(stream).toEmitApolloQueryResult({
         data: undefined,
-        error: new CombinedGraphQLErrors([error]),
+        error: new CombinedGraphQLErrors([error], { data: undefined }),
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: true,
       });
       expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: undefined,
-        error: new CombinedGraphQLErrors([error]),
+        error: new CombinedGraphQLErrors([error], { data: undefined }),
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: true,
@@ -2300,7 +2300,7 @@ describe("ObservableQuery", () => {
 
       await expect(stream).toEmitApolloQueryResult({
         data: undefined,
-        error: new CombinedGraphQLErrors([error]),
+        error: new CombinedGraphQLErrors([error], { data: undefined }),
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: true,
@@ -2308,7 +2308,7 @@ describe("ObservableQuery", () => {
 
       expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: undefined,
-        error: new CombinedGraphQLErrors([error]),
+        error: new CombinedGraphQLErrors([error], { data: undefined }),
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: true,
@@ -2331,7 +2331,7 @@ describe("ObservableQuery", () => {
 
       await expect(stream).toEmitApolloQueryResult({
         data: undefined,
-        error: new CombinedGraphQLErrors([error]),
+        error: new CombinedGraphQLErrors([error], { data: undefined }),
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: true,
@@ -2342,7 +2342,7 @@ describe("ObservableQuery", () => {
 
       expect(currentResult).toEqualStrictTyped({
         data: undefined,
-        error: new CombinedGraphQLErrors([error]),
+        error: new CombinedGraphQLErrors([error], { data: undefined }),
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: true,
@@ -2371,14 +2371,14 @@ describe("ObservableQuery", () => {
 
       await expect(stream).toEmitApolloQueryResult({
         data: dataOne,
-        error: new CombinedGraphQLErrors([error]),
+        error: new CombinedGraphQLErrors([error], { data: dataOne }),
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: false,
       });
       expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: dataOne,
-        error: new CombinedGraphQLErrors([error]),
+        error: new CombinedGraphQLErrors([error], { data: dataOne }),
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: false,
@@ -2435,7 +2435,7 @@ describe("ObservableQuery", () => {
 
       await expect(stream).toEmitApolloQueryResult({
         data: undefined,
-        error: new CombinedGraphQLErrors([error]),
+        error: new CombinedGraphQLErrors([error], { data: dataOne }),
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: true,

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -81,7 +81,10 @@ describe("ObservableQuery", () => {
   const error = new GraphQLError("is offline.", undefined, null, null, [
     "people_one",
   ]);
-  const wrappedError = new CombinedGraphQLErrors([error], { data: dataOne });
+  const wrappedError = new CombinedGraphQLErrors({
+    data: dataOne,
+    errors: [error],
+  });
 
   describe("reobserve", () => {
     describe("to change pollInterval", () => {
@@ -468,12 +471,12 @@ describe("ObservableQuery", () => {
       });
 
       await expect(observable.refetch()).rejects.toThrow(
-        new CombinedGraphQLErrors([error], { data: dataOne })
+        new CombinedGraphQLErrors({ data: dataOne, errors: [error] })
       );
 
       await expect(stream).toEmitApolloQueryResult({
         data: dataOne,
-        error: new CombinedGraphQLErrors([error], { data: dataOne }),
+        error: new CombinedGraphQLErrors({ data: dataOne, errors: [error] }),
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: false,
@@ -1028,14 +1031,14 @@ describe("ObservableQuery", () => {
 
       await expect(stream).toEmitApolloQueryResult({
         data: undefined,
-        error: new CombinedGraphQLErrors([error], { data: undefined }),
+        error: new CombinedGraphQLErrors({ errors: [error] }),
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: true,
       });
       expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: undefined,
-        error: new CombinedGraphQLErrors([error], { data: undefined }),
+        error: new CombinedGraphQLErrors({ errors: [error] }),
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: true,
@@ -2300,7 +2303,7 @@ describe("ObservableQuery", () => {
 
       await expect(stream).toEmitApolloQueryResult({
         data: undefined,
-        error: new CombinedGraphQLErrors([error], { data: undefined }),
+        error: new CombinedGraphQLErrors({ errors: [error] }),
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: true,
@@ -2308,7 +2311,7 @@ describe("ObservableQuery", () => {
 
       expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: undefined,
-        error: new CombinedGraphQLErrors([error], { data: undefined }),
+        error: new CombinedGraphQLErrors({ errors: [error] }),
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: true,
@@ -2331,7 +2334,7 @@ describe("ObservableQuery", () => {
 
       await expect(stream).toEmitApolloQueryResult({
         data: undefined,
-        error: new CombinedGraphQLErrors([error], { data: undefined }),
+        error: new CombinedGraphQLErrors({ errors: [error] }),
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: true,
@@ -2342,7 +2345,7 @@ describe("ObservableQuery", () => {
 
       expect(currentResult).toEqualStrictTyped({
         data: undefined,
-        error: new CombinedGraphQLErrors([error], { data: undefined }),
+        error: new CombinedGraphQLErrors({ errors: [error] }),
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: true,
@@ -2371,14 +2374,14 @@ describe("ObservableQuery", () => {
 
       await expect(stream).toEmitApolloQueryResult({
         data: dataOne,
-        error: new CombinedGraphQLErrors([error], { data: dataOne }),
+        error: new CombinedGraphQLErrors({ data: dataOne, errors: [error] }),
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: false,
       });
       expect(observable.getCurrentResult()).toEqualStrictTyped({
         data: dataOne,
-        error: new CombinedGraphQLErrors([error], { data: dataOne }),
+        error: new CombinedGraphQLErrors({ data: dataOne, errors: [error] }),
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: false,
@@ -2435,7 +2438,7 @@ describe("ObservableQuery", () => {
 
       await expect(stream).toEmitApolloQueryResult({
         data: undefined,
-        error: new CombinedGraphQLErrors([error], { data: dataOne }),
+        error: new CombinedGraphQLErrors({ data: dataOne, errors: [error] }),
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: true,

--- a/src/core/__tests__/equalByQuery.ts
+++ b/src/core/__tests__/equalByQuery.ts
@@ -290,7 +290,7 @@ describe("equalByQuery", () => {
         { data: data123 },
         {
           data: data123,
-          error: new CombinedGraphQLErrors([oopsError]),
+          error: new CombinedGraphQLErrors([oopsError], { data: data123 }),
         }
       )
     ).toBe(false);
@@ -300,7 +300,7 @@ describe("equalByQuery", () => {
         query,
         {
           data: data123,
-          error: new CombinedGraphQLErrors([oopsError]),
+          error: new CombinedGraphQLErrors([oopsError], { data: data123 }),
         },
         { data: data123 }
       )
@@ -311,11 +311,11 @@ describe("equalByQuery", () => {
         query,
         {
           data: data123,
-          error: new CombinedGraphQLErrors([oopsError]),
+          error: new CombinedGraphQLErrors([oopsError], { data: data123 }),
         },
         {
           data: data123,
-          error: new CombinedGraphQLErrors([oopsError]),
+          error: new CombinedGraphQLErrors([oopsError], { data: data123 }),
         }
       )
     ).toBe(true);
@@ -325,11 +325,11 @@ describe("equalByQuery", () => {
         query,
         {
           data: data123,
-          error: new CombinedGraphQLErrors([oopsError]),
+          error: new CombinedGraphQLErrors([oopsError], { data: data123 }),
         },
         {
           data: data123,
-          error: new CombinedGraphQLErrors([differentError]),
+          error: new CombinedGraphQLErrors([differentError], { data: data123 }),
         }
       )
     ).toBe(false);
@@ -339,11 +339,11 @@ describe("equalByQuery", () => {
         query,
         {
           data: data123,
-          error: new CombinedGraphQLErrors([oopsError]),
+          error: new CombinedGraphQLErrors([oopsError], { data: data123 }),
         },
         {
           data: data123,
-          error: new CombinedGraphQLErrors([oopsError]),
+          error: new CombinedGraphQLErrors([oopsError], { data: data123 }),
         }
       )
     ).toBe(true);
@@ -353,11 +353,13 @@ describe("equalByQuery", () => {
         query,
         {
           data: data123,
-          error: new CombinedGraphQLErrors([oopsError]),
+          error: new CombinedGraphQLErrors([oopsError], { data: data123 }),
         },
         {
           data: { ...data123, b: 100 },
-          error: new CombinedGraphQLErrors([oopsError]),
+          error: new CombinedGraphQLErrors([oopsError], {
+            data: { ...data123, b: 100 },
+          }),
         }
       )
     ).toBe(true);
@@ -365,18 +367,29 @@ describe("equalByQuery", () => {
     expect(
       equalByQuery(
         query,
-        { data: data123, error: new CombinedGraphQLErrors([]) },
-        { data: data123, error: new CombinedGraphQLErrors([]) }
+        {
+          data: data123,
+          error: new CombinedGraphQLErrors([], { data: data123 }),
+        },
+        {
+          data: data123,
+          error: new CombinedGraphQLErrors([], { data: data123 }),
+        }
       )
     ).toBe(true);
 
     expect(
       equalByQuery(
         query,
-        { data: data123, error: new CombinedGraphQLErrors([]) },
+        {
+          data: data123,
+          error: new CombinedGraphQLErrors([], { data: data123 }),
+        },
         {
           data: { ...data123, b: 100 },
-          error: new CombinedGraphQLErrors([]),
+          error: new CombinedGraphQLErrors([], {
+            data: { ...data123, b: 100 },
+          }),
         }
       )
     ).toBe(true);

--- a/src/core/__tests__/equalByQuery.ts
+++ b/src/core/__tests__/equalByQuery.ts
@@ -290,7 +290,10 @@ describe("equalByQuery", () => {
         { data: data123 },
         {
           data: data123,
-          error: new CombinedGraphQLErrors([oopsError], { data: data123 }),
+          error: new CombinedGraphQLErrors({
+            data: data123,
+            errors: [oopsError],
+          }),
         }
       )
     ).toBe(false);
@@ -300,7 +303,10 @@ describe("equalByQuery", () => {
         query,
         {
           data: data123,
-          error: new CombinedGraphQLErrors([oopsError], { data: data123 }),
+          error: new CombinedGraphQLErrors({
+            data: data123,
+            errors: [oopsError],
+          }),
         },
         { data: data123 }
       )
@@ -311,54 +317,16 @@ describe("equalByQuery", () => {
         query,
         {
           data: data123,
-          error: new CombinedGraphQLErrors([oopsError], { data: data123 }),
+          error: new CombinedGraphQLErrors({
+            data: data123,
+            errors: [oopsError],
+          }),
         },
         {
           data: data123,
-          error: new CombinedGraphQLErrors([oopsError], { data: data123 }),
-        }
-      )
-    ).toBe(true);
-
-    expect(
-      equalByQuery(
-        query,
-        {
-          data: data123,
-          error: new CombinedGraphQLErrors([oopsError], { data: data123 }),
-        },
-        {
-          data: data123,
-          error: new CombinedGraphQLErrors([differentError], { data: data123 }),
-        }
-      )
-    ).toBe(false);
-
-    expect(
-      equalByQuery(
-        query,
-        {
-          data: data123,
-          error: new CombinedGraphQLErrors([oopsError], { data: data123 }),
-        },
-        {
-          data: data123,
-          error: new CombinedGraphQLErrors([oopsError], { data: data123 }),
-        }
-      )
-    ).toBe(true);
-
-    expect(
-      equalByQuery(
-        query,
-        {
-          data: data123,
-          error: new CombinedGraphQLErrors([oopsError], { data: data123 }),
-        },
-        {
-          data: { ...data123, b: 100 },
-          error: new CombinedGraphQLErrors([oopsError], {
-            data: { ...data123, b: 100 },
+          error: new CombinedGraphQLErrors({
+            data: data123,
+            errors: [oopsError],
           }),
         }
       )
@@ -369,11 +337,37 @@ describe("equalByQuery", () => {
         query,
         {
           data: data123,
-          error: new CombinedGraphQLErrors([], { data: data123 }),
+          error: new CombinedGraphQLErrors({
+            data: data123,
+            errors: [oopsError],
+          }),
         },
         {
           data: data123,
-          error: new CombinedGraphQLErrors([], { data: data123 }),
+          error: new CombinedGraphQLErrors({
+            data: data123,
+            errors: [differentError],
+          }),
+        }
+      )
+    ).toBe(false);
+
+    expect(
+      equalByQuery(
+        query,
+        {
+          data: data123,
+          error: new CombinedGraphQLErrors({
+            data: data123,
+            errors: [oopsError],
+          }),
+        },
+        {
+          data: data123,
+          error: new CombinedGraphQLErrors({
+            data: data123,
+            errors: [oopsError],
+          }),
         }
       )
     ).toBe(true);
@@ -383,12 +377,47 @@ describe("equalByQuery", () => {
         query,
         {
           data: data123,
-          error: new CombinedGraphQLErrors([], { data: data123 }),
+          error: new CombinedGraphQLErrors({
+            data: data123,
+            errors: [oopsError],
+          }),
         },
         {
           data: { ...data123, b: 100 },
-          error: new CombinedGraphQLErrors([], {
+          error: new CombinedGraphQLErrors({
             data: { ...data123, b: 100 },
+            errors: [oopsError],
+          }),
+        }
+      )
+    ).toBe(true);
+
+    expect(
+      equalByQuery(
+        query,
+        {
+          data: data123,
+          error: new CombinedGraphQLErrors({ data: data123, errors: [] }),
+        },
+        {
+          data: data123,
+          error: new CombinedGraphQLErrors({ data: data123, errors: [] }),
+        }
+      )
+    ).toBe(true);
+
+    expect(
+      equalByQuery(
+        query,
+        {
+          data: data123,
+          error: new CombinedGraphQLErrors({ data: data123, errors: [] }),
+        },
+        {
+          data: { ...data123, b: 100 },
+          error: new CombinedGraphQLErrors({
+            data: { ...data123, b: 100 },
+            errors: [],
           }),
         }
       )

--- a/src/errors/CombinedGraphQLErrors.ts
+++ b/src/errors/CombinedGraphQLErrors.ts
@@ -17,7 +17,7 @@ export class CombinedGraphQLErrors extends Error {
 
   constructor(
     errors: Array<GraphQLFormattedError> | ReadonlyArray<GraphQLFormattedError>,
-    options: { data: Record<string, unknown> | null }
+    options: { data: Record<string, unknown> | null | undefined }
   ) {
     super(formatMessage(errors));
     this.errors = errors;

--- a/src/errors/CombinedGraphQLErrors.ts
+++ b/src/errors/CombinedGraphQLErrors.ts
@@ -11,7 +11,7 @@ export class CombinedGraphQLErrors extends Error {
   /**
    * The raw list of GraphQL errors returned in a GraphQL response.
    */
-  readonly errors: GraphQLFormattedError[];
+  readonly errors: ReadonlyArray<GraphQLFormattedError>;
 
   /**
    * Partial data returned in the GraphQL response.

--- a/src/errors/CombinedGraphQLErrors.ts
+++ b/src/errors/CombinedGraphQLErrors.ts
@@ -11,12 +11,12 @@ export class CombinedGraphQLErrors extends Error {
   /**
    * The raw list of GraphQL errors returned in a GraphQL response.
    */
-  errors: ReadonlyArray<GraphQLFormattedError>;
+  readonly errors: GraphQLFormattedError[];
 
   /**
    * Partial data returned in the GraphQL response.
    */
-  data: Record<string, unknown> | null | undefined;
+  readonly data: Record<string, unknown> | null | undefined;
 
   constructor(result: FetchResult<unknown>) {
     const errors = getGraphQLErrorsFromResult(result);

--- a/src/errors/CombinedGraphQLErrors.ts
+++ b/src/errors/CombinedGraphQLErrors.ts
@@ -1,5 +1,8 @@
 import type { GraphQLFormattedError } from "graphql";
 
+import type { FetchResult } from "@apollo/client/core";
+import { getGraphQLErrorsFromResult } from "@apollo/client/utilities";
+
 /**
  * Represents the combined list of GraphQL errors returned from the server in a
  * GraphQL response.
@@ -15,13 +18,12 @@ export class CombinedGraphQLErrors extends Error {
    */
   data: Record<string, unknown> | null | undefined;
 
-  constructor(
-    errors: Array<GraphQLFormattedError> | ReadonlyArray<GraphQLFormattedError>,
-    options: { data: Record<string, unknown> | null | undefined }
-  ) {
+  constructor(result: FetchResult<unknown>) {
+    const errors = getGraphQLErrorsFromResult(result);
+
     super(formatMessage(errors));
     this.errors = errors;
-    this.data = options.data;
+    this.data = result.data as Record<string, unknown>;
     this.name = "CombinedGraphQLErrors";
 
     Object.setPrototypeOf(this, CombinedGraphQLErrors.prototype);

--- a/src/errors/CombinedGraphQLErrors.ts
+++ b/src/errors/CombinedGraphQLErrors.ts
@@ -10,11 +10,18 @@ export class CombinedGraphQLErrors extends Error {
    */
   errors: ReadonlyArray<GraphQLFormattedError>;
 
+  /**
+   * Partial data returned in the GraphQL response.
+   */
+  data: Record<string, unknown> | null | undefined;
+
   constructor(
-    errors: Array<GraphQLFormattedError> | ReadonlyArray<GraphQLFormattedError>
+    errors: Array<GraphQLFormattedError> | ReadonlyArray<GraphQLFormattedError>,
+    options: { data: Record<string, unknown> | null }
   ) {
     super(formatMessage(errors));
     this.errors = errors;
+    this.data = options.data;
     this.name = "CombinedGraphQLErrors";
 
     Object.setPrototypeOf(this, CombinedGraphQLErrors.prototype);

--- a/src/link/subscriptions/__tests__/graphqlWsLink.ts
+++ b/src/link/subscriptions/__tests__/graphqlWsLink.ts
@@ -169,9 +169,7 @@ describe("GraphQLWSlink", () => {
 
       const obs = execute(link, { query: subscription });
       await expect(observableToArray(obs)).rejects.toEqual(
-        new CombinedGraphQLErrors([{ message: "Foo bar." }], {
-          data: undefined,
-        })
+        new CombinedGraphQLErrors({ errors: [{ message: "Foo bar." }] })
       );
     });
   });

--- a/src/link/subscriptions/__tests__/graphqlWsLink.ts
+++ b/src/link/subscriptions/__tests__/graphqlWsLink.ts
@@ -169,7 +169,9 @@ describe("GraphQLWSlink", () => {
 
       const obs = execute(link, { query: subscription });
       await expect(observableToArray(obs)).rejects.toEqual(
-        new CombinedGraphQLErrors([{ message: "Foo bar." }])
+        new CombinedGraphQLErrors([{ message: "Foo bar." }], {
+          data: undefined,
+        })
       );
     });
   });

--- a/src/link/subscriptions/index.ts
+++ b/src/link/subscriptions/index.ts
@@ -77,8 +77,8 @@ export class GraphQLWsLink extends ApolloLink {
             }
 
             return observer.error(
-              new CombinedGraphQLErrors(Array.isArray(err) ? err : [err], {
-                data: undefined,
+              new CombinedGraphQLErrors({
+                errors: Array.isArray(err) ? err : [err],
               })
             );
           },

--- a/src/link/subscriptions/index.ts
+++ b/src/link/subscriptions/index.ts
@@ -77,7 +77,9 @@ export class GraphQLWsLink extends ApolloLink {
             }
 
             return observer.error(
-              new CombinedGraphQLErrors(Array.isArray(err) ? err : [err])
+              new CombinedGraphQLErrors(Array.isArray(err) ? err : [err], {
+                data: undefined,
+              })
             );
           },
           // casting around a wrong type in graphql-ws, which incorrectly expects `Sink<ExecutionResult>`

--- a/src/react/hooks/__tests__/useBackgroundQuery.test.tsx
+++ b/src/react/hooks/__tests__/useBackgroundQuery.test.tsx
@@ -2550,7 +2550,9 @@ it("applies `errorPolicy` on next fetch when it changes between renders", async 
       error: null,
       result: {
         data: { greeting: "Hello" },
-        error: new CombinedGraphQLErrors([{ message: "oops" }]),
+        error: new CombinedGraphQLErrors([{ message: "oops" }], {
+          data: undefined,
+        }),
         networkStatus: NetworkStatus.error,
       },
     });
@@ -3197,7 +3199,9 @@ it("properly handles changing options along with changing `variables`", async ()
             name: "Doctor Strangecache",
           },
         },
-        error: new CombinedGraphQLErrors([{ message: "oops" }]),
+        error: new CombinedGraphQLErrors([{ message: "oops" }], {
+          data: undefined,
+        }),
         networkStatus: NetworkStatus.error,
       },
     });
@@ -4817,7 +4821,16 @@ it("masks partial data returned from data on errors with errorPolicy `all`", asy
           name: null,
         },
       },
-      error: new CombinedGraphQLErrors([{ message: "Couldn't get name" }]),
+      error: new CombinedGraphQLErrors([{ message: "Couldn't get name" }], {
+        data: {
+          currentUser: {
+            __typename: "User",
+            id: 1,
+            name: null,
+            age: 34,
+          },
+        },
+      }),
       networkStatus: NetworkStatus.error,
     });
   }
@@ -5206,7 +5219,9 @@ describe("refetch", () => {
 
       expect(renderedComponents).toStrictEqual(["ErrorFallback"]);
       expect(snapshot.error).toEqual(
-        new CombinedGraphQLErrors([{ message: "Something went wrong" }])
+        new CombinedGraphQLErrors([{ message: "Something went wrong" }], {
+          data: undefined,
+        })
       );
     }
 
@@ -5400,9 +5415,10 @@ describe("refetch", () => {
               name: "Spider-Man",
             },
           },
-          error: new CombinedGraphQLErrors([
-            { message: "Something went wrong" },
-          ]),
+          error: new CombinedGraphQLErrors(
+            [{ message: "Something went wrong" }],
+            { data: undefined }
+          ),
           networkStatus: NetworkStatus.error,
         },
       });
@@ -5501,9 +5517,18 @@ describe("refetch", () => {
               name: null,
             },
           },
-          error: new CombinedGraphQLErrors([
-            { message: "Something went wrong" },
-          ]),
+          error: new CombinedGraphQLErrors(
+            [{ message: "Something went wrong" }],
+            {
+              data: {
+                character: {
+                  __typename: "Character",
+                  id: "1",
+                  name: null,
+                },
+              },
+            }
+          ),
           networkStatus: NetworkStatus.error,
         },
       });
@@ -5608,7 +5633,9 @@ describe("refetch", () => {
 
       expect(renderedComponents).toStrictEqual([ErrorFallback]);
       expect(snapshot).toEqual({
-        error: new CombinedGraphQLErrors([{ message: "Oops couldn't fetch" }]),
+        error: new CombinedGraphQLErrors([{ message: "Oops couldn't fetch" }], {
+          data: null,
+        }),
         result: null,
       });
     }
@@ -5629,7 +5656,9 @@ describe("refetch", () => {
         // TODO: We should reset the snapshot between renders to better capture
         // the actual result. This makes it seem like the error is rendered, but
         // in this is just leftover from the previous snapshot.
-        error: new CombinedGraphQLErrors([{ message: "Oops couldn't fetch" }]),
+        error: new CombinedGraphQLErrors([{ message: "Oops couldn't fetch" }], {
+          data: null,
+        }),
         result: {
           data: { todo: { id: "1", name: "Clean room", completed: true } },
           error: undefined,
@@ -5735,7 +5764,9 @@ describe("refetch", () => {
 
       expect(renderedComponents).toStrictEqual([ErrorFallback]);
       expect(snapshot).toEqual({
-        error: new CombinedGraphQLErrors([{ message: "Oops couldn't fetch" }]),
+        error: new CombinedGraphQLErrors([{ message: "Oops couldn't fetch" }], {
+          data: null,
+        }),
         result: null,
       });
     }
@@ -5753,9 +5784,10 @@ describe("refetch", () => {
 
       expect(renderedComponents).toStrictEqual([ErrorFallback]);
       expect(snapshot).toEqual({
-        error: new CombinedGraphQLErrors([
-          { message: "Oops couldn't fetch again" },
-        ]),
+        error: new CombinedGraphQLErrors(
+          [{ message: "Oops couldn't fetch again" }],
+          { data: null }
+        ),
         result: null,
       });
     }

--- a/src/react/hooks/__tests__/useBackgroundQuery.test.tsx
+++ b/src/react/hooks/__tests__/useBackgroundQuery.test.tsx
@@ -2550,9 +2550,7 @@ it("applies `errorPolicy` on next fetch when it changes between renders", async 
       error: null,
       result: {
         data: { greeting: "Hello" },
-        error: new CombinedGraphQLErrors([{ message: "oops" }], {
-          data: undefined,
-        }),
+        error: new CombinedGraphQLErrors({ errors: [{ message: "oops" }] }),
         networkStatus: NetworkStatus.error,
       },
     });
@@ -3199,9 +3197,7 @@ it("properly handles changing options along with changing `variables`", async ()
             name: "Doctor Strangecache",
           },
         },
-        error: new CombinedGraphQLErrors([{ message: "oops" }], {
-          data: undefined,
-        }),
+        error: new CombinedGraphQLErrors({ errors: [{ message: "oops" }] }),
         networkStatus: NetworkStatus.error,
       },
     });
@@ -4821,7 +4817,7 @@ it("masks partial data returned from data on errors with errorPolicy `all`", asy
           name: null,
         },
       },
-      error: new CombinedGraphQLErrors([{ message: "Couldn't get name" }], {
+      error: new CombinedGraphQLErrors({
         data: {
           currentUser: {
             __typename: "User",
@@ -4830,6 +4826,7 @@ it("masks partial data returned from data on errors with errorPolicy `all`", asy
             age: 34,
           },
         },
+        errors: [{ message: "Couldn't get name" }],
       }),
       networkStatus: NetworkStatus.error,
     });
@@ -5219,8 +5216,8 @@ describe("refetch", () => {
 
       expect(renderedComponents).toStrictEqual(["ErrorFallback"]);
       expect(snapshot.error).toEqual(
-        new CombinedGraphQLErrors([{ message: "Something went wrong" }], {
-          data: undefined,
+        new CombinedGraphQLErrors({
+          errors: [{ message: "Something went wrong" }],
         })
       );
     }
@@ -5415,10 +5412,9 @@ describe("refetch", () => {
               name: "Spider-Man",
             },
           },
-          error: new CombinedGraphQLErrors(
-            [{ message: "Something went wrong" }],
-            { data: undefined }
-          ),
+          error: new CombinedGraphQLErrors({
+            errors: [{ message: "Something went wrong" }],
+          }),
           networkStatus: NetworkStatus.error,
         },
       });
@@ -5517,18 +5513,16 @@ describe("refetch", () => {
               name: null,
             },
           },
-          error: new CombinedGraphQLErrors(
-            [{ message: "Something went wrong" }],
-            {
-              data: {
-                character: {
-                  __typename: "Character",
-                  id: "1",
-                  name: null,
-                },
+          error: new CombinedGraphQLErrors({
+            data: {
+              character: {
+                __typename: "Character",
+                id: "1",
+                name: null,
               },
-            }
-          ),
+            },
+            errors: [{ message: "Something went wrong" }],
+          }),
           networkStatus: NetworkStatus.error,
         },
       });
@@ -5633,8 +5627,9 @@ describe("refetch", () => {
 
       expect(renderedComponents).toStrictEqual([ErrorFallback]);
       expect(snapshot).toEqual({
-        error: new CombinedGraphQLErrors([{ message: "Oops couldn't fetch" }], {
+        error: new CombinedGraphQLErrors({
           data: null,
+          errors: [{ message: "Oops couldn't fetch" }],
         }),
         result: null,
       });
@@ -5656,8 +5651,9 @@ describe("refetch", () => {
         // TODO: We should reset the snapshot between renders to better capture
         // the actual result. This makes it seem like the error is rendered, but
         // in this is just leftover from the previous snapshot.
-        error: new CombinedGraphQLErrors([{ message: "Oops couldn't fetch" }], {
+        error: new CombinedGraphQLErrors({
           data: null,
+          errors: [{ message: "Oops couldn't fetch" }],
         }),
         result: {
           data: { todo: { id: "1", name: "Clean room", completed: true } },
@@ -5764,8 +5760,9 @@ describe("refetch", () => {
 
       expect(renderedComponents).toStrictEqual([ErrorFallback]);
       expect(snapshot).toEqual({
-        error: new CombinedGraphQLErrors([{ message: "Oops couldn't fetch" }], {
+        error: new CombinedGraphQLErrors({
           data: null,
+          errors: [{ message: "Oops couldn't fetch" }],
         }),
         result: null,
       });
@@ -5784,10 +5781,10 @@ describe("refetch", () => {
 
       expect(renderedComponents).toStrictEqual([ErrorFallback]);
       expect(snapshot).toEqual({
-        error: new CombinedGraphQLErrors(
-          [{ message: "Oops couldn't fetch again" }],
-          { data: null }
-        ),
+        error: new CombinedGraphQLErrors({
+          data: null,
+          errors: [{ message: "Oops couldn't fetch again" }],
+        }),
         result: null,
       });
     }

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -1695,7 +1695,7 @@ describe("useLazyQuery Hook", () => {
     }
 
     await expect(execute()).rejects.toEqual(
-      new CombinedGraphQLErrors([{ message: "error 1" }])
+      new CombinedGraphQLErrors([{ message: "error 1" }], { data: undefined })
     );
 
     {
@@ -1707,13 +1707,15 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.error,
         previousData: undefined,
-        error: new CombinedGraphQLErrors([{ message: "error 1" }]),
+        error: new CombinedGraphQLErrors([{ message: "error 1" }], {
+          data: undefined,
+        }),
         variables: {},
       });
     }
 
     await expect(execute()).rejects.toEqual(
-      new CombinedGraphQLErrors([{ message: "error 2" }])
+      new CombinedGraphQLErrors([{ message: "error 2" }], { data: undefined })
     );
 
     {
@@ -1725,7 +1727,9 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.error,
         previousData: undefined,
-        error: new CombinedGraphQLErrors([{ message: "error 2" }]),
+        error: new CombinedGraphQLErrors([{ message: "error 2" }], {
+          data: undefined,
+        }),
         variables: {},
       });
     }
@@ -1788,7 +1792,9 @@ describe("useLazyQuery Hook", () => {
 
     await expect(execute()).resolves.toEqualStrictTyped({
       data: { currentUser: null },
-      error: new CombinedGraphQLErrors([{ message: "Not logged in" }]),
+      error: new CombinedGraphQLErrors([{ message: "Not logged in" }], {
+        data: { currentUser: null },
+      }),
     });
 
     {
@@ -1800,14 +1806,18 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.error,
         previousData: undefined,
-        error: new CombinedGraphQLErrors([{ message: "Not logged in" }]),
+        error: new CombinedGraphQLErrors([{ message: "Not logged in" }], {
+          data: { currentUser: null },
+        }),
         variables: {},
       });
     }
 
     await expect(execute()).resolves.toEqualStrictTyped({
       data: { currentUser: null },
-      error: new CombinedGraphQLErrors([{ message: "Not logged in 2" }]),
+      error: new CombinedGraphQLErrors([{ message: "Not logged in 2" }], {
+        data: { currentUser: null },
+      }),
     });
 
     {
@@ -1819,7 +1829,9 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.error,
         previousData: undefined,
-        error: new CombinedGraphQLErrors([{ message: "Not logged in 2" }]),
+        error: new CombinedGraphQLErrors([{ message: "Not logged in 2" }], {
+          data: { currentUser: null },
+        }),
         variables: {},
       });
     }
@@ -2411,7 +2423,7 @@ describe("useLazyQuery Hook", () => {
     expect(execute).toBe(originalExecute);
 
     await expect(execute({ variables: { id: "2" } })).rejects.toEqual(
-      new CombinedGraphQLErrors([{ message: "Oops" }])
+      new CombinedGraphQLErrors([{ message: "Oops" }], { data: undefined })
     );
 
     {
@@ -2419,7 +2431,9 @@ describe("useLazyQuery Hook", () => {
 
       expect(result).toEqualLazyQueryResult({
         data: { user: { id: "1", name: "John Doe" } },
-        error: new CombinedGraphQLErrors([{ message: "Oops" }]),
+        error: new CombinedGraphQLErrors([{ message: "Oops" }], {
+          data: undefined,
+        }),
         called: true,
         loading: false,
         networkStatus: NetworkStatus.error,
@@ -2446,7 +2460,9 @@ describe("useLazyQuery Hook", () => {
 
       expect(result).toEqualLazyQueryResult({
         data: { user: { id: "1", name: "John Doe" } },
-        error: new CombinedGraphQLErrors([{ message: "Oops" }]),
+        error: new CombinedGraphQLErrors([{ message: "Oops" }], {
+          data: undefined,
+        }),
         called: true,
         loading: false,
         networkStatus: NetworkStatus.error,
@@ -4271,9 +4287,10 @@ test("applies `errorPolicy` on next fetch when it changes between renders", asyn
       data: {
         character: null,
       },
-      error: new CombinedGraphQLErrors([
-        { message: "Could not find character 1" },
-      ]),
+      error: new CombinedGraphQLErrors(
+        [{ message: "Could not find character 1" }],
+        { data: { character: null } }
+      ),
       called: true,
       loading: false,
       networkStatus: NetworkStatus.error,

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -1695,7 +1695,7 @@ describe("useLazyQuery Hook", () => {
     }
 
     await expect(execute()).rejects.toEqual(
-      new CombinedGraphQLErrors([{ message: "error 1" }], { data: undefined })
+      new CombinedGraphQLErrors({ errors: [{ message: "error 1" }] })
     );
 
     {
@@ -1707,15 +1707,13 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.error,
         previousData: undefined,
-        error: new CombinedGraphQLErrors([{ message: "error 1" }], {
-          data: undefined,
-        }),
+        error: new CombinedGraphQLErrors({ errors: [{ message: "error 1" }] }),
         variables: {},
       });
     }
 
     await expect(execute()).rejects.toEqual(
-      new CombinedGraphQLErrors([{ message: "error 2" }], { data: undefined })
+      new CombinedGraphQLErrors({ errors: [{ message: "error 2" }] })
     );
 
     {
@@ -1727,9 +1725,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.error,
         previousData: undefined,
-        error: new CombinedGraphQLErrors([{ message: "error 2" }], {
-          data: undefined,
-        }),
+        error: new CombinedGraphQLErrors({ errors: [{ message: "error 2" }] }),
         variables: {},
       });
     }
@@ -1792,8 +1788,9 @@ describe("useLazyQuery Hook", () => {
 
     await expect(execute()).resolves.toEqualStrictTyped({
       data: { currentUser: null },
-      error: new CombinedGraphQLErrors([{ message: "Not logged in" }], {
+      error: new CombinedGraphQLErrors({
         data: { currentUser: null },
+        errors: [{ message: "Not logged in" }],
       }),
     });
 
@@ -1806,8 +1803,9 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.error,
         previousData: undefined,
-        error: new CombinedGraphQLErrors([{ message: "Not logged in" }], {
+        error: new CombinedGraphQLErrors({
           data: { currentUser: null },
+          errors: [{ message: "Not logged in" }],
         }),
         variables: {},
       });
@@ -1815,8 +1813,9 @@ describe("useLazyQuery Hook", () => {
 
     await expect(execute()).resolves.toEqualStrictTyped({
       data: { currentUser: null },
-      error: new CombinedGraphQLErrors([{ message: "Not logged in 2" }], {
+      error: new CombinedGraphQLErrors({
         data: { currentUser: null },
+        errors: [{ message: "Not logged in 2" }],
       }),
     });
 
@@ -1829,8 +1828,9 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.error,
         previousData: undefined,
-        error: new CombinedGraphQLErrors([{ message: "Not logged in 2" }], {
+        error: new CombinedGraphQLErrors({
           data: { currentUser: null },
+          errors: [{ message: "Not logged in 2" }],
         }),
         variables: {},
       });
@@ -2423,7 +2423,7 @@ describe("useLazyQuery Hook", () => {
     expect(execute).toBe(originalExecute);
 
     await expect(execute({ variables: { id: "2" } })).rejects.toEqual(
-      new CombinedGraphQLErrors([{ message: "Oops" }], { data: undefined })
+      new CombinedGraphQLErrors({ errors: [{ message: "Oops" }] })
     );
 
     {
@@ -2431,9 +2431,7 @@ describe("useLazyQuery Hook", () => {
 
       expect(result).toEqualLazyQueryResult({
         data: { user: { id: "1", name: "John Doe" } },
-        error: new CombinedGraphQLErrors([{ message: "Oops" }], {
-          data: undefined,
-        }),
+        error: new CombinedGraphQLErrors({ errors: [{ message: "Oops" }] }),
         called: true,
         loading: false,
         networkStatus: NetworkStatus.error,
@@ -2460,9 +2458,7 @@ describe("useLazyQuery Hook", () => {
 
       expect(result).toEqualLazyQueryResult({
         data: { user: { id: "1", name: "John Doe" } },
-        error: new CombinedGraphQLErrors([{ message: "Oops" }], {
-          data: undefined,
-        }),
+        error: new CombinedGraphQLErrors({ errors: [{ message: "Oops" }] }),
         called: true,
         loading: false,
         networkStatus: NetworkStatus.error,
@@ -4287,10 +4283,10 @@ test("applies `errorPolicy` on next fetch when it changes between renders", asyn
       data: {
         character: null,
       },
-      error: new CombinedGraphQLErrors(
-        [{ message: "Could not find character 1" }],
-        { data: { character: null } }
-      ),
+      error: new CombinedGraphQLErrors({
+        data: { character: null },
+        errors: [{ message: "Could not find character 1" }],
+      }),
       called: true,
       loading: false,
       networkStatus: NetworkStatus.error,

--- a/src/react/hooks/__tests__/useLoadableQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLoadableQuery.test.tsx
@@ -1804,7 +1804,9 @@ it("applies `errorPolicy` on next fetch when it changes between renders", async 
     expect(renderedComponents).not.toContain(ErrorFallback);
     expect(snapshot.result).toEqual({
       data: { greeting: "Hello" },
-      error: new CombinedGraphQLErrors([{ message: "oops" }]),
+      error: new CombinedGraphQLErrors([{ message: "oops" }], {
+        data: undefined,
+      }),
       networkStatus: NetworkStatus.error,
     });
   }
@@ -2723,7 +2725,9 @@ it("throws errors when errors are returned after calling `refetch`", async () =>
 
     expect(renderedComponents).toStrictEqual([ErrorFallback]);
     expect(snapshot.error).toEqual(
-      new CombinedGraphQLErrors([{ message: "Something went wrong" }])
+      new CombinedGraphQLErrors([{ message: "Something went wrong" }], {
+        data: undefined,
+      })
     );
   }
 });
@@ -2895,7 +2899,9 @@ it('returns errors after calling `refetch` when errorPolicy is set to "all"', as
     expect(snapshot.error).toBeNull();
     expect(snapshot.result).toEqual({
       data: { character: { id: "1", name: "Captain Marvel" } },
-      error: new CombinedGraphQLErrors([{ message: "Something went wrong" }]),
+      error: new CombinedGraphQLErrors([{ message: "Something went wrong" }], {
+        data: undefined,
+      }),
       networkStatus: NetworkStatus.error,
     });
   }
@@ -2983,7 +2989,9 @@ it('handles partial data results after calling `refetch` when errorPolicy is set
     expect(snapshot.error).toBeNull();
     expect(snapshot.result).toEqual({
       data: { character: { id: "1", name: null } },
-      error: new CombinedGraphQLErrors([{ message: "Something went wrong" }]),
+      error: new CombinedGraphQLErrors([{ message: "Something went wrong" }], {
+        data: { character: { id: "1", name: null } },
+      }),
       networkStatus: NetworkStatus.error,
     });
   }

--- a/src/react/hooks/__tests__/useLoadableQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLoadableQuery.test.tsx
@@ -1804,9 +1804,7 @@ it("applies `errorPolicy` on next fetch when it changes between renders", async 
     expect(renderedComponents).not.toContain(ErrorFallback);
     expect(snapshot.result).toEqual({
       data: { greeting: "Hello" },
-      error: new CombinedGraphQLErrors([{ message: "oops" }], {
-        data: undefined,
-      }),
+      error: new CombinedGraphQLErrors({ errors: [{ message: "oops" }] }),
       networkStatus: NetworkStatus.error,
     });
   }
@@ -2725,8 +2723,8 @@ it("throws errors when errors are returned after calling `refetch`", async () =>
 
     expect(renderedComponents).toStrictEqual([ErrorFallback]);
     expect(snapshot.error).toEqual(
-      new CombinedGraphQLErrors([{ message: "Something went wrong" }], {
-        data: undefined,
+      new CombinedGraphQLErrors({
+        errors: [{ message: "Something went wrong" }],
       })
     );
   }
@@ -2899,8 +2897,8 @@ it('returns errors after calling `refetch` when errorPolicy is set to "all"', as
     expect(snapshot.error).toBeNull();
     expect(snapshot.result).toEqual({
       data: { character: { id: "1", name: "Captain Marvel" } },
-      error: new CombinedGraphQLErrors([{ message: "Something went wrong" }], {
-        data: undefined,
+      error: new CombinedGraphQLErrors({
+        errors: [{ message: "Something went wrong" }],
       }),
       networkStatus: NetworkStatus.error,
     });
@@ -2989,8 +2987,9 @@ it('handles partial data results after calling `refetch` when errorPolicy is set
     expect(snapshot.error).toBeNull();
     expect(snapshot.result).toEqual({
       data: { character: { id: "1", name: null } },
-      error: new CombinedGraphQLErrors([{ message: "Something went wrong" }], {
+      error: new CombinedGraphQLErrors({
         data: { character: { id: "1", name: null } },
+        errors: [{ message: "Something went wrong" }],
       }),
       networkStatus: NetworkStatus.error,
     });

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -430,12 +430,16 @@ describe("useMutation Hook", () => {
       const [createTodo] = getCurrentSnapshot();
 
       await expect(createTodo({ variables })).rejects.toThrow(
-        new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }])
+        new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }], {
+          data: CREATE_TODO_RESULT,
+        })
       );
 
       expect(onError).toHaveBeenCalledTimes(1);
       expect(onError).toHaveBeenLastCalledWith(
-        new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }]),
+        new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }], {
+          data: CREATE_TODO_RESULT,
+        }),
         expect.anything()
       );
     });
@@ -483,7 +487,9 @@ describe("useMutation Hook", () => {
       const [createTodo] = getCurrentSnapshot();
 
       await expect(createTodo({ variables })).rejects.toThrow(
-        new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }])
+        new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }], {
+          data: undefined,
+        })
       );
 
       {
@@ -502,7 +508,9 @@ describe("useMutation Hook", () => {
 
         expect(result).toEqualStrictTyped({
           data: undefined,
-          error: new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }]),
+          error: new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }], {
+            data: undefined,
+          }),
           loading: false,
           called: true,
         });
@@ -555,7 +563,9 @@ describe("useMutation Hook", () => {
       const [createTodo] = getCurrentSnapshot();
 
       await expect(createTodo({ variables })).rejects.toThrow(
-        new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }])
+        new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }], {
+          data: undefined,
+        })
       );
 
       {
@@ -574,7 +584,9 @@ describe("useMutation Hook", () => {
 
         expect(result).toEqualStrictTyped({
           data: undefined,
-          error: new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }]),
+          error: new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }], {
+            data: CREATE_TODO_RESULT,
+          }),
           loading: false,
           called: true,
         });
@@ -628,7 +640,9 @@ describe("useMutation Hook", () => {
 
       await expect(createTodo({ variables })).resolves.toEqualStrictTyped({
         data: CREATE_TODO_RESULT,
-        error: new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }]),
+        error: new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }], {
+          data: CREATE_TODO_RESULT,
+        }),
       });
 
       {
@@ -647,7 +661,9 @@ describe("useMutation Hook", () => {
 
         expect(result).toEqualStrictTyped({
           data: CREATE_TODO_RESULT,
-          error: new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }]),
+          error: new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }], {
+            data: CREATE_TODO_RESULT,
+          }),
           loading: false,
           called: true,
         });
@@ -709,7 +725,9 @@ describe("useMutation Hook", () => {
 
       await expect(createTodo({ variables })).resolves.toEqualStrictTyped({
         data: CREATE_TODO_RESULT,
-        error: new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }]),
+        error: new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }], {
+          data: CREATE_TODO_RESULT,
+        }),
       });
 
       {
@@ -728,7 +746,9 @@ describe("useMutation Hook", () => {
 
         expect(result).toEqualStrictTyped({
           data: CREATE_TODO_RESULT,
-          error: new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }]),
+          error: new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }], {
+            data: CREATE_TODO_RESULT,
+          }),
           loading: false,
           called: true,
         });
@@ -736,7 +756,9 @@ describe("useMutation Hook", () => {
 
       expect(onError).toHaveBeenCalledTimes(1);
       expect(onError).toHaveBeenLastCalledWith(
-        new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }]),
+        new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }], {
+          data: CREATE_TODO_RESULT,
+        }),
         expect.anything()
       );
       expect(onCompleted).not.toHaveBeenCalled();
@@ -1473,7 +1495,7 @@ describe("useMutation Hook", () => {
 
       await expect(
         createTodo({ variables, onCompleted, onError })
-      ).rejects.toThrow(new CombinedGraphQLErrors(errors));
+      ).rejects.toThrow(new CombinedGraphQLErrors(errors, { data: undefined }));
 
       {
         const [, result] = await takeSnapshot();
@@ -1491,7 +1513,7 @@ describe("useMutation Hook", () => {
 
         expect(result).toEqualStrictTyped({
           data: undefined,
-          error: new CombinedGraphQLErrors(errors),
+          error: new CombinedGraphQLErrors(errors, { data: undefined }),
           loading: false,
           called: true,
         });
@@ -1502,7 +1524,7 @@ describe("useMutation Hook", () => {
       expect(onCompleted).toHaveBeenCalledTimes(0);
       expect(onError).toHaveBeenCalledTimes(1);
       expect(onError).toHaveBeenCalledWith(
-        new CombinedGraphQLErrors(errors),
+        new CombinedGraphQLErrors(errors, { data: undefined }),
         expect.objectContaining({ variables })
       );
     });
@@ -1552,7 +1574,9 @@ describe("useMutation Hook", () => {
       const [createTodo] = getCurrentSnapshot();
       const onError = jest.fn();
       await expect(createTodo({ variables, onError })).rejects.toThrow(
-        new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }])
+        new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }], {
+          data: undefined,
+        })
       );
 
       {
@@ -1571,7 +1595,9 @@ describe("useMutation Hook", () => {
 
         expect(result).toEqualStrictTyped({
           data: undefined,
-          error: new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }]),
+          error: new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }], {
+            data: undefined,
+          }),
           loading: false,
           called: true,
         });
@@ -1579,7 +1605,9 @@ describe("useMutation Hook", () => {
 
       expect(onError).toHaveBeenCalledTimes(1);
       expect(onError).toHaveBeenCalledWith(
-        new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }]),
+        new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }], {
+          data: undefined,
+        }),
         expect.objectContaining({ variables })
       );
       expect(hookOnError).not.toHaveBeenCalled();
@@ -1652,7 +1680,7 @@ describe("useMutation Hook", () => {
       }
 
       await expect(createTodo({ variables })).rejects.toThrow(
-        new CombinedGraphQLErrors(errors)
+        new CombinedGraphQLErrors(errors, { data: undefined })
       );
 
       {
@@ -1671,7 +1699,7 @@ describe("useMutation Hook", () => {
 
         expect(result).toEqualStrictTyped({
           data: undefined,
-          error: new CombinedGraphQLErrors(errors),
+          error: new CombinedGraphQLErrors(errors, { data: undefined }),
           loading: false,
           called: true,
         });
@@ -1683,7 +1711,7 @@ describe("useMutation Hook", () => {
       expect(onError).toHaveBeenCalledTimes(0);
       expect(onError1).toHaveBeenCalledTimes(1);
       expect(onError1).toHaveBeenCalledWith(
-        new CombinedGraphQLErrors(errors),
+        new CombinedGraphQLErrors(errors, { data: undefined }),
         expect.objectContaining({ variables })
       );
     });
@@ -4000,7 +4028,9 @@ describe("useMutation Hook", () => {
       );
 
       await expect(promise).rejects.toThrow(
-        new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }])
+        new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }], {
+          data: undefined,
+        })
       );
 
       {
@@ -4008,7 +4038,9 @@ describe("useMutation Hook", () => {
 
         expect(result).toEqualStrictTyped({
           data: undefined,
-          error: new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }]),
+          error: new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }], {
+            data: undefined,
+          }),
           loading: false,
           called: true,
         });
@@ -4018,7 +4050,9 @@ describe("useMutation Hook", () => {
 
       expect(onError).toHaveBeenCalledTimes(1);
       expect(onError).toHaveBeenLastCalledWith(
-        new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }]),
+        new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }], {
+          data: undefined,
+        }),
         expect.anything()
       );
       expect(consoleSpies.error).not.toHaveBeenCalled();

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -430,15 +430,17 @@ describe("useMutation Hook", () => {
       const [createTodo] = getCurrentSnapshot();
 
       await expect(createTodo({ variables })).rejects.toThrow(
-        new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }], {
+        new CombinedGraphQLErrors({
           data: CREATE_TODO_RESULT,
+          errors: [{ message: CREATE_TODO_ERROR }],
         })
       );
 
       expect(onError).toHaveBeenCalledTimes(1);
       expect(onError).toHaveBeenLastCalledWith(
-        new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }], {
+        new CombinedGraphQLErrors({
           data: CREATE_TODO_RESULT,
+          errors: [{ message: CREATE_TODO_ERROR }],
         }),
         expect.anything()
       );
@@ -487,9 +489,7 @@ describe("useMutation Hook", () => {
       const [createTodo] = getCurrentSnapshot();
 
       await expect(createTodo({ variables })).rejects.toThrow(
-        new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }], {
-          data: undefined,
-        })
+        new CombinedGraphQLErrors({ errors: [{ message: CREATE_TODO_ERROR }] })
       );
 
       {
@@ -508,8 +508,8 @@ describe("useMutation Hook", () => {
 
         expect(result).toEqualStrictTyped({
           data: undefined,
-          error: new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }], {
-            data: undefined,
+          error: new CombinedGraphQLErrors({
+            errors: [{ message: CREATE_TODO_ERROR }],
           }),
           loading: false,
           called: true,
@@ -563,9 +563,7 @@ describe("useMutation Hook", () => {
       const [createTodo] = getCurrentSnapshot();
 
       await expect(createTodo({ variables })).rejects.toThrow(
-        new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }], {
-          data: undefined,
-        })
+        new CombinedGraphQLErrors({ errors: [{ message: CREATE_TODO_ERROR }] })
       );
 
       {
@@ -584,8 +582,9 @@ describe("useMutation Hook", () => {
 
         expect(result).toEqualStrictTyped({
           data: undefined,
-          error: new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }], {
+          error: new CombinedGraphQLErrors({
             data: CREATE_TODO_RESULT,
+            errors: [{ message: CREATE_TODO_ERROR }],
           }),
           loading: false,
           called: true,
@@ -640,8 +639,9 @@ describe("useMutation Hook", () => {
 
       await expect(createTodo({ variables })).resolves.toEqualStrictTyped({
         data: CREATE_TODO_RESULT,
-        error: new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }], {
+        error: new CombinedGraphQLErrors({
           data: CREATE_TODO_RESULT,
+          errors: [{ message: CREATE_TODO_ERROR }],
         }),
       });
 
@@ -661,8 +661,9 @@ describe("useMutation Hook", () => {
 
         expect(result).toEqualStrictTyped({
           data: CREATE_TODO_RESULT,
-          error: new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }], {
+          error: new CombinedGraphQLErrors({
             data: CREATE_TODO_RESULT,
+            errors: [{ message: CREATE_TODO_ERROR }],
           }),
           loading: false,
           called: true,
@@ -725,8 +726,9 @@ describe("useMutation Hook", () => {
 
       await expect(createTodo({ variables })).resolves.toEqualStrictTyped({
         data: CREATE_TODO_RESULT,
-        error: new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }], {
+        error: new CombinedGraphQLErrors({
           data: CREATE_TODO_RESULT,
+          errors: [{ message: CREATE_TODO_ERROR }],
         }),
       });
 
@@ -746,8 +748,9 @@ describe("useMutation Hook", () => {
 
         expect(result).toEqualStrictTyped({
           data: CREATE_TODO_RESULT,
-          error: new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }], {
+          error: new CombinedGraphQLErrors({
             data: CREATE_TODO_RESULT,
+            errors: [{ message: CREATE_TODO_ERROR }],
           }),
           loading: false,
           called: true,
@@ -756,8 +759,9 @@ describe("useMutation Hook", () => {
 
       expect(onError).toHaveBeenCalledTimes(1);
       expect(onError).toHaveBeenLastCalledWith(
-        new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }], {
+        new CombinedGraphQLErrors({
           data: CREATE_TODO_RESULT,
+          errors: [{ message: CREATE_TODO_ERROR }],
         }),
         expect.anything()
       );
@@ -1495,7 +1499,7 @@ describe("useMutation Hook", () => {
 
       await expect(
         createTodo({ variables, onCompleted, onError })
-      ).rejects.toThrow(new CombinedGraphQLErrors(errors, { data: undefined }));
+      ).rejects.toThrow(new CombinedGraphQLErrors({ errors }));
 
       {
         const [, result] = await takeSnapshot();
@@ -1513,7 +1517,7 @@ describe("useMutation Hook", () => {
 
         expect(result).toEqualStrictTyped({
           data: undefined,
-          error: new CombinedGraphQLErrors(errors, { data: undefined }),
+          error: new CombinedGraphQLErrors({ errors }),
           loading: false,
           called: true,
         });
@@ -1524,7 +1528,7 @@ describe("useMutation Hook", () => {
       expect(onCompleted).toHaveBeenCalledTimes(0);
       expect(onError).toHaveBeenCalledTimes(1);
       expect(onError).toHaveBeenCalledWith(
-        new CombinedGraphQLErrors(errors, { data: undefined }),
+        new CombinedGraphQLErrors({ errors }),
         expect.objectContaining({ variables })
       );
     });
@@ -1574,9 +1578,7 @@ describe("useMutation Hook", () => {
       const [createTodo] = getCurrentSnapshot();
       const onError = jest.fn();
       await expect(createTodo({ variables, onError })).rejects.toThrow(
-        new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }], {
-          data: undefined,
-        })
+        new CombinedGraphQLErrors({ errors: [{ message: CREATE_TODO_ERROR }] })
       );
 
       {
@@ -1595,8 +1597,8 @@ describe("useMutation Hook", () => {
 
         expect(result).toEqualStrictTyped({
           data: undefined,
-          error: new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }], {
-            data: undefined,
+          error: new CombinedGraphQLErrors({
+            errors: [{ message: CREATE_TODO_ERROR }],
           }),
           loading: false,
           called: true,
@@ -1605,9 +1607,7 @@ describe("useMutation Hook", () => {
 
       expect(onError).toHaveBeenCalledTimes(1);
       expect(onError).toHaveBeenCalledWith(
-        new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }], {
-          data: undefined,
-        }),
+        new CombinedGraphQLErrors({ errors: [{ message: CREATE_TODO_ERROR }] }),
         expect.objectContaining({ variables })
       );
       expect(hookOnError).not.toHaveBeenCalled();
@@ -1680,7 +1680,7 @@ describe("useMutation Hook", () => {
       }
 
       await expect(createTodo({ variables })).rejects.toThrow(
-        new CombinedGraphQLErrors(errors, { data: undefined })
+        new CombinedGraphQLErrors({ errors })
       );
 
       {
@@ -1699,7 +1699,7 @@ describe("useMutation Hook", () => {
 
         expect(result).toEqualStrictTyped({
           data: undefined,
-          error: new CombinedGraphQLErrors(errors, { data: undefined }),
+          error: new CombinedGraphQLErrors({ errors }),
           loading: false,
           called: true,
         });
@@ -1711,7 +1711,7 @@ describe("useMutation Hook", () => {
       expect(onError).toHaveBeenCalledTimes(0);
       expect(onError1).toHaveBeenCalledTimes(1);
       expect(onError1).toHaveBeenCalledWith(
-        new CombinedGraphQLErrors(errors, { data: undefined }),
+        new CombinedGraphQLErrors({ errors }),
         expect.objectContaining({ variables })
       );
     });
@@ -4028,9 +4028,7 @@ describe("useMutation Hook", () => {
       );
 
       await expect(promise).rejects.toThrow(
-        new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }], {
-          data: undefined,
-        })
+        new CombinedGraphQLErrors({ errors: [{ message: CREATE_TODO_ERROR }] })
       );
 
       {
@@ -4038,8 +4036,8 @@ describe("useMutation Hook", () => {
 
         expect(result).toEqualStrictTyped({
           data: undefined,
-          error: new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }], {
-            data: undefined,
+          error: new CombinedGraphQLErrors({
+            errors: [{ message: CREATE_TODO_ERROR }],
           }),
           loading: false,
           called: true,
@@ -4050,9 +4048,7 @@ describe("useMutation Hook", () => {
 
       expect(onError).toHaveBeenCalledTimes(1);
       expect(onError).toHaveBeenLastCalledWith(
-        new CombinedGraphQLErrors([{ message: CREATE_TODO_ERROR }], {
-          data: undefined,
-        }),
+        new CombinedGraphQLErrors({ errors: [{ message: CREATE_TODO_ERROR }] }),
         expect.anything()
       );
       expect(consoleSpies.error).not.toHaveBeenCalled();

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -2913,7 +2913,9 @@ describe("useQuery Hook", () => {
 
         expect(result).toEqualQueryResult({
           data: undefined,
-          error: new CombinedGraphQLErrors([{ message: "error" }]),
+          error: new CombinedGraphQLErrors([{ message: "error" }], {
+            data: undefined,
+          }),
           loading: false,
           networkStatus: NetworkStatus.error,
           previousData: undefined,
@@ -2968,9 +2970,10 @@ describe("useQuery Hook", () => {
 
         expect(result).toEqualQueryResult({
           data: undefined,
-          error: new CombinedGraphQLErrors([
-            { message: 'Could not fetch "hello"' },
-          ]),
+          error: new CombinedGraphQLErrors(
+            [{ message: 'Could not fetch "hello"' }],
+            { data: { hello: null } }
+          ),
           loading: false,
           networkStatus: NetworkStatus.error,
           previousData: undefined,
@@ -3137,9 +3140,10 @@ describe("useQuery Hook", () => {
 
         expect(result).toEqualQueryResult({
           data: { hello: null },
-          error: new CombinedGraphQLErrors([
-            { message: 'Could not fetch "hello"' },
-          ]),
+          error: new CombinedGraphQLErrors(
+            [{ message: 'Could not fetch "hello"' }],
+            { data: { hello: null } }
+          ),
           loading: false,
           networkStatus: NetworkStatus.error,
           previousData: undefined,
@@ -3251,7 +3255,9 @@ describe("useQuery Hook", () => {
 
         expect(result).toEqualQueryResult({
           data: undefined,
-          error: new CombinedGraphQLErrors([{ message: "error" }]),
+          error: new CombinedGraphQLErrors([{ message: "error" }], {
+            data: undefined,
+          }),
           loading: false,
           networkStatus: NetworkStatus.error,
           previousData: undefined,
@@ -3266,7 +3272,9 @@ describe("useQuery Hook", () => {
 
         expect(result).toEqualQueryResult({
           data: undefined,
-          error: new CombinedGraphQLErrors([{ message: "error" }]),
+          error: new CombinedGraphQLErrors([{ message: "error" }], {
+            data: undefined,
+          }),
           loading: false,
           networkStatus: NetworkStatus.error,
           previousData: undefined,
@@ -3562,7 +3570,9 @@ describe("useQuery Hook", () => {
 
         expect(result).toEqualQueryResult({
           data: undefined,
-          error: new CombinedGraphQLErrors([{ message: "error" }]),
+          error: new CombinedGraphQLErrors([{ message: "error" }], {
+            data: undefined,
+          }),
           loading: false,
           networkStatus: NetworkStatus.error,
           previousData: undefined,
@@ -3678,7 +3688,9 @@ describe("useQuery Hook", () => {
 
         expect(result).toEqualQueryResult({
           data: undefined,
-          error: new CombinedGraphQLErrors([{ message: "error 1" }]),
+          error: new CombinedGraphQLErrors([{ message: "error 1" }], {
+            data: undefined,
+          }),
           loading: false,
           networkStatus: NetworkStatus.error,
           previousData: undefined,
@@ -3687,7 +3699,7 @@ describe("useQuery Hook", () => {
       }
 
       await expect(getCurrentSnapshot().refetch()).rejects.toEqual(
-        new CombinedGraphQLErrors([{ message: "error 2" }])
+        new CombinedGraphQLErrors([{ message: "error 2" }], { data: undefined })
       );
 
       {
@@ -3707,7 +3719,9 @@ describe("useQuery Hook", () => {
 
         expect(result).toEqualQueryResult({
           data: undefined,
-          error: new CombinedGraphQLErrors([{ message: "error 2" }]),
+          error: new CombinedGraphQLErrors([{ message: "error 2" }], {
+            data: undefined,
+          }),
           loading: false,
           networkStatus: NetworkStatus.error,
           previousData: undefined,
@@ -3771,7 +3785,9 @@ describe("useQuery Hook", () => {
 
         expect(result).toEqualQueryResult({
           data: undefined,
-          error: new CombinedGraphQLErrors([{ message: "error 1" }]),
+          error: new CombinedGraphQLErrors([{ message: "error 1" }], {
+            data: undefined,
+          }),
           loading: false,
           networkStatus: NetworkStatus.error,
           previousData: undefined,
@@ -3780,7 +3796,7 @@ describe("useQuery Hook", () => {
       }
 
       await expect(getCurrentSnapshot().refetch()).rejects.toEqual(
-        new CombinedGraphQLErrors([{ message: "error 2" }])
+        new CombinedGraphQLErrors([{ message: "error 2" }], { data: undefined })
       );
 
       {
@@ -3788,7 +3804,9 @@ describe("useQuery Hook", () => {
 
         expect(result).toEqualQueryResult({
           data: undefined,
-          error: new CombinedGraphQLErrors([{ message: "error 2" }]),
+          error: new CombinedGraphQLErrors([{ message: "error 2" }], {
+            data: undefined,
+          }),
           loading: false,
           networkStatus: NetworkStatus.error,
           previousData: undefined,
@@ -3852,7 +3870,9 @@ describe("useQuery Hook", () => {
 
         expect(result).toEqualQueryResult({
           data: undefined,
-          error: new CombinedGraphQLErrors([{ message: "same error" }]),
+          error: new CombinedGraphQLErrors([{ message: "same error" }], {
+            data: undefined,
+          }),
           loading: false,
           networkStatus: NetworkStatus.error,
           previousData: undefined,
@@ -3861,7 +3881,9 @@ describe("useQuery Hook", () => {
       }
 
       await expect(getCurrentSnapshot().refetch()).rejects.toEqual(
-        new CombinedGraphQLErrors([{ message: "same error" }])
+        new CombinedGraphQLErrors([{ message: "same error" }], {
+          data: undefined,
+        })
       );
 
       {
@@ -3881,7 +3903,9 @@ describe("useQuery Hook", () => {
 
         expect(result).toEqualQueryResult({
           data: undefined,
-          error: new CombinedGraphQLErrors([{ message: "same error" }]),
+          error: new CombinedGraphQLErrors([{ message: "same error" }], {
+            data: undefined,
+          }),
           loading: false,
           networkStatus: NetworkStatus.error,
           previousData: undefined,
@@ -3951,7 +3975,9 @@ describe("useQuery Hook", () => {
 
         expect(result).toEqualQueryResult({
           data: undefined,
-          error: new CombinedGraphQLErrors([{ message: "same error" }]),
+          error: new CombinedGraphQLErrors([{ message: "same error" }], {
+            data: undefined,
+          }),
           loading: false,
           networkStatus: NetworkStatus.error,
           previousData: undefined,
@@ -3985,7 +4011,9 @@ describe("useQuery Hook", () => {
       }
 
       await expect(getCurrentSnapshot().refetch()).rejects.toEqual(
-        new CombinedGraphQLErrors([{ message: "same error" }])
+        new CombinedGraphQLErrors([{ message: "same error" }], {
+          data: undefined,
+        })
       );
 
       {
@@ -4004,7 +4032,9 @@ describe("useQuery Hook", () => {
         expect(result).toEqualQueryResult({
           // TODO: Is this correct behavior here?
           data: { hello: "world" },
-          error: new CombinedGraphQLErrors([{ message: "same error" }]),
+          error: new CombinedGraphQLErrors([{ message: "same error" }], {
+            data: undefined,
+          }),
           loading: false,
           networkStatus: NetworkStatus.error,
           previousData: { hello: "world" },
@@ -4947,7 +4977,9 @@ describe("useQuery Hook", () => {
 
       expect(snapshot.useQueryResult!).toEqualQueryResult({
         data: undefined,
-        error: new CombinedGraphQLErrors([{ message: "Intentional error" }]),
+        error: new CombinedGraphQLErrors([{ message: "Intentional error" }], {
+          data: { person: null },
+        }),
         loading: false,
         networkStatus: NetworkStatus.error,
         previousData: undefined,
@@ -4972,7 +5004,9 @@ describe("useQuery Hook", () => {
 
       expect(snapshot.useQueryResult!).toEqualQueryResult({
         data: undefined,
-        error: new CombinedGraphQLErrors([{ message: "Intentional error" }]),
+        error: new CombinedGraphQLErrors([{ message: "Intentional error" }], {
+          data: { person: null },
+        }),
         loading: false,
         networkStatus: NetworkStatus.error,
         previousData: undefined,
@@ -4994,7 +5028,9 @@ describe("useQuery Hook", () => {
 
       expect(snapshot.useQueryResult!).toEqualQueryResult({
         data: undefined,
-        error: new CombinedGraphQLErrors([{ message: "Intentional error" }]),
+        error: new CombinedGraphQLErrors([{ message: "Intentional error" }], {
+          data: { person: null },
+        }),
         loading: false,
         networkStatus: NetworkStatus.error,
         previousData: undefined,
@@ -5007,7 +5043,9 @@ describe("useQuery Hook", () => {
         snapshot.useQueryResult?.observable.getCurrentResult(false)!
       ).toEqualStrictTyped({
         data: undefined,
-        error: new CombinedGraphQLErrors([{ message: "Intentional error" }]),
+        error: new CombinedGraphQLErrors([{ message: "Intentional error" }], {
+          data: { person: null },
+        }),
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: true,
@@ -5051,7 +5089,9 @@ describe("useQuery Hook", () => {
 
       expect(snapshot.useQueryResult!).toEqualQueryResult({
         data: undefined,
-        error: new CombinedGraphQLErrors([{ message: "Intentional error" }]),
+        error: new CombinedGraphQLErrors([{ message: "Intentional error" }], {
+          data: { person: null },
+        }),
         loading: false,
         networkStatus: NetworkStatus.error,
         previousData: undefined,
@@ -5064,7 +5104,9 @@ describe("useQuery Hook", () => {
         snapshot.useQueryResult?.observable.getCurrentResult(false)!
       ).toEqualStrictTyped({
         data: undefined,
-        error: new CombinedGraphQLErrors([{ message: "Intentional error" }]),
+        error: new CombinedGraphQLErrors([{ message: "Intentional error" }], {
+          data: { person: null },
+        }),
         loading: false,
         networkStatus: NetworkStatus.error,
         partial: true,
@@ -5218,7 +5260,9 @@ describe("useQuery Hook", () => {
 
       expect(snapshot.useQueryResult!).toEqualQueryResult({
         data: undefined,
-        error: new CombinedGraphQLErrors([{ message: "Intentional error" }]),
+        error: new CombinedGraphQLErrors([{ message: "Intentional error" }], {
+          data: { person: null },
+        }),
         loading: false,
         networkStatus: NetworkStatus.error,
         previousData: undefined,
@@ -5243,7 +5287,9 @@ describe("useQuery Hook", () => {
 
       expect(snapshot.useQueryResult!).toEqualQueryResult({
         data: undefined,
-        error: new CombinedGraphQLErrors([{ message: "Intentional error" }]),
+        error: new CombinedGraphQLErrors([{ message: "Intentional error" }], {
+          data: { person: null },
+        }),
         loading: false,
         networkStatus: NetworkStatus.error,
         previousData: undefined,
@@ -5268,7 +5314,9 @@ describe("useQuery Hook", () => {
       // the other query has finished and re-rendered.
       expect(snapshot.useQueryResult!).toEqualQueryResult({
         data: undefined,
-        error: new CombinedGraphQLErrors([{ message: "Intentional error" }]),
+        error: new CombinedGraphQLErrors([{ message: "Intentional error" }], {
+          data: { person: null },
+        }),
         loading: false,
         networkStatus: NetworkStatus.error,
         previousData: undefined,
@@ -5464,7 +5512,9 @@ describe("useQuery Hook", () => {
 
       expect(snapshot.useQueryResult!).toEqualQueryResult({
         data: undefined,
-        error: new CombinedGraphQLErrors([{ message: "Intentional error" }]),
+        error: new CombinedGraphQLErrors([{ message: "Intentional error" }], {
+          data: { person: null },
+        }),
         loading: false,
         networkStatus: NetworkStatus.error,
         previousData: undefined,
@@ -5489,7 +5539,9 @@ describe("useQuery Hook", () => {
 
       expect(snapshot.useQueryResult!).toEqualQueryResult({
         data: undefined,
-        error: new CombinedGraphQLErrors([{ message: "Intentional error" }]),
+        error: new CombinedGraphQLErrors([{ message: "Intentional error" }], {
+          data: { person: null },
+        }),
         loading: false,
         networkStatus: NetworkStatus.error,
         previousData: undefined,
@@ -5511,7 +5563,9 @@ describe("useQuery Hook", () => {
 
       expect(snapshot.useQueryResult!).toEqualQueryResult({
         data: undefined,
-        error: new CombinedGraphQLErrors([{ message: "Intentional error" }]),
+        error: new CombinedGraphQLErrors([{ message: "Intentional error" }], {
+          data: { person: null },
+        }),
         loading: false,
         networkStatus: NetworkStatus.error,
         previousData: undefined,
@@ -9368,13 +9422,16 @@ describe("useQuery Hook", () => {
             name: "R2-D2",
           },
         },
-        error: new CombinedGraphQLErrors([
-          {
-            message:
-              "homeWorld for character with ID 1000 could not be fetched.",
-            path: ["hero", "heroFriends", 0, "homeWorld"],
-          },
-        ]),
+        error: new CombinedGraphQLErrors(
+          [
+            {
+              message:
+                "homeWorld for character with ID 1000 could not be fetched.",
+              path: ["hero", "heroFriends", 0, "homeWorld"],
+            },
+          ],
+          { data: undefined }
+        ),
         loading: false,
         networkStatus: NetworkStatus.error,
         previousData: {
@@ -9542,13 +9599,26 @@ describe("useQuery Hook", () => {
             name: "R2-D2",
           },
         },
-        error: new CombinedGraphQLErrors([
+        error: new CombinedGraphQLErrors(
+          [
+            {
+              message:
+                "homeWorld for character with ID 1000 could not be fetched.",
+              path: ["hero", "heroFriends", 0, "homeWorld"],
+            },
+          ],
           {
-            message:
-              "homeWorld for character with ID 1000 could not be fetched.",
-            path: ["hero", "heroFriends", 0, "homeWorld"],
-          },
-        ]),
+            data: {
+              hero: {
+                heroFriends: [
+                  { homeWorld: null, id: "1000", name: "Luke Skywalker" },
+                  { homeWorld: "Alderaan", id: "1003", name: "Leia Organa" },
+                ],
+                name: "R2-D2",
+              },
+            },
+          }
+        ),
         loading: false,
         networkStatus: NetworkStatus.error,
         previousData: {
@@ -10002,7 +10072,9 @@ describe("useQuery Hook", () => {
 
     await expect(takeSnapshot()).resolves.toEqualQueryResult({
       data: undefined,
-      error: new CombinedGraphQLErrors([graphQLError]),
+      error: new CombinedGraphQLErrors([graphQLError], {
+        data: { user: { __typename: "User", id: "1", name: null } },
+      }),
       loading: false,
       networkStatus: NetworkStatus.error,
       previousData: undefined,
@@ -10024,7 +10096,9 @@ describe("useQuery Hook", () => {
 
     await expect(takeSnapshot()).resolves.toEqualQueryResult({
       data: undefined,
-      error: new CombinedGraphQLErrors([graphQLError]),
+      error: new CombinedGraphQLErrors([graphQLError], {
+        data: { user: { __typename: "User", id: "1", name: null } },
+      }),
       loading: false,
       networkStatus: NetworkStatus.error,
       previousData: undefined,
@@ -10999,7 +11073,11 @@ describe("useQuery Hook", () => {
               name: null,
             },
           },
-          error: new CombinedGraphQLErrors([{ message: "Couldn't get name" }]),
+          error: new CombinedGraphQLErrors([{ message: "Couldn't get name" }], {
+            data: {
+              currentUser: { __typename: "User", id: 1, name: null, age: 34 },
+            },
+          }),
           loading: false,
           networkStatus: NetworkStatus.error,
           previousData: undefined,

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -2913,9 +2913,7 @@ describe("useQuery Hook", () => {
 
         expect(result).toEqualQueryResult({
           data: undefined,
-          error: new CombinedGraphQLErrors([{ message: "error" }], {
-            data: undefined,
-          }),
+          error: new CombinedGraphQLErrors({ errors: [{ message: "error" }] }),
           loading: false,
           networkStatus: NetworkStatus.error,
           previousData: undefined,
@@ -2970,10 +2968,10 @@ describe("useQuery Hook", () => {
 
         expect(result).toEqualQueryResult({
           data: undefined,
-          error: new CombinedGraphQLErrors(
-            [{ message: 'Could not fetch "hello"' }],
-            { data: { hello: null } }
-          ),
+          error: new CombinedGraphQLErrors({
+            data: { hello: null },
+            errors: [{ message: 'Could not fetch "hello"' }],
+          }),
           loading: false,
           networkStatus: NetworkStatus.error,
           previousData: undefined,
@@ -3140,10 +3138,10 @@ describe("useQuery Hook", () => {
 
         expect(result).toEqualQueryResult({
           data: { hello: null },
-          error: new CombinedGraphQLErrors(
-            [{ message: 'Could not fetch "hello"' }],
-            { data: { hello: null } }
-          ),
+          error: new CombinedGraphQLErrors({
+            data: { hello: null },
+            errors: [{ message: 'Could not fetch "hello"' }],
+          }),
           loading: false,
           networkStatus: NetworkStatus.error,
           previousData: undefined,
@@ -3255,9 +3253,7 @@ describe("useQuery Hook", () => {
 
         expect(result).toEqualQueryResult({
           data: undefined,
-          error: new CombinedGraphQLErrors([{ message: "error" }], {
-            data: undefined,
-          }),
+          error: new CombinedGraphQLErrors({ errors: [{ message: "error" }] }),
           loading: false,
           networkStatus: NetworkStatus.error,
           previousData: undefined,
@@ -3272,9 +3268,7 @@ describe("useQuery Hook", () => {
 
         expect(result).toEqualQueryResult({
           data: undefined,
-          error: new CombinedGraphQLErrors([{ message: "error" }], {
-            data: undefined,
-          }),
+          error: new CombinedGraphQLErrors({ errors: [{ message: "error" }] }),
           loading: false,
           networkStatus: NetworkStatus.error,
           previousData: undefined,
@@ -3570,9 +3564,7 @@ describe("useQuery Hook", () => {
 
         expect(result).toEqualQueryResult({
           data: undefined,
-          error: new CombinedGraphQLErrors([{ message: "error" }], {
-            data: undefined,
-          }),
+          error: new CombinedGraphQLErrors({ errors: [{ message: "error" }] }),
           loading: false,
           networkStatus: NetworkStatus.error,
           previousData: undefined,
@@ -3688,8 +3680,8 @@ describe("useQuery Hook", () => {
 
         expect(result).toEqualQueryResult({
           data: undefined,
-          error: new CombinedGraphQLErrors([{ message: "error 1" }], {
-            data: undefined,
+          error: new CombinedGraphQLErrors({
+            errors: [{ message: "error 1" }],
           }),
           loading: false,
           networkStatus: NetworkStatus.error,
@@ -3699,7 +3691,7 @@ describe("useQuery Hook", () => {
       }
 
       await expect(getCurrentSnapshot().refetch()).rejects.toEqual(
-        new CombinedGraphQLErrors([{ message: "error 2" }], { data: undefined })
+        new CombinedGraphQLErrors({ errors: [{ message: "error 2" }] })
       );
 
       {
@@ -3719,8 +3711,8 @@ describe("useQuery Hook", () => {
 
         expect(result).toEqualQueryResult({
           data: undefined,
-          error: new CombinedGraphQLErrors([{ message: "error 2" }], {
-            data: undefined,
+          error: new CombinedGraphQLErrors({
+            errors: [{ message: "error 2" }],
           }),
           loading: false,
           networkStatus: NetworkStatus.error,
@@ -3785,8 +3777,8 @@ describe("useQuery Hook", () => {
 
         expect(result).toEqualQueryResult({
           data: undefined,
-          error: new CombinedGraphQLErrors([{ message: "error 1" }], {
-            data: undefined,
+          error: new CombinedGraphQLErrors({
+            errors: [{ message: "error 1" }],
           }),
           loading: false,
           networkStatus: NetworkStatus.error,
@@ -3796,7 +3788,7 @@ describe("useQuery Hook", () => {
       }
 
       await expect(getCurrentSnapshot().refetch()).rejects.toEqual(
-        new CombinedGraphQLErrors([{ message: "error 2" }], { data: undefined })
+        new CombinedGraphQLErrors({ errors: [{ message: "error 2" }] })
       );
 
       {
@@ -3804,8 +3796,8 @@ describe("useQuery Hook", () => {
 
         expect(result).toEqualQueryResult({
           data: undefined,
-          error: new CombinedGraphQLErrors([{ message: "error 2" }], {
-            data: undefined,
+          error: new CombinedGraphQLErrors({
+            errors: [{ message: "error 2" }],
           }),
           loading: false,
           networkStatus: NetworkStatus.error,
@@ -3870,8 +3862,8 @@ describe("useQuery Hook", () => {
 
         expect(result).toEqualQueryResult({
           data: undefined,
-          error: new CombinedGraphQLErrors([{ message: "same error" }], {
-            data: undefined,
+          error: new CombinedGraphQLErrors({
+            errors: [{ message: "same error" }],
           }),
           loading: false,
           networkStatus: NetworkStatus.error,
@@ -3881,9 +3873,7 @@ describe("useQuery Hook", () => {
       }
 
       await expect(getCurrentSnapshot().refetch()).rejects.toEqual(
-        new CombinedGraphQLErrors([{ message: "same error" }], {
-          data: undefined,
-        })
+        new CombinedGraphQLErrors({ errors: [{ message: "same error" }] })
       );
 
       {
@@ -3903,8 +3893,8 @@ describe("useQuery Hook", () => {
 
         expect(result).toEqualQueryResult({
           data: undefined,
-          error: new CombinedGraphQLErrors([{ message: "same error" }], {
-            data: undefined,
+          error: new CombinedGraphQLErrors({
+            errors: [{ message: "same error" }],
           }),
           loading: false,
           networkStatus: NetworkStatus.error,
@@ -3975,8 +3965,8 @@ describe("useQuery Hook", () => {
 
         expect(result).toEqualQueryResult({
           data: undefined,
-          error: new CombinedGraphQLErrors([{ message: "same error" }], {
-            data: undefined,
+          error: new CombinedGraphQLErrors({
+            errors: [{ message: "same error" }],
           }),
           loading: false,
           networkStatus: NetworkStatus.error,
@@ -4011,9 +4001,7 @@ describe("useQuery Hook", () => {
       }
 
       await expect(getCurrentSnapshot().refetch()).rejects.toEqual(
-        new CombinedGraphQLErrors([{ message: "same error" }], {
-          data: undefined,
-        })
+        new CombinedGraphQLErrors({ errors: [{ message: "same error" }] })
       );
 
       {
@@ -4032,8 +4020,8 @@ describe("useQuery Hook", () => {
         expect(result).toEqualQueryResult({
           // TODO: Is this correct behavior here?
           data: { hello: "world" },
-          error: new CombinedGraphQLErrors([{ message: "same error" }], {
-            data: undefined,
+          error: new CombinedGraphQLErrors({
+            errors: [{ message: "same error" }],
           }),
           loading: false,
           networkStatus: NetworkStatus.error,
@@ -4977,8 +4965,9 @@ describe("useQuery Hook", () => {
 
       expect(snapshot.useQueryResult!).toEqualQueryResult({
         data: undefined,
-        error: new CombinedGraphQLErrors([{ message: "Intentional error" }], {
+        error: new CombinedGraphQLErrors({
           data: { person: null },
+          errors: [{ message: "Intentional error" }],
         }),
         loading: false,
         networkStatus: NetworkStatus.error,
@@ -5004,8 +4993,9 @@ describe("useQuery Hook", () => {
 
       expect(snapshot.useQueryResult!).toEqualQueryResult({
         data: undefined,
-        error: new CombinedGraphQLErrors([{ message: "Intentional error" }], {
+        error: new CombinedGraphQLErrors({
           data: { person: null },
+          errors: [{ message: "Intentional error" }],
         }),
         loading: false,
         networkStatus: NetworkStatus.error,
@@ -5028,8 +5018,9 @@ describe("useQuery Hook", () => {
 
       expect(snapshot.useQueryResult!).toEqualQueryResult({
         data: undefined,
-        error: new CombinedGraphQLErrors([{ message: "Intentional error" }], {
+        error: new CombinedGraphQLErrors({
           data: { person: null },
+          errors: [{ message: "Intentional error" }],
         }),
         loading: false,
         networkStatus: NetworkStatus.error,
@@ -5043,8 +5034,9 @@ describe("useQuery Hook", () => {
         snapshot.useQueryResult?.observable.getCurrentResult(false)!
       ).toEqualStrictTyped({
         data: undefined,
-        error: new CombinedGraphQLErrors([{ message: "Intentional error" }], {
+        error: new CombinedGraphQLErrors({
           data: { person: null },
+          errors: [{ message: "Intentional error" }],
         }),
         loading: false,
         networkStatus: NetworkStatus.error,
@@ -5089,8 +5081,9 @@ describe("useQuery Hook", () => {
 
       expect(snapshot.useQueryResult!).toEqualQueryResult({
         data: undefined,
-        error: new CombinedGraphQLErrors([{ message: "Intentional error" }], {
+        error: new CombinedGraphQLErrors({
           data: { person: null },
+          errors: [{ message: "Intentional error" }],
         }),
         loading: false,
         networkStatus: NetworkStatus.error,
@@ -5104,8 +5097,9 @@ describe("useQuery Hook", () => {
         snapshot.useQueryResult?.observable.getCurrentResult(false)!
       ).toEqualStrictTyped({
         data: undefined,
-        error: new CombinedGraphQLErrors([{ message: "Intentional error" }], {
+        error: new CombinedGraphQLErrors({
           data: { person: null },
+          errors: [{ message: "Intentional error" }],
         }),
         loading: false,
         networkStatus: NetworkStatus.error,
@@ -5260,8 +5254,9 @@ describe("useQuery Hook", () => {
 
       expect(snapshot.useQueryResult!).toEqualQueryResult({
         data: undefined,
-        error: new CombinedGraphQLErrors([{ message: "Intentional error" }], {
+        error: new CombinedGraphQLErrors({
           data: { person: null },
+          errors: [{ message: "Intentional error" }],
         }),
         loading: false,
         networkStatus: NetworkStatus.error,
@@ -5287,8 +5282,9 @@ describe("useQuery Hook", () => {
 
       expect(snapshot.useQueryResult!).toEqualQueryResult({
         data: undefined,
-        error: new CombinedGraphQLErrors([{ message: "Intentional error" }], {
+        error: new CombinedGraphQLErrors({
           data: { person: null },
+          errors: [{ message: "Intentional error" }],
         }),
         loading: false,
         networkStatus: NetworkStatus.error,
@@ -5314,8 +5310,9 @@ describe("useQuery Hook", () => {
       // the other query has finished and re-rendered.
       expect(snapshot.useQueryResult!).toEqualQueryResult({
         data: undefined,
-        error: new CombinedGraphQLErrors([{ message: "Intentional error" }], {
+        error: new CombinedGraphQLErrors({
           data: { person: null },
+          errors: [{ message: "Intentional error" }],
         }),
         loading: false,
         networkStatus: NetworkStatus.error,
@@ -5512,8 +5509,9 @@ describe("useQuery Hook", () => {
 
       expect(snapshot.useQueryResult!).toEqualQueryResult({
         data: undefined,
-        error: new CombinedGraphQLErrors([{ message: "Intentional error" }], {
+        error: new CombinedGraphQLErrors({
           data: { person: null },
+          errors: [{ message: "Intentional error" }],
         }),
         loading: false,
         networkStatus: NetworkStatus.error,
@@ -5539,8 +5537,9 @@ describe("useQuery Hook", () => {
 
       expect(snapshot.useQueryResult!).toEqualQueryResult({
         data: undefined,
-        error: new CombinedGraphQLErrors([{ message: "Intentional error" }], {
+        error: new CombinedGraphQLErrors({
           data: { person: null },
+          errors: [{ message: "Intentional error" }],
         }),
         loading: false,
         networkStatus: NetworkStatus.error,
@@ -5563,8 +5562,9 @@ describe("useQuery Hook", () => {
 
       expect(snapshot.useQueryResult!).toEqualQueryResult({
         data: undefined,
-        error: new CombinedGraphQLErrors([{ message: "Intentional error" }], {
+        error: new CombinedGraphQLErrors({
           data: { person: null },
+          errors: [{ message: "Intentional error" }],
         }),
         loading: false,
         networkStatus: NetworkStatus.error,
@@ -9422,16 +9422,15 @@ describe("useQuery Hook", () => {
             name: "R2-D2",
           },
         },
-        error: new CombinedGraphQLErrors(
-          [
+        error: new CombinedGraphQLErrors({
+          errors: [
             {
               message:
                 "homeWorld for character with ID 1000 could not be fetched.",
               path: ["hero", "heroFriends", 0, "homeWorld"],
             },
           ],
-          { data: undefined }
-        ),
+        }),
         loading: false,
         networkStatus: NetworkStatus.error,
         previousData: {
@@ -9599,26 +9598,24 @@ describe("useQuery Hook", () => {
             name: "R2-D2",
           },
         },
-        error: new CombinedGraphQLErrors(
-          [
+        error: new CombinedGraphQLErrors({
+          data: {
+            hero: {
+              heroFriends: [
+                { homeWorld: null, id: "1000", name: "Luke Skywalker" },
+                { homeWorld: "Alderaan", id: "1003", name: "Leia Organa" },
+              ],
+              name: "R2-D2",
+            },
+          },
+          errors: [
             {
               message:
                 "homeWorld for character with ID 1000 could not be fetched.",
               path: ["hero", "heroFriends", 0, "homeWorld"],
             },
           ],
-          {
-            data: {
-              hero: {
-                heroFriends: [
-                  { homeWorld: null, id: "1000", name: "Luke Skywalker" },
-                  { homeWorld: "Alderaan", id: "1003", name: "Leia Organa" },
-                ],
-                name: "R2-D2",
-              },
-            },
-          }
-        ),
+        }),
         loading: false,
         networkStatus: NetworkStatus.error,
         previousData: {
@@ -10072,8 +10069,9 @@ describe("useQuery Hook", () => {
 
     await expect(takeSnapshot()).resolves.toEqualQueryResult({
       data: undefined,
-      error: new CombinedGraphQLErrors([graphQLError], {
+      error: new CombinedGraphQLErrors({
         data: { user: { __typename: "User", id: "1", name: null } },
+        errors: [graphQLError],
       }),
       loading: false,
       networkStatus: NetworkStatus.error,
@@ -10096,8 +10094,9 @@ describe("useQuery Hook", () => {
 
     await expect(takeSnapshot()).resolves.toEqualQueryResult({
       data: undefined,
-      error: new CombinedGraphQLErrors([graphQLError], {
+      error: new CombinedGraphQLErrors({
         data: { user: { __typename: "User", id: "1", name: null } },
+        errors: [graphQLError],
       }),
       loading: false,
       networkStatus: NetworkStatus.error,
@@ -11073,10 +11072,11 @@ describe("useQuery Hook", () => {
               name: null,
             },
           },
-          error: new CombinedGraphQLErrors([{ message: "Couldn't get name" }], {
+          error: new CombinedGraphQLErrors({
             data: {
               currentUser: { __typename: "User", id: 1, name: null, age: 34 },
             },
+            errors: [{ message: "Couldn't get name" }],
           }),
           loading: false,
           networkStatus: NetworkStatus.error,

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -154,7 +154,9 @@ describe("useSubscription Hook", () => {
 
     await expect(takeSnapshot()).resolves.toEqualStrictTyped({
       data: undefined,
-      error: new CombinedGraphQLErrors([{ message: "test" }]),
+      error: new CombinedGraphQLErrors([{ message: "test" }], {
+        data: errorResult.result.data,
+      }),
       loading: false,
     });
 
@@ -162,7 +164,9 @@ describe("useSubscription Hook", () => {
 
     expect(onError).toHaveBeenCalledTimes(1);
     expect(onError).toHaveBeenCalledWith(
-      new CombinedGraphQLErrors([{ message: "test" }])
+      new CombinedGraphQLErrors([{ message: "test" }], {
+        data: errorResult.result.data,
+      })
     );
   });
 
@@ -233,14 +237,18 @@ describe("useSubscription Hook", () => {
 
     await expect(takeSnapshot()).resolves.toEqualStrictTyped({
       data: undefined,
-      error: new CombinedGraphQLErrors([{ message: "test" }]),
+      error: new CombinedGraphQLErrors([{ message: "test" }], {
+        data: errorResult.result.data,
+      }),
       loading: false,
     });
 
     expect(onData).toHaveBeenCalledTimes(1);
     expect(onError).toHaveBeenCalledTimes(1);
     expect(onError).toHaveBeenLastCalledWith(
-      new CombinedGraphQLErrors([{ message: "test" }])
+      new CombinedGraphQLErrors([{ message: "test" }], {
+        data: errorResult.result.data,
+      })
     );
     expect(onComplete).toHaveBeenCalledTimes(0);
 
@@ -1242,7 +1250,8 @@ followed by new in-flight setup", async () => {
             expect(snapshot).toEqualStrictTyped({
               loading: false,
               error: new CombinedGraphQLErrors(
-                graphQlErrorResult.result!.errors as any
+                graphQlErrorResult.result!.errors as any,
+                { data: graphQlErrorResult.result!.data }
               ),
               data: undefined,
             });
@@ -1250,7 +1259,9 @@ followed by new in-flight setup", async () => {
 
           expect(onError).toHaveBeenCalledTimes(1);
           expect(onError).toHaveBeenCalledWith(
-            new CombinedGraphQLErrors(graphQlErrorResult.result!.errors!)
+            new CombinedGraphQLErrors(graphQlErrorResult.result!.errors!, {
+              data: graphQlErrorResult.result!.data,
+            })
           );
           expect(onData).toHaveBeenCalledTimes(0);
           expect(errorBoundaryOnError).toHaveBeenCalledTimes(0);
@@ -1276,7 +1287,8 @@ followed by new in-flight setup", async () => {
           expect(snapshot).toEqualStrictTyped({
             loading: false,
             error: new CombinedGraphQLErrors(
-              graphQlErrorResult.result!.errors!
+              graphQlErrorResult.result!.errors!,
+              { data: graphQlErrorResult.result!.data }
             ),
             data: { totalLikes: 42 },
           });
@@ -1284,7 +1296,9 @@ followed by new in-flight setup", async () => {
 
         expect(onError).toHaveBeenCalledTimes(1);
         expect(onError).toHaveBeenCalledWith(
-          new CombinedGraphQLErrors(graphQlErrorResult.result!.errors!)
+          new CombinedGraphQLErrors(graphQlErrorResult.result!.errors!, {
+            data: graphQlErrorResult.result!.data,
+          })
         );
         expect(onData).toHaveBeenCalledTimes(0);
         expect(errorBoundaryOnError).toHaveBeenCalledTimes(0);
@@ -1754,7 +1768,7 @@ describe("`restart` callback", () => {
       expect(snapshot).toEqualStrictTyped({
         loading: false,
         data: undefined,
-        error: new CombinedGraphQLErrors([error]),
+        error: new CombinedGraphQLErrors([error], { data: undefined }),
       });
     }
 

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -154,8 +154,9 @@ describe("useSubscription Hook", () => {
 
     await expect(takeSnapshot()).resolves.toEqualStrictTyped({
       data: undefined,
-      error: new CombinedGraphQLErrors([{ message: "test" }], {
+      error: new CombinedGraphQLErrors({
         data: errorResult.result.data,
+        errors: [{ message: "test" }],
       }),
       loading: false,
     });
@@ -164,8 +165,9 @@ describe("useSubscription Hook", () => {
 
     expect(onError).toHaveBeenCalledTimes(1);
     expect(onError).toHaveBeenCalledWith(
-      new CombinedGraphQLErrors([{ message: "test" }], {
+      new CombinedGraphQLErrors({
         data: errorResult.result.data,
+        errors: [{ message: "test" }],
       })
     );
   });
@@ -237,8 +239,9 @@ describe("useSubscription Hook", () => {
 
     await expect(takeSnapshot()).resolves.toEqualStrictTyped({
       data: undefined,
-      error: new CombinedGraphQLErrors([{ message: "test" }], {
+      error: new CombinedGraphQLErrors({
         data: errorResult.result.data,
+        errors: [{ message: "test" }],
       }),
       loading: false,
     });
@@ -246,8 +249,9 @@ describe("useSubscription Hook", () => {
     expect(onData).toHaveBeenCalledTimes(1);
     expect(onError).toHaveBeenCalledTimes(1);
     expect(onError).toHaveBeenLastCalledWith(
-      new CombinedGraphQLErrors([{ message: "test" }], {
+      new CombinedGraphQLErrors({
         data: errorResult.result.data,
+        errors: [{ message: "test" }],
       })
     );
     expect(onComplete).toHaveBeenCalledTimes(0);
@@ -1249,19 +1253,14 @@ followed by new in-flight setup", async () => {
             const snapshot = await takeSnapshot();
             expect(snapshot).toEqualStrictTyped({
               loading: false,
-              error: new CombinedGraphQLErrors(
-                graphQlErrorResult.result!.errors as any,
-                { data: graphQlErrorResult.result!.data }
-              ),
+              error: new CombinedGraphQLErrors(graphQlErrorResult.result!),
               data: undefined,
             });
           }
 
           expect(onError).toHaveBeenCalledTimes(1);
           expect(onError).toHaveBeenCalledWith(
-            new CombinedGraphQLErrors(graphQlErrorResult.result!.errors!, {
-              data: graphQlErrorResult.result!.data,
-            })
+            new CombinedGraphQLErrors(graphQlErrorResult.result!)
           );
           expect(onData).toHaveBeenCalledTimes(0);
           expect(errorBoundaryOnError).toHaveBeenCalledTimes(0);
@@ -1286,19 +1285,14 @@ followed by new in-flight setup", async () => {
           const snapshot = await takeSnapshot();
           expect(snapshot).toEqualStrictTyped({
             loading: false,
-            error: new CombinedGraphQLErrors(
-              graphQlErrorResult.result!.errors!,
-              { data: graphQlErrorResult.result!.data }
-            ),
+            error: new CombinedGraphQLErrors(graphQlErrorResult.result!),
             data: { totalLikes: 42 },
           });
         }
 
         expect(onError).toHaveBeenCalledTimes(1);
         expect(onError).toHaveBeenCalledWith(
-          new CombinedGraphQLErrors(graphQlErrorResult.result!.errors!, {
-            data: graphQlErrorResult.result!.data,
-          })
+          new CombinedGraphQLErrors(graphQlErrorResult.result!)
         );
         expect(onData).toHaveBeenCalledTimes(0);
         expect(errorBoundaryOnError).toHaveBeenCalledTimes(0);
@@ -1768,7 +1762,7 @@ describe("`restart` callback", () => {
       expect(snapshot).toEqualStrictTyped({
         loading: false,
         data: undefined,
-        error: new CombinedGraphQLErrors([error], { data: undefined }),
+        error: new CombinedGraphQLErrors({ errors: [error] }),
       });
     }
 

--- a/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
@@ -3560,7 +3560,9 @@ describe("useSuspenseQuery", () => {
 
     expect(error).toBeInstanceOf(CombinedGraphQLErrors);
     expect(error).toEqual(
-      new CombinedGraphQLErrors([{ message: "`id` should not be null" }])
+      new CombinedGraphQLErrors([{ message: "`id` should not be null" }], {
+        data: undefined,
+      })
     );
   });
 
@@ -3697,7 +3699,9 @@ describe("useSuspenseQuery", () => {
 
     expect(error).toBeInstanceOf(CombinedGraphQLErrors);
     expect(error).toEqual(
-      new CombinedGraphQLErrors([{ message: "`id` should not be null" }])
+      new CombinedGraphQLErrors([{ message: "`id` should not be null" }], {
+        data: undefined,
+      })
     );
   });
 
@@ -3725,7 +3729,9 @@ describe("useSuspenseQuery", () => {
     const [error] = renders.errors;
 
     expect(error).toBeInstanceOf(CombinedGraphQLErrors);
-    expect(error).toEqual(new CombinedGraphQLErrors(graphQLErrors));
+    expect(error).toEqual(
+      new CombinedGraphQLErrors(graphQLErrors, { data: undefined })
+    );
   });
 
   it('does not throw or return network errors when errorPolicy is set to "ignore"', async () => {
@@ -3952,7 +3958,7 @@ describe("useSuspenseQuery", () => {
       expect(result.current).toEqualStrictTyped({
         data: undefined,
         networkStatus: NetworkStatus.error,
-        error: new CombinedGraphQLErrors([graphQLError]),
+        error: new CombinedGraphQLErrors([graphQLError], { data: undefined }),
       });
     });
 
@@ -3964,14 +3970,16 @@ describe("useSuspenseQuery", () => {
       {
         data: undefined,
         networkStatus: NetworkStatus.error,
-        error: new CombinedGraphQLErrors([graphQLError]),
+        error: new CombinedGraphQLErrors([graphQLError], { data: undefined }),
       },
     ]);
 
     const { error } = result.current;
 
     expect(error).toBeInstanceOf(CombinedGraphQLErrors);
-    expect(error).toEqual(new CombinedGraphQLErrors([graphQLError]));
+    expect(error).toEqual(
+      new CombinedGraphQLErrors([graphQLError], { data: undefined })
+    );
   });
 
   it('responds to cache updates and clears errors after an error returns when errorPolicy is set to "all"', async () => {
@@ -3993,7 +4001,7 @@ describe("useSuspenseQuery", () => {
       expect(result.current).toEqualStrictTyped({
         data: undefined,
         networkStatus: NetworkStatus.error,
-        error: new CombinedGraphQLErrors([graphQLError]),
+        error: new CombinedGraphQLErrors([graphQLError], { data: undefined }),
       });
     });
 
@@ -4027,7 +4035,7 @@ describe("useSuspenseQuery", () => {
       {
         data: undefined,
         networkStatus: NetworkStatus.error,
-        error: new CombinedGraphQLErrors([graphQLError]),
+        error: new CombinedGraphQLErrors([graphQLError], { data: undefined }),
       },
       {
         data: { currentUser: { id: "1", name: "Cache User" } },
@@ -4050,7 +4058,9 @@ describe("useSuspenseQuery", () => {
       { mocks }
     );
 
-    const expectedError = new CombinedGraphQLErrors(graphQLErrors);
+    const expectedError = new CombinedGraphQLErrors(graphQLErrors, {
+      data: undefined,
+    });
 
     await waitFor(() => {
       expect(result.current).toEqualStrictTyped({
@@ -4091,7 +4101,9 @@ describe("useSuspenseQuery", () => {
       { mocks }
     );
 
-    const expectedError = new CombinedGraphQLErrors([graphQLError]);
+    const expectedError = new CombinedGraphQLErrors([graphQLError], {
+      data: { currentUser: { id: "1", name: null } },
+    });
 
     await waitFor(() => {
       expect(result.current).toEqualStrictTyped({
@@ -4122,7 +4134,9 @@ describe("useSuspenseQuery", () => {
       { mocks }
     );
 
-    const expectedError = new CombinedGraphQLErrors([graphQLError]);
+    const expectedError = new CombinedGraphQLErrors([graphQLError], {
+      data: undefined,
+    });
 
     await waitFor(() => {
       expect(result.current.error).toEqual(expectedError);
@@ -4168,7 +4182,9 @@ describe("useSuspenseQuery", () => {
       { mocks, initialProps: { id: "1" } }
     );
 
-    const expectedError = new CombinedGraphQLErrors(graphQLErrors);
+    const expectedError = new CombinedGraphQLErrors(graphQLErrors, {
+      data: undefined,
+    });
 
     await waitFor(() => {
       expect(result.current).toEqualStrictTyped({
@@ -4584,7 +4600,9 @@ describe("useSuspenseQuery", () => {
     });
 
     expect(renders.errors).toEqual([
-      new CombinedGraphQLErrors([{ message: "Something went wrong" }]),
+      new CombinedGraphQLErrors([{ message: "Something went wrong" }], {
+        data: undefined,
+      }),
     ]);
     expect(renders.frames).toEqualStrictTyped([
       {
@@ -4695,9 +4713,10 @@ describe("useSuspenseQuery", () => {
       { mocks }
     );
 
-    const expectedError = new CombinedGraphQLErrors([
-      { message: "Something went wrong" },
-    ]);
+    const expectedError = new CombinedGraphQLErrors(
+      [{ message: "Something went wrong" }],
+      { data: undefined }
+    );
 
     await waitFor(() => {
       expect(result.current).toEqualStrictTyped({
@@ -4772,9 +4791,10 @@ describe("useSuspenseQuery", () => {
       { mocks }
     );
 
-    const expectedError = new CombinedGraphQLErrors([
-      { message: "Something went wrong" },
-    ]);
+    const expectedError = new CombinedGraphQLErrors(
+      [{ message: "Something went wrong" }],
+      { data: { user: { id: "1", name: null } } }
+    );
 
     await waitFor(() => {
       expect(result.current).toEqualStrictTyped({
@@ -6089,7 +6109,9 @@ describe("useSuspenseQuery", () => {
       expect(result.current).toEqualStrictTyped({
         ...successMock.result,
         networkStatus: NetworkStatus.error,
-        error: new CombinedGraphQLErrors([{ message: "oops" }]),
+        error: new CombinedGraphQLErrors([{ message: "oops" }], {
+          data: undefined,
+        }),
       });
     });
 
@@ -6114,7 +6136,9 @@ describe("useSuspenseQuery", () => {
       {
         ...successMock.result,
         networkStatus: NetworkStatus.error,
-        error: new CombinedGraphQLErrors([{ message: "oops" }]),
+        error: new CombinedGraphQLErrors([{ message: "oops" }], {
+          data: undefined,
+        }),
       },
     ]);
   });
@@ -6664,7 +6688,9 @@ describe("useSuspenseQuery", () => {
       void result.current.refetch();
     });
 
-    const expectedError = new CombinedGraphQLErrors([{ message: "oops" }]);
+    const expectedError = new CombinedGraphQLErrors([{ message: "oops" }], {
+      data: undefined,
+    });
 
     await waitFor(() => {
       expect(result.current).toEqualStrictTyped({
@@ -8577,7 +8603,9 @@ describe("useSuspenseQuery", () => {
 
     expect(error).toBeInstanceOf(CombinedGraphQLErrors);
     expect(error).toEqual(
-      new CombinedGraphQLErrors([{ message: "Could not fetch greeting" }])
+      new CombinedGraphQLErrors([{ message: "Could not fetch greeting" }], {
+        data: undefined,
+      })
     );
   });
 
@@ -8623,7 +8651,9 @@ describe("useSuspenseQuery", () => {
 
     expect(error).toBeInstanceOf(CombinedGraphQLErrors);
     expect(error).toEqual(
-      new CombinedGraphQLErrors([{ message: "Could not fetch greeting" }])
+      new CombinedGraphQLErrors([{ message: "Could not fetch greeting" }], {
+        data: { greeting: null },
+      })
     );
   });
 
@@ -8754,12 +8784,16 @@ describe("useSuspenseQuery", () => {
 
     expect(error).toBeInstanceOf(CombinedGraphQLErrors);
     expect(error).toEqual(
-      new CombinedGraphQLErrors([
-        {
-          message: "homeWorld for character with ID 1000 could not be fetched.",
-          path: ["hero", "heroFriends", 0, "homeWorld"],
-        },
-      ])
+      new CombinedGraphQLErrors(
+        [
+          {
+            message:
+              "homeWorld for character with ID 1000 could not be fetched.",
+            path: ["hero", "heroFriends", 0, "homeWorld"],
+          },
+        ],
+        { data: undefined }
+      )
     );
   });
 
@@ -8877,13 +8911,34 @@ describe("useSuspenseQuery", () => {
           },
         },
         networkStatus: NetworkStatus.error,
-        error: new CombinedGraphQLErrors([
+        error: new CombinedGraphQLErrors(
+          [
+            {
+              message:
+                "homeWorld for character with ID 1000 could not be fetched.",
+              path: ["hero", "heroFriends", 0, "homeWorld"],
+            },
+          ],
           {
-            message:
-              "homeWorld for character with ID 1000 could not be fetched.",
-            path: ["hero", "heroFriends", 0, "homeWorld"],
-          },
-        ]),
+            data: {
+              hero: {
+                heroFriends: [
+                  {
+                    id: "1000",
+                    name: "Luke Skywalker",
+                    homeWorld: null,
+                  },
+                  {
+                    id: "1003",
+                    name: "Leia Organa",
+                    homeWorld: "Alderaan",
+                  },
+                ],
+                name: "R2-D2",
+              },
+            },
+          }
+        ),
       });
     });
 
@@ -8928,13 +8983,34 @@ describe("useSuspenseQuery", () => {
           },
         },
         networkStatus: NetworkStatus.error,
-        error: new CombinedGraphQLErrors([
+        error: new CombinedGraphQLErrors(
+          [
+            {
+              message:
+                "homeWorld for character with ID 1000 could not be fetched.",
+              path: ["hero", "heroFriends", 0, "homeWorld"],
+            },
+          ],
           {
-            message:
-              "homeWorld for character with ID 1000 could not be fetched.",
-            path: ["hero", "heroFriends", 0, "homeWorld"],
-          },
-        ]),
+            data: {
+              hero: {
+                heroFriends: [
+                  {
+                    id: "1000",
+                    name: "Luke Skywalker",
+                    homeWorld: null,
+                  },
+                  {
+                    id: "1003",
+                    name: "Leia Organa",
+                    homeWorld: "Alderaan",
+                  },
+                ],
+                name: "R2-D2",
+              },
+            },
+          }
+        ),
       },
     ]);
   });
@@ -9198,13 +9274,26 @@ describe("useSuspenseQuery", () => {
           },
         },
         networkStatus: NetworkStatus.error,
-        error: new CombinedGraphQLErrors([
+        error: new CombinedGraphQLErrors(
+          [
+            {
+              message:
+                "homeWorld for character with ID 1000 could not be fetched.",
+              path: ["hero", "heroFriends", 0, "homeWorld"],
+            },
+          ],
           {
-            message:
-              "homeWorld for character with ID 1000 could not be fetched.",
-            path: ["hero", "heroFriends", 0, "homeWorld"],
-          },
-        ]),
+            data: {
+              hero: {
+                heroFriends: [
+                  { id: "1000", name: "Luke Skywalker" },
+                  { id: "1003", name: "Leia Organa" },
+                ],
+                name: "R2-D2",
+              },
+            },
+          }
+        ),
       });
     });
 
@@ -9345,13 +9434,26 @@ describe("useSuspenseQuery", () => {
           },
         },
         networkStatus: NetworkStatus.error,
-        error: new CombinedGraphQLErrors([
+        error: new CombinedGraphQLErrors(
+          [
+            {
+              message:
+                "homeWorld for character with ID 1000 could not be fetched.",
+              path: ["hero", "heroFriends", 0, "homeWorld"],
+            },
+          ],
           {
-            message:
-              "homeWorld for character with ID 1000 could not be fetched.",
-            path: ["hero", "heroFriends", 0, "homeWorld"],
-          },
-        ]),
+            data: {
+              hero: {
+                heroFriends: [
+                  { id: "1000", name: "Luke Skywalker" },
+                  { id: "1003", name: "Leia Organa" },
+                ],
+                name: "R2-D2",
+              },
+            },
+          }
+        ),
       },
       {
         data: {
@@ -10670,7 +10772,9 @@ describe("useSuspenseQuery", () => {
 
       expect(renderedComponents).toStrictEqual([ErrorFallback]);
       expect(snapshot.error).toEqual(
-        new CombinedGraphQLErrors([{ message: "Could not fetch letters" }])
+        new CombinedGraphQLErrors([{ message: "Could not fetch letters" }], {
+          data: null,
+        })
       );
     }
 
@@ -11611,7 +11715,16 @@ describe("useSuspenseQuery", () => {
       });
 
       expect(result?.error).toEqual(
-        new CombinedGraphQLErrors([{ message: "Couldn't get name" }])
+        new CombinedGraphQLErrors([{ message: "Couldn't get name" }], {
+          data: {
+            currentUser: {
+              __typename: "User",
+              id: 1,
+              name: null,
+              age: 34,
+            },
+          },
+        })
       );
     }
   });

--- a/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
@@ -9286,8 +9286,8 @@ describe("useSuspenseQuery", () => {
             data: {
               hero: {
                 heroFriends: [
-                  { id: "1000", name: "Luke Skywalker" },
-                  { id: "1003", name: "Leia Organa" },
+                  { id: "1000", name: "Luke Skywalker", homeWorld: null },
+                  { id: "1003", name: "Leia Organa", homeWorld: "Alderaan" },
                 ],
                 name: "R2-D2",
               },
@@ -9446,8 +9446,8 @@ describe("useSuspenseQuery", () => {
             data: {
               hero: {
                 heroFriends: [
-                  { id: "1000", name: "Luke Skywalker" },
-                  { id: "1003", name: "Leia Organa" },
+                  { id: "1000", name: "Luke Skywalker", homeWorld: null },
+                  { id: "1003", name: "Leia Organa", homeWorld: "Alderaan" },
                 ],
                 name: "R2-D2",
               },

--- a/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
@@ -3560,8 +3560,8 @@ describe("useSuspenseQuery", () => {
 
     expect(error).toBeInstanceOf(CombinedGraphQLErrors);
     expect(error).toEqual(
-      new CombinedGraphQLErrors([{ message: "`id` should not be null" }], {
-        data: undefined,
+      new CombinedGraphQLErrors({
+        errors: [{ message: "`id` should not be null" }],
       })
     );
   });
@@ -3699,8 +3699,8 @@ describe("useSuspenseQuery", () => {
 
     expect(error).toBeInstanceOf(CombinedGraphQLErrors);
     expect(error).toEqual(
-      new CombinedGraphQLErrors([{ message: "`id` should not be null" }], {
-        data: undefined,
+      new CombinedGraphQLErrors({
+        errors: [{ message: "`id` should not be null" }],
       })
     );
   });
@@ -3729,9 +3729,7 @@ describe("useSuspenseQuery", () => {
     const [error] = renders.errors;
 
     expect(error).toBeInstanceOf(CombinedGraphQLErrors);
-    expect(error).toEqual(
-      new CombinedGraphQLErrors(graphQLErrors, { data: undefined })
-    );
+    expect(error).toEqual(new CombinedGraphQLErrors({ errors: graphQLErrors }));
   });
 
   it('does not throw or return network errors when errorPolicy is set to "ignore"', async () => {
@@ -3958,7 +3956,7 @@ describe("useSuspenseQuery", () => {
       expect(result.current).toEqualStrictTyped({
         data: undefined,
         networkStatus: NetworkStatus.error,
-        error: new CombinedGraphQLErrors([graphQLError], { data: undefined }),
+        error: new CombinedGraphQLErrors({ errors: [graphQLError] }),
       });
     });
 
@@ -3970,7 +3968,7 @@ describe("useSuspenseQuery", () => {
       {
         data: undefined,
         networkStatus: NetworkStatus.error,
-        error: new CombinedGraphQLErrors([graphQLError], { data: undefined }),
+        error: new CombinedGraphQLErrors({ errors: [graphQLError] }),
       },
     ]);
 
@@ -3978,7 +3976,7 @@ describe("useSuspenseQuery", () => {
 
     expect(error).toBeInstanceOf(CombinedGraphQLErrors);
     expect(error).toEqual(
-      new CombinedGraphQLErrors([graphQLError], { data: undefined })
+      new CombinedGraphQLErrors({ errors: [graphQLError] })
     );
   });
 
@@ -4001,7 +3999,7 @@ describe("useSuspenseQuery", () => {
       expect(result.current).toEqualStrictTyped({
         data: undefined,
         networkStatus: NetworkStatus.error,
-        error: new CombinedGraphQLErrors([graphQLError], { data: undefined }),
+        error: new CombinedGraphQLErrors({ errors: [graphQLError] }),
       });
     });
 
@@ -4035,7 +4033,7 @@ describe("useSuspenseQuery", () => {
       {
         data: undefined,
         networkStatus: NetworkStatus.error,
-        error: new CombinedGraphQLErrors([graphQLError], { data: undefined }),
+        error: new CombinedGraphQLErrors({ errors: [graphQLError] }),
       },
       {
         data: { currentUser: { id: "1", name: "Cache User" } },
@@ -4058,9 +4056,7 @@ describe("useSuspenseQuery", () => {
       { mocks }
     );
 
-    const expectedError = new CombinedGraphQLErrors(graphQLErrors, {
-      data: undefined,
-    });
+    const expectedError = new CombinedGraphQLErrors({ errors: graphQLErrors });
 
     await waitFor(() => {
       expect(result.current).toEqualStrictTyped({
@@ -4101,8 +4097,9 @@ describe("useSuspenseQuery", () => {
       { mocks }
     );
 
-    const expectedError = new CombinedGraphQLErrors([graphQLError], {
+    const expectedError = new CombinedGraphQLErrors({
       data: { currentUser: { id: "1", name: null } },
+      errors: [graphQLError],
     });
 
     await waitFor(() => {
@@ -4134,9 +4131,7 @@ describe("useSuspenseQuery", () => {
       { mocks }
     );
 
-    const expectedError = new CombinedGraphQLErrors([graphQLError], {
-      data: undefined,
-    });
+    const expectedError = new CombinedGraphQLErrors({ errors: [graphQLError] });
 
     await waitFor(() => {
       expect(result.current.error).toEqual(expectedError);
@@ -4182,9 +4177,7 @@ describe("useSuspenseQuery", () => {
       { mocks, initialProps: { id: "1" } }
     );
 
-    const expectedError = new CombinedGraphQLErrors(graphQLErrors, {
-      data: undefined,
-    });
+    const expectedError = new CombinedGraphQLErrors({ errors: graphQLErrors });
 
     await waitFor(() => {
       expect(result.current).toEqualStrictTyped({
@@ -4600,8 +4593,8 @@ describe("useSuspenseQuery", () => {
     });
 
     expect(renders.errors).toEqual([
-      new CombinedGraphQLErrors([{ message: "Something went wrong" }], {
-        data: undefined,
+      new CombinedGraphQLErrors({
+        errors: [{ message: "Something went wrong" }],
       }),
     ]);
     expect(renders.frames).toEqualStrictTyped([
@@ -4713,10 +4706,9 @@ describe("useSuspenseQuery", () => {
       { mocks }
     );
 
-    const expectedError = new CombinedGraphQLErrors(
-      [{ message: "Something went wrong" }],
-      { data: undefined }
-    );
+    const expectedError = new CombinedGraphQLErrors({
+      errors: [{ message: "Something went wrong" }],
+    });
 
     await waitFor(() => {
       expect(result.current).toEqualStrictTyped({
@@ -4791,10 +4783,10 @@ describe("useSuspenseQuery", () => {
       { mocks }
     );
 
-    const expectedError = new CombinedGraphQLErrors(
-      [{ message: "Something went wrong" }],
-      { data: { user: { id: "1", name: null } } }
-    );
+    const expectedError = new CombinedGraphQLErrors({
+      data: { user: { id: "1", name: null } },
+      errors: [{ message: "Something went wrong" }],
+    });
 
     await waitFor(() => {
       expect(result.current).toEqualStrictTyped({
@@ -6109,9 +6101,7 @@ describe("useSuspenseQuery", () => {
       expect(result.current).toEqualStrictTyped({
         ...successMock.result,
         networkStatus: NetworkStatus.error,
-        error: new CombinedGraphQLErrors([{ message: "oops" }], {
-          data: undefined,
-        }),
+        error: new CombinedGraphQLErrors({ errors: [{ message: "oops" }] }),
       });
     });
 
@@ -6136,9 +6126,7 @@ describe("useSuspenseQuery", () => {
       {
         ...successMock.result,
         networkStatus: NetworkStatus.error,
-        error: new CombinedGraphQLErrors([{ message: "oops" }], {
-          data: undefined,
-        }),
+        error: new CombinedGraphQLErrors({ errors: [{ message: "oops" }] }),
       },
     ]);
   });
@@ -6688,8 +6676,8 @@ describe("useSuspenseQuery", () => {
       void result.current.refetch();
     });
 
-    const expectedError = new CombinedGraphQLErrors([{ message: "oops" }], {
-      data: undefined,
+    const expectedError = new CombinedGraphQLErrors({
+      errors: [{ message: "oops" }],
     });
 
     await waitFor(() => {
@@ -8603,8 +8591,8 @@ describe("useSuspenseQuery", () => {
 
     expect(error).toBeInstanceOf(CombinedGraphQLErrors);
     expect(error).toEqual(
-      new CombinedGraphQLErrors([{ message: "Could not fetch greeting" }], {
-        data: undefined,
+      new CombinedGraphQLErrors({
+        errors: [{ message: "Could not fetch greeting" }],
       })
     );
   });
@@ -8651,8 +8639,9 @@ describe("useSuspenseQuery", () => {
 
     expect(error).toBeInstanceOf(CombinedGraphQLErrors);
     expect(error).toEqual(
-      new CombinedGraphQLErrors([{ message: "Could not fetch greeting" }], {
+      new CombinedGraphQLErrors({
         data: { greeting: null },
+        errors: [{ message: "Could not fetch greeting" }],
       })
     );
   });
@@ -8784,16 +8773,15 @@ describe("useSuspenseQuery", () => {
 
     expect(error).toBeInstanceOf(CombinedGraphQLErrors);
     expect(error).toEqual(
-      new CombinedGraphQLErrors(
-        [
+      new CombinedGraphQLErrors({
+        errors: [
           {
             message:
               "homeWorld for character with ID 1000 could not be fetched.",
             path: ["hero", "heroFriends", 0, "homeWorld"],
           },
         ],
-        { data: undefined }
-      )
+      })
     );
   });
 
@@ -8911,34 +8899,32 @@ describe("useSuspenseQuery", () => {
           },
         },
         networkStatus: NetworkStatus.error,
-        error: new CombinedGraphQLErrors(
-          [
+        error: new CombinedGraphQLErrors({
+          data: {
+            hero: {
+              heroFriends: [
+                {
+                  id: "1000",
+                  name: "Luke Skywalker",
+                  homeWorld: null,
+                },
+                {
+                  id: "1003",
+                  name: "Leia Organa",
+                  homeWorld: "Alderaan",
+                },
+              ],
+              name: "R2-D2",
+            },
+          },
+          errors: [
             {
               message:
                 "homeWorld for character with ID 1000 could not be fetched.",
               path: ["hero", "heroFriends", 0, "homeWorld"],
             },
           ],
-          {
-            data: {
-              hero: {
-                heroFriends: [
-                  {
-                    id: "1000",
-                    name: "Luke Skywalker",
-                    homeWorld: null,
-                  },
-                  {
-                    id: "1003",
-                    name: "Leia Organa",
-                    homeWorld: "Alderaan",
-                  },
-                ],
-                name: "R2-D2",
-              },
-            },
-          }
-        ),
+        }),
       });
     });
 
@@ -8983,34 +8969,32 @@ describe("useSuspenseQuery", () => {
           },
         },
         networkStatus: NetworkStatus.error,
-        error: new CombinedGraphQLErrors(
-          [
+        error: new CombinedGraphQLErrors({
+          data: {
+            hero: {
+              heroFriends: [
+                {
+                  id: "1000",
+                  name: "Luke Skywalker",
+                  homeWorld: null,
+                },
+                {
+                  id: "1003",
+                  name: "Leia Organa",
+                  homeWorld: "Alderaan",
+                },
+              ],
+              name: "R2-D2",
+            },
+          },
+          errors: [
             {
               message:
                 "homeWorld for character with ID 1000 could not be fetched.",
               path: ["hero", "heroFriends", 0, "homeWorld"],
             },
           ],
-          {
-            data: {
-              hero: {
-                heroFriends: [
-                  {
-                    id: "1000",
-                    name: "Luke Skywalker",
-                    homeWorld: null,
-                  },
-                  {
-                    id: "1003",
-                    name: "Leia Organa",
-                    homeWorld: "Alderaan",
-                  },
-                ],
-                name: "R2-D2",
-              },
-            },
-          }
-        ),
+        }),
       },
     ]);
   });
@@ -9274,26 +9258,24 @@ describe("useSuspenseQuery", () => {
           },
         },
         networkStatus: NetworkStatus.error,
-        error: new CombinedGraphQLErrors(
-          [
+        error: new CombinedGraphQLErrors({
+          data: {
+            hero: {
+              heroFriends: [
+                { id: "1000", name: "Luke Skywalker", homeWorld: null },
+                { id: "1003", name: "Leia Organa", homeWorld: "Alderaan" },
+              ],
+              name: "R2-D2",
+            },
+          },
+          errors: [
             {
               message:
                 "homeWorld for character with ID 1000 could not be fetched.",
               path: ["hero", "heroFriends", 0, "homeWorld"],
             },
           ],
-          {
-            data: {
-              hero: {
-                heroFriends: [
-                  { id: "1000", name: "Luke Skywalker", homeWorld: null },
-                  { id: "1003", name: "Leia Organa", homeWorld: "Alderaan" },
-                ],
-                name: "R2-D2",
-              },
-            },
-          }
-        ),
+        }),
       });
     });
 
@@ -9434,26 +9416,24 @@ describe("useSuspenseQuery", () => {
           },
         },
         networkStatus: NetworkStatus.error,
-        error: new CombinedGraphQLErrors(
-          [
+        error: new CombinedGraphQLErrors({
+          data: {
+            hero: {
+              heroFriends: [
+                { id: "1000", name: "Luke Skywalker", homeWorld: null },
+                { id: "1003", name: "Leia Organa", homeWorld: "Alderaan" },
+              ],
+              name: "R2-D2",
+            },
+          },
+          errors: [
             {
               message:
                 "homeWorld for character with ID 1000 could not be fetched.",
               path: ["hero", "heroFriends", 0, "homeWorld"],
             },
           ],
-          {
-            data: {
-              hero: {
-                heroFriends: [
-                  { id: "1000", name: "Luke Skywalker", homeWorld: null },
-                  { id: "1003", name: "Leia Organa", homeWorld: "Alderaan" },
-                ],
-                name: "R2-D2",
-              },
-            },
-          }
-        ),
+        }),
       },
       {
         data: {
@@ -10772,8 +10752,9 @@ describe("useSuspenseQuery", () => {
 
       expect(renderedComponents).toStrictEqual([ErrorFallback]);
       expect(snapshot.error).toEqual(
-        new CombinedGraphQLErrors([{ message: "Could not fetch letters" }], {
+        new CombinedGraphQLErrors({
           data: null,
+          errors: [{ message: "Could not fetch letters" }],
         })
       );
     }
@@ -11715,7 +11696,7 @@ describe("useSuspenseQuery", () => {
       });
 
       expect(result?.error).toEqual(
-        new CombinedGraphQLErrors([{ message: "Couldn't get name" }], {
+        new CombinedGraphQLErrors({
           data: {
             currentUser: {
               __typename: "User",
@@ -11724,6 +11705,7 @@ describe("useSuspenseQuery", () => {
               age: 34,
             },
           },
+          errors: [{ message: "Couldn't get name" }],
         })
       );
     }

--- a/src/react/query-preloader/__tests__/createQueryPreloader.test.tsx
+++ b/src/react/query-preloader/__tests__/createQueryPreloader.test.tsx
@@ -1499,7 +1499,7 @@ test("throws when error is returned", async () => {
 
     expect(renderedComponents).toStrictEqual(["ErrorFallback"]);
     expect(snapshot.error).toEqual(
-      new CombinedGraphQLErrors([{ message: "Oops" }], { data: undefined })
+      new CombinedGraphQLErrors({ errors: [{ message: "Oops" }] })
     );
   }
 });
@@ -1532,9 +1532,7 @@ test("returns error when error policy is 'all'", async () => {
     expect(renderedComponents).toStrictEqual(["ReadQueryHook"]);
     expect(snapshot.result).toEqual({
       data: undefined,
-      error: new CombinedGraphQLErrors([{ message: "Oops" }], {
-        data: undefined,
-      }),
+      error: new CombinedGraphQLErrors({ errors: [{ message: "Oops" }] }),
       networkStatus: NetworkStatus.error,
     });
     expect(snapshot.error).toEqual(null);

--- a/src/react/query-preloader/__tests__/createQueryPreloader.test.tsx
+++ b/src/react/query-preloader/__tests__/createQueryPreloader.test.tsx
@@ -1499,7 +1499,7 @@ test("throws when error is returned", async () => {
 
     expect(renderedComponents).toStrictEqual(["ErrorFallback"]);
     expect(snapshot.error).toEqual(
-      new CombinedGraphQLErrors([{ message: "Oops" }])
+      new CombinedGraphQLErrors([{ message: "Oops" }], { data: undefined })
     );
   }
 });
@@ -1532,7 +1532,9 @@ test("returns error when error policy is 'all'", async () => {
     expect(renderedComponents).toStrictEqual(["ReadQueryHook"]);
     expect(snapshot.result).toEqual({
       data: undefined,
-      error: new CombinedGraphQLErrors([{ message: "Oops" }]),
+      error: new CombinedGraphQLErrors([{ message: "Oops" }], {
+        data: undefined,
+      }),
       networkStatus: NetworkStatus.error,
     });
     expect(snapshot.error).toEqual(null);

--- a/src/react/ssr/__tests__/getDataFromTree.test.tsx
+++ b/src/react/ssr/__tests__/getDataFromTree.test.tsx
@@ -125,8 +125,9 @@ describe("SSR", () => {
           expect(data).toMatchObject({ allPeople: { people: null } });
           expect(error).toBeDefined();
           expect(error).toEqual(
-            new CombinedGraphQLErrors([{ message: "this is an error" }], {
+            new CombinedGraphQLErrors({
               data: { allPeople: { people: null } },
+              errors: [{ message: "this is an error" }],
             })
           );
         }

--- a/src/react/ssr/__tests__/getDataFromTree.test.tsx
+++ b/src/react/ssr/__tests__/getDataFromTree.test.tsx
@@ -125,7 +125,9 @@ describe("SSR", () => {
           expect(data).toMatchObject({ allPeople: { people: null } });
           expect(error).toBeDefined();
           expect(error).toEqual(
-            new CombinedGraphQLErrors([{ message: "this is an error" }])
+            new CombinedGraphQLErrors([{ message: "this is an error" }], {
+              data: { allPeople: { people: null } },
+            })
           );
         }
 

--- a/src/testing/experimental/__tests__/createTestSchema.test.tsx
+++ b/src/testing/experimental/__tests__/createTestSchema.test.tsx
@@ -743,10 +743,12 @@ describe("schema proxy", () => {
       const { snapshot } = await renderStream.takeRender();
 
       expect(snapshot.error).toEqual(
-        new CombinedGraphQLErrors(
-          [{ message: "Could not resolve type", path: ["viewer", "book"] }],
-          { data: null }
-        )
+        new CombinedGraphQLErrors({
+          data: null,
+          errors: [
+            { message: "Could not resolve type", path: ["viewer", "book"] },
+          ],
+        })
       );
     }
   });
@@ -819,10 +821,11 @@ describe("schema proxy", () => {
       const { snapshot } = await renderStream.takeRender();
 
       expect(snapshot.error).toEqual(
-        new CombinedGraphQLErrors(
-          [{ message: 'Expected { foo: "bar" } to be a GraphQL schema.' }],
-          { data: undefined }
-        )
+        new CombinedGraphQLErrors({
+          errors: [
+            { message: 'Expected { foo: "bar" } to be a GraphQL schema.' },
+          ],
+        })
       );
     }
   });

--- a/src/testing/experimental/__tests__/createTestSchema.test.tsx
+++ b/src/testing/experimental/__tests__/createTestSchema.test.tsx
@@ -743,9 +743,10 @@ describe("schema proxy", () => {
       const { snapshot } = await renderStream.takeRender();
 
       expect(snapshot.error).toEqual(
-        new CombinedGraphQLErrors([
-          { message: "Could not resolve type", path: ["viewer", "book"] },
-        ])
+        new CombinedGraphQLErrors(
+          [{ message: "Could not resolve type", path: ["viewer", "book"] }],
+          { data: null }
+        )
       );
     }
   });
@@ -818,9 +819,10 @@ describe("schema proxy", () => {
       const { snapshot } = await renderStream.takeRender();
 
       expect(snapshot.error).toEqual(
-        new CombinedGraphQLErrors([
-          { message: 'Expected { foo: "bar" } to be a GraphQL schema.' },
-        ])
+        new CombinedGraphQLErrors(
+          [{ message: 'Expected { foo: "bar" } to be a GraphQL schema.' }],
+          { data: undefined }
+        )
       );
     }
   });


### PR DESCRIPTION
Closes #12483 

Adds a `data` property to `CombinedGraphQLErrors` that captures any partial data returned by the server when `errors` are returned.