### PR TITLE
Minor `QueryInfo` refactor

### DIFF
--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -1680,8 +1680,6 @@ class QueryInfo {
     init(query: {
         document: DocumentNode;
         variables: Record<string, any> | undefined;
-        observableQuery?: ObservableQuery<any, any>;
-        lastRequestId?: number;
     }): this;
     // (undocumented)
     lastRequestId: number;

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -722,8 +722,6 @@ class QueryInfo {
     init(query: {
         document: DocumentNode;
         variables: Record<string, any> | undefined;
-        observableQuery?: ObservableQuery<any, any>;
-        lastRequestId?: number;
     }): this;
     // (undocumented)
     lastRequestId: number;

--- a/.api-reports/api-report-react_hooks.api.md
+++ b/.api-reports/api-report-react_hooks.api.md
@@ -538,8 +538,6 @@ class QueryInfo {
     init(query: {
         document: DocumentNode;
         variables: Record<string, any> | undefined;
-        observableQuery?: ObservableQuery<any, any>;
-        lastRequestId?: number;
     }): this;
     // (undocumented)
     lastRequestId: number;

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -1795,8 +1795,6 @@ class QueryInfo {
     init(query: {
         document: DocumentNode;
         variables: Record<string, any> | undefined;
-        observableQuery?: ObservableQuery<any, any>;
-        lastRequestId?: number;
     }): this;
     // (undocumented)
     lastRequestId: number;

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 42563,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 37833,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 32930,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27693
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 42554,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 37874,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 32871,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27681
 }

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -109,7 +109,6 @@ export class QueryInfo {
     Object.assign(this, {
       document: query.document,
       variables: query.variables,
-      networkError: null,
     });
 
     return this;

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -99,7 +99,6 @@ export class QueryInfo {
   public init(query: {
     document: DocumentNode;
     variables: Record<string, any> | undefined;
-    lastRequestId?: number;
   }): this {
     if (!equal(query.variables, this.variables)) {
       this.lastDiff = void 0;
@@ -112,10 +111,6 @@ export class QueryInfo {
       variables: query.variables,
       networkError: null,
     });
-
-    if (query.lastRequestId) {
-      this.lastRequestId = query.lastRequestId;
-    }
 
     return this;
   }

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -99,7 +99,6 @@ export class QueryInfo {
   public init(query: {
     document: DocumentNode;
     variables: Record<string, any> | undefined;
-    observableQuery?: ObservableQuery<any, any>;
     lastRequestId?: number;
   }): this {
     if (!equal(query.variables, this.variables)) {
@@ -113,10 +112,6 @@ export class QueryInfo {
       variables: query.variables,
       networkError: null,
     });
-
-    if (query.observableQuery) {
-      this.setObservableQuery(query.observableQuery);
-    }
 
     if (query.lastRequestId) {
       this.lastRequestId = query.lastRequestId;

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -814,11 +814,8 @@ export class QueryManager {
 
     // We give queryInfo the transformed query to ensure the first cache diff
     // uses the transformed query instead of the raw query
-    queryInfo.init({
-      document: query,
-      observableQuery: observable,
-      variables: observable.variables,
-    });
+    queryInfo.init({ document: query, variables: observable.variables });
+    queryInfo.setObservableQuery(observable);
 
     return observable;
   }


### PR DESCRIPTION
In an effort to move toward dismantling `QueryInfo`, this PR removes the `observableQuery` and `lastRequestId` options from `QueryInfo.init`. The `observableQuery` option was only used in one place and was used to call `setObservableQuery` which I just inlined in the one call site. The `lastRequestId` option wasn't used at all so I removed this entirely.