### PR TITLE
Change `notifyOnNetworkStatusChange` default to `true`

### DIFF
--- a/.changeset/thin-peas-hear.md
+++ b/.changeset/thin-peas-hear.md
@@ -1,0 +1,16 @@
+---
+"@apollo/client": major
+---
+
+`notifyOnNetworkStatusChange` now defaults to `true`. This means that loading states will be emitted (core API) or rendered (React) by default when calling `refetch`, `fetchMore`, etc. To maintain the old behavior, set `notifyOnNetworkStatusChange` to `false` in `defaultOptions`.
+
+```ts
+new ApolloClient({
+  defaultOptions: {
+    watchQuery: {
+      // Use the v3 default
+      notifyOnNetworkStatusChange: false
+    }
+  }
+})
+```

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 42887,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38300,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 32775,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27714
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 42852,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38311,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 32787,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27726
 }

--- a/src/__tests__/ApolloClient.ts
+++ b/src/__tests__/ApolloClient.ts
@@ -2966,8 +2966,8 @@ describe("ApolloClient", () => {
       const stream2 = new ObservableStream(result.queries[0]);
 
       await expect(stream2).toEmitTypedValue({
-        loading: false,
-        networkStatus: NetworkStatus.ready,
+        loading: true,
+        networkStatus: NetworkStatus.refetch,
         partial: false,
         data: { foo: { bar: 1 } },
       });

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -729,6 +729,7 @@ describe("client", () => {
           hello
         }
       `,
+      notifyOnNetworkStatusChange: false,
     });
 
     const stream = new ObservableStream(observable);
@@ -3672,6 +3673,13 @@ describe("@connection", () => {
       void obs.refetch();
 
       await expect(stream).toEmitTypedValue({
+        data: { count: "initial" },
+        loading: true,
+        networkStatus: NetworkStatus.refetch,
+        partial: false,
+      });
+
+      await expect(stream).toEmitTypedValue({
         data: { count: 0 },
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -3695,6 +3703,13 @@ describe("@connection", () => {
       expect(nextFetchPolicyCallCount).toBe(3);
 
       client.cache.evict({ fieldName: "count" });
+
+      await expect(stream).toEmitTypedValue({
+        data: undefined,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        partial: true,
+      });
 
       await expect(stream).toEmitTypedValue({
         data: { count: 1 },
@@ -3770,6 +3785,12 @@ describe("@connection", () => {
 
       expect(fetchPolicyRecord).toEqual(["cache-first", "network-only"]);
 
+      await expect(stream).toEmitTypedValue({
+        data: { linkCount: 1 },
+        loading: true,
+        networkStatus: NetworkStatus.refetch,
+        partial: false,
+      });
       await expect(stream).toEmitTypedValue({
         data: { linkCount: 2 },
         loading: false,
@@ -5282,6 +5303,15 @@ describe("custom document transforms", () => {
 
     expect(data).toEqual({
       products: [{ __typename: "Product", id: 2 }],
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: {
+        products: [{ __typename: "Product", id: 1, metrics: "1000/vpm" }],
+      },
+      loading: true,
+      networkStatus: NetworkStatus.fetchMore,
+      partial: false,
     });
 
     await expect(stream).toEmitTypedValue({

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -2663,10 +2663,7 @@ describe("client", () => {
       cache: new InMemoryCache(),
     });
 
-    const observable = client.watchQuery({
-      query,
-      notifyOnNetworkStatusChange: true,
-    });
+    const observable = client.watchQuery({ query });
 
     let stream = new ObservableStream(observable);
 
@@ -3800,8 +3797,6 @@ describe("@connection", () => {
       expect(fetchPolicyRecord).toEqual(["cache-first", "network-only"]);
 
       const finalResult = await observable.reobserve({
-        // Allow delivery of loading:true result.
-        notifyOnNetworkStatusChange: true,
         // Force a network request in addition to loading:true cache result.
         fetchPolicy: "cache-and-network",
       });

--- a/src/__tests__/dataMasking.ts
+++ b/src/__tests__/dataMasking.ts
@@ -2569,6 +2569,7 @@ describe("client.watchQuery", () => {
         __typename: "User";
         id: number;
         name: string;
+        age: number;
       } & { " $fragmentRefs"?: { UserFieldsFragment: UserFieldsFragment } };
     }
 

--- a/src/__tests__/dataMasking.ts
+++ b/src/__tests__/dataMasking.ts
@@ -1584,7 +1584,10 @@ describe("client.watchQuery", () => {
       link: new MockLink(mocks),
     });
 
-    const observable = client.watchQuery({ query });
+    const observable = client.watchQuery({
+      query,
+      notifyOnNetworkStatusChange: false,
+    });
     const stream = new ObservableStream(observable);
 
     {
@@ -1620,9 +1623,7 @@ describe("client.watchQuery", () => {
 
     // Since we don't set notifyOnNetworkStatus to `true`, we don't expect to
     // see another result since the masked data did not change
-    await expect(stream.takeNext()).rejects.toThrow(
-      new Error("Timeout waiting for next event")
-    );
+    await expect(stream).not.toEmitAnything();
   });
 
   test("masks result of setVariables", async () => {
@@ -1708,7 +1709,7 @@ describe("client.watchQuery", () => {
 
     const result = await observable.setVariables({ id: 2 });
 
-    expect(result?.data).toEqual({
+    expect(result.data).toEqual({
       user: {
         __typename: "User",
         id: 2,
@@ -1716,21 +1717,27 @@ describe("client.watchQuery", () => {
       },
     });
 
-    {
-      const { data } = await stream.takeNext();
+    await expect(stream).toEmitTypedValue({
+      data: undefined,
+      loading: true,
+      networkStatus: NetworkStatus.setVariables,
+      partial: true,
+    });
 
-      expect(data).toEqual({
+    await expect(stream).toEmitTypedValue({
+      data: {
         user: {
           __typename: "User",
           id: 2,
           name: "User 2",
         },
-      });
-    }
+      },
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
 
-    await expect(stream.takeNext()).rejects.toThrow(
-      new Error("Timeout waiting for next event")
-    );
+    await expect(stream).not.toEmitAnything();
   });
 
   test("masks result of reobserve", async () => {
@@ -1816,7 +1823,7 @@ describe("client.watchQuery", () => {
 
     const result = await observable.reobserve({ variables: { id: 2 } });
 
-    expect(result?.data).toEqual({
+    expect(result.data).toEqual({
       user: {
         __typename: "User",
         id: 2,
@@ -1824,21 +1831,27 @@ describe("client.watchQuery", () => {
       },
     });
 
-    {
-      const { data } = await stream.takeNext();
+    await expect(stream).toEmitTypedValue({
+      data: undefined,
+      loading: true,
+      networkStatus: NetworkStatus.setVariables,
+      partial: true,
+    });
 
-      expect(data).toEqual({
+    await expect(stream).toEmitTypedValue({
+      data: {
         user: {
           __typename: "User",
           id: 2,
           name: "User 2",
         },
-      });
-    }
+      },
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
 
-    await expect(stream.takeNext()).rejects.toThrow(
-      new Error("Timeout waiting for next event")
-    );
+    await expect(stream).not.toEmitAnything();
   });
 
   test("does not mask data passed to updateQuery", async () => {
@@ -2404,17 +2417,25 @@ describe("client.watchQuery", () => {
     const observable = client.watchQuery({ query, fetchPolicy: "no-cache" });
     const stream = new ObservableStream(observable);
 
-    {
-      const { data } = await stream.takeNext();
+    await expect(stream).toEmitTypedValue({
+      data: undefined,
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      partial: true,
+    });
 
-      expect(data).toEqual({
+    await expect(stream).toEmitTypedValue({
+      data: {
         currentUser: {
           __typename: "User",
           id: 1,
           name: "Test User",
         },
-      });
-    }
+      },
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
 
     expect(console.warn).toHaveBeenCalledTimes(1);
     expect(console.warn).toHaveBeenCalledWith(NO_CACHE_WARNING, "MaskedQuery");
@@ -2473,18 +2494,27 @@ describe("client.watchQuery", () => {
     const observable = client.watchQuery({ query, fetchPolicy: "no-cache" });
     const stream = new ObservableStream(observable);
 
-    {
-      const { data } = await stream.takeNext();
+    await expect(stream).toEmitTypedValue({
+      data: undefined,
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      partial: true,
+    });
 
-      expect(data).toEqual({
+    await expect(stream).toEmitTypedValue({
+      data: {
         currentUser: {
           __typename: "User",
           id: 1,
           name: "Test User",
+          // @ts-expect-error using a no-cache query
           age: 30,
         },
-      });
-    }
+      },
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
 
     expect(console.warn).not.toHaveBeenCalled();
   });
@@ -2540,18 +2570,26 @@ describe("client.watchQuery", () => {
     const observable = client.watchQuery({ query, fetchPolicy: "no-cache" });
     const stream = new ObservableStream(observable);
 
-    {
-      const { data } = await stream.takeNext();
+    await expect(stream).toEmitTypedValue({
+      data: undefined,
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      partial: true,
+    });
 
-      expect(data).toEqual({
+    await expect(stream).toEmitTypedValue({
+      data: {
         currentUser: {
           __typename: "User",
           id: 1,
           name: "Test User",
           age: 30,
         },
-      });
-    }
+      },
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
 
     expect(console.warn).not.toHaveBeenCalled();
   });
@@ -2616,18 +2654,26 @@ describe("client.watchQuery", () => {
     const observable = client.watchQuery({ query, fetchPolicy: "no-cache" });
     const stream = new ObservableStream(observable);
 
-    {
-      const { data } = await stream.takeNext();
+    await expect(stream).toEmitTypedValue({
+      data: undefined,
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      partial: true,
+    });
 
-      expect(data).toEqual({
+    await expect(stream).toEmitTypedValue({
+      data: {
         currentUser: {
           __typename: "User",
           id: 1,
           name: "Test User",
           age: 30,
         },
-      });
-    }
+      },
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
 
     expect(console.warn).toHaveBeenCalledTimes(1);
     expect(console.warn).toHaveBeenCalledWith(NO_CACHE_WARNING, "MaskedQuery");

--- a/src/__tests__/dataMasking.ts
+++ b/src/__tests__/dataMasking.ts
@@ -2491,16 +2491,14 @@ describe("client.watchQuery", () => {
 
   test("does not warn on no-cache queries when all fragments use `@unmask`", async () => {
     using _ = spyOnConsole("warn");
-    type UserFieldsFragment = {
-      age: number;
-    } & { " $fragmentName"?: "UserFieldsFragment" };
 
     interface Query {
       currentUser: {
         __typename: "User";
         id: number;
         name: string;
-      } & { " $fragmentRefs"?: { UserFieldsFragment: UserFieldsFragment } };
+        age: number;
+      };
     }
 
     const query: MaskedDocumentNode<Query, never> = gql`

--- a/src/__tests__/fetchMore.ts
+++ b/src/__tests__/fetchMore.ts
@@ -1314,12 +1314,7 @@ describe("fetchMore on an observable query", () => {
         cache: new InMemoryCache(),
       });
 
-      const observable = client.watchQuery({
-        query,
-        variables,
-        notifyOnNetworkStatusChange: true,
-      });
-
+      const observable = client.watchQuery({ query, variables });
       const stream = new ObservableStream(observable);
 
       const { data, networkStatus } = await stream.takeNext();
@@ -1377,12 +1372,7 @@ describe("fetchMore on an observable query", () => {
         }),
       });
 
-      const observable = client.watchQuery({
-        query,
-        variables,
-        notifyOnNetworkStatusChange: true,
-      });
-
+      const observable = client.watchQuery({ query, variables });
       const stream = new ObservableStream(observable);
 
       const { data, networkStatus } = await stream.takeNext();
@@ -1458,11 +1448,7 @@ describe("fetchMore on an observable query", () => {
       cache: new InMemoryCache(),
     });
 
-    const observable = client.watchQuery({
-      query,
-      variables,
-      notifyOnNetworkStatusChange: true,
-    });
+    const observable = client.watchQuery({ query, variables });
 
     const stream = new ObservableStream(observable);
 
@@ -1777,11 +1763,7 @@ describe("fetchMore on an observable query with connection", () => {
         cache: new InMemoryCache(),
       });
 
-      const observable = client.watchQuery({
-        query,
-        variables,
-        notifyOnNetworkStatusChange: true,
-      });
+      const observable = client.watchQuery({ query, variables });
 
       const stream = new ObservableStream(observable);
 
@@ -1848,11 +1830,7 @@ describe("fetchMore on an observable query with connection", () => {
         }),
       });
 
-      const observable = client.watchQuery({
-        query,
-        variables,
-        notifyOnNetworkStatusChange: true,
-      });
+      const observable = client.watchQuery({ query, variables });
 
       const stream = new ObservableStream(observable);
 
@@ -1894,7 +1872,6 @@ test("uses updateQuery to update the result of the query with no-cache queries",
   const observable = client.watchQuery({
     query,
     fetchPolicy: "no-cache",
-    notifyOnNetworkStatusChange: true,
     variables: { limit: 2 },
   });
 

--- a/src/__tests__/fetchMore.ts
+++ b/src/__tests__/fetchMore.ts
@@ -325,6 +325,15 @@ describe("fetchMore on an observable query", () => {
         expect(fetchMoreResult.data!.entry.comments).toHaveLength(10);
       }
 
+      await expect(stream).toEmitTypedValue({
+        data: {
+          entry: { __typename: "Entry", comments: expect.arrayWithLength(10) },
+        },
+        loading: true,
+        networkStatus: NetworkStatus.fetchMore,
+        partial: false,
+      });
+
       {
         const result = await stream.takeNext();
         const combinedComments = result.data!.entry.comments;
@@ -374,6 +383,15 @@ describe("fetchMore on an observable query", () => {
         // This is the server result
         expect(fetchMoreResult.data!.entry.comments).toHaveLength(10);
       }
+
+      await expect(stream).toEmitTypedValue({
+        data: {
+          entry: { __typename: "Entry", comments: expect.arrayWithLength(10) },
+        },
+        loading: true,
+        networkStatus: NetworkStatus.fetchMore,
+        partial: false,
+      });
 
       {
         const result = await stream.takeNext();
@@ -432,6 +450,15 @@ describe("fetchMore on an observable query", () => {
         });
       }
 
+      await expect(stream).toEmitTypedValue({
+        data: {
+          entry: { __typename: "Entry", comments: expect.arrayWithLength(10) },
+        },
+        loading: true,
+        networkStatus: NetworkStatus.fetchMore,
+        partial: false,
+      });
+
       {
         const result = await stream.takeNext();
         const combinedComments = result.data!.entry.comments;
@@ -484,6 +511,15 @@ describe("fetchMore on an observable query", () => {
 
         expect(fetchMoreResult.data!.entry.comments).toHaveLength(10); // this is the server result
       }
+
+      await expect(stream).toEmitTypedValue({
+        data: {
+          entry: { __typename: "Entry", comments: expect.arrayWithLength(10) },
+        },
+        loading: true,
+        networkStatus: NetworkStatus.fetchMore,
+        partial: false,
+      });
 
       {
         const result = await stream.takeNext();
@@ -643,6 +679,13 @@ describe("fetchMore on an observable query", () => {
       }
 
       await expect(stream).toEmitTypedValue({
+        data: { TODO: tasks.slice(0, 2) },
+        loading: true,
+        networkStatus: NetworkStatus.fetchMore,
+        partial: false,
+      });
+
+      await expect(stream).toEmitTypedValue({
         loading: false,
         networkStatus: NetworkStatus.ready,
         data: {
@@ -670,6 +713,13 @@ describe("fetchMore on an observable query", () => {
           },
         });
       }
+
+      await expect(stream).toEmitTypedValue({
+        data: { TODO: tasks.slice(0, 4) },
+        loading: true,
+        networkStatus: NetworkStatus.fetchMore,
+        partial: false,
+      });
 
       await expect(stream).toEmitTypedValue({
         loading: false,
@@ -846,6 +896,13 @@ describe("fetchMore on an observable query", () => {
       }
 
       await expect(stream).toEmitTypedValue({
+        data: { TODO: tasks.slice(0, 2) },
+        loading: true,
+        networkStatus: NetworkStatus.fetchMore,
+        partial: false,
+      });
+
+      await expect(stream).toEmitTypedValue({
         loading: false,
         networkStatus: NetworkStatus.ready,
         data: {
@@ -873,6 +930,13 @@ describe("fetchMore on an observable query", () => {
           },
         });
       }
+
+      await expect(stream).toEmitTypedValue({
+        data: { TODO: tasks.slice(0, 4) },
+        loading: true,
+        networkStatus: NetworkStatus.fetchMore,
+        partial: false,
+      });
 
       await expect(stream).toEmitTypedValue({
         loading: false,
@@ -1148,6 +1212,13 @@ describe("fetchMore on an observable query", () => {
 
       expect(observable.options.fetchPolicy).toBe("cache-first");
     }
+
+    await expect(stream).toEmitTypedValue({
+      data: { groceries: initialGroceries },
+      loading: true,
+      networkStatus: NetworkStatus.fetchMore,
+      partial: false,
+    });
 
     // This result comes entirely from the cache, without updating the
     // original variables for the ObservableQuery, because the
@@ -1596,6 +1667,18 @@ describe("fetchMore on an observable query with connection", () => {
         expect(fetchMoreResult.data!.entry.comments).toHaveLength(10);
       }
 
+      await expect(stream).toEmitTypedValue({
+        data: {
+          entry: {
+            __typename: "Entry",
+            comments: expect.arrayWithLength(10),
+          },
+        },
+        loading: true,
+        networkStatus: NetworkStatus.fetchMore,
+        partial: false,
+      });
+
       {
         const result = await stream.takeNext();
         const combinedComments = result.data!.entry.comments;
@@ -1647,6 +1730,18 @@ describe("fetchMore on an observable query with connection", () => {
         // this is the server result
         expect(fetchMoreResult.data!.entry.comments).toHaveLength(10);
       }
+
+      await expect(stream).toEmitTypedValue({
+        data: {
+          entry: {
+            __typename: "Entry",
+            comments: expect.arrayWithLength(10),
+          },
+        },
+        loading: true,
+        networkStatus: NetworkStatus.fetchMore,
+        partial: false,
+      });
 
       {
         const result = await stream.takeNext();

--- a/src/__tests__/local-state/export.ts
+++ b/src/__tests__/local-state/export.ts
@@ -749,6 +749,13 @@ describe("@client @export tests", () => {
     });
 
     await expect(stream).toEmitTypedValue({
+      data: undefined,
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      partial: true,
+    });
+
+    await expect(stream).toEmitTypedValue({
       data: {
         currentAuthorId: testAuthorId2,
         postCount: testPostCount2,
@@ -953,6 +960,13 @@ describe("@client @export tests", () => {
       data: {
         widgetCount: 500,
       },
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: undefined,
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      partial: true,
     });
 
     await expect(stream).toEmitTypedValue({

--- a/src/__tests__/local-state/general.ts
+++ b/src/__tests__/local-state/general.ts
@@ -443,6 +443,13 @@ describe("Cache manipulation", () => {
     });
 
     await expect(stream).toEmitTypedValue({
+      data: { serverData, selectedItemId: -1 },
+      loading: true,
+      networkStatus: NetworkStatus.refetch,
+      partial: false,
+    });
+
+    await expect(stream).toEmitTypedValue({
       data: {
         serverData,
         selectedItemId: 123,

--- a/src/__tests__/local-state/general.ts
+++ b/src/__tests__/local-state/general.ts
@@ -854,7 +854,6 @@ describe("Combining client and server state/operations", () => {
       variables: {
         id: 1,
       },
-      notifyOnNetworkStatusChange: true,
     };
 
     const PersonType = new GraphQLObjectType({

--- a/src/__tests__/mutationResults.ts
+++ b/src/__tests__/mutationResults.ts
@@ -6,7 +6,7 @@ import type { Subscription } from "rxjs";
 import { firstValueFrom, from, Observable } from "rxjs";
 
 import type { FetchResult } from "@apollo/client";
-import { ApolloClient } from "@apollo/client";
+import { ApolloClient, NetworkStatus } from "@apollo/client";
 import { InMemoryCache } from "@apollo/client/cache";
 import { CombinedGraphQLErrors } from "@apollo/client/errors";
 import { ApolloLink } from "@apollo/client/link/core";
@@ -1289,11 +1289,19 @@ describe("mutation results", () => {
 
     await watchedQuery.refetch(variables2);
 
-    {
-      const result = await stream.takeNext();
+    await expect(stream).toEmitTypedValue({
+      data: undefined,
+      loading: true,
+      networkStatus: NetworkStatus.refetch,
+      partial: true,
+    });
 
-      expect(result.data).toEqual({ echo: "b" });
-    }
+    await expect(stream).toEmitTypedValue({
+      data: { echo: "b" },
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
 
     await expect(
       client.mutate({
@@ -1306,11 +1314,12 @@ describe("mutation results", () => {
       })
     ).resolves.toStrictEqualTyped({ data: resetMutationResult.data });
 
-    {
-      const result = await stream.takeNext();
-
-      expect(result.data).toEqual({ echo: "0" });
-    }
+    await expect(stream).toEmitTypedValue({
+      data: { echo: "0" },
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
   });
 
   it("allows mutations with optional arguments", async () => {

--- a/src/__tests__/refetchQueries.ts
+++ b/src/__tests__/refetchQueries.ts
@@ -91,7 +91,10 @@ describe("client.refetchQueries", () => {
 
   function setup(client = makeClient()) {
     function watch<T>(query: TypedDocumentNode<T>) {
-      const obsQuery = client.watchQuery({ query });
+      const obsQuery = client.watchQuery({
+        query,
+        notifyOnNetworkStatusChange: false,
+      });
       return new Promise<ObservableQuery<T>>((resolve, reject) => {
         subs.push(
           obsQuery.subscribe({

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -4108,6 +4108,7 @@ describe("type policies", function () {
         }
       >({
         query,
+        notifyOnNetworkStatusChange: false,
         variables: {
           query: "Basquiat",
           first: 3,

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1043,7 +1043,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     };
 
     const variables = options.variables && { ...options.variables };
-    const { notifyOnNetworkStatusChange = false } = options;
+    const { notifyOnNetworkStatusChange = true } = options;
     const { observable, fromLink } = this.fetch(
       options,
       newNetworkStatus,

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -800,7 +800,7 @@ export class QueryManager {
     };
 
     if (typeof options.notifyOnNetworkStatusChange === "undefined") {
-      options.notifyOnNetworkStatusChange = false;
+      options.notifyOnNetworkStatusChange = true;
     }
 
     const queryInfo = new QueryInfo(this);
@@ -1339,7 +1339,7 @@ export class QueryManager {
       fetchPolicy = (defaults && defaults.fetchPolicy) || "cache-first",
       errorPolicy = (defaults && defaults.errorPolicy) || "none",
       returnPartialData = false,
-      notifyOnNetworkStatusChange = false,
+      notifyOnNetworkStatusChange = true,
       context = {},
     } = options;
 

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -3697,6 +3697,8 @@ describe("ApolloClient", () => {
         partial: false,
       });
 
+      observable.stopPolling();
+
       const result = await client.query({
         query,
         variables,

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -619,6 +619,13 @@ describe("ApolloClient", () => {
     void observableQuery.reobserve({ variables: { id: 2 } });
 
     await expect(stream).toEmitTypedValue({
+      data: undefined,
+      loading: true,
+      networkStatus: NetworkStatus.setVariables,
+      partial: true,
+    });
+
+    await expect(stream).toEmitTypedValue({
       data: {
         person: {
           __typename: "Person",
@@ -710,6 +717,19 @@ describe("ApolloClient", () => {
     void observable.refetch();
 
     await expect(stream1).toEmitTypedValue({
+      data: data1,
+      loading: true,
+      networkStatus: NetworkStatus.refetch,
+      partial: false,
+    });
+    await expect(stream2).toEmitTypedValue({
+      data: data1,
+      loading: true,
+      networkStatus: NetworkStatus.refetch,
+      partial: false,
+    });
+
+    await expect(stream1).toEmitTypedValue({
       data: data2,
       loading: false,
       networkStatus: NetworkStatus.ready,
@@ -724,6 +744,13 @@ describe("ApolloClient", () => {
 
     stream1.unsubscribe();
     void observable.refetch();
+
+    await expect(stream2).toEmitTypedValue({
+      data: data2,
+      loading: true,
+      networkStatus: NetworkStatus.refetch,
+      partial: false,
+    });
 
     await expect(stream2).toEmitTypedValue({
       data: data3,
@@ -2950,6 +2977,14 @@ describe("ApolloClient", () => {
     });
 
     await expect(handle.refetch()).rejects.toThrow(expectedError);
+
+    await expect(stream).toEmitTypedValue({
+      data: firstResult.data,
+      loading: true,
+      networkStatus: NetworkStatus.refetch,
+      partial: false,
+    });
+
     await expect(stream).toEmitTypedValue({
       data: firstResult.data,
       error: expectedError,
@@ -3857,6 +3892,13 @@ describe("ApolloClient", () => {
       // reset the store after data has returned
       void client.resetStore();
 
+      await expect(stream).toEmitTypedValue({
+        data: undefined,
+        loading: true,
+        networkStatus: NetworkStatus.refetch,
+        partial: true,
+      });
+
       // only refetch once and make sure data has changed
       await expect(stream).toEmitTypedValue({
         data: data2,
@@ -4396,6 +4438,13 @@ describe("ApolloClient", () => {
 
       // refetch the observed queries after data has returned
       void client.reFetchObservableQueries();
+
+      await expect(stream).toEmitTypedValue({
+        data,
+        loading: true,
+        networkStatus: NetworkStatus.refetch,
+        partial: false,
+      });
 
       await expect(stream).toEmitTypedValue({
         data: data2,
@@ -5678,6 +5727,13 @@ describe("ApolloClient", () => {
         refetchQueries: [query],
       });
 
+      await expect(stream).toEmitTypedValue({
+        data,
+        loading: true,
+        networkStatus: NetworkStatus.refetch,
+        partial: false,
+      });
+
       await expect(stream).toEmitTypedValue(
         {
           data: secondReqData,
@@ -5770,6 +5826,13 @@ describe("ApolloClient", () => {
         variables: mutationVariables,
         // spread the query into a new object to simulate multiple instances
         refetchQueries: [{ ...query }],
+      });
+
+      await expect(stream).toEmitTypedValue({
+        data,
+        loading: true,
+        networkStatus: NetworkStatus.refetch,
+        partial: false,
       });
 
       await expect(stream).toEmitTypedValue(
@@ -6769,6 +6832,13 @@ describe("ApolloClient", () => {
         fetchPolicy: "no-cache",
       });
       const stream = new ObservableStream(observable);
+
+      await expect(stream).toEmitTypedValue({
+        data: undefined,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        partial: true,
+      });
 
       await expect(stream).toEmitTypedValue({
         data,

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -521,7 +521,6 @@ describe("ApolloClient", () => {
         watchQuery: {
           fetchPolicy: "cache-and-network",
           returnPartialData: false,
-          notifyOnNetworkStatusChange: true,
         },
         query: {
           fetchPolicy: "network-only",
@@ -772,7 +771,6 @@ describe("ApolloClient", () => {
       variables: {
         id: "1",
       },
-      notifyOnNetworkStatusChange: true,
     };
     const request2 = {
       query: gql`
@@ -785,7 +783,6 @@ describe("ApolloClient", () => {
       variables: {
         id: "2",
       },
-      notifyOnNetworkStatusChange: true,
     };
     const request3 = {
       query: gql`
@@ -798,7 +795,6 @@ describe("ApolloClient", () => {
       variables: {
         id: "3",
       },
-      notifyOnNetworkStatusChange: true,
     };
 
     const data1 = {
@@ -1509,7 +1505,6 @@ describe("ApolloClient", () => {
     const observable = client.watchQuery({
       query,
       pollInterval: 30,
-      notifyOnNetworkStatusChange: true,
     });
     const stream = new ObservableStream(observable);
 

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -475,6 +475,13 @@ describe("ObservableQuery", () => {
 
       await expect(stream).toEmitTypedValue({
         data: dataOne,
+        loading: true,
+        networkStatus: NetworkStatus.refetch,
+        partial: false,
+      });
+
+      await expect(stream).toEmitTypedValue({
+        data: dataOne,
         error: new CombinedGraphQLErrors({ data: dataOne, errors: [error] }),
         loading: false,
         networkStatus: NetworkStatus.error,
@@ -483,6 +490,13 @@ describe("ObservableQuery", () => {
 
       await expect(observable.refetch()).resolves.toStrictEqualTyped({
         data: dataOne,
+      });
+
+      await expect(stream).toEmitTypedValue({
+        data: dataOne,
+        loading: true,
+        networkStatus: NetworkStatus.refetch,
+        partial: false,
       });
 
       await expect(stream).toEmitTypedValue({
@@ -521,6 +535,13 @@ describe("ObservableQuery", () => {
       });
 
       await observable.reobserve({ fetchPolicy: "network-only" });
+
+      await expect(stream).toEmitTypedValue({
+        data: dataOne,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        partial: false,
+      });
 
       await expect(stream).toEmitTypedValue({
         data: dataTwo,
@@ -905,6 +926,12 @@ describe("ObservableQuery", () => {
       ).resolves.toStrictEqualTyped({ data: dataTwo });
 
       await expect(stream).toEmitTypedValue({
+        data: undefined,
+        loading: true,
+        networkStatus: NetworkStatus.setVariables,
+        partial: true,
+      });
+      await expect(stream).toEmitTypedValue({
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -990,6 +1017,12 @@ describe("ObservableQuery", () => {
       ).resolves.toStrictEqualTyped({ data: dataTwo });
 
       await expect(stream).toEmitTypedValue({
+        data: undefined,
+        loading: true,
+        networkStatus: NetworkStatus.setVariables,
+        partial: true,
+      });
+      await expect(stream).toEmitTypedValue({
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -1047,6 +1080,12 @@ describe("ObservableQuery", () => {
         observable.setVariables(differentVariables)
       ).resolves.toStrictEqualTyped({ data: dataTwo });
 
+      await expect(stream).toEmitTypedValue({
+        data: undefined,
+        loading: true,
+        networkStatus: NetworkStatus.setVariables,
+        partial: true,
+      });
       await expect(stream).toEmitTypedValue({
         data: dataTwo,
         loading: false,
@@ -1242,6 +1281,13 @@ describe("ObservableQuery", () => {
       ).resolves.toStrictEqualTyped({ data: dataTwo });
 
       await expect(stream).toEmitTypedValue({
+        data: undefined,
+        loading: true,
+        networkStatus: NetworkStatus.setVariables,
+        partial: true,
+      });
+
+      await expect(stream).toEmitTypedValue({
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -1289,6 +1335,13 @@ describe("ObservableQuery", () => {
       });
 
       await observable.refetch(differentVariables);
+
+      await expect(stream).toEmitTypedValue({
+        data: undefined,
+        loading: true,
+        networkStatus: NetworkStatus.refetch,
+        partial: true,
+      });
 
       await expect(stream).toEmitTypedValue({
         data: dataTwo,
@@ -1341,6 +1394,13 @@ describe("ObservableQuery", () => {
       observers[1].complete();
 
       await expect(stream).toEmitTypedValue({
+        data: undefined,
+        loading: true,
+        networkStatus: NetworkStatus.refetch,
+        partial: true,
+      });
+
+      await expect(stream).toEmitTypedValue({
         data: dataTwo,
         loading: false,
         networkStatus: NetworkStatus.ready,
@@ -1390,6 +1450,13 @@ describe("ObservableQuery", () => {
         },
       });
       observers[2].complete();
+
+      await expect(stream).toEmitTypedValue({
+        data: undefined,
+        loading: true,
+        networkStatus: NetworkStatus.refetch,
+        partial: true,
+      });
 
       await expect(stream).toEmitTypedValue({
         data: {
@@ -1882,6 +1949,19 @@ describe("ObservableQuery", () => {
         await expect(stream).toEmitTypedValue({
           data: {
             getVars: [
+              { __typename: "Var", name: "a" },
+              { __typename: "Var", name: "b" },
+              { __typename: "Var", name: "c" },
+            ],
+          },
+          loading: true,
+          networkStatus: NetworkStatus.refetch,
+          partial: false,
+        });
+
+        await expect(stream).toEmitTypedValue({
+          data: {
+            getVars: [
               { __typename: "Var", name: "d" },
               { __typename: "Var", name: "e" },
             ],
@@ -2071,6 +2151,13 @@ describe("ObservableQuery", () => {
         });
 
         await observableWithVariablesVar.refetch({ variables: ["d", "e"] });
+
+        await expect(stream).toEmitTypedValue({
+          data: undefined,
+          loading: true,
+          networkStatus: NetworkStatus.refetch,
+          partial: true,
+        });
 
         await expect(stream).toEmitTypedValue({
           data: {
@@ -3107,6 +3194,7 @@ describe("ObservableQuery", () => {
             query,
             fetchPolicy,
             nextFetchPolicy,
+            notifyOnNetworkStatusChange: false,
           });
 
           expect(observableQuery.getCurrentResult()).toStrictEqualTyped(

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -265,7 +265,6 @@ describe("ObservableQuery", () => {
       const observable = client.watchQuery({
         query: queryWithVars,
         variables: variables1,
-        notifyOnNetworkStatusChange: true,
       });
 
       const stream = new ObservableStream(observable);
@@ -333,11 +332,7 @@ describe("ObservableQuery", () => {
         ]),
       });
 
-      const observable = client.watchQuery({
-        query,
-        variables,
-        notifyOnNetworkStatusChange: true,
-      });
+      const observable = client.watchQuery({ query, variables });
 
       const stream = new ObservableStream(observable);
 
@@ -408,10 +403,7 @@ describe("ObservableQuery", () => {
         partial: false,
       });
 
-      await observable.reobserve({
-        variables: variables2,
-        notifyOnNetworkStatusChange: true,
-      });
+      await observable.reobserve({ variables: variables2 });
 
       await expect(stream).toEmitTypedValue({
         data: undefined,
@@ -854,11 +846,7 @@ describe("ObservableQuery", () => {
         ]),
       });
 
-      const observable = client.watchQuery({
-        query,
-        variables,
-        notifyOnNetworkStatusChange: true,
-      });
+      const observable = client.watchQuery({ query, variables });
 
       const stream = new ObservableStream(observable);
 
@@ -1135,7 +1123,6 @@ describe("ObservableQuery", () => {
       const observable = client.watchQuery({
         query: firstRequest.query,
         variables: firstRequest.variables,
-        notifyOnNetworkStatusChange: true,
       });
 
       const stream = new ObservableStream(observable);
@@ -1188,7 +1175,6 @@ describe("ObservableQuery", () => {
       const observable = client.watchQuery({
         query: firstRequest.query,
         variables: firstRequest.variables,
-        notifyOnNetworkStatusChange: true,
       });
 
       const stream = new ObservableStream(observable);
@@ -1565,7 +1551,6 @@ describe("ObservableQuery", () => {
         query: queryWithVars,
         variables: variables1,
         fetchPolicy: "cache-and-network",
-        notifyOnNetworkStatusChange: true,
       });
 
       const stream = new ObservableStream(observable);
@@ -1679,7 +1664,6 @@ describe("ObservableQuery", () => {
           }
           return currentFetchPolicy;
         },
-        notifyOnNetworkStatusChange: true,
       });
 
       expect(observable.options.fetchPolicy).toBe("cache-and-network");
@@ -1811,7 +1795,6 @@ describe("ObservableQuery", () => {
         query,
         fetchPolicy: "cache-and-network",
         returnPartialData: true,
-        notifyOnNetworkStatusChange: true,
       });
 
       const stream = new ObservableStream(observable);
@@ -2268,7 +2251,6 @@ describe("ObservableQuery", () => {
       const observable = client.watchQuery({
         query: queryWithFragment,
         variables,
-        notifyOnNetworkStatusChange: true,
       });
 
       const stream = new ObservableStream(observable);

--- a/src/core/__tests__/fetchPolicies.ts
+++ b/src/core/__tests__/fetchPolicies.ts
@@ -432,7 +432,6 @@ describe("no-cache", () => {
         `,
         fetchPolicy: "no-cache",
         variables: { id: "1" },
-        notifyOnNetworkStatusChange: true,
       });
 
       const stream = new ObservableStream(observable);
@@ -743,7 +742,6 @@ describe("cache-and-network", function () {
       `,
       fetchPolicy: "cache-and-network",
       variables: { id: "1" },
-      notifyOnNetworkStatusChange: true,
     });
 
     const stream = new ObservableStream(observable);

--- a/src/core/__tests__/fetchPolicies.ts
+++ b/src/core/__tests__/fetchPolicies.ts
@@ -693,6 +693,13 @@ describe("cache-only", () => {
     await observable.refetch();
 
     await expect(stream).toEmitTypedValue({
+      data: { count: 1 },
+      loading: true,
+      networkStatus: NetworkStatus.refetch,
+      partial: false,
+    });
+
+    await expect(stream).toEmitTypedValue({
       loading: false,
       networkStatus: NetworkStatus.ready,
       data: {
@@ -949,6 +956,20 @@ describe("nextFetchPolicy", () => {
       data: {
         echo: {
           __typename: "Echo",
+          linkCounter: 1,
+          opName: "EchoQuery",
+          opVars: {},
+        },
+      },
+      loading: true,
+      networkStatus: NetworkStatus.refetch,
+      partial: false,
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: {
+        echo: {
+          __typename: "Echo",
           linkCounter: 2,
           opName: "EchoQuery",
           opVars: {
@@ -986,6 +1007,22 @@ describe("nextFetchPolicy", () => {
       // Changing variables resets the fetchPolicy to its initial value.
       expect(observable.options.fetchPolicy).toBe("cache-first");
     }
+
+    await expect(stream).toEmitTypedValue({
+      data: {
+        echo: {
+          __typename: "Echo",
+          linkCounter: 2,
+          opName: "EchoQuery",
+          opVars: {
+            refetching: true,
+          },
+        },
+      },
+      loading: true,
+      networkStatus: NetworkStatus.setVariables,
+      partial: false,
+    });
 
     await expect(stream).toEmitTypedValue({
       data: {
@@ -1089,6 +1126,20 @@ describe("nextFetchPolicy", () => {
         },
       });
     }
+
+    await expect(stream).toEmitTypedValue({
+      data: {
+        echo: {
+          __typename: "Echo",
+          linkCounter: 1,
+          opName: "EchoQuery",
+          opVars: {},
+        },
+      },
+      loading: true,
+      networkStatus: NetworkStatus.refetch,
+      partial: false,
+    });
 
     await expect(stream).toEmitTypedValue({
       data: {
@@ -1257,6 +1308,20 @@ describe("nextFetchPolicy", () => {
         },
       });
     }
+
+    await expect(stream).toEmitTypedValue({
+      data: {
+        echo: {
+          __typename: "Echo",
+          linkCounter: 1,
+          opName: "EchoQuery",
+          opVars: {},
+        },
+      },
+      loading: true,
+      networkStatus: NetworkStatus.refetch,
+      partial: false,
+    });
 
     await expect(stream).toEmitTypedValue({
       data: {

--- a/src/core/__tests__/fetchPolicies.ts
+++ b/src/core/__tests__/fetchPolicies.ts
@@ -358,6 +358,8 @@ describe("no-cache", () => {
       await client.query({
         query,
         fetchPolicy: "no-cache",
+        // TODO: This value makes no sense since its a promise-based API. We
+        // should remove support for this option in client.query
         notifyOnNetworkStatusChange: true,
       });
       const actualResult = await client.query({ query });

--- a/src/react/hooks/__tests__/useBackgroundQuery.test.tsx
+++ b/src/react/hooks/__tests__/useBackgroundQuery.test.tsx
@@ -5027,7 +5027,7 @@ describe("refetch", () => {
             },
           },
         },
-        delay: 10,
+        delay: 20,
       },
       {
         request: { query, variables: { id: "1" } },
@@ -5040,7 +5040,7 @@ describe("refetch", () => {
             },
           },
         },
-        delay: 10,
+        delay: 20,
       },
     ];
 

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -820,17 +820,11 @@ describe("useLazyQuery Hook", () => {
 
     using _disabledAct = disableActEnvironment();
     const { takeSnapshot, getCurrentSnapshot } =
-      await renderHookToSnapshotStream(
-        () =>
-          useLazyQuery(helloQuery, {
-            notifyOnNetworkStatusChange: true,
-          }),
-        {
-          wrapper: ({ children }) => (
-            <MockedProvider mocks={mocks}>{children}</MockedProvider>
-          ),
-        }
-      );
+      await renderHookToSnapshotStream(() => useLazyQuery(helloQuery), {
+        wrapper: ({ children }) => (
+          <MockedProvider mocks={mocks}>{children}</MockedProvider>
+        ),
+      });
 
     {
       const [, result] = await takeSnapshot();

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -473,6 +473,7 @@ describe("useLazyQuery Hook", () => {
     await expect(takeSnapshot).not.toRerender();
   });
 
+  // TODO: Invert this since this now matches the previous test
   test("renders loading states when changing queries with notifyOnNetworkStatusChange", async () => {
     const query1 = gql`
       query {
@@ -698,6 +699,7 @@ describe("useLazyQuery Hook", () => {
     await expect(takeSnapshot).not.toRerender();
   });
 
+  // TODO: Invert this
   it('renders loading states each time the execution function is called when using a "network-only" fetch policy with notifyOnNetworkStatusChange', async () => {
     const mocks = [
       {
@@ -1139,6 +1141,7 @@ describe("useLazyQuery Hook", () => {
     await expect(takeSnapshot).not.toRerender();
   });
 
+  // TODO: Invert this
   test("renders loading states when a query is re-run and variables changes with notifyOnNetworkStatusChange", async () => {
     const CAR_QUERY_BY_ID = gql`
       query ($id: Int) {
@@ -1588,6 +1591,7 @@ describe("useLazyQuery Hook", () => {
     await expect(takeSnapshot).not.toRerender();
   });
 
+  // TODO: Invert this
   test("renders loading states with a cache-and-network fetch policy when changing variables with notifyOnNetworkStatusChange", async () => {
     const { query, mocks } = setupVariablesCase();
 
@@ -4167,6 +4171,7 @@ test("uses cached result when switching to variables already written to the cach
   await expect(takeSnapshot).not.toRerender();
 });
 
+// TODO: Invert test
 test("renders loading states where necessary when switching to variables maybe written to the cache with notifyOnNetworkStatusChange", async () => {
   const { query, mocks } = setupVariablesCase();
 

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -101,8 +101,6 @@ describe("useLazyQuery Hook", () => {
         data: undefined,
         called: true,
         loading: true,
-        // @ts-expect-error
-        partial: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
         variables: {},
@@ -175,8 +173,6 @@ describe("useLazyQuery Hook", () => {
         data: undefined,
         called: true,
         loading: true,
-        // @ts-expect-error
-        partial: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
         variables: { id: 1 },
@@ -317,8 +313,6 @@ describe("useLazyQuery Hook", () => {
         data: undefined,
         called: true,
         loading: true,
-        // @ts-expect-error
-        partial: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
         variables: {},
@@ -448,8 +442,6 @@ describe("useLazyQuery Hook", () => {
         data: undefined,
         called: true,
         loading: true,
-        // @ts-expect-error
-        partial: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
         variables: {},
@@ -680,8 +672,6 @@ describe("useLazyQuery Hook", () => {
         data: undefined,
         called: true,
         loading: true,
-        // @ts-expect-error
-        partial: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
         variables: {},
@@ -972,8 +962,6 @@ describe("useLazyQuery Hook", () => {
         data: undefined,
         called: true,
         loading: true,
-        // @ts-expect-error
-        partial: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
         variables: {},
@@ -1125,8 +1113,6 @@ describe("useLazyQuery Hook", () => {
         data: undefined,
         called: true,
         loading: true,
-        // @ts-expect-error
-        partial: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
         variables: { id: 1 },
@@ -1773,7 +1759,6 @@ describe("useLazyQuery Hook", () => {
         data: undefined,
         called: false,
         loading: false,
-        partial: true,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
         // @ts-expect-error should be undefined
@@ -1800,8 +1785,6 @@ describe("useLazyQuery Hook", () => {
         },
         called: true,
         loading: false,
-        // @ts-expect-error
-        partial: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
         variables: { id: "1" },
@@ -1825,8 +1808,6 @@ describe("useLazyQuery Hook", () => {
         },
         called: true,
         loading: false,
-        // @ts-expect-error
-        partial: false,
         networkStatus: NetworkStatus.ready,
         previousData: {
           character: { __typename: "Character", id: "1", name: "Spider-Man" },
@@ -1892,8 +1873,6 @@ describe("useLazyQuery Hook", () => {
         data: undefined,
         called: true,
         loading: true,
-        // @ts-expect-error
-        partial: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
         variables: {},
@@ -2016,8 +1995,6 @@ describe("useLazyQuery Hook", () => {
         data: undefined,
         called: true,
         loading: true,
-        // @ts-expect-error
-        partial: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
         variables: {},
@@ -2375,8 +2352,6 @@ describe("useLazyQuery Hook", () => {
         data: undefined,
         called: true,
         loading: true,
-        // @ts-expect-error
-        partial: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
         variables: {},
@@ -2905,8 +2880,6 @@ describe("useLazyQuery Hook", () => {
           data: undefined,
           called: true,
           loading: true,
-          // @ts-expect-error
-          partial: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
           variables: {},
@@ -2986,8 +2959,6 @@ describe("useLazyQuery Hook", () => {
           data: undefined,
           called: true,
           loading: true,
-          // @ts-expect-error
-          partial: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
           variables: {},
@@ -3064,8 +3035,6 @@ describe("useLazyQuery Hook", () => {
           data: undefined,
           called: true,
           loading: true,
-          // @ts-expect-error
-          partial: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
           variables: {},
@@ -3140,8 +3109,6 @@ describe("useLazyQuery Hook", () => {
         data: undefined,
         called: true,
         loading: true,
-        // @ts-expect-error
-        partial: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
         variables: {},
@@ -3252,8 +3219,6 @@ describe("useLazyQuery Hook", () => {
           data: undefined,
           called: true,
           loading: true,
-          // @ts-expect-error
-          partial: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
           variables: {},
@@ -3368,8 +3333,6 @@ describe("useLazyQuery Hook", () => {
           data: undefined,
           called: true,
           loading: true,
-          // @ts-expect-error
-          partial: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
           variables: {},
@@ -3484,8 +3447,6 @@ describe("useLazyQuery Hook", () => {
           data: undefined,
           called: true,
           loading: true,
-          // @ts-expect-error
-          partial: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
           variables: {},
@@ -3587,8 +3548,6 @@ describe("useLazyQuery Hook", () => {
           data: undefined,
           called: true,
           loading: true,
-          // @ts-expect-error
-          partial: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
           variables: {},
@@ -3722,8 +3681,6 @@ describe("useLazyQuery Hook", () => {
           data: undefined,
           called: true,
           loading: true,
-          // @ts-expect-error
-          partial: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
           variables: {},
@@ -4075,8 +4032,6 @@ test("uses the updated client when executing the function after changing clients
       data: undefined,
       called: true,
       loading: true,
-      // @ts-expect-error
-      partial: true,
       networkStatus: NetworkStatus.loading,
       previousData: undefined,
       variables: {},
@@ -4124,8 +4079,6 @@ test("uses the updated client when executing the function after changing clients
   //     data: undefined,
   //     called: true,
   //     loading: true,
-  //     // @ts-expect-error
-  //     partial: true,
   //     networkStatus: NetworkStatus.loading,
   //     previousData: { greeting: "Hello client 1" },
   //     variables: {},
@@ -4198,8 +4151,6 @@ test("responds to cache updates after executing query", async () => {
       data: undefined,
       called: true,
       loading: true,
-      // @ts-expect-error
-      partial: true,
       networkStatus: NetworkStatus.loading,
       previousData: undefined,
       variables: {},
@@ -4293,8 +4244,6 @@ test("responds to cache updates after changing variables", async () => {
       data: undefined,
       called: true,
       loading: true,
-      // @ts-expect-error
-      partial: true,
       networkStatus: NetworkStatus.loading,
       previousData: undefined,
       variables: { id: "1" },
@@ -4465,8 +4414,6 @@ test("uses cached result when switching to variables already written to the cach
       data: undefined,
       called: true,
       loading: true,
-      // @ts-expect-error
-      partial: true,
       networkStatus: NetworkStatus.loading,
       previousData: undefined,
       variables: { id: "1" },
@@ -4748,8 +4695,6 @@ test("applies `errorPolicy` on next fetch when it changes between renders", asyn
       data: undefined,
       called: true,
       loading: true,
-      // @ts-expect-error
-      partial: true,
       networkStatus: NetworkStatus.loading,
       previousData: undefined,
       variables: { id: "1" },
@@ -4890,8 +4835,6 @@ test("applies `context` on next fetch when it changes between renders", async ()
       data: undefined,
       called: true,
       loading: true,
-      // @ts-expect-error
-      partial: true,
       networkStatus: NetworkStatus.loading,
       previousData: undefined,
       variables: {},
@@ -5124,8 +5067,6 @@ test("applies `refetchWritePolicy` on next fetch when it changes between renders
       data: undefined,
       called: true,
       loading: true,
-      // @ts-expect-error
-      partial: true,
       networkStatus: NetworkStatus.loading,
       previousData: undefined,
       variables: { min: 0, max: 12 },
@@ -5346,8 +5287,6 @@ test("applies `returnPartialData` on next fetch when it changes between renders"
       data: undefined,
       called: true,
       loading: true,
-      // @ts-expect-error
-      partial: true,
       networkStatus: NetworkStatus.loading,
       previousData: undefined,
       variables: { id: "1" },

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -329,6 +329,19 @@ describe("useLazyQuery Hook", () => {
       const [, result] = await takeSnapshot();
 
       expect(result).toStrictEqualTyped({
+        data: undefined,
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: { hello: "world" },
+        variables: {},
+      });
+    }
+
+    {
+      const [, result] = await takeSnapshot();
+
+      expect(result).toStrictEqualTyped({
         data: { name: "changed" },
         called: true,
         loading: false,
@@ -429,6 +442,19 @@ describe("useLazyQuery Hook", () => {
     await expect(refetch()).resolves.toStrictEqualTyped({
       data: { name: "changed" },
     });
+
+    {
+      const [, result] = await takeSnapshot();
+
+      expect(result).toStrictEqualTyped({
+        data: undefined,
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.refetch,
+        previousData: { hello: "world" },
+        variables: {},
+      });
+    }
 
     {
       const [, result] = await takeSnapshot();
@@ -641,6 +667,19 @@ describe("useLazyQuery Hook", () => {
     await expect(execute()).resolves.toStrictEqualTyped({
       data: { hello: "world 2" },
     });
+
+    {
+      const [, result] = await takeSnapshot();
+
+      expect(result).toStrictEqualTyped({
+        data: { hello: "world 1" },
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: undefined,
+        variables: {},
+      });
+    }
 
     {
       const [, result] = await takeSnapshot();
@@ -940,10 +979,36 @@ describe("useLazyQuery Hook", () => {
       const [, result] = await takeSnapshot();
 
       expect(result).toStrictEqualTyped({
+        data: { hello: "world 1" },
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.poll,
+        previousData: undefined,
+        variables: {},
+      });
+    }
+
+    {
+      const [, result] = await takeSnapshot();
+
+      expect(result).toStrictEqualTyped({
         data: { hello: "world 2" },
         called: true,
         loading: false,
         networkStatus: NetworkStatus.ready,
+        previousData: { hello: "world 1" },
+        variables: {},
+      });
+    }
+
+    {
+      const [, result] = await takeSnapshot();
+
+      expect(result).toStrictEqualTyped({
+        data: { hello: "world 2" },
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.poll,
         previousData: { hello: "world 1" },
         variables: {},
       });
@@ -1049,6 +1114,19 @@ describe("useLazyQuery Hook", () => {
     await expect(execute({ variables: { id: 2 } })).resolves.toStrictEqualTyped(
       { data: data2 }
     );
+
+    {
+      const [, result] = await takeSnapshot();
+
+      expect(result).toStrictEqualTyped({
+        data: undefined,
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.setVariables,
+        previousData: data1,
+        variables: { id: 2 },
+      });
+    }
 
     {
       const [, result] = await takeSnapshot();
@@ -1726,6 +1804,19 @@ describe("useLazyQuery Hook", () => {
       expect(result).toStrictEqualTyped({
         data: undefined,
         called: true,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: undefined,
+        variables: {},
+      });
+    }
+
+    {
+      const [, result] = await takeSnapshot();
+
+      expect(result).toStrictEqualTyped({
+        data: undefined,
+        called: true,
         loading: false,
         networkStatus: NetworkStatus.error,
         previousData: undefined,
@@ -1827,11 +1918,25 @@ describe("useLazyQuery Hook", () => {
       const [, result] = await takeSnapshot();
 
       expect(result).toStrictEqualTyped({
+        // TODO: Is this correct or should it be the previous partial result?
+        data: undefined,
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: { currentUser: null },
+        variables: {},
+      });
+    }
+
+    {
+      const [, result] = await takeSnapshot();
+
+      expect(result).toStrictEqualTyped({
         data: { currentUser: null },
         called: true,
         loading: false,
         networkStatus: NetworkStatus.error,
-        previousData: undefined,
+        previousData: { currentUser: null },
         error: new CombinedGraphQLErrors({
           data: { currentUser: null },
           errors: [{ message: "Not logged in 2" }],
@@ -1873,7 +1978,11 @@ describe("useLazyQuery Hook", () => {
 
     using _disabledAct = disableActEnvironment();
     const { takeSnapshot, peekSnapshot } = await renderHookToSnapshotStream(
-      () => useLazyQuery(query, { errorPolicy: "ignore" }),
+      () =>
+        useLazyQuery(query, {
+          errorPolicy: "ignore",
+          notifyOnNetworkStatusChange: false,
+        }),
       {
         wrapper: ({ children }) => (
           <MockedProvider mocks={mocks}>{children}</MockedProvider>
@@ -2046,6 +2155,19 @@ describe("useLazyQuery Hook", () => {
     await expect(promise2).resolves.toStrictEqualTyped({
       data: mocks[1].result.data,
     });
+
+    {
+      const [, result] = await takeSnapshot();
+
+      expect(result).toStrictEqualTyped({
+        data: undefined,
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.setVariables,
+        previousData: undefined,
+        variables: { id: "2" },
+      });
+    }
 
     {
       const [, result] = await takeSnapshot();
@@ -2392,6 +2514,19 @@ describe("useLazyQuery Hook", () => {
       const [, result] = await takeSnapshot();
 
       expect(result).toStrictEqualTyped({
+        data: undefined,
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.setVariables,
+        previousData: undefined,
+        variables: { id: "1" },
+      });
+    }
+
+    {
+      const [, result] = await takeSnapshot();
+
+      expect(result).toStrictEqualTyped({
         data: { user: { id: "1", name: "John Doe" } },
         called: true,
         loading: false,
@@ -2434,12 +2569,25 @@ describe("useLazyQuery Hook", () => {
       const [, result] = await takeSnapshot();
 
       expect(result).toStrictEqualTyped({
-        data: { user: { id: "1", name: "John Doe" } },
+        data: undefined,
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.setVariables,
+        previousData: { user: { id: "1", name: "John Doe" } },
+        variables: { id: "2" },
+      });
+    }
+
+    {
+      const [, result] = await takeSnapshot();
+
+      expect(result).toStrictEqualTyped({
+        data: undefined,
         error: new CombinedGraphQLErrors({ errors: [{ message: "Oops" }] }),
         called: true,
         loading: false,
         networkStatus: NetworkStatus.error,
-        previousData: undefined,
+        previousData: { user: { id: "1", name: "John Doe" } },
         variables: { id: "2" },
       });
     }
@@ -2461,17 +2609,30 @@ describe("useLazyQuery Hook", () => {
       const [, result] = await takeSnapshot();
 
       expect(result).toStrictEqualTyped({
-        data: { user: { id: "1", name: "John Doe" } },
+        data: undefined,
         error: new CombinedGraphQLErrors({ errors: [{ message: "Oops" }] }),
         called: true,
         loading: false,
         networkStatus: NetworkStatus.error,
-        previousData: undefined,
+        previousData: { user: { id: "1", name: "John Doe" } },
         variables: { id: "2" },
       });
     }
 
     await execute({ variables: { id: "3" } });
+
+    {
+      const [, result] = await takeSnapshot();
+
+      expect(result).toStrictEqualTyped({
+        data: undefined,
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.setVariables,
+        previousData: { user: { id: "1", name: "John Doe" } },
+        variables: { id: "3" },
+      });
+    }
 
     {
       const [, result] = await takeSnapshot();
@@ -3830,6 +3991,21 @@ test("responds to cache updates after changing variables", async () => {
     const [, result] = await takeSnapshot();
 
     expect(result).toStrictEqualTyped({
+      data: undefined,
+      called: true,
+      loading: true,
+      networkStatus: NetworkStatus.setVariables,
+      previousData: {
+        character: { __typename: "Character", id: "1", name: "Spider-Man" },
+      },
+      variables: { id: "2" },
+    });
+  }
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
       data: {
         character: { __typename: "Character", id: "2", name: "Black Widow" },
       },
@@ -4285,6 +4461,21 @@ test("applies `errorPolicy` on next fetch when it changes between renders", asyn
 
     expect(result).toStrictEqualTyped({
       data: {
+        character: { __typename: "Character", id: "1", name: "Spider-Man" },
+      },
+      called: true,
+      loading: true,
+      networkStatus: NetworkStatus.refetch,
+      previousData: undefined,
+      variables: { id: "1" },
+    });
+  }
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: {
         character: null,
       },
       error: new CombinedGraphQLErrors({
@@ -4393,6 +4584,19 @@ test("applies `context` on next fetch when it changes between renders", async ()
     const [, result] = await takeSnapshot();
 
     expect(result).toStrictEqualTyped({
+      data: { context: { source: "initialHookValue" } },
+      called: true,
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      previousData: undefined,
+      variables: {},
+    });
+  }
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
       data: { context: { source: "rerender" } },
       called: true,
       loading: false,
@@ -4424,6 +4628,19 @@ test("applies `context` on next fetch when it changes between renders", async ()
     const [, result] = await takeSnapshot();
 
     expect(result).toStrictEqualTyped({
+      data: { context: { source: "rerender" } },
+      called: true,
+      loading: true,
+      networkStatus: NetworkStatus.refetch,
+      previousData: { context: { source: "initialHookValue" } },
+      variables: {},
+    });
+  }
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
       data: { context: { source: "rerenderForRefetch" } },
       called: true,
       loading: false,
@@ -4438,6 +4655,19 @@ test("applies `context` on next fetch when it changes between renders", async ()
   ).resolves.toStrictEqualTyped({
     data: { context: { source: "execute" } },
   });
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: { context: { source: "rerenderForRefetch" } },
+      called: true,
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      previousData: { context: { source: "rerender" } },
+      variables: {},
+    });
+  }
 
   {
     const [, result] = await takeSnapshot();
@@ -4560,6 +4790,19 @@ test("applies `refetchWritePolicy` on next fetch when it changes between renders
     const [, result] = await takeSnapshot();
 
     expect(result).toStrictEqualTyped({
+      data: mocks[0].result.data,
+      called: true,
+      loading: true,
+      networkStatus: NetworkStatus.refetch,
+      previousData: undefined,
+      variables: { min: 12, max: 30 },
+    });
+  }
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
       data: { primes: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29] },
       called: true,
       loading: false,
@@ -4593,6 +4836,19 @@ test("applies `refetchWritePolicy` on next fetch when it changes between renders
   }
 
   void refetch({ min: 30, max: 50 });
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: { primes: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29] },
+      called: true,
+      loading: true,
+      networkStatus: NetworkStatus.refetch,
+      previousData: mocks[0].result.data,
+      variables: { min: 30, max: 50 },
+    });
+  }
 
   {
     const [, result] = await takeSnapshot();

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -820,11 +820,19 @@ describe("useLazyQuery Hook", () => {
 
     using _disabledAct = disableActEnvironment();
     const { takeSnapshot, getCurrentSnapshot } =
-      await renderHookToSnapshotStream(() => useLazyQuery(helloQuery), {
-        wrapper: ({ children }) => (
-          <MockedProvider mocks={mocks}>{children}</MockedProvider>
-        ),
-      });
+      await renderHookToSnapshotStream(
+        () =>
+          useLazyQuery(helloQuery, {
+            // TODO: This should be the default but breaks this test when
+            // removing it because the loading state is not emitted
+            notifyOnNetworkStatusChange: true,
+          }),
+        {
+          wrapper: ({ children }) => (
+            <MockedProvider mocks={mocks}>{children}</MockedProvider>
+          ),
+        }
+      );
 
     {
       const [, result] = await takeSnapshot();

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -199,8 +199,7 @@ describe("useLazyQuery Hook", () => {
     await expect(takeSnapshot).not.toRerender();
   });
 
-  // TODO: Invert this since the previoius test is now the same
-  test("sets initial loading state when notifyOnNetworkStatusChange is true", async () => {
+  test("does not emit loading state when notifyOnNetworkStatusChange is false", async () => {
     const mocks = [
       {
         request: { query: helloQuery },
@@ -212,7 +211,7 @@ describe("useLazyQuery Hook", () => {
     using _disabledAct = disableActEnvironment();
     const { takeSnapshot, getCurrentSnapshot } =
       await renderHookToSnapshotStream(
-        () => useLazyQuery(helloQuery, { notifyOnNetworkStatusChange: true }),
+        () => useLazyQuery(helloQuery, { notifyOnNetworkStatusChange: false }),
         {
           wrapper: ({ children }) => (
             <MockedProvider mocks={mocks}>{children}</MockedProvider>
@@ -239,19 +238,6 @@ describe("useLazyQuery Hook", () => {
     expect(result).toStrictEqualTyped({
       data: { hello: "world" },
     });
-
-    {
-      const [, result] = await takeSnapshot();
-
-      expect(result).toStrictEqualTyped({
-        data: undefined,
-        called: true,
-        loading: true,
-        networkStatus: NetworkStatus.loading,
-        previousData: undefined,
-        variables: {},
-      });
-    }
 
     {
       const [, result] = await takeSnapshot();
@@ -533,8 +519,7 @@ describe("useLazyQuery Hook", () => {
     await expect(takeSnapshot).not.toRerender();
   });
 
-  // TODO: Invert this since this now matches the previous test
-  test("renders loading states when changing queries with notifyOnNetworkStatusChange", async () => {
+  test("does not render loading states when changing queries with notifyOnNetworkStatusChange: false", async () => {
     const query1 = gql`
       query {
         hello
@@ -563,7 +548,7 @@ describe("useLazyQuery Hook", () => {
     const { takeSnapshot, getCurrentSnapshot, rerender } =
       await renderHookToSnapshotStream(
         ({ query }) =>
-          useLazyQuery(query, { notifyOnNetworkStatusChange: true }),
+          useLazyQuery(query, { notifyOnNetworkStatusChange: false }),
         {
           initialProps: { query: query1 },
           wrapper: ({ children }) => (
@@ -597,18 +582,6 @@ describe("useLazyQuery Hook", () => {
       const [, result] = await takeSnapshot();
 
       expect(result).toStrictEqualTyped({
-        data: undefined,
-        called: true,
-        loading: true,
-        networkStatus: NetworkStatus.loading,
-        previousData: undefined,
-        variables: {},
-      });
-    }
-    {
-      const [, result] = await takeSnapshot();
-
-      expect(result).toStrictEqualTyped({
         data: { hello: "world" },
         called: true,
         loading: false,
@@ -636,19 +609,6 @@ describe("useLazyQuery Hook", () => {
     await expect(execute()).resolves.toStrictEqualTyped({
       data: { name: "changed" },
     });
-
-    {
-      const [, result] = await takeSnapshot();
-
-      expect(result).toStrictEqualTyped({
-        data: undefined,
-        called: true,
-        loading: true,
-        networkStatus: NetworkStatus.loading,
-        previousData: { hello: "world" },
-        variables: {},
-      });
-    }
 
     {
       const [, result] = await takeSnapshot();
@@ -774,8 +734,7 @@ describe("useLazyQuery Hook", () => {
     await expect(takeSnapshot).not.toRerender();
   });
 
-  // TODO: Invert this
-  it('renders loading states each time the execution function is called when using a "network-only" fetch policy with notifyOnNetworkStatusChange', async () => {
+  it('does not render loading states when the execution function is called when using a "network-only" fetch policy with notifyOnNetworkStatusChange: false', async () => {
     const mocks = [
       {
         request: { query: helloQuery },
@@ -794,7 +753,7 @@ describe("useLazyQuery Hook", () => {
       await renderHookToSnapshotStream(
         () =>
           useLazyQuery(helloQuery, {
-            notifyOnNetworkStatusChange: true,
+            notifyOnNetworkStatusChange: false,
             fetchPolicy: "network-only",
           }),
         {
@@ -827,19 +786,6 @@ describe("useLazyQuery Hook", () => {
       const [, result] = await takeSnapshot();
 
       expect(result).toStrictEqualTyped({
-        data: undefined,
-        called: true,
-        loading: true,
-        networkStatus: NetworkStatus.loading,
-        previousData: undefined,
-        variables: {},
-      });
-    }
-
-    {
-      const [, result] = await takeSnapshot();
-
-      expect(result).toStrictEqualTyped({
         data: { hello: "world 1" },
         called: true,
         loading: false,
@@ -852,19 +798,6 @@ describe("useLazyQuery Hook", () => {
     await expect(execute()).resolves.toStrictEqualTyped({
       data: { hello: "world 2" },
     });
-
-    {
-      const [, result] = await takeSnapshot();
-
-      expect(result).toStrictEqualTyped({
-        data: { hello: "world 1" },
-        called: true,
-        loading: true,
-        networkStatus: NetworkStatus.loading,
-        previousData: undefined,
-        variables: {},
-      });
-    }
 
     {
       const [, result] = await takeSnapshot();
@@ -1246,8 +1179,7 @@ describe("useLazyQuery Hook", () => {
     await expect(takeSnapshot).not.toRerender();
   });
 
-  // TODO: Invert this
-  test("renders loading states when a query is re-run and variables changes with notifyOnNetworkStatusChange", async () => {
+  test("does not render loading states when a query is re-run and variables changes with notifyOnNetworkStatusChange: false", async () => {
     const CAR_QUERY_BY_ID = gql`
       query ($id: Int) {
         car(id: $id) {
@@ -1290,7 +1222,7 @@ describe("useLazyQuery Hook", () => {
     const { takeSnapshot, getCurrentSnapshot } =
       await renderHookToSnapshotStream(
         () =>
-          useLazyQuery(CAR_QUERY_BY_ID, { notifyOnNetworkStatusChange: true }),
+          useLazyQuery(CAR_QUERY_BY_ID, { notifyOnNetworkStatusChange: false }),
         {
           wrapper: ({ children }) => (
             <MockedProvider mocks={mocks}>{children}</MockedProvider>
@@ -1321,19 +1253,6 @@ describe("useLazyQuery Hook", () => {
       const [, result] = await takeSnapshot();
 
       expect(result).toStrictEqualTyped({
-        data: undefined,
-        called: true,
-        loading: true,
-        networkStatus: NetworkStatus.loading,
-        previousData: undefined,
-        variables: { id: 1 },
-      });
-    }
-
-    {
-      const [, result] = await takeSnapshot();
-
-      expect(result).toStrictEqualTyped({
         data: data1,
         called: true,
         loading: false,
@@ -1347,18 +1266,6 @@ describe("useLazyQuery Hook", () => {
       { data: data2 }
     );
 
-    {
-      const [, result] = await takeSnapshot();
-
-      expect(result).toStrictEqualTyped({
-        data: undefined,
-        called: true,
-        loading: true,
-        networkStatus: NetworkStatus.setVariables,
-        previousData: data1,
-        variables: { id: 2 },
-      });
-    }
     {
       const [, result] = await takeSnapshot();
 
@@ -1696,8 +1603,7 @@ describe("useLazyQuery Hook", () => {
     await expect(takeSnapshot).not.toRerender();
   });
 
-  // TODO: Invert this
-  test("renders loading states with a cache-and-network fetch policy when changing variables with notifyOnNetworkStatusChange", async () => {
+  test("renders loading states with a cache-and-network fetch policy when changing variables with notifyOnNetworkStatusChange: false when there is cached data", async () => {
     const { query, mocks } = setupVariablesCase();
 
     const client = new ApolloClient({
@@ -1727,7 +1633,7 @@ describe("useLazyQuery Hook", () => {
         () =>
           useLazyQuery(query, {
             fetchPolicy: "cache-and-network",
-            notifyOnNetworkStatusChange: true,
+            notifyOnNetworkStatusChange: false,
           }),
         {
           wrapper: ({ children }) => (
@@ -4523,8 +4429,7 @@ test("uses cached result when switching to variables already written to the cach
   await expect(takeSnapshot).not.toRerender();
 });
 
-// TODO: Invert test
-test("renders loading states where necessary when switching to variables maybe written to the cache with notifyOnNetworkStatusChange", async () => {
+test("does not render loading states when switching to variables maybe written to the cache with notifyOnNetworkStatusChange: false", async () => {
   const { query, mocks } = setupVariablesCase();
 
   const client = new ApolloClient({
@@ -4542,7 +4447,7 @@ test("renders loading states where necessary when switching to variables maybe w
 
   using _disabledAct = disableActEnvironment();
   const { takeSnapshot, getCurrentSnapshot } = await renderHookToSnapshotStream(
-    () => useLazyQuery(query, { notifyOnNetworkStatusChange: true }),
+    () => useLazyQuery(query, { notifyOnNetworkStatusChange: false }),
     {
       wrapper: ({ children }) => (
         <ApolloProvider client={client}>{children}</ApolloProvider>
@@ -4573,19 +4478,6 @@ test("renders loading states where necessary when switching to variables maybe w
       },
     }
   );
-
-  {
-    const [, result] = await takeSnapshot();
-
-    expect(result).toStrictEqualTyped({
-      data: undefined,
-      called: true,
-      loading: true,
-      networkStatus: NetworkStatus.loading,
-      previousData: undefined,
-      variables: { id: "1" },
-    });
-  }
 
   {
     const [, result] = await takeSnapshot();
@@ -4646,25 +4538,6 @@ test("renders loading states where necessary when switching to variables maybe w
       },
     }
   );
-
-  {
-    const [, result] = await takeSnapshot();
-
-    expect(result).toStrictEqualTyped({
-      data: undefined,
-      called: true,
-      loading: true,
-      networkStatus: NetworkStatus.setVariables,
-      previousData: {
-        character: {
-          __typename: "Character",
-          id: "2",
-          name: "Cached Character",
-        },
-      },
-      variables: { id: "3" },
-    });
-  }
 
   {
     const [, result] = await takeSnapshot();

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -169,6 +169,7 @@ describe("useLazyQuery Hook", () => {
     await expect(takeSnapshot).not.toRerender();
   });
 
+  // TODO: Invert this since the previoius test is now the same
   test("sets initial loading state when notifyOnNetworkStatusChange is true", async () => {
     const mocks = [
       {

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -804,112 +804,106 @@ describe("useLazyQuery Hook", () => {
     await expect(takeSnapshot).not.toRerender();
   });
 
-  // TODO: When removing the explicit `notifyOnNetworkStatusChange` option to
-  // `useLazyQuery` (which should be the default), this test breaks as it does
-  // not emit the loading state correctly.
-  it.failing(
-    "should persist previous data when a query is refetched",
-    async () => {
-      const mocks = [
-        {
-          request: { query: helloQuery },
-          result: { data: { hello: "world 1" } },
-          delay: 20,
-        },
-        {
-          request: { query: helloQuery },
-          result: { data: { hello: "world 2" } },
-          delay: 20,
-        },
-      ];
-
-      using _disabledAct = disableActEnvironment();
-      const { takeSnapshot, getCurrentSnapshot } =
-        await renderHookToSnapshotStream(() => useLazyQuery(helloQuery), {
-          wrapper: ({ children }) => (
-            <MockedProvider mocks={mocks}>{children}</MockedProvider>
-          ),
-        });
-
+  it("should persist previous data when a query is refetched", async () => {
+    const mocks = [
       {
-        const [, result] = await takeSnapshot();
+        request: { query: helloQuery },
+        result: { data: { hello: "world 1" } },
+        delay: 20,
+      },
+      {
+        request: { query: helloQuery },
+        result: { data: { hello: "world 2" } },
+        delay: 20,
+      },
+    ];
 
-        expect(result).toStrictEqualTyped({
-          data: undefined,
-          called: false,
-          loading: false,
-          networkStatus: NetworkStatus.ready,
-          previousData: undefined,
-          variables: {},
-        });
-      }
-
-      const [execute] = getCurrentSnapshot();
-
-      await expect(execute()).resolves.toStrictEqualTyped({
-        data: { hello: "world 1" },
+    using _disabledAct = disableActEnvironment();
+    const { takeSnapshot, getCurrentSnapshot } =
+      await renderHookToSnapshotStream(() => useLazyQuery(helloQuery), {
+        wrapper: ({ children }) => (
+          <MockedProvider mocks={mocks}>{children}</MockedProvider>
+        ),
       });
 
-      {
-        const [, result] = await takeSnapshot();
+    {
+      const [, result] = await takeSnapshot();
 
-        expect(result).toStrictEqualTyped({
-          data: undefined,
-          called: true,
-          loading: true,
-          networkStatus: NetworkStatus.loading,
-          previousData: undefined,
-          variables: {},
-        });
-      }
-
-      {
-        const [, result] = await takeSnapshot();
-
-        expect(result).toStrictEqualTyped({
-          data: { hello: "world 1" },
-          called: true,
-          loading: false,
-          networkStatus: NetworkStatus.ready,
-          previousData: undefined,
-          variables: {},
-        });
-      }
-
-      const [, { refetch }] = getCurrentSnapshot();
-
-      await expect(refetch()).resolves.toStrictEqualTyped({
-        data: { hello: "world 2" },
+      expect(result).toStrictEqualTyped({
+        data: undefined,
+        called: false,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: undefined,
+        variables: {},
       });
-
-      {
-        const [, result] = await takeSnapshot();
-
-        expect(result).toStrictEqualTyped({
-          data: { hello: "world 1" },
-          called: true,
-          loading: true,
-          networkStatus: NetworkStatus.refetch,
-          previousData: undefined,
-          variables: {},
-        });
-      }
-      {
-        const [, result] = await takeSnapshot();
-
-        expect(result).toStrictEqualTyped({
-          data: { hello: "world 2" },
-          called: true,
-          loading: false,
-          networkStatus: NetworkStatus.ready,
-          previousData: { hello: "world 1" },
-          variables: {},
-        });
-      }
-
-      await expect(takeSnapshot).not.toRerender();
     }
-  );
+
+    const [execute] = getCurrentSnapshot();
+
+    await expect(execute()).resolves.toStrictEqualTyped({
+      data: { hello: "world 1" },
+    });
+
+    {
+      const [, result] = await takeSnapshot();
+
+      expect(result).toStrictEqualTyped({
+        data: undefined,
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: undefined,
+        variables: {},
+      });
+    }
+
+    {
+      const [, result] = await takeSnapshot();
+
+      expect(result).toStrictEqualTyped({
+        data: { hello: "world 1" },
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: undefined,
+        variables: {},
+      });
+    }
+
+    const [, { refetch }] = getCurrentSnapshot();
+
+    await expect(refetch()).resolves.toStrictEqualTyped({
+      data: { hello: "world 2" },
+    });
+
+    {
+      const [, result] = await takeSnapshot();
+
+      expect(result).toStrictEqualTyped({
+        data: { hello: "world 1" },
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.refetch,
+        previousData: undefined,
+        variables: {},
+      });
+    }
+    {
+      const [, result] = await takeSnapshot();
+
+      expect(result).toStrictEqualTyped({
+        data: { hello: "world 2" },
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: { hello: "world 1" },
+        variables: {},
+      });
+    }
+
+    await expect(takeSnapshot).not.toRerender();
+  });
 
   // TODO: Determine if this hook makes sense for polling or if that should be
   // reserved for useQuery. At the very least, we need to figure out if you can

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -2121,7 +2121,9 @@ describe("useLazyQuery Hook", () => {
 
     using _disabledAct = disableActEnvironment();
     const { takeSnapshot, peekSnapshot } = await renderHookToSnapshotStream(
-      () => useLazyQuery(query),
+      // This test is too complicated between the react versions when testing
+      // the loading state
+      () => useLazyQuery(query, { notifyOnNetworkStatusChange: false }),
       {
         wrapper: ({ children }) => (
           <MockedProvider mocks={mocks}>{children}</MockedProvider>
@@ -2154,19 +2156,6 @@ describe("useLazyQuery Hook", () => {
     await expect(promise2).resolves.toStrictEqualTyped({
       data: mocks[1].result.data,
     });
-
-    {
-      const [, result] = await takeSnapshot();
-
-      expect(result).toStrictEqualTyped({
-        data: undefined,
-        called: true,
-        loading: true,
-        networkStatus: NetworkStatus.setVariables,
-        previousData: undefined,
-        variables: { id: "2" },
-      });
-    }
 
     {
       const [, result] = await takeSnapshot();

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -98,6 +98,21 @@ describe("useLazyQuery Hook", () => {
       const [, result] = await takeSnapshot();
 
       expect(result).toStrictEqualTyped({
+        data: undefined,
+        called: true,
+        loading: true,
+        // @ts-expect-error
+        partial: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: undefined,
+        variables: {},
+      });
+    }
+
+    {
+      const [, result] = await takeSnapshot();
+
+      expect(result).toStrictEqualTyped({
         data: { hello: "world" },
         called: true,
         loading: false,
@@ -152,6 +167,21 @@ describe("useLazyQuery Hook", () => {
     expect(result).toStrictEqualTyped({
       data: { hello: "world 1" },
     });
+
+    {
+      const [, result] = await takeSnapshot();
+
+      expect(result).toStrictEqualTyped({
+        data: undefined,
+        called: true,
+        loading: true,
+        // @ts-expect-error
+        partial: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: undefined,
+        variables: { id: 1 },
+      });
+    }
 
     {
       const [, result] = await takeSnapshot();
@@ -298,6 +328,21 @@ describe("useLazyQuery Hook", () => {
       const [, result] = await takeSnapshot();
 
       expect(result).toStrictEqualTyped({
+        data: undefined,
+        called: true,
+        loading: true,
+        // @ts-expect-error
+        partial: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: undefined,
+        variables: {},
+      });
+    }
+
+    {
+      const [, result] = await takeSnapshot();
+
+      expect(result).toStrictEqualTyped({
         data: { hello: "world" },
         called: true,
         loading: false,
@@ -409,6 +454,21 @@ describe("useLazyQuery Hook", () => {
     await expect(execute()).resolves.toStrictEqualTyped({
       data: { hello: "world" },
     });
+
+    {
+      const [, result] = await takeSnapshot();
+
+      expect(result).toStrictEqualTyped({
+        data: undefined,
+        called: true,
+        loading: true,
+        // @ts-expect-error
+        partial: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: undefined,
+        variables: {},
+      });
+    }
 
     {
       const [, result] = await takeSnapshot();
@@ -652,6 +712,21 @@ describe("useLazyQuery Hook", () => {
     await expect(execute()).resolves.toStrictEqualTyped({
       data: { hello: "world 1" },
     });
+
+    {
+      const [, result] = await takeSnapshot();
+
+      expect(result).toStrictEqualTyped({
+        data: undefined,
+        called: true,
+        loading: true,
+        // @ts-expect-error
+        partial: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: undefined,
+        variables: {},
+      });
+    }
 
     {
       const [, result] = await takeSnapshot();
@@ -961,6 +1036,21 @@ describe("useLazyQuery Hook", () => {
       const [, result] = await takeSnapshot();
 
       expect(result).toStrictEqualTyped({
+        data: undefined,
+        called: true,
+        loading: true,
+        // @ts-expect-error
+        partial: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: undefined,
+        variables: {},
+      });
+    }
+
+    {
+      const [, result] = await takeSnapshot();
+
+      expect(result).toStrictEqualTyped({
         data: { hello: "world 1" },
         called: true,
         loading: false,
@@ -1094,6 +1184,21 @@ describe("useLazyQuery Hook", () => {
     await expect(execute({ variables: { id: 1 } })).resolves.toStrictEqualTyped(
       { data: data1 }
     );
+
+    {
+      const [, result] = await takeSnapshot();
+
+      expect(result).toStrictEqualTyped({
+        data: undefined,
+        called: true,
+        loading: true,
+        // @ts-expect-error
+        partial: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: undefined,
+        variables: { id: 1 },
+      });
+    }
 
     {
       const [, result] = await takeSnapshot();
@@ -1785,6 +1890,21 @@ describe("useLazyQuery Hook", () => {
       expect(result).toStrictEqualTyped({
         data: undefined,
         called: true,
+        loading: true,
+        // @ts-expect-error
+        partial: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: undefined,
+        variables: {},
+      });
+    }
+
+    {
+      const [, result] = await takeSnapshot();
+
+      expect(result).toStrictEqualTyped({
+        data: undefined,
+        called: true,
         loading: false,
         networkStatus: NetworkStatus.error,
         previousData: undefined,
@@ -1887,6 +2007,21 @@ describe("useLazyQuery Hook", () => {
         errors: [{ message: "Not logged in" }],
       }),
     });
+
+    {
+      const [, result] = await takeSnapshot();
+
+      expect(result).toStrictEqualTyped({
+        data: undefined,
+        called: true,
+        loading: true,
+        // @ts-expect-error
+        partial: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: undefined,
+        variables: {},
+      });
+    }
 
     {
       const [, result] = await takeSnapshot();
@@ -2231,6 +2366,21 @@ describe("useLazyQuery Hook", () => {
     await expect(execute()).resolves.toStrictEqualTyped({
       data: { hello: "Greetings" },
     });
+
+    {
+      const [, result] = await takeSnapshot();
+
+      expect(result).toStrictEqualTyped({
+        data: undefined,
+        called: true,
+        loading: true,
+        // @ts-expect-error
+        partial: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: undefined,
+        variables: {},
+      });
+    }
 
     {
       const [, result] = await takeSnapshot();
@@ -2752,6 +2902,21 @@ describe("useLazyQuery Hook", () => {
 
         expect(result).toStrictEqualTyped({
           data: undefined,
+          called: true,
+          loading: true,
+          // @ts-expect-error
+          partial: true,
+          networkStatus: NetworkStatus.loading,
+          previousData: undefined,
+          variables: {},
+        });
+      }
+
+      {
+        const [, result] = await takeSnapshot();
+
+        expect(result).toStrictEqualTyped({
+          data: undefined,
           error: networkError,
           called: true,
           loading: false,
@@ -2812,6 +2977,21 @@ describe("useLazyQuery Hook", () => {
         data: undefined,
         error: networkError,
       });
+
+      {
+        const [, result] = await takeSnapshot();
+
+        expect(result).toStrictEqualTyped({
+          data: undefined,
+          called: true,
+          loading: true,
+          // @ts-expect-error
+          partial: true,
+          networkStatus: NetworkStatus.loading,
+          previousData: undefined,
+          variables: {},
+        });
+      }
 
       {
         const [, result] = await takeSnapshot();
@@ -2882,6 +3062,21 @@ describe("useLazyQuery Hook", () => {
         expect(result).toStrictEqualTyped({
           data: undefined,
           called: true,
+          loading: true,
+          // @ts-expect-error
+          partial: true,
+          networkStatus: NetworkStatus.loading,
+          previousData: undefined,
+          variables: {},
+        });
+      }
+
+      {
+        const [, result] = await takeSnapshot();
+
+        expect(result).toStrictEqualTyped({
+          data: undefined,
+          called: true,
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
@@ -2928,6 +3123,7 @@ describe("useLazyQuery Hook", () => {
     const promise = execute();
     expect(requests).toBe(1);
 
+    await wait(10);
     await client.clearStore();
 
     await expect(promise).rejects.toEqual(
@@ -2935,6 +3131,21 @@ describe("useLazyQuery Hook", () => {
         "Store reset while query was in flight (not completed in link chain)"
       )
     );
+
+    {
+      const [, result] = await takeSnapshot();
+
+      expect(result).toStrictEqualTyped({
+        data: undefined,
+        called: true,
+        loading: true,
+        // @ts-expect-error
+        partial: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: undefined,
+        variables: {},
+      });
+    }
 
     {
       const [, result] = await takeSnapshot();
@@ -3032,6 +3243,21 @@ describe("useLazyQuery Hook", () => {
           },
         },
       });
+
+      {
+        const [, result] = await takeSnapshot();
+
+        expect(result).toStrictEqualTyped({
+          data: undefined,
+          called: true,
+          loading: true,
+          // @ts-expect-error
+          partial: true,
+          networkStatus: NetworkStatus.loading,
+          previousData: undefined,
+          variables: {},
+        });
+      }
 
       {
         const [, result] = await takeSnapshot();
@@ -3138,6 +3364,21 @@ describe("useLazyQuery Hook", () => {
         const [, result] = await takeSnapshot();
 
         expect(result).toStrictEqualTyped({
+          data: undefined,
+          called: true,
+          loading: true,
+          // @ts-expect-error
+          partial: true,
+          networkStatus: NetworkStatus.loading,
+          previousData: undefined,
+          variables: {},
+        });
+      }
+
+      {
+        const [, result] = await takeSnapshot();
+
+        expect(result).toStrictEqualTyped({
           data: {
             currentUser: {
               __typename: "User",
@@ -3239,6 +3480,21 @@ describe("useLazyQuery Hook", () => {
         const [, result] = await takeSnapshot();
 
         expect(result).toStrictEqualTyped({
+          data: undefined,
+          called: true,
+          loading: true,
+          // @ts-expect-error
+          partial: true,
+          networkStatus: NetworkStatus.loading,
+          previousData: undefined,
+          variables: {},
+        });
+      }
+
+      {
+        const [, result] = await takeSnapshot();
+
+        expect(result).toStrictEqualTyped({
           data: {
             currentUser: {
               __typename: "User",
@@ -3322,6 +3578,21 @@ describe("useLazyQuery Hook", () => {
 
       const [execute] = getCurrentSnapshot();
       await execute();
+
+      {
+        const [, result] = await takeSnapshot();
+
+        expect(result).toStrictEqualTyped({
+          data: undefined,
+          called: true,
+          loading: true,
+          // @ts-expect-error
+          partial: true,
+          networkStatus: NetworkStatus.loading,
+          previousData: undefined,
+          variables: {},
+        });
+      }
 
       {
         const [, result] = await takeSnapshot();
@@ -3442,6 +3713,21 @@ describe("useLazyQuery Hook", () => {
 
       const [execute] = getCurrentSnapshot();
       await execute();
+
+      {
+        const [, result] = await takeSnapshot();
+
+        expect(result).toStrictEqualTyped({
+          data: undefined,
+          called: true,
+          loading: true,
+          // @ts-expect-error
+          partial: true,
+          networkStatus: NetworkStatus.loading,
+          previousData: undefined,
+          variables: {},
+        });
+      }
 
       {
         const [, result] = await takeSnapshot();
@@ -3785,6 +4071,21 @@ test("uses the updated client when executing the function after changing clients
     const [, result] = await takeSnapshot();
 
     expect(result).toStrictEqualTyped({
+      data: undefined,
+      called: true,
+      loading: true,
+      // @ts-expect-error
+      partial: true,
+      networkStatus: NetworkStatus.loading,
+      previousData: undefined,
+      variables: {},
+    });
+  }
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
       data: { greeting: "Hello client 1" },
       called: true,
       loading: false,
@@ -3812,6 +4113,23 @@ test("uses the updated client when executing the function after changing clients
   await expect(execute()).resolves.toStrictEqualTyped({
     data: { greeting: "Hello client 2" },
   });
+
+  // TODO: Changing clients should emit a loading state. This should be fixed when
+  // we let ObservableQuery emit the initial loading state instead.
+  // {
+  //   const [, result] = await takeSnapshot();
+  //
+  //   expect(result).toStrictEqualTyped({
+  //     data: undefined,
+  //     called: true,
+  //     loading: true,
+  //     // @ts-expect-error
+  //     partial: true,
+  //     networkStatus: NetworkStatus.loading,
+  //     previousData: { greeting: "Hello client 1" },
+  //     variables: {},
+  //   });
+  // }
 
   {
     const [, result] = await takeSnapshot();
@@ -3871,6 +4189,21 @@ test("responds to cache updates after executing query", async () => {
   await expect(execute()).resolves.toStrictEqualTyped({
     data: { greeting: "Hello" },
   });
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      called: true,
+      loading: true,
+      // @ts-expect-error
+      partial: true,
+      networkStatus: NetworkStatus.loading,
+      previousData: undefined,
+      variables: {},
+    });
+  }
 
   {
     const [, result] = await takeSnapshot();
@@ -3951,6 +4284,21 @@ test("responds to cache updates after changing variables", async () => {
       },
     }
   );
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      called: true,
+      loading: true,
+      // @ts-expect-error
+      partial: true,
+      networkStatus: NetworkStatus.loading,
+      previousData: undefined,
+      variables: { id: "1" },
+    });
+  }
 
   {
     const [, result] = await takeSnapshot();
@@ -4108,6 +4456,21 @@ test("uses cached result when switching to variables already written to the cach
       },
     }
   );
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      called: true,
+      loading: true,
+      // @ts-expect-error
+      partial: true,
+      networkStatus: NetworkStatus.loading,
+      previousData: undefined,
+      variables: { id: "1" },
+    });
+  }
 
   {
     const [, result] = await takeSnapshot();
@@ -4414,6 +4777,21 @@ test("applies `errorPolicy` on next fetch when it changes between renders", asyn
     const [, result] = await takeSnapshot();
 
     expect(result).toStrictEqualTyped({
+      data: undefined,
+      called: true,
+      loading: true,
+      // @ts-expect-error
+      partial: true,
+      networkStatus: NetworkStatus.loading,
+      previousData: undefined,
+      variables: { id: "1" },
+    });
+  }
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
       data: {
         character: { __typename: "Character", id: "1", name: "Spider-Man" },
       },
@@ -4536,6 +4914,21 @@ test("applies `context` on next fetch when it changes between renders", async ()
   await expect(execute()).resolves.toStrictEqualTyped({
     data: { context: { source: "initialHookValue" } },
   });
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      called: true,
+      loading: true,
+      // @ts-expect-error
+      partial: true,
+      networkStatus: NetworkStatus.loading,
+      previousData: undefined,
+      variables: {},
+    });
+  }
 
   {
     const [, result] = await takeSnapshot();
@@ -4760,6 +5153,21 @@ test("applies `refetchWritePolicy` on next fetch when it changes between renders
     const [, result] = await takeSnapshot();
 
     expect(result).toStrictEqualTyped({
+      data: undefined,
+      called: true,
+      loading: true,
+      // @ts-expect-error
+      partial: true,
+      networkStatus: NetworkStatus.loading,
+      previousData: undefined,
+      variables: { min: 0, max: 12 },
+    });
+  }
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
       data: mocks[0].result.data,
       called: true,
       loading: false,
@@ -4962,6 +5370,21 @@ test("applies `returnPartialData` on next fetch when it changes between renders"
       },
     }
   );
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      called: true,
+      loading: true,
+      // @ts-expect-error
+      partial: true,
+      networkStatus: NetworkStatus.loading,
+      previousData: undefined,
+      variables: { id: "1" },
+    });
+  }
 
   {
     const [, result] = await takeSnapshot();

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -804,114 +804,112 @@ describe("useLazyQuery Hook", () => {
     await expect(takeSnapshot).not.toRerender();
   });
 
-  it("should persist previous data when a query is refetched", async () => {
-    const mocks = [
-      {
-        request: { query: helloQuery },
-        result: { data: { hello: "world 1" } },
-        delay: 20,
-      },
-      {
-        request: { query: helloQuery },
-        result: { data: { hello: "world 2" } },
-        delay: 20,
-      },
-    ];
-
-    using _disabledAct = disableActEnvironment();
-    const { takeSnapshot, getCurrentSnapshot } =
-      await renderHookToSnapshotStream(
-        () =>
-          useLazyQuery(helloQuery, {
-            // TODO: This should be the default but breaks this test when
-            // removing it because the loading state is not emitted
-            notifyOnNetworkStatusChange: true,
-          }),
+  // TODO: When removing the explicit `notifyOnNetworkStatusChange` option to
+  // `useLazyQuery` (which should be the default), this test breaks as it does
+  // not emit the loading state correctly.
+  it.failing(
+    "should persist previous data when a query is refetched",
+    async () => {
+      const mocks = [
         {
+          request: { query: helloQuery },
+          result: { data: { hello: "world 1" } },
+          delay: 20,
+        },
+        {
+          request: { query: helloQuery },
+          result: { data: { hello: "world 2" } },
+          delay: 20,
+        },
+      ];
+
+      using _disabledAct = disableActEnvironment();
+      const { takeSnapshot, getCurrentSnapshot } =
+        await renderHookToSnapshotStream(() => useLazyQuery(helloQuery), {
           wrapper: ({ children }) => (
             <MockedProvider mocks={mocks}>{children}</MockedProvider>
           ),
-        }
-      );
+        });
 
-    {
-      const [, result] = await takeSnapshot();
+      {
+        const [, result] = await takeSnapshot();
 
-      expect(result).toStrictEqualTyped({
-        data: undefined,
-        called: false,
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        previousData: undefined,
-        variables: {},
-      });
-    }
+        expect(result).toStrictEqualTyped({
+          data: undefined,
+          called: false,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: undefined,
+          variables: {},
+        });
+      }
 
-    const [execute] = getCurrentSnapshot();
+      const [execute] = getCurrentSnapshot();
 
-    await expect(execute()).resolves.toStrictEqualTyped({
-      data: { hello: "world 1" },
-    });
-
-    {
-      const [, result] = await takeSnapshot();
-
-      expect(result).toStrictEqualTyped({
-        data: undefined,
-        called: true,
-        loading: true,
-        networkStatus: NetworkStatus.loading,
-        previousData: undefined,
-        variables: {},
-      });
-    }
-
-    {
-      const [, result] = await takeSnapshot();
-
-      expect(result).toStrictEqualTyped({
+      await expect(execute()).resolves.toStrictEqualTyped({
         data: { hello: "world 1" },
-        called: true,
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        previousData: undefined,
-        variables: {},
       });
-    }
 
-    const [, { refetch }] = getCurrentSnapshot();
+      {
+        const [, result] = await takeSnapshot();
 
-    await expect(refetch()).resolves.toStrictEqualTyped({
-      data: { hello: "world 2" },
-    });
+        expect(result).toStrictEqualTyped({
+          data: undefined,
+          called: true,
+          loading: true,
+          networkStatus: NetworkStatus.loading,
+          previousData: undefined,
+          variables: {},
+        });
+      }
 
-    {
-      const [, result] = await takeSnapshot();
+      {
+        const [, result] = await takeSnapshot();
 
-      expect(result).toStrictEqualTyped({
-        data: { hello: "world 1" },
-        called: true,
-        loading: true,
-        networkStatus: NetworkStatus.refetch,
-        previousData: undefined,
-        variables: {},
-      });
-    }
-    {
-      const [, result] = await takeSnapshot();
+        expect(result).toStrictEqualTyped({
+          data: { hello: "world 1" },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: undefined,
+          variables: {},
+        });
+      }
 
-      expect(result).toStrictEqualTyped({
+      const [, { refetch }] = getCurrentSnapshot();
+
+      await expect(refetch()).resolves.toStrictEqualTyped({
         data: { hello: "world 2" },
-        called: true,
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        previousData: { hello: "world 1" },
-        variables: {},
       });
-    }
 
-    await expect(takeSnapshot).not.toRerender();
-  });
+      {
+        const [, result] = await takeSnapshot();
+
+        expect(result).toStrictEqualTyped({
+          data: { hello: "world 1" },
+          called: true,
+          loading: true,
+          networkStatus: NetworkStatus.refetch,
+          previousData: undefined,
+          variables: {},
+        });
+      }
+      {
+        const [, result] = await takeSnapshot();
+
+        expect(result).toStrictEqualTyped({
+          data: { hello: "world 2" },
+          called: true,
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          previousData: { hello: "world 1" },
+          variables: {},
+        });
+      }
+
+      await expect(takeSnapshot).not.toRerender();
+    }
+  );
 
   // TODO: Determine if this hook makes sense for polling or if that should be
   // reserved for useQuery. At the very least, we need to figure out if you can

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -3506,9 +3506,7 @@ describe("useMutation Hook", () => {
 
       function App() {
         renderStream.mergeSnapshot({
-          useQueryResult: useQuery(NumbersQuery, {
-            notifyOnNetworkStatusChange: true,
-          }),
+          useQueryResult: useQuery(NumbersQuery),
           useMutationResult: useMutation(RemoveNumberMutation, {
             update(cache) {
               const oldData = cache.readQuery({ query: NumbersQuery });

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -2988,9 +2988,31 @@ describe("useMutation Hook", () => {
 
         expect(query).toStrictEqualTyped({
           data: GET_TODOS_RESULT_1,
-          loading: false,
-          networkStatus: NetworkStatus.ready,
-          previousData: undefined,
+          loading: true,
+          networkStatus: NetworkStatus.refetch,
+          previousData: GET_TODOS_RESULT_1,
+          variables: {},
+        });
+
+        expect(mutation).toStrictEqualTyped({
+          data: undefined,
+          error: undefined,
+          loading: true,
+          called: true,
+        });
+      }
+
+      {
+        const {
+          query,
+          mutation: [, mutation],
+        } = await takeSnapshot();
+
+        expect(query).toStrictEqualTyped({
+          data: GET_TODOS_RESULT_1,
+          loading: true,
+          networkStatus: NetworkStatus.refetch,
+          previousData: GET_TODOS_RESULT_1,
           variables: {},
         });
 
@@ -3165,9 +3187,31 @@ describe("useMutation Hook", () => {
 
         expect(query).toStrictEqualTyped({
           data: GET_TODOS_RESULT_1,
-          loading: false,
-          networkStatus: NetworkStatus.ready,
-          previousData: undefined,
+          loading: true,
+          networkStatus: NetworkStatus.refetch,
+          previousData: GET_TODOS_RESULT_1,
+          variables: {},
+        });
+
+        expect(mutation).toStrictEqualTyped({
+          data: undefined,
+          error: undefined,
+          loading: true,
+          called: true,
+        });
+      }
+
+      {
+        const {
+          query,
+          mutation: [, mutation],
+        } = await takeSnapshot();
+
+        expect(query).toStrictEqualTyped({
+          data: GET_TODOS_RESULT_1,
+          loading: true,
+          networkStatus: NetworkStatus.refetch,
+          previousData: GET_TODOS_RESULT_1,
           variables: {},
         });
 

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -8472,12 +8472,14 @@ describe("useQuery Hook", () => {
       });
 
       using _disabledAct = disableActEnvironment();
-      const { takeSnapshot, getCurrentSnapshot } =
-        await renderHookToSnapshotStream(() => useQuery(query), {
+      const { takeSnapshot } = await renderHookToSnapshotStream(
+        () => useQuery(query),
+        {
           wrapper: ({ children }) => (
             <ApolloProvider client={client}>{children}</ApolloProvider>
           ),
-        });
+        }
+      );
 
       await expect(takeSnapshot()).resolves.toStrictEqualTyped({
         data: undefined,

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -1868,10 +1868,34 @@ describe("useQuery Hook", () => {
         const result = await takeSnapshot();
 
         expect(result).toStrictEqualTyped({
+          data: { hello: "world 1" },
+          loading: true,
+          networkStatus: NetworkStatus.poll,
+          previousData: { hello: "world 1" },
+          variables: {},
+        });
+      }
+
+      {
+        const result = await takeSnapshot();
+
+        expect(result).toStrictEqualTyped({
           data: { hello: "world 2" },
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: { hello: "world 1" },
+          variables: {},
+        });
+      }
+
+      {
+        const result = await takeSnapshot();
+
+        expect(result).toStrictEqualTyped({
+          data: { hello: "world 2" },
+          loading: true,
+          networkStatus: NetworkStatus.poll,
+          previousData: { hello: "world 2" },
           variables: {},
         });
       }
@@ -1997,10 +2021,34 @@ describe("useQuery Hook", () => {
         const result = await takeSnapshot();
 
         expect(result).toStrictEqualTyped({
+          data: { hello: "world 1" },
+          loading: true,
+          networkStatus: NetworkStatus.poll,
+          previousData: { hello: "world 1" },
+          variables: {},
+        });
+      }
+
+      {
+        const result = await takeSnapshot();
+
+        expect(result).toStrictEqualTyped({
           data: { hello: "world 2" },
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: { hello: "world 1" },
+          variables: {},
+        });
+      }
+
+      {
+        const result = await takeSnapshot();
+
+        expect(result).toStrictEqualTyped({
+          data: { hello: "world 2" },
+          loading: true,
+          networkStatus: NetworkStatus.poll,
+          previousData: { hello: "world 2" },
           variables: {},
         });
       }
@@ -2434,7 +2482,18 @@ describe("useQuery Hook", () => {
         expect(requestSpy).toHaveBeenCalledTimes(1);
       }
 
-      await wait(25);
+      {
+        const result = await takeSnapshot();
+
+        expect(result).toStrictEqualTyped({
+          data: { hello: "world 1" },
+          loading: true,
+          networkStatus: NetworkStatus.poll,
+          previousData: { hello: "world 1" },
+          variables: {},
+        });
+        expect(requestSpy).toHaveBeenCalledTimes(2);
+      }
 
       {
         const result = await takeSnapshot();
@@ -2527,6 +2586,18 @@ describe("useQuery Hook", () => {
         const result = await takeSnapshot();
 
         expect(result).toStrictEqualTyped({
+          data: { hello: "world 1" },
+          loading: true,
+          networkStatus: NetworkStatus.poll,
+          previousData: { hello: "world 1" },
+          variables: {},
+        });
+      }
+
+      {
+        const result = await takeSnapshot();
+
+        expect(result).toStrictEqualTyped({
           data: { hello: "world 2" },
           loading: false,
           networkStatus: NetworkStatus.ready,
@@ -2547,10 +2618,34 @@ describe("useQuery Hook", () => {
         const result = await takeSnapshot();
 
         expect(result).toStrictEqualTyped({
+          data: { hello: "world 2" },
+          loading: true,
+          networkStatus: NetworkStatus.poll,
+          previousData: { hello: "world 2" },
+          variables: {},
+        });
+      }
+
+      {
+        const result = await takeSnapshot();
+
+        expect(result).toStrictEqualTyped({
           data: { hello: "world 3" },
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: { hello: "world 2" },
+          variables: {},
+        });
+      }
+
+      {
+        const result = await takeSnapshot();
+
+        expect(result).toStrictEqualTyped({
+          data: { hello: "world 3" },
+          loading: true,
+          networkStatus: NetworkStatus.poll,
+          previousData: { hello: "world 3" },
           variables: {},
         });
       }
@@ -4128,6 +4223,18 @@ describe("useQuery Hook", () => {
         const result = await takeSnapshot();
 
         expect(result).toStrictEqualTyped({
+          data: { letters: ab },
+          loading: true,
+          networkStatus: NetworkStatus.fetchMore,
+          previousData: { letters: ab },
+          variables: { limit: 2 },
+        });
+      }
+
+      {
+        const result = await takeSnapshot();
+
+        expect(result).toStrictEqualTyped({
           data: { letters: ab.concat(cd) },
           loading: false,
           networkStatus: NetworkStatus.ready,
@@ -4272,6 +4379,18 @@ describe("useQuery Hook", () => {
       expect(fetchMoreResult).toStrictEqualTyped({
         data: { letters: cd },
       });
+
+      {
+        const result = await takeSnapshot();
+
+        expect(result).toStrictEqualTyped({
+          data: { letters: ab },
+          loading: true,
+          networkStatus: NetworkStatus.fetchMore,
+          previousData: { letters: ab },
+          variables: { limit: 2 },
+        });
+      }
 
       {
         const result = await takeSnapshot();
@@ -5855,13 +5974,17 @@ describe("useQuery Hook", () => {
     }
 
     await user.click(screen.getByText("Run mutation"));
+    // Mutation started
     await renderStream.takeRender();
 
     {
       const { snapshot } = await renderStream.takeRender();
 
       expect(snapshot.useQueryResult!).toStrictEqualTyped({
-        data: {
+        data: undefined,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: {
           author: {
             __typename: "Author",
             id: 1,
@@ -5873,12 +5996,12 @@ describe("useQuery Hook", () => {
             },
           },
         },
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        previousData: undefined,
         variables: {},
       });
     }
+
+    // Mutation completed
+    await renderStream.takeRender();
 
     {
       const { snapshot } = await renderStream.takeRender();
@@ -8382,14 +8505,12 @@ describe("useQuery Hook", () => {
       });
 
       using _disabledAct = disableActEnvironment();
-      const { takeSnapshot } = await renderHookToSnapshotStream(
-        () => useQuery(query),
-        {
+      const { takeSnapshot, getCurrentSnapshot } =
+        await renderHookToSnapshotStream(() => useQuery(query), {
           wrapper: ({ children }) => (
             <ApolloProvider client={client}>{children}</ApolloProvider>
           ),
-        }
-      );
+        });
 
       await expect(takeSnapshot()).resolves.toStrictEqualTyped({
         data: undefined,
@@ -8408,10 +8529,26 @@ describe("useQuery Hook", () => {
       });
 
       await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+        data: { hello: "world 1" },
+        loading: true,
+        networkStatus: NetworkStatus.poll,
+        previousData: { hello: "world 1" },
+        variables: {},
+      });
+
+      await expect(takeSnapshot()).resolves.toStrictEqualTyped({
         data: { hello: "world 2" },
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: { hello: "world 1" },
+        variables: {},
+      });
+
+      await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+        data: { hello: "world 2" },
+        loading: true,
+        networkStatus: NetworkStatus.poll,
+        previousData: { hello: "world 2" },
         variables: {},
       });
 

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -3550,7 +3550,6 @@ describe("useQuery Hook", () => {
       }> = ({ breed = "airedale" }) => {
         const { data, refetch, networkStatus } = useQuery(GET_DOG_DETAILS, {
           variables: { breed },
-          notifyOnNetworkStatusChange: true,
         });
         if (networkStatus === 1) return <p>Loading!</p>;
         return (
@@ -3938,10 +3937,7 @@ describe("useQuery Hook", () => {
 
       using _disabledAct = disableActEnvironment();
       const { takeSnapshot, getCurrentSnapshot } =
-        await renderHookToSnapshotStream(
-          () => useQuery(query, { notifyOnNetworkStatusChange: true }),
-          { wrapper }
-        );
+        await renderHookToSnapshotStream(() => useQuery(query), { wrapper });
 
       {
         const result = await takeSnapshot();
@@ -4042,10 +4038,7 @@ describe("useQuery Hook", () => {
 
       using _disabledAct = disableActEnvironment();
       const { takeSnapshot, getCurrentSnapshot } =
-        await renderHookToSnapshotStream(
-          () => useQuery(query, { notifyOnNetworkStatusChange: true }),
-          { wrapper }
-        );
+        await renderHookToSnapshotStream(() => useQuery(query), { wrapper });
 
       {
         const result = await takeSnapshot();
@@ -4560,7 +4553,6 @@ describe("useQuery Hook", () => {
         await renderHookToSnapshotStream(
           () =>
             useQuery(query, {
-              notifyOnNetworkStatusChange: true,
               fetchPolicy: "no-cache",
               variables: { limit: 2 },
             }),
@@ -6074,11 +6066,7 @@ describe("useQuery Hook", () => {
       using _disabledAct = disableActEnvironment();
       const { takeSnapshot, getCurrentSnapshot } =
         await renderHookToSnapshotStream(
-          () =>
-            useQuery(query, {
-              variables: { id: 1 },
-              notifyOnNetworkStatusChange: true,
-            }),
+          () => useQuery(query, { variables: { id: 1 } }),
           { wrapper }
         );
       {
@@ -6159,19 +6147,13 @@ describe("useQuery Hook", () => {
 
       using _disabledAct = disableActEnvironment();
       const { takeSnapshot, getCurrentSnapshot } =
-        await renderHookToSnapshotStream(
-          () =>
-            useQuery(query, {
-              notifyOnNetworkStatusChange: true,
-            }),
-          {
-            wrapper: ({ children }) => (
-              <MockedProvider mocks={mocks} cache={cache}>
-                {children}
-              </MockedProvider>
-            ),
-          }
-        );
+        await renderHookToSnapshotStream(() => useQuery(query), {
+          wrapper: ({ children }) => (
+            <MockedProvider mocks={mocks} cache={cache}>
+              {children}
+            </MockedProvider>
+          ),
+        });
 
       {
         const result = await takeSnapshot();
@@ -6318,7 +6300,6 @@ describe("useQuery Hook", () => {
             () =>
               useQuery(query, {
                 variables: { min: 0, max: 12 },
-                notifyOnNetworkStatusChange: true,
                 // This is the key line in this test.
                 refetchWritePolicy: "overwrite",
               }),
@@ -6422,7 +6403,6 @@ describe("useQuery Hook", () => {
             () =>
               useQuery(query, {
                 variables: { min: 0, max: 12 },
-                notifyOnNetworkStatusChange: true,
                 // This is the key line in this test.
                 refetchWritePolicy: "merge",
               }),
@@ -6527,7 +6507,6 @@ describe("useQuery Hook", () => {
             () =>
               useQuery(query, {
                 variables: { min: 0, max: 12 },
-                notifyOnNetworkStatusChange: true,
                 // Intentionally not passing refetchWritePolicy.
               }),
             { wrapper }
@@ -6667,7 +6646,6 @@ describe("useQuery Hook", () => {
         ({ id }) =>
           useQuery(CAR_QUERY_BY_ID, {
             variables: { id },
-            notifyOnNetworkStatusChange: true,
             fetchPolicy: "network-only",
           }),
         {
@@ -7542,7 +7520,6 @@ describe("useQuery Hook", () => {
             useQuery(query, {
               fetchPolicy: "network-only",
               variables,
-              notifyOnNetworkStatusChange: true,
               nextFetchPolicy,
             }),
           {
@@ -7938,7 +7915,6 @@ describe("useQuery Hook", () => {
           return useQuery(partialQuery, {
             variables: { id },
             returnPartialData: false,
-            notifyOnNetworkStatusChange: true,
           });
         },
         {
@@ -8024,10 +8000,7 @@ describe("useQuery Hook", () => {
 
       using _disabledAct = disableActEnvironment();
       const { takeSnapshot, getCurrentSnapshot } =
-        await renderHookToSnapshotStream(
-          () => useQuery(query, { notifyOnNetworkStatusChange: true }),
-          { wrapper }
-        );
+        await renderHookToSnapshotStream(() => useQuery(query), { wrapper });
 
       await expect(takeSnapshot()).resolves.toStrictEqualTyped({
         data: undefined,
@@ -8132,10 +8105,7 @@ describe("useQuery Hook", () => {
 
       using _disabledAct = disableActEnvironment();
       const { takeSnapshot, getCurrentSnapshot } =
-        await renderHookToSnapshotStream(
-          () => useQuery(query, { notifyOnNetworkStatusChange: true }),
-          { wrapper }
-        );
+        await renderHookToSnapshotStream(() => useQuery(query), { wrapper });
 
       await expect(takeSnapshot()).resolves.toStrictEqualTyped({
         data: undefined,
@@ -8264,10 +8234,7 @@ describe("useQuery Hook", () => {
       const { takeSnapshot, getCurrentSnapshot, rerender } =
         await renderHookToSnapshotStream(
           ({ query }) => {
-            return useQuery(query, {
-              fetchPolicy: "cache-and-network",
-              notifyOnNetworkStatusChange: true,
-            });
+            return useQuery(query, { fetchPolicy: "cache-and-network" });
           },
           {
             initialProps: { query: aQuery as DocumentNode },
@@ -10195,14 +10162,11 @@ describe("useQuery Hook", () => {
 
     using _disabledAct = disableActEnvironment();
     const { takeSnapshot, getCurrentSnapshot } =
-      await renderHookToSnapshotStream(
-        () => useQuery(query, { notifyOnNetworkStatusChange: true }),
-        {
-          wrapper: ({ children }) => (
-            <MockedProvider mocks={mocks}>{children}</MockedProvider>
-          ),
-        }
-      );
+      await renderHookToSnapshotStream(() => useQuery(query), {
+        wrapper: ({ children }) => (
+          <MockedProvider mocks={mocks}>{children}</MockedProvider>
+        ),
+      });
 
     await expect(takeSnapshot()).resolves.toStrictEqualTyped({
       data: undefined,

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -367,7 +367,7 @@ export function useLazyQuery<
 
         return promise;
       },
-      [observable, stableOptions, updateResult, calledDuringRender]
+      [observable, updateResult, calledDuringRender]
     );
 
   const executeRef = React.useRef(execute);

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -358,7 +358,10 @@ export function useLazyQuery<
         const promise = observable.reobserve(options);
 
         // TODO: This should be fixed in core
-        if (!resultRef.current && stableOptions?.notifyOnNetworkStatusChange) {
+        if (
+          !resultRef.current &&
+          observable.options.notifyOnNetworkStatusChange
+        ) {
           updateResult(observable.getCurrentResult(), forceUpdateState);
         }
 

--- a/src/react/query-preloader/createQueryPreloader.ts
+++ b/src/react/query-preloader/createQueryPreloader.ts
@@ -178,6 +178,7 @@ const _createQueryPreloader: typeof createQueryPreloader = (client) => {
       client.watchQuery({
         ...options,
         query,
+        notifyOnNetworkStatusChange: false,
       } as WatchQueryOptions<any, any>),
       {
         autoDisposeTimeoutMs:

--- a/src/react/types/types.documentation.ts
+++ b/src/react/types/types.documentation.ts
@@ -72,7 +72,7 @@ export interface QueryOptionsDocumentation {
   /**
    * If `true`, the in-progress query's associated component re-renders whenever the network status changes or a network error occurs.
    *
-   * The default value is `false`.
+   * The default value is `true`.
    *
    * @docGroup 2. Networking options
    */
@@ -395,7 +395,7 @@ export interface MutationOptionsDocumentation {
   /**
    * If `true`, the in-progress mutation's associated component re-renders whenever the network status changes or a network error occurs.
    *
-   * The default value is `false`.
+   * The default value is `true`.
    *
    * @docGroup 2. Networking options
    */

--- a/src/testing/matchers/arrayWithLength.ts
+++ b/src/testing/matchers/arrayWithLength.ts
@@ -1,0 +1,18 @@
+import type { MatcherFunction } from "expect";
+
+export const arrayWithLength: MatcherFunction<[length: number]> = function (
+  actual,
+  length
+) {
+  if (!Array.isArray(actual)) {
+    throw new Error("Actual value must be an array");
+  }
+
+  const pass = actual.length === length;
+
+  return {
+    pass,
+    message: () =>
+      `expected array to ${pass ? "not be" : "be"} of length ${length}`,
+  };
+};

--- a/src/testing/matchers/index.d.ts
+++ b/src/testing/matchers/index.d.ts
@@ -85,10 +85,16 @@ interface ApolloCustomMatchers<R = void, T = {}> {
   : (expected: FilterUnserializableProperties<T>) => R;
 }
 
+interface ApolloCustomAsymmetricMatchers {
+  arrayWithLength: (length: number) => any;
+}
+
 declare global {
   namespace jest {
     interface Matchers<R = void, T = {}>
       extends ApolloCustomMatchers<R, T>,
         RenderStreamMatchers<R, T> {}
+
+    interface Expect extends ApolloCustomAsymmetricMatchers {}
   }
 }

--- a/src/testing/matchers/index.ts
+++ b/src/testing/matchers/index.ts
@@ -1,5 +1,6 @@
 import { expect } from "@jest/globals";
 
+import { arrayWithLength } from "./arrayWithLength.js";
 import { toBeDisposed } from "./toBeDisposed.js";
 import { toBeGarbageCollected } from "./toBeGarbageCollected.js";
 import { toComplete } from "./toComplete.js";
@@ -12,6 +13,7 @@ import { toMatchDocument } from "./toMatchDocument.js";
 import { toStrictEqualTyped } from "./toStrictEqualTyped.js";
 
 expect.extend({
+  arrayWithLength,
   toComplete,
   toEmitAnything,
   toEmitError,


### PR DESCRIPTION
Closes #12505

Changes the default value of `notifyOnNetworkStatusChange` to `true` so that loading states are emitted/rendered by default.