### PR TITLE
Fix warnings emitted to console from `ObservableQuery` tests

### DIFF
--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -3426,7 +3426,9 @@ describe("ObservableQuery", () => {
         cache: new InMemoryCache(),
       });
 
-      const observable = client.watchQuery({ query });
+      // Don't write results to the cache to prevent cache write warnings on
+      // missing data
+      const observable = client.watchQuery({ query, fetchPolicy: "no-cache" });
 
       expect(observable.query).toMatchDocument(gql`
         query {

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -3294,9 +3294,7 @@ describe("ObservableQuery", () => {
             { request: queryOptions, result: { data: { value: 1 } } },
             { request: queryOptions, result: { data: { value: 2 } } },
             { request: queryOptions, result: { data: { value: 3 } } },
-          ]).setOnError((error) => {
-            throw error;
-          }),
+          ]),
           assumeImmutableResults,
           cache,
         });
@@ -3312,6 +3310,7 @@ describe("ObservableQuery", () => {
                 try {
                   data.value = "oyez";
                 } catch (error) {
+                  observable.stopPolling();
                   reject(error);
                 }
               } else {


### PR DESCRIPTION
These were quite noisy and made it difficult to debug.