### PR TITLE
Combine `variables` and `variablesMatcher` in `MockLink`

### DIFF
--- a/.api-reports/api-report-testing_core.api.md
+++ b/.api-reports/api-report-testing_core.api.md
@@ -8,7 +8,6 @@ import { ApolloClient } from '@apollo/client';
 import { ApolloLink } from '@apollo/client/link/core';
 import type { DocumentNode } from 'graphql';
 import type { FetchResult } from '@apollo/client/link/core';
-import type { GraphQLRequest } from '@apollo/client/link/core';
 import { Observable } from 'rxjs';
 import type { Operation } from '@apollo/client/link/core';
 import type { Unmasked } from '@apollo/client/masking';
@@ -28,6 +27,16 @@ interface MockApolloLink extends ApolloLink {
 }
 
 // @public (undocumented)
+export interface MockedRequest<TVariables = Record<string, any>> {
+    // (undocumented)
+    query: DocumentNode;
+    // Warning: (ae-forgotten-export) The symbol "VariableMatcher" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    variables?: TVariables | VariableMatcher<TVariables>;
+}
+
+// @public (undocumented)
 export interface MockedResponse<out TData = Record<string, any>, out TVariables = Record<string, any>> {
     // (undocumented)
     delay?: number;
@@ -36,13 +45,9 @@ export interface MockedResponse<out TData = Record<string, any>, out TVariables 
     // (undocumented)
     maxUsageCount?: number;
     // (undocumented)
-    request: GraphQLRequest<TVariables>;
+    request: MockedRequest<TVariables>;
     // (undocumented)
     result?: FetchResult<Unmasked<TData>> | ResultFunction<FetchResult<Unmasked<TData>>, TVariables>;
-    // Warning: (ae-forgotten-export) The symbol "VariableMatcher" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
-    variableMatcher?: VariableMatcher<TVariables>;
 }
 
 // @public (undocumented)
@@ -57,7 +62,7 @@ interface MockedSubscriptionResult {
 
 // @public (undocumented)
 export class MockLink extends ApolloLink {
-    constructor(mockedResponses: ReadonlyArray<MockedResponse<any, any>>, options?: MockLinkOptions);
+    constructor(mockedResponses: ReadonlyArray<MockedResponse<Record<string, any>, Record<string, any>>>, options?: MockLinkOptions);
     // (undocumented)
     addMockedResponse(mockedResponse: MockedResponse): void;
     // (undocumented)

--- a/.api-reports/api-report-testing_internal.api.md
+++ b/.api-reports/api-report-testing_internal.api.md
@@ -9,11 +9,11 @@ import { ApolloLink } from '@apollo/client';
 import type { ApolloPayloadResult } from '@apollo/client';
 import { FetchResult } from '@apollo/client';
 import type { GraphQLFormattedError } from 'graphql-17-alpha2';
-import { GraphQLRequest } from '@apollo/client';
 import { HttpLink } from '@apollo/client/link/http';
 import type { InitialIncrementalExecutionResult } from 'graphql-17-alpha2';
 import type { MaskedDocumentNode } from '@apollo/client/masking';
 import type { MockedProviderProps } from '@apollo/client/testing/react';
+import { MockedRequest } from '@apollo/client/testing/core';
 import type { MockedResponse } from '@apollo/client/testing/core';
 import type { Observable } from 'rxjs';
 import type { Queries } from '@testing-library/dom';
@@ -35,11 +35,10 @@ export function actAsync<T>(scope: () => T | Promise<T>): Promise<T>;
 // @public (undocumented)
 export function addDelayToMocks<T extends MockedResponse<unknown>[]>(mocks: T, delay?: number, override?: boolean): {
     delay: number;
-    request: GraphQLRequest<Record<string, any>>;
+    request: MockedRequest<Record<string, any>>;
     maxUsageCount?: number;
     result?: FetchResult<unknown> | ResultFunction<FetchResult<unknown>, Record<string, any>> | undefined;
     error?: Error;
-    variableMatcher?: ((arg: Record<string, any>) => boolean) | undefined;
 }[];
 
 // @public (undocumented)
@@ -212,7 +211,7 @@ export function setupSimpleCase(): {
 
 // @public (undocumented)
 export function setupVariablesCase(): {
-    mocks: MockedResponse<VariablesCaseData, Record<string, any>>[];
+    mocks: MockedResponse<VariablesCaseData, VariablesCaseVariables>[];
     query: TypedDocumentNode<VariablesCaseData, VariablesCaseVariables>;
 };
 

--- a/.changeset/ninety-bags-bake.md
+++ b/.changeset/ninety-bags-bake.md
@@ -1,0 +1,17 @@
+---
+"@apollo/client": major
+---
+
+Mocked responses passed to `MockLink` now accept a callback for the `request.variables` option. This is used to determine if the mock should be matched for a set of request variables. With this change, the `variableMatcher` option has been removed in favor of passing a callback to `variables`. Update by moving the callback function from `variableMatcher` to `request.variables`.
+
+```diff
+new MockLink([
+  {
+    request: {
+      query,
++     variables: (requestVariables) => true
+    },
+-   variableMatcher: (requestVariables) => true
+  }
+]);
+```

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 42912,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38348,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 32805,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27800
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 42763,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38290,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 32814,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27796
 }

--- a/src/react/query-preloader/__tests__/createQueryPreloader.test.tsx
+++ b/src/react/query-preloader/__tests__/createQueryPreloader.test.tsx
@@ -445,7 +445,9 @@ test("useReadQuery handles auto-resubscribe with returnPartialData", async () =>
   const link = new ApolloLink((operation) => {
     fetchCount++;
     const mock = mocks.find(
-      (mock) => mock.request.variables?.id === operation.variables.id
+      (mock) =>
+        typeof mock.request.variables === "object" &&
+        mock.request.variables?.id === operation.variables.id
     );
 
     if (!mock) {

--- a/src/react/ssr/__tests__/prerenderStatic.test.tsx
+++ b/src/react/ssr/__tests__/prerenderStatic.test.tsx
@@ -611,8 +611,7 @@ test("`maxRerenders` will throw an error if exceeded", async () => {
     cache: new InMemoryCache(),
     link: new MockLink([
       {
-        request: { query },
-        variableMatcher: () => true,
+        request: { query, variables: () => true },
         result: (arg) => ({ data: { hello: "world" + arg.depth } }),
         maxUsageCount: Number.POSITIVE_INFINITY,
       } satisfies MockedResponse<{ hello: string }, { depth: number }>,
@@ -658,8 +657,7 @@ test("`maxRerenders` defaults to 50", async () => {
     cache: new InMemoryCache(),
     link: new MockLink([
       {
-        request: { query },
-        variableMatcher: () => true,
+        request: { query, variables: () => true },
         result: (arg) => ({ data: { hello: "world" + arg.depth } }),
         maxUsageCount: Number.POSITIVE_INFINITY,
       } satisfies MockedResponse<{ hello: string }, { depth: number }>,

--- a/src/testing/core/index.ts
+++ b/src/testing/core/index.ts
@@ -1,4 +1,5 @@
 export type {
+  MockedRequest,
   MockedResponse,
   MockLinkOptions,
   ResultFunction,

--- a/src/testing/core/mocking/__tests__/__snapshots__/mockLink.ts.snap
+++ b/src/testing/core/mocking/__tests__/__snapshots__/mockLink.ts.snap
@@ -43,7 +43,7 @@ query ($id: ID!) {
 Request variables: {\\"id\\":1}
 
 Failed to match variables against 1 mock for this query. The available mocks had the following variables:
-  <function>
+  <function variables>
 "
 `;
 

--- a/src/testing/core/mocking/__tests__/__snapshots__/mockLink.ts.snap
+++ b/src/testing/core/mocking/__tests__/__snapshots__/mockLink.ts.snap
@@ -32,7 +32,7 @@ Request variables: {}
 "
 `;
 
-exports[`fails when variableMatcher returns false 1`] = `
+exports[`fails when variables returns false 1`] = `
 "No more mocked responses for the query:
 query ($id: ID!) {
   user(id: $id) {
@@ -43,7 +43,7 @@ query ($id: ID!) {
 Request variables: {\\"id\\":1}
 
 Failed to match variables against 1 mock for this query. The available mocks had the following variables:
-  <undefined>
+  <function>
 "
 `;
 

--- a/src/testing/core/mocking/__tests__/mockLink.ts
+++ b/src/testing/core/mocking/__tests__/mockLink.ts
@@ -555,36 +555,6 @@ test("throws error when query is a plain string", async () => {
   ).toThrow(/^Expecting a parsed GraphQL document/);
 });
 
-// TODO: Should we consider combining these options and allowing `variables` to
-// accept a callback function? Doing so would make this error obsolete.
-test("throws error when passing variableMatcher and variables", async () => {
-  expect(
-    () =>
-      new MockLink([
-        {
-          request: {
-            query: gql`
-              query ($id: ID!) {
-                user(id: $id) {
-                  name
-                }
-              }
-            `,
-            variables: { id: 1 },
-          },
-          variableMatcher: () => true,
-          result: {
-            data: null,
-          },
-        },
-      ])
-  ).toThrow(
-    new InvariantError(
-      "Mocked response should use either `request.variables` or `variableMatcher` but not both"
-    )
-  );
-});
-
 test("throws error when given a client-only query", async () => {
   expect(
     () =>
@@ -659,7 +629,7 @@ test("throws error when passing maxUsageCount <= 0", async () => {
   );
 });
 
-test("passes variables to the variableMatcher", async () => {
+test("passes variables to the `variables` callback function", async () => {
   const query = gql`
     query ($id: ID!) {
       user(id: $id) {
@@ -673,8 +643,7 @@ test("passes variables to the variableMatcher", async () => {
 
   const link = new MockLink([
     {
-      request: { query },
-      variableMatcher,
+      request: { query, variables: variableMatcher },
       result: { data: { user: { __typename: "User", name: "Test" } } },
     },
   ]);
@@ -700,13 +669,11 @@ test("uses mock when variableMatcher returns true", async () => {
 
   const link = new MockLink([
     {
-      request: { query },
-      variableMatcher: ({ id }) => id === 1,
+      request: { query, variables: ({ id }) => id === 1 },
       result: { data: { user: { __typename: "User", name: "User 1" } } },
     },
     {
-      request: { query },
-      variableMatcher: ({ id }) => id === 2,
+      request: { query, variables: ({ id }) => id === 2 },
       result: { data: { user: { __typename: "User", name: "User 2" } } },
     },
   ]);
@@ -720,7 +687,7 @@ test("uses mock when variableMatcher returns true", async () => {
   });
 });
 
-test("fails when variableMatcher returns false", async () => {
+test("fails when variables returns false", async () => {
   const query = gql`
     query ($id: ID!) {
       user(id: $id) {
@@ -732,8 +699,7 @@ test("fails when variableMatcher returns false", async () => {
   const link = new MockLink(
     [
       {
-        request: { query },
-        variableMatcher: () => false,
+        request: { query, variables: () => false },
         result: { data: { user: { __typename: "User", name: "User 1" } } },
       },
     ],

--- a/src/testing/core/mocking/__tests__/mockLink.ts
+++ b/src/testing/core/mocking/__tests__/mockLink.ts
@@ -658,7 +658,7 @@ test("passes variables to the `variables` callback function", async () => {
   expect(variableMatcher).toHaveBeenCalledWith(variables);
 });
 
-test("uses mock when variableMatcher returns true", async () => {
+test("uses mock when `variables` as callback returns true", async () => {
   const query = gql`
     query ($id: ID!) {
       user(id: $id) {

--- a/src/testing/core/mocking/mockLink.ts
+++ b/src/testing/core/mocking/mockLink.ts
@@ -36,12 +36,17 @@ type VariableMatcher<V = Record<string, any>> = CovariantUnaryFunction<
   boolean
 >;
 
+interface MockedRequest<out TVariables> {
+  query: DocumentNode;
+  variables?: TVariables | VariableMatcher<TVariables>;
+}
+
 export interface MockedResponse<
   // @ts-ignore
   out TData = Record<string, any>,
   out TVariables = Record<string, any>,
 > {
-  request: GraphQLRequest<TVariables>;
+  request: MockedRequest<TVariables>;
   maxUsageCount?: number;
   result?:
     | FetchResult<Unmasked<TData>>

--- a/src/testing/core/mocking/mockLink.ts
+++ b/src/testing/core/mocking/mockLink.ts
@@ -62,7 +62,7 @@ interface NormalizedMockedResponse {
 }
 
 type UnmatchedVariables = Array<
-  Record<string, any> | "<undefined>" | "<function>"
+  Record<string, any> | "<undefined>" | `<function ${string}>`
 >;
 
 export interface MockLinkOptions {
@@ -110,7 +110,7 @@ export class MockLink extends ApolloLink {
         const matched = variables(operation.variables);
 
         if (!matched) {
-          unmatchedVars.push("<function>");
+          unmatchedVars.push(`<function ${variables.name}>`);
         }
 
         return matched;

--- a/src/testing/core/mocking/mockLink.ts
+++ b/src/testing/core/mocking/mockLink.ts
@@ -1,8 +1,8 @@
 import { equal } from "@wry/equality";
+import type { DocumentNode } from "graphql";
 import { Observable, throwError } from "rxjs";
 
 import type {
-  DocumentNode,
   FetchResult,
   GraphQLRequest,
   Operation,

--- a/src/testing/core/mocking/mockLink.ts
+++ b/src/testing/core/mocking/mockLink.ts
@@ -27,7 +27,10 @@ export type ResultFunction<T, V = Record<string, any>> = CovariantUnaryFunction<
   T
 >;
 
-type VariableMatcher<V> = CovariantUnaryFunction<V, boolean>;
+type VariableMatcher<V = Record<string, any>> = CovariantUnaryFunction<
+  V,
+  boolean
+>;
 
 export interface MockedRequest<TVariables = Record<string, any>> {
   query: DocumentNode;

--- a/src/testing/core/mocking/mockLink.ts
+++ b/src/testing/core/mocking/mockLink.ts
@@ -33,7 +33,7 @@ export type ResultFunction<T, V = Record<string, any>> = CovariantUnaryFunction<
 
 type VariableMatcher<V> = CovariantUnaryFunction<V, boolean>;
 
-interface MockedRequest<TVariables = Record<string, any>> {
+interface MockedRequest<TVariables> {
   query: DocumentNode;
   variables?: TVariables | VariableMatcher<TVariables>;
 }

--- a/src/testing/core/mocking/mockLink.ts
+++ b/src/testing/core/mocking/mockLink.ts
@@ -72,7 +72,9 @@ export class MockLink extends ApolloLink {
     {};
 
   constructor(
-    mockedResponses: ReadonlyArray<MockedResponse<any, any>>,
+    mockedResponses: ReadonlyArray<
+      MockedResponse<Record<string, any>, Record<string, any>>
+    >,
     options: MockLinkOptions = {}
   ) {
     super();

--- a/src/testing/core/mocking/mockLink.ts
+++ b/src/testing/core/mocking/mockLink.ts
@@ -2,11 +2,7 @@ import { equal } from "@wry/equality";
 import type { DocumentNode } from "graphql";
 import { Observable, throwError } from "rxjs";
 
-import type {
-  FetchResult,
-  GraphQLRequest,
-  Operation,
-} from "@apollo/client/link/core";
+import type { FetchResult, Operation } from "@apollo/client/link/core";
 import { ApolloLink } from "@apollo/client/link/core";
 import type { Unmasked } from "@apollo/client/masking";
 import {
@@ -33,7 +29,7 @@ export type ResultFunction<T, V = Record<string, any>> = CovariantUnaryFunction<
 
 type VariableMatcher<V> = CovariantUnaryFunction<V, boolean>;
 
-interface MockedRequest<TVariables> {
+interface MockedRequest<TVariables = Record<string, any>> {
   query: DocumentNode;
   variables?: TVariables | VariableMatcher<TVariables>;
 }
@@ -54,7 +50,7 @@ export interface MockedResponse<
 
 interface NormalizedMockedResponse {
   original: MockedResponse;
-  request: GraphQLRequest;
+  request: MockedRequest;
   maxUsageCount: number;
   result?: FetchResult | ResultFunction<FetchResult, any>;
   error?: Error;
@@ -197,7 +193,7 @@ export class MockLink extends ApolloLink {
     });
   }
 
-  private getMockedResponses(request: GraphQLRequest) {
+  private getMockedResponses(request: MockedRequest) {
     const key = JSON.stringify({
       query: print(addTypenameToDocument(request.query)),
     });

--- a/src/testing/core/mocking/mockLink.ts
+++ b/src/testing/core/mocking/mockLink.ts
@@ -61,6 +61,10 @@ interface NormalizedMockedResponse {
   delay?: number;
 }
 
+type UnmatchedVariables = Array<
+  Record<string, any> | "<undefined>" | "<function>"
+>;
+
 export interface MockLinkOptions {
   showWarnings?: boolean;
 }
@@ -96,9 +100,7 @@ export class MockLink extends ApolloLink {
 
   public request(operation: Operation): Observable<FetchResult> | null {
     this.operation = operation;
-    const unmatchedVars: Array<
-      Record<string, any> | "<undefined>" | "<function>"
-    > = [];
+    const unmatchedVars: UnmatchedVariables = [];
     const mocks = this.getMockedResponses(operation);
 
     const index = mocks.findIndex((mock) => {
@@ -213,7 +215,7 @@ export class MockLink extends ApolloLink {
 
 function getErrorMessage(
   operation: Operation,
-  unmatchedVars: Array<Record<string, any> | "<undefined>" | "<function>">
+  unmatchedVars: UnmatchedVariables
 ) {
   return `No more mocked responses for the query:
 ${print(operation.query)}

--- a/src/testing/core/mocking/mockLink.ts
+++ b/src/testing/core/mocking/mockLink.ts
@@ -29,7 +29,7 @@ export type ResultFunction<T, V = Record<string, any>> = CovariantUnaryFunction<
 
 type VariableMatcher<V> = CovariantUnaryFunction<V, boolean>;
 
-interface MockedRequest<TVariables = Record<string, any>> {
+export interface MockedRequest<TVariables = Record<string, any>> {
   query: DocumentNode;
   variables?: TVariables | VariableMatcher<TVariables>;
 }

--- a/src/testing/internal/scenarios/index.ts
+++ b/src/testing/internal/scenarios/index.ts
@@ -51,17 +51,17 @@ export function setupVariablesCase() {
     `;
   const CHARACTERS = ["Spider-Man", "Black Widow", "Iron Man", "Hulk"];
 
-  const mocks: MockedResponse<VariablesCaseData>[] = [...CHARACTERS].map(
-    (name, index) => ({
-      request: { query, variables: { id: String(index + 1) } },
-      result: {
-        data: {
-          character: { __typename: "Character", id: String(index + 1), name },
-        },
+  const mocks: MockedResponse<VariablesCaseData, VariablesCaseVariables>[] = [
+    ...CHARACTERS,
+  ].map((name, index) => ({
+    request: { query, variables: { id: String(index + 1) } },
+    result: {
+      data: {
+        character: { __typename: "Character", id: String(index + 1), name },
       },
-      delay: 20,
-    })
-  );
+    },
+    delay: 20,
+  }));
 
   return { mocks, query };
 }

--- a/src/testing/react/__tests__/MockedProvider.test.tsx
+++ b/src/testing/react/__tests__/MockedProvider.test.tsx
@@ -129,7 +129,7 @@ describe("General use", () => {
     });
   });
 
-  it("should pass the variables to the variableMatcher", async () => {
+  it("should pass the variables to the `variables` callback function", async () => {
     function Component({ ...variables }: Variables) {
       useQuery<Data, Variables>(query, { variables });
       return null;
@@ -138,8 +138,8 @@ describe("General use", () => {
     const mock2: MockedResponse<Data, Variables> = {
       request: {
         query,
+        variables: jest.fn().mockReturnValue(true),
       },
-      variableMatcher: jest.fn().mockReturnValue(true),
       result: { data: { user } },
     };
 
@@ -150,13 +150,11 @@ describe("General use", () => {
     );
 
     await waitFor(() => {
-      expect(mock2.variableMatcher as jest.Mock).toHaveBeenCalledWith(
-        variables
-      );
+      expect(mock2.request.variables).toHaveBeenCalledWith(variables);
     });
   });
 
-  it("should use a mock if the variableMatcher returns true", async () => {
+  it("should use the mock if the `variables` callback function returns true", async () => {
     let finished = false;
 
     function Component({ username }: Variables) {
@@ -173,8 +171,8 @@ describe("General use", () => {
     const mock2: MockedResponse<Data, Variables> = {
       request: {
         query,
+        variables: (v) => v.username === variables.username,
       },
-      variableMatcher: (v) => v.username === variables.username,
       result: { data: { user } },
     };
 
@@ -279,7 +277,7 @@ describe("General use", () => {
     });
   });
 
-  it("should error if the variableMatcher returns false", async () => {
+  it("should error if the `variables` as callback returns false", async () => {
     let finished = false;
     function Component({ ...variables }: Variables) {
       const { loading, error } = useQuery<Data, Variables>(query, {
@@ -295,8 +293,8 @@ describe("General use", () => {
     const mock2: MockedResponse<Data, Variables> = {
       request: {
         query,
+        variables: () => false,
       },
-      variableMatcher: () => false,
       result: { data: { user } },
     };
 

--- a/src/testing/react/__tests__/__snapshots__/MockedProvider.test.tsx.snap
+++ b/src/testing/react/__tests__/__snapshots__/MockedProvider.test.tsx.snap
@@ -19,7 +19,7 @@ query GetUser($username: String!) {
 Request variables: {"username":"mock_username"}
 
 Failed to match variables against 1 mock for this query. The available mocks had the following variables:
-  <function>
+  <function variables>
 ]
 `;
 

--- a/src/testing/react/__tests__/__snapshots__/MockedProvider.test.tsx.snap
+++ b/src/testing/react/__tests__/__snapshots__/MockedProvider.test.tsx.snap
@@ -7,20 +7,7 @@ Object {
 }
 `;
 
-exports[`General use should error if the query in the mock and component do not match 1`] = `
-[Error: No more mocked responses for the query:
-query GetUser($username: String!) {
-  user(username: $username) {
-    id
-    __typename
-  }
-}
-
-Request variables: {"username":"mock_username"}
-]
-`;
-
-exports[`General use should error if the variableMatcher returns false 1`] = `
+exports[`General use should error if the \`variables\` as callback returns false 1`] = `
 [Error: No more mocked responses for the query:
 query GetUser($username: String!) {
   user(username: $username) {
@@ -32,7 +19,20 @@ query GetUser($username: String!) {
 Request variables: {"username":"mock_username"}
 
 Failed to match variables against 1 mock for this query. The available mocks had the following variables:
-  <undefined>
+  <function>
+]
+`;
+
+exports[`General use should error if the query in the mock and component do not match 1`] = `
+[Error: No more mocked responses for the query:
+query GetUser($username: String!) {
+  user(username: $username) {
+    id
+    __typename
+  }
+}
+
+Request variables: {"username":"mock_username"}
 ]
 `;
 
@@ -137,7 +137,7 @@ Request variables: {"username":"mock_username"}
 ]
 `;
 
-exports[`General use should use a mock if the variableMatcher returns true 1`] = `
+exports[`General use should use the mock if the \`variables\` callback function returns true 1`] = `
 Object {
   "__typename": "User",
   "id": "user_id",


### PR DESCRIPTION
Combine `variables` and `variableMatcher` by updating `variables` to accept a callback function. This reduces the need to validate that either one or the other option is passed but not both.