### PR TITLE
Add support for callback on `delay` and default to random delay

### DIFF
--- a/.api-reports/api-report-testing.api.md
+++ b/.api-reports/api-report-testing.api.md
@@ -11,6 +11,7 @@ import { MockLinkOptions } from '@apollo/client/testing/core';
 import { mockObservableLink } from '@apollo/client/testing/core';
 import { mockSingleLink } from '@apollo/client/testing/core';
 import { MockSubscriptionLink } from '@apollo/client/testing/core';
+import { realisticDelay } from '@apollo/client/testing/core';
 import { ResultFunction } from '@apollo/client/testing/core';
 import { tick } from '@apollo/client/testing/core';
 import { wait } from '@apollo/client/testing/core';
@@ -31,6 +32,8 @@ export { mockObservableLink }
 export { mockSingleLink }
 
 export { MockSubscriptionLink }
+
+export { realisticDelay }
 
 export { ResultFunction }
 

--- a/.api-reports/api-report-testing_core.api.md
+++ b/.api-reports/api-report-testing_core.api.md
@@ -39,7 +39,7 @@ export interface MockedRequest<TVariables = Record<string, any>> {
 // @public (undocumented)
 export interface MockedResponse<out TData = Record<string, any>, out TVariables = Record<string, any>> {
     // (undocumented)
-    delay?: number;
+    delay?: number | MockLink.DelayFunction;
     // (undocumented)
     error?: Error;
     // (undocumented)
@@ -61,6 +61,19 @@ interface MockedSubscriptionResult {
 }
 
 // @public (undocumented)
+export namespace MockLink {
+    // (undocumented)
+    export interface DefaultOptions {
+        // (undocumented)
+        delay?: MockLink.Delay;
+    }
+    // (undocumented)
+    export type Delay = number | DelayFunction;
+    // (undocumented)
+    export type DelayFunction = (operation: Operation) => number;
+}
+
+// @public (undocumented)
 export class MockLink extends ApolloLink {
     constructor(mockedResponses: ReadonlyArray<MockedResponse<Record<string, any>, Record<string, any>>>, options?: MockLinkOptions);
     // (undocumented)
@@ -75,6 +88,8 @@ export class MockLink extends ApolloLink {
 
 // @public (undocumented)
 export interface MockLinkOptions {
+    // (undocumented)
+    defaultOptions?: MockLink.DefaultOptions;
     // (undocumented)
     showWarnings?: boolean;
 }
@@ -109,6 +124,12 @@ export class MockSubscriptionLink extends ApolloLink {
     // (undocumented)
     unsubscribers: any[];
 }
+
+// @public (undocumented)
+export function realisticDelay({ min, max, }?: {
+    min?: number;
+    max?: number;
+}): () => number;
 
 // Warning: (ae-forgotten-export) The symbol "CovariantUnaryFunction" needs to be exported by the entry point index.d.ts
 //

--- a/.api-reports/api-report-testing_internal.api.md
+++ b/.api-reports/api-report-testing_internal.api.md
@@ -15,6 +15,7 @@ import type { MaskedDocumentNode } from '@apollo/client/masking';
 import type { MockedProviderProps } from '@apollo/client/testing/react';
 import { MockedRequest } from '@apollo/client/testing/core';
 import type { MockedResponse } from '@apollo/client/testing/core';
+import { MockLink } from '@apollo/client/testing/core';
 import type { Observable } from 'rxjs';
 import type { Queries } from '@testing-library/dom';
 import type { queries } from '@testing-library/dom';
@@ -34,11 +35,11 @@ export function actAsync<T>(scope: () => T | Promise<T>): Promise<T>;
 
 // @public (undocumented)
 export function addDelayToMocks<T extends MockedResponse<unknown>[]>(mocks: T, delay?: number, override?: boolean): {
-    delay: number;
     request: MockedRequest<Record<string, any>>;
     maxUsageCount?: number;
     result?: FetchResult<unknown> | ResultFunction<FetchResult<unknown>, Record<string, any>> | undefined;
     error?: Error;
+    delay: number | MockLink.DelayFunction;
 }[];
 
 // @public (undocumented)

--- a/.api-reports/api-report-testing_react.api.md
+++ b/.api-reports/api-report-testing_react.api.md
@@ -9,6 +9,7 @@ import { ApolloClient } from '@apollo/client/core';
 import type { ApolloLink } from '@apollo/client/link/core';
 import type { DefaultOptions } from '@apollo/client/core';
 import type { MockedResponse } from '@apollo/client/testing/core';
+import { MockLink } from '@apollo/client/testing/core';
 import * as React_2 from 'react';
 import type { Resolvers } from '@apollo/client/core';
 
@@ -36,6 +37,8 @@ export interface MockedProviderProps {
     defaultOptions?: DefaultOptions;
     // (undocumented)
     link?: ApolloLink;
+    // (undocumented)
+    mockLinkDefaultOptions?: MockLink.DefaultOptions;
     // (undocumented)
     mocks?: ReadonlyArray<MockedResponse<any, any>>;
     // (undocumented)

--- a/.changeset/afraid-moons-arrive.md
+++ b/.changeset/afraid-moons-arrive.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": minor
+---
+
+Allow mocked responses passed to `MockLink` to accept a callback for the `delay` option. The `delay` callback will be given the current operation which can be used to determine what delay should be used for the mock.

--- a/.changeset/early-eggs-develop.md
+++ b/.changeset/early-eggs-develop.md
@@ -1,0 +1,22 @@
+---
+"@apollo/client": minor
+---
+
+Introduce a new `realisticDelay` helper function for use with the `delay` callback for mocked responses used with `MockLink`. `realisticDelay` will generate a random value between 20 and 50ms to provide an experience closer to unpredictable network latency. `realisticDelay` can be configured with a `min` and `max` to set different thresholds if the defaults are not sufficient.
+
+```ts
+import { realisticDelay } from '@apollo/client/testing';
+
+new MockLink([
+  {
+    request: { query },
+    result: { data: { greeting: 'Hello' }},
+    delay: realisticDelay()
+  },
+  {
+    request: { query },
+    result: { data: { greeting: 'Hello' }},
+    delay: realisticDelay({ min: 10, max: 100 })
+  },
+]);
+```

--- a/.changeset/shaggy-pugs-add.md
+++ b/.changeset/shaggy-pugs-add.md
@@ -1,0 +1,35 @@
+---
+"@apollo/client": minor
+---
+
+Add ability to specify a default `delay` for all mocked responses passed to `MockLink`. If an explicit delay is not provided in the mock configuration, the default delay will be used instead.
+
+```ts
+new MockLink(
+  [
+    // Use the default delay
+    {
+      request: { query },
+      result: { data: { greeting: 'Hello' }},
+    },
+    {
+      request: { query },
+      result: { data: { greeting: 'Hello' }},
+      // Override the default for this mock
+      delay: 10
+    },
+  ],
+  {
+    defaultOptions: {
+      // Use a default delay of 20ms for all mocks without a specified delay
+      delay: 20,
+
+      // altenatively use a callback which will be executed for each mock
+      delay: () => getRandomNumber(),
+
+      // or use the built-in `realisticDelay`. This is th default
+      delay: realisticDelay(),
+    }
+  }
+);
+```

--- a/.changeset/swift-rivers-share.md
+++ b/.changeset/swift-rivers-share.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": major
+---
+
+Default the `delay` for all mocked responses passed to `MockLink` using `realisticDelay`. This ensures your test handles loading states by default and is not reliant on a specific timing.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 42845,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38391,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 32769,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27769
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 42910,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38372,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 32848,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27736
 }

--- a/src/testing/core/index.ts
+++ b/src/testing/core/index.ts
@@ -4,7 +4,11 @@ export type {
   MockLinkOptions,
   ResultFunction,
 } from "./mocking/mockLink.js";
-export { MockLink, mockSingleLink } from "./mocking/mockLink.js";
+export {
+  MockLink,
+  mockSingleLink,
+  realisticDelay,
+} from "./mocking/mockLink.js";
 export {
   mockObservableLink,
   MockSubscriptionLink,

--- a/src/testing/core/mocking/__tests__/mockLink.ts
+++ b/src/testing/core/mocking/__tests__/mockLink.ts
@@ -1215,16 +1215,14 @@ test("uses a mock infinite number of times when `maxUsageCount` is configured wi
   const result = { data: { user: { __typename: "User", id: 1 } } };
   const variables = { username: "username" };
 
-  const link = new MockLink(
-    [
-      {
-        request: { query, variables },
-        maxUsageCount: Number.POSITIVE_INFINITY,
-        result,
-      },
-    ],
-    { defaultOptions: { delay: 0 } }
-  );
+  const link = new MockLink([
+    {
+      request: { query, variables },
+      maxUsageCount: Number.POSITIVE_INFINITY,
+      result,
+      delay: 0,
+    },
+  ]);
 
   for (let i = 0; i < 100; i++) {
     const stream = new ObservableStream(execute(link, { query, variables }));

--- a/src/testing/core/mocking/__tests__/mockLink.ts
+++ b/src/testing/core/mocking/__tests__/mockLink.ts
@@ -267,14 +267,29 @@ test("prefers configured delay over default delay", async () => {
         result: { data: { a: "a" } },
         delay: 20,
       },
+      {
+        request: { query },
+        result: { data: { a: "a" } },
+      },
     ],
     { defaultOptions: { delay: 50 } }
   );
 
-  const stream = new ObservableStream(execute(link, { query }));
+  {
+    const stream = new ObservableStream(execute(link, { query }));
 
-  await expect(stream).toEmitNext({ timeout: 25 });
-  await expect(stream).toComplete();
+    await expect(stream).toEmitNext({ timeout: 25 });
+    await expect(stream).toComplete();
+  }
+
+  // This uses the default delay
+  {
+    const stream = new ObservableStream(execute(link, { query }));
+
+    await expect(stream).not.toEmitAnything({ timeout: 45 });
+    await expect(stream).toEmitNext({ timeout: 6 });
+    await expect(stream).toComplete();
+  }
 });
 
 test("uses realistic delay by default", async () => {

--- a/src/testing/core/mocking/__tests__/mockLink.ts
+++ b/src/testing/core/mocking/__tests__/mockLink.ts
@@ -233,6 +233,29 @@ test("allows default dynamic delay to be defined for all mocks", async () => {
   }
 });
 
+test("prefers configured delay over default delay", async () => {
+  const query = gql`
+    query {
+      a
+    }
+  `;
+  const link = new MockLink(
+    [
+      {
+        request: { query },
+        result: { data: { a: "a" } },
+        delay: 20,
+      },
+    ],
+    { defaultOptions: { delay: 50 } }
+  );
+
+  const stream = new ObservableStream(execute(link, { query }));
+
+  await expect(stream).toEmitNext({ timeout: 25 });
+  await expect(stream).toComplete();
+});
+
 test("uses realistic delay by default", async () => {
   const query = gql`
     query A {

--- a/src/testing/core/mocking/__tests__/mockLink.ts
+++ b/src/testing/core/mocking/__tests__/mockLink.ts
@@ -1194,13 +1194,16 @@ test("uses a mock infinite number of times when `maxUsageCount` is configured wi
   const result = { data: { user: { __typename: "User", id: 1 } } };
   const variables = { username: "username" };
 
-  const link = new MockLink([
-    {
-      request: { query, variables },
-      maxUsageCount: Number.POSITIVE_INFINITY,
-      result,
-    },
-  ]);
+  const link = new MockLink(
+    [
+      {
+        request: { query, variables },
+        maxUsageCount: Number.POSITIVE_INFINITY,
+        result,
+      },
+    ],
+    { defaultOptions: { delay: 0 } }
+  );
 
   for (let i = 0; i < 100; i++) {
     const stream = new ObservableStream(execute(link, { query, variables }));

--- a/src/testing/core/mocking/__tests__/mockLink.ts
+++ b/src/testing/core/mocking/__tests__/mockLink.ts
@@ -233,6 +233,27 @@ test("allows default dynamic delay to be defined for all mocks", async () => {
   }
 });
 
+test("uses realistic delay by default", async () => {
+  const query = gql`
+    query A {
+      a
+    }
+  `;
+  const link = new MockLink([
+    { request: { query }, result: { data: { a: "a" } } },
+  ]);
+
+  {
+    const stream = new ObservableStream(execute(link, { query }));
+
+    // The default min is 20 so we don't expect to see anything before then
+    await expect(stream).not.toEmitAnything({ timeout: 15 });
+    // The default max is 50 so we should definitely have a result now
+    await expect(stream).toEmitNext({ timeout: 36 });
+    await expect(stream).toComplete();
+  }
+});
+
 test("matches like mocks sequentially", async () => {
   const query = gql`
     query {

--- a/src/testing/core/mocking/__tests__/mockLink.ts
+++ b/src/testing/core/mocking/__tests__/mockLink.ts
@@ -73,6 +73,27 @@ test("should require result or error when delay is just large", async () => {
   }
 });
 
+test("waits to return result based on static delay", async () => {
+  const query = gql`
+    query {
+      a
+    }
+  `;
+  const link = new MockLink([
+    {
+      request: { query },
+      result: { data: { a: "a" } },
+      delay: 100,
+    },
+  ]);
+
+  const stream = new ObservableStream(execute(link, { query }));
+
+  await expect(stream).not.toEmitAnything({ timeout: 95 });
+  await expect(stream).toEmitNext({ timeout: 6 });
+  await expect(stream).toComplete();
+});
+
 test("returns matched mock", async () => {
   const query = gql`
     query {

--- a/src/testing/core/mocking/mockLink.ts
+++ b/src/testing/core/mocking/mockLink.ts
@@ -63,14 +63,15 @@ interface NormalizedMockedResponse {
 
 export interface MockLinkOptions {
   showWarnings?: boolean;
-  defaultOptions?: {
-    delay?: MockLink.Delay;
-  };
+  defaultOptions?: MockLink.DefaultOptions;
 }
 
 export declare namespace MockLink {
   export type DelayFunction = (operation: Operation) => number;
   export type Delay = number | DelayFunction;
+  export interface DefaultOptions {
+    delay?: MockLink.Delay;
+  }
 }
 
 export function realisticDelay({

--- a/src/testing/core/mocking/mockLink.ts
+++ b/src/testing/core/mocking/mockLink.ts
@@ -63,15 +63,19 @@ interface NormalizedMockedResponse {
 
 export interface MockLinkOptions {
   showWarnings?: boolean;
+  defaultDelay?: MockLink.Delay;
 }
 
 export declare namespace MockLink {
   export type DelayFunction = (operation: Operation) => number;
+  export type Delay = number | DelayFunction;
 }
 
 export class MockLink extends ApolloLink {
   public operation!: Operation;
   public showWarnings: boolean = true;
+
+  private defaultDelay: MockLink.Delay = 0;
   private mockedResponsesByKey: { [key: string]: NormalizedMockedResponse[] } =
     {};
 
@@ -83,6 +87,7 @@ export class MockLink extends ApolloLink {
   ) {
     super();
     this.showWarnings = options.showWarnings ?? true;
+    this.defaultDelay = options.defaultDelay ?? 0;
 
     if (mockedResponses) {
       mockedResponses.forEach((mockedResponse) => {

--- a/src/testing/core/mocking/mockLink.ts
+++ b/src/testing/core/mocking/mockLink.ts
@@ -48,7 +48,7 @@ export interface MockedResponse<
     | FetchResult<Unmasked<TData>>
     | ResultFunction<FetchResult<Unmasked<TData>>, TVariables>;
   error?: Error;
-  delay?: number;
+  delay?: number | MockLink.DelayFunction;
 }
 
 interface NormalizedMockedResponse {
@@ -58,11 +58,15 @@ interface NormalizedMockedResponse {
   maxUsageCount: number;
   result?: FetchResult | ResultFunction<FetchResult, any>;
   error?: Error;
-  delay?: number;
+  delay?: number | MockLink.DelayFunction;
 }
 
 export interface MockLinkOptions {
   showWarnings?: boolean;
+}
+
+export declare namespace MockLink {
+  export type DelayFunction = (operation: Operation) => number;
 }
 
 export class MockLink extends ApolloLink {

--- a/src/testing/core/mocking/mockLink.ts
+++ b/src/testing/core/mocking/mockLink.ts
@@ -237,7 +237,7 @@ export class MockLink extends ApolloLink {
       ...getDefaultValues(getOperationDefinition(request.query)),
       ...request.variables,
     };
-    response.delay ??= 0;
+    response.delay ??= this.defaultDelay;
 
     return response;
   }

--- a/src/testing/core/mocking/mockLink.ts
+++ b/src/testing/core/mocking/mockLink.ts
@@ -163,7 +163,12 @@ export class MockLink extends ApolloLink {
       mocks.splice(index, 1);
     }
 
-    if (!matched.result && !matched.error && matched.delay !== Infinity) {
+    const delay =
+      typeof matched.delay === "function" ?
+        matched.delay(operation)
+      : matched.delay;
+
+    if (!matched.result && !matched.error && delay !== Infinity) {
       return throwError(
         () =>
           new Error(
@@ -192,7 +197,7 @@ export class MockLink extends ApolloLink {
           );
         }
         observer.complete();
-      }, matched.delay ?? 0);
+      }, delay);
 
       return () => {
         clearTimeout(timer);

--- a/src/testing/core/mocking/mockLink.ts
+++ b/src/testing/core/mocking/mockLink.ts
@@ -63,7 +63,9 @@ interface NormalizedMockedResponse {
 
 export interface MockLinkOptions {
   showWarnings?: boolean;
-  defaultDelay?: MockLink.Delay;
+  defaultOptions?: {
+    delay?: MockLink.Delay;
+  };
 }
 
 export declare namespace MockLink {
@@ -87,7 +89,7 @@ export class MockLink extends ApolloLink {
   ) {
     super();
     this.showWarnings = options.showWarnings ?? true;
-    this.defaultDelay = options.defaultDelay ?? 0;
+    this.defaultDelay = options.defaultOptions?.delay ?? 0;
 
     if (mockedResponses) {
       mockedResponses.forEach((mockedResponse) => {

--- a/src/testing/core/mocking/mockLink.ts
+++ b/src/testing/core/mocking/mockLink.ts
@@ -58,7 +58,7 @@ interface NormalizedMockedResponse {
   maxUsageCount: number;
   result?: FetchResult | ResultFunction<FetchResult, any>;
   error?: Error;
-  delay?: number | MockLink.DelayFunction;
+  delay: number | MockLink.DelayFunction;
 }
 
 export interface MockLinkOptions {
@@ -248,6 +248,7 @@ function normalizeMockedResponse(
     ...getDefaultValues(getOperationDefinition(request.query)),
     ...request.variables,
   };
+  response.delay ??= 0;
 
   return response;
 }

--- a/src/testing/core/mocking/mockLink.ts
+++ b/src/testing/core/mocking/mockLink.ts
@@ -73,6 +73,15 @@ export declare namespace MockLink {
   export type Delay = number | DelayFunction;
 }
 
+export function realisticDelay({
+  min = 20,
+  max = 50,
+}: { min?: number; max?: number } = {}) {
+  invariant(max > min, "realisticDelay: `min` must be less than `max`");
+
+  return () => Math.floor(Math.random() * (max - min) + min);
+}
+
 export class MockLink extends ApolloLink {
   public operation!: Operation;
   public showWarnings: boolean = true;

--- a/src/testing/core/mocking/mockLink.ts
+++ b/src/testing/core/mocking/mockLink.ts
@@ -87,7 +87,7 @@ export class MockLink extends ApolloLink {
   public operation!: Operation;
   public showWarnings: boolean = true;
 
-  private defaultDelay: MockLink.Delay = 0;
+  private defaultDelay: MockLink.Delay;
   private mockedResponsesByKey: { [key: string]: NormalizedMockedResponse[] } =
     {};
 

--- a/src/testing/core/mocking/mockLink.ts
+++ b/src/testing/core/mocking/mockLink.ts
@@ -99,7 +99,7 @@ export class MockLink extends ApolloLink {
   public addMockedResponse(mockedResponse: MockedResponse) {
     validateMockedResponse(mockedResponse);
 
-    const normalized = normalizeMockedResponse(mockedResponse);
+    const normalized = this.normalizeMockedResponse(mockedResponse);
     this.getMockedResponses(normalized.request).push(normalized);
   }
 
@@ -223,6 +223,24 @@ export class MockLink extends ApolloLink {
 
     return mockedResponses;
   }
+
+  private normalizeMockedResponse(
+    mockedResponse: MockedResponse
+  ): NormalizedMockedResponse {
+    const { request } = mockedResponse;
+    const response = cloneDeep(mockedResponse) as NormalizedMockedResponse;
+
+    response.original = mockedResponse;
+    response.request.query = getServerQuery(request.query);
+    response.maxUsageCount ??= 1;
+    response.variablesWithDefaults = {
+      ...getDefaultValues(getOperationDefinition(request.query)),
+      ...request.variables,
+    };
+    response.delay ??= 0;
+
+    return response;
+  }
 }
 
 function getErrorMessage(
@@ -243,24 +261,6 @@ ${unmatchedVars.map((d) => `  ${stringifyForDebugging(d)}`).join("\n")}
 `
   : ""
 }`;
-}
-
-function normalizeMockedResponse(
-  mockedResponse: MockedResponse
-): NormalizedMockedResponse {
-  const { request } = mockedResponse;
-  const response = cloneDeep(mockedResponse) as NormalizedMockedResponse;
-
-  response.original = mockedResponse;
-  response.request.query = getServerQuery(request.query);
-  response.maxUsageCount ??= 1;
-  response.variablesWithDefaults = {
-    ...getDefaultValues(getOperationDefinition(request.query)),
-    ...request.variables,
-  };
-  response.delay ??= 0;
-
-  return response;
 }
 
 function getServerQuery(query: DocumentNode) {

--- a/src/testing/core/mocking/mockLink.ts
+++ b/src/testing/core/mocking/mockLink.ts
@@ -98,7 +98,7 @@ export class MockLink extends ApolloLink {
   ) {
     super();
     this.showWarnings = options.showWarnings ?? true;
-    this.defaultDelay = options.defaultOptions?.delay ?? 0;
+    this.defaultDelay = options.defaultOptions?.delay ?? realisticDelay();
 
     if (mockedResponses) {
       mockedResponses.forEach((mockedResponse) => {

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -9,6 +9,7 @@ export {
   mockObservableLink,
   mockSingleLink,
   MockSubscriptionLink,
+  realisticDelay,
   tick,
   wait,
   withErrorSpy,

--- a/src/testing/react/MockedProvider.tsx
+++ b/src/testing/react/MockedProvider.tsx
@@ -19,6 +19,7 @@ export interface MockedProviderProps {
   children?: any;
   link?: ApolloLink;
   showWarnings?: boolean;
+  mockLinkDefaultOptions?: MockLink.DefaultOptions;
   /**
    * If set to true, the MockedProvider will try to connect to the Apollo DevTools.
    * Defaults to false.
@@ -44,13 +45,19 @@ export class MockedProvider extends React.Component<
       resolvers,
       link,
       showWarnings,
+      mockLinkDefaultOptions,
       connectToDevTools = false,
     } = this.props;
     const client = new ApolloClient({
       cache: cache || new Cache(),
       defaultOptions,
       connectToDevTools,
-      link: link || new MockLink(mocks || [], { showWarnings }),
+      link:
+        link ||
+        new MockLink(mocks || [], {
+          showWarnings,
+          defaultOptions: mockLinkDefaultOptions,
+        }),
       resolvers,
     });
 

--- a/src/testing/react/__tests__/MockedProvider.test.tsx
+++ b/src/testing/react/__tests__/MockedProvider.test.tsx
@@ -681,6 +681,7 @@ describe("General use", () => {
         },
         maxUsageCount: Number.POSITIVE_INFINITY,
         result: { data: { user } },
+        delay: 0,
       },
     ];
 


### PR DESCRIPTION
Adds support for a callback function on the `delay` property passed to a mocked response. This makes it possible to return dynamic values based on the request.

A new `realisticDelay` function has been created for use with the new `delay` option which will generate a random number between the threshold to simulate a more realistic experience like you would with network latency. `realisticDelay` is now the default `delay` if not otherwise specified.

To make it easier to change the default, `MockLink` now accepts a `defaultOptions.delay` value which will be used as the default for all mocks if provided.