### PR TITLE
Remove `onError` and `setOnError` from `ApolloLink`

### DIFF
--- a/.api-reports/api-report-link_core.api.md
+++ b/.api-reports/api-report-link_core.api.md
@@ -8,7 +8,6 @@ import type { DefaultContext } from '@apollo/client';
 import type { DocumentNode } from 'graphql';
 import type { GraphQLFormattedError } from 'graphql';
 import type { Observable } from 'rxjs';
-import type { Subscriber } from 'rxjs';
 
 // @public (undocumented)
 export class ApolloLink {
@@ -28,13 +27,9 @@ export class ApolloLink {
     // @internal
     readonly left?: ApolloLink;
     // (undocumented)
-    protected onError(error: any, observer?: Subscriber<FetchResult>): false | void;
-    // (undocumented)
     request(operation: Operation, forward?: NextLink): Observable<FetchResult> | null;
     // @internal
     readonly right?: ApolloLink;
-    // (undocumented)
-    setOnError(fn: ApolloLink["onError"]): this;
     // (undocumented)
     static split(test: (op: Operation) => boolean, left: ApolloLink | RequestHandler, right?: ApolloLink | RequestHandler): ApolloLink;
     // (undocumented)

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -21,7 +21,6 @@ import type { Observer } from 'rxjs';
 import { resetCaches } from 'graphql-tag';
 import type { SelectionSetNode } from 'graphql';
 import type { Subscribable } from 'rxjs';
-import type { Subscriber } from 'rxjs';
 import type { Subscription } from 'rxjs';
 import { Trie } from '@wry/trie';
 import { TypedDocumentNode } from '@graphql-typed-document-node/core';
@@ -197,13 +196,9 @@ export class ApolloLink {
     // @internal
     readonly left?: ApolloLink;
     // (undocumented)
-    protected onError(error: any, observer?: Subscriber<FetchResult>): false | void;
-    // (undocumented)
     request(operation: Operation, forward?: NextLink): Observable<FetchResult> | null;
     // @internal
     readonly right?: ApolloLink;
-    // (undocumented)
-    setOnError(fn: ApolloLink["onError"]): this;
     // (undocumented)
     static split(test: (op: Operation) => boolean, left: ApolloLink | RequestHandler, right?: ApolloLink | RequestHandler): ApolloLink;
     // (undocumented)

--- a/.changeset/giant-apes-thank.md
+++ b/.changeset/giant-apes-thank.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": major
+---
+
+Remove the `onError` and `setOnError` methods from `ApolloLink`. `onError` was only used by `MockLink` to rewrite errors if `setOnError` was used.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 42828,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38348,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 32795,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27800
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 42846,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38305,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 32777,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27762
 }

--- a/src/__tests__/mutationResults.ts
+++ b/src/__tests__/mutationResults.ts
@@ -164,9 +164,7 @@ describe("mutation results", () => {
           delay,
         },
         ...mockedResponses
-      ).setOnError((error) => {
-        throw error;
-      }),
+      ),
       cache: new InMemoryCache({
         dataIdFromObject: (obj: any) => {
           if (obj.id && obj.__typename) {

--- a/src/cache/inmemory/__tests__/policies.ts
+++ b/src/cache/inmemory/__tests__/policies.ts
@@ -3654,9 +3654,7 @@ describe("type policies", function () {
             },
           },
         },
-      ]).setOnError((error) => {
-        throw new Error(error);
-      });
+      ]);
 
       const client = new ApolloClient({ link, cache });
 
@@ -4095,9 +4093,7 @@ describe("type policies", function () {
             },
           },
         },
-      ]).setOnError((error) => {
-        throw new Error(error);
-      });
+      ]);
 
       const client = new ApolloClient({ link, cache });
 

--- a/src/link/core/ApolloLink.ts
+++ b/src/link/core/ApolloLink.ts
@@ -1,4 +1,4 @@
-import type { Observable, Subscriber } from "rxjs";
+import type { Observable } from "rxjs";
 import { EMPTY } from "rxjs";
 
 import {
@@ -136,29 +136,6 @@ export class ApolloLink {
     forward?: NextLink
   ): Observable<FetchResult> | null {
     throw newInvariantError("request is not implemented");
-  }
-
-  protected onError(
-    error: any,
-    observer?: Subscriber<FetchResult>
-  ): false | void {
-    if (observer && observer.error) {
-      observer.error(error);
-      // Returning false indicates that observer.error does not need to be
-      // called again, since it was already called (on the previous line).
-      // Calling observer.error again would not cause any real problems,
-      // since only the first call matters, but custom onError functions
-      // might have other reasons for wanting to prevent the default
-      // behavior by returning false.
-      return false;
-    }
-    // Throw errors will be passed to observer.error.
-    throw error;
-  }
-
-  public setOnError(fn: ApolloLink["onError"]): this {
-    this.onError = fn;
-    return this;
   }
 
   /**

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -823,7 +823,11 @@ describe("useQuery Hook", () => {
           },
           {
             wrapper: ({ children }) => (
-              <MockedProvider mocks={mocks} cache={cache}>
+              <MockedProvider
+                mocks={mocks}
+                cache={cache}
+                mockLinkDefaultOptions={{ delay: 0 }}
+              >
                 {children}
               </MockedProvider>
             ),

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -2106,8 +2106,6 @@ describe("useQuery Hook", () => {
 
       const link = new MockLink(mocks);
       const requestSpy = jest.spyOn(link, "request");
-      const onErrorFn = jest.fn();
-      link.setOnError(onErrorFn);
       const wrapper = ({ children }: any) => (
         <MockedProvider link={link} cache={cache}>
           {children}
@@ -2162,10 +2160,6 @@ describe("useQuery Hook", () => {
         )
       ).rejects.toThrow();
 
-      await waitFor(() => {
-        expect(onErrorFn).toHaveBeenCalledTimes(0);
-      });
-
       requestSpy.mockRestore();
     });
 
@@ -2201,8 +2195,6 @@ describe("useQuery Hook", () => {
 
       const link = new MockLink(mocks);
       const requestSpy = jest.spyOn(link, "request");
-      const onErrorFn = jest.fn();
-      link.setOnError(onErrorFn);
 
       const client = new ApolloClient({
         queryDeduplication: false,
@@ -2275,7 +2267,6 @@ describe("useQuery Hook", () => {
       jest.advanceTimersByTime(200);
 
       expect(requestSpy).toHaveBeenCalledTimes(2);
-      expect(onErrorFn).toHaveBeenCalledTimes(0);
 
       jest.useRealTimers();
     });
@@ -2307,8 +2298,6 @@ describe("useQuery Hook", () => {
       const cache = new InMemoryCache();
       const link = new MockLink(mocks);
       const requestSpy = jest.spyOn(link, "request");
-      const onErrorFn = jest.fn();
-      link.setOnError(onErrorFn);
       const wrapper = ({ children }: any) => (
         <React.StrictMode>
           <MockedProvider link={link} cache={cache}>
@@ -2362,7 +2351,6 @@ describe("useQuery Hook", () => {
         )
       ).rejects.toThrow();
       expect(requestSpy).toHaveBeenCalledTimes(requestSpyCallCount);
-      expect(onErrorFn).toHaveBeenCalledTimes(0);
 
       requestSpy.mockRestore();
     });
@@ -2398,8 +2386,6 @@ describe("useQuery Hook", () => {
 
       const link = new MockLink(mocks);
       const requestSpy = jest.spyOn(link, "request");
-      const onErrorFn = jest.fn();
-      link.setOnError(onErrorFn);
 
       const client = new ApolloClient({ link, cache });
 
@@ -2464,7 +2450,6 @@ describe("useQuery Hook", () => {
       await expect(takeSnapshot).not.toRerender({ timeout: 50 });
       // TODO rarely seeing 3 here investigate further
       expect(requestSpy).toHaveBeenCalledTimes(2);
-      expect(onErrorFn).toHaveBeenCalledTimes(0);
     });
 
     it("should start and stop polling in Strict Mode", async () => {
@@ -2495,8 +2480,6 @@ describe("useQuery Hook", () => {
       const cache = new InMemoryCache();
       const link = new MockLink(mocks);
       const requestSpy = jest.spyOn(link, "request");
-      const onErrorFn = jest.fn();
-      link.setOnError(onErrorFn);
       const wrapper = ({ children }: any) => (
         <React.StrictMode>
           <MockedProvider link={link} cache={cache}>
@@ -2555,7 +2538,6 @@ describe("useQuery Hook", () => {
       getCurrentSnapshot().startPolling(20);
 
       expect(requestSpy).toHaveBeenCalledTimes(2);
-      expect(onErrorFn).toHaveBeenCalledTimes(0);
 
       {
         const result = await takeSnapshot();
@@ -2582,7 +2564,6 @@ describe("useQuery Hook", () => {
       }
 
       expect(requestSpy).toHaveBeenCalledTimes(4);
-      expect(onErrorFn).toHaveBeenCalledTimes(0);
       requestSpy.mockRestore();
     });
 

--- a/src/testing/core/mocking/mockClient.ts
+++ b/src/testing/core/mocking/mockClient.ts
@@ -5,6 +5,7 @@ import { InMemoryCache } from "@apollo/client/cache";
 
 import { mockSingleLink } from "./mockLink.js";
 
+// TODO: Deprecate this function
 export function createMockClient<TData>(
   data: TData,
   query: DocumentNode,
@@ -14,8 +15,6 @@ export function createMockClient<TData>(
     link: mockSingleLink({
       request: { query, variables },
       result: { data },
-    }).setOnError((error) => {
-      throw error;
     }),
     cache: new InMemoryCache(),
   });

--- a/src/testing/core/mocking/mockLink.ts
+++ b/src/testing/core/mocking/mockLink.ts
@@ -172,14 +172,7 @@ export class MockLink extends ApolloLink {
         );
       }
 
-      return throwError(() => {
-        const error = new Error(message);
-
-        // TODO: Remove this once `onError` and `setOnError` is removed.
-        if (this.onError(error) !== false) {
-          return error;
-        }
-      });
+      return throwError(() => new Error(message));
     }
 
     if (matched.maxUsageCount > 1) {

--- a/src/testing/react/__tests__/MockedProvider.test.tsx
+++ b/src/testing/react/__tests__/MockedProvider.test.tsx
@@ -998,61 +998,6 @@ describe("General use", () => {
     consoleSpy.mockRestore();
   });
 
-  it("should support custom error handling using setOnError", async () => {
-    let finished = false;
-    function Component({ ...variables }: Variables) {
-      useQuery<Data, Variables>(query, { variables });
-      return null;
-    }
-
-    const mockLink = new MockLink([], { showWarnings: false });
-    mockLink.setOnError((error) => {
-      expect(error).toMatchSnapshot();
-      finished = true;
-    });
-    const link = ApolloLink.from([errorLink, mockLink]);
-
-    render(
-      <MockedProvider link={link}>
-        <Component {...variables} />
-      </MockedProvider>
-    );
-
-    await waitFor(() => {
-      expect(finished).toBe(true);
-    });
-  });
-
-  it("should pipe exceptions thrown in custom onError functions through the link chain", async () => {
-    let finished = false;
-    function Component({ ...variables }: Variables) {
-      const { loading, error } = useQuery<Data, Variables>(query, {
-        variables,
-      });
-      if (!loading) {
-        expect(error).toMatchSnapshot();
-        finished = true;
-      }
-      return null;
-    }
-
-    const mockLink = new MockLink([], { showWarnings: false });
-    mockLink.setOnError(() => {
-      throw new Error("oh no!");
-    });
-    const link = ApolloLink.from([errorLink, mockLink]);
-
-    render(
-      <MockedProvider link={link}>
-        <Component {...variables} />
-      </MockedProvider>
-    );
-
-    await waitFor(() => {
-      expect(finished).toBe(true);
-    });
-  });
-
   it("should support loading state testing with delay", async () => {
     jest.useFakeTimers();
 

--- a/src/testing/react/__tests__/__snapshots__/MockedProvider.test.tsx.snap
+++ b/src/testing/react/__tests__/__snapshots__/MockedProvider.test.tsx.snap
@@ -84,8 +84,6 @@ Object {
 }
 `;
 
-exports[`General use should pipe exceptions thrown in custom onError functions through the link chain 1`] = `[Error: oh no!]`;
-
 exports[`General use should return "Mocked response should contain" errors in response 1`] = `
 [Error: Mocked response should contain either \`result\`, \`error\` or a \`delay\` of \`Infinity\`:
 {
@@ -108,32 +106,6 @@ query GetUser($username: String!) {
 }
 
 Request variables: {}
-]
-`;
-
-exports[`General use should support custom error handling using setOnError 1`] = `
-[Error: No more mocked responses for the query:
-query GetUser($username: String!) {
-  user(username: $username) {
-    id
-    __typename
-  }
-}
-
-Request variables: {"username":"mock_username"}
-]
-`;
-
-exports[`General use should support custom error handling using setOnError 2`] = `
-[Error: No more mocked responses for the query:
-query GetUser($username: String!) {
-  user(username: $username) {
-    id
-    __typename
-  }
-}
-
-Request variables: {"username":"mock_username"}
 ]
 `;
 


### PR DESCRIPTION
Closes #12529

Removed the `onError` and `setOnError` methods on `ApolloLink`. These seemed to only be useful to `MockLink` to rewrite the error thrown, but this is undocumented and very confusing. This has been removed with no replacement.