### PR TITLE
Fix value of `ObservableQuery.variables` to be `undefined` when variables are empty

### DIFF
--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -1234,7 +1234,7 @@ interface MutationStoreValue {
     // (undocumented)
     mutation: DocumentNode_2;
     // (undocumented)
-    variables: Record<string, any>;
+    variables: Record<string, any> | undefined;
 }
 
 // @public @deprecated (undocumented)
@@ -1982,7 +1982,7 @@ export interface WatchQueryOptions<TVariables extends OperationVariables = Opera
     refetchWritePolicy?: RefetchWritePolicy;
     returnPartialData?: boolean;
     skipPollAttempt?: () => boolean;
-    variables?: TVariables;
+    variables?: NoInfer_2<TVariables>;
 }
 
 // @public (undocumented)
@@ -2025,10 +2025,10 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/cache/inmemory/policies.ts:167:3 - (ae-forgotten-export) The symbol "FieldReadFunction_2" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/policies.ts:168:3 - (ae-forgotten-export) The symbol "FieldMergeFunction_2" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/types.ts:133:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:140:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:141:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:184:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:454:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:143:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:144:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:188:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:460:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -510,7 +510,7 @@ interface MutationStoreValue {
     // (undocumented)
     mutation: DocumentNode;
     // (undocumented)
-    variables: Record<string, any>;
+    variables: Record<string, any> | undefined;
 }
 
 // @public @deprecated (undocumented)
@@ -1598,16 +1598,16 @@ interface WatchQueryOptions_2<TVariables extends OperationVariables_2 = Operatio
     refetchWritePolicy?: RefetchWritePolicy;
     returnPartialData?: boolean;
     skipPollAttempt?: () => boolean;
-    variables?: TVariables;
+    variables?: NoInfer_2<TVariables>;
 }
 
 // Warnings were encountered during analysis:
 //
 // src/core/LocalState.ts:71:3 - (ae-forgotten-export) The symbol "ApolloClient_2" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:140:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:141:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:184:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:454:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:143:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:144:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:188:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:460:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:204:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:233:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:195:3 - (ae-forgotten-export) The symbol "UpdateQueryOptions" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report-utilities_internal.api.md
+++ b/.api-reports/api-report-utilities_internal.api.md
@@ -76,6 +76,9 @@ const globalCaches: {
     canonicalStringify?: () => number;
 };
 
+// @public
+export function normalizeVariables<TVariables>(variables: TVariables): NonNullable<TVariables> | undefined;
+
 // @public (undocumented)
 type ObservableEvent<T> = {
     type: "complete";

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -1520,7 +1520,7 @@ interface MutationStoreValue {
     // (undocumented)
     mutation: DocumentNode;
     // (undocumented)
-    variables: Record<string, any>;
+    variables: Record<string, any> | undefined;
 }
 
 // @public @deprecated (undocumented)
@@ -2437,7 +2437,7 @@ export interface WatchQueryOptions<TVariables extends OperationVariables = Opera
     refetchWritePolicy?: RefetchWritePolicy;
     returnPartialData?: boolean;
     skipPollAttempt?: () => boolean;
-    variables?: TVariables;
+    variables?: NoInfer_2<TVariables>;
 }
 
 // @public (undocumented)
@@ -2479,10 +2479,10 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/cache/inmemory/policies.ts:166:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/policies.ts:166:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/types.ts:133:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:140:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:141:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:184:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:454:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:143:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:144:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:188:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:460:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
 // src/link/http/selectHttpOptionsAndBody.ts:128:1 - (ae-forgotten-export) The symbol "HttpQueryOptions" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.changeset/fair-ways-enjoy.md
+++ b/.changeset/fair-ways-enjoy.md
@@ -1,0 +1,7 @@
+---
+"@apollo/client": patch
+---
+
+`ObservableQuery.variables` now returns `undefined` if no variables were set from `watchQuery` or if `variables` was set to an empty object. This ensures the value of `variables` lines up with the type.
+
+This change also propogates to `useQuery` and `useLazyQuery`. The `variables` property returned from these hooks will be `undefined` instead of an empty object if no `variables` were set.

--- a/.changeset/sixty-meals-travel.md
+++ b/.changeset/sixty-meals-travel.md
@@ -1,0 +1,13 @@
+---
+"@apollo/client": minor
+---
+
+`ObservableQuery` `variables` can now be reset back to `undefined` by calling `reobserve` with a `variables` key set to `undefined`:
+
+```ts
+observable.reobserve({ variables: undefined });
+```
+
+Previously this would leave `variables` unchanged and would require setting `variables` to an empty object.
+
+Calling `reobserve({ variables: {} })` has the same effect as `undefined` and will reset `ObservableQuery.variables` back to `undefined`.

--- a/.changeset/sour-starfishes-pump.md
+++ b/.changeset/sour-starfishes-pump.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Ensure `variables` passed to the `update` callback is `undefined` instead of an empty object when `variables` are not defined.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43024,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38481,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 32989,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27891
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43094,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38547,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 32966,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27880
 }

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43094,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38547,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 32966,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27880
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43112,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38549,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 32997,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27868
 }

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 42984,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38432,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 32968,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27861
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43024,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38481,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 32989,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27891
 }

--- a/src/__tests__/__snapshots__/exports.ts.snap
+++ b/src/__tests__/__snapshots__/exports.ts.snap
@@ -487,6 +487,7 @@ Array [
   "getApolloCacheMemoryInternals",
   "getApolloClientMemoryInternals",
   "getInMemoryCacheMemoryInternals",
+  "normalizeVariables",
   "onAnyEvent",
   "registerGlobalCache",
   "toQueryResult",

--- a/src/__tests__/dataMasking.ts
+++ b/src/__tests__/dataMasking.ts
@@ -5671,7 +5671,7 @@ describe("client.mutate", () => {
           },
         },
       },
-      { context: undefined, variables: {} }
+      { context: undefined, variables: undefined }
     );
   });
 

--- a/src/__tests__/dataMasking.ts
+++ b/src/__tests__/dataMasking.ts
@@ -5086,7 +5086,7 @@ describe("observableQuery.subscribeToMore", () => {
       },
       {
         complete: true,
-        variables: {},
+        variables: undefined,
         previousData: {
           recentComment: {
             __typename: "Comment",
@@ -5229,7 +5229,7 @@ describe("observableQuery.subscribeToMore", () => {
       },
       {
         complete: true,
-        variables: {},
+        variables: undefined,
         previousData: {
           recentComment: {
             __typename: "Comment",
@@ -5378,7 +5378,7 @@ describe("observableQuery.subscribeToMore", () => {
       },
       {
         complete: true,
-        variables: {},
+        variables: undefined,
         previousData: {
           recentComment: {
             __typename: "Comment",

--- a/src/__tests__/mutationResults.ts
+++ b/src/__tests__/mutationResults.ts
@@ -11,7 +11,7 @@ import { InMemoryCache } from "@apollo/client/cache";
 import { CombinedGraphQLErrors } from "@apollo/client/errors";
 import { ApolloLink } from "@apollo/client/link/core";
 import type { MockedResponse } from "@apollo/client/testing";
-import { mockSingleLink } from "@apollo/client/testing";
+import { MockLink, mockSingleLink } from "@apollo/client/testing";
 import {
   ObservableStream,
   spyOnConsole,
@@ -647,19 +647,22 @@ describe("mutation results", () => {
     };
 
     const client = new ApolloClient({
-      link: mockSingleLink(
-        {
-          request: { query: queryWithTypename } as any,
-          result,
-        },
-        {
-          request: { query: queryTodos },
-          result: queryTodosResult,
-        },
-        {
-          request: { query: mutationTodo },
-          result: mutationTodoResult,
-        }
+      link: new MockLink(
+        [
+          {
+            request: { query: queryWithTypename } as any,
+            result,
+          },
+          {
+            request: { query: queryTodos },
+            result: queryTodosResult,
+          },
+          {
+            request: { query: mutationTodo },
+            result: mutationTodoResult,
+          },
+        ],
+        { defaultOptions: { delay: 0 } }
       ),
       cache: new InMemoryCache({
         dataIdFromObject: (obj: any) => {

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1058,7 +1058,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     // variables: undefined to reobserve, otherwise `compact` will ignore the
     // `variables` key from from `newOptions`.
     mergedOptions.variables =
-      newOptions && hasOwnProperty.call(newOptions, "variables") ?
+      newOptions && "variables" in newOptions ?
         newOptions.variables
       : this.options.variables;
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -244,8 +244,7 @@ export class ObservableQuery<
 
       // `variables` might be an empty object due to QueryManager.getVariables,
       // so we reset to `undefined` if there are no values
-      variables:
-        variables && Object.keys(variables).length > 0 ? variables : undefined,
+      variables: normalizeVariables(variables),
     };
 
     this.queryId = queryInfo.queryId || queryManager.generateQueryId();
@@ -793,9 +792,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
   public async setVariables(
     variables: TVariables
   ): Promise<QueryResult<TData>> {
-    if (variables && Object.keys(variables).length === 0) {
-      (variables as any) = undefined;
-    }
+    variables = normalizeVariables(variables) as TVariables;
 
     if (equal(this.variables, variables)) {
       // If we have no observers, then we don't actually want to make a network
@@ -1077,9 +1074,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
 
     // note: This may mutate this.options.variables when not using a disposable
     // observable. This is intentional
-    if (options.variables && Object.keys(options.variables).length === 0) {
-      options.variables = undefined;
-    }
+    options.variables = normalizeVariables(options.variables);
 
     this.lastQuery = query;
 
@@ -1370,6 +1365,13 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     }
 
     return this.reobserve();
+  }
+}
+
+// Treat {} and undefined as the same variables
+function normalizeVariables<TVariables>(variables: TVariables) {
+  if (variables && Object.keys(variables).length > 0) {
+    return variables;
   }
 }
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -793,6 +793,10 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
   public async setVariables(
     variables: TVariables
   ): Promise<QueryResult<TData>> {
+    if (variables && Object.keys(variables).length === 0) {
+      (variables as any) = undefined;
+    }
+
     if (equal(this.variables, variables)) {
       // If we have no observers, then we don't actually want to make a network
       // request. As soon as someone observes the query, the request will kick

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1076,9 +1076,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
       // Reset options.fetchPolicy to its original value when variables change,
       // unless a new fetchPolicy was provided by newOptions.
       if (
-        newOptions &&
-        newOptions.variables &&
-        !equal(newOptions.variables, oldVariables) &&
+        !equal(options.variables, oldVariables) &&
         // Don't mess with the fetchPolicy if it's currently "standby".
         fetchPolicy !== "standby" &&
         // If we're changing the fetchPolicy anyway, don't try to change it here
@@ -1102,8 +1100,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
 
       if (
         oldNetworkStatus !== NetworkStatus.loading &&
-        newOptions?.variables &&
-        !equal(newOptions.variables, oldVariables)
+        !equal(options.variables, oldVariables)
       ) {
         newNetworkStatus = NetworkStatus.setVariables;
       }

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1049,6 +1049,14 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     const oldFetchPolicy = this.options.fetchPolicy;
 
     const mergedOptions = compact(this.options, newOptions || {});
+
+    // Allow variables to be reset back to `undefined` if explicitly passed as
+    // variables: undefined to reobserve.
+    mergedOptions.variables =
+      newOptions && hasOwnProperty.call(newOptions, "variables") ?
+        newOptions.variables
+      : this.options.variables;
+
     const options =
       useDisposableObservable ?
         // Disposable Observable fetches receive a shallow copy of this.options

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -104,11 +104,7 @@ export class ObservableQuery<
    * An object containing the variables that were provided for the query.
    */
   public get variables(): TVariables | undefined {
-    const variables = this.options.variables;
-
-    if (variables && Object.keys(variables).length > 0) {
-      return variables;
-    }
+    return this.options.variables;
   }
 
   private subject: BehaviorSubject<ApolloQueryResult<MaybeMasked<TData>>>;
@@ -231,6 +227,7 @@ export class ObservableQuery<
       initialFetchPolicy = fetchPolicy === "standby" ? defaultFetchPolicy : (
         fetchPolicy
       ),
+      variables,
     } = options;
 
     this.options = {
@@ -244,6 +241,11 @@ export class ObservableQuery<
       // This ensures this.options.fetchPolicy always has a string value, in
       // case options.fetchPolicy was not provided.
       fetchPolicy,
+
+      // `variables` might be an empty object due to QueryManager.getVariables,
+      // so we reset to `undefined` if there are no values
+      variables:
+        variables && Object.keys(variables).length > 0 ? variables : undefined,
     };
 
     this.queryId = queryInfo.queryId || queryManager.generateQueryId();

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -21,7 +21,10 @@ import {
   preventUnhandledRejection,
 } from "@apollo/client/utilities";
 import { __DEV__ } from "@apollo/client/utilities/environment";
-import { toQueryResult } from "@apollo/client/utilities/internal";
+import {
+  normalizeVariables,
+  toQueryResult,
+} from "@apollo/client/utilities/internal";
 import { invariant } from "@apollo/client/utilities/invariant";
 
 import { equalByQuery } from "./equalByQuery.js";
@@ -1366,13 +1369,6 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     }
 
     return this.reobserve();
-  }
-}
-
-// Treat {} and undefined as the same variables
-function normalizeVariables<TVariables>(variables: TVariables) {
-  if (variables && Object.keys(variables).length > 0) {
-    return variables;
   }
 }
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -104,7 +104,11 @@ export class ObservableQuery<
    * An object containing the variables that were provided for the query.
    */
   public get variables(): TVariables | undefined {
-    return this.options.variables;
+    const variables = this.options.variables;
+
+    if (variables && Object.keys(variables).length > 0) {
+      return variables;
+    }
   }
 
   private subject: BehaviorSubject<ApolloQueryResult<MaybeMasked<TData>>>;

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1063,6 +1063,8 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     const query = this.transformDocument(options.query);
     const { fetchPolicy } = options;
 
+    // note: This may mutate this.options.variables when not using a disposable
+    // observable. This is intentional
     if (options.variables && Object.keys(options.variables).length === 0) {
       options.variables = undefined;
     }

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1052,7 +1052,8 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     const mergedOptions = compact(this.options, newOptions || {});
 
     // Allow variables to be reset back to `undefined` if explicitly passed as
-    // variables: undefined to reobserve.
+    // variables: undefined to reobserve, otherwise `compact` will ignore the
+    // `variables` key from from `newOptions`.
     mergedOptions.variables =
       newOptions && hasOwnProperty.call(newOptions, "variables") ?
         newOptions.variables

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1063,6 +1063,10 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     const query = this.transformDocument(options.query);
     const { fetchPolicy } = options;
 
+    if (options.variables && Object.keys(options.variables).length === 0) {
+      options.variables = undefined;
+    }
+
     this.lastQuery = query;
 
     if (!useDisposableObservable) {

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -10,6 +10,7 @@ import {
 } from "@apollo/client/utilities";
 import { mergeIncrementalData } from "@apollo/client/utilities";
 import { DeepMerger } from "@apollo/client/utilities";
+import { normalizeVariables } from "@apollo/client/utilities/internal";
 
 import type { ObservableQuery } from "./ObservableQuery.js";
 import type { QueryManager } from "./QueryManager.js";
@@ -89,7 +90,9 @@ export class QueryInfo {
     document: DocumentNode;
     variables: Record<string, any> | undefined;
   }): this {
-    if (!equal(query.variables, this.variables)) {
+    const variables = normalizeVariables(query.variables);
+
+    if (!equal(variables, this.variables)) {
       this.lastDiff = void 0;
       // Ensure we don't continue to receive cache updates for old variables
       this.cancel();
@@ -97,7 +100,7 @@ export class QueryInfo {
 
     Object.assign(this, {
       document: query.document,
-      variables: query.variables,
+      variables,
     });
 
     return this;

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -58,7 +58,11 @@ import {
 } from "@apollo/client/utilities";
 import { mergeIncrementalData } from "@apollo/client/utilities";
 import { __DEV__ } from "@apollo/client/utilities/environment";
-import { onAnyEvent, toQueryResult } from "@apollo/client/utilities/internal";
+import {
+  normalizeVariables,
+  onAnyEvent,
+  toQueryResult,
+} from "@apollo/client/utilities/internal";
 import {
   invariant,
   newInvariantError,
@@ -106,7 +110,7 @@ const IGNORE = {} as IgnoreModifier;
 
 interface MutationStoreValue {
   mutation: DocumentNode;
-  variables: Record<string, any>;
+  variables: Record<string, any> | undefined;
   loading: boolean;
   error: Error | null;
 }
@@ -293,6 +297,8 @@ export class QueryManager {
         context
       )) as TVariables;
     }
+
+    variables = normalizeVariables(variables);
 
     const mutationStoreValue =
       this.mutationStore &&

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -5356,6 +5356,31 @@ describe(".variables", () => {
       offset: 0,
     });
   });
+
+  test("resets variables to undefined when passing variables as undefined", () => {
+    const query: TypedDocumentNode<
+      { users: Array<{ name: string }> },
+      { limit?: number; offset?: number }
+    > = gql`
+      query ($limit: Int, $offset: Int) {
+        users(limit: $limit, offset: $offset) {
+          name
+        }
+      }
+    `;
+
+    const client = new ApolloClient({ cache: new InMemoryCache() });
+    const observable = client.watchQuery({
+      query,
+      variables: { limit: 10, offset: 0 },
+    });
+
+    expect(observable.variables).toStrictEqualTyped({ limit: 10, offset: 0 });
+
+    void observable.reobserve({ variables: undefined }).catch(() => {});
+
+    expect(observable.variables).toBeUndefined();
+  });
 });
 
 test.skip("type test for `from`", () => {

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -2419,7 +2419,10 @@ describe("ObservableQuery", () => {
       it("should not warn if passed { variables } and query declares $variables", async () => {
         using _ = spyOnConsole("warn");
 
-        const queryWithVariablesVar = gql`
+        const queryWithVariablesVar: TypedDocumentNode<
+          { getVars: Array<{ __typename: "Var"; name: string }> },
+          { variables: string[] }
+        > = gql`
           query QueryWithVariablesVar($variables: [String!]) {
             getVars(variables: $variables) {
               __typename

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -2291,7 +2291,10 @@ describe("ObservableQuery", () => {
       it("should warn if passed { variables } and query does not declare $variables", async () => {
         using _ = spyOnConsole("warn");
 
-        const queryWithVarsVar = gql`
+        const queryWithVarsVar: TypedDocumentNode<
+          { getVars: Array<{ __typename: "Var"; name: string }> },
+          { vars: string[] }
+        > = gql`
           query QueryWithVarsVar($vars: [String!]) {
             getVars(variables: $vars) {
               __typename

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -5299,6 +5299,63 @@ describe(".variables", () => {
 
     expect(observable.variables).toStrictEqualTyped({ limit: 10, offset: 0 });
   });
+
+  test("handles undefined keys", () => {
+    const query: TypedDocumentNode<
+      { users: Array<{ name: string }> },
+      { limit?: number; offset: number }
+    > = gql`
+      query ($limit: Int, $offset: Int!) {
+        users(limit: $limit, offset: $offset) {
+          name
+        }
+      }
+    `;
+
+    const client = new ApolloClient({ cache: new InMemoryCache() });
+    const observable = client.watchQuery({
+      query,
+      variables: { limit: undefined, offset: 0 },
+    });
+
+    expect(observable.variables).toStrictEqualTyped({
+      limit: undefined,
+      offset: 0,
+    });
+
+    void observable.setVariables({ limit: 10, offset: 0 }).catch(() => {});
+    expect(observable.variables).toStrictEqualTyped({ limit: 10, offset: 0 });
+
+    void observable
+      .setVariables({ limit: undefined, offset: 0 })
+      .catch(() => {});
+    expect(observable.variables).toStrictEqualTyped({
+      limit: undefined,
+      offset: 0,
+    });
+
+    void observable.refetch({ limit: 10, offset: 0 }).catch(() => {});
+    expect(observable.variables).toStrictEqualTyped({ limit: 10, offset: 0 });
+
+    void observable.refetch({ limit: undefined, offset: 0 }).catch(() => {});
+    expect(observable.variables).toStrictEqualTyped({
+      limit: undefined,
+      offset: 0,
+    });
+
+    void observable
+      .reobserve({ variables: { limit: 10, offset: 0 } })
+      .catch(() => {});
+    expect(observable.variables).toStrictEqualTyped({ limit: 10, offset: 0 });
+
+    void observable
+      .reobserve({ variables: { limit: undefined, offset: 0 } })
+      .catch(() => {});
+    expect(observable.variables).toStrictEqualTyped({
+      limit: undefined,
+      offset: 0,
+    });
+  });
 });
 
 test.skip("type test for `from`", () => {

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -1469,6 +1469,13 @@ describe("ObservableQuery", () => {
       const stream = new ObservableStream(observable);
 
       await expect(stream).toEmitTypedValue({
+        data: undefined,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        partial: true,
+      });
+
+      await expect(stream).toEmitTypedValue({
         data: { users: [{ __typename: "User", id: 1 }] },
         loading: false,
         networkStatus: NetworkStatus.ready,

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -110,7 +110,7 @@ export interface WatchQueryOptions<
   refetchWritePolicy?: RefetchWritePolicy;
 
   /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#variables:member} */
-  variables?: TVariables;
+  variables?: NoInfer<TVariables>;
 
   /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#errorPolicy:member} */
   errorPolicy?: ErrorPolicy;

--- a/src/react/hooks/__tests__/useBackgroundQuery.test.tsx
+++ b/src/react/hooks/__tests__/useBackgroundQuery.test.tsx
@@ -6976,7 +6976,7 @@ describe("fetchMore", () => {
         subscriptionData: {
           data: { greetingUpdated: "Subscription hello" },
         },
-        variables: {},
+        variables: undefined,
       }
     );
   });

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -83,7 +83,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -116,7 +116,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -155,7 +155,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -224,7 +224,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -244,7 +244,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -296,7 +296,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -328,7 +328,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -343,7 +343,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -373,7 +373,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: { hello: "world" },
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -425,7 +425,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -457,7 +457,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -472,7 +472,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -504,7 +504,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: { hello: "world" },
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -560,7 +560,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -579,7 +579,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -594,7 +594,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -611,7 +611,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: { hello: "world" },
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -655,7 +655,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -687,7 +687,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -717,7 +717,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: { hello: "world 1" },
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -762,7 +762,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -781,7 +781,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -798,7 +798,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: { hello: "world 1" },
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -836,7 +836,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -855,7 +855,7 @@ describe("useLazyQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -868,7 +868,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -887,7 +887,7 @@ describe("useLazyQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.refetch,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
     {
@@ -899,7 +899,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: { hello: "world 1" },
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -945,7 +945,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -977,7 +977,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -1005,7 +1005,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: { hello: "world 1" },
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -1031,7 +1031,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: { hello: "world 2" },
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -1096,7 +1096,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -1225,7 +1225,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -1303,7 +1303,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -1322,7 +1322,7 @@ describe("useLazyQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -1335,7 +1335,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: { hello: "from cache" },
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -1384,7 +1384,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -1403,7 +1403,7 @@ describe("useLazyQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -1416,7 +1416,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: { hello: "from cache" },
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -1433,7 +1433,7 @@ describe("useLazyQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: { hello: "from cache" },
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -1446,7 +1446,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: { hello: "from link" },
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -1497,8 +1497,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        // @ts-expect-error should be undefined
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -1637,8 +1636,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        // @ts-expect-error should be undefined
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -1858,7 +1856,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -1889,7 +1887,7 @@ describe("useLazyQuery Hook", () => {
         networkStatus: NetworkStatus.error,
         previousData: undefined,
         error: new CombinedGraphQLErrors({ errors: [{ message: "error 1" }] }),
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -1920,7 +1918,7 @@ describe("useLazyQuery Hook", () => {
         networkStatus: NetworkStatus.error,
         previousData: undefined,
         error: new CombinedGraphQLErrors({ errors: [{ message: "error 2" }] }),
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -1976,7 +1974,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -2014,7 +2012,7 @@ describe("useLazyQuery Hook", () => {
           data: { currentUser: null },
           errors: [{ message: "Not logged in" }],
         }),
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -2053,7 +2051,7 @@ describe("useLazyQuery Hook", () => {
           data: { currentUser: null },
           errors: [{ message: "Not logged in 2" }],
         }),
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -2113,7 +2111,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -2130,7 +2128,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -2255,7 +2253,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {} as Variables,
+        variables: undefined,
       });
     }
 
@@ -2320,7 +2318,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -2335,7 +2333,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -2367,7 +2365,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -2509,7 +2507,7 @@ describe("useLazyQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: { user: { id: "2", name: "John Doe" } },
-          variables: {},
+          variables: undefined,
         });
       });
 
@@ -2594,8 +2592,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        // @ts-expect-error Need to fix the return value of this property
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -2614,8 +2611,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        // @ts-expect-error Need to fix the return value of this property
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -2865,7 +2861,7 @@ describe("useLazyQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -2882,7 +2878,7 @@ describe("useLazyQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -2896,7 +2892,7 @@ describe("useLazyQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.error,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -2941,7 +2937,7 @@ describe("useLazyQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -2961,7 +2957,7 @@ describe("useLazyQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -2975,7 +2971,7 @@ describe("useLazyQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.error,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -3020,7 +3016,7 @@ describe("useLazyQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -3037,7 +3033,7 @@ describe("useLazyQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -3050,7 +3046,7 @@ describe("useLazyQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -3084,7 +3080,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -3111,7 +3107,7 @@ describe("useLazyQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -3127,7 +3123,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.error,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -3221,7 +3217,7 @@ describe("useLazyQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -3240,7 +3236,7 @@ describe("useLazyQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -3335,7 +3331,7 @@ describe("useLazyQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -3355,7 +3351,7 @@ describe("useLazyQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -3449,7 +3445,7 @@ describe("useLazyQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -3469,7 +3465,7 @@ describe("useLazyQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -3550,7 +3546,7 @@ describe("useLazyQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -3569,7 +3565,7 @@ describe("useLazyQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -3602,7 +3598,7 @@ describe("useLazyQuery Hook", () => {
           previousData: {
             currentUser: { __typename: "User", id: 1, name: "Test User" },
           },
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -3683,7 +3679,7 @@ describe("useLazyQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -3702,7 +3698,7 @@ describe("useLazyQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -4015,7 +4011,7 @@ test("uses the updated client when executing the function after changing clients
       loading: false,
       networkStatus: NetworkStatus.ready,
       previousData: undefined,
-      variables: {},
+      variables: undefined,
     });
   }
 
@@ -4034,7 +4030,7 @@ test("uses the updated client when executing the function after changing clients
       loading: true,
       networkStatus: NetworkStatus.loading,
       previousData: undefined,
-      variables: {},
+      variables: undefined,
     });
   }
 
@@ -4047,7 +4043,7 @@ test("uses the updated client when executing the function after changing clients
       loading: false,
       networkStatus: NetworkStatus.ready,
       previousData: undefined,
-      variables: {},
+      variables: undefined,
     });
   }
 
@@ -4062,7 +4058,7 @@ test("uses the updated client when executing the function after changing clients
       loading: false,
       networkStatus: NetworkStatus.ready,
       previousData: undefined,
-      variables: {},
+      variables: undefined,
     });
   }
 
@@ -4079,7 +4075,7 @@ test("uses the updated client when executing the function after changing clients
       loading: true,
       networkStatus: NetworkStatus.loading,
       previousData: { greeting: "Hello client 1" },
-      variables: {},
+      variables: undefined,
     });
   }
 
@@ -4092,7 +4088,7 @@ test("uses the updated client when executing the function after changing clients
       loading: false,
       networkStatus: NetworkStatus.ready,
       previousData: { greeting: "Hello client 1" },
-      variables: {},
+      variables: undefined,
     });
   }
 
@@ -4132,7 +4128,7 @@ test("responds to cache updates after executing query", async () => {
       loading: false,
       networkStatus: NetworkStatus.ready,
       previousData: undefined,
-      variables: {},
+      variables: undefined,
     });
   }
 
@@ -4151,7 +4147,7 @@ test("responds to cache updates after executing query", async () => {
       loading: true,
       networkStatus: NetworkStatus.loading,
       previousData: undefined,
-      variables: {},
+      variables: undefined,
     });
   }
 
@@ -4164,7 +4160,7 @@ test("responds to cache updates after executing query", async () => {
       loading: false,
       networkStatus: NetworkStatus.ready,
       previousData: undefined,
-      variables: {},
+      variables: undefined,
     });
   }
 
@@ -4186,7 +4182,7 @@ test("responds to cache updates after executing query", async () => {
       previousData: {
         greeting: "Hello",
       },
-      variables: {},
+      variables: undefined,
     });
   }
 
@@ -4220,8 +4216,7 @@ test("responds to cache updates after changing variables", async () => {
       loading: false,
       networkStatus: NetworkStatus.ready,
       previousData: undefined,
-      // @ts-expect-error this should be undefined
-      variables: {},
+      variables: undefined,
     });
   }
 
@@ -4390,8 +4385,7 @@ test("uses cached result when switching to variables already written to the cach
       loading: false,
       networkStatus: NetworkStatus.ready,
       previousData: undefined,
-      // @ts-expect-error this should be undefined
-      variables: {},
+      variables: undefined,
     });
   }
 
@@ -4504,8 +4498,7 @@ test("does not render loading states when switching to variables maybe written t
       loading: false,
       networkStatus: NetworkStatus.ready,
       previousData: undefined,
-      // @ts-expect-error this should be undefined
-      variables: {},
+      variables: undefined,
     });
   }
 
@@ -4671,8 +4664,7 @@ test("applies `errorPolicy` on next fetch when it changes between renders", asyn
       loading: false,
       networkStatus: NetworkStatus.ready,
       previousData: undefined,
-      // @ts-expect-error this should be undefined
-      variables: {},
+      variables: undefined,
     });
   }
 
@@ -4816,7 +4808,7 @@ test("applies `context` on next fetch when it changes between renders", async ()
       loading: false,
       networkStatus: NetworkStatus.ready,
       previousData: undefined,
-      variables: {},
+      variables: undefined,
     });
   }
 
@@ -4835,7 +4827,7 @@ test("applies `context` on next fetch when it changes between renders", async ()
       loading: true,
       networkStatus: NetworkStatus.loading,
       previousData: undefined,
-      variables: {},
+      variables: undefined,
     });
   }
 
@@ -4848,7 +4840,7 @@ test("applies `context` on next fetch when it changes between renders", async ()
       loading: false,
       networkStatus: NetworkStatus.ready,
       previousData: undefined,
-      variables: {},
+      variables: undefined,
     });
   }
 
@@ -4863,7 +4855,7 @@ test("applies `context` on next fetch when it changes between renders", async ()
       loading: false,
       networkStatus: NetworkStatus.ready,
       previousData: undefined,
-      variables: {},
+      variables: undefined,
     });
   }
 
@@ -4880,7 +4872,7 @@ test("applies `context` on next fetch when it changes between renders", async ()
       loading: true,
       networkStatus: NetworkStatus.loading,
       previousData: undefined,
-      variables: {},
+      variables: undefined,
     });
   }
 
@@ -4893,7 +4885,7 @@ test("applies `context` on next fetch when it changes between renders", async ()
       loading: false,
       networkStatus: NetworkStatus.ready,
       previousData: { context: { source: "initialHookValue" } },
-      variables: {},
+      variables: undefined,
     });
   }
 
@@ -4908,7 +4900,7 @@ test("applies `context` on next fetch when it changes between renders", async ()
       loading: false,
       networkStatus: NetworkStatus.ready,
       previousData: { context: { source: "initialHookValue" } },
-      variables: {},
+      variables: undefined,
     });
   }
 
@@ -4924,7 +4916,7 @@ test("applies `context` on next fetch when it changes between renders", async ()
       loading: true,
       networkStatus: NetworkStatus.refetch,
       previousData: { context: { source: "initialHookValue" } },
-      variables: {},
+      variables: undefined,
     });
   }
 
@@ -4937,7 +4929,7 @@ test("applies `context` on next fetch when it changes between renders", async ()
       loading: false,
       networkStatus: NetworkStatus.ready,
       previousData: { context: { source: "rerender" } },
-      variables: {},
+      variables: undefined,
     });
   }
 
@@ -4956,7 +4948,7 @@ test("applies `context` on next fetch when it changes between renders", async ()
       loading: true,
       networkStatus: NetworkStatus.loading,
       previousData: { context: { source: "rerender" } },
-      variables: {},
+      variables: undefined,
     });
   }
 
@@ -4969,7 +4961,7 @@ test("applies `context` on next fetch when it changes between renders", async ()
       loading: false,
       networkStatus: NetworkStatus.ready,
       previousData: { context: { source: "rerenderForRefetch" } },
-      variables: {},
+      variables: undefined,
     });
   }
 
@@ -5047,8 +5039,7 @@ test("applies `refetchWritePolicy` on next fetch when it changes between renders
       loading: false,
       networkStatus: NetworkStatus.ready,
       previousData: undefined,
-      // @ts-expect-error needs to be undefined
-      variables: {},
+      variables: undefined,
     });
   }
 
@@ -5264,7 +5255,7 @@ test("applies `returnPartialData` on next fetch when it changes between renders"
       loading: false,
       networkStatus: NetworkStatus.ready,
       previousData: undefined,
-      variables: {},
+      variables: undefined,
     });
   }
 
@@ -5409,8 +5400,7 @@ test("applies updated `fetchPolicy` on next fetch when it changes between render
       loading: false,
       networkStatus: NetworkStatus.ready,
       previousData: undefined,
-      // @ts-expect-error should be undefined
-      variables: {},
+      variables: undefined,
     });
   }
 
@@ -5538,7 +5528,7 @@ test("renders loading states at appropriate times on next fetch after updating `
       loading: false,
       networkStatus: NetworkStatus.ready,
       previousData: undefined,
-      variables: {},
+      variables: undefined,
     });
   }
 
@@ -5557,7 +5547,7 @@ test("renders loading states at appropriate times on next fetch after updating `
       loading: false,
       networkStatus: NetworkStatus.ready,
       previousData: undefined,
-      variables: {},
+      variables: undefined,
     });
   }
 
@@ -5572,7 +5562,7 @@ test("renders loading states at appropriate times on next fetch after updating `
       loading: false,
       networkStatus: NetworkStatus.ready,
       previousData: undefined,
-      variables: {},
+      variables: undefined,
     });
   }
 
@@ -5589,7 +5579,7 @@ test("renders loading states at appropriate times on next fetch after updating `
       loading: true,
       networkStatus: NetworkStatus.loading,
       previousData: undefined,
-      variables: {},
+      variables: undefined,
     });
   }
 
@@ -5602,7 +5592,7 @@ test("renders loading states at appropriate times on next fetch after updating `
       loading: false,
       networkStatus: NetworkStatus.ready,
       previousData: { greeting: "Hello 1" },
-      variables: {},
+      variables: undefined,
     });
   }
 
@@ -5617,7 +5607,7 @@ test("renders loading states at appropriate times on next fetch after updating `
       loading: false,
       networkStatus: NetworkStatus.ready,
       previousData: { greeting: "Hello 1" },
-      variables: {},
+      variables: undefined,
     });
   }
 
@@ -5634,7 +5624,7 @@ test("renders loading states at appropriate times on next fetch after updating `
       loading: false,
       networkStatus: NetworkStatus.ready,
       previousData: { greeting: "Hello 2" },
-      variables: {},
+      variables: undefined,
     });
   }
 

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -103,7 +103,7 @@ describe("useLazyQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -315,7 +315,7 @@ describe("useLazyQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -360,7 +360,7 @@ describe("useLazyQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: { hello: "world" },
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -444,7 +444,7 @@ describe("useLazyQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -491,7 +491,7 @@ describe("useLazyQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.refetch,
         previousData: { hello: "world" },
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -674,7 +674,7 @@ describe("useLazyQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -704,7 +704,7 @@ describe("useLazyQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -964,7 +964,7 @@ describe("useLazyQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -992,7 +992,7 @@ describe("useLazyQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.poll,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -1018,7 +1018,7 @@ describe("useLazyQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.poll,
         previousData: { hello: "world 1" },
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -1759,8 +1759,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        // @ts-expect-error should be undefined
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -1873,7 +1872,7 @@ describe("useLazyQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -1904,7 +1903,7 @@ describe("useLazyQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -1995,7 +1994,7 @@ describe("useLazyQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -2034,7 +2033,7 @@ describe("useLazyQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: { currentUser: null },
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -2352,7 +2351,7 @@ describe("useLazyQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 

--- a/src/react/hooks/__tests__/useLoadableQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLoadableQuery.test.tsx
@@ -4812,7 +4812,7 @@ it("can subscribe to subscriptions and react to cache updates via `subscribeToMo
       subscriptionData: {
         data: { greetingUpdated: "Subscription hello" },
       },
-      variables: {},
+      variables: undefined,
     }
   );
 });

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -2711,7 +2711,7 @@ describe("useMutation Hook", () => {
           networkStatus: NetworkStatus.ready,
           loading: false,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
         expect(mutation).toStrictEqualTyped({
           data: undefined,
@@ -2748,7 +2748,7 @@ describe("useMutation Hook", () => {
             networkStatus: NetworkStatus.ready,
             loading: false,
             previousData: undefined,
-            variables: {},
+            variables: undefined,
           });
 
           expect(mutation).toStrictEqualTyped({
@@ -2763,7 +2763,7 @@ describe("useMutation Hook", () => {
             networkStatus: NetworkStatus.ready,
             loading: false,
             previousData: { todoCount: 0 },
-            variables: {},
+            variables: undefined,
           });
         }
 
@@ -2795,7 +2795,7 @@ describe("useMutation Hook", () => {
           networkStatus: NetworkStatus.ready,
           loading: false,
           previousData: { todoCount: 0 },
-          variables: {},
+          variables: undefined,
         });
 
         expect(mutation).toStrictEqualTyped({
@@ -2816,7 +2816,7 @@ describe("useMutation Hook", () => {
             networkStatus: NetworkStatus.ready,
             loading: false,
             previousData: { todoCount: 0 },
-            variables: {},
+            variables: undefined,
           });
 
           expect(mutation).toStrictEqualTyped({
@@ -2838,7 +2838,7 @@ describe("useMutation Hook", () => {
             networkStatus: NetworkStatus.ready,
             loading: false,
             previousData: { todoCount: 0 },
-            variables: {},
+            variables: undefined,
           });
 
           expect(mutation).toStrictEqualTyped({
@@ -2914,7 +2914,7 @@ describe("useMutation Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
 
         expect(mutation).toStrictEqualTyped({
@@ -2936,7 +2936,7 @@ describe("useMutation Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
 
         expect(mutation).toStrictEqualTyped({
@@ -2969,7 +2969,7 @@ describe("useMutation Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
 
         expect(mutation).toStrictEqualTyped({
@@ -2991,7 +2991,7 @@ describe("useMutation Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.refetch,
           previousData: GET_TODOS_RESULT_1,
-          variables: {},
+          variables: undefined,
         });
 
         expect(mutation).toStrictEqualTyped({
@@ -3013,7 +3013,7 @@ describe("useMutation Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.refetch,
           previousData: GET_TODOS_RESULT_1,
-          variables: {},
+          variables: undefined,
         });
 
         expect(mutation).toStrictEqualTyped({
@@ -3035,7 +3035,7 @@ describe("useMutation Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: GET_TODOS_RESULT_1,
-          variables: {},
+          variables: undefined,
         });
 
         expect(mutation).toStrictEqualTyped({
@@ -3113,7 +3113,7 @@ describe("useMutation Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
 
         expect(mutation).toStrictEqualTyped({
@@ -3135,7 +3135,7 @@ describe("useMutation Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
 
         expect(mutation).toStrictEqualTyped({
@@ -3168,7 +3168,7 @@ describe("useMutation Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
 
         expect(mutation).toStrictEqualTyped({
@@ -3190,7 +3190,7 @@ describe("useMutation Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.refetch,
           previousData: GET_TODOS_RESULT_1,
-          variables: {},
+          variables: undefined,
         });
 
         expect(mutation).toStrictEqualTyped({
@@ -3212,7 +3212,7 @@ describe("useMutation Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.refetch,
           previousData: GET_TODOS_RESULT_1,
-          variables: {},
+          variables: undefined,
         });
 
         expect(mutation).toStrictEqualTyped({
@@ -3234,7 +3234,7 @@ describe("useMutation Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: GET_TODOS_RESULT_1,
-          variables: {},
+          variables: undefined,
         });
 
         expect(mutation).toStrictEqualTyped({
@@ -3312,7 +3312,7 @@ describe("useMutation Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
 
         expect(mutation).toStrictEqualTyped({
@@ -3334,7 +3334,7 @@ describe("useMutation Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
 
         expect(mutation).toStrictEqualTyped({
@@ -3370,7 +3370,7 @@ describe("useMutation Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
 
         expect(mutation).toStrictEqualTyped({

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -4545,7 +4545,7 @@ describe("data masking", () => {
           },
         },
       },
-      { context: undefined, variables: {} }
+      { context: undefined, variables: undefined }
     );
   });
 });

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -95,7 +95,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -107,7 +107,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -146,7 +146,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -160,7 +160,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -174,7 +174,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
 
         expect(result).toBe(oldResult);
@@ -215,7 +215,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -227,7 +227,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -241,7 +241,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -364,7 +364,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -376,7 +376,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -390,7 +390,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
     });
@@ -439,7 +439,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
 
         expect(refetch).toBe(result.refetch);
@@ -1057,7 +1057,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -1069,7 +1069,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
     });
@@ -1140,7 +1140,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
 
         expect(result1).toStrictEqualTyped({
@@ -1148,7 +1148,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -1160,7 +1160,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
 
         expect(result1).toStrictEqualTyped({
@@ -1168,7 +1168,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -1180,7 +1180,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
 
         expect(result1).toStrictEqualTyped({
@@ -1188,7 +1188,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -1202,7 +1202,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
 
         expect(result1).toStrictEqualTyped({
@@ -1210,7 +1210,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -1271,7 +1271,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -1285,7 +1285,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -1297,7 +1297,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -1345,7 +1345,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -1357,7 +1357,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: { hello: "from cache" },
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -1403,7 +1403,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -1415,7 +1415,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -1460,7 +1460,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -1503,7 +1503,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -1515,7 +1515,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -1652,7 +1652,7 @@ describe("useQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -1664,7 +1664,7 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
   });
@@ -1724,7 +1724,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -1736,7 +1736,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -1782,7 +1782,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: { linkCount: 1 },
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -1794,7 +1794,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: { linkCount: 1 },
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -1848,7 +1848,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -1860,7 +1860,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -1872,7 +1872,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.poll,
           previousData: { hello: "world 1" },
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -1884,7 +1884,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: { hello: "world 1" },
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -1896,7 +1896,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.poll,
           previousData: { hello: "world 2" },
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -1908,7 +1908,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: { hello: "world 2" },
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -1959,7 +1959,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -1971,7 +1971,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -1988,7 +1988,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: { hello: "world 1" },
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -2004,7 +2004,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: { hello: "world 1" },
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -2016,7 +2016,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.poll,
           previousData: { hello: "world 1" },
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -2028,7 +2028,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: { hello: "world 1" },
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -2040,7 +2040,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.poll,
           previousData: { hello: "world 2" },
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -2052,7 +2052,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: { hello: "world 2" },
-          variables: {},
+          variables: undefined,
         });
       }
     });
@@ -2102,7 +2102,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -2114,7 +2114,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -2169,7 +2169,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -2181,7 +2181,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
         expect(requestSpy).toHaveBeenCalled();
       }
@@ -2263,7 +2263,7 @@ describe("useQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       await expect(takeSnapshot()).resolves.toStrictEqualTyped({
@@ -2271,7 +2271,7 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
       expect(requestSpy).toHaveBeenCalledTimes(1);
 
@@ -2280,14 +2280,14 @@ describe("useQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.poll,
         previousData: { hello: "world 1" },
-        variables: {},
+        variables: undefined,
       });
       await expect(takeSnapshot()).resolves.toStrictEqualTyped({
         data: { hello: "world 2" },
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: { hello: "world 1" },
-        variables: {},
+        variables: undefined,
       });
       expect(requestSpy).toHaveBeenCalledTimes(2);
 
@@ -2345,7 +2345,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -2357,7 +2357,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -2438,7 +2438,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -2450,7 +2450,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
         expect(requestSpy).toHaveBeenCalledTimes(1);
       }
@@ -2463,7 +2463,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.poll,
           previousData: { hello: "world 1" },
-          variables: {},
+          variables: undefined,
         });
         expect(requestSpy).toHaveBeenCalledTimes(2);
       }
@@ -2476,7 +2476,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: { hello: "world 1" },
-          variables: {},
+          variables: undefined,
         });
         expect(requestSpy).toHaveBeenCalledTimes(2);
       }
@@ -2539,7 +2539,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -2551,7 +2551,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -2563,7 +2563,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.poll,
           previousData: { hello: "world 1" },
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -2575,7 +2575,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: { hello: "world 1" },
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -2595,7 +2595,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.poll,
           previousData: { hello: "world 2" },
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -2607,7 +2607,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: { hello: "world 2" },
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -2619,7 +2619,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.poll,
           previousData: { hello: "world 3" },
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -2631,7 +2631,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: { hello: "world 3" },
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -2679,7 +2679,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -2691,7 +2691,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -2751,7 +2751,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
 
         await waitFor(
@@ -2761,7 +2761,7 @@ describe("useQuery Hook", () => {
               loading: false,
               networkStatus: NetworkStatus.ready,
               previousData: undefined,
-              variables: {},
+              variables: undefined,
             });
           },
           { interval: 1 }
@@ -2773,7 +2773,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: { hello: "world 1" },
-          variables: {},
+          variables: undefined,
         });
 
         skipPollAttempt.mockImplementation(() => true);
@@ -2784,7 +2784,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: { hello: "world 1" },
-          variables: {},
+          variables: undefined,
         });
 
         await jest.advanceTimersByTimeAsync(12);
@@ -2793,7 +2793,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: { hello: "world 1" },
-          variables: {},
+          variables: undefined,
         });
 
         await jest.advanceTimersByTimeAsync(12);
@@ -2802,7 +2802,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: { hello: "world 1" },
-          variables: {},
+          variables: undefined,
         });
 
         skipPollAttempt.mockImplementation(() => false);
@@ -2813,7 +2813,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: { hello: "world 2" },
-          variables: {},
+          variables: undefined,
         });
       });
 
@@ -2867,7 +2867,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
 
         await waitFor(
@@ -2877,7 +2877,7 @@ describe("useQuery Hook", () => {
               loading: false,
               networkStatus: NetworkStatus.ready,
               previousData: undefined,
-              variables: {},
+              variables: undefined,
             });
           },
           { interval: 1 }
@@ -2889,7 +2889,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: { hello: "world 1" },
-          variables: {},
+          variables: undefined,
         });
 
         skipPollAttempt.mockImplementation(() => true);
@@ -2900,7 +2900,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: { hello: "world 1" },
-          variables: {},
+          variables: undefined,
         });
 
         await jest.advanceTimersByTimeAsync(12);
@@ -2909,7 +2909,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: { hello: "world 1" },
-          variables: {},
+          variables: undefined,
         });
 
         await jest.advanceTimersByTimeAsync(12);
@@ -2918,7 +2918,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: { hello: "world 1" },
-          variables: {},
+          variables: undefined,
         });
 
         skipPollAttempt.mockImplementation(() => false);
@@ -2929,7 +2929,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: { hello: "world 2" },
-          variables: {},
+          variables: undefined,
         });
       });
     });
@@ -2975,7 +2975,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -2988,7 +2988,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.error,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
     });
@@ -3030,7 +3030,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -3046,7 +3046,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.error,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -3090,7 +3090,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -3102,7 +3102,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -3144,7 +3144,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -3156,7 +3156,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -3200,7 +3200,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -3216,7 +3216,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.error,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -3258,7 +3258,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -3271,7 +3271,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.error,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -3315,7 +3315,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -3328,7 +3328,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.error,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -3343,7 +3343,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.error,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -3741,7 +3741,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -3756,7 +3756,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.error,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -3772,7 +3772,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.refetch,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -3787,7 +3787,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.error,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -3838,7 +3838,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -3853,7 +3853,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.error,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -3872,7 +3872,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.error,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -3920,7 +3920,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -3935,7 +3935,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.error,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -3951,7 +3951,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.refetch,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -3966,7 +3966,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.error,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -4021,7 +4021,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
       {
@@ -4035,7 +4035,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.error,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -4049,7 +4049,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.refetch,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
       {
@@ -4060,7 +4060,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -4075,7 +4075,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.refetch,
           previousData: { hello: "world" },
-          variables: {},
+          variables: undefined,
         });
       }
       {
@@ -4090,7 +4090,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.error,
           previousData: { hello: "world" },
-          variables: {},
+          variables: undefined,
         });
       }
     });
@@ -4894,7 +4894,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -4906,7 +4906,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -5043,7 +5043,7 @@ describe("useQuery Hook", () => {
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
         // @ts-expect-error should be undefined
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -5069,7 +5069,7 @@ describe("useQuery Hook", () => {
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
         // @ts-expect-error should be undefined
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -5332,7 +5332,7 @@ describe("useQuery Hook", () => {
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
         // @ts-expect-error should be undefined
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -5358,7 +5358,7 @@ describe("useQuery Hook", () => {
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
         // @ts-expect-error should be undefined
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -5587,7 +5587,7 @@ describe("useQuery Hook", () => {
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
         // @ts-expect-error should be undefined
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -5613,7 +5613,7 @@ describe("useQuery Hook", () => {
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
         // @ts-expect-error should be undefined
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -5746,7 +5746,7 @@ describe("useQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -5769,7 +5769,7 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -5911,7 +5911,7 @@ describe("useQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -5934,7 +5934,7 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -5961,7 +5961,7 @@ describe("useQuery Hook", () => {
             },
           },
         },
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -6002,7 +6002,7 @@ describe("useQuery Hook", () => {
             },
           },
         },
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -6136,7 +6136,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
       {
@@ -6147,7 +6147,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -6163,7 +6163,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.refetch,
           previousData: { hello: "world 1" },
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -6176,7 +6176,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.error,
           previousData: { hello: "world 1" },
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -6192,7 +6192,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.refetch,
           previousData: { hello: "world 1" },
-          variables: {},
+          variables: undefined,
         });
       }
       {
@@ -6203,7 +6203,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: { hello: "world 1" },
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -6852,7 +6852,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -6864,7 +6864,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -6889,7 +6889,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: carsData,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -6904,7 +6904,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: allCarsData,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -6918,7 +6918,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: allCarsData,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -7111,7 +7111,7 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       await rerender({ skip: false });
@@ -7121,7 +7121,7 @@ describe("useQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       await expect(takeSnapshot()).resolves.toStrictEqualTyped({
@@ -7129,7 +7129,7 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       await expect(takeSnapshot).not.toRerender();
@@ -7161,7 +7161,7 @@ describe("useQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       await expect(takeSnapshot()).resolves.toStrictEqualTyped({
@@ -7169,7 +7169,7 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       await rerender({ skip: true, variables: { someVar: true } });
@@ -7236,7 +7236,7 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       await rerender({ fetchPolicy: "cache-first" });
@@ -7246,7 +7246,7 @@ describe("useQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       await expect(takeSnapshot()).resolves.toStrictEqualTyped({
@@ -7254,7 +7254,7 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       await expect(takeSnapshot).not.toRerender();
@@ -7296,7 +7296,7 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       const refetchResult = await getCurrentSnapshot().refetch();
@@ -7358,7 +7358,7 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       function check(
@@ -7381,7 +7381,7 @@ describe("useQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       await expect(takeSnapshot()).resolves.toStrictEqualTyped({
@@ -7389,7 +7389,7 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       check(correctInitialFetchPolicy, correctInitialFetchPolicy);
@@ -7748,7 +7748,7 @@ describe("useQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     });
 
@@ -7819,7 +7819,7 @@ describe("useQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     });
 
@@ -7980,7 +7980,7 @@ describe("useQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       await expect(takeSnapshot()).resolves.toStrictEqualTyped({
@@ -7988,7 +7988,7 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       await getCurrentSnapshot().refetch();
@@ -7998,7 +7998,7 @@ describe("useQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.refetch,
         previousData: data1,
-        variables: {},
+        variables: undefined,
       });
 
       await expect(takeSnapshot()).resolves.toStrictEqualTyped({
@@ -8006,7 +8006,7 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: data1,
-        variables: {},
+        variables: undefined,
       });
 
       await expect(takeSnapshot).not.toRerender();
@@ -8085,7 +8085,7 @@ describe("useQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       await expect(takeSnapshot()).resolves.toStrictEqualTyped({
@@ -8093,7 +8093,7 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       setTimeout(() => getCurrentSnapshot().refetch());
@@ -8103,7 +8103,7 @@ describe("useQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.refetch,
         previousData: data1,
-        variables: {},
+        variables: undefined,
       });
 
       await expect(takeSnapshot()).resolves.toStrictEqualTyped({
@@ -8111,7 +8111,7 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: data1,
-        variables: {},
+        variables: undefined,
       });
 
       void getCurrentSnapshot().refetch({ vin: "ABCDEFG0123456789" });
@@ -8222,7 +8222,7 @@ describe("useQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       await expect(takeSnapshot()).resolves.toStrictEqualTyped({
@@ -8230,7 +8230,7 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       await rerender({ query: abQuery });
@@ -8240,7 +8240,7 @@ describe("useQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: { a: "a" },
-        variables: {},
+        variables: undefined,
       });
 
       await expect(takeSnapshot()).resolves.toStrictEqualTyped({
@@ -8248,7 +8248,7 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: { a: "a" },
-        variables: {},
+        variables: undefined,
       });
 
       const result = await getCurrentSnapshot().observable.reobserve();
@@ -8262,7 +8262,7 @@ describe("useQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: { a: "aa", b: 1 },
-        variables: {},
+        variables: undefined,
       });
 
       await expect(takeSnapshot()).resolves.toStrictEqualTyped({
@@ -8270,7 +8270,7 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: { a: "aa", b: 1 },
-        variables: {},
+        variables: undefined,
       });
 
       await rerender({ query: bQuery });
@@ -8280,7 +8280,7 @@ describe("useQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: { a: "aaa", b: 2 },
-        variables: {},
+        variables: undefined,
       });
 
       await expect(takeSnapshot()).resolves.toStrictEqualTyped({
@@ -8288,7 +8288,7 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: { b: 2 },
-        variables: {},
+        variables: undefined,
       });
 
       await expect(takeSnapshot).not.toRerender();
@@ -8459,7 +8459,7 @@ describe("useQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       await expect(takeSnapshot()).resolves.toStrictEqualTyped({
@@ -8467,7 +8467,7 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       await expect(takeSnapshot()).resolves.toStrictEqualTyped({
@@ -8475,7 +8475,7 @@ describe("useQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.poll,
         previousData: { hello: "world 1" },
-        variables: {},
+        variables: undefined,
       });
 
       await expect(takeSnapshot()).resolves.toStrictEqualTyped({
@@ -8483,7 +8483,7 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: { hello: "world 1" },
-        variables: {},
+        variables: undefined,
       });
 
       await expect(takeSnapshot()).resolves.toStrictEqualTyped({
@@ -8491,7 +8491,7 @@ describe("useQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.poll,
         previousData: { hello: "world 2" },
-        variables: {},
+        variables: undefined,
       });
 
       await expect(takeSnapshot()).resolves.toStrictEqualTyped({
@@ -8499,7 +8499,7 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: { hello: "world 2" },
-        variables: {},
+        variables: undefined,
       });
     });
   });
@@ -8595,14 +8595,14 @@ describe("useQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
       expect(result.current.b).toStrictEqualTyped({
         data: undefined,
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       await waitFor(() => {
@@ -8615,14 +8615,14 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
       expect(result.current.b).toStrictEqualTyped({
         data: bData,
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     }
 
@@ -8772,7 +8772,7 @@ describe("useQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       await waitFor(() => {
@@ -8784,7 +8784,7 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       expect(cache.readQuery({ query })).toEqual({ hello: "hello 1" });
@@ -8802,7 +8802,7 @@ describe("useQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       await waitFor(() => {
@@ -8814,7 +8814,7 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       expect(cache.readQuery({ query })).toEqual({ hello: "hello 2" });
@@ -8858,7 +8858,7 @@ describe("useQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       setTimeout(() => {
@@ -8885,7 +8885,7 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       setTimeout(() => {
@@ -8927,7 +8927,7 @@ describe("useQuery Hook", () => {
             __typename: "Greeting",
           },
         },
-        variables: {},
+        variables: undefined,
       });
 
       await expect(takeSnapshot).not.toRerender();
@@ -8969,7 +8969,7 @@ describe("useQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       setTimeout(() => {
@@ -8996,7 +8996,7 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       setTimeout(() => {
@@ -9038,7 +9038,7 @@ describe("useQuery Hook", () => {
             { message: "Hello again", __typename: "Greeting" },
           ],
         },
-        variables: {},
+        variables: undefined,
       });
 
       setTimeout(() => {
@@ -9088,7 +9088,7 @@ describe("useQuery Hook", () => {
             { message: "Hello again", __typename: "Greeting" },
           ],
         },
-        variables: {},
+        variables: undefined,
       });
 
       await expect(takeSnapshot).not.toRerender();
@@ -9133,7 +9133,7 @@ describe("useQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       setTimeout(() => {
@@ -9188,7 +9188,7 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       setTimeout(() => {
@@ -9264,7 +9264,7 @@ describe("useQuery Hook", () => {
             },
           ],
         },
-        variables: {},
+        variables: undefined,
       });
     });
 
@@ -9304,7 +9304,7 @@ describe("useQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       setTimeout(() => {
@@ -9331,7 +9331,7 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       setTimeout(() => {
@@ -9373,7 +9373,7 @@ describe("useQuery Hook", () => {
             __typename: "Greeting",
           },
         },
-        variables: {},
+        variables: undefined,
       });
 
       await expect(takeSnapshot).not.toRerender();
@@ -9417,7 +9417,7 @@ describe("useQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       setTimeout(() => {
@@ -9462,7 +9462,7 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       setTimeout(() => {
@@ -9535,7 +9535,7 @@ describe("useQuery Hook", () => {
             name: "R2-D2",
           },
         },
-        variables: {},
+        variables: undefined,
       });
 
       await expect(takeSnapshot).not.toRerender();
@@ -9579,7 +9579,7 @@ describe("useQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       setTimeout(() => {
@@ -9624,7 +9624,7 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       setTimeout(() => {
@@ -9720,7 +9720,7 @@ describe("useQuery Hook", () => {
             name: "R2-D2",
           },
         },
-        variables: {},
+        variables: undefined,
       });
 
       await expect(takeSnapshot).not.toRerender();
@@ -9776,7 +9776,7 @@ describe("useQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       link.simulateResult({
@@ -9805,7 +9805,7 @@ describe("useQuery Hook", () => {
             recipient: { __typename: "Person", name: "Cached Alice" },
           },
         },
-        variables: {},
+        variables: undefined,
       });
 
       link.simulateResult({
@@ -9840,7 +9840,7 @@ describe("useQuery Hook", () => {
             recipient: { __typename: "Person", name: "Cached Alice" },
           },
         },
-        variables: {},
+        variables: undefined,
       });
 
       await expect(takeSnapshot).not.toRerender();
@@ -9903,7 +9903,7 @@ describe("useQuery Hook", () => {
         loading: true,
         networkStatus: NetworkStatus.loading,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       link.simulateResult({
@@ -9931,7 +9931,7 @@ describe("useQuery Hook", () => {
             recipient: { __typename: "Person", name: "Cached Alice" },
           },
         },
-        variables: {},
+        variables: undefined,
       });
 
       link.simulateResult({
@@ -9966,7 +9966,7 @@ describe("useQuery Hook", () => {
             recipient: { __typename: "Person", name: "Cached Alice" },
           },
         },
-        variables: {},
+        variables: undefined,
       });
 
       await expect(takeSnapshot).not.toRerender();
@@ -10089,7 +10089,7 @@ describe("useQuery Hook", () => {
       loading: true,
       networkStatus: NetworkStatus.loading,
       previousData: undefined,
-      variables: {},
+      variables: undefined,
     });
 
     await client.clearStore();
@@ -10102,7 +10102,7 @@ describe("useQuery Hook", () => {
       loading: false,
       networkStatus: NetworkStatus.error,
       previousData: undefined,
-      variables: {},
+      variables: undefined,
     });
 
     link.simulateResult({ result: { data: { hello: "Greetings" } } }, true);
@@ -10148,7 +10148,7 @@ describe("useQuery Hook", () => {
       loading: true,
       networkStatus: NetworkStatus.loading,
       previousData: undefined,
-      variables: {},
+      variables: undefined,
     });
 
     await expect(takeSnapshot()).resolves.toStrictEqualTyped({
@@ -10160,7 +10160,7 @@ describe("useQuery Hook", () => {
       loading: false,
       networkStatus: NetworkStatus.error,
       previousData: undefined,
-      variables: {},
+      variables: undefined,
     });
 
     const { refetch } = getCurrentSnapshot();
@@ -10173,7 +10173,7 @@ describe("useQuery Hook", () => {
       loading: true,
       networkStatus: NetworkStatus.refetch,
       previousData: undefined,
-      variables: {},
+      variables: undefined,
     });
 
     await expect(takeSnapshot()).resolves.toStrictEqualTyped({
@@ -10185,7 +10185,7 @@ describe("useQuery Hook", () => {
       loading: false,
       networkStatus: NetworkStatus.error,
       previousData: undefined,
-      variables: {},
+      variables: undefined,
     });
 
     await expect(takeSnapshot).not.toRerender({ timeout: 200 });
@@ -10268,7 +10268,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -10286,7 +10286,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -10384,7 +10384,7 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
 
       await expect(renderStream).not.toRerender();
@@ -10479,7 +10479,7 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {},
+        variables: undefined,
       });
     });
 
@@ -10568,7 +10568,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -10604,7 +10604,7 @@ describe("useQuery Hook", () => {
               name: "Test User",
             },
           },
-          variables: {},
+          variables: undefined,
         });
       }
     });
@@ -10694,7 +10694,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -10817,7 +10817,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.ready,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
     );
@@ -10917,7 +10917,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -10941,7 +10941,7 @@ describe("useQuery Hook", () => {
               name: "Test User",
             },
           },
-          variables: {},
+          variables: undefined,
         });
       }
     });
@@ -11044,7 +11044,7 @@ describe("useQuery Hook", () => {
           loading: true,
           networkStatus: NetworkStatus.loading,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
 
@@ -11067,7 +11067,7 @@ describe("useQuery Hook", () => {
               id: 1,
             },
           } as Query,
-          variables: {},
+          variables: undefined,
         });
       }
     });
@@ -11165,7 +11165,7 @@ describe("useQuery Hook", () => {
           loading: false,
           networkStatus: NetworkStatus.error,
           previousData: undefined,
-          variables: {},
+          variables: undefined,
         });
       }
     });

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -5042,7 +5042,6 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        // @ts-expect-error should be undefined
         variables: undefined,
       });
     }
@@ -5068,7 +5067,6 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        // @ts-expect-error should be undefined
         variables: undefined,
       });
     }
@@ -5331,7 +5329,6 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        // @ts-expect-error should be undefined
         variables: undefined,
       });
     }
@@ -5357,7 +5354,6 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        // @ts-expect-error should be undefined
         variables: undefined,
       });
     }
@@ -5586,7 +5582,6 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        // @ts-expect-error should be undefined
         variables: undefined,
       });
     }
@@ -5612,7 +5607,6 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        // @ts-expect-error should be undefined
         variables: undefined,
       });
     }

--- a/src/react/hooks/__tests__/useQueryRefHandlers.test.tsx
+++ b/src/react/hooks/__tests__/useQueryRefHandlers.test.tsx
@@ -2099,7 +2099,7 @@ test("can subscribe to subscriptions and react to cache updates via `subscribeTo
       subscriptionData: {
         data: { greetingUpdated: "Subscription hello" },
       },
-      variables: {},
+      variables: undefined,
     }
   );
 });

--- a/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
@@ -9563,7 +9563,7 @@ describe("useSuspenseQuery", () => {
         subscriptionData: {
           data: { greetingUpdated: "Subscription hello" },
         },
-        variables: {},
+        variables: undefined,
       }
     );
 

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -346,8 +346,7 @@ export function useLazyQuery<
 
         const options: Partial<WatchQueryOptions<TVariables, TData>> = {
           ...executeOptions,
-          // TODO: Figure out a better way to reset variables back to empty
-          variables: (executeOptions?.variables ?? {}) as TVariables,
+          variables: executeOptions?.variables as TVariables,
         };
 
         if (observable.options.fetchPolicy === "standby") {

--- a/src/utilities/internal/index.ts
+++ b/src/utilities/internal/index.ts
@@ -5,4 +5,5 @@ export {
   getInMemoryCacheMemoryInternals,
   registerGlobalCache,
 } from "../internal/getMemoryInternals.js";
+export { normalizeVariables } from "./normalizeVariables.js";
 export { toQueryResult } from "./toQueryResult.js";

--- a/src/utilities/internal/normalizeVariables.ts
+++ b/src/utilities/internal/normalizeVariables.ts
@@ -1,0 +1,6 @@
+/** Returns variables if there are 1 or more keys, otherwise returns undefined */
+export function normalizeVariables<TVariables>(variables: TVariables) {
+  if (variables && Object.keys(variables).length > 0) {
+    return variables;
+  }
+}


### PR DESCRIPTION
Fixes the value of `ObservableQuery.variables` to be `undefined` when `variables` are not set. This change means that we treat `{}` and `undefined` as the same variables value, so `variables` are normalized to `undefined` in cases where variables are set to `{}`. This ensure the `TVariables` type better aligns with the `variables` type.

This change also makes it possible to reset variables back to its empty state by calling `reobserve({ variables: undefined })`. Previously this required `reobserve({ variables: {} })` since the `undefined` value was ignored.