### PR TITLE
Add static `is` methods to error types for type narrowing

### DIFF
--- a/.api-reports/api-report-errors.api.md
+++ b/.api-reports/api-report-errors.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-import type { ErrorLike } from '@apollo/client/core';
+import type { ErrorLike } from '@apollo/client';
 import type { FetchResult } from '@apollo/client/link/core';
 import type { FetchResult as FetchResult_2 } from '@apollo/client';
 import type { GraphQLFormattedError } from 'graphql';
@@ -14,6 +14,7 @@ export class CombinedGraphQLErrors extends Error {
     constructor(result: FetchResult_2<unknown>);
     readonly data: Record<string, unknown> | null | undefined;
     readonly errors: ReadonlyArray<GraphQLFormattedError>;
+    static is(error: unknown): error is CombinedGraphQLErrors;
 }
 
 // @public
@@ -21,6 +22,7 @@ export class CombinedProtocolErrors extends Error {
     constructor(protocolErrors: Array<GraphQLFormattedError> | ReadonlyArray<GraphQLFormattedError>);
     // (undocumented)
     errors: ReadonlyArray<GraphQLFormattedError>;
+    static is(error: unknown): error is CombinedProtocolErrors;
 }
 
 // @public (undocumented)
@@ -43,6 +45,7 @@ export const PROTOCOL_ERRORS_SYMBOL: unique symbol;
 export class ServerError extends Error {
     // Warning: (ae-forgotten-export) The symbol "ServerErrorOptions" needs to be exported by the entry point index.d.ts
     constructor(message: string, options: ServerErrorOptions);
+    static is(error: unknown): error is ServerError;
     response: Response;
     result: Record<string, any> | string;
     statusCode: number;
@@ -61,6 +64,7 @@ export class ServerParseError extends Error {
     // Warning: (ae-forgotten-export) The symbol "ServerParseErrorOptions" needs to be exported by the entry point index.d.ts
     constructor(originalParseError: unknown, options: ServerParseErrorOptions);
     bodyText: string;
+    static is(error: unknown): error is ServerParseError;
     response: Response;
     statusCode: number;
 }
@@ -79,6 +83,7 @@ export function toErrorLike(error: unknown): ErrorLike;
 // @public
 export class UnconventionalError extends Error {
     constructor(errorType: unknown);
+    static is(error: unknown): error is UnconventionalError;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -395,6 +395,7 @@ export class CombinedGraphQLErrors extends Error {
     constructor(result: FetchResult<unknown>);
     readonly data: Record<string, unknown> | null | undefined;
     readonly errors: ReadonlyArray<GraphQLFormattedError>;
+    static is(error: unknown): error is CombinedGraphQLErrors;
 }
 
 // @public
@@ -402,6 +403,7 @@ export class CombinedProtocolErrors extends Error {
     constructor(protocolErrors: Array<GraphQLFormattedError> | ReadonlyArray<GraphQLFormattedError>);
     // (undocumented)
     errors: ReadonlyArray<GraphQLFormattedError>;
+    static is(error: unknown): error is CombinedProtocolErrors;
 }
 
 // Warning: (ae-forgotten-export) The symbol "CombineByTypeName" needs to be exported by the entry point index.d.ts
@@ -2154,6 +2156,7 @@ export const serializeFetchParameter: (p: any, label: string) => string;
 export class ServerError extends Error {
     // Warning: (ae-forgotten-export) The symbol "ServerErrorOptions" needs to be exported by the entry point index.d.ts
     constructor(message: string, options: ServerErrorOptions);
+    static is(error: unknown): error is ServerError;
     response: Response;
     result: Record<string, any> | string;
     statusCode: number;
@@ -2172,6 +2175,7 @@ export class ServerParseError extends Error {
     // Warning: (ae-forgotten-export) The symbol "ServerParseErrorOptions" needs to be exported by the entry point index.d.ts
     constructor(originalParseError: unknown, options: ServerParseErrorOptions);
     bodyText: string;
+    static is(error: unknown): error is ServerParseError;
     response: Response;
     statusCode: number;
 }
@@ -2337,6 +2341,7 @@ export type TypePolicy = {
 // @public
 export class UnconventionalError extends Error {
     constructor(errorType: unknown);
+    static is(error: unknown): error is UnconventionalError;
 }
 
 // @public (undocumented)

--- a/.changeset/four-countries-clean.md
+++ b/.changeset/four-countries-clean.md
@@ -1,0 +1,24 @@
+---
+"@apollo/client": minor
+---
+
+Add a static `is` method to error types defined by Apollo Client. `is` makes it simpler to determine whether an error is a specific type, which can be helpful in cases where you'd like to narrow the error type in order to use specific properties from that error.
+
+This change applies to the following error types:
+- `CombinedGraphQLErrors`
+- `CombinedProtocolErrors`
+- `ServerError`
+- `ServerParseError`
+- `UnconventionalError`
+
+**Example**
+
+```ts
+import { CombinedGraphQLErrors } from "@apollo/client";
+
+if (CombinedGraphQLErrors.is(error)) {
+  console.log(error.message);
+  error.errors.forEach((graphQLError) => console.log(graphQLError.message))
+}
+```
+

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 42828,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38328,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 32795,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27750
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 42972,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38439,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 32834,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27796
 }

--- a/integration-tests/next/src/libs/apolloClient.ts
+++ b/integration-tests/next/src/libs/apolloClient.ts
@@ -20,7 +20,7 @@ export const APOLLO_STATE_PROP_NAME = "__APOLLO_STATE__";
 let apolloClient: ApolloClient;
 
 const errorLink = onError(({ error }) => {
-  if (error instanceof CombinedGraphQLErrors) {
+  if (CombinedGraphQLErrors.is(error)) {
     error.errors.forEach(({ message, locations, path }) =>
       console.log(
         `[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`

--- a/src/config/jest/areCombinedGraphQLErrorsEqual.ts
+++ b/src/config/jest/areCombinedGraphQLErrorsEqual.ts
@@ -7,8 +7,8 @@ export const areCombinedGraphQLErrorsEqual: Tester = function (
   b,
   customTesters
 ) {
-  const isACombinedGraphQLErrors = a && CombinedGraphQLErrors.is(a);
-  const isBCombinedGraphQLErrors = b && CombinedGraphQLErrors.is(b);
+  const isACombinedGraphQLErrors = CombinedGraphQLErrors.is(a);
+  const isBCombinedGraphQLErrors = CombinedGraphQLErrors.is(b);
 
   if (isACombinedGraphQLErrors && isBCombinedGraphQLErrors) {
     return (

--- a/src/config/jest/areCombinedGraphQLErrorsEqual.ts
+++ b/src/config/jest/areCombinedGraphQLErrorsEqual.ts
@@ -1,12 +1,14 @@
 import type { Tester } from "@jest/expect-utils";
 
+import { CombinedGraphQLErrors } from "@apollo/client";
+
 export const areCombinedGraphQLErrorsEqual: Tester = function (
   a,
   b,
   customTesters
 ) {
-  const isACombinedGraphQLErrors = a && a.name === "CombinedGraphQLErrors";
-  const isBCombinedGraphQLErrors = b && b.name === "CombinedGraphQLErrors";
+  const isACombinedGraphQLErrors = a && CombinedGraphQLErrors.is(a);
+  const isBCombinedGraphQLErrors = b && CombinedGraphQLErrors.is(b);
 
   if (isACombinedGraphQLErrors && isBCombinedGraphQLErrors) {
     return (

--- a/src/config/jest/areCombinedProtocolErrorsEqual.ts
+++ b/src/config/jest/areCombinedProtocolErrorsEqual.ts
@@ -7,8 +7,8 @@ export const areCombinedProtocolErrorsEqual: Tester = function (
   b,
   customTesters
 ) {
-  const isACombinedProtocolErrors = a && CombinedProtocolErrors.is(a);
-  const isBCombinedProtocolErrors = b && CombinedProtocolErrors.is(b);
+  const isACombinedProtocolErrors = CombinedProtocolErrors.is(a);
+  const isBCombinedProtocolErrors = CombinedProtocolErrors.is(b);
 
   if (isACombinedProtocolErrors && isBCombinedProtocolErrors) {
     return (

--- a/src/config/jest/areCombinedProtocolErrorsEqual.ts
+++ b/src/config/jest/areCombinedProtocolErrorsEqual.ts
@@ -1,12 +1,14 @@
 import type { Tester } from "@jest/expect-utils";
 
+import { CombinedProtocolErrors } from "@apollo/client";
+
 export const areCombinedProtocolErrorsEqual: Tester = function (
   a,
   b,
   customTesters
 ) {
-  const isACombinedProtocolErrors = a && a.name === "CombinedProtocolErrors";
-  const isBCombinedProtocolErrors = b && b.name === "CombinedProtocolErrors";
+  const isACombinedProtocolErrors = a && CombinedProtocolErrors.is(a);
+  const isBCombinedProtocolErrors = b && CombinedProtocolErrors.is(b);
 
   if (isACombinedProtocolErrors && isBCombinedProtocolErrors) {
     return (

--- a/src/config/jest/areServerErrorsEqual.ts
+++ b/src/config/jest/areServerErrorsEqual.ts
@@ -3,8 +3,8 @@ import type { Tester } from "@jest/expect-utils";
 import { ServerError } from "@apollo/client";
 
 export const areServerErrorsEqual: Tester = function (a, b, customTesters) {
-  const isAServerError = a && ServerError.is(a);
-  const isBServerError = b && ServerError.is(b);
+  const isAServerError = ServerError.is(a);
+  const isBServerError = ServerError.is(b);
 
   if (isAServerError && isBServerError) {
     return (

--- a/src/config/jest/areServerErrorsEqual.ts
+++ b/src/config/jest/areServerErrorsEqual.ts
@@ -1,8 +1,10 @@
 import type { Tester } from "@jest/expect-utils";
 
+import { ServerError } from "@apollo/client";
+
 export const areServerErrorsEqual: Tester = function (a, b, customTesters) {
-  const isAServerError = a && a.name === "ServerError";
-  const isBServerError = b && b.name === "ServerError";
+  const isAServerError = a && ServerError.is(a);
+  const isBServerError = b && ServerError.is(b);
 
   if (isAServerError && isBServerError) {
     return (

--- a/src/errors/CombinedGraphQLErrors.ts
+++ b/src/errors/CombinedGraphQLErrors.ts
@@ -1,6 +1,6 @@
 import type { GraphQLFormattedError } from "graphql";
 
-import type { FetchResult } from "@apollo/client";
+import type { ErrorLike, FetchResult } from "@apollo/client";
 import { getGraphQLErrorsFromResult } from "@apollo/client/utilities";
 
 /**
@@ -8,6 +8,17 @@ import { getGraphQLErrorsFromResult } from "@apollo/client/utilities";
  * GraphQL response.
  */
 export class CombinedGraphQLErrors extends Error {
+  /** Determine if an error is a `CombinedGraphQLErrors` instance */
+  static is(error: ErrorLike): error is CombinedGraphQLErrors {
+    return (
+      error instanceof CombinedGraphQLErrors ||
+      // Fallback to check for the name property in case there are multiple
+      // versions of Apollo Client installed, or something else causes
+      // instanceof to return false.
+      error.name === "CombinedGraphQLErrors"
+    );
+  }
+
   /**
    * The raw list of GraphQL errors returned in a GraphQL response.
    */

--- a/src/errors/CombinedGraphQLErrors.ts
+++ b/src/errors/CombinedGraphQLErrors.ts
@@ -1,7 +1,9 @@
 import type { GraphQLFormattedError } from "graphql";
 
-import type { ErrorLike, FetchResult } from "@apollo/client";
+import type { FetchResult } from "@apollo/client";
 import { getGraphQLErrorsFromResult } from "@apollo/client/utilities";
+
+import { hasName } from "./utils.js";
 
 /**
  * Represents the combined list of GraphQL errors returned from the server in a
@@ -9,13 +11,13 @@ import { getGraphQLErrorsFromResult } from "@apollo/client/utilities";
  */
 export class CombinedGraphQLErrors extends Error {
   /** Determine if an error is a `CombinedGraphQLErrors` instance */
-  static is(error: ErrorLike): error is CombinedGraphQLErrors {
+  static is(error: unknown): error is CombinedGraphQLErrors {
     return (
       error instanceof CombinedGraphQLErrors ||
-      // Fallback to check for the name property in case there are multiple
-      // versions of Apollo Client installed, or something else causes
-      // instanceof to return false.
-      error.name === "CombinedGraphQLErrors"
+      // Fallback to check for the name in case there are multiple versions of
+      // Apollo Client installed, or something else causes instanceof to
+      // return false.
+      hasName(error, "CombinedGraphQLErrors")
     );
   }
 

--- a/src/errors/CombinedProtocolErrors.ts
+++ b/src/errors/CombinedProtocolErrors.ts
@@ -1,6 +1,6 @@
 import type { GraphQLFormattedError } from "graphql";
 
-import type { ErrorLike } from "@apollo/client";
+import { hasName } from "./utils.js";
 
 /**
  * Fatal transport-level errors returned when executing a subscription using the
@@ -9,13 +9,13 @@ import type { ErrorLike } from "@apollo/client";
  */
 export class CombinedProtocolErrors extends Error {
   /** Determine if an error is a `CombinedProtocolErrors` instance */
-  static is(error: ErrorLike): error is CombinedProtocolErrors {
+  static is(error: unknown): error is CombinedProtocolErrors {
     return (
       error instanceof CombinedProtocolErrors ||
-      // Fallback to check for the name property in case there are multiple
-      // versions of Apollo Client installed, or something else causes
-      // instanceof to return false.
-      error.name === "CombinedProtocolErrors"
+      // Fallback to check for the name in case there are multiple versions of
+      // Apollo Client installed, or something else causes instanceof to
+      // return false.
+      hasName(error, "CombinedProtocolErrors")
     );
   }
 

--- a/src/errors/CombinedProtocolErrors.ts
+++ b/src/errors/CombinedProtocolErrors.ts
@@ -1,11 +1,24 @@
 import type { GraphQLFormattedError } from "graphql";
 
+import type { ErrorLike } from "@apollo/client";
+
 /**
  * Fatal transport-level errors returned when executing a subscription using the
  * multipart HTTP subscription protocol. See the documentation on the
  * [multipart HTTP protocol for GraphQL Subscriptions](https://www.apollographql.com/docs/graphos/routing/operations/subscriptions/multipart-protocol) for more information on these errors.
  */
 export class CombinedProtocolErrors extends Error {
+  /** Determine if an error is a `CombinedProtocolErrors` instance */
+  static is(error: ErrorLike): error is CombinedProtocolErrors {
+    return (
+      error instanceof CombinedProtocolErrors ||
+      // Fallback to check for the name property in case there are multiple
+      // versions of Apollo Client installed, or something else causes
+      // instanceof to return false.
+      error.name === "CombinedProtocolErrors"
+    );
+  }
+
   errors: ReadonlyArray<GraphQLFormattedError>;
 
   constructor(

--- a/src/errors/ServerError.ts
+++ b/src/errors/ServerError.ts
@@ -1,4 +1,4 @@
-import type { ErrorLike } from "@apollo/client";
+import { hasName } from "./utils.js";
 
 interface ServerErrorOptions {
   response: Response;
@@ -10,13 +10,13 @@ interface ServerErrorOptions {
  */
 export class ServerError extends Error {
   /** Determine if an error is a `ServerError` instance */
-  static is(error: ErrorLike): error is ServerError {
+  static is(error: unknown): error is ServerError {
     return (
       error instanceof ServerError ||
       // Fallback to check for the name property in case there are multiple
       // versions of Apollo Client installed, or something else causes
       // instanceof to return false.
-      error.name === "ServerError"
+      hasName(error, "ServerError")
     );
   }
 

--- a/src/errors/ServerError.ts
+++ b/src/errors/ServerError.ts
@@ -1,3 +1,5 @@
+import type { ErrorLike } from "@apollo/client";
+
 interface ServerErrorOptions {
   response: Response;
   result: Record<string, any> | string;
@@ -7,6 +9,17 @@ interface ServerErrorOptions {
  * Thrown when a non-200 response is returned from the server.
  */
 export class ServerError extends Error {
+  /** Determine if an error is a `ServerError` instance */
+  static is(error: ErrorLike): error is ServerError {
+    return (
+      error instanceof ServerError ||
+      // Fallback to check for the name property in case there are multiple
+      // versions of Apollo Client installed, or something else causes
+      // instanceof to return false.
+      error.name === "ServerError"
+    );
+  }
+
   /**
    * The server response.
    */

--- a/src/errors/ServerParseError.ts
+++ b/src/errors/ServerParseError.ts
@@ -1,3 +1,5 @@
+import type { ErrorLike } from "@apollo/client";
+
 interface ServerParseErrorOptions {
   response: Response;
   bodyText: string;
@@ -7,6 +9,16 @@ interface ServerParseErrorOptions {
  * Thrown when failing to parse the response as JSON from the server.
  */
 export class ServerParseError extends Error {
+  /** Determine if an error is an `ServerParseError` instance */
+  static is(error: ErrorLike): error is ServerParseError {
+    return (
+      error instanceof ServerParseError ||
+      // Fallback to check for the name property in case there are multiple
+      // versions of Apollo Client installed, or something else causes
+      // instanceof to return false.
+      error.name === "ServerParseError"
+    );
+  }
   /**
    * The server response.
    */

--- a/src/errors/ServerParseError.ts
+++ b/src/errors/ServerParseError.ts
@@ -1,4 +1,4 @@
-import type { ErrorLike } from "@apollo/client";
+import { hasName } from "./utils.js";
 
 interface ServerParseErrorOptions {
   response: Response;
@@ -10,13 +10,13 @@ interface ServerParseErrorOptions {
  */
 export class ServerParseError extends Error {
   /** Determine if an error is an `ServerParseError` instance */
-  static is(error: ErrorLike): error is ServerParseError {
+  static is(error: unknown): error is ServerParseError {
     return (
       error instanceof ServerParseError ||
-      // Fallback to check for the name property in case there are multiple
-      // versions of Apollo Client installed, or something else causes
-      // instanceof to return false.
-      error.name === "ServerParseError"
+      // Fallback to check for the name in case there are multiple versions of
+      // Apollo Client installed, or something else causes instanceof to
+      // return false.
+      hasName(error, "ServerParseError")
     );
   }
   /**

--- a/src/errors/UnconventionalError.ts
+++ b/src/errors/UnconventionalError.ts
@@ -1,9 +1,22 @@
+import type { ErrorLike } from "@apollo/client";
+
 /**
  * A wrapper error type that represents a non-standard error thrown from a
  * response, such as a symbol or plain object. Read the `cause` property to
  * determine the source of the error.
  */
 export class UnconventionalError extends Error {
+  /** Determine if an error is an `UnconventionalError` instance */
+  static is(error: ErrorLike): error is UnconventionalError {
+    return (
+      error instanceof UnconventionalError ||
+      // Fallback to check for the name property in case there are multiple
+      // versions of Apollo Client installed, or something else causes
+      // instanceof to return false.
+      error.name === "UnconventionalError"
+    );
+  }
+
   constructor(errorType: unknown) {
     super("An error of unexpected shape occurred.", { cause: errorType });
     this.name = "UnconventionalError";

--- a/src/errors/UnconventionalError.ts
+++ b/src/errors/UnconventionalError.ts
@@ -1,4 +1,4 @@
-import type { ErrorLike } from "@apollo/client";
+import { hasName } from "./utils.js";
 
 /**
  * A wrapper error type that represents a non-standard error thrown from a
@@ -7,13 +7,13 @@ import type { ErrorLike } from "@apollo/client";
  */
 export class UnconventionalError extends Error {
   /** Determine if an error is an `UnconventionalError` instance */
-  static is(error: ErrorLike): error is UnconventionalError {
+  static is(error: unknown): error is UnconventionalError {
     return (
       error instanceof UnconventionalError ||
       // Fallback to check for the name property in case there are multiple
       // versions of Apollo Client installed, or something else causes
       // instanceof to return false.
-      error.name === "UnconventionalError"
+      hasName(error, "UnconventionalError")
     );
   }
 

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,4 +1,4 @@
-import type { ErrorLike } from "@apollo/client/core";
+import type { ErrorLike } from "@apollo/client";
 import type { FetchResult } from "@apollo/client/link/core";
 
 import { CombinedProtocolErrors } from "./CombinedProtocolErrors.js";
@@ -19,10 +19,10 @@ export function graphQLResultHasProtocolErrors<T>(
   result: FetchResult<T>
 ): result is FetchResultWithSymbolExtensions<T> {
   if (result.extensions) {
-    return (
+    return CombinedProtocolErrors.is(
       (result as FetchResultWithSymbolExtensions<T>).extensions[
         PROTOCOL_ERRORS_SYMBOL
-      ] instanceof CombinedProtocolErrors
+      ]
     );
   }
   return false;

--- a/src/errors/utils.ts
+++ b/src/errors/utils.ts
@@ -1,0 +1,8 @@
+export function hasName(error: unknown, name: string) {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    error.name === name
+  );
+}


### PR DESCRIPTION
Make it easier to type-narrow an error type by adding static `is` methods to each error type. 