### PR TITLE
Fix import from `@apollo/client/core`

### DIFF
--- a/.api-reports/api-report-errors.api.md
+++ b/.api-reports/api-report-errors.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-import type { ErrorLike } from '@apollo/client/core';
+import type { ErrorLike } from '@apollo/client';
 import type { FetchResult } from '@apollo/client/link/core';
 import type { FetchResult as FetchResult_2 } from '@apollo/client';
 import type { GraphQLFormattedError } from 'graphql';

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,4 +1,4 @@
-import type { ErrorLike } from "@apollo/client/core";
+import type { ErrorLike } from "@apollo/client";
 import type { FetchResult } from "@apollo/client/link/core";
 
 import { CombinedProtocolErrors } from "./CombinedProtocolErrors.js";


### PR DESCRIPTION
I found a rogue import from the recent work merged in that imported from `@apollo/client/core`. This updates the import to `@apollo/client`.