### PR TITLE
Better types for `variables` throughout the client

### DIFF
--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -108,6 +108,7 @@ import { TypePolicy } from '@apollo/client/cache';
 import { UnconventionalError } from '@apollo/client/errors';
 import { Unmasked } from '@apollo/client/masking';
 import { UriFunction } from '@apollo/client/link/http';
+import type { VariablesOption } from '@apollo/client/utilities';
 import { WatchFragmentOptions } from '@apollo/client/cache';
 import { WatchFragmentResult } from '@apollo/client/cache';
 
@@ -709,7 +710,7 @@ export interface FetchMoreQueryOptions<TVariables, TData = unknown> {
     // (undocumented)
     context?: DefaultContext;
     query?: DocumentNode_2 | TypedDocumentNode<TData, TVariables>;
-    variables?: Partial<TVariables>;
+    variables?: Partial<NoInfer_2<TVariables>>;
 }
 
 // @public
@@ -1193,23 +1194,21 @@ export interface MutateResult<TData = unknown> {
 export type MutationFetchPolicy = Extract<FetchPolicy, "network-only" | "no-cache">;
 
 // @public (undocumented)
-export interface MutationOptions<TData = unknown, TVariables = OperationVariables, TContext = DefaultContext, TCache extends ApolloCache = ApolloCache> {
-    awaitRefetchQueries?: boolean;
-    context?: TContext;
-    errorPolicy?: ErrorPolicy;
-    fetchPolicy?: MutationFetchPolicy;
-    keepRootFields?: boolean;
-    mutation: DocumentNode_2 | TypedDocumentNode<TData, TVariables>;
-    onQueryUpdated?: OnQueryUpdated<any>;
-    // Warning: (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
+export type MutationOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, TContext = DefaultContext, TCache extends ApolloCache = ApolloCache> = {
     optimisticResponse?: Unmasked<NoInfer_2<TData>> | ((vars: TVariables, { IGNORE }: {
         IGNORE: IgnoreModifier;
     }) => Unmasked<NoInfer_2<TData>> | IgnoreModifier);
-    refetchQueries?: ((result: FetchResult<Unmasked<TData>>) => InternalRefetchQueriesInclude) | InternalRefetchQueriesInclude;
-    update?: MutationUpdaterFunction<TData, TVariables, TContext, TCache>;
     updateQueries?: MutationQueryReducersMap<TData>;
-    variables?: TVariables;
-}
+    refetchQueries?: ((result: FetchResult<Unmasked<TData>>) => InternalRefetchQueriesInclude) | InternalRefetchQueriesInclude;
+    awaitRefetchQueries?: boolean;
+    update?: MutationUpdaterFunction<TData, TVariables, TContext, TCache>;
+    onQueryUpdated?: OnQueryUpdated<any>;
+    errorPolicy?: ErrorPolicy;
+    context?: TContext;
+    fetchPolicy?: MutationFetchPolicy;
+    keepRootFields?: boolean;
+    mutation: DocumentNode_2 | TypedDocumentNode<TData, TVariables>;
+} & VariablesOption<NoInfer_2<TVariables>>;
 
 // @public (undocumented)
 export type MutationQueryReducer<T> = (previousResult: Record<string, any>, options: {
@@ -1327,6 +1326,25 @@ interface ObservableAndInfo<TData> {
 }
 
 // @public (undocumented)
+export namespace ObservableQuery {
+    // (undocumented)
+    export type Options<TData = unknown, TVariables extends OperationVariables = OperationVariables> = {
+        fetchPolicy: WatchQueryFetchPolicy;
+        nextFetchPolicy?: WatchQueryFetchPolicy | ((this: WatchQueryOptions<TVariables, TData>, currentFetchPolicy: WatchQueryFetchPolicy, context: NextFetchPolicyContext<TData, TVariables>) => WatchQueryFetchPolicy);
+        initialFetchPolicy: WatchQueryFetchPolicy;
+        refetchWritePolicy?: RefetchWritePolicy;
+        errorPolicy?: ErrorPolicy;
+        context?: DefaultContext;
+        pollInterval?: number;
+        notifyOnNetworkStatusChange?: boolean;
+        returnPartialData?: boolean;
+        skipPollAttempt?: () => boolean;
+        query: DocumentNode_2 | TypedDocumentNode<TData, TVariables>;
+        variables: TVariables;
+    };
+}
+
+// @public (undocumented)
 export class ObservableQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables> implements Subscribable<ApolloQueryResult<MaybeMasked<TData>>>, InteropObservable<ApolloQueryResult<MaybeMasked<TData>>> {
     // (undocumented)
     ["@@observable"]: () => Subscribable<ApolloQueryResult<MaybeMasked<TData>>>;
@@ -1356,7 +1374,7 @@ export class ObservableQuery<TData = unknown, TVariables extends OperationVariab
     // @internal (undocumented)
     protected notify(): void;
     // (undocumented)
-    readonly options: WatchQueryOptions<TVariables, TData>;
+    readonly options: ObservableQuery.Options<TData, TVariables>;
     // (undocumented)
     pipe: Observable_2<ApolloQueryResult<MaybeMasked<TData>>>["pipe"];
     // (undocumented)
@@ -1366,7 +1384,7 @@ export class ObservableQuery<TData = unknown, TVariables extends OperationVariab
     // (undocumented)
     readonly queryName?: string;
     refetch(variables?: Partial<TVariables>): Promise<QueryResult<TData>>;
-    reobserve(newOptions?: Partial<WatchQueryOptions<TVariables, TData>>): Promise<QueryResult<MaybeMasked<TData>>>;
+    reobserve(newOptions?: Partial<ObservableQuery.Options<TData, TVariables>>): Promise<QueryResult<MaybeMasked<TData>>>;
     // @internal (undocumented)
     resetDiff(): void;
     // (undocumented)
@@ -1377,14 +1395,14 @@ export class ObservableQuery<TData = unknown, TVariables extends OperationVariab
     protected scheduleNotify(): void;
     setVariables(variables: TVariables): Promise<QueryResult<TData>>;
     // @internal (undocumented)
-    silentSetOptions(newOptions: Partial<WatchQueryOptions<TVariables, TData>>): void;
+    silentSetOptions(newOptions: Partial<ObservableQuery.Options<TData, TVariables>>): void;
     startPolling(pollInterval: number): void;
     stopPolling(): void;
     // (undocumented)
     subscribe: (observer: Partial<Observer<ApolloQueryResult<MaybeMasked<TData>>>> | ((value: ApolloQueryResult<MaybeMasked<TData>>) => void)) => Subscription;
     subscribeToMore<TSubscriptionData = TData, TSubscriptionVariables extends OperationVariables = TVariables>(options: SubscribeToMoreOptions<TData, TSubscriptionVariables, TSubscriptionData, TVariables>): () => void;
     updateQuery(mapFn: UpdateQueryMapFn<TData, TVariables>): void;
-    get variables(): TVariables | undefined;
+    get variables(): TVariables;
 }
 
 // @public (undocumented)
@@ -1543,6 +1561,8 @@ class QueryManager {
     // (undocumented)
     getOrCreateQuery(queryId: string): QueryInfo;
     // (undocumented)
+    getVariables<TVariables>(document: DocumentNode_2, variables?: TVariables): TVariables;
+    // (undocumented)
     protected inFlightLinkObservables: Trie<{
         observable?: Observable_2<FetchResult<any>>;
     }>;
@@ -1642,16 +1662,15 @@ interface QueryManagerOptions {
 }
 
 // @public
-interface QueryOptions<TVariables = OperationVariables, TData = unknown> {
-    context?: DefaultContext;
-    errorPolicy?: ErrorPolicy;
-    fetchPolicy?: FetchPolicy;
-    notifyOnNetworkStatusChange?: boolean;
-    pollInterval?: number;
+type QueryOptions<TVariables extends OperationVariables = OperationVariables, TData = unknown> = {
     query: DocumentNode_2 | TypedDocumentNode<TData, TVariables>;
+    errorPolicy?: ErrorPolicy;
+    context?: DefaultContext;
+    fetchPolicy?: FetchPolicy;
+    pollInterval?: number;
+    notifyOnNetworkStatusChange?: boolean;
     returnPartialData?: boolean;
-    variables?: TVariables;
-}
+} & VariablesOption<NoInfer_2<TVariables>>;
 export { QueryOptions as PureQueryOptions }
 export { QueryOptions }
 
@@ -1851,14 +1870,13 @@ export type SubscribeToMoreUpdateQueryFn<TData = unknown, TVariables extends Ope
 };
 
 // @public (undocumented)
-export interface SubscriptionOptions<TVariables = OperationVariables, TData = unknown> {
-    context?: DefaultContext;
-    errorPolicy?: ErrorPolicy;
-    extensions?: Record<string, any>;
-    fetchPolicy?: FetchPolicy;
+export type SubscriptionOptions<TVariables extends OperationVariables = OperationVariables, TData = unknown> = {
     query: DocumentNode_2 | TypedDocumentNode<TData, TVariables>;
-    variables?: TVariables;
-}
+    fetchPolicy?: FetchPolicy;
+    errorPolicy?: ErrorPolicy;
+    context?: DefaultContext;
+    extensions?: Record<string, any>;
+} & VariablesOption<NoInfer_2<TVariables>>;
 
 // @public (undocumented)
 type ToReferenceFunction = (objOrIdOrRef: StoreObject | string | Reference, mergeIntoStore?: boolean) => Reference | undefined;
@@ -1969,21 +1987,19 @@ type WatchFragmentResult_2<TData> = {
 export type WatchQueryFetchPolicy = FetchPolicy | "cache-and-network";
 
 // @public
-export interface WatchQueryOptions<TVariables extends OperationVariables = OperationVariables, TData = unknown> {
-    context?: DefaultContext;
-    errorPolicy?: ErrorPolicy;
+export type WatchQueryOptions<TVariables extends OperationVariables = OperationVariables, TData = unknown> = {
     fetchPolicy?: WatchQueryFetchPolicy;
-    initialFetchPolicy?: WatchQueryFetchPolicy;
-    // Warning: (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
     nextFetchPolicy?: WatchQueryFetchPolicy | ((this: WatchQueryOptions<TVariables, TData>, currentFetchPolicy: WatchQueryFetchPolicy, context: NextFetchPolicyContext<TData, TVariables>) => WatchQueryFetchPolicy);
-    notifyOnNetworkStatusChange?: boolean;
-    pollInterval?: number;
-    query: DocumentNode_2 | TypedDocumentNode<TData, TVariables>;
+    initialFetchPolicy?: WatchQueryFetchPolicy;
     refetchWritePolicy?: RefetchWritePolicy;
+    errorPolicy?: ErrorPolicy;
+    context?: DefaultContext;
+    pollInterval?: number;
+    notifyOnNetworkStatusChange?: boolean;
     returnPartialData?: boolean;
     skipPollAttempt?: () => boolean;
-    variables?: TVariables;
-}
+    query: DocumentNode_2 | TypedDocumentNode<TData, TVariables>;
+} & VariablesOption<NoInfer_2<TVariables>>;
 
 // @public (undocumented)
 interface WriteContext extends ReadMergeModifyContext {
@@ -2025,10 +2041,12 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/cache/inmemory/policies.ts:167:3 - (ae-forgotten-export) The symbol "FieldReadFunction_2" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/policies.ts:168:3 - (ae-forgotten-export) The symbol "FieldMergeFunction_2" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/types.ts:133:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:140:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:141:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:84:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:190:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:191:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:184:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:454:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
+// src/core/watchQueryOptions.ts:269:3 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -72,7 +72,7 @@ import type { Unmasked } from '@apollo/client/masking';
 import type { Unmasked as Unmasked_2 } from '@apollo/client';
 import type { UpdateQueryMapFn as UpdateQueryMapFn_2 } from '@apollo/client';
 import type { UriFunction } from '@apollo/client/link/http';
-import type { VariablesOption } from '@apollo/client/react/internal';
+import type { VariablesOption } from '@apollo/client/utilities';
 import type { WatchFragmentOptions } from '@apollo/client/cache';
 import type { WatchFragmentResult } from '@apollo/client/cache';
 import type { WatchQueryFetchPolicy } from '@apollo/client';
@@ -296,7 +296,7 @@ interface FetchMoreQueryOptions<TVariables, TData = unknown> {
     // (undocumented)
     context?: DefaultContext;
     query?: DocumentNode | TypedDocumentNode<TData, TVariables>;
-    variables?: Partial<TVariables>;
+    variables?: Partial<NoInfer_2<TVariables>>;
 }
 
 // @public
@@ -461,28 +461,21 @@ export type MutationFunctionOptions<TData = unknown, TVariables = OperationVaria
 export type MutationHookOptions<TData = unknown, TVariables = OperationVariables, TContext = DefaultContext_2, TCache extends ApolloCache_2 = ApolloCache_2> = useMutation.Options<TData, TVariables, TContext, TCache>;
 
 // @public (undocumented)
-interface MutationOptions<TData = unknown, TVariables = OperationVariables_2, TContext = DefaultContext, TCache extends ApolloCache = ApolloCache> {
-    awaitRefetchQueries?: boolean;
-    context?: TContext;
-    // Warning: (ae-forgotten-export) The symbol "ErrorPolicy" needs to be exported by the entry point index.d.ts
-    errorPolicy?: ErrorPolicy;
-    // Warning: (ae-forgotten-export) The symbol "MutationFetchPolicy" needs to be exported by the entry point index.d.ts
-    fetchPolicy?: MutationFetchPolicy;
-    keepRootFields?: boolean;
-    mutation: DocumentNode | TypedDocumentNode<TData, TVariables>;
-    // Warning: (ae-forgotten-export) The symbol "OnQueryUpdated" needs to be exported by the entry point index.d.ts
-    onQueryUpdated?: OnQueryUpdated<any>;
-    // Warning: (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
+type MutationOptions<TData = unknown, TVariables extends OperationVariables_2 = OperationVariables_2, TContext = DefaultContext, TCache extends ApolloCache = ApolloCache> = {
     optimisticResponse?: Unmasked<NoInfer_2<TData>> | ((vars: TVariables, { IGNORE }: {
         IGNORE: IgnoreModifier;
     }) => Unmasked<NoInfer_2<TData>> | IgnoreModifier);
-    refetchQueries?: ((result: FetchResult<Unmasked<TData>>) => InternalRefetchQueriesInclude) | InternalRefetchQueriesInclude;
-    // Warning: (ae-forgotten-export) The symbol "MutationUpdaterFunction" needs to be exported by the entry point index.d.ts
-    update?: MutationUpdaterFunction<TData, TVariables, TContext, TCache>;
-    // Warning: (ae-forgotten-export) The symbol "MutationQueryReducersMap" needs to be exported by the entry point index.d.ts
     updateQueries?: MutationQueryReducersMap<TData>;
-    variables?: TVariables;
-}
+    refetchQueries?: ((result: FetchResult<Unmasked<TData>>) => InternalRefetchQueriesInclude) | InternalRefetchQueriesInclude;
+    awaitRefetchQueries?: boolean;
+    update?: MutationUpdaterFunction<TData, TVariables, TContext, TCache>;
+    onQueryUpdated?: OnQueryUpdated<any>;
+    errorPolicy?: ErrorPolicy;
+    context?: TContext;
+    fetchPolicy?: MutationFetchPolicy;
+    keepRootFields?: boolean;
+    mutation: DocumentNode | TypedDocumentNode<TData, TVariables>;
+} & VariablesOption<NoInfer_2<TVariables>>;
 
 // @public (undocumented)
 type MutationQueryReducer<T> = (previousResult: Record<string, any>, options: {
@@ -556,6 +549,25 @@ interface ObservableAndInfo<TData> {
 }
 
 // @public (undocumented)
+namespace ObservableQuery {
+    // (undocumented)
+    type Options<TData = unknown, TVariables extends OperationVariables_2 = OperationVariables_2> = {
+        fetchPolicy: WatchQueryFetchPolicy_2;
+        nextFetchPolicy?: WatchQueryFetchPolicy_2 | ((this: WatchQueryOptions_2<TVariables, TData>, currentFetchPolicy: WatchQueryFetchPolicy_2, context: NextFetchPolicyContext<TData, TVariables>) => WatchQueryFetchPolicy_2);
+        initialFetchPolicy: WatchQueryFetchPolicy_2;
+        refetchWritePolicy?: RefetchWritePolicy;
+        errorPolicy?: ErrorPolicy;
+        context?: DefaultContext;
+        pollInterval?: number;
+        notifyOnNetworkStatusChange?: boolean;
+        returnPartialData?: boolean;
+        skipPollAttempt?: () => boolean;
+        query: DocumentNode | TypedDocumentNode<TData, TVariables>;
+        variables: TVariables;
+    };
+}
+
+// @public (undocumented)
 class ObservableQuery<TData = unknown, TVariables extends OperationVariables_2 = OperationVariables_2> implements Subscribable<ApolloQueryResult<MaybeMasked<TData>>>, InteropObservable<ApolloQueryResult<MaybeMasked<TData>>> {
     // (undocumented)
     ["@@observable"]: () => Subscribable<ApolloQueryResult<MaybeMasked<TData>>>;
@@ -586,7 +598,7 @@ class ObservableQuery<TData = unknown, TVariables extends OperationVariables_2 =
     // @internal (undocumented)
     protected notify(): void;
     // (undocumented)
-    readonly options: WatchQueryOptions_2<TVariables, TData>;
+    readonly options: ObservableQuery.Options<TData, TVariables>;
     // (undocumented)
     pipe: Observable<ApolloQueryResult<MaybeMasked<TData>>>["pipe"];
     // (undocumented)
@@ -596,7 +608,7 @@ class ObservableQuery<TData = unknown, TVariables extends OperationVariables_2 =
     // (undocumented)
     readonly queryName?: string;
     refetch(variables?: Partial<TVariables>): Promise<QueryResult_2<TData>>;
-    reobserve(newOptions?: Partial<WatchQueryOptions_2<TVariables, TData>>): Promise<QueryResult_2<MaybeMasked<TData>>>;
+    reobserve(newOptions?: Partial<ObservableQuery.Options<TData, TVariables>>): Promise<QueryResult_2<MaybeMasked<TData>>>;
     // @internal (undocumented)
     resetDiff(): void;
     // (undocumented)
@@ -607,7 +619,7 @@ class ObservableQuery<TData = unknown, TVariables extends OperationVariables_2 =
     protected scheduleNotify(): void;
     setVariables(variables: TVariables): Promise<QueryResult_2<TData>>;
     // @internal (undocumented)
-    silentSetOptions(newOptions: Partial<WatchQueryOptions_2<TVariables, TData>>): void;
+    silentSetOptions(newOptions: Partial<ObservableQuery.Options<TData, TVariables>>): void;
     startPolling(pollInterval: number): void;
     stopPolling(): void;
     // (undocumented)
@@ -616,7 +628,7 @@ class ObservableQuery<TData = unknown, TVariables extends OperationVariables_2 =
     subscribeToMore<TSubscriptionData = TData, TSubscriptionVariables extends OperationVariables_2 = TVariables>(options: SubscribeToMoreOptions<TData, TSubscriptionVariables, TSubscriptionData, TVariables>): () => void;
     // Warning: (ae-forgotten-export) The symbol "UpdateQueryMapFn" needs to be exported by the entry point index.d.ts
     updateQuery(mapFn: UpdateQueryMapFn<TData, TVariables>): void;
-    get variables(): TVariables | undefined;
+    get variables(): TVariables;
 }
 
 // @public @deprecated (undocumented)
@@ -638,8 +650,6 @@ export type PreloadQueryFetchPolicy = Extract<WatchQueryFetchPolicy, "cache-firs
 
 // @public
 export interface PreloadQueryFunction {
-    // Warning: (ae-forgotten-export) The symbol "PreloadQueryOptionsArg" needs to be exported by the entry point index.d.ts
-    <TData, TVariables extends OperationVariables, TOptions extends Omit<PreloadQueryOptions, "variables">>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: PreloadQueryOptionsArg<NoInfer_2<TVariables>, TOptions>): PreloadedQueryRef<TOptions["errorPolicy"] extends "ignore" | "all" ? TOptions["returnPartialData"] extends true ? DeepPartial<TData> | undefined : TData | undefined : TOptions["returnPartialData"] extends true ? DeepPartial<TData> : TData, TVariables>;
     <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: PreloadQueryOptions<NoInfer_2<TVariables>> & {
         returnPartialData: true;
         errorPolicy: "ignore" | "all";
@@ -650,7 +660,9 @@ export interface PreloadQueryFunction {
     <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: PreloadQueryOptions<NoInfer_2<TVariables>> & {
         returnPartialData: true;
     }): PreloadedQueryRef<DeepPartial<TData>, TVariables>;
-    <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: PreloadQueryOptionsArg<NoInfer_2<TVariables>>): PreloadedQueryRef<TData, TVariables>;
+    <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: Record<string, never> extends (OnlyRequiredProperties<TVariables>) ? [
+    options?: PreloadQueryOptions<NoInfer_2<TVariables>>
+    ] : [options: PreloadQueryOptions<NoInfer_2<TVariables>>]): PreloadedQueryRef<TData, TVariables>;
 }
 
 // @public (undocumented)
@@ -661,15 +673,6 @@ export type PreloadQueryOptions<TVariables extends OperationVariables = Operatio
     returnPartialData?: boolean;
     refetchWritePolicy?: RefetchWritePolicy_2;
 } & VariablesOption<TVariables>;
-
-// @public (undocumented)
-type PreloadQueryOptionsArg<TVariables extends OperationVariables, TOptions = unknown> = [TVariables] extends [never] ? [
-options?: PreloadQueryOptions<never> & TOptions
-] : {} extends OnlyRequiredProperties<TVariables> ? [
-options?: PreloadQueryOptions<NoInfer_2<TVariables>> & Omit<TOptions, "variables">
-] : [
-options: PreloadQueryOptions<NoInfer_2<TVariables>> & Omit<TOptions, "variables">
-];
 
 // @public @deprecated (undocumented)
 export type QueryHookOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables> = useQuery.Options<TData, TVariables>;
@@ -760,6 +763,8 @@ class QueryManager {
     getObservableQueries(include?: InternalRefetchQueriesInclude): Map<string, ObservableQuery<any, OperationVariables_2>>;
     // (undocumented)
     getOrCreateQuery(queryId: string): QueryInfo;
+    // (undocumented)
+    getVariables<TVariables>(document: DocumentNode, variables?: TVariables): TVariables;
     // (undocumented)
     protected inFlightLinkObservables: Trie<{
         observable?: Observable<FetchResult<any>>;
@@ -863,16 +868,15 @@ interface QueryManagerOptions {
 }
 
 // @public
-interface QueryOptions<TVariables = OperationVariables_2, TData = unknown> {
-    context?: DefaultContext;
-    errorPolicy?: ErrorPolicy;
-    fetchPolicy?: FetchPolicy;
-    notifyOnNetworkStatusChange?: boolean;
-    pollInterval?: number;
+type QueryOptions<TVariables extends OperationVariables_2 = OperationVariables_2, TData = unknown> = {
     query: DocumentNode | TypedDocumentNode<TData, TVariables>;
+    errorPolicy?: ErrorPolicy;
+    context?: DefaultContext;
+    fetchPolicy?: FetchPolicy;
+    pollInterval?: number;
+    notifyOnNetworkStatusChange?: boolean;
     returnPartialData?: boolean;
-    variables?: TVariables;
-}
+} & VariablesOption<NoInfer_2<TVariables>>;
 
 export { QueryRef }
 
@@ -984,14 +988,13 @@ type SubscribeToMoreUpdateQueryFn<TData = unknown, TVariables extends OperationV
 export type SubscriptionHookOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables> = useSubscription.Options<TData, TVariables>;
 
 // @public (undocumented)
-interface SubscriptionOptions<TVariables = OperationVariables_2, TData = unknown> {
-    context?: DefaultContext;
-    errorPolicy?: ErrorPolicy;
-    extensions?: Record<string, any>;
-    fetchPolicy?: FetchPolicy;
+type SubscriptionOptions<TVariables extends OperationVariables_2 = OperationVariables_2, TData = unknown> = {
     query: DocumentNode | TypedDocumentNode<TData, TVariables>;
-    variables?: TVariables;
-}
+    fetchPolicy?: FetchPolicy;
+    errorPolicy?: ErrorPolicy;
+    context?: DefaultContext;
+    extensions?: Record<string, any>;
+} & VariablesOption<NoInfer_2<TVariables>>;
 
 // @public @deprecated (undocumented)
 export type SubscriptionResult<TData = unknown, TVariables extends OperationVariables = OperationVariables> = useSubscription.Result<TData>;
@@ -1047,12 +1050,6 @@ type UpdateQueryOptions<TData, TVariables> = {
 export function useApolloClient(override?: ApolloClient): ApolloClient;
 
 // @public (undocumented)
-export function useBackgroundQuery<TData, TVariables extends OperationVariables, TOptions extends Omit<useBackgroundQuery.Options, "variables">>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options?: useBackgroundQuery.Options<NoInfer_2<TVariables>> & TOptions): [
-(QueryRef<TOptions["errorPolicy"] extends "ignore" | "all" ? TOptions["returnPartialData"] extends true ? DeepPartial<TData> | undefined : TData | undefined : TOptions["returnPartialData"] extends true ? DeepPartial<TData> : TData, TVariables> | (TOptions["skip"] extends boolean ? undefined : never)),
-useBackgroundQuery.Result<TData, TVariables>
-];
-
-// @public (undocumented)
 export function useBackgroundQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
     returnPartialData: true;
     errorPolicy: "ignore" | "all";
@@ -1095,9 +1092,6 @@ useBackgroundQuery.Result<TData, TVariables>
 ];
 
 // @public (undocumented)
-export function useBackgroundQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options?: useBackgroundQuery.Options<NoInfer_2<TVariables>>): [QueryRef<TData, TVariables>, useBackgroundQuery.Result<TData, TVariables>];
-
-// @public (undocumented)
 export function useBackgroundQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken): [undefined, useBackgroundQuery.Result<TData, TVariables>];
 
 // @public (undocumented)
@@ -1109,7 +1103,20 @@ useBackgroundQuery.Result<TData, TVariables>
 ];
 
 // @public (undocumented)
-export function useBackgroundQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options?: SkipToken | useBackgroundQuery.Options<NoInfer_2<TVariables>>): [
+export function useBackgroundQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: Record<string, never> extends (OnlyRequiredProperties<TVariables>) ? [
+options?: useBackgroundQuery.Options<NoInfer_2<TVariables>>
+] : [options: useBackgroundQuery.Options<NoInfer_2<TVariables>>]): [QueryRef<TData, TVariables>, useBackgroundQuery.Result<TData, TVariables>];
+
+// @public (undocumented)
+export function useBackgroundQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: Record<string, never> extends (OnlyRequiredProperties<TVariables>) ? [
+options?: SkipToken | useBackgroundQuery.Options<NoInfer_2<TVariables>>
+] : [options: SkipToken | useBackgroundQuery.Options<NoInfer_2<TVariables>>]): [
+QueryRef<TData, TVariables> | undefined,
+useBackgroundQuery.Result<TData, TVariables>
+];
+
+// @public (undocumented)
+export function useBackgroundQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | useBackgroundQuery.Options<NoInfer_2<TVariables>>): [
 QueryRef<TData, TVariables> | undefined,
 useBackgroundQuery.Result<TData, TVariables>
 ];
@@ -1119,18 +1126,16 @@ export namespace useBackgroundQuery {
     // (undocumented)
     export type FetchPolicy = Extract<WatchQueryFetchPolicy, "cache-first" | "network-only" | "no-cache" | "cache-and-network">;
     // (undocumented)
-    export interface Options<TVariables extends OperationVariables = OperationVariables> {
+    export type Options<TVariables extends OperationVariables = OperationVariables> = {
         client?: ApolloClient;
-        context?: DefaultContext_2;
+        refetchWritePolicy?: RefetchWritePolicy_2;
         errorPolicy?: ErrorPolicy_2;
+        context?: DefaultContext_2;
+        returnPartialData?: boolean;
         fetchPolicy?: FetchPolicy;
         queryKey?: string | number | any[];
-        refetchWritePolicy?: RefetchWritePolicy_2;
-        returnPartialData?: boolean;
-        // @deprecated
         skip?: boolean;
-        variables?: TVariables;
-    }
+    } & VariablesOption<TVariables>;
     // (undocumented)
     export type Result<TData = unknown, TVariables extends OperationVariables = OperationVariables> = {
         subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
@@ -1181,9 +1186,7 @@ export function useLazyQuery<TData = unknown, TVariables extends OperationVariab
 // @public (undocumented)
 export namespace useLazyQuery {
     // (undocumented)
-    export type ExecFunction<TData, TVariables extends OperationVariables> = (...args: [TVariables] extends [never] ? [
-    options?: useLazyQuery.ExecOptions<TVariables>
-    ] : Record<string, never> extends OnlyRequiredProperties<TVariables> ? [
+    export type ExecFunction<TData, TVariables extends OperationVariables> = (...args: Record<string, never> extends OnlyRequiredProperties<TVariables> ? [
     options?: useLazyQuery.ExecOptions<TVariables>
     ] : [options: useLazyQuery.ExecOptions<TVariables>]) => Promise<QueryResult_3<TData>>;
     // (undocumented)
@@ -1196,7 +1199,6 @@ export namespace useLazyQuery {
         context?: DefaultContext_2;
         errorPolicy?: ErrorPolicy_2;
         fetchPolicy?: WatchQueryFetchPolicy;
-        // Warning: (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
         nextFetchPolicy?: WatchQueryFetchPolicy | ((this: WatchQueryOptions<TVariables, TData>, currentFetchPolicy: WatchQueryFetchPolicy, context: NextFetchPolicyContext<TData, TVariables>) => WatchQueryFetchPolicy);
         notifyOnNetworkStatusChange?: boolean;
         pollInterval?: number;
@@ -1205,37 +1207,38 @@ export namespace useLazyQuery {
         skipPollAttempt?: () => boolean;
     }
     // (undocumented)
-    export interface Result<TData, TVariables extends OperationVariables> {
-        called: boolean;
-        client: ApolloClient;
-        data: MaybeMasked_2<TData> | undefined;
-        error?: ErrorLike_2;
+    export type Result<TData, TVariables extends OperationVariables> = {
+        startPolling: (pollInterval: number) => void;
+        stopPolling: () => void;
+        subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
+        updateQuery: (mapFn: UpdateQueryMapFn_2<TData, TVariables>) => void;
+        refetch: (variables?: Partial<TVariables>) => Promise<QueryResult_3<MaybeMasked_2<TData>>>;
         fetchMore: <TFetchData = TData, TFetchVars extends OperationVariables = TVariables>(fetchMoreOptions: FetchMoreQueryOptions_2<TFetchVars, TFetchData> & {
             updateQuery?: (previousQueryResult: Unmasked_2<TData>, options: {
                 fetchMoreResult: Unmasked_2<TFetchData>;
                 variables: TFetchVars;
             }) => Unmasked_2<TData>;
         }) => Promise<QueryResult_3<MaybeMasked_2<TFetchData>>>;
+        client: ApolloClient;
+        observable: ObservableQuery_2<TData, TVariables>;
+        data: MaybeMasked_2<TData> | undefined;
+        previousData?: MaybeMasked_2<TData>;
+        error?: ErrorLike_2;
         loading: boolean;
         networkStatus: NetworkStatus_2;
-        observable: ObservableQuery_2<TData, TVariables>;
-        previousData?: MaybeMasked_2<TData>;
-        refetch: (variables?: Partial<TVariables>) => Promise<QueryResult_3<MaybeMasked_2<TData>>>;
-        startPolling: (pollInterval: number) => void;
-        stopPolling: () => void;
-        subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
-        updateQuery: (mapFn: UpdateQueryMapFn_2<TData, TVariables>) => void;
-        variables: TVariables | undefined;
-    }
+    } & ({
+        called: true;
+        variables: TVariables;
+    } | {
+        called: false;
+        variables: Partial<TVariables>;
+    });
     // (undocumented)
     export type ResultTuple<TData, TVariables extends OperationVariables> = [
     execute: ExecFunction<TData, TVariables>,
     result: useLazyQuery.Result<TData, TVariables>
     ];
 }
-
-// @public (undocumented)
-export function useLoadableQuery<TData, TVariables extends OperationVariables, TOptions extends useLoadableQuery.Options>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options?: useLoadableQuery.Options & TOptions): useLoadableQuery.Result<TOptions["errorPolicy"] extends "ignore" | "all" ? TOptions["returnPartialData"] extends true ? DeepPartial<TData> | undefined : TData | undefined : TOptions["returnPartialData"] extends true ? DeepPartial<TData> : TData, TVariables>;
 
 // @public (undocumented)
 export function useLoadableQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useLoadableQuery.Options & {
@@ -1261,7 +1264,9 @@ export namespace useLoadableQuery {
     // (undocumented)
     export type FetchPolicy = Extract<WatchQueryFetchPolicy, "cache-first" | "network-only" | "no-cache" | "cache-and-network">;
     // (undocumented)
-    export type LoadQueryFunction<TVariables extends OperationVariables> = (...args: [TVariables] extends [never] ? [] : {} extends OnlyRequiredProperties<TVariables> ? [variables?: TVariables] : [variables: TVariables]) => void;
+    export type LoadQueryFunction<TVariables extends OperationVariables> = (...args: Record<string, never> extends OnlyRequiredProperties<TVariables> ? [
+    variables?: TVariables
+    ] : [variables: TVariables]) => void;
     // (undocumented)
     export interface Options {
         client?: ApolloClient;
@@ -1334,27 +1339,28 @@ export namespace useMutation {
 }
 
 // @public
-export function useQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options?: useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>): useQuery.Result<TData, TVariables>;
+export function useQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: Record<string, never> extends (OnlyRequiredProperties<TVariables>) ? [
+options?: useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>
+] : [options: useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>]): useQuery.Result<TData, TVariables>;
 
 // @public (undocumented)
 export namespace useQuery {
     // (undocumented)
-    export interface Options<TData = unknown, TVariables extends OperationVariables = OperationVariables> {
-        client?: ApolloClient;
-        context?: DefaultContext_2;
-        errorPolicy?: ErrorPolicy_2;
+    export type Options<TData = unknown, TVariables extends OperationVariables = OperationVariables> = {
         fetchPolicy?: WatchQueryFetchPolicy;
-        initialFetchPolicy?: WatchQueryFetchPolicy;
         nextFetchPolicy?: WatchQueryFetchPolicy | ((this: WatchQueryOptions<TVariables, TData>, currentFetchPolicy: WatchQueryFetchPolicy, context: NextFetchPolicyContext<TData, TVariables>) => WatchQueryFetchPolicy);
-        notifyOnNetworkStatusChange?: boolean;
-        pollInterval?: number;
+        initialFetchPolicy?: WatchQueryFetchPolicy;
         refetchWritePolicy?: RefetchWritePolicy_2;
+        errorPolicy?: ErrorPolicy_2;
+        pollInterval?: number;
+        notifyOnNetworkStatusChange?: boolean;
         returnPartialData?: boolean;
-        skip?: boolean;
         skipPollAttempt?: () => boolean;
         ssr?: boolean;
-        variables?: TVariables;
-    }
+        client?: ApolloClient;
+        context?: DefaultContext_2;
+        skip?: boolean;
+    } & VariablesOption<TVariables>;
     // (undocumented)
     export interface Result<TData = unknown, TVariables extends OperationVariables = OperationVariables> {
         client: ApolloClient;
@@ -1375,7 +1381,7 @@ export namespace useQuery {
         stopPolling: () => void;
         subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
         updateQuery: (mapFn: UpdateQueryMapFn_2<TData, TVariables>) => void;
-        variables: TVariables | undefined;
+        variables: TVariables;
     }
 }
 
@@ -1423,7 +1429,9 @@ export namespace useReadQuery {
 export type UseReadQueryResult<TData = unknown> = useReadQuery.Result<TData>;
 
 // @public
-export function useSubscription<TData = unknown, TVariables extends OperationVariables = OperationVariables>(subscription: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: useSubscription.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>): useSubscription.Result<TData>;
+export function useSubscription<TData = unknown, TVariables extends OperationVariables = OperationVariables>(subscription: DocumentNode | TypedDocumentNode<TData, TVariables>, ...[options]: Record<string, never> extends OnlyRequiredProperties<TVariables> ? [
+options?: useSubscription.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>
+] : [options: useSubscription.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>]): useSubscription.Result<TData>;
 
 // @public (undocumented)
 export namespace useSubscription {
@@ -1444,20 +1452,19 @@ export namespace useSubscription {
         subscriptionData: OnDataResult<TData>;
     }
     // (undocumented)
-    export interface Options<TData = unknown, TVariables extends OperationVariables = OperationVariables> {
-        client?: ApolloClient;
-        context?: DefaultContext_2;
-        errorPolicy?: ErrorPolicy_2;
-        extensions?: Record<string, any>;
+    export type Options<TData = unknown, TVariables extends OperationVariables = OperationVariables> = {
         fetchPolicy?: FetchPolicy_2;
-        ignoreResults?: boolean;
+        errorPolicy?: ErrorPolicy_2;
+        shouldResubscribe?: boolean | ((options: Options<TData, TVariables>) => boolean);
+        client?: ApolloClient;
+        skip?: boolean;
+        context?: DefaultContext_2;
+        extensions?: Record<string, any>;
         onComplete?: () => void;
         onData?: (options: OnDataOptions<TData>) => any;
         onError?: (error: ErrorLike_2) => void;
-        shouldResubscribe?: boolean | ((options: Options<TData, TVariables>) => boolean);
-        skip?: boolean;
-        variables?: TVariables;
-    }
+        ignoreResults?: boolean;
+    } & VariablesOption<TVariables>;
     // (undocumented)
     export interface Result<TData = unknown> {
         data?: MaybeMasked<TData>;
@@ -1509,9 +1516,6 @@ export type UseSuspenseFragmentOptions<TData, TVariables extends OperationVariab
 export type UseSuspenseFragmentResult<TData> = useSuspenseFragment.Result<TData>;
 
 // @public (undocumented)
-export function useSuspenseQuery<TData, TVariables extends OperationVariables, TOptions extends Omit<useSuspenseQuery.Options, "variables">>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options?: useSuspenseQuery.Options<NoInfer_2<TVariables>> & TOptions): useSuspenseQuery.Result<TOptions["errorPolicy"] extends "ignore" | "all" ? TOptions["returnPartialData"] extends true ? DeepPartial<TData> | undefined : TData | undefined : TOptions["returnPartialData"] extends true ? TOptions["skip"] extends boolean ? DeepPartial<TData> | undefined : DeepPartial<TData> : TOptions["skip"] extends boolean ? TData | undefined : TData, TVariables>;
-
-// @public (undocumented)
 export function useSuspenseQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
     returnPartialData: true;
     errorPolicy: "ignore" | "all";
@@ -1539,33 +1543,38 @@ export function useSuspenseQuery<TData = unknown, TVariables extends OperationVa
 }): useSuspenseQuery.Result<TData | undefined, TVariables>;
 
 // @public (undocumented)
-export function useSuspenseQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options?: useSuspenseQuery.Options<NoInfer_2<TVariables>>): useSuspenseQuery.Result<TData, TVariables>;
-
-// @public (undocumented)
 export function useSuspenseQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
     returnPartialData: true;
 })): useSuspenseQuery.Result<DeepPartial<TData> | undefined, TVariables>;
 
 // @public (undocumented)
-export function useSuspenseQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options?: SkipToken | useSuspenseQuery.Options<NoInfer_2<TVariables>>): useSuspenseQuery.Result<TData | undefined, TVariables>;
+export function useSuspenseQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: Record<string, never> extends (OnlyRequiredProperties<TVariables>) ? [
+options?: useSuspenseQuery.Options<NoInfer_2<TVariables>>
+] : [options: useSuspenseQuery.Options<NoInfer_2<TVariables>>]): useSuspenseQuery.Result<TData, TVariables>;
+
+// @public (undocumented)
+export function useSuspenseQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: Record<string, never> extends (OnlyRequiredProperties<TVariables>) ? [
+options?: SkipToken | useSuspenseQuery.Options<NoInfer_2<TVariables>>
+] : [options: SkipToken | useSuspenseQuery.Options<NoInfer_2<TVariables>>]): useSuspenseQuery.Result<TData | undefined, TVariables>;
+
+// @public (undocumented)
+export function useSuspenseQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | useSuspenseQuery.Options<NoInfer_2<TVariables>>): useSuspenseQuery.Result<TData | undefined, TVariables>;
 
 // @public (undocumented)
 export namespace useSuspenseQuery {
     // (undocumented)
     export type FetchPolicy = Extract<WatchQueryFetchPolicy, "cache-first" | "network-only" | "no-cache" | "cache-and-network">;
     // (undocumented)
-    export interface Options<TVariables extends OperationVariables = OperationVariables> {
+    export type Options<TVariables extends OperationVariables = OperationVariables> = {
         client?: ApolloClient;
         context?: DefaultContext_2;
         errorPolicy?: ErrorPolicy_2;
+        returnPartialData?: boolean;
+        refetchWritePolicy?: RefetchWritePolicy_2;
         fetchPolicy?: FetchPolicy;
         queryKey?: string | number | any[];
-        refetchWritePolicy?: RefetchWritePolicy_2;
-        returnPartialData?: boolean;
-        // @deprecated
         skip?: boolean;
-        variables?: TVariables;
-    }
+    } & VariablesOption<TVariables>;
     // (undocumented)
     export interface Result<TData = unknown, TVariables extends OperationVariables = OperationVariables> {
         client: ApolloClient;
@@ -1585,34 +1594,40 @@ export type UseSuspenseQueryResult<TData = unknown, TVariables extends Operation
 type WatchQueryFetchPolicy_2 = FetchPolicy | "cache-and-network";
 
 // @public
-interface WatchQueryOptions_2<TVariables extends OperationVariables_2 = OperationVariables_2, TData = unknown> {
-    context?: DefaultContext;
-    errorPolicy?: ErrorPolicy;
+type WatchQueryOptions_2<TVariables extends OperationVariables_2 = OperationVariables_2, TData = unknown> = {
     fetchPolicy?: WatchQueryFetchPolicy_2;
-    initialFetchPolicy?: WatchQueryFetchPolicy_2;
     nextFetchPolicy?: WatchQueryFetchPolicy_2 | ((this: WatchQueryOptions_2<TVariables, TData>, currentFetchPolicy: WatchQueryFetchPolicy_2, context: NextFetchPolicyContext<TData, TVariables>) => WatchQueryFetchPolicy_2);
-    notifyOnNetworkStatusChange?: boolean;
-    pollInterval?: number;
-    query: DocumentNode | TypedDocumentNode<TData, TVariables>;
-    // Warning: (ae-forgotten-export) The symbol "RefetchWritePolicy" needs to be exported by the entry point index.d.ts
+    initialFetchPolicy?: WatchQueryFetchPolicy_2;
     refetchWritePolicy?: RefetchWritePolicy;
+    errorPolicy?: ErrorPolicy;
+    context?: DefaultContext;
+    pollInterval?: number;
+    notifyOnNetworkStatusChange?: boolean;
     returnPartialData?: boolean;
     skipPollAttempt?: () => boolean;
-    variables?: TVariables;
-}
+    query: DocumentNode | TypedDocumentNode<TData, TVariables>;
+} & VariablesOption<NoInfer_2<TVariables>>;
 
 // Warnings were encountered during analysis:
 //
 // src/core/LocalState.ts:71:3 - (ae-forgotten-export) The symbol "ApolloClient_2" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:140:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:141:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:84:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:96:5 - (ae-forgotten-export) The symbol "RefetchWritePolicy" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:190:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:191:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:184:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:454:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:204:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:233:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
-// src/core/watchQueryOptions.ts:195:3 - (ae-forgotten-export) The symbol "UpdateQueryOptions" needs to be exported by the entry point index.d.ts
-// src/react/hooks/useLoadableQuery.ts:72:7 - (ae-forgotten-export) The symbol "ResetFunction" needs to be exported by the entry point index.d.ts
-// src/react/hooks/useSuspenseFragment.ts:73:5 - (ae-forgotten-export) The symbol "From" needs to be exported by the entry point index.d.ts
+// src/core/watchQueryOptions.ts:193:3 - (ae-forgotten-export) The symbol "UpdateQueryOptions" needs to be exported by the entry point index.d.ts
+// src/core/watchQueryOptions.ts:269:3 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
+// src/core/watchQueryOptions.ts:277:3 - (ae-forgotten-export) The symbol "MutationQueryReducersMap" needs to be exported by the entry point index.d.ts
+// src/core/watchQueryOptions.ts:288:3 - (ae-forgotten-export) The symbol "MutationUpdaterFunction" needs to be exported by the entry point index.d.ts
+// src/core/watchQueryOptions.ts:291:3 - (ae-forgotten-export) The symbol "OnQueryUpdated" needs to be exported by the entry point index.d.ts
+// src/core/watchQueryOptions.ts:294:3 - (ae-forgotten-export) The symbol "ErrorPolicy" needs to be exported by the entry point index.d.ts
+// src/core/watchQueryOptions.ts:300:3 - (ae-forgotten-export) The symbol "MutationFetchPolicy" needs to be exported by the entry point index.d.ts
+// src/react/hooks/useLoadableQuery.ts:73:7 - (ae-forgotten-export) The symbol "ResetFunction" needs to be exported by the entry point index.d.ts
+// src/react/hooks/useSuspenseFragment.ts:72:5 - (ae-forgotten-export) The symbol "From" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -46,7 +46,6 @@ import type { NoInfer as NoInfer_2 } from '@apollo/client/utilities';
 import { Observable } from 'rxjs';
 import { ObservableQuery as ObservableQuery_2 } from '@apollo/client';
 import type { Observer } from 'rxjs';
-import type { OnlyRequiredProperties } from '@apollo/client/utilities';
 import type { OnQueryUpdated as OnQueryUpdated_2 } from '@apollo/client';
 import type { OperationVariables } from '@apollo/client';
 import { PreloadedQueryRef } from '@apollo/client/react/internal';
@@ -660,7 +659,7 @@ export interface PreloadQueryFunction {
     <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: PreloadQueryOptions<NoInfer_2<TVariables>> & {
         returnPartialData: true;
     }): PreloadedQueryRef<DeepPartial<TData>, TVariables>;
-    <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: Record<string, never> extends (OnlyRequiredProperties<TVariables>) ? [
+    <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
     options?: PreloadQueryOptions<NoInfer_2<TVariables>>
     ] : [options: PreloadQueryOptions<NoInfer_2<TVariables>>]): PreloadedQueryRef<TData, TVariables>;
 }
@@ -1103,12 +1102,12 @@ useBackgroundQuery.Result<TData, TVariables>
 ];
 
 // @public (undocumented)
-export function useBackgroundQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: Record<string, never> extends (OnlyRequiredProperties<TVariables>) ? [
+export function useBackgroundQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
 options?: useBackgroundQuery.Options<NoInfer_2<TVariables>>
 ] : [options: useBackgroundQuery.Options<NoInfer_2<TVariables>>]): [QueryRef<TData, TVariables>, useBackgroundQuery.Result<TData, TVariables>];
 
 // @public (undocumented)
-export function useBackgroundQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: Record<string, never> extends (OnlyRequiredProperties<TVariables>) ? [
+export function useBackgroundQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
 options?: SkipToken | useBackgroundQuery.Options<NoInfer_2<TVariables>>
 ] : [options: SkipToken | useBackgroundQuery.Options<NoInfer_2<TVariables>>]): [
 QueryRef<TData, TVariables> | undefined,
@@ -1186,7 +1185,7 @@ export function useLazyQuery<TData = unknown, TVariables extends OperationVariab
 // @public (undocumented)
 export namespace useLazyQuery {
     // (undocumented)
-    export type ExecFunction<TData, TVariables extends OperationVariables> = (...args: Record<string, never> extends OnlyRequiredProperties<TVariables> ? [
+    export type ExecFunction<TData, TVariables extends OperationVariables> = (...args: {} extends TVariables ? [
     options?: useLazyQuery.ExecOptions<TVariables>
     ] : [options: useLazyQuery.ExecOptions<TVariables>]) => Promise<QueryResult_3<TData>>;
     // (undocumented)
@@ -1264,9 +1263,7 @@ export namespace useLoadableQuery {
     // (undocumented)
     export type FetchPolicy = Extract<WatchQueryFetchPolicy, "cache-first" | "network-only" | "no-cache" | "cache-and-network">;
     // (undocumented)
-    export type LoadQueryFunction<TVariables extends OperationVariables> = (...args: Record<string, never> extends OnlyRequiredProperties<TVariables> ? [
-    variables?: TVariables
-    ] : [variables: TVariables]) => void;
+    export type LoadQueryFunction<TVariables extends OperationVariables> = (...args: {} extends TVariables ? [variables?: TVariables] : [variables: TVariables]) => void;
     // (undocumented)
     export interface Options {
         client?: ApolloClient;
@@ -1339,7 +1336,7 @@ export namespace useMutation {
 }
 
 // @public
-export function useQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: Record<string, never> extends (OnlyRequiredProperties<TVariables>) ? [
+export function useQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
 options?: useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>
 ] : [options: useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>]): useQuery.Result<TData, TVariables>;
 
@@ -1429,7 +1426,7 @@ export namespace useReadQuery {
 export type UseReadQueryResult<TData = unknown> = useReadQuery.Result<TData>;
 
 // @public
-export function useSubscription<TData = unknown, TVariables extends OperationVariables = OperationVariables>(subscription: DocumentNode | TypedDocumentNode<TData, TVariables>, ...[options]: Record<string, never> extends OnlyRequiredProperties<TVariables> ? [
+export function useSubscription<TData = unknown, TVariables extends OperationVariables = OperationVariables>(subscription: DocumentNode | TypedDocumentNode<TData, TVariables>, ...[options]: {} extends (TVariables) ? [
 options?: useSubscription.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>
 ] : [options: useSubscription.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>]): useSubscription.Result<TData>;
 
@@ -1548,12 +1545,12 @@ export function useSuspenseQuery<TData = unknown, TVariables extends OperationVa
 })): useSuspenseQuery.Result<DeepPartial<TData> | undefined, TVariables>;
 
 // @public (undocumented)
-export function useSuspenseQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: Record<string, never> extends (OnlyRequiredProperties<TVariables>) ? [
+export function useSuspenseQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
 options?: useSuspenseQuery.Options<NoInfer_2<TVariables>>
 ] : [options: useSuspenseQuery.Options<NoInfer_2<TVariables>>]): useSuspenseQuery.Result<TData, TVariables>;
 
 // @public (undocumented)
-export function useSuspenseQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: Record<string, never> extends (OnlyRequiredProperties<TVariables>) ? [
+export function useSuspenseQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
 options?: SkipToken | useSuspenseQuery.Options<NoInfer_2<TVariables>>
 ] : [options: SkipToken | useSuspenseQuery.Options<NoInfer_2<TVariables>>]): useSuspenseQuery.Result<TData | undefined, TVariables>;
 
@@ -1615,8 +1612,8 @@ type WatchQueryOptions_2<TVariables extends OperationVariables_2 = OperationVari
 // src/core/ObservableQuery.ts:96:5 - (ae-forgotten-export) The symbol "RefetchWritePolicy" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:190:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:191:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:184:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:454:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:186:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:456:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:204:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:233:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:193:3 - (ae-forgotten-export) The symbol "UpdateQueryOptions" needs to be exported by the entry point index.d.ts
@@ -1626,7 +1623,7 @@ type WatchQueryOptions_2<TVariables extends OperationVariables_2 = OperationVari
 // src/core/watchQueryOptions.ts:291:3 - (ae-forgotten-export) The symbol "OnQueryUpdated" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:294:3 - (ae-forgotten-export) The symbol "ErrorPolicy" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:300:3 - (ae-forgotten-export) The symbol "MutationFetchPolicy" needs to be exported by the entry point index.d.ts
-// src/react/hooks/useLoadableQuery.ts:73:7 - (ae-forgotten-export) The symbol "ResetFunction" needs to be exported by the entry point index.d.ts
+// src/react/hooks/useLoadableQuery.ts:69:7 - (ae-forgotten-export) The symbol "ResetFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useSuspenseFragment.ts:72:5 - (ae-forgotten-export) The symbol "From" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-react_internal.api.md
+++ b/.api-reports/api-report-react_internal.api.md
@@ -13,7 +13,6 @@ import type { MaybeMasked } from '@apollo/client/masking';
 import type { MaybeMasked as MaybeMasked_2 } from '@apollo/client';
 import type { Observable } from 'rxjs';
 import type { ObservableQuery } from '@apollo/client';
-import type { OnlyRequiredProperties } from '@apollo/client/utilities';
 import type { OperationVariables } from '@apollo/client';
 import type { PromiseWithState } from '@apollo/client/utilities';
 import type { QueryResult } from '@apollo/client';
@@ -163,7 +162,7 @@ export class InternalQueryReference<TData = unknown> {
     // (undocumented)
     softRetain(): () => void;
     // (undocumented)
-    get watchQueryOptions(): WatchQueryOptions<OperationVariables, TData>;
+    get watchQueryOptions(): ObservableQuery.Options<TData, OperationVariables>;
 }
 
 // @public (undocumented)
@@ -258,17 +257,6 @@ export function unwrapQueryRef<TData>(queryRef: Partial<WrappedQueryRef<TData>>)
 
 // @public (undocumented)
 export function updateWrappedQueryRef<TData>(queryRef: WrappedQueryRef<TData>, promise: QueryRefPromise<TData>): void;
-
-// @public (undocumented)
-export type VariablesOption<TVariables extends OperationVariables> = [
-TVariables
-] extends [never] ? {
-    variables?: Record<string, never>;
-} : Record<string, never> extends OnlyRequiredProperties<TVariables> ? {
-    variables?: TVariables;
-} : {
-    variables: TVariables;
-};
 
 // @public (undocumented)
 interface WrappableHooks {

--- a/.api-reports/api-report-utilities.api.md
+++ b/.api-reports/api-report-utilities.api.md
@@ -426,11 +426,6 @@ export function offsetLimitPagination<T = Reference_2>(keyArgs?: KeyArgs): Field
 // @public (undocumented)
 export function omitDeep<T, K extends string>(value: T, key: K): DeepOmit<T, K>;
 
-// @public
-export type OnlyRequiredProperties<T> = {
-    [K in keyof T as {} extends Pick<T, K> ? never : K]: T[K];
-};
-
 // @public (undocumented)
 type OptionsUnion<TData, TVariables extends OperationVariables, TContext> = WatchQueryOptions<TVariables, TData> | QueryOptions<TVariables, TData> | MutationOptions<TData, TVariables, TContext, any>;
 
@@ -608,7 +603,7 @@ type UnionToIntersection_2<U> = (U extends any ? (k: U) => void : never) extends
 export function valueToObjectRepresentation(argObj: any, name: NameNode, value: ValueNode, variables?: Object): void;
 
 // @public (undocumented)
-export type VariablesOption<TVariables extends OperationVariables> = Record<string, never> extends OnlyRequiredProperties<TVariables> ? {
+export type VariablesOption<TVariables extends OperationVariables> = {} extends TVariables ? {
     variables?: TVariables;
 } : {
     variables: TVariables;

--- a/.api-reports/api-report-utilities.api.md
+++ b/.api-reports/api-report-utilities.api.md
@@ -608,6 +608,13 @@ type UnionToIntersection_2<U> = (U extends any ? (k: U) => void : never) extends
 export function valueToObjectRepresentation(argObj: any, name: NameNode, value: ValueNode, variables?: Object): void;
 
 // @public (undocumented)
+export type VariablesOption<TVariables extends OperationVariables> = Record<string, never> extends OnlyRequiredProperties<TVariables> ? {
+    variables?: TVariables;
+} : {
+    variables: TVariables;
+};
+
+// @public (undocumented)
 export type VariableValue = (node: VariableNode) => any;
 
 // @public (undocumented)

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -813,7 +813,8 @@ export interface FetchMoreQueryOptions<TVariables, TData = unknown> {
     // (undocumented)
     context?: DefaultContext;
     query?: DocumentNode | TypedDocumentNode<TData, TVariables>;
-    variables?: Partial<TVariables>;
+    // Warning: (ae-forgotten-export) The symbol "NoInfer_2" needs to be exported by the entry point index.d.ts
+    variables?: Partial<NoInfer_2<TVariables>>;
 }
 
 // @public
@@ -1477,25 +1478,24 @@ export interface MutateResult<TData = unknown> {
 // @public (undocumented)
 export type MutationFetchPolicy = Extract<FetchPolicy, "network-only" | "no-cache">;
 
+// Warning: (ae-forgotten-export) The symbol "VariablesOption" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
-export interface MutationOptions<TData = unknown, TVariables = OperationVariables, TContext = DefaultContext, TCache extends ApolloCache = ApolloCache> {
-    awaitRefetchQueries?: boolean;
-    context?: TContext;
-    errorPolicy?: ErrorPolicy;
-    fetchPolicy?: MutationFetchPolicy;
-    keepRootFields?: boolean;
-    mutation: DocumentNode | TypedDocumentNode<TData, TVariables>;
-    onQueryUpdated?: OnQueryUpdated<any>;
-    // Warning: (ae-forgotten-export) The symbol "NoInfer_2" needs to be exported by the entry point index.d.ts
-    // Warning: (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
+export type MutationOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, TContext = DefaultContext, TCache extends ApolloCache = ApolloCache> = {
     optimisticResponse?: Unmasked<NoInfer_2<TData>> | ((vars: TVariables, { IGNORE }: {
         IGNORE: IgnoreModifier;
     }) => Unmasked<NoInfer_2<TData>> | IgnoreModifier);
-    refetchQueries?: ((result: FetchResult<Unmasked<TData>>) => InternalRefetchQueriesInclude) | InternalRefetchQueriesInclude;
-    update?: MutationUpdaterFunction<TData, TVariables, TContext, TCache>;
     updateQueries?: MutationQueryReducersMap<TData>;
-    variables?: TVariables;
-}
+    refetchQueries?: ((result: FetchResult<Unmasked<TData>>) => InternalRefetchQueriesInclude) | InternalRefetchQueriesInclude;
+    awaitRefetchQueries?: boolean;
+    update?: MutationUpdaterFunction<TData, TVariables, TContext, TCache>;
+    onQueryUpdated?: OnQueryUpdated<any>;
+    errorPolicy?: ErrorPolicy;
+    context?: TContext;
+    fetchPolicy?: MutationFetchPolicy;
+    keepRootFields?: boolean;
+    mutation: DocumentNode | TypedDocumentNode<TData, TVariables>;
+} & VariablesOption<NoInfer_2<TVariables>>;
 
 // @public (undocumented)
 export type MutationQueryReducer<T> = (previousResult: Record<string, any>, options: {
@@ -1617,6 +1617,25 @@ interface ObservableAndInfo<TData> {
 }
 
 // @public (undocumented)
+export namespace ObservableQuery {
+    // (undocumented)
+    export type Options<TData = unknown, TVariables extends OperationVariables = OperationVariables> = {
+        fetchPolicy: WatchQueryFetchPolicy;
+        nextFetchPolicy?: WatchQueryFetchPolicy | ((this: WatchQueryOptions<TVariables, TData>, currentFetchPolicy: WatchQueryFetchPolicy, context: NextFetchPolicyContext<TData, TVariables>) => WatchQueryFetchPolicy);
+        initialFetchPolicy: WatchQueryFetchPolicy;
+        refetchWritePolicy?: RefetchWritePolicy;
+        errorPolicy?: ErrorPolicy;
+        context?: DefaultContext;
+        pollInterval?: number;
+        notifyOnNetworkStatusChange?: boolean;
+        returnPartialData?: boolean;
+        skipPollAttempt?: () => boolean;
+        query: DocumentNode | TypedDocumentNode<TData, TVariables>;
+        variables: TVariables;
+    };
+}
+
+// @public (undocumented)
 export class ObservableQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables> implements Subscribable<ApolloQueryResult<MaybeMasked<TData>>>, InteropObservable<ApolloQueryResult<MaybeMasked<TData>>> {
     // (undocumented)
     ["@@observable"]: () => Subscribable<ApolloQueryResult<MaybeMasked<TData>>>;
@@ -1646,7 +1665,7 @@ export class ObservableQuery<TData = unknown, TVariables extends OperationVariab
     // @internal (undocumented)
     protected notify(): void;
     // (undocumented)
-    readonly options: WatchQueryOptions<TVariables, TData>;
+    readonly options: ObservableQuery.Options<TData, TVariables>;
     // (undocumented)
     pipe: Observable<ApolloQueryResult<MaybeMasked<TData>>>["pipe"];
     // (undocumented)
@@ -1656,7 +1675,7 @@ export class ObservableQuery<TData = unknown, TVariables extends OperationVariab
     // (undocumented)
     readonly queryName?: string;
     refetch(variables?: Partial<TVariables>): Promise<QueryResult<TData>>;
-    reobserve(newOptions?: Partial<WatchQueryOptions<TVariables, TData>>): Promise<QueryResult<MaybeMasked<TData>>>;
+    reobserve(newOptions?: Partial<ObservableQuery.Options<TData, TVariables>>): Promise<QueryResult<MaybeMasked<TData>>>;
     // @internal (undocumented)
     resetDiff(): void;
     // (undocumented)
@@ -1667,15 +1686,20 @@ export class ObservableQuery<TData = unknown, TVariables extends OperationVariab
     protected scheduleNotify(): void;
     setVariables(variables: TVariables): Promise<QueryResult<TData>>;
     // @internal (undocumented)
-    silentSetOptions(newOptions: Partial<WatchQueryOptions<TVariables, TData>>): void;
+    silentSetOptions(newOptions: Partial<ObservableQuery.Options<TData, TVariables>>): void;
     startPolling(pollInterval: number): void;
     stopPolling(): void;
     // (undocumented)
     subscribe: (observer: Partial<Observer<ApolloQueryResult<MaybeMasked<TData>>>> | ((value: ApolloQueryResult<MaybeMasked<TData>>) => void)) => Subscription;
     subscribeToMore<TSubscriptionData = TData, TSubscriptionVariables extends OperationVariables = TVariables>(options: SubscribeToMoreOptions<TData, TSubscriptionVariables, TSubscriptionData, TVariables>): () => void;
     updateQuery(mapFn: UpdateQueryMapFn<TData, TVariables>): void;
-    get variables(): TVariables | undefined;
+    get variables(): TVariables;
 }
+
+// @public
+type OnlyRequiredProperties<T> = {
+    [K in keyof T as {} extends Pick<T, K> ? never : K]: T[K];
+};
 
 // @public (undocumented)
 export type OnQueryUpdated<TResult> = (observableQuery: ObservableQuery<any>, diff: Cache_2.DiffResult<any>, lastDiff: Cache_2.DiffResult<any> | undefined) => boolean | TResult;
@@ -1874,6 +1898,8 @@ class QueryManager {
     // (undocumented)
     getOrCreateQuery(queryId: string): QueryInfo;
     // (undocumented)
+    getVariables<TVariables>(document: DocumentNode, variables?: TVariables): TVariables;
+    // (undocumented)
     protected inFlightLinkObservables: Trie<{
         observable?: Observable<FetchResult<any>>;
     }>;
@@ -1973,16 +1999,15 @@ interface QueryManagerOptions {
 }
 
 // @public
-interface QueryOptions<TVariables = OperationVariables, TData = unknown> {
-    context?: DefaultContext;
-    errorPolicy?: ErrorPolicy;
-    fetchPolicy?: FetchPolicy;
-    notifyOnNetworkStatusChange?: boolean;
-    pollInterval?: number;
+type QueryOptions<TVariables extends OperationVariables = OperationVariables, TData = unknown> = {
     query: DocumentNode | TypedDocumentNode<TData, TVariables>;
+    errorPolicy?: ErrorPolicy;
+    context?: DefaultContext;
+    fetchPolicy?: FetchPolicy;
+    pollInterval?: number;
+    notifyOnNetworkStatusChange?: boolean;
     returnPartialData?: boolean;
-    variables?: TVariables;
-}
+} & VariablesOption<NoInfer_2<TVariables>>;
 export { QueryOptions as PureQueryOptions }
 export { QueryOptions }
 
@@ -2272,14 +2297,13 @@ export type SubscribeToMoreUpdateQueryFn<TData = unknown, TVariables extends Ope
 };
 
 // @public (undocumented)
-export interface SubscriptionOptions<TVariables = OperationVariables, TData = unknown> {
-    context?: DefaultContext;
-    errorPolicy?: ErrorPolicy;
-    extensions?: Record<string, any>;
-    fetchPolicy?: FetchPolicy;
+export type SubscriptionOptions<TVariables extends OperationVariables = OperationVariables, TData = unknown> = {
     query: DocumentNode | TypedDocumentNode<TData, TVariables>;
-    variables?: TVariables;
-}
+    fetchPolicy?: FetchPolicy;
+    errorPolicy?: ErrorPolicy;
+    context?: DefaultContext;
+    extensions?: Record<string, any>;
+} & VariablesOption<NoInfer_2<TVariables>>;
 
 // Warning: (ae-forgotten-export) The symbol "unionToIntersection" needs to be exported by the entry point index.d.ts
 //
@@ -2389,6 +2413,15 @@ export interface UriFunction {
     (operation: Operation): string;
 }
 
+// Warning: (ae-forgotten-export) The symbol "OnlyRequiredProperties" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+type VariablesOption<TVariables extends OperationVariables> = Record<string, never> extends OnlyRequiredProperties<TVariables> ? {
+    variables?: TVariables;
+} : {
+    variables: TVariables;
+};
+
 // Warning: (ae-forgotten-export) The symbol "verbosityLevels" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
@@ -2424,21 +2457,19 @@ export type WatchFragmentResult<TData> = {
 export type WatchQueryFetchPolicy = FetchPolicy | "cache-and-network";
 
 // @public
-export interface WatchQueryOptions<TVariables extends OperationVariables = OperationVariables, TData = unknown> {
-    context?: DefaultContext;
-    errorPolicy?: ErrorPolicy;
+export type WatchQueryOptions<TVariables extends OperationVariables = OperationVariables, TData = unknown> = {
     fetchPolicy?: WatchQueryFetchPolicy;
-    initialFetchPolicy?: WatchQueryFetchPolicy;
-    // Warning: (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
     nextFetchPolicy?: WatchQueryFetchPolicy | ((this: WatchQueryOptions<TVariables, TData>, currentFetchPolicy: WatchQueryFetchPolicy, context: NextFetchPolicyContext<TData, TVariables>) => WatchQueryFetchPolicy);
-    notifyOnNetworkStatusChange?: boolean;
-    pollInterval?: number;
-    query: DocumentNode | TypedDocumentNode<TData, TVariables>;
+    initialFetchPolicy?: WatchQueryFetchPolicy;
     refetchWritePolicy?: RefetchWritePolicy;
+    errorPolicy?: ErrorPolicy;
+    context?: DefaultContext;
+    pollInterval?: number;
+    notifyOnNetworkStatusChange?: boolean;
     returnPartialData?: boolean;
     skipPollAttempt?: () => boolean;
-    variables?: TVariables;
-}
+    query: DocumentNode | TypedDocumentNode<TData, TVariables>;
+} & VariablesOption<NoInfer_2<TVariables>>;
 
 // @public (undocumented)
 interface WriteContext extends ReadMergeModifyContext {
@@ -2479,10 +2510,12 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/cache/inmemory/policies.ts:166:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/policies.ts:166:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/types.ts:133:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:140:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:141:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:84:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:190:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:191:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:184:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:454:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
+// src/core/watchQueryOptions.ts:269:3 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
 // src/link/http/selectHttpOptionsAndBody.ts:128:1 - (ae-forgotten-export) The symbol "HttpQueryOptions" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -1725,11 +1725,6 @@ export class ObservableQuery<TData = unknown, TVariables extends OperationVariab
     get variables(): TVariables;
 }
 
-// @public
-type OnlyRequiredProperties<T> = {
-    [K in keyof T as {} extends Pick<T, K> ? never : K]: T[K];
-};
-
 // @public (undocumented)
 export type OnQueryUpdated<TResult> = (observableQuery: ObservableQuery<any>, diff: Cache_2.DiffResult<any>, lastDiff: Cache_2.DiffResult<any> | undefined) => boolean | TResult;
 
@@ -2445,10 +2440,8 @@ export interface UriFunction {
     (operation: Operation): string;
 }
 
-// Warning: (ae-forgotten-export) The symbol "OnlyRequiredProperties" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
-type VariablesOption<TVariables extends OperationVariables> = Record<string, never> extends OnlyRequiredProperties<TVariables> ? {
+type VariablesOption<TVariables extends OperationVariables> = {} extends TVariables ? {
     variables?: TVariables;
 } : {
     variables: TVariables;
@@ -2545,8 +2538,8 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/core/ObservableQuery.ts:84:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:190:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:191:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:184:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:454:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:186:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:456:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:269:3 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
 // src/link/http/selectHttpOptionsAndBody.ts:128:1 - (ae-forgotten-export) The symbol "HttpQueryOptions" needs to be exported by the entry point index.d.ts
 

--- a/.changeset/funny-terms-deny.md
+++ b/.changeset/funny-terms-deny.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": major
+---
+
+`ObservableQuery.variables` can now be reset back to empty when calling `reobserve` with `variables: undefined`. Previously the `variables` key would be ignored so `variables` would remain unchanged.

--- a/.changeset/gentle-badgers-train.md
+++ b/.changeset/gentle-badgers-train.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": major
+---
+
+`never` is no longer supported as a valid `TVariables` generic argument for APIs that require `variables` as part of its type. Use `Record<string, never>` instead.

--- a/.changeset/great-roses-jog.md
+++ b/.changeset/great-roses-jog.md
@@ -2,4 +2,14 @@
 "@apollo/client": patch
 ---
 
-`client.watchQuery` now enforces a `variables` option if `TVariables` contains required variables. `ObservableQuery.variables` has been updated to return `TVariables` rather than `TVariables | undefined`. If there are no variables or a query contains all optional variables, `{}` will be returned when no `variables` have been defined.
+The `variables` option used with various APIs are now enforced more consistently across the client when `TVariables` contains required variables. If required `variables` are not provided, TypeScript will now complain that it requires a `variables` option.
+
+This change affects the following APIs:
+- `client.query`
+- `client.mutate`
+- `client.subscribe`
+- `client.watchQuery`
+- `useBackgroundQuery`
+- `useQuery`
+- `useSubscription`
+- `useSuspenseQuery`

--- a/.changeset/great-roses-jog.md
+++ b/.changeset/great-roses-jog.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+`client.watchQuery` now enforces a `variables` option if `TVariables` contains required variables. `ObservableQuery.variables` has been updated to return `TVariables` rather than `TVariables | undefined`. If there are no variables or a query contains all optional variables, `{}` will be returned when no `variables` have been defined.

--- a/.changeset/hungry-bikes-cough.md
+++ b/.changeset/hungry-bikes-cough.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix type of `variables` returned from `useLazyQuery`. When `called` is `false`, `variables` is now `Partial<TVariables>` instead of `TVariables`.

--- a/.changeset/itchy-chefs-run.md
+++ b/.changeset/itchy-chefs-run.md
@@ -1,0 +1,23 @@
+---
+"@apollo/client": major
+---
+
+When passing a `variables` key with the value `undefined`, the value will be replaced by the default value in the query, if it is provided, rather than leave it as `undefined`.
+
+```ts
+// given this query
+const query = gql`
+  query PaginatedQuery($limit: Int! = 10, $offset: Int) {
+    list(limit: $limit, offset: $offset) {
+      id
+    }
+  }
+`
+
+const observable = client.query({ query, variables: { limit: 5, offset: 0 }});
+console.log(observable.variables) // => { limit: 5, offset: 0 }
+
+observable.reobserve({ variables: { limit: undefined, offset: 10 }})
+// limit is now `10`. This would previously be `undefined`
+console.log(observable.variables) // => { limit: 10, offset: 10 }
+```

--- a/.changeset/tidy-pandas-punch.md
+++ b/.changeset/tidy-pandas-punch.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+`ObservableQuery.variables` has been updated to return `TVariables` rather than `TVariables | undefined`. This is more consistent with the runtime value where an empty object (`{}`) will be returned when the `variables` option is not provided.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 42984,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38432,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 32968,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27861
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43143,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38553,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33085,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27953
 }

--- a/src/__tests__/dataMasking.ts
+++ b/src/__tests__/dataMasking.ts
@@ -3845,7 +3845,7 @@ describe("client.query", () => {
       } & { " $fragmentRefs"?: { UserFieldsFragment: UserFieldsFragment } };
     }
 
-    const query: MaskedDocumentNode<Query, never> = gql`
+    const query: MaskedDocumentNode<Query, Record<string, never>> = gql`
       query MaskedQuery {
         currentUser {
           id
@@ -3905,7 +3905,7 @@ describe("client.query", () => {
       } & { " $fragmentRefs"?: { UserFieldsFragment: UserFieldsFragment } };
     }
 
-    const query: TypedDocumentNode<Query, never> = gql`
+    const query: TypedDocumentNode<Query, Record<string, never>> = gql`
       query MaskedQuery {
         currentUser {
           id
@@ -3966,7 +3966,7 @@ describe("client.query", () => {
       } & { " $fragmentRefs"?: { UserFieldsFragment: UserFieldsFragment } };
     }
 
-    const query: TypedDocumentNode<Query, never> = gql`
+    const query: TypedDocumentNode<Query, Record<string, never>> = gql`
       query MaskedQuery {
         currentUser {
           id
@@ -4166,7 +4166,7 @@ describe("client.query", () => {
       } & { " $fragmentRefs"?: { UserFieldsFragment: UserFieldsFragment } };
     }
 
-    const query: MaskedDocumentNode<Query, never> = gql`
+    const query: MaskedDocumentNode<Query, Record<string, never>> = gql`
       query MaskedQuery {
         currentUser {
           id
@@ -4230,7 +4230,7 @@ describe("client.query", () => {
       } & { " $fragmentRefs"?: { UserFieldsFragment: UserFieldsFragment } };
     }
 
-    const query: MaskedDocumentNode<Query, never> = gql`
+    const query: MaskedDocumentNode<Query, Record<string, never>> = gql`
       query MaskedQuery {
         currentUser {
           id
@@ -4294,7 +4294,7 @@ describe("client.query", () => {
       } & { " $fragmentRefs"?: { UserFieldsFragment: UserFieldsFragment } };
     }
 
-    const query: MaskedDocumentNode<Query, never> = gql`
+    const query: MaskedDocumentNode<Query, Record<string, never>> = gql`
       query MaskedQuery {
         currentUser {
           id
@@ -4358,7 +4358,7 @@ describe("client.query", () => {
       } & { " $fragmentRefs"?: { UserFieldsFragment: UserFieldsFragment } };
     }
 
-    const query: MaskedDocumentNode<Query, never> = gql`
+    const query: MaskedDocumentNode<Query, Record<string, never>> = gql`
       query MaskedQuery {
         currentUser {
           id

--- a/src/__tests__/dataMasking.ts
+++ b/src/__tests__/dataMasking.ts
@@ -5440,7 +5440,7 @@ describe("client.mutate", () => {
       };
     }
 
-    const mutation: MaskedDocumentNode<Mutation, never> = gql`
+    const mutation: MaskedDocumentNode<Mutation, Record<string, never>> = gql`
       mutation MaskedMutation {
         updateUser {
           id
@@ -5502,7 +5502,7 @@ describe("client.mutate", () => {
       };
     }
 
-    const mutation: TypedDocumentNode<Mutation, never> = gql`
+    const mutation: TypedDocumentNode<Mutation, Record<string, never>> = gql`
       mutation MaskedMutation {
         updateUser {
           id
@@ -5565,7 +5565,7 @@ describe("client.mutate", () => {
       };
     }
 
-    const mutation: TypedDocumentNode<Mutation, never> = gql`
+    const mutation: TypedDocumentNode<Mutation, Record<string, never>> = gql`
       mutation MaskedMutation {
         updateUser {
           id
@@ -5627,7 +5627,7 @@ describe("client.mutate", () => {
       };
     }
 
-    const mutation: MaskedDocumentNode<Mutation, never> = gql`
+    const mutation: MaskedDocumentNode<Mutation, Record<string, never>> = gql`
       mutation MaskedMutation {
         updateUser {
           id
@@ -5699,7 +5699,7 @@ describe("client.mutate", () => {
       };
     }
 
-    const mutation: MaskedDocumentNode<Mutation, never> = gql`
+    const mutation: MaskedDocumentNode<Mutation, Record<string, never>> = gql`
       mutation MaskedMutation {
         updateUser {
           id
@@ -5752,7 +5752,7 @@ describe("client.mutate", () => {
         | null;
     }
 
-    const mutation: MaskedDocumentNode<Mutation, never> = gql`
+    const mutation: MaskedDocumentNode<Mutation, Record<string, never>> = gql`
       mutation MaskedMutation {
         updateUser {
           id
@@ -5811,7 +5811,7 @@ describe("client.mutate", () => {
       };
     }
 
-    const mutation: MaskedDocumentNode<Mutation, never> = gql`
+    const mutation: MaskedDocumentNode<Mutation, Record<string, never>> = gql`
       mutation MaskedMutation {
         updateUser {
           id
@@ -5891,7 +5891,7 @@ describe("client.mutate", () => {
       };
     }
 
-    const mutation: MaskedDocumentNode<Mutation, never> = gql`
+    const mutation: MaskedDocumentNode<Mutation, Record<string, never>> = gql`
       mutation MaskedMutation {
         updateUser {
           id
@@ -5960,7 +5960,7 @@ describe("client.mutate", () => {
       };
     }
 
-    const mutation: MaskedDocumentNode<Mutation, never> = gql`
+    const mutation: MaskedDocumentNode<Mutation, Record<string, never>> = gql`
       mutation MaskedMutation {
         updateUser {
           id
@@ -6026,7 +6026,7 @@ describe("client.mutate", () => {
       };
     }
 
-    const mutation: MaskedDocumentNode<Mutation, never> = gql`
+    const mutation: MaskedDocumentNode<Mutation, Record<string, never>> = gql`
       mutation MaskedMutation {
         updateUser {
           id
@@ -6097,7 +6097,7 @@ describe("client.mutate", () => {
       };
     }
 
-    const mutation: MaskedDocumentNode<Mutation, never> = gql`
+    const mutation: MaskedDocumentNode<Mutation, Record<string, never>> = gql`
       mutation MaskedMutation {
         updateUser {
           id

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -443,7 +443,12 @@ export class ApolloClient implements DataProxy {
     options: WatchQueryOptions<TVariables, TData>
   ): ObservableQuery<TData, TVariables> {
     if (this.defaultOptions.watchQuery) {
-      options = mergeOptions(this.defaultOptions.watchQuery, options as any);
+      options = mergeOptions(
+        this.defaultOptions.watchQuery as Partial<
+          WatchQueryOptions<TVariables, TData>
+        >,
+        options
+      );
     }
 
     return this.queryManager.watchQuery<TData, TVariables>(options);

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -147,7 +147,7 @@ export class ObservableQuery<
   // untransformed query to ensure document transforms with runtime conditionals
   // are run on the original document.
   public get query(): TypedDocumentNode<TData, TVariables> {
-    return this.lastQuery || this.options.query;
+    return this.lastQuery;
   }
 
   /**
@@ -168,7 +168,7 @@ export class ObservableQuery<
 
   private waitForOwnResult: boolean;
   private last?: Last<TData, TVariables>;
-  private lastQuery?: DocumentNode;
+  private lastQuery: DocumentNode;
 
   private queryInfo: QueryInfo;
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1114,12 +1114,13 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
 
     this.lastQuery = query;
 
-    // Allow variables to get reevaluated when passing variables: undefined,
-    // otherwise `compact` will ignore the `variables` key. We do this after we
-    // run the query transform to ensure we get default variables from the
-    // transformed query. Note: setting this on options.variables may mutate
-    // this.options.variables in the case of a non-disposable query. This is
-    // intentional.
+    // Reevaluate variables to allow resetting variables with variables: undefined,
+    // otherwise `compact` will ignore the `variables` key in `newOptions`. We
+    // do this after we run the query transform to ensure we get default
+    // variables from the transformed query.
+    //
+    // Note: updating options.variables may mutate this.options.variables
+    // in the case of a non-disposable query. This is intentional.
     options.variables =
       newOptions && "variables" in newOptions ?
         this.getVariablesWithDefaults(newOptions.variables)

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -150,8 +150,6 @@ export class ObservableQuery<
     return this.lastQuery || this.options.query;
   }
 
-  // Computed shorthand for this.options.variables, preserved for
-  // backwards compatibility.
   /**
    * An object containing the variables that were provided for the query.
    */

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1181,7 +1181,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
       }
     };
 
-    const variables = options.variables && { ...options.variables };
+    const variables = { ...options.variables };
     const { notifyOnNetworkStatusChange = true } = options;
     const { observable, fromLink } = this.fetch(
       options,

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1246,7 +1246,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
 
   private reportResult(
     result: ApolloQueryResult<TData>,
-    variables: TVariables | undefined
+    variables: TVariables
   ) {
     const lastError = this.getLastError();
     const isDifferent = this.isDifferentFromLastResult(result, variables);
@@ -1261,7 +1261,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     }
   }
 
-  private reportError(error: Error, variables: TVariables | undefined) {
+  private reportError(error: Error, variables: TVariables) {
     // Since we don't get the current result on errors, only the error, we
     // must mirror the updates that occur in QueryStore.markQueryError here
     const errorResult: ApolloQueryResult<TData> = {

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -813,7 +813,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
 
   /** @internal */
   public silentSetOptions(
-    newOptions: Partial<WatchQueryOptions<TVariables, TData>>
+    newOptions: Partial<ObservableQuery.Options<TData, TVariables>>
   ) {
     const mergedOptions = compact(this.options, newOptions || {});
     assign(this.options, mergedOptions);

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1121,10 +1121,9 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     //
     // Note: updating options.variables may mutate this.options.variables
     // in the case of a non-disposable query. This is intentional.
-    options.variables =
-      newOptions && "variables" in newOptions ?
-        this.getVariablesWithDefaults(newOptions.variables)
-      : options.variables;
+    if (newOptions && "variables" in newOptions) {
+      options.variables = this.getVariablesWithDefaults(newOptions.variables);
+    }
 
     if (!useDisposableObservable) {
       // We can skip calling updatePolling if we're not changing this.options.

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1068,7 +1068,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
    * merged with the current options when given.
    */
   public reobserve(
-    newOptions?: Partial<WatchQueryOptions<TVariables, TData>>
+    newOptions?: Partial<ObservableQuery.Options<TData, TVariables>>
   ): Promise<QueryResult<MaybeMasked<TData>>> {
     this.isTornDown = false;
     let newNetworkStatus: NetworkStatus | undefined;

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -566,13 +566,10 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
       }
     }
 
-    if (variables && !equal(this.options.variables, variables)) {
+    if (variables && !equal(this.variables, variables)) {
       // Update the existing options with new variables
       reobserveOptions.variables = this.options.variables =
-        this.getVariablesWithDefaults({
-          ...this.options.variables,
-          ...variables,
-        });
+        this.getVariablesWithDefaults({ ...this.variables, ...variables });
     }
 
     this.queryInfo.resetLastWrite();

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -601,7 +601,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
           query: this.options.query,
           ...fetchMoreOptions,
           variables: {
-            ...this.options.variables,
+            ...this.variables,
             ...fetchMoreOptions.variables,
           },
         }
@@ -1092,7 +1092,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
       newNetworkStatus === NetworkStatus.poll;
 
     // Save the old variables, since Object.assign may modify them below.
-    const oldVariables = this.options.variables;
+    const oldVariables = this.variables;
     const oldFetchPolicy = this.options.fetchPolicy;
 
     const mergedOptions = compact(this.options, newOptions || {});

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -955,7 +955,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
   }
 
   private fetch(
-    options: WatchQueryOptions<TVariables, TData>,
+    options: ObservableQuery.Options<TData, TVariables>,
     newNetworkStatus: NetworkStatus,
     emitLoadingState: boolean,
     query?: DocumentNode

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -940,12 +940,11 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
         // that end, the options.nextFetchPolicy option provides an easy way to
         // update options.fetchPolicy after the initial network request, without
         // having to call observableQuery.reobserve.
-        options.fetchPolicy = (options as any).nextFetchPolicy(fetchPolicy, {
-          reason,
-          options,
-          observable: this,
-          initialFetchPolicy,
-        });
+        options.fetchPolicy = options.nextFetchPolicy.call(
+          options as any,
+          fetchPolicy,
+          { reason, options, observable: this, initialFetchPolicy }
+        );
       } else if (reason === "variables-changed") {
         options.fetchPolicy = initialFetchPolicy;
       } else {

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -536,7 +536,9 @@ export class ObservableQuery<
    * the previous values of those variables will be used.
    */
   public refetch(variables?: Partial<TVariables>): Promise<QueryResult<TData>> {
-    const reobserveOptions: Partial<WatchQueryOptions> = {
+    const reobserveOptions: Partial<
+      ObservableQuery.Options<TData, TVariables>
+    > = {
       // Always disable polling for refetches.
       pollInterval: 0,
     };
@@ -574,7 +576,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     return this.reobserve({
       ...reobserveOptions,
       [newNetworkStatusSymbol]: NetworkStatus.refetch,
-    } as WatchQueryOptions<TVariables, TData>);
+    });
   }
 
   /**
@@ -859,7 +861,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
       fetchPolicy: this.options.initialFetchPolicy,
       variables,
       [newNetworkStatusSymbol]: NetworkStatus.setVariables,
-    } as Partial<WatchQueryOptions<TVariables, TData>>);
+    });
   }
 
   /**
@@ -1018,7 +1020,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
                 "no-cache"
               : "network-only",
             [newNetworkStatusSymbol]: NetworkStatus.poll,
-          } as Partial<WatchQueryOptions<TVariables, TData>>).then(poll, poll);
+          }).then(poll, poll);
         } else {
           poll();
         }
@@ -1409,7 +1411,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
           // Otherwise go back to the original this.options.fetchPolicy.
           return fetchPolicy!;
         },
-      } as WatchQueryOptions<TVariables, TData>);
+      });
     }
 
     return this.reobserve();

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1765,7 +1765,7 @@ export class QueryManager {
     const resultsFromLink = () =>
       this.getResultsFromLink<TData>(queryInfo, cacheWriteBehavior, {
         query,
-        variables: variables as any,
+        variables: variables as TVars,
         context,
         fetchPolicy,
         errorPolicy,

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -7817,6 +7817,28 @@ describe.skip("type tests", () => {
     client.watchQuery({ query, variables: {} });
     client.watchQuery({ query, variables: { foo: "bar" } });
     client.watchQuery({ query, variables: { bar: "baz" } });
+
+    client.query({ query });
+    client.query({ query, variables: {} });
+    client.query({ query, variables: { foo: "bar" } });
+    client.query({ query, variables: { bar: "baz" } });
+  });
+
+  test("variables are optional and can be anything with unspecified TVariables on a TypedDocumentNode", () => {
+    const query: TypedDocumentNode<{ greeting: string }> = gql``;
+    const client = new ApolloClient({ cache: new InMemoryCache() });
+
+    client.watchQuery({ query });
+    client.watchQuery({ query, variables: {} });
+    client.watchQuery({ query, variables: undefined });
+    client.watchQuery({ query, variables: { foo: "bar" } });
+    client.watchQuery({ query, variables: { bar: "baz" } });
+
+    client.query({ query });
+    client.query({ query, variables: {} });
+    client.query({ query, variables: undefined });
+    client.query({ query, variables: { foo: "bar" } });
+    client.query({ query, variables: { bar: "baz" } });
   });
 
   test("variables are optional when TVariables are empty", () => {
@@ -7828,10 +7850,24 @@ describe.skip("type tests", () => {
 
     client.watchQuery({ query });
     client.watchQuery({ query, variables: {} });
+    client.watchQuery({ query, variables: undefined });
     client.watchQuery({
       query,
-      // @ts-expect-error unknown variables
-      variables: { bar: "baz" },
+      variables: {
+        // @ts-expect-error unknown variables
+        bar: "baz",
+      },
+    });
+
+    client.query({ query });
+    client.query({ query, variables: {} });
+    client.query({ query, variables: undefined });
+    client.query({
+      query,
+      variables: {
+        // @ts-expect-error unknown variables
+        bar: "baz",
+      },
     });
   });
 
@@ -7856,6 +7892,24 @@ describe.skip("type tests", () => {
       // @ts-expect-error unknown variables
       variables: { foo: "bar" },
     });
+
+    // @ts-expect-error
+    client.query({ query });
+    client.query({
+      query,
+      // @ts-expect-error
+      variables: {},
+    });
+    client.query({
+      query,
+      // @ts-expect-error
+      variables: undefined,
+    });
+    client.query({
+      query,
+      // @ts-expect-error unknown variables
+      variables: { foo: "bar" },
+    });
   });
 
   test("optional variables are optional", () => {
@@ -7865,6 +7919,7 @@ describe.skip("type tests", () => {
 
     client.watchQuery({ query });
     client.watchQuery({ query, variables: {} });
+    client.watchQuery({ query, variables: undefined });
     client.watchQuery({ query, variables: { limit: 10 } });
     client.watchQuery({
       query,
@@ -7881,6 +7936,26 @@ describe.skip("type tests", () => {
         foo: "bar",
       },
     });
+
+    client.query({ query });
+    client.query({ query, variables: {} });
+    client.query({ query, variables: undefined });
+    client.query({ query, variables: { limit: 10 } });
+    client.query({
+      query,
+      variables: {
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
+    client.query({
+      query,
+      variables: {
+        limit: 10,
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
   });
 
   test("enforced required variables when TVariables includes required variables", () => {
@@ -7890,8 +7965,16 @@ describe.skip("type tests", () => {
 
     // @ts-expect-error empty variables
     client.watchQuery({ query });
-    // @ts-expect-error empty variables
-    client.watchQuery({ query, variables: {} });
+    client.watchQuery({
+      query,
+      // @ts-expect-error empty variables
+      variables: {},
+    });
+    client.watchQuery({
+      query,
+      // @ts-expect-error empty variables
+      variables: undefined,
+    });
     client.watchQuery({ query, variables: { id: "1" } });
     client.watchQuery({
       query,
@@ -7901,6 +7984,35 @@ describe.skip("type tests", () => {
       },
     });
     client.watchQuery({
+      query,
+      variables: {
+        id: "1",
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
+
+    // @ts-expect-error empty variables
+    client.query({ query });
+    client.query({
+      query,
+      // @ts-expect-error empty variables
+      variables: {},
+    });
+    client.query({
+      query,
+      // @ts-expect-error empty variables
+      variables: undefined,
+    });
+    client.query({ query, variables: { id: "1" } });
+    client.query({
+      query,
+      variables: {
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
+    client.query({
       query,
       variables: {
         id: "1",
@@ -7919,8 +8031,16 @@ describe.skip("type tests", () => {
 
     // @ts-expect-error empty variables
     client.watchQuery({ query });
-    // @ts-expect-error empty variables
-    client.watchQuery({ query, variables: {} });
+    client.watchQuery({
+      query,
+      // @ts-expect-error empty variables
+      variables: {},
+    });
+    client.watchQuery({
+      query,
+      // @ts-expect-error empty variables
+      variables: undefined,
+    });
     client.watchQuery({ query, variables: { id: "1" } });
     client.watchQuery({
       query,
@@ -7937,6 +8057,43 @@ describe.skip("type tests", () => {
       },
     });
     client.watchQuery({
+      query,
+      variables: {
+        id: "1",
+        language: "en",
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
+
+    // @ts-expect-error empty variables
+    client.query({ query });
+    client.query({
+      query,
+      // @ts-expect-error empty variables
+      variables: {},
+    });
+    client.query({
+      query,
+      // @ts-expect-error empty variables
+      variables: undefined,
+    });
+    client.query({ query, variables: { id: "1" } });
+    client.query({
+      query,
+      // @ts-expect-error missing required variables
+      variables: { language: "en" },
+    });
+    client.query({ query, variables: { id: "1", language: "en" } });
+    client.query({
+      query,
+      variables: {
+        id: "1",
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
+    client.query({
       query,
       variables: {
         id: "1",

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -7824,6 +7824,11 @@ describe.skip("type tests", () => {
     client.query({ query, variables: { foo: "bar" } });
     client.query({ query, variables: { bar: "baz" } });
 
+    client.subscribe({ query });
+    client.subscribe({ query, variables: {} });
+    client.subscribe({ query, variables: { foo: "bar" } });
+    client.subscribe({ query, variables: { bar: "baz" } });
+
     client.mutate({ mutation });
     client.mutate({ mutation, variables: {} });
     client.mutate({ mutation, variables: { foo: "bar" } });
@@ -7846,6 +7851,12 @@ describe.skip("type tests", () => {
     client.query({ query, variables: undefined });
     client.query({ query, variables: { foo: "bar" } });
     client.query({ query, variables: { bar: "baz" } });
+
+    client.subscribe({ query });
+    client.subscribe({ query, variables: {} });
+    client.subscribe({ query, variables: undefined });
+    client.subscribe({ query, variables: { foo: "bar" } });
+    client.subscribe({ query, variables: { bar: "baz" } });
 
     client.mutate({ mutation });
     client.mutate({ mutation, variables: {} });
@@ -7880,6 +7891,17 @@ describe.skip("type tests", () => {
     client.query({ query, variables: {} });
     client.query({ query, variables: undefined });
     client.query({
+      query,
+      variables: {
+        // @ts-expect-error unknown variables
+        bar: "baz",
+      },
+    });
+
+    client.subscribe({ query });
+    client.subscribe({ query, variables: {} });
+    client.subscribe({ query, variables: undefined });
+    client.subscribe({
       query,
       variables: {
         // @ts-expect-error unknown variables
@@ -7935,6 +7957,24 @@ describe.skip("type tests", () => {
       variables: undefined,
     });
     client.query({
+      query,
+      // @ts-expect-error unknown variables
+      variables: { foo: "bar" },
+    });
+
+    // @ts-expect-error
+    client.subscribe({ query });
+    client.subscribe({
+      query,
+      // @ts-expect-error
+      variables: {},
+    });
+    client.subscribe({
+      query,
+      // @ts-expect-error
+      variables: undefined,
+    });
+    client.subscribe({
       query,
       // @ts-expect-error unknown variables
       variables: { foo: "bar" },
@@ -7998,6 +8038,26 @@ describe.skip("type tests", () => {
       },
     });
     client.query({
+      query,
+      variables: {
+        limit: 10,
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
+
+    client.subscribe({ query });
+    client.subscribe({ query, variables: {} });
+    client.subscribe({ query, variables: undefined });
+    client.subscribe({ query, variables: { limit: 10 } });
+    client.subscribe({
+      query,
+      variables: {
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
+    client.subscribe({
       query,
       variables: {
         limit: 10,
@@ -8084,6 +8144,35 @@ describe.skip("type tests", () => {
       },
     });
     client.query({
+      query,
+      variables: {
+        id: "1",
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
+
+    // @ts-expect-error empty variables
+    client.subscribe({ query });
+    client.subscribe({
+      query,
+      // @ts-expect-error empty variables
+      variables: {},
+    });
+    client.subscribe({
+      query,
+      // @ts-expect-error empty variables
+      variables: undefined,
+    });
+    client.subscribe({ query, variables: { id: "1" } });
+    client.subscribe({
+      query,
+      variables: {
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
+    client.subscribe({
       query,
       variables: {
         id: "1",
@@ -8198,6 +8287,43 @@ describe.skip("type tests", () => {
       },
     });
     client.query({
+      query,
+      variables: {
+        id: "1",
+        language: "en",
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
+
+    // @ts-expect-error empty variables
+    client.subscribe({ query });
+    client.subscribe({
+      query,
+      // @ts-expect-error empty variables
+      variables: {},
+    });
+    client.subscribe({
+      query,
+      // @ts-expect-error empty variables
+      variables: undefined,
+    });
+    client.subscribe({ query, variables: { id: "1" } });
+    client.subscribe({
+      query,
+      // @ts-expect-error missing required variables
+      variables: { language: "en" },
+    });
+    client.subscribe({ query, variables: { id: "1", language: "en" } });
+    client.subscribe({
+      query,
+      variables: {
+        id: "1",
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
+    client.subscribe({
       query,
       variables: {
         id: "1",

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -7811,6 +7811,7 @@ describe("ApolloClient", () => {
 describe.skip("type tests", () => {
   test("variables are optional and can be anything with an DocumentNode", () => {
     const query = gql``;
+    const mutation = gql``;
     const client = new ApolloClient({ cache: new InMemoryCache() });
 
     client.watchQuery({ query });
@@ -7822,10 +7823,16 @@ describe.skip("type tests", () => {
     client.query({ query, variables: {} });
     client.query({ query, variables: { foo: "bar" } });
     client.query({ query, variables: { bar: "baz" } });
+
+    client.mutate({ mutation });
+    client.mutate({ mutation, variables: {} });
+    client.mutate({ mutation, variables: { foo: "bar" } });
+    client.mutate({ mutation, variables: { bar: "baz" } });
   });
 
   test("variables are optional and can be anything with unspecified TVariables on a TypedDocumentNode", () => {
     const query: TypedDocumentNode<{ greeting: string }> = gql``;
+    const mutation: TypedDocumentNode<{ greeting: string }> = gql``;
     const client = new ApolloClient({ cache: new InMemoryCache() });
 
     client.watchQuery({ query });
@@ -7839,10 +7846,20 @@ describe.skip("type tests", () => {
     client.query({ query, variables: undefined });
     client.query({ query, variables: { foo: "bar" } });
     client.query({ query, variables: { bar: "baz" } });
+
+    client.mutate({ mutation });
+    client.mutate({ mutation, variables: {} });
+    client.mutate({ mutation, variables: undefined });
+    client.mutate({ mutation, variables: { foo: "bar" } });
+    client.mutate({ mutation, variables: { bar: "baz" } });
   });
 
   test("variables are optional when TVariables are empty", () => {
     const query: TypedDocumentNode<
+      { greeting: string },
+      Record<string, never>
+    > = gql``;
+    const mutation: TypedDocumentNode<
       { greeting: string },
       Record<string, never>
     > = gql``;
@@ -7869,10 +7886,22 @@ describe.skip("type tests", () => {
         bar: "baz",
       },
     });
+
+    client.mutate({ mutation });
+    client.mutate({ mutation, variables: {} });
+    client.mutate({ mutation, variables: undefined });
+    client.mutate({
+      mutation,
+      variables: {
+        // @ts-expect-error unknown variables
+        bar: "baz",
+      },
+    });
   });
 
   test("is invalid when TVariables is never", () => {
     const query: TypedDocumentNode<{ greeting: string }, never> = gql``;
+    const mutation: TypedDocumentNode<{ greeting: string }, never> = gql``;
     const client = new ApolloClient({ cache: new InMemoryCache() });
 
     // @ts-expect-error
@@ -7910,10 +7939,30 @@ describe.skip("type tests", () => {
       // @ts-expect-error unknown variables
       variables: { foo: "bar" },
     });
+
+    // @ts-expect-error
+    client.mutate({ mutation });
+    client.mutate({
+      mutation,
+      // @ts-expect-error
+      variables: {},
+    });
+    client.mutate({
+      mutation,
+      // @ts-expect-error
+      variables: undefined,
+    });
+    client.mutate({
+      mutation,
+      // @ts-expect-error unknown variables
+      variables: { foo: "bar" },
+    });
   });
 
   test("optional variables are optional", () => {
     const query: TypedDocumentNode<{ posts: string[] }, { limit?: number }> =
+      gql``;
+    const mutation: TypedDocumentNode<{ posts: string[] }, { limit?: number }> =
       gql``;
     const client = new ApolloClient({ cache: new InMemoryCache() });
 
@@ -7956,10 +8005,32 @@ describe.skip("type tests", () => {
         foo: "bar",
       },
     });
+
+    client.mutate({ mutation });
+    client.mutate({ mutation, variables: {} });
+    client.mutate({ mutation, variables: undefined });
+    client.mutate({ mutation, variables: { limit: 10 } });
+    client.mutate({
+      mutation,
+      variables: {
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
+    client.mutate({
+      mutation,
+      variables: {
+        limit: 10,
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
   });
 
   test("enforced required variables when TVariables includes required variables", () => {
     const query: TypedDocumentNode<{ character: string }, { id: string }> =
+      gql``;
+    const mutation: TypedDocumentNode<{ character: string }, { id: string }> =
       gql``;
     const client = new ApolloClient({ cache: new InMemoryCache() });
 
@@ -8020,10 +8091,43 @@ describe.skip("type tests", () => {
         foo: "bar",
       },
     });
+
+    // @ts-expect-error empty variables
+    client.mutate({ mutation });
+    client.mutate({
+      mutation,
+      // @ts-expect-error empty variables
+      variables: {},
+    });
+    client.mutate({
+      mutation,
+      // @ts-expect-error empty variables
+      variables: undefined,
+    });
+    client.mutate({ mutation, variables: { id: "1" } });
+    client.mutate({
+      mutation,
+      variables: {
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
+    client.mutate({
+      mutation,
+      variables: {
+        id: "1",
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
   });
 
   test("requires variables with mixed TVariables", () => {
     const query: TypedDocumentNode<
+      { character: string },
+      { id: string; language?: string }
+    > = gql``;
+    const mutation: TypedDocumentNode<
       { character: string },
       { id: string; language?: string }
     > = gql``;
@@ -8095,6 +8199,43 @@ describe.skip("type tests", () => {
     });
     client.query({
       query,
+      variables: {
+        id: "1",
+        language: "en",
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
+
+    // @ts-expect-error empty variables
+    client.mutate({ mutation });
+    client.mutate({
+      mutation,
+      // @ts-expect-error empty variables
+      variables: {},
+    });
+    client.mutate({
+      mutation,
+      // @ts-expect-error empty variables
+      variables: undefined,
+    });
+    client.mutate({ mutation, variables: { id: "1" } });
+    client.mutate({
+      mutation,
+      // @ts-expect-error missing required variables
+      variables: { language: "en" },
+    });
+    client.mutate({ mutation, variables: { id: "1", language: "en" } });
+    client.mutate({
+      mutation,
+      variables: {
+        id: "1",
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
+    client.mutate({
+      mutation,
       variables: {
         id: "1",
         language: "en",

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -1428,7 +1428,7 @@ describe("ApolloClient", () => {
       notifyOnNetworkStatusChange: false,
     });
     const stream = new ObservableStream(observable);
-    const originalOptions = { ...observable.options };
+    const originalOptions = { ...observable.options } as Record<string, any>;
 
     await expect(stream).toEmitTypedValue({
       data: data1,
@@ -1446,7 +1446,7 @@ describe("ApolloClient", () => {
       partial: false,
     });
 
-    const updatedOptions = { ...observable.options };
+    const updatedOptions = { ...observable.options } as Record<string, any>;
     delete originalOptions.variables;
     delete updatedOptions.variables;
     expect(updatedOptions).toEqual(originalOptions);

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -2352,7 +2352,10 @@ describe("ObservableQuery", () => {
       it("should warn if passed { variables } and query does not declare $variables", async () => {
         using _ = spyOnConsole("warn");
 
-        const queryWithVarsVar = gql`
+        const queryWithVarsVar: TypedDocumentNode<
+          { getVars: Array<{ __typename: "Var"; name: string }> },
+          { vars: string[] }
+        > = gql`
           query QueryWithVarsVar($vars: [String!]) {
             getVars(variables: $vars) {
               __typename
@@ -2419,6 +2422,7 @@ describe("ObservableQuery", () => {
         // It's a common mistake to call refetch({ variables }) when you meant
         // to call refetch(variables).
         const promise = observableWithVarsVar.refetch({
+          // @ts-expect-error
           variables: { vars: ["d", "e"] },
         });
 
@@ -2476,7 +2480,10 @@ describe("ObservableQuery", () => {
       it("should not warn if passed { variables } and query declares $variables", async () => {
         using _ = spyOnConsole("warn");
 
-        const queryWithVariablesVar = gql`
+        const queryWithVariablesVar: TypedDocumentNode<
+          { getVars: Array<{ __typename: "Var"; name: string }> },
+          { variables: string[] }
+        > = gql`
           query QueryWithVariablesVar($variables: [String!]) {
             getVars(variables: $variables) {
               __typename

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -5226,7 +5226,7 @@ test("emits loading state when calling reobserve with new fetch policy after cha
 });
 
 describe(".variables", () => {
-  test("returns undefined when no variables are passed", () => {
+  test("returns empty object when no variables are passed", () => {
     const query: TypedDocumentNode<
       { greeting: string },
       Record<string, never>

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -239,15 +239,12 @@ export interface SubscribeToMoreFunction<
   ): () => void;
 }
 
-export interface SubscriptionOptions<
-  TVariables = OperationVariables,
+export type SubscriptionOptions<
+  TVariables extends OperationVariables = OperationVariables,
   TData = unknown,
-> {
+> = {
   /** {@inheritDoc @apollo/client!SubscriptionOptionsDocumentation#query:member} */
   query: DocumentNode | TypedDocumentNode<TData, TVariables>;
-
-  /** {@inheritDoc @apollo/client!SubscriptionOptionsDocumentation#variables:member} */
-  variables?: TVariables;
 
   /** {@inheritDoc @apollo/client!SubscriptionOptionsDocumentation#fetchPolicy:member} */
   fetchPolicy?: FetchPolicy;
@@ -260,7 +257,7 @@ export interface SubscriptionOptions<
 
   /** {@inheritDoc @apollo/client!SubscriptionOptionsDocumentation#extensions:member} */
   extensions?: Record<string, any>;
-}
+} & VariablesOption<NoInfer<TVariables>>;
 
 export type MutationOptions<
   TData = unknown,

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -262,12 +262,12 @@ export interface SubscriptionOptions<
   extensions?: Record<string, any>;
 }
 
-export interface MutationOptions<
+export type MutationOptions<
   TData = unknown,
-  TVariables = OperationVariables,
+  TVariables extends OperationVariables = OperationVariables,
   TContext = DefaultContext,
   TCache extends ApolloCache = ApolloCache,
-> {
+> = {
   /** {@inheritDoc @apollo/client!MutationOptionsDocumentation#optimisticResponse:member} */
   optimisticResponse?:
     | Unmasked<NoInfer<TData>>
@@ -296,9 +296,6 @@ export interface MutationOptions<
   /** {@inheritDoc @apollo/client!MutationOptionsDocumentation#errorPolicy:member} */
   errorPolicy?: ErrorPolicy;
 
-  /** {@inheritDoc @apollo/client!MutationOptionsDocumentation#variables:member} */
-  variables?: TVariables;
-
   /** {@inheritDoc @apollo/client!MutationOptionsDocumentation#context:member} */
   context?: TContext;
 
@@ -310,4 +307,4 @@ export interface MutationOptions<
 
   /** {@inheritDoc @apollo/client!MutationOptionsDocumentation#mutation:member} */
   mutation: DocumentNode | TypedDocumentNode<TData, TVariables>;
-}
+} & VariablesOption<NoInfer<TVariables>>;

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -59,15 +59,12 @@ export type ErrorPolicy = "none" | "ignore" | "all";
 /**
  * Query options.
  */
-export interface QueryOptions<
-  TVariables = OperationVariables,
+export type QueryOptions<
+  TVariables extends OperationVariables = OperationVariables,
   TData = unknown,
-> {
+> = {
   /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#query:member} */
   query: DocumentNode | TypedDocumentNode<TData, TVariables>;
-
-  /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#variables:member} */
-  variables?: TVariables;
 
   /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#errorPolicy:member} */
   errorPolicy?: ErrorPolicy;
@@ -86,7 +83,7 @@ export interface QueryOptions<
 
   /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#returnPartialData:member} */
   returnPartialData?: boolean;
-}
+} & VariablesOption<NoInfer<TVariables>>;
 
 /**
  * Watched query options.

--- a/src/react/hooks/__tests__/useBackgroundQuery.test.tsx
+++ b/src/react/hooks/__tests__/useBackgroundQuery.test.tsx
@@ -2790,7 +2790,17 @@ it("applies changed `refetchWritePolicy` to next fetch when changing between ren
 });
 
 it("applies `returnPartialData` on next fetch when it changes between renders", async () => {
-  const { query } = setupVariablesCase();
+  const query: TypedDocumentNode<
+    VariablesCaseData,
+    Record<string, never>
+  > = gql`
+    query CharacterQuery($id: ID!) {
+      character(id: $id) {
+        id
+        name
+      }
+    }
+  `;
 
   interface PartialData {
     character: {
@@ -3930,7 +3940,7 @@ it("masks queries when dataMasking is `true`", async () => {
     } & { " $fragmentRefs"?: { UserFieldsFragment: UserFieldsFragment } };
   }
 
-  const query: MaskedDocumentNode<Query, never> = gql`
+  const query: MaskedDocumentNode<Query, Record<string, never>> = gql`
     query MaskedQuery {
       currentUser {
         id
@@ -4019,7 +4029,7 @@ it("does not mask query when dataMasking is `false`", async () => {
     } & { " $fragmentRefs"?: { UserFieldsFragment: UserFieldsFragment } };
   }
 
-  const query: TypedDocumentNode<Query, never> = gql`
+  const query: TypedDocumentNode<Query, Record<string, never>> = gql`
     query MaskedQuery {
       currentUser {
         id
@@ -4105,7 +4115,7 @@ it("does not mask query by default", async () => {
     } & { " $fragmentRefs"?: { UserFieldsFragment: UserFieldsFragment } };
   }
 
-  const query: TypedDocumentNode<Query, never> = gql`
+  const query: TypedDocumentNode<Query, Record<string, never>> = gql`
     query MaskedQuery {
       currentUser {
         id
@@ -4190,7 +4200,7 @@ it("masks queries updated by the cache", async () => {
     } & { " $fragmentRefs"?: { UserFieldsFragment: UserFieldsFragment } };
   }
 
-  const query: MaskedDocumentNode<Query, never> = gql`
+  const query: MaskedDocumentNode<Query, Record<string, never>> = gql`
     query MaskedQuery {
       currentUser {
         id
@@ -4307,7 +4317,7 @@ it("does not rerender when updating field in named fragment", async () => {
     } & { " $fragmentRefs"?: { UserFieldsFragment: UserFieldsFragment } };
   }
 
-  const query: MaskedDocumentNode<Query, never> = gql`
+  const query: MaskedDocumentNode<Query, Record<string, never>> = gql`
     query MaskedQuery {
       currentUser {
         id
@@ -4421,7 +4431,7 @@ it("masks result from cache when using with cache-first fetch policy", async () 
     } & { " $fragmentRefs"?: { UserFieldsFragment: UserFieldsFragment } };
   }
 
-  const query: MaskedDocumentNode<Query, never> = gql`
+  const query: MaskedDocumentNode<Query, Record<string, never>> = gql`
     query MaskedQuery {
       currentUser {
         id
@@ -4517,7 +4527,7 @@ it("masks cache and network result when using cache-and-network fetch policy", a
     } & { " $fragmentRefs"?: { UserFieldsFragment: UserFieldsFragment } };
   }
 
-  const query: MaskedDocumentNode<Query, never> = gql`
+  const query: MaskedDocumentNode<Query, Record<string, never>> = gql`
     query MaskedQuery {
       currentUser {
         id
@@ -4633,7 +4643,7 @@ it("masks partial cache data when returnPartialData is `true`", async () => {
     } & { " $fragmentRefs"?: { UserFieldsFragment: UserFieldsFragment } };
   }
 
-  const query: MaskedDocumentNode<Query, never> = gql`
+  const query: MaskedDocumentNode<Query, Record<string, never>> = gql`
     query MaskedQuery {
       currentUser {
         id
@@ -4748,7 +4758,7 @@ it("masks partial data returned from data on errors with errorPolicy `all`", asy
     } & { " $fragmentRefs"?: { UserFieldsFragment: UserFieldsFragment } };
   }
 
-  const query: MaskedDocumentNode<Query, never> = gql`
+  const query: MaskedDocumentNode<Query, Record<string, never>> = gql`
     query MaskedQuery {
       currentUser {
         id
@@ -7012,7 +7022,7 @@ describe.skip("type tests", () => {
     const { query } = setupVariablesCase();
 
     {
-      const [queryRef] = useBackgroundQuery(query);
+      const [queryRef] = useBackgroundQuery(query, { variables: { id: "1" } });
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<VariablesCaseData>();
@@ -7022,7 +7032,7 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery<
         VariablesCaseData,
         VariablesCaseVariables
-      >(query);
+      >(query, { variables: { id: "1" } });
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<VariablesCaseData>();
@@ -7031,7 +7041,9 @@ describe.skip("type tests", () => {
     const { query: maskedQuery } = setupMaskedVariablesCase();
 
     {
-      const [queryRef] = useBackgroundQuery(maskedQuery);
+      const [queryRef] = useBackgroundQuery(maskedQuery, {
+        variables: { id: "1" },
+      });
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<Masked<MaskedVariablesCaseData>>();
@@ -7041,7 +7053,7 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery<
         MaskedVariablesCaseData,
         VariablesCaseVariables
-      >(maskedQuery);
+      >(maskedQuery, { variables: { id: "1" } });
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<MaskedVariablesCaseData>();
@@ -7051,7 +7063,7 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery<
         Masked<MaskedVariablesCaseData>,
         VariablesCaseVariables
-      >(maskedQuery);
+      >(maskedQuery, { variables: { id: "1" } });
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<Masked<MaskedVariablesCaseData>>();
@@ -7062,7 +7074,10 @@ describe.skip("type tests", () => {
     const { query } = setupVariablesCase();
 
     {
-      const [queryRef] = useBackgroundQuery(query, { errorPolicy: "ignore" });
+      const [queryRef] = useBackgroundQuery(query, {
+        errorPolicy: "ignore",
+        variables: { id: "1" },
+      });
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<VariablesCaseData | undefined>();
@@ -7072,7 +7087,7 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery<
         VariablesCaseData,
         VariablesCaseVariables
-      >(query, { errorPolicy: "ignore" });
+      >(query, { errorPolicy: "ignore", variables: { id: "1" } });
 
       const { data } = useReadQuery(queryRef);
 
@@ -7082,7 +7097,9 @@ describe.skip("type tests", () => {
     const { query: maskedQuery } = setupMaskedVariablesCase();
 
     {
-      const [queryRef] = useBackgroundQuery(maskedQuery);
+      const [queryRef] = useBackgroundQuery(maskedQuery, {
+        variables: { id: "1" },
+      });
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<Masked<MaskedVariablesCaseData>>();
@@ -7092,7 +7109,7 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery<
         MaskedVariablesCaseData,
         VariablesCaseVariables
-      >(maskedQuery);
+      >(maskedQuery, { variables: { id: "1" } });
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<MaskedVariablesCaseData>();
@@ -7102,7 +7119,7 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery<
         Masked<MaskedVariablesCaseData>,
         VariablesCaseVariables
-      >(maskedQuery);
+      >(maskedQuery, { variables: { id: "1" } });
       const { data: data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<Masked<MaskedVariablesCaseData>>();
@@ -7113,14 +7130,20 @@ describe.skip("type tests", () => {
     const { query } = setupVariablesCase();
 
     {
-      const [queryRef] = useBackgroundQuery(query, { errorPolicy: "all" });
+      const [queryRef] = useBackgroundQuery(query, {
+        errorPolicy: "all",
+        variables: { id: "1" },
+      });
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<VariablesCaseData | undefined>();
     }
 
     {
-      const [queryRef] = useBackgroundQuery(query, { errorPolicy: "all" });
+      const [queryRef] = useBackgroundQuery(query, {
+        errorPolicy: "all",
+        variables: { id: "1" },
+      });
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<VariablesCaseData | undefined>();
@@ -7131,6 +7154,7 @@ describe.skip("type tests", () => {
     {
       const [queryRef] = useBackgroundQuery(maskedQuery, {
         errorPolicy: "all",
+        variables: { id: "1" },
       });
       const { data } = useReadQuery(queryRef);
 
@@ -7143,7 +7167,7 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery<
         MaskedVariablesCaseData,
         VariablesCaseVariables
-      >(maskedQuery, { errorPolicy: "all" });
+      >(maskedQuery, { errorPolicy: "all", variables: { id: "1" } });
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<MaskedVariablesCaseData | undefined>();
@@ -7153,7 +7177,7 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery<
         Masked<MaskedVariablesCaseData>,
         VariablesCaseVariables
-      >(maskedQuery, { errorPolicy: "all" });
+      >(maskedQuery, { errorPolicy: "all", variables: { id: "1" } });
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<
@@ -7166,14 +7190,20 @@ describe.skip("type tests", () => {
     const { query } = setupVariablesCase();
 
     {
-      const [queryRef] = useBackgroundQuery(query, { errorPolicy: "none" });
+      const [queryRef] = useBackgroundQuery(query, {
+        errorPolicy: "none",
+        variables: { id: "1" },
+      });
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<VariablesCaseData>();
     }
 
     {
-      const [queryRef] = useBackgroundQuery(query, { errorPolicy: "none" });
+      const [queryRef] = useBackgroundQuery(query, {
+        errorPolicy: "none",
+        variables: { id: "1" },
+      });
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<VariablesCaseData>();
@@ -7184,6 +7214,7 @@ describe.skip("type tests", () => {
     {
       const [queryRef] = useBackgroundQuery(maskedQuery, {
         errorPolicy: "none",
+        variables: { id: "1" },
       });
       const { data } = useReadQuery(queryRef);
 
@@ -7194,7 +7225,7 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery<
         MaskedVariablesCaseData,
         VariablesCaseVariables
-      >(maskedQuery, { errorPolicy: "none" });
+      >(maskedQuery, { errorPolicy: "none", variables: { id: "1" } });
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<MaskedVariablesCaseData>();
@@ -7204,7 +7235,7 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery<
         Masked<MaskedVariablesCaseData>,
         VariablesCaseVariables
-      >(maskedQuery, { errorPolicy: "none" });
+      >(maskedQuery, { errorPolicy: "none", variables: { id: "1" } });
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<Masked<MaskedVariablesCaseData>>();
@@ -7215,7 +7246,10 @@ describe.skip("type tests", () => {
     const { query } = setupVariablesCase();
 
     {
-      const [queryRef] = useBackgroundQuery(query, { returnPartialData: true });
+      const [queryRef] = useBackgroundQuery(query, {
+        returnPartialData: true,
+        variables: { id: "1" },
+      });
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<DeepPartial<VariablesCaseData>>();
@@ -7225,7 +7259,7 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery<
         VariablesCaseData,
         VariablesCaseVariables
-      >(query, { returnPartialData: true });
+      >(query, { returnPartialData: true, variables: { id: "1" } });
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<DeepPartial<VariablesCaseData>>();
@@ -7236,6 +7270,7 @@ describe.skip("type tests", () => {
     {
       const [queryRef] = useBackgroundQuery(maskedQuery, {
         returnPartialData: true,
+        variables: { id: "1" },
       });
       const { data } = useReadQuery(queryRef);
 
@@ -7248,7 +7283,7 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery<
         MaskedVariablesCaseData,
         VariablesCaseVariables
-      >(maskedQuery, { returnPartialData: true });
+      >(maskedQuery, { returnPartialData: true, variables: { id: "1" } });
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<DeepPartial<MaskedVariablesCaseData>>();
@@ -7258,7 +7293,7 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery<
         Masked<MaskedVariablesCaseData>,
         VariablesCaseVariables
-      >(maskedQuery, { returnPartialData: true });
+      >(maskedQuery, { returnPartialData: true, variables: { id: "1" } });
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<
@@ -7273,6 +7308,7 @@ describe.skip("type tests", () => {
     {
       const [queryRef] = useBackgroundQuery(query, {
         returnPartialData: false,
+        variables: { id: "1" },
       });
       const { data } = useReadQuery(queryRef);
 
@@ -7283,7 +7319,7 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery<
         VariablesCaseData,
         VariablesCaseVariables
-      >(query, { returnPartialData: false });
+      >(query, { returnPartialData: false, variables: { id: "1" } });
 
       const { data } = useReadQuery(queryRef);
 
@@ -7295,6 +7331,7 @@ describe.skip("type tests", () => {
     {
       const [queryRef] = useBackgroundQuery(maskedQuery, {
         returnPartialData: false,
+        variables: { id: "1" },
       });
       const { data } = useReadQuery(queryRef);
 
@@ -7305,7 +7342,7 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery<
         MaskedVariablesCaseData,
         VariablesCaseVariables
-      >(maskedQuery, { returnPartialData: false });
+      >(maskedQuery, { returnPartialData: false, variables: { id: "1" } });
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<MaskedVariablesCaseData>();
@@ -7315,7 +7352,7 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery<
         Masked<MaskedVariablesCaseData>,
         VariablesCaseVariables
-      >(maskedQuery, { returnPartialData: false });
+      >(maskedQuery, { returnPartialData: false, variables: { id: "1" } });
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<Masked<MaskedVariablesCaseData>>();
@@ -7326,7 +7363,10 @@ describe.skip("type tests", () => {
     const { query } = setupVariablesCase();
 
     {
-      const [queryRef] = useBackgroundQuery(query, { fetchPolicy: "no-cache" });
+      const [queryRef] = useBackgroundQuery(query, {
+        fetchPolicy: "no-cache",
+        variables: { id: "1" },
+      });
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<VariablesCaseData>();
@@ -7336,7 +7376,7 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery<
         VariablesCaseData,
         VariablesCaseVariables
-      >(query, { fetchPolicy: "no-cache" });
+      >(query, { fetchPolicy: "no-cache", variables: { id: "1" } });
 
       const { data } = useReadQuery(queryRef);
 
@@ -7348,6 +7388,7 @@ describe.skip("type tests", () => {
     {
       const [queryRef] = useBackgroundQuery(maskedQuery, {
         fetchPolicy: "no-cache",
+        variables: { id: "1" },
       });
       const { data } = useReadQuery(queryRef);
 
@@ -7358,7 +7399,7 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery<
         MaskedVariablesCaseData,
         VariablesCaseVariables
-      >(maskedQuery, { fetchPolicy: "no-cache" });
+      >(maskedQuery, { fetchPolicy: "no-cache", variables: { id: "1" } });
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<MaskedVariablesCaseData>();
@@ -7368,7 +7409,7 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery<
         Masked<MaskedVariablesCaseData>,
         VariablesCaseVariables
-      >(maskedQuery, { fetchPolicy: "no-cache" });
+      >(maskedQuery, { fetchPolicy: "no-cache", variables: { id: "1" } });
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<Masked<MaskedVariablesCaseData>>();
@@ -7383,6 +7424,7 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery(query, {
         returnPartialData: true,
         errorPolicy: "ignore",
+        variables: { id: "1" },
       });
       const { data } = useReadQuery(queryRef);
 
@@ -7398,6 +7440,7 @@ describe.skip("type tests", () => {
       >(query, {
         returnPartialData: true,
         errorPolicy: "ignore",
+        variables: { id: "1" },
       });
       const { data } = useReadQuery(queryRef);
 
@@ -7410,6 +7453,7 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery(maskedQuery, {
         returnPartialData: true,
         errorPolicy: "ignore",
+        variables: { id: "1" },
       });
       const { data } = useReadQuery(queryRef);
 
@@ -7422,7 +7466,11 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery<
         MaskedVariablesCaseData,
         VariablesCaseVariables
-      >(maskedQuery, { returnPartialData: true, errorPolicy: "ignore" });
+      >(maskedQuery, {
+        returnPartialData: true,
+        errorPolicy: "ignore",
+        variables: { id: "1" },
+      });
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<
@@ -7434,7 +7482,11 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery<
         Masked<MaskedVariablesCaseData>,
         VariablesCaseVariables
-      >(maskedQuery, { returnPartialData: true, errorPolicy: "ignore" });
+      >(maskedQuery, {
+        returnPartialData: true,
+        errorPolicy: "ignore",
+        variables: { id: "1" },
+      });
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<
@@ -7446,6 +7498,7 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery(query, {
         returnPartialData: true,
         errorPolicy: "none",
+        variables: { id: "1" },
       });
       const { data } = useReadQuery(queryRef);
 
@@ -7456,7 +7509,11 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery<
         VariablesCaseData,
         VariablesCaseVariables
-      >(query, { returnPartialData: true, errorPolicy: "none" });
+      >(query, {
+        returnPartialData: true,
+        errorPolicy: "none",
+        variables: { id: "1" },
+      });
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<DeepPartial<VariablesCaseData>>();
@@ -7466,6 +7523,7 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery(maskedQuery, {
         returnPartialData: true,
         errorPolicy: "none",
+        variables: { id: "1" },
       });
       const { data } = useReadQuery(queryRef);
 
@@ -7478,7 +7536,11 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery<
         MaskedVariablesCaseData,
         VariablesCaseVariables
-      >(maskedQuery, { returnPartialData: true, errorPolicy: "none" });
+      >(maskedQuery, {
+        returnPartialData: true,
+        errorPolicy: "none",
+        variables: { id: "1" },
+      });
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<DeepPartial<MaskedVariablesCaseData>>();
@@ -7488,7 +7550,11 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery<
         Masked<MaskedVariablesCaseData>,
         VariablesCaseVariables
-      >(maskedQuery, { returnPartialData: true, errorPolicy: "none" });
+      >(maskedQuery, {
+        returnPartialData: true,
+        errorPolicy: "none",
+        variables: { id: "1" },
+      });
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<
@@ -7505,6 +7571,7 @@ describe.skip("type tests", () => {
         fetchPolicy: "no-cache",
         returnPartialData: true,
         errorPolicy: "none",
+        variables: { id: "1" },
       });
       const { data } = useReadQuery(queryRef);
 
@@ -7519,6 +7586,7 @@ describe.skip("type tests", () => {
         fetchPolicy: "no-cache",
         returnPartialData: true,
         errorPolicy: "none",
+        variables: { id: "1" },
       });
 
       const { data } = useReadQuery(queryRef);
@@ -7533,6 +7601,7 @@ describe.skip("type tests", () => {
         fetchPolicy: "no-cache",
         returnPartialData: true,
         errorPolicy: "none",
+        variables: { id: "1" },
       });
       const { data } = useReadQuery(queryRef);
 
@@ -7549,6 +7618,7 @@ describe.skip("type tests", () => {
         fetchPolicy: "no-cache",
         returnPartialData: true,
         errorPolicy: "none",
+        variables: { id: "1" },
       });
       const { data } = useReadQuery(queryRef);
 
@@ -7563,6 +7633,7 @@ describe.skip("type tests", () => {
         fetchPolicy: "no-cache",
         returnPartialData: true,
         errorPolicy: "none",
+        variables: { id: "1" },
       });
       const { data } = useReadQuery(queryRef);
 
@@ -7577,7 +7648,10 @@ describe.skip("type tests", () => {
     const { query: maskedQuery } = setupMaskedVariablesCase();
 
     {
-      const [queryRef] = useBackgroundQuery(query, { skip: true });
+      const [queryRef] = useBackgroundQuery(query, {
+        skip: true,
+        variables: { id: "1" },
+      });
 
       expectTypeOf(queryRef).toEqualTypeOf<
         QueryRef<VariablesCaseData, VariablesCaseVariables> | undefined
@@ -7591,7 +7665,7 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery<
         VariablesCaseData,
         VariablesCaseVariables
-      >(query, { skip: true });
+      >(query, { skip: true, variables: { id: "1" } });
 
       expectTypeOf(queryRef).toEqualTypeOf<
         QueryRef<VariablesCaseData, VariablesCaseVariables> | undefined
@@ -7602,7 +7676,10 @@ describe.skip("type tests", () => {
     }
 
     {
-      const [queryRef] = useBackgroundQuery(maskedQuery, { skip: true });
+      const [queryRef] = useBackgroundQuery(maskedQuery, {
+        skip: true,
+        variables: { id: "1" },
+      });
 
       expectTypeOf(queryRef).toEqualTypeOf<
         | QueryRef<Masked<MaskedVariablesCaseData>, VariablesCaseVariables>
@@ -7621,7 +7698,7 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery<
         MaskedVariablesCaseData,
         VariablesCaseVariables
-      >(maskedQuery, { skip: true });
+      >(maskedQuery, { skip: true, variables: { id: "1" } });
 
       expectTypeOf(queryRef).toEqualTypeOf<
         QueryRef<MaskedVariablesCaseData, VariablesCaseVariables> | undefined
@@ -7636,7 +7713,7 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery<
         Masked<MaskedVariablesCaseData>,
         VariablesCaseVariables
-      >(maskedQuery, { skip: true });
+      >(maskedQuery, { skip: true, variables: { id: "1" } });
 
       expectTypeOf(queryRef).toEqualTypeOf<
         | QueryRef<Masked<MaskedVariablesCaseData>, VariablesCaseVariables>
@@ -7659,7 +7736,10 @@ describe.skip("type tests", () => {
     };
 
     {
-      const [queryRef] = useBackgroundQuery(query, { skip: options.skip });
+      const [queryRef] = useBackgroundQuery(query, {
+        skip: options.skip,
+        variables: { id: "1" },
+      });
 
       expectTypeOf(queryRef).toEqualTypeOf<
         QueryRef<VariablesCaseData, VariablesCaseVariables> | undefined
@@ -7672,6 +7752,7 @@ describe.skip("type tests", () => {
     {
       const [queryRef] = useBackgroundQuery(maskedQuery, {
         skip: options.skip,
+        variables: { id: "1" },
       });
 
       expectTypeOf(queryRef).toEqualTypeOf<
@@ -7691,7 +7772,7 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery<
         MaskedVariablesCaseData,
         VariablesCaseVariables
-      >(maskedQuery, { skip: options.skip });
+      >(maskedQuery, { skip: options.skip, variables: { id: "1" } });
 
       expectTypeOf(queryRef).toEqualTypeOf<
         QueryRef<MaskedVariablesCaseData, VariablesCaseVariables> | undefined
@@ -7706,7 +7787,7 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery<
         Masked<MaskedVariablesCaseData>,
         VariablesCaseVariables
-      >(maskedQuery, { skip: options.skip });
+      >(maskedQuery, { skip: options.skip, variables: { id: "1" } });
 
       expectTypeOf(queryRef).toEqualTypeOf<
         | QueryRef<Masked<MaskedVariablesCaseData>, VariablesCaseVariables>
@@ -7776,7 +7857,7 @@ describe.skip("type tests", () => {
     {
       const [queryRef] = useBackgroundQuery(
         query,
-        options.skip ? skipToken : undefined
+        options.skip ? skipToken : { variables: { id: "1" } }
       );
 
       expectTypeOf(queryRef).toEqualTypeOf<
@@ -7791,7 +7872,7 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery<
         VariablesCaseData,
         VariablesCaseVariables
-      >(query, options.skip ? skipToken : undefined);
+      >(query, options.skip ? skipToken : { variables: { id: "1" } });
 
       expectTypeOf(queryRef).toEqualTypeOf<
         QueryRef<VariablesCaseData, VariablesCaseVariables> | undefined
@@ -7806,7 +7887,7 @@ describe.skip("type tests", () => {
     {
       const [queryRef] = useBackgroundQuery(
         maskedQuery,
-        options.skip ? skipToken : undefined
+        options.skip ? skipToken : { variables: { id: "1" } }
       );
 
       expectTypeOf(queryRef).toEqualTypeOf<
@@ -7826,7 +7907,7 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery<
         MaskedVariablesCaseData,
         VariablesCaseVariables
-      >(maskedQuery, options.skip ? skipToken : undefined);
+      >(maskedQuery, options.skip ? skipToken : { variables: { id: "1" } });
 
       expectTypeOf(queryRef).toEqualTypeOf<
         QueryRef<MaskedVariablesCaseData, VariablesCaseVariables> | undefined
@@ -7841,7 +7922,7 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery<
         Masked<MaskedVariablesCaseData>,
         VariablesCaseVariables
-      >(maskedQuery, options.skip ? skipToken : undefined);
+      >(maskedQuery, options.skip ? skipToken : { variables: { id: "1" } });
 
       expectTypeOf(queryRef).toEqualTypeOf<
         | QueryRef<Masked<MaskedVariablesCaseData>, VariablesCaseVariables>
@@ -7866,7 +7947,9 @@ describe.skip("type tests", () => {
     {
       const [queryRef] = useBackgroundQuery(
         query,
-        options.skip ? skipToken : { returnPartialData: true }
+        options.skip ? skipToken : (
+          { returnPartialData: true, variables: { id: "1" } }
+        )
       );
 
       expectTypeOf(queryRef).toEqualTypeOf<
@@ -7883,7 +7966,12 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery<
         VariablesCaseData,
         VariablesCaseVariables
-      >(query, options.skip ? skipToken : { returnPartialData: true });
+      >(
+        query,
+        options.skip ? skipToken : (
+          { returnPartialData: true, variables: { id: "1" } }
+        )
+      );
 
       expectTypeOf(queryRef).toEqualTypeOf<
         | QueryRef<DeepPartial<VariablesCaseData>, VariablesCaseVariables>
@@ -7900,7 +7988,9 @@ describe.skip("type tests", () => {
     {
       const [queryRef] = useBackgroundQuery(
         maskedQuery,
-        options.skip ? skipToken : { returnPartialData: true }
+        options.skip ? skipToken : (
+          { returnPartialData: true, variables: { id: "1" } }
+        )
       );
 
       expectTypeOf(queryRef).toEqualTypeOf<
@@ -7923,7 +8013,12 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery<
         MaskedVariablesCaseData,
         VariablesCaseVariables
-      >(maskedQuery, options.skip ? skipToken : { returnPartialData: true });
+      >(
+        maskedQuery,
+        options.skip ? skipToken : (
+          { returnPartialData: true, variables: { id: "1" } }
+        )
+      );
 
       expectTypeOf(queryRef).toEqualTypeOf<
         | QueryRef<DeepPartial<MaskedVariablesCaseData>, VariablesCaseVariables>
@@ -7942,7 +8037,12 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery<
         Masked<MaskedVariablesCaseData>,
         VariablesCaseVariables
-      >(maskedQuery, options.skip ? skipToken : { returnPartialData: true });
+      >(
+        maskedQuery,
+        options.skip ? skipToken : (
+          { returnPartialData: true, variables: { id: "1" } }
+        )
+      );
 
       expectTypeOf(queryRef).toEqualTypeOf<
         | QueryRef<
@@ -7965,7 +8065,9 @@ describe.skip("type tests", () => {
     const { query, unmaskedQuery } = setupMaskedVariablesCase();
 
     {
-      const [, { refetch }] = useBackgroundQuery(query);
+      const [, { refetch }] = useBackgroundQuery(query, {
+        variables: { id: "1" },
+      });
       const { data } = await refetch();
 
       expectTypeOf(data).toEqualTypeOf<
@@ -7974,7 +8076,9 @@ describe.skip("type tests", () => {
     }
 
     {
-      const [, { refetch }] = useBackgroundQuery(unmaskedQuery);
+      const [, { refetch }] = useBackgroundQuery(unmaskedQuery, {
+        variables: { id: "1" },
+      });
       const { data } = await refetch();
 
       expectTypeOf(data).toEqualTypeOf<MaskedVariablesCaseData | undefined>();
@@ -7985,7 +8089,9 @@ describe.skip("type tests", () => {
     const { query, unmaskedQuery } = setupMaskedVariablesCase();
 
     {
-      const [, { fetchMore }] = useBackgroundQuery(query);
+      const [, { fetchMore }] = useBackgroundQuery(query, {
+        variables: { id: "1" },
+      });
 
       const { data } = await fetchMore({
         updateQuery: (queryData, { fetchMoreResult }) => {
@@ -8005,7 +8111,9 @@ describe.skip("type tests", () => {
     }
 
     {
-      const [, { fetchMore }] = useBackgroundQuery(unmaskedQuery);
+      const [, { fetchMore }] = useBackgroundQuery(unmaskedQuery, {
+        variables: { id: "1" },
+      });
 
       const { data } = await fetchMore({
         updateQuery: (queryData, { fetchMoreResult }) => {
@@ -8051,7 +8159,9 @@ describe.skip("type tests", () => {
     const { query, unmaskedQuery } = setupMaskedVariablesCase();
 
     {
-      const [, { subscribeToMore }] = useBackgroundQuery(query);
+      const [, { subscribeToMore }] = useBackgroundQuery(query, {
+        variables: { id: "1" },
+      });
 
       const subscription: MaskedDocumentNode<
         Subscription,
@@ -8112,7 +8222,9 @@ describe.skip("type tests", () => {
     }
 
     {
-      const [, { subscribeToMore }] = useBackgroundQuery(unmaskedQuery);
+      const [, { subscribeToMore }] = useBackgroundQuery(unmaskedQuery, {
+        variables: { id: "1" },
+      });
 
       const subscription: TypedDocumentNode<Subscription, never> = gql`
         subscription {

--- a/src/react/hooks/__tests__/useBackgroundQuery.test.tsx
+++ b/src/react/hooks/__tests__/useBackgroundQuery.test.tsx
@@ -8282,4 +8282,307 @@ describe.skip("type tests", () => {
       });
     }
   });
+
+  test("variables are optional and can be anything with an DocumentNode", () => {
+    const query = gql``;
+
+    useBackgroundQuery(query);
+    useBackgroundQuery(query, {});
+    useBackgroundQuery(query, { variables: {} });
+    useBackgroundQuery(query, { variables: { foo: "bar" } });
+    useBackgroundQuery(query, { variables: { bar: "baz" } });
+
+    let skip!: boolean;
+    useBackgroundQuery(query, skip ? skipToken : undefined);
+    useBackgroundQuery(query, skip ? skipToken : {});
+    useBackgroundQuery(query, skip ? skipToken : { variables: {} });
+    useBackgroundQuery(query, skip ? skipToken : { variables: { foo: "bar" } });
+    useBackgroundQuery(query, skip ? skipToken : { variables: { bar: "baz" } });
+  });
+
+  test("variables are optional and can be anything with unspecified TVariables on a TypedDocumentNode", () => {
+    const query: TypedDocumentNode<{ greeting: string }> = gql``;
+
+    useBackgroundQuery(query);
+    useBackgroundQuery(query, {});
+    useBackgroundQuery(query, { variables: {} });
+    useBackgroundQuery(query, { variables: { foo: "bar" } });
+    useBackgroundQuery(query, { variables: { bar: "baz" } });
+
+    let skip!: boolean;
+    useBackgroundQuery(query, skip ? skipToken : undefined);
+    useBackgroundQuery(query, skip ? skipToken : {});
+    useBackgroundQuery(query, skip ? skipToken : { variables: {} });
+    useBackgroundQuery(query, skip ? skipToken : { variables: { foo: "bar" } });
+    useBackgroundQuery(query, skip ? skipToken : { variables: { bar: "baz" } });
+  });
+
+  test("variables are optional when TVariables are empty", () => {
+    const query: TypedDocumentNode<
+      { greeting: string },
+      Record<string, never>
+    > = gql``;
+
+    useBackgroundQuery(query);
+    useBackgroundQuery(query, {});
+    useBackgroundQuery(query, { variables: {} });
+    useBackgroundQuery(query, {
+      variables: {
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
+
+    let skip!: boolean;
+    useBackgroundQuery(query, skip ? skipToken : undefined);
+    useBackgroundQuery(query, skip ? skipToken : {});
+    useBackgroundQuery(query, skip ? skipToken : { variables: {} });
+    useBackgroundQuery(
+      query,
+      // @ts-expect-error unknown variables
+      skip ? skipToken : { variables: { foo: "bar" } }
+    );
+  });
+
+  test("is invalid when TVariables is `never`", () => {
+    const query: TypedDocumentNode<{ greeting: string }, never> = gql``;
+
+    // @ts-expect-error
+    useBackgroundQuery(query);
+    // @ts-expect-error
+    useBackgroundQuery(query, {});
+    useBackgroundQuery(query, {
+      // @ts-expect-error
+      variables: {},
+    });
+    useBackgroundQuery(query, {
+      // @ts-expect-error
+      variables: undefined,
+    });
+    useBackgroundQuery(query, {
+      // @ts-expect-error
+      variables: {
+        foo: "bar",
+      },
+    });
+
+    let skip!: boolean;
+    // @ts-expect-error
+    useBackgroundQuery(query, skip ? skipToken : undefined);
+    useBackgroundQuery(
+      query,
+      // @ts-expect-error
+      skip ? skipToken : {}
+    );
+    useBackgroundQuery(
+      query,
+      // @ts-expect-error
+      skip ? skipToken : { variables: {} }
+    );
+    useBackgroundQuery(
+      query,
+      // @ts-expect-error
+      skip ? skipToken : { variables: undefined }
+    );
+    useBackgroundQuery(
+      query,
+      // @ts-expect-error unknown variables
+      skip ? skipToken : { variables: { foo: "bar" } }
+    );
+  });
+
+  test("optional variables are optional", () => {
+    const query: TypedDocumentNode<{ posts: string[] }, { limit?: number }> =
+      gql``;
+
+    useBackgroundQuery(query);
+    useBackgroundQuery(query, {});
+    useBackgroundQuery(query, { variables: {} });
+    useBackgroundQuery(query, { variables: { limit: 10 } });
+    useBackgroundQuery(query, {
+      variables: {
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
+    useBackgroundQuery(query, {
+      variables: {
+        limit: 10,
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
+
+    let skip!: boolean;
+    useBackgroundQuery(query, skip ? skipToken : undefined);
+    useBackgroundQuery(query, skip ? skipToken : {});
+    useBackgroundQuery(query, skip ? skipToken : { variables: {} });
+    useBackgroundQuery(query, skip ? skipToken : { variables: { limit: 10 } });
+    useBackgroundQuery(
+      query,
+      skip ? skipToken : (
+        {
+          variables: {
+            // @ts-expect-error unknown variables
+            foo: "bar",
+          },
+        }
+      )
+    );
+    useBackgroundQuery(
+      query,
+      skip ? skipToken : (
+        {
+          variables: {
+            limit: 10,
+            // @ts-expect-error unknown variables
+            foo: "bar",
+          },
+        }
+      )
+    );
+  });
+
+  test("enforces required variables when TVariables includes required variables", () => {
+    const query: TypedDocumentNode<{ character: string }, { id: string }> =
+      gql``;
+
+    // @ts-expect-error empty variables
+    useBackgroundQuery(query);
+    // @ts-expect-error empty variables
+    useBackgroundQuery(query, {});
+    // @ts-expect-error empty variables
+    useBackgroundQuery(query, { variables: {} });
+    useBackgroundQuery(query, { variables: { id: "1" } });
+    useBackgroundQuery(query, {
+      variables: {
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
+    useBackgroundQuery(query, {
+      variables: {
+        id: "1",
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
+
+    let skip!: boolean;
+    // @ts-expect-error missing variables option
+    useBackgroundQuery(query, skip ? skipToken : undefined);
+    useBackgroundQuery(
+      query,
+      // @ts-expect-error missing variables option
+      skip ? skipToken : {}
+    );
+    useBackgroundQuery(
+      query,
+      // @ts-expect-error missing required variables
+      skip ? skipToken : { variables: {} }
+    );
+    useBackgroundQuery(query, skip ? skipToken : { variables: { id: "1" } });
+    useBackgroundQuery(
+      query,
+      skip ? skipToken : (
+        {
+          variables: {
+            // @ts-expect-error unknown variables
+            foo: "bar",
+          },
+        }
+      )
+    );
+    useBackgroundQuery(
+      query,
+      skip ? skipToken : (
+        {
+          variables: {
+            id: "1",
+            // @ts-expect-error unknown variables
+            foo: "bar",
+          },
+        }
+      )
+    );
+  });
+
+  test("requires variables with mixed TVariables", () => {
+    const query: TypedDocumentNode<
+      { character: string },
+      { id: string; language?: string }
+    > = gql``;
+
+    // @ts-expect-error empty variables
+    useBackgroundQuery(query);
+    // @ts-expect-error empty variables
+    useBackgroundQuery(query, {});
+    // @ts-expect-error empty variables
+    useBackgroundQuery(query, { variables: {} });
+    useBackgroundQuery(query, { variables: { id: "1" } });
+    useBackgroundQuery(query, {
+      // @ts-expect-error missing required variables
+      variables: { language: "en" },
+    });
+    useBackgroundQuery(query, { variables: { id: "1", language: "en" } });
+    useBackgroundQuery(query, {
+      variables: {
+        id: "1",
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
+    useBackgroundQuery(query, {
+      variables: {
+        id: "1",
+        language: "en",
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
+
+    let skip!: boolean;
+    // @ts-expect-error missing variables option
+    useBackgroundQuery(query, skip ? skipToken : undefined);
+    useBackgroundQuery(
+      query,
+      // @ts-expect-error missing variables option
+      skip ? skipToken : {}
+    );
+    useBackgroundQuery(
+      query,
+      // @ts-expect-error missing required variables
+      skip ? skipToken : { variables: {} }
+    );
+    useBackgroundQuery(query, skip ? skipToken : { variables: { id: "1" } });
+    useBackgroundQuery(
+      query,
+      skip ? skipToken : { variables: { id: "1", language: "en" } }
+    );
+    useBackgroundQuery(
+      query,
+      skip ? skipToken : (
+        {
+          variables: {
+            id: "1",
+            // @ts-expect-error unknown variables
+            foo: "bar",
+          },
+        }
+      )
+    );
+    useBackgroundQuery(
+      query,
+      skip ? skipToken : (
+        {
+          variables: {
+            id: "1",
+            language: "en",
+            // @ts-expect-error unknown variables
+            foo: "bar",
+          },
+        }
+      )
+    );
+  });
 });

--- a/src/react/hooks/__tests__/useBackgroundQuery.test.tsx
+++ b/src/react/hooks/__tests__/useBackgroundQuery.test.tsx
@@ -7011,21 +7011,22 @@ describe.skip("type tests", () => {
   it("returns TData in default case", () => {
     const { query } = setupVariablesCase();
 
-    const [inferredQueryRef] = useBackgroundQuery(query);
-    const { data: inferred } = useReadQuery(inferredQueryRef);
+    {
+      const [queryRef] = useBackgroundQuery(query);
+      const { data } = useReadQuery(queryRef);
 
-    expectTypeOf(inferred).toEqualTypeOf<VariablesCaseData>();
-    expectTypeOf(inferred).not.toEqualTypeOf<VariablesCaseData | undefined>();
+      expectTypeOf(data).toEqualTypeOf<VariablesCaseData>();
+    }
 
-    const [explicitQueryRef] = useBackgroundQuery<
-      VariablesCaseData,
-      VariablesCaseVariables
-    >(query);
+    {
+      const [queryRef] = useBackgroundQuery<
+        VariablesCaseData,
+        VariablesCaseVariables
+      >(query);
+      const { data } = useReadQuery(queryRef);
 
-    const { data: explicit } = useReadQuery(explicitQueryRef);
-
-    expectTypeOf(explicit).toEqualTypeOf<VariablesCaseData>();
-    expectTypeOf(explicit).not.toEqualTypeOf<VariablesCaseData | undefined>();
+      expectTypeOf(data).toEqualTypeOf<VariablesCaseData>();
+    }
 
     const { query: maskedQuery } = setupMaskedVariablesCase();
 
@@ -7034,7 +7035,6 @@ describe.skip("type tests", () => {
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<Masked<MaskedVariablesCaseData>>();
-      expectTypeOf(data).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
     }
 
     {
@@ -7045,7 +7045,6 @@ describe.skip("type tests", () => {
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<MaskedVariablesCaseData>();
-      expectTypeOf(data).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
     }
 
     {
@@ -7056,32 +7055,29 @@ describe.skip("type tests", () => {
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<Masked<MaskedVariablesCaseData>>();
-      expectTypeOf(data).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
     }
   });
 
   it('returns TData | undefined with errorPolicy: "ignore"', () => {
     const { query } = setupVariablesCase();
 
-    const [inferredQueryRef] = useBackgroundQuery(query, {
-      errorPolicy: "ignore",
-    });
-    const { data: inferred } = useReadQuery(inferredQueryRef);
+    {
+      const [queryRef] = useBackgroundQuery(query, { errorPolicy: "ignore" });
+      const { data } = useReadQuery(queryRef);
 
-    expectTypeOf(inferred).toEqualTypeOf<VariablesCaseData | undefined>();
-    expectTypeOf(inferred).not.toEqualTypeOf<VariablesCaseData>();
+      expectTypeOf(data).toEqualTypeOf<VariablesCaseData | undefined>();
+    }
 
-    const [explicitQueryRef] = useBackgroundQuery<
-      VariablesCaseData,
-      VariablesCaseVariables
-    >(query, {
-      errorPolicy: "ignore",
-    });
+    {
+      const [queryRef] = useBackgroundQuery<
+        VariablesCaseData,
+        VariablesCaseVariables
+      >(query, { errorPolicy: "ignore" });
 
-    const { data: explicit } = useReadQuery(explicitQueryRef);
+      const { data } = useReadQuery(queryRef);
 
-    expectTypeOf(explicit).toEqualTypeOf<VariablesCaseData | undefined>();
-    expectTypeOf(explicit).not.toEqualTypeOf<VariablesCaseData>();
+      expectTypeOf(data).toEqualTypeOf<VariablesCaseData | undefined>();
+    }
 
     const { query: maskedQuery } = setupMaskedVariablesCase();
 
@@ -7090,7 +7086,6 @@ describe.skip("type tests", () => {
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<Masked<MaskedVariablesCaseData>>();
-      expectTypeOf(data).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
     }
 
     {
@@ -7101,7 +7096,6 @@ describe.skip("type tests", () => {
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<MaskedVariablesCaseData>();
-      expectTypeOf(data).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
     }
 
     {
@@ -7109,31 +7103,28 @@ describe.skip("type tests", () => {
         Masked<MaskedVariablesCaseData>,
         VariablesCaseVariables
       >(maskedQuery);
-      const { data } = useReadQuery(queryRef);
+      const { data: data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<Masked<MaskedVariablesCaseData>>();
-      expectTypeOf(data).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
     }
   });
 
   it('returns TData | undefined with errorPolicy: "all"', () => {
     const { query } = setupVariablesCase();
 
-    const [inferredQueryRef] = useBackgroundQuery(query, {
-      errorPolicy: "all",
-    });
-    const { data: inferred } = useReadQuery(inferredQueryRef);
+    {
+      const [queryRef] = useBackgroundQuery(query, { errorPolicy: "all" });
+      const { data } = useReadQuery(queryRef);
 
-    expectTypeOf(inferred).toEqualTypeOf<VariablesCaseData | undefined>();
-    expectTypeOf(inferred).not.toEqualTypeOf<VariablesCaseData>();
+      expectTypeOf(data).toEqualTypeOf<VariablesCaseData | undefined>();
+    }
 
-    const [explicitQueryRef] = useBackgroundQuery(query, {
-      errorPolicy: "all",
-    });
-    const { data: explicit } = useReadQuery(explicitQueryRef);
+    {
+      const [queryRef] = useBackgroundQuery(query, { errorPolicy: "all" });
+      const { data } = useReadQuery(queryRef);
 
-    expectTypeOf(explicit).toEqualTypeOf<VariablesCaseData | undefined>();
-    expectTypeOf(explicit).not.toEqualTypeOf<VariablesCaseData>();
+      expectTypeOf(data).toEqualTypeOf<VariablesCaseData | undefined>();
+    }
 
     const { query: maskedQuery } = setupMaskedVariablesCase();
 
@@ -7146,9 +7137,6 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         Masked<MaskedVariablesCaseData> | undefined
       >();
-      expectTypeOf(data).not.toEqualTypeOf<
-        UnmaskedVariablesCaseData | undefined
-      >();
     }
 
     {
@@ -7159,9 +7147,6 @@ describe.skip("type tests", () => {
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<MaskedVariablesCaseData | undefined>();
-      expectTypeOf(data).not.toEqualTypeOf<
-        UnmaskedVariablesCaseData | undefined
-      >();
     }
 
     {
@@ -7174,30 +7159,25 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         Masked<MaskedVariablesCaseData> | undefined
       >();
-      expectTypeOf(data).not.toEqualTypeOf<
-        UnmaskedVariablesCaseData | undefined
-      >();
     }
   });
 
   it('returns TData with errorPolicy: "none"', () => {
     const { query } = setupVariablesCase();
 
-    const [inferredQueryRef] = useBackgroundQuery(query, {
-      errorPolicy: "none",
-    });
-    const { data: inferred } = useReadQuery(inferredQueryRef);
+    {
+      const [queryRef] = useBackgroundQuery(query, { errorPolicy: "none" });
+      const { data } = useReadQuery(queryRef);
 
-    expectTypeOf(inferred).toEqualTypeOf<VariablesCaseData>();
-    expectTypeOf(inferred).not.toEqualTypeOf<VariablesCaseData | undefined>();
+      expectTypeOf(data).toEqualTypeOf<VariablesCaseData>();
+    }
 
-    const [explicitQueryRef] = useBackgroundQuery(query, {
-      errorPolicy: "none",
-    });
-    const { data: explicit } = useReadQuery(explicitQueryRef);
+    {
+      const [queryRef] = useBackgroundQuery(query, { errorPolicy: "none" });
+      const { data } = useReadQuery(queryRef);
 
-    expectTypeOf(explicit).toEqualTypeOf<VariablesCaseData>();
-    expectTypeOf(explicit).not.toEqualTypeOf<VariablesCaseData | undefined>();
+      expectTypeOf(data).toEqualTypeOf<VariablesCaseData>();
+    }
 
     const { query: maskedQuery } = setupMaskedVariablesCase();
 
@@ -7208,7 +7188,6 @@ describe.skip("type tests", () => {
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<Masked<MaskedVariablesCaseData>>();
-      expectTypeOf(data).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
     }
 
     {
@@ -7219,7 +7198,6 @@ describe.skip("type tests", () => {
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<MaskedVariablesCaseData>();
-      expectTypeOf(data).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
     }
 
     {
@@ -7230,32 +7208,28 @@ describe.skip("type tests", () => {
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<Masked<MaskedVariablesCaseData>>();
-      expectTypeOf(data).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
     }
   });
 
   it("returns DeepPartial<TData> with returnPartialData: true", () => {
     const { query } = setupVariablesCase();
 
-    const [inferredQueryRef] = useBackgroundQuery(query, {
-      returnPartialData: true,
-    });
-    const { data: inferred } = useReadQuery(inferredQueryRef);
+    {
+      const [queryRef] = useBackgroundQuery(query, { returnPartialData: true });
+      const { data } = useReadQuery(queryRef);
 
-    expectTypeOf(inferred).toEqualTypeOf<DeepPartial<VariablesCaseData>>();
-    expectTypeOf(inferred).not.toEqualTypeOf<VariablesCaseData>();
+      expectTypeOf(data).toEqualTypeOf<DeepPartial<VariablesCaseData>>();
+    }
 
-    const [explicitQueryRef] = useBackgroundQuery<
-      VariablesCaseData,
-      VariablesCaseVariables
-    >(query, {
-      returnPartialData: true,
-    });
+    {
+      const [queryRef] = useBackgroundQuery<
+        VariablesCaseData,
+        VariablesCaseVariables
+      >(query, { returnPartialData: true });
+      const { data } = useReadQuery(queryRef);
 
-    const { data: explicit } = useReadQuery(explicitQueryRef);
-
-    expectTypeOf(explicit).toEqualTypeOf<DeepPartial<VariablesCaseData>>();
-    expectTypeOf(explicit).not.toEqualTypeOf<VariablesCaseData>();
+      expectTypeOf(data).toEqualTypeOf<DeepPartial<VariablesCaseData>>();
+    }
 
     const { query: maskedQuery } = setupMaskedVariablesCase();
 
@@ -7267,9 +7241,6 @@ describe.skip("type tests", () => {
 
       expectTypeOf(data).toEqualTypeOf<
         DeepPartial<Masked<MaskedVariablesCaseData>>
-      >();
-      expectTypeOf(data).not.toEqualTypeOf<
-        DeepPartial<UnmaskedVariablesCaseData>
       >();
     }
 
@@ -7281,9 +7252,6 @@ describe.skip("type tests", () => {
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<DeepPartial<MaskedVariablesCaseData>>();
-      expectTypeOf(data).not.toEqualTypeOf<
-        DeepPartial<UnmaskedVariablesCaseData>
-      >();
     }
 
     {
@@ -7296,34 +7264,31 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         DeepPartial<Masked<MaskedVariablesCaseData>>
       >();
-      expectTypeOf(data).not.toEqualTypeOf<
-        DeepPartial<UnmaskedVariablesCaseData>
-      >();
     }
   });
 
   it("returns TData with returnPartialData: false", () => {
     const { query } = setupVariablesCase();
 
-    const [inferredQueryRef] = useBackgroundQuery(query, {
-      returnPartialData: false,
-    });
-    const { data: inferred } = useReadQuery(inferredQueryRef);
+    {
+      const [queryRef] = useBackgroundQuery(query, {
+        returnPartialData: false,
+      });
+      const { data } = useReadQuery(queryRef);
 
-    expectTypeOf(inferred).toEqualTypeOf<VariablesCaseData>();
-    expectTypeOf(inferred).not.toEqualTypeOf<DeepPartial<VariablesCaseData>>();
+      expectTypeOf(data).toEqualTypeOf<VariablesCaseData>();
+    }
 
-    const [explicitQueryRef] = useBackgroundQuery<
-      VariablesCaseData,
-      VariablesCaseVariables
-    >(query, {
-      returnPartialData: false,
-    });
+    {
+      const [queryRef] = useBackgroundQuery<
+        VariablesCaseData,
+        VariablesCaseVariables
+      >(query, { returnPartialData: false });
 
-    const { data: explicit } = useReadQuery(explicitQueryRef);
+      const { data } = useReadQuery(queryRef);
 
-    expectTypeOf(explicit).toEqualTypeOf<VariablesCaseData>();
-    expectTypeOf(explicit).not.toEqualTypeOf<DeepPartial<VariablesCaseData>>();
+      expectTypeOf(data).toEqualTypeOf<VariablesCaseData>();
+    }
 
     const { query: maskedQuery } = setupMaskedVariablesCase();
 
@@ -7334,7 +7299,6 @@ describe.skip("type tests", () => {
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<Masked<MaskedVariablesCaseData>>();
-      expectTypeOf(data).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
     }
 
     {
@@ -7345,7 +7309,6 @@ describe.skip("type tests", () => {
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<MaskedVariablesCaseData>();
-      expectTypeOf(data).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
     }
 
     {
@@ -7356,32 +7319,29 @@ describe.skip("type tests", () => {
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<Masked<MaskedVariablesCaseData>>();
-      expectTypeOf(data).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
     }
   });
 
   it("returns TData when passing an option that does not affect TData", () => {
     const { query } = setupVariablesCase();
 
-    const [inferredQueryRef] = useBackgroundQuery(query, {
-      fetchPolicy: "no-cache",
-    });
-    const { data: inferred } = useReadQuery(inferredQueryRef);
+    {
+      const [queryRef] = useBackgroundQuery(query, { fetchPolicy: "no-cache" });
+      const { data } = useReadQuery(queryRef);
 
-    expectTypeOf(inferred).toEqualTypeOf<VariablesCaseData>();
-    expectTypeOf(inferred).not.toEqualTypeOf<DeepPartial<VariablesCaseData>>();
+      expectTypeOf(data).toEqualTypeOf<VariablesCaseData>();
+    }
 
-    const [explicitQueryRef] = useBackgroundQuery<
-      VariablesCaseData,
-      VariablesCaseVariables
-    >(query, {
-      fetchPolicy: "no-cache",
-    });
+    {
+      const [queryRef] = useBackgroundQuery<
+        VariablesCaseData,
+        VariablesCaseVariables
+      >(query, { fetchPolicy: "no-cache" });
 
-    const { data: explicit } = useReadQuery(explicitQueryRef);
+      const { data } = useReadQuery(queryRef);
 
-    expectTypeOf(explicit).toEqualTypeOf<VariablesCaseData>();
-    expectTypeOf(explicit).not.toEqualTypeOf<DeepPartial<VariablesCaseData>>();
+      expectTypeOf(data).toEqualTypeOf<VariablesCaseData>();
+    }
 
     const { query: maskedQuery } = setupMaskedVariablesCase();
 
@@ -7392,7 +7352,6 @@ describe.skip("type tests", () => {
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<Masked<MaskedVariablesCaseData>>();
-      expectTypeOf(data).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
     }
 
     {
@@ -7403,7 +7362,6 @@ describe.skip("type tests", () => {
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<MaskedVariablesCaseData>();
-      expectTypeOf(data).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
     }
 
     {
@@ -7414,7 +7372,6 @@ describe.skip("type tests", () => {
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<Masked<MaskedVariablesCaseData>>();
-      expectTypeOf(data).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
     }
   });
 
@@ -7422,39 +7379,32 @@ describe.skip("type tests", () => {
     const { query } = setupVariablesCase();
     const { query: maskedQuery } = setupMaskedVariablesCase();
 
-    const [inferredPartialDataIgnoreQueryRef] = useBackgroundQuery(query, {
-      returnPartialData: true,
-      errorPolicy: "ignore",
-    });
-    const { data: inferredPartialDataIgnore } = useReadQuery(
-      inferredPartialDataIgnoreQueryRef
-    );
+    {
+      const [queryRef] = useBackgroundQuery(query, {
+        returnPartialData: true,
+        errorPolicy: "ignore",
+      });
+      const { data } = useReadQuery(queryRef);
 
-    expectTypeOf(inferredPartialDataIgnore).toEqualTypeOf<
-      DeepPartial<VariablesCaseData> | undefined
-    >();
-    expectTypeOf(
-      inferredPartialDataIgnore
-    ).not.toEqualTypeOf<VariablesCaseData>();
+      expectTypeOf(data).toEqualTypeOf<
+        DeepPartial<VariablesCaseData> | undefined
+      >();
+    }
 
-    const [explicitPartialDataIgnoreQueryRef] = useBackgroundQuery<
-      VariablesCaseData,
-      VariablesCaseVariables
-    >(query, {
-      returnPartialData: true,
-      errorPolicy: "ignore",
-    });
+    {
+      const [queryRef] = useBackgroundQuery<
+        VariablesCaseData,
+        VariablesCaseVariables
+      >(query, {
+        returnPartialData: true,
+        errorPolicy: "ignore",
+      });
+      const { data } = useReadQuery(queryRef);
 
-    const { data: explicitPartialDataIgnore } = useReadQuery(
-      explicitPartialDataIgnoreQueryRef
-    );
-
-    expectTypeOf(explicitPartialDataIgnore).toEqualTypeOf<
-      DeepPartial<VariablesCaseData> | undefined
-    >();
-    expectTypeOf(
-      explicitPartialDataIgnore
-    ).not.toEqualTypeOf<VariablesCaseData>();
+      expectTypeOf(data).toEqualTypeOf<
+        DeepPartial<VariablesCaseData> | undefined
+      >();
+    }
 
     {
       const [queryRef] = useBackgroundQuery(maskedQuery, {
@@ -7465,9 +7415,6 @@ describe.skip("type tests", () => {
 
       expectTypeOf(data).toEqualTypeOf<
         DeepPartial<Masked<MaskedVariablesCaseData>> | undefined
-      >();
-      expectTypeOf(data).not.toEqualTypeOf<
-        DeepPartial<UnmaskedVariablesCaseData> | undefined
       >();
     }
 
@@ -7481,9 +7428,6 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         DeepPartial<MaskedVariablesCaseData> | undefined
       >();
-      expectTypeOf(data).not.toEqualTypeOf<
-        DeepPartial<UnmaskedVariablesCaseData> | undefined
-      >();
     }
 
     {
@@ -7496,45 +7440,27 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         DeepPartial<Masked<MaskedVariablesCaseData>> | undefined
       >();
-      expectTypeOf(data).not.toEqualTypeOf<
-        DeepPartial<UnmaskedVariablesCaseData> | undefined
-      >();
     }
 
-    const [inferredPartialDataNoneQueryRef] = useBackgroundQuery(query, {
-      returnPartialData: true,
-      errorPolicy: "none",
-    });
+    {
+      const [queryRef] = useBackgroundQuery(query, {
+        returnPartialData: true,
+        errorPolicy: "none",
+      });
+      const { data } = useReadQuery(queryRef);
 
-    const { data: inferredPartialDataNone } = useReadQuery(
-      inferredPartialDataNoneQueryRef
-    );
+      expectTypeOf(data).toEqualTypeOf<DeepPartial<VariablesCaseData>>();
+    }
 
-    expectTypeOf(inferredPartialDataNone).toEqualTypeOf<
-      DeepPartial<VariablesCaseData>
-    >();
-    expectTypeOf(
-      inferredPartialDataNone
-    ).not.toEqualTypeOf<VariablesCaseData>();
+    {
+      const [queryRef] = useBackgroundQuery<
+        VariablesCaseData,
+        VariablesCaseVariables
+      >(query, { returnPartialData: true, errorPolicy: "none" });
+      const { data } = useReadQuery(queryRef);
 
-    const [explicitPartialDataNoneQueryRef] = useBackgroundQuery<
-      VariablesCaseData,
-      VariablesCaseVariables
-    >(query, {
-      returnPartialData: true,
-      errorPolicy: "none",
-    });
-
-    const { data: explicitPartialDataNone } = useReadQuery(
-      explicitPartialDataNoneQueryRef
-    );
-
-    expectTypeOf(explicitPartialDataNone).toEqualTypeOf<
-      DeepPartial<VariablesCaseData>
-    >();
-    expectTypeOf(
-      explicitPartialDataNone
-    ).not.toEqualTypeOf<VariablesCaseData>();
+      expectTypeOf(data).toEqualTypeOf<DeepPartial<VariablesCaseData>>();
+    }
 
     {
       const [queryRef] = useBackgroundQuery(maskedQuery, {
@@ -7546,9 +7472,6 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         DeepPartial<Masked<MaskedVariablesCaseData>>
       >();
-      expectTypeOf(data).not.toEqualTypeOf<
-        DeepPartial<UnmaskedVariablesCaseData>
-      >();
     }
 
     {
@@ -7559,9 +7482,6 @@ describe.skip("type tests", () => {
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<DeepPartial<MaskedVariablesCaseData>>();
-      expectTypeOf(data).not.toEqualTypeOf<
-        DeepPartial<UnmaskedVariablesCaseData>
-      >();
     }
 
     {
@@ -7574,38 +7494,37 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         DeepPartial<Masked<MaskedVariablesCaseData>>
       >();
-      expectTypeOf(data).not.toEqualTypeOf<
-        DeepPartial<UnmaskedVariablesCaseData>
-      >();
     }
   });
 
   it("returns correct TData type when combined options that do not affect TData", () => {
     const { query } = setupVariablesCase();
 
-    const [inferredQueryRef] = useBackgroundQuery(query, {
-      fetchPolicy: "no-cache",
-      returnPartialData: true,
-      errorPolicy: "none",
-    });
-    const { data: inferred } = useReadQuery(inferredQueryRef);
+    {
+      const [queryRef] = useBackgroundQuery(query, {
+        fetchPolicy: "no-cache",
+        returnPartialData: true,
+        errorPolicy: "none",
+      });
+      const { data } = useReadQuery(queryRef);
 
-    expectTypeOf(inferred).toEqualTypeOf<DeepPartial<VariablesCaseData>>();
-    expectTypeOf(inferred).not.toEqualTypeOf<VariablesCaseData>();
+      expectTypeOf(data).toEqualTypeOf<DeepPartial<VariablesCaseData>>();
+    }
 
-    const [explicitQueryRef] = useBackgroundQuery<
-      VariablesCaseData,
-      VariablesCaseVariables
-    >(query, {
-      fetchPolicy: "no-cache",
-      returnPartialData: true,
-      errorPolicy: "none",
-    });
+    {
+      const [queryRef] = useBackgroundQuery<
+        VariablesCaseData,
+        VariablesCaseVariables
+      >(query, {
+        fetchPolicy: "no-cache",
+        returnPartialData: true,
+        errorPolicy: "none",
+      });
 
-    const { data: explicit } = useReadQuery(explicitQueryRef);
+      const { data } = useReadQuery(queryRef);
 
-    expectTypeOf(explicit).toEqualTypeOf<DeepPartial<VariablesCaseData>>();
-    expectTypeOf(explicit).not.toEqualTypeOf<VariablesCaseData>();
+      expectTypeOf(data).toEqualTypeOf<DeepPartial<VariablesCaseData>>();
+    }
 
     const { query: maskedQuery } = setupMaskedVariablesCase();
 
@@ -7620,9 +7539,6 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         DeepPartial<Masked<MaskedVariablesCaseData>>
       >();
-      expectTypeOf(data).not.toEqualTypeOf<
-        DeepPartial<UnmaskedVariablesCaseData>
-      >();
     }
 
     {
@@ -7637,9 +7553,6 @@ describe.skip("type tests", () => {
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<DeepPartial<MaskedVariablesCaseData>>();
-      expectTypeOf(data).not.toEqualTypeOf<
-        DeepPartial<UnmaskedVariablesCaseData>
-      >();
     }
 
     {
@@ -7655,9 +7568,6 @@ describe.skip("type tests", () => {
 
       expectTypeOf(data).toEqualTypeOf<
         DeepPartial<Masked<MaskedVariablesCaseData>>
-      >();
-      expectTypeOf(data).not.toEqualTypeOf<
-        DeepPartial<UnmaskedVariablesCaseData>
       >();
     }
   });
@@ -7666,34 +7576,30 @@ describe.skip("type tests", () => {
     const { query } = setupVariablesCase();
     const { query: maskedQuery } = setupMaskedVariablesCase();
 
-    const [inferredQueryRef] = useBackgroundQuery(query, {
-      skip: true,
-    });
+    {
+      const [queryRef] = useBackgroundQuery(query, { skip: true });
 
-    expectTypeOf(inferredQueryRef).toEqualTypeOf<
-      QueryRef<VariablesCaseData, VariablesCaseVariables> | undefined
-    >();
-    expectTypeOf(inferredQueryRef).toMatchTypeOf<
-      QueryReference<VariablesCaseData, VariablesCaseVariables> | undefined
-    >();
-    expectTypeOf(inferredQueryRef).not.toEqualTypeOf<
-      QueryRef<VariablesCaseData>
-    >();
+      expectTypeOf(queryRef).toEqualTypeOf<
+        QueryRef<VariablesCaseData, VariablesCaseVariables> | undefined
+      >();
+      expectTypeOf(queryRef).toMatchTypeOf<
+        QueryReference<VariablesCaseData, VariablesCaseVariables> | undefined
+      >();
+    }
 
-    const [explicitQueryRef] = useBackgroundQuery<
-      VariablesCaseData,
-      VariablesCaseVariables
-    >(query, { skip: true });
+    {
+      const [queryRef] = useBackgroundQuery<
+        VariablesCaseData,
+        VariablesCaseVariables
+      >(query, { skip: true });
 
-    expectTypeOf(explicitQueryRef).toEqualTypeOf<
-      QueryRef<VariablesCaseData, VariablesCaseVariables> | undefined
-    >();
-    expectTypeOf(explicitQueryRef).toMatchTypeOf<
-      QueryReference<VariablesCaseData, VariablesCaseVariables> | undefined
-    >();
-    expectTypeOf(explicitQueryRef).not.toEqualTypeOf<
-      QueryRef<VariablesCaseData, VariablesCaseVariables>
-    >();
+      expectTypeOf(queryRef).toEqualTypeOf<
+        QueryRef<VariablesCaseData, VariablesCaseVariables> | undefined
+      >();
+      expectTypeOf(queryRef).toMatchTypeOf<
+        QueryReference<VariablesCaseData, VariablesCaseVariables> | undefined
+      >();
+    }
 
     {
       const [queryRef] = useBackgroundQuery(maskedQuery, { skip: true });
@@ -7702,8 +7608,12 @@ describe.skip("type tests", () => {
         | QueryRef<Masked<MaskedVariablesCaseData>, VariablesCaseVariables>
         | undefined
       >();
-      expectTypeOf(queryRef).not.toEqualTypeOf<
-        QueryRef<MaskedVariablesCaseData, VariablesCaseVariables> | undefined
+      expectTypeOf(queryRef).toMatchTypeOf<
+        | QueryReference<
+            Masked<MaskedVariablesCaseData>,
+            VariablesCaseVariables
+          >
+        | undefined
       >();
     }
 
@@ -7716,8 +7626,8 @@ describe.skip("type tests", () => {
       expectTypeOf(queryRef).toEqualTypeOf<
         QueryRef<MaskedVariablesCaseData, VariablesCaseVariables> | undefined
       >();
-      expectTypeOf(queryRef).not.toEqualTypeOf<
-        | QueryRef<Masked<MaskedVariablesCaseData>, VariablesCaseVariables>
+      expectTypeOf(queryRef).toMatchTypeOf<
+        | QueryReference<MaskedVariablesCaseData, VariablesCaseVariables>
         | undefined
       >();
     }
@@ -7732,8 +7642,12 @@ describe.skip("type tests", () => {
         | QueryRef<Masked<MaskedVariablesCaseData>, VariablesCaseVariables>
         | undefined
       >();
-      expectTypeOf(queryRef).not.toEqualTypeOf<
-        QueryRef<MaskedVariablesCaseData, VariablesCaseVariables> | undefined
+      expectTypeOf(queryRef).toMatchTypeOf<
+        | QueryReference<
+            Masked<MaskedVariablesCaseData>,
+            VariablesCaseVariables
+          >
+        | undefined
       >();
     }
 
@@ -7744,19 +7658,16 @@ describe.skip("type tests", () => {
       skip: true,
     };
 
-    const [dynamicQueryRef] = useBackgroundQuery(query, {
-      skip: options.skip,
-    });
+    {
+      const [queryRef] = useBackgroundQuery(query, { skip: options.skip });
 
-    expectTypeOf(dynamicQueryRef).toEqualTypeOf<
-      QueryRef<VariablesCaseData, VariablesCaseVariables> | undefined
-    >();
-    expectTypeOf(dynamicQueryRef).toMatchTypeOf<
-      QueryReference<VariablesCaseData, VariablesCaseVariables> | undefined
-    >();
-    expectTypeOf(dynamicQueryRef).not.toEqualTypeOf<
-      QueryRef<VariablesCaseData, VariablesCaseVariables>
-    >();
+      expectTypeOf(queryRef).toEqualTypeOf<
+        QueryRef<VariablesCaseData, VariablesCaseVariables> | undefined
+      >();
+      expectTypeOf(queryRef).toMatchTypeOf<
+        QueryReference<VariablesCaseData, VariablesCaseVariables> | undefined
+      >();
+    }
 
     {
       const [queryRef] = useBackgroundQuery(maskedQuery, {
@@ -7767,8 +7678,12 @@ describe.skip("type tests", () => {
         | QueryRef<Masked<MaskedVariablesCaseData>, VariablesCaseVariables>
         | undefined
       >();
-      expectTypeOf(queryRef).not.toEqualTypeOf<
-        QueryRef<UnmaskedVariablesCaseData, VariablesCaseVariables> | undefined
+      expectTypeOf(queryRef).toMatchTypeOf<
+        | QueryReference<
+            Masked<MaskedVariablesCaseData>,
+            VariablesCaseVariables
+          >
+        | undefined
       >();
     }
 
@@ -7781,8 +7696,8 @@ describe.skip("type tests", () => {
       expectTypeOf(queryRef).toEqualTypeOf<
         QueryRef<MaskedVariablesCaseData, VariablesCaseVariables> | undefined
       >();
-      expectTypeOf(queryRef).not.toEqualTypeOf<
-        | QueryRef<Masked<MaskedVariablesCaseData>, VariablesCaseVariables>
+      expectTypeOf(queryRef).toMatchTypeOf<
+        | QueryReference<MaskedVariablesCaseData, VariablesCaseVariables>
         | undefined
       >();
     }
@@ -7797,8 +7712,12 @@ describe.skip("type tests", () => {
         | QueryRef<Masked<MaskedVariablesCaseData>, VariablesCaseVariables>
         | undefined
       >();
-      expectTypeOf(queryRef).not.toEqualTypeOf<
-        QueryRef<MaskedVariablesCaseData, VariablesCaseVariables> | undefined
+      expectTypeOf(queryRef).toMatchTypeOf<
+        | QueryReference<
+            Masked<MaskedVariablesCaseData>,
+            VariablesCaseVariables
+          >
+        | undefined
       >();
     }
   });
@@ -7806,22 +7725,20 @@ describe.skip("type tests", () => {
   it("returns `undefined` when using `skipToken` unconditionally", () => {
     const { query } = setupVariablesCase();
 
-    const [inferredQueryRef] = useBackgroundQuery(query, skipToken);
+    {
+      const [queryRef] = useBackgroundQuery(query, skipToken);
 
-    expectTypeOf(inferredQueryRef).toEqualTypeOf<undefined>();
-    expectTypeOf(inferredQueryRef).not.toEqualTypeOf<
-      QueryRef<VariablesCaseData, VariablesCaseVariables> | undefined
-    >();
+      expectTypeOf(queryRef).toEqualTypeOf<undefined>();
+    }
 
-    const [explicitQueryRef] = useBackgroundQuery<
-      VariablesCaseData,
-      VariablesCaseVariables
-    >(query, skipToken);
+    {
+      const [queryRef] = useBackgroundQuery<
+        VariablesCaseData,
+        VariablesCaseVariables
+      >(query, skipToken);
 
-    expectTypeOf(explicitQueryRef).toEqualTypeOf<undefined>();
-    expectTypeOf(explicitQueryRef).not.toEqualTypeOf<
-      QueryRef<VariablesCaseData, VariablesCaseVariables> | undefined
-    >();
+      expectTypeOf(queryRef).toEqualTypeOf<undefined>();
+    }
 
     const { query: maskedQuery } = setupMaskedVariablesCase();
 
@@ -7829,10 +7746,6 @@ describe.skip("type tests", () => {
       const [queryRef] = useBackgroundQuery(maskedQuery, skipToken);
 
       expectTypeOf(queryRef).toEqualTypeOf<undefined>();
-      expectTypeOf(queryRef).not.toEqualTypeOf<
-        | QueryRef<Masked<MaskedVariablesCaseData>, VariablesCaseVariables>
-        | undefined
-      >();
     }
 
     {
@@ -7842,9 +7755,6 @@ describe.skip("type tests", () => {
       >(maskedQuery, skipToken);
 
       expectTypeOf(queryRef).toEqualTypeOf<undefined>();
-      expectTypeOf(queryRef).not.toEqualTypeOf<
-        QueryRef<MaskedVariablesCaseData, VariablesCaseVariables> | undefined
-      >();
     }
 
     {
@@ -7854,10 +7764,6 @@ describe.skip("type tests", () => {
       >(maskedQuery, skipToken);
 
       expectTypeOf(queryRef).toEqualTypeOf<undefined>();
-      expectTypeOf(queryRef).not.toEqualTypeOf<
-        | QueryRef<Masked<MaskedVariablesCaseData>, VariablesCaseVariables>
-        | undefined
-      >();
     }
   });
 
@@ -7867,35 +7773,33 @@ describe.skip("type tests", () => {
       skip: true,
     };
 
-    const [inferredQueryRef] = useBackgroundQuery(
-      query,
-      options.skip ? skipToken : undefined
-    );
+    {
+      const [queryRef] = useBackgroundQuery(
+        query,
+        options.skip ? skipToken : undefined
+      );
 
-    expectTypeOf(inferredQueryRef).toEqualTypeOf<
-      QueryRef<VariablesCaseData, VariablesCaseVariables> | undefined
-    >();
-    expectTypeOf(inferredQueryRef).toMatchTypeOf<
-      QueryReference<VariablesCaseData, VariablesCaseVariables> | undefined
-    >();
-    expectTypeOf(inferredQueryRef).not.toEqualTypeOf<
-      QueryRef<VariablesCaseData, VariablesCaseVariables>
-    >();
+      expectTypeOf(queryRef).toEqualTypeOf<
+        QueryRef<VariablesCaseData, VariablesCaseVariables> | undefined
+      >();
+      expectTypeOf(queryRef).toMatchTypeOf<
+        QueryReference<VariablesCaseData, VariablesCaseVariables> | undefined
+      >();
+    }
 
-    const [explicitQueryRef] = useBackgroundQuery<
-      VariablesCaseData,
-      VariablesCaseVariables
-    >(query, options.skip ? skipToken : undefined);
+    {
+      const [queryRef] = useBackgroundQuery<
+        VariablesCaseData,
+        VariablesCaseVariables
+      >(query, options.skip ? skipToken : undefined);
 
-    expectTypeOf(explicitQueryRef).toEqualTypeOf<
-      QueryRef<VariablesCaseData, VariablesCaseVariables> | undefined
-    >();
-    expectTypeOf(explicitQueryRef).toMatchTypeOf<
-      QueryReference<VariablesCaseData, VariablesCaseVariables> | undefined
-    >();
-    expectTypeOf(explicitQueryRef).not.toEqualTypeOf<
-      QueryRef<VariablesCaseData, VariablesCaseVariables>
-    >();
+      expectTypeOf(queryRef).toEqualTypeOf<
+        QueryRef<VariablesCaseData, VariablesCaseVariables> | undefined
+      >();
+      expectTypeOf(queryRef).toMatchTypeOf<
+        QueryReference<VariablesCaseData, VariablesCaseVariables> | undefined
+      >();
+    }
 
     const { query: maskedQuery } = setupMaskedVariablesCase();
 
@@ -7909,8 +7813,12 @@ describe.skip("type tests", () => {
         | QueryRef<Masked<MaskedVariablesCaseData>, VariablesCaseVariables>
         | undefined
       >();
-      expectTypeOf(queryRef).not.toEqualTypeOf<
-        QueryRef<MaskedVariablesCaseData, VariablesCaseVariables> | undefined
+      expectTypeOf(queryRef).toMatchTypeOf<
+        | QueryReference<
+            Masked<MaskedVariablesCaseData>,
+            VariablesCaseVariables
+          >
+        | undefined
       >();
     }
 
@@ -7923,8 +7831,8 @@ describe.skip("type tests", () => {
       expectTypeOf(queryRef).toEqualTypeOf<
         QueryRef<MaskedVariablesCaseData, VariablesCaseVariables> | undefined
       >();
-      expectTypeOf(queryRef).not.toEqualTypeOf<
-        | QueryRef<Masked<MaskedVariablesCaseData>, VariablesCaseVariables>
+      expectTypeOf(queryRef).toMatchTypeOf<
+        | QueryReference<MaskedVariablesCaseData, VariablesCaseVariables>
         | undefined
       >();
     }
@@ -7939,8 +7847,12 @@ describe.skip("type tests", () => {
         | QueryRef<Masked<MaskedVariablesCaseData>, VariablesCaseVariables>
         | undefined
       >();
-      expectTypeOf(queryRef).not.toEqualTypeOf<
-        QueryRef<MaskedVariablesCaseData, VariablesCaseVariables> | undefined
+      expectTypeOf(queryRef).toMatchTypeOf<
+        | QueryReference<
+            Masked<MaskedVariablesCaseData>,
+            VariablesCaseVariables
+          >
+        | undefined
       >();
     }
   });
@@ -7951,39 +7863,37 @@ describe.skip("type tests", () => {
       skip: true,
     };
 
-    const [inferredQueryRef] = useBackgroundQuery(
-      query,
-      options.skip ? skipToken : { returnPartialData: true }
-    );
+    {
+      const [queryRef] = useBackgroundQuery(
+        query,
+        options.skip ? skipToken : { returnPartialData: true }
+      );
 
-    expectTypeOf(inferredQueryRef).toEqualTypeOf<
-      | QueryRef<DeepPartial<VariablesCaseData>, VariablesCaseVariables>
-      | undefined
-    >();
-    expectTypeOf(inferredQueryRef).toMatchTypeOf<
-      | QueryReference<DeepPartial<VariablesCaseData>, VariablesCaseVariables>
-      | undefined
-    >();
-    expectTypeOf(inferredQueryRef).not.toEqualTypeOf<
-      QueryRef<VariablesCaseData, VariablesCaseVariables>
-    >();
+      expectTypeOf(queryRef).toEqualTypeOf<
+        | QueryRef<DeepPartial<VariablesCaseData>, VariablesCaseVariables>
+        | undefined
+      >();
+      expectTypeOf(queryRef).toMatchTypeOf<
+        | QueryReference<DeepPartial<VariablesCaseData>, VariablesCaseVariables>
+        | undefined
+      >();
+    }
 
-    const [explicitQueryRef] = useBackgroundQuery<
-      VariablesCaseData,
-      VariablesCaseVariables
-    >(query, options.skip ? skipToken : { returnPartialData: true });
+    {
+      const [queryRef] = useBackgroundQuery<
+        VariablesCaseData,
+        VariablesCaseVariables
+      >(query, options.skip ? skipToken : { returnPartialData: true });
 
-    expectTypeOf(explicitQueryRef).toEqualTypeOf<
-      | QueryRef<DeepPartial<VariablesCaseData>, VariablesCaseVariables>
-      | undefined
-    >();
-    expectTypeOf(explicitQueryRef).toMatchTypeOf<
-      | QueryReference<DeepPartial<VariablesCaseData>, VariablesCaseVariables>
-      | undefined
-    >();
-    expectTypeOf(explicitQueryRef).not.toEqualTypeOf<
-      QueryRef<VariablesCaseData, VariablesCaseVariables>
-    >();
+      expectTypeOf(queryRef).toEqualTypeOf<
+        | QueryRef<DeepPartial<VariablesCaseData>, VariablesCaseVariables>
+        | undefined
+      >();
+      expectTypeOf(queryRef).toMatchTypeOf<
+        | QueryReference<DeepPartial<VariablesCaseData>, VariablesCaseVariables>
+        | undefined
+      >();
+    }
 
     const { query: maskedQuery } = setupMaskedVariablesCase();
 
@@ -8000,8 +7910,11 @@ describe.skip("type tests", () => {
           >
         | undefined
       >();
-      expectTypeOf(queryRef).not.toEqualTypeOf<
-        | QueryRef<DeepPartial<MaskedVariablesCaseData>, VariablesCaseVariables>
+      expectTypeOf(queryRef).toMatchTypeOf<
+        | QueryReference<
+            DeepPartial<Masked<MaskedVariablesCaseData>>,
+            VariablesCaseVariables
+          >
         | undefined
       >();
     }
@@ -8016,9 +7929,9 @@ describe.skip("type tests", () => {
         | QueryRef<DeepPartial<MaskedVariablesCaseData>, VariablesCaseVariables>
         | undefined
       >();
-      expectTypeOf(queryRef).not.toEqualTypeOf<
-        | QueryRef<
-            DeepPartial<Masked<MaskedVariablesCaseData>>,
+      expectTypeOf(queryRef).toMatchTypeOf<
+        | QueryReference<
+            DeepPartial<MaskedVariablesCaseData>,
             VariablesCaseVariables
           >
         | undefined
@@ -8038,8 +7951,11 @@ describe.skip("type tests", () => {
           >
         | undefined
       >();
-      expectTypeOf(queryRef).not.toEqualTypeOf<
-        | QueryRef<DeepPartial<MaskedVariablesCaseData>, VariablesCaseVariables>
+      expectTypeOf(queryRef).toMatchTypeOf<
+        | QueryReference<
+            DeepPartial<Masked<MaskedVariablesCaseData>>,
+            VariablesCaseVariables
+          >
         | undefined
       >();
     }
@@ -8050,24 +7966,18 @@ describe.skip("type tests", () => {
 
     {
       const [, { refetch }] = useBackgroundQuery(query);
+      const { data } = await refetch();
 
-      const result = await refetch();
-
-      expectTypeOf(result.data).toEqualTypeOf<
+      expectTypeOf(data).toEqualTypeOf<
         Masked<MaskedVariablesCaseData> | undefined
       >();
-      expectTypeOf(result.data).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
     }
 
     {
       const [, { refetch }] = useBackgroundQuery(unmaskedQuery);
+      const { data } = await refetch();
 
-      const result = await refetch();
-
-      expectTypeOf(result.data).toEqualTypeOf<
-        MaskedVariablesCaseData | undefined
-      >();
-      expectTypeOf(result.data).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
+      expectTypeOf(data).toEqualTypeOf<MaskedVariablesCaseData | undefined>();
     }
   });
 
@@ -8077,32 +7987,27 @@ describe.skip("type tests", () => {
     {
       const [, { fetchMore }] = useBackgroundQuery(query);
 
-      const result = await fetchMore({
+      const { data } = await fetchMore({
         updateQuery: (queryData, { fetchMoreResult }) => {
           expectTypeOf(queryData).toEqualTypeOf<UnmaskedVariablesCaseData>();
-          expectTypeOf(queryData).not.toEqualTypeOf<MaskedVariablesCaseData>();
 
           expectTypeOf(
             fetchMoreResult
           ).toEqualTypeOf<UnmaskedVariablesCaseData>();
-          expectTypeOf(
-            fetchMoreResult
-          ).not.toEqualTypeOf<MaskedVariablesCaseData>();
 
           return {} as UnmaskedVariablesCaseData;
         },
       });
 
-      expectTypeOf(result.data).toEqualTypeOf<
+      expectTypeOf(data).toEqualTypeOf<
         Masked<MaskedVariablesCaseData> | undefined
       >();
-      expectTypeOf(result.data).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
     }
 
     {
       const [, { fetchMore }] = useBackgroundQuery(unmaskedQuery);
 
-      const result = await fetchMore({
+      const { data } = await fetchMore({
         updateQuery: (queryData, { fetchMoreResult }) => {
           expectTypeOf(queryData).toEqualTypeOf<UnmaskedVariablesCaseData>();
           expectTypeOf(queryData).not.toEqualTypeOf<MaskedVariablesCaseData>();
@@ -8118,10 +8023,7 @@ describe.skip("type tests", () => {
         },
       });
 
-      expectTypeOf(result.data).toEqualTypeOf<
-        MaskedVariablesCaseData | undefined
-      >();
-      expectTypeOf(result.data).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
+      expectTypeOf(data).toEqualTypeOf<MaskedVariablesCaseData | undefined>();
     }
   });
 

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -5988,8 +5988,12 @@ describe.skip("Type Tests", () => {
     void execute();
     void execute({});
     void execute({ variables: {} });
-    // @ts-expect-error unknown variables
-    void execute({ variables: { foo: "bar" } });
+    void execute({
+      variables: {
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
   });
 
   test("is invalid when TVariables is `never`", () => {

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -5997,6 +5997,7 @@ describe.skip("Type Tests", () => {
 
     const [execute] = useLazyQuery(query);
 
+    // @ts-expect-error
     void execute();
     // @ts-expect-error expecting variables key
     void execute({});

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -1497,7 +1497,6 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        // @ts-expect-error should be undefined
         variables: {},
       });
     }
@@ -1637,7 +1636,6 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        // @ts-expect-error should be undefined
         variables: {},
       });
     }
@@ -1761,7 +1759,6 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        // @ts-expect-error should be undefined
         variables: {},
       });
     }
@@ -2255,7 +2252,7 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        variables: {} as Variables,
+        variables: {},
       });
     }
 
@@ -2594,7 +2591,6 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        // @ts-expect-error Need to fix the return value of this property
         variables: {},
       });
     }
@@ -2614,7 +2610,6 @@ describe("useLazyQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        // @ts-expect-error Need to fix the return value of this property
         variables: {},
       });
     }
@@ -4220,7 +4215,6 @@ test("responds to cache updates after changing variables", async () => {
       loading: false,
       networkStatus: NetworkStatus.ready,
       previousData: undefined,
-      // @ts-expect-error this should be undefined
       variables: {},
     });
   }
@@ -4390,7 +4384,6 @@ test("uses cached result when switching to variables already written to the cach
       loading: false,
       networkStatus: NetworkStatus.ready,
       previousData: undefined,
-      // @ts-expect-error this should be undefined
       variables: {},
     });
   }
@@ -4504,7 +4497,6 @@ test("does not render loading states when switching to variables maybe written t
       loading: false,
       networkStatus: NetworkStatus.ready,
       previousData: undefined,
-      // @ts-expect-error this should be undefined
       variables: {},
     });
   }
@@ -4671,7 +4663,6 @@ test("applies `errorPolicy` on next fetch when it changes between renders", asyn
       loading: false,
       networkStatus: NetworkStatus.ready,
       previousData: undefined,
-      // @ts-expect-error this should be undefined
       variables: {},
     });
   }
@@ -5047,7 +5038,6 @@ test("applies `refetchWritePolicy` on next fetch when it changes between renders
       loading: false,
       networkStatus: NetworkStatus.ready,
       previousData: undefined,
-      // @ts-expect-error needs to be undefined
       variables: {},
     });
   }
@@ -5409,7 +5399,6 @@ test("applies updated `fetchPolicy` on next fetch when it changes between render
       loading: false,
       networkStatus: NetworkStatus.ready,
       previousData: undefined,
-      // @ts-expect-error should be undefined
       variables: {},
     });
   }

--- a/src/react/hooks/__tests__/useLoadableQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLoadableQuery.test.tsx
@@ -4943,11 +4943,12 @@ describe.skip("type tests", () => {
     loadQuery({ foo: "bar" });
   });
 
-  it("does not allow variables when TVariables is `never`", () => {
+  it("is not valid when TVariables is `never`", () => {
     const query: TypedDocumentNode<{ greeting: string }, never> = gql``;
 
     const [loadQuery] = useLoadableQuery(query);
 
+    // @ts-expect-error
     loadQuery();
     // @ts-expect-error no variables argument allowed
     loadQuery({});

--- a/src/react/hooks/__tests__/useLoadableQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLoadableQuery.test.tsx
@@ -73,7 +73,7 @@ interface SimpleQueryData {
 }
 
 function useSimpleQueryCase() {
-  const query: TypedDocumentNode<SimpleQueryData, never> = gql`
+  const query: TypedDocumentNode<SimpleQueryData, Record<string, never>> = gql`
     query GreetingQuery {
       greeting
     }
@@ -933,7 +933,7 @@ it("passes context to the link", async () => {
     context: Record<string, any>;
   }
 
-  const query: TypedDocumentNode<QueryData, never> = gql`
+  const query: TypedDocumentNode<QueryData, Record<string, never>> = gql`
     query ContextQuery {
       context
     }
@@ -999,7 +999,7 @@ it("passes context to the link", async () => {
 
 it("returns initial cache data followed by network data when the fetch policy is `cache-and-network`", async () => {
   type QueryData = { hello: string };
-  const query: TypedDocumentNode<QueryData, never> = gql`
+  const query: TypedDocumentNode<QueryData, Record<string, never>> = gql`
     query {
       hello
     }
@@ -1507,7 +1507,7 @@ it('does not suspend deferred queries with data in the cache and using a "cache-
     };
   }
 
-  const query: TypedDocumentNode<Data, never> = gql`
+  const query: TypedDocumentNode<Data, Record<string, never>> = gql`
     query {
       greeting {
         message
@@ -1819,7 +1819,7 @@ it("applies `context` on next fetch when it changes between renders", async () =
     phase: string;
   }
 
-  const query: TypedDocumentNode<Data, never> = gql`
+  const query: TypedDocumentNode<Data, Record<string, never>> = gql`
     query {
       phase
     }
@@ -4439,7 +4439,7 @@ it('does not suspend deferred queries with partial data in the cache and using a
     };
   }
 
-  const query: TypedDocumentNode<QueryData, never> = gql`
+  const query: TypedDocumentNode<QueryData, Record<string, never>> = gql`
     query {
       greeting {
         message

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -5042,7 +5042,6 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        // @ts-expect-error should be undefined
         variables: {},
       });
     }
@@ -5068,7 +5067,6 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        // @ts-expect-error should be undefined
         variables: {},
       });
     }
@@ -5331,7 +5329,6 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        // @ts-expect-error should be undefined
         variables: {},
       });
     }
@@ -5357,7 +5354,6 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        // @ts-expect-error should be undefined
         variables: {},
       });
     }
@@ -5586,7 +5582,6 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        // @ts-expect-error should be undefined
         variables: {},
       });
     }
@@ -5612,7 +5607,6 @@ describe("useQuery Hook", () => {
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
-        // @ts-expect-error should be undefined
         variables: {},
       });
     }

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -11180,4 +11180,148 @@ describe.skip("Type Tests", () => {
     // @ts-expect-error
     variables?.nonExistingVariable;
   });
+
+  test("variables are optional and can be anything with an DocumentNode", () => {
+    const query = gql``;
+
+    useQuery(query);
+    useQuery(query, {});
+    useQuery(query, { variables: {} });
+    useQuery(query, { variables: { foo: "bar" } });
+    useQuery(query, { variables: { bar: "baz" } });
+  });
+
+  test("variables are optional and can be anything with unspecified TVariables on a TypedDocumentNode", () => {
+    const query: TypedDocumentNode<{ greeting: string }> = gql``;
+
+    useQuery(query);
+    useQuery(query, {});
+    useQuery(query, { variables: {} });
+    useQuery(query, { variables: { foo: "bar" } });
+    useQuery(query, { variables: { bar: "baz" } });
+  });
+
+  test("variables are optional when TVariables are empty", () => {
+    const query: TypedDocumentNode<
+      { greeting: string },
+      Record<string, never>
+    > = gql``;
+
+    useQuery(query);
+    useQuery(query, {});
+    useQuery(query, { variables: {} });
+    useQuery(query, {
+      variables: {
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
+  });
+
+  test("is invalid when TVariables is `never`", () => {
+    const query: TypedDocumentNode<{ greeting: string }, never> = gql``;
+
+    // @ts-expect-error
+    useQuery(query);
+    // @ts-expect-error
+    useQuery(query, {});
+    useQuery(query, {
+      // @ts-expect-error
+      variables: {},
+    });
+    useQuery(query, {
+      // @ts-expect-error
+      variables: undefined,
+    });
+    useQuery(query, {
+      // @ts-expect-error
+      variables: {
+        foo: "bar",
+      },
+    });
+  });
+
+  test("optional variables are optional", () => {
+    const query: TypedDocumentNode<{ posts: string[] }, { limit?: number }> =
+      gql``;
+
+    useQuery(query);
+    useQuery(query, {});
+    useQuery(query, { variables: {} });
+    useQuery(query, { variables: { limit: 10 } });
+    useQuery(query, {
+      variables: {
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
+    useQuery(query, {
+      variables: {
+        limit: 10,
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
+  });
+
+  test("enforces required variables when TVariables includes required variables", () => {
+    const query: TypedDocumentNode<{ character: string }, { id: string }> =
+      gql``;
+
+    // @ts-expect-error empty variables
+    useQuery(query);
+    // @ts-expect-error empty variables
+    useQuery(query, {});
+    // @ts-expect-error empty variables
+    useQuery(query, { variables: {} });
+    useQuery(query, { variables: { id: "1" } });
+    useQuery(query, {
+      variables: {
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
+    useQuery(query, {
+      variables: {
+        id: "1",
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
+  });
+
+  test("requires variables with mixed TVariables", () => {
+    const query: TypedDocumentNode<
+      { character: string },
+      { id: string; language?: string }
+    > = gql``;
+
+    // @ts-expect-error empty variables
+    useQuery(query);
+    // @ts-expect-error empty variables
+    useQuery(query, {});
+    // @ts-expect-error empty variables
+    useQuery(query, { variables: {} });
+    useQuery(query, { variables: { id: "1" } });
+    useQuery(query, {
+      // @ts-expect-error missing required variables
+      variables: { language: "en" },
+    });
+    useQuery(query, { variables: { id: "1", language: "en" } });
+    useQuery(query, {
+      variables: {
+        id: "1",
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
+    useQuery(query, {
+      variables: {
+        id: "1",
+        language: "en",
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
+  });
 });

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -2466,4 +2466,154 @@ describe.skip("Type Tests", () => {
 
     expectTypeOf(data).toEqualTypeOf<Subscription | undefined>();
   });
+
+  test("variables are optional and can be anything with an DocumentNode", () => {
+    const subscription = gql``;
+
+    useSubscription(subscription);
+    useSubscription(subscription, {});
+    useSubscription(subscription, { variables: {} });
+    useSubscription(subscription, { variables: { foo: "bar" } });
+    useSubscription(subscription, { variables: { bar: "baz" } });
+  });
+
+  test("variables are optional and can be anything with unspecified TVariables on a TypedDocumentNode", () => {
+    const subscription: TypedDocumentNode<{ greeting: string }> = gql``;
+
+    useSubscription(subscription);
+    useSubscription(subscription, {});
+    useSubscription(subscription, { variables: {} });
+    useSubscription(subscription, { variables: { foo: "bar" } });
+    useSubscription(subscription, { variables: { bar: "baz" } });
+  });
+
+  test("variables are optional when TVariables are empty", () => {
+    const subscription: TypedDocumentNode<
+      { greeting: string },
+      Record<string, never>
+    > = gql``;
+
+    useSubscription(subscription);
+    useSubscription(subscription, {});
+    useSubscription(subscription, { variables: {} });
+    useSubscription(subscription, {
+      variables: {
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
+  });
+
+  test("is invalid when TVariables is `never`", () => {
+    const subscription: TypedDocumentNode<{ greeting: string }, never> = gql``;
+
+    // @ts-expect-error
+    useSubscription(subscription);
+    // @ts-expect-error
+    useSubscription(subscription, {});
+    useSubscription(subscription, {
+      // @ts-expect-error
+      variables: {},
+    });
+    useSubscription(subscription, {
+      // @ts-expect-error
+      variables: undefined,
+    });
+    useSubscription(subscription, {
+      // @ts-expect-error
+      variables: {
+        foo: "bar",
+      },
+    });
+  });
+
+  test("optional variables are optional", () => {
+    const subscription: TypedDocumentNode<
+      { posts: string[] },
+      { limit?: number }
+    > = gql``;
+
+    useSubscription(subscription);
+    useSubscription(subscription, {});
+    useSubscription(subscription, { variables: {} });
+    useSubscription(subscription, { variables: { limit: 10 } });
+    useSubscription(subscription, {
+      variables: {
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
+    useSubscription(subscription, {
+      variables: {
+        limit: 10,
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
+  });
+
+  test("enforces required variables when TVariables includes required variables", () => {
+    const subscription: TypedDocumentNode<
+      { character: string },
+      { id: string }
+    > = gql``;
+
+    // @ts-expect-error empty variables
+    useSubscription(subscription);
+    // @ts-expect-error empty variables
+    useSubscription(subscription, {});
+    useSubscription(subscription, {
+      // @ts-expect-error empty variables
+      variables: {},
+    });
+    useSubscription(subscription, { variables: { id: "1" } });
+    useSubscription(subscription, {
+      variables: {
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
+    useSubscription(subscription, {
+      variables: {
+        id: "1",
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
+  });
+
+  test("requires variables with mixed TVariables", () => {
+    const subscription: TypedDocumentNode<
+      { character: string },
+      { id: string; language?: string }
+    > = gql``;
+
+    // @ts-expect-error empty variables
+    useSubscription(subscription);
+    // @ts-expect-error empty variables
+    useSubscription(subscription, {});
+    // @ts-expect-error empty variables
+    useSubscription(subscription, { variables: {} });
+    useSubscription(subscription, { variables: { id: "1" } });
+    useSubscription(subscription, {
+      // @ts-expect-error missing required variables
+      variables: { language: "en" },
+    });
+    useSubscription(subscription, { variables: { id: "1", language: "en" } });
+    useSubscription(subscription, {
+      variables: {
+        id: "1",
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
+    useSubscription(subscription, {
+      variables: {
+        id: "1",
+        language: "en",
+        // @ts-expect-error unknown variables
+        foo: "bar",
+      },
+    });
+  });
 });

--- a/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
@@ -12251,7 +12251,7 @@ describe("useSuspenseQuery", () => {
       {
         const { data } = useSuspenseQuery(
           query,
-          options.skip ? skipToken : undefined
+          options.skip ? skipToken : { variables: { id: "1" } }
         );
 
         expectTypeOf(data).toEqualTypeOf<VariablesCaseData | undefined>();
@@ -12261,7 +12261,7 @@ describe("useSuspenseQuery", () => {
         const { data } = useSuspenseQuery<
           VariablesCaseData,
           VariablesCaseVariables
-        >(query, options.skip ? skipToken : undefined);
+        >(query, options.skip ? skipToken : { variables: { id: "1" } });
 
         expectTypeOf(data).toEqualTypeOf<VariablesCaseData | undefined>();
       }
@@ -12271,7 +12271,7 @@ describe("useSuspenseQuery", () => {
       {
         const { data } = useSuspenseQuery(
           maskedQuery,
-          options.skip ? skipToken : undefined
+          options.skip ? skipToken : { variables: { id: "1" } }
         );
 
         expectTypeOf(data).toEqualTypeOf<
@@ -12283,7 +12283,7 @@ describe("useSuspenseQuery", () => {
         const { data } = useSuspenseQuery<
           MaskedVariablesCaseData,
           VariablesCaseVariables
-        >(maskedQuery, options.skip ? skipToken : undefined);
+        >(maskedQuery, options.skip ? skipToken : { variables: { id: "1" } });
 
         expectTypeOf(data).toEqualTypeOf<MaskedVariablesCaseData | undefined>();
       }
@@ -12292,7 +12292,7 @@ describe("useSuspenseQuery", () => {
         const { data } = useSuspenseQuery<
           Masked<MaskedVariablesCaseData>,
           VariablesCaseVariables
-        >(maskedQuery, options.skip ? skipToken : undefined);
+        >(maskedQuery, options.skip ? skipToken : { variables: { id: "1" } });
 
         expectTypeOf(data).toEqualTypeOf<
           Masked<MaskedVariablesCaseData> | undefined
@@ -12901,6 +12901,13 @@ describe("useSuspenseQuery", () => {
       useSuspenseQuery(query, { variables: {} });
       useSuspenseQuery(query, { variables: { foo: "bar" } });
       useSuspenseQuery(query, { variables: { bar: "baz" } });
+
+      let skip!: boolean;
+      useSuspenseQuery(query, skip ? skipToken : undefined);
+      useSuspenseQuery(query, skip ? skipToken : {});
+      useSuspenseQuery(query, skip ? skipToken : { variables: {} });
+      useSuspenseQuery(query, skip ? skipToken : { variables: { foo: "bar" } });
+      useSuspenseQuery(query, skip ? skipToken : { variables: { bar: "baz" } });
     });
 
     test("variables are optional and can be anything with unspecified TVariables on a TypedDocumentNode", () => {
@@ -12911,6 +12918,13 @@ describe("useSuspenseQuery", () => {
       useSuspenseQuery(query, { variables: {} });
       useSuspenseQuery(query, { variables: { foo: "bar" } });
       useSuspenseQuery(query, { variables: { bar: "baz" } });
+
+      let skip!: boolean;
+      useSuspenseQuery(query, skip ? skipToken : undefined);
+      useSuspenseQuery(query, skip ? skipToken : {});
+      useSuspenseQuery(query, skip ? skipToken : { variables: {} });
+      useSuspenseQuery(query, skip ? skipToken : { variables: { foo: "bar" } });
+      useSuspenseQuery(query, skip ? skipToken : { variables: { bar: "baz" } });
     });
 
     test("variables are optional when TVariables are empty", () => {
@@ -12928,6 +12942,16 @@ describe("useSuspenseQuery", () => {
           foo: "bar",
         },
       });
+
+      let skip!: boolean;
+      useSuspenseQuery(query, skip ? skipToken : undefined);
+      useSuspenseQuery(query, skip ? skipToken : {});
+      useSuspenseQuery(query, skip ? skipToken : { variables: {} });
+      useSuspenseQuery(
+        query,
+        // @ts-expect-error unknown variables
+        skip ? skipToken : { variables: { foo: "bar" } }
+      );
     });
 
     test("is invalid when TVariables is `never`", () => {
@@ -12951,6 +12975,30 @@ describe("useSuspenseQuery", () => {
           foo: "bar",
         },
       });
+
+      let skip!: boolean;
+      // @ts-expect-error
+      useSuspenseQuery(query, skip ? skipToken : undefined);
+      useSuspenseQuery(
+        query,
+        // @ts-expect-error
+        skip ? skipToken : {}
+      );
+      useSuspenseQuery(
+        query,
+        // @ts-expect-error
+        skip ? skipToken : { variables: {} }
+      );
+      useSuspenseQuery(
+        query,
+        // @ts-expect-error
+        skip ? skipToken : { variables: undefined }
+      );
+      useSuspenseQuery(
+        query,
+        // @ts-expect-error unknown variables
+        skip ? skipToken : { variables: { foo: "bar" } }
+      );
     });
 
     test("optional variables are optional", () => {
@@ -12974,6 +13022,35 @@ describe("useSuspenseQuery", () => {
           foo: "bar",
         },
       });
+
+      let skip!: boolean;
+      useSuspenseQuery(query, skip ? skipToken : undefined);
+      useSuspenseQuery(query, skip ? skipToken : {});
+      useSuspenseQuery(query, skip ? skipToken : { variables: {} });
+      useSuspenseQuery(query, skip ? skipToken : { variables: { limit: 10 } });
+      useSuspenseQuery(
+        query,
+        skip ? skipToken : (
+          {
+            variables: {
+              // @ts-expect-error unknown variables
+              foo: "bar",
+            },
+          }
+        )
+      );
+      useSuspenseQuery(
+        query,
+        skip ? skipToken : (
+          {
+            variables: {
+              limit: 10,
+              // @ts-expect-error unknown variables
+              foo: "bar",
+            },
+          }
+        )
+      );
     });
 
     test("enforces required variables when TVariables includes required variables", () => {
@@ -13000,6 +13077,44 @@ describe("useSuspenseQuery", () => {
           foo: "bar",
         },
       });
+
+      let skip!: boolean;
+      // @ts-expect-error missing variables option
+      useSuspenseQuery(query, skip ? skipToken : undefined);
+      useSuspenseQuery(
+        query,
+        // @ts-expect-error missing variables option
+        skip ? skipToken : {}
+      );
+      useSuspenseQuery(
+        query,
+        // @ts-expect-error missing required variables
+        skip ? skipToken : { variables: {} }
+      );
+      useSuspenseQuery(query, skip ? skipToken : { variables: { id: "1" } });
+      useSuspenseQuery(
+        query,
+        skip ? skipToken : (
+          {
+            variables: {
+              // @ts-expect-error unknown variables
+              foo: "bar",
+            },
+          }
+        )
+      );
+      useSuspenseQuery(
+        query,
+        skip ? skipToken : (
+          {
+            variables: {
+              id: "1",
+              // @ts-expect-error unknown variables
+              foo: "bar",
+            },
+          }
+        )
+      );
     });
 
     test("requires variables with mixed TVariables", () => {
@@ -13035,6 +13150,50 @@ describe("useSuspenseQuery", () => {
           foo: "bar",
         },
       });
+
+      let skip!: boolean;
+      // @ts-expect-error missing variables option
+      useSuspenseQuery(query, skip ? skipToken : undefined);
+      useSuspenseQuery(
+        query,
+        // @ts-expect-error missing variables option
+        skip ? skipToken : {}
+      );
+      useSuspenseQuery(
+        query,
+        // @ts-expect-error missing required variables
+        skip ? skipToken : { variables: {} }
+      );
+      useSuspenseQuery(query, skip ? skipToken : { variables: { id: "1" } });
+      useSuspenseQuery(
+        query,
+        skip ? skipToken : { variables: { id: "1", language: "en" } }
+      );
+      useSuspenseQuery(
+        query,
+        skip ? skipToken : (
+          {
+            variables: {
+              id: "1",
+              // @ts-expect-error unknown variables
+              foo: "bar",
+            },
+          }
+        )
+      );
+      useSuspenseQuery(
+        query,
+        skip ? skipToken : (
+          {
+            variables: {
+              id: "1",
+              language: "en",
+              // @ts-expect-error unknown variables
+              foo: "bar",
+            },
+          }
+        )
+      );
     });
   });
 });

--- a/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
@@ -165,7 +165,7 @@ async function renderSuspenseHook<Result, Props>(
 }
 
 function useSimpleQueryCase() {
-  const query: TypedDocumentNode<SimpleQueryData> = gql`
+  const query: TypedDocumentNode<SimpleQueryData, Record<string, never>> = gql`
     query UserQuery {
       greeting
     }
@@ -241,7 +241,7 @@ function useErrorCase<TData extends ErrorCaseData>({
   networkError?: Error;
   graphQLErrors?: GraphQLError[];
 } = {}) {
-  const query: TypedDocumentNode<TData, never> = gql`
+  const query: TypedDocumentNode<TData, Record<string, never>> = gql`
     query MyQuery {
       currentUser {
         id
@@ -3290,6 +3290,7 @@ describe("useSuspenseQuery", () => {
     });
 
     const { result, renders } = await renderSuspenseHook(
+      // @ts-expect-error we do not recommend this pattern
       () => useSuspenseQuery(query),
       { client }
     );
@@ -3325,6 +3326,7 @@ describe("useSuspenseQuery", () => {
     });
 
     const { result, renders } = await renderSuspenseHook(
+      // @ts-expect-error we do not recommend this pattern
       () => useSuspenseQuery(query),
       { strictMode: true, client }
     );
@@ -10778,7 +10780,7 @@ describe("useSuspenseQuery", () => {
       } & { " $fragmentRefs"?: { UserFieldsFragment: UserFieldsFragment } };
     }
 
-    const query: MaskedDocumentNode<Query, never> = gql`
+    const query: MaskedDocumentNode<Query, Record<string, never>> = gql`
       query MaskedQuery {
         currentUser {
           id
@@ -10816,7 +10818,10 @@ describe("useSuspenseQuery", () => {
 
     const renderStream = createRenderStream({
       initialSnapshot: {
-        result: null as useSuspenseQuery.Result<Masked<Query>, never> | null,
+        result: null as useSuspenseQuery.Result<
+          Masked<Query>,
+          Record<string, never>
+        > | null,
       },
     });
 
@@ -10870,7 +10875,7 @@ describe("useSuspenseQuery", () => {
       } & { " $fragmentRefs"?: { UserFieldsFragment: UserFieldsFragment } };
     }
 
-    const query: TypedDocumentNode<Query, never> = gql`
+    const query: TypedDocumentNode<Query, Record<string, never>> = gql`
       query MaskedQuery {
         currentUser {
           id
@@ -10908,7 +10913,10 @@ describe("useSuspenseQuery", () => {
 
     const renderStream = createRenderStream({
       initialSnapshot: {
-        result: null as useSuspenseQuery.Result<Query, never> | null,
+        result: null as useSuspenseQuery.Result<
+          Query,
+          Record<string, never>
+        > | null,
       },
     });
 
@@ -10960,7 +10968,7 @@ describe("useSuspenseQuery", () => {
       } & { " $fragmentRefs"?: { UserFieldsFragment: UserFieldsFragment } };
     }
 
-    const query: TypedDocumentNode<Query, never> = gql`
+    const query: TypedDocumentNode<Query, Record<string, never>> = gql`
       query MaskedQuery {
         currentUser {
           id
@@ -10997,7 +11005,10 @@ describe("useSuspenseQuery", () => {
 
     const renderStream = createRenderStream({
       initialSnapshot: {
-        result: null as useSuspenseQuery.Result<Query, never> | null,
+        result: null as useSuspenseQuery.Result<
+          Query,
+          Record<string, never>
+        > | null,
       },
     });
 
@@ -11049,7 +11060,7 @@ describe("useSuspenseQuery", () => {
       } & { " $fragmentRefs"?: { UserFieldsFragment: UserFieldsFragment } };
     }
 
-    const query: MaskedDocumentNode<Query, never> = gql`
+    const query: MaskedDocumentNode<Query, Record<string, never>> = gql`
       query MaskedQuery {
         currentUser {
           id
@@ -11087,7 +11098,10 @@ describe("useSuspenseQuery", () => {
 
     const renderStream = createRenderStream({
       initialSnapshot: {
-        result: null as useSuspenseQuery.Result<Masked<Query>, never> | null,
+        result: null as useSuspenseQuery.Result<
+          Masked<Query>,
+          Record<string, never>
+        > | null,
       },
     });
 
@@ -11168,7 +11182,7 @@ describe("useSuspenseQuery", () => {
       } & { " $fragmentRefs"?: { UserFieldsFragment: UserFieldsFragment } };
     }
 
-    const query: MaskedDocumentNode<Query, never> = gql`
+    const query: MaskedDocumentNode<Query, Record<string, never>> = gql`
       query MaskedQuery {
         currentUser {
           id
@@ -11206,7 +11220,10 @@ describe("useSuspenseQuery", () => {
 
     const renderStream = createRenderStream({
       initialSnapshot: {
-        result: null as useSuspenseQuery.Result<Masked<Query>, never> | null,
+        result: null as useSuspenseQuery.Result<
+          Masked<Query>,
+          Record<string, never>
+        > | null,
       },
     });
 
@@ -11284,7 +11301,7 @@ describe("useSuspenseQuery", () => {
       } & { " $fragmentRefs"?: { UserFieldsFragment: UserFieldsFragment } };
     }
 
-    const query: MaskedDocumentNode<Query, never> = gql`
+    const query: MaskedDocumentNode<Query, Record<string, never>> = gql`
       query MaskedQuery {
         currentUser {
           id
@@ -11334,7 +11351,10 @@ describe("useSuspenseQuery", () => {
 
     const renderStream = createRenderStream({
       initialSnapshot: {
-        result: null as useSuspenseQuery.Result<Masked<Query>, never> | null,
+        result: null as useSuspenseQuery.Result<
+          Masked<Query>,
+          Record<string, never>
+        > | null,
       },
     });
 
@@ -11382,7 +11402,7 @@ describe("useSuspenseQuery", () => {
       } & { " $fragmentRefs"?: { UserFieldsFragment: UserFieldsFragment } };
     }
 
-    const query: MaskedDocumentNode<Query, never> = gql`
+    const query: MaskedDocumentNode<Query, Record<string, never>> = gql`
       query MaskedQuery {
         currentUser {
           id
@@ -11433,7 +11453,10 @@ describe("useSuspenseQuery", () => {
 
     const renderStream = createRenderStream({
       initialSnapshot: {
-        result: null as useSuspenseQuery.Result<Masked<Query>, never> | null,
+        result: null as useSuspenseQuery.Result<
+          Masked<Query>,
+          Record<string, never>
+        > | null,
       },
     });
 
@@ -11498,7 +11521,7 @@ describe("useSuspenseQuery", () => {
       } & { " $fragmentRefs"?: { UserFieldsFragment: UserFieldsFragment } };
     }
 
-    const query: MaskedDocumentNode<Query, never> = gql`
+    const query: MaskedDocumentNode<Query, Record<string, never>> = gql`
       query MaskedQuery {
         currentUser {
           id
@@ -11554,7 +11577,7 @@ describe("useSuspenseQuery", () => {
       initialSnapshot: {
         result: null as useSuspenseQuery.Result<
           DeepPartial<Masked<Query>>,
-          never
+          Record<string, never>
         > | null,
       },
     });
@@ -11616,7 +11639,7 @@ describe("useSuspenseQuery", () => {
       } & { " $fragmentRefs"?: { UserFieldsFragment: UserFieldsFragment } };
     }
 
-    const query: MaskedDocumentNode<Query, never> = gql`
+    const query: MaskedDocumentNode<Query, Record<string, never>> = gql`
       query MaskedQuery {
         currentUser {
           id
@@ -11658,7 +11681,7 @@ describe("useSuspenseQuery", () => {
       initialSnapshot: {
         result: null as useSuspenseQuery.Result<
           Masked<Query> | undefined,
-          never
+          Record<string, never>
         > | null,
       },
     });
@@ -11730,88 +11753,98 @@ describe("useSuspenseQuery", () => {
     it("disallows wider variables type than specified", () => {
       const { query } = useVariablesQueryCase();
 
-      // @ts-expect-error should not allow wider TVariables type
-      useSuspenseQuery(query, { variables: { id: "1", foo: "bar" } });
+      useSuspenseQuery(query, {
+        variables: {
+          id: "1",
+          // @ts-expect-error unknown variable
+          foo: "bar",
+        },
+      });
     });
 
     it("returns TData in default case", () => {
       const { query } = useVariablesQueryCase();
 
-      const { data: inferred } = useSuspenseQuery(query);
+      {
+        const { data } = useSuspenseQuery(query, {
+          variables: { id: "1" },
+        });
 
-      expectTypeOf(inferred).toEqualTypeOf<VariablesCaseData>();
-      expectTypeOf(inferred).not.toEqualTypeOf<VariablesCaseData | undefined>();
+        expectTypeOf(data).toEqualTypeOf<VariablesCaseData>();
+      }
 
-      const { data: explicit } = useSuspenseQuery<
-        VariablesCaseData,
-        VariablesCaseVariables
-      >(query);
+      {
+        const { data } = useSuspenseQuery<
+          VariablesCaseData,
+          VariablesCaseVariables
+        >(query, { variables: { id: "1" } });
 
-      expectTypeOf(explicit).toEqualTypeOf<VariablesCaseData>();
-      expectTypeOf(explicit).not.toEqualTypeOf<VariablesCaseData | undefined>();
+        expectTypeOf(data).toEqualTypeOf<VariablesCaseData>();
+      }
 
       const { query: maskedQuery } = useMaskedVariablesQueryCase();
 
       {
-        const { data } = useSuspenseQuery(maskedQuery);
+        const { data } = useSuspenseQuery(maskedQuery, {
+          variables: { id: "1" },
+        });
 
         expectTypeOf(data).toEqualTypeOf<Masked<MaskedVariablesCaseData>>();
-        expectTypeOf(data).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
       }
 
       {
         const { data } = useSuspenseQuery<
           MaskedVariablesCaseData,
           VariablesCaseVariables
-        >(maskedQuery);
+        >(maskedQuery, { variables: { id: "1" } });
 
         expectTypeOf(data).toEqualTypeOf<MaskedVariablesCaseData>();
-        expectTypeOf(data).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
       }
 
       {
         const { data } = useSuspenseQuery<
           Masked<MaskedVariablesCaseData>,
           VariablesCaseVariables
-        >(maskedQuery);
+        >(maskedQuery, { variables: { id: "1" } });
 
         expectTypeOf(data).toEqualTypeOf<Masked<MaskedVariablesCaseData>>();
-        expectTypeOf(data).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
       }
     });
 
     it('returns TData | undefined with errorPolicy: "ignore"', () => {
       const { query } = useVariablesQueryCase();
 
-      const { data: inferred } = useSuspenseQuery(query, {
-        errorPolicy: "ignore",
-      });
+      {
+        const { data } = useSuspenseQuery(query, {
+          errorPolicy: "ignore",
+          variables: { id: "1" },
+        });
 
-      expectTypeOf(inferred).toEqualTypeOf<VariablesCaseData | undefined>();
-      expectTypeOf(inferred).not.toEqualTypeOf<VariablesCaseData>();
+        expectTypeOf(data).toEqualTypeOf<VariablesCaseData | undefined>();
+      }
 
-      const { data: explicit } = useSuspenseQuery<
-        VariablesCaseData,
-        VariablesCaseVariables
-      >(query, {
-        errorPolicy: "ignore",
-      });
+      {
+        const { data } = useSuspenseQuery<
+          VariablesCaseData,
+          VariablesCaseVariables
+        >(query, {
+          errorPolicy: "ignore",
+          variables: { id: "1" },
+        });
 
-      expectTypeOf(explicit).toEqualTypeOf<VariablesCaseData | undefined>();
-      expectTypeOf(explicit).not.toEqualTypeOf<VariablesCaseData>();
+        expectTypeOf(data).toEqualTypeOf<VariablesCaseData | undefined>();
+      }
 
       const { query: maskedQuery } = useMaskedVariablesQueryCase();
 
       {
         const { data } = useSuspenseQuery(maskedQuery, {
           errorPolicy: "ignore",
+          variables: { id: "1" },
         });
 
         expectTypeOf(data).toEqualTypeOf<
           Masked<MaskedVariablesCaseData> | undefined
-        >();
-        expectTypeOf(data).not.toEqualTypeOf<
-          UnmaskedVariablesCaseData | undefined
         >();
       }
 
@@ -11819,25 +11852,19 @@ describe("useSuspenseQuery", () => {
         const { data } = useSuspenseQuery<
           MaskedVariablesCaseData,
           VariablesCaseVariables
-        >(maskedQuery, { errorPolicy: "ignore" });
+        >(maskedQuery, { errorPolicy: "ignore", variables: { id: "1" } });
 
         expectTypeOf(data).toEqualTypeOf<MaskedVariablesCaseData | undefined>();
-        expectTypeOf(data).not.toEqualTypeOf<
-          UnmaskedVariablesCaseData | undefined
-        >();
       }
 
       {
         const { data } = useSuspenseQuery<
           Masked<MaskedVariablesCaseData>,
           VariablesCaseVariables
-        >(maskedQuery, { errorPolicy: "ignore" });
+        >(maskedQuery, { errorPolicy: "ignore", variables: { id: "1" } });
 
         expectTypeOf(data).toEqualTypeOf<
           Masked<MaskedVariablesCaseData> | undefined
-        >();
-        expectTypeOf(data).not.toEqualTypeOf<
-          UnmaskedVariablesCaseData | undefined
         >();
       }
     });
@@ -11845,33 +11872,37 @@ describe("useSuspenseQuery", () => {
     it('returns TData | undefined with errorPolicy: "all"', () => {
       const { query } = useVariablesQueryCase();
 
-      const { data: inferred } = useSuspenseQuery(query, {
-        errorPolicy: "all",
-      });
+      {
+        const { data } = useSuspenseQuery(query, {
+          errorPolicy: "all",
+          variables: { id: "1" },
+        });
 
-      expectTypeOf(inferred).toEqualTypeOf<VariablesCaseData | undefined>();
-      expectTypeOf(inferred).not.toEqualTypeOf<VariablesCaseData>();
+        expectTypeOf(data).toEqualTypeOf<VariablesCaseData | undefined>();
+      }
 
-      const { data: explicit } = useSuspenseQuery<
-        VariablesCaseData,
-        VariablesCaseVariables
-      >(query, {
-        errorPolicy: "all",
-      });
+      {
+        const { data } = useSuspenseQuery<
+          VariablesCaseData,
+          VariablesCaseVariables
+        >(query, {
+          errorPolicy: "all",
+          variables: { id: "1" },
+        });
 
-      expectTypeOf(explicit).toEqualTypeOf<VariablesCaseData | undefined>();
-      expectTypeOf(explicit).not.toEqualTypeOf<VariablesCaseData>();
+        expectTypeOf(data).toEqualTypeOf<VariablesCaseData | undefined>();
+      }
 
       const { query: maskedQuery } = useMaskedVariablesQueryCase();
 
       {
-        const { data } = useSuspenseQuery(maskedQuery, { errorPolicy: "all" });
+        const { data } = useSuspenseQuery(maskedQuery, {
+          errorPolicy: "all",
+          variables: { id: "1" },
+        });
 
         expectTypeOf(data).toEqualTypeOf<
           Masked<MaskedVariablesCaseData> | undefined
-        >();
-        expectTypeOf(data).not.toEqualTypeOf<
-          UnmaskedVariablesCaseData | undefined
         >();
       }
 
@@ -11879,25 +11910,19 @@ describe("useSuspenseQuery", () => {
         const { data } = useSuspenseQuery<
           MaskedVariablesCaseData,
           VariablesCaseVariables
-        >(maskedQuery, { errorPolicy: "all" });
+        >(maskedQuery, { errorPolicy: "all", variables: { id: "1" } });
 
         expectTypeOf(data).toEqualTypeOf<MaskedVariablesCaseData | undefined>();
-        expectTypeOf(data).not.toEqualTypeOf<
-          UnmaskedVariablesCaseData | undefined
-        >();
       }
 
       {
         const { data } = useSuspenseQuery<
           Masked<MaskedVariablesCaseData>,
           VariablesCaseVariables
-        >(maskedQuery, { errorPolicy: "all" });
+        >(maskedQuery, { errorPolicy: "all", variables: { id: "1" } });
 
         expectTypeOf(data).toEqualTypeOf<
           Masked<MaskedVariablesCaseData> | undefined
-        >();
-        expectTypeOf(data).not.toEqualTypeOf<
-          UnmaskedVariablesCaseData | undefined
         >();
       }
     });
@@ -11905,85 +11930,91 @@ describe("useSuspenseQuery", () => {
     it('returns TData with errorPolicy: "none"', () => {
       const { query } = useVariablesQueryCase();
 
-      const { data: inferred } = useSuspenseQuery(query, {
-        errorPolicy: "none",
-      });
+      {
+        const { data } = useSuspenseQuery(query, {
+          errorPolicy: "none",
+          variables: { id: "1" },
+        });
 
-      expectTypeOf(inferred).toEqualTypeOf<VariablesCaseData>();
-      expectTypeOf(inferred).not.toEqualTypeOf<VariablesCaseData | undefined>();
+        expectTypeOf(data).toEqualTypeOf<VariablesCaseData>();
+      }
 
-      const { data: explicit } = useSuspenseQuery<
-        VariablesCaseData,
-        VariablesCaseVariables
-      >(query, {
-        errorPolicy: "none",
-      });
+      {
+        const { data } = useSuspenseQuery<
+          VariablesCaseData,
+          VariablesCaseVariables
+        >(query, {
+          errorPolicy: "none",
+          variables: { id: "1" },
+        });
 
-      expectTypeOf(explicit).toEqualTypeOf<VariablesCaseData>();
-      expectTypeOf(explicit).not.toEqualTypeOf<VariablesCaseData | undefined>();
+        expectTypeOf(data).toEqualTypeOf<VariablesCaseData>();
+      }
 
       const { query: maskedQuery } = useMaskedVariablesQueryCase();
 
       {
-        const { data } = useSuspenseQuery(maskedQuery, { errorPolicy: "none" });
+        const { data } = useSuspenseQuery(maskedQuery, {
+          errorPolicy: "none",
+          variables: { id: "1" },
+        });
 
         expectTypeOf(data).toEqualTypeOf<Masked<MaskedVariablesCaseData>>();
-        expectTypeOf(data).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
       }
 
       {
         const { data } = useSuspenseQuery<
           MaskedVariablesCaseData,
           VariablesCaseVariables
-        >(maskedQuery, { errorPolicy: "none" });
+        >(maskedQuery, { errorPolicy: "none", variables: { id: "1" } });
 
         expectTypeOf(data).toEqualTypeOf<MaskedVariablesCaseData>();
-        expectTypeOf(data).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
       }
 
       {
         const { data } = useSuspenseQuery<
           Masked<MaskedVariablesCaseData>,
           VariablesCaseVariables
-        >(maskedQuery, { errorPolicy: "none" });
+        >(maskedQuery, { errorPolicy: "none", variables: { id: "1" } });
 
         expectTypeOf(data).toEqualTypeOf<Masked<MaskedVariablesCaseData>>();
-        expectTypeOf(data).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
       }
     });
 
     it("returns DeepPartial<TData> with returnPartialData: true", () => {
       const { query } = useVariablesQueryCase();
 
-      const { data: inferred } = useSuspenseQuery(query, {
-        returnPartialData: true,
-      });
+      {
+        const { data } = useSuspenseQuery(query, {
+          returnPartialData: true,
+          variables: { id: "1" },
+        });
 
-      expectTypeOf(inferred).toEqualTypeOf<DeepPartial<VariablesCaseData>>();
-      expectTypeOf(inferred).not.toEqualTypeOf<VariablesCaseData>();
+        expectTypeOf(data).toEqualTypeOf<DeepPartial<VariablesCaseData>>();
+      }
 
-      const { data: explicit } = useSuspenseQuery<
-        VariablesCaseData,
-        VariablesCaseVariables
-      >(query, {
-        returnPartialData: true,
-      });
+      {
+        const { data: explicit } = useSuspenseQuery<
+          VariablesCaseData,
+          VariablesCaseVariables
+        >(query, {
+          returnPartialData: true,
+          variables: { id: "1" },
+        });
 
-      expectTypeOf(explicit).toEqualTypeOf<DeepPartial<VariablesCaseData>>();
-      expectTypeOf(explicit).not.toEqualTypeOf<VariablesCaseData>();
+        expectTypeOf(explicit).toEqualTypeOf<DeepPartial<VariablesCaseData>>();
+      }
 
       const { query: maskedQuery } = useMaskedVariablesQueryCase();
 
       {
         const { data } = useSuspenseQuery(maskedQuery, {
           returnPartialData: true,
+          variables: { id: "1" },
         });
 
         expectTypeOf(data).toEqualTypeOf<
           DeepPartial<Masked<MaskedVariablesCaseData>>
-        >();
-        expectTypeOf(data).not.toEqualTypeOf<
-          DeepPartial<UnmaskedVariablesCaseData>
         >();
       }
 
@@ -11991,13 +12022,10 @@ describe("useSuspenseQuery", () => {
         const { data } = useSuspenseQuery<
           MaskedVariablesCaseData,
           VariablesCaseVariables
-        >(maskedQuery, { returnPartialData: true });
+        >(maskedQuery, { returnPartialData: true, variables: { id: "1" } });
 
         expectTypeOf(data).toEqualTypeOf<
           DeepPartial<MaskedVariablesCaseData>
-        >();
-        expectTypeOf(data).not.toEqualTypeOf<
-          DeepPartial<UnmaskedVariablesCaseData>
         >();
       }
 
@@ -12005,13 +12033,10 @@ describe("useSuspenseQuery", () => {
         const { data } = useSuspenseQuery<
           Masked<MaskedVariablesCaseData>,
           VariablesCaseVariables
-        >(maskedQuery, { returnPartialData: true });
+        >(maskedQuery, { returnPartialData: true, variables: { id: "1" } });
 
         expectTypeOf(data).toEqualTypeOf<
           DeepPartial<Masked<MaskedVariablesCaseData>>
-        >();
-        expectTypeOf(data).not.toEqualTypeOf<
-          DeepPartial<UnmaskedVariablesCaseData>
         >();
       }
     });
@@ -12019,78 +12044,80 @@ describe("useSuspenseQuery", () => {
     it("returns TData with returnPartialData: false", () => {
       const { query } = useVariablesQueryCase();
 
-      const { data: inferred } = useSuspenseQuery(query, {
-        returnPartialData: false,
-      });
+      {
+        const { data } = useSuspenseQuery(query, {
+          returnPartialData: false,
+          variables: { id: "1" },
+        });
 
-      expectTypeOf(inferred).toEqualTypeOf<VariablesCaseData>();
-      expectTypeOf(inferred).not.toEqualTypeOf<
-        DeepPartial<VariablesCaseData>
-      >();
+        expectTypeOf(data).toEqualTypeOf<VariablesCaseData>();
+      }
 
-      const { data: explicit } = useSuspenseQuery<
-        VariablesCaseData,
-        VariablesCaseVariables
-      >(query, {
-        returnPartialData: false,
-      });
+      {
+        const { data } = useSuspenseQuery<
+          VariablesCaseData,
+          VariablesCaseVariables
+        >(query, {
+          returnPartialData: false,
+          variables: { id: "1" },
+        });
 
-      expectTypeOf(explicit).toEqualTypeOf<VariablesCaseData>();
-      expectTypeOf(explicit).not.toEqualTypeOf<
-        DeepPartial<VariablesCaseData>
-      >();
+        expectTypeOf(data).toEqualTypeOf<VariablesCaseData>();
+      }
 
       const { query: maskedQuery } = useMaskedVariablesQueryCase();
 
       {
         const { data } = useSuspenseQuery(maskedQuery, {
           returnPartialData: false,
+          variables: { id: "1" },
         });
 
         expectTypeOf(data).toEqualTypeOf<Masked<MaskedVariablesCaseData>>();
-        expectTypeOf(data).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
       }
 
       {
         const { data } = useSuspenseQuery<
           MaskedVariablesCaseData,
           VariablesCaseVariables
-        >(maskedQuery, { returnPartialData: false });
+        >(maskedQuery, { returnPartialData: false, variables: { id: "1" } });
 
         expectTypeOf(data).toEqualTypeOf<MaskedVariablesCaseData>();
-        expectTypeOf(data).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
       }
 
       {
         const { data } = useSuspenseQuery<
           Masked<MaskedVariablesCaseData>,
           VariablesCaseVariables
-        >(maskedQuery, { returnPartialData: false });
+        >(maskedQuery, { returnPartialData: false, variables: { id: "1" } });
 
         expectTypeOf(data).toEqualTypeOf<Masked<MaskedVariablesCaseData>>();
-        expectTypeOf(data).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
       }
     });
 
     it("returns TData | undefined when skip is present", () => {
       const { query } = useVariablesQueryCase();
 
-      const { data: inferred } = useSuspenseQuery(query, {
-        skip: true,
-      });
+      {
+        const { data } = useSuspenseQuery(query, {
+          skip: true,
+          variables: { id: "1" },
+        });
 
-      expectTypeOf(inferred).toEqualTypeOf<VariablesCaseData | undefined>();
-      expectTypeOf(inferred).not.toEqualTypeOf<VariablesCaseData>();
+        expectTypeOf(data).toEqualTypeOf<VariablesCaseData | undefined>();
+      }
 
-      const { data: explicit } = useSuspenseQuery<
-        VariablesCaseData,
-        VariablesCaseVariables
-      >(query, {
-        skip: true,
-      });
+      {
+        const { data } = useSuspenseQuery<
+          VariablesCaseData,
+          VariablesCaseVariables
+        >(query, {
+          skip: true,
+          variables: { id: "1" },
+        });
 
-      expectTypeOf(explicit).toEqualTypeOf<VariablesCaseData | undefined>();
-      expectTypeOf(explicit).not.toEqualTypeOf<VariablesCaseData>();
+        expectTypeOf(data).toEqualTypeOf<VariablesCaseData | undefined>();
+      }
 
       // TypeScript is too smart and using a `const` or `let` boolean variable
       // for the `skip` option results in a false positive. Using an options
@@ -12099,23 +12126,25 @@ describe("useSuspenseQuery", () => {
         skip: true,
       };
 
-      const { data: dynamic } = useSuspenseQuery(query, {
-        skip: options.skip,
-      });
+      {
+        const { data } = useSuspenseQuery(query, {
+          skip: options.skip,
+          variables: { id: "1" },
+        });
 
-      expectTypeOf(dynamic).toEqualTypeOf<VariablesCaseData | undefined>();
-      expectTypeOf(dynamic).not.toEqualTypeOf<VariablesCaseData>();
+        expectTypeOf(data).toEqualTypeOf<VariablesCaseData | undefined>();
+      }
 
       const { query: maskedQuery } = useMaskedVariablesQueryCase();
 
       {
-        const { data } = useSuspenseQuery(maskedQuery, { skip: true });
+        const { data } = useSuspenseQuery(maskedQuery, {
+          skip: true,
+          variables: { id: "1" },
+        });
 
         expectTypeOf(data).toEqualTypeOf<
           Masked<MaskedVariablesCaseData> | undefined
-        >();
-        expectTypeOf(data).not.toEqualTypeOf<
-          UnmaskedVariablesCaseData | undefined
         >();
       }
 
@@ -12123,25 +12152,19 @@ describe("useSuspenseQuery", () => {
         const { data } = useSuspenseQuery<
           MaskedVariablesCaseData,
           VariablesCaseVariables
-        >(maskedQuery, { skip: true });
+        >(maskedQuery, { skip: true, variables: { id: "1" } });
 
         expectTypeOf(data).toEqualTypeOf<MaskedVariablesCaseData | undefined>();
-        expectTypeOf(data).not.toEqualTypeOf<
-          UnmaskedVariablesCaseData | undefined
-        >();
       }
 
       {
         const { data } = useSuspenseQuery<
           Masked<MaskedVariablesCaseData>,
           VariablesCaseVariables
-        >(maskedQuery, { skip: true });
+        >(maskedQuery, { skip: true, variables: { id: "1" } });
 
         expectTypeOf(data).toEqualTypeOf<
           Masked<MaskedVariablesCaseData> | undefined
-        >();
-        expectTypeOf(data).not.toEqualTypeOf<
-          UnmaskedVariablesCaseData | undefined
         >();
       }
 
@@ -12153,13 +12176,10 @@ describe("useSuspenseQuery", () => {
         const { data } = useSuspenseQuery<
           Masked<MaskedVariablesCaseData>,
           VariablesCaseVariables
-        >(maskedQuery, { skip: options.skip });
+        >(maskedQuery, { skip: options.skip, variables: { id: "1" } });
 
         expectTypeOf(data).toEqualTypeOf<
           Masked<MaskedVariablesCaseData> | undefined
-        >();
-        expectTypeOf(data).not.toEqualTypeOf<
-          UnmaskedVariablesCaseData | undefined
         >();
       }
     });
@@ -12170,21 +12190,23 @@ describe("useSuspenseQuery", () => {
         skip: true,
       };
 
-      const { data: inferred } = useSuspenseQuery(
-        query,
-        options.skip ? skipToken : { variables: { id: "1" } }
-      );
+      {
+        const { data } = useSuspenseQuery(
+          query,
+          options.skip ? skipToken : { variables: { id: "1" } }
+        );
 
-      expectTypeOf(inferred).toEqualTypeOf<VariablesCaseData | undefined>();
-      expectTypeOf(inferred).not.toEqualTypeOf<VariablesCaseData>();
+        expectTypeOf(data).toEqualTypeOf<VariablesCaseData | undefined>();
+      }
 
-      const { data: explicit } = useSuspenseQuery<
-        VariablesCaseData,
-        VariablesCaseVariables
-      >(query, options.skip ? skipToken : { variables: { id: "1" } });
+      {
+        const { data } = useSuspenseQuery<
+          VariablesCaseData,
+          VariablesCaseVariables
+        >(query, options.skip ? skipToken : { variables: { id: "1" } });
 
-      expectTypeOf(explicit).toEqualTypeOf<VariablesCaseData | undefined>();
-      expectTypeOf(explicit).not.toEqualTypeOf<VariablesCaseData>();
+        expectTypeOf(data).toEqualTypeOf<VariablesCaseData | undefined>();
+      }
 
       const { query: maskedQuery } = useMaskedVariablesQueryCase();
 
@@ -12197,9 +12219,6 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           Masked<MaskedVariablesCaseData> | undefined
         >();
-        expectTypeOf(data).not.toEqualTypeOf<
-          UnmaskedVariablesCaseData | undefined
-        >();
       }
 
       {
@@ -12209,9 +12228,6 @@ describe("useSuspenseQuery", () => {
         >(maskedQuery, options.skip ? skipToken : { variables: { id: "1" } });
 
         expectTypeOf(data).toEqualTypeOf<MaskedVariablesCaseData | undefined>();
-        expectTypeOf(data).not.toEqualTypeOf<
-          UnmaskedVariablesCaseData | undefined
-        >();
       }
 
       {
@@ -12223,9 +12239,6 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           Masked<MaskedVariablesCaseData> | undefined
         >();
-        expectTypeOf(data).not.toEqualTypeOf<
-          UnmaskedVariablesCaseData | undefined
-        >();
       }
     });
 
@@ -12235,21 +12248,23 @@ describe("useSuspenseQuery", () => {
         skip: true,
       };
 
-      const { data: inferred } = useSuspenseQuery(
-        query,
-        options.skip ? skipToken : undefined
-      );
+      {
+        const { data } = useSuspenseQuery(
+          query,
+          options.skip ? skipToken : undefined
+        );
 
-      expectTypeOf(inferred).toEqualTypeOf<VariablesCaseData | undefined>();
-      expectTypeOf(inferred).not.toEqualTypeOf<VariablesCaseData>();
+        expectTypeOf(data).toEqualTypeOf<VariablesCaseData | undefined>();
+      }
 
-      const { data: explicit } = useSuspenseQuery<
-        VariablesCaseData,
-        VariablesCaseVariables
-      >(query, options.skip ? skipToken : undefined);
+      {
+        const { data } = useSuspenseQuery<
+          VariablesCaseData,
+          VariablesCaseVariables
+        >(query, options.skip ? skipToken : undefined);
 
-      expectTypeOf(explicit).toEqualTypeOf<VariablesCaseData | undefined>();
-      expectTypeOf(explicit).not.toEqualTypeOf<VariablesCaseData>();
+        expectTypeOf(data).toEqualTypeOf<VariablesCaseData | undefined>();
+      }
 
       const { query: maskedQuery } = useMaskedVariablesQueryCase();
 
@@ -12262,9 +12277,6 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           Masked<MaskedVariablesCaseData> | undefined
         >();
-        expectTypeOf(data).not.toEqualTypeOf<
-          UnmaskedVariablesCaseData | undefined
-        >();
       }
 
       {
@@ -12274,9 +12286,6 @@ describe("useSuspenseQuery", () => {
         >(maskedQuery, options.skip ? skipToken : undefined);
 
         expectTypeOf(data).toEqualTypeOf<MaskedVariablesCaseData | undefined>();
-        expectTypeOf(data).not.toEqualTypeOf<
-          UnmaskedVariablesCaseData | undefined
-        >();
       }
 
       {
@@ -12288,9 +12297,6 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           Masked<MaskedVariablesCaseData> | undefined
         >();
-        expectTypeOf(data).not.toEqualTypeOf<
-          UnmaskedVariablesCaseData | undefined
-        >();
       }
     });
 
@@ -12300,39 +12306,47 @@ describe("useSuspenseQuery", () => {
         skip: true,
       };
 
-      const { data: inferred } = useSuspenseQuery(
-        query,
-        options.skip ? skipToken : { returnPartialData: true }
-      );
+      {
+        const { data } = useSuspenseQuery(
+          query,
+          options.skip ? skipToken : (
+            { returnPartialData: true, variables: { id: "1" } }
+          )
+        );
 
-      expectTypeOf(inferred).toEqualTypeOf<
-        DeepPartial<VariablesCaseData> | undefined
-      >();
-      expectTypeOf(inferred).not.toEqualTypeOf<VariablesCaseData>();
+        expectTypeOf(data).toEqualTypeOf<
+          DeepPartial<VariablesCaseData> | undefined
+        >();
+      }
 
-      const { data: explicit } = useSuspenseQuery<
-        VariablesCaseData,
-        VariablesCaseVariables
-      >(query, options.skip ? skipToken : { returnPartialData: true });
+      {
+        const { data } = useSuspenseQuery<
+          VariablesCaseData,
+          VariablesCaseVariables
+        >(
+          query,
+          options.skip ? skipToken : (
+            { returnPartialData: true, variables: { id: "id" } }
+          )
+        );
 
-      expectTypeOf(explicit).toEqualTypeOf<
-        DeepPartial<VariablesCaseData> | undefined
-      >();
-      expectTypeOf(explicit).not.toEqualTypeOf<VariablesCaseData>();
+        expectTypeOf(data).toEqualTypeOf<
+          DeepPartial<VariablesCaseData> | undefined
+        >();
+      }
 
       const { query: maskedQuery } = useMaskedVariablesQueryCase();
 
       {
         const { data } = useSuspenseQuery(
           maskedQuery,
-          options.skip ? skipToken : { returnPartialData: true }
+          options.skip ? skipToken : (
+            { returnPartialData: true, variables: { id: "1" } }
+          )
         );
 
         expectTypeOf(data).toEqualTypeOf<
           DeepPartial<Masked<MaskedVariablesCaseData>> | undefined
-        >();
-        expectTypeOf(data).not.toEqualTypeOf<
-          DeepPartial<UnmaskedVariablesCaseData> | undefined
         >();
       }
 
@@ -12340,13 +12354,15 @@ describe("useSuspenseQuery", () => {
         const { data } = useSuspenseQuery<
           MaskedVariablesCaseData,
           VariablesCaseVariables
-        >(maskedQuery, options.skip ? skipToken : { returnPartialData: true });
+        >(
+          maskedQuery,
+          options.skip ? skipToken : (
+            { returnPartialData: true, variables: { id: "1" } }
+          )
+        );
 
         expectTypeOf(data).toEqualTypeOf<
           DeepPartial<MaskedVariablesCaseData> | undefined
-        >();
-        expectTypeOf(data).not.toEqualTypeOf<
-          DeepPartial<UnmaskedVariablesCaseData> | undefined
         >();
       }
 
@@ -12354,13 +12370,15 @@ describe("useSuspenseQuery", () => {
         const { data } = useSuspenseQuery<
           Masked<MaskedVariablesCaseData>,
           VariablesCaseVariables
-        >(maskedQuery, options.skip ? skipToken : { returnPartialData: true });
+        >(
+          maskedQuery,
+          options.skip ? skipToken : (
+            { returnPartialData: true, variables: { id: "1" } }
+          )
+        );
 
         expectTypeOf(data).toEqualTypeOf<
           DeepPartial<Masked<MaskedVariablesCaseData>> | undefined
-        >();
-        expectTypeOf(data).not.toEqualTypeOf<
-          DeepPartial<UnmaskedVariablesCaseData> | undefined
         >();
       }
     });
@@ -12368,56 +12386,54 @@ describe("useSuspenseQuery", () => {
     it("returns TData when passing an option that does not affect TData", () => {
       const { query } = useVariablesQueryCase();
 
-      const { data: inferred } = useSuspenseQuery(query, {
-        fetchPolicy: "no-cache",
-      });
+      {
+        const { data } = useSuspenseQuery(query, {
+          fetchPolicy: "no-cache",
+          variables: { id: "1" },
+        });
 
-      expectTypeOf(inferred).toEqualTypeOf<VariablesCaseData>();
-      expectTypeOf(inferred).not.toEqualTypeOf<
-        DeepPartial<VariablesCaseData>
-      >();
+        expectTypeOf(data).toEqualTypeOf<VariablesCaseData>();
+      }
 
-      const { data: explicit } = useSuspenseQuery<
-        VariablesCaseData,
-        VariablesCaseVariables
-      >(query, {
-        fetchPolicy: "no-cache",
-      });
+      {
+        const { data: data } = useSuspenseQuery<
+          VariablesCaseData,
+          VariablesCaseVariables
+        >(query, {
+          fetchPolicy: "no-cache",
+          variables: { id: "1" },
+        });
 
-      expectTypeOf(explicit).toEqualTypeOf<VariablesCaseData>();
-      expectTypeOf(explicit).not.toEqualTypeOf<
-        DeepPartial<VariablesCaseData>
-      >();
+        expectTypeOf(data).toEqualTypeOf<VariablesCaseData>();
+      }
 
       const { query: maskedQuery } = useMaskedVariablesQueryCase();
 
       {
         const { data } = useSuspenseQuery(maskedQuery, {
           fetchPolicy: "no-cache",
+          variables: { id: "1" },
         });
 
         expectTypeOf(data).toEqualTypeOf<Masked<MaskedVariablesCaseData>>();
-        expectTypeOf(data).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
       }
 
       {
         const { data } = useSuspenseQuery<
           MaskedVariablesCaseData,
           VariablesCaseVariables
-        >(maskedQuery, { fetchPolicy: "no-cache" });
+        >(maskedQuery, { fetchPolicy: "no-cache", variables: { id: "1" } });
 
         expectTypeOf(data).toEqualTypeOf<MaskedVariablesCaseData>();
-        expectTypeOf(data).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
       }
 
       {
         const { data } = useSuspenseQuery<
           Masked<MaskedVariablesCaseData>,
           VariablesCaseVariables
-        >(maskedQuery, { fetchPolicy: "no-cache" });
+        >(maskedQuery, { fetchPolicy: "no-cache", variables: { id: "1" } });
 
         expectTypeOf(data).toEqualTypeOf<Masked<MaskedVariablesCaseData>>();
-        expectTypeOf(data).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
       }
     });
 
@@ -12433,205 +12449,189 @@ describe("useSuspenseQuery", () => {
       const { query } = useVariablesQueryCase();
       const { query: maskedQuery } = useMaskedVariablesQueryCase();
 
-      const { data: inferredPartialDataIgnore } = useSuspenseQuery(query, {
-        returnPartialData: true,
-        errorPolicy: "ignore",
-      });
+      {
+        const { data } = useSuspenseQuery(query, {
+          returnPartialData: true,
+          errorPolicy: "ignore",
+          variables: { id: "1" },
+        });
 
-      expectTypeOf(inferredPartialDataIgnore).toEqualTypeOf<
-        DeepPartial<VariablesCaseData> | undefined
-      >();
-      expectTypeOf(
-        inferredPartialDataIgnore
-      ).not.toEqualTypeOf<VariablesCaseData>();
+        expectTypeOf(data).toEqualTypeOf<
+          DeepPartial<VariablesCaseData> | undefined
+        >();
+      }
 
-      const { data: explicitPartialDataIgnore } = useSuspenseQuery<
-        VariablesCaseData,
-        VariablesCaseVariables
-      >(query, {
-        returnPartialData: true,
-        errorPolicy: "ignore",
-      });
+      {
+        const { data } = useSuspenseQuery<
+          VariablesCaseData,
+          VariablesCaseVariables
+        >(query, {
+          returnPartialData: true,
+          errorPolicy: "ignore",
+          variables: { id: "1" },
+        });
 
-      expectTypeOf(explicitPartialDataIgnore).toEqualTypeOf<
-        DeepPartial<VariablesCaseData> | undefined
-      >();
-      expectTypeOf(
-        explicitPartialDataIgnore
-      ).not.toEqualTypeOf<VariablesCaseData>();
+        expectTypeOf(data).toEqualTypeOf<
+          DeepPartial<VariablesCaseData> | undefined
+        >();
+      }
 
       {
         const { data } = useSuspenseQuery(maskedQuery, {
           returnPartialData: true,
           errorPolicy: "ignore",
+          variables: { id: "1" },
         });
 
         expectTypeOf(data).toEqualTypeOf<
           DeepPartial<Masked<MaskedVariablesCaseData>> | undefined
         >();
-        expectTypeOf(data).not.toEqualTypeOf<
-          DeepPartial<UnmaskedVariablesCaseData> | undefined
-        >();
       }
 
-      const { data: inferredPartialDataNone } = useSuspenseQuery(query, {
-        returnPartialData: true,
-        errorPolicy: "none",
-      });
+      {
+        const { data } = useSuspenseQuery(query, {
+          returnPartialData: true,
+          errorPolicy: "none",
+          variables: { id: "1" },
+        });
 
-      expectTypeOf(inferredPartialDataNone).toEqualTypeOf<
-        DeepPartial<VariablesCaseData>
-      >();
-      expectTypeOf(
-        inferredPartialDataNone
-      ).not.toEqualTypeOf<VariablesCaseData>();
+        expectTypeOf(data).toEqualTypeOf<DeepPartial<VariablesCaseData>>();
+      }
 
-      const { data: explicitPartialDataNone } = useSuspenseQuery<
-        VariablesCaseData,
-        VariablesCaseVariables
-      >(query, {
-        returnPartialData: true,
-        errorPolicy: "none",
-      });
+      {
+        const { data } = useSuspenseQuery<
+          VariablesCaseData,
+          VariablesCaseVariables
+        >(query, {
+          returnPartialData: true,
+          errorPolicy: "none",
+          variables: { id: "1" },
+        });
 
-      expectTypeOf(explicitPartialDataNone).toEqualTypeOf<
-        DeepPartial<VariablesCaseData>
-      >();
-      expectTypeOf(
-        explicitPartialDataNone
-      ).not.toEqualTypeOf<VariablesCaseData>();
+        expectTypeOf(data).toEqualTypeOf<DeepPartial<VariablesCaseData>>();
+      }
 
       {
         const { data } = useSuspenseQuery(maskedQuery, {
           returnPartialData: true,
           errorPolicy: "ignore",
+          variables: { id: "1" },
         });
 
         expectTypeOf(data).toEqualTypeOf<
           DeepPartial<Masked<MaskedVariablesCaseData>> | undefined
         >();
-        expectTypeOf(data).not.toEqualTypeOf<
-          DeepPartial<UnmaskedVariablesCaseData> | undefined
-        >();
       }
 
-      const { data: inferredSkipIgnore } = useSuspenseQuery(query, {
-        skip: options.skip,
-        errorPolicy: "ignore",
-      });
+      {
+        const { data } = useSuspenseQuery(query, {
+          skip: options.skip,
+          errorPolicy: "ignore",
+          variables: { id: "1" },
+        });
 
-      expectTypeOf(inferredSkipIgnore).toEqualTypeOf<
-        VariablesCaseData | undefined
-      >();
-      expectTypeOf(
-        inferredPartialDataIgnore
-      ).not.toEqualTypeOf<VariablesCaseData>();
+        expectTypeOf(data).toEqualTypeOf<VariablesCaseData | undefined>();
+      }
 
-      const { data: explicitSkipIgnore } = useSuspenseQuery<
-        VariablesCaseData,
-        VariablesCaseVariables
-      >(query, {
-        skip: options.skip,
-        errorPolicy: "ignore",
-      });
+      {
+        const { data } = useSuspenseQuery<
+          VariablesCaseData,
+          VariablesCaseVariables
+        >(query, {
+          skip: options.skip,
+          errorPolicy: "ignore",
+          variables: { id: "1" },
+        });
 
-      expectTypeOf(explicitSkipIgnore).toEqualTypeOf<
-        VariablesCaseData | undefined
-      >();
-      expectTypeOf(explicitSkipIgnore).not.toEqualTypeOf<VariablesCaseData>();
+        expectTypeOf(data).toEqualTypeOf<VariablesCaseData | undefined>();
+      }
 
       {
         const { data } = useSuspenseQuery(maskedQuery, {
           skip: options.skip,
           errorPolicy: "ignore",
+          variables: { id: "1" },
         });
 
         expectTypeOf(data).toEqualTypeOf<
           Masked<MaskedVariablesCaseData> | undefined
         >();
-        expectTypeOf(data).not.toEqualTypeOf<
-          UnmaskedVariablesCaseData | undefined
-        >();
       }
 
-      const { data: inferredSkipNone } = useSuspenseQuery(query, {
-        skip: options.skip,
-        errorPolicy: "none",
-      });
+      {
+        const { data } = useSuspenseQuery(query, {
+          skip: options.skip,
+          errorPolicy: "none",
+          variables: { id: "1" },
+        });
 
-      expectTypeOf(inferredSkipNone).toEqualTypeOf<
-        VariablesCaseData | undefined
-      >();
-      expectTypeOf(inferredSkipNone).not.toEqualTypeOf<VariablesCaseData>();
+        expectTypeOf(data).toEqualTypeOf<VariablesCaseData | undefined>();
+      }
 
-      const { data: explicitSkipNone } = useSuspenseQuery<
-        VariablesCaseData,
-        VariablesCaseVariables
-      >(query, {
-        skip: options.skip,
-        errorPolicy: "none",
-      });
+      {
+        const { data } = useSuspenseQuery<
+          VariablesCaseData,
+          VariablesCaseVariables
+        >(query, {
+          skip: options.skip,
+          errorPolicy: "none",
+          variables: { id: "1" },
+        });
 
-      expectTypeOf(explicitSkipNone).toEqualTypeOf<
-        VariablesCaseData | undefined
-      >();
-      expectTypeOf(explicitSkipNone).not.toEqualTypeOf<VariablesCaseData>();
+        expectTypeOf(data).toEqualTypeOf<VariablesCaseData | undefined>();
+      }
 
       {
         const { data } = useSuspenseQuery(maskedQuery, {
           skip: options.skip,
           errorPolicy: "none",
+          variables: { id: "1" },
         });
 
         expectTypeOf(data).toEqualTypeOf<
           Masked<MaskedVariablesCaseData> | undefined
         >();
-        expectTypeOf(data).not.toEqualTypeOf<
-          UnmaskedVariablesCaseData | undefined
+      }
+
+      {
+        const { data } = useSuspenseQuery(query, {
+          skip: options.skip,
+          returnPartialData: true,
+          errorPolicy: "none",
+          variables: { id: "1" },
+        });
+
+        expectTypeOf(data).toEqualTypeOf<
+          DeepPartial<VariablesCaseData> | undefined
         >();
       }
 
-      const { data: inferredPartialDataNoneSkip } = useSuspenseQuery(query, {
-        skip: options.skip,
-        returnPartialData: true,
-        errorPolicy: "none",
-      });
+      {
+        const { data } = useSuspenseQuery<
+          VariablesCaseData,
+          VariablesCaseVariables
+        >(query, {
+          skip: options.skip,
+          returnPartialData: true,
+          errorPolicy: "none",
+          variables: { id: "1" },
+        });
 
-      expectTypeOf(inferredPartialDataNoneSkip).toEqualTypeOf<
-        DeepPartial<VariablesCaseData> | undefined
-      >();
-      expectTypeOf(
-        inferredPartialDataNoneSkip
-      ).not.toEqualTypeOf<VariablesCaseData>();
-
-      const { data: explicitPartialDataNoneSkip } = useSuspenseQuery<
-        VariablesCaseData,
-        VariablesCaseVariables
-      >(query, {
-        skip: options.skip,
-        returnPartialData: true,
-        errorPolicy: "none",
-      });
-
-      expectTypeOf(explicitPartialDataNoneSkip).toEqualTypeOf<
-        DeepPartial<VariablesCaseData> | undefined
-      >();
-      expectTypeOf(
-        explicitPartialDataNoneSkip
-      ).not.toEqualTypeOf<VariablesCaseData>();
+        expectTypeOf(data).toEqualTypeOf<
+          DeepPartial<VariablesCaseData> | undefined
+        >();
+      }
 
       {
         const { data } = useSuspenseQuery(maskedQuery, {
           skip: options.skip,
           returnPartialData: true,
           errorPolicy: "none",
+          variables: { id: "1" },
         });
 
         expectTypeOf(data).toEqualTypeOf<
           DeepPartial<Masked<MaskedVariablesCaseData>> | undefined
-        >();
-        expectTypeOf(data).not.toEqualTypeOf<
-          DeepPartial<UnmaskedVariablesCaseData> | undefined
         >();
       }
     });
@@ -12639,26 +12639,30 @@ describe("useSuspenseQuery", () => {
     it("returns correct TData type when combined options that do not affect TData", () => {
       const { query } = useVariablesQueryCase();
 
-      const { data: inferred } = useSuspenseQuery(query, {
-        fetchPolicy: "no-cache",
-        returnPartialData: true,
-        errorPolicy: "none",
-      });
+      {
+        const { data } = useSuspenseQuery(query, {
+          fetchPolicy: "no-cache",
+          returnPartialData: true,
+          errorPolicy: "none",
+          variables: { id: "1" },
+        });
 
-      expectTypeOf(inferred).toEqualTypeOf<DeepPartial<VariablesCaseData>>();
-      expectTypeOf(inferred).not.toEqualTypeOf<VariablesCaseData>();
+        expectTypeOf(data).toEqualTypeOf<DeepPartial<VariablesCaseData>>();
+      }
 
-      const { data: explicit } = useSuspenseQuery<
-        VariablesCaseData,
-        VariablesCaseVariables
-      >(query, {
-        fetchPolicy: "no-cache",
-        returnPartialData: true,
-        errorPolicy: "none",
-      });
+      {
+        const { data } = useSuspenseQuery<
+          VariablesCaseData,
+          VariablesCaseVariables
+        >(query, {
+          fetchPolicy: "no-cache",
+          returnPartialData: true,
+          errorPolicy: "none",
+          variables: { id: "1" },
+        });
 
-      expectTypeOf(explicit).toEqualTypeOf<DeepPartial<VariablesCaseData>>();
-      expectTypeOf(explicit).not.toEqualTypeOf<VariablesCaseData>();
+        expectTypeOf(data).toEqualTypeOf<DeepPartial<VariablesCaseData>>();
+      }
 
       const { query: maskedQuery } = useMaskedVariablesQueryCase();
 
@@ -12667,13 +12671,11 @@ describe("useSuspenseQuery", () => {
           fetchPolicy: "no-cache",
           returnPartialData: true,
           errorPolicy: "none",
+          variables: { id: "1" },
         });
 
         expectTypeOf(data).toEqualTypeOf<
           DeepPartial<Masked<MaskedVariablesCaseData>>
-        >();
-        expectTypeOf(data).not.toEqualTypeOf<
-          DeepPartial<UnmaskedVariablesCaseData>
         >();
       }
 
@@ -12685,13 +12687,11 @@ describe("useSuspenseQuery", () => {
           fetchPolicy: "no-cache",
           returnPartialData: true,
           errorPolicy: "none",
+          variables: { id: "1" },
         });
 
         expectTypeOf(data).toEqualTypeOf<
           DeepPartial<MaskedVariablesCaseData>
-        >();
-        expectTypeOf(data).not.toEqualTypeOf<
-          DeepPartial<UnmaskedVariablesCaseData>
         >();
       }
 
@@ -12703,13 +12703,11 @@ describe("useSuspenseQuery", () => {
           fetchPolicy: "no-cache",
           returnPartialData: true,
           errorPolicy: "none",
+          variables: { id: "1" },
         });
 
         expectTypeOf(data).toEqualTypeOf<
           DeepPartial<Masked<MaskedVariablesCaseData>>
-        >();
-        expectTypeOf(data).not.toEqualTypeOf<
-          DeepPartial<UnmaskedVariablesCaseData>
         >();
       }
     });
@@ -12718,29 +12716,21 @@ describe("useSuspenseQuery", () => {
       const { query, unmaskedQuery } = useMaskedVariablesQueryCase();
 
       {
-        const { refetch } = useSuspenseQuery(query);
+        const { refetch } = useSuspenseQuery(query, { variables: { id: "1" } });
+        const { data } = await refetch();
 
-        const result = await refetch();
-
-        expectTypeOf(result.data).toEqualTypeOf<
+        expectTypeOf(data).toEqualTypeOf<
           Masked<MaskedVariablesCaseData> | undefined
         >();
-        expectTypeOf(
-          result.data
-        ).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
       }
 
       {
-        const { refetch } = useSuspenseQuery(unmaskedQuery);
+        const { refetch } = useSuspenseQuery(unmaskedQuery, {
+          variables: { id: "1" },
+        });
+        const { data } = await refetch();
 
-        const result = await refetch();
-
-        expectTypeOf(result.data).toEqualTypeOf<
-          MaskedVariablesCaseData | undefined
-        >();
-        expectTypeOf(
-          result.data
-        ).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
+        expectTypeOf(data).toEqualTypeOf<MaskedVariablesCaseData | undefined>();
       }
     });
 
@@ -12748,61 +12738,44 @@ describe("useSuspenseQuery", () => {
       const { query, unmaskedQuery } = useMaskedVariablesQueryCase();
 
       {
-        const { fetchMore } = useSuspenseQuery(query);
+        const { fetchMore } = useSuspenseQuery(query, {
+          variables: { id: "1" },
+        });
 
-        const result = await fetchMore({
+        const { data } = await fetchMore({
           updateQuery: (queryData, { fetchMoreResult }) => {
             expectTypeOf(queryData).toEqualTypeOf<UnmaskedVariablesCaseData>();
             expectTypeOf(
-              queryData
-            ).not.toEqualTypeOf<MaskedVariablesCaseData>();
-
-            expectTypeOf(
               fetchMoreResult
             ).toEqualTypeOf<UnmaskedVariablesCaseData>();
-            expectTypeOf(
-              fetchMoreResult
-            ).not.toEqualTypeOf<MaskedVariablesCaseData>();
 
             return {} as UnmaskedVariablesCaseData;
           },
         });
 
-        expectTypeOf(result.data).toEqualTypeOf<
+        expectTypeOf(data).toEqualTypeOf<
           Masked<MaskedVariablesCaseData> | undefined
         >();
-        expectTypeOf(
-          result.data
-        ).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
       }
 
       {
-        const { fetchMore } = useSuspenseQuery(unmaskedQuery);
+        const { fetchMore } = useSuspenseQuery(unmaskedQuery, {
+          variables: { id: "1" },
+        });
 
-        const result = await fetchMore({
+        const { data } = await fetchMore({
           updateQuery: (queryData, { fetchMoreResult }) => {
             expectTypeOf(queryData).toEqualTypeOf<UnmaskedVariablesCaseData>();
-            expectTypeOf(
-              queryData
-            ).not.toEqualTypeOf<MaskedVariablesCaseData>();
 
             expectTypeOf(
               fetchMoreResult
             ).toEqualTypeOf<UnmaskedVariablesCaseData>();
-            expectTypeOf(
-              fetchMoreResult
-            ).not.toEqualTypeOf<MaskedVariablesCaseData>();
 
             return {} as UnmaskedVariablesCaseData;
           },
         });
 
-        expectTypeOf(result.data).toEqualTypeOf<
-          MaskedVariablesCaseData | undefined
-        >();
-        expectTypeOf(
-          result.data
-        ).not.toEqualTypeOf<UnmaskedVariablesCaseData>();
+        expectTypeOf(data).toEqualTypeOf<MaskedVariablesCaseData | undefined>();
       }
     });
 
@@ -12830,9 +12803,14 @@ describe("useSuspenseQuery", () => {
       const { query, unmaskedQuery } = useMaskedVariablesQueryCase();
 
       {
-        const { subscribeToMore } = useSuspenseQuery(query);
+        const { subscribeToMore } = useSuspenseQuery(query, {
+          variables: { id: "1" },
+        });
 
-        const subscription: MaskedDocumentNode<Subscription, never> = gql`
+        const subscription: MaskedDocumentNode<
+          Subscription,
+          Record<string, never>
+        > = gql`
           subscription {
             pushLetter {
               id
@@ -12849,16 +12827,10 @@ describe("useSuspenseQuery", () => {
           document: subscription,
           updateQuery: (queryData, { subscriptionData }) => {
             expectTypeOf(queryData).toEqualTypeOf<UnmaskedVariablesCaseData>();
-            expectTypeOf(
-              queryData
-            ).not.toEqualTypeOf<MaskedVariablesCaseData>();
 
             expectTypeOf(
               subscriptionData.data
             ).toEqualTypeOf<UnmaskedSubscription>();
-            expectTypeOf(
-              subscriptionData.data
-            ).not.toEqualTypeOf<Subscription>();
 
             return {} as UnmaskedVariablesCaseData;
           },
@@ -12866,9 +12838,14 @@ describe("useSuspenseQuery", () => {
       }
 
       {
-        const { subscribeToMore } = useSuspenseQuery(unmaskedQuery);
+        const { subscribeToMore } = useSuspenseQuery(unmaskedQuery, {
+          variables: { id: "1" },
+        });
 
-        const subscription: TypedDocumentNode<Subscription, never> = gql`
+        const subscription: TypedDocumentNode<
+          Subscription,
+          Record<string, never>
+        > = gql`
           subscription {
             pushLetter {
               id
@@ -12888,9 +12865,6 @@ describe("useSuspenseQuery", () => {
             { subscriptionData, complete, previousData }
           ) => {
             expectTypeOf(queryData).toEqualTypeOf<UnmaskedVariablesCaseData>();
-            expectTypeOf(
-              queryData
-            ).not.toEqualTypeOf<MaskedVariablesCaseData>();
 
             expectTypeOf(complete).toEqualTypeOf<boolean>();
             expectTypeOf(previousData).toEqualTypeOf<
@@ -12912,14 +12886,155 @@ describe("useSuspenseQuery", () => {
             expectTypeOf(
               subscriptionData.data
             ).toEqualTypeOf<UnmaskedSubscription>();
-            expectTypeOf(
-              subscriptionData.data
-            ).not.toEqualTypeOf<Subscription>();
 
             return {} as UnmaskedVariablesCaseData;
           },
         });
       }
+    });
+
+    test("variables are optional and can be anything with an DocumentNode", () => {
+      const query = gql``;
+
+      useSuspenseQuery(query);
+      useSuspenseQuery(query, {});
+      useSuspenseQuery(query, { variables: {} });
+      useSuspenseQuery(query, { variables: { foo: "bar" } });
+      useSuspenseQuery(query, { variables: { bar: "baz" } });
+    });
+
+    test("variables are optional and can be anything with unspecified TVariables on a TypedDocumentNode", () => {
+      const query: TypedDocumentNode<{ greeting: string }> = gql``;
+
+      useSuspenseQuery(query);
+      useSuspenseQuery(query, {});
+      useSuspenseQuery(query, { variables: {} });
+      useSuspenseQuery(query, { variables: { foo: "bar" } });
+      useSuspenseQuery(query, { variables: { bar: "baz" } });
+    });
+
+    test("variables are optional when TVariables are empty", () => {
+      const query: TypedDocumentNode<
+        { greeting: string },
+        Record<string, never>
+      > = gql``;
+
+      useSuspenseQuery(query);
+      useSuspenseQuery(query, {});
+      useSuspenseQuery(query, { variables: {} });
+      useSuspenseQuery(query, {
+        variables: {
+          // @ts-expect-error unknown variables
+          foo: "bar",
+        },
+      });
+    });
+
+    test("is invalid when TVariables is `never`", () => {
+      const query: TypedDocumentNode<{ greeting: string }, never> = gql``;
+
+      // @ts-expect-error
+      useSuspenseQuery(query);
+      // @ts-expect-error
+      useSuspenseQuery(query, {});
+      useSuspenseQuery(query, {
+        // @ts-expect-error
+        variables: {},
+      });
+      useSuspenseQuery(query, {
+        // @ts-expect-error
+        variables: undefined,
+      });
+      useSuspenseQuery(query, {
+        // @ts-expect-error
+        variables: {
+          foo: "bar",
+        },
+      });
+    });
+
+    test("optional variables are optional", () => {
+      const query: TypedDocumentNode<{ posts: string[] }, { limit?: number }> =
+        gql``;
+
+      useSuspenseQuery(query);
+      useSuspenseQuery(query, {});
+      useSuspenseQuery(query, { variables: {} });
+      useSuspenseQuery(query, { variables: { limit: 10 } });
+      useSuspenseQuery(query, {
+        variables: {
+          // @ts-expect-error unknown variables
+          foo: "bar",
+        },
+      });
+      useSuspenseQuery(query, {
+        variables: {
+          limit: 10,
+          // @ts-expect-error unknown variables
+          foo: "bar",
+        },
+      });
+    });
+
+    test("enforces required variables when TVariables includes required variables", () => {
+      const query: TypedDocumentNode<{ character: string }, { id: string }> =
+        gql``;
+
+      // @ts-expect-error empty variables
+      useSuspenseQuery(query);
+      // @ts-expect-error empty variables
+      useSuspenseQuery(query, {});
+      // @ts-expect-error empty variables
+      useSuspenseQuery(query, { variables: {} });
+      useSuspenseQuery(query, { variables: { id: "1" } });
+      useSuspenseQuery(query, {
+        variables: {
+          // @ts-expect-error unknown variables
+          foo: "bar",
+        },
+      });
+      useSuspenseQuery(query, {
+        variables: {
+          id: "1",
+          // @ts-expect-error unknown variables
+          foo: "bar",
+        },
+      });
+    });
+
+    test("requires variables with mixed TVariables", () => {
+      const query: TypedDocumentNode<
+        { character: string },
+        { id: string; language?: string }
+      > = gql``;
+
+      // @ts-expect-error empty variables
+      useSuspenseQuery(query);
+      // @ts-expect-error empty variables
+      useSuspenseQuery(query, {});
+      // @ts-expect-error empty variables
+      useSuspenseQuery(query, { variables: {} });
+      useSuspenseQuery(query, { variables: { id: "1" } });
+      useSuspenseQuery(query, {
+        // @ts-expect-error missing required variables
+        variables: { language: "en" },
+      });
+      useSuspenseQuery(query, { variables: { id: "1", language: "en" } });
+      useSuspenseQuery(query, {
+        variables: {
+          id: "1",
+          // @ts-expect-error unknown variables
+          foo: "bar",
+        },
+      });
+      useSuspenseQuery(query, {
+        variables: {
+          id: "1",
+          language: "en",
+          // @ts-expect-error unknown variables
+          foo: "bar",
+        },
+      });
     });
   });
 });

--- a/src/react/hooks/internal/validateSuspenseHookOptions.ts
+++ b/src/react/hooks/internal/validateSuspenseHookOptions.ts
@@ -1,0 +1,44 @@
+import type {
+  OperationVariables,
+  WatchQueryFetchPolicy,
+  WatchQueryOptions,
+} from "@apollo/client";
+import { invariant } from "@apollo/client/utilities/invariant";
+
+export function validateSuspenseHookOptions<
+  TData,
+  TVariables extends OperationVariables,
+>(options: WatchQueryOptions<TVariables, TData>) {
+  const { fetchPolicy, returnPartialData } = options;
+
+  validateFetchPolicy(fetchPolicy);
+  validatePartialDataReturn(fetchPolicy, returnPartialData);
+}
+
+function validateFetchPolicy(
+  fetchPolicy: WatchQueryFetchPolicy = "cache-first"
+) {
+  const supportedFetchPolicies: WatchQueryFetchPolicy[] = [
+    "cache-first",
+    "network-only",
+    "no-cache",
+    "cache-and-network",
+  ];
+
+  invariant(
+    supportedFetchPolicies.includes(fetchPolicy),
+    `The fetch policy \`%s\` is not supported with suspense.`,
+    fetchPolicy
+  );
+}
+
+function validatePartialDataReturn(
+  fetchPolicy: WatchQueryFetchPolicy | undefined,
+  returnPartialData: boolean | undefined
+) {
+  if (fetchPolicy === "no-cache" && returnPartialData) {
+    invariant.warn(
+      "Using `returnPartialData` with a `no-cache` fetch policy has no effect. To read partial data from the cache, consider using an alternate fetch policy."
+    );
+  }
+}

--- a/src/react/hooks/useBackgroundQuery.ts
+++ b/src/react/hooks/useBackgroundQuery.ts
@@ -29,7 +29,6 @@ import {
 import type {
   DeepPartial,
   NoInfer,
-  OnlyRequiredProperties,
   VariablesOption,
 } from "@apollo/client/utilities";
 
@@ -191,9 +190,7 @@ export function useBackgroundQuery<
   TVariables extends OperationVariables = OperationVariables,
 >(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  ...[options]: Record<string, never> extends (
-    OnlyRequiredProperties<TVariables>
-  ) ?
+  ...[options]: {} extends TVariables ?
     [options?: useBackgroundQuery.Options<NoInfer<TVariables>>]
   : [options: useBackgroundQuery.Options<NoInfer<TVariables>>]
 ): [QueryRef<TData, TVariables>, useBackgroundQuery.Result<TData, TVariables>];
@@ -203,9 +200,7 @@ export function useBackgroundQuery<
   TVariables extends OperationVariables = OperationVariables,
 >(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  ...[options]: Record<string, never> extends (
-    OnlyRequiredProperties<TVariables>
-  ) ?
+  ...[options]: {} extends TVariables ?
     [options?: SkipToken | useBackgroundQuery.Options<NoInfer<TVariables>>]
   : [options: SkipToken | useBackgroundQuery.Options<NoInfer<TVariables>>]
 ): [
@@ -229,9 +224,7 @@ export function useBackgroundQuery<
   TVariables extends OperationVariables = OperationVariables,
 >(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  ...[options]: Record<string, never> extends (
-    OnlyRequiredProperties<TVariables>
-  ) ?
+  ...[options]: {} extends TVariables ?
     [options?: SkipToken | useBackgroundQuery.Options<NoInfer<TVariables>>]
   : [options: SkipToken | useBackgroundQuery.Options<NoInfer<TVariables>>]
 ): [

--- a/src/react/hooks/useBackgroundQuery.ts
+++ b/src/react/hooks/useBackgroundQuery.ts
@@ -224,9 +224,7 @@ export function useBackgroundQuery<
   TVariables extends OperationVariables = OperationVariables,
 >(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  ...[options]: {} extends TVariables ?
-    [options?: SkipToken | useBackgroundQuery.Options<NoInfer<TVariables>>]
-  : [options: SkipToken | useBackgroundQuery.Options<NoInfer<TVariables>>]
+  options?: SkipToken | useBackgroundQuery.Options<NoInfer<TVariables>>
 ): [
   QueryRef<TData, TVariables> | undefined,
   useBackgroundQuery.Result<TData, TVariables>,

--- a/src/react/hooks/useBackgroundQuery.ts
+++ b/src/react/hooks/useBackgroundQuery.ts
@@ -26,7 +26,12 @@ import {
   updateWrappedQueryRef,
   wrapQueryRef,
 } from "@apollo/client/react/internal";
-import type { DeepPartial, NoInfer } from "@apollo/client/utilities";
+import type {
+  DeepPartial,
+  NoInfer,
+  OnlyRequiredProperties,
+  VariablesOption,
+} from "@apollo/client/utilities";
 
 import type { SkipToken } from "./constants.js";
 import { wrapHook } from "./internal/index.js";
@@ -39,17 +44,14 @@ export declare namespace useBackgroundQuery {
     "cache-first" | "network-only" | "no-cache" | "cache-and-network"
   >;
 
-  export interface Options<
+  export type Options<
     TVariables extends OperationVariables = OperationVariables,
-  > {
+  > = {
     /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#client:member} */
     client?: ApolloClient;
 
     /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#refetchWritePolicy:member} */
     refetchWritePolicy?: RefetchWritePolicy;
-
-    /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#variables:member} */
-    variables?: TVariables;
 
     /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#errorPolicy:member} */
     errorPolicy?: ErrorPolicy;
@@ -77,7 +79,7 @@ export declare namespace useBackgroundQuery {
      * ```
      */
     skip?: boolean;
-  }
+  } & VariablesOption<TVariables>;
 
   export type Result<
     TData = unknown,
@@ -93,29 +95,6 @@ export declare namespace useBackgroundQuery {
     refetch: RefetchFunction<TData, TVariables>;
   };
 }
-
-export function useBackgroundQuery<
-  TData,
-  TVariables extends OperationVariables,
-  TOptions extends Omit<useBackgroundQuery.Options, "variables">,
->(
-  query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  options?: useBackgroundQuery.Options<NoInfer<TVariables>> & TOptions
-): [
-  (
-    | QueryRef<
-        TOptions["errorPolicy"] extends "ignore" | "all" ?
-          TOptions["returnPartialData"] extends true ?
-            DeepPartial<TData> | undefined
-          : TData | undefined
-        : TOptions["returnPartialData"] extends true ? DeepPartial<TData>
-        : TData,
-        TVariables
-      >
-    | (TOptions["skip"] extends boolean ? undefined : never)
-  ),
-  useBackgroundQuery.Result<TData, TVariables>,
-];
 
 export function useBackgroundQuery<
   TData = unknown,
@@ -189,14 +168,6 @@ export function useBackgroundQuery<
   TVariables extends OperationVariables = OperationVariables,
 >(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  options?: useBackgroundQuery.Options<NoInfer<TVariables>>
-): [QueryRef<TData, TVariables>, useBackgroundQuery.Result<TData, TVariables>];
-
-export function useBackgroundQuery<
-  TData = unknown,
-  TVariables extends OperationVariables = OperationVariables,
->(
-  query: DocumentNode | TypedDocumentNode<TData, TVariables>,
   options: SkipToken
 ): [undefined, useBackgroundQuery.Result<TData, TVariables>];
 
@@ -220,7 +191,23 @@ export function useBackgroundQuery<
   TVariables extends OperationVariables = OperationVariables,
 >(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  options?: SkipToken | useBackgroundQuery.Options<NoInfer<TVariables>>
+  ...[options]: Record<string, never> extends (
+    OnlyRequiredProperties<TVariables>
+  ) ?
+    [options?: useBackgroundQuery.Options<NoInfer<TVariables>>]
+  : [options: useBackgroundQuery.Options<NoInfer<TVariables>>]
+): [QueryRef<TData, TVariables>, useBackgroundQuery.Result<TData, TVariables>];
+
+export function useBackgroundQuery<
+  TData = unknown,
+  TVariables extends OperationVariables = OperationVariables,
+>(
+  query: DocumentNode | TypedDocumentNode<TData, TVariables>,
+  ...[options]: Record<string, never> extends (
+    OnlyRequiredProperties<TVariables>
+  ) ?
+    [options?: SkipToken | useBackgroundQuery.Options<NoInfer<TVariables>>]
+  : [options: SkipToken | useBackgroundQuery.Options<NoInfer<TVariables>>]
 ): [
   QueryRef<TData, TVariables> | undefined,
   useBackgroundQuery.Result<TData, TVariables>,
@@ -231,9 +218,22 @@ export function useBackgroundQuery<
   TVariables extends OperationVariables = OperationVariables,
 >(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  options:
-    | (SkipToken & Partial<useBackgroundQuery.Options<NoInfer<TVariables>>>)
-    | useBackgroundQuery.Options<NoInfer<TVariables>> = {}
+  options: SkipToken | useBackgroundQuery.Options<NoInfer<TVariables>>
+): [
+  QueryRef<TData, TVariables> | undefined,
+  useBackgroundQuery.Result<TData, TVariables>,
+];
+
+export function useBackgroundQuery<
+  TData = unknown,
+  TVariables extends OperationVariables = OperationVariables,
+>(
+  query: DocumentNode | TypedDocumentNode<TData, TVariables>,
+  ...[options]: Record<string, never> extends (
+    OnlyRequiredProperties<TVariables>
+  ) ?
+    [options?: SkipToken | useBackgroundQuery.Options<NoInfer<TVariables>>]
+  : [options: SkipToken | useBackgroundQuery.Options<NoInfer<TVariables>>]
 ): [
   QueryRef<TData, TVariables> | undefined,
   useBackgroundQuery.Result<TData, TVariables>,
@@ -243,7 +243,7 @@ export function useBackgroundQuery<
     // eslint-disable-next-line react-compiler/react-compiler
     useBackgroundQuery_,
     useApolloClient(typeof options === "object" ? options.client : undefined)
-  )(query, options);
+  )(query, options ?? ({} as any));
 }
 
 function useBackgroundQuery_<

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -80,7 +80,7 @@ export declare namespace useLazyQuery {
     context?: DefaultContext;
   }
 
-  export interface Result<TData, TVariables extends OperationVariables> {
+  export type Result<TData, TVariables extends OperationVariables> = {
     /** {@inheritDoc @apollo/client!QueryResultDocumentation#startPolling:member} */
     startPolling: (pollInterval: number) => void;
 
@@ -97,9 +97,6 @@ export declare namespace useLazyQuery {
     refetch: (
       variables?: Partial<TVariables>
     ) => Promise<QueryResult<MaybeMasked<TData>>>;
-
-    /** {@inheritDoc @apollo/client!QueryResultDocumentation#variables:member} */
-    variables: TVariables;
 
     /** {@inheritDoc @apollo/client!QueryResultDocumentation#fetchMore:member} */
     fetchMore: <
@@ -137,14 +134,30 @@ export declare namespace useLazyQuery {
 
     /** {@inheritDoc @apollo/client!QueryResultDocumentation#networkStatus:member} */
     networkStatus: NetworkStatus;
+  } & (
+    | {
+        /**
+         * If `true`, the associated lazy query has been executed.
+         *
+         * @docGroup 2. Network info
+         */
+        called: true;
 
-    /**
-     * If `true`, the associated lazy query has been executed.
-     *
-     * @docGroup 2. Network info
-     */
-    called: boolean;
-  }
+        /** {@inheritDoc @apollo/client!QueryResultDocumentation#variables:member} */
+        variables: TVariables;
+      }
+    | {
+        /**
+         * If `true`, the associated lazy query has been executed.
+         *
+         * @docGroup 2. Network info
+         */
+        called: false;
+
+        /** {@inheritDoc @apollo/client!QueryResultDocumentation#variables:member} */
+        variables: Partial<TVariables>;
+      }
+  );
 
   export type ExecOptions<
     TVariables extends OperationVariables = OperationVariables,

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -172,9 +172,7 @@ export declare namespace useLazyQuery {
   ];
 
   export type ExecFunction<TData, TVariables extends OperationVariables> = (
-    ...args: [TVariables] extends [never] ?
-      [options?: useLazyQuery.ExecOptions<TVariables>]
-    : Record<string, never> extends OnlyRequiredProperties<TVariables> ?
+    ...args: Record<string, never> extends OnlyRequiredProperties<TVariables> ?
       [options?: useLazyQuery.ExecOptions<TVariables>]
     : [options: useLazyQuery.ExecOptions<TVariables>]
   ) => Promise<QueryResult<TData>>;

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -22,11 +22,7 @@ import type {
   WatchQueryOptions,
 } from "@apollo/client";
 import { NetworkStatus } from "@apollo/client";
-import type {
-  NoInfer,
-  OnlyRequiredProperties,
-  VariablesOption,
-} from "@apollo/client/utilities";
+import type { NoInfer, VariablesOption } from "@apollo/client/utilities";
 import { maybeDeepFreeze } from "@apollo/client/utilities";
 import { invariant } from "@apollo/client/utilities/invariant";
 
@@ -172,7 +168,7 @@ export declare namespace useLazyQuery {
   ];
 
   export type ExecFunction<TData, TVariables extends OperationVariables> = (
-    ...args: Record<string, never> extends OnlyRequiredProperties<TVariables> ?
+    ...args: {} extends TVariables ?
       [options?: useLazyQuery.ExecOptions<TVariables>]
     : [options: useLazyQuery.ExecOptions<TVariables>]
   ) => Promise<QueryResult<TData>>;

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -304,16 +304,17 @@ export function useLazyQuery<
   }, [observable]);
 
   React.useEffect(() => {
-    const updatedOptions = {
-      query,
-      errorPolicy: stableOptions?.errorPolicy,
-      context: stableOptions?.context,
-      refetchWritePolicy: stableOptions?.refetchWritePolicy,
-      returnPartialData: stableOptions?.returnPartialData,
-      notifyOnNetworkStatusChange: stableOptions?.notifyOnNetworkStatusChange,
-      nextFetchPolicy: options?.nextFetchPolicy,
-      skipPollAttempt: options?.skipPollAttempt,
-    } as Partial<WatchQueryOptions<TVariables, TData>>;
+    const updatedOptions: Partial<ObservableQuery.Options<TData, TVariables>> =
+      {
+        query,
+        errorPolicy: stableOptions?.errorPolicy,
+        context: stableOptions?.context,
+        refetchWritePolicy: stableOptions?.refetchWritePolicy,
+        returnPartialData: stableOptions?.returnPartialData,
+        notifyOnNetworkStatusChange: stableOptions?.notifyOnNetworkStatusChange,
+        nextFetchPolicy: options?.nextFetchPolicy,
+        skipPollAttempt: options?.skipPollAttempt,
+      };
 
     // Wait to apply the changed fetch policy until after the execute
     // function has been called. The execute function will handle setting the
@@ -322,7 +323,7 @@ export function useLazyQuery<
       observable.options.fetchPolicy !== "standby" &&
       stableOptions?.fetchPolicy
     ) {
-      (updatedOptions as any).fetchPolicy = stableOptions?.fetchPolicy;
+      updatedOptions.fetchPolicy = stableOptions.fetchPolicy;
     }
 
     observable.silentSetOptions(updatedOptions);

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -359,7 +359,7 @@ export function useLazyQuery<
           // If `variables` is not given, reset back to empty variables by
           // ensuring the key exists in options
           variables: executeOptions?.variables,
-        } as Partial<WatchQueryOptions<TVariables, TData>>);
+        });
       },
       [observable, calledDuringRender]
     );

--- a/src/react/hooks/useLoadableQuery.ts
+++ b/src/react/hooks/useLoadableQuery.ts
@@ -38,6 +38,7 @@ import { __DEV__ } from "@apollo/client/utilities/environment";
 import { invariant } from "@apollo/client/utilities/invariant";
 
 import { __use, useDeepMemo, useRenderGuard } from "./internal/index.js";
+import { validateSuspenseHookOptions } from "./internal/validateSuspenseHookOptions.js";
 import { useApolloClient } from "./useApolloClient.js";
 
 type ResetFunction = () => void;
@@ -325,43 +326,6 @@ export function useLoadableQuery<
   return [loadQuery, queryRef, { fetchMore, refetch, reset, subscribeToMore }];
 }
 
-function validateOptions<TData, TVariables extends OperationVariables>(
-  options: WatchQueryOptions<TVariables, TData>
-) {
-  const { fetchPolicy, returnPartialData } = options;
-
-  validateFetchPolicy(fetchPolicy);
-  validatePartialDataReturn(fetchPolicy, returnPartialData);
-}
-
-function validateFetchPolicy(
-  fetchPolicy: WatchQueryFetchPolicy = "cache-first"
-) {
-  const supportedFetchPolicies: WatchQueryFetchPolicy[] = [
-    "cache-first",
-    "network-only",
-    "no-cache",
-    "cache-and-network",
-  ];
-
-  invariant(
-    supportedFetchPolicies.includes(fetchPolicy),
-    `The fetch policy \`%s\` is not supported with suspense.`,
-    fetchPolicy
-  );
-}
-
-function validatePartialDataReturn(
-  fetchPolicy: WatchQueryFetchPolicy | undefined,
-  returnPartialData: boolean | undefined
-) {
-  if (fetchPolicy === "no-cache" && returnPartialData) {
-    invariant.warn(
-      "Using `returnPartialData` with a `no-cache` fetch policy has no effect. To read partial data from the cache, consider using an alternate fetch policy."
-    );
-  }
-}
-
 function useWatchQueryOptions<TData, TVariables extends OperationVariables>({
   client,
   query,
@@ -386,7 +350,7 @@ function useWatchQueryOptions<TData, TVariables extends OperationVariables>({
     };
 
     if (__DEV__) {
-      validateOptions(watchQueryOptions as any);
+      validateSuspenseHookOptions(watchQueryOptions as any);
     }
 
     return watchQueryOptions as WatchQueryOptions<TVariables, TData>;

--- a/src/react/hooks/useLoadableQuery.ts
+++ b/src/react/hooks/useLoadableQuery.ts
@@ -48,8 +48,8 @@ export declare namespace useLoadableQuery {
     // which case we don't want to allow a variables argument. In other
     // words, we don't want to allow variables to be passed as an argument to this
     // function if the query does not expect variables in the document.
-    ...args: [TVariables] extends [never] ? []
-    : {} extends OnlyRequiredProperties<TVariables> ? [variables?: TVariables]
+    ...args: Record<string, never> extends OnlyRequiredProperties<TVariables> ?
+      [variables?: TVariables]
     : [variables: TVariables]
   ) => void;
 

--- a/src/react/hooks/useLoadableQuery.ts
+++ b/src/react/hooks/useLoadableQuery.ts
@@ -30,10 +30,7 @@ import {
   updateWrappedQueryRef,
   wrapQueryRef,
 } from "@apollo/client/react/internal";
-import type {
-  DeepPartial,
-  OnlyRequiredProperties,
-} from "@apollo/client/utilities";
+import type { DeepPartial } from "@apollo/client/utilities";
 import { __DEV__ } from "@apollo/client/utilities/environment";
 import { invariant } from "@apollo/client/utilities/invariant";
 
@@ -49,8 +46,7 @@ export declare namespace useLoadableQuery {
     // which case we don't want to allow a variables argument. In other
     // words, we don't want to allow variables to be passed as an argument to this
     // function if the query does not expect variables in the document.
-    ...args: Record<string, never> extends OnlyRequiredProperties<TVariables> ?
-      [variables?: TVariables]
+    ...args: {} extends TVariables ? [variables?: TVariables]
     : [variables: TVariables]
   ) => void;
 

--- a/src/react/hooks/useLoadableQuery.ts
+++ b/src/react/hooks/useLoadableQuery.ts
@@ -104,23 +104,6 @@ export declare namespace useLoadableQuery {
 }
 
 export function useLoadableQuery<
-  TData,
-  TVariables extends OperationVariables,
-  TOptions extends useLoadableQuery.Options,
->(
-  query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  options?: useLoadableQuery.Options & TOptions
-): useLoadableQuery.Result<
-  TOptions["errorPolicy"] extends "ignore" | "all" ?
-    TOptions["returnPartialData"] extends true ?
-      DeepPartial<TData> | undefined
-    : TData | undefined
-  : TOptions["returnPartialData"] extends true ? DeepPartial<TData>
-  : TData,
-  TVariables
->;
-
-export function useLoadableQuery<
   TData = unknown,
   TVariables extends OperationVariables = OperationVariables,
 >(

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -175,7 +175,7 @@ interface ObsQueryWithMeta<TData, TVariables extends OperationVariables>
   [lastWatchOptions]?: Readonly<WatchQueryOptions<TVariables, TData>>;
 }
 
-interface InternalResult<TData, TVariables extends OperationVariables> {
+interface InternalResult<TData> {
   // These members are populated by getCurrentResult and setResult, and it's
   // okay/normal for them to be initially undefined.
   current: ApolloQueryResult<TData>;
@@ -186,7 +186,7 @@ interface InternalState<TData, TVariables extends OperationVariables> {
   client: ReturnType<typeof useApolloClient>;
   query: DocumentNode | TypedDocumentNode<TData, TVariables>;
   observable: ObsQueryWithMeta<TData, TVariables>;
-  resultData: InternalResult<TData, TVariables>;
+  resultData: InternalResult<TData>;
 }
 
 /**
@@ -379,7 +379,7 @@ function useInitialFetchPolicyIfNecessary<
 
 function useResultSubscription<TData, TVariables extends OperationVariables>(
   observable: ObsQueryWithMeta<TData, TVariables>,
-  resultData: InternalResult<TData, TVariables>,
+  resultData: InternalResult<TData>,
   resultOverride: ApolloQueryResult<any> | undefined
 ) {
   "use no memo";
@@ -441,7 +441,7 @@ function useResubscribeIfNecessary<
   TVariables extends OperationVariables,
 >(
   /** this hook will mutate properties on `resultData` */
-  resultData: InternalResult<TData, TVariables>,
+  resultData: InternalResult<TData>,
   /** this hook will mutate properties on `observable` */
   observable: ObsQueryWithMeta<TData, TVariables>,
   watchQueryOptions: Readonly<WatchQueryOptions<TVariables, TData>>

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -34,11 +34,7 @@ import type {
 } from "@apollo/client";
 import { NetworkStatus, ObservableQuery } from "@apollo/client";
 import type { MaybeMasked, Unmasked } from "@apollo/client/masking";
-import type {
-  NoInfer,
-  OnlyRequiredProperties,
-  VariablesOption,
-} from "@apollo/client/utilities";
+import type { NoInfer, VariablesOption } from "@apollo/client/utilities";
 import { maybeDeepFreeze, mergeOptions } from "@apollo/client/utilities";
 
 import type { NextFetchPolicyContext } from "../../core/watchQueryOptions.js";
@@ -221,9 +217,7 @@ export function useQuery<
   TVariables extends OperationVariables = OperationVariables,
 >(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  ...[options]: Record<string, never> extends (
-    OnlyRequiredProperties<TVariables>
-  ) ?
+  ...[options]: {} extends TVariables ?
     [options?: useQuery.Options<NoInfer<TData>, NoInfer<TVariables>>]
   : [options: useQuery.Options<NoInfer<TData>, NoInfer<TVariables>>]
 ): useQuery.Result<TData, TVariables> {
@@ -240,8 +234,7 @@ function useQuery_<TData, TVariables extends OperationVariables>(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
   ...[
     options = {} as useQuery.Options<NoInfer<TData>, NoInfer<TVariables>>,
-  ]: Record<string, never> extends OnlyRequiredProperties<TVariables> ?
-    [options?: useQuery.Options<TData, TVariables>]
+  ]: {} extends TVariables ? [options?: useQuery.Options<TData, TVariables>]
   : [options: useQuery.Options<TData, TVariables>]
 ): useQuery.Result<TData, TVariables> {
   const client = useApolloClient(options.client);

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -159,13 +159,6 @@ export declare namespace useQuery {
       }
     ) => Promise<QueryResult<MaybeMasked<TFetchData>>>;
   }
-
-  export type OptionsArg<
-    TData = unknown,
-    TVariables extends OperationVariables = OperationVariables,
-  > = Record<string, never> extends OnlyRequiredProperties<TVariables> ?
-    [options?: Options<TData, TVariables>]
-  : [options: Options<TData, TVariables>];
 }
 
 const lastWatchOptions = Symbol();
@@ -228,7 +221,11 @@ export function useQuery<
   TVariables extends OperationVariables = OperationVariables,
 >(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  ...[options]: useQuery.OptionsArg<NoInfer<TData>, NoInfer<TVariables>>
+  ...[options]: Record<string, never> extends (
+    OnlyRequiredProperties<TVariables>
+  ) ?
+    [options?: useQuery.Options<NoInfer<TData>, NoInfer<TVariables>>]
+  : [options: useQuery.Options<NoInfer<TData>, NoInfer<TVariables>>]
 ): useQuery.Result<TData, TVariables> {
   "use no memo";
   return wrapHook(
@@ -241,10 +238,11 @@ export function useQuery<
 
 function useQuery_<TData, TVariables extends OperationVariables>(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  ...[options = {} as useQuery.Options<TData, TVariables>]: useQuery.OptionsArg<
-    NoInfer<TData>,
-    NoInfer<TVariables>
-  >
+  ...[
+    options = {} as useQuery.Options<NoInfer<TData>, NoInfer<TVariables>>,
+  ]: Record<string, never> extends OnlyRequiredProperties<TVariables> ?
+    [options?: useQuery.Options<TData, TVariables>]
+  : [options: useQuery.Options<TData, TVariables>]
 ): useQuery.Result<TData, TVariables> {
   const client = useApolloClient(options.client);
   const { skip, ssr, ...opts } = options;

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -163,7 +163,7 @@ export declare namespace useQuery {
   export type OptionsArg<
     TData = unknown,
     TVariables extends OperationVariables = OperationVariables,
-  > = [Record<string, never>] extends [OnlyRequiredProperties<TVariables>] ?
+  > = Record<string, never> extends OnlyRequiredProperties<TVariables> ?
     [options?: Options<TData, TVariables>]
   : [options: Options<TData, TVariables>];
 }

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -227,15 +227,15 @@ export function useQuery<
     // eslint-disable-next-line react-compiler/react-compiler
     useQuery_,
     useApolloClient(options && options.client)
-  )(query, options!);
+  )(query, options);
 }
 
 function useQuery_<TData, TVariables extends OperationVariables>(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  ...[
-    options = {} as useQuery.Options<NoInfer<TData>, NoInfer<TVariables>>,
-  ]: {} extends TVariables ? [options?: useQuery.Options<TData, TVariables>]
-  : [options: useQuery.Options<TData, TVariables>]
+  options: useQuery.Options<
+    NoInfer<TData>,
+    NoInfer<TVariables>
+  > = {} as useQuery.Options<TData, TVariables>
 ): useQuery.Result<TData, TVariables> {
   const client = useApolloClient(options.client);
   const { skip, ssr, ...opts } = options;

--- a/src/react/hooks/useSubscription.ts
+++ b/src/react/hooks/useSubscription.ts
@@ -12,6 +12,7 @@ import type {
   FetchPolicy,
   OperationVariables,
   SubscribeResult,
+  SubscriptionOptions,
 } from "@apollo/client";
 import type { MaybeMasked } from "@apollo/client/masking";
 import type { NoInfer, VariablesOption } from "@apollo/client/utilities";
@@ -354,7 +355,7 @@ function createSubscription<
     errorPolicy,
     context,
     extensions,
-  };
+  } as SubscriptionOptions<TVariables, TData>;
   const __ = {
     ...options,
     client,
@@ -374,7 +375,7 @@ function createSubscription<
       // lazily start the subscription when the first observer subscribes
       // to get around strict mode
       if (!observable) {
-        observable = client.subscribe(options as any);
+        observable = client.subscribe(options);
       }
       const sub = observable.subscribe(observer);
       return () => sub.unsubscribe();

--- a/src/react/hooks/useSubscription.ts
+++ b/src/react/hooks/useSubscription.ts
@@ -14,7 +14,11 @@ import type {
   SubscribeResult,
 } from "@apollo/client";
 import type { MaybeMasked } from "@apollo/client/masking";
-import type { NoInfer } from "@apollo/client/utilities";
+import type {
+  NoInfer,
+  OnlyRequiredProperties,
+  VariablesOption,
+} from "@apollo/client/utilities";
 import { invariant } from "@apollo/client/utilities/invariant";
 
 import { useDeepMemo } from "./internal/useDeepMemo.js";
@@ -23,13 +27,10 @@ import { useApolloClient } from "./useApolloClient.js";
 import { useSyncExternalStore } from "./useSyncExternalStore.js";
 
 export declare namespace useSubscription {
-  export interface Options<
+  export type Options<
     TData = unknown,
     TVariables extends OperationVariables = OperationVariables,
-  > {
-    /** {@inheritDoc @apollo/client!SubscriptionOptionsDocumentation#variables:member} */
-    variables?: TVariables;
-
+  > = {
     /** {@inheritDoc @apollo/client!SubscriptionOptionsDocumentation#fetchPolicy:member} */
     fetchPolicy?: FetchPolicy;
 
@@ -67,7 +68,7 @@ export declare namespace useSubscription {
      * @defaultValue `false`
      */
     ignoreResults?: boolean;
-  }
+  } & VariablesOption<TVariables>;
 
   export interface Result<TData = unknown> {
     /** {@inheritDoc @apollo/client!SubscriptionResultDocumentation#loading:member} */
@@ -181,7 +182,12 @@ export function useSubscription<
   TVariables extends OperationVariables = OperationVariables,
 >(
   subscription: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  options: useSubscription.Options<NoInfer<TData>, NoInfer<TVariables>> = {}
+  ...[options = {} as useSubscription.Options<TData, TVariables>]: Record<
+    string,
+    never
+  > extends OnlyRequiredProperties<TVariables> ?
+    [options?: useSubscription.Options<NoInfer<TData>, NoInfer<TVariables>>]
+  : [options: useSubscription.Options<NoInfer<TData>, NoInfer<TVariables>>]
 ): useSubscription.Result<TData> {
   const client = useApolloClient(options.client);
 

--- a/src/react/hooks/useSubscription.ts
+++ b/src/react/hooks/useSubscription.ts
@@ -379,7 +379,7 @@ function createSubscription<
       // lazily start the subscription when the first observer subscribes
       // to get around strict mode
       if (!observable) {
-        observable = client.subscribe(options);
+        observable = client.subscribe(options as any);
       }
       const sub = observable.subscribe(observer);
       return () => sub.unsubscribe();

--- a/src/react/hooks/useSubscription.ts
+++ b/src/react/hooks/useSubscription.ts
@@ -14,11 +14,7 @@ import type {
   SubscribeResult,
 } from "@apollo/client";
 import type { MaybeMasked } from "@apollo/client/masking";
-import type {
-  NoInfer,
-  OnlyRequiredProperties,
-  VariablesOption,
-} from "@apollo/client/utilities";
+import type { NoInfer, VariablesOption } from "@apollo/client/utilities";
 import { invariant } from "@apollo/client/utilities/invariant";
 
 import { useDeepMemo } from "./internal/useDeepMemo.js";
@@ -182,10 +178,9 @@ export function useSubscription<
   TVariables extends OperationVariables = OperationVariables,
 >(
   subscription: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  ...[options = {} as useSubscription.Options<TData, TVariables>]: Record<
-    string,
-    never
-  > extends OnlyRequiredProperties<TVariables> ?
+  ...[options = {} as useSubscription.Options<TData, TVariables>]: {} extends (
+    TVariables
+  ) ?
     [options?: useSubscription.Options<NoInfer<TData>, NoInfer<TVariables>>]
   : [options: useSubscription.Options<NoInfer<TData>, NoInfer<TVariables>>]
 ): useSubscription.Result<TData> {

--- a/src/react/hooks/useSuspenseQuery.ts
+++ b/src/react/hooks/useSuspenseQuery.ts
@@ -204,9 +204,7 @@ export function useSuspenseQuery<
   TVariables extends OperationVariables = OperationVariables,
 >(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  ...[options]: {} extends TVariables ?
-    [options?: SkipToken | useSuspenseQuery.Options<NoInfer<TVariables>>]
-  : [options: SkipToken | useSuspenseQuery.Options<NoInfer<TVariables>>]
+  options?: SkipToken | useSuspenseQuery.Options<NoInfer<TVariables>>
 ): useSuspenseQuery.Result<TData | undefined, TVariables> {
   return wrapHook(
     "useSuspenseQuery",

--- a/src/react/hooks/useSuspenseQuery.ts
+++ b/src/react/hooks/useSuspenseQuery.ts
@@ -24,7 +24,12 @@ import type {
   RefetchFunction,
 } from "@apollo/client/react/internal";
 import { getSuspenseCache } from "@apollo/client/react/internal";
-import type { DeepPartial, NoInfer } from "@apollo/client/utilities";
+import type {
+  DeepPartial,
+  NoInfer,
+  OnlyRequiredProperties,
+  VariablesOption,
+} from "@apollo/client/utilities";
 import { __DEV__ } from "@apollo/client/utilities/environment";
 import { invariant } from "@apollo/client/utilities/invariant";
 
@@ -39,17 +44,14 @@ export declare namespace useSuspenseQuery {
     "cache-first" | "network-only" | "no-cache" | "cache-and-network"
   >;
 
-  export interface Options<
+  export type Options<
     TVariables extends OperationVariables = OperationVariables,
-  > {
+  > = {
     /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#client:member} */
     client?: ApolloClient;
 
     /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#context:member} */
     context?: DefaultContext;
-
-    /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#variables:member} */
-    variables?: TVariables;
 
     /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#errorPolicy:member} */
     errorPolicy?: ErrorPolicy;
@@ -77,7 +79,7 @@ export declare namespace useSuspenseQuery {
      * ```
      */
     skip?: boolean;
-  }
+  } & VariablesOption<TVariables>;
 
   export interface Result<
     TData = unknown,
@@ -106,26 +108,30 @@ export declare namespace useSuspenseQuery {
   }
 }
 
-export function useSuspenseQuery<
-  TData,
-  TVariables extends OperationVariables,
-  TOptions extends Omit<useSuspenseQuery.Options, "variables">,
->(
-  query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  options?: useSuspenseQuery.Options<NoInfer<TVariables>> & TOptions
-): useSuspenseQuery.Result<
-  TOptions["errorPolicy"] extends "ignore" | "all" ?
-    TOptions["returnPartialData"] extends true ?
-      DeepPartial<TData> | undefined
-    : TData | undefined
-  : TOptions["returnPartialData"] extends true ?
-    TOptions["skip"] extends boolean ?
-      DeepPartial<TData> | undefined
-    : DeepPartial<TData>
-  : TOptions["skip"] extends boolean ? TData | undefined
-  : TData,
-  TVariables
->;
+// export function useSuspenseQuery<
+//   TData,
+//   TVariables extends OperationVariables,
+//   TOptions extends Omit<useSuspenseQuery.Options, "variables">,
+// >(
+//   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
+//   ...[options]: Record<string, never> extends (
+//     OnlyRequiredProperties<TVariables>
+//   ) ?
+//     [options?: useSuspenseQuery.Options<NoInfer<TVariables>> & TOptions]
+//   : [options: useSuspenseQuery.Options<NoInfer<TVariables>>]
+// ): useSuspenseQuery.Result<
+//   TOptions["errorPolicy"] extends "ignore" | "all" ?
+//     TOptions["returnPartialData"] extends true ?
+//       DeepPartial<TData> | undefined
+//     : TData | undefined
+//   : TOptions["returnPartialData"] extends true ?
+//     TOptions["skip"] extends boolean ?
+//       DeepPartial<TData> | undefined
+//     : DeepPartial<TData>
+//   : TOptions["skip"] extends boolean ? TData | undefined
+//   : TData,
+//   TVariables
+// >;
 
 export function useSuspenseQuery<
   TData = unknown,
@@ -179,13 +185,13 @@ export function useSuspenseQuery<
   }
 ): useSuspenseQuery.Result<TData | undefined, TVariables>;
 
-export function useSuspenseQuery<
-  TData = unknown,
-  TVariables extends OperationVariables = OperationVariables,
->(
-  query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  options?: useSuspenseQuery.Options<NoInfer<TVariables>>
-): useSuspenseQuery.Result<TData, TVariables>;
+// export function useSuspenseQuery<
+//   TData = unknown,
+//   TVariables extends OperationVariables = OperationVariables,
+// >(
+//   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
+//   options?: useSuspenseQuery.Options<NoInfer<TVariables>>
+// ): useSuspenseQuery.Result<TData, TVariables>;
 
 export function useSuspenseQuery<
   TData = unknown,
@@ -204,8 +210,28 @@ export function useSuspenseQuery<
   TVariables extends OperationVariables = OperationVariables,
 >(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  options?: SkipToken | useSuspenseQuery.Options<NoInfer<TVariables>>
+  options: SkipToken | undefined
 ): useSuspenseQuery.Result<TData | undefined, TVariables>;
+
+export function useSuspenseQuery<
+  TData = unknown,
+  TVariables extends OperationVariables = OperationVariables,
+>(
+  query: DocumentNode | TypedDocumentNode<TData, TVariables>,
+  options: SkipToken | useSuspenseQuery.Options<NoInfer<TVariables>>
+): useSuspenseQuery.Result<TData | undefined, TVariables>;
+
+export function useSuspenseQuery<
+  TData = unknown,
+  TVariables extends OperationVariables = OperationVariables,
+>(
+  query: DocumentNode | TypedDocumentNode<TData, TVariables>,
+  ...[options]: Record<string, never> extends (
+    OnlyRequiredProperties<TVariables>
+  ) ?
+    [options?: useSuspenseQuery.Options<NoInfer<TVariables>>]
+  : [options: useSuspenseQuery.Options<NoInfer<TVariables>>]
+): useSuspenseQuery.Result<TData, TVariables>;
 
 export function useSuspenseQuery<
   TData = unknown,

--- a/src/react/hooks/useSuspenseQuery.ts
+++ b/src/react/hooks/useSuspenseQuery.ts
@@ -108,31 +108,6 @@ export declare namespace useSuspenseQuery {
   }
 }
 
-// export function useSuspenseQuery<
-//   TData,
-//   TVariables extends OperationVariables,
-//   TOptions extends Omit<useSuspenseQuery.Options, "variables">,
-// >(
-//   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-//   ...[options]: Record<string, never> extends (
-//     OnlyRequiredProperties<TVariables>
-//   ) ?
-//     [options?: useSuspenseQuery.Options<NoInfer<TVariables>> & TOptions]
-//   : [options: useSuspenseQuery.Options<NoInfer<TVariables>>]
-// ): useSuspenseQuery.Result<
-//   TOptions["errorPolicy"] extends "ignore" | "all" ?
-//     TOptions["returnPartialData"] extends true ?
-//       DeepPartial<TData> | undefined
-//     : TData | undefined
-//   : TOptions["returnPartialData"] extends true ?
-//     TOptions["skip"] extends boolean ?
-//       DeepPartial<TData> | undefined
-//     : DeepPartial<TData>
-//   : TOptions["skip"] extends boolean ? TData | undefined
-//   : TData,
-//   TVariables
-// >;
-
 export function useSuspenseQuery<
   TData = unknown,
   TVariables extends OperationVariables = OperationVariables,
@@ -185,14 +160,6 @@ export function useSuspenseQuery<
   }
 ): useSuspenseQuery.Result<TData | undefined, TVariables>;
 
-// export function useSuspenseQuery<
-//   TData = unknown,
-//   TVariables extends OperationVariables = OperationVariables,
-// >(
-//   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-//   options?: useSuspenseQuery.Options<NoInfer<TVariables>>
-// ): useSuspenseQuery.Result<TData, TVariables>;
-
 export function useSuspenseQuery<
   TData = unknown,
   TVariables extends OperationVariables = OperationVariables,
@@ -210,16 +177,12 @@ export function useSuspenseQuery<
   TVariables extends OperationVariables = OperationVariables,
 >(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  options: SkipToken | undefined
-): useSuspenseQuery.Result<TData | undefined, TVariables>;
-
-export function useSuspenseQuery<
-  TData = unknown,
-  TVariables extends OperationVariables = OperationVariables,
->(
-  query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  options: SkipToken | useSuspenseQuery.Options<NoInfer<TVariables>>
-): useSuspenseQuery.Result<TData | undefined, TVariables>;
+  ...[options]: Record<string, never> extends (
+    OnlyRequiredProperties<TVariables>
+  ) ?
+    [options?: useSuspenseQuery.Options<NoInfer<TVariables>>]
+  : [options: useSuspenseQuery.Options<NoInfer<TVariables>>]
+): useSuspenseQuery.Result<TData, TVariables>;
 
 export function useSuspenseQuery<
   TData = unknown,
@@ -229,9 +192,17 @@ export function useSuspenseQuery<
   ...[options]: Record<string, never> extends (
     OnlyRequiredProperties<TVariables>
   ) ?
-    [options?: useSuspenseQuery.Options<NoInfer<TVariables>>]
-  : [options: useSuspenseQuery.Options<NoInfer<TVariables>>]
-): useSuspenseQuery.Result<TData, TVariables>;
+    [options?: SkipToken | useSuspenseQuery.Options<NoInfer<TVariables>>]
+  : [options: SkipToken | useSuspenseQuery.Options<NoInfer<TVariables>>]
+): useSuspenseQuery.Result<TData | undefined, TVariables>;
+
+export function useSuspenseQuery<
+  TData = unknown,
+  TVariables extends OperationVariables = OperationVariables,
+>(
+  query: DocumentNode | TypedDocumentNode<TData, TVariables>,
+  options: SkipToken | useSuspenseQuery.Options<NoInfer<TVariables>>
+): useSuspenseQuery.Result<TData | undefined, TVariables>;
 
 export function useSuspenseQuery<
   TData = unknown,

--- a/src/react/hooks/useSuspenseQuery.ts
+++ b/src/react/hooks/useSuspenseQuery.ts
@@ -31,11 +31,11 @@ import type {
   VariablesOption,
 } from "@apollo/client/utilities";
 import { __DEV__ } from "@apollo/client/utilities/environment";
-import { invariant } from "@apollo/client/utilities/invariant";
 
 import type { SkipToken } from "./constants.js";
 import { skipToken } from "./constants.js";
 import { __use, useDeepMemo, wrapHook } from "./internal/index.js";
+import { validateSuspenseHookOptions } from "./internal/validateSuspenseHookOptions.js";
 import { useApolloClient } from "./useApolloClient.js";
 
 export declare namespace useSuspenseQuery {
@@ -338,43 +338,6 @@ function useSuspenseQuery_<
   }, [client, fetchMore, refetch, result, subscribeToMore]);
 }
 
-function validateOptions<TData, TVariables extends OperationVariables>(
-  options: WatchQueryOptions<TVariables, TData>
-) {
-  const { fetchPolicy, returnPartialData } = options;
-
-  validateFetchPolicy(fetchPolicy);
-  validatePartialDataReturn(fetchPolicy, returnPartialData);
-}
-
-function validateFetchPolicy(
-  fetchPolicy: WatchQueryFetchPolicy = "cache-first"
-) {
-  const supportedFetchPolicies: WatchQueryFetchPolicy[] = [
-    "cache-first",
-    "network-only",
-    "no-cache",
-    "cache-and-network",
-  ];
-
-  invariant(
-    supportedFetchPolicies.includes(fetchPolicy),
-    `The fetch policy \`%s\` is not supported with suspense.`,
-    fetchPolicy
-  );
-}
-
-function validatePartialDataReturn(
-  fetchPolicy: WatchQueryFetchPolicy | undefined,
-  returnPartialData: boolean | undefined
-) {
-  if (fetchPolicy === "no-cache" && returnPartialData) {
-    invariant.warn(
-      "Using `returnPartialData` with a `no-cache` fetch policy has no effect. To read partial data from the cache, consider using an alternate fetch policy."
-    );
-  }
-}
-
 interface UseWatchQueryOptionsHookOptions<
   TData,
   TVariables extends OperationVariables,
@@ -417,7 +380,7 @@ export function useWatchQueryOptions<
     };
 
     if (__DEV__) {
-      validateOptions(watchQueryOptions);
+      validateSuspenseHookOptions(watchQueryOptions);
     }
 
     // Assign the updated fetch policy after our validation since `standby` is

--- a/src/react/hooks/useSuspenseQuery.ts
+++ b/src/react/hooks/useSuspenseQuery.ts
@@ -27,7 +27,6 @@ import { getSuspenseCache } from "@apollo/client/react/internal";
 import type {
   DeepPartial,
   NoInfer,
-  OnlyRequiredProperties,
   VariablesOption,
 } from "@apollo/client/utilities";
 import { __DEV__ } from "@apollo/client/utilities/environment";
@@ -177,9 +176,7 @@ export function useSuspenseQuery<
   TVariables extends OperationVariables = OperationVariables,
 >(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  ...[options]: Record<string, never> extends (
-    OnlyRequiredProperties<TVariables>
-  ) ?
+  ...[options]: {} extends TVariables ?
     [options?: useSuspenseQuery.Options<NoInfer<TVariables>>]
   : [options: useSuspenseQuery.Options<NoInfer<TVariables>>]
 ): useSuspenseQuery.Result<TData, TVariables>;
@@ -189,9 +186,7 @@ export function useSuspenseQuery<
   TVariables extends OperationVariables = OperationVariables,
 >(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  ...[options]: Record<string, never> extends (
-    OnlyRequiredProperties<TVariables>
-  ) ?
+  ...[options]: {} extends TVariables ?
     [options?: SkipToken | useSuspenseQuery.Options<NoInfer<TVariables>>]
   : [options: SkipToken | useSuspenseQuery.Options<NoInfer<TVariables>>]
 ): useSuspenseQuery.Result<TData | undefined, TVariables>;
@@ -209,9 +204,7 @@ export function useSuspenseQuery<
   TVariables extends OperationVariables = OperationVariables,
 >(
   query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  ...[options]: Record<string, never> extends (
-    OnlyRequiredProperties<TVariables>
-  ) ?
+  ...[options]: {} extends TVariables ?
     [options?: SkipToken | useSuspenseQuery.Options<NoInfer<TVariables>>]
   : [options: SkipToken | useSuspenseQuery.Options<NoInfer<TVariables>>]
 ): useSuspenseQuery.Result<TData | undefined, TVariables> {

--- a/src/react/query-preloader/__tests__/createQueryPreloader.test.tsx
+++ b/src/react/query-preloader/__tests__/createQueryPreloader.test.tsx
@@ -2023,11 +2023,13 @@ describe.skip("type tests", () => {
     });
   });
 
-  test("does not allow variables when TVariables is `never`", () => {
+  test("is invalid when TVariables is `never`", () => {
     type Data = { greeting: string };
     const query: TypedDocumentNode<Data, never> = gql``;
 
+    // @ts-expect-error
     preloadQuery(query);
+    // @ts-expect-error
     preloadQuery<Data, never>(query);
     preloadQuery(query, {
       // @ts-expect-error

--- a/src/react/query-preloader/createQueryPreloader.ts
+++ b/src/react/query-preloader/createQueryPreloader.ts
@@ -43,19 +43,6 @@ export type PreloadQueryOptions<
   refetchWritePolicy?: RefetchWritePolicy;
 } & VariablesOption<TVariables>;
 
-type PreloadQueryOptionsArg<
-  TVariables extends OperationVariables,
-  TOptions = unknown,
-> = Record<string, never> extends OnlyRequiredProperties<TVariables> ?
-  [
-    options?: PreloadQueryOptions<NoInfer<TVariables>> &
-      Omit<TOptions, "variables">,
-  ]
-: [
-    options: PreloadQueryOptions<NoInfer<TVariables>> &
-      Omit<TOptions, "variables">,
-  ];
-
 /**
  * A function that will begin loading a query when called. It's result can be
  * read by `useReadQuery` which will suspend until the query is loaded.
@@ -111,7 +98,11 @@ export interface PreloadQueryFunction {
   /** {@inheritDoc @apollo/client!PreloadQueryFunction:interface} */
   <TData = unknown, TVariables extends OperationVariables = OperationVariables>(
     query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-    ...[options]: PreloadQueryOptionsArg<NoInfer<TVariables>>
+    ...[options]: Record<string, never> extends (
+      OnlyRequiredProperties<TVariables>
+    ) ?
+      [options?: PreloadQueryOptions<NoInfer<TVariables>>]
+    : [options: PreloadQueryOptions<NoInfer<TVariables>>]
   ): PreloadedQueryRef<TData, TVariables>;
 }
 

--- a/src/react/query-preloader/createQueryPreloader.ts
+++ b/src/react/query-preloader/createQueryPreloader.ts
@@ -17,7 +17,6 @@ import {
 import type {
   DeepPartial,
   NoInfer,
-  OnlyRequiredProperties,
   VariablesOption,
 } from "@apollo/client/utilities";
 
@@ -98,9 +97,7 @@ export interface PreloadQueryFunction {
   /** {@inheritDoc @apollo/client!PreloadQueryFunction:interface} */
   <TData = unknown, TVariables extends OperationVariables = OperationVariables>(
     query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-    ...[options]: Record<string, never> extends (
-      OnlyRequiredProperties<TVariables>
-    ) ?
+    ...[options]: {} extends TVariables ?
       [options?: PreloadQueryOptions<NoInfer<TVariables>>]
     : [options: PreloadQueryOptions<NoInfer<TVariables>>]
   ): PreloadedQueryRef<TData, TVariables>;

--- a/src/react/query-preloader/createQueryPreloader.ts
+++ b/src/react/query-preloader/createQueryPreloader.ts
@@ -46,9 +46,7 @@ export type PreloadQueryOptions<
 type PreloadQueryOptionsArg<
   TVariables extends OperationVariables,
   TOptions = unknown,
-> = [TVariables] extends [never] ?
-  [options?: PreloadQueryOptions<never> & TOptions]
-: Record<string, never> extends OnlyRequiredProperties<TVariables> ?
+> = [Record<string, never>] extends [OnlyRequiredProperties<TVariables>] ?
   [
     options?: PreloadQueryOptions<NoInfer<TVariables>> &
       Omit<TOptions, "variables">,
@@ -85,24 +83,6 @@ type PreloadQueryOptionsArg<
  * ```
  */
 export interface PreloadQueryFunction {
-  /** {@inheritDoc @apollo/client!PreloadQueryFunction:interface} */
-  <
-    TData,
-    TVariables extends OperationVariables,
-    TOptions extends Omit<PreloadQueryOptions, "variables">,
-  >(
-    query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-    ...[options]: PreloadQueryOptionsArg<NoInfer<TVariables>, TOptions>
-  ): PreloadedQueryRef<
-    TOptions["errorPolicy"] extends "ignore" | "all" ?
-      TOptions["returnPartialData"] extends true ?
-        DeepPartial<TData> | undefined
-      : TData | undefined
-    : TOptions["returnPartialData"] extends true ? DeepPartial<TData>
-    : TData,
-    TVariables
-  >;
-
   /** {@inheritDoc @apollo/client!PreloadQueryFunction:interface} */
   <TData = unknown, TVariables extends OperationVariables = OperationVariables>(
     query: DocumentNode | TypedDocumentNode<TData, TVariables>,

--- a/src/react/query-preloader/createQueryPreloader.ts
+++ b/src/react/query-preloader/createQueryPreloader.ts
@@ -46,7 +46,7 @@ export type PreloadQueryOptions<
 type PreloadQueryOptionsArg<
   TVariables extends OperationVariables,
   TOptions = unknown,
-> = [Record<string, never>] extends [OnlyRequiredProperties<TVariables>] ?
+> = Record<string, never> extends OnlyRequiredProperties<TVariables> ?
   [
     options?: PreloadQueryOptions<NoInfer<TVariables>> &
       Omit<TOptions, "variables">,

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -140,7 +140,6 @@ export { stripTypename } from "./common/stripTypename.js";
 export type { IsStrictlyAny } from "./types/IsStrictlyAny.js";
 export type { DeepOmit } from "./types/DeepOmit.js";
 export type { DeepPartial } from "./types/DeepPartial.js";
-export type { OnlyRequiredProperties } from "./types/OnlyRequiredProperties.js";
 export type { Prettify } from "./types/Prettify.js";
 export type { Primitive } from "./types/Primitive.js";
 export type { UnionToIntersection } from "./types/UnionToIntersection.js";

--- a/src/utilities/types/OnlyRequiredProperties.ts
+++ b/src/utilities/types/OnlyRequiredProperties.ts
@@ -1,6 +1,0 @@
-/**
- * Returns a new type that only contains the required properties from `T`
- */
-export type OnlyRequiredProperties<T> = {
-  [K in keyof T as {} extends Pick<T, K> ? never : K]: T[K];
-};

--- a/src/utilities/types/VariablesOption.ts
+++ b/src/utilities/types/VariablesOption.ts
@@ -1,9 +1,7 @@
 import type { OperationVariables } from "@apollo/client";
 
-import type { OnlyRequiredProperties } from "./OnlyRequiredProperties.js";
-
 export type VariablesOption<TVariables extends OperationVariables> =
-  Record<string, never> extends OnlyRequiredProperties<TVariables> ?
+  {} extends TVariables ?
     {
       /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#variables:member} */
       variables?: TVariables;


### PR DESCRIPTION
Adds more robust types for `variables` throughout the client. A few changes have been made:
- Enforce a `variables` option when there are required variables in `TVariables`. This is enforced on core APIs (`client.query`, `client.watchQuery`, etc) as well as hooks that did not already have it (`useQuery`, `useSuspenseQuery`, etc.)
- Update the return type of `ObservableQuery.variables` to be `TVariables` instead of `TVariables | undefined` since the runtime value will always be an empty object when variables aren't defined

On top of this, `reobserve` has been tweaked in regards to how it handles `undefined` in relation to `variables`. If `reobserve({ variables: undefined })` is passed, this will reset variables back to an empty variables, or default variables pulled from the query document. Previously `variables` was ignored and variables remained unchanged.

Additionally, using `undefined` as a value for a variable will now set that value back to the default from the query document if one is provided for that value. Previously the value would remain as `undefined`.

> [!NOTE]
> `useMutation` has not been changed due to the variable merging behavior it has between the hook and the `execute` function.