### PR TITLE
Minor refactor: use `query` for `fetchMore`

### DIFF
--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -1523,8 +1523,6 @@ class QueryManager {
     // (undocumented)
     fetchObservableWithInfo<TData, TVars extends OperationVariables>(queryInfo: QueryInfo, options: WatchQueryOptions<TVars, TData>, networkStatus?: NetworkStatus, query?: DocumentNode_2 | TypedDocumentNode<TData, TVars>, emitLoadingState?: boolean): ObservableAndInfo<TData>;
     // (undocumented)
-    fetchQuery<TData, TVars extends OperationVariables>(queryId: string, options: WatchQueryOptions<TVars, TData>, networkStatus?: NetworkStatus): Promise<QueryResult<TData>>;
-    // (undocumented)
     generateMutationId(): string;
     // (undocumented)
     generateQueryId(): string;

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -741,8 +741,6 @@ class QueryManager {
     // (undocumented)
     fetchObservableWithInfo<TData, TVars extends OperationVariables_2>(queryInfo: QueryInfo, options: WatchQueryOptions_2<TVars, TData>, networkStatus?: NetworkStatus, query?: DocumentNode | TypedDocumentNode<TData, TVars>, emitLoadingState?: boolean): ObservableAndInfo<TData>;
     // (undocumented)
-    fetchQuery<TData, TVars extends OperationVariables_2>(queryId: string, options: WatchQueryOptions_2<TVars, TData>, networkStatus?: NetworkStatus): Promise<QueryResult_2<TData>>;
-    // (undocumented)
     generateMutationId(): string;
     // (undocumented)
     generateQueryId(): string;

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -1854,8 +1854,6 @@ class QueryManager {
     // (undocumented)
     fetchObservableWithInfo<TData, TVars extends OperationVariables>(queryInfo: QueryInfo, options: WatchQueryOptions<TVars, TData>, networkStatus?: NetworkStatus, query?: DocumentNode | TypedDocumentNode<TData, TVars>, emitLoadingState?: boolean): ObservableAndInfo<TData>;
     // (undocumented)
-    fetchQuery<TData, TVars extends OperationVariables>(queryId: string, options: WatchQueryOptions<TVars, TData>, networkStatus?: NetworkStatus): Promise<QueryResult<TData>>;
-    // (undocumented)
     generateMutationId(): string;
     // (undocumented)
     generateQueryId(): string;

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 42984,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38432,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 32968,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27861
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 42946,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38461,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 32902,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27858
 }

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -499,7 +499,10 @@ export class ApolloClient implements DataProxy {
       "pollInterval option only supported on watchQuery."
     );
 
-    return this.queryManager.query<TData, TVariables>(options);
+    return this.queryManager.query<TData, TVariables>({
+      ...options,
+      query: this.queryManager.transform(options.query),
+    });
   }
 
   /**

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -555,12 +555,6 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
           },
         }
       )),
-      // The fetchMore request goes immediately to the network and does
-      // not automatically write its result to the cache (hence no-cache
-      // instead of network-only), because we allow the caller of
-      // fetchMore to provide an updateQuery callback that determines how
-      // the data gets written to the cache.
-      fetchPolicy: "no-cache",
       notifyOnNetworkStatusChange: this.options.notifyOnNetworkStatusChange,
     } as WatchQueryOptions<TFetchVars, TFetchData>;
 
@@ -599,7 +593,18 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     }
 
     return this.queryManager
-      .query({ ...combinedOptions, fetchPolicy: "no-cache" }, qid)
+      .query(
+        {
+          ...combinedOptions,
+          // The fetchMore request goes immediately to the network and does
+          // not automatically write its result to the cache (hence no-cache
+          // instead of network-only), because we allow the caller of
+          // fetchMore to provide an updateQuery callback that determines how
+          // the data gets written to the cache.
+          fetchPolicy: "no-cache",
+        },
+        qid
+      )
       .then((fetchMoreResult) => {
         this.queryManager.removeQuery(qid);
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -599,7 +599,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     }
 
     return this.queryManager
-      .fetchQuery(qid, combinedOptions, NetworkStatus.fetchMore)
+      .query({ ...combinedOptions, fetchPolicy: "no-cache" }, qid)
       .then((fetchMoreResult) => {
         this.queryManager.removeQuery(qid);
 

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -829,11 +829,11 @@ export class QueryManager {
   ): Promise<QueryResult<MaybeMasked<TData>>> {
     checkDocument(options.query, OperationTypeNode.QUERY);
 
-    return this.fetchQuery<TData, TVars>(queryId, { ...options, query })
+    return this.fetchQuery<TData, TVars>(queryId, options)
       .then((value) => ({
         ...value,
         data: this.maskOperation({
-          document: query,
+          document: options.query,
           data: value?.data,
           fetchPolicy: options.fetchPolicy,
           id: queryId,

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -829,8 +829,6 @@ export class QueryManager {
   ): Promise<QueryResult<MaybeMasked<TData>>> {
     checkDocument(options.query, OperationTypeNode.QUERY);
 
-    const query = this.transform(options.query);
-
     return this.fetchQuery<TData, TVars>(queryId, { ...options, query })
       .then((value) => ({
         ...value,

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -4198,7 +4198,7 @@ describe("ApolloClient", () => {
       const queryId = "1";
       // TODO: Determine if there is a better way to test this without digging
       // into implementation details
-      const promise = client["queryManager"].fetchQuery(queryId, { query });
+      const promise = client["queryManager"].query({ query }, queryId);
 
       client["queryManager"].removeQuery(queryId);
 
@@ -4232,10 +4232,7 @@ describe("ApolloClient", () => {
           },
         ]),
       });
-      // TODO: Determine if there is a better way to test this.
-      const promise = client["queryManager"].fetchQuery("made up id", {
-        query,
-      });
+      const promise = client.query({ query });
 
       // Need to delay the reset at least until the fetchRequest method
       // has had a chance to enter this request into fetchQueryRejectFns.
@@ -4747,10 +4744,7 @@ describe("ApolloClient", () => {
           },
         ]),
       });
-      // TODO: Determine if there is a better way to test this
-      const promise = client["queryManager"].fetchQuery("made up id", {
-        query,
-      });
+      const promise = client.query({ query });
       void client.reFetchObservableQueries();
 
       await expect(promise).resolves.toBeTruthy();


### PR DESCRIPTION
By moving to `queryManager.query` for `fetchMore`, this means we can more easily refactor the chain of function calls for `client.query` to reduce the need for `QueryInfo` in the future.

As a result of this change, I was able to eliminate `fetchQuery` and inline the implementation in `queryManager.query`. I've got some future refactors in mind that will take this further to narrow down some of the additional chain of calls that are specific to `ObservableQuery`, but this one is small enough that I think we can get it in before then.