### PR TITLE
Fix test flake introduced by changes to `MockLink`

### DIFF
--- a/src/__tests__/mutationResults.ts
+++ b/src/__tests__/mutationResults.ts
@@ -650,10 +650,12 @@ describe("mutation results", () => {
       {
         request: { query: queryTodos },
         result: queryTodosResult,
+        delay: 0,
       },
       {
         request: { query: mutationTodo },
         result: mutationTodoResult,
+        delay: 0,
       }
     );
 


### PR DESCRIPTION
Fixes the annoying [test flake](https://app.circleci.com/pipelines/github/apollographql/apollo-client/27629/workflows/4cea4050-0229-4d8c-9c66-02b869cb8f02/jobs/253330) that shows up from time to time by resetting the `delay` back to the old default value of `0`