### PR TITLE
Don't call `broadcastQueries` when a query is stopped

### DIFF
--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -851,8 +851,6 @@ class QueryManager {
     startGraphQLSubscription<TData = unknown>(options: SubscriptionOptions): Observable_2<SubscribeResult<TData>>;
     stop(): void;
     // (undocumented)
-    stopQuery(queryId: string): void;
-    // (undocumented)
     transform(document: DocumentNode_2): DocumentNode_2;
     // (undocumented)
     watchQuery<T, TVariables extends OperationVariables = OperationVariables>(options: WatchQueryOptions<TVariables, T>): ObservableQuery<T, TVariables>;

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -831,8 +831,6 @@ class QueryManager {
     startGraphQLSubscription<TData = unknown>(options: SubscriptionOptions): Observable<SubscribeResult<TData>>;
     stop(): void;
     // (undocumented)
-    stopQuery(queryId: string): void;
-    // (undocumented)
     transform(document: DocumentNode): DocumentNode;
     // (undocumented)
     watchQuery<T, TVariables extends OperationVariables_2 = OperationVariables_2>(options: WatchQueryOptions_2<TVariables, T>): ObservableQuery<T, TVariables>;

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -1992,8 +1992,6 @@ class QueryManager {
     startGraphQLSubscription<TData = unknown>(options: SubscriptionOptions): Observable<SubscribeResult<TData>>;
     stop(): void;
     // (undocumented)
-    stopQuery(queryId: string): void;
-    // (undocumented)
     transform(document: DocumentNode): DocumentNode;
     // (undocumented)
     watchQuery<T, TVariables extends OperationVariables = OperationVariables>(options: WatchQueryOptions<TVariables, T>): ObservableQuery<T, TVariables>;

--- a/.changeset/small-poems-rest.md
+++ b/.changeset/small-poems-rest.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": major
+---
+
+Don't `broadcastQueries` when a query is torn down.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43424,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38812,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33179,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 28041
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43407,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38866,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33208,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 28032
 }

--- a/src/__tests__/refetchQueries.ts
+++ b/src/__tests__/refetchQueries.ts
@@ -124,7 +124,7 @@ describe("client.refetchQueries", () => {
   }
 
   it("includes watched queries affected by updateCache", async () => {
-    expect.assertions(11);
+    expect.assertions(9);
     const client = makeClient();
     const [aObs, bObs, abObs] = await setup(client);
 
@@ -200,7 +200,7 @@ describe("client.refetchQueries", () => {
   });
 
   it("includes watched queries named in options.include", async () => {
-    expect.assertions(13);
+    expect.assertions(11);
     const client = makeClient();
     const [aObs, bObs, abObs] = await setup(client);
 
@@ -284,7 +284,7 @@ describe("client.refetchQueries", () => {
   });
 
   it("includes query DocumentNode objects specified in options.include", async () => {
-    expect.assertions(13);
+    expect.assertions(11);
     const client = makeClient();
     const [aObs, bObs, abObs] = await setup(client);
 
@@ -369,7 +369,7 @@ describe("client.refetchQueries", () => {
   });
 
   it('includes all queries when options.include === "all"', async () => {
-    expect.assertions(13);
+    expect.assertions(11);
     const client = makeClient();
     const [aObs, bObs, abObs] = await setup(client);
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1296,7 +1296,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     // stop all active GraphQL subscriptions
     this.subscriptions.forEach((sub) => sub.unsubscribe());
     this.subscriptions.clear();
-    this.queryManager.stopQuery(this.queryId);
+    this.queryManager.removeQuery(this.queryId);
     this.isTornDown = true;
   }
 

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1122,10 +1122,6 @@ export class QueryManager {
     return makeObservable(variables);
   }
 
-  public stopQuery(queryId: string) {
-    this.removeQuery(queryId);
-  }
-
   public removeQuery(queryId: string) {
     // teardown all links
     // Both `QueryManager.fetchRequest` and `QueryManager.query` create separate promises

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1124,7 +1124,6 @@ export class QueryManager {
 
   public stopQuery(queryId: string) {
     this.removeQuery(queryId);
-    this.broadcastQueries();
   }
 
   public removeQuery(queryId: string) {

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -848,7 +848,7 @@ export class QueryManager {
           id: queryId,
         }),
       }))
-      .finally(() => this.stopQuery(queryId));
+      .finally(() => this.removeQuery(queryId));
   }
 
   private queryIdCounter = 1;


### PR DESCRIPTION
Closes #10291

Don't `broadcastQueries` when a query is torn down. This should save a bit on performance by avoiding potentially lots of notifications to other queries purely because a query was removed.