### PR TITLE
fix: cancellable in-flight multipart urql subscriptions

### DIFF
--- a/.changeset/hot-kangaroos-eat.md
+++ b/.changeset/hot-kangaroos-eat.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix in-flight multipart urql subscription cancellation

--- a/src/utilities/subscriptions/urql/index.ts
+++ b/src/utilities/subscriptions/urql/index.ts
@@ -35,7 +35,9 @@ export function createFetchMultipartSubscription(
       const currentFetch = preferredFetch || maybe(() => fetch) || backupFetch;
       const observerNext = observer.next.bind(observer);
 
-      currentFetch!(uri, options)
+      const abortController = new AbortController();
+
+      currentFetch!(uri, { ...options, signal: abortController.signal })
         .then((response) => {
           const ctype = response.headers?.get("content-type");
 
@@ -51,6 +53,10 @@ export function createFetchMultipartSubscription(
         .catch((err: any) => {
           handleError(err, observer);
         });
+
+      return () => {
+        abortController.abort();
+      };
     });
   };
 }


### PR DESCRIPTION
This is a tiny fix to the urql multipart subscription exchange helper so that it closes gracefully when urql attempts to trigger an unsubscribe.

I see that in the 4.0 release [they're slated for removal](https://github.com/apollographql/apollo-client/pull/12428/files), but the spec implemented by the helpers here is not the same as implemented by `urql` (less strict `accept` header, different response structure, no graceful heartbeat handling), hence this small fix while people figure out how to swap.