### PR TITLE
Remove `typeDefs` option

### DIFF
--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -163,8 +163,6 @@ export class ApolloClient implements DataProxy {
     stop(): void;
     subscribe<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: SubscriptionOptions<TVariables, TData>): Observable_2<SubscribeResult<MaybeMasked<TData>>>;
     // (undocumented)
-    readonly typeDefs: ApolloClientOptions["typeDefs"];
-    // (undocumented)
     version: string;
     watchFragment<TData = unknown, TVariables = OperationVariables>(options: WatchFragmentOptions<TData, TVariables>): Observable_2<WatchFragmentResult<TData>>;
     watchQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: WatchQueryOptions<TVariables, TData>): ObservableQuery<TData, TVariables>;
@@ -197,8 +195,6 @@ export interface ApolloClientOptions {
     resolvers?: Resolvers | Resolvers[];
     ssrForceFetchDelay?: number;
     ssrMode?: boolean;
-    // (undocumented)
-    typeDefs?: string | string[] | DocumentNode_2 | DocumentNode_2[];
     uri?: string | HttpLink.UriFunction;
     version?: string;
 }

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -84,6 +84,7 @@ import type { wrapperSymbol } from '@apollo/client/react/internal';
 class ApolloClient_2 implements DataProxy {
     // (undocumented)
     __actionHookForDevTools(cb: () => any): void;
+    // Warning: (ae-forgotten-export) The symbol "ApolloClientOptions" needs to be exported by the entry point index.d.ts
     constructor(options: ApolloClientOptions);
     // (undocumented)
     __requestRaw(payload: GraphQLRequest): Observable<FormattedExecutionResult>;
@@ -139,10 +140,6 @@ class ApolloClient_2 implements DataProxy {
     // Warning: (ae-forgotten-export) The symbol "SubscriptionOptions" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "SubscribeResult" needs to be exported by the entry point index.d.ts
     subscribe<TData = unknown, TVariables extends OperationVariables_2 = OperationVariables_2>(options: SubscriptionOptions<TVariables, TData>): Observable<SubscribeResult<MaybeMasked<TData>>>;
-    // Warning: (ae-forgotten-export) The symbol "ApolloClientOptions" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
-    readonly typeDefs: ApolloClientOptions["typeDefs"];
     // (undocumented)
     version: string;
     watchFragment<TData = unknown, TVariables = OperationVariables_2>(options: WatchFragmentOptions<TData, TVariables>): Observable<WatchFragmentResult<TData>>;
@@ -179,8 +176,6 @@ interface ApolloClientOptions {
     resolvers?: Resolvers | Resolvers[];
     ssrForceFetchDelay?: number;
     ssrMode?: boolean;
-    // (undocumented)
-    typeDefs?: string | string[] | DocumentNode | DocumentNode[];
     uri?: string | HttpLink.UriFunction;
     version?: string;
 }

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -138,8 +138,6 @@ export class ApolloClient implements DataProxy {
     stop(): void;
     subscribe<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: SubscriptionOptions<TVariables, TData>): Observable<SubscribeResult<MaybeMasked<TData>>>;
     // (undocumented)
-    readonly typeDefs: ApolloClientOptions["typeDefs"];
-    // (undocumented)
     version: string;
     watchFragment<TData = unknown, TVariables = OperationVariables>(options: WatchFragmentOptions<TData, TVariables>): Observable<WatchFragmentResult<TData>>;
     watchQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: WatchQueryOptions<TVariables, TData>): ObservableQuery<TData, TVariables>;
@@ -172,8 +170,6 @@ export interface ApolloClientOptions {
     resolvers?: Resolvers | Resolvers[];
     ssrForceFetchDelay?: number;
     ssrMode?: boolean;
-    // (undocumented)
-    typeDefs?: string | string[] | DocumentNode | DocumentNode[];
     uri?: string | HttpLink.UriFunction;
     version?: string;
 }

--- a/.changeset/brave-moons-juggle.md
+++ b/.changeset/brave-moons-juggle.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": major
+---
+
+Remove the `typeDefs` option from `ApolloClient`.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43406,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38821,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33185,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 28045
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43397,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38845,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33172,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 28017
 }

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -1,4 +1,4 @@
-import type { DocumentNode, FormattedExecutionResult } from "graphql";
+import type { FormattedExecutionResult } from "graphql";
 import { OperationTypeNode } from "graphql";
 import type { Observable } from "rxjs";
 import { map } from "rxjs";
@@ -136,7 +136,6 @@ export interface ApolloClientOptions {
    */
   assumeImmutableResults?: boolean;
   resolvers?: Resolvers | Resolvers[];
-  typeDefs?: string | string[] | DocumentNode | DocumentNode[];
   fragmentMatcher?: FragmentMatcher;
   /**
    * A custom name (e.g., `iOS`) that identifies this particular client among your set of clients. Apollo Server and Apollo Studio use this property as part of the [client awareness](https://www.apollographql.com/docs/apollo-server/monitoring/metrics#identifying-distinct-clients) feature.
@@ -202,7 +201,6 @@ export class ApolloClient implements DataProxy {
   public version: string;
   public queryDeduplication: boolean;
   public defaultOptions: DefaultOptions;
-  public readonly typeDefs: ApolloClientOptions["typeDefs"];
   public readonly devtoolsConfig: DevtoolsOptions;
 
   private queryManager: QueryManager;
@@ -263,7 +261,6 @@ export class ApolloClient implements DataProxy {
       defaultContext,
       assumeImmutableResults = cache.assumeImmutableResults,
       resolvers,
-      typeDefs,
       fragmentMatcher,
       name: clientAwarenessName,
       version: clientAwarenessVersion,
@@ -282,7 +279,6 @@ export class ApolloClient implements DataProxy {
     this.cache = cache;
     this.queryDeduplication = queryDeduplication;
     this.defaultOptions = defaultOptions || {};
-    this.typeDefs = typeDefs;
     this.devtoolsConfig = {
       ...devtools,
       enabled: devtools?.enabled ?? connectToDevTools,


### PR DESCRIPTION
Closes #12584

Removes the `typeDefs` option from `ApolloClient`. This option was not used anywhere besides setting a property inside the `ApolloClient` instance.