### PR TITLE
Remove `TContext` generic argument

### DIFF
--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -143,7 +143,7 @@ export class ApolloClient implements DataProxy {
     getResolvers(): Resolvers;
     // (undocumented)
     link: ApolloLink;
-    mutate<TData = unknown, TVariables extends OperationVariables = OperationVariables, TContext extends Record<string, any> = DefaultContext, TCache extends ApolloCache = ApolloCache>(options: MutationOptions<TData, TVariables, TContext>): Promise<MutateResult<MaybeMasked<TData>>>;
+    mutate<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends ApolloCache = ApolloCache>(options: MutationOptions<TData, TVariables, TCache>): Promise<MutateResult<MaybeMasked<TData>>>;
     onClearStore(cb: () => Promise<any>): () => void;
     onResetStore(cb: () => Promise<any>): () => void;
     set prioritizeCacheValues(value: boolean);
@@ -516,17 +516,17 @@ export interface MutateResult<TData = unknown> {
 export type MutationFetchPolicy = Extract<FetchPolicy, "network-only" | "no-cache">;
 
 // @public (undocumented)
-export type MutationOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, TContext = DefaultContext, TCache extends ApolloCache = ApolloCache> = {
+export type MutationOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends ApolloCache = ApolloCache> = {
     optimisticResponse?: Unmasked<NoInfer_2<TData>> | ((vars: TVariables, { IGNORE }: {
         IGNORE: IgnoreModifier;
     }) => Unmasked<NoInfer_2<TData>> | IgnoreModifier);
     updateQueries?: MutationQueryReducersMap<TData>;
     refetchQueries?: ((result: FetchResult<Unmasked<TData>>) => InternalRefetchQueriesInclude) | InternalRefetchQueriesInclude;
     awaitRefetchQueries?: boolean;
-    update?: MutationUpdaterFunction<TData, TVariables, TContext, TCache>;
+    update?: MutationUpdaterFunction<TData, TVariables, TCache>;
     onQueryUpdated?: OnQueryUpdated<any>;
     errorPolicy?: ErrorPolicy;
-    context?: TContext;
+    context?: DefaultContext;
     fetchPolicy?: MutationFetchPolicy;
     keepRootFields?: boolean;
     mutation: DocumentNode_2 | TypedDocumentNode<TData, TVariables>;
@@ -564,8 +564,8 @@ export type MutationUpdaterFn<T = {
 }> = (cache: ApolloCache, mutationResult: FetchResult<T>) => void;
 
 // @public (undocumented)
-export type MutationUpdaterFunction<TData, TVariables, TContext, TCache extends ApolloCache> = (cache: TCache, result: Omit<FetchResult<Unmasked<TData>>, "context">, options: {
-    context?: TContext;
+export type MutationUpdaterFunction<TData, TVariables, TCache extends ApolloCache> = (cache: TCache, result: Omit<FetchResult<Unmasked<TData>>, "context">, options: {
+    context?: DefaultContext;
     variables?: TVariables;
 }) => void;
 
@@ -804,28 +804,28 @@ class QueryManager {
     // (undocumented)
     get link(): ApolloLink;
     // (undocumented)
-    markMutationOptimistic<TData, TVariables extends OperationVariables, TContext, TCache extends ApolloCache>(optimisticResponse: any, mutation: {
+    markMutationOptimistic<TData, TVariables extends OperationVariables, TCache extends ApolloCache>(optimisticResponse: any, mutation: {
         mutationId: string;
         document: DocumentNode_2;
         variables?: TVariables;
         fetchPolicy?: MutationFetchPolicy;
         errorPolicy: ErrorPolicy;
-        context?: TContext;
+        context?: DefaultContext;
         updateQueries: UpdateQueries<TData>;
-        update?: MutationUpdaterFunction<TData, TVariables, TContext, TCache>;
+        update?: MutationUpdaterFunction<TData, TVariables, TCache>;
         keepRootFields?: boolean;
     }): boolean;
     // (undocumented)
-    markMutationResult<TData, TVariables extends OperationVariables, TContext, TCache extends ApolloCache>(mutation: {
+    markMutationResult<TData, TVariables extends OperationVariables, TCache extends ApolloCache>(mutation: {
         mutationId: string;
         result: FetchResult<TData>;
         document: DocumentNode_2;
         variables?: TVariables;
         fetchPolicy?: MutationFetchPolicy;
         errorPolicy: ErrorPolicy;
-        context?: TContext;
+        context?: DefaultContext;
         updateQueries: UpdateQueries<TData>;
-        update?: MutationUpdaterFunction<TData, TVariables, TContext, TCache>;
+        update?: MutationUpdaterFunction<TData, TVariables, TCache>;
         awaitRefetchQueries?: boolean;
         refetchQueries?: InternalRefetchQueriesInclude;
         removeOptimistic?: string;
@@ -841,7 +841,7 @@ class QueryManager {
     // (undocumented)
     maskOperation<TData = unknown>(options: MaskOperationOptions<TData>): MaybeMasked<TData>;
     // (undocumented)
-    mutate<TData, TVariables extends OperationVariables, TContext extends Record<string, any>, TCache extends ApolloCache>({ mutation, variables, optimisticResponse, updateQueries, refetchQueries, awaitRefetchQueries, update: updateWithProxyFn, onQueryUpdated, fetchPolicy, errorPolicy, keepRootFields, context, }: MutationOptions<TData, TVariables, TContext>): Promise<MutateResult<MaybeMasked<TData>>>;
+    mutate<TData, TVariables extends OperationVariables, TCache extends ApolloCache>({ mutation, variables, optimisticResponse, updateQueries, refetchQueries, awaitRefetchQueries, update: updateWithProxyFn, onQueryUpdated, fetchPolicy, errorPolicy, keepRootFields, context, }: MutationOptions<TData, TVariables, TCache>): Promise<MutateResult<MaybeMasked<TData>>>;
     // (undocumented)
     mutationStore?: {
         [mutationId: string]: MutationStoreValue;
@@ -1121,8 +1121,8 @@ export type WatchQueryOptions<TVariables extends OperationVariables = OperationV
 // src/core/ObservableQuery.ts:190:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:191:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:190:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:465:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/watchQueryOptions.ts:262:3 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:463:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
+// src/core/watchQueryOptions.ts:261:3 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report-link_core.api.md
+++ b/.api-reports/api-report-link_core.api.md
@@ -43,7 +43,7 @@ export interface ApolloPayloadResult<TData = Record<string, any>, TExtensions = 
     // (undocumented)
     errors?: ReadonlyArray<GraphQLFormattedError>;
     // (undocumented)
-    payload: SingleExecutionResult<TData, DefaultContext, TExtensions> | ExecutionPatchResult<TData, TExtensions> | null;
+    payload: SingleExecutionResult<TData, TExtensions> | ExecutionPatchResult<TData, TExtensions> | null;
 }
 
 // @public (undocumented)
@@ -99,7 +99,7 @@ interface ExecutionPatchResultBase {
 }
 
 // @public (undocumented)
-export type FetchResult<TData = Record<string, any>, TContext = Record<string, any>, TExtensions = Record<string, any>> = SingleExecutionResult<TData, TContext, TExtensions> | ExecutionPatchResult<TData, TExtensions>;
+export type FetchResult<TData = Record<string, any>, TExtensions = Record<string, any>> = SingleExecutionResult<TData, TExtensions> | ExecutionPatchResult<TData, TExtensions>;
 
 // @public (undocumented)
 export const from: typeof ApolloLink.from;
@@ -170,9 +170,9 @@ export type Path = ReadonlyArray<string | number>;
 export type RequestHandler = (operation: Operation, forward: NextLink) => Observable<FetchResult> | null;
 
 // @public (undocumented)
-export interface SingleExecutionResult<TData = Record<string, any>, TContext = DefaultContext, TExtensions = Record<string, any>> {
+export interface SingleExecutionResult<TData = Record<string, any>, TExtensions = Record<string, any>> {
     // (undocumented)
-    context?: TContext;
+    context?: DefaultContext;
     // (undocumented)
     data?: TData | null;
     // (undocumented)

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -92,6 +92,8 @@ class ApolloClient_2 implements DataProxy {
     // (undocumented)
     cache: ApolloCache;
     clearStore(): Promise<any[]>;
+    // Warning: (ae-forgotten-export) The symbol "DefaultContext" needs to be exported by the entry point index.d.ts
+    //
     // (undocumented)
     get defaultContext(): Partial<DefaultContext>;
     // (undocumented)
@@ -110,10 +112,9 @@ class ApolloClient_2 implements DataProxy {
     getResolvers(): Resolvers;
     // (undocumented)
     link: ApolloLink;
-    // Warning: (ae-forgotten-export) The symbol "DefaultContext" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "MutationOptions" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "MutateResult" needs to be exported by the entry point index.d.ts
-    mutate<TData = unknown, TVariables extends OperationVariables_2 = OperationVariables_2, TContext extends Record<string, any> = DefaultContext, TCache extends ApolloCache = ApolloCache>(options: MutationOptions<TData, TVariables, TContext>): Promise<MutateResult<MaybeMasked<TData>>>;
+    mutate<TData = unknown, TVariables extends OperationVariables_2 = OperationVariables_2, TCache extends ApolloCache = ApolloCache>(options: MutationOptions<TData, TVariables, TCache>): Promise<MutateResult<MaybeMasked<TData>>>;
     onClearStore(cb: () => Promise<any>): () => void;
     onResetStore(cb: () => Promise<any>): () => void;
     set prioritizeCacheValues(value: boolean);
@@ -472,23 +473,23 @@ interface MutateResult<TData = unknown> {
 type MutationFetchPolicy = Extract<FetchPolicy, "network-only" | "no-cache">;
 
 // @public @deprecated (undocumented)
-export type MutationFunctionOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, TContext = DefaultContext_2, TCache extends ApolloCache_2 = ApolloCache_2> = useMutation.MutationFunctionOptions<TData, TVariables, TContext, TCache>;
+export type MutationFunctionOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, _TContext = DefaultContext_2, TCache extends ApolloCache_2 = ApolloCache_2> = useMutation.MutationFunctionOptions<TData, TVariables, TCache>;
 
 // @public @deprecated (undocumented)
-export type MutationHookOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, TContext = DefaultContext_2, TCache extends ApolloCache_2 = ApolloCache_2> = useMutation.Options<TData, TVariables, TContext, TCache>;
+export type MutationHookOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, _TContext = DefaultContext_2, TCache extends ApolloCache_2 = ApolloCache_2> = useMutation.Options<TData, TVariables, TCache>;
 
 // @public (undocumented)
-type MutationOptions<TData = unknown, TVariables extends OperationVariables_2 = OperationVariables_2, TContext = DefaultContext, TCache extends ApolloCache = ApolloCache> = {
+type MutationOptions<TData = unknown, TVariables extends OperationVariables_2 = OperationVariables_2, TCache extends ApolloCache = ApolloCache> = {
     optimisticResponse?: Unmasked<NoInfer_2<TData>> | ((vars: TVariables, { IGNORE }: {
         IGNORE: IgnoreModifier;
     }) => Unmasked<NoInfer_2<TData>> | IgnoreModifier);
     updateQueries?: MutationQueryReducersMap<TData>;
     refetchQueries?: ((result: FetchResult<Unmasked<TData>>) => InternalRefetchQueriesInclude) | InternalRefetchQueriesInclude;
     awaitRefetchQueries?: boolean;
-    update?: MutationUpdaterFunction<TData, TVariables, TContext, TCache>;
+    update?: MutationUpdaterFunction<TData, TVariables, TCache>;
     onQueryUpdated?: OnQueryUpdated<any>;
     errorPolicy?: ErrorPolicy;
-    context?: TContext;
+    context?: DefaultContext;
     fetchPolicy?: MutationFetchPolicy;
     keepRootFields?: boolean;
     mutation: DocumentNode | TypedDocumentNode<TData, TVariables>;
@@ -524,11 +525,11 @@ interface MutationStoreValue {
 }
 
 // @public @deprecated (undocumented)
-export type MutationTuple<TData, TVariables extends OperationVariables, TContext = DefaultContext_2, TCache extends ApolloCache_2 = ApolloCache_2> = useMutation.ResultTuple<TData, TVariables, TContext, TCache>;
+export type MutationTuple<TData, TVariables extends OperationVariables, _TContext = DefaultContext_2, TCache extends ApolloCache_2 = ApolloCache_2> = useMutation.ResultTuple<TData, TVariables, TCache>;
 
 // @public (undocumented)
-type MutationUpdaterFunction<TData, TVariables, TContext, TCache extends ApolloCache> = (cache: TCache, result: Omit<FetchResult<Unmasked<TData>>, "context">, options: {
-    context?: TContext;
+type MutationUpdaterFunction<TData, TVariables, TCache extends ApolloCache> = (cache: TCache, result: Omit<FetchResult<Unmasked<TData>>, "context">, options: {
+    context?: DefaultContext;
     variables?: TVariables;
 }) => void;
 
@@ -791,28 +792,28 @@ class QueryManager {
     // (undocumented)
     get link(): ApolloLink;
     // (undocumented)
-    markMutationOptimistic<TData, TVariables extends OperationVariables_2, TContext, TCache extends ApolloCache>(optimisticResponse: any, mutation: {
+    markMutationOptimistic<TData, TVariables extends OperationVariables_2, TCache extends ApolloCache>(optimisticResponse: any, mutation: {
         mutationId: string;
         document: DocumentNode;
         variables?: TVariables;
         fetchPolicy?: MutationFetchPolicy;
         errorPolicy: ErrorPolicy;
-        context?: TContext;
+        context?: DefaultContext;
         updateQueries: UpdateQueries<TData>;
-        update?: MutationUpdaterFunction<TData, TVariables, TContext, TCache>;
+        update?: MutationUpdaterFunction<TData, TVariables, TCache>;
         keepRootFields?: boolean;
     }): boolean;
     // (undocumented)
-    markMutationResult<TData, TVariables extends OperationVariables_2, TContext, TCache extends ApolloCache>(mutation: {
+    markMutationResult<TData, TVariables extends OperationVariables_2, TCache extends ApolloCache>(mutation: {
         mutationId: string;
         result: FetchResult<TData>;
         document: DocumentNode;
         variables?: TVariables;
         fetchPolicy?: MutationFetchPolicy;
         errorPolicy: ErrorPolicy;
-        context?: TContext;
+        context?: DefaultContext;
         updateQueries: UpdateQueries<TData>;
-        update?: MutationUpdaterFunction<TData, TVariables, TContext, TCache>;
+        update?: MutationUpdaterFunction<TData, TVariables, TCache>;
         awaitRefetchQueries?: boolean;
         refetchQueries?: InternalRefetchQueriesInclude;
         removeOptimistic?: string;
@@ -828,7 +829,7 @@ class QueryManager {
     // (undocumented)
     maskOperation<TData = unknown>(options: MaskOperationOptions<TData>): MaybeMasked<TData>;
     // (undocumented)
-    mutate<TData, TVariables extends OperationVariables_2, TContext extends Record<string, any>, TCache extends ApolloCache>({ mutation, variables, optimisticResponse, updateQueries, refetchQueries, awaitRefetchQueries, update: updateWithProxyFn, onQueryUpdated, fetchPolicy, errorPolicy, keepRootFields, context, }: MutationOptions<TData, TVariables, TContext>): Promise<MutateResult<MaybeMasked<TData>>>;
+    mutate<TData, TVariables extends OperationVariables_2, TCache extends ApolloCache>({ mutation, variables, optimisticResponse, updateQueries, refetchQueries, awaitRefetchQueries, update: updateWithProxyFn, onQueryUpdated, fetchPolicy, errorPolicy, keepRootFields, context, }: MutationOptions<TData, TVariables, TCache>): Promise<MutateResult<MaybeMasked<TData>>>;
     // (undocumented)
     mutationStore?: {
         [mutationId: string]: MutationStoreValue;
@@ -1308,43 +1309,43 @@ export type UseLoadableQueryResult<TData = unknown, TVariables extends Operation
 // Warning: (ae-forgotten-export) The symbol "MakeRequiredVariablesOptional" needs to be exported by the entry point index.d.ts
 //
 // @public
-export function useMutation<TData = unknown, TVariables extends OperationVariables = OperationVariables, TContext = DefaultContext_2, TCache extends ApolloCache_2 = ApolloCache_2, TConfiguredVariables extends Partial<TVariables> = {}>(mutation: DocumentNode_2 | TypedDocumentNode<TData, TVariables>, options?: useMutation.Options<NoInfer_2<TData>, NoInfer_2<TVariables>, TContext, TCache, {
+export function useMutation<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends ApolloCache_2 = ApolloCache_2, TConfiguredVariables extends Partial<TVariables> = {}>(mutation: DocumentNode_2 | TypedDocumentNode<TData, TVariables>, options?: useMutation.Options<NoInfer_2<TData>, NoInfer_2<TVariables>, TCache, {
     [K in keyof TConfiguredVariables]: K extends keyof TVariables ? TConfiguredVariables[K] : never;
-}>): useMutation.ResultTuple<TData, MakeRequiredVariablesOptional<TVariables, TConfiguredVariables>, TContext, TCache>;
+}>): useMutation.ResultTuple<TData, MakeRequiredVariablesOptional<TVariables, TConfiguredVariables>, TCache>;
 
 // @public (undocumented)
 export namespace useMutation {
     // (undocumented)
-    export type MutationFunction<TData, TVariables extends OperationVariables, TContext = DefaultContext_2, TCache extends ApolloCache_2 = ApolloCache_2> = (...[options]: {} extends TVariables ? [
-    options?: MutationFunctionOptions<TData, TVariables, TContext, TCache> & {
+    export type MutationFunction<TData, TVariables extends OperationVariables, TCache extends ApolloCache_2 = ApolloCache_2> = (...[options]: {} extends TVariables ? [
+    options?: MutationFunctionOptions<TData, TVariables, TCache> & {
         variables?: TVariables;
     }
     ] : [
-    options: MutationFunctionOptions<TData, TVariables, TContext, TCache> & {
+    options: MutationFunctionOptions<TData, TVariables, TCache> & {
         variables: TVariables;
     }
     ]) => Promise<MutateResult_2<MaybeMasked_2<TData>>>;
     // (undocumented)
-    export type MutationFunctionOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, TContext = DefaultContext_2, TCache extends ApolloCache_2 = ApolloCache_2> = Options<TData, TVariables, TContext, TCache> & {
+    export type MutationFunctionOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends ApolloCache_2 = ApolloCache_2> = Options<TData, TVariables, TCache> & {
         mutation?: DocumentNode_2 | TypedDocumentNode<TData, TVariables>;
     };
     // (undocumented)
-    export interface Options<TData = unknown, TVariables extends OperationVariables = OperationVariables, TContext = DefaultContext_2, TCache extends ApolloCache_2 = ApolloCache_2, TConfiguredVariables extends Partial<TVariables> = Partial<TVariables>> {
+    export interface Options<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends ApolloCache_2 = ApolloCache_2, TConfiguredVariables extends Partial<TVariables> = Partial<TVariables>> {
         awaitRefetchQueries?: boolean;
         client?: ApolloClient;
-        context?: TContext;
+        context?: DefaultContext_2;
         errorPolicy?: ErrorPolicy_2;
         fetchPolicy?: MutationFetchPolicy_2;
         keepRootFields?: boolean;
         notifyOnNetworkStatusChange?: boolean;
-        onCompleted?: (data: MaybeMasked_2<TData>, clientOptions?: Options<TData, TVariables, TContext, TCache>) => void;
-        onError?: (error: ErrorLike_2, clientOptions?: Options<TData, TVariables, TContext, TCache>) => void;
+        onCompleted?: (data: MaybeMasked_2<TData>, clientOptions?: Options<TData, TVariables, TCache>) => void;
+        onError?: (error: ErrorLike_2, clientOptions?: Options<TData, TVariables, TCache>) => void;
         onQueryUpdated?: OnQueryUpdated_2<any>;
         optimisticResponse?: Unmasked_2<NoInfer_2<TData>> | ((vars: TVariables, { IGNORE }: {
             IGNORE: IgnoreModifier;
         }) => Unmasked_2<NoInfer_2<TData>> | IgnoreModifier);
         refetchQueries?: ((result: FetchResult_2<Unmasked_2<TData>>) => InternalRefetchQueriesInclude_2) | InternalRefetchQueriesInclude_2;
-        update?: MutationUpdaterFunction_2<TData, TVariables, TContext, TCache>;
+        update?: MutationUpdaterFunction_2<TData, TVariables, TCache>;
         updateQueries?: MutationQueryReducersMap_2<TData>;
         variables?: TConfiguredVariables;
     }
@@ -1358,8 +1359,8 @@ export namespace useMutation {
         reset: () => void;
     }
     // (undocumented)
-    export type ResultTuple<TData, TVariables extends OperationVariables, TContext = DefaultContext_2, TCache extends ApolloCache_2 = ApolloCache_2> = [
-    mutate: MutationFunction<TData, TVariables, TContext, TCache>,
+    export type ResultTuple<TData, TVariables extends OperationVariables, TCache extends ApolloCache_2 = ApolloCache_2> = [
+    mutate: MutationFunction<TData, TVariables, TCache>,
     result: Result<TData>
     ];
 }
@@ -1642,16 +1643,16 @@ type WatchQueryOptions_2<TVariables extends OperationVariables_2 = OperationVari
 // src/core/ObservableQuery.ts:190:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:191:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:190:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:465:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:463:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:208:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:237:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:236:5 - (ae-forgotten-export) The symbol "Resolver" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:186:3 - (ae-forgotten-export) The symbol "UpdateQueryOptions" needs to be exported by the entry point index.d.ts
-// src/core/watchQueryOptions.ts:262:3 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
-// src/core/watchQueryOptions.ts:270:3 - (ae-forgotten-export) The symbol "MutationQueryReducersMap" needs to be exported by the entry point index.d.ts
-// src/core/watchQueryOptions.ts:281:3 - (ae-forgotten-export) The symbol "MutationUpdaterFunction" needs to be exported by the entry point index.d.ts
-// src/core/watchQueryOptions.ts:284:3 - (ae-forgotten-export) The symbol "OnQueryUpdated" needs to be exported by the entry point index.d.ts
-// src/core/watchQueryOptions.ts:287:3 - (ae-forgotten-export) The symbol "ErrorPolicy" needs to be exported by the entry point index.d.ts
-// src/core/watchQueryOptions.ts:293:3 - (ae-forgotten-export) The symbol "MutationFetchPolicy" needs to be exported by the entry point index.d.ts
+// src/core/watchQueryOptions.ts:261:3 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
+// src/core/watchQueryOptions.ts:269:3 - (ae-forgotten-export) The symbol "MutationQueryReducersMap" needs to be exported by the entry point index.d.ts
+// src/core/watchQueryOptions.ts:280:3 - (ae-forgotten-export) The symbol "MutationUpdaterFunction" needs to be exported by the entry point index.d.ts
+// src/core/watchQueryOptions.ts:283:3 - (ae-forgotten-export) The symbol "OnQueryUpdated" needs to be exported by the entry point index.d.ts
+// src/core/watchQueryOptions.ts:286:3 - (ae-forgotten-export) The symbol "ErrorPolicy" needs to be exported by the entry point index.d.ts
+// src/core/watchQueryOptions.ts:292:3 - (ae-forgotten-export) The symbol "MutationFetchPolicy" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useLoadableQuery.ts:69:7 - (ae-forgotten-export) The symbol "ResetFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useSuspenseFragment.ts:72:5 - (ae-forgotten-export) The symbol "From" needs to be exported by the entry point index.d.ts
 

--- a/.api-reports/api-report-utilities.api.md
+++ b/.api-reports/api-report-utilities.api.md
@@ -412,7 +412,7 @@ export function mergeIncrementalData<TData extends object>(prevResult: TData, re
 // Warning: (ae-forgotten-export) The symbol "OptionsUnion" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export function mergeOptions<TDefaultOptions extends Partial<OptionsUnion<any, any, any>>, TOptions extends TDefaultOptions>(defaults: TDefaultOptions | Partial<TDefaultOptions> | undefined, options: TOptions | Partial<TOptions>): TOptions & TDefaultOptions;
+export function mergeOptions<TDefaultOptions extends Partial<OptionsUnion<any, any>>, TOptions extends TDefaultOptions>(defaults: TDefaultOptions | Partial<TDefaultOptions> | undefined, options: TOptions | Partial<TOptions>): TOptions & TDefaultOptions;
 
 // @public
 type NoInfer_2<T> = [T][T extends any ? 0 : never];
@@ -427,7 +427,7 @@ export function offsetLimitPagination<T = Reference_2>(keyArgs?: KeyArgs): Field
 export function omitDeep<T, K extends string>(value: T, key: K): DeepOmit<T, K>;
 
 // @public (undocumented)
-type OptionsUnion<TData, TVariables extends OperationVariables, TContext> = WatchQueryOptions<TVariables, TData> | QueryOptions<TVariables, TData> | MutationOptions<TData, TVariables, TContext, any>;
+type OptionsUnion<TData, TVariables extends OperationVariables> = WatchQueryOptions<TVariables, TData> | QueryOptions<TVariables, TData> | MutationOptions<TData, TVariables, any>;
 
 // @public (undocumented)
 interface PendingPromise<TValue> extends Promise<TValue> {

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -118,7 +118,7 @@ export class ApolloClient implements DataProxy {
     getResolvers(): Resolvers;
     // (undocumented)
     link: ApolloLink;
-    mutate<TData = unknown, TVariables extends OperationVariables = OperationVariables, TContext extends Record<string, any> = DefaultContext, TCache extends ApolloCache = ApolloCache>(options: MutationOptions<TData, TVariables, TContext>): Promise<MutateResult<MaybeMasked<TData>>>;
+    mutate<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends ApolloCache = ApolloCache>(options: MutationOptions<TData, TVariables, TCache>): Promise<MutateResult<MaybeMasked<TData>>>;
     onClearStore(cb: () => Promise<any>): () => void;
     onResetStore(cb: () => Promise<any>): () => void;
     set prioritizeCacheValues(value: boolean);
@@ -212,7 +212,7 @@ export interface ApolloPayloadResult<TData = Record<string, any>, TExtensions = 
     // (undocumented)
     errors?: ReadonlyArray<GraphQLFormattedError>;
     // (undocumented)
-    payload: SingleExecutionResult<TData, DefaultContext, TExtensions> | ExecutionPatchResult<TData, TExtensions> | null;
+    payload: SingleExecutionResult<TData, TExtensions> | ExecutionPatchResult<TData, TExtensions> | null;
 }
 
 // @public (undocumented)
@@ -854,7 +854,7 @@ export interface FetchMoreQueryOptions<TVariables, TData = unknown> {
 export type FetchPolicy = "cache-first" | "network-only" | "cache-only" | "no-cache";
 
 // @public (undocumented)
-export type FetchResult<TData = Record<string, any>, TContext = Record<string, any>, TExtensions = Record<string, any>> = SingleExecutionResult<TData, TContext, TExtensions> | ExecutionPatchResult<TData, TExtensions>;
+export type FetchResult<TData = Record<string, any>, TExtensions = Record<string, any>> = SingleExecutionResult<TData, TExtensions> | ExecutionPatchResult<TData, TExtensions>;
 
 // @public (undocumented)
 export interface FieldFunctionOptions<TArgs = Record<string, any>, TVars = Record<string, any>> {
@@ -1451,7 +1451,7 @@ type MergeObjectsFunction = <T extends StoreObject | Reference>(existing: T, inc
 // Warning: (ae-forgotten-export) The symbol "OptionsUnion" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export function mergeOptions<TDefaultOptions extends Partial<OptionsUnion<any, any, any>>, TOptions extends TDefaultOptions>(defaults: TDefaultOptions | Partial<TDefaultOptions> | undefined, options: TOptions | Partial<TOptions>): TOptions & TDefaultOptions;
+export function mergeOptions<TDefaultOptions extends Partial<OptionsUnion<any, any>>, TOptions extends TDefaultOptions>(defaults: TDefaultOptions | Partial<TDefaultOptions> | undefined, options: TOptions | Partial<TOptions>): TOptions & TDefaultOptions;
 
 // @public (undocumented)
 export interface MergeTree {
@@ -1542,17 +1542,17 @@ export type MutationFetchPolicy = Extract<FetchPolicy, "network-only" | "no-cach
 // Warning: (ae-forgotten-export) The symbol "VariablesOption" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export type MutationOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, TContext = DefaultContext, TCache extends ApolloCache = ApolloCache> = {
+export type MutationOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends ApolloCache = ApolloCache> = {
     optimisticResponse?: Unmasked<NoInfer_2<TData>> | ((vars: TVariables, { IGNORE }: {
         IGNORE: IgnoreModifier;
     }) => Unmasked<NoInfer_2<TData>> | IgnoreModifier);
     updateQueries?: MutationQueryReducersMap<TData>;
     refetchQueries?: ((result: FetchResult<Unmasked<TData>>) => InternalRefetchQueriesInclude) | InternalRefetchQueriesInclude;
     awaitRefetchQueries?: boolean;
-    update?: MutationUpdaterFunction<TData, TVariables, TContext, TCache>;
+    update?: MutationUpdaterFunction<TData, TVariables, TCache>;
     onQueryUpdated?: OnQueryUpdated<any>;
     errorPolicy?: ErrorPolicy;
-    context?: TContext;
+    context?: DefaultContext;
     fetchPolicy?: MutationFetchPolicy;
     keepRootFields?: boolean;
     mutation: DocumentNode | TypedDocumentNode<TData, TVariables>;
@@ -1590,8 +1590,8 @@ export type MutationUpdaterFn<T = {
 }> = (cache: ApolloCache, mutationResult: FetchResult<T>) => void;
 
 // @public (undocumented)
-export type MutationUpdaterFunction<TData, TVariables, TContext, TCache extends ApolloCache> = (cache: TCache, result: Omit<FetchResult<Unmasked<TData>>, "context">, options: {
-    context?: TContext;
+export type MutationUpdaterFunction<TData, TVariables, TCache extends ApolloCache> = (cache: TCache, result: Omit<FetchResult<Unmasked<TData>>, "context">, options: {
+    context?: DefaultContext;
     variables?: TVariables;
 }) => void;
 
@@ -1799,7 +1799,7 @@ export type OptimisticStoreItem = {
 };
 
 // @public (undocumented)
-type OptionsUnion<TData, TVariables extends OperationVariables, TContext> = WatchQueryOptions<TVariables, TData> | QueryOptions<TVariables, TData> | MutationOptions<TData, TVariables, TContext, any>;
+type OptionsUnion<TData, TVariables extends OperationVariables> = WatchQueryOptions<TVariables, TData> | QueryOptions<TVariables, TData> | MutationOptions<TData, TVariables, any>;
 
 // @public (undocumented)
 export function parseAndCheckHttpResponse(operations: Operation | Operation[]): (response: Response) => Promise<any>;
@@ -1965,28 +1965,28 @@ class QueryManager {
     // (undocumented)
     get link(): ApolloLink;
     // (undocumented)
-    markMutationOptimistic<TData, TVariables extends OperationVariables, TContext, TCache extends ApolloCache>(optimisticResponse: any, mutation: {
+    markMutationOptimistic<TData, TVariables extends OperationVariables, TCache extends ApolloCache>(optimisticResponse: any, mutation: {
         mutationId: string;
         document: DocumentNode;
         variables?: TVariables;
         fetchPolicy?: MutationFetchPolicy;
         errorPolicy: ErrorPolicy;
-        context?: TContext;
+        context?: DefaultContext;
         updateQueries: UpdateQueries<TData>;
-        update?: MutationUpdaterFunction<TData, TVariables, TContext, TCache>;
+        update?: MutationUpdaterFunction<TData, TVariables, TCache>;
         keepRootFields?: boolean;
     }): boolean;
     // (undocumented)
-    markMutationResult<TData, TVariables extends OperationVariables, TContext, TCache extends ApolloCache>(mutation: {
+    markMutationResult<TData, TVariables extends OperationVariables, TCache extends ApolloCache>(mutation: {
         mutationId: string;
         result: FetchResult<TData>;
         document: DocumentNode;
         variables?: TVariables;
         fetchPolicy?: MutationFetchPolicy;
         errorPolicy: ErrorPolicy;
-        context?: TContext;
+        context?: DefaultContext;
         updateQueries: UpdateQueries<TData>;
-        update?: MutationUpdaterFunction<TData, TVariables, TContext, TCache>;
+        update?: MutationUpdaterFunction<TData, TVariables, TCache>;
         awaitRefetchQueries?: boolean;
         refetchQueries?: InternalRefetchQueriesInclude;
         removeOptimistic?: string;
@@ -2002,7 +2002,7 @@ class QueryManager {
     // (undocumented)
     maskOperation<TData = unknown>(options: MaskOperationOptions<TData>): MaybeMasked<TData>;
     // (undocumented)
-    mutate<TData, TVariables extends OperationVariables, TContext extends Record<string, any>, TCache extends ApolloCache>({ mutation, variables, optimisticResponse, updateQueries, refetchQueries, awaitRefetchQueries, update: updateWithProxyFn, onQueryUpdated, fetchPolicy, errorPolicy, keepRootFields, context, }: MutationOptions<TData, TVariables, TContext>): Promise<MutateResult<MaybeMasked<TData>>>;
+    mutate<TData, TVariables extends OperationVariables, TCache extends ApolloCache>({ mutation, variables, optimisticResponse, updateQueries, refetchQueries, awaitRefetchQueries, update: updateWithProxyFn, onQueryUpdated, fetchPolicy, errorPolicy, keepRootFields, context, }: MutationOptions<TData, TVariables, TCache>): Promise<MutateResult<MaybeMasked<TData>>>;
     // (undocumented)
     mutationStore?: {
         [mutationId: string]: MutationStoreValue;
@@ -2265,9 +2265,9 @@ interface ServerParseErrorOptions {
 export function setLogVerbosity(level: VerbosityLevel): VerbosityLevel;
 
 // @public (undocumented)
-export interface SingleExecutionResult<TData = Record<string, any>, TContext = DefaultContext, TExtensions = Record<string, any>> {
+export interface SingleExecutionResult<TData = Record<string, any>, TExtensions = Record<string, any>> {
     // (undocumented)
-    context?: TContext;
+    context?: DefaultContext;
     // (undocumented)
     data?: TData | null;
     // (undocumented)
@@ -2557,8 +2557,8 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/core/ObservableQuery.ts:190:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:191:5 - (ae-forgotten-export) The symbol "QueryInfo" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:190:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:465:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/watchQueryOptions.ts:262:3 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:463:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
+// src/core/watchQueryOptions.ts:261:3 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.changeset/short-tomatoes-attend.md
+++ b/.changeset/short-tomatoes-attend.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": major
+---
+
+Remove `TContext` generic argument from all types that use it. `TContext` is replaced with `DefaultContext` which can be modified using declaration merging.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43474,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38886,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33196,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 28042
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43397,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38845,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33172,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 28017
 }

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43406,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38821,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33185,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 28045
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43474,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38886,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33196,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 28042
 }

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -531,17 +531,14 @@ export class ApolloClient implements DataProxy {
   public mutate<
     TData = unknown,
     TVariables extends OperationVariables = OperationVariables,
-    TContext extends Record<string, any> = DefaultContext,
     TCache extends ApolloCache = ApolloCache,
   >(
-    options: MutationOptions<TData, TVariables, TContext>
+    options: MutationOptions<TData, TVariables, TCache>
   ): Promise<MutateResult<MaybeMasked<TData>>> {
     if (this.defaultOptions.mutate) {
       options = mergeOptions(this.defaultOptions.mutate, options);
     }
-    return this.queryManager.mutate<TData, TVariables, TContext, TCache>(
-      options
-    );
+    return this.queryManager.mutate<TData, TVariables, TCache>(options);
   }
 
   /**

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -263,7 +263,6 @@ export class QueryManager {
   public async mutate<
     TData,
     TVariables extends OperationVariables,
-    TContext extends Record<string, any>,
     TCache extends ApolloCache,
   >({
     mutation,
@@ -278,7 +277,7 @@ export class QueryManager {
     errorPolicy = this.defaultOptions.mutate?.errorPolicy || "none",
     keepRootFields,
     context,
-  }: MutationOptions<TData, TVariables, TContext>): Promise<
+  }: MutationOptions<TData, TVariables, TCache>): Promise<
     MutateResult<MaybeMasked<TData>>
   > {
     invariant(
@@ -318,7 +317,7 @@ export class QueryManager {
 
     const isOptimistic =
       optimisticResponse &&
-      this.markMutationOptimistic<TData, TVariables, TContext, TCache>(
+      this.markMutationOptimistic<TData, TVariables, TCache>(
         optimisticResponse,
         {
           mutationId,
@@ -372,7 +371,7 @@ export class QueryManager {
             }
 
             return from(
-              this.markMutationResult<TData, TVariables, TContext, TCache>({
+              this.markMutationResult<TData, TVariables, TCache>({
                 mutationId,
                 result: storeResult,
                 document: mutation,
@@ -451,7 +450,6 @@ export class QueryManager {
   public markMutationResult<
     TData,
     TVariables extends OperationVariables,
-    TContext,
     TCache extends ApolloCache,
   >(
     mutation: {
@@ -461,9 +459,9 @@ export class QueryManager {
       variables?: TVariables;
       fetchPolicy?: MutationFetchPolicy;
       errorPolicy: ErrorPolicy;
-      context?: TContext;
+      context?: DefaultContext;
       updateQueries: UpdateQueries<TData>;
-      update?: MutationUpdaterFunction<TData, TVariables, TContext, TCache>;
+      update?: MutationUpdaterFunction<TData, TVariables, TCache>;
       awaitRefetchQueries?: boolean;
       refetchQueries?: InternalRefetchQueriesInclude;
       removeOptimistic?: string;
@@ -662,7 +660,6 @@ export class QueryManager {
   public markMutationOptimistic<
     TData,
     TVariables extends OperationVariables,
-    TContext,
     TCache extends ApolloCache,
   >(
     optimisticResponse: any,
@@ -672,9 +669,9 @@ export class QueryManager {
       variables?: TVariables;
       fetchPolicy?: MutationFetchPolicy;
       errorPolicy: ErrorPolicy;
-      context?: TContext;
+      context?: DefaultContext;
       updateQueries: UpdateQueries<TData>;
-      update?: MutationUpdaterFunction<TData, TVariables, TContext, TCache>;
+      update?: MutationUpdaterFunction<TData, TVariables, TCache>;
       keepRootFields?: boolean;
     }
   ) {
@@ -689,7 +686,7 @@ export class QueryManager {
 
     this.cache.recordOptimisticTransaction((cache) => {
       try {
-        this.markMutationResult<TData, TVariables, TContext, TCache>(
+        this.markMutationResult<TData, TVariables, TCache>(
           {
             ...mutation,
             result: { data },

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -222,13 +222,12 @@ export type MutationUpdaterFn<T = { [key: string]: any }> = (
 export type MutationUpdaterFunction<
   TData,
   TVariables,
-  TContext,
   TCache extends ApolloCache,
 > = (
   cache: TCache,
   result: Omit<FetchResult<Unmasked<TData>>, "context">,
   options: {
-    context?: TContext;
+    context?: DefaultContext;
     variables?: TVariables;
   }
 ) => void;

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -255,7 +255,6 @@ export type SubscriptionOptions<
 export type MutationOptions<
   TData = unknown,
   TVariables extends OperationVariables = OperationVariables,
-  TContext = DefaultContext,
   TCache extends ApolloCache = ApolloCache,
 > = {
   /** {@inheritDoc @apollo/client!MutationOptionsDocumentation#optimisticResponse:member} */
@@ -278,7 +277,7 @@ export type MutationOptions<
   awaitRefetchQueries?: boolean;
 
   /** {@inheritDoc @apollo/client!MutationOptionsDocumentation#update:member} */
-  update?: MutationUpdaterFunction<TData, TVariables, TContext, TCache>;
+  update?: MutationUpdaterFunction<TData, TVariables, TCache>;
 
   /** {@inheritDoc @apollo/client!MutationOptionsDocumentation#onQueryUpdated:member} */
   onQueryUpdated?: OnQueryUpdated<any>;
@@ -287,7 +286,7 @@ export type MutationOptions<
   errorPolicy?: ErrorPolicy;
 
   /** {@inheritDoc @apollo/client!MutationOptionsDocumentation#context:member} */
-  context?: TContext;
+  context?: DefaultContext;
 
   /** {@inheritDoc @apollo/client!MutationOptionsDocumentation#fetchPolicy:member} */
   fetchPolicy?: MutationFetchPolicy;

--- a/src/link/core/types.ts
+++ b/src/link/core/types.ts
@@ -56,7 +56,7 @@ export interface ApolloPayloadResult<
   TExtensions = Record<string, any>,
 > {
   payload:
-    | SingleExecutionResult<TData, DefaultContext, TExtensions>
+    | SingleExecutionResult<TData, TExtensions>
     | ExecutionPatchResult<TData, TExtensions>
     | null;
   // Transport layer errors (as distinct from GraphQL or NetworkErrors),
@@ -110,22 +110,20 @@ export interface OperationContext extends DefaultContext {
 
 export interface SingleExecutionResult<
   TData = Record<string, any>,
-  TContext = DefaultContext,
   TExtensions = Record<string, any>,
 > {
   // data might be undefined if errorPolicy was set to 'ignore'
   data?: TData | null;
-  context?: TContext;
+  context?: DefaultContext;
   errors?: ReadonlyArray<GraphQLFormattedError>;
   extensions?: TExtensions;
 }
 
 export type FetchResult<
   TData = Record<string, any>,
-  TContext = Record<string, any>,
   TExtensions = Record<string, any>,
 > =
-  | SingleExecutionResult<TData, TContext, TExtensions>
+  | SingleExecutionResult<TData, TExtensions>
   | ExecutionPatchResult<TData, TExtensions>;
 
 export type NextLink = (operation: Operation) => Observable<FetchResult>;

--- a/src/react/hooks/__tests__/useMutation.test.tsx
+++ b/src/react/hooks/__tests__/useMutation.test.tsx
@@ -2331,17 +2331,16 @@ describe("useMutation Hook", () => {
 
       let foundContext = false;
       const Component = () => {
-        const [createTodo] = useMutation<
-          Todo,
-          { description: string },
-          { id: number }
-        >(CREATE_TODO_MUTATION, {
-          context,
-          update(_, __, options) {
-            expect(options.context).toEqual(context);
-            foundContext = true;
-          },
-        });
+        const [createTodo] = useMutation<Todo, { description: string }>(
+          CREATE_TODO_MUTATION,
+          {
+            context,
+            update(_, __, options) {
+              expect(options.context).toEqual(context);
+              foundContext = true;
+            },
+          }
+        );
 
         useEffect(() => {
           void createTodo({ variables });

--- a/src/react/hooks/useMutation.ts
+++ b/src/react/hooks/useMutation.ts
@@ -43,7 +43,6 @@ export declare namespace useMutation {
   export interface Options<
     TData = unknown,
     TVariables extends OperationVariables = OperationVariables,
-    TContext = DefaultContext,
     TCache extends ApolloCache = ApolloCache,
     TConfiguredVariables extends Partial<TVariables> = Partial<TVariables>,
   > {
@@ -69,7 +68,7 @@ export declare namespace useMutation {
     awaitRefetchQueries?: boolean;
 
     /** {@inheritDoc @apollo/client!MutationOptionsDocumentation#update:member} */
-    update?: MutationUpdaterFunction<TData, TVariables, TContext, TCache>;
+    update?: MutationUpdaterFunction<TData, TVariables, TCache>;
 
     /** {@inheritDoc @apollo/client!MutationOptionsDocumentation#onQueryUpdated:member} */
     onQueryUpdated?: OnQueryUpdated<any>;
@@ -81,7 +80,7 @@ export declare namespace useMutation {
     variables?: TConfiguredVariables;
 
     /** {@inheritDoc @apollo/client!MutationOptionsDocumentation#context:member} */
-    context?: TContext;
+    context?: DefaultContext;
 
     /** {@inheritDoc @apollo/client!MutationOptionsDocumentation#fetchPolicy:member} */
     fetchPolicy?: MutationFetchPolicy;
@@ -98,13 +97,13 @@ export declare namespace useMutation {
     /** {@inheritDoc @apollo/client!MutationOptionsDocumentation#onCompleted:member} */
     onCompleted?: (
       data: MaybeMasked<TData>,
-      clientOptions?: Options<TData, TVariables, TContext, TCache>
+      clientOptions?: Options<TData, TVariables, TCache>
     ) => void;
 
     /** {@inheritDoc @apollo/client!MutationOptionsDocumentation#onError:member} */
     onError?: (
       error: ErrorLike,
-      clientOptions?: Options<TData, TVariables, TContext, TCache>
+      clientOptions?: Options<TData, TVariables, TCache>
     ) => void;
   }
 
@@ -131,38 +130,26 @@ export declare namespace useMutation {
   export type ResultTuple<
     TData,
     TVariables extends OperationVariables,
-    TContext = DefaultContext,
     TCache extends ApolloCache = ApolloCache,
   > = [
-    mutate: MutationFunction<TData, TVariables, TContext, TCache>,
+    mutate: MutationFunction<TData, TVariables, TCache>,
     result: Result<TData>,
   ];
 
   export type MutationFunction<
     TData,
     TVariables extends OperationVariables,
-    TContext = DefaultContext,
     TCache extends ApolloCache = ApolloCache,
   > = (
     ...[options]: {} extends TVariables ?
       [
-        options?: MutationFunctionOptions<
-          TData,
-          TVariables,
-          TContext,
-          TCache
-        > & {
+        options?: MutationFunctionOptions<TData, TVariables, TCache> & {
           /** {@inheritDoc @apollo/client!MutationOptionsDocumentation#variables:member} */
           variables?: TVariables;
         },
       ]
     : [
-        options: MutationFunctionOptions<
-          TData,
-          TVariables,
-          TContext,
-          TCache
-        > & {
+        options: MutationFunctionOptions<TData, TVariables, TCache> & {
           /** {@inheritDoc @apollo/client!MutationOptionsDocumentation#variables:member} */
           variables: TVariables;
         },
@@ -172,9 +159,8 @@ export declare namespace useMutation {
   export type MutationFunctionOptions<
     TData = unknown,
     TVariables extends OperationVariables = OperationVariables,
-    TContext = DefaultContext,
     TCache extends ApolloCache = ApolloCache,
-  > = Options<TData, TVariables, TContext, TCache> & {
+  > = Options<TData, TVariables, TCache> & {
     /** {@inheritDoc @apollo/client!MutationOptionsDocumentation#mutation:member} */
     // TODO: Remove this option. We shouldn't allow the mutation to be overridden
     // in the mutation function
@@ -232,7 +218,6 @@ export declare namespace useMutation {
 export function useMutation<
   TData = unknown,
   TVariables extends OperationVariables = OperationVariables,
-  TContext = DefaultContext,
   TCache extends ApolloCache = ApolloCache,
   TConfiguredVariables extends Partial<TVariables> = {},
 >(
@@ -240,7 +225,6 @@ export function useMutation<
   options?: useMutation.Options<
     NoInfer<TData>,
     NoInfer<TVariables>,
-    TContext,
     TCache,
     {
       [K in keyof TConfiguredVariables]: K extends keyof TVariables ?
@@ -251,7 +235,6 @@ export function useMutation<
 ): useMutation.ResultTuple<
   TData,
   MakeRequiredVariablesOptional<TVariables, TConfiguredVariables>,
-  TContext,
   TCache
 > {
   const client = useApolloClient(options?.client);
@@ -277,14 +260,8 @@ export function useMutation<
       executeOptions: useMutation.MutationFunctionOptions<
         TData,
         TVariables,
-        TContext,
         TCache
-      > = {} as useMutation.MutationFunctionOptions<
-        TData,
-        TVariables,
-        TContext,
-        TCache
-      >
+      > = {} as useMutation.MutationFunctionOptions<TData, TVariables, TCache>
     ) => {
       const { options, mutation } = ref.current;
       const baseOptions = { ...options, mutation };

--- a/src/react/types/deprecated.ts
+++ b/src/react/types/deprecated.ts
@@ -61,9 +61,9 @@ export type LazyQueryExecFunction<
 export type MutationHookOptions<
   TData = unknown,
   TVariables extends OperationVariables = OperationVariables,
-  TContext = DefaultContext,
+  _TContext = DefaultContext,
   TCache extends ApolloCache = ApolloCache,
-> = useMutation.Options<TData, TVariables, TContext, TCache>;
+> = useMutation.Options<TData, TVariables, TCache>;
 
 /** @deprecated Use `useMutation.Result` instead */
 export type MutationResult<TData = unknown> = useMutation.Result<TData>;
@@ -72,17 +72,17 @@ export type MutationResult<TData = unknown> = useMutation.Result<TData>;
 export type MutationFunctionOptions<
   TData = unknown,
   TVariables extends OperationVariables = OperationVariables,
-  TContext = DefaultContext,
+  _TContext = DefaultContext,
   TCache extends ApolloCache = ApolloCache,
-> = useMutation.MutationFunctionOptions<TData, TVariables, TContext, TCache>;
+> = useMutation.MutationFunctionOptions<TData, TVariables, TCache>;
 
 /** @deprecated Use `useMutation.ResultTuple` instead */
 export type MutationTuple<
   TData,
   TVariables extends OperationVariables,
-  TContext = DefaultContext,
+  _TContext = DefaultContext,
   TCache extends ApolloCache = ApolloCache,
-> = useMutation.ResultTuple<TData, TVariables, TContext, TCache>;
+> = useMutation.ResultTuple<TData, TVariables, TCache>;
 
 /** @deprecated Use `useSubscription.Result` instead */
 export type SubscriptionResult<

--- a/src/utilities/common/mergeOptions.ts
+++ b/src/utilities/common/mergeOptions.ts
@@ -7,13 +7,13 @@ import type {
 
 import { compact } from "./compact.js";
 
-type OptionsUnion<TData, TVariables extends OperationVariables, TContext> =
+type OptionsUnion<TData, TVariables extends OperationVariables> =
   | WatchQueryOptions<TVariables, TData>
   | QueryOptions<TVariables, TData>
-  | MutationOptions<TData, TVariables, TContext, any>;
+  | MutationOptions<TData, TVariables, any>;
 
 export function mergeOptions<
-  TDefaultOptions extends Partial<OptionsUnion<any, any, any>>,
+  TDefaultOptions extends Partial<OptionsUnion<any, any>>,
   TOptions extends TDefaultOptions,
 >(
   defaults: TDefaultOptions | Partial<TDefaultOptions> | undefined,


### PR DESCRIPTION
Closes #12582

With https://github.com/apollographql/apollo-client/pull/12576 in place, we prefer to use the `DefaultContext` type as the type used for `context` options throughout the client. `context` is global and shared with the link chain, so the existing `TContext` arg can be a detriment to the DX, especially if you're not careful to align the type in multiple places.

This change should help avoid those footguns and make it easier to work with a single context type throughout the client.