### PR TITLE
Add caution to schema testing doc

### DIFF
--- a/docs/source/development-testing/schema-driven-testing.mdx
+++ b/docs/source/development-testing/schema-driven-testing.mdx
@@ -4,6 +4,10 @@ description: Using createTestSchema and associated APIs
 minVersion: 3.10.0
 ---
 
+<Caution>
+The testing utilities described in this document are deprecated and will be removed in the next major version of Apollo Client. Please use [GraphQL Testing Library](https://github.com/apollographql/graphql-testing-library) instead.
+</Caution>
+
 This article describes best practices for writing integration tests using testing utilities released as experimental in v3.10. These testing tools allow developers to execute queries against a schema configured with mock resolvers and default scalar values in order to test an entire Apollo Client application, including the [link chain](/react/api/link/introduction).
 
 ## Guiding principles


### PR DESCRIPTION
We will be removing the experimental testing utilities in v4 (https://github.com/apollographql/apollo-client/pull/12595) now that we've launched [GraphQL Testing Library](https://github.com/apollographql/graphql-testing-library). This PR adds a caution block to the beginning of the page that warns of the upcoming removal of the API.

Preview:
<img width="968" alt="Screenshot 2025-04-29 at 4 42 17 PM" src="https://github.com/user-attachments/assets/3b7c6c7e-2836-480d-be93-841dfb625bfb" />
