### PR TITLE
Retain `data` in `useQuery` when `skip` is set to `true`

### DIFF
--- a/.changeset/mighty-queens-judge.md
+++ b/.changeset/mighty-queens-judge.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+The `error` property is no longer present when `skip` is `true` in `useQuery`.

--- a/.changeset/proud-beans-invent.md
+++ b/.changeset/proud-beans-invent.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+When updating `skip` from `false` to `true` in `useQuery`, retain `data` if it is available rather than setting it to `undefined`.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43394,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38793,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33187,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 28016
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43379,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38872,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33189,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27998
 }

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -1556,7 +1556,6 @@ describe("useQuery Hook", () => {
 
       await expect(takeSnapshot()).resolves.toStrictEqualTyped({
         data: undefined,
-        error: undefined,
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
@@ -1582,7 +1581,6 @@ describe("useQuery Hook", () => {
 
       await expect(takeSnapshot()).resolves.toStrictEqualTyped({
         data: undefined,
-        error: undefined,
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: { user: { __typename: "User", id: 1, name: "User 1" } },
@@ -1976,13 +1974,10 @@ describe("useQuery Hook", () => {
         const result = await takeSnapshot();
 
         expect(result).toStrictEqualTyped({
-          // TODO: wut?
-          data: undefined,
-          // TODO: wut?
-          error: undefined,
+          data: { hello: "world 1" },
           loading: false,
           networkStatus: NetworkStatus.ready,
-          previousData: { hello: "world 1" },
+          previousData: undefined,
           variables: {},
         });
       }
@@ -1998,7 +1993,7 @@ describe("useQuery Hook", () => {
           data: { hello: "world 1" },
           loading: false,
           networkStatus: NetworkStatus.ready,
-          previousData: { hello: "world 1" },
+          previousData: undefined,
           variables: {},
         });
       }
@@ -7096,7 +7091,6 @@ describe("useQuery Hook", () => {
 
       await expect(takeSnapshot()).resolves.toStrictEqualTyped({
         data: undefined,
-        error: undefined,
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
@@ -7165,7 +7159,6 @@ describe("useQuery Hook", () => {
 
       await expect(takeSnapshot()).resolves.toStrictEqualTyped({
         data: undefined,
-        error: undefined,
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: { hello: "world" },
@@ -7221,7 +7214,6 @@ describe("useQuery Hook", () => {
 
       await expect(takeSnapshot()).resolves.toStrictEqualTyped({
         data: undefined,
-        error: undefined,
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
@@ -7281,7 +7273,6 @@ describe("useQuery Hook", () => {
 
       await expect(takeSnapshot()).resolves.toStrictEqualTyped({
         data: undefined,
-        error: undefined,
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,
@@ -7343,7 +7334,6 @@ describe("useQuery Hook", () => {
 
       await expect(takeSnapshot()).resolves.toStrictEqualTyped({
         data: undefined,
-        error: undefined,
         loading: false,
         networkStatus: NetworkStatus.ready,
         previousData: undefined,

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -1623,8 +1623,6 @@ describe("useQuery Hook", () => {
     const client = new ApolloClient({
       link,
       cache: new InMemoryCache(),
-      // TODO: is this really needed for this test?
-      ssrMode: true,
     });
 
     using _disabledAct = disableActEnvironment();

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -262,12 +262,22 @@ function useQuery_<TData, TVariables extends OperationVariables>(
       () => client.watchQuery(watchQueryOptions)
     );
 
+    const result = observable.getCurrentResult();
+
+    // TODO: This really should live in `ObservableQuery`, but with the ongoing
+    // work in https://github.com/apollographql/apollo-client/pull/12556 we
+    // should wait to add this.
+    if (observable.options.fetchPolicy === "standby" && result.loading) {
+      result.networkStatus = NetworkStatus.ready;
+      result.loading = false;
+    }
+
     return {
       client,
       query,
       observable,
       resultData: {
-        current: observable.getCurrentResult(),
+        current: result,
         // Reuse previousData from previous InternalState (if any) to provide
         // continuity of previousData even if/when the query or client changes.
         previousData: previous?.resultData.current.data,

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -455,9 +455,13 @@ function useResubscribeIfNecessary<
     // Make sure getCurrentResult returns a fresh ApolloQueryResult<TData>,
     // but save the current data as this.previousData, just like setResult
     // usually does.
-    resultData.previousData =
-      resultData.current.data || resultData.previousData;
-    resultData.current = observable.getCurrentResult();
+    const result = observable.getCurrentResult();
+
+    if (!equal(result.data, resultData.current.data)) {
+      resultData.previousData =
+        resultData.current.data || resultData.previousData;
+    }
+    resultData.current = result;
   }
   observable[lastWatchOptions] = watchQueryOptions;
 }

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -316,25 +316,10 @@ function useQuery_<TData, TVariables extends OperationVariables>(
     () => (ssr === false ? useQuery.ssrDisabledResult : void 0)
   );
 
-  const resultOverride =
-    skip || watchQueryOptions.fetchPolicy === "standby" ?
-      // When skipping a query (ie. we're not querying for data but still want to
-      // render children), make sure the `data` is cleared out and `loading` is
-      // set to `false` (since we aren't loading anything).
-      //
-      // NOTE: We no longer think this is the correct behavior. Skipping should
-      // not automatically set `data` to `undefined`, but instead leave the
-      // previous data in place. In other words, skipping should not mandate that
-      // previously received data is all of a sudden removed. Unfortunately,
-      // changing this is breaking, so we'll have to wait until Apollo Client 4.0
-      // to address this.
-      useQuery.skipStandbyResult
-    : ssrDisabledOverride;
-
   const result = useResultSubscription<TData, TVariables>(
     observable,
     resultData,
-    resultOverride
+    ssrDisabledOverride
   );
 
   const obsQueryFields = React.useMemo(

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -468,11 +468,3 @@ useQuery.ssrDisabledResult = maybeDeepFreeze({
   networkStatus: NetworkStatus.loading,
   partial: true,
 }) satisfies ApolloQueryResult<any> as ApolloQueryResult<any>;
-
-useQuery.skipStandbyResult = maybeDeepFreeze({
-  loading: false,
-  data: void 0 as any,
-  error: void 0,
-  networkStatus: NetworkStatus.ready,
-  partial: true,
-}) satisfies ApolloQueryResult<any> as ApolloQueryResult<any>;

--- a/src/react/ssr/useSSRQuery.ts
+++ b/src/react/ssr/useSSRQuery.ts
@@ -1,7 +1,9 @@
 import type { DocumentNode } from "graphql";
 
-import type { ObservableQuery } from "@apollo/client";
+import type { ApolloQueryResult, ObservableQuery } from "@apollo/client";
+import { NetworkStatus } from "@apollo/client";
 import { useApolloClient, useQuery } from "@apollo/client/react";
+import { maybeDeepFreeze } from "@apollo/client/utilities";
 
 import type { PrerenderStaticInternalContext } from "./prerenderStatic.js";
 
@@ -33,7 +35,7 @@ export const useSSRQuery = function (
   if (options.skip) {
     return withoutObservableAccess({
       ...baseResult,
-      ...useQuery.skipStandbyResult,
+      ...skipStandbyResult,
     });
   }
   if (options.ssr === false) {
@@ -77,3 +79,11 @@ function withoutObservableAccess<T>(
   });
   return value as any;
 }
+
+const skipStandbyResult = maybeDeepFreeze({
+  loading: false,
+  data: void 0 as any,
+  error: void 0,
+  networkStatus: NetworkStatus.ready,
+  partial: true,
+}) satisfies ApolloQueryResult<any> as ApolloQueryResult<any>;


### PR DESCRIPTION
Fixes #8309

When `skip` is set to `true` after it was previously `false`, `data` would be set to `undefined` even if there was a value. This PR retains `data` if it was populated when `skip` becomes `true`.