### PR TITLE
Add test for changing variables with `network-only` fetch policy

### DIFF
--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -12120,6 +12120,7 @@ describe("useQuery Hook", () => {
 
     await expect(takeSnapshot()).resolves.toStrictEqualTyped({
       data: undefined,
+      dataState: "empty",
       loading: true,
       networkStatus: NetworkStatus.loading,
       previousData: undefined,
@@ -12128,6 +12129,7 @@ describe("useQuery Hook", () => {
 
     await expect(takeSnapshot()).resolves.toStrictEqualTyped({
       data: { greeting: "Hello, Bob" },
+      dataState: "complete",
       loading: false,
       networkStatus: NetworkStatus.ready,
       previousData: undefined,
@@ -12138,6 +12140,7 @@ describe("useQuery Hook", () => {
 
     await expect(takeSnapshot()).resolves.toStrictEqualTyped({
       data: undefined,
+      dataState: "empty",
       loading: true,
       networkStatus: NetworkStatus.setVariables,
       previousData: { greeting: "Hello, Bob" },
@@ -12146,6 +12149,7 @@ describe("useQuery Hook", () => {
 
     await expect(takeSnapshot()).resolves.toStrictEqualTyped({
       data: { greeting: "Hello, Sally" },
+      dataState: "complete",
       loading: false,
       networkStatus: NetworkStatus.ready,
       previousData: { greeting: "Hello, Bob" },
@@ -12156,6 +12160,7 @@ describe("useQuery Hook", () => {
 
     await expect(takeSnapshot()).resolves.toStrictEqualTyped({
       data: undefined,
+      dataState: "empty",
       loading: true,
       networkStatus: NetworkStatus.setVariables,
       previousData: { greeting: "Hello, Sally" },
@@ -12164,6 +12169,7 @@ describe("useQuery Hook", () => {
 
     await expect(takeSnapshot()).resolves.toStrictEqualTyped({
       data: { greeting: "Hello again, Bob" },
+      dataState: "complete",
       loading: false,
       networkStatus: NetworkStatus.ready,
       previousData: { greeting: "Hello, Sally" },


### PR DESCRIPTION
Supercedes https://github.com/apollographql/apollo-client/pull/12230

This will likely be solved by https://github.com/apollographql/apollo-client/pull/12556 so we'll add this test case to the test suite once #12556 is merged.