### PR TITLE
Remove unneeded `fromLink` tracking

### DIFF
--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1371,10 +1371,6 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     );
 
     if (!useDisposableObservable && !this.linkSubscription) {
-      if (this.linkSubscription) {
-        this.linkSubscription.unsubscribe();
-      }
-
       this.linkSubscription = subscription;
     }
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1066,7 +1066,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     const initialFetchPolicy = this.options.fetchPolicy;
     const queryInfo = this.queryManager.getOrCreateQuery(this.queryId);
     queryInfo.setObservableQuery(this);
-    const { observable, fromLink } = this.queryManager.fetchObservableWithInfo(
+    const { observable } = this.queryManager.fetchObservableWithInfo(
       queryInfo,
       options,
       networkStatus,
@@ -1181,7 +1181,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
         complete: () => this.input.complete(),
       });
 
-    return { fromLink, subscription, observable };
+    return { subscription, observable };
   }
 
   // Turns polling on or off based on this.options.pollInterval.

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1066,7 +1066,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     const initialFetchPolicy = this.options.fetchPolicy;
     const queryInfo = this.queryManager.getOrCreateQuery(this.queryId);
     queryInfo.setObservableQuery(this);
-    const { observable } = this.queryManager.fetchObservableWithInfo(
+    const observable = this.queryManager.fetchObservableWithInfo(
       queryInfo,
       options,
       networkStatus,

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1066,7 +1066,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     const initialFetchPolicy = this.options.fetchPolicy;
     const queryInfo = this.queryManager.getOrCreateQuery(this.queryId);
     queryInfo.setObservableQuery(this);
-    const observable = this.queryManager.fetchObservableWithInfo(
+    const observable = this.queryManager.fetchObservable(
       queryInfo,
       options,
       networkStatus,

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1364,13 +1364,13 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
 
     this.resubscribeCache();
 
-    const { subscription, observable, fromLink } = this.fetch(
+    const { subscription, observable } = this.fetch(
       options,
       newNetworkStatus,
       query
     );
 
-    if (!useDisposableObservable && (fromLink || !this.linkSubscription)) {
+    if (!useDisposableObservable && !this.linkSubscription) {
       if (this.linkSubscription) {
         this.linkSubscription.unsubscribe();
       }

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1078,8 +1078,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
         // This has to happen in a "middleware wrapper" around `fetchQuery` call,
         // since our definition of "synchronously" should start only after
         // @exports variables have resolved.
-        const result = forward();
-        result.observable = result.observable.pipe(
+        return forward().pipe(
           // we cannot use `tap` here, since it allows only for a "before subscription"
           // hook with `subscribe` and we care for "directly before and after subscription"
           (source) =>
@@ -1129,7 +1128,6 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
               }
             )
         );
-        return result;
       }
     );
 

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1731,7 +1731,7 @@ export class QueryManager {
       context?: DefaultContext;
     },
     cacheWriteBehavior: CacheWriteBehavior
-  ): ObservableAndInfo<TData> {
+  ): Observable<QueryNotification.Value<TData, any>> {
     queryInfo.init({
       document: query,
       variables,
@@ -1845,57 +1845,43 @@ export class QueryManager {
         const diff = readCache();
 
         if (diff.complete) {
-          return {
-            fromLink: false,
-            observable: resultsFromCache(diff, NetworkStatus.ready),
-          };
+          return resultsFromCache(diff, NetworkStatus.ready);
         }
 
         if (returnPartialData) {
-          return {
-            fromLink: true,
-            observable: concat(
-              resultsFromCache(diff, NetworkStatus.loading),
-              resultsFromLink()
-            ),
-          };
+          return concat(
+            resultsFromCache(diff, NetworkStatus.loading),
+            resultsFromLink()
+          );
         }
 
-        return { fromLink: true, observable: resultsFromLink() };
+        return resultsFromLink();
       }
 
       case "cache-and-network": {
         const diff = readCache();
 
         if (diff.complete || returnPartialData) {
-          return {
-            fromLink: true,
-            observable: concat(
-              resultsFromCache(diff, NetworkStatus.loading),
-              resultsFromLink()
-            ),
-          };
+          return concat(
+            resultsFromCache(diff, NetworkStatus.loading),
+            resultsFromLink()
+          );
         }
 
-        return { fromLink: true, observable: resultsFromLink() };
+        return resultsFromLink();
       }
 
       case "cache-only":
-        return {
-          fromLink: false,
-          observable: concat(
-            resultsFromCache(readCache(), NetworkStatus.ready)
-          ),
-        };
+        return concat(resultsFromCache(readCache(), NetworkStatus.ready));
 
       case "network-only":
-        return { fromLink: true, observable: resultsFromLink() };
+        return resultsFromLink();
 
       case "no-cache":
-        return { fromLink: true, observable: resultsFromLink() };
+        return resultsFromLink();
 
       case "standby":
-        return { fromLink: false, observable: EMPTY };
+        return EMPTY;
     }
   }
 

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1424,7 +1424,7 @@ export class QueryManager {
         ) ?
           CacheWriteBehavior.OVERWRITE
         : CacheWriteBehavior.MERGE;
-      const observableWithInfo = fetchQueryMiddleware(() =>
+      const observable = fetchQueryMiddleware(() =>
         this.fetchQueryByPolicy<TData, TVars>(
           queryInfo,
           normalized,
@@ -1444,7 +1444,7 @@ export class QueryManager {
         );
       }
 
-      return observableWithInfo;
+      return observable;
     };
 
     // This cancel function needs to be set before the concast is created,

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1376,8 +1376,9 @@ export class QueryManager {
     // or setVariables.
     networkStatus = NetworkStatus.loading,
     query = options.query,
-    fetchQueryMiddleware = (forward: () => ObservableAndInfo<TData>) =>
-      forward()
+    fetchQueryMiddleware = (
+      forward: () => Observable<QueryNotification.Value<TData, any>>
+    ) => forward()
   ): Observable<QueryNotification.Value<TData, any>> {
     const variables = this.getVariables(query, options.variables) as TVars;
 
@@ -1443,7 +1444,7 @@ export class QueryManager {
         );
       }
 
-      return observableWithInfo.observable;
+      return observableWithInfo;
     };
 
     // This cancel function needs to be set before the concast is created,

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -175,7 +175,7 @@ export class QueryManager {
 
   /**
    * Whether to prioritize cache values over network results when
-   * `fetchObservableWithInfo` is called.
+   * `fetchObservable` is called.
    * This will essentially turn a `"network-only"` or `"cache-and-network"`
    * fetchPolicy into a `"cache-first"` fetchPolicy, but without influencing
    * the `fetchPolicy` of the `ObservableQuery`.
@@ -707,7 +707,7 @@ export class QueryManager {
     networkStatus?: NetworkStatus
   ): Promise<QueryResult<TData>> {
     return lastValueFrom(
-      this.fetchObservableWithInfo(
+      this.fetchObservable(
         this.getOrCreateQuery(queryId),
         options,
         networkStatus
@@ -1368,7 +1368,7 @@ export class QueryManager {
     );
   }
 
-  public fetchObservableWithInfo<TData, TVars extends OperationVariables>(
+  public fetchObservable<TData, TVars extends OperationVariables>(
     queryInfo: QueryInfo,
     options: WatchQueryOptions<TVars, TData>,
     // The initial networkStatus for this fetch, most often

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1443,7 +1443,7 @@ export class QueryManager {
         );
       }
 
-      return observableWithInfo;
+      return observableWithInfo.observable;
     };
 
     // This cancel function needs to be set before the concast is created,
@@ -1483,10 +1483,9 @@ export class QueryManager {
           normalized.variables,
           normalized.context
         )
-      ).pipe(mergeMap((variables) => fromVariables(variables).observable));
+      ).pipe(mergeMap((variables) => fromVariables(variables)));
     } else {
-      const sourcesWithInfo = fromVariables(normalized.variables);
-      observable = sourcesWithInfo.observable;
+      observable = fromVariables(normalized.variables);
     }
 
     return observable.pipe(

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1900,13 +1900,6 @@ function validateDidEmitValue<T>() {
   });
 }
 
-// Return types used by fetchQueryByPolicy and other private methods above.
-interface ObservableAndInfo<TData> {
-  // Metadata properties that can be returned in addition to the Observable.
-  fromLink: boolean;
-  observable: Observable<QueryNotification.Value<TData, any>>;
-}
-
 function isFullyUnmaskedOperation(document: DocumentNode) {
   let isUnmasked = true;
 

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1468,8 +1468,7 @@ export class QueryManager {
     const fetchCancelSubject = new Subject<
       QueryNotification.Value<TData, TVars>
     >();
-    let observable: Observable<QueryNotification.Value<TData, TVars>>,
-      containsDataFromLink: boolean;
+    let observable: Observable<QueryNotification.Value<TData, TVars>>;
     // If the query has @export(as: ...) directives, then we need to
     // process those directives asynchronously. When there are no
     // @export directives (the common case), we deliberately avoid
@@ -1485,16 +1484,8 @@ export class QueryManager {
           normalized.context
         )
       ).pipe(mergeMap((variables) => fromVariables(variables).observable));
-
-      // there is just no way we can synchronously get the *right* value here,
-      // so we will assume `true`, which is the behaviour before the bug fix in
-      // #10597. This means that bug is not fixed in that case, and is probably
-      // un-fixable with reasonable effort for the edge case of @export as
-      // directives.
-      containsDataFromLink = true;
     } else {
       const sourcesWithInfo = fromVariables(normalized.variables);
-      containsDataFromLink = sourcesWithInfo.fromLink;
       observable = sourcesWithInfo.observable;
     }
 

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -711,7 +711,7 @@ export class QueryManager {
         this.getOrCreateQuery(queryId),
         options,
         networkStatus
-      ).observable.pipe(
+      ).pipe(
         filterMap((value) => {
           switch (value.kind) {
             case "E":
@@ -1378,7 +1378,7 @@ export class QueryManager {
     query = options.query,
     fetchQueryMiddleware = (forward: () => ObservableAndInfo<TData>) =>
       forward()
-  ): ObservableAndInfo<TData> {
+  ): Observable<QueryNotification.Value<TData, any>> {
     const variables = this.getVariables(query, options.variables) as TVars;
 
     const defaults = this.defaultOptions.watchQuery;
@@ -1498,14 +1498,11 @@ export class QueryManager {
       observable = sourcesWithInfo.observable;
     }
 
-    return {
-      observable: observable.pipe(
-        tap({ error: cleanupCancelFn, complete: cleanupCancelFn }),
-        mergeWith(fetchCancelSubject),
-        share()
-      ),
-      fromLink: containsDataFromLink,
-    };
+    return observable.pipe(
+      tap({ error: cleanupCancelFn, complete: cleanupCancelFn }),
+      mergeWith(fetchCancelSubject),
+      share()
+    );
   }
 
   public refetchQueries<TResult>({


### PR DESCRIPTION
While working through #12556, I discovered that the `fromLink` tracking is no longer really needed as tests pass fine removing it. This removes that code and simplifies the downstream code paths.