### PR TITLE
Fix incorrect local state changets

### DIFF
--- a/.changeset/funny-boats-wink.md
+++ b/.changeset/funny-boats-wink.md
@@ -5,9 +5,9 @@
 Revamp local resolvers and fix several issues from the existing `resolvers` option.
 - Throwing errors in a resolver will set the field value as `null` and add an error to the response's `errors` array.
 - Remote results are dealiased before they are passed as the parent object to a resolver so that you can access fields by their field name.
-- You can now specify a `rootValue` with `LocalState` which will be used as the `parent` value passed to root resolvers. This value can be any static value or a function that returns a root value which executes for each request.
-- The `LocalState` class now accepts a `Resolvers` generic that provides autocompletion and type checking against your resolver types to ensure your resolvers are type-safe.
-- `data: null` is now handled correctly when the server does not provide a result.
+- You can now specify a `context` function that you can use to customize the `requestContext` given to resolvers.
+- The `LocalState` class accepts a `Resolvers` generic that provides autocompletion and type checking against your resolver types to ensure your resolvers are type-safe.
+- `data: null` is now handled correctly and does not call your local resolvers when the server does not provide a result.
 - Additional warnings have been added to provide hints when resolvers behave unexpectedly.
 
 ```ts
@@ -17,18 +17,19 @@ import { Resolvers } from "./path/to/local-resolvers-types.ts";
 
 // LocalState now accepts a `Resolvers` generic.
 const localState = new LocalState<Resolvers>({
-  // rootValue can be of any type, not just an object
-  rootValue: {
+  // The return value of this funciton
+  context: (options) => ({
     // ...
-  },
+  }),
   resolvers: {
     // ...
   }
 });
 
-// You may also pass a `RootValue` generic used to type-check the `rootValue` option.
-// This type is inferred from your root resolvers parent type if not provided.
-new LocalState<Resolvers, RootValue>({
+// You may also pass a `ContextValue` generic used to ensure the `context`
+// function returns the correct type. This type is inferred from your resolvers
+// if not provided.
+new LocalState<Resolvers, ContextValue>({
   // ...
 });
 ```

--- a/.changeset/strong-rivers-fry.md
+++ b/.changeset/strong-rivers-fry.md
@@ -6,8 +6,9 @@ The resolver function's `context` argument (the 3rd argument) has changed to pro
 
 ```ts
 {
-  // the request context
-  requestContext: DefaultContext,
+  // the request context. By default `TContextValue` is of type `DefaultContext`,
+  // but can be changed if a `context` function is provided.
+  requestContext: TContextValue,
   // The client instance making the request
   client: ApolloClient,
   // Whether the resolver is run as a result of gathering exported variables
@@ -16,7 +17,7 @@ The resolver function's `context` argument (the 3rd argument) has changed to pro
 }
 ```
 
-To migrate, pull any request context from `context` and the `cache` from the `client` property:
+To migrate, pull any request context from `requestContext` and the `cache` from the `client` property:
 
 ```diff
 new LocalState({


### PR DESCRIPTION
We removed `rootValue` in favor of `context` but I forgot to update the changesets so this corrects them before we release the next alpha.