### PR TITLE
remove `ObservableQuery.queryId`, return `Set` from `getObservableQueries`

### DIFF
--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -1111,8 +1111,8 @@ export type WatchQueryOptions<TVariables extends OperationVariables = OperationV
 //
 // src/core/ObservableQuery.ts:135:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:295:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:193:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:476:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:194:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:477:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:261:3 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -138,7 +138,7 @@ export class ApolloClient implements DataProxy {
     get documentTransform(): DocumentTransform;
     extract(optimistic?: boolean): unknown;
     getMemoryInternals?: typeof getApolloClientMemoryInternals;
-    getObservableQueries(include?: RefetchQueriesInclude): Map<string, ObservableQuery<any>>;
+    getObservableQueries(include?: RefetchQueriesInclude): Set<ObservableQuery<any>>;
     // (undocumented)
     link: ApolloLink;
     get localState(): LocalState | undefined;
@@ -443,14 +443,13 @@ interface MaskFragmentOptions<TData> {
 
 // @public (undocumented)
 interface MaskOperationOptions<TData> {
+    cause?: object;
     // (undocumented)
     data: TData;
     // (undocumented)
     document: DocumentNode_2;
     // (undocumented)
     fetchPolicy?: WatchQueryFetchPolicy;
-    // (undocumented)
-    id: string;
 }
 
 export { MaybeMasked }
@@ -604,7 +603,7 @@ export class ObservableQuery<TData = unknown, TVariables extends OperationVariab
     ["@@observable"]: () => Subscribable<ApolloQueryResult<MaybeMasked<TData>>>;
     // (undocumented)
     [Symbol.observable]: () => Subscribable<ApolloQueryResult<MaybeMasked<TData>>>;
-    constructor({ queryManager, options, transformedQuery, queryId, }: {
+    constructor({ queryManager, options, transformedQuery, }: {
         queryManager: QueryManager;
         options: WatchQueryOptions<TVariables, TData>;
         transformedQuery?: DocumentNode_2 | TypedDocumentNode<TData, TVariables>;
@@ -636,8 +635,6 @@ export class ObservableQuery<TData = unknown, TVariables extends OperationVariab
     pipe: Observable_2<ApolloQueryResult<MaybeMasked<TData>>>["pipe"];
     // (undocumented)
     get query(): TypedDocumentNode<TData, TVariables>;
-    // (undocumented)
-    readonly queryId: string;
     // (undocumented)
     readonly queryName?: string;
     refetch(variables?: Partial<TVariables>): ObservableQuery.ResultPromise<QueryResult<TData>>;
@@ -765,7 +762,7 @@ class QueryManager {
     // (undocumented)
     getDocumentInfo(document: DocumentNode_2): TransformCacheEntry;
     // (undocumented)
-    getObservableQueries(include?: InternalRefetchQueriesInclude): Map<string, ObservableQuery<any, OperationVariables>>;
+    getObservableQueries(include?: InternalRefetchQueriesInclude): Set<ObservableQuery<any, OperationVariables>>;
     // (undocumented)
     getVariables<TVariables>(document: DocumentNode_2, variables?: TVariables): TVariables;
     // (undocumented)
@@ -823,7 +820,7 @@ class QueryManager {
     obsQueries: Set<ObservableQuery<any, any>>;
     prioritizeCacheValues: boolean;
     // (undocumented)
-    query<TData, TVars extends OperationVariables = OperationVariables>(options: QueryOptions<TVars, TData>, queryId?: string): Promise<QueryResult<MaybeMasked<TData>>>;
+    query<TData, TVars extends OperationVariables = OperationVariables>(options: QueryOptions<TVars, TData>): Promise<QueryResult<MaybeMasked<TData>>>;
     // (undocumented)
     refetchObservableQueries(includeStandby?: boolean): Promise<QueryResult<any>[]>;
     // (undocumented)
@@ -1113,9 +1110,9 @@ export type WatchQueryOptions<TVariables extends OperationVariables = OperationV
 // Warnings were encountered during analysis:
 //
 // src/core/ObservableQuery.ts:135:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:297:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:189:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:471:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:295:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:193:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:476:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:261:3 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -1694,11 +1694,11 @@ type WatchQueryOptions_2<TVariables extends OperationVariables_2 = OperationVari
 // src/core/ObservableQuery.ts:135:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:147:5 - (ae-forgotten-export) The symbol "RefetchWritePolicy" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:295:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:193:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:476:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:188:3 - (ae-forgotten-export) The symbol "ErrorLike" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:190:3 - (ae-forgotten-export) The symbol "NetworkStatus" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:234:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:194:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:477:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:192:3 - (ae-forgotten-export) The symbol "ErrorLike" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:194:3 - (ae-forgotten-export) The symbol "NetworkStatus" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:238:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:186:3 - (ae-forgotten-export) The symbol "UpdateQueryOptions" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:261:3 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:269:3 - (ae-forgotten-export) The symbol "MutationQueryReducersMap" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -107,7 +107,7 @@ class ApolloClient_2 implements DataProxy {
     extract(optimistic?: boolean): unknown;
     getMemoryInternals?: typeof getApolloClientMemoryInternals;
     // Warning: (ae-forgotten-export) The symbol "RefetchQueriesInclude" needs to be exported by the entry point index.d.ts
-    getObservableQueries(include?: RefetchQueriesInclude): Map<string, ObservableQuery<any>>;
+    getObservableQueries(include?: RefetchQueriesInclude): Set<ObservableQuery<any>>;
     // (undocumented)
     link: ApolloLink;
     get localState(): LocalState | undefined;
@@ -409,6 +409,7 @@ interface MaskFragmentOptions<TData> {
 
 // @public (undocumented)
 interface MaskOperationOptions<TData> {
+    cause?: object;
     // (undocumented)
     data: TData;
     // (undocumented)
@@ -417,8 +418,6 @@ interface MaskOperationOptions<TData> {
     //
     // (undocumented)
     fetchPolicy?: WatchQueryFetchPolicy_2;
-    // (undocumented)
-    id: string;
 }
 
 // @public (undocumented)
@@ -562,7 +561,7 @@ class ObservableQuery<TData = unknown, TVariables extends OperationVariables_2 =
     ["@@observable"]: () => Subscribable<ApolloQueryResult<MaybeMasked<TData>>>;
     // (undocumented)
     [Symbol.observable]: () => Subscribable<ApolloQueryResult<MaybeMasked<TData>>>;
-    constructor({ queryManager, options, transformedQuery, queryId, }: {
+    constructor({ queryManager, options, transformedQuery, }: {
         queryManager: QueryManager;
         options: WatchQueryOptions_2<TVariables, TData>;
         transformedQuery?: DocumentNode | TypedDocumentNode<TData, TVariables>;
@@ -595,8 +594,6 @@ class ObservableQuery<TData = unknown, TVariables extends OperationVariables_2 =
     pipe: Observable<ApolloQueryResult<MaybeMasked<TData>>>["pipe"];
     // (undocumented)
     get query(): TypedDocumentNode<TData, TVariables>;
-    // (undocumented)
-    readonly queryId: string;
     // (undocumented)
     readonly queryName?: string;
     refetch(variables?: Partial<TVariables>): ObservableQuery.ResultPromise<QueryResult_2<TData>>;
@@ -755,7 +752,7 @@ class QueryManager {
     // (undocumented)
     getDocumentInfo(document: DocumentNode): TransformCacheEntry;
     // (undocumented)
-    getObservableQueries(include?: InternalRefetchQueriesInclude): Map<string, ObservableQuery<any, OperationVariables_2>>;
+    getObservableQueries(include?: InternalRefetchQueriesInclude): Set<ObservableQuery<any, OperationVariables_2>>;
     // (undocumented)
     getVariables<TVariables>(document: DocumentNode, variables?: TVariables): TVariables;
     // (undocumented)
@@ -813,7 +810,7 @@ class QueryManager {
     obsQueries: Set<ObservableQuery<any, any>>;
     prioritizeCacheValues: boolean;
     // (undocumented)
-    query<TData, TVars extends OperationVariables_2 = OperationVariables_2>(options: QueryOptions<TVars, TData>, queryId?: string): Promise<QueryResult_2<MaybeMasked<TData>>>;
+    query<TData, TVars extends OperationVariables_2 = OperationVariables_2>(options: QueryOptions<TVars, TData>): Promise<QueryResult_2<MaybeMasked<TData>>>;
     // (undocumented)
     refetchObservableQueries(includeStandby?: boolean): Promise<QueryResult_2<any>[]>;
     // Warning: (ae-forgotten-export) The symbol "InternalRefetchQueriesOptions" needs to be exported by the entry point index.d.ts
@@ -1696,12 +1693,12 @@ type WatchQueryOptions_2<TVariables extends OperationVariables_2 = OperationVari
 //
 // src/core/ObservableQuery.ts:135:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:147:5 - (ae-forgotten-export) The symbol "RefetchWritePolicy" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:297:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:189:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:471:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:192:3 - (ae-forgotten-export) The symbol "ErrorLike" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:194:3 - (ae-forgotten-export) The symbol "NetworkStatus" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:238:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:295:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:193:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:476:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:188:3 - (ae-forgotten-export) The symbol "ErrorLike" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:190:3 - (ae-forgotten-export) The symbol "NetworkStatus" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:234:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:186:3 - (ae-forgotten-export) The symbol "UpdateQueryOptions" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:261:3 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:269:3 - (ae-forgotten-export) The symbol "MutationQueryReducersMap" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -116,7 +116,7 @@ export class ApolloClient implements DataProxy {
     extract(optimistic?: boolean): unknown;
     // Warning: (ae-forgotten-export) The symbol "getApolloClientMemoryInternals" needs to be exported by the entry point index.d.ts
     getMemoryInternals?: typeof getApolloClientMemoryInternals;
-    getObservableQueries(include?: RefetchQueriesInclude): Map<string, ObservableQuery<any>>;
+    getObservableQueries(include?: RefetchQueriesInclude): Set<ObservableQuery<any>>;
     // (undocumented)
     link: ApolloLink;
     // Warning: (ae-forgotten-export) The symbol "LocalState" needs to be exported by the entry point index.d.ts
@@ -1602,14 +1602,13 @@ interface MaskFragmentOptions<TData> {
 
 // @public (undocumented)
 interface MaskOperationOptions<TData> {
+    cause?: object;
     // (undocumented)
     data: TData;
     // (undocumented)
     document: DocumentNode;
     // (undocumented)
     fetchPolicy?: WatchQueryFetchPolicy;
-    // (undocumented)
-    id: string;
 }
 
 // @public
@@ -1905,7 +1904,7 @@ export class ObservableQuery<TData = unknown, TVariables extends OperationVariab
     ["@@observable"]: () => Subscribable<ApolloQueryResult<MaybeMasked<TData>>>;
     // (undocumented)
     [Symbol.observable]: () => Subscribable<ApolloQueryResult<MaybeMasked<TData>>>;
-    constructor({ queryManager, options, transformedQuery, queryId, }: {
+    constructor({ queryManager, options, transformedQuery, }: {
         queryManager: QueryManager;
         options: WatchQueryOptions<TVariables, TData>;
         transformedQuery?: DocumentNode | TypedDocumentNode<TData, TVariables>;
@@ -1937,8 +1936,6 @@ export class ObservableQuery<TData = unknown, TVariables extends OperationVariab
     pipe: Observable<ApolloQueryResult<MaybeMasked<TData>>>["pipe"];
     // (undocumented)
     get query(): TypedDocumentNode<TData, TVariables>;
-    // (undocumented)
-    readonly queryId: string;
     // (undocumented)
     readonly queryName?: string;
     refetch(variables?: Partial<TVariables>): ObservableQuery.ResultPromise<QueryResult<TData>>;
@@ -2155,7 +2152,7 @@ class QueryManager {
     // (undocumented)
     getDocumentInfo(document: DocumentNode): TransformCacheEntry;
     // (undocumented)
-    getObservableQueries(include?: InternalRefetchQueriesInclude): Map<string, ObservableQuery<any, OperationVariables>>;
+    getObservableQueries(include?: InternalRefetchQueriesInclude): Set<ObservableQuery<any, OperationVariables>>;
     // (undocumented)
     getVariables<TVariables>(document: DocumentNode, variables?: TVariables): TVariables;
     // (undocumented)
@@ -2213,7 +2210,7 @@ class QueryManager {
     obsQueries: Set<ObservableQuery<any, any>>;
     prioritizeCacheValues: boolean;
     // (undocumented)
-    query<TData, TVars extends OperationVariables = OperationVariables>(options: QueryOptions<TVars, TData>, queryId?: string): Promise<QueryResult<MaybeMasked<TData>>>;
+    query<TData, TVars extends OperationVariables = OperationVariables>(options: QueryOptions<TVars, TData>): Promise<QueryResult<MaybeMasked<TData>>>;
     // (undocumented)
     refetchObservableQueries(includeStandby?: boolean): Promise<QueryResult<any>[]>;
     // (undocumented)
@@ -2768,9 +2765,9 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/cache/inmemory/policies.ts:166:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/types.ts:133:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:135:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:297:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:189:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:471:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:295:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:193:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:476:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:261:3 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
 // src/local-state/LocalState.ts:140:5 - (ae-forgotten-export) The symbol "LocalState" needs to be exported by the entry point index.d.ts
 // src/local-state/LocalState.ts:174:7 - (ae-forgotten-export) The symbol "LocalState" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -2766,8 +2766,8 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/cache/inmemory/types.ts:133:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:135:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:295:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:193:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:476:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:194:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:477:7 - (ae-forgotten-export) The symbol "UpdateQueries" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:261:3 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
 // src/local-state/LocalState.ts:140:5 - (ae-forgotten-export) The symbol "LocalState" needs to be exported by the entry point index.d.ts
 // src/local-state/LocalState.ts:174:7 - (ae-forgotten-export) The symbol "LocalState" needs to be exported by the entry point index.d.ts

--- a/.changeset/kind-crews-warn.md
+++ b/.changeset/kind-crews-warn.md
@@ -3,4 +3,4 @@
 ---
 
 `ObservableQuery` no longer has a `queryId` property.
-`ApolloClient.getObservableQueries` no longer returns a `Map<queryId, ObservableQuery>`, but a `Set<ObservableQuery>`.
+`ApolloClient.getObservableQueries` no longer returns a `Map<string, ObservableQuery>`, but a `Set<ObservableQuery>`.

--- a/.changeset/kind-crews-warn.md
+++ b/.changeset/kind-crews-warn.md
@@ -1,0 +1,6 @@
+---
+"@apollo/client": major
+---
+
+`ObservableQuery` no longer has a `queryId` property.
+`ApolloClient.getObservableQueries` no longer returns a `Map<queryId, ObservableQuery>`, but a `Set<ObservableQuery>`.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 42982,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38129,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33068,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27513
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43016,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38156,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33080,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27507
 }

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43016,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38156,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33080,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27507
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43057,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38132,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33072,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27501
 }

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43048,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38171,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33124,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27567
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 42982,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38129,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33068,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27513
 }

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -527,7 +527,7 @@ export class ApolloClient implements DataProxy {
   >(
     options: SubscriptionOptions<TVariables, TData>
   ): SubscriptionObservable<SubscribeResult<MaybeMasked<TData>>> {
-    const id = this.queryManager.generateQueryId();
+    const cause = {};
 
     const observable =
       this.queryManager.startGraphQLSubscription<TData>(options);
@@ -539,7 +539,7 @@ export class ApolloClient implements DataProxy {
           document: options.query,
           data: result.data,
           fetchPolicy: options.fetchPolicy,
-          id,
+          cause,
         }),
       }))
     );
@@ -810,7 +810,7 @@ export class ApolloClient implements DataProxy {
    */
   public getObservableQueries(
     include: RefetchQueriesInclude = "active"
-  ): Map<string, ObservableQuery<any>> {
+  ): Set<ObservableQuery<any>> {
     return this.queryManager.getObservableQueries(include);
   }
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -228,7 +228,6 @@ export class ObservableQuery<
     InteropObservable<ApolloQueryResult<MaybeMasked<TData>>>
 {
   public readonly options: ObservableQuery.Options<TData, TVariables>;
-  public readonly queryId: string;
   public readonly queryName?: string;
 
   /** @internal will be read and written from `QueryInfo` */
@@ -292,15 +291,12 @@ export class ObservableQuery<
     queryManager,
     options,
     transformedQuery = queryManager.transform(options.query),
-    queryId = queryManager.generateQueryId(),
   }: {
     queryManager: QueryManager;
     options: WatchQueryOptions<TVariables, TData>;
     transformedQuery?: DocumentNode | TypedDocumentNode<TData, TVariables>;
     queryId?: string;
   }) {
-    this.queryId = queryId;
-
     this.queryManager = queryManager;
 
     // active state
@@ -1497,7 +1493,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
             document: this.query,
             data: result.data,
             fetchPolicy: this.options.fetchPolicy,
-            id: this.queryId,
+            cause: this,
           }),
         }
       : result;

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -140,7 +140,12 @@ interface MaskFragmentOptions<TData> {
 interface MaskOperationOptions<TData> {
   document: DocumentNode;
   data: TData;
-  id: string;
+  /**
+   * Can be used to identify the cause to prevent warning for the same cause twice.
+   * This would be an object like e.g. an `ObervableQuery`.
+   * If the `cause` is not provided, we will warn every time.
+   */
+  cause?: object;
   fetchPolicy?: WatchQueryFetchPolicy;
 }
 
@@ -343,6 +348,7 @@ export class QueryManager {
     this.broadcastQueries();
 
     return new Promise((resolve, reject) => {
+      const cause = {};
       return this.getObservableFromLink<TData>(
         mutation,
         {
@@ -413,7 +419,7 @@ export class QueryManager {
                   document: mutation,
                   data: storeResult.data,
                   fetchPolicy,
-                  id: mutationId,
+                  cause,
                 }) as any,
               };
 
@@ -847,8 +853,7 @@ export class QueryManager {
     TData,
     TVars extends OperationVariables = OperationVariables,
   >(
-    options: QueryOptions<TVars, TData>,
-    queryId = this.generateQueryId()
+    options: QueryOptions<TVars, TData>
   ): Promise<QueryResult<MaybeMasked<TData>>> {
     const query = this.transform(options.query);
 
@@ -861,7 +866,6 @@ export class QueryManager {
         document: query,
         data: value?.data,
         fetchPolicy: options.fetchPolicy,
-        id: queryId,
       }),
     }));
   }
@@ -914,7 +918,7 @@ export class QueryManager {
   public getObservableQueries(
     include: InternalRefetchQueriesInclude = "active"
   ) {
-    const queries = new Map<string, ObservableQuery<any>>();
+    const queries = new Set<ObservableQuery<any>>();
     const queryNames = new Map<string, string | undefined>();
     const queryNamesAndQueryStrings = new Map<string, boolean>();
     const legacyQueryOptions = new Set<QueryOptions>();
@@ -935,10 +939,9 @@ export class QueryManager {
     }
 
     this.obsQueries.forEach((oq) => {
-      const queryId = oq.queryId;
       const document = print(this.transform(oq.options.query));
       if (include === "all") {
-        queries.set(queryId, oq);
+        queries.add(oq);
         return;
       }
 
@@ -956,7 +959,7 @@ export class QueryManager {
         (queryName && queryNamesAndQueryStrings.has(queryName)) ||
         (document && queryNamesAndQueryStrings.has(document))
       ) {
-        queries.set(queryId, oq);
+        queries.add(oq);
         if (queryName) queryNamesAndQueryStrings.set(queryName, true);
         if (document) queryNamesAndQueryStrings.set(document, true);
       }
@@ -971,7 +974,7 @@ export class QueryManager {
             fetchPolicy: "network-only",
           },
         });
-        queries.set(oq.queryId, oq);
+        queries.add(oq);
       });
     }
 
@@ -1003,7 +1006,7 @@ export class QueryManager {
     const observableQueryPromises: Promise<QueryResult<any>>[] = [];
 
     this.getObservableQueries(includeStandby ? "all" : "active").forEach(
-      (observableQuery, queryId) => {
+      (observableQuery) => {
         const { fetchPolicy } = observableQuery.options;
         if (
           includeStandby ||
@@ -1547,8 +1550,8 @@ export class QueryManager {
     ApolloCache,
     TResult
   >): InternalRefetchQueriesMap<TResult> {
-    const includedQueriesById = new Map<
-      string,
+    const includedQueriesByOq = new Map<
+      ObservableQuery<any>,
       {
         oq: ObservableQuery<any>;
         lastDiff?: Cache.DiffResult<any>;
@@ -1559,7 +1562,7 @@ export class QueryManager {
     if (include) {
       this.getObservableQueries(include).forEach((oq, queryId) => {
         const current = oq.getCurrentResult();
-        includedQueriesById.set(queryId, {
+        includedQueriesByOq.set(oq, {
           oq,
           lastDiff: {
             result: current?.data,
@@ -1625,7 +1628,7 @@ export class QueryManager {
               // Since we're about to handle this query now, remove it from
               // includedQueriesById, in case it was added earlier because of
               // options.include.
-              includedQueriesById.delete(oq.queryId);
+              includedQueriesByOq.delete(oq);
 
               let result: TResult | boolean | Promise<QueryResult<any>> =
                 onQueryUpdated(oq, diff, lastDiff);
@@ -1656,15 +1659,15 @@ export class QueryManager {
               // If we don't have an onQueryUpdated function, and onQueryUpdated
               // was not disabled by passing null, make sure this query is
               // "included" like any other options.include-specified query.
-              includedQueriesById.set(oq.queryId, { oq, lastDiff, diff });
+              includedQueriesByOq.set(oq, { oq, lastDiff, diff });
             }
           }
         },
       });
     }
 
-    if (includedQueriesById.size) {
-      includedQueriesById.forEach(({ oq, lastDiff, diff }, queryId) => {
+    if (includedQueriesByOq.size) {
+      includedQueriesByOq.forEach(({ oq, lastDiff, diff }) => {
         let result: TResult | boolean | Promise<QueryResult<any>> | undefined;
 
         // If onQueryUpdated is provided, we want to use it for all included
@@ -1703,7 +1706,7 @@ export class QueryManager {
     return results;
   }
 
-  private noCacheWarningsByQueryId = new Set<string>();
+  private noCacheWarningsByCause = new WeakSet<object>();
 
   public maskOperation<TData = unknown>(
     options: MaskOperationOptions<TData>
@@ -1711,17 +1714,16 @@ export class QueryManager {
     const { document, data } = options;
 
     if (__DEV__) {
-      const { fetchPolicy, id } = options;
+      const { fetchPolicy, cause = {} } = options;
       const operationType = getOperationDefinition(document)?.operation;
-      const operationId = (operationType?.[0] ?? "o") + id;
 
       if (
         this.dataMasking &&
         fetchPolicy === "no-cache" &&
         !isFullyUnmaskedOperation(document) &&
-        !this.noCacheWarningsByQueryId.has(operationId)
+        !this.noCacheWarningsByCause.has(cause)
       ) {
-        this.noCacheWarningsByQueryId.add(operationId);
+        this.noCacheWarningsByCause.add(cause);
 
         invariant.warn(
           '[%s]: Fragments masked by data masking are inaccessible when using fetch policy "no-cache". Please add `@unmask` to each fragment spread to access the data.',

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1560,7 +1560,7 @@ export class QueryManager {
     >();
 
     if (include) {
-      this.getObservableQueries(include).forEach((oq, queryId) => {
+      this.getObservableQueries(include).forEach((oq) => {
         const current = oq.getCurrentResult();
         includedQueriesByOq.set(oq, {
           oq,


### PR DESCRIPTION
This is a logical next step after #12647 and saves another 100 bytes, but I didn't want to add it to that PR, so I'm opening it separately.