### PR TITLE
Downgrade minimum supported RxJS version

### DIFF
--- a/.changeset/gold-planets-cover.md
+++ b/.changeset/gold-planets-cover.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Downgrade minimum supported `rxjs` peer dependency version to 7.3.0.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,7 +161,7 @@ workflows:
           matrix:
             parameters:
               project:
-                ["Core Tests", "ReactDOM 17", "ReactDOM 18", "ReactDOM 19"]
+                ["Core Tests", "Core Tests - RxJS min version", ReactDOM 17", "ReactDOM 18", "ReactDOM 19"]
       - Circularity
       - Publint
       - Attest

--- a/config/jest.config.ts
+++ b/config/jest.config.ts
@@ -26,6 +26,7 @@ const defaults = {
     ],
   },
   resolver: "<rootDir>/config/jest/resolver.ts",
+  transformIgnorePatterns: ["/node_modules/(?!(rxjs)/)"],
   prettierPath: null,
   moduleNameMapper: {
     // Our internal testing utilities are not part of the final build, so we

--- a/config/jest.config.ts
+++ b/config/jest.config.ts
@@ -67,6 +67,14 @@ const tsStandardConfig = {
   ],
 };
 
+const tsRxJSMinConfig = {
+  ...tsStandardConfig,
+  displayName: "Core Tests - RxJS min version",
+  moduleNameMapper: {
+    "^rxjs$": "rxjs-min",
+  },
+};
+
 // For both React (Jest) "projects", ignore core tests (.ts files) as they
 // do not import React, to avoid running them twice.
 const standardReact19Config = {
@@ -108,6 +116,7 @@ const standardReact17Config = {
 export default {
   projects: [
     tsStandardConfig,
+    tsRxJSMinConfig,
     standardReact17Config,
     standardReact18Config,
     standardReact19Config,

--- a/package-lock.json
+++ b/package-lock.json
@@ -122,7 +122,7 @@
         "graphql-ws": "^5.5.5 || ^6.0.3",
         "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc",
         "react-dom": "^17.0.0 || ^18.0.0 || >=19.0.0-rc",
-        "rxjs": "^7.8.0",
+        "rxjs": "^7.3.0",
         "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
       },
       "peerDependenciesMeta": {
@@ -10471,6 +10471,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/inquirer/node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/inquirer/node_modules/wrap-ansi": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -12562,6 +12572,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/load-yaml-file": {
@@ -15026,6 +15046,8 @@
     },
     "node_modules/rxjs": {
       "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,6 +102,7 @@
         "recast": "0.23.9",
         "rimraf": "5.0.9",
         "rxjs": "7.8.1",
+        "rxjs-min": "npm:rxjs@7.3.0",
         "size-limit": "11.1.4",
         "size-limit-apollo-plugin": "file:config/size-limit",
         "sorcery": "^1.0.0",
@@ -15053,6 +15054,24 @@
       "dependencies": {
         "tslib": "^2.1.0"
       }
+    },
+    "node_modules/rxjs-min": {
+      "name": "rxjs",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.3.0.tgz",
+      "integrity": "sha512-p2yuGIg9S1epc3vrjKf6iVb3RCaAYjYskkO+jHIaV0IjOPlJop4UnodOoFb2xeNwlguqLYvGw1b1McillYb5Gw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "~2.1.0"
+      }
+    },
+    "node_modules/rxjs-min/node_modules/tslib": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/sade": {
       "version": "1.8.1",

--- a/package.json
+++ b/package.json
@@ -230,6 +230,7 @@
     "recast": "0.23.9",
     "rimraf": "5.0.9",
     "rxjs": "7.8.1",
+    "rxjs-min": "npm:rxjs@7.3.0",
     "size-limit": "11.1.4",
     "size-limit-apollo-plugin": "file:config/size-limit",
     "sorcery": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "graphql-ws": "^5.5.5 || ^6.0.3",
     "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc",
     "react-dom": "^17.0.0 || ^18.0.0 || >=19.0.0-rc",
-    "rxjs": "^7.8.0",
+    "rxjs": "^7.3.0",
     "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
Closes #12603

Downgrades the minimum required `rxjs` peer dependency version to 7.3.0.