### PR TITLE
Don't call `reobserve` when changing most options in `useQuery` and instead apply them

### DIFF
--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -609,6 +609,8 @@ export class ObservableQuery<TData = unknown, TVariables extends OperationVariab
         transformedQuery?: DocumentNode_2 | TypedDocumentNode<TData, TVariables>;
         queryId?: string;
     });
+    // @internal @deprecated (undocumented)
+    applyOptions(newOptions: Partial<ObservableQuery.Options<TData, TVariables>>): void;
     fetchMore<TFetchData = TData, TFetchVars extends OperationVariables = TVariables>(fetchMoreOptions: FetchMoreQueryOptions<TFetchVars, TFetchData> & {
         updateQuery?: (previousQueryResult: Unmasked<TData>, options: {
             fetchMoreResult: Unmasked<TFetchData>;
@@ -642,8 +644,6 @@ export class ObservableQuery<TData = unknown, TVariables extends OperationVariab
     // @internal @deprecated
     reset(): void;
     setVariables(variables: TVariables): Promise<QueryResult<TData>>;
-    // @internal @deprecated (undocumented)
-    silentSetOptions(newOptions: Partial<ObservableQuery.Options<TData, TVariables>>): void;
     startPolling(pollInterval: number): void;
     stop(): void;
     stopPolling(): void;

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -567,6 +567,8 @@ class ObservableQuery<TData = unknown, TVariables extends OperationVariables_2 =
         transformedQuery?: DocumentNode | TypedDocumentNode<TData, TVariables>;
         queryId?: string;
     });
+    // @internal @deprecated (undocumented)
+    applyOptions(newOptions: Partial<ObservableQuery.Options<TData, TVariables>>): void;
     // Warning: (ae-forgotten-export) The symbol "FetchMoreQueryOptions" needs to be exported by the entry point index.d.ts
     fetchMore<TFetchData = TData, TFetchVars extends OperationVariables_2 = TVariables>(fetchMoreOptions: FetchMoreQueryOptions<TFetchVars, TFetchData> & {
         updateQuery?: (previousQueryResult: Unmasked<TData>, options: {
@@ -601,8 +603,6 @@ class ObservableQuery<TData = unknown, TVariables extends OperationVariables_2 =
     // @internal @deprecated
     reset(): void;
     setVariables(variables: TVariables): Promise<QueryResult_2<TData>>;
-    // @internal @deprecated (undocumented)
-    silentSetOptions(newOptions: Partial<ObservableQuery.Options<TData, TVariables>>): void;
     startPolling(pollInterval: number): void;
     stop(): void;
     stopPolling(): void;

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -1910,6 +1910,8 @@ export class ObservableQuery<TData = unknown, TVariables extends OperationVariab
         transformedQuery?: DocumentNode | TypedDocumentNode<TData, TVariables>;
         queryId?: string;
     });
+    // @internal @deprecated (undocumented)
+    applyOptions(newOptions: Partial<ObservableQuery.Options<TData, TVariables>>): void;
     fetchMore<TFetchData = TData, TFetchVars extends OperationVariables = TVariables>(fetchMoreOptions: FetchMoreQueryOptions<TFetchVars, TFetchData> & {
         updateQuery?: (previousQueryResult: Unmasked<TData>, options: {
             fetchMoreResult: Unmasked<TFetchData>;
@@ -1943,8 +1945,6 @@ export class ObservableQuery<TData = unknown, TVariables extends OperationVariab
     // @internal @deprecated
     reset(): void;
     setVariables(variables: TVariables): Promise<QueryResult<TData>>;
-    // @internal @deprecated (undocumented)
-    silentSetOptions(newOptions: Partial<ObservableQuery.Options<TData, TVariables>>): void;
     startPolling(pollInterval: number): void;
     stop(): void;
     stopPolling(): void;

--- a/.changeset/many-seas-call.md
+++ b/.changeset/many-seas-call.md
@@ -1,0 +1,11 @@
+---
+"@apollo/client": major
+---
+
+Changing most options in `useQuery` when rerendering will no longer automatically trigger a `reobserve` which may cause network fetches. Instead, the changed options will be applied for the next fetch.
+
+The only options that now trigger a `reobserve` when changed between renders are:
+- `query`
+- `variables`
+- `skip`
+- Changing `fetchPolicy` from `standby` to a different `fetchPolicy`

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43057,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38132,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33072,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27501
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43055,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38120,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33096,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27511
 }

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -946,7 +946,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
   }
 
   /** @internal */
-  public silentSetOptions(
+  public applyOptions(
     newOptions: Partial<ObservableQuery.Options<TData, TVariables>>
   ) {
     const mergedOptions = compact(this.options, newOptions || {});

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -951,6 +951,10 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
   ) {
     const mergedOptions = compact(this.options, newOptions || {});
     assign(this.options, mergedOptions);
+
+    if (this.options.fetchPolicy === "standby") {
+      this.cancelPolling();
+    }
   }
 
   /**

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -11929,6 +11929,145 @@ test("applies `refetchWritePolicy` on next fetch when it changes between renders
   await expect(takeSnapshot).not.toRerender();
 });
 
+test("applies `returnPartialData` on next fetch when it changes between renders", async () => {
+  const fullQuery = gql`
+    query ($id: ID!) {
+      character(id: $id) {
+        id
+        name
+      }
+    }
+  `;
+
+  const partialQuery = gql`
+    query ($id: ID!) {
+      character(id: $id) {
+        id
+      }
+    }
+  `;
+
+  const client = new ApolloClient({
+    cache: new InMemoryCache(),
+    link: new MockLink([
+      {
+        request: { query: fullQuery, variables: { id: "1" } },
+        result: {
+          data: {
+            character: {
+              __typename: "Character",
+              id: "1",
+              name: "Doctor Strange",
+            },
+          },
+        },
+        delay: 20,
+      },
+      {
+        request: { query: fullQuery, variables: { id: "2" } },
+        result: {
+          data: {
+            character: {
+              __typename: "Character",
+              id: "2",
+              name: "Hulk",
+            },
+          },
+        },
+        delay: 20,
+      },
+    ]),
+  });
+
+  client.writeQuery({
+    query: partialQuery,
+    data: { character: { __typename: "Character", id: "1" } },
+    variables: { id: "1" },
+  });
+
+  client.writeQuery({
+    query: partialQuery,
+    data: { character: { __typename: "Character", id: "2" } },
+    variables: { id: "2" },
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot, getCurrentSnapshot, rerender } =
+    await renderHookToSnapshotStream(
+      ({ id, returnPartialData }) =>
+        useQuery(fullQuery, { returnPartialData, variables: { id } }),
+      {
+        initialProps: { id: "1", returnPartialData: false },
+        wrapper: ({ children }) => (
+          <ApolloProvider client={client}>{children}</ApolloProvider>
+        ),
+      }
+    );
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    previousData: undefined,
+    variables: { id: "1" },
+  });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: {
+      character: { __typename: "Character", id: "1", name: "Doctor Strange" },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    previousData: undefined,
+    variables: { id: "1" },
+  });
+
+  await rerender({ id: "1", returnPartialData: true });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: {
+      character: { __typename: "Character", id: "1", name: "Doctor Strange" },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    previousData: undefined,
+    variables: { id: "1" },
+  });
+
+  await rerender({ id: "2", returnPartialData: true });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: {
+      character: { __typename: "Character", id: "2" },
+    },
+    dataState: "partial",
+    loading: true,
+    networkStatus: NetworkStatus.setVariables,
+    previousData: {
+      character: { __typename: "Character", id: "1", name: "Doctor Strange" },
+    },
+    variables: { id: "2" },
+  });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: {
+      character: { __typename: "Character", id: "2", name: "Hulk" },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    previousData: {
+      character: { __typename: "Character", id: "2" },
+    },
+    variables: { id: "2" },
+  });
+
+  await expect(takeSnapshot).not.toRerender();
+});
+
 describe.skip("Type Tests", () => {
   test("returns narrowed TData in default case", () => {
     const { query } = setupSimpleCase();

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -23,6 +23,7 @@ import type {
   ErrorPolicy,
   FetchPolicy,
   OperationVariables,
+  RefetchWritePolicy,
   TypedDocumentNode,
   WatchQueryFetchPolicy,
   WatchQueryOptions,
@@ -11764,6 +11765,166 @@ test("applies `context` on next fetch when it changes between renders", async ()
     previousData: { context: { source: "initialHookValue" } },
     variables: {},
   });
+
+  await expect(takeSnapshot).not.toRerender();
+});
+
+test("applies `refetchWritePolicy` on next fetch when it changes between renders", async () => {
+  const query: TypedDocumentNode<
+    { primes: number[] },
+    { min: number; max: number }
+  > = gql`
+    query GetPrimes($min: number, $max: number) {
+      primes(min: $min, max: $max)
+    }
+  `;
+
+  const mocks = [
+    {
+      request: { query, variables: { min: 0, max: 12 } },
+      result: { data: { primes: [2, 3, 5, 7, 11] } },
+      delay: 20,
+    },
+    {
+      request: { query, variables: { min: 12, max: 30 } },
+      result: { data: { primes: [13, 17, 19, 23, 29] } },
+      delay: 10,
+    },
+    {
+      request: { query, variables: { min: 30, max: 50 } },
+      result: { data: { primes: [31, 37, 41, 43, 47] } },
+      delay: 10,
+    },
+  ];
+
+  const mergeParams: [number[] | undefined, number[]][] = [];
+  const cache = new InMemoryCache({
+    typePolicies: {
+      Query: {
+        fields: {
+          primes: {
+            keyArgs: false,
+            merge(existing: number[] | undefined, incoming: number[]) {
+              mergeParams.push([existing, incoming]);
+              return existing ? existing.concat(incoming) : incoming;
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const client = new ApolloClient({
+    cache,
+    link: new MockLink(mocks),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot, getCurrentSnapshot, rerender } =
+    await renderHookToSnapshotStream(
+      ({ refetchWritePolicy }) =>
+        useQuery(query, {
+          fetchPolicy: "network-only",
+          refetchWritePolicy,
+          variables: { min: 0, max: 12 },
+        }),
+      {
+        initialProps: { refetchWritePolicy: "merge" as RefetchWritePolicy },
+        wrapper: ({ children }) => (
+          <ApolloProvider client={client}>{children}</ApolloProvider>
+        ),
+      }
+    );
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    previousData: undefined,
+    variables: { min: 0, max: 12 },
+  });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: mocks[0].result.data,
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    previousData: undefined,
+    variables: { min: 0, max: 12 },
+  });
+
+  expect(mergeParams).toEqual([[undefined, [2, 3, 5, 7, 11]]]);
+
+  const { refetch } = getCurrentSnapshot();
+
+  void refetch({ min: 12, max: 30 });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: mocks[0].result.data,
+    dataState: "complete",
+    loading: true,
+    networkStatus: NetworkStatus.refetch,
+    previousData: undefined,
+    variables: { min: 12, max: 30 },
+  });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: { primes: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29] },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    previousData: mocks[0].result.data,
+    variables: { min: 12, max: 30 },
+  });
+
+  expect(mergeParams).toEqual([
+    [undefined, [2, 3, 5, 7, 11]],
+    [
+      [2, 3, 5, 7, 11],
+      [13, 17, 19, 23, 29],
+    ],
+  ]);
+
+  await rerender({ refetchWritePolicy: "overwrite" });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: { primes: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29] },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    previousData: mocks[0].result.data,
+    variables: { min: 12, max: 30 },
+  });
+
+  void refetch({ min: 30, max: 50 });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: { primes: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29] },
+    dataState: "complete",
+    loading: true,
+    networkStatus: NetworkStatus.refetch,
+    previousData: mocks[0].result.data,
+    variables: { min: 30, max: 50 },
+  });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: mocks[2].result.data,
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    previousData: { primes: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29] },
+    variables: { min: 30, max: 50 },
+  });
+
+  expect(mergeParams).toEqual([
+    [undefined, [2, 3, 5, 7, 11]],
+    [
+      [2, 3, 5, 7, 11],
+      [13, 17, 19, 23, 29],
+    ],
+    [undefined, [31, 37, 41, 43, 47]],
+  ]);
 
   await expect(takeSnapshot).not.toRerender();
 });

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -11993,17 +11993,16 @@ test("applies `returnPartialData` on next fetch when it changes between renders"
   });
 
   using _disabledAct = disableActEnvironment();
-  const { takeSnapshot, getCurrentSnapshot, rerender } =
-    await renderHookToSnapshotStream(
-      ({ id, returnPartialData }) =>
-        useQuery(fullQuery, { returnPartialData, variables: { id } }),
-      {
-        initialProps: { id: "1", returnPartialData: false },
-        wrapper: ({ children }) => (
-          <ApolloProvider client={client}>{children}</ApolloProvider>
-        ),
-      }
-    );
+  const { takeSnapshot, rerender } = await renderHookToSnapshotStream(
+    ({ id, returnPartialData }) =>
+      useQuery(fullQuery, { returnPartialData, variables: { id } }),
+    {
+      initialProps: { id: "1", returnPartialData: false },
+      wrapper: ({ children }) => (
+        <ApolloProvider client={client}>{children}</ApolloProvider>
+      ),
+    }
+  );
 
   await expect(takeSnapshot()).resolves.toStrictEqualTyped({
     data: undefined,
@@ -12094,20 +12093,19 @@ test("applies updated `fetchPolicy` on next fetch when it changes between render
   });
 
   using _disabledAct = disableActEnvironment();
-  const { takeSnapshot, getCurrentSnapshot, rerender } =
-    await renderHookToSnapshotStream(
-      ({ id, fetchPolicy }) =>
-        useQuery(query, { fetchPolicy, variables: { id } }),
-      {
-        initialProps: {
-          id: "1",
-          fetchPolicy: "cache-first" as WatchQueryFetchPolicy,
-        },
-        wrapper: ({ children }) => (
-          <ApolloProvider client={client}>{children}</ApolloProvider>
-        ),
-      }
-    );
+  const { takeSnapshot, rerender } = await renderHookToSnapshotStream(
+    ({ id, fetchPolicy }) =>
+      useQuery(query, { fetchPolicy, variables: { id } }),
+    {
+      initialProps: {
+        id: "1",
+        fetchPolicy: "cache-first" as WatchQueryFetchPolicy,
+      },
+      wrapper: ({ children }) => (
+        <ApolloProvider client={client}>{children}</ApolloProvider>
+      ),
+    }
+  );
 
   await expect(takeSnapshot()).resolves.toStrictEqualTyped({
     data: {

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -52,6 +52,7 @@ import {
   enableFakeTimers,
   setupPaginatedCase,
   setupSimpleCase,
+  setupVariablesCase,
   spyOnConsole,
   wait,
 } from "@apollo/client/testing/internal";
@@ -12063,6 +12064,101 @@ test("applies `returnPartialData` on next fetch when it changes between renders"
       character: { __typename: "Character", id: "2" },
     },
     variables: { id: "2" },
+  });
+
+  await expect(takeSnapshot).not.toRerender();
+});
+
+test("applies updated `fetchPolicy` on next fetch when it changes between renders", async () => {
+  const { query, mocks } = setupVariablesCase();
+
+  const client = new ApolloClient({
+    cache: new InMemoryCache(),
+    link: new MockLink(mocks),
+  });
+
+  client.writeQuery({
+    query,
+    data: {
+      character: { __typename: "Character", id: "1", name: "Spider-Cache" },
+    },
+    variables: { id: "1" },
+  });
+
+  client.writeQuery({
+    query,
+    data: {
+      character: { __typename: "Character", id: "2", name: "Cached Widow" },
+    },
+    variables: { id: "2" },
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot, getCurrentSnapshot, rerender } =
+    await renderHookToSnapshotStream(
+      ({ id, fetchPolicy }) =>
+        useQuery(query, { fetchPolicy, variables: { id } }),
+      {
+        initialProps: {
+          id: "1",
+          fetchPolicy: "cache-first" as WatchQueryFetchPolicy,
+        },
+        wrapper: ({ children }) => (
+          <ApolloProvider client={client}>{children}</ApolloProvider>
+        ),
+      }
+    );
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: {
+      character: { __typename: "Character", id: "1", name: "Spider-Cache" },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    previousData: undefined,
+    variables: { id: "1" },
+  });
+
+  await rerender({ id: "1", fetchPolicy: "cache-and-network" });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: {
+      character: { __typename: "Character", id: "1", name: "Spider-Cache" },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    previousData: undefined,
+    variables: { id: "1" },
+  });
+
+  await rerender({ id: "2", fetchPolicy: "cache-and-network" });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: {
+      character: { __typename: "Character", id: "2", name: "Cached Widow" },
+    },
+    dataState: "complete",
+    loading: true,
+    networkStatus: NetworkStatus.setVariables,
+    previousData: {
+      character: { __typename: "Character", id: "1", name: "Spider-Cache" },
+    },
+    variables: { id: "1" },
+  });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: {
+      character: { __typename: "Character", id: "2", name: "Black Widow" },
+    },
+    dataState: "complete",
+    loading: true,
+    networkStatus: NetworkStatus.setVariables,
+    previousData: {
+      character: { __typename: "Character", id: "1", name: "Spider-Cache" },
+    },
+    variables: { id: "1" },
   });
 
   await expect(takeSnapshot).not.toRerender();

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -11862,11 +11862,11 @@ test("applies `refetchWritePolicy` on next fetch when it changes between renders
   void refetch({ min: 12, max: 30 });
 
   await expect(takeSnapshot()).resolves.toStrictEqualTyped({
-    data: mocks[0].result.data,
-    dataState: "complete",
+    data: undefined,
+    dataState: "empty",
     loading: true,
     networkStatus: NetworkStatus.refetch,
-    previousData: undefined,
+    previousData: mocks[0].result.data,
     variables: { min: 12, max: 30 },
   });
 
@@ -11901,11 +11901,11 @@ test("applies `refetchWritePolicy` on next fetch when it changes between renders
   void refetch({ min: 30, max: 50 });
 
   await expect(takeSnapshot()).resolves.toStrictEqualTyped({
-    data: { primes: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29] },
-    dataState: "complete",
+    data: undefined,
+    dataState: "empty",
     loading: true,
     networkStatus: NetworkStatus.refetch,
-    previousData: mocks[0].result.data,
+    previousData: { primes: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29] },
     variables: { min: 30, max: 50 },
   });
 
@@ -12143,7 +12143,7 @@ test("applies updated `fetchPolicy` on next fetch when it changes between render
     previousData: {
       character: { __typename: "Character", id: "1", name: "Spider-Cache" },
     },
-    variables: { id: "1" },
+    variables: { id: "2" },
   });
 
   await expect(takeSnapshot()).resolves.toStrictEqualTyped({
@@ -12151,12 +12151,12 @@ test("applies updated `fetchPolicy` on next fetch when it changes between render
       character: { __typename: "Character", id: "2", name: "Black Widow" },
     },
     dataState: "complete",
-    loading: true,
-    networkStatus: NetworkStatus.setVariables,
+    loading: false,
+    networkStatus: NetworkStatus.ready,
     previousData: {
-      character: { __typename: "Character", id: "1", name: "Spider-Cache" },
+      character: { __typename: "Character", id: "2", name: "Cached Widow" },
     },
-    variables: { id: "1" },
+    variables: { id: "2" },
   });
 
   await expect(takeSnapshot).not.toRerender();
@@ -12243,7 +12243,7 @@ test("renders loading states at appropriate times on next fetch after updating `
     data: { greeting: "Hello 2" },
     dataState: "complete",
     loading: true,
-    networkStatus: NetworkStatus.loading,
+    networkStatus: NetworkStatus.refetch,
     previousData: { greeting: "Hello 1" },
     variables: {},
   });

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -20,6 +20,7 @@ import React, { Fragment, useEffect, useState } from "react";
 import { asapScheduler, Observable, observeOn, of } from "rxjs";
 
 import type {
+  ErrorPolicy,
   FetchPolicy,
   OperationVariables,
   TypedDocumentNode,
@@ -42,7 +43,10 @@ import {
   useQuery,
 } from "@apollo/client/react";
 import { MockLink, MockSubscriptionLink } from "@apollo/client/testing";
-import type { SimpleCaseData } from "@apollo/client/testing/internal";
+import type {
+  SimpleCaseData,
+  VariablesCaseVariables,
+} from "@apollo/client/testing/internal";
 import {
   enableFakeTimers,
   setupPaginatedCase,
@@ -11548,6 +11552,132 @@ describe("useQuery Hook", () => {
       }
     });
   });
+});
+
+test("applies `errorPolicy` on next fetch when it changes between renders", async () => {
+  const query: TypedDocumentNode<
+    {
+      character: { __typename: "Character"; id: string; name: string } | null;
+    },
+    VariablesCaseVariables
+  > = gql`
+    query CharacterQuery($id: ID!) {
+      character(id: $id) {
+        id
+        name
+      }
+    }
+  `;
+
+  const client = new ApolloClient({
+    cache: new InMemoryCache(),
+    link: new MockLink([
+      {
+        request: { query, variables: { id: "1" } },
+        result: {
+          data: {
+            character: { __typename: "Character", id: "1", name: "Spider-Man" },
+          },
+        },
+        delay: 20,
+      },
+      {
+        request: { query, variables: { id: "1" } },
+        result: {
+          data: {
+            character: null,
+          },
+          errors: [{ message: "Could not find character 1" }],
+        },
+        delay: 20,
+      },
+    ]),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot, getCurrentSnapshot, rerender } =
+    await renderHookToSnapshotStream(
+      ({ errorPolicy }: { errorPolicy: ErrorPolicy }) =>
+        useQuery(query, {
+          // Use network-only to show no network requests are made between
+          // renders
+          fetchPolicy: "network-only",
+          errorPolicy,
+          variables: { id: "1" },
+        }),
+      {
+        initialProps: { errorPolicy: "none" },
+        wrapper: ({ children }) => (
+          <ApolloProvider client={client}>{children}</ApolloProvider>
+        ),
+      }
+    );
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    previousData: undefined,
+    variables: { id: "1" },
+  });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: {
+      character: { __typename: "Character", id: "1", name: "Spider-Man" },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    previousData: undefined,
+    variables: { id: "1" },
+  });
+
+  await rerender({ errorPolicy: "all" });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: {
+      character: { __typename: "Character", id: "1", name: "Spider-Man" },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    previousData: undefined,
+    variables: { id: "1" },
+  });
+
+  const { refetch } = getCurrentSnapshot();
+  void refetch();
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: {
+      character: { __typename: "Character", id: "1", name: "Spider-Man" },
+    },
+    dataState: "complete",
+    loading: true,
+    networkStatus: NetworkStatus.refetch,
+    previousData: undefined,
+    variables: { id: "1" },
+  });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: {
+      character: null,
+    },
+    dataState: "complete",
+    error: new CombinedGraphQLErrors({
+      data: { character: null },
+      errors: [{ message: "Could not find character 1" }],
+    }),
+    loading: false,
+    networkStatus: NetworkStatus.error,
+    previousData: {
+      character: { __typename: "Character", id: "1", name: "Spider-Man" },
+    },
+    variables: { id: "1" },
+  });
+
+  await expect(takeSnapshot).not.toRerender();
 });
 
 describe.skip("Type Tests", () => {

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -12164,6 +12164,128 @@ test("applies updated `fetchPolicy` on next fetch when it changes between render
   await expect(takeSnapshot).not.toRerender();
 });
 
+test("renders loading states at appropriate times on next fetch after updating `notifyOnNetworkStatusChange`", async () => {
+  const { query } = setupSimpleCase();
+
+  let count = 0;
+  const client = new ApolloClient({
+    cache: new InMemoryCache(),
+    link: new MockLink([
+      {
+        request: { query },
+        result: () => ({ data: { greeting: `Hello ${++count}` } }),
+        maxUsageCount: Number.POSITIVE_INFINITY,
+      },
+    ]),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot, getCurrentSnapshot, rerender } =
+    await renderHookToSnapshotStream(
+      ({ notifyOnNetworkStatusChange }) =>
+        useQuery(query, {
+          notifyOnNetworkStatusChange,
+          fetchPolicy: "network-only",
+        }),
+      {
+        initialProps: { notifyOnNetworkStatusChange: false },
+        wrapper: ({ children }) => (
+          <ApolloProvider client={client}>{children}</ApolloProvider>
+        ),
+      }
+    );
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    previousData: undefined,
+    variables: {},
+  });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: { greeting: "Hello 1" },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    previousData: undefined,
+    variables: {},
+  });
+
+  await expect(getCurrentSnapshot().refetch()).resolves.toStrictEqualTyped({
+    data: { greeting: "Hello 2" },
+  });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: { greeting: "Hello 2" },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    previousData: { greeting: "Hello 1" },
+    variables: {},
+  });
+
+  await rerender({ notifyOnNetworkStatusChange: true });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: { greeting: "Hello 2" },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    previousData: { greeting: "Hello 1" },
+    variables: {},
+  });
+
+  await expect(getCurrentSnapshot().refetch()).resolves.toStrictEqualTyped({
+    data: { greeting: "Hello 3" },
+  });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: { greeting: "Hello 2" },
+    dataState: "complete",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    previousData: { greeting: "Hello 1" },
+    variables: {},
+  });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: { greeting: "Hello 3" },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    previousData: { greeting: "Hello 2" },
+    variables: {},
+  });
+
+  await rerender({ notifyOnNetworkStatusChange: false });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: { greeting: "Hello 3" },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    previousData: { greeting: "Hello 2" },
+    variables: {},
+  });
+
+  await expect(getCurrentSnapshot().refetch()).resolves.toStrictEqualTyped({
+    data: { greeting: "Hello 4" },
+  });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: { greeting: "Hello 4" },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    previousData: { greeting: "Hello 3" },
+    variables: {},
+  });
+
+  await expect(takeSnapshot).not.toRerender();
+});
+
 describe.skip("Type Tests", () => {
   test("returns narrowed TData in default case", () => {
     const { query } = setupSimpleCase();

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -11680,6 +11680,94 @@ test("applies `errorPolicy` on next fetch when it changes between renders", asyn
   await expect(takeSnapshot).not.toRerender();
 });
 
+test("applies `context` on next fetch when it changes between renders", async () => {
+  const query = gql`
+    query {
+      context
+    }
+  `;
+
+  const client = new ApolloClient({
+    cache: new InMemoryCache(),
+    link: new ApolloLink((operation) => {
+      const context = operation.getContext();
+
+      return new Observable((observer) => {
+        setTimeout(() => {
+          observer.next({ data: { context: { source: context.source } } });
+          observer.complete();
+        }, 20);
+      });
+    }),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot, getCurrentSnapshot, rerender } =
+    await renderHookToSnapshotStream(
+      ({ context }) =>
+        useQuery(query, { context, fetchPolicy: "network-only" }),
+      {
+        initialProps: { context: { source: "initialHookValue" } },
+        wrapper: ({ children }) => (
+          <ApolloProvider client={client}>{children}</ApolloProvider>
+        ),
+      }
+    );
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    previousData: undefined,
+    variables: {},
+  });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: { context: { source: "initialHookValue" } },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    previousData: undefined,
+    variables: {},
+  });
+
+  await rerender({ context: { source: "rerender" } });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: { context: { source: "initialHookValue" } },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    previousData: undefined,
+    variables: {},
+  });
+
+  await expect(getCurrentSnapshot().refetch()).resolves.toStrictEqualTyped({
+    data: { context: { source: "rerender" } },
+  });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: { context: { source: "initialHookValue" } },
+    dataState: "complete",
+    loading: true,
+    networkStatus: NetworkStatus.refetch,
+    previousData: undefined,
+    variables: {},
+  });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: { context: { source: "rerender" } },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    previousData: { context: { source: "initialHookValue" } },
+    variables: {},
+  });
+
+  await expect(takeSnapshot).not.toRerender();
+});
+
 describe.skip("Type Tests", () => {
   test("returns narrowed TData in default case", () => {
     const { query } = setupSimpleCase();

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -11597,23 +11597,24 @@ test("applies `errorPolicy` on next fetch when it changes between renders", asyn
   });
 
   using _disabledAct = disableActEnvironment();
-  const { takeSnapshot, getCurrentSnapshot, rerender } =
-    await renderHookToSnapshotStream(
-      ({ errorPolicy }: { errorPolicy: ErrorPolicy }) =>
-        useQuery(query, {
-          // Use network-only to show no network requests are made between
-          // renders
-          fetchPolicy: "network-only",
-          errorPolicy,
-          variables: { id: "1" },
-        }),
-      {
-        initialProps: { errorPolicy: "none" },
-        wrapper: ({ children }) => (
-          <ApolloProvider client={client}>{children}</ApolloProvider>
-        ),
-      }
-    );
+  const renderStream = await renderHookToSnapshotStream(
+    ({ errorPolicy }: { errorPolicy: ErrorPolicy }) =>
+      useQuery(query, {
+        // Use network-only to show no network requests are made between
+        // renders
+        fetchPolicy: "network-only",
+        errorPolicy,
+        variables: { id: "1" },
+      }),
+    {
+      initialProps: { errorPolicy: "none" },
+      wrapper: ({ children }) => (
+        <ApolloProvider client={client}>{children}</ApolloProvider>
+      ),
+    }
+  );
+
+  const { takeSnapshot, getCurrentSnapshot, rerender } = renderStream;
 
   await expect(takeSnapshot()).resolves.toStrictEqualTyped({
     data: undefined,
@@ -11637,16 +11638,7 @@ test("applies `errorPolicy` on next fetch when it changes between renders", asyn
 
   await rerender({ errorPolicy: "all" });
 
-  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
-    data: {
-      character: { __typename: "Character", id: "1", name: "Spider-Man" },
-    },
-    dataState: "complete",
-    loading: false,
-    networkStatus: NetworkStatus.ready,
-    previousData: undefined,
-    variables: { id: "1" },
-  });
+  await expect(renderStream).toRerenderWithSimilarSnapshot();
 
   const { refetch } = getCurrentSnapshot();
   void refetch();
@@ -11704,17 +11696,16 @@ test("applies `context` on next fetch when it changes between renders", async ()
   });
 
   using _disabledAct = disableActEnvironment();
-  const { takeSnapshot, getCurrentSnapshot, rerender } =
-    await renderHookToSnapshotStream(
-      ({ context }) =>
-        useQuery(query, { context, fetchPolicy: "network-only" }),
-      {
-        initialProps: { context: { source: "initialHookValue" } },
-        wrapper: ({ children }) => (
-          <ApolloProvider client={client}>{children}</ApolloProvider>
-        ),
-      }
-    );
+  const renderStream = await renderHookToSnapshotStream(
+    ({ context }) => useQuery(query, { context, fetchPolicy: "network-only" }),
+    {
+      initialProps: { context: { source: "initialHookValue" } },
+      wrapper: ({ children }) => (
+        <ApolloProvider client={client}>{children}</ApolloProvider>
+      ),
+    }
+  );
+  const { takeSnapshot, getCurrentSnapshot, rerender } = renderStream;
 
   await expect(takeSnapshot()).resolves.toStrictEqualTyped({
     data: undefined,
@@ -11736,14 +11727,7 @@ test("applies `context` on next fetch when it changes between renders", async ()
 
   await rerender({ context: { source: "rerender" } });
 
-  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
-    data: { context: { source: "initialHookValue" } },
-    dataState: "complete",
-    loading: false,
-    networkStatus: NetworkStatus.ready,
-    previousData: undefined,
-    variables: {},
-  });
+  await expect(renderStream).toRerenderWithSimilarSnapshot();
 
   await expect(getCurrentSnapshot().refetch()).resolves.toStrictEqualTyped({
     data: { context: { source: "rerender" } },
@@ -11821,21 +11805,21 @@ test("applies `refetchWritePolicy` on next fetch when it changes between renders
   });
 
   using _disabledAct = disableActEnvironment();
-  const { takeSnapshot, getCurrentSnapshot, rerender } =
-    await renderHookToSnapshotStream(
-      ({ refetchWritePolicy }) =>
-        useQuery(query, {
-          fetchPolicy: "network-only",
-          refetchWritePolicy,
-          variables: { min: 0, max: 12 },
-        }),
-      {
-        initialProps: { refetchWritePolicy: "merge" as RefetchWritePolicy },
-        wrapper: ({ children }) => (
-          <ApolloProvider client={client}>{children}</ApolloProvider>
-        ),
-      }
-    );
+  const renderStream = await renderHookToSnapshotStream(
+    ({ refetchWritePolicy }) =>
+      useQuery(query, {
+        fetchPolicy: "network-only",
+        refetchWritePolicy,
+        variables: { min: 0, max: 12 },
+      }),
+    {
+      initialProps: { refetchWritePolicy: "merge" as RefetchWritePolicy },
+      wrapper: ({ children }) => (
+        <ApolloProvider client={client}>{children}</ApolloProvider>
+      ),
+    }
+  );
+  const { takeSnapshot, getCurrentSnapshot, rerender } = renderStream;
 
   await expect(takeSnapshot()).resolves.toStrictEqualTyped({
     data: undefined,
@@ -11889,14 +11873,7 @@ test("applies `refetchWritePolicy` on next fetch when it changes between renders
 
   await rerender({ refetchWritePolicy: "overwrite" });
 
-  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
-    data: { primes: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29] },
-    dataState: "complete",
-    loading: false,
-    networkStatus: NetworkStatus.ready,
-    previousData: mocks[0].result.data,
-    variables: { min: 12, max: 30 },
-  });
+  await expect(renderStream).toRerenderWithSimilarSnapshot();
 
   void refetch({ min: 30, max: 50 });
 
@@ -11993,7 +11970,7 @@ test("applies `returnPartialData` on next fetch when it changes between renders"
   });
 
   using _disabledAct = disableActEnvironment();
-  const { takeSnapshot, rerender } = await renderHookToSnapshotStream(
+  const renderStream = await renderHookToSnapshotStream(
     ({ id, returnPartialData }) =>
       useQuery(fullQuery, { returnPartialData, variables: { id } }),
     {
@@ -12003,6 +11980,8 @@ test("applies `returnPartialData` on next fetch when it changes between renders"
       ),
     }
   );
+
+  const { takeSnapshot, rerender } = renderStream;
 
   await expect(takeSnapshot()).resolves.toStrictEqualTyped({
     data: undefined,
@@ -12026,16 +12005,7 @@ test("applies `returnPartialData` on next fetch when it changes between renders"
 
   await rerender({ id: "1", returnPartialData: true });
 
-  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
-    data: {
-      character: { __typename: "Character", id: "1", name: "Doctor Strange" },
-    },
-    dataState: "complete",
-    loading: false,
-    networkStatus: NetworkStatus.ready,
-    previousData: undefined,
-    variables: { id: "1" },
-  });
+  await expect(renderStream).toRerenderWithSimilarSnapshot();
 
   await rerender({ id: "2", returnPartialData: true });
 
@@ -12093,7 +12063,7 @@ test("applies updated `fetchPolicy` on next fetch when it changes between render
   });
 
   using _disabledAct = disableActEnvironment();
-  const { takeSnapshot, rerender } = await renderHookToSnapshotStream(
+  const renderStream = await renderHookToSnapshotStream(
     ({ id, fetchPolicy }) =>
       useQuery(query, { fetchPolicy, variables: { id } }),
     {
@@ -12106,6 +12076,7 @@ test("applies updated `fetchPolicy` on next fetch when it changes between render
       ),
     }
   );
+  const { takeSnapshot, rerender } = renderStream;
 
   await expect(takeSnapshot()).resolves.toStrictEqualTyped({
     data: {
@@ -12120,16 +12091,7 @@ test("applies updated `fetchPolicy` on next fetch when it changes between render
 
   await rerender({ id: "1", fetchPolicy: "cache-and-network" });
 
-  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
-    data: {
-      character: { __typename: "Character", id: "1", name: "Spider-Cache" },
-    },
-    dataState: "complete",
-    loading: false,
-    networkStatus: NetworkStatus.ready,
-    previousData: undefined,
-    variables: { id: "1" },
-  });
+  await expect(renderStream).toRerenderWithSimilarSnapshot();
 
   await rerender({ id: "2", fetchPolicy: "cache-and-network" });
 
@@ -12178,20 +12140,20 @@ test("renders loading states at appropriate times on next fetch after updating `
   });
 
   using _disabledAct = disableActEnvironment();
-  const { takeSnapshot, getCurrentSnapshot, rerender } =
-    await renderHookToSnapshotStream(
-      ({ notifyOnNetworkStatusChange }) =>
-        useQuery(query, {
-          notifyOnNetworkStatusChange,
-          fetchPolicy: "network-only",
-        }),
-      {
-        initialProps: { notifyOnNetworkStatusChange: false },
-        wrapper: ({ children }) => (
-          <ApolloProvider client={client}>{children}</ApolloProvider>
-        ),
-      }
-    );
+  const renderStream = await renderHookToSnapshotStream(
+    ({ notifyOnNetworkStatusChange }) =>
+      useQuery(query, {
+        notifyOnNetworkStatusChange,
+        fetchPolicy: "network-only",
+      }),
+    {
+      initialProps: { notifyOnNetworkStatusChange: false },
+      wrapper: ({ children }) => (
+        <ApolloProvider client={client}>{children}</ApolloProvider>
+      ),
+    }
+  );
+  const { takeSnapshot, getCurrentSnapshot, rerender } = renderStream;
 
   await expect(takeSnapshot()).resolves.toStrictEqualTyped({
     data: undefined,
@@ -12226,14 +12188,7 @@ test("renders loading states at appropriate times on next fetch after updating `
 
   await rerender({ notifyOnNetworkStatusChange: true });
 
-  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
-    data: { greeting: "Hello 2" },
-    dataState: "complete",
-    loading: false,
-    networkStatus: NetworkStatus.ready,
-    previousData: { greeting: "Hello 1" },
-    variables: {},
-  });
+  await expect(renderStream).toRerenderWithSimilarSnapshot();
 
   await expect(getCurrentSnapshot().refetch()).resolves.toStrictEqualTyped({
     data: { greeting: "Hello 3" },
@@ -12259,14 +12214,7 @@ test("renders loading states at appropriate times on next fetch after updating `
 
   await rerender({ notifyOnNetworkStatusChange: false });
 
-  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
-    data: { greeting: "Hello 3" },
-    dataState: "complete",
-    loading: false,
-    networkStatus: NetworkStatus.ready,
-    previousData: { greeting: "Hello 2" },
-    variables: {},
-  });
+  await expect(renderStream).toRerenderWithSimilarSnapshot();
 
   await expect(getCurrentSnapshot().refetch()).resolves.toStrictEqualTyped({
     data: { greeting: "Hello 4" },

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -391,7 +391,7 @@ export function useLazyQuery<
       updatedOptions.fetchPolicy = stableOptions.fetchPolicy;
     }
 
-    observable.silentSetOptions(updatedOptions);
+    observable.applyOptions(updatedOptions);
   }, [
     query,
     observable,

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -485,7 +485,7 @@ function useResubscribeIfNecessary<
     if (shouldReobserve(observable[lastWatchOptions], watchQueryOptions)) {
       observable.reobserve(watchQueryOptions);
     } else {
-      observable.silentSetOptions(watchQueryOptions);
+      observable.applyOptions(watchQueryOptions);
     }
 
     // Make sure getCurrentResult returns a fresh ApolloQueryResult<TData>,

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -482,7 +482,11 @@ function useResubscribeIfNecessary<
     // subscriptions, though it does feel less than ideal that reobserve
     // (potentially) kicks off a network request (for example, when the
     // variables have changed), which is technically a side-effect.
-    observable.reobserve(watchQueryOptions);
+    if (shouldReobserve(observable[lastWatchOptions], watchQueryOptions)) {
+      observable.reobserve(watchQueryOptions);
+    } else {
+      observable.silentSetOptions(watchQueryOptions);
+    }
 
     // Make sure getCurrentResult returns a fresh ApolloQueryResult<TData>,
     // but save the current data as this.previousData, just like setResult
@@ -496,6 +500,18 @@ function useResubscribeIfNecessary<
     resultData.current = result;
   }
   observable[lastWatchOptions] = watchQueryOptions;
+}
+
+function shouldReobserve<TData, TVariables extends OperationVariables>(
+  previousOptions: Readonly<WatchQueryOptions<TVariables, TData>>,
+  options: Readonly<WatchQueryOptions<TVariables, TData>>
+) {
+  return (
+    previousOptions.query !== options.query ||
+    !equal(previousOptions.variables, options.variables) ||
+    (previousOptions.fetchPolicy === "standby" &&
+      options.fetchPolicy !== "standby")
+  );
 }
 
 useQuery.ssrDisabledResult = maybeDeepFreeze({

--- a/src/react/internal/cache/QueryReference.ts
+++ b/src/react/internal/cache/QueryReference.ts
@@ -255,10 +255,10 @@ export class InternalQueryReference<
 
     try {
       if (avoidNetworkRequests) {
-        observable.silentSetOptions({ fetchPolicy: "standby" });
+        observable.applyOptions({ fetchPolicy: "standby" });
       } else {
         observable.reset();
-        observable.silentSetOptions({ fetchPolicy: "cache-first" });
+        observable.applyOptions({ fetchPolicy: "cache-first" });
       }
 
       if (!avoidNetworkRequests) {
@@ -266,7 +266,7 @@ export class InternalQueryReference<
       }
       this.subscribeToQuery();
     } finally {
-      observable.silentSetOptions({ fetchPolicy: originalFetchPolicy });
+      observable.applyOptions({ fetchPolicy: originalFetchPolicy });
     }
   }
 
@@ -332,7 +332,7 @@ export class InternalQueryReference<
     ) {
       this.initiateFetch(this.observable.reobserve(watchQueryOptions));
     } else {
-      this.observable.silentSetOptions(watchQueryOptions);
+      this.observable.applyOptions(watchQueryOptions);
     }
 
     return this.promise;

--- a/src/testing/matchers/index.d.ts
+++ b/src/testing/matchers/index.d.ts
@@ -149,9 +149,9 @@ interface ApolloCustomMatchers<R = void, T = {}> {
     };
 
   toRerenderWithSimilarSnapshot: T extends RenderStream<infer Snapshot> ?
-    (options: ToRerenderWithSimilarSnapshotOptions<Snapshot>) => Promise<R>
+    (options?: ToRerenderWithSimilarSnapshotOptions<Snapshot>) => Promise<R>
   : T extends SnapshotStream<infer Snapshot, any> ?
-    (options: ToRerenderWithSimilarSnapshotOptions<Snapshot>) => Promise<R>
+    (options?: ToRerenderWithSimilarSnapshotOptions<Snapshot>) => Promise<R>
   : {
       error: "matcher needs to be called on a `RenderStream` instance";
     };


### PR DESCRIPTION
Fixes #11835

Changing most options for `useQuery` no longer calls `reobserve` to avoid network requests when unnecessary. Instead the options are applied to the next fetch.