### PR TITLE
Remove `context` from `useLazyQuery` hook options

### DIFF
--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -1162,7 +1162,6 @@ export namespace useLazyQuery {
     // (undocumented)
     export interface Options<TData = unknown, TVariables extends OperationVariables = OperationVariables> {
         client?: ApolloClient;
-        context?: DefaultContext_2;
         errorPolicy?: ErrorPolicy_2;
         fetchPolicy?: WatchQueryFetchPolicy;
         nextFetchPolicy?: WatchQueryFetchPolicy | ((this: WatchQueryOptions<TVariables, TData>, currentFetchPolicy: WatchQueryFetchPolicy, context: NextFetchPolicyContext<TData, TVariables>) => WatchQueryFetchPolicy);

--- a/.changeset/shaggy-singers-tickle.md
+++ b/.changeset/shaggy-singers-tickle.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": major
+---
+
+Remove `context` from `useLazyQuery` hook options. If used, `context` must now be provided to the `execute` function. `context` will reset to `{}` if not provided as an option to `execute`.

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -76,9 +76,6 @@ export declare namespace useLazyQuery {
 
     /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#client:member} */
     client?: ApolloClient;
-
-    /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#context:member} */
-    context?: DefaultContext;
   }
 
   export type Result<
@@ -373,7 +370,6 @@ export function useLazyQuery<
       {
         query,
         errorPolicy: stableOptions?.errorPolicy,
-        context: stableOptions?.context,
         refetchWritePolicy: stableOptions?.refetchWritePolicy,
         returnPartialData: stableOptions?.returnPartialData,
         notifyOnNetworkStatusChange: stableOptions?.notifyOnNetworkStatusChange,
@@ -420,11 +416,11 @@ export function useLazyQuery<
         }
 
         return observable.reobserve({
-          ...executeOptions,
           fetchPolicy,
           // If `variables` is not given, reset back to empty variables by
           // ensuring the key exists in options
           variables: executeOptions?.variables,
+          context: executeOptions?.context ?? {},
         });
       },
       [observable, calledDuringRender]


### PR DESCRIPTION
Closes #12448 

Removes `context` from the `useLazyQuery` hook options. Uses the latest `context` value passed to `execute` or resets if not provided.