### PR TITLE
`loading` is now `true `when a response is still streaming. Adds `NetworkStatus.streaming`

### DIFF
--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -537,7 +537,8 @@ export enum NetworkStatus {
     poll = 6,
     ready = 7,
     refetch = 4,
-    setVariables = 2
+    setVariables = 2,
+    streaming = 9
 }
 
 // @public (undocumented)

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -481,7 +481,8 @@ enum NetworkStatus {
     poll = 6,
     ready = 7,
     refetch = 4,
-    setVariables = 2
+    setVariables = 2,
+    streaming = 9
 }
 
 // @public (undocumented)

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -1795,7 +1795,8 @@ export enum NetworkStatus {
     poll = 6,
     ready = 7,
     refetch = 4,
-    setVariables = 2
+    setVariables = 2,
+    streaming = 9
 }
 
 // @public (undocumented)

--- a/.changeset/beige-kings-grow.md
+++ b/.changeset/beige-kings-grow.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": major
+---
+
+A `@defer` query that has not yet finished streaming is now considered loading and thus the `loading` flag will be `true` until the response has completed. A new `NetworkStatus.streaming` value has been introduced and will be set as the `networkStatus` while the response is streaming.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43015,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38077,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33033,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27466
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 42958,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38049,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33099,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27513
 }

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 42958,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38049,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33099,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27513
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43022,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38097,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33111,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27515
 }

--- a/src/__tests__/dataMasking.ts
+++ b/src/__tests__/dataMasking.ts
@@ -2206,9 +2206,8 @@ describe("client.watchQuery", () => {
         greeting: { message: "Hello world", __typename: "Greeting" },
       },
       dataState: "streaming",
-      // TODO: Is this loading state correct?
-      loading: false,
-      networkStatus: NetworkStatus.ready,
+      loading: true,
+      networkStatus: NetworkStatus.streaming,
       partial: true,
     });
 

--- a/src/__tests__/fetchMore.ts
+++ b/src/__tests__/fetchMore.ts
@@ -2323,8 +2323,8 @@ test("calling `fetchMore` on an ObservableQuery that hasn't finished deferring y
   await expect(stream).toEmitTypedValue({
     data: initialData,
     dataState: "streaming",
-    loading: false,
-    networkStatus: NetworkStatus.ready,
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
     partial: true,
   });
 
@@ -2355,8 +2355,8 @@ test("calling `fetchMore` on an ObservableQuery that hasn't finished deferring y
       ],
     },
     dataState: "streaming",
-    loading: false,
-    networkStatus: NetworkStatus.ready,
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
     partial: true,
   });
 
@@ -2416,8 +2416,10 @@ test("calling `fetchMore` on an ObservableQuery that hasn't finished deferring y
       ],
     },
     dataState: "streaming",
-    loading: false,
-    networkStatus: NetworkStatus.ready,
+    loading: true,
+    // TODO: This should be streaming. Should be fixed with
+    // https://github.com/apollographql/apollo-client/issues/12668
+    networkStatus: NetworkStatus.loading,
     partial: true,
   });
 });

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1629,6 +1629,9 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
   }
 
   private calculateNetworkStatus(baseNetworkStatus: NetworkStatus) {
+    if (baseNetworkStatus === NetworkStatus.streaming) {
+      return baseNetworkStatus;
+    }
     // in the future, this could be more complex logic, e.g. "refetch" and
     // "fetchMore" having priority over "polling" or "loading" network statuses
     // as for now we just take the "latest" operation that is still active,

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1060,16 +1060,20 @@ export class QueryManager {
 
         const aqr = {
           data: result.data as TData,
-          dataState: result.data ? "complete" : "empty",
-          loading: false,
-          networkStatus: NetworkStatus.ready,
-          partial: !result.data,
+          ...(isExecutionPatchResult(result) && result.hasNext ?
+            {
+              loading: true,
+              networkStatus: NetworkStatus.streaming,
+              dataState: "streaming",
+              partial: true,
+            }
+          : {
+              dataState: result.data ? "complete" : "empty",
+              loading: false,
+              networkStatus: NetworkStatus.ready,
+              partial: !result.data,
+            }),
         } as ApolloQueryResult<TData>;
-
-        if (isExecutionPatchResult(result) && result.hasNext) {
-          aqr.dataState = "streaming";
-          aqr.partial = true;
-        }
 
         // In the case we start multiple network requests simulatenously, we
         // want to ensure we properly set `data` if we're reporting on an old

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -7498,8 +7498,8 @@ describe("ApolloClient", () => {
       const initialResult: ApolloQueryResult<typeof initialData> = {
         data: initialData,
         dataState: "streaming",
-        loading: false,
-        networkStatus: 7,
+        loading: true,
+        networkStatus: NetworkStatus.streaming,
         partial: true,
       };
 
@@ -7543,11 +7543,9 @@ describe("ApolloClient", () => {
         ],
         hasNext: true,
       };
-      const resultAfterFirstChunk = {
-        ...structuredClone(initialResult),
-        dataState: "streaming",
-        partial: true,
-      } as ApolloQueryResult<any>;
+      const resultAfterFirstChunk = structuredClone(
+        initialResult
+      ) as ApolloQueryResult<any>;
       resultAfterFirstChunk.data.people.friends[0].name = "Leia";
 
       defer.enqueueSubsequentChunk(firstChunk);
@@ -7575,6 +7573,8 @@ describe("ApolloClient", () => {
       };
       const resultAfterSecondChunk = {
         ...structuredClone(resultAfterFirstChunk),
+        loading: false,
+        networkStatus: NetworkStatus.ready,
         dataState: "complete",
         partial: false,
       } as ApolloQueryResult<any>;

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -3487,8 +3487,8 @@ describe("ObservableQuery", () => {
           },
         },
         dataState: "streaming",
-        loading: false,
-        networkStatus: NetworkStatus.ready,
+        loading: true,
+        networkStatus: NetworkStatus.streaming,
         partial: true,
       });
 

--- a/src/core/networkStatus.ts
+++ b/src/core/networkStatus.ts
@@ -43,6 +43,13 @@ export enum NetworkStatus {
    * No request is in flight for this query, but one or more errors were detected.
    */
   error = 8,
+
+  /**
+   * Indicates that a `@defer` query has received at least the first chunk of
+   * the result but the full result has not yet been fully streamed to the
+   * client.
+   */
+  streaming = 9,
 }
 
 /**
@@ -52,7 +59,7 @@ export enum NetworkStatus {
 export function isNetworkRequestInFlight(
   networkStatus?: NetworkStatus
 ): boolean {
-  return networkStatus ? networkStatus < 7 : false;
+  return networkStatus ? networkStatus < 7 || networkStatus === 9 : false;
 }
 
 /**

--- a/src/core/networkStatus.ts
+++ b/src/core/networkStatus.ts
@@ -59,7 +59,7 @@ export enum NetworkStatus {
 export function isNetworkRequestInFlight(
   networkStatus?: NetworkStatus
 ): boolean {
-  return networkStatus ? networkStatus < 7 || networkStatus === 9 : false;
+  return !isNetworkRequestSettled(networkStatus)
 }
 
 /**

--- a/src/core/networkStatus.ts
+++ b/src/core/networkStatus.ts
@@ -59,7 +59,7 @@ export enum NetworkStatus {
 export function isNetworkRequestInFlight(
   networkStatus?: NetworkStatus
 ): boolean {
-  return !isNetworkRequestSettled(networkStatus)
+  return !isNetworkRequestSettled(networkStatus);
 }
 
 /**

--- a/src/react/hooks/__tests__/useBackgroundQuery.test.tsx
+++ b/src/react/hooks/__tests__/useBackgroundQuery.test.tsx
@@ -1489,7 +1489,7 @@ it('does not suspend deferred queries with data in the cache and using a "cache-
       },
       dataState: "streaming",
       error: undefined,
-      networkStatus: NetworkStatus.ready,
+      networkStatus: NetworkStatus.streaming,
     });
   }
 
@@ -3915,7 +3915,7 @@ it('does not suspend deferred queries with partial data in the cache and using a
       },
       dataState: "streaming",
       error: undefined,
-      networkStatus: NetworkStatus.ready,
+      networkStatus: NetworkStatus.streaming,
     });
   }
 

--- a/src/react/hooks/__tests__/useLoadableQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLoadableQuery.test.tsx
@@ -1641,7 +1641,7 @@ it('does not suspend deferred queries with data in the cache and using a "cache-
       },
       dataState: "streaming",
       error: undefined,
-      networkStatus: NetworkStatus.ready,
+      networkStatus: NetworkStatus.streaming,
     });
   }
 
@@ -4669,7 +4669,7 @@ it('does not suspend deferred queries with partial data in the cache and using a
       },
       dataState: "streaming",
       error: undefined,
-      networkStatus: NetworkStatus.ready,
+      networkStatus: NetworkStatus.streaming,
     });
   }
 

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -9217,8 +9217,8 @@ describe("useQuery Hook", () => {
           },
         },
         dataState: "streaming",
-        loading: false,
-        networkStatus: NetworkStatus.ready,
+        loading: true,
+        networkStatus: NetworkStatus.streaming,
         previousData: undefined,
         variables: {},
       });
@@ -9331,8 +9331,8 @@ describe("useQuery Hook", () => {
           ],
         },
         dataState: "streaming",
-        loading: false,
-        networkStatus: NetworkStatus.ready,
+        loading: true,
+        networkStatus: NetworkStatus.streaming,
         previousData: undefined,
         variables: {},
       });
@@ -9369,8 +9369,8 @@ describe("useQuery Hook", () => {
           ],
         },
         dataState: "streaming",
-        loading: false,
-        networkStatus: NetworkStatus.ready,
+        loading: true,
+        networkStatus: NetworkStatus.streaming,
         previousData: {
           greetings: [
             { message: "Hello world", __typename: "Greeting" },
@@ -9527,8 +9527,8 @@ describe("useQuery Hook", () => {
           ],
         },
         dataState: "streaming",
-        loading: false,
-        networkStatus: NetworkStatus.ready,
+        loading: true,
+        networkStatus: NetworkStatus.streaming,
         previousData: undefined,
         variables: {},
       });
@@ -9585,8 +9585,8 @@ describe("useQuery Hook", () => {
           ],
         },
         dataState: "streaming",
-        loading: false,
-        networkStatus: NetworkStatus.ready,
+        loading: true,
+        networkStatus: NetworkStatus.streaming,
         previousData: {
           allProducts: [
             {
@@ -9673,8 +9673,8 @@ describe("useQuery Hook", () => {
           },
         },
         dataState: "streaming",
-        loading: false,
-        networkStatus: NetworkStatus.ready,
+        loading: true,
+        networkStatus: NetworkStatus.streaming,
         previousData: undefined,
         variables: {},
       });
@@ -9807,8 +9807,8 @@ describe("useQuery Hook", () => {
           },
         },
         dataState: "streaming",
-        loading: false,
-        networkStatus: NetworkStatus.ready,
+        loading: true,
+        networkStatus: NetworkStatus.streaming,
         previousData: undefined,
         variables: {},
       });
@@ -9958,8 +9958,8 @@ describe("useQuery Hook", () => {
           },
         },
         dataState: "streaming",
-        loading: false,
-        networkStatus: NetworkStatus.ready,
+        loading: true,
+        networkStatus: NetworkStatus.streaming,
         previousData: undefined,
         variables: {},
       });
@@ -10136,8 +10136,8 @@ describe("useQuery Hook", () => {
           },
         },
         dataState: "streaming",
-        loading: false,
-        networkStatus: NetworkStatus.ready,
+        loading: true,
+        networkStatus: NetworkStatus.streaming,
         previousData: {
           greeting: {
             __typename: "Greeting",
@@ -10266,8 +10266,8 @@ describe("useQuery Hook", () => {
           },
         },
         dataState: "streaming",
-        loading: false,
-        networkStatus: NetworkStatus.ready,
+        loading: true,
+        networkStatus: NetworkStatus.streaming,
         previousData: {
           greeting: {
             __typename: "Greeting",

--- a/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
@@ -7167,7 +7167,7 @@ describe("useSuspenseQuery", () => {
       expect(result.current).toStrictEqualTyped({
         data: { greeting: { message: "Hello world", __typename: "Greeting" } },
         dataState: "streaming",
-        networkStatus: NetworkStatus.ready,
+        networkStatus: NetworkStatus.streaming,
         error: undefined,
       });
     });
@@ -7208,7 +7208,7 @@ describe("useSuspenseQuery", () => {
       {
         data: { greeting: { message: "Hello world", __typename: "Greeting" } },
         dataState: "streaming",
-        networkStatus: NetworkStatus.ready,
+        networkStatus: NetworkStatus.streaming,
         error: undefined,
       },
       {
@@ -7271,7 +7271,7 @@ describe("useSuspenseQuery", () => {
             greeting: { message: "Hello world", __typename: "Greeting" },
           },
           dataState: "streaming",
-          networkStatus: NetworkStatus.ready,
+          networkStatus: NetworkStatus.streaming,
           error: undefined,
         });
       });
@@ -7314,7 +7314,7 @@ describe("useSuspenseQuery", () => {
             greeting: { message: "Hello world", __typename: "Greeting" },
           },
           dataState: "streaming",
-          networkStatus: NetworkStatus.ready,
+          networkStatus: NetworkStatus.streaming,
           error: undefined,
         },
         {
@@ -7465,7 +7465,7 @@ describe("useSuspenseQuery", () => {
           },
         },
         dataState: "streaming",
-        networkStatus: NetworkStatus.ready,
+        networkStatus: NetworkStatus.streaming,
         error: undefined,
       });
     });
@@ -7523,7 +7523,7 @@ describe("useSuspenseQuery", () => {
           },
         },
         dataState: "streaming",
-        networkStatus: NetworkStatus.ready,
+        networkStatus: NetworkStatus.streaming,
         error: undefined,
       },
       {
@@ -7605,7 +7605,7 @@ describe("useSuspenseQuery", () => {
           },
         },
         dataState: "streaming",
-        networkStatus: NetworkStatus.ready,
+        networkStatus: NetworkStatus.streaming,
         error: undefined,
       });
     });
@@ -7664,7 +7664,7 @@ describe("useSuspenseQuery", () => {
           },
         },
         dataState: "streaming",
-        networkStatus: NetworkStatus.ready,
+        networkStatus: NetworkStatus.streaming,
         error: undefined,
       },
       {
@@ -7726,7 +7726,7 @@ describe("useSuspenseQuery", () => {
           ],
         },
         dataState: "streaming",
-        networkStatus: NetworkStatus.ready,
+        networkStatus: NetworkStatus.streaming,
         error: undefined,
       });
     });
@@ -7762,7 +7762,7 @@ describe("useSuspenseQuery", () => {
           ],
         },
         dataState: "streaming",
-        networkStatus: NetworkStatus.ready,
+        networkStatus: NetworkStatus.streaming,
         error: undefined,
       });
     });
@@ -7815,7 +7815,7 @@ describe("useSuspenseQuery", () => {
           ],
         },
         dataState: "streaming",
-        networkStatus: NetworkStatus.ready,
+        networkStatus: NetworkStatus.streaming,
         error: undefined,
       },
       {
@@ -7833,7 +7833,7 @@ describe("useSuspenseQuery", () => {
           ],
         },
         dataState: "streaming",
-        networkStatus: NetworkStatus.ready,
+        networkStatus: NetworkStatus.streaming,
         error: undefined,
       },
       {
@@ -7934,7 +7934,7 @@ describe("useSuspenseQuery", () => {
           ],
         },
         dataState: "streaming",
-        networkStatus: NetworkStatus.ready,
+        networkStatus: NetworkStatus.streaming,
         error: undefined,
       });
     });
@@ -7990,7 +7990,7 @@ describe("useSuspenseQuery", () => {
           ],
         },
         dataState: "streaming",
-        networkStatus: NetworkStatus.ready,
+        networkStatus: NetworkStatus.streaming,
         error: undefined,
       });
     });
@@ -8035,7 +8035,7 @@ describe("useSuspenseQuery", () => {
           },
         },
         dataState: "streaming",
-        networkStatus: NetworkStatus.ready,
+        networkStatus: NetworkStatus.streaming,
         error: undefined,
       });
     });
@@ -8105,7 +8105,7 @@ describe("useSuspenseQuery", () => {
           },
         },
         dataState: "streaming",
-        networkStatus: NetworkStatus.ready,
+        networkStatus: NetworkStatus.streaming,
         error: undefined,
       });
     });
@@ -8169,7 +8169,7 @@ describe("useSuspenseQuery", () => {
           },
         },
         dataState: "streaming",
-        networkStatus: NetworkStatus.ready,
+        networkStatus: NetworkStatus.streaming,
         error: undefined,
       },
       {
@@ -8199,7 +8199,7 @@ describe("useSuspenseQuery", () => {
           },
         },
         dataState: "streaming",
-        networkStatus: NetworkStatus.ready,
+        networkStatus: NetworkStatus.streaming,
         error: undefined,
       },
       {
@@ -8270,7 +8270,7 @@ describe("useSuspenseQuery", () => {
           },
         },
         dataState: "streaming",
-        networkStatus: NetworkStatus.ready,
+        networkStatus: NetworkStatus.streaming,
         error: undefined,
       });
     });
@@ -8327,7 +8327,7 @@ describe("useSuspenseQuery", () => {
           },
         },
         dataState: "streaming",
-        networkStatus: NetworkStatus.ready,
+        networkStatus: NetworkStatus.streaming,
         error: undefined,
       },
       {
@@ -8410,7 +8410,7 @@ describe("useSuspenseQuery", () => {
           ],
         },
         dataState: "streaming",
-        networkStatus: NetworkStatus.ready,
+        networkStatus: NetworkStatus.streaming,
         error: undefined,
       });
     });
@@ -8491,7 +8491,7 @@ describe("useSuspenseQuery", () => {
     //       ],
     //     },
     //     dataState: "streaming",
-    //     networkStatus: NetworkStatus.ready,
+    //     networkStatus: NetworkStatus.streaming,
     //     error: undefined,
     //   });
     // });
@@ -8569,7 +8569,7 @@ describe("useSuspenseQuery", () => {
           ],
         },
         dataState: "streaming",
-        networkStatus: NetworkStatus.ready,
+        networkStatus: NetworkStatus.streaming,
         error: undefined,
       },
       {
@@ -8608,7 +8608,7 @@ describe("useSuspenseQuery", () => {
       //     ],
       //   },
       //   dataState: "streaming",
-      //   networkStatus: NetworkStatus.ready,
+      //   networkStatus: NetworkStatus.streaming,
       //   error: undefined,
       // },
       {
@@ -8697,7 +8697,7 @@ describe("useSuspenseQuery", () => {
             ],
           },
           dataState: "streaming",
-          networkStatus: NetworkStatus.ready,
+          networkStatus: NetworkStatus.streaming,
           error: undefined,
         });
       });
@@ -8779,7 +8779,7 @@ describe("useSuspenseQuery", () => {
             ],
           },
           dataState: "streaming",
-          networkStatus: NetworkStatus.ready,
+          networkStatus: NetworkStatus.streaming,
           error: undefined,
         });
       });
@@ -8860,7 +8860,7 @@ describe("useSuspenseQuery", () => {
             ],
           },
           dataState: "streaming",
-          networkStatus: NetworkStatus.ready,
+          networkStatus: NetworkStatus.streaming,
           error: undefined,
         },
         {
@@ -8898,7 +8898,7 @@ describe("useSuspenseQuery", () => {
             ],
           },
           dataState: "streaming",
-          networkStatus: NetworkStatus.ready,
+          networkStatus: NetworkStatus.streaming,
           error: undefined,
         },
         {
@@ -9131,7 +9131,7 @@ describe("useSuspenseQuery", () => {
           },
         },
         dataState: "streaming",
-        networkStatus: NetworkStatus.ready,
+        networkStatus: NetworkStatus.streaming,
         error: undefined,
       });
     });
@@ -9187,7 +9187,7 @@ describe("useSuspenseQuery", () => {
           },
         },
         dataState: "streaming",
-        networkStatus: NetworkStatus.ready,
+        networkStatus: NetworkStatus.streaming,
         error: undefined,
       },
     ]);
@@ -9270,7 +9270,7 @@ describe("useSuspenseQuery", () => {
           },
         },
         dataState: "streaming",
-        networkStatus: NetworkStatus.ready,
+        networkStatus: NetworkStatus.streaming,
         error: undefined,
       });
     });
@@ -9373,7 +9373,7 @@ describe("useSuspenseQuery", () => {
           },
         },
         dataState: "streaming",
-        networkStatus: NetworkStatus.ready,
+        networkStatus: NetworkStatus.streaming,
         error: undefined,
       },
       {
@@ -9488,7 +9488,7 @@ describe("useSuspenseQuery", () => {
           },
         },
         dataState: "streaming",
-        networkStatus: NetworkStatus.ready,
+        networkStatus: NetworkStatus.streaming,
         error: undefined,
       });
     });
@@ -9564,7 +9564,7 @@ describe("useSuspenseQuery", () => {
           },
         },
         dataState: "streaming",
-        networkStatus: NetworkStatus.ready,
+        networkStatus: NetworkStatus.streaming,
         error: undefined,
       },
       {
@@ -9644,7 +9644,7 @@ describe("useSuspenseQuery", () => {
           },
         },
         dataState: "streaming",
-        networkStatus: NetworkStatus.ready,
+        networkStatus: NetworkStatus.streaming,
         error: undefined,
       });
     });
@@ -9744,7 +9744,7 @@ describe("useSuspenseQuery", () => {
           },
         },
         dataState: "streaming",
-        networkStatus: NetworkStatus.ready,
+        networkStatus: NetworkStatus.streaming,
         error: undefined,
       });
     });
@@ -9839,7 +9839,7 @@ describe("useSuspenseQuery", () => {
           },
         },
         dataState: "streaming",
-        networkStatus: NetworkStatus.ready,
+        networkStatus: NetworkStatus.streaming,
         error: undefined,
       },
       {
@@ -9884,7 +9884,7 @@ describe("useSuspenseQuery", () => {
           },
         },
         dataState: "streaming",
-        networkStatus: NetworkStatus.ready,
+        networkStatus: NetworkStatus.streaming,
         error: undefined,
       },
       {

--- a/src/react/query-preloader/__tests__/createQueryPreloader.test.tsx
+++ b/src/react/query-preloader/__tests__/createQueryPreloader.test.tsx
@@ -1851,7 +1851,7 @@ test("suspends deferred queries until initial chunk loads then rerenders with de
       data: { greeting: { message: "Hello world", __typename: "Greeting" } },
       dataState: "streaming",
       error: undefined,
-      networkStatus: NetworkStatus.ready,
+      networkStatus: NetworkStatus.streaming,
     });
   }
 


### PR DESCRIPTION
Fixes #12653

Adds `NetworkStatus.streaming` and sets `loading` to `true` when a `@defer` response is waiting for more chunks.

