### PR TITLE
Better stack trace on failures with `toEmit*` matchers

### DIFF
--- a/src/testing/matchers/toComplete.ts
+++ b/src/testing/matchers/toComplete.ts
@@ -3,6 +3,7 @@ import type { MatcherFunction } from "expect";
 import type { ObservableStream } from "@apollo/client/testing/internal";
 
 import type { TakeOptions } from "../internal/ObservableStream.js";
+import { EventMismatchError } from "../internal/ObservableStream.js";
 
 export const toComplete: MatcherFunction<[options?: TakeOptions]> =
   async function (actual, options) {
@@ -27,6 +28,11 @@ export const toComplete: MatcherFunction<[options?: TakeOptions]> =
           pass: false,
           message: () =>
             hint + "\n\nExpected stream to complete but it did not.",
+        };
+      } else if (EventMismatchError.is(error)) {
+        return {
+          pass: false,
+          message: () => error.formatMessage("toEmitNext"),
         };
       } else {
         throw error;

--- a/src/testing/matchers/toEmitError.ts
+++ b/src/testing/matchers/toEmitError.ts
@@ -2,7 +2,10 @@ import type { MatcherContext, MatcherFunction } from "expect";
 
 import type { ObservableStream } from "@apollo/client/testing/internal";
 
-import type { TakeOptions } from "../internal/ObservableStream.js";
+import {
+  EventMismatchError,
+  type TakeOptions,
+} from "../internal/ObservableStream.js";
 
 function isErrorEqual(this: MatcherContext, expected: any, actual: any) {
   if (typeof expected === "string" && actual instanceof Error) {
@@ -62,6 +65,11 @@ export const toEmitError: MatcherFunction<
         pass: false,
         message: () =>
           hint + "\n\nExpected stream to emit an error but it did not.",
+      };
+    } else if (EventMismatchError.is(error)) {
+      return {
+        pass: false,
+        message: () => error.formatMessage("toEmitError"),
       };
     } else {
       throw error;

--- a/src/testing/matchers/toEmitNext.ts
+++ b/src/testing/matchers/toEmitNext.ts
@@ -3,6 +3,7 @@ import type { MatcherFunction } from "expect";
 import type { ObservableStream } from "@apollo/client/testing/internal";
 
 import type { TakeOptions } from "../internal/ObservableStream.js";
+import { EventMismatchError } from "../internal/ObservableStream.js";
 
 export const toEmitNext: MatcherFunction<[options?: TakeOptions]> =
   async function (actual, options) {
@@ -31,6 +32,11 @@ export const toEmitNext: MatcherFunction<[options?: TakeOptions]> =
           pass: false,
           message: () =>
             hint + "\n\nExpected stream to emit a value but it did not.",
+        };
+      } else if (EventMismatchError.is(error)) {
+        return {
+          pass: false,
+          message: () => error.formatMessage("toEmitNext"),
         };
       } else {
         throw error;

--- a/src/testing/matchers/toEmitTypedValue.ts
+++ b/src/testing/matchers/toEmitTypedValue.ts
@@ -5,6 +5,7 @@ import type { MatcherHintOptions } from "jest-matcher-utils";
 import type { ObservableStream } from "@apollo/client/testing/internal";
 
 import type { TakeOptions } from "../internal/ObservableStream.js";
+import { EventMismatchError } from "../internal/ObservableStream.js";
 
 import { getSerializableProperties } from "./utils/getSerializableProperties.js";
 
@@ -70,6 +71,11 @@ export const toEmitTypedValue: MatcherFunction<
         pass: false,
         message: () =>
           hint + "\n\nExpected stream to emit a value but it did not.",
+      };
+    } else if (EventMismatchError.is(error)) {
+      return {
+        pass: false,
+        message: () => error.formatMessage("toEmitTypedValue"),
       };
     } else {
       throw error;


### PR DESCRIPTION
When using the `toEmit*` matchers currently, mismatches in the event type cause a test failure but the stack trace is very hard to figure out. If you use something like `toEmitError()`, but a `next` value is emitted, your stack trace looks something like this:

```
  ● client › emits InvariantError when link chain completes without emitting a result

    expect(stream).toEqual(expected)

    - Expected  - 2
    + Received  + 9

      Object {
    -   "error": Anything,
    -   "type": "error",
    +   "type": "next",
    +   "value": Object {
    +     "data": undefined,
    +     "dataState": "empty",
    +     "error": [Invariant Violation: The link chain completed without emitting a value. This is likely unintentional and should be updated to emit a value before completing.],
    +     "loading": false,
    +     "networkStatus": 8,
    +     "partial": true,
    +   },
      }

      142 |   const hint = matcherUtils.matcherHint("toEqual", "stream", "expected");
      143 |
    > 144 |   throw new Error(
          |         ^
      145 |     hint +
      146 |       "\n\n" +
      147 |       matcherUtils.printDiffOrStringify(

      at validateEquals (testing/internal/ObservableStream.ts:144:9)
      at ObservableStream.<anonymous> (testing/internal/ObservableStream.ts:105:5)
      at step (../node_modules/tslib/tslib.js:195:27)
      at Object.next (../node_modules/tslib/tslib.js:176:57)
      at fulfilled (../node_modules/tslib/tslib.js:166:62)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 124 skipped, 125 total
Snapshots:   0 total
Time:        4.498 s
Ran all test suites matching /src\/__tests__\/client.ts/i.
```

Note how the code hint points at the thrown error in `ObservableStream` and the stack trace doesn't reference the test that caused the error. This makes it very difficult to debug the source of the error.

With this PR, the stack traces are now fixed:

```
  ● client › emits InvariantError when link chain completes without emitting a result

    expect(stream).toEmitError(expected)

    - Expected  - 2
    + Received  + 9

      Object {
    -   "error": Anything,
    -   "type": "error",
    +   "type": "next",
    +   "value": Object {
    +     "data": undefined,
    +     "dataState": "empty",
    +     "error": [Invariant Violation: The link chain completed without emitting a value. This is likely unintentional and should be updated to emit a value before completing.],
    +     "loading": false,
    +     "networkStatus": 8,
    +     "partial": true,
    +   },
      }

      755 |     };
      756 |
    > 757 |     await expect(stream).toEmitError();
          |                          ^
      758 |
      759 |     await expect(stream).toEmitTypedValue(emittedValue);
      760 |

      at __tests__/client.ts:757:26
      at step (../node_modules/tslib/tslib.js:195:27)
      at Object.next (../node_modules/tslib/tslib.js:176:57)
      at fulfilled (../node_modules/tslib/tslib.js:166:62)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 124 skipped, 125 total
Snapshots:   0 total
Time:        2.773 s, estimated 7 s
Ran all test suites matching /src\/__tests__\/client.ts/i.
```