### PR TITLE
Minor improvements to `useQuery`/`ObservableQuery`

### DIFF
--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43629,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38666,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33289,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27602
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43565,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38609,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33337,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27582
 }

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1491,15 +1491,15 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
   }
 
   private maskResult<T extends { data: any }>(result: T): T {
-    return {
-      ...result,
-      data: this.queryManager.maskOperation({
-        document: this.query,
-        data: result.data,
-        fetchPolicy: this.options.fetchPolicy,
-        cause: this,
-      }),
-    };
+    const masked = this.queryManager.maskOperation({
+      document: this.query,
+      data: result.data,
+      fetchPolicy: this.options.fetchPolicy,
+      cause: this,
+    });
+
+    // Maintain object identity as much as possible
+    return masked === result.data ? result : { ...result, data: masked };
   }
 
   private dirty: boolean = false;

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -525,11 +525,7 @@ export class ObservableQuery<
           networkStatus: NetworkStatus.loading,
         };
       case "standby":
-        return {
-          ...defaultResult,
-          loading: false,
-          networkStatus: NetworkStatus.ready,
-        };
+        return empty;
 
       default:
         return defaultResult;

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -478,13 +478,6 @@ export class ObservableQuery<
       this.queryManager.prioritizeCacheValues ?
         "cache-first"
       : initialFetchPolicy || this.options.fetchPolicy;
-    const defaultResult: ApolloQueryResult<TData> = {
-      data: undefined,
-      dataState: "empty",
-      loading: true,
-      networkStatus: NetworkStatus.loading,
-      partial: true,
-    };
 
     const cacheResult = (): ApolloQueryResult<TData> => {
       const diff = this.getCacheDiff();
@@ -528,7 +521,7 @@ export class ObservableQuery<
         return empty;
 
       default:
-        return defaultResult;
+        return uninitialized;
     }
   }
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1491,17 +1491,15 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
   }
 
   private maskResult<T extends { data: any }>(result: T): T {
-    return result && "data" in result ?
-        {
-          ...result,
-          data: this.queryManager.maskOperation({
-            document: this.query,
-            data: result.data,
-            fetchPolicy: this.options.fetchPolicy,
-            cause: this,
-          }),
-        }
-      : result;
+    return {
+      ...result,
+      data: this.queryManager.maskOperation({
+        document: this.query,
+        data: result.data,
+        fetchPolicy: this.options.fetchPolicy,
+        cause: this,
+      }),
+    };
   }
 
   private dirty: boolean = false;

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -17,7 +17,7 @@ import { GraphQLError } from "graphql";
 import { gql } from "graphql-tag";
 import type { ReactNode } from "react";
 import React, { Fragment, useEffect, useState } from "react";
-import { asapScheduler, Observable, observeOn, of } from "rxjs";
+import { asapScheduler, delay, Observable, observeOn, of } from "rxjs";
 
 import type {
   FetchPolicy,
@@ -7626,7 +7626,7 @@ describe("useQuery Hook", () => {
       let linkCount = 0;
       const link = new ApolloLink(() =>
         // Emit the value  async so we can observe the loading state
-        of({ data: { hello: ++linkCount } }).pipe(observeOn(asapScheduler))
+        of({ data: { hello: ++linkCount } }).pipe(delay(100))
       );
 
       const client = new ApolloClient({

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -17,7 +17,7 @@ import { GraphQLError } from "graphql";
 import { gql } from "graphql-tag";
 import type { ReactNode } from "react";
 import React, { Fragment, useEffect, useState } from "react";
-import { asapScheduler, delay, Observable, observeOn, of } from "rxjs";
+import { asapScheduler, Observable, observeOn, of } from "rxjs";
 
 import type {
   FetchPolicy,
@@ -7626,7 +7626,7 @@ describe("useQuery Hook", () => {
       let linkCount = 0;
       const link = new ApolloLink(() =>
         // Emit the value  async so we can observe the loading state
-        of({ data: { hello: ++linkCount } }).pipe(delay(100))
+        of({ data: { hello: ++linkCount } }).pipe(observeOn(asapScheduler))
       );
 
       const client = new ApolloClient({

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -363,10 +363,9 @@ function useQuery_<TData, TVariables extends OperationVariables>(
 
   const previousData = resultData.previousData;
   return React.useMemo(() => {
-    const { data, partial, ...rest } = result;
+    const { partial, ...rest } = result;
 
     return {
-      data, // Ensure always defined, even if result.data is missing.
       ...rest,
       client,
       observable,

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -415,7 +415,6 @@ function useResultSubscription<TData, TVariables extends OperationVariables>(
             }
 
             if (
-              previousResult &&
               previousResult.data &&
               !equal(previousResult.data, result.data)
             ) {

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -412,13 +412,7 @@ function useResultSubscription<TData, TVariables extends OperationVariables>(
             // Make sure we're not attempting to re-render similar results
             // TODO: Eventually move this check inside ObservableQuery. We should
             // probably not emit a new result if the result is the same.
-            if (
-              previousResult &&
-              previousResult.loading === result.loading &&
-              previousResult.networkStatus === result.networkStatus &&
-              equal(previousResult.data, result.data) &&
-              equal(previousResult.error, result.error)
-            ) {
+            if (equal(previousResult, result)) {
               return;
             }
 

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -332,9 +332,10 @@ function useQuery_<TData, TVariables extends OperationVariables>(
 
   const { observable, resultData } = state;
 
-  if (!watchQueryOptions.fetchPolicy) {
-    watchQueryOptions.fetchPolicy = observable.options.initialFetchPolicy;
-  }
+  useInitialFetchPolicyIfNecessary<TData, TVariables>(
+    watchQueryOptions,
+    observable
+  );
 
   useResubscribeIfNecessary<TData, TVariables>(
     resultData, // might get mutated during render
@@ -373,6 +374,19 @@ function useQuery_<TData, TVariables extends OperationVariables>(
       ...obsQueryFields,
     };
   }, [result, client, observable, previousData, obsQueryFields]);
+}
+
+function useInitialFetchPolicyIfNecessary<
+  TData,
+  TVariables extends OperationVariables,
+>(
+  watchQueryOptions: WatchQueryOptions<TVariables, TData>,
+  observable: ObsQueryWithMeta<TData, TVariables>
+) {
+  "use no memo";
+  if (!watchQueryOptions.fetchPolicy) {
+    watchQueryOptions.fetchPolicy = observable.options.initialFetchPolicy;
+  }
 }
 
 function useResult<TData, TVariables extends OperationVariables>(

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -342,7 +342,7 @@ function useQuery_<TData, TVariables extends OperationVariables>(
     watchQueryOptions
   );
 
-  const result = useResultSubscription<TData, TVariables>(
+  const result = useResult<TData, TVariables>(
     observable,
     resultData,
     options.ssr
@@ -375,7 +375,7 @@ function useQuery_<TData, TVariables extends OperationVariables>(
   }, [result, client, observable, previousData, obsQueryFields]);
 }
 
-function useResultSubscription<TData, TVariables extends OperationVariables>(
+function useResult<TData, TVariables extends OperationVariables>(
   observable: ObsQueryWithMeta<TData, TVariables>,
   resultData: InternalResult<TData>,
   ssr: boolean | undefined

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -343,16 +343,10 @@ function useQuery_<TData, TVariables extends OperationVariables>(
     watchQueryOptions
   );
 
-  const resultOverride = useSyncExternalStore(
-    () => () => {},
-    () => void 0,
-    () => (ssr === false ? useQuery.ssrDisabledResult : void 0)
-  );
-
   const result = useResultSubscription<TData, TVariables>(
     observable,
     resultData,
-    resultOverride
+    options.ssr
   );
 
   const obsQueryFields = React.useMemo(
@@ -399,7 +393,7 @@ function useInitialFetchPolicyIfNecessary<
 function useResultSubscription<TData, TVariables extends OperationVariables>(
   observable: ObsQueryWithMeta<TData, TVariables>,
   resultData: InternalResult<TData>,
-  resultOverride: ApolloQueryResult<any> | undefined
+  ssr: boolean | undefined
 ) {
   "use no memo";
   return useSyncExternalStore(
@@ -452,8 +446,8 @@ function useResultSubscription<TData, TVariables extends OperationVariables>(
 
       [observable, resultData]
     ),
-    () => resultOverride || resultData.current,
-    () => resultOverride || resultData.current
+    () => resultData.current,
+    () => (ssr === false ? useQuery.ssrDisabledResult : resultData.current)
   );
 }
 

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -408,18 +408,15 @@ function useResultSubscription<TData, TVariables extends OperationVariables>(
           // new value.
           .pipe(observeOn(asapScheduler))
           .subscribe((result) => {
-            const previousResult = resultData.current;
+            const previous = resultData.current;
             // Make sure we're not attempting to re-render similar results
-            if (equal(previousResult, result)) {
+            if (equal(previous, result)) {
               return;
             }
 
-            if (
-              previousResult.data &&
-              !equal(previousResult.data, result.data)
-            ) {
+            if (previous.data && !equal(previous.data, result.data)) {
               // eslint-disable-next-line react-compiler/react-compiler
-              resultData.previousData = previousResult.data as TData;
+              resultData.previousData = previous.data as TData;
             }
 
             resultData.current = result;

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -410,8 +410,6 @@ function useResultSubscription<TData, TVariables extends OperationVariables>(
           .subscribe((result) => {
             const previousResult = resultData.current;
             // Make sure we're not attempting to re-render similar results
-            // TODO: Eventually move this check inside ObservableQuery. We should
-            // probably not emit a new result if the result is the same.
             if (equal(previousResult, result)) {
               return;
             }

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -332,10 +332,9 @@ function useQuery_<TData, TVariables extends OperationVariables>(
 
   const { observable, resultData } = state;
 
-  useInitialFetchPolicyIfNecessary<TData, TVariables>(
-    watchQueryOptions,
-    observable
-  );
+  if (!watchQueryOptions.fetchPolicy) {
+    watchQueryOptions.fetchPolicy = observable.options.initialFetchPolicy;
+  }
 
   useResubscribeIfNecessary<TData, TVariables>(
     resultData, // might get mutated during render
@@ -374,19 +373,6 @@ function useQuery_<TData, TVariables extends OperationVariables>(
       ...obsQueryFields,
     };
   }, [result, client, observable, previousData, obsQueryFields]);
-}
-
-function useInitialFetchPolicyIfNecessary<
-  TData,
-  TVariables extends OperationVariables,
->(
-  watchQueryOptions: WatchQueryOptions<TVariables, TData>,
-  observable: ObsQueryWithMeta<TData, TVariables>
-) {
-  "use no memo";
-  if (!watchQueryOptions.fetchPolicy) {
-    watchQueryOptions.fetchPolicy = observable.options.initialFetchPolicy;
-  }
 }
 
 function useResultSubscription<TData, TVariables extends OperationVariables>(

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -368,8 +368,8 @@ function useQuery_<TData, TVariables extends OperationVariables>(
     return {
       data, // Ensure always defined, even if result.data is missing.
       ...rest,
-      client: client,
-      observable: observable,
+      client,
+      observable,
       variables: observable.variables,
       previousData,
       ...obsQueryFields,


### PR DESCRIPTION
As I was playing around with trying to use `observable.getCurrentResult` inside `useSyncExternalStore`, I found a couple places that could use a small bit of improvement. This is the result of those changes which reduces some bundle size in the process.