### PR TITLE
Update persisted query link error handling to match the rest of the client

### DIFF
--- a/.api-reports/api-report-link_error.api.md
+++ b/.api-reports/api-report-link_error.api.md
@@ -13,14 +13,24 @@ import type { Operation } from '@apollo/client/link';
 
 export interface ErrorHandler {
     // (undocumented)
-    (error: ErrorResponse): Observable<FetchResult> | void;
+    (options: ErrorHandlerOptions): Observable<FetchResult> | void;
 }
 
 // @public (undocumented)
 export namespace ErrorLink {
     export interface ErrorHandler {
         // (undocumented)
-        (error: ErrorResponse): Observable<FetchResult> | void;
+        (options: ErrorHandlerOptions): Observable<FetchResult> | void;
+    }
+    // (undocumented)
+    export interface ErrorHandlerOptions {
+        error: ErrorLike;
+        // (undocumented)
+        forward: NextLink;
+        // (undocumented)
+        operation: Operation;
+        // (undocumented)
+        result?: FetchResult;
     }
 }
 
@@ -29,17 +39,6 @@ export class ErrorLink extends ApolloLink {
     constructor(errorHandler: ErrorLink.ErrorHandler);
     // (undocumented)
     request(operation: Operation, forward: NextLink): Observable<FetchResult> | null;
-}
-
-// @public (undocumented)
-export interface ErrorResponse {
-    error: ErrorLike;
-    // (undocumented)
-    forward: NextLink;
-    // (undocumented)
-    operation: Operation;
-    // (undocumented)
-    response?: FetchResult;
 }
 
 // @public (undocumented)

--- a/.api-reports/api-report-link_persisted-queries.api.md
+++ b/.api-reports/api-report-link_persisted-queries.api.md
@@ -7,17 +7,26 @@
 import { ApolloLink } from '@apollo/client/link';
 import type { DocumentNode } from 'graphql';
 import type { ErrorLike } from '@apollo/client';
+import type { FormattedExecutionResult } from 'graphql';
 import type { Operation } from '@apollo/client/link';
 
 // @public (undocumented)
 interface BaseOptions {
     // (undocumented)
-    disable?: (error: ErrorResponse) => boolean;
+    disable?: (error: PersistedQueryLink.DisableFunctionOptions) => boolean;
     // (undocumented)
-    retry?: (error: ErrorResponse) => boolean;
+    retry?: (error: PersistedQueryLink.RetryFunctionOptions) => boolean;
     // (undocumented)
     useGETForHashedQueries?: boolean;
 }
+
+// @public (undocumented)
+type CallbackOptions = {
+    error: ErrorLike;
+    operation: Operation;
+    meta: ErrorMeta;
+    result?: FormattedExecutionResult;
+};
 
 // @public (undocumented)
 export const createPersistedQueryLink: (options: PersistedQueryLink.Options) => ApolloLink & ({
@@ -39,22 +48,12 @@ type ErrorMeta = {
 };
 
 // @public (undocumented)
-export interface ErrorResponse {
-    // (undocumented)
-    error: ErrorLike;
-    // Warning: (ae-forgotten-export) The symbol "ErrorMeta" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
-    meta: ErrorMeta;
-    // (undocumented)
-    operation: Operation;
-}
-
-// @public (undocumented)
 type GenerateHashFunction = (document: DocumentNode) => string | PromiseLike<string>;
 
 // @public (undocumented)
 export namespace PersistedQueryLink {
+    // (undocumented)
+    export type DisableFunctionOptions = CallbackOptions;
     // (undocumented)
     export interface GenerateHashOptions extends BaseOptions {
         // Warning: (ae-forgotten-export) The symbol "GenerateHashFunction" needs to be exported by the entry point index.d.ts
@@ -66,6 +65,10 @@ export namespace PersistedQueryLink {
     }
     // (undocumented)
     export type Options = SHA256Options | GenerateHashOptions;
+    // Warning: (ae-forgotten-export) The symbol "CallbackOptions" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    export type RetryFunctionOptions = CallbackOptions;
     // Warning: (ae-forgotten-export) The symbol "BaseOptions" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
@@ -85,6 +88,10 @@ type SHA256Function = (...args: any[]) => string | PromiseLike<string>;
 
 // @public (undocumented)
 export const VERSION = 1;
+
+// Warnings were encountered during analysis:
+//
+// src/link/persisted-queries/index.ts:37:3 - (ae-forgotten-export) The symbol "ErrorMeta" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report-link_persisted-queries.api.md
+++ b/.api-reports/api-report-link_persisted-queries.api.md
@@ -13,9 +13,9 @@ import type { Operation } from '@apollo/client/link';
 // @public (undocumented)
 interface BaseOptions {
     // (undocumented)
-    disable?: (error: PersistedQueryLink.DisableFunctionOptions) => boolean;
+    disable?: (options: PersistedQueryLink.DisableFunctionOptions) => boolean;
     // (undocumented)
-    retry?: (error: PersistedQueryLink.RetryFunctionOptions) => boolean;
+    retry?: (options: PersistedQueryLink.RetryFunctionOptions) => boolean;
     // (undocumented)
     useGETForHashedQueries?: boolean;
 }

--- a/.api-reports/api-report-link_persisted-queries.api.md
+++ b/.api-reports/api-report-link_persisted-queries.api.md
@@ -6,11 +6,8 @@
 
 import { ApolloLink } from '@apollo/client/link';
 import type { DocumentNode } from 'graphql';
-import type { FormattedExecutionResult } from 'graphql';
-import type { GraphQLFormattedError } from 'graphql';
+import type { ErrorLike } from '@apollo/client';
 import type { Operation } from '@apollo/client/link';
-import type { ServerError } from '@apollo/client/errors';
-import type { ServerParseError } from '@apollo/client/errors';
 
 // @public (undocumented)
 interface BaseOptions {
@@ -44,17 +41,13 @@ type ErrorMeta = {
 // @public (undocumented)
 export interface ErrorResponse {
     // (undocumented)
-    graphQLErrors?: ReadonlyArray<GraphQLFormattedError>;
+    error: ErrorLike;
     // Warning: (ae-forgotten-export) The symbol "ErrorMeta" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
     meta: ErrorMeta;
     // (undocumented)
-    networkError?: Error | ServerParseError | ServerError | null;
-    // (undocumented)
     operation: Operation;
-    // (undocumented)
-    response?: FormattedExecutionResult;
 }
 
 // @public (undocumented)

--- a/.api-reports/api-report-link_persisted-queries.api.md
+++ b/.api-reports/api-report-link_persisted-queries.api.md
@@ -9,6 +9,7 @@ import type { DocumentNode } from 'graphql';
 import type { ErrorLike } from '@apollo/client';
 import type { FormattedExecutionResult } from 'graphql';
 import type { Operation } from '@apollo/client/link';
+import type { Prettify } from '@apollo/client/utilities/internal';
 
 // @public (undocumented)
 interface BaseOptions {
@@ -53,7 +54,7 @@ type GenerateHashFunction = (document: DocumentNode) => string | PromiseLike<str
 // @public (undocumented)
 export namespace PersistedQueryLink {
     // (undocumented)
-    export type DisableFunctionOptions = CallbackOptions;
+    export type DisableFunctionOptions = Prettify<CallbackOptions>;
     // (undocumented)
     export interface GenerateHashOptions extends BaseOptions {
         // Warning: (ae-forgotten-export) The symbol "GenerateHashFunction" needs to be exported by the entry point index.d.ts
@@ -68,7 +69,7 @@ export namespace PersistedQueryLink {
     // Warning: (ae-forgotten-export) The symbol "CallbackOptions" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    export type RetryFunctionOptions = CallbackOptions;
+    export type RetryFunctionOptions = Prettify<CallbackOptions>;
     // Warning: (ae-forgotten-export) The symbol "BaseOptions" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
@@ -91,7 +92,7 @@ export const VERSION = 1;
 
 // Warnings were encountered during analysis:
 //
-// src/link/persisted-queries/index.ts:37:3 - (ae-forgotten-export) The symbol "ErrorMeta" needs to be exported by the entry point index.d.ts
+// src/link/persisted-queries/index.ts:38:3 - (ae-forgotten-export) The symbol "ErrorMeta" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.changeset/sharp-glasses-sneeze.md
+++ b/.changeset/sharp-glasses-sneeze.md
@@ -1,0 +1,39 @@
+---
+"@apollo/client": major
+---
+
+The `ErrorResponse` object passed to the `disable` and `retry` callback options provided to `createPersistedQueryLink` no longer provides separate `graphQLErrors` and `networkError` properties and instead have been combined to a single `error` property of type `ErrorLike`.
+
+
+```diff
+// The following also applies to the retry function since it has the same signature
+createPersistedQueryLink({
+  disable: (errorResponse) => {
+-   if (errorResponse.graphQLErrors) {
++   if (CombinedGraphQLErrors.is(errorResponse.error)) {
+      // ... handle GraphQL errors
+    }
+
+-   if (errorResponse.networkError) {
++   if (errorResponse.error) {
+      // ... handle a NetworkError errors
+    }
+  }
+});
+```
+
+The `response` property has also been removed. To access partial data returned in GraphQL responses, access the `data` property on the `CombinedGraphQLErrors` instance.
+
+```diff
+createPersistedQueryLink({
+  disable: (errorResponse) => {
+-   if (errorResponse.response) {
+-     const data = errorResponse.response.data;
++   if (CombinedGraphQLErrors.is(errorResponse.error)) {
++     const data = errorResponse.error.data;
+
+      // ... handle GraphQL errors
+    }
+  }
+});
+```

--- a/.changeset/sharp-glasses-sneeze.md
+++ b/.changeset/sharp-glasses-sneeze.md
@@ -34,7 +34,6 @@ The `response` property has also been renamed to `result`.
 createPersistedQueryLink({
 -  disable: ({ response }) => {
 +  disable: ({ result }) => {
-
       // ... handle GraphQL errors
     }
   }

--- a/.changeset/sharp-glasses-sneeze.md
+++ b/.changeset/sharp-glasses-sneeze.md
@@ -28,15 +28,12 @@ createPersistedQueryLink({
 });
 ```
 
-The `response` property has also been removed. To access partial data returned in GraphQL responses, access the `data` property on the `CombinedGraphQLErrors` instance.
+The `response` property has also been renamed to `result`.
 
 ```diff
 createPersistedQueryLink({
-  disable: (errorResponse) => {
--   if (errorResponse.response) {
--     const data = errorResponse.response.data;
-+   if (CombinedGraphQLErrors.is(errorResponse.error)) {
-+     const data = errorResponse.error.data;
+-  disable: ({ response }) => {
++  disable: ({ result }) => {
 
       // ... handle GraphQL errors
     }

--- a/.changeset/sharp-glasses-sneeze.md
+++ b/.changeset/sharp-glasses-sneeze.md
@@ -6,19 +6,25 @@ The `ErrorResponse` object passed to the `disable` and `retry` callback options 
 
 
 ```diff
-// The following also applies to the retry function since it has the same signature
+// The following also applies to the `retry` function since it has the same signature
 createPersistedQueryLink({
-  disable: (errorResponse) => {
--   if (errorResponse.graphQLErrors) {
-+   if (CombinedGraphQLErrors.is(errorResponse.error)) {
+- disable: ({ graphQLErrors, networkError }) => {
++ disable: ({ error }) => {
+-   if (graphQLErrors) {
++   if (CombinedGraphQLErrors.is(error)) {
       // ... handle GraphQL errors
     }
 
--   if (errorResponse.networkError) {
-+   if (errorResponse.error) {
-      // ... handle a NetworkError errors
+-   if (networkError) {
++   if (error) {
+      // ... handle link errors
     }
-  }
+
+    // optionally check for a specific kind of error
+-   if (networkError) {
++   if (ServerError.is(error)) {
+      // ... handle a server error
+    }
 });
 ```
 

--- a/.changeset/stupid-paws-jam.md
+++ b/.changeset/stupid-paws-jam.md
@@ -1,0 +1,12 @@
+---
+"@apollo/client": major
+---
+
+The `response` property in `onError` link has been renamed to `result`.
+
+```diff
+- onError(({ response }) => {
++ onError(({ result }) => {
+    // ...
+});
+```

--- a/src/link/error/__tests__/index.ts
+++ b/src/link/error/__tests__/index.ts
@@ -47,7 +47,7 @@ describe("error handling", () => {
     expect(callback).toHaveBeenLastCalledWith({
       forward: expect.any(Function),
       operation: expect.objectContaining({ query, variables: {} }),
-      response: { errors: [error] },
+      result: { errors: [error] },
       error: new CombinedGraphQLErrors({ errors: [error] }),
     });
   });
@@ -331,7 +331,7 @@ describe("error handling", () => {
         operationName: "MySubscription",
         variables: {},
       }),
-      response: {
+      result: {
         extensions: {
           [PROTOCOL_ERRORS_SYMBOL]: new CombinedProtocolErrors([
             {
@@ -464,10 +464,10 @@ describe("error handling", () => {
       }
     `;
 
-    const errorLink = onError(({ response }) => {
+    const errorLink = onError(({ result }) => {
       // ignore errors
-      if (isFormattedExecutionResult(response)) {
-        delete response!.errors;
+      if (isFormattedExecutionResult(result)) {
+        delete result!.errors;
       }
     });
 
@@ -556,7 +556,7 @@ describe("error handling", () => {
         operationName: "Foo",
         variables: {},
       }),
-      response: { data: { foo: true }, errors: [error] },
+      result: { data: { foo: true }, errors: [error] },
       error: new CombinedGraphQLErrors({
         data: { foo: true },
         errors: [error],
@@ -593,7 +593,7 @@ describe("error handling with class", () => {
     expect(callback).toHaveBeenLastCalledWith({
       forward: expect.any(Function),
       operation: expect.objectContaining({ query, variables: {} }),
-      response: { errors: [error] },
+      result: { errors: [error] },
       error: new CombinedGraphQLErrors({ errors: [error] }),
     });
   });
@@ -683,7 +683,7 @@ describe("error handling with class", () => {
         operationName: "MySubscription",
         variables: {},
       }),
-      response: {
+      result: {
         extensions: {
           [PROTOCOL_ERRORS_SYMBOL]: new CombinedProtocolErrors([
             {

--- a/src/link/error/index.ts
+++ b/src/link/error/index.ts
@@ -11,22 +11,22 @@ import {
 import type { FetchResult, NextLink, Operation } from "@apollo/client/link";
 import { ApolloLink } from "@apollo/client/link";
 
-export interface ErrorResponse {
-  /**
-   * Error that caused the callback to be triggered.
-   */
-  error: ErrorLike;
-  response?: FetchResult;
-  operation: Operation;
-  forward: NextLink;
-}
-
 export namespace ErrorLink {
   /**
    * Callback to be triggered when an error occurs within the link stack.
    */
   export interface ErrorHandler {
-    (error: ErrorResponse): Observable<FetchResult> | void;
+    (error: ErrorHandlerOptions): Observable<FetchResult> | void;
+  }
+
+  export interface ErrorHandlerOptions {
+    /**
+     * Error that caused the callback to be triggered.
+     */
+    error: ErrorLike;
+    result?: FetchResult;
+    operation: Operation;
+    forward: NextLink;
   }
 }
 
@@ -51,14 +51,14 @@ export function onError(errorHandler: ErrorHandler): ApolloLink {
             if (errors) {
               retriedResult = errorHandler({
                 error: new CombinedGraphQLErrors(result, errors),
-                response: result,
+                result,
                 operation,
                 forward,
               });
             } else if (graphQLResultHasProtocolErrors(result)) {
               retriedResult = errorHandler({
                 error: result.extensions[PROTOCOL_ERRORS_SYMBOL],
-                response: result,
+                result,
                 operation,
                 forward,
               });

--- a/src/link/error/index.ts
+++ b/src/link/error/index.ts
@@ -16,7 +16,7 @@ export namespace ErrorLink {
    * Callback to be triggered when an error occurs within the link stack.
    */
   export interface ErrorHandler {
-    (error: ErrorHandlerOptions): Observable<FetchResult> | void;
+    (options: ErrorHandlerOptions): Observable<FetchResult> | void;
   }
 
   export interface ErrorHandlerOptions {

--- a/src/link/persisted-queries/__tests__/persisted-queries.test.ts
+++ b/src/link/persisted-queries/__tests__/persisted-queries.test.ts
@@ -348,12 +348,7 @@ describe("failure path", () => {
         createHttpLink()
       );
 
-      const stream = new ObservableStream(
-        execute(link, {
-          query,
-          variables,
-        }) as Observable<FormattedExecutionResult>
-      );
+      const stream = new ObservableStream(execute(link, { query, variables }));
 
       await expect(stream).toEmitTypedValue({ data });
 

--- a/src/link/persisted-queries/__tests__/persisted-queries.test.ts
+++ b/src/link/persisted-queries/__tests__/persisted-queries.test.ts
@@ -1015,7 +1015,6 @@ test("calls `disable` with error emitted from link chain", async () => {
       },
     },
     error: new Error("Something went wrong"),
-    response: undefined,
     meta: {
       persistedQueryNotFound: false,
       persistedQueryNotSupported: false,
@@ -1057,7 +1056,6 @@ test("calls `disable` with ServerError when response has non-2xx status code", a
       },
     },
     error: serverError,
-    response: undefined,
     meta: {
       persistedQueryNotFound: false,
       persistedQueryNotSupported: false,
@@ -1095,9 +1093,6 @@ test("calls `disable` with GraphQL errors when returned in response", async () =
     error: new CombinedGraphQLErrors({
       errors: [{ message: "Something went wrong" }],
     }),
-    response: {
-      errors: [{ message: "Something went wrong" }],
-    },
     meta: {
       persistedQueryNotFound: false,
       persistedQueryNotSupported: false,
@@ -1146,7 +1141,6 @@ test("calls `disable` with GraphQL errors when parsed from non-2xx response", as
     error: new CombinedGraphQLErrors({
       errors: [{ message: "Something went wrong" }],
     }),
-    response: undefined,
     meta: {
       persistedQueryNotFound: false,
       persistedQueryNotSupported: false,
@@ -1366,7 +1360,6 @@ test("calls `retry` with error emitted from link chain", async () => {
       },
     },
     error: new Error("Something went wrong"),
-    response: undefined,
     meta: {
       persistedQueryNotFound: false,
       persistedQueryNotSupported: false,
@@ -1408,7 +1401,6 @@ test("calls `retry` with ServerError when response has non-2xx status code", asy
       },
     },
     error: serverError,
-    response: undefined,
     meta: {
       persistedQueryNotFound: false,
       persistedQueryNotSupported: false,
@@ -1446,9 +1438,6 @@ test("calls `retry` with GraphQL errors when returned in response", async () => 
     error: new CombinedGraphQLErrors({
       errors: [{ message: "Something went wrong" }],
     }),
-    response: {
-      errors: [{ message: "Something went wrong" }],
-    },
     meta: {
       persistedQueryNotFound: false,
       persistedQueryNotSupported: false,
@@ -1497,7 +1486,6 @@ test("calls `retry` with GraphQL errors when parsed from non-2xx response", asyn
     error: new CombinedGraphQLErrors({
       errors: [{ message: "Something went wrong" }],
     }),
-    response: undefined,
     meta: {
       persistedQueryNotFound: false,
       persistedQueryNotSupported: false,

--- a/src/link/persisted-queries/__tests__/persisted-queries.test.ts
+++ b/src/link/persisted-queries/__tests__/persisted-queries.test.ts
@@ -7,7 +7,7 @@ import { gql } from "graphql-tag";
 import { times } from "lodash";
 import { firstValueFrom, Observable, of, throwError } from "rxjs";
 
-import { ServerError, version } from "@apollo/client";
+import { CombinedGraphQLErrors, ServerError, version } from "@apollo/client";
 import { ApolloLink } from "@apollo/client/link";
 import { createHttpLink } from "@apollo/client/link/http";
 import {
@@ -1014,8 +1014,7 @@ test("calls `disable` with error emitted from link chain", async () => {
         persistedQuery: { version: VERSION, sha256Hash: sha256(queryString) },
       },
     },
-    networkError: new Error("Something went wrong"),
-    graphQLErrors: undefined,
+    error: new Error("Something went wrong"),
     response: undefined,
     meta: {
       persistedQueryNotFound: false,
@@ -1057,8 +1056,7 @@ test("calls `disable` with ServerError when response has non-2xx status code", a
         persistedQuery: { version: VERSION, sha256Hash: sha256(queryString) },
       },
     },
-    networkError: serverError,
-    graphQLErrors: undefined,
+    error: serverError,
     response: undefined,
     meta: {
       persistedQueryNotFound: false,
@@ -1094,8 +1092,9 @@ test("calls `disable` with GraphQL errors when returned in response", async () =
         persistedQuery: { version: VERSION, sha256Hash: sha256(queryString) },
       },
     },
-    networkError: undefined,
-    graphQLErrors: [{ message: "Something went wrong" }],
+    error: new CombinedGraphQLErrors({
+      errors: [{ message: "Something went wrong" }],
+    }),
     response: {
       errors: [{ message: "Something went wrong" }],
     },
@@ -1144,8 +1143,9 @@ test("calls `disable` with GraphQL errors when parsed from non-2xx response", as
         persistedQuery: { version: VERSION, sha256Hash: sha256(queryString) },
       },
     },
-    networkError: serverError,
-    graphQLErrors: [{ message: "Something went wrong" }],
+    error: new CombinedGraphQLErrors({
+      errors: [{ message: "Something went wrong" }],
+    }),
     response: undefined,
     meta: {
       persistedQueryNotFound: false,
@@ -1365,8 +1365,7 @@ test("calls `retry` with error emitted from link chain", async () => {
         persistedQuery: { version: VERSION, sha256Hash: sha256(queryString) },
       },
     },
-    networkError: new Error("Something went wrong"),
-    graphQLErrors: undefined,
+    error: new Error("Something went wrong"),
     response: undefined,
     meta: {
       persistedQueryNotFound: false,
@@ -1408,8 +1407,7 @@ test("calls `retry` with ServerError when response has non-2xx status code", asy
         persistedQuery: { version: VERSION, sha256Hash: sha256(queryString) },
       },
     },
-    networkError: serverError,
-    graphQLErrors: undefined,
+    error: serverError,
     response: undefined,
     meta: {
       persistedQueryNotFound: false,
@@ -1445,8 +1443,9 @@ test("calls `retry` with GraphQL errors when returned in response", async () => 
         persistedQuery: { version: VERSION, sha256Hash: sha256(queryString) },
       },
     },
-    networkError: undefined,
-    graphQLErrors: [{ message: "Something went wrong" }],
+    error: new CombinedGraphQLErrors({
+      errors: [{ message: "Something went wrong" }],
+    }),
     response: {
       errors: [{ message: "Something went wrong" }],
     },
@@ -1495,8 +1494,9 @@ test("calls `retry` with GraphQL errors when parsed from non-2xx response", asyn
         persistedQuery: { version: VERSION, sha256Hash: sha256(queryString) },
       },
     },
-    networkError: serverError,
-    graphQLErrors: [{ message: "Something went wrong" }],
+    error: new CombinedGraphQLErrors({
+      errors: [{ message: "Something went wrong" }],
+    }),
     response: undefined,
     meta: {
       persistedQueryNotFound: false,

--- a/src/link/persisted-queries/__tests__/persisted-queries.test.ts
+++ b/src/link/persisted-queries/__tests__/persisted-queries.test.ts
@@ -1148,6 +1148,9 @@ test("calls `disable` with GraphQL errors when parsed from non-2xx response", as
       persistedQueryNotFound: false,
       persistedQueryNotSupported: false,
     },
+    result: {
+      errors: [{ message: "Something went wrong" }],
+    },
   });
 });
 
@@ -1495,6 +1498,9 @@ test("calls `retry` with GraphQL errors when parsed from non-2xx response", asyn
     meta: {
       persistedQueryNotFound: false,
       persistedQueryNotSupported: false,
+    },
+    result: {
+      errors: [{ message: "Something went wrong" }],
     },
   });
 });

--- a/src/link/persisted-queries/__tests__/persisted-queries.test.ts
+++ b/src/link/persisted-queries/__tests__/persisted-queries.test.ts
@@ -1153,3 +1153,286 @@ test("calls `disable` with GraphQL errors when parsed from non-2xx response", as
     },
   });
 });
+
+test("retries when `retry` returns true", async () => {
+  const fetch = jest.fn(async () => Response.json({ data }));
+
+  fetch.mockImplementationOnce(async () =>
+    Promise.resolve(
+      Response.json(
+        {
+          errors: [
+            {
+              message: "Not found",
+              extensions: {
+                code: "PERSISTED_QUERY_NOT_FOUND",
+              },
+            },
+          ],
+        },
+        { status: 500 }
+      )
+    )
+  );
+
+  const link = createPersistedQueryLink({
+    sha256,
+    retry: () => true,
+  }).concat(createHttpLink({ fetch }));
+
+  const stream = new ObservableStream(execute(link, { query, variables }));
+
+  await expect(stream).toEmitTypedValue({ data });
+
+  expect(fetch).toHaveBeenCalledTimes(2);
+  expect(fetch).toHaveBeenNthCalledWith(
+    1,
+    "/graphql",
+    expect.objectContaining({
+      body: JSON.stringify({
+        operationName: "Test",
+        variables,
+        extensions: {
+          clientLibrary: { name: "@apollo/client", version },
+          persistedQuery: {
+            version: VERSION,
+            sha256Hash: sha256(queryString),
+          },
+        },
+      }),
+    })
+  );
+  expect(fetch).toHaveBeenNthCalledWith(
+    2,
+    "/graphql",
+    expect.objectContaining({
+      body: JSON.stringify({
+        operationName: "Test",
+        variables,
+        extensions: {
+          clientLibrary: { name: "@apollo/client", version },
+          persistedQuery: {
+            version: VERSION,
+            sha256Hash: sha256(queryString),
+          },
+        },
+        query: queryString,
+      }),
+    })
+  );
+});
+
+test("does not retry when `retry` returns false", async () => {
+  const fetch = jest.fn(async () =>
+    Response.json({
+      errors: [
+        {
+          message: "Not found",
+          extensions: {
+            code: "PERSISTED_QUERY_NOT_FOUND",
+          },
+        },
+      ],
+    })
+  );
+
+  const link = createPersistedQueryLink({
+    sha256,
+    retry: () => false,
+  }).concat(createHttpLink({ fetch }));
+
+  const stream = new ObservableStream(execute(link, { query, variables }));
+
+  await expect(stream).toEmitTypedValue({
+    errors: [
+      {
+        message: "Not found",
+        extensions: { code: "PERSISTED_QUERY_NOT_FOUND" },
+      },
+    ],
+  });
+
+  expect(fetch).toHaveBeenCalledTimes(1);
+  expect(fetch).toHaveBeenNthCalledWith(
+    1,
+    "/graphql",
+    expect.objectContaining({
+      body: JSON.stringify({
+        operationName: "Test",
+        variables,
+        extensions: {
+          clientLibrary: { name: "@apollo/client", version },
+          persistedQuery: {
+            version: VERSION,
+            sha256Hash: sha256(queryString),
+          },
+        },
+      }),
+    })
+  );
+});
+
+test("calls `retry` with error emitted from link chain", async () => {
+  const terminatingLink = new ApolloLink(() => {
+    return throwError(() => new Error("Something went wrong"));
+  });
+
+  const retry = jest.fn(() => false);
+
+  const link = createPersistedQueryLink({ sha256, retry }).concat(
+    terminatingLink
+  );
+
+  const stream = new ObservableStream(execute(link, { query, variables }));
+
+  await expect(stream).toEmitError(new Error("Something went wrong"));
+
+  expect(retry).toHaveBeenCalledTimes(1);
+  expect(retry).toHaveBeenCalledWith({
+    operation: {
+      query,
+      variables,
+      operationName: "Test",
+      extensions: {
+        persistedQuery: { version: VERSION, sha256Hash: sha256(queryString) },
+      },
+    },
+    networkError: new Error("Something went wrong"),
+    graphQLErrors: undefined,
+    response: undefined,
+    meta: {
+      persistedQueryNotFound: false,
+      persistedQueryNotSupported: false,
+    },
+  });
+});
+
+test("calls `retry` with ServerError when response has non-2xx status code", async () => {
+  const response = new Response("Something went wrong", { status: 500 });
+  const fetch = jest.fn(async () => response);
+
+  const retry = jest.fn(() => false);
+
+  const link = createPersistedQueryLink({ sha256, retry }).concat(
+    createHttpLink({ fetch })
+  );
+
+  const stream = new ObservableStream(execute(link, { query, variables }));
+
+  const serverError = new ServerError(
+    "Response not successful: Received status code 500",
+    {
+      response,
+      bodyText: "Something went wrong",
+    }
+  );
+
+  await expect(stream).toEmitError(serverError);
+
+  expect(retry).toHaveBeenCalledTimes(1);
+  expect(retry).toHaveBeenCalledWith({
+    operation: {
+      query,
+      variables,
+      operationName: "Test",
+      extensions: {
+        clientLibrary: { name: "@apollo/client", version },
+        persistedQuery: { version: VERSION, sha256Hash: sha256(queryString) },
+      },
+    },
+    networkError: serverError,
+    graphQLErrors: undefined,
+    response: undefined,
+    meta: {
+      persistedQueryNotFound: false,
+      persistedQueryNotSupported: false,
+    },
+  });
+});
+
+test("calls `retry` with GraphQL errors when returned in response", async () => {
+  const terminatingLink = new ApolloLink(() => {
+    return of({ errors: [{ message: "Something went wrong" }] });
+  });
+
+  const retry = jest.fn(() => false);
+
+  const link = createPersistedQueryLink({ sha256, retry }).concat(
+    terminatingLink
+  );
+
+  const stream = new ObservableStream(execute(link, { query, variables }));
+
+  await expect(stream).toEmitTypedValue({
+    errors: [{ message: "Something went wrong" }],
+  });
+
+  expect(retry).toHaveBeenCalledTimes(1);
+  expect(retry).toHaveBeenCalledWith({
+    operation: {
+      query,
+      variables,
+      operationName: "Test",
+      extensions: {
+        persistedQuery: { version: VERSION, sha256Hash: sha256(queryString) },
+      },
+    },
+    networkError: undefined,
+    graphQLErrors: [{ message: "Something went wrong" }],
+    response: {
+      errors: [{ message: "Something went wrong" }],
+    },
+    meta: {
+      persistedQueryNotFound: false,
+      persistedQueryNotSupported: false,
+    },
+  });
+});
+
+test("calls `retry` with GraphQL errors when parsed from non-2xx response", async () => {
+  const response = Response.json(
+    { errors: [{ message: "Something went wrong" }] },
+    { status: 500 }
+  );
+  const fetch = jest.fn(async () => response);
+
+  const retry = jest.fn(() => false);
+
+  const link = createPersistedQueryLink({ sha256, retry }).concat(
+    createHttpLink({ fetch })
+  );
+
+  const stream = new ObservableStream(execute(link, { query, variables }));
+
+  const serverError = new ServerError(
+    "Response not successful: Received status code 500",
+    {
+      response,
+      bodyText: JSON.stringify({
+        errors: [{ message: "Something went wrong" }],
+      }),
+    }
+  );
+
+  await expect(stream).toEmitError(serverError);
+
+  expect(retry).toHaveBeenCalledTimes(1);
+  expect(retry).toHaveBeenCalledWith({
+    operation: {
+      query,
+      variables,
+      operationName: "Test",
+      extensions: {
+        clientLibrary: { name: "@apollo/client", version },
+        persistedQuery: { version: VERSION, sha256Hash: sha256(queryString) },
+      },
+    },
+    networkError: serverError,
+    graphQLErrors: [{ message: "Something went wrong" }],
+    response: undefined,
+    meta: {
+      persistedQueryNotFound: false,
+      persistedQueryNotSupported: false,
+    },
+  });
+});

--- a/src/link/persisted-queries/__tests__/persisted-queries.test.ts
+++ b/src/link/persisted-queries/__tests__/persisted-queries.test.ts
@@ -11,7 +11,7 @@ import { version } from "@apollo/client";
 import { ApolloLink } from "@apollo/client/link";
 import { createHttpLink } from "@apollo/client/link/http";
 import {
-  createPersistedQueryLink as createPersistedQuery,
+  createPersistedQueryLink,
   VERSION,
 } from "@apollo/client/link/persisted-queries";
 import {
@@ -92,7 +92,7 @@ describe("happy path", () => {
       "/graphql",
       () => new Promise((resolve) => resolve({ body: response }))
     );
-    const link = createPersistedQuery({ sha256 }).concat(createHttpLink());
+    const link = createPersistedQueryLink({ sha256 }).concat(createHttpLink());
     const observable = execute(link, { query, variables });
     const stream = new ObservableStream(observable);
 
@@ -124,7 +124,7 @@ describe("happy path", () => {
       "/graphql",
       () => new Promise((resolve) => resolve({ body: response }))
     );
-    const link = createPersistedQuery({ sha256 }).concat(createHttpLink());
+    const link = createPersistedQueryLink({ sha256 }).concat(createHttpLink());
     const observable = execute(link, { query, variables });
     const stream = new ObservableStream(observable);
 
@@ -149,7 +149,7 @@ describe("happy path", () => {
       { repeat: 1 }
     );
     const hashSpy = jest.fn(sha256);
-    const link = createPersistedQuery({ sha256: hashSpy }).concat(
+    const link = createPersistedQueryLink({ sha256: hashSpy }).concat(
       createHttpLink()
     );
 
@@ -185,7 +185,7 @@ describe("happy path", () => {
       hashRefs.push(new WeakRef(newHash));
       return newHash as string;
     }
-    const persistedLink = createPersistedQuery({ sha256: hash });
+    const persistedLink = createPersistedQueryLink({ sha256: hash });
     await new Promise<void>((complete) =>
       execute(persistedLink.concat(createHttpLink()), {
         query,
@@ -204,7 +204,7 @@ describe("happy path", () => {
       () => new Promise((resolve) => resolve({ body: response }))
     );
     const generateHash = (query: any) => Promise.resolve("foo");
-    const link = createPersistedQuery({ generateHash }).concat(
+    const link = createPersistedQueryLink({ generateHash }).concat(
       createHttpLink()
     );
 
@@ -225,7 +225,7 @@ describe("happy path", () => {
       "/graphql",
       () => new Promise((resolve) => resolve({ body: response }))
     );
-    const link = createPersistedQuery({ sha256 }).concat(createHttpLink());
+    const link = createPersistedQueryLink({ sha256 }).concat(createHttpLink());
 
     const observable = execute(link, { query: "1234", variables } as any);
     const stream = new ObservableStream(observable);
@@ -244,7 +244,7 @@ describe("happy path", () => {
         }, 100);
       });
     });
-    const link = createPersistedQuery({ sha256 }).concat(delay);
+    const link = createPersistedQueryLink({ sha256 }).concat(delay);
 
     const observable = execute(link, { query, variables });
     const stream = new ObservableStream(observable);
@@ -257,7 +257,7 @@ describe("happy path", () => {
   });
 
   it("should error if `sha256` and `generateHash` options are both missing", async () => {
-    const createPersistedQueryFn = createPersistedQuery as any;
+    const createPersistedQueryFn = createPersistedQueryLink as any;
 
     expect(() => createPersistedQueryFn()).toThrow(
       'Missing/invalid "sha256" or "generateHash" function'
@@ -267,7 +267,7 @@ describe("happy path", () => {
   it.each(["sha256", "generateHash"])(
     "should error if `%s` option is not a function",
     async (option) => {
-      const createPersistedQueryFn = createPersistedQuery as any;
+      const createPersistedQueryFn = createPersistedQueryLink as any;
 
       expect(() => createPersistedQueryFn({ [option]: "ooops" })).toThrow(
         'Missing/invalid "sha256" or "generateHash" function'
@@ -283,7 +283,7 @@ describe("happy path", () => {
       "/graphql",
       () => new Promise((resolve) => resolve({ body: response }))
     );
-    const link = createPersistedQuery({
+    const link = createPersistedQueryLink({
       sha256(data) {
         return crypto.createHmac("sha256", data).digest("hex");
       },
@@ -345,7 +345,9 @@ describe("failure path", () => {
           () => new Promise((resolve) => resolve({ body: response })),
           { repeat: 1 }
         );
-        const link = createPersistedQuery({ sha256 }).concat(createHttpLink());
+        const link = createPersistedQueryLink({ sha256 }).concat(
+          createHttpLink()
+        );
         (
           execute(link, {
             query,
@@ -390,7 +392,7 @@ describe("failure path", () => {
       "/graphql",
       () => new Promise((resolve) => resolve({ body: response }))
     );
-    const link = createPersistedQuery({
+    const link = createPersistedQueryLink({
       sha256,
       useGETForHashedQueries: true,
     }).concat(createHttpLink());
@@ -424,7 +426,7 @@ describe("failure path", () => {
       () => new Promise((resolve) => resolve({ body: response })),
       { repeat: 1 }
     );
-    const link = createPersistedQuery({ sha256 }).concat(createHttpLink());
+    const link = createPersistedQueryLink({ sha256 }).concat(createHttpLink());
     const observable = execute(link, { query, variables });
     const stream = new ObservableStream(observable);
 
@@ -480,7 +482,7 @@ describe("failure path", () => {
       () => new Promise((resolve) => resolve({ body: response })),
       { repeat: 1 }
     );
-    const link = createPersistedQuery({
+    const link = createPersistedQueryLink({
       sha256,
       disable({ operation }) {
         operation.setContext({
@@ -553,7 +555,9 @@ describe("failure path", () => {
           () => new Promise((resolve) => resolve({ body: response })),
           { repeat: 1 }
         );
-        const link = createPersistedQuery({ sha256 }).concat(createHttpLink());
+        const link = createPersistedQueryLink({ sha256 }).concat(
+          createHttpLink()
+        );
 
         (
           execute(link, {
@@ -620,7 +624,7 @@ describe("failure path", () => {
         hashRefs.push(new WeakRef(newHash));
         return newHash as string;
       }
-      const persistedLink = createPersistedQuery({ sha256: hash });
+      const persistedLink = createPersistedQueryLink({ sha256: hash });
       await new Promise<void>((complete) =>
         execute(persistedLink.concat(createHttpLink()), {
           query,
@@ -647,7 +651,7 @@ describe("failure path", () => {
       () => new Promise((resolve) => resolve({ body: response })),
       { repeat: 1 }
     );
-    const link = createPersistedQuery({ sha256 }).concat(createHttpLink());
+    const link = createPersistedQueryLink({ sha256 }).concat(createHttpLink());
     const observable = execute(link, { query, variables });
     const stream = new ObservableStream(observable);
 
@@ -690,7 +694,7 @@ describe("failure path", () => {
         // @ts-expect-error
         return global.fetch.apply(null, args);
       };
-      const link = createPersistedQuery({ sha256 }).concat(
+      const link = createPersistedQueryLink({ sha256 }).concat(
         createHttpLink({ fetch: fetcher } as any)
       );
 
@@ -748,7 +752,7 @@ describe("failure path", () => {
         // @ts-expect-error
         return global.fetch.apply(null, args);
       };
-      const link = createPersistedQuery({ sha256 }).concat(
+      const link = createPersistedQueryLink({ sha256 }).concat(
         createHttpLink({ fetch: fetcher } as any)
       );
 
@@ -787,7 +791,7 @@ describe("failure path", () => {
         return global.fetch.apply(null, args);
       };
 
-      const link = createPersistedQuery({ sha256 }).concat(
+      const link = createPersistedQueryLink({ sha256 }).concat(
         createHttpLink({ fetch: fetcher } as any)
       );
 

--- a/src/link/persisted-queries/__tests__/persisted-queries.test.ts
+++ b/src/link/persisted-queries/__tests__/persisted-queries.test.ts
@@ -1,7 +1,6 @@
 import crypto from "crypto";
 
 import fetchMock from "fetch-mock";
-import type { FormattedExecutionResult } from "graphql";
 import { print } from "graphql";
 import { gql } from "graphql-tag";
 import { times } from "lodash";

--- a/src/link/persisted-queries/__tests__/persisted-queries.test.ts
+++ b/src/link/persisted-queries/__tests__/persisted-queries.test.ts
@@ -1097,6 +1097,9 @@ test("calls `disable` with GraphQL errors when returned in response", async () =
       persistedQueryNotFound: false,
       persistedQueryNotSupported: false,
     },
+    result: {
+      errors: [{ message: "Something went wrong" }],
+    },
   });
 });
 
@@ -1441,6 +1444,9 @@ test("calls `retry` with GraphQL errors when returned in response", async () => 
     meta: {
       persistedQueryNotFound: false,
       persistedQueryNotSupported: false,
+    },
+    result: {
+      errors: [{ message: "Something went wrong" }],
     },
   });
 });

--- a/src/link/persisted-queries/__tests__/react.test.tsx
+++ b/src/link/persisted-queries/__tests__/react.test.tsx
@@ -12,7 +12,7 @@ import { ApolloClient, version } from "@apollo/client";
 import { InMemoryCache as Cache } from "@apollo/client/cache";
 import { createHttpLink } from "@apollo/client/link/http";
 import {
-  createPersistedQueryLink as createPersistedQuery,
+  createPersistedQueryLink,
   VERSION,
 } from "@apollo/client/link/persisted-queries";
 import { ApolloProvider, useQuery } from "@apollo/client/react";
@@ -85,7 +85,7 @@ describe("react application", () => {
       { repeat: 1 }
     );
 
-    const link = createPersistedQuery({ sha256 }).concat(createHttpLink());
+    const link = createPersistedQueryLink({ sha256 }).concat(createHttpLink());
 
     const client = new ApolloClient({
       link,

--- a/src/link/persisted-queries/index.ts
+++ b/src/link/persisted-queries/index.ts
@@ -273,20 +273,13 @@ export const createPersistedQueryLink = (
             return cb();
           }
 
-          const graphQLErrors: GraphQLFormattedError[] = [];
-
-          const responseErrors = response.errors;
-          if (isNonEmptyArray(responseErrors)) {
-            graphQLErrors.push(...responseErrors);
-          }
-
           handleRetry(
             {
               response,
               operation,
               graphQLErrors:
-                isNonEmptyArray(graphQLErrors) ? graphQLErrors : void 0,
-              meta: processErrors(graphQLErrors),
+                isNonEmptyArray(response.errors) ? response.errors : void 0,
+              meta: processErrors(response.errors),
             },
             cb
           );

--- a/src/link/persisted-queries/index.ts
+++ b/src/link/persisted-queries/index.ts
@@ -176,7 +176,7 @@ export const createPersistedQueryLink = (
       const { query } = operation;
 
       return new Observable((observer: Observer<FetchResult>) => {
-        let subscription: Subscription;
+        let subscription: Subscription | undefined;
         let retried = false;
         let originalFetchOptions: any;
         let setFetchOptions = false;

--- a/src/link/persisted-queries/index.ts
+++ b/src/link/persisted-queries/index.ts
@@ -35,6 +35,7 @@ type CallbackOptions = {
   error: ErrorLike;
   operation: Operation;
   meta: ErrorMeta;
+  result?: FormattedExecutionResult;
 };
 
 type ErrorMeta = {
@@ -230,18 +231,19 @@ export const createPersistedQueryLink = (
         }
 
         const handler: Observer<FetchResult> = {
-          next: (response) => {
-            if (!isFormattedExecutionResult(response) || !response.errors) {
-              return observer.next(response);
+          next: (result) => {
+            if (!isFormattedExecutionResult(result) || !result.errors) {
+              return observer.next(result);
             }
 
             handleRetry(
               {
                 operation,
-                error: new CombinedGraphQLErrors(response),
-                meta: processErrors(response.errors),
+                error: new CombinedGraphQLErrors(result),
+                meta: processErrors(result.errors),
+                result,
               },
-              () => observer.next(response)
+              () => observer.next(result)
             );
           },
           error: (error) => {

--- a/src/link/persisted-queries/index.ts
+++ b/src/link/persisted-queries/index.ts
@@ -20,6 +20,7 @@ import {
   isFormattedExecutionResult,
 } from "@apollo/client/utilities";
 import { __DEV__ } from "@apollo/client/utilities/environment";
+import type { Prettify } from "@apollo/client/utilities/internal";
 import {
   AutoCleanedWeakCache,
   compact,
@@ -67,8 +68,8 @@ export namespace PersistedQueryLink {
 
   export type Options = SHA256Options | GenerateHashOptions;
 
-  export type RetryFunctionOptions = CallbackOptions;
-  export type DisableFunctionOptions = CallbackOptions;
+  export type RetryFunctionOptions = Prettify<CallbackOptions>;
+  export type DisableFunctionOptions = Prettify<CallbackOptions>;
 }
 
 function processErrors(

--- a/src/link/persisted-queries/index.ts
+++ b/src/link/persisted-queries/index.ts
@@ -183,6 +183,12 @@ export const createPersistedQueryLink = (
         let setFetchOptions = false;
 
         function handleRetry(errorResponse: ErrorResponse, cb: () => void) {
+          if (retried) {
+            return cb();
+          }
+
+          retried = true;
+
           // if the server doesn't support persisted queries, don't try anymore
           enabled = !disable(errorResponse);
           if (!enabled) {
@@ -223,12 +229,6 @@ export const createPersistedQueryLink = (
           networkError: ErrorLike,
           cb: () => void
         ) {
-          if (retried) {
-            return cb();
-          }
-
-          retried = true;
-
           const graphQLErrors: GraphQLFormattedError[] = [];
 
           // This is persisted-query specific (see #9410) and deviates from the
@@ -269,11 +269,9 @@ export const createPersistedQueryLink = (
             response = undefined;
           }
 
-          if (!response?.errors || retried) {
+          if (!response?.errors) {
             return cb();
           }
-
-          retried = true;
 
           const graphQLErrors: GraphQLFormattedError[] = [];
 

--- a/src/link/persisted-queries/index.ts
+++ b/src/link/persisted-queries/index.ts
@@ -6,7 +6,6 @@ import type {
 import type { Observer, Subscription } from "rxjs";
 import { Observable } from "rxjs";
 
-import type { ErrorLike } from "@apollo/client";
 import type { ServerParseError } from "@apollo/client/errors";
 import { ServerError, toErrorLike } from "@apollo/client/errors";
 import type { FetchResult, Operation } from "@apollo/client/link";
@@ -225,8 +224,8 @@ export const createPersistedQueryLink = (
           cb();
         }
 
-        const handler = {
-          next: (response: FetchResult) => {
+        const handler: Observer<FetchResult> = {
+          next: (response) => {
             if (!isFormattedExecutionResult(response)) {
               // if the response is not an expected format, we ignore it.
               // Network errors will still be handled correctly,
@@ -249,7 +248,7 @@ export const createPersistedQueryLink = (
               () => observer.next(response)
             );
           },
-          error: (error: unknown) => {
+          error: (error) => {
             const networkError = toErrorLike(error);
             let graphQLErrors: GraphQLFormattedError[] = [];
 

--- a/src/link/persisted-queries/index.ts
+++ b/src/link/persisted-queries/index.ts
@@ -33,7 +33,6 @@ export const VERSION = 1;
 
 export interface ErrorResponse {
   error: ErrorLike;
-  response?: FormattedExecutionResult;
   operation: Operation;
   meta: ErrorMeta;
 }
@@ -242,7 +241,6 @@ export const createPersistedQueryLink = (
 
             handleRetry(
               {
-                response,
                 operation,
                 error: new CombinedGraphQLErrors(response),
                 meta: processErrors(response.errors),

--- a/src/link/persisted-queries/index.ts
+++ b/src/link/persisted-queries/index.ts
@@ -199,12 +199,12 @@ export const createPersistedQueryLink = (
             // but we don't pass any unexpected data to userland callbacks
             response = undefined;
           }
-          if ((response && response.errors) || networkError) {
+          if (response?.errors || networkError) {
             retried = true;
 
             const graphQLErrors: GraphQLFormattedError[] = [];
 
-            const responseErrors = response && response.errors;
+            const responseErrors = response?.errors;
             if (isNonEmptyArray(responseErrors)) {
               graphQLErrors.push(...responseErrors);
             }
@@ -216,7 +216,7 @@ export const createPersistedQueryLink = (
               try {
                 const result = JSON.parse(networkError.bodyText);
                 const networkErrors: GraphQLFormattedError[] | undefined =
-                  result && (result.errors as GraphQLFormattedError[]);
+                  result?.errors as GraphQLFormattedError[];
 
                 if (isNonEmptyArray(networkErrors)) {
                   graphQLErrors.push(...networkErrors);

--- a/src/link/persisted-queries/index.ts
+++ b/src/link/persisted-queries/index.ts
@@ -272,14 +272,14 @@ export const createPersistedQueryLink = (
         };
         const handler = {
           next: (response: FetchResult) => {
-            maybeRetry({ response }, () => observer.next!(response));
+            maybeRetry({ response }, () => observer.next(response));
           },
           error: (error: unknown) => {
             maybeRetry({ networkError: toErrorLike(error) }, () =>
-              observer.error!(error)
+              observer.error(error)
             );
           },
-          complete: observer.complete!.bind(observer),
+          complete: observer.complete.bind(observer),
         };
 
         // don't send the query the first time

--- a/src/link/persisted-queries/index.ts
+++ b/src/link/persisted-queries/index.ts
@@ -177,7 +177,7 @@ export const createPersistedQueryLink = (
 
       const { query } = operation;
 
-      return new Observable((observer: Observer<FetchResult>) => {
+      return new Observable((observer) => {
         let subscription: Subscription | undefined;
         let retried = false;
         let originalFetchOptions: any;

--- a/src/link/persisted-queries/index.ts
+++ b/src/link/persisted-queries/index.ts
@@ -272,7 +272,7 @@ export const createPersistedQueryLink = (
                 operation,
                 meta: processErrors(graphQLErrors),
               },
-              () => observer.error(networkError)
+              () => observer.error(error)
             );
           },
           complete: observer.complete.bind(observer),

--- a/src/link/persisted-queries/index.ts
+++ b/src/link/persisted-queries/index.ts
@@ -189,13 +189,17 @@ export const createPersistedQueryLink = (
           },
           cb: () => void
         ) => {
+          if (retried) {
+            return cb();
+          }
+
           if (!isFormattedExecutionResult(response)) {
             // if the response is not an expected format, we set it to `undefined`
             // network errors will still be handled correctly,
             // but we don't pass any unexpected data to userland callbacks
             response = undefined;
           }
-          if (!retried && ((response && response.errors) || networkError)) {
+          if ((response && response.errors) || networkError) {
             retried = true;
 
             const graphQLErrors: GraphQLFormattedError[] = [];

--- a/src/link/persisted-queries/index.ts
+++ b/src/link/persisted-queries/index.ts
@@ -229,7 +229,7 @@ export const createPersistedQueryLink = (
           networkError: ErrorLike,
           cb: () => void
         ) {
-          const graphQLErrors: GraphQLFormattedError[] = [];
+          let graphQLErrors: GraphQLFormattedError[] = [];
 
           // This is persisted-query specific (see #9410) and deviates from the
           // GraphQL-over-HTTP spec for application/json responses.
@@ -241,7 +241,7 @@ export const createPersistedQueryLink = (
                 result?.errors as GraphQLFormattedError[];
 
               if (isNonEmptyArray(errors)) {
-                graphQLErrors.push(...errors);
+                graphQLErrors = errors;
               }
             } catch {}
           }

--- a/src/link/persisted-queries/index.ts
+++ b/src/link/persisted-queries/index.ts
@@ -237,11 +237,11 @@ export const createPersistedQueryLink = (
           if (ServerError.is(networkError) && networkError.bodyText) {
             try {
               const result = JSON.parse(networkError.bodyText);
-              const networkErrors: GraphQLFormattedError[] | undefined =
+              const errors: GraphQLFormattedError[] | undefined =
                 result?.errors as GraphQLFormattedError[];
 
-              if (isNonEmptyArray(networkErrors)) {
-                graphQLErrors.push(...networkErrors);
+              if (isNonEmptyArray(errors)) {
+                graphQLErrors.push(...errors);
               }
             } catch {}
           }

--- a/src/link/persisted-queries/index.ts
+++ b/src/link/persisted-queries/index.ts
@@ -224,7 +224,7 @@ export const createPersistedQueryLink = (
               } catch {}
             }
 
-            const disablePayload: ErrorResponse = {
+            const errorResponse: ErrorResponse = {
               response,
               networkError,
               operation,
@@ -234,7 +234,7 @@ export const createPersistedQueryLink = (
             };
 
             // if the server doesn't support persisted queries, don't try anymore
-            enabled = !disable(disablePayload);
+            enabled = !disable(errorResponse);
             if (!enabled) {
               delete operation.extensions.persistedQuery;
               // clear hashes from cache, we don't need them anymore
@@ -242,7 +242,7 @@ export const createPersistedQueryLink = (
             }
 
             // if its not found, we can try it again, otherwise just report the error
-            if (retry(disablePayload)) {
+            if (retry(errorResponse)) {
               // need to recall the link chain
               if (subscription) subscription.unsubscribe();
               // actually send the query this time

--- a/src/link/persisted-queries/index.ts
+++ b/src/link/persisted-queries/index.ts
@@ -254,11 +254,7 @@ export const createPersistedQueryLink = (
         }
 
         const maybeRetry = (
-          {
-            response,
-          }: {
-            response?: FetchResult;
-          },
+          response: FetchResult | undefined,
           cb: () => void
         ) => {
           if (retried) {
@@ -326,7 +322,7 @@ export const createPersistedQueryLink = (
         };
         const handler = {
           next: (response: FetchResult) => {
-            maybeRetry({ response }, () => observer.next(response));
+            maybeRetry(response, () => observer.next(response));
           },
           error: (error: unknown) => {
             maybeRetryNetworkError(toErrorLike(error), () =>

--- a/src/link/persisted-queries/index.ts
+++ b/src/link/persisted-queries/index.ts
@@ -181,13 +181,83 @@ export const createPersistedQueryLink = (
         let retried = false;
         let originalFetchOptions: any;
         let setFetchOptions = false;
+
+        function maybeRetryNetworkError(
+          networkError: ErrorLike,
+          cb: () => void
+        ) {
+          if (retried) {
+            return cb();
+          }
+
+          retried = true;
+
+          const graphQLErrors: GraphQLFormattedError[] = [];
+
+          // This is persisted-query specific (see #9410) and deviates from the
+          // GraphQL-over-HTTP spec for application/json responses.
+          // This is intentional.
+          if (ServerError.is(networkError) && networkError.bodyText) {
+            try {
+              const result = JSON.parse(networkError.bodyText);
+              const networkErrors: GraphQLFormattedError[] | undefined =
+                result?.errors as GraphQLFormattedError[];
+
+              if (isNonEmptyArray(networkErrors)) {
+                graphQLErrors.push(...networkErrors);
+              }
+            } catch {}
+          }
+
+          const errorResponse: ErrorResponse = {
+            networkError,
+            operation,
+            graphQLErrors:
+              isNonEmptyArray(graphQLErrors) ? graphQLErrors : void 0,
+            meta: processErrors(graphQLErrors),
+          };
+
+          // if the server doesn't support persisted queries, don't try anymore
+          enabled = !disable(errorResponse);
+          if (!enabled) {
+            delete operation.extensions.persistedQuery;
+            // clear hashes from cache, we don't need them anymore
+            resetHashCache();
+          }
+
+          // if its not found, we can try it again, otherwise just report the error
+          if (retry(errorResponse)) {
+            // need to recall the link chain
+            if (subscription) subscription.unsubscribe();
+            // actually send the query this time
+            operation.setContext({
+              http: {
+                includeQuery: true,
+                ...(enabled ? { includeExtensions: true } : {}),
+              },
+              fetchOptions: {
+                // Since we're including the full query, which may be
+                // large, we should send it in the body of a POST request.
+                // See issue #7456.
+                method: "POST",
+              },
+            });
+            if (setFetchOptions) {
+              operation.setContext({ fetchOptions: originalFetchOptions });
+            }
+            subscription = forward(operation).subscribe(handler);
+
+            return;
+          }
+
+          cb();
+        }
+
         const maybeRetry = (
           {
             response,
-            networkError,
           }: {
             response?: FetchResult;
-            networkError?: ErrorLike;
           },
           cb: () => void
         ) => {
@@ -201,7 +271,7 @@ export const createPersistedQueryLink = (
             // but we don't pass any unexpected data to userland callbacks
             response = undefined;
           }
-          if (response?.errors || networkError) {
+          if (response?.errors) {
             retried = true;
 
             const graphQLErrors: GraphQLFormattedError[] = [];
@@ -211,24 +281,8 @@ export const createPersistedQueryLink = (
               graphQLErrors.push(...responseErrors);
             }
 
-            // This is persisted-query specific (see #9410) and deviates from the
-            // GraphQL-over-HTTP spec for application/json responses.
-            // This is intentional.
-            if (ServerError.is(networkError) && networkError.bodyText) {
-              try {
-                const result = JSON.parse(networkError.bodyText);
-                const networkErrors: GraphQLFormattedError[] | undefined =
-                  result?.errors as GraphQLFormattedError[];
-
-                if (isNonEmptyArray(networkErrors)) {
-                  graphQLErrors.push(...networkErrors);
-                }
-              } catch {}
-            }
-
             const errorResponse: ErrorResponse = {
               response,
-              networkError,
               operation,
               graphQLErrors:
                 isNonEmptyArray(graphQLErrors) ? graphQLErrors : void 0,
@@ -275,7 +329,7 @@ export const createPersistedQueryLink = (
             maybeRetry({ response }, () => observer.next(response));
           },
           error: (error: unknown) => {
-            maybeRetry({ networkError: toErrorLike(error) }, () =>
+            maybeRetryNetworkError(toErrorLike(error), () =>
               observer.error(error)
             );
           },

--- a/src/link/persisted-queries/index.ts
+++ b/src/link/persisted-queries/index.ts
@@ -231,14 +231,7 @@ export const createPersistedQueryLink = (
 
         const handler: Observer<FetchResult> = {
           next: (response) => {
-            if (!isFormattedExecutionResult(response)) {
-              // if the response is not an expected format, we ignore it.
-              // Network errors will still be handled correctly,
-              // but we don't pass any unexpected data to userland callbacks
-              return;
-            }
-
-            if (!response.errors) {
+            if (!isFormattedExecutionResult(response) || !response.errors) {
               return observer.next(response);
             }
 

--- a/src/link/persisted-queries/index.ts
+++ b/src/link/persisted-queries/index.ts
@@ -272,7 +272,7 @@ export const createPersistedQueryLink = (
 
             const graphQLErrors: GraphQLFormattedError[] = [];
 
-            const responseErrors = response?.errors;
+            const responseErrors = response.errors;
             if (isNonEmptyArray(responseErrors)) {
               graphQLErrors.push(...responseErrors);
             }

--- a/src/link/persisted-queries/index.ts
+++ b/src/link/persisted-queries/index.ts
@@ -246,16 +246,16 @@ export const createPersistedQueryLink = (
               () => observer.next(result)
             );
           },
-          error: (error) => {
-            const networkError = toErrorLike(error);
+          error: (incomingError) => {
+            const error = toErrorLike(incomingError);
             let graphQLErrors: ReadonlyArray<GraphQLFormattedError> | undefined;
 
             // This is persisted-query specific (see #9410) and deviates from the
             // GraphQL-over-HTTP spec for application/json responses.
             // This is intentional.
-            if (ServerError.is(networkError) && networkError.bodyText) {
+            if (ServerError.is(error) && error.bodyText) {
               try {
-                const result = JSON.parse(networkError.bodyText) as
+                const result = JSON.parse(error.bodyText) as
                   | FormattedExecutionResult
                   | undefined;
 
@@ -268,11 +268,11 @@ export const createPersistedQueryLink = (
                 error:
                   isNonEmptyArray(graphQLErrors) ?
                     new CombinedGraphQLErrors({ errors: graphQLErrors })
-                  : networkError,
+                  : error,
                 operation,
                 meta: processErrors(graphQLErrors),
               },
-              () => observer.error(error)
+              () => observer.error(incomingError)
             );
           },
           complete: observer.complete.bind(observer),

--- a/src/link/persisted-queries/index.ts
+++ b/src/link/persisted-queries/index.ts
@@ -49,8 +49,8 @@ type GenerateHashFunction = (
 ) => string | PromiseLike<string>;
 
 interface BaseOptions {
-  disable?: (error: PersistedQueryLink.DisableFunctionOptions) => boolean;
-  retry?: (error: PersistedQueryLink.RetryFunctionOptions) => boolean;
+  disable?: (options: PersistedQueryLink.DisableFunctionOptions) => boolean;
+  retry?: (options: PersistedQueryLink.RetryFunctionOptions) => boolean;
   useGETForHashedQueries?: boolean;
 }
 


### PR DESCRIPTION
Closes #12569

Updates `createPersistedQueryLink` to combine `graphQLErrors` and `networkError` properties into a single `error` property to match the rest of the client. `error` is of type `ErrorLike`.

The `response` property has also been removed in favor of accessing `data` from the `CombinedGraphQLErrors` instance.