### PR TITLE
Set `loading: false` with `cache-only` queries with no data in the cache

### DIFF
--- a/.changeset/great-scissors-jam.md
+++ b/.changeset/great-scissors-jam.md
@@ -1,0 +1,7 @@
+---
+"@apollo/client": major
+---
+
+`cache-only` queries will now initialize with `loading: false` and `networkStatus: NetworkStatus.ready` when there is no data in the cache.
+
+This means `useQuery` will no longer render a short initial loading state before rendering `loading: false` and `ObservableQuery.getCurrentResult()` will now return `loading: false` immediately.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43294,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38360,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33284,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27732
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43238,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38359,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33310,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27730
 }

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43238,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38359,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33310,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27730
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43264,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38360,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33277,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27705
 }

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -509,7 +509,11 @@ export class ObservableQuery<
     };
 
     switch (fetchPolicy) {
-      case "cache-only":
+      case "cache-only": {
+        const result = cacheResult();
+
+        return result.dataState === "empty" ? empty : result;
+      }
       case "cache-first":
         return cacheResult();
       case "cache-and-network":

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -510,9 +510,11 @@ export class ObservableQuery<
 
     switch (fetchPolicy) {
       case "cache-only": {
-        const result = cacheResult();
-
-        return result.dataState === "empty" ? empty : result;
+        return {
+          ...cacheResult(),
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+        };
       }
       case "cache-first":
         return cacheResult();

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -3431,6 +3431,46 @@ describe("ObservableQuery", () => {
       await expect(stream).not.toEmitAnything();
     });
 
+    it("returns loading: false on cache-only fetchPolicy queries when calling getCurrentResult with no data in the cache", async () => {
+      const client = new ApolloClient({
+        cache: new InMemoryCache(),
+        link: ApolloLink.empty(),
+      });
+
+      const observable = client.watchQuery({
+        query,
+        variables,
+        fetchPolicy: "cache-only",
+      });
+
+      expect(observable.getCurrentResult()).toStrictEqualTyped({
+        data: undefined,
+        dataState: "empty",
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        partial: true,
+      });
+
+      const stream = new ObservableStream(observable);
+
+      await expect(stream).toEmitTypedValue({
+        data: undefined,
+        dataState: "empty",
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        partial: true,
+      });
+      expect(observable.getCurrentResult()).toStrictEqualTyped({
+        data: undefined,
+        dataState: "empty",
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        partial: true,
+      });
+
+      await expect(stream).not.toEmitAnything();
+    });
+
     it("handles multiple calls to getCurrentResult without losing data", async () => {
       const query = gql`
         {

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -2896,8 +2896,6 @@ describe("ObservableQuery", () => {
 
       const observable = client.watchQuery({ query, variables });
 
-      // TODO: Should this be the initial loading state until we've attempted to
-      // execute the query?
       expect(observable.getCurrentResult()).toStrictEqualTyped({
         data: dataOne,
         dataState: "complete",

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -3471,6 +3471,48 @@ describe("ObservableQuery", () => {
       await expect(stream).not.toEmitAnything();
     });
 
+    it("returns loading: false on cache-only fetchPolicy queries when calling getCurrentResult with data in the cache", async () => {
+      const client = new ApolloClient({
+        cache: new InMemoryCache(),
+        link: ApolloLink.empty(),
+      });
+
+      client.writeQuery({ query, variables, data: dataOne });
+
+      const observable = client.watchQuery({
+        query,
+        variables,
+        fetchPolicy: "cache-only",
+      });
+
+      expect(observable.getCurrentResult()).toStrictEqualTyped({
+        data: dataOne,
+        dataState: "complete",
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        partial: false,
+      });
+
+      const stream = new ObservableStream(observable);
+
+      await expect(stream).toEmitTypedValue({
+        data: dataOne,
+        dataState: "complete",
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        partial: false,
+      });
+      expect(observable.getCurrentResult()).toStrictEqualTyped({
+        data: dataOne,
+        dataState: "complete",
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        partial: false,
+      });
+
+      await expect(stream).not.toEmitAnything();
+    });
+
     it("handles multiple calls to getCurrentResult without losing data", async () => {
       const query = gql`
         {

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -3431,7 +3431,7 @@ describe("ObservableQuery", () => {
       await expect(stream).not.toEmitAnything();
     });
 
-    it("returns loading: false on cache-only fetchPolicy queries when calling getCurrentResult with no data in the cache", async () => {
+    it("returns loading: false on cache-only queries when calling getCurrentResult with no data in the cache", async () => {
       const client = new ApolloClient({
         cache: new InMemoryCache(),
         link: ApolloLink.empty(),
@@ -3471,7 +3471,7 @@ describe("ObservableQuery", () => {
       await expect(stream).not.toEmitAnything();
     });
 
-    it("returns loading: false on cache-only fetchPolicy queries when calling getCurrentResult with data in the cache", async () => {
+    it("returns loading: false on cache-only queries when calling getCurrentResult with data in the cache", async () => {
       const client = new ApolloClient({
         cache: new InMemoryCache(),
         link: ApolloLink.empty(),

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -10556,6 +10556,39 @@ describe("useQuery Hook", () => {
     await expect(takeSnapshot).not.toRerender({ timeout: 200 });
   });
 
+  test("initializes with loading: false on an empty cache when using `cache-only`", async () => {
+    const query = gql`
+      query {
+        hello
+      }
+    `;
+    const client = new ApolloClient({
+      cache: new InMemoryCache(),
+      link: ApolloLink.empty(),
+    });
+
+    using _disabledAct = disableActEnvironment();
+    const { takeSnapshot } = await renderHookToSnapshotStream(
+      () => useQuery(query, { fetchPolicy: "cache-only" }),
+      {
+        wrapper: ({ children }) => (
+          <ApolloProvider client={client}>{children}</ApolloProvider>
+        ),
+      }
+    );
+
+    await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+      data: undefined,
+      dataState: "empty",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      previousData: undefined,
+      variables: {},
+    });
+
+    await expect(takeSnapshot).not.toRerender();
+  });
+
   describe("data masking", () => {
     it("masks queries when dataMasking is `true`", async () => {
       type UserFieldsFragment = {

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -10589,6 +10589,54 @@ describe("useQuery Hook", () => {
     await expect(takeSnapshot).not.toRerender();
   });
 
+  test("initializes with loading: false on an partial cache when using `cache-only` with returnPartialData: true", async () => {
+    const query = gql`
+      query {
+        user {
+          id
+          name
+        }
+      }
+    `;
+    const client = new ApolloClient({
+      cache: new InMemoryCache(),
+      link: ApolloLink.empty(),
+    });
+
+    client.writeQuery({
+      query: gql`
+        query {
+          user {
+            id
+          }
+        }
+      `,
+      data: { user: { __typename: "User", id: "1" } },
+    });
+
+    using _disabledAct = disableActEnvironment();
+    const { takeSnapshot } = await renderHookToSnapshotStream(
+      () =>
+        useQuery(query, { returnPartialData: true, fetchPolicy: "cache-only" }),
+      {
+        wrapper: ({ children }) => (
+          <ApolloProvider client={client}>{children}</ApolloProvider>
+        ),
+      }
+    );
+
+    await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+      data: { user: { __typename: "User", id: "1" } },
+      dataState: "partial",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      previousData: undefined,
+      variables: {},
+    });
+
+    await expect(takeSnapshot).not.toRerender();
+  });
+
   describe("data masking", () => {
     it("masks queries when dataMasking is `true`", async () => {
       type UserFieldsFragment = {


### PR DESCRIPTION
Supersedes #12021

Sets the initial `loading` state to `false` for a `cache-only` query when no data is in the cache.