### PR TITLE
Don't allow `fetchMore` or updates to polling for `cache-only` queries and exclude from `client.refetchQueries`

### DIFF
--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -1041,8 +1041,8 @@ export type WatchQueryOptions<TVariables extends OperationVariables = OperationV
 
 // Warnings were encountered during analysis:
 //
-// src/core/ObservableQuery.ts:138:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:298:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:134:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:294:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:187:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:261:3 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
 

--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -1041,8 +1041,8 @@ export type WatchQueryOptions<TVariables extends OperationVariables = OperationV
 
 // Warnings were encountered during analysis:
 //
-// src/core/ObservableQuery.ts:133:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:293:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:138:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:298:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:187:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:261:3 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
 

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -1640,9 +1640,9 @@ type WatchQueryOptions_2<TVariables extends OperationVariables_2 = OperationVari
 
 // Warnings were encountered during analysis:
 //
-// src/core/ObservableQuery.ts:133:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:145:5 - (ae-forgotten-export) The symbol "RefetchWritePolicy" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:293:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:138:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:150:5 - (ae-forgotten-export) The symbol "RefetchWritePolicy" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:298:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:187:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:236:3 - (ae-forgotten-export) The symbol "ErrorLike" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:238:3 - (ae-forgotten-export) The symbol "NetworkStatus" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -1640,9 +1640,9 @@ type WatchQueryOptions_2<TVariables extends OperationVariables_2 = OperationVari
 
 // Warnings were encountered during analysis:
 //
-// src/core/ObservableQuery.ts:138:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:150:5 - (ae-forgotten-export) The symbol "RefetchWritePolicy" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:298:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:134:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:146:5 - (ae-forgotten-export) The symbol "RefetchWritePolicy" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:294:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:187:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:236:3 - (ae-forgotten-export) The symbol "ErrorLike" needs to be exported by the entry point index.d.ts
 // src/core/types.ts:238:3 - (ae-forgotten-export) The symbol "NetworkStatus" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -2701,8 +2701,8 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/cache/inmemory/policies.ts:166:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/policies.ts:166:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/types.ts:133:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:133:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:293:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:138:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:298:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:187:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:261:3 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
 // src/local-state/LocalState.ts:140:5 - (ae-forgotten-export) The symbol "LocalState" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -2701,8 +2701,8 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/cache/inmemory/policies.ts:166:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/policies.ts:166:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/types.ts:133:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:138:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:298:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:134:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:294:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:187:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:261:3 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
 // src/local-state/LocalState.ts:140:5 - (ae-forgotten-export) The symbol "LocalState" needs to be exported by the entry point index.d.ts

--- a/.changeset/clever-islands-talk.md
+++ b/.changeset/clever-islands-talk.md
@@ -2,4 +2,4 @@
 "@apollo/client": major
 ---
 
-An error is now thrown when trying to call `refetch` or `fetchMore` on a `cache-only` query.
+An error is now thrown when trying to call `fetchMore` on a `cache-only` query.

--- a/.changeset/clever-islands-talk.md
+++ b/.changeset/clever-islands-talk.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": major
+---
+
+An error is now thrown when trying to call `refetch` or `fetchMore` on a `cache-only` query.

--- a/.changeset/four-tables-cheat.md
+++ b/.changeset/four-tables-cheat.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": major
+---
+
+`cache-only` queries are no longer refetched when calling `client.reFetchObservableQueries` when `includeStandby` is `true`.

--- a/.changeset/lemon-pans-sit.md
+++ b/.changeset/lemon-pans-sit.md
@@ -2,4 +2,4 @@
 "@apollo/client": major
 ---
 
-`cache-only` queries are now excluded from `client.refetchQueries` when using `include: 'all'`, `include: 'active'`, or a `cache-only` query is listed in `include`. `cache-only` queries affected by `updateCache` are also excluded from `refetchQueries` when `onQueryUpdated` is not provided.
+`cache-only` queries are now excluded from `client.refetchQueries` in all situations. `cache-only` queries affected by `updateCache` are also excluded from `refetchQueries` when `onQueryUpdated` is not provided.

--- a/.changeset/lemon-pans-sit.md
+++ b/.changeset/lemon-pans-sit.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": major
+---
+
+`cache-only` queries are now excluded from `client.refetchQueries` when using `include: 'all'` or `include: 'active'` since `cache-only` queries are no longer refetchable. Calling `client.refetchQueries` and including the `cache-only` query explicitly in `include` will throw.

--- a/.changeset/lemon-pans-sit.md
+++ b/.changeset/lemon-pans-sit.md
@@ -2,7 +2,4 @@
 "@apollo/client": major
 ---
 
-`cache-only` queries are now excluded from `client.refetchQueries` when using `include: 'all'` or `include: 'active'` since `cache-only` queries are no longer refetchable. `cache-only` queries affected by `updateCache` are also excluded from `refetchQueries` when `onQueryUpdated` is not provided.
-
-Calling `client.refetchQueries` and including the `cache-only` query explicitly in `include` will throw.
-
+`cache-only` queries are now excluded from `client.refetchQueries` when using `include: 'all'`, `include: 'active'`, or a `cache-only` query is listed in `include`. `cache-only` queries affected by `updateCache` are also excluded from `refetchQueries` when `onQueryUpdated` is not provided.

--- a/.changeset/lemon-pans-sit.md
+++ b/.changeset/lemon-pans-sit.md
@@ -2,4 +2,7 @@
 "@apollo/client": major
 ---
 
-`cache-only` queries are now excluded from `client.refetchQueries` when using `include: 'all'` or `include: 'active'` since `cache-only` queries are no longer refetchable. Calling `client.refetchQueries` and including the `cache-only` query explicitly in `include` will throw.
+`cache-only` queries are now excluded from `client.refetchQueries` when using `include: 'all'` or `include: 'active'` since `cache-only` queries are no longer refetchable. `cache-only` queries affected by `updateCache` are also excluded from `refetchQueries` when `onQueryUpdated` is not provided.
+
+Calling `client.refetchQueries` and including the `cache-only` query explicitly in `include` will throw.
+

--- a/.changeset/stupid-eagles-fetch.md
+++ b/.changeset/stupid-eagles-fetch.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": major
+---
+
+`cache-only` queries no longer poll when a `pollInterval` is set. Instead a warning is now emitted that polling has no effect. If the `fetchPolicy` is changed to `cache-only` after polling is already active, polling is stopped.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43694,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38673,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33384,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27653
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43700,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38671,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33401,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27608
 }

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43783,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38741,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33478,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27687
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43694,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38673,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33384,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27653
 }

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43749,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38793,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33481,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27689
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43783,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38741,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33478,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27687
 }

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43700,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38671,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43750,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38684,
   "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33401,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27608
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27641
 }

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43545,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38567,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33328,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27615
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43749,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38793,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33481,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27689
 }

--- a/src/__tests__/fetchMore.ts
+++ b/src/__tests__/fetchMore.ts
@@ -2458,7 +2458,7 @@ test("does not allow fetchMore on a cache-only query", async () => {
   });
 
   const expectedError = new InvariantError(
-    "Cannot execute `fetchMore` for a 'cache-only' query. Please use a different fetch policy."
+    "Cannot execute `fetchMore` for 'cache-only' query 'Comment'. Please use a different fetch policy."
   );
 
   await expect(

--- a/src/__tests__/fetchMore.ts
+++ b/src/__tests__/fetchMore.ts
@@ -2457,21 +2457,13 @@ test("does not allow fetchMore on a cache-only query", async () => {
     partial: true,
   });
 
-  const expectedError = new InvariantError(
-    "Cannot execute `fetchMore` for 'cache-only' query 'Comment'. Please use a different fetch policy."
-  );
-
-  await expect(
+  expect(() =>
     observable.fetchMore({ variables: { start: 10, limit: 10 } })
-  ).rejects.toEqual(expectedError);
-
-  await expect(stream).toEmitSimilarValue({
-    expected: (previous) => ({
-      ...previous,
-      error: expectedError,
-      networkStatus: NetworkStatus.error,
-    }),
-  });
+  ).toThrow(
+    new InvariantError(
+      "Cannot execute `fetchMore` for 'cache-only' query 'Comment'. Please use a different fetch policy."
+    )
+  );
 
   await expect(stream).not.toEmitAnything();
 });

--- a/src/__tests__/refetchQueries.ts
+++ b/src/__tests__/refetchQueries.ts
@@ -713,7 +713,7 @@ describe("client.refetchQueries", () => {
       })
     ).rejects.toEqual(
       new InvariantError(
-        "Cannot execute `refetch` for a 'cache-only' query. Please use a different fetch policy."
+        "Cannot execute `refetch` for 'cache-only' query 'C'. Please use a different fetch policy."
       )
     );
 
@@ -734,7 +734,7 @@ describe("client.refetchQueries", () => {
       data: { c: "C" },
       dataState: "complete",
       error: new InvariantError(
-        "Cannot execute `refetch` for a 'cache-only' query. Please use a different fetch policy."
+        "Cannot execute `refetch` for 'cache-only' query 'C'. Please use a different fetch policy."
       ),
       loading: false,
       networkStatus: NetworkStatus.error,

--- a/src/__tests__/refetchQueries.ts
+++ b/src/__tests__/refetchQueries.ts
@@ -716,7 +716,7 @@ describe("client.refetchQueries", () => {
     unsubscribe();
   });
 
-  it("includes named cache-only queries in refetchQueries but returns error", async () => {
+  it("does not include named cache-only queries in refetchQueries", async () => {
     const cQuery = gql`
       query C {
         c
@@ -761,33 +761,15 @@ describe("client.refetchQueries", () => {
         include: [aQuery, cQuery],
         onQueryUpdated: activeOQU.onQueryUpdated,
       })
-    ).rejects.toEqual(
-      new InvariantError(
-        "Cannot execute `refetch` for 'cache-only' query 'C'. Please use a different fetch policy."
-      )
-    );
+    ).resolves.toEqual([{ data: { a: "A" } }]);
 
-    await activeOQU.check([
-      [aObs, { a: "A" }],
-      [cObs, { c: "C" }],
-    ]);
+    await activeOQU.check([[aObs, { a: "A" }]]);
 
     await expect(aStream).toEmitTypedValue({
       data: { a: "A" },
       dataState: "complete",
       loading: false,
       networkStatus: NetworkStatus.ready,
-      partial: false,
-    });
-
-    await expect(cStream).toEmitTypedValue({
-      data: { c: "C" },
-      dataState: "complete",
-      error: new InvariantError(
-        "Cannot execute `refetch` for 'cache-only' query 'C'. Please use a different fetch policy."
-      ),
-      loading: false,
-      networkStatus: NetworkStatus.error,
       partial: false,
     });
 

--- a/src/__tests__/refetchQueries.ts
+++ b/src/__tests__/refetchQueries.ts
@@ -11,7 +11,6 @@ import {
   ObservableQuery,
 } from "@apollo/client";
 import { ObservableStream } from "@apollo/client/testing/internal";
-import { InvariantError } from "@apollo/client/utilities/invariant";
 
 describe("client.refetchQueries", () => {
   it("is public and callable", async () => {

--- a/src/__tests__/refetchQueries.ts
+++ b/src/__tests__/refetchQueries.ts
@@ -491,6 +491,55 @@ describe("client.refetchQueries", () => {
     unsubscribe();
   });
 
+  it('does not include cache-only queries when options.include === "active"', async () => {
+    const cQuery = gql`
+      query {
+        c
+      }
+    `;
+    const client = makeClient();
+    client.writeQuery({ query: cQuery, data: { c: "C" } });
+
+    const [aObs, bObs, abObs] = await setup(client);
+
+    const cObs = client.watchQuery({
+      query: cQuery,
+      fetchPolicy: "cache-only",
+    });
+
+    const cStream = new ObservableStream(cObs);
+
+    await expect(cStream).toEmitTypedValue({
+      data: { c: "C" },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
+
+    const activeOQU = obsUpdatedCheck(() => true);
+    const activeResults = await client.refetchQueries({
+      include: "active",
+      onQueryUpdated: activeOQU.onQueryUpdated,
+    });
+
+    await activeOQU.check([
+      [aObs, { a: "A" }],
+      [bObs, { b: "B" }],
+      [abObs, { a: "A", b: "B" }],
+    ]);
+
+    sortObjects(activeResults);
+
+    expect(activeResults).toEqual([
+      { data: { a: "A" } },
+      { data: { b: "B" } },
+      { data: { a: "A", b: "B" } },
+    ]);
+
+    unsubscribe();
+  });
+
   it("includes queries named in refetchQueries even if they have `standby` fetchPolicy", async () => {
     const client = makeClient();
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1685,18 +1685,6 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     });
   }
 
-  private setError(error: ErrorLike) {
-    this.setResult(
-      {
-        ...this.getCurrentResult(),
-        error,
-        loading: false,
-        networkStatus: NetworkStatus.error,
-      },
-      { shouldEmit: EmitBehavior.force }
-    );
-  }
-
   private operator: OperatorFunction<
     QueryNotification.Value<TData> & {
       query: DocumentNode | TypedDocumentNode<TData, TVariables>;

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1247,11 +1247,6 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
       return;
     }
 
-    invariant(
-      pollInterval,
-      "Attempted to start a polling query without a polling interval."
-    );
-
     const info = pollingInfo || (this.pollingInfo = {} as any);
     info.interval = pollInterval;
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1235,10 +1235,16 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
 
     const {
       pollingInfo,
-      options: { pollInterval },
+      options: { fetchPolicy, pollInterval },
     } = this;
 
-    if (!pollInterval || !this.hasObservers()) {
+    if (!pollInterval || !this.hasObservers() || fetchPolicy === "cache-only") {
+      if (pollInterval && fetchPolicy === "cache-only") {
+        invariant.warn(
+          "Cannot poll on a 'cache-only' query and as such, polling is disabled. Please use a different fetch policy."
+        );
+      }
+
       this.cancelPolling();
       return;
     }

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -656,21 +656,6 @@ export class ObservableQuery<
   ): ObservableQuery.ResultPromise<QueryResult<TData>> {
     const { fetchPolicy } = this.options;
 
-    if (fetchPolicy === "cache-only") {
-      const error = newInvariantError(
-        "Cannot execute `refetch` for 'cache-only' query '%s'. Please use a different fetch policy.",
-        getOperationName(this.query, "(anonymous)")
-      );
-
-      this.setError(error);
-
-      const promise = Object.assign(Promise.reject(error), {
-        retain: () => promise,
-      });
-
-      return promise;
-    }
-
     const reobserveOptions: Partial<
       ObservableQuery.Options<TData, TVariables>
     > = {

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1235,7 +1235,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
 
     const {
       pollingInfo,
-      options: { fetchPolicy, pollInterval },
+      options: { pollInterval },
     } = this;
 
     if (!pollInterval || !this.hasObservers()) {
@@ -1250,12 +1250,6 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     invariant(
       pollInterval,
       "Attempted to start a polling query without a polling interval."
-    );
-
-    invariant(
-      fetchPolicy !== "cache-only" && fetchPolicy !== "standby",
-      "Cannot begin polling on a '%s' query. Please use a different fetch policy.",
-      fetchPolicy
     );
 
     const info = pollingInfo || (this.pollingInfo = {} as any);

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1220,15 +1220,6 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     } = this;
 
     if (!pollInterval || !this.hasObservers() || fetchPolicy === "cache-only") {
-      if (
-        !this.didWarnCacheOnlyPolling &&
-        pollInterval &&
-        fetchPolicy === "cache-only"
-      ) {
-        invariant.warn(
-          "Cannot poll on 'cache-only' query '%s' and as such, polling is disabled. Please use a different fetch policy.",
-          getOperationName(this.query, "(anonymous)")
-        );
       if (__DEV__) {
         if (
           !this.didWarnCacheOnlyPolling &&

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -23,10 +23,7 @@ import {
   preventUnhandledRejection,
   toQueryResult,
 } from "@apollo/client/utilities/internal";
-import {
-  invariant,
-  newInvariantError,
-} from "@apollo/client/utilities/invariant";
+import { invariant } from "@apollo/client/utilities/invariant";
 
 import { equalByQuery } from "./equalByQuery.js";
 import { isNetworkRequestInFlight, NetworkStatus } from "./networkStatus.js";
@@ -34,7 +31,6 @@ import type { QueryManager } from "./QueryManager.js";
 import type {
   ApolloQueryResult,
   DefaultContext,
-  ErrorLike,
   OperationVariables,
   QueryNotification,
   QueryResult,

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1229,7 +1229,18 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
           "Cannot poll on 'cache-only' query '%s' and as such, polling is disabled. Please use a different fetch policy.",
           getOperationName(this.query, "(anonymous)")
         );
-        this.didWarnCacheOnlyPolling = true;
+      if (__DEV__) {
+        if (
+          !this.didWarnCacheOnlyPolling &&
+          pollInterval &&
+          fetchPolicy === "cache-only"
+        ) {
+          invariant.warn(
+            "Cannot poll on 'cache-only' query '%s' and as such, polling is disabled. Please use a different fetch policy.",
+            getOperationName(this.query, "(anonymous)")
+          );
+          this.didWarnCacheOnlyPolling = true;
+        }
       }
 
       this.cancelPolling();

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -660,15 +660,7 @@ export class ObservableQuery<
         "Cannot execute `refetch` for a 'cache-only' query. Please use a different fetch policy."
       );
 
-      this.setResult(
-        {
-          ...this.getCurrentResult(),
-          error,
-          loading: false,
-          networkStatus: NetworkStatus.error,
-        },
-        { shouldEmit: EmitBehavior.force }
-      );
+      this.setError(error);
 
       const promise = Object.assign(Promise.reject(error), {
         retain: () => promise,

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1207,6 +1207,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
   }
 
   // Turns polling on or off based on this.options.pollInterval.
+  private didWarnCacheOnlyPolling = false;
   private updatePolling() {
     // Avoid polling in SSR mode
     if (this.queryManager.ssrMode) {
@@ -1219,11 +1220,16 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     } = this;
 
     if (!pollInterval || !this.hasObservers() || fetchPolicy === "cache-only") {
-      if (pollInterval && fetchPolicy === "cache-only") {
+      if (
+        !this.didWarnCacheOnlyPolling &&
+        pollInterval &&
+        fetchPolicy === "cache-only"
+      ) {
         invariant.warn(
           "Cannot poll on 'cache-only' query '%s' and as such, polling is disabled. Please use a different fetch policy.",
           getOperationName(this.query, "(anonymous)")
         );
+        this.didWarnCacheOnlyPolling = true;
       }
 
       this.cancelPolling();

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -670,7 +670,11 @@ export class ObservableQuery<
         { shouldEmit: EmitBehavior.force }
       );
 
-      return this.toRejectedResultPromise(error);
+      const promise = Object.assign(Promise.reject(error), {
+        retain: () => promise,
+      });
+
+      return promise;
     }
 
     const reobserveOptions: Partial<
@@ -1830,16 +1834,6 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
 
   private getVariablesWithDefaults(variables: TVariables | undefined) {
     return this.queryManager.getVariables(this.query, variables);
-  }
-
-  private toRejectedResultPromise(
-    error: ErrorLike
-  ): ObservableQuery.ResultPromise<never> {
-    const promise = Object.assign(Promise.reject(error), {
-      retain: () => promise,
-    });
-
-    return promise;
   }
 }
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1243,7 +1243,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
       return;
     }
 
-    if (pollingInfo && pollingInfo?.interval === pollInterval) {
+    if (pollingInfo?.interval === pollInterval) {
       return;
     }
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1706,12 +1706,15 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
   }
 
   private setError(error: ErrorLike) {
-    this.setResult({
-      ...this.getCurrentResult(),
-      error,
-      loading: false,
-      networkStatus: NetworkStatus.error,
-    });
+    this.setResult(
+      {
+        ...this.getCurrentResult(),
+        error,
+        loading: false,
+        networkStatus: NetworkStatus.error,
+      },
+      { shouldEmit: EmitBehavior.force }
+    );
   }
 
   private operator: OperatorFunction<

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -649,6 +649,14 @@ export class ObservableQuery<
   public refetch(
     variables?: Partial<TVariables>
   ): ObservableQuery.ResultPromise<QueryResult<TData>> {
+    const { fetchPolicy } = this.options;
+
+    invariant(
+      fetchPolicy !== "cache-only" && fetchPolicy !== "standby",
+      "Cannot execute `refetch` for a '%s' query. Please use a different fetch policy.",
+      fetchPolicy
+    );
+
     const reobserveOptions: Partial<
       ObservableQuery.Options<TData, TVariables>
     > = {
@@ -659,7 +667,6 @@ export class ObservableQuery<
     // Unless the provided fetchPolicy always consults the network
     // (no-cache, network-only, or cache-and-network), override it with
     // network-only to force the refetch for this fetchQuery call.
-    const { fetchPolicy } = this.options;
     if (fetchPolicy === "no-cache") {
       reobserveOptions.fetchPolicy = "no-cache";
     } else {
@@ -708,6 +715,14 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
       ) => Unmasked<TData>;
     }
   ): Promise<QueryResult<TFetchData>> {
+    const { fetchPolicy } = this.options;
+
+    invariant(
+      fetchPolicy !== "cache-only" && fetchPolicy !== "standby",
+      "Cannot execute `fetchMore` for a '%s' query. Please use a different fetch policy.",
+      fetchPolicy
+    );
+
     const combinedOptions = {
       ...(fetchMoreOptions.query ? fetchMoreOptions : (
         {
@@ -1207,7 +1222,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
 
     const {
       pollingInfo,
-      options: { pollInterval },
+      options: { fetchPolicy, pollInterval },
     } = this;
 
     if (!pollInterval || !this.hasObservers()) {
@@ -1215,13 +1230,19 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
       return;
     }
 
-    if (pollingInfo && pollingInfo.interval === pollInterval) {
+    if (pollingInfo && pollingInfo?.interval === pollInterval) {
       return;
     }
 
     invariant(
       pollInterval,
       "Attempted to start a polling query without a polling interval."
+    );
+
+    invariant(
+      fetchPolicy !== "cache-only" && fetchPolicy !== "standby",
+      "Cannot begin polling on a '%s' query. Please use a different fetch policy.",
+      fetchPolicy
     );
 
     const info = pollingInfo || (this.pollingInfo = {} as any);

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -18,6 +18,7 @@ import {
   compact,
   filterMap,
   getOperationDefinition,
+  getOperationName,
   getQueryDefinition,
   preventUnhandledRejection,
   toQueryResult,
@@ -657,7 +658,8 @@ export class ObservableQuery<
 
     if (fetchPolicy === "cache-only") {
       const error = newInvariantError(
-        "Cannot execute `refetch` for a 'cache-only' query. Please use a different fetch policy."
+        "Cannot execute `refetch` for 'cache-only' query '%s'. Please use a different fetch policy.",
+        getOperationName(this.query, "(anonymous)")
       );
 
       this.setError(error);
@@ -729,7 +731,8 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
   ): Promise<QueryResult<TFetchData>> {
     if (this.options.fetchPolicy === "cache-only") {
       const error = newInvariantError(
-        "Cannot execute `fetchMore` for a 'cache-only' query. Please use a different fetch policy."
+        "Cannot execute `fetchMore` for 'cache-only' query '%s'. Please use a different fetch policy.",
+        getOperationName(this.query, "(anonymous)")
       );
 
       this.setError(error);
@@ -1241,7 +1244,8 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     if (!pollInterval || !this.hasObservers() || fetchPolicy === "cache-only") {
       if (pollInterval && fetchPolicy === "cache-only") {
         invariant.warn(
-          "Cannot poll on a 'cache-only' query and as such, polling is disabled. Please use a different fetch policy."
+          "Cannot poll on 'cache-only' query '%s' and as such, polling is disabled. Please use a different fetch policy.",
+          getOperationName(this.query, "(anonymous)")
         );
       }
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -714,15 +714,11 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
       ) => Unmasked<TData>;
     }
   ): Promise<QueryResult<TFetchData>> {
-    if (this.options.fetchPolicy === "cache-only") {
-      const error = newInvariantError(
-        "Cannot execute `fetchMore` for 'cache-only' query '%s'. Please use a different fetch policy.",
-        getOperationName(this.query, "(anonymous)")
-      );
-
-      this.setError(error);
-      return Promise.reject(error);
-    }
+    invariant(
+      this.options.fetchPolicy !== "cache-only",
+      "Cannot execute `fetchMore` for 'cache-only' query '%s'. Please use a different fetch policy.",
+      getOperationName(this.query, "(anonymous)")
+    );
 
     const combinedOptions = {
       ...(fetchMoreOptions.query ? fetchMoreOptions : (

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1292,7 +1292,7 @@ export class QueryManager {
 
     if (include) {
       this.getObservableQueries(include).forEach((oq) => {
-        if (oq.options.fetchPolicy === "cache-only") {
+        if (include === "active" && oq.options.fetchPolicy === "cache-only") {
           return;
         }
 

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1292,6 +1292,10 @@ export class QueryManager {
 
     if (include) {
       this.getObservableQueries(include).forEach((oq) => {
+        if (oq.options.fetchPolicy === "cache-only") {
+          return;
+        }
+
         const current = oq.getCurrentResult();
         includedQueriesByOq.set(oq, {
           oq,

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -731,8 +731,8 @@ export class QueryManager {
       (observableQuery) => {
         const { fetchPolicy } = observableQuery.options;
         if (
-          includeStandby ||
-          (fetchPolicy !== "standby" && fetchPolicy !== "cache-only")
+          (includeStandby || fetchPolicy !== "standby") &&
+          fetchPolicy !== "cache-only"
         ) {
           observableQueryPromises.push(observableQuery.refetch());
         }

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1292,10 +1292,7 @@ export class QueryManager {
 
     if (include) {
       this.getObservableQueries(include).forEach((oq) => {
-        if (
-          (include === "active" || include === "all") &&
-          oq.options.fetchPolicy === "cache-only"
-        ) {
+        if (oq.options.fetchPolicy === "cache-only") {
           return;
         }
 

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1292,7 +1292,10 @@ export class QueryManager {
 
     if (include) {
       this.getObservableQueries(include).forEach((oq) => {
-        if (include === "active" && oq.options.fetchPolicy === "cache-only") {
+        if (
+          (include === "active" || include === "all") &&
+          oq.options.fetchPolicy === "cache-only"
+        ) {
           return;
         }
 

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1393,7 +1393,10 @@ export class QueryManager {
               return result;
             }
 
-            if (onQueryUpdated !== null) {
+            if (
+              onQueryUpdated !== null &&
+              oq.options.fetchPolicy !== "cache-only"
+            ) {
               // If we don't have an onQueryUpdated function, and onQueryUpdated
               // was not disabled by passing null, make sure this query is
               // "included" like any other options.include-specified query.

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -5070,6 +5070,43 @@ describe("ApolloClient", () => {
       expect(refetchCount).toEqual(1);
     });
 
+    it("should not call refetch on a cache-only Observable if the observed queries are refetched and the includeStandby parameter is set to true", async () => {
+      const query = gql`
+        query {
+          author {
+            firstName
+            lastName
+          }
+        }
+      `;
+
+      const client = new ApolloClient({
+        cache: new InMemoryCache(),
+        link: new MockLink([]),
+      });
+
+      const options = {
+        query,
+        fetchPolicy: "cache-only",
+      } as WatchQueryOptions;
+
+      let refetchCount = 0;
+
+      const obs = client.watchQuery(options);
+      obs.subscribe({});
+      obs.refetch = () => {
+        ++refetchCount;
+        return null as never;
+      };
+
+      const includeStandBy = true;
+      void client.reFetchObservableQueries(includeStandBy);
+
+      await wait(50);
+
+      expect(refetchCount).toEqual(0);
+    });
+
     it("should not call refetch on a non-subscribed Observable", async () => {
       const query = gql`
         query {

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -30,7 +30,6 @@ import {
 import type { DeepPartial } from "@apollo/client/utilities";
 import { DocumentTransform } from "@apollo/client/utilities";
 import { removeDirectivesFromDocument } from "@apollo/client/utilities/internal";
-import { InvariantError } from "@apollo/client/utilities/invariant";
 
 describe("ObservableQuery", () => {
   // Standard data for all these tests

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -457,7 +457,7 @@ describe("ObservableQuery", () => {
       it("warns and does not start polling on a cache-only query when using reobserve to change poll interval", async () => {
         using _ = spyOnConsole("warn");
         const query = gql`
-          query {
+          query CountQuery {
             count
           }
         `;
@@ -487,7 +487,8 @@ describe("ObservableQuery", () => {
 
         expect(console.warn).toHaveBeenCalledTimes(1);
         expect(console.warn).toHaveBeenCalledWith(
-          "Cannot poll on a 'cache-only' query and as such, polling is disabled. Please use a different fetch policy."
+          "Cannot poll on 'cache-only' query '%s' and as such, polling is disabled. Please use a different fetch policy.",
+          "CountQuery"
         );
 
         await expect(stream).not.toEmitAnything();
@@ -496,7 +497,7 @@ describe("ObservableQuery", () => {
       it("warns and does not start polling on a cache-only query when initializing with poll interval", async () => {
         using _ = spyOnConsole("warn");
         const query = gql`
-          query {
+          query CountQuery {
             count
           }
         `;
@@ -515,7 +516,8 @@ describe("ObservableQuery", () => {
 
         expect(console.warn).toHaveBeenCalledTimes(1);
         expect(console.warn).toHaveBeenCalledWith(
-          "Cannot poll on a 'cache-only' query and as such, polling is disabled. Please use a different fetch policy."
+          "Cannot poll on 'cache-only' query '%s' and as such, polling is disabled. Please use a different fetch policy.",
+          "CountQuery"
         );
 
         await expect(stream).toEmitTypedValue({
@@ -532,7 +534,7 @@ describe("ObservableQuery", () => {
       it("warns and does not start polling on a cache-only query when calling startPolling", async () => {
         using _ = spyOnConsole("warn");
         const query = gql`
-          query {
+          query CountQuery {
             count
           }
         `;
@@ -560,7 +562,8 @@ describe("ObservableQuery", () => {
 
         expect(console.warn).toHaveBeenCalledTimes(1);
         expect(console.warn).toHaveBeenCalledWith(
-          "Cannot poll on a 'cache-only' query and as such, polling is disabled. Please use a different fetch policy."
+          "Cannot poll on 'cache-only' query '%s' and as such, polling is disabled. Please use a different fetch policy.",
+          "CountQuery"
         );
 
         await expect(stream).not.toEmitAnything();
@@ -569,7 +572,7 @@ describe("ObservableQuery", () => {
       it("cancels polling when changing to a cache-only fetchPolicy", async () => {
         using _ = spyOnConsole("warn");
         const query = gql`
-          query {
+          query CountQuery {
             count
           }
         `;
@@ -628,7 +631,8 @@ describe("ObservableQuery", () => {
 
         expect(console.warn).toHaveBeenCalledTimes(1);
         expect(console.warn).toHaveBeenCalledWith(
-          "Cannot poll on a 'cache-only' query and as such, polling is disabled. Please use a different fetch policy."
+          "Cannot poll on 'cache-only' query '%s' and as such, polling is disabled. Please use a different fetch policy.",
+          "CountQuery"
         );
 
         await expect(stream).not.toEmitAnything();
@@ -2159,7 +2163,7 @@ describe("ObservableQuery", () => {
       });
 
       const expectedError = new InvariantError(
-        "Cannot execute `refetch` for a 'cache-only' query. Please use a different fetch policy."
+        "Cannot execute `refetch` for 'cache-only' query 'query'. Please use a different fetch policy."
       );
 
       await expect(observable.refetch()).rejects.toEqual(expectedError);
@@ -4853,7 +4857,7 @@ describe("ObservableQuery", () => {
                 loading: false,
                 networkStatus: NetworkStatus.error,
                 error: new InvariantError(
-                  "Cannot execute `refetch` for a 'cache-only' query. Please use a different fetch policy."
+                  "Cannot execute `refetch` for 'cache-only' query '(anonymous)'. Please use a different fetch policy."
                 ),
                 data: cacheValues.update2,
                 dataState: "complete",
@@ -4922,7 +4926,7 @@ describe("ObservableQuery", () => {
                 loading: false,
                 networkStatus: NetworkStatus.error,
                 error: new InvariantError(
-                  "Cannot execute `refetch` for a 'cache-only' query. Please use a different fetch policy."
+                  "Cannot execute `refetch` for 'cache-only' query '(anonymous)'. Please use a different fetch policy."
                 ),
                 data: cacheValues.update2,
                 dataState: "complete",

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -4854,11 +4854,7 @@ describe("ObservableQuery", () => {
             },
             resultAfterRefetchCall: {
               emit: {
-                loading: false,
-                networkStatus: NetworkStatus.error,
-                error: new InvariantError(
-                  "Cannot execute `refetch` for 'cache-only' query '(anonymous)'. Please use a different fetch policy."
-                ),
+                ...loadingStates.refetching,
                 data: cacheValues.update2,
                 dataState: "complete",
                 partial: false,
@@ -4866,13 +4862,20 @@ describe("ObservableQuery", () => {
             },
             resultAfterCacheUpdate3: {
               emit: {
-                ...loadingStates.done,
+                ...loadingStates.refetching,
                 data: cacheValues.update3,
                 dataState: "complete",
                 partial: false,
               },
             },
-            resultAfterRefetchNext: undefined,
+            resultAfterRefetchNext: {
+              emit: {
+                ...loadingStates.done,
+                data: cacheValues.refetch,
+                dataState: "complete",
+                partial: false,
+              },
+            },
             resultAfterCacheUpdate4: {
               emit: {
                 ...loadingStates.done,
@@ -4922,12 +4925,8 @@ describe("ObservableQuery", () => {
               },
             },
             resultAfterRefetchCall: {
-              emit: {
-                loading: false,
-                networkStatus: NetworkStatus.error,
-                error: new InvariantError(
-                  "Cannot execute `refetch` for 'cache-only' query '(anonymous)'. Please use a different fetch policy."
-                ),
+              currentResult: {
+                ...loadingStates.refetching,
                 data: cacheValues.update2,
                 dataState: "complete",
                 partial: false,
@@ -4935,13 +4934,20 @@ describe("ObservableQuery", () => {
             },
             resultAfterCacheUpdate3: {
               emit: {
-                ...loadingStates.done,
+                ...loadingStates.refetching,
                 data: cacheValues.update3,
                 dataState: "complete",
                 partial: false,
               },
             },
-            resultAfterRefetchNext: undefined,
+            resultAfterRefetchNext: {
+              emit: {
+                ...loadingStates.done,
+                data: cacheValues.refetch,
+                dataState: "complete",
+                partial: false,
+              },
+            },
             resultAfterCacheUpdate4: {
               emit: {
                 ...loadingStates.done,

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -5200,7 +5200,7 @@ describe("ObservableQuery", () => {
 
           await lastValueFrom(subject, { defaultValue: undefined });
           subject = new Subject();
-          void observableQuery.refetch();
+          void observableQuery.refetch().catch(() => {});
           await check(resultAfterRefetchCall, "resultAfterRefetchCall");
 
           cache.writeQuery({ query, data: cacheValues.update3 });

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -4850,7 +4850,11 @@ describe("ObservableQuery", () => {
             },
             resultAfterRefetchCall: {
               emit: {
-                ...loadingStates.refetching,
+                loading: false,
+                networkStatus: NetworkStatus.error,
+                error: new InvariantError(
+                  "Cannot execute `refetch` for a 'cache-only' query. Please use a different fetch policy."
+                ),
                 data: cacheValues.update2,
                 dataState: "complete",
                 partial: false,
@@ -4858,20 +4862,13 @@ describe("ObservableQuery", () => {
             },
             resultAfterCacheUpdate3: {
               emit: {
-                ...loadingStates.refetching,
+                ...loadingStates.done,
                 data: cacheValues.update3,
                 dataState: "complete",
                 partial: false,
               },
             },
-            resultAfterRefetchNext: {
-              emit: {
-                ...loadingStates.done,
-                data: cacheValues.refetch,
-                dataState: "complete",
-                partial: false,
-              },
-            },
+            resultAfterRefetchNext: undefined,
             resultAfterCacheUpdate4: {
               emit: {
                 ...loadingStates.done,
@@ -4921,8 +4918,12 @@ describe("ObservableQuery", () => {
               },
             },
             resultAfterRefetchCall: {
-              currentResult: {
-                ...loadingStates.refetching,
+              emit: {
+                loading: false,
+                networkStatus: NetworkStatus.error,
+                error: new InvariantError(
+                  "Cannot execute `refetch` for a 'cache-only' query. Please use a different fetch policy."
+                ),
                 data: cacheValues.update2,
                 dataState: "complete",
                 partial: false,
@@ -4930,20 +4931,13 @@ describe("ObservableQuery", () => {
             },
             resultAfterCacheUpdate3: {
               emit: {
-                ...loadingStates.refetching,
+                ...loadingStates.done,
                 data: cacheValues.update3,
                 dataState: "complete",
                 partial: false,
               },
             },
-            resultAfterRefetchNext: {
-              emit: {
-                ...loadingStates.done,
-                data: cacheValues.refetch,
-                dataState: "complete",
-                partial: false,
-              },
-            },
+            resultAfterRefetchNext: undefined,
             resultAfterCacheUpdate4: {
               emit: {
                 ...loadingStates.done,

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -5216,7 +5216,7 @@ describe("ObservableQuery", () => {
           cache.writeQuery({ query, data: cacheValues.update4 });
           await check(resultAfterCacheUpdate4, "resultAfterCacheUpdate4");
 
-          expect(stream).not.toEmitAnything();
+          await expect(stream).not.toEmitAnything();
         }
       );
     }

--- a/src/core/__tests__/fetchPolicies.ts
+++ b/src/core/__tests__/fetchPolicies.ts
@@ -12,7 +12,6 @@ import {
   ObservableStream,
   spyOnConsole,
 } from "@apollo/client/testing/internal";
-import { InvariantError } from "@apollo/client/utilities/invariant";
 
 import type { ApolloQueryResult } from "../types.js";
 import type {

--- a/src/core/__tests__/fetchPolicies.ts
+++ b/src/core/__tests__/fetchPolicies.ts
@@ -620,7 +620,7 @@ describe("cache-only", () => {
     });
 
     const query = gql`
-      query {
+      query CountQuery {
         count
       }
     `;
@@ -651,7 +651,7 @@ describe("cache-only", () => {
     expect(observable.options.fetchPolicy).toBe("cache-only");
 
     const expectedError = new InvariantError(
-      "Cannot execute `refetch` for a 'cache-only' query. Please use a different fetch policy."
+      "Cannot execute `refetch` for 'cache-only' query 'CountQuery'. Please use a different fetch policy."
     );
 
     await expect(observable.refetch()).rejects.toEqual(expectedError);

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -5307,7 +5307,7 @@ describe("useQuery Hook", () => {
       });
 
       const expectedError = new InvariantError(
-        "Cannot execute `fetchMore` for a 'cache-only' query. Please use a different fetch policy."
+        "Cannot execute `fetchMore` for 'cache-only' query 'letters'. Please use a different fetch policy."
       );
 
       await expect(
@@ -6787,7 +6787,7 @@ describe("useQuery Hook", () => {
 
     it("does not allow refetch on a cache-only query", async () => {
       const query = gql`
-        {
+        query Greeting {
           hello
         }
       `;
@@ -6823,7 +6823,7 @@ describe("useQuery Hook", () => {
       });
 
       const expectedError = new InvariantError(
-        "Cannot execute `refetch` for a 'cache-only' query. Please use a different fetch policy."
+        "Cannot execute `refetch` for 'cache-only' query 'Greeting'. Please use a different fetch policy."
       );
 
       await expect(getCurrentSnapshot().refetch()).rejects.toEqual(

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -5306,23 +5306,13 @@ describe("useQuery Hook", () => {
         variables: { limit: 2 },
       });
 
-      const expectedError = new InvariantError(
-        "Cannot execute `fetchMore` for 'cache-only' query 'letters'. Please use a different fetch policy."
-      );
-
-      await expect(
+      expect(() =>
         getCurrentSnapshot().fetchMore({ variables: { limit: 2 } })
-      ).rejects.toEqual(expectedError);
-
-      await expect(takeSnapshot()).resolves.toStrictEqualTyped({
-        data: undefined,
-        dataState: "empty",
-        error: expectedError,
-        loading: false,
-        networkStatus: NetworkStatus.error,
-        previousData: undefined,
-        variables: { limit: 2 },
-      });
+      ).toThrow(
+        new InvariantError(
+          "Cannot execute `fetchMore` for 'cache-only' query 'letters'. Please use a different fetch policy."
+        )
+      );
 
       await expect(takeSnapshot).not.toRerender();
     });

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -6785,7 +6785,7 @@ describe("useQuery Hook", () => {
       await expect(takeSnapshot).not.toRerender();
     });
 
-    it("does not allow refetch on a cache-only query", async () => {
+    it("allows refetch on a cache-only query", async () => {
       const query = gql`
         query Greeting {
           hello
@@ -6822,20 +6822,15 @@ describe("useQuery Hook", () => {
         variables: {},
       });
 
-      const expectedError = new InvariantError(
-        "Cannot execute `refetch` for 'cache-only' query 'Greeting'. Please use a different fetch policy."
-      );
-
-      await expect(getCurrentSnapshot().refetch()).rejects.toEqual(
-        expectedError
-      );
+      await expect(getCurrentSnapshot().refetch()).resolves.toStrictEqualTyped({
+        data: { hello: "world" },
+      });
 
       await expect(takeSnapshot()).resolves.toStrictEqualTyped({
-        data: undefined,
-        dataState: "empty",
-        error: expectedError,
+        data: { hello: "world" },
+        dataState: "complete",
         loading: false,
-        networkStatus: NetworkStatus.error,
+        networkStatus: NetworkStatus.ready,
         previousData: undefined,
         variables: {},
       });

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -327,7 +327,7 @@ export function useLazyQuery<
     React.useCallback(
       (forceUpdate) => {
         const subscription = observable.subscribe((result) => {
-          if (!equal(resultRef.current || initialResult, result)) {
+          if (!equal(resultRef.current, result)) {
             updateResult(result, forceUpdate);
           }
         });


### PR DESCRIPTION
Fixes #11997

Throws an error when `fetchMore` is called on a `cache-only` query. Additionally a warning will be emitted when setting a poll interval on a `cache-only` query and polling will be cancelled.

`cache-only` queries are now excluded from `refetchQueries` when using `include: 'all' | 'active'` and when listed as a query in `include`.

`cache-only` queries are also excluded from `client.reFetchObservableQueries` when `includeStandby` is `true`.