### PR TITLE
Don't warn for missing resolvers

### DIFF
--- a/.changeset/kind-taxis-thank.md
+++ b/.changeset/kind-taxis-thank.md
@@ -1,0 +1,7 @@
+---
+"@apollo/client": patch
+---
+
+Don't warn about a missing resolver if a `@client` does not have a configured resolver. It is possible the cache contains a `read` function for the field and the warning added confusion.
+
+Note that `read` functions without a defined resolver will receive the `existing` argument as `null` instead of `undefined` even when data hasn't been written to the cache. This is because `LocalState` sets a default value of `null` when a resolver is not defined to ensure that the field contains a value in case a `read` function is not defined rather than omitting the field entirely.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43730,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38702,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33448,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27662
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43694,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38700,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33342,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27657
 }

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
   "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43674,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38705,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33447,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27639
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38653,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33389,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27619
 }

--- a/src/__tests__/local-state/general.ts
+++ b/src/__tests__/local-state/general.ts
@@ -577,6 +577,67 @@ describe("Cache manipulation", () => {
 
     await expect(stream).not.toEmitAnything();
   });
+
+  test("runs read functions for nested @client fields without resolver warnings", async () => {
+    using _ = spyOnConsole("warn");
+    const query = gql`
+      query {
+        color {
+          hex
+          saved @client
+        }
+      }
+    `;
+
+    const link = new ApolloLink(() => {
+      return of({ data: { color: { __typename: "Color", hex: "#000" } } }).pipe(
+        delay(20)
+      );
+    });
+
+    const read = jest.fn(() => false);
+
+    const cache = new InMemoryCache({
+      typePolicies: {
+        Color: {
+          keyFields: ["hex"],
+          fields: {
+            saved: { read },
+          },
+        },
+      },
+    });
+
+    const client = new ApolloClient({
+      link,
+      cache,
+      localState: new LocalState(),
+    });
+
+    const stream = new ObservableStream(client.watchQuery({ query }));
+
+    await expect(stream).toEmitTypedValue({
+      data: undefined,
+      dataState: "empty",
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      partial: true,
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: { color: { __typename: "Color", hex: "#000", saved: false } },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
+
+    expect(read).toHaveBeenCalledTimes(1);
+    // TODO: Is `null` an ok value here? This is the result of running the
+    // default resolver which returns `null`.
+    expect(read).toHaveBeenCalledWith(null, expect.anything());
+    expect(console.warn).not.toHaveBeenCalled();
+  });
 });
 
 describe("Sample apps", () => {

--- a/src/__tests__/local-state/general.ts
+++ b/src/__tests__/local-state/general.ts
@@ -633,8 +633,6 @@ describe("Cache manipulation", () => {
     });
 
     expect(read).toHaveBeenCalledTimes(1);
-    // TODO: Is `null` an ok value here? This is the result of running the
-    // default resolver which returns `null`.
     expect(read).toHaveBeenCalledWith(null, expect.anything());
     expect(console.warn).not.toHaveBeenCalled();
   });

--- a/src/local-state/LocalState.ts
+++ b/src/local-state/LocalState.ts
@@ -615,13 +615,6 @@ export class LocalState<
           }
 
           if (!returnPartialData) {
-            if (__DEV__) {
-              invariant.warn(
-                "Could not find a resolver for the '%s' field. The field value has been set to `null`.",
-                resolverName
-              );
-            }
-
             return null;
           }
         }

--- a/src/local-state/__tests__/LocalState/base.test.ts
+++ b/src/local-state/__tests__/LocalState/base.test.ts
@@ -573,7 +573,7 @@ test("throws error when query does not contain client fields", async () => {
   );
 });
 
-test("warns when a resolver is missing for an `@client` field", async () => {
+test("does not warn when a resolver is missing for an `@client` field", async () => {
   using _ = spyOnConsole("warn");
   const document = gql`
     query {
@@ -598,14 +598,10 @@ test("warns when a resolver is missing for an `@client` field", async () => {
     })
   ).resolves.toStrictEqualTyped({ data: { foo: null } });
 
-  expect(console.warn).toHaveBeenCalledTimes(1);
-  expect(console.warn).toHaveBeenCalledWith(
-    "Could not find a resolver for the '%s' field. The field value has been set to `null`.",
-    "Query.foo"
-  );
+  expect(console.warn).not.toHaveBeenCalled();
 });
 
-test("warns for client child fields of a server field", async () => {
+test("does not warn for client child fields of a server field", async () => {
   using _ = spyOnConsole("warn");
   const document = gql`
     query {
@@ -634,11 +630,7 @@ test("warns for client child fields of a server field", async () => {
     data: { foo: { __typename: "Foo", bar: null } },
   });
 
-  expect(console.warn).toHaveBeenCalledTimes(1);
-  expect(console.warn).toHaveBeenCalledWith(
-    "Could not find a resolver for the '%s' field. The field value has been set to `null`.",
-    "Foo.bar"
-  );
+  expect(console.warn).not.toHaveBeenCalled();
 });
 
 test("warns when a resolver returns undefined and sets value to null", async () => {

--- a/src/local-state/__tests__/LocalState/cache.test.ts
+++ b/src/local-state/__tests__/LocalState/cache.test.ts
@@ -338,7 +338,7 @@ test("handles read functions for root object field from cache if resolver is not
   });
 });
 
-test("warns if resolver is not defined if cache does not have value", async () => {
+test("does not warn if resolver is not defined if cache does not have value", async () => {
   using _ = spyOnConsole("warn");
   const document = gql`
     query {
@@ -363,11 +363,7 @@ test("warns if resolver is not defined if cache does not have value", async () =
     })
   ).resolves.toStrictEqualTyped({ data: { count: null } });
 
-  expect(console.warn).toHaveBeenCalledTimes(1);
-  expect(console.warn).toHaveBeenCalledWith(
-    "Could not find a resolver for the '%s' field. The field value has been set to `null`.",
-    "Query.count"
-  );
+  expect(console.warn).not.toHaveBeenCalled();
 });
 
 test("reads from the cache on a nested scalar field by default if a resolver is not defined", async () => {
@@ -713,11 +709,7 @@ test("does not confuse field missing resolver with root field of same name on a 
     },
   });
 
-  expect(console.warn).toHaveBeenCalledTimes(1);
-  expect(console.warn).toHaveBeenCalledWith(
-    "Could not find a resolver for the '%s' field. The field value has been set to `null`.",
-    "User.count"
-  );
+  expect(console.warn).not.toHaveBeenCalled();
 });
 
 test("does not confuse field missing resolver with root field of same name on a non-normalized record", async () => {
@@ -769,11 +761,7 @@ test("does not confuse field missing resolver with root field of same name on a 
     },
   });
 
-  expect(console.warn).toHaveBeenCalledTimes(1);
-  expect(console.warn).toHaveBeenCalledWith(
-    "Could not find a resolver for the '%s' field. The field value has been set to `null`.",
-    "User.count"
-  );
+  expect(console.warn).not.toHaveBeenCalled();
 });
 
 test("warns on undefined value if partial data is written to the cache for an object client field", async () => {


### PR DESCRIPTION
Fixes #12730

Remove the warning for a missing resolver when encountering an `@client` field that does not have a cache value. This is less confusing when `@client` fields are managed by `read` functions since local resolvers aren't required in order to use `@client` fields.