### PR TITLE
also allow Complete and Partial datastate type overrides

### DIFF
--- a/.api-reports/api-report-cache.api.md
+++ b/.api-reports/api-report-cache.api.md
@@ -7,6 +7,7 @@
 import type { ApolloCache as ApolloCache_2 } from '@apollo/client';
 import type { AsStoreObject } from '@apollo/client/utilities';
 import { canonicalStringify } from '@apollo/client/utilities';
+import type { DataValue } from '@apollo/client';
 import type { DeepPartial } from '@apollo/client/utilities';
 import type { DocumentNode } from 'graphql';
 import type { FieldNode } from 'graphql';
@@ -222,12 +223,12 @@ export function createFragmentRegistry(...fragments: DocumentNode[]): FragmentRe
 export namespace DataProxy {
     // (undocumented)
     export type DiffResult<TData> = {
-        result: TData;
+        result: DataValue.Complete<TData>;
         complete: true;
         missing?: never;
         fromOptimisticTransaction?: boolean;
     } | {
-        result: DeepPartial<TData> | null;
+        result: DataValue.Partial<TData> | null;
         complete: false;
         missing?: MissingFieldError;
         fromOptimisticTransaction?: boolean;

--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -230,18 +230,26 @@ export { DataProxy }
 
 // @public (undocumented)
 export type DataState<TData> = {
-    data: TData;
+    data: DataValue.Complete<TData>;
     dataState: "complete";
 } | {
-    data: Streaming<TData>;
+    data: DataValue.Streaming<TData>;
     dataState: "streaming";
 } | {
-    data: DeepPartial<TData>;
+    data: DataValue.Partial<TData>;
     dataState: "partial";
 } | {
     data: undefined;
     dataState: "empty";
 };
+
+// @public (undocumented)
+export namespace DataValue {
+    // Warning: (ae-forgotten-export) The symbol "OverridableTypes" needs to be exported by the entry point index.d.ts
+    export type Complete<TData> = ApplyHKTImplementationWithDefault<TypeOverrides, "Complete", OverridableTypes.Defaults, TData>;
+    export type Partial<TData> = ApplyHKTImplementationWithDefault<TypeOverrides, "Partial", OverridableTypes.Defaults, TData>;
+    export type Streaming<TData> = ApplyHKTImplementationWithDefault<TypeOverrides, "Streaming", OverridableTypes.Defaults, TData>;
+}
 
 // @public (undocumented)
 export interface DefaultContext extends Record<string, any> {
@@ -512,13 +520,7 @@ export { NormalizedCache }
 export { NormalizedCacheObject }
 
 // @public
-export type NormalizedExecutionResult<TData = Record<string, unknown>, TExtensions = Record<string, unknown>> = Omit<FormattedExecutionResult<TData, TExtensions>, "data"> & ({
-    data: TData;
-    dataState: "complete";
-} | {
-    data: Streaming<TData>;
-    dataState: "streaming";
-});
+export type NormalizedExecutionResult<TData = Record<string, unknown>, TExtensions = Record<string, unknown>> = Omit<FormattedExecutionResult<TData, TExtensions>, "data"> & GetDataState<TData, "streaming" | "complete">;
 
 export { Observable }
 
@@ -624,11 +626,33 @@ export { OptimisticStoreItem }
 // @public (undocumented)
 namespace OverridableTypes {
     // (undocumented)
+    interface Complete extends HKT {
+        // (undocumented)
+        arg1: unknown;
+        // (undocumented)
+        return: this["arg1"];
+    }
+    // (undocumented)
     interface Defaults {
         // Warning: (ae-forgotten-export) The symbol "OverridableTypes" needs to be exported by the entry point index.d.ts
         //
         // (undocumented)
+        Complete: Complete;
+        // Warning: (ae-forgotten-export) The symbol "OverridableTypes" needs to be exported by the entry point index.d.ts
+        //
+        // (undocumented)
+        Partial: Partial;
+        // Warning: (ae-forgotten-export) The symbol "OverridableTypes" needs to be exported by the entry point index.d.ts
+        //
+        // (undocumented)
         Streaming: Streaming;
+    }
+    // (undocumented)
+    interface Partial extends HKT {
+        // (undocumented)
+        arg1: unknown;
+        // (undocumented)
+        return: DeepPartial<this["arg1"]>;
     }
     // (undocumented)
     interface Streaming extends HKT {
@@ -877,11 +901,6 @@ export { split }
 export { StoreObject }
 
 export { StoreValue }
-
-// Warning: (ae-forgotten-export) The symbol "OverridableTypes" needs to be exported by the entry point index.d.ts
-//
-// @public
-export type Streaming<TData> = ApplyHKTImplementationWithDefault<TypeOverrides, "Streaming", OverridableTypes.Defaults, TData>;
 
 // @public (undocumented)
 export interface SubscribeResult<TData = unknown> {

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -239,18 +239,26 @@ export function createQueryPreloader(client: ApolloClient): PreloadQueryFunction
 
 // @public (undocumented)
 type DataState<TData> = {
-    data: TData;
+    data: DataValue.Complete<TData>;
     dataState: "complete";
 } | {
-    data: Streaming<TData>;
+    data: DataValue.Streaming<TData>;
     dataState: "streaming";
 } | {
-    data: DeepPartial<TData>;
+    data: DataValue.Partial<TData>;
     dataState: "partial";
 } | {
     data: undefined;
     dataState: "empty";
 };
+
+// @public (undocumented)
+namespace DataValue {
+    // Warning: (ae-forgotten-export) The symbol "OverridableTypes" needs to be exported by the entry point index.d.ts
+    type Complete<TData> = ApplyHKTImplementationWithDefault<TypeOverrides, "Complete", OverridableTypes.Defaults, TData>;
+    type Partial<TData> = ApplyHKTImplementationWithDefault<TypeOverrides, "Partial", OverridableTypes.Defaults, TData>;
+    type Streaming<TData> = ApplyHKTImplementationWithDefault<TypeOverrides, "Streaming", OverridableTypes.Defaults, TData>;
+}
 
 // @public (undocumented)
 interface DefaultContext extends Record<string, any> {
@@ -495,13 +503,7 @@ interface NextFetchPolicyContext<TData, TVariables extends OperationVariables_2>
 }
 
 // @public
-type NormalizedExecutionResult<TData = Record<string, unknown>, TExtensions = Record<string, unknown>> = Omit<FormattedExecutionResult<TData, TExtensions>, "data"> & ({
-    data: TData;
-    dataState: "complete";
-} | {
-    data: Streaming<TData>;
-    dataState: "streaming";
-});
+type NormalizedExecutionResult<TData = Record<string, unknown>, TExtensions = Record<string, unknown>> = Omit<FormattedExecutionResult<TData, TExtensions>, "data"> & GetDataState<TData, "streaming" | "complete">;
 
 // @public (undocumented)
 interface ObservableAndInfo<TData> {
@@ -610,11 +612,33 @@ type OperationVariables_2 = Record<string, any>;
 // @public (undocumented)
 namespace OverridableTypes {
     // (undocumented)
+    interface Complete extends HKT {
+        // (undocumented)
+        arg1: unknown;
+        // (undocumented)
+        return: this["arg1"];
+    }
+    // (undocumented)
     interface Defaults {
         // Warning: (ae-forgotten-export) The symbol "OverridableTypes" needs to be exported by the entry point index.d.ts
         //
         // (undocumented)
+        Complete: Complete;
+        // Warning: (ae-forgotten-export) The symbol "OverridableTypes" needs to be exported by the entry point index.d.ts
+        //
+        // (undocumented)
+        Partial: Partial;
+        // Warning: (ae-forgotten-export) The symbol "OverridableTypes" needs to be exported by the entry point index.d.ts
+        //
+        // (undocumented)
         Streaming: Streaming;
+    }
+    // (undocumented)
+    interface Partial extends HKT {
+        // (undocumented)
+        arg1: unknown;
+        // (undocumented)
+        return: DeepPartial<this["arg1"]>;
     }
     // (undocumented)
     interface Streaming extends HKT {
@@ -883,11 +907,6 @@ export type SkipToken = typeof skipToken;
 
 // @public (undocumented)
 export const skipToken: unique symbol;
-
-// Warning: (ae-forgotten-export) The symbol "OverridableTypes" needs to be exported by the entry point index.d.ts
-//
-// @public
-type Streaming<TData> = ApplyHKTImplementationWithDefault<TypeOverrides, "Streaming", OverridableTypes.Defaults, TData>;
 
 // @public (undocumented)
 interface SubscribeResult<TData = unknown> {
@@ -1624,10 +1643,10 @@ type WatchQueryOptions_2<TVariables extends OperationVariables_2 = OperationVari
 // src/core/ObservableQuery.ts:157:5 - (ae-forgotten-export) The symbol "RefetchWritePolicy" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:305:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:187:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:236:3 - (ae-forgotten-export) The symbol "ErrorLike" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:238:3 - (ae-forgotten-export) The symbol "NetworkStatus" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:255:7 - (ae-forgotten-export) The symbol "Streaming" needs to be exported by the entry point index.d.ts
-// src/core/types.ts:308:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:313:3 - (ae-forgotten-export) The symbol "ErrorLike" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:315:3 - (ae-forgotten-export) The symbol "NetworkStatus" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:327:7 - (ae-forgotten-export) The symbol "DataValue" needs to be exported by the entry point index.d.ts
+// src/core/types.ts:374:3 - (ae-forgotten-export) The symbol "MutationQueryReducer" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:177:3 - (ae-forgotten-export) The symbol "UpdateQueryOptions" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:260:3 - (ae-forgotten-export) The symbol "MutationQueryReducersMap" needs to be exported by the entry point index.d.ts
 // src/core/watchQueryOptions.ts:263:3 - (ae-forgotten-export) The symbol "NormalizedExecutionResult" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -491,12 +491,12 @@ export interface DataMasking {
 export namespace DataProxy {
     // (undocumented)
     export type DiffResult<TData> = {
-        result: TData;
+        result: DataValue.Complete<TData>;
         complete: true;
         missing?: never;
         fromOptimisticTransaction?: boolean;
     } | {
-        result: DeepPartial<TData> | null;
+        result: DataValue.Partial<TData> | null;
         complete: false;
         missing?: MissingFieldError;
         fromOptimisticTransaction?: boolean;
@@ -554,18 +554,27 @@ export interface DataProxy {
 
 // @public (undocumented)
 export type DataState<TData> = {
-    data: TData;
+    data: DataValue.Complete<TData>;
     dataState: "complete";
 } | {
-    data: Streaming<TData>;
+    data: DataValue.Streaming<TData>;
     dataState: "streaming";
 } | {
-    data: DeepPartial<TData>;
+    data: DataValue.Partial<TData>;
     dataState: "partial";
 } | {
     data: undefined;
     dataState: "empty";
 };
+
+// @public (undocumented)
+export namespace DataValue {
+    // Warning: (ae-forgotten-export) The symbol "ApplyHKTImplementationWithDefault" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "OverridableTypes" needs to be exported by the entry point index.d.ts
+    export type Complete<TData> = ApplyHKTImplementationWithDefault<TypeOverrides, "Complete", OverridableTypes.Defaults, TData>;
+    export type Partial<TData> = ApplyHKTImplementationWithDefault<TypeOverrides, "Partial", OverridableTypes.Defaults, TData>;
+    export type Streaming<TData> = ApplyHKTImplementationWithDefault<TypeOverrides, "Streaming", OverridableTypes.Defaults, TData>;
+}
 
 // Warning: (ae-forgotten-export) The symbol "DeepPartialPrimitive" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "DeepPartialMap" needs to be exported by the entry point index.d.ts
@@ -577,6 +586,8 @@ export type DataState<TData> = {
 // @public
 type DeepPartial<T> = T extends DeepPartialPrimitive ? T : T extends Map<infer TKey, infer TValue> ? DeepPartialMap<TKey, TValue> : T extends ReadonlyMap<infer TKey, infer TValue> ? DeepPartialReadonlyMap<TKey, TValue> : T extends Set<infer TItem> ? DeepPartialSet<TItem> : T extends ReadonlySet<infer TItem> ? DeepPartialReadonlySet<TItem> : T extends (...args: any[]) => unknown ? T | undefined : T extends object ? T extends (ReadonlyArray<infer TItem>) ? TItem[] extends (T) ? readonly TItem[] extends T ? ReadonlyArray<DeepPartial<TItem | undefined>> : Array<DeepPartial<TItem | undefined>> : DeepPartialObject<T> : DeepPartialObject<T> : unknown;
 
+// Warning: (ae-forgotten-export) The symbol "DeepPartial" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
 type DeepPartialMap<TKey, TValue> = {} & Map<DeepPartial<TKey>, DeepPartial<TValue>>;
 
@@ -947,7 +958,6 @@ interface FragmentRegistryAPI {
     transform<D extends DocumentNode>(document: D): D;
 }
 
-// Warning: (ae-forgotten-export) The symbol "ApplyHKTImplementationWithDefault" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "DefaultImplementation" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
@@ -1840,13 +1850,7 @@ export interface NormalizedCacheObject {
 }
 
 // @public
-export type NormalizedExecutionResult<TData = Record<string, unknown>, TExtensions = Record<string, unknown>> = Omit<FormattedExecutionResult<TData, TExtensions>, "data"> & ({
-    data: TData;
-    dataState: "complete";
-} | {
-    data: Streaming<TData>;
-    dataState: "streaming";
-});
+export type NormalizedExecutionResult<TData = Record<string, unknown>, TExtensions = Record<string, unknown>> = Omit<FormattedExecutionResult<TData, TExtensions>, "data"> & GetDataState<TData, "streaming" | "complete">;
 
 export { Observable }
 
@@ -1980,11 +1984,33 @@ export type OptimisticStoreItem = {
 // @public (undocumented)
 namespace OverridableTypes {
     // (undocumented)
+    interface Complete extends HKT {
+        // (undocumented)
+        arg1: unknown;
+        // (undocumented)
+        return: this["arg1"];
+    }
+    // (undocumented)
     interface Defaults {
         // Warning: (ae-forgotten-export) The symbol "OverridableTypes" needs to be exported by the entry point index.d.ts
         //
         // (undocumented)
+        Complete: Complete;
+        // Warning: (ae-forgotten-export) The symbol "OverridableTypes" needs to be exported by the entry point index.d.ts
+        //
+        // (undocumented)
+        Partial: Partial;
+        // Warning: (ae-forgotten-export) The symbol "OverridableTypes" needs to be exported by the entry point index.d.ts
+        //
+        // (undocumented)
         Streaming: Streaming;
+    }
+    // (undocumented)
+    interface Partial extends HKT {
+        // (undocumented)
+        arg1: unknown;
+        // (undocumented)
+        return: DeepPartial<this["arg1"]>;
     }
     // (undocumented)
     interface Streaming extends HKT {
@@ -2431,11 +2457,6 @@ Item
 // @public
 export type StoreValue = number | string | string[] | Reference | Reference[] | null | undefined | void | Object;
 
-// Warning: (ae-forgotten-export) The symbol "OverridableTypes" needs to be exported by the entry point index.d.ts
-//
-// @public
-export type Streaming<TData> = ApplyHKTImplementationWithDefault<TypeOverrides, "Streaming", OverridableTypes.Defaults, TData>;
-
 // @public (undocumented)
 class Stump extends Layer {
     constructor(root: EntityStore.Root);
@@ -2686,7 +2707,6 @@ interface WriteContext extends ReadMergeModifyContext {
 
 // Warnings were encountered during analysis:
 //
-// src/cache/core/types/DataProxy.ts:137:9 - (ae-forgotten-export) The symbol "DeepPartial" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/policies.ts:97:3 - (ae-forgotten-export) The symbol "FragmentMap" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/policies.ts:166:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/policies.ts:166:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts

--- a/.changeset/proud-walls-shave.md
+++ b/.changeset/proud-walls-shave.md
@@ -1,0 +1,43 @@
+---
+"@apollo/client": minor
+---
+
+Overridable types for `dataState: "complete"`, `dataState: "streaming"` and
+`dataState: "partial"` responses.
+
+This adds the `DataValue` namespace exported from Apollo Client with the three
+types `DataValue.Complete`, `DataValue.Streaming` and `DataValue.Partial`.
+
+These types will be used to mark `TData` in the respective states.
+
+* `Complete` defaults to `TData`
+* `Streaming` defaults to `TData`
+* `Partial` defaults to `DeepPartial<TData>`
+
+All three can be overwritten, e.g. to be `DeepReadonly` using higher kinded types
+by following this pattern:
+
+```ts
+import { HKT, DeepPartial } from "@apollo/client/utilities";
+import { DeepReadonly } from "some-type-helper-library";
+
+interface CompleteOverride extends HKT {
+  return: DeepReadonly<this["arg1"]>;
+}
+
+interface StreamingOverride extends HKT {
+  return: DeepReadonly<this["arg1"]>;
+}
+
+interface PartialOverride extends HKT {
+  return: DeepReadonly<DeepPartial<this["arg1"]>>;
+}
+
+declare module "@apollo/client" {
+  export interface TypeOverrides {
+    Complete: CompleteOverride;
+    Streaming: StreamingOverride;
+    Partial: PartialOverride;
+  }
+}
+```

--- a/integration-tests/pnpm-lock.yaml
+++ b/integration-tests/pnpm-lock.yaml
@@ -169,6 +169,9 @@ importers:
       '@apollo/client':
         specifier: 3.13.0
         version: 3.13.0(@types/react@18.2.14)(graphql@16.10.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      expect-type:
+        specifier: ^1.2.1
+        version: 1.2.1
       graphql:
         specifier: ^16.8.1
         version: 16.10.0
@@ -3655,6 +3658,10 @@ packages:
   exit@0.1.2:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
+
+  expect-type@1.2.1:
+    resolution: {integrity: sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==}
+    engines: {node: '>=12.0.0'}
 
   expect@27.5.1:
     resolution: {integrity: sha512-E1q5hSUG2AmYQwQJ041nvgpkODHQvB+RKlB4IYdru6uJsyFTRyZAP463M+1lINorwbqAmUggi6+WwkD8lCS/Dw==}
@@ -11314,6 +11321,8 @@ snapshots:
       strip-final-newline: 2.0.0
 
   exit@0.1.2: {}
+
+  expect-type@1.2.1: {}
 
   expect@27.5.1:
     dependencies:

--- a/integration-tests/vite/package.json
+++ b/integration-tests/vite/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@apollo/client": "3.13.0",
+    "expect-type": "^1.2.1",
     "graphql": "^16.8.1",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",

--- a/integration-tests/vite/src/App.tsx
+++ b/integration-tests/vite/src/App.tsx
@@ -57,7 +57,7 @@ function Main() {
 
   return data ?
       <ul>
-        {data?.products.map(({ id, title }) => <li key={id}>{title}</li>)}
+        {data?.products?.map(({ id, title } = {}) => <li key={id}>{title}</li>)}
       </ul>
     : <>loading</>;
 }

--- a/integration-tests/vite/src/enhanceDataStates.ts
+++ b/integration-tests/vite/src/enhanceDataStates.ts
@@ -1,15 +1,18 @@
 import { DeepPartial, HKT } from "@apollo/client/utilities";
 import { ApplyHKT } from "@apollo/client/utilities/internal";
-import { gql, TypedDocumentNode, TData } from "@apollo/client";
+import { gql, DataValue, TypedDocumentNode } from "@apollo/client";
 import { useQuery } from "@apollo/client/react";
 import { expectTypeOf } from "expect-type";
 import { DocumentTypeDecoration } from "@graphql-typed-document-node/core";
 
+declare const complete: unique symbol;
+declare const streaming: unique symbol;
+
 type ExtendedTypedDocumentNode<TCompleteData, TVariables, TStreaming> =
   TypedDocumentNode<
     TCompleteData & {
-      _complete?: TCompleteData;
-      _streaming?: TStreaming;
+      [complete]?: TCompleteData;
+      [streaming]?: TStreaming;
     },
     TVariables
   >;
@@ -17,12 +20,12 @@ type ExtendedTypedDocumentNode<TCompleteData, TVariables, TStreaming> =
 declare namespace MyImplementation {
   interface Complete extends HKT {
     arg1: unknown; // TData
-    return: this["arg1"] extends { _complete?: infer TComplete } ? TComplete
+    return: this["arg1"] extends { [complete]?: infer TComplete } ? TComplete
     : this["arg1"];
   }
   interface Streaming extends HKT {
     arg1: unknown; // TData
-    return: this["arg1"] extends { _streaming?: infer TStreaming } ? TStreaming
+    return: this["arg1"] extends { [streaming]?: infer TStreaming } ? TStreaming
     : DeepPartial<this["arg1"]>;
   }
   interface Partial extends HKT {
@@ -92,9 +95,9 @@ if (1 > 2 /* skip running this */) {
   type TData =
     typeof query extends DocumentTypeDecoration<infer TData, any> ? TData
     : never;
-  expectTypeOf<TData.Complete<TData>>().toEqualTypeOf<CompleteData>();
-  expectTypeOf<TData.Streaming<TData>>().toEqualTypeOf<StreamingData>();
-  expectTypeOf<TData.PartialData<TData>>().toEqualTypeOf<
+  expectTypeOf<DataValue.Complete<TData>>().toEqualTypeOf<CompleteData>();
+  expectTypeOf<DataValue.Streaming<TData>>().toEqualTypeOf<StreamingData>();
+  expectTypeOf<DataValue.Partial<TData>>().toEqualTypeOf<
     DeepPartial<CompleteData>
   >();
 

--- a/integration-tests/vite/src/enhanceDataStates.ts
+++ b/integration-tests/vite/src/enhanceDataStates.ts
@@ -1,12 +1,6 @@
 import { DeepPartial, HKT } from "@apollo/client/utilities";
 import { ApplyHKT } from "@apollo/client/utilities/internal";
-import {
-  gql,
-  TypedDocumentNode,
-  Complete,
-  Streaming,
-  PartialData,
-} from "@apollo/client";
+import { gql, TypedDocumentNode, TData } from "@apollo/client";
 import { useQuery } from "@apollo/client/react";
 import { expectTypeOf } from "expect-type";
 import { DocumentTypeDecoration } from "@graphql-typed-document-node/core";
@@ -98,9 +92,11 @@ if (1 > 2 /* skip running this */) {
   type TData =
     typeof query extends DocumentTypeDecoration<infer TData, any> ? TData
     : never;
-  expectTypeOf<Complete<TData>>().toEqualTypeOf<CompleteData>();
-  expectTypeOf<Streaming<TData>>().toEqualTypeOf<StreamingData>();
-  expectTypeOf<PartialData<TData>>().toEqualTypeOf<DeepPartial<CompleteData>>();
+  expectTypeOf<TData.Complete<TData>>().toEqualTypeOf<CompleteData>();
+  expectTypeOf<TData.Streaming<TData>>().toEqualTypeOf<StreamingData>();
+  expectTypeOf<TData.PartialData<TData>>().toEqualTypeOf<
+    DeepPartial<CompleteData>
+  >();
 
   const result = useQuery(query, {
     variables: { id: "123" },

--- a/integration-tests/vite/src/enhanceDataStates.ts
+++ b/integration-tests/vite/src/enhanceDataStates.ts
@@ -3,7 +3,6 @@ import { ApplyHKT } from "@apollo/client/utilities/internal";
 import { gql, DataValue, TypedDocumentNode } from "@apollo/client";
 import { useQuery } from "@apollo/client/react";
 import { expectTypeOf } from "expect-type";
-import { DocumentTypeDecoration } from "@graphql-typed-document-node/core";
 
 declare const complete: unique symbol;
 declare const streaming: unique symbol;
@@ -93,7 +92,7 @@ const query: ExtendedTypedDocumentNode<
 
 if (1 > 2 /* skip running this */) {
   type TData =
-    typeof query extends DocumentTypeDecoration<infer TData, any> ? TData
+    typeof query extends TypedDocumentNode<infer TData, any> ? TData
     : never;
   expectTypeOf<DataValue.Complete<TData>>().toEqualTypeOf<CompleteData>();
   expectTypeOf<DataValue.Streaming<TData>>().toEqualTypeOf<StreamingData>();

--- a/integration-tests/vite/src/enhanceDataStates.ts
+++ b/integration-tests/vite/src/enhanceDataStates.ts
@@ -1,0 +1,125 @@
+import { DeepPartial, HKT } from "@apollo/client/utilities";
+import { ApplyHKT } from "@apollo/client/utilities/internal";
+import {
+  gql,
+  TypedDocumentNode,
+  Complete,
+  Streaming,
+  PartialData,
+} from "@apollo/client";
+import { useQuery } from "@apollo/client/react";
+import { expectTypeOf } from "expect-type";
+import { DocumentTypeDecoration } from "@graphql-typed-document-node/core";
+
+type ExtendedTypedDocumentNode<TCompleteData, TVariables, TStreaming> =
+  TypedDocumentNode<
+    TCompleteData & {
+      _complete?: TCompleteData;
+      _streaming?: TStreaming;
+    },
+    TVariables
+  >;
+
+declare namespace MyImplementation {
+  interface Complete extends HKT {
+    arg1: unknown; // TData
+    return: this["arg1"] extends { _complete?: infer TComplete } ? TComplete
+    : this["arg1"];
+  }
+  interface Streaming extends HKT {
+    arg1: unknown; // TData
+    return: this["arg1"] extends { _streaming?: infer TStreaming } ? TStreaming
+    : DeepPartial<this["arg1"]>;
+  }
+  interface Partial extends HKT {
+    arg1: unknown; // TData
+    return: DeepPartial<ApplyHKT<Complete, this["arg1"]>>;
+  }
+}
+
+declare module "@apollo/client" {
+  export interface TypeOverrides {
+    Complete: MyImplementation.Complete;
+    Streaming: MyImplementation.Streaming;
+    Partial: MyImplementation.Partial;
+  }
+}
+
+type CompleteData = {
+  __typename: string;
+  id: string;
+  name: string;
+  age: number;
+  description: string;
+};
+type StreamingData = {
+  __typename: string;
+  id: string;
+} & (
+  | {
+      name: string;
+      age: number;
+    }
+  | {
+      name?: undefined;
+      age?: undefined;
+    }
+) &
+  (
+    | {
+        description: string;
+      }
+    | {
+        description?: undefined;
+      }
+  );
+
+const query: ExtendedTypedDocumentNode<
+  CompleteData,
+  { id: string },
+  StreamingData
+> = gql`
+  query GetUser($Id: String!) {
+    user(id: $Id) {
+      __typename
+      id
+      ... @defer {
+        name
+        age
+      }
+      ... @defer {
+        description
+      }
+    }
+  }
+`;
+
+if (1 > 2 /* skip running this */) {
+  type TData =
+    typeof query extends DocumentTypeDecoration<infer TData, any> ? TData
+    : never;
+  expectTypeOf<Complete<TData>>().toEqualTypeOf<CompleteData>();
+  expectTypeOf<Streaming<TData>>().toEqualTypeOf<StreamingData>();
+  expectTypeOf<PartialData<TData>>().toEqualTypeOf<DeepPartial<CompleteData>>();
+
+  const result = useQuery(query, {
+    variables: { id: "123" },
+    returnPartialData: true,
+  });
+  if (result.dataState === "complete") {
+    expectTypeOf(result.data).toEqualTypeOf<CompleteData>();
+  }
+  if (result.dataState === "streaming") {
+    expectTypeOf(result.data).toEqualTypeOf<StreamingData>();
+    if (result.data.name) {
+      expectTypeOf(result.data.name).toEqualTypeOf<string>();
+      expectTypeOf(result.data.age).toEqualTypeOf<number>();
+    } else {
+      expectTypeOf(result.data.name).toEqualTypeOf<string | undefined>();
+      expectTypeOf(result.data.age).toEqualTypeOf<number | undefined>();
+    }
+  }
+  if (result.dataState === "partial") {
+    expectTypeOf(result.data).toEqualTypeOf<DeepPartial<CompleteData>>();
+  }
+}

--- a/integration-tests/vite/src/enhanceDataStates.ts
+++ b/integration-tests/vite/src/enhanceDataStates.ts
@@ -92,8 +92,7 @@ const query: ExtendedTypedDocumentNode<
 
 if (1 > 2 /* skip running this */) {
   type TData =
-    typeof query extends TypedDocumentNode<infer TData, any> ? TData
-    : never;
+    typeof query extends TypedDocumentNode<infer TData, any> ? TData : never;
   expectTypeOf<DataValue.Complete<TData>>().toEqualTypeOf<CompleteData>();
   expectTypeOf<DataValue.Streaming<TData>>().toEqualTypeOf<StreamingData>();
   expectTypeOf<DataValue.Partial<TData>>().toEqualTypeOf<

--- a/src/__tests__/ApolloClient.ts
+++ b/src/__tests__/ApolloClient.ts
@@ -10,7 +10,7 @@ import type {
   MutateResult,
   ObservableQuery,
   QueryOptions,
-  TData,
+  DataValue,
 } from "@apollo/client";
 import { ApolloClient, NetworkStatus, setLogVerbosity } from "@apollo/client";
 import { createFragmentRegistry, InMemoryCache } from "@apollo/client/cache";
@@ -3438,7 +3438,7 @@ describe("ApolloClient", () => {
 
           if (result.dataState === "streaming") {
             expectTypeOf(result.data).toEqualTypeOf<
-              TData.Streaming<Masked<Query>>
+              DataValue.Streaming<Masked<Query>>
             >();
           }
 

--- a/src/__tests__/ApolloClient.ts
+++ b/src/__tests__/ApolloClient.ts
@@ -10,7 +10,7 @@ import type {
   MutateResult,
   ObservableQuery,
   QueryOptions,
-  Streaming,
+  TData,
 } from "@apollo/client";
 import { ApolloClient, NetworkStatus, setLogVerbosity } from "@apollo/client";
 import { createFragmentRegistry, InMemoryCache } from "@apollo/client/cache";
@@ -3437,7 +3437,9 @@ describe("ApolloClient", () => {
           }
 
           if (result.dataState === "streaming") {
-            expectTypeOf(result.data).toEqualTypeOf<Streaming<Masked<Query>>>();
+            expectTypeOf(result.data).toEqualTypeOf<
+              TData.Streaming<Masked<Query>>
+            >();
           }
 
           if (result.dataState === "empty") {

--- a/src/cache/core/types/DataProxy.ts
+++ b/src/cache/core/types/DataProxy.ts
@@ -1,7 +1,7 @@
 import type { TypedDocumentNode } from "@graphql-typed-document-node/core";
 import type { DocumentNode } from "graphql"; // ignore-comment eslint-disable-line import/no-extraneous-dependencies, import/no-unresolved
 
-import type { OperationVariables, TData } from "@apollo/client";
+import type { OperationVariables, DataValue } from "@apollo/client";
 import type { Unmasked } from "@apollo/client/masking";
 import type { Reference } from "@apollo/client/utilities";
 
@@ -128,13 +128,13 @@ export namespace DataProxy {
 
   export type DiffResult<TData> =
     | {
-        result: TData.Complete<TData>;
+        result: DataValue.Complete<TData>;
         complete: true;
         missing?: never;
         fromOptimisticTransaction?: boolean;
       }
     | {
-        result: TData.Partial<TData> | null;
+        result: DataValue.Partial<TData> | null;
         complete: false;
         missing?: MissingFieldError;
         fromOptimisticTransaction?: boolean;

--- a/src/cache/core/types/DataProxy.ts
+++ b/src/cache/core/types/DataProxy.ts
@@ -1,9 +1,9 @@
 import type { TypedDocumentNode } from "@graphql-typed-document-node/core";
 import type { DocumentNode } from "graphql"; // ignore-comment eslint-disable-line import/no-extraneous-dependencies, import/no-unresolved
 
-import type { OperationVariables } from "@apollo/client";
+import type { Complete, OperationVariables, PartialData } from "@apollo/client";
 import type { Unmasked } from "@apollo/client/masking";
-import type { DeepPartial, Reference } from "@apollo/client/utilities";
+import type { Reference } from "@apollo/client/utilities";
 
 import type { MissingFieldError } from "./common.js";
 
@@ -128,13 +128,13 @@ export namespace DataProxy {
 
   export type DiffResult<TData> =
     | {
-        result: TData;
+        result: Complete<TData>;
         complete: true;
         missing?: never;
         fromOptimisticTransaction?: boolean;
       }
     | {
-        result: DeepPartial<TData> | null;
+        result: PartialData<TData> | null;
         complete: false;
         missing?: MissingFieldError;
         fromOptimisticTransaction?: boolean;

--- a/src/cache/core/types/DataProxy.ts
+++ b/src/cache/core/types/DataProxy.ts
@@ -1,7 +1,7 @@
 import type { TypedDocumentNode } from "@graphql-typed-document-node/core";
 import type { DocumentNode } from "graphql"; // ignore-comment eslint-disable-line import/no-extraneous-dependencies, import/no-unresolved
 
-import type { Complete, OperationVariables, PartialData } from "@apollo/client";
+import type { OperationVariables, TData } from "@apollo/client";
 import type { Unmasked } from "@apollo/client/masking";
 import type { Reference } from "@apollo/client/utilities";
 
@@ -128,13 +128,13 @@ export namespace DataProxy {
 
   export type DiffResult<TData> =
     | {
-        result: Complete<TData>;
+        result: TData.Complete<TData>;
         complete: true;
         missing?: never;
         fromOptimisticTransaction?: boolean;
       }
     | {
-        result: PartialData<TData> | null;
+        result: TData.Partial<TData> | null;
         complete: false;
         missing?: MissingFieldError;
         fromOptimisticTransaction?: boolean;

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -16,7 +16,6 @@ import { invariant } from "@apollo/client/utilities/invariant";
 import type { ObservableQuery } from "./ObservableQuery.js";
 import type { QueryManager } from "./QueryManager.js";
 import type {
-  Complete,
   DefaultContext,
   InternalRefetchQueriesInclude,
   MutationQueryReducer,
@@ -24,7 +23,7 @@ import type {
   NormalizedExecutionResult,
   OnQueryUpdated,
   OperationVariables,
-  Streaming,
+  TData,
   TypedDocumentNode,
 } from "./types.js";
 import type {
@@ -112,7 +111,7 @@ export class QueryInfo<
   private readonly observableQuery?: ObservableQuery<any, any>;
   private incremental?: Incremental.IncrementalRequest<
     Record<string, unknown>,
-    Complete<TData> | Streaming<TData>
+    TData.Complete<TData> | TData.Streaming<TData>
   >;
 
   constructor(
@@ -179,7 +178,7 @@ export class QueryInfo<
     cacheData: TData | DeepPartial<TData> | undefined | null,
     incoming: FetchResult<TData>,
     query: DocumentNode
-  ): FormattedExecutionResult<Complete<TData> | Streaming<TData>> {
+  ): FormattedExecutionResult<TData.Complete<TData> | TData.Streaming<TData>> {
     const { incrementalHandler } = this.queryManager;
 
     if (incrementalHandler.isIncrementalResult(incoming)) {
@@ -189,7 +188,7 @@ export class QueryInfo<
         query,
       }) as Incremental.IncrementalRequest<
         Record<string, unknown>,
-        Complete<TData> | Streaming<TData>
+        TData.Complete<TData> | TData.Streaming<TData>
       >;
 
       return this.incremental.handle(cacheData, incoming);
@@ -205,7 +204,7 @@ export class QueryInfo<
       errorPolicy,
       cacheWriteBehavior,
     }: OperationInfo<TData, TVariables>
-  ): FormattedExecutionResult<Complete<TData> | Streaming<TData>> {
+  ): FormattedExecutionResult<TData.Complete<TData> | TData.Streaming<TData>> {
     const diffOptions = {
       query,
       variables,
@@ -344,7 +343,9 @@ export class QueryInfo<
       keepRootFields?: boolean;
     },
     cache = this.cache
-  ): Promise<FormattedExecutionResult<Complete<TData> | Streaming<TData>>> {
+  ): Promise<
+    FormattedExecutionResult<TData.Complete<TData> | TData.Streaming<TData>>
+  > {
     const cacheWrites: Cache.WriteOptions[] = [];
     const skipCache = mutation.cacheWriteBehavior === CacheWriteBehavior.FORBID;
 

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -16,6 +16,7 @@ import { invariant } from "@apollo/client/utilities/invariant";
 import type { ObservableQuery } from "./ObservableQuery.js";
 import type { QueryManager } from "./QueryManager.js";
 import type {
+  Complete,
   DefaultContext,
   InternalRefetchQueriesInclude,
   MutationQueryReducer,
@@ -111,7 +112,7 @@ export class QueryInfo<
   private readonly observableQuery?: ObservableQuery<any, any>;
   private incremental?: Incremental.IncrementalRequest<
     Record<string, unknown>,
-    TData | Streaming<TData>
+    Complete<TData> | Streaming<TData>
   >;
 
   constructor(
@@ -178,7 +179,7 @@ export class QueryInfo<
     cacheData: TData | DeepPartial<TData> | undefined | null,
     incoming: FetchResult<TData>,
     query: DocumentNode
-  ): FormattedExecutionResult<TData | Streaming<TData>> {
+  ): FormattedExecutionResult<Complete<TData> | Streaming<TData>> {
     const { incrementalHandler } = this.queryManager;
 
     if (incrementalHandler.isIncrementalResult(incoming)) {
@@ -188,7 +189,7 @@ export class QueryInfo<
         query,
       }) as Incremental.IncrementalRequest<
         Record<string, unknown>,
-        TData | Streaming<TData>
+        Complete<TData> | Streaming<TData>
       >;
 
       return this.incremental.handle(cacheData, incoming);
@@ -204,7 +205,7 @@ export class QueryInfo<
       errorPolicy,
       cacheWriteBehavior,
     }: OperationInfo<TData, TVariables>
-  ): FormattedExecutionResult<TData | Streaming<TData>> {
+  ): FormattedExecutionResult<Complete<TData> | Streaming<TData>> {
     const diffOptions = {
       query,
       variables,
@@ -343,7 +344,7 @@ export class QueryInfo<
       keepRootFields?: boolean;
     },
     cache = this.cache
-  ): Promise<FormattedExecutionResult<TData | Streaming<TData>>> {
+  ): Promise<FormattedExecutionResult<Complete<TData> | Streaming<TData>>> {
     const cacheWrites: Cache.WriteOptions[] = [];
     const skipCache = mutation.cacheWriteBehavior === CacheWriteBehavior.FORBID;
 

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -23,7 +23,7 @@ import type {
   NormalizedExecutionResult,
   OnQueryUpdated,
   OperationVariables,
-  TData,
+  DataValue,
   TypedDocumentNode,
 } from "./types.js";
 import type {
@@ -111,7 +111,7 @@ export class QueryInfo<
   private readonly observableQuery?: ObservableQuery<any, any>;
   private incremental?: Incremental.IncrementalRequest<
     Record<string, unknown>,
-    TData.Complete<TData> | TData.Streaming<TData>
+    DataValue.Complete<TData> | DataValue.Streaming<TData>
   >;
 
   constructor(
@@ -178,7 +178,9 @@ export class QueryInfo<
     cacheData: TData | DeepPartial<TData> | undefined | null,
     incoming: FetchResult<TData>,
     query: DocumentNode
-  ): FormattedExecutionResult<TData.Complete<TData> | TData.Streaming<TData>> {
+  ): FormattedExecutionResult<
+    DataValue.Complete<TData> | DataValue.Streaming<TData>
+  > {
     const { incrementalHandler } = this.queryManager;
 
     if (incrementalHandler.isIncrementalResult(incoming)) {
@@ -188,7 +190,7 @@ export class QueryInfo<
         query,
       }) as Incremental.IncrementalRequest<
         Record<string, unknown>,
-        TData.Complete<TData> | TData.Streaming<TData>
+        DataValue.Complete<TData> | DataValue.Streaming<TData>
       >;
 
       return this.incremental.handle(cacheData, incoming);
@@ -204,7 +206,9 @@ export class QueryInfo<
       errorPolicy,
       cacheWriteBehavior,
     }: OperationInfo<TData, TVariables>
-  ): FormattedExecutionResult<TData.Complete<TData> | TData.Streaming<TData>> {
+  ): FormattedExecutionResult<
+    DataValue.Complete<TData> | DataValue.Streaming<TData>
+  > {
     const diffOptions = {
       query,
       variables,
@@ -344,7 +348,9 @@ export class QueryInfo<
     },
     cache = this.cache
   ): Promise<
-    FormattedExecutionResult<TData.Complete<TData> | TData.Streaming<TData>>
+    FormattedExecutionResult<
+      DataValue.Complete<TData> | DataValue.Streaming<TData>
+    >
   > {
     const cacheWrites: Cache.WriteOptions[] = [];
     const skipCache = mutation.cacheWriteBehavior === CacheWriteBehavior.FORBID;

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -23,7 +23,6 @@ export type {
 export { isNetworkRequestSettled, NetworkStatus } from "./networkStatus.js";
 export type {
   ApolloQueryResult,
-  Complete,
   DataState,
   DefaultContext,
   ErrorLike,
@@ -41,16 +40,15 @@ export type {
   NormalizedExecutionResult,
   OnQueryUpdated,
   OperationVariables,
-  PartialData,
   QueryResult,
   RefetchQueriesInclude,
   RefetchQueriesOptions,
   RefetchQueriesPromiseResults,
   RefetchQueriesResult,
   RefetchQueryDescriptor,
-  Streaming,
   SubscribeResult,
   SubscriptionObservable,
+  TData,
   TypedDocumentNode,
   TypeOverrides,
 } from "./types.js";

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -23,6 +23,7 @@ export type {
 export { isNetworkRequestSettled, NetworkStatus } from "./networkStatus.js";
 export type {
   ApolloQueryResult,
+  Complete,
   DataState,
   DefaultContext,
   ErrorLike,
@@ -40,6 +41,7 @@ export type {
   NormalizedExecutionResult,
   OnQueryUpdated,
   OperationVariables,
+  PartialData,
   QueryResult,
   RefetchQueriesInclude,
   RefetchQueriesOptions,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -24,6 +24,7 @@ export { isNetworkRequestSettled, NetworkStatus } from "./networkStatus.js";
 export type {
   ApolloQueryResult,
   DataState,
+  DataValue,
   DefaultContext,
   ErrorLike,
   GetDataState,
@@ -48,7 +49,6 @@ export type {
   RefetchQueryDescriptor,
   SubscribeResult,
   SubscriptionObservable,
-  TData,
   TypedDocumentNode,
   TypeOverrides,
 } from "./types.js";

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -50,102 +50,103 @@ namespace OverridableTypes {
   }
 }
 
-/**
- * Returns a representation of `TData` in it's "complete" state.
- *
- * @defaultValue `TData` if no overrides are provided.
- *
- * @example
- * You can override this type globally - this example shows how to override it
- * with `DeepPartial<TData>`:
- *
- * ```ts
- * import { HKT, DeepPartial } from "@apollo/client/utilities";
- *
- * type CompleteOverride<TData> = TData extends { _complete?: infer _Complete } ? _Complete : TData;
- *
- * interface CompleteOverrideHKT extends HKT {
- *   return: CompleteOverride<this["arg1"]>;
- * }
- *
- * declare module "@apollo/client" {
- *   export interface TypeOverrides {
- *     Complete: CompleteOverrideHKT;
- *   }
- * }
- * ```
- */
-export type Complete<TData> = ApplyHKTImplementationWithDefault<
-  TypeOverrides,
-  "Complete",
-  OverridableTypes.Defaults,
-  TData
->;
+export declare namespace TData {
+  /**
+   * Returns a representation of `TData` in it's "complete" state.
+   *
+   * @defaultValue `TData` if no overrides are provided.
+   *
+   * @example
+   * You can override this type globally - this example shows how to override it
+   * with `DeepPartial<TData>`:
+   *
+   * ```ts
+   * import { HKT, DeepPartial } from "@apollo/client/utilities";
+   *
+   * type CompleteOverride<TData> = TData extends { _complete?: infer _Complete } ? _Complete : TData;
+   *
+   * interface CompleteOverrideHKT extends HKT {
+   *   return: CompleteOverride<this["arg1"]>;
+   * }
+   *
+   * declare module "@apollo/client" {
+   *   export interface TypeOverrides {
+   *     Complete: CompleteOverrideHKT;
+   *   }
+   * }
+   * ```
+   */
+  export type Complete<TData> = ApplyHKTImplementationWithDefault<
+    TypeOverrides,
+    "Complete",
+    OverridableTypes.Defaults,
+    TData
+  >;
 
-/**
- * Returns a representation of `TData` while it is streaming.
- *
- * @defaultValue `TData` if no overrides are provided.
- *
- * @example
- * You can override this type globally - this example shows how to override it
- * with `DeepPartial<TData>`:
- *
- * ```ts
- * import { HKT, DeepPartial } from "@apollo/client/utilities";
- *
- * type StreamingOverride<TData> = DeepPartial<TData>;
- *
- * interface StreamingOverrideHKT extends HKT {
- *   return: StreamingOverride<this["arg1"]>;
- * }
- *
- * declare module "@apollo/client" {
- *   export interface TypeOverrides {
- *     Streaming: StreamingOverrideHKT;
- *   }
- * }
- * ```
- */
-export type Streaming<TData> = ApplyHKTImplementationWithDefault<
-  TypeOverrides,
-  "Streaming",
-  OverridableTypes.Defaults,
-  TData
->;
+  /**
+   * Returns a representation of `TData` while it is streaming.
+   *
+   * @defaultValue `TData` if no overrides are provided.
+   *
+   * @example
+   * You can override this type globally - this example shows how to override it
+   * with `DeepPartial<TData>`:
+   *
+   * ```ts
+   * import { HKT, DeepPartial } from "@apollo/client/utilities";
+   *
+   * type StreamingOverride<TData> = DeepPartial<TData>;
+   *
+   * interface StreamingOverrideHKT extends HKT {
+   *   return: StreamingOverride<this["arg1"]>;
+   * }
+   *
+   * declare module "@apollo/client" {
+   *   export interface TypeOverrides {
+   *     Streaming: StreamingOverrideHKT;
+   *   }
+   * }
+   * ```
+   */
+  export type Streaming<TData> = ApplyHKTImplementationWithDefault<
+    TypeOverrides,
+    "Streaming",
+    OverridableTypes.Defaults,
+    TData
+  >;
 
-/**
- * Returns a representation of `TData` while it is partial.
- *
- * @defaultValue `DeepPartial<TData>` if no overrides are provided.
- *
- * @example
- * You can override this type globally - this example shows how to override it
- * with `DeepPartial<TData>`:
- *
- * ```ts
- * import { HKT, DeepPartial } from "@apollo/client/utilities";
- *
- * type PartialOverride<TData> = DeepPartial<Complete<TData>>;
- *
- * interface PartialOverrideHKT extends HKT {
- *   return: PartialOverride<this["arg1"]>;
- * }
- *
- * declare module "@apollo/client" {
- *   export interface TypeOverrides {
- *     Partial: PartialOverrideHKT;
- *   }
- * }
- * ```
- */
-export type PartialData<TData> = ApplyHKTImplementationWithDefault<
-  TypeOverrides,
-  "Partial",
-  OverridableTypes.Defaults,
-  TData
->;
-
+  /**
+   * Returns a representation of `TData` while it is partial.
+   *
+   * @defaultValue `DeepPartial<TData>` if no overrides are provided.
+   *
+   * @example
+   * You can override this type globally - this example shows how to override it
+   * with `DeepPartial<TData>`:
+   *
+   * ```ts
+   * import { HKT, DeepPartial } from "@apollo/client/utilities";
+   *
+   * type PartialOverride<TData> = DeepPartial<Complete<TData>>;
+   *
+   * interface PartialOverrideHKT extends HKT {
+   *   return: PartialOverride<this["arg1"]>;
+   * }
+   *
+   * declare module "@apollo/client" {
+   *   export interface TypeOverrides {
+   *     Partial: PartialOverrideHKT;
+   *   }
+   * }
+   * ```
+   */
+  export type Partial<TData> = ApplyHKTImplementationWithDefault<
+    TypeOverrides,
+    "Partial",
+    OverridableTypes.Defaults,
+    TData
+  >;
+}
 export interface DefaultContext extends Record<string, any> {
   /**
    * Indicates whether `queryDeduplication` was enabled for the request.
@@ -323,17 +324,17 @@ export type ApolloQueryResult<
 
 export type DataState<TData> =
   | {
-      data: Complete<TData>;
+      data: TData.Complete<TData>;
       /** {@inheritDoc @apollo/client!QueryResultDocumentation#dataState:member} */
       dataState: "complete";
     }
   | {
-      data: Streaming<TData>;
+      data: TData.Streaming<TData>;
       /** {@inheritDoc @apollo/client!QueryResultDocumentation#dataState:member} */
       dataState: "streaming";
     }
   | {
-      data: PartialData<TData>;
+      data: TData.Partial<TData>;
       /** {@inheritDoc @apollo/client!QueryResultDocumentation#dataState:member} */
       dataState: "partial";
     }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -50,7 +50,7 @@ namespace OverridableTypes {
   }
 }
 
-export declare namespace TData {
+export declare namespace DataValue {
   /**
    * Returns a representation of `TData` in it's "complete" state.
    *
@@ -324,17 +324,17 @@ export type ApolloQueryResult<
 
 export type DataState<TData> =
   | {
-      data: TData.Complete<TData>;
+      data: DataValue.Complete<TData>;
       /** {@inheritDoc @apollo/client!QueryResultDocumentation#dataState:member} */
       dataState: "complete";
     }
   | {
-      data: TData.Streaming<TData>;
+      data: DataValue.Streaming<TData>;
       /** {@inheritDoc @apollo/client!QueryResultDocumentation#dataState:member} */
       dataState: "streaming";
     }
   | {
-      data: TData.Partial<TData>;
+      data: DataValue.Partial<TData>;
       /** {@inheritDoc @apollo/client!QueryResultDocumentation#dataState:member} */
       dataState: "partial";
     }

--- a/src/react/hooks/__tests__/useBackgroundQuery.test.tsx
+++ b/src/react/hooks/__tests__/useBackgroundQuery.test.tsx
@@ -18,7 +18,7 @@ import type {
   DataState,
   ErrorPolicy,
   OperationVariables,
-  TData,
+  DataValue,
   TypedDocumentNode,
 } from "@apollo/client";
 import {
@@ -7215,7 +7215,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | TData.Streaming<VariablesCaseData>
+        VariablesCaseData | DataValue.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -7224,7 +7224,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
     }
 
@@ -7243,7 +7245,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | TData.Streaming<VariablesCaseData>
+        VariablesCaseData | DataValue.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -7252,7 +7254,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
     }
 
@@ -7273,7 +7277,7 @@ describe.skip("type tests", () => {
       >;
       expectTypeOf(data).toEqualTypeOf<
         | Masked<MaskedVariablesCaseData>
-        | TData.Streaming<Masked<MaskedVariablesCaseData>>
+        | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -7283,7 +7287,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          TData.Streaming<Masked<MaskedVariablesCaseData>>
+          DataValue.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
     }
@@ -7303,7 +7307,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        MaskedVariablesCaseData | TData.Streaming<MaskedVariablesCaseData>
+        MaskedVariablesCaseData | DataValue.Streaming<MaskedVariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -7313,7 +7317,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          TData.Streaming<MaskedVariablesCaseData>
+          DataValue.Streaming<MaskedVariablesCaseData>
         >();
       }
     }
@@ -7334,7 +7338,7 @@ describe.skip("type tests", () => {
       >;
       expectTypeOf(data).toEqualTypeOf<
         | Masked<MaskedVariablesCaseData>
-        | TData.Streaming<Masked<MaskedVariablesCaseData>>
+        | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -7344,7 +7348,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          TData.Streaming<Masked<MaskedVariablesCaseData>>
+          DataValue.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
     }
@@ -7368,7 +7372,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | undefined | TData.Streaming<VariablesCaseData>
+        VariablesCaseData | undefined | DataValue.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "empty"
@@ -7379,7 +7383,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
 
       if (dataState === "empty") {
@@ -7403,7 +7409,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | undefined | TData.Streaming<VariablesCaseData>
+        VariablesCaseData | undefined | DataValue.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "empty"
@@ -7414,7 +7420,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
 
       if (dataState === "empty") {
@@ -7441,7 +7449,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | Masked<MaskedVariablesCaseData>
         | undefined
-        | TData.Streaming<Masked<MaskedVariablesCaseData>>
+        | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "empty"
@@ -7453,7 +7461,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          TData.Streaming<Masked<MaskedVariablesCaseData>>
+          DataValue.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
 
@@ -7479,7 +7487,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | MaskedVariablesCaseData
         | undefined
-        | TData.Streaming<MaskedVariablesCaseData>
+        | DataValue.Streaming<MaskedVariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "empty"
@@ -7491,7 +7499,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          TData.Streaming<MaskedVariablesCaseData>
+          DataValue.Streaming<MaskedVariablesCaseData>
         >();
       }
 
@@ -7517,7 +7525,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | Masked<MaskedVariablesCaseData>
         | undefined
-        | TData.Streaming<Masked<MaskedVariablesCaseData>>
+        | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "empty"
@@ -7529,7 +7537,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          TData.Streaming<Masked<MaskedVariablesCaseData>>
+          DataValue.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
 
@@ -7557,7 +7565,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | undefined | TData.Streaming<VariablesCaseData>
+        VariablesCaseData | undefined | DataValue.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "empty"
@@ -7568,7 +7576,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
 
       if (dataState === "empty") {
@@ -7591,7 +7601,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | undefined | TData.Streaming<VariablesCaseData>
+        VariablesCaseData | undefined | DataValue.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "empty"
@@ -7602,7 +7612,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
 
       if (dataState === "empty") {
@@ -7629,7 +7641,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | Masked<MaskedVariablesCaseData>
         | undefined
-        | TData.Streaming<Masked<MaskedVariablesCaseData>>
+        | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "empty"
@@ -7641,7 +7653,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          TData.Streaming<Masked<MaskedVariablesCaseData>>
+          DataValue.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
 
@@ -7667,7 +7679,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | MaskedVariablesCaseData
         | undefined
-        | TData.Streaming<MaskedVariablesCaseData>
+        | DataValue.Streaming<MaskedVariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "empty"
@@ -7679,7 +7691,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          TData.Streaming<MaskedVariablesCaseData>
+          DataValue.Streaming<MaskedVariablesCaseData>
         >();
       }
 
@@ -7705,7 +7717,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | Masked<MaskedVariablesCaseData>
         | undefined
-        | TData.Streaming<Masked<MaskedVariablesCaseData>>
+        | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "empty"
@@ -7717,7 +7729,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          TData.Streaming<Masked<MaskedVariablesCaseData>>
+          DataValue.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
 
@@ -7745,7 +7757,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | TData.Streaming<VariablesCaseData>
+        VariablesCaseData | DataValue.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -7754,7 +7766,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
     }
 
@@ -7773,7 +7787,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | TData.Streaming<VariablesCaseData>
+        VariablesCaseData | DataValue.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -7782,7 +7796,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
     }
 
@@ -7804,7 +7820,7 @@ describe.skip("type tests", () => {
       >;
       expectTypeOf(data).toEqualTypeOf<
         | Masked<MaskedVariablesCaseData>
-        | TData.Streaming<Masked<MaskedVariablesCaseData>>
+        | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -7814,7 +7830,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          TData.Streaming<Masked<MaskedVariablesCaseData>>
+          DataValue.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
     }
@@ -7834,7 +7850,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        MaskedVariablesCaseData | TData.Streaming<MaskedVariablesCaseData>
+        MaskedVariablesCaseData | DataValue.Streaming<MaskedVariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -7844,7 +7860,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          TData.Streaming<MaskedVariablesCaseData>
+          DataValue.Streaming<MaskedVariablesCaseData>
         >();
       }
     }
@@ -7865,7 +7881,7 @@ describe.skip("type tests", () => {
       >;
       expectTypeOf(data).toEqualTypeOf<
         | Masked<MaskedVariablesCaseData>
-        | TData.Streaming<Masked<MaskedVariablesCaseData>>
+        | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -7875,7 +7891,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          TData.Streaming<Masked<MaskedVariablesCaseData>>
+          DataValue.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
     }
@@ -7901,7 +7917,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | VariablesCaseData
         | DeepPartial<VariablesCaseData>
-        | TData.Streaming<VariablesCaseData>
+        | DataValue.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -7912,7 +7928,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
 
       if (dataState === "partial") {
@@ -7937,7 +7955,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | VariablesCaseData
         | DeepPartial<VariablesCaseData>
-        | TData.Streaming<VariablesCaseData>
+        | DataValue.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -7948,7 +7966,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
 
       if (dataState === "partial") {
@@ -7975,7 +7995,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | Masked<MaskedVariablesCaseData>
         | DeepPartial<Masked<MaskedVariablesCaseData>>
-        | TData.Streaming<Masked<MaskedVariablesCaseData>>
+        | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -7987,7 +8007,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          TData.Streaming<Masked<MaskedVariablesCaseData>>
+          DataValue.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
 
@@ -8015,7 +8035,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | MaskedVariablesCaseData
         | DeepPartial<MaskedVariablesCaseData>
-        | TData.Streaming<MaskedVariablesCaseData>
+        | DataValue.Streaming<MaskedVariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -8027,7 +8047,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          TData.Streaming<MaskedVariablesCaseData>
+          DataValue.Streaming<MaskedVariablesCaseData>
         >();
       }
 
@@ -8055,7 +8075,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | Masked<MaskedVariablesCaseData>
         | DeepPartial<Masked<MaskedVariablesCaseData>>
-        | TData.Streaming<Masked<MaskedVariablesCaseData>>
+        | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -8067,7 +8087,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          TData.Streaming<Masked<MaskedVariablesCaseData>>
+          DataValue.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
 
@@ -8097,7 +8117,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | TData.Streaming<VariablesCaseData>
+        VariablesCaseData | DataValue.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -8106,7 +8126,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
     }
 
@@ -8126,7 +8148,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | TData.Streaming<VariablesCaseData>
+        VariablesCaseData | DataValue.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -8135,7 +8157,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
     }
 
@@ -8157,7 +8181,7 @@ describe.skip("type tests", () => {
       >;
       expectTypeOf(data).toEqualTypeOf<
         | Masked<MaskedVariablesCaseData>
-        | TData.Streaming<Masked<MaskedVariablesCaseData>>
+        | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -8167,7 +8191,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          TData.Streaming<Masked<MaskedVariablesCaseData>>
+          DataValue.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
     }
@@ -8187,7 +8211,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        MaskedVariablesCaseData | TData.Streaming<MaskedVariablesCaseData>
+        MaskedVariablesCaseData | DataValue.Streaming<MaskedVariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -8197,7 +8221,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          TData.Streaming<MaskedVariablesCaseData>
+          DataValue.Streaming<MaskedVariablesCaseData>
         >();
       }
     }
@@ -8219,7 +8243,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         Masked<
           | MaskedVariablesCaseData
-          | TData.Streaming<Masked<MaskedVariablesCaseData>>
+          | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
         >
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
@@ -8230,7 +8254,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          TData.Streaming<Masked<MaskedVariablesCaseData>>
+          DataValue.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
     }
@@ -8258,7 +8282,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | VariablesCaseData
         | DeepPartial<VariablesCaseData>
-        | TData.Streaming<VariablesCaseData>
+        | DataValue.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -8269,7 +8293,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
 
       if (dataState === "partial") {
@@ -8295,7 +8321,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | VariablesCaseData
         | DeepPartial<VariablesCaseData>
-        | TData.Streaming<VariablesCaseData>
+        | DataValue.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -8306,7 +8332,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
 
       if (dataState === "partial") {
@@ -8334,7 +8362,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | TData.Streaming<VariablesCaseData>
+        VariablesCaseData | DataValue.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -8343,7 +8371,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
     }
 
@@ -8367,7 +8397,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | TData.Streaming<VariablesCaseData>
+        VariablesCaseData | DataValue.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -8376,7 +8406,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
     }
   });
@@ -8399,7 +8431,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | TData.Streaming<VariablesCaseData>
+        VariablesCaseData | DataValue.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -8408,7 +8440,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
     }
 
@@ -8428,7 +8462,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | TData.Streaming<VariablesCaseData>
+        VariablesCaseData | DataValue.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -8437,7 +8471,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
     }
 
@@ -8459,7 +8495,7 @@ describe.skip("type tests", () => {
       >;
       expectTypeOf(data).toEqualTypeOf<
         | Masked<MaskedVariablesCaseData>
-        | TData.Streaming<Masked<MaskedVariablesCaseData>>
+        | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -8469,7 +8505,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          TData.Streaming<Masked<MaskedVariablesCaseData>>
+          DataValue.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
     }
@@ -8489,7 +8525,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        MaskedVariablesCaseData | TData.Streaming<MaskedVariablesCaseData>
+        MaskedVariablesCaseData | DataValue.Streaming<MaskedVariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -8499,7 +8535,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          TData.Streaming<MaskedVariablesCaseData>
+          DataValue.Streaming<MaskedVariablesCaseData>
         >();
       }
     }
@@ -8520,7 +8556,7 @@ describe.skip("type tests", () => {
       >;
       expectTypeOf(data).toEqualTypeOf<
         | Masked<MaskedVariablesCaseData>
-        | TData.Streaming<Masked<MaskedVariablesCaseData>>
+        | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -8530,7 +8566,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          TData.Streaming<Masked<MaskedVariablesCaseData>>
+          DataValue.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
     }
@@ -8559,7 +8595,7 @@ describe.skip("type tests", () => {
         | VariablesCaseData
         | DeepPartial<VariablesCaseData>
         | undefined
-        | TData.Streaming<VariablesCaseData>
+        | DataValue.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial" | "empty"
@@ -8570,7 +8606,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
 
       if (dataState === "partial") {
@@ -8603,7 +8641,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | VariablesCaseData
         | DeepPartial<VariablesCaseData>
-        | TData.Streaming<VariablesCaseData>
+        | DataValue.Streaming<VariablesCaseData>
         | undefined
       >();
       expectTypeOf(dataState).toEqualTypeOf<
@@ -8615,7 +8653,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
 
       if (dataState === "partial") {
@@ -8645,7 +8685,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | Masked<MaskedVariablesCaseData>
         | DeepPartial<Masked<MaskedVariablesCaseData>>
-        | TData.Streaming<Masked<MaskedVariablesCaseData>>
+        | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
         | undefined
       >();
       expectTypeOf(dataState).toEqualTypeOf<
@@ -8658,7 +8698,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          TData.Streaming<Masked<MaskedVariablesCaseData>>
+          DataValue.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
 
@@ -8694,7 +8734,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | MaskedVariablesCaseData
         | DeepPartial<MaskedVariablesCaseData>
-        | TData.Streaming<MaskedVariablesCaseData>
+        | DataValue.Streaming<MaskedVariablesCaseData>
         | undefined
       >();
       expectTypeOf(dataState).toEqualTypeOf<
@@ -8707,7 +8747,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          TData.Streaming<MaskedVariablesCaseData>
+          DataValue.Streaming<MaskedVariablesCaseData>
         >();
       }
 
@@ -8743,7 +8783,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | Masked<MaskedVariablesCaseData>
         | DeepPartial<Masked<MaskedVariablesCaseData>>
-        | TData.Streaming<Masked<MaskedVariablesCaseData>>
+        | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
         | undefined
       >();
       expectTypeOf(dataState).toEqualTypeOf<
@@ -8756,7 +8796,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          TData.Streaming<Masked<MaskedVariablesCaseData>>
+          DataValue.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
 
@@ -8789,7 +8829,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | VariablesCaseData
         | DeepPartial<VariablesCaseData>
-        | TData.Streaming<VariablesCaseData>
+        | DataValue.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -8800,7 +8840,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
 
       if (dataState === "partial") {
@@ -8829,7 +8871,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | VariablesCaseData
         | DeepPartial<VariablesCaseData>
-        | TData.Streaming<VariablesCaseData>
+        | DataValue.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -8840,7 +8882,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
 
       if (dataState === "partial") {
@@ -8866,7 +8910,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | Masked<MaskedVariablesCaseData>
         | DeepPartial<Masked<MaskedVariablesCaseData>>
-        | TData.Streaming<Masked<MaskedVariablesCaseData>>
+        | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -8878,7 +8922,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          TData.Streaming<Masked<MaskedVariablesCaseData>>
+          DataValue.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
 
@@ -8910,7 +8954,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | MaskedVariablesCaseData
         | DeepPartial<MaskedVariablesCaseData>
-        | TData.Streaming<MaskedVariablesCaseData>
+        | DataValue.Streaming<MaskedVariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -8922,7 +8966,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          TData.Streaming<MaskedVariablesCaseData>
+          DataValue.Streaming<MaskedVariablesCaseData>
         >();
       }
 
@@ -8954,7 +8998,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | Masked<MaskedVariablesCaseData>
         | DeepPartial<Masked<MaskedVariablesCaseData>>
-        | TData.Streaming<Masked<MaskedVariablesCaseData>>
+        | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -8966,7 +9010,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          TData.Streaming<Masked<MaskedVariablesCaseData>>
+          DataValue.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
 
@@ -8998,7 +9042,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | TData.Streaming<VariablesCaseData>
+        VariablesCaseData | DataValue.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -9007,7 +9051,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
     }
 
@@ -9032,7 +9078,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | TData.Streaming<VariablesCaseData>
+        VariablesCaseData | DataValue.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -9041,7 +9087,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
     }
 
@@ -9065,7 +9113,7 @@ describe.skip("type tests", () => {
       >;
       expectTypeOf(data).toEqualTypeOf<
         | Masked<MaskedVariablesCaseData>
-        | TData.Streaming<Masked<MaskedVariablesCaseData>>
+        | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -9075,7 +9123,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          TData.Streaming<Masked<MaskedVariablesCaseData>>
+          DataValue.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
     }
@@ -9100,7 +9148,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        MaskedVariablesCaseData | TData.Streaming<MaskedVariablesCaseData>
+        MaskedVariablesCaseData | DataValue.Streaming<MaskedVariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -9110,7 +9158,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          TData.Streaming<MaskedVariablesCaseData>
+          DataValue.Streaming<MaskedVariablesCaseData>
         >();
       }
     }
@@ -9136,7 +9184,7 @@ describe.skip("type tests", () => {
       >;
       expectTypeOf(data).toEqualTypeOf<
         | Masked<MaskedVariablesCaseData>
-        | TData.Streaming<Masked<MaskedVariablesCaseData>>
+        | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -9146,7 +9194,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          TData.Streaming<Masked<MaskedVariablesCaseData>>
+          DataValue.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
     }

--- a/src/react/hooks/__tests__/useBackgroundQuery.test.tsx
+++ b/src/react/hooks/__tests__/useBackgroundQuery.test.tsx
@@ -18,7 +18,7 @@ import type {
   DataState,
   ErrorPolicy,
   OperationVariables,
-  Streaming,
+  TData,
   TypedDocumentNode,
 } from "@apollo/client";
 import {
@@ -7215,7 +7215,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | Streaming<VariablesCaseData>
+        VariablesCaseData | TData.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -7224,7 +7224,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
     }
 
@@ -7243,7 +7243,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | Streaming<VariablesCaseData>
+        VariablesCaseData | TData.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -7252,7 +7252,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
     }
 
@@ -7273,7 +7273,7 @@ describe.skip("type tests", () => {
       >;
       expectTypeOf(data).toEqualTypeOf<
         | Masked<MaskedVariablesCaseData>
-        | Streaming<Masked<MaskedVariablesCaseData>>
+        | TData.Streaming<Masked<MaskedVariablesCaseData>>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -7283,7 +7283,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          Streaming<Masked<MaskedVariablesCaseData>>
+          TData.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
     }
@@ -7303,7 +7303,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        MaskedVariablesCaseData | Streaming<MaskedVariablesCaseData>
+        MaskedVariablesCaseData | TData.Streaming<MaskedVariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -7312,7 +7312,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<MaskedVariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          TData.Streaming<MaskedVariablesCaseData>
+        >();
       }
     }
 
@@ -7332,7 +7334,7 @@ describe.skip("type tests", () => {
       >;
       expectTypeOf(data).toEqualTypeOf<
         | Masked<MaskedVariablesCaseData>
-        | Streaming<Masked<MaskedVariablesCaseData>>
+        | TData.Streaming<Masked<MaskedVariablesCaseData>>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -7342,7 +7344,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          Streaming<Masked<MaskedVariablesCaseData>>
+          TData.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
     }
@@ -7366,7 +7368,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | undefined | Streaming<VariablesCaseData>
+        VariablesCaseData | undefined | TData.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "empty"
@@ -7377,7 +7379,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
 
       if (dataState === "empty") {
@@ -7401,7 +7403,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | undefined | Streaming<VariablesCaseData>
+        VariablesCaseData | undefined | TData.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "empty"
@@ -7412,7 +7414,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
 
       if (dataState === "empty") {
@@ -7439,7 +7441,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | Masked<MaskedVariablesCaseData>
         | undefined
-        | Streaming<Masked<MaskedVariablesCaseData>>
+        | TData.Streaming<Masked<MaskedVariablesCaseData>>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "empty"
@@ -7451,7 +7453,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          Streaming<Masked<MaskedVariablesCaseData>>
+          TData.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
 
@@ -7475,7 +7477,9 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        MaskedVariablesCaseData | undefined | Streaming<MaskedVariablesCaseData>
+        | MaskedVariablesCaseData
+        | undefined
+        | TData.Streaming<MaskedVariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "empty"
@@ -7486,7 +7490,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<MaskedVariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          TData.Streaming<MaskedVariablesCaseData>
+        >();
       }
 
       if (dataState === "empty") {
@@ -7511,7 +7517,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | Masked<MaskedVariablesCaseData>
         | undefined
-        | Streaming<Masked<MaskedVariablesCaseData>>
+        | TData.Streaming<Masked<MaskedVariablesCaseData>>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "empty"
@@ -7523,7 +7529,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          Streaming<Masked<MaskedVariablesCaseData>>
+          TData.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
 
@@ -7551,7 +7557,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | undefined | Streaming<VariablesCaseData>
+        VariablesCaseData | undefined | TData.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "empty"
@@ -7562,7 +7568,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
 
       if (dataState === "empty") {
@@ -7585,7 +7591,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | undefined | Streaming<VariablesCaseData>
+        VariablesCaseData | undefined | TData.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "empty"
@@ -7596,7 +7602,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
 
       if (dataState === "empty") {
@@ -7623,7 +7629,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | Masked<MaskedVariablesCaseData>
         | undefined
-        | Streaming<Masked<MaskedVariablesCaseData>>
+        | TData.Streaming<Masked<MaskedVariablesCaseData>>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "empty"
@@ -7635,7 +7641,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          Streaming<Masked<MaskedVariablesCaseData>>
+          TData.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
 
@@ -7659,7 +7665,9 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        MaskedVariablesCaseData | undefined | Streaming<MaskedVariablesCaseData>
+        | MaskedVariablesCaseData
+        | undefined
+        | TData.Streaming<MaskedVariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "empty"
@@ -7670,7 +7678,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<MaskedVariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          TData.Streaming<MaskedVariablesCaseData>
+        >();
       }
 
       if (dataState === "empty") {
@@ -7695,7 +7705,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | Masked<MaskedVariablesCaseData>
         | undefined
-        | Streaming<Masked<MaskedVariablesCaseData>>
+        | TData.Streaming<Masked<MaskedVariablesCaseData>>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "empty"
@@ -7707,7 +7717,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          Streaming<Masked<MaskedVariablesCaseData>>
+          TData.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
 
@@ -7735,7 +7745,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | Streaming<VariablesCaseData>
+        VariablesCaseData | TData.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -7744,7 +7754,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
     }
 
@@ -7763,7 +7773,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | Streaming<VariablesCaseData>
+        VariablesCaseData | TData.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -7772,7 +7782,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
     }
 
@@ -7794,7 +7804,7 @@ describe.skip("type tests", () => {
       >;
       expectTypeOf(data).toEqualTypeOf<
         | Masked<MaskedVariablesCaseData>
-        | Streaming<Masked<MaskedVariablesCaseData>>
+        | TData.Streaming<Masked<MaskedVariablesCaseData>>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -7804,7 +7814,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          Streaming<Masked<MaskedVariablesCaseData>>
+          TData.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
     }
@@ -7824,7 +7834,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        MaskedVariablesCaseData | Streaming<MaskedVariablesCaseData>
+        MaskedVariablesCaseData | TData.Streaming<MaskedVariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -7833,7 +7843,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<MaskedVariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          TData.Streaming<MaskedVariablesCaseData>
+        >();
       }
     }
 
@@ -7853,7 +7865,7 @@ describe.skip("type tests", () => {
       >;
       expectTypeOf(data).toEqualTypeOf<
         | Masked<MaskedVariablesCaseData>
-        | Streaming<Masked<MaskedVariablesCaseData>>
+        | TData.Streaming<Masked<MaskedVariablesCaseData>>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -7863,7 +7875,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          Streaming<Masked<MaskedVariablesCaseData>>
+          TData.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
     }
@@ -7889,7 +7901,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | VariablesCaseData
         | DeepPartial<VariablesCaseData>
-        | Streaming<VariablesCaseData>
+        | TData.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -7900,7 +7912,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
 
       if (dataState === "partial") {
@@ -7925,7 +7937,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | VariablesCaseData
         | DeepPartial<VariablesCaseData>
-        | Streaming<VariablesCaseData>
+        | TData.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -7936,7 +7948,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
 
       if (dataState === "partial") {
@@ -7963,7 +7975,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | Masked<MaskedVariablesCaseData>
         | DeepPartial<Masked<MaskedVariablesCaseData>>
-        | Streaming<Masked<MaskedVariablesCaseData>>
+        | TData.Streaming<Masked<MaskedVariablesCaseData>>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -7975,7 +7987,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          Streaming<Masked<MaskedVariablesCaseData>>
+          TData.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
 
@@ -8003,7 +8015,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | MaskedVariablesCaseData
         | DeepPartial<MaskedVariablesCaseData>
-        | Streaming<MaskedVariablesCaseData>
+        | TData.Streaming<MaskedVariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -8014,7 +8026,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<MaskedVariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          TData.Streaming<MaskedVariablesCaseData>
+        >();
       }
 
       if (dataState === "partial") {
@@ -8041,7 +8055,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | Masked<MaskedVariablesCaseData>
         | DeepPartial<Masked<MaskedVariablesCaseData>>
-        | Streaming<Masked<MaskedVariablesCaseData>>
+        | TData.Streaming<Masked<MaskedVariablesCaseData>>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -8053,7 +8067,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          Streaming<Masked<MaskedVariablesCaseData>>
+          TData.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
 
@@ -8083,7 +8097,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | Streaming<VariablesCaseData>
+        VariablesCaseData | TData.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -8092,7 +8106,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
     }
 
@@ -8112,7 +8126,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | Streaming<VariablesCaseData>
+        VariablesCaseData | TData.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -8121,7 +8135,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
     }
 
@@ -8143,7 +8157,7 @@ describe.skip("type tests", () => {
       >;
       expectTypeOf(data).toEqualTypeOf<
         | Masked<MaskedVariablesCaseData>
-        | Streaming<Masked<MaskedVariablesCaseData>>
+        | TData.Streaming<Masked<MaskedVariablesCaseData>>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -8153,7 +8167,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          Streaming<Masked<MaskedVariablesCaseData>>
+          TData.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
     }
@@ -8173,7 +8187,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        MaskedVariablesCaseData | Streaming<MaskedVariablesCaseData>
+        MaskedVariablesCaseData | TData.Streaming<MaskedVariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -8182,7 +8196,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<MaskedVariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          TData.Streaming<MaskedVariablesCaseData>
+        >();
       }
     }
 
@@ -8202,7 +8218,8 @@ describe.skip("type tests", () => {
       >;
       expectTypeOf(data).toEqualTypeOf<
         Masked<
-          MaskedVariablesCaseData | Streaming<Masked<MaskedVariablesCaseData>>
+          | MaskedVariablesCaseData
+          | TData.Streaming<Masked<MaskedVariablesCaseData>>
         >
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
@@ -8213,7 +8230,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          Streaming<Masked<MaskedVariablesCaseData>>
+          TData.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
     }
@@ -8241,7 +8258,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | VariablesCaseData
         | DeepPartial<VariablesCaseData>
-        | Streaming<VariablesCaseData>
+        | TData.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -8252,7 +8269,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
 
       if (dataState === "partial") {
@@ -8278,7 +8295,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | VariablesCaseData
         | DeepPartial<VariablesCaseData>
-        | Streaming<VariablesCaseData>
+        | TData.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -8289,7 +8306,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
 
       if (dataState === "partial") {
@@ -8317,7 +8334,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | Streaming<VariablesCaseData>
+        VariablesCaseData | TData.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -8326,7 +8343,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
     }
 
@@ -8350,7 +8367,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | Streaming<VariablesCaseData>
+        VariablesCaseData | TData.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -8359,7 +8376,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
     }
   });
@@ -8382,7 +8399,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | Streaming<VariablesCaseData>
+        VariablesCaseData | TData.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -8391,7 +8408,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
     }
 
@@ -8411,7 +8428,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | Streaming<VariablesCaseData>
+        VariablesCaseData | TData.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -8420,7 +8437,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
     }
 
@@ -8442,7 +8459,7 @@ describe.skip("type tests", () => {
       >;
       expectTypeOf(data).toEqualTypeOf<
         | Masked<MaskedVariablesCaseData>
-        | Streaming<Masked<MaskedVariablesCaseData>>
+        | TData.Streaming<Masked<MaskedVariablesCaseData>>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -8452,7 +8469,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          Streaming<Masked<MaskedVariablesCaseData>>
+          TData.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
     }
@@ -8472,7 +8489,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        MaskedVariablesCaseData | Streaming<MaskedVariablesCaseData>
+        MaskedVariablesCaseData | TData.Streaming<MaskedVariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -8481,7 +8498,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<MaskedVariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          TData.Streaming<MaskedVariablesCaseData>
+        >();
       }
     }
 
@@ -8501,7 +8520,7 @@ describe.skip("type tests", () => {
       >;
       expectTypeOf(data).toEqualTypeOf<
         | Masked<MaskedVariablesCaseData>
-        | Streaming<Masked<MaskedVariablesCaseData>>
+        | TData.Streaming<Masked<MaskedVariablesCaseData>>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -8511,7 +8530,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          Streaming<Masked<MaskedVariablesCaseData>>
+          TData.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
     }
@@ -8540,7 +8559,7 @@ describe.skip("type tests", () => {
         | VariablesCaseData
         | DeepPartial<VariablesCaseData>
         | undefined
-        | Streaming<VariablesCaseData>
+        | TData.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial" | "empty"
@@ -8551,7 +8570,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
 
       if (dataState === "partial") {
@@ -8584,7 +8603,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | VariablesCaseData
         | DeepPartial<VariablesCaseData>
-        | Streaming<VariablesCaseData>
+        | TData.Streaming<VariablesCaseData>
         | undefined
       >();
       expectTypeOf(dataState).toEqualTypeOf<
@@ -8596,7 +8615,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
 
       if (dataState === "partial") {
@@ -8626,7 +8645,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | Masked<MaskedVariablesCaseData>
         | DeepPartial<Masked<MaskedVariablesCaseData>>
-        | Streaming<Masked<MaskedVariablesCaseData>>
+        | TData.Streaming<Masked<MaskedVariablesCaseData>>
         | undefined
       >();
       expectTypeOf(dataState).toEqualTypeOf<
@@ -8639,7 +8658,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          Streaming<Masked<MaskedVariablesCaseData>>
+          TData.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
 
@@ -8675,7 +8694,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | MaskedVariablesCaseData
         | DeepPartial<MaskedVariablesCaseData>
-        | Streaming<MaskedVariablesCaseData>
+        | TData.Streaming<MaskedVariablesCaseData>
         | undefined
       >();
       expectTypeOf(dataState).toEqualTypeOf<
@@ -8687,7 +8706,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<MaskedVariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          TData.Streaming<MaskedVariablesCaseData>
+        >();
       }
 
       if (dataState === "partial") {
@@ -8722,7 +8743,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | Masked<MaskedVariablesCaseData>
         | DeepPartial<Masked<MaskedVariablesCaseData>>
-        | Streaming<Masked<MaskedVariablesCaseData>>
+        | TData.Streaming<Masked<MaskedVariablesCaseData>>
         | undefined
       >();
       expectTypeOf(dataState).toEqualTypeOf<
@@ -8735,7 +8756,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          Streaming<Masked<MaskedVariablesCaseData>>
+          TData.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
 
@@ -8768,7 +8789,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | VariablesCaseData
         | DeepPartial<VariablesCaseData>
-        | Streaming<VariablesCaseData>
+        | TData.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -8779,7 +8800,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
 
       if (dataState === "partial") {
@@ -8808,7 +8829,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | VariablesCaseData
         | DeepPartial<VariablesCaseData>
-        | Streaming<VariablesCaseData>
+        | TData.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -8819,7 +8840,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
 
       if (dataState === "partial") {
@@ -8845,7 +8866,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | Masked<MaskedVariablesCaseData>
         | DeepPartial<Masked<MaskedVariablesCaseData>>
-        | Streaming<Masked<MaskedVariablesCaseData>>
+        | TData.Streaming<Masked<MaskedVariablesCaseData>>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -8857,7 +8878,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          Streaming<Masked<MaskedVariablesCaseData>>
+          TData.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
 
@@ -8889,7 +8910,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | MaskedVariablesCaseData
         | DeepPartial<MaskedVariablesCaseData>
-        | Streaming<MaskedVariablesCaseData>
+        | TData.Streaming<MaskedVariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -8900,7 +8921,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<MaskedVariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          TData.Streaming<MaskedVariablesCaseData>
+        >();
       }
 
       if (dataState === "partial") {
@@ -8931,7 +8954,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | Masked<MaskedVariablesCaseData>
         | DeepPartial<Masked<MaskedVariablesCaseData>>
-        | Streaming<Masked<MaskedVariablesCaseData>>
+        | TData.Streaming<Masked<MaskedVariablesCaseData>>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -8943,7 +8966,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          Streaming<Masked<MaskedVariablesCaseData>>
+          TData.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
 
@@ -8975,7 +8998,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | Streaming<VariablesCaseData>
+        VariablesCaseData | TData.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -8984,7 +9007,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
     }
 
@@ -9009,7 +9032,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | Streaming<VariablesCaseData>
+        VariablesCaseData | TData.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -9018,7 +9041,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
     }
 
@@ -9042,7 +9065,7 @@ describe.skip("type tests", () => {
       >;
       expectTypeOf(data).toEqualTypeOf<
         | Masked<MaskedVariablesCaseData>
-        | Streaming<Masked<MaskedVariablesCaseData>>
+        | TData.Streaming<Masked<MaskedVariablesCaseData>>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -9052,7 +9075,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          Streaming<Masked<MaskedVariablesCaseData>>
+          TData.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
     }
@@ -9077,7 +9100,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        MaskedVariablesCaseData | Streaming<MaskedVariablesCaseData>
+        MaskedVariablesCaseData | TData.Streaming<MaskedVariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -9086,7 +9109,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<MaskedVariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          TData.Streaming<MaskedVariablesCaseData>
+        >();
       }
     }
 
@@ -9111,7 +9136,7 @@ describe.skip("type tests", () => {
       >;
       expectTypeOf(data).toEqualTypeOf<
         | Masked<MaskedVariablesCaseData>
-        | Streaming<Masked<MaskedVariablesCaseData>>
+        | TData.Streaming<Masked<MaskedVariablesCaseData>>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -9121,7 +9146,7 @@ describe.skip("type tests", () => {
 
       if (dataState === "streaming") {
         expectTypeOf(data).toEqualTypeOf<
-          Streaming<Masked<MaskedVariablesCaseData>>
+          TData.Streaming<Masked<MaskedVariablesCaseData>>
         >();
       }
     }

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -15,7 +15,7 @@ import type {
   ErrorPolicy,
   QueryResult,
   RefetchWritePolicy,
-  TData,
+  DataValue,
   TypedDocumentNode,
   WatchQueryFetchPolicy,
 } from "@apollo/client";
@@ -6182,7 +6182,7 @@ describe.skip("Type Tests", () => {
     }
 
     if (dataState === "streaming") {
-      expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
+      expectTypeOf(data).toEqualTypeOf<DataValue.Streaming<SimpleCaseData>>();
     }
 
     if (dataState === "empty") {
@@ -6215,7 +6215,7 @@ describe.skip("Type Tests", () => {
     }
 
     if (dataState === "streaming") {
-      expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
+      expectTypeOf(data).toEqualTypeOf<DataValue.Streaming<SimpleCaseData>>();
     }
 
     if (dataState === "empty") {
@@ -6287,7 +6287,7 @@ describe.skip("Type Tests", () => {
     ] = useLazyQuery(query);
 
     expectTypeOf(data).toEqualTypeOf<
-      Masked<Query> | TData.Streaming<Masked<Query>> | undefined
+      Masked<Query> | DataValue.Streaming<Masked<Query>> | undefined
     >();
     expectTypeOf(previousData).toEqualTypeOf<Masked<Query> | undefined>();
 
@@ -6400,7 +6400,7 @@ describe.skip("Type Tests", () => {
     ] = useLazyQuery(query);
 
     expectTypeOf(data).toEqualTypeOf<
-      Query | TData.Streaming<Query> | undefined
+      Query | DataValue.Streaming<Query> | undefined
     >();
     expectTypeOf(previousData).toEqualTypeOf<Query | undefined>();
 

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -15,7 +15,7 @@ import type {
   ErrorPolicy,
   QueryResult,
   RefetchWritePolicy,
-  Streaming,
+  TData,
   TypedDocumentNode,
   WatchQueryFetchPolicy,
 } from "@apollo/client";
@@ -6182,7 +6182,7 @@ describe.skip("Type Tests", () => {
     }
 
     if (dataState === "streaming") {
-      expectTypeOf(data).toEqualTypeOf<Streaming<SimpleCaseData>>();
+      expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
     }
 
     if (dataState === "empty") {
@@ -6215,7 +6215,7 @@ describe.skip("Type Tests", () => {
     }
 
     if (dataState === "streaming") {
-      expectTypeOf(data).toEqualTypeOf<Streaming<SimpleCaseData>>();
+      expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
     }
 
     if (dataState === "empty") {
@@ -6287,7 +6287,7 @@ describe.skip("Type Tests", () => {
     ] = useLazyQuery(query);
 
     expectTypeOf(data).toEqualTypeOf<
-      Masked<Query> | Streaming<Masked<Query>> | undefined
+      Masked<Query> | TData.Streaming<Masked<Query>> | undefined
     >();
     expectTypeOf(previousData).toEqualTypeOf<Masked<Query> | undefined>();
 
@@ -6399,7 +6399,9 @@ describe.skip("Type Tests", () => {
       { data, previousData, fetchMore, refetch, subscribeToMore, updateQuery },
     ] = useLazyQuery(query);
 
-    expectTypeOf(data).toEqualTypeOf<Query | Streaming<Query> | undefined>();
+    expectTypeOf(data).toEqualTypeOf<
+      Query | TData.Streaming<Query> | undefined
+    >();
     expectTypeOf(previousData).toEqualTypeOf<Query | undefined>();
 
     subscribeToMore({

--- a/src/react/hooks/__tests__/useLoadableQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLoadableQuery.test.tsx
@@ -20,8 +20,8 @@ import type {
   ErrorPolicy,
   OperationVariables,
   RefetchWritePolicy,
-  Streaming,
   SubscribeToMoreOptions,
+  TData,
   TypedDocumentNode,
 } from "@apollo/client";
 import {
@@ -5188,7 +5188,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | Streaming<VariablesCaseData>
+        VariablesCaseData | TData.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -5197,7 +5197,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
     }
 
@@ -5219,7 +5219,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | Streaming<VariablesCaseData>
+        VariablesCaseData | TData.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -5228,7 +5228,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
     }
   });
@@ -5253,7 +5253,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | Streaming<VariablesCaseData> | undefined
+        VariablesCaseData | TData.Streaming<VariablesCaseData> | undefined
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "empty"
@@ -5264,7 +5264,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
 
       if (dataState === "empty") {
@@ -5290,7 +5290,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | Streaming<VariablesCaseData> | undefined
+        VariablesCaseData | TData.Streaming<VariablesCaseData> | undefined
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "empty"
@@ -5301,7 +5301,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
 
       if (dataState === "empty") {
@@ -5330,7 +5330,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | Streaming<VariablesCaseData> | undefined
+        VariablesCaseData | TData.Streaming<VariablesCaseData> | undefined
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "empty"
@@ -5341,7 +5341,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
 
       if (dataState === "empty") {
@@ -5367,7 +5367,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | Streaming<VariablesCaseData> | undefined
+        VariablesCaseData | TData.Streaming<VariablesCaseData> | undefined
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "empty"
@@ -5378,7 +5378,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
 
       if (dataState === "empty") {
@@ -5407,7 +5407,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | Streaming<VariablesCaseData>
+        VariablesCaseData | TData.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -5416,7 +5416,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
     }
 
@@ -5431,7 +5431,7 @@ describe.skip("type tests", () => {
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | Streaming<VariablesCaseData>
+        VariablesCaseData | TData.Streaming<VariablesCaseData>
       >();
     }
   });
@@ -5458,7 +5458,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | VariablesCaseData
         | DeepPartial<VariablesCaseData>
-        | Streaming<VariablesCaseData>
+        | TData.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -5469,7 +5469,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
 
       if (dataState === "partial") {
@@ -5497,7 +5497,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | VariablesCaseData
         | DeepPartial<VariablesCaseData>
-        | Streaming<VariablesCaseData>
+        | TData.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -5508,7 +5508,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
 
       if (dataState === "partial") {
@@ -5537,7 +5537,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | Streaming<VariablesCaseData>
+        VariablesCaseData | TData.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -5546,7 +5546,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
     }
 
@@ -5568,7 +5568,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | Streaming<VariablesCaseData>
+        VariablesCaseData | TData.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -5577,7 +5577,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
     }
   });
@@ -5602,7 +5602,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | Streaming<VariablesCaseData>
+        VariablesCaseData | TData.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -5611,7 +5611,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
     }
 
@@ -5633,7 +5633,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | Streaming<VariablesCaseData>
+        VariablesCaseData | TData.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -5642,7 +5642,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
     }
   });
@@ -5670,7 +5670,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | VariablesCaseData
         | DeepPartial<VariablesCaseData>
-        | Streaming<VariablesCaseData>
+        | TData.Streaming<VariablesCaseData>
         | undefined
       >();
       expectTypeOf(dataState).toEqualTypeOf<
@@ -5682,7 +5682,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
 
       if (dataState === "partial") {
@@ -5714,7 +5714,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | VariablesCaseData
         | DeepPartial<VariablesCaseData>
-        | Streaming<VariablesCaseData>
+        | TData.Streaming<VariablesCaseData>
         | undefined
       >();
       expectTypeOf(dataState).toEqualTypeOf<
@@ -5726,7 +5726,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
 
       if (dataState === "partial") {
@@ -5758,7 +5758,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | VariablesCaseData
         | DeepPartial<VariablesCaseData>
-        | Streaming<VariablesCaseData>
+        | TData.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -5769,7 +5769,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
 
       if (dataState === "partial") {
@@ -5797,7 +5797,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | VariablesCaseData
         | DeepPartial<VariablesCaseData>
-        | Streaming<VariablesCaseData>
+        | TData.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -5808,7 +5808,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
 
       if (dataState === "partial") {
@@ -5841,7 +5841,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | VariablesCaseData
         | DeepPartial<VariablesCaseData>
-        | Streaming<VariablesCaseData>
+        | TData.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -5852,7 +5852,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
 
       if (dataState === "partial") {
@@ -5884,7 +5884,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | VariablesCaseData
         | DeepPartial<VariablesCaseData>
-        | Streaming<VariablesCaseData>
+        | TData.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -5895,7 +5895,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
       }
 
       if (dataState === "partial") {

--- a/src/react/hooks/__tests__/useLoadableQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLoadableQuery.test.tsx
@@ -21,7 +21,7 @@ import type {
   OperationVariables,
   RefetchWritePolicy,
   SubscribeToMoreOptions,
-  TData,
+  DataValue,
   TypedDocumentNode,
 } from "@apollo/client";
 import {
@@ -5188,7 +5188,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | TData.Streaming<VariablesCaseData>
+        VariablesCaseData | DataValue.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -5197,7 +5197,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
     }
 
@@ -5219,7 +5221,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | TData.Streaming<VariablesCaseData>
+        VariablesCaseData | DataValue.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -5228,7 +5230,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
     }
   });
@@ -5253,7 +5257,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | TData.Streaming<VariablesCaseData> | undefined
+        VariablesCaseData | DataValue.Streaming<VariablesCaseData> | undefined
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "empty"
@@ -5264,7 +5268,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
 
       if (dataState === "empty") {
@@ -5290,7 +5296,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | TData.Streaming<VariablesCaseData> | undefined
+        VariablesCaseData | DataValue.Streaming<VariablesCaseData> | undefined
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "empty"
@@ -5301,7 +5307,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
 
       if (dataState === "empty") {
@@ -5330,7 +5338,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | TData.Streaming<VariablesCaseData> | undefined
+        VariablesCaseData | DataValue.Streaming<VariablesCaseData> | undefined
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "empty"
@@ -5341,7 +5349,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
 
       if (dataState === "empty") {
@@ -5367,7 +5377,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | TData.Streaming<VariablesCaseData> | undefined
+        VariablesCaseData | DataValue.Streaming<VariablesCaseData> | undefined
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "empty"
@@ -5378,7 +5388,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
 
       if (dataState === "empty") {
@@ -5407,7 +5419,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | TData.Streaming<VariablesCaseData>
+        VariablesCaseData | DataValue.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -5416,7 +5428,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
     }
 
@@ -5431,7 +5445,7 @@ describe.skip("type tests", () => {
       const { data } = useReadQuery(queryRef);
 
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | TData.Streaming<VariablesCaseData>
+        VariablesCaseData | DataValue.Streaming<VariablesCaseData>
       >();
     }
   });
@@ -5458,7 +5472,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | VariablesCaseData
         | DeepPartial<VariablesCaseData>
-        | TData.Streaming<VariablesCaseData>
+        | DataValue.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -5469,7 +5483,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
 
       if (dataState === "partial") {
@@ -5497,7 +5513,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | VariablesCaseData
         | DeepPartial<VariablesCaseData>
-        | TData.Streaming<VariablesCaseData>
+        | DataValue.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -5508,7 +5524,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
 
       if (dataState === "partial") {
@@ -5537,7 +5555,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | TData.Streaming<VariablesCaseData>
+        VariablesCaseData | DataValue.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -5546,7 +5564,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
     }
 
@@ -5568,7 +5588,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | TData.Streaming<VariablesCaseData>
+        VariablesCaseData | DataValue.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -5577,7 +5597,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
     }
   });
@@ -5602,7 +5624,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | TData.Streaming<VariablesCaseData>
+        VariablesCaseData | DataValue.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -5611,7 +5633,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
     }
 
@@ -5633,7 +5657,7 @@ describe.skip("type tests", () => {
         >
       >;
       expectTypeOf(data).toEqualTypeOf<
-        VariablesCaseData | TData.Streaming<VariablesCaseData>
+        VariablesCaseData | DataValue.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -5642,7 +5666,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
     }
   });
@@ -5670,7 +5696,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | VariablesCaseData
         | DeepPartial<VariablesCaseData>
-        | TData.Streaming<VariablesCaseData>
+        | DataValue.Streaming<VariablesCaseData>
         | undefined
       >();
       expectTypeOf(dataState).toEqualTypeOf<
@@ -5682,7 +5708,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
 
       if (dataState === "partial") {
@@ -5714,7 +5742,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | VariablesCaseData
         | DeepPartial<VariablesCaseData>
-        | TData.Streaming<VariablesCaseData>
+        | DataValue.Streaming<VariablesCaseData>
         | undefined
       >();
       expectTypeOf(dataState).toEqualTypeOf<
@@ -5726,7 +5754,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
 
       if (dataState === "partial") {
@@ -5758,7 +5788,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | VariablesCaseData
         | DeepPartial<VariablesCaseData>
-        | TData.Streaming<VariablesCaseData>
+        | DataValue.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -5769,7 +5799,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
 
       if (dataState === "partial") {
@@ -5797,7 +5829,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | VariablesCaseData
         | DeepPartial<VariablesCaseData>
-        | TData.Streaming<VariablesCaseData>
+        | DataValue.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -5808,7 +5840,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
 
       if (dataState === "partial") {
@@ -5841,7 +5875,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | VariablesCaseData
         | DeepPartial<VariablesCaseData>
-        | TData.Streaming<VariablesCaseData>
+        | DataValue.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -5852,7 +5886,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
 
       if (dataState === "partial") {
@@ -5884,7 +5920,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | VariablesCaseData
         | DeepPartial<VariablesCaseData>
-        | TData.Streaming<VariablesCaseData>
+        | DataValue.Streaming<VariablesCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -5895,7 +5931,9 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<VariablesCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<
+          DataValue.Streaming<VariablesCaseData>
+        >();
       }
 
       if (dataState === "partial") {

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -24,7 +24,7 @@ import type {
   FetchPolicy,
   OperationVariables,
   RefetchWritePolicy,
-  TData,
+  DataValue,
   TypedDocumentNode,
   WatchQueryFetchPolicy,
   WatchQueryOptions,
@@ -13267,7 +13267,7 @@ describe.skip("Type Tests", () => {
     }
 
     if (dataState === "streaming") {
-      expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
+      expectTypeOf(data).toEqualTypeOf<DataValue.Streaming<SimpleCaseData>>();
     }
 
     if (dataState === "empty") {
@@ -13293,7 +13293,7 @@ describe.skip("Type Tests", () => {
     }
 
     if (dataState === "streaming") {
-      expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
+      expectTypeOf(data).toEqualTypeOf<DataValue.Streaming<SimpleCaseData>>();
     }
 
     if (dataState === "empty") {

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -24,7 +24,7 @@ import type {
   FetchPolicy,
   OperationVariables,
   RefetchWritePolicy,
-  Streaming,
+  TData,
   TypedDocumentNode,
   WatchQueryFetchPolicy,
   WatchQueryOptions,
@@ -13267,7 +13267,7 @@ describe.skip("Type Tests", () => {
     }
 
     if (dataState === "streaming") {
-      expectTypeOf(data).toEqualTypeOf<Streaming<SimpleCaseData>>();
+      expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
     }
 
     if (dataState === "empty") {
@@ -13293,7 +13293,7 @@ describe.skip("Type Tests", () => {
     }
 
     if (dataState === "streaming") {
-      expectTypeOf(data).toEqualTypeOf<Streaming<SimpleCaseData>>();
+      expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
     }
 
     if (dataState === "empty") {

--- a/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
@@ -21,7 +21,7 @@ import type {
   OperationVariables,
   QueryResult,
   SubscribeToMoreOptions,
-  TData,
+  DataValue,
   TypedDocumentNode,
 } from "@apollo/client";
 import {
@@ -12273,7 +12273,7 @@ describe("useSuspenseQuery", () => {
         });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | TData.Streaming<VariablesCaseData>
+          VariablesCaseData | DataValue.Streaming<VariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -12283,7 +12283,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<VariablesCaseData>
+            DataValue.Streaming<VariablesCaseData>
           >();
         }
       }
@@ -12295,7 +12295,7 @@ describe("useSuspenseQuery", () => {
         >(query, { variables: { id: "1" } });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | TData.Streaming<VariablesCaseData>
+          VariablesCaseData | DataValue.Streaming<VariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -12305,7 +12305,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<VariablesCaseData>
+            DataValue.Streaming<VariablesCaseData>
           >();
         }
       }
@@ -12319,7 +12319,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | TData.Streaming<Masked<MaskedVariablesCaseData>>
+          | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -12329,7 +12329,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<Masked<MaskedVariablesCaseData>>
+            DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
       }
@@ -12341,7 +12341,7 @@ describe("useSuspenseQuery", () => {
         >(maskedQuery, { variables: { id: "1" } });
 
         expectTypeOf(data).toEqualTypeOf<
-          MaskedVariablesCaseData | TData.Streaming<MaskedVariablesCaseData>
+          MaskedVariablesCaseData | DataValue.Streaming<MaskedVariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -12351,7 +12351,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<MaskedVariablesCaseData>
+            DataValue.Streaming<MaskedVariablesCaseData>
           >();
         }
       }
@@ -12364,7 +12364,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | TData.Streaming<Masked<MaskedVariablesCaseData>>
+          | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -12374,7 +12374,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<Masked<MaskedVariablesCaseData>>
+            DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
       }
@@ -12390,7 +12390,7 @@ describe("useSuspenseQuery", () => {
         });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | TData.Streaming<VariablesCaseData> | undefined
+          VariablesCaseData | DataValue.Streaming<VariablesCaseData> | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "empty"
@@ -12402,7 +12402,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<VariablesCaseData>
+            DataValue.Streaming<VariablesCaseData>
           >();
         }
 
@@ -12421,7 +12421,7 @@ describe("useSuspenseQuery", () => {
         });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | TData.Streaming<VariablesCaseData> | undefined
+          VariablesCaseData | DataValue.Streaming<VariablesCaseData> | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "empty"
@@ -12433,7 +12433,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<VariablesCaseData>
+            DataValue.Streaming<VariablesCaseData>
           >();
         }
 
@@ -12452,7 +12452,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | TData.Streaming<Masked<MaskedVariablesCaseData>>
+          | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -12465,7 +12465,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<Masked<MaskedVariablesCaseData>>
+            DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -12482,7 +12482,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | MaskedVariablesCaseData
-          | TData.Streaming<MaskedVariablesCaseData>
+          | DataValue.Streaming<MaskedVariablesCaseData>
           | undefined
         >();
       }
@@ -12495,7 +12495,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | TData.Streaming<Masked<MaskedVariablesCaseData>>
+          | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -12508,7 +12508,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<Masked<MaskedVariablesCaseData>>
+            DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -12528,7 +12528,7 @@ describe("useSuspenseQuery", () => {
         });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | TData.Streaming<VariablesCaseData> | undefined
+          VariablesCaseData | DataValue.Streaming<VariablesCaseData> | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "empty"
@@ -12540,7 +12540,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<VariablesCaseData>
+            DataValue.Streaming<VariablesCaseData>
           >();
         }
 
@@ -12559,7 +12559,7 @@ describe("useSuspenseQuery", () => {
         });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | TData.Streaming<VariablesCaseData> | undefined
+          VariablesCaseData | DataValue.Streaming<VariablesCaseData> | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "empty"
@@ -12571,7 +12571,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<VariablesCaseData>
+            DataValue.Streaming<VariablesCaseData>
           >();
         }
 
@@ -12590,7 +12590,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | TData.Streaming<Masked<MaskedVariablesCaseData>>
+          | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -12603,7 +12603,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<Masked<MaskedVariablesCaseData>>
+            DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -12620,7 +12620,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | MaskedVariablesCaseData
-          | TData.Streaming<MaskedVariablesCaseData>
+          | DataValue.Streaming<MaskedVariablesCaseData>
           | undefined
         >();
       }
@@ -12633,7 +12633,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | TData.Streaming<Masked<MaskedVariablesCaseData>>
+          | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -12646,7 +12646,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<Masked<MaskedVariablesCaseData>>
+            DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -12666,7 +12666,7 @@ describe("useSuspenseQuery", () => {
         });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | TData.Streaming<VariablesCaseData>
+          VariablesCaseData | DataValue.Streaming<VariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -12676,7 +12676,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<VariablesCaseData>
+            DataValue.Streaming<VariablesCaseData>
           >();
         }
       }
@@ -12691,7 +12691,7 @@ describe("useSuspenseQuery", () => {
         });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | TData.Streaming<VariablesCaseData>
+          VariablesCaseData | DataValue.Streaming<VariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -12701,7 +12701,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<VariablesCaseData>
+            DataValue.Streaming<VariablesCaseData>
           >();
         }
       }
@@ -12716,7 +12716,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | TData.Streaming<Masked<MaskedVariablesCaseData>>
+          | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -12726,7 +12726,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<Masked<MaskedVariablesCaseData>>
+            DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
       }
@@ -12738,7 +12738,7 @@ describe("useSuspenseQuery", () => {
         >(maskedQuery, { errorPolicy: "none", variables: { id: "1" } });
 
         expectTypeOf(data).toEqualTypeOf<
-          MaskedVariablesCaseData | TData.Streaming<MaskedVariablesCaseData>
+          MaskedVariablesCaseData | DataValue.Streaming<MaskedVariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -12748,7 +12748,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<MaskedVariablesCaseData>
+            DataValue.Streaming<MaskedVariablesCaseData>
           >();
         }
       }
@@ -12761,7 +12761,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | TData.Streaming<Masked<MaskedVariablesCaseData>>
+          | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -12771,7 +12771,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<Masked<MaskedVariablesCaseData>>
+            DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
       }
@@ -12789,7 +12789,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | VariablesCaseData
           | DeepPartial<VariablesCaseData>
-          | TData.Streaming<VariablesCaseData>
+          | DataValue.Streaming<VariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "partial"
@@ -12801,7 +12801,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<VariablesCaseData>
+            DataValue.Streaming<VariablesCaseData>
           >();
         }
 
@@ -12822,7 +12822,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | VariablesCaseData
           | DeepPartial<VariablesCaseData>
-          | TData.Streaming<VariablesCaseData>
+          | DataValue.Streaming<VariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "partial"
@@ -12834,7 +12834,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<VariablesCaseData>
+            DataValue.Streaming<VariablesCaseData>
           >();
         }
 
@@ -12853,7 +12853,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | TData.Streaming<Masked<MaskedVariablesCaseData>>
+          | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           | DeepPartial<Masked<MaskedVariablesCaseData>>
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -12866,7 +12866,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<Masked<MaskedVariablesCaseData>>
+            DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -12886,7 +12886,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | MaskedVariablesCaseData
           | DeepPartial<MaskedVariablesCaseData>
-          | TData.Streaming<MaskedVariablesCaseData>
+          | DataValue.Streaming<MaskedVariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "partial"
@@ -12898,7 +12898,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<MaskedVariablesCaseData>
+            DataValue.Streaming<MaskedVariablesCaseData>
           >();
         }
 
@@ -12917,7 +12917,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | TData.Streaming<Masked<MaskedVariablesCaseData>>
+          | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           | DeepPartial<Masked<MaskedVariablesCaseData>>
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -12930,7 +12930,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<Masked<MaskedVariablesCaseData>>
+            DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -12952,7 +12952,7 @@ describe("useSuspenseQuery", () => {
         });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | TData.Streaming<VariablesCaseData>
+          VariablesCaseData | DataValue.Streaming<VariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -12962,7 +12962,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<VariablesCaseData>
+            DataValue.Streaming<VariablesCaseData>
           >();
         }
       }
@@ -12977,7 +12977,7 @@ describe("useSuspenseQuery", () => {
         });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | TData.Streaming<VariablesCaseData>
+          VariablesCaseData | DataValue.Streaming<VariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -12987,7 +12987,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<VariablesCaseData>
+            DataValue.Streaming<VariablesCaseData>
           >();
         }
       }
@@ -13002,7 +13002,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | TData.Streaming<Masked<MaskedVariablesCaseData>>
+          | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -13012,7 +13012,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<Masked<MaskedVariablesCaseData>>
+            DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
       }
@@ -13024,7 +13024,7 @@ describe("useSuspenseQuery", () => {
         >(maskedQuery, { returnPartialData: false, variables: { id: "1" } });
 
         expectTypeOf(data).toEqualTypeOf<
-          MaskedVariablesCaseData | TData.Streaming<MaskedVariablesCaseData>
+          MaskedVariablesCaseData | DataValue.Streaming<MaskedVariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -13034,7 +13034,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<MaskedVariablesCaseData>
+            DataValue.Streaming<MaskedVariablesCaseData>
           >();
         }
       }
@@ -13047,7 +13047,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | TData.Streaming<Masked<MaskedVariablesCaseData>>
+          | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -13057,7 +13057,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<Masked<MaskedVariablesCaseData>>
+            DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
       }
@@ -13073,7 +13073,7 @@ describe("useSuspenseQuery", () => {
         });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | TData.Streaming<VariablesCaseData> | undefined
+          VariablesCaseData | DataValue.Streaming<VariablesCaseData> | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "empty"
@@ -13085,7 +13085,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<VariablesCaseData>
+            DataValue.Streaming<VariablesCaseData>
           >();
         }
 
@@ -13104,7 +13104,7 @@ describe("useSuspenseQuery", () => {
         });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | TData.Streaming<VariablesCaseData> | undefined
+          VariablesCaseData | DataValue.Streaming<VariablesCaseData> | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "empty"
@@ -13116,7 +13116,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<VariablesCaseData>
+            DataValue.Streaming<VariablesCaseData>
           >();
         }
 
@@ -13139,7 +13139,7 @@ describe("useSuspenseQuery", () => {
         });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | TData.Streaming<VariablesCaseData> | undefined
+          VariablesCaseData | DataValue.Streaming<VariablesCaseData> | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "empty"
@@ -13151,7 +13151,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<VariablesCaseData>
+            DataValue.Streaming<VariablesCaseData>
           >();
         }
 
@@ -13170,7 +13170,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | TData.Streaming<Masked<MaskedVariablesCaseData>>
+          | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -13183,7 +13183,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<Masked<MaskedVariablesCaseData>>
+            DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -13200,7 +13200,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | MaskedVariablesCaseData
-          | TData.Streaming<MaskedVariablesCaseData>
+          | DataValue.Streaming<MaskedVariablesCaseData>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -13213,7 +13213,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<MaskedVariablesCaseData>
+            DataValue.Streaming<MaskedVariablesCaseData>
           >();
         }
 
@@ -13230,7 +13230,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | TData.Streaming<Masked<MaskedVariablesCaseData>>
+          | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -13243,7 +13243,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<Masked<MaskedVariablesCaseData>>
+            DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -13264,7 +13264,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | TData.Streaming<Masked<MaskedVariablesCaseData>>
+          | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -13277,7 +13277,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<Masked<MaskedVariablesCaseData>>
+            DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -13300,7 +13300,7 @@ describe("useSuspenseQuery", () => {
         );
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | TData.Streaming<VariablesCaseData> | undefined
+          VariablesCaseData | DataValue.Streaming<VariablesCaseData> | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "empty"
@@ -13312,7 +13312,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<VariablesCaseData>
+            DataValue.Streaming<VariablesCaseData>
           >();
         }
 
@@ -13328,7 +13328,7 @@ describe("useSuspenseQuery", () => {
         >(query, options.skip ? skipToken : { variables: { id: "1" } });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | TData.Streaming<VariablesCaseData> | undefined
+          VariablesCaseData | DataValue.Streaming<VariablesCaseData> | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "empty"
@@ -13340,7 +13340,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<VariablesCaseData>
+            DataValue.Streaming<VariablesCaseData>
           >();
         }
 
@@ -13359,7 +13359,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | TData.Streaming<Masked<MaskedVariablesCaseData>>
+          | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -13372,7 +13372,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<Masked<MaskedVariablesCaseData>>
+            DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -13389,7 +13389,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | MaskedVariablesCaseData
-          | TData.Streaming<MaskedVariablesCaseData>
+          | DataValue.Streaming<MaskedVariablesCaseData>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -13402,7 +13402,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<MaskedVariablesCaseData>
+            DataValue.Streaming<MaskedVariablesCaseData>
           >();
         }
 
@@ -13419,7 +13419,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | TData.Streaming<Masked<MaskedVariablesCaseData>>
+          | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -13432,7 +13432,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<Masked<MaskedVariablesCaseData>>
+            DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -13455,7 +13455,7 @@ describe("useSuspenseQuery", () => {
         );
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | TData.Streaming<VariablesCaseData> | undefined
+          VariablesCaseData | DataValue.Streaming<VariablesCaseData> | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "empty"
@@ -13467,7 +13467,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<VariablesCaseData>
+            DataValue.Streaming<VariablesCaseData>
           >();
         }
 
@@ -13483,7 +13483,7 @@ describe("useSuspenseQuery", () => {
         >(query, options.skip ? skipToken : { variables: { id: "1" } });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | TData.Streaming<VariablesCaseData> | undefined
+          VariablesCaseData | DataValue.Streaming<VariablesCaseData> | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "empty"
@@ -13495,7 +13495,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<VariablesCaseData>
+            DataValue.Streaming<VariablesCaseData>
           >();
         }
 
@@ -13514,7 +13514,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | TData.Streaming<Masked<MaskedVariablesCaseData>>
+          | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -13527,7 +13527,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<Masked<MaskedVariablesCaseData>>
+            DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -13544,7 +13544,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | MaskedVariablesCaseData
-          | TData.Streaming<MaskedVariablesCaseData>
+          | DataValue.Streaming<MaskedVariablesCaseData>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -13557,7 +13557,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<MaskedVariablesCaseData>
+            DataValue.Streaming<MaskedVariablesCaseData>
           >();
         }
 
@@ -13574,7 +13574,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | TData.Streaming<Masked<MaskedVariablesCaseData>>
+          | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -13587,7 +13587,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<Masked<MaskedVariablesCaseData>>
+            DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -13614,7 +13614,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | VariablesCaseData
           | DeepPartial<VariablesCaseData>
-          | TData.Streaming<VariablesCaseData>
+          | DataValue.Streaming<VariablesCaseData>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -13627,7 +13627,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<VariablesCaseData>
+            DataValue.Streaming<VariablesCaseData>
           >();
         }
 
@@ -13654,7 +13654,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | VariablesCaseData
           | DeepPartial<VariablesCaseData>
-          | TData.Streaming<VariablesCaseData>
+          | DataValue.Streaming<VariablesCaseData>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -13667,7 +13667,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<VariablesCaseData>
+            DataValue.Streaming<VariablesCaseData>
           >();
         }
 
@@ -13693,7 +13693,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
           | DeepPartial<Masked<MaskedVariablesCaseData>>
-          | TData.Streaming<Masked<MaskedVariablesCaseData>>
+          | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -13706,7 +13706,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<Masked<MaskedVariablesCaseData>>
+            DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -13735,7 +13735,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | MaskedVariablesCaseData
           | DeepPartial<MaskedVariablesCaseData>
-          | TData.Streaming<MaskedVariablesCaseData>
+          | DataValue.Streaming<MaskedVariablesCaseData>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -13748,7 +13748,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<MaskedVariablesCaseData>
+            DataValue.Streaming<MaskedVariablesCaseData>
           >();
         }
 
@@ -13777,7 +13777,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
           | DeepPartial<Masked<MaskedVariablesCaseData>>
-          | TData.Streaming<Masked<MaskedVariablesCaseData>>
+          | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -13790,7 +13790,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<Masked<MaskedVariablesCaseData>>
+            DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -13816,7 +13816,7 @@ describe("useSuspenseQuery", () => {
         });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | TData.Streaming<VariablesCaseData>
+          VariablesCaseData | DataValue.Streaming<VariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -13826,7 +13826,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<VariablesCaseData>
+            DataValue.Streaming<VariablesCaseData>
           >();
         }
       }
@@ -13841,7 +13841,7 @@ describe("useSuspenseQuery", () => {
         });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | TData.Streaming<VariablesCaseData>
+          VariablesCaseData | DataValue.Streaming<VariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -13851,7 +13851,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<VariablesCaseData>
+            DataValue.Streaming<VariablesCaseData>
           >();
         }
       }
@@ -13866,7 +13866,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | TData.Streaming<Masked<MaskedVariablesCaseData>>
+          | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -13876,7 +13876,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<Masked<MaskedVariablesCaseData>>
+            DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
       }
@@ -13888,7 +13888,7 @@ describe("useSuspenseQuery", () => {
         >(maskedQuery, { fetchPolicy: "no-cache", variables: { id: "1" } });
 
         expectTypeOf(data).toEqualTypeOf<
-          MaskedVariablesCaseData | TData.Streaming<MaskedVariablesCaseData>
+          MaskedVariablesCaseData | DataValue.Streaming<MaskedVariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -13898,7 +13898,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<MaskedVariablesCaseData>
+            DataValue.Streaming<MaskedVariablesCaseData>
           >();
         }
       }
@@ -13911,7 +13911,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | TData.Streaming<Masked<MaskedVariablesCaseData>>
+          | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -13921,7 +13921,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<Masked<MaskedVariablesCaseData>>
+            DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
       }
@@ -13949,7 +13949,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | VariablesCaseData
           | DeepPartial<VariablesCaseData>
-          | TData.Streaming<VariablesCaseData>
+          | DataValue.Streaming<VariablesCaseData>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -13962,7 +13962,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<VariablesCaseData>
+            DataValue.Streaming<VariablesCaseData>
           >();
         }
 
@@ -13988,7 +13988,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | VariablesCaseData
           | DeepPartial<VariablesCaseData>
-          | TData.Streaming<VariablesCaseData>
+          | DataValue.Streaming<VariablesCaseData>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -14001,7 +14001,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<VariablesCaseData>
+            DataValue.Streaming<VariablesCaseData>
           >();
         }
 
@@ -14024,7 +14024,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
           | DeepPartial<Masked<MaskedVariablesCaseData>>
-          | TData.Streaming<Masked<MaskedVariablesCaseData>>
+          | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -14037,7 +14037,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<Masked<MaskedVariablesCaseData>>
+            DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -14062,7 +14062,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | VariablesCaseData
           | DeepPartial<VariablesCaseData>
-          | TData.Streaming<VariablesCaseData>
+          | DataValue.Streaming<VariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "partial"
@@ -14074,7 +14074,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<VariablesCaseData>
+            DataValue.Streaming<VariablesCaseData>
           >();
         }
 
@@ -14096,7 +14096,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | VariablesCaseData
           | DeepPartial<VariablesCaseData>
-          | TData.Streaming<VariablesCaseData>
+          | DataValue.Streaming<VariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "partial"
@@ -14108,7 +14108,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<VariablesCaseData>
+            DataValue.Streaming<VariablesCaseData>
           >();
         }
 
@@ -14127,7 +14127,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
           | DeepPartial<Masked<MaskedVariablesCaseData>>
-          | TData.Streaming<Masked<MaskedVariablesCaseData>>
+          | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -14140,7 +14140,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<Masked<MaskedVariablesCaseData>>
+            DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -14163,7 +14163,7 @@ describe("useSuspenseQuery", () => {
         });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | TData.Streaming<VariablesCaseData> | undefined
+          VariablesCaseData | DataValue.Streaming<VariablesCaseData> | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "empty"
@@ -14175,7 +14175,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<VariablesCaseData>
+            DataValue.Streaming<VariablesCaseData>
           >();
         }
 
@@ -14195,7 +14195,7 @@ describe("useSuspenseQuery", () => {
         });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | TData.Streaming<VariablesCaseData> | undefined
+          VariablesCaseData | DataValue.Streaming<VariablesCaseData> | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "empty"
@@ -14207,7 +14207,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<VariablesCaseData>
+            DataValue.Streaming<VariablesCaseData>
           >();
         }
 
@@ -14225,7 +14225,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | TData.Streaming<Masked<MaskedVariablesCaseData>>
+          | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -14238,7 +14238,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<Masked<MaskedVariablesCaseData>>
+            DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -14255,7 +14255,7 @@ describe("useSuspenseQuery", () => {
         });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | TData.Streaming<VariablesCaseData> | undefined
+          VariablesCaseData | DataValue.Streaming<VariablesCaseData> | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "empty"
@@ -14267,7 +14267,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<VariablesCaseData>
+            DataValue.Streaming<VariablesCaseData>
           >();
         }
 
@@ -14287,7 +14287,7 @@ describe("useSuspenseQuery", () => {
         });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | TData.Streaming<VariablesCaseData> | undefined
+          VariablesCaseData | DataValue.Streaming<VariablesCaseData> | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "empty"
@@ -14299,7 +14299,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<VariablesCaseData>
+            DataValue.Streaming<VariablesCaseData>
           >();
         }
 
@@ -14317,7 +14317,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | TData.Streaming<Masked<MaskedVariablesCaseData>>
+          | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -14330,7 +14330,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<Masked<MaskedVariablesCaseData>>
+            DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -14350,7 +14350,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | VariablesCaseData
           | DeepPartial<VariablesCaseData>
-          | TData.Streaming<VariablesCaseData>
+          | DataValue.Streaming<VariablesCaseData>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -14363,7 +14363,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<VariablesCaseData>
+            DataValue.Streaming<VariablesCaseData>
           >();
         }
 
@@ -14390,7 +14390,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | VariablesCaseData
           | DeepPartial<VariablesCaseData>
-          | TData.Streaming<VariablesCaseData>
+          | DataValue.Streaming<VariablesCaseData>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -14403,7 +14403,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<VariablesCaseData>
+            DataValue.Streaming<VariablesCaseData>
           >();
         }
 
@@ -14427,7 +14427,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
           | DeepPartial<Masked<MaskedVariablesCaseData>>
-          | TData.Streaming<Masked<MaskedVariablesCaseData>>
+          | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -14440,7 +14440,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<Masked<MaskedVariablesCaseData>>
+            DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -14470,7 +14470,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | VariablesCaseData
           | DeepPartial<VariablesCaseData>
-          | TData.Streaming<VariablesCaseData>
+          | DataValue.Streaming<VariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "partial"
@@ -14482,7 +14482,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<VariablesCaseData>
+            DataValue.Streaming<VariablesCaseData>
           >();
         }
 
@@ -14505,7 +14505,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | VariablesCaseData
           | DeepPartial<VariablesCaseData>
-          | TData.Streaming<VariablesCaseData>
+          | DataValue.Streaming<VariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "partial"
@@ -14517,7 +14517,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<VariablesCaseData>
+            DataValue.Streaming<VariablesCaseData>
           >();
         }
 
@@ -14539,7 +14539,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
           | DeepPartial<Masked<MaskedVariablesCaseData>>
-          | TData.Streaming<Masked<MaskedVariablesCaseData>>
+          | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "partial"
@@ -14551,7 +14551,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<Masked<MaskedVariablesCaseData>>
+            DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -14576,7 +14576,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | MaskedVariablesCaseData
           | DeepPartial<MaskedVariablesCaseData>
-          | TData.Streaming<MaskedVariablesCaseData>
+          | DataValue.Streaming<MaskedVariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "partial"
@@ -14588,7 +14588,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<MaskedVariablesCaseData>
+            DataValue.Streaming<MaskedVariablesCaseData>
           >();
         }
 
@@ -14613,7 +14613,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
           | DeepPartial<Masked<MaskedVariablesCaseData>>
-          | TData.Streaming<Masked<MaskedVariablesCaseData>>
+          | DataValue.Streaming<Masked<MaskedVariablesCaseData>>
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "partial"
@@ -14625,7 +14625,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            TData.Streaming<Masked<MaskedVariablesCaseData>>
+            DataValue.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 

--- a/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
@@ -20,8 +20,8 @@ import type {
   ErrorPolicy,
   OperationVariables,
   QueryResult,
-  Streaming,
   SubscribeToMoreOptions,
+  TData,
   TypedDocumentNode,
 } from "@apollo/client";
 import {
@@ -12273,7 +12273,7 @@ describe("useSuspenseQuery", () => {
         });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | Streaming<VariablesCaseData>
+          VariablesCaseData | TData.Streaming<VariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -12282,7 +12282,9 @@ describe("useSuspenseQuery", () => {
         }
 
         if (dataState === "streaming") {
-          expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+          expectTypeOf(data).toEqualTypeOf<
+            TData.Streaming<VariablesCaseData>
+          >();
         }
       }
 
@@ -12293,7 +12295,7 @@ describe("useSuspenseQuery", () => {
         >(query, { variables: { id: "1" } });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | Streaming<VariablesCaseData>
+          VariablesCaseData | TData.Streaming<VariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -12302,7 +12304,9 @@ describe("useSuspenseQuery", () => {
         }
 
         if (dataState === "streaming") {
-          expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+          expectTypeOf(data).toEqualTypeOf<
+            TData.Streaming<VariablesCaseData>
+          >();
         }
       }
 
@@ -12315,7 +12319,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | Streaming<Masked<MaskedVariablesCaseData>>
+          | TData.Streaming<Masked<MaskedVariablesCaseData>>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -12325,7 +12329,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<Masked<MaskedVariablesCaseData>>
+            TData.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
       }
@@ -12337,7 +12341,7 @@ describe("useSuspenseQuery", () => {
         >(maskedQuery, { variables: { id: "1" } });
 
         expectTypeOf(data).toEqualTypeOf<
-          MaskedVariablesCaseData | Streaming<MaskedVariablesCaseData>
+          MaskedVariablesCaseData | TData.Streaming<MaskedVariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -12347,7 +12351,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<MaskedVariablesCaseData>
+            TData.Streaming<MaskedVariablesCaseData>
           >();
         }
       }
@@ -12360,7 +12364,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | Streaming<Masked<MaskedVariablesCaseData>>
+          | TData.Streaming<Masked<MaskedVariablesCaseData>>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -12370,7 +12374,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<Masked<MaskedVariablesCaseData>>
+            TData.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
       }
@@ -12386,7 +12390,7 @@ describe("useSuspenseQuery", () => {
         });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | Streaming<VariablesCaseData> | undefined
+          VariablesCaseData | TData.Streaming<VariablesCaseData> | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "empty"
@@ -12397,7 +12401,9 @@ describe("useSuspenseQuery", () => {
         }
 
         if (dataState === "streaming") {
-          expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+          expectTypeOf(data).toEqualTypeOf<
+            TData.Streaming<VariablesCaseData>
+          >();
         }
 
         if (dataState === "empty") {
@@ -12415,7 +12421,7 @@ describe("useSuspenseQuery", () => {
         });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | Streaming<VariablesCaseData> | undefined
+          VariablesCaseData | TData.Streaming<VariablesCaseData> | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "empty"
@@ -12426,7 +12432,9 @@ describe("useSuspenseQuery", () => {
         }
 
         if (dataState === "streaming") {
-          expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+          expectTypeOf(data).toEqualTypeOf<
+            TData.Streaming<VariablesCaseData>
+          >();
         }
 
         if (dataState === "empty") {
@@ -12444,7 +12452,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | Streaming<Masked<MaskedVariablesCaseData>>
+          | TData.Streaming<Masked<MaskedVariablesCaseData>>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -12457,7 +12465,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<Masked<MaskedVariablesCaseData>>
+            TData.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -12474,7 +12482,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | MaskedVariablesCaseData
-          | Streaming<MaskedVariablesCaseData>
+          | TData.Streaming<MaskedVariablesCaseData>
           | undefined
         >();
       }
@@ -12487,7 +12495,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | Streaming<Masked<MaskedVariablesCaseData>>
+          | TData.Streaming<Masked<MaskedVariablesCaseData>>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -12500,7 +12508,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<Masked<MaskedVariablesCaseData>>
+            TData.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -12520,7 +12528,7 @@ describe("useSuspenseQuery", () => {
         });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | Streaming<VariablesCaseData> | undefined
+          VariablesCaseData | TData.Streaming<VariablesCaseData> | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "empty"
@@ -12531,7 +12539,9 @@ describe("useSuspenseQuery", () => {
         }
 
         if (dataState === "streaming") {
-          expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+          expectTypeOf(data).toEqualTypeOf<
+            TData.Streaming<VariablesCaseData>
+          >();
         }
 
         if (dataState === "empty") {
@@ -12549,7 +12559,7 @@ describe("useSuspenseQuery", () => {
         });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | Streaming<VariablesCaseData> | undefined
+          VariablesCaseData | TData.Streaming<VariablesCaseData> | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "empty"
@@ -12560,7 +12570,9 @@ describe("useSuspenseQuery", () => {
         }
 
         if (dataState === "streaming") {
-          expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+          expectTypeOf(data).toEqualTypeOf<
+            TData.Streaming<VariablesCaseData>
+          >();
         }
 
         if (dataState === "empty") {
@@ -12578,7 +12590,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | Streaming<Masked<MaskedVariablesCaseData>>
+          | TData.Streaming<Masked<MaskedVariablesCaseData>>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -12591,7 +12603,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<Masked<MaskedVariablesCaseData>>
+            TData.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -12608,7 +12620,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | MaskedVariablesCaseData
-          | Streaming<MaskedVariablesCaseData>
+          | TData.Streaming<MaskedVariablesCaseData>
           | undefined
         >();
       }
@@ -12621,7 +12633,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | Streaming<Masked<MaskedVariablesCaseData>>
+          | TData.Streaming<Masked<MaskedVariablesCaseData>>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -12634,7 +12646,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<Masked<MaskedVariablesCaseData>>
+            TData.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -12654,7 +12666,7 @@ describe("useSuspenseQuery", () => {
         });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | Streaming<VariablesCaseData>
+          VariablesCaseData | TData.Streaming<VariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -12663,7 +12675,9 @@ describe("useSuspenseQuery", () => {
         }
 
         if (dataState === "streaming") {
-          expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+          expectTypeOf(data).toEqualTypeOf<
+            TData.Streaming<VariablesCaseData>
+          >();
         }
       }
 
@@ -12677,7 +12691,7 @@ describe("useSuspenseQuery", () => {
         });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | Streaming<VariablesCaseData>
+          VariablesCaseData | TData.Streaming<VariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -12686,7 +12700,9 @@ describe("useSuspenseQuery", () => {
         }
 
         if (dataState === "streaming") {
-          expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+          expectTypeOf(data).toEqualTypeOf<
+            TData.Streaming<VariablesCaseData>
+          >();
         }
       }
 
@@ -12700,7 +12716,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | Streaming<Masked<MaskedVariablesCaseData>>
+          | TData.Streaming<Masked<MaskedVariablesCaseData>>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -12710,7 +12726,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<Masked<MaskedVariablesCaseData>>
+            TData.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
       }
@@ -12722,7 +12738,7 @@ describe("useSuspenseQuery", () => {
         >(maskedQuery, { errorPolicy: "none", variables: { id: "1" } });
 
         expectTypeOf(data).toEqualTypeOf<
-          MaskedVariablesCaseData | Streaming<MaskedVariablesCaseData>
+          MaskedVariablesCaseData | TData.Streaming<MaskedVariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -12732,7 +12748,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<MaskedVariablesCaseData>
+            TData.Streaming<MaskedVariablesCaseData>
           >();
         }
       }
@@ -12745,7 +12761,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | Streaming<Masked<MaskedVariablesCaseData>>
+          | TData.Streaming<Masked<MaskedVariablesCaseData>>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -12755,7 +12771,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<Masked<MaskedVariablesCaseData>>
+            TData.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
       }
@@ -12773,7 +12789,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | VariablesCaseData
           | DeepPartial<VariablesCaseData>
-          | Streaming<VariablesCaseData>
+          | TData.Streaming<VariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "partial"
@@ -12784,7 +12800,9 @@ describe("useSuspenseQuery", () => {
         }
 
         if (dataState === "streaming") {
-          expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+          expectTypeOf(data).toEqualTypeOf<
+            TData.Streaming<VariablesCaseData>
+          >();
         }
 
         if (dataState === "partial") {
@@ -12804,7 +12822,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | VariablesCaseData
           | DeepPartial<VariablesCaseData>
-          | Streaming<VariablesCaseData>
+          | TData.Streaming<VariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "partial"
@@ -12815,7 +12833,9 @@ describe("useSuspenseQuery", () => {
         }
 
         if (dataState === "streaming") {
-          expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+          expectTypeOf(data).toEqualTypeOf<
+            TData.Streaming<VariablesCaseData>
+          >();
         }
 
         if (dataState === "partial") {
@@ -12833,7 +12853,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | Streaming<Masked<MaskedVariablesCaseData>>
+          | TData.Streaming<Masked<MaskedVariablesCaseData>>
           | DeepPartial<Masked<MaskedVariablesCaseData>>
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -12846,7 +12866,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<Masked<MaskedVariablesCaseData>>
+            TData.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -12866,7 +12886,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | MaskedVariablesCaseData
           | DeepPartial<MaskedVariablesCaseData>
-          | Streaming<MaskedVariablesCaseData>
+          | TData.Streaming<MaskedVariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "partial"
@@ -12878,7 +12898,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<MaskedVariablesCaseData>
+            TData.Streaming<MaskedVariablesCaseData>
           >();
         }
 
@@ -12897,7 +12917,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | Streaming<Masked<MaskedVariablesCaseData>>
+          | TData.Streaming<Masked<MaskedVariablesCaseData>>
           | DeepPartial<Masked<MaskedVariablesCaseData>>
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -12910,7 +12930,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<Masked<MaskedVariablesCaseData>>
+            TData.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -12932,7 +12952,7 @@ describe("useSuspenseQuery", () => {
         });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | Streaming<VariablesCaseData>
+          VariablesCaseData | TData.Streaming<VariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -12941,7 +12961,9 @@ describe("useSuspenseQuery", () => {
         }
 
         if (dataState === "streaming") {
-          expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+          expectTypeOf(data).toEqualTypeOf<
+            TData.Streaming<VariablesCaseData>
+          >();
         }
       }
 
@@ -12955,7 +12977,7 @@ describe("useSuspenseQuery", () => {
         });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | Streaming<VariablesCaseData>
+          VariablesCaseData | TData.Streaming<VariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -12964,7 +12986,9 @@ describe("useSuspenseQuery", () => {
         }
 
         if (dataState === "streaming") {
-          expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+          expectTypeOf(data).toEqualTypeOf<
+            TData.Streaming<VariablesCaseData>
+          >();
         }
       }
 
@@ -12978,7 +13002,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | Streaming<Masked<MaskedVariablesCaseData>>
+          | TData.Streaming<Masked<MaskedVariablesCaseData>>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -12988,7 +13012,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<Masked<MaskedVariablesCaseData>>
+            TData.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
       }
@@ -13000,7 +13024,7 @@ describe("useSuspenseQuery", () => {
         >(maskedQuery, { returnPartialData: false, variables: { id: "1" } });
 
         expectTypeOf(data).toEqualTypeOf<
-          MaskedVariablesCaseData | Streaming<MaskedVariablesCaseData>
+          MaskedVariablesCaseData | TData.Streaming<MaskedVariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -13010,7 +13034,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<MaskedVariablesCaseData>
+            TData.Streaming<MaskedVariablesCaseData>
           >();
         }
       }
@@ -13023,7 +13047,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | Streaming<Masked<MaskedVariablesCaseData>>
+          | TData.Streaming<Masked<MaskedVariablesCaseData>>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -13033,7 +13057,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<Masked<MaskedVariablesCaseData>>
+            TData.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
       }
@@ -13049,7 +13073,7 @@ describe("useSuspenseQuery", () => {
         });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | Streaming<VariablesCaseData> | undefined
+          VariablesCaseData | TData.Streaming<VariablesCaseData> | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "empty"
@@ -13060,7 +13084,9 @@ describe("useSuspenseQuery", () => {
         }
 
         if (dataState === "streaming") {
-          expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+          expectTypeOf(data).toEqualTypeOf<
+            TData.Streaming<VariablesCaseData>
+          >();
         }
 
         if (dataState === "empty") {
@@ -13078,7 +13104,7 @@ describe("useSuspenseQuery", () => {
         });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | Streaming<VariablesCaseData> | undefined
+          VariablesCaseData | TData.Streaming<VariablesCaseData> | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "empty"
@@ -13089,7 +13115,9 @@ describe("useSuspenseQuery", () => {
         }
 
         if (dataState === "streaming") {
-          expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+          expectTypeOf(data).toEqualTypeOf<
+            TData.Streaming<VariablesCaseData>
+          >();
         }
 
         if (dataState === "empty") {
@@ -13111,7 +13139,7 @@ describe("useSuspenseQuery", () => {
         });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | Streaming<VariablesCaseData> | undefined
+          VariablesCaseData | TData.Streaming<VariablesCaseData> | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "empty"
@@ -13122,7 +13150,9 @@ describe("useSuspenseQuery", () => {
         }
 
         if (dataState === "streaming") {
-          expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+          expectTypeOf(data).toEqualTypeOf<
+            TData.Streaming<VariablesCaseData>
+          >();
         }
 
         if (dataState === "empty") {
@@ -13140,7 +13170,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | Streaming<Masked<MaskedVariablesCaseData>>
+          | TData.Streaming<Masked<MaskedVariablesCaseData>>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -13153,7 +13183,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<Masked<MaskedVariablesCaseData>>
+            TData.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -13170,7 +13200,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | MaskedVariablesCaseData
-          | Streaming<MaskedVariablesCaseData>
+          | TData.Streaming<MaskedVariablesCaseData>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -13183,7 +13213,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<MaskedVariablesCaseData>
+            TData.Streaming<MaskedVariablesCaseData>
           >();
         }
 
@@ -13200,7 +13230,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | Streaming<Masked<MaskedVariablesCaseData>>
+          | TData.Streaming<Masked<MaskedVariablesCaseData>>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -13213,7 +13243,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<Masked<MaskedVariablesCaseData>>
+            TData.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -13234,7 +13264,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | Streaming<Masked<MaskedVariablesCaseData>>
+          | TData.Streaming<Masked<MaskedVariablesCaseData>>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -13247,7 +13277,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<Masked<MaskedVariablesCaseData>>
+            TData.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -13270,7 +13300,7 @@ describe("useSuspenseQuery", () => {
         );
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | Streaming<VariablesCaseData> | undefined
+          VariablesCaseData | TData.Streaming<VariablesCaseData> | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "empty"
@@ -13281,7 +13311,9 @@ describe("useSuspenseQuery", () => {
         }
 
         if (dataState === "streaming") {
-          expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+          expectTypeOf(data).toEqualTypeOf<
+            TData.Streaming<VariablesCaseData>
+          >();
         }
 
         if (dataState === "empty") {
@@ -13296,7 +13328,7 @@ describe("useSuspenseQuery", () => {
         >(query, options.skip ? skipToken : { variables: { id: "1" } });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | Streaming<VariablesCaseData> | undefined
+          VariablesCaseData | TData.Streaming<VariablesCaseData> | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "empty"
@@ -13307,7 +13339,9 @@ describe("useSuspenseQuery", () => {
         }
 
         if (dataState === "streaming") {
-          expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+          expectTypeOf(data).toEqualTypeOf<
+            TData.Streaming<VariablesCaseData>
+          >();
         }
 
         if (dataState === "empty") {
@@ -13325,7 +13359,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | Streaming<Masked<MaskedVariablesCaseData>>
+          | TData.Streaming<Masked<MaskedVariablesCaseData>>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -13338,7 +13372,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<Masked<MaskedVariablesCaseData>>
+            TData.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -13355,7 +13389,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | MaskedVariablesCaseData
-          | Streaming<MaskedVariablesCaseData>
+          | TData.Streaming<MaskedVariablesCaseData>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -13368,7 +13402,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<MaskedVariablesCaseData>
+            TData.Streaming<MaskedVariablesCaseData>
           >();
         }
 
@@ -13385,7 +13419,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | Streaming<Masked<MaskedVariablesCaseData>>
+          | TData.Streaming<Masked<MaskedVariablesCaseData>>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -13398,7 +13432,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<Masked<MaskedVariablesCaseData>>
+            TData.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -13421,7 +13455,7 @@ describe("useSuspenseQuery", () => {
         );
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | Streaming<VariablesCaseData> | undefined
+          VariablesCaseData | TData.Streaming<VariablesCaseData> | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "empty"
@@ -13432,7 +13466,9 @@ describe("useSuspenseQuery", () => {
         }
 
         if (dataState === "streaming") {
-          expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+          expectTypeOf(data).toEqualTypeOf<
+            TData.Streaming<VariablesCaseData>
+          >();
         }
 
         if (dataState === "empty") {
@@ -13447,7 +13483,7 @@ describe("useSuspenseQuery", () => {
         >(query, options.skip ? skipToken : { variables: { id: "1" } });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | Streaming<VariablesCaseData> | undefined
+          VariablesCaseData | TData.Streaming<VariablesCaseData> | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "empty"
@@ -13458,7 +13494,9 @@ describe("useSuspenseQuery", () => {
         }
 
         if (dataState === "streaming") {
-          expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+          expectTypeOf(data).toEqualTypeOf<
+            TData.Streaming<VariablesCaseData>
+          >();
         }
 
         if (dataState === "empty") {
@@ -13476,7 +13514,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | Streaming<Masked<MaskedVariablesCaseData>>
+          | TData.Streaming<Masked<MaskedVariablesCaseData>>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -13489,7 +13527,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<Masked<MaskedVariablesCaseData>>
+            TData.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -13506,7 +13544,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | MaskedVariablesCaseData
-          | Streaming<MaskedVariablesCaseData>
+          | TData.Streaming<MaskedVariablesCaseData>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -13519,7 +13557,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<MaskedVariablesCaseData>
+            TData.Streaming<MaskedVariablesCaseData>
           >();
         }
 
@@ -13536,7 +13574,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | Streaming<Masked<MaskedVariablesCaseData>>
+          | TData.Streaming<Masked<MaskedVariablesCaseData>>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -13549,7 +13587,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<Masked<MaskedVariablesCaseData>>
+            TData.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -13576,7 +13614,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | VariablesCaseData
           | DeepPartial<VariablesCaseData>
-          | Streaming<VariablesCaseData>
+          | TData.Streaming<VariablesCaseData>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -13588,7 +13626,9 @@ describe("useSuspenseQuery", () => {
         }
 
         if (dataState === "streaming") {
-          expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+          expectTypeOf(data).toEqualTypeOf<
+            TData.Streaming<VariablesCaseData>
+          >();
         }
 
         if (dataState === "partial") {
@@ -13614,7 +13654,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | VariablesCaseData
           | DeepPartial<VariablesCaseData>
-          | Streaming<VariablesCaseData>
+          | TData.Streaming<VariablesCaseData>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -13626,7 +13666,9 @@ describe("useSuspenseQuery", () => {
         }
 
         if (dataState === "streaming") {
-          expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+          expectTypeOf(data).toEqualTypeOf<
+            TData.Streaming<VariablesCaseData>
+          >();
         }
 
         if (dataState === "partial") {
@@ -13651,7 +13693,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
           | DeepPartial<Masked<MaskedVariablesCaseData>>
-          | Streaming<Masked<MaskedVariablesCaseData>>
+          | TData.Streaming<Masked<MaskedVariablesCaseData>>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -13664,7 +13706,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<Masked<MaskedVariablesCaseData>>
+            TData.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -13693,7 +13735,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | MaskedVariablesCaseData
           | DeepPartial<MaskedVariablesCaseData>
-          | Streaming<MaskedVariablesCaseData>
+          | TData.Streaming<MaskedVariablesCaseData>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -13706,7 +13748,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<MaskedVariablesCaseData>
+            TData.Streaming<MaskedVariablesCaseData>
           >();
         }
 
@@ -13735,7 +13777,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
           | DeepPartial<Masked<MaskedVariablesCaseData>>
-          | Streaming<Masked<MaskedVariablesCaseData>>
+          | TData.Streaming<Masked<MaskedVariablesCaseData>>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -13748,7 +13790,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<Masked<MaskedVariablesCaseData>>
+            TData.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -13774,7 +13816,7 @@ describe("useSuspenseQuery", () => {
         });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | Streaming<VariablesCaseData>
+          VariablesCaseData | TData.Streaming<VariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -13783,7 +13825,9 @@ describe("useSuspenseQuery", () => {
         }
 
         if (dataState === "streaming") {
-          expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+          expectTypeOf(data).toEqualTypeOf<
+            TData.Streaming<VariablesCaseData>
+          >();
         }
       }
 
@@ -13797,7 +13841,7 @@ describe("useSuspenseQuery", () => {
         });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | Streaming<VariablesCaseData>
+          VariablesCaseData | TData.Streaming<VariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -13806,7 +13850,9 @@ describe("useSuspenseQuery", () => {
         }
 
         if (dataState === "streaming") {
-          expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+          expectTypeOf(data).toEqualTypeOf<
+            TData.Streaming<VariablesCaseData>
+          >();
         }
       }
 
@@ -13820,7 +13866,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | Streaming<Masked<MaskedVariablesCaseData>>
+          | TData.Streaming<Masked<MaskedVariablesCaseData>>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -13830,7 +13876,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<Masked<MaskedVariablesCaseData>>
+            TData.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
       }
@@ -13842,7 +13888,7 @@ describe("useSuspenseQuery", () => {
         >(maskedQuery, { fetchPolicy: "no-cache", variables: { id: "1" } });
 
         expectTypeOf(data).toEqualTypeOf<
-          MaskedVariablesCaseData | Streaming<MaskedVariablesCaseData>
+          MaskedVariablesCaseData | TData.Streaming<MaskedVariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -13852,7 +13898,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<MaskedVariablesCaseData>
+            TData.Streaming<MaskedVariablesCaseData>
           >();
         }
       }
@@ -13865,7 +13911,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | Streaming<Masked<MaskedVariablesCaseData>>
+          | TData.Streaming<Masked<MaskedVariablesCaseData>>
         >();
         expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -13875,7 +13921,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<Masked<MaskedVariablesCaseData>>
+            TData.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
       }
@@ -13903,7 +13949,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | VariablesCaseData
           | DeepPartial<VariablesCaseData>
-          | Streaming<VariablesCaseData>
+          | TData.Streaming<VariablesCaseData>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -13915,7 +13961,9 @@ describe("useSuspenseQuery", () => {
         }
 
         if (dataState === "streaming") {
-          expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+          expectTypeOf(data).toEqualTypeOf<
+            TData.Streaming<VariablesCaseData>
+          >();
         }
 
         if (dataState === "partial") {
@@ -13940,7 +13988,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | VariablesCaseData
           | DeepPartial<VariablesCaseData>
-          | Streaming<VariablesCaseData>
+          | TData.Streaming<VariablesCaseData>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -13952,7 +14000,9 @@ describe("useSuspenseQuery", () => {
         }
 
         if (dataState === "streaming") {
-          expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+          expectTypeOf(data).toEqualTypeOf<
+            TData.Streaming<VariablesCaseData>
+          >();
         }
 
         if (dataState === "partial") {
@@ -13974,7 +14024,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
           | DeepPartial<Masked<MaskedVariablesCaseData>>
-          | Streaming<Masked<MaskedVariablesCaseData>>
+          | TData.Streaming<Masked<MaskedVariablesCaseData>>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -13987,7 +14037,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<Masked<MaskedVariablesCaseData>>
+            TData.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -14012,7 +14062,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | VariablesCaseData
           | DeepPartial<VariablesCaseData>
-          | Streaming<VariablesCaseData>
+          | TData.Streaming<VariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "partial"
@@ -14023,7 +14073,9 @@ describe("useSuspenseQuery", () => {
         }
 
         if (dataState === "streaming") {
-          expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+          expectTypeOf(data).toEqualTypeOf<
+            TData.Streaming<VariablesCaseData>
+          >();
         }
 
         if (dataState === "partial") {
@@ -14044,7 +14096,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | VariablesCaseData
           | DeepPartial<VariablesCaseData>
-          | Streaming<VariablesCaseData>
+          | TData.Streaming<VariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "partial"
@@ -14055,7 +14107,9 @@ describe("useSuspenseQuery", () => {
         }
 
         if (dataState === "streaming") {
-          expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+          expectTypeOf(data).toEqualTypeOf<
+            TData.Streaming<VariablesCaseData>
+          >();
         }
 
         if (dataState === "partial") {
@@ -14073,7 +14127,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
           | DeepPartial<Masked<MaskedVariablesCaseData>>
-          | Streaming<Masked<MaskedVariablesCaseData>>
+          | TData.Streaming<Masked<MaskedVariablesCaseData>>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -14086,7 +14140,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<Masked<MaskedVariablesCaseData>>
+            TData.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -14109,7 +14163,7 @@ describe("useSuspenseQuery", () => {
         });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | Streaming<VariablesCaseData> | undefined
+          VariablesCaseData | TData.Streaming<VariablesCaseData> | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "empty"
@@ -14120,7 +14174,9 @@ describe("useSuspenseQuery", () => {
         }
 
         if (dataState === "streaming") {
-          expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+          expectTypeOf(data).toEqualTypeOf<
+            TData.Streaming<VariablesCaseData>
+          >();
         }
 
         if (dataState === "empty") {
@@ -14139,7 +14195,7 @@ describe("useSuspenseQuery", () => {
         });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | Streaming<VariablesCaseData> | undefined
+          VariablesCaseData | TData.Streaming<VariablesCaseData> | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "empty"
@@ -14150,7 +14206,9 @@ describe("useSuspenseQuery", () => {
         }
 
         if (dataState === "streaming") {
-          expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+          expectTypeOf(data).toEqualTypeOf<
+            TData.Streaming<VariablesCaseData>
+          >();
         }
 
         if (dataState === "empty") {
@@ -14167,7 +14225,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | Streaming<Masked<MaskedVariablesCaseData>>
+          | TData.Streaming<Masked<MaskedVariablesCaseData>>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -14180,7 +14238,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<Masked<MaskedVariablesCaseData>>
+            TData.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -14197,7 +14255,7 @@ describe("useSuspenseQuery", () => {
         });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | Streaming<VariablesCaseData> | undefined
+          VariablesCaseData | TData.Streaming<VariablesCaseData> | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "empty"
@@ -14208,7 +14266,9 @@ describe("useSuspenseQuery", () => {
         }
 
         if (dataState === "streaming") {
-          expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+          expectTypeOf(data).toEqualTypeOf<
+            TData.Streaming<VariablesCaseData>
+          >();
         }
 
         if (dataState === "empty") {
@@ -14227,7 +14287,7 @@ describe("useSuspenseQuery", () => {
         });
 
         expectTypeOf(data).toEqualTypeOf<
-          VariablesCaseData | Streaming<VariablesCaseData> | undefined
+          VariablesCaseData | TData.Streaming<VariablesCaseData> | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "empty"
@@ -14238,7 +14298,9 @@ describe("useSuspenseQuery", () => {
         }
 
         if (dataState === "streaming") {
-          expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+          expectTypeOf(data).toEqualTypeOf<
+            TData.Streaming<VariablesCaseData>
+          >();
         }
 
         if (dataState === "empty") {
@@ -14255,7 +14317,7 @@ describe("useSuspenseQuery", () => {
 
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
-          | Streaming<Masked<MaskedVariablesCaseData>>
+          | TData.Streaming<Masked<MaskedVariablesCaseData>>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -14268,7 +14330,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<Masked<MaskedVariablesCaseData>>
+            TData.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -14288,7 +14350,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | VariablesCaseData
           | DeepPartial<VariablesCaseData>
-          | Streaming<VariablesCaseData>
+          | TData.Streaming<VariablesCaseData>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -14300,7 +14362,9 @@ describe("useSuspenseQuery", () => {
         }
 
         if (dataState === "streaming") {
-          expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+          expectTypeOf(data).toEqualTypeOf<
+            TData.Streaming<VariablesCaseData>
+          >();
         }
 
         if (dataState === "partial") {
@@ -14326,7 +14390,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | VariablesCaseData
           | DeepPartial<VariablesCaseData>
-          | Streaming<VariablesCaseData>
+          | TData.Streaming<VariablesCaseData>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -14338,7 +14402,9 @@ describe("useSuspenseQuery", () => {
         }
 
         if (dataState === "streaming") {
-          expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+          expectTypeOf(data).toEqualTypeOf<
+            TData.Streaming<VariablesCaseData>
+          >();
         }
 
         if (dataState === "partial") {
@@ -14361,7 +14427,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
           | DeepPartial<Masked<MaskedVariablesCaseData>>
-          | Streaming<Masked<MaskedVariablesCaseData>>
+          | TData.Streaming<Masked<MaskedVariablesCaseData>>
           | undefined
         >();
         expectTypeOf(dataState).toEqualTypeOf<
@@ -14374,7 +14440,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<Masked<MaskedVariablesCaseData>>
+            TData.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -14404,7 +14470,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | VariablesCaseData
           | DeepPartial<VariablesCaseData>
-          | Streaming<VariablesCaseData>
+          | TData.Streaming<VariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "partial"
@@ -14415,7 +14481,9 @@ describe("useSuspenseQuery", () => {
         }
 
         if (dataState === "streaming") {
-          expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+          expectTypeOf(data).toEqualTypeOf<
+            TData.Streaming<VariablesCaseData>
+          >();
         }
 
         if (dataState === "partial") {
@@ -14437,7 +14505,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | VariablesCaseData
           | DeepPartial<VariablesCaseData>
-          | Streaming<VariablesCaseData>
+          | TData.Streaming<VariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "partial"
@@ -14448,7 +14516,9 @@ describe("useSuspenseQuery", () => {
         }
 
         if (dataState === "streaming") {
-          expectTypeOf(data).toEqualTypeOf<Streaming<VariablesCaseData>>();
+          expectTypeOf(data).toEqualTypeOf<
+            TData.Streaming<VariablesCaseData>
+          >();
         }
 
         if (dataState === "partial") {
@@ -14469,7 +14539,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
           | DeepPartial<Masked<MaskedVariablesCaseData>>
-          | Streaming<Masked<MaskedVariablesCaseData>>
+          | TData.Streaming<Masked<MaskedVariablesCaseData>>
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "partial"
@@ -14481,7 +14551,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<Masked<MaskedVariablesCaseData>>
+            TData.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 
@@ -14506,7 +14576,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | MaskedVariablesCaseData
           | DeepPartial<MaskedVariablesCaseData>
-          | Streaming<MaskedVariablesCaseData>
+          | TData.Streaming<MaskedVariablesCaseData>
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "partial"
@@ -14518,7 +14588,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<MaskedVariablesCaseData>
+            TData.Streaming<MaskedVariablesCaseData>
           >();
         }
 
@@ -14543,7 +14613,7 @@ describe("useSuspenseQuery", () => {
         expectTypeOf(data).toEqualTypeOf<
           | Masked<MaskedVariablesCaseData>
           | DeepPartial<Masked<MaskedVariablesCaseData>>
-          | Streaming<Masked<MaskedVariablesCaseData>>
+          | TData.Streaming<Masked<MaskedVariablesCaseData>>
         >();
         expectTypeOf(dataState).toEqualTypeOf<
           "complete" | "streaming" | "partial"
@@ -14555,7 +14625,7 @@ describe("useSuspenseQuery", () => {
 
         if (dataState === "streaming") {
           expectTypeOf(data).toEqualTypeOf<
-            Streaming<Masked<MaskedVariablesCaseData>>
+            TData.Streaming<Masked<MaskedVariablesCaseData>>
           >();
         }
 

--- a/src/react/query-preloader/__tests__/createQueryPreloader.test.tsx
+++ b/src/react/query-preloader/__tests__/createQueryPreloader.test.tsx
@@ -14,7 +14,7 @@ import { Observable } from "rxjs";
 import type {
   DataState,
   OperationVariables,
-  TData,
+  DataValue,
   TypedDocumentNode,
 } from "@apollo/client";
 import {
@@ -2463,7 +2463,7 @@ describe.skip("type tests", () => {
         >
       >();
       expectTypeOf(data).toEqualTypeOf<
-        SimpleCaseData | TData.Streaming<SimpleCaseData>
+        SimpleCaseData | DataValue.Streaming<SimpleCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -2472,7 +2472,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<DataValue.Streaming<SimpleCaseData>>();
       }
     }
 
@@ -2489,7 +2489,7 @@ describe.skip("type tests", () => {
         >
       >();
       expectTypeOf(data).toEqualTypeOf<
-        SimpleCaseData | TData.Streaming<SimpleCaseData>
+        SimpleCaseData | DataValue.Streaming<SimpleCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -2498,7 +2498,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<DataValue.Streaming<SimpleCaseData>>();
       }
     }
   });
@@ -2517,7 +2517,7 @@ describe.skip("type tests", () => {
         >
       >();
       expectTypeOf(data).toEqualTypeOf<
-        SimpleCaseData | TData.Streaming<SimpleCaseData> | undefined
+        SimpleCaseData | DataValue.Streaming<SimpleCaseData> | undefined
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "empty"
@@ -2528,7 +2528,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<DataValue.Streaming<SimpleCaseData>>();
       }
 
       if (dataState === "empty") {
@@ -2551,7 +2551,7 @@ describe.skip("type tests", () => {
         >
       >();
       expectTypeOf(data).toEqualTypeOf<
-        SimpleCaseData | TData.Streaming<SimpleCaseData> | undefined
+        SimpleCaseData | DataValue.Streaming<SimpleCaseData> | undefined
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "empty"
@@ -2562,7 +2562,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<DataValue.Streaming<SimpleCaseData>>();
       }
 
       if (dataState === "empty") {
@@ -2585,7 +2585,7 @@ describe.skip("type tests", () => {
         >
       >();
       expectTypeOf(data).toEqualTypeOf<
-        SimpleCaseData | TData.Streaming<SimpleCaseData> | undefined
+        SimpleCaseData | DataValue.Streaming<SimpleCaseData> | undefined
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "empty"
@@ -2596,7 +2596,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<DataValue.Streaming<SimpleCaseData>>();
       }
 
       if (dataState === "empty") {
@@ -2619,7 +2619,7 @@ describe.skip("type tests", () => {
         >
       >();
       expectTypeOf(data).toEqualTypeOf<
-        SimpleCaseData | TData.Streaming<SimpleCaseData> | undefined
+        SimpleCaseData | DataValue.Streaming<SimpleCaseData> | undefined
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "empty"
@@ -2630,7 +2630,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<DataValue.Streaming<SimpleCaseData>>();
       }
 
       if (dataState === "empty") {
@@ -2653,7 +2653,7 @@ describe.skip("type tests", () => {
         >
       >();
       expectTypeOf(data).toEqualTypeOf<
-        SimpleCaseData | TData.Streaming<SimpleCaseData>
+        SimpleCaseData | DataValue.Streaming<SimpleCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -2662,7 +2662,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<DataValue.Streaming<SimpleCaseData>>();
       }
     }
 
@@ -2681,7 +2681,7 @@ describe.skip("type tests", () => {
         >
       >();
       expectTypeOf(data).toEqualTypeOf<
-        SimpleCaseData | TData.Streaming<SimpleCaseData>
+        SimpleCaseData | DataValue.Streaming<SimpleCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -2690,7 +2690,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<DataValue.Streaming<SimpleCaseData>>();
       }
     }
   });
@@ -2711,7 +2711,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | SimpleCaseData
         | DeepPartial<SimpleCaseData>
-        | TData.Streaming<SimpleCaseData>
+        | DataValue.Streaming<SimpleCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -2722,7 +2722,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<DataValue.Streaming<SimpleCaseData>>();
       }
 
       if (dataState === "partial") {
@@ -2747,7 +2747,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | SimpleCaseData
         | DeepPartial<SimpleCaseData>
-        | TData.Streaming<SimpleCaseData>
+        | DataValue.Streaming<SimpleCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -2758,7 +2758,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<DataValue.Streaming<SimpleCaseData>>();
       }
 
       if (dataState === "partial") {
@@ -2781,7 +2781,7 @@ describe.skip("type tests", () => {
         >
       >();
       expectTypeOf(data).toEqualTypeOf<
-        SimpleCaseData | TData.Streaming<SimpleCaseData>
+        SimpleCaseData | DataValue.Streaming<SimpleCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -2790,7 +2790,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<DataValue.Streaming<SimpleCaseData>>();
       }
     }
 
@@ -2809,7 +2809,7 @@ describe.skip("type tests", () => {
         >
       >();
       expectTypeOf(data).toEqualTypeOf<
-        SimpleCaseData | TData.Streaming<SimpleCaseData>
+        SimpleCaseData | DataValue.Streaming<SimpleCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -2818,7 +2818,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<DataValue.Streaming<SimpleCaseData>>();
       }
     }
   });
@@ -2837,7 +2837,7 @@ describe.skip("type tests", () => {
         >
       >();
       expectTypeOf(data).toEqualTypeOf<
-        SimpleCaseData | TData.Streaming<SimpleCaseData>
+        SimpleCaseData | DataValue.Streaming<SimpleCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -2846,7 +2846,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<DataValue.Streaming<SimpleCaseData>>();
       }
     }
 
@@ -2865,7 +2865,7 @@ describe.skip("type tests", () => {
         >
       >();
       expectTypeOf(data).toEqualTypeOf<
-        SimpleCaseData | TData.Streaming<SimpleCaseData>
+        SimpleCaseData | DataValue.Streaming<SimpleCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -2874,7 +2874,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<DataValue.Streaming<SimpleCaseData>>();
       }
     }
   });
@@ -2898,7 +2898,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | SimpleCaseData
         | DeepPartial<SimpleCaseData>
-        | TData.Streaming<SimpleCaseData>
+        | DataValue.Streaming<SimpleCaseData>
         | undefined
       >();
       expectTypeOf(dataState).toEqualTypeOf<
@@ -2910,7 +2910,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<DataValue.Streaming<SimpleCaseData>>();
       }
 
       if (dataState === "partial") {
@@ -2940,7 +2940,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | SimpleCaseData
         | DeepPartial<SimpleCaseData>
-        | TData.Streaming<SimpleCaseData>
+        | DataValue.Streaming<SimpleCaseData>
         | undefined
       >();
       expectTypeOf(dataState).toEqualTypeOf<
@@ -2952,7 +2952,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<DataValue.Streaming<SimpleCaseData>>();
       }
 
       if (dataState === "partial") {
@@ -2982,7 +2982,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | SimpleCaseData
         | DeepPartial<SimpleCaseData>
-        | TData.Streaming<SimpleCaseData>
+        | DataValue.Streaming<SimpleCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -2993,7 +2993,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<DataValue.Streaming<SimpleCaseData>>();
       }
 
       if (dataState === "partial") {
@@ -3019,7 +3019,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | SimpleCaseData
         | DeepPartial<SimpleCaseData>
-        | TData.Streaming<SimpleCaseData>
+        | DataValue.Streaming<SimpleCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -3030,7 +3030,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<DataValue.Streaming<SimpleCaseData>>();
       }
 
       if (dataState === "partial") {
@@ -3059,7 +3059,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | SimpleCaseData
         | DeepPartial<SimpleCaseData>
-        | TData.Streaming<SimpleCaseData>
+        | DataValue.Streaming<SimpleCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -3070,7 +3070,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<DataValue.Streaming<SimpleCaseData>>();
       }
 
       if (dataState === "partial") {
@@ -3097,7 +3097,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | SimpleCaseData
         | DeepPartial<SimpleCaseData>
-        | TData.Streaming<SimpleCaseData>
+        | DataValue.Streaming<SimpleCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -3108,7 +3108,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<DataValue.Streaming<SimpleCaseData>>();
       }
 
       if (dataState === "partial") {

--- a/src/react/query-preloader/__tests__/createQueryPreloader.test.tsx
+++ b/src/react/query-preloader/__tests__/createQueryPreloader.test.tsx
@@ -14,7 +14,7 @@ import { Observable } from "rxjs";
 import type {
   DataState,
   OperationVariables,
-  Streaming,
+  TData,
   TypedDocumentNode,
 } from "@apollo/client";
 import {
@@ -2463,7 +2463,7 @@ describe.skip("type tests", () => {
         >
       >();
       expectTypeOf(data).toEqualTypeOf<
-        SimpleCaseData | Streaming<SimpleCaseData>
+        SimpleCaseData | TData.Streaming<SimpleCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -2472,7 +2472,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
       }
     }
 
@@ -2489,7 +2489,7 @@ describe.skip("type tests", () => {
         >
       >();
       expectTypeOf(data).toEqualTypeOf<
-        SimpleCaseData | Streaming<SimpleCaseData>
+        SimpleCaseData | TData.Streaming<SimpleCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -2498,7 +2498,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
       }
     }
   });
@@ -2517,7 +2517,7 @@ describe.skip("type tests", () => {
         >
       >();
       expectTypeOf(data).toEqualTypeOf<
-        SimpleCaseData | Streaming<SimpleCaseData> | undefined
+        SimpleCaseData | TData.Streaming<SimpleCaseData> | undefined
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "empty"
@@ -2528,7 +2528,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
       }
 
       if (dataState === "empty") {
@@ -2551,7 +2551,7 @@ describe.skip("type tests", () => {
         >
       >();
       expectTypeOf(data).toEqualTypeOf<
-        SimpleCaseData | Streaming<SimpleCaseData> | undefined
+        SimpleCaseData | TData.Streaming<SimpleCaseData> | undefined
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "empty"
@@ -2562,7 +2562,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
       }
 
       if (dataState === "empty") {
@@ -2585,7 +2585,7 @@ describe.skip("type tests", () => {
         >
       >();
       expectTypeOf(data).toEqualTypeOf<
-        SimpleCaseData | Streaming<SimpleCaseData> | undefined
+        SimpleCaseData | TData.Streaming<SimpleCaseData> | undefined
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "empty"
@@ -2596,7 +2596,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
       }
 
       if (dataState === "empty") {
@@ -2619,7 +2619,7 @@ describe.skip("type tests", () => {
         >
       >();
       expectTypeOf(data).toEqualTypeOf<
-        SimpleCaseData | Streaming<SimpleCaseData> | undefined
+        SimpleCaseData | TData.Streaming<SimpleCaseData> | undefined
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "empty"
@@ -2630,7 +2630,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
       }
 
       if (dataState === "empty") {
@@ -2653,7 +2653,7 @@ describe.skip("type tests", () => {
         >
       >();
       expectTypeOf(data).toEqualTypeOf<
-        SimpleCaseData | Streaming<SimpleCaseData>
+        SimpleCaseData | TData.Streaming<SimpleCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -2662,7 +2662,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
       }
     }
 
@@ -2681,7 +2681,7 @@ describe.skip("type tests", () => {
         >
       >();
       expectTypeOf(data).toEqualTypeOf<
-        SimpleCaseData | Streaming<SimpleCaseData>
+        SimpleCaseData | TData.Streaming<SimpleCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -2690,7 +2690,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
       }
     }
   });
@@ -2709,7 +2709,9 @@ describe.skip("type tests", () => {
         >
       >();
       expectTypeOf(data).toEqualTypeOf<
-        SimpleCaseData | DeepPartial<SimpleCaseData> | Streaming<SimpleCaseData>
+        | SimpleCaseData
+        | DeepPartial<SimpleCaseData>
+        | TData.Streaming<SimpleCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -2720,7 +2722,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
       }
 
       if (dataState === "partial") {
@@ -2743,7 +2745,9 @@ describe.skip("type tests", () => {
         >
       >();
       expectTypeOf(data).toEqualTypeOf<
-        SimpleCaseData | DeepPartial<SimpleCaseData> | Streaming<SimpleCaseData>
+        | SimpleCaseData
+        | DeepPartial<SimpleCaseData>
+        | TData.Streaming<SimpleCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -2754,7 +2758,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
       }
 
       if (dataState === "partial") {
@@ -2777,7 +2781,7 @@ describe.skip("type tests", () => {
         >
       >();
       expectTypeOf(data).toEqualTypeOf<
-        SimpleCaseData | Streaming<SimpleCaseData>
+        SimpleCaseData | TData.Streaming<SimpleCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -2786,7 +2790,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
       }
     }
 
@@ -2805,7 +2809,7 @@ describe.skip("type tests", () => {
         >
       >();
       expectTypeOf(data).toEqualTypeOf<
-        SimpleCaseData | Streaming<SimpleCaseData>
+        SimpleCaseData | TData.Streaming<SimpleCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -2814,7 +2818,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
       }
     }
   });
@@ -2833,7 +2837,7 @@ describe.skip("type tests", () => {
         >
       >();
       expectTypeOf(data).toEqualTypeOf<
-        SimpleCaseData | Streaming<SimpleCaseData>
+        SimpleCaseData | TData.Streaming<SimpleCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -2842,7 +2846,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
       }
     }
 
@@ -2861,7 +2865,7 @@ describe.skip("type tests", () => {
         >
       >();
       expectTypeOf(data).toEqualTypeOf<
-        SimpleCaseData | Streaming<SimpleCaseData>
+        SimpleCaseData | TData.Streaming<SimpleCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
 
@@ -2870,7 +2874,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
       }
     }
   });
@@ -2894,7 +2898,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | SimpleCaseData
         | DeepPartial<SimpleCaseData>
-        | Streaming<SimpleCaseData>
+        | TData.Streaming<SimpleCaseData>
         | undefined
       >();
       expectTypeOf(dataState).toEqualTypeOf<
@@ -2906,7 +2910,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
       }
 
       if (dataState === "partial") {
@@ -2936,7 +2940,7 @@ describe.skip("type tests", () => {
       expectTypeOf(data).toEqualTypeOf<
         | SimpleCaseData
         | DeepPartial<SimpleCaseData>
-        | Streaming<SimpleCaseData>
+        | TData.Streaming<SimpleCaseData>
         | undefined
       >();
       expectTypeOf(dataState).toEqualTypeOf<
@@ -2948,7 +2952,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
       }
 
       if (dataState === "partial") {
@@ -2976,7 +2980,9 @@ describe.skip("type tests", () => {
         >
       >();
       expectTypeOf(data).toEqualTypeOf<
-        SimpleCaseData | DeepPartial<SimpleCaseData> | Streaming<SimpleCaseData>
+        | SimpleCaseData
+        | DeepPartial<SimpleCaseData>
+        | TData.Streaming<SimpleCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -2987,7 +2993,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
       }
 
       if (dataState === "partial") {
@@ -3011,7 +3017,9 @@ describe.skip("type tests", () => {
         >
       >();
       expectTypeOf(data).toEqualTypeOf<
-        SimpleCaseData | DeepPartial<SimpleCaseData> | Streaming<SimpleCaseData>
+        | SimpleCaseData
+        | DeepPartial<SimpleCaseData>
+        | TData.Streaming<SimpleCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -3022,7 +3030,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
       }
 
       if (dataState === "partial") {
@@ -3049,7 +3057,9 @@ describe.skip("type tests", () => {
         >
       >();
       expectTypeOf(data).toEqualTypeOf<
-        SimpleCaseData | DeepPartial<SimpleCaseData> | Streaming<SimpleCaseData>
+        | SimpleCaseData
+        | DeepPartial<SimpleCaseData>
+        | TData.Streaming<SimpleCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -3060,7 +3070,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
       }
 
       if (dataState === "partial") {
@@ -3085,7 +3095,9 @@ describe.skip("type tests", () => {
         >
       >();
       expectTypeOf(data).toEqualTypeOf<
-        SimpleCaseData | DeepPartial<SimpleCaseData> | Streaming<SimpleCaseData>
+        | SimpleCaseData
+        | DeepPartial<SimpleCaseData>
+        | TData.Streaming<SimpleCaseData>
       >();
       expectTypeOf(dataState).toEqualTypeOf<
         "complete" | "streaming" | "partial"
@@ -3096,7 +3108,7 @@ describe.skip("type tests", () => {
       }
 
       if (dataState === "streaming") {
-        expectTypeOf(data).toEqualTypeOf<Streaming<SimpleCaseData>>();
+        expectTypeOf(data).toEqualTypeOf<TData.Streaming<SimpleCaseData>>();
       }
 
       if (dataState === "partial") {

--- a/src/testing/internal/markAsStreaming.ts
+++ b/src/testing/internal/markAsStreaming.ts
@@ -1,5 +1,5 @@
-import type { Streaming } from "@apollo/client";
+import type { TData } from "@apollo/client";
 
 export function markAsStreaming<TData>(data: TData) {
-  return data as Streaming<TData>;
+  return data as TData.Streaming<TData>;
 }

--- a/src/testing/internal/markAsStreaming.ts
+++ b/src/testing/internal/markAsStreaming.ts
@@ -1,5 +1,5 @@
-import type { TData } from "@apollo/client";
+import type { DataValue } from "@apollo/client";
 
 export function markAsStreaming<TData>(data: TData) {
-  return data as TData.Streaming<TData>;
+  return data as DataValue.Streaming<TData>;
 }


### PR DESCRIPTION
I first thought that we would be okay with only a `Streaming` override, but in the end we don't know what certain codegen setups might create, so we probably also need a `Complete` and `Partial` override.

That would also be an escape hatch for use cases like #12738, allowing users to introduce `DeepReadonly` themselves.

Since `Partial` is already a TS builtin and `PartialData` felt weird, I opted for a namespace that exports all three - the name `TData` is very much up for debate here.