### PR TITLE
Fix a bug where the new `operationType` property wasn't passed into `operation`.

### DIFF
--- a/.changeset/fresh-swans-remain.md
+++ b/.changeset/fresh-swans-remain.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix a bug where the new `operationType` property wasn't passed into `operation`.

--- a/src/link/utils/transformOperation.ts
+++ b/src/link/utils/transformOperation.ts
@@ -6,6 +6,7 @@ export function transformOperation(operation: GraphQLRequest): GraphQLRequest {
     variables: operation.variables || {},
     extensions: operation.extensions || {},
     operationName: operation.operationName,
+    operationType: operation.operationType,
     query: operation.query,
   };
 


### PR DESCRIPTION
I noticed this while reviewing https://github.com/apollographql/apollo-client/pull/12742