### PR TITLE
Add `refetchObservableQueries` aliased method

### DIFF
--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -152,7 +152,9 @@ export class ApolloClient implements DataProxy {
     queryDeduplication: boolean;
     readFragment<T = unknown, TVariables = OperationVariables>(options: DataProxy.Fragment<TVariables, T>, optimistic?: boolean): Unmasked<T> | null;
     readQuery<TData = unknown, TVariables = OperationVariables>(options: DataProxy.Query<TVariables, TData>, optimistic?: boolean): Unmasked<TData> | null;
-    reFetchObservableQueries(includeStandby?: boolean): Promise<QueryResult<any>[]>;
+    // @deprecated
+    reFetchObservableQueries: (includeStandby?: boolean) => Promise<QueryResult<any>[]>;
+    refetchObservableQueries(includeStandby?: boolean): Promise<QueryResult<any>[]>;
     refetchQueries<TCache extends ApolloCache = ApolloCache, TResult = Promise<QueryResult<any>>>(options: RefetchQueriesOptions<TCache, TResult>): RefetchQueriesResult<TResult>;
     resetStore(): Promise<QueryResult<any>[] | null>;
     restore(serializedState: unknown): ApolloCache;

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -131,7 +131,9 @@ class ApolloClient_2 implements DataProxy {
     queryDeduplication: boolean;
     readFragment<T = unknown, TVariables = OperationVariables_2>(options: DataProxy.Fragment<TVariables, T>, optimistic?: boolean): Unmasked<T> | null;
     readQuery<TData = unknown, TVariables = OperationVariables_2>(options: DataProxy.Query<TVariables, TData>, optimistic?: boolean): Unmasked<TData> | null;
-    reFetchObservableQueries(includeStandby?: boolean): Promise<QueryResult_2<any>[]>;
+    // @deprecated
+    reFetchObservableQueries: (includeStandby?: boolean) => Promise<QueryResult_2<any>[]>;
+    refetchObservableQueries(includeStandby?: boolean): Promise<QueryResult_2<any>[]>;
     // Warning: (ae-forgotten-export) The symbol "RefetchQueriesOptions" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "RefetchQueriesResult" needs to be exported by the entry point index.d.ts
     refetchQueries<TCache extends ApolloCache = ApolloCache, TResult = Promise<QueryResult_2<any>>>(options: RefetchQueriesOptions<TCache, TResult>): RefetchQueriesResult<TResult>;

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -132,7 +132,9 @@ export class ApolloClient implements DataProxy {
     queryDeduplication: boolean;
     readFragment<T = unknown, TVariables = OperationVariables>(options: DataProxy.Fragment<TVariables, T>, optimistic?: boolean): Unmasked<T> | null;
     readQuery<TData = unknown, TVariables = OperationVariables>(options: DataProxy.Query<TVariables, TData>, optimistic?: boolean): Unmasked<TData> | null;
-    reFetchObservableQueries(includeStandby?: boolean): Promise<QueryResult<any>[]>;
+    // @deprecated
+    reFetchObservableQueries: (includeStandby?: boolean) => Promise<QueryResult<any>[]>;
+    refetchObservableQueries(includeStandby?: boolean): Promise<QueryResult<any>[]>;
     refetchQueries<TCache extends ApolloCache = ApolloCache, TResult = Promise<QueryResult<any>>>(options: RefetchQueriesOptions<TCache, TResult>): RefetchQueriesResult<TResult>;
     resetStore(): Promise<QueryResult<any>[] | null>;
     restore(serializedState: unknown): ApolloCache;

--- a/.changeset/ninety-nails-compete.md
+++ b/.changeset/ninety-nails-compete.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": minor
+---
+
+Add `client.refetchObservableQueries` as an alias to `client.reFetchObservableQueries`. `reFetchObservableQueries` is now deprecated and will be removed in a future major version.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43672,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38739,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33372,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27611
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43732,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38684,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33365,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27586
 }

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -2640,7 +2640,7 @@ describe("client", () => {
 
     // @ts-ignore
     const spy = jest.spyOn(client.queryManager, "refetchObservableQueries");
-    await client.reFetchObservableQueries();
+    await client.refetchObservableQueries();
     expect(spy).toHaveBeenCalled();
   });
 

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -702,7 +702,7 @@ export class ApolloClient implements DataProxy {
         })
       )
       .then(() => Promise.all(this.resetStoreCallbacks.map((fn) => fn())))
-      .then(() => this.reFetchObservableQueries());
+      .then(() => this.refetchObservableQueries());
   }
 
   /**
@@ -766,9 +766,9 @@ export class ApolloClient implements DataProxy {
   /**
    * Refetches all of your active queries.
    *
-   * `reFetchObservableQueries()` is useful if you want to bring the client back to proper state in case of a network outage
+   * `refetchObservableQueries()` is useful if you want to bring the client back to proper state in case of a network outage
    *
-   * It is important to remember that `reFetchObservableQueries()` *will* refetch any active
+   * It is important to remember that `refetchObservableQueries()` *will* refetch any active
    * queries. This means that any components that might be mounted will execute
    * their queries again using your network interface. If you do not want to
    * re-execute any queries then you should make sure to stop watching any
@@ -782,7 +782,7 @@ export class ApolloClient implements DataProxy {
   }
 
   /**
-   * Refetches specified active queries. Similar to "reFetchObservableQueries()" but with a specific list of queries.
+   * Refetches specified active queries. Similar to "refetchObservableQueries()" but with a specific list of queries.
    *
    * `refetchQueries()` is useful for use cases to imperatively refresh a selection of queries.
    *

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -261,8 +261,8 @@ export class ApolloClient implements DataProxy {
     this.mutate = this.mutate.bind(this);
     this.watchFragment = this.watchFragment.bind(this);
     this.resetStore = this.resetStore.bind(this);
-    this.reFetchObservableQueries = this.reFetchObservableQueries.bind(this);
-    this.refetchObservableQueries = this.refetchObservableQueries.bind(this);
+    this.reFetchObservableQueries = this.refetchObservableQueries =
+      this.refetchObservableQueries.bind(this);
 
     this.version = version;
 

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -262,6 +262,7 @@ export class ApolloClient implements DataProxy {
     this.watchFragment = this.watchFragment.bind(this);
     this.resetStore = this.resetStore.bind(this);
     this.reFetchObservableQueries = this.reFetchObservableQueries.bind(this);
+    this.refetchObservableQueries = this.refetchObservableQueries.bind(this);
 
     this.version = version;
 
@@ -757,8 +758,24 @@ export class ApolloClient implements DataProxy {
    * re-execute any queries then you should make sure to stop watching any
    * active queries.
    * Takes optional parameter `includeStandby` which will include queries in standby-mode when refetching.
+   *
+   * @deprecated Please use `refetchObservableQueries` instead.
    */
-  public reFetchObservableQueries(
+  public reFetchObservableQueries = this.refetchObservableQueries;
+
+  /**
+   * Refetches all of your active queries.
+   *
+   * `reFetchObservableQueries()` is useful if you want to bring the client back to proper state in case of a network outage
+   *
+   * It is important to remember that `reFetchObservableQueries()` *will* refetch any active
+   * queries. This means that any components that might be mounted will execute
+   * their queries again using your network interface. If you do not want to
+   * re-execute any queries then you should make sure to stop watching any
+   * active queries.
+   * Takes optional parameter `includeStandby` which will include queries in standby-mode when refetching.
+   */
+  public refetchObservableQueries(
     includeStandby?: boolean
   ): Promise<QueryResult<any>[]> {
     return this.queryManager.refetchObservableQueries(includeStandby);

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -4680,7 +4680,7 @@ describe("ApolloClient", () => {
         partial: false,
       });
 
-      await client.reFetchObservableQueries();
+      await client.refetchObservableQueries();
 
       expect(observable.getCurrentResult()).toStrictEqualTyped({
         data: dataChanged,
@@ -4761,7 +4761,7 @@ describe("ApolloClient", () => {
       expect(timesFired).toBe(1);
 
       // refetch the observed queries after data has returned
-      void client.reFetchObservableQueries();
+      void client.refetchObservableQueries();
 
       await expect(stream).toEmitTypedValue({
         data,
@@ -4824,7 +4824,7 @@ describe("ApolloClient", () => {
       expect(timesFired).toBe(1);
 
       stream.unsubscribe();
-      void client.reFetchObservableQueries();
+      void client.refetchObservableQueries();
 
       await wait(50);
 
@@ -4877,7 +4877,7 @@ describe("ApolloClient", () => {
       });
       expect(timesFired).toBe(1);
 
-      void client.reFetchObservableQueries();
+      void client.refetchObservableQueries();
 
       await expect(stream).toEmitTypedValue({
         data,
@@ -4920,7 +4920,7 @@ describe("ApolloClient", () => {
       const promise = client["queryManager"].fetchQuery({
         query,
       });
-      void client.reFetchObservableQueries();
+      void client.refetchObservableQueries();
 
       await expect(promise).resolves.toBeTruthy();
     });
@@ -4954,7 +4954,7 @@ describe("ApolloClient", () => {
       obs.subscribe({});
       obs.refetch = jest.fn();
 
-      void client.reFetchObservableQueries();
+      void client.refetchObservableQueries();
 
       await wait(0);
 
@@ -4990,7 +4990,7 @@ describe("ApolloClient", () => {
         return null as never;
       };
 
-      void client.reFetchObservableQueries();
+      void client.refetchObservableQueries();
 
       await wait(50);
 
@@ -5026,7 +5026,7 @@ describe("ApolloClient", () => {
         return null as never;
       };
 
-      void client.reFetchObservableQueries();
+      void client.refetchObservableQueries();
 
       await wait(50);
 
@@ -5063,7 +5063,7 @@ describe("ApolloClient", () => {
       };
 
       const includeStandBy = true;
-      void client.reFetchObservableQueries(includeStandBy);
+      void client.refetchObservableQueries(includeStandBy);
 
       await wait(50);
 
@@ -5100,7 +5100,7 @@ describe("ApolloClient", () => {
       };
 
       const includeStandBy = true;
-      void client.reFetchObservableQueries(includeStandBy);
+      void client.refetchObservableQueries(includeStandBy);
 
       await wait(50);
 
@@ -5134,7 +5134,7 @@ describe("ApolloClient", () => {
         return null as never;
       };
 
-      void client.reFetchObservableQueries();
+      void client.refetchObservableQueries();
 
       await wait(50);
 
@@ -5161,7 +5161,7 @@ describe("ApolloClient", () => {
         () =>
           new Observable((observer) => {
             // refetch observed queries as soon as we hear about the query
-            void client.reFetchObservableQueries();
+            void client.refetchObservableQueries();
             observer.next({ data });
             observer.complete();
           })

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -7291,7 +7291,7 @@ describe("useQuery Hook", () => {
         });
       }
 
-      void client.reFetchObservableQueries();
+      void client.refetchObservableQueries();
 
       {
         const result = await takeSnapshot();


### PR DESCRIPTION
Finally time to deprecate the annoyance 😆 