### PR TITLE
dispose of queryRefs faster on rejection

### DIFF
--- a/src/react/internal/cache/QueryReference.ts
+++ b/src/react/internal/cache/QueryReference.ts
@@ -79,7 +79,7 @@ export interface PreloadedQueryRef<
 }
 
 interface InternalQueryReferenceOptions {
-  onDispose?: () => void;
+  onDispose: (ref: InternalQueryReference<any, any>) => void;
   autoDisposeTimeoutMs?: number;
 }
 
@@ -209,9 +209,10 @@ export class InternalQueryReference<
     this.dispose = this.dispose.bind(this);
     this.observable = observable;
 
-    if (options.onDispose) {
-      this.onDispose = options.onDispose;
-    }
+    this.onDispose = () => {
+      clearTimeout(this.autoDisposeTimeoutId);
+      options.onDispose?.(this);
+    };
 
     this.setResult();
     this.subscribeToQuery();
@@ -351,7 +352,7 @@ export class InternalQueryReference<
     return this.initiateFetch(this.observable.fetchMore<TData>(options));
   }
 
-  private dispose() {
+  public dispose() {
     this.subscription.unsubscribe();
   }
 


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:

### Checklist:
- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
-->
