### PR TITLE
Apply document transforms on `client.read*` APIs

### DIFF
--- a/.changeset/great-peaches-design.md
+++ b/.changeset/great-peaches-design.md
@@ -1,0 +1,7 @@
+---
+"@apollo/client": major
+---
+
+Apply document transforms before reading data from the cache for `client.readQuery`, `client.readFragment`, `client.watchFragment`, `useFragment`, and `useSuspenseFragment`.
+
+NOTE: This change does not affect the equivalent `cache.*` APIs. To read data from the cache without first running document transforms, run `cache.readQuery`, `cache.readFragment`, etc.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43696,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38670,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33351,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27632
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43724,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38684,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33429,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27613
 }

--- a/src/__tests__/ApolloClient.ts
+++ b/src/__tests__/ApolloClient.ts
@@ -285,7 +285,7 @@ describe("ApolloClient", () => {
           `,
         });
       }).toThrowError(
-        "Found 0 fragments. `fragmentName` must be provided when there is not exactly 1 fragment."
+        'Schema type definitions not allowed in queries. Found: "SchemaDefinition"'
       );
     });
 

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -1,3 +1,4 @@
+import type { DocumentNode } from "graphql";
 import { OperationTypeNode } from "graphql";
 import type { Observable } from "rxjs";
 import { map } from "rxjs";
@@ -578,7 +579,10 @@ export class ApolloClient implements DataProxy {
     options: DataProxy.Query<TVariables, TData>,
     optimistic: boolean = false
   ): Unmasked<TData> | null {
-    return this.cache.readQuery<TData, TVariables>(options, optimistic);
+    return this.cache.readQuery<TData, TVariables>(
+      { ...options, query: this.transform(options.query) },
+      optimistic
+    );
   }
 
   /**
@@ -603,6 +607,7 @@ export class ApolloClient implements DataProxy {
   ): Observable<WatchFragmentResult<TData>> {
     return this.cache.watchFragment({
       ...options,
+      fragment: this.transform(options.fragment),
       [Symbol.for("apollo.dataMasking")]: this.queryManager.dataMasking,
     });
   }
@@ -625,7 +630,10 @@ export class ApolloClient implements DataProxy {
     options: DataProxy.Fragment<TVariables, T>,
     optimistic: boolean = false
   ): Unmasked<T> | null {
-    return this.cache.readFragment<T, TVariables>(options, optimistic);
+    return this.cache.readFragment<T, TVariables>(
+      { ...options, fragment: this.transform(options.fragment) },
+      optimistic
+    );
   }
 
   /**
@@ -877,6 +885,10 @@ export class ApolloClient implements DataProxy {
 
   public get defaultContext() {
     return this.queryManager.defaultContext;
+  }
+
+  private transform(document: DocumentNode) {
+    return this.queryManager.transform(document);
   }
 
   /**

--- a/src/react/hooks/useFragment.ts
+++ b/src/react/hooks/useFragment.ts
@@ -136,7 +136,10 @@ function useFragment_<TData, TVariables extends OperationVariables>(
       ...stableOptions,
       returnPartialData: true,
       id: from,
-      query: cache["getFragmentDoc"](fragment, fragmentName),
+      query: cache["getFragmentDoc"](
+        client["transform"](fragment),
+        fragmentName
+      ),
       optimistic,
     });
 

--- a/src/react/internal/cache/FragmentReference.ts
+++ b/src/react/internal/cache/FragmentReference.ts
@@ -184,7 +184,10 @@ export class FragmentReference<
 
     const diff = cache.diff<TData, TVariables>({
       ...options,
-      query: cache["getFragmentDoc"](fragment, fragmentName),
+      query: cache["getFragmentDoc"](
+        client["transform"](fragment),
+        fragmentName
+      ),
       returnPartialData: true,
       id: from,
       optimistic: true,


### PR DESCRIPTION
Closes #12745

Applies document transforms to `client.readQuery`, `client.readFragment`, `client.watchFragment`, `useFragment`, and `useSuspenseFragment`.