### PR TITLE
Disallow `mutation` option in `mutate` callback returned from `useMutation`

### DIFF
--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -632,9 +632,7 @@ export namespace useMutation {
     }
     ]) => Promise<ApolloClient.MutateResult<MaybeMasked<TData>>>;
     // (undocumented)
-    export type MutationFunctionOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends ApolloCache = ApolloCache> = Options<TData, TVariables, TCache> & {
-        mutation?: DocumentNode_2 | TypedDocumentNode<TData, TVariables>;
-    };
+    export type MutationFunctionOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends ApolloCache = ApolloCache> = Options<TData, TVariables, TCache>;
     // (undocumented)
     export interface Options<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends ApolloCache = ApolloCache, TConfiguredVariables extends Partial<TVariables> = Partial<TVariables>> {
         awaitRefetchQueries?: boolean;

--- a/.changeset/heavy-ways-call.md
+++ b/.changeset/heavy-ways-call.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": major
+---
+
+Disallow the `mutation` option for the `mutate` function returned from `useMutation`.

--- a/src/react/hooks/useMutation.ts
+++ b/src/react/hooks/useMutation.ts
@@ -157,12 +157,7 @@ export declare namespace useMutation {
     TData = unknown,
     TVariables extends OperationVariables = OperationVariables,
     TCache extends ApolloCache = ApolloCache,
-  > = Options<TData, TVariables, TCache> & {
-    /** {@inheritDoc @apollo/client!MutationOptionsDocumentation#mutation:member} */
-    // TODO: Remove this option. We shouldn't allow the mutation to be overridden
-    // in the mutation function
-    mutation?: DocumentNode | TypedDocumentNode<TData, TVariables>;
-  };
+  > = Options<TData, TVariables, TCache>;
 
   export namespace DocumentationTypes {
     /** {@inheritDoc @apollo/client!useMutation:function(1)} */


### PR DESCRIPTION
I discovered this when looking doing a pass through the docs.