### PR TITLE
Update `HttpLink` types for `fetchOptions` and `credentials`

### DIFF
--- a/.api-reports/api-report-link_http.api.md
+++ b/.api-reports/api-report-link_http.api.md
@@ -89,9 +89,9 @@ export namespace HttpLink {
         preserveHeaderCase?: boolean;
     }
     export interface Options {
-        credentials?: string;
+        credentials?: RequestCredentials;
         fetch?: typeof fetch;
-        fetchOptions?: any;
+        fetchOptions?: RequestInit;
         headers?: Record<string, string>;
         includeExtensions?: boolean;
         includeUnusedVariables?: boolean;

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -1370,9 +1370,9 @@ export namespace HttpLink {
         preserveHeaderCase?: boolean;
     }
     export interface Options {
-        credentials?: string;
+        credentials?: RequestCredentials;
         fetch?: typeof fetch;
-        fetchOptions?: any;
+        fetchOptions?: RequestInit;
         headers?: Record<string, string>;
         includeExtensions?: boolean;
         includeUnusedVariables?: boolean;

--- a/.changeset/purple-eyes-divide.md
+++ b/.changeset/purple-eyes-divide.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+The `fetchOptions` option provided to `HttpLink` and `BatchHttpLink` is now `RequestInit` instead of `any`. The `credentials` option is now a `RequestCredentials` type instead of a `string`.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43862,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38777,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33487,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27626
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43890,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38731,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33462,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27595
 }

--- a/src/link/http/HttpLink.ts
+++ b/src/link/http/HttpLink.ts
@@ -129,12 +129,12 @@ export declare namespace HttpLink {
     /**
      * The credentials policy you want to use for the fetch call.
      */
-    credentials?: string;
+    credentials?: RequestCredentials;
 
     /**
      * Any overrides of the fetch options argument to pass to the fetch call.
      */
-    fetchOptions?: any;
+    fetchOptions?: RequestInit;
 
     /**
      * If set to true, use the HTTP GET method for query operations. Mutations

--- a/src/link/http/__tests__/HttpLink.ts
+++ b/src/link/http/__tests__/HttpLink.ts
@@ -709,7 +709,7 @@ describe("HttpLink", () => {
 
     it("adds creds to the request from the setup", async () => {
       const variables = { params: "stub" };
-      const link = createHttpLink({ uri: "data", credentials: "same-team-yo" });
+      const link = createHttpLink({ uri: "data", credentials: "include" });
 
       const observable = execute(link, { query: sampleQuery, variables });
       const stream = new ObservableStream(observable);
@@ -717,19 +717,19 @@ describe("HttpLink", () => {
       await expect(stream).toEmitTypedValue(data);
 
       const creds = fetchMock.lastCall()![1]!.credentials;
-      expect(creds).toBe("same-team-yo");
+      expect(creds).toBe("include");
     });
 
     it("prioritizes creds from the context over the setup", async () => {
       const variables = { params: "stub" };
       const middleware = new ApolloLink((operation, forward) => {
         operation.setContext({
-          credentials: "same-team-yo",
+          credentials: "omit",
         });
         return forward(operation);
       });
       const link = middleware.concat(
-        createHttpLink({ uri: "data", credentials: "error" })
+        createHttpLink({ uri: "data", credentials: "include" })
       );
 
       const observable = execute(link, { query: sampleQuery, variables });
@@ -738,7 +738,7 @@ describe("HttpLink", () => {
       await expect(stream).toEmitTypedValue(data);
 
       const creds = fetchMock.lastCall()![1]!.credentials;
-      expect(creds).toBe("same-team-yo");
+      expect(creds).toBe("omit");
     });
 
     it("adds uri to the request from the context", async () => {
@@ -782,7 +782,7 @@ describe("HttpLink", () => {
         return forward(operation);
       });
       const link = middleware.concat(
-        createHttpLink({ uri: "data", credentials: "error" })
+        createHttpLink({ uri: "data", credentials: "include" })
       );
 
       const observable = execute(link, { query: sampleQuery, variables });
@@ -817,7 +817,7 @@ describe("HttpLink", () => {
       const variables = { params: "stub" };
       const link = createHttpLink({
         uri: "data",
-        fetchOptions: { someOption: "foo", mode: "no-cors" },
+        fetchOptions: { mode: "no-cors" },
       });
 
       const observable = execute(link, { query: sampleQuery, variables });
@@ -825,8 +825,7 @@ describe("HttpLink", () => {
 
       await expect(stream).toEmitTypedValue(data);
 
-      const { someOption, mode, headers } = fetchMock.lastCall()![1] as any;
-      expect(someOption).toBe("foo");
+      const { mode, headers } = fetchMock.lastCall()![1] as any;
       expect(mode).toBe("no-cors");
       expect(headers["content-type"]).toBe("application/json");
     });
@@ -914,13 +913,13 @@ describe("HttpLink", () => {
       const middleware = new ApolloLink((operation, forward) => {
         operation.setContext({
           fetchOptions: {
-            someOption: "foo",
+            mode: "cors",
           },
         });
         return forward(operation);
       });
       const link = middleware.concat(
-        createHttpLink({ uri: "data", fetchOptions: { someOption: "bar" } })
+        createHttpLink({ uri: "data", fetchOptions: { mode: "no-cors" } })
       );
 
       const observable = execute(link, { query: sampleQuery, variables });
@@ -928,8 +927,8 @@ describe("HttpLink", () => {
 
       await expect(stream).toEmitTypedValue(data);
 
-      const { someOption } = fetchMock.lastCall()![1] as any;
-      expect(someOption).toBe("foo");
+      const { mode } = fetchMock.lastCall()![1] as any;
+      expect(mode).toBe("cors");
     });
 
     it("allows for not sending the query with the request", async () => {


### PR DESCRIPTION
Discovered while working on #12819