### PR TITLE
Export `isNetworkStatusInFlight`

### DIFF
--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -530,6 +530,9 @@ export namespace InternalTypes {
 }
 
 // @public
+export function isNetworkRequestInFlight(networkStatus?: NetworkStatus): boolean;
+
+// @public
 export function isNetworkRequestSettled(networkStatus?: NetworkStatus): boolean;
 
 export { isReference }

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -1438,6 +1438,9 @@ const _invalidateModifier: unique symbol;
 type IsAny<T> = 0 extends 1 & T ? true : false;
 
 // @public
+export function isNetworkRequestInFlight(networkStatus?: NetworkStatus): boolean;
+
+// @public
 export function isNetworkRequestSettled(networkStatus?: NetworkStatus): boolean;
 
 // @public

--- a/.changeset/rude-pigs-own.md
+++ b/.changeset/rude-pigs-own.md
@@ -1,0 +1,6 @@
+---
+"@apollo/client-codemod-migrate-3-to-4": patch
+"@apollo/client": patch
+---
+
+Export `isNetworkStatusInFlight` from `@apollo/client`.

--- a/scripts/codemods/ac3-to-ac4/src/renames.ts
+++ b/scripts/codemods/ac3-to-ac4/src/renames.ts
@@ -710,6 +710,18 @@ export const renames: Array<IdentifierRename | ModuleRename> = [
       importType: "type",
     })
   ),
+  ...[{ from: "isNetworkRequestInFlight" }].map(
+    moveInto({
+      from: {
+        module: "@apollo/client/core/networkStatus",
+        alternativeModules: ["@apollo/client/core"],
+      },
+      to: {
+        module: "@apollo/client",
+      },
+      importType: "value",
+    })
+  ),
   // no direct 1:1 drop-in replacement
   // {
   //   from: { module: "@apollo/client/react/ssr", identifier: "renderToStringWithData" },

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -27,7 +27,11 @@ export type {
   UpdateQueryOptions,
   WatchQueryFetchPolicy,
 } from "./watchQueryOptions.js";
-export { isNetworkRequestSettled, NetworkStatus } from "./networkStatus.js";
+export {
+  isNetworkRequestInFlight,
+  isNetworkRequestSettled,
+  NetworkStatus,
+} from "./networkStatus.js";
 export type {
   DataState,
   DataValue,


### PR DESCRIPTION
Discovered this while I was working on the devtools repo. Looks like because of the way v3 was bundled, this was missed.