### PR TITLE
docs: fix npx codemod command for Apollo Client migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,11 +254,11 @@ Apollo Client 4.0 provides a comprehensive codemod to automate migration:
 
 ```bash
 # Basic usage
-npx apollo-client-codemod-migrate-3-to-4 src
+npx @apollo/client-codemod-migrate-3-to-4 src
 
 # TypeScript projects (run separately)
-npx apollo-client-codemod-migrate-3-to-4 --parser ts --extensions ts src
-npx apollo-client-codemod-migrate-3-to-4 --parser tsx --extensions tsx src
+npx @apollo/client-codemod-migrate-3-to-4 --parser ts --extensions ts src
+npx @apollo/client-codemod-migrate-3-to-4 --parser tsx --extensions tsx src
 ```
 
 The codemod handles:


### PR DESCRIPTION
Hi, while migrating from 3.14 to 4 and following the guide, I noticed the command was incorrect. 

fixes
```
npm error code E404
npm error 404 Not Found - GET https://registry.npmjs.org/apollo-client-codemod-migrate-3-to-4 - Not found
npm error 404
npm error 404  'apollo-client-codemod-migrate-3-to-4@*' is not in this registry.
```

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:

### Checklist:
- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
-->
