### PR TITLE
restore `getMemoryInternals` access in dev builds

### DIFF
--- a/.changeset/hip-badgers-reply.md
+++ b/.changeset/hip-badgers-reply.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+restore `getMemoryInternals` access in dev builds

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43875,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38673,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33588,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27661
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43866,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38687,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33629,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27594
 }

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -541,7 +541,7 @@ export abstract class ApolloCache {
    * information to the DevTools.
    * Use at your own risk!
    */
-  public getMemoryInternals?: typeof getApolloCacheMemoryInternals;
+  public declare getMemoryInternals?: typeof getApolloCacheMemoryInternals;
 }
 
 if (__DEV__) {

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -1537,7 +1537,7 @@ export class ApolloClient {
    * }
    * ```
    */
-  public getMemoryInternals?: typeof getApolloClientMemoryInternals;
+  public declare getMemoryInternals?: typeof getApolloClientMemoryInternals;
 }
 
 if (__DEV__) {

--- a/src/link/core/ApolloLink.ts
+++ b/src/link/core/ApolloLink.ts
@@ -493,5 +493,5 @@ export class ApolloLink {
    * @internal
    * Can be provided by a link that has an internal cache to report it's memory details.
    */
-  getMemoryInternals?: () => unknown;
+  declare getMemoryInternals?: () => unknown;
 }


### PR DESCRIPTION
This should do it... look at the build output diff :)