### PR TITLE
Ensure error codes are importable

### DIFF
--- a/.changeset/slimy-meals-bathe.md
+++ b/.changeset/slimy-meals-bathe.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Ensure `invariantErrorCodes.js` is importable

--- a/.changeset/slimy-meals-bathe.md
+++ b/.changeset/slimy-meals-bathe.md
@@ -2,4 +2,4 @@
 "@apollo/client": patch
 ---
 
-Ensure `invariantErrorCodes.js` is importable
+Ensure `invariantErrorCodes.js`/`invariantErrorCodes.cjs` is importable.

--- a/config/prepareDist.ts
+++ b/config/prepareDist.ts
@@ -42,6 +42,7 @@ export const prepareDist: BuildStep = async (options) => {
 
       packageJson.exports = {
         "./package.json": "./package.json",
+        "./invariantErrorCodes.js": "./invariantErrorCodes.js",
         "./*.js": "./legacyEntryPoints/*.js",
         "./*.cjs": "./legacyEntryPoints/*.cjs",
         "./*.d.ts": "./legacyEntryPoints/*.d.ts",

--- a/config/prepareDist.ts
+++ b/config/prepareDist.ts
@@ -43,6 +43,7 @@ export const prepareDist: BuildStep = async (options) => {
       packageJson.exports = {
         "./package.json": "./package.json",
         "./invariantErrorCodes.js": "./invariantErrorCodes.js",
+        "./invariantErrorCodes.cjs": "./__cjs/invariantErrorCodes.cjs",
         "./*.js": "./legacyEntryPoints/*.js",
         "./*.cjs": "./legacyEntryPoints/*.cjs",
         "./*.d.ts": "./legacyEntryPoints/*.d.ts",


### PR DESCRIPTION
We need to import `invariantErrorCodes` for the devtools, but currently it resolves to the wrong location. `invariantErrorCodes.js` is written in the top-level folder but it resolves to `legacyImports/invariantErrorsCodes.js` which doesn't exist. This adds a mapping to the `exports` field to ensure it can be resolved.