### PR TITLE
Ensure that `PreloadedQueryRef` instances are unsubscribed when garbage collected

### DIFF
--- a/.changeset/clever-students-guess.md
+++ b/.changeset/clever-students-guess.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Ensure that `PreloadedQueryRef` instances are unsubscribed when garbage collected

--- a/package.json
+++ b/package.json
@@ -66,6 +66,10 @@
       "production": "./src/utilities/internal/index.production.ts",
       "default": "./src/utilities/internal/index.ts"
     },
+    "./utilities/polyfilled": {
+      "react-native": "./src/utilities/internal/polyfilled/index.react-native.ts",
+      "default": "./src/utilities/internal/polyfilled/index.ts"
+    },
     "./utilities/internal/globals": "./src/utilities/internal/globals/index.ts",
     "./utilities/subscriptions/relay": "./src/utilities/subscriptions/relay/index.ts",
     "./utilities/invariant": {

--- a/src/react/query-preloader/__tests__/createQueryPreloader.test.tsx
+++ b/src/react/query-preloader/__tests__/createQueryPreloader.test.tsx
@@ -1,4 +1,4 @@
-import { act, screen } from "@testing-library/react";
+import { act, screen, waitFor } from "@testing-library/react";
 import {
   createRenderStream,
   disableActEnvironment,
@@ -2005,6 +2005,102 @@ test("does not mask results by default", async () => {
       networkStatus: NetworkStatus.ready,
     });
   }
+});
+
+describe("PreloadedQueryRef` disposal", () => {
+  test("when the `PreloadedQueryRef` is disposed of, the ObservableQuery is unsubscribed", async () => {
+    const { query, mocks } = setupVariablesCase();
+    const client = new ApolloClient({
+      cache: new InMemoryCache(),
+      link: new MockLink(mocks),
+    });
+    const preloadQuery = createQueryPreloader(client);
+
+    let queryRef: PreloadedQueryRef | null = preloadQuery(query, {
+      variables: { id: "1" },
+    });
+    const internalQueryRef = unwrapQueryRef(queryRef)!;
+
+    expect(internalQueryRef.observable.hasObservers()).toBe(true);
+    expect(internalQueryRef["softReferences"]).toBe(1);
+    queryRef = null;
+
+    await waitFor(() => {
+      global.gc!();
+      expect(internalQueryRef.observable.hasObservers()).toBe(false);
+    });
+    expect(internalQueryRef["softReferences"]).toBe(0);
+  });
+
+  test("when the `PreloadedQueryRef` is disposed of, while the initial request is still ongoing the ObservableQuery stays subscribed to", async () => {
+    const { query } = setupVariablesCase();
+    const link = new MockSubscriptionLink();
+    const client = new ApolloClient({
+      cache: new InMemoryCache(),
+      link,
+    });
+    const preloadQuery = createQueryPreloader(client);
+
+    let queryRef: PreloadedQueryRef | null = preloadQuery(query, {
+      variables: { id: "1" },
+    });
+    const internalQueryRef = unwrapQueryRef(queryRef)!;
+
+    expect(internalQueryRef.observable.hasObservers()).toBe(true);
+    expect(internalQueryRef["softReferences"]).toBe(1);
+    queryRef = null;
+
+    await expect(
+      waitFor(() => {
+        global.gc!();
+        expect(internalQueryRef.observable.hasObservers()).toBe(false);
+      })
+    ).rejects.toThrow();
+    expect(internalQueryRef["softReferences"]).toBe(1);
+
+    link.simulateResult(
+      {
+        result: {
+          data: {
+            character: { __typename: "Character", id: "1", name },
+          },
+        },
+      },
+      true
+    );
+
+    await waitFor(() => {
+      global.gc!();
+      expect(internalQueryRef.observable.hasObservers()).toBe(false);
+    });
+    expect(internalQueryRef["softReferences"]).toBe(0);
+  });
+
+  test("when retained by a component, the soft retain lets go", async () => {
+    const { query, mocks } = setupVariablesCase();
+    const client = new ApolloClient({
+      cache: new InMemoryCache(),
+      link: new MockLink(mocks),
+    });
+    const preloadQuery = createQueryPreloader(client);
+
+    const queryRef = preloadQuery(query, {
+      variables: { id: "1" },
+    });
+    const internalQueryRef = unwrapQueryRef(queryRef)!;
+
+    expect(internalQueryRef["softReferences"]).toBe(1);
+
+    using _disabledAct = disableActEnvironment();
+    const { renderStream } = await renderDefaultTestApp<VariablesCaseData>({
+      client,
+      queryRef,
+    });
+    await renderStream.takeRender();
+    await renderStream.takeRender();
+
+    expect(internalQueryRef["softReferences"]).toBe(0);
+  });
 });
 
 describe.skip("type tests", () => {

--- a/src/utilities/internal/polyfilled/FinalizationRegistry.ts
+++ b/src/utilities/internal/polyfilled/FinalizationRegistry.ts
@@ -1,0 +1,55 @@
+import { invariant } from "@apollo/client/utilities/invariant";
+
+interface Entry<T> {
+  targetRef: WeakRef<WeakKey>;
+  value: T;
+}
+
+/**
+ * An approximation of `FinalizationRegistry` based on `WeakRef`.
+ * Checks every 500ms if registered values have been garbage collected.
+ */
+export const FinalizationRegistry: typeof globalThis.FinalizationRegistry = class FinalizationRegistry<
+  T,
+> {
+  private intervalLength = 500;
+  private callback: (value: T) => void;
+  private references = new Set<Entry<T>>();
+  private unregisterTokens = new WeakMap<WeakKey, Entry<T>>();
+  private interval: ReturnType<typeof setInterval> | null = null;
+  constructor(callback: (value: T) => void) {
+    this.callback = callback;
+    this.handler = this.handler.bind(this);
+  }
+  handler() {
+    if (this.references.size === 0) {
+      clearInterval(this.interval!);
+      this.interval = null;
+      return;
+    }
+    this.references.forEach((entry) => {
+      if (entry.targetRef.deref() === undefined) {
+        this.references.delete(entry);
+        this.callback(entry.value);
+      }
+    });
+  }
+  register(target: WeakKey, value: T, unregisterToken?: WeakKey): void {
+    const entry = { targetRef: new WeakRef(target), value };
+    this.references.add(entry);
+    if (unregisterToken) {
+      // some simplifications here as it's an internal polyfill
+      // we don't allow the same unregisterToken to be reused
+      invariant(!this.unregisterTokens.has(unregisterToken));
+      this.unregisterTokens.set(unregisterToken, entry);
+    }
+    if (!this.interval) {
+      this.interval = setInterval(this.handler, this.intervalLength);
+    }
+  }
+  unregister(unregisterToken: WeakKey): boolean {
+    this.references.delete(this.unregisterTokens.get(unregisterToken)!);
+    return this.unregisterTokens.delete(unregisterToken);
+  }
+  [Symbol.toStringTag] = "FinalizationRegistry" as const;
+};

--- a/src/utilities/internal/polyfilled/__tests__/FinalizationRegistry.test.ts
+++ b/src/utilities/internal/polyfilled/__tests__/FinalizationRegistry.test.ts
@@ -1,0 +1,84 @@
+import { waitFor } from "@testing-library/react";
+
+// eslint-disable-next-line local-rules/no-relative-imports
+import { FinalizationRegistry } from "../FinalizationRegistry.js";
+
+test("register", async () => {
+  const cleanedUp: number[] = [];
+  const registry = new FinalizationRegistry<number>((value) => {
+    cleanedUp.push(value);
+  });
+  // @ts-ignore we want to speed this up a bit
+  registry["intervalLength"] = 1;
+
+  let obj1: {} | null = {};
+  let obj2: {} | null = {};
+  let obj3: {} | null = {};
+
+  registry.register(obj1, 1);
+  registry.register(obj2, 2);
+  registry.register(obj3, 3);
+
+  expect(cleanedUp).toStrictEqual([]);
+
+  obj1 = null;
+  await waitFor(() => {
+    global.gc!();
+    expect(cleanedUp).toStrictEqual([1]);
+  });
+
+  obj3 = null;
+  await waitFor(() => {
+    global.gc!();
+    expect(cleanedUp).toStrictEqual([1, 3]);
+  });
+
+  obj2 = null;
+  await waitFor(() => {
+    global.gc!();
+    expect(cleanedUp).toStrictEqual([1, 3, 2]);
+  });
+});
+
+test("unregister", async () => {
+  const cleanedUp: number[] = [];
+  const registry = new FinalizationRegistry<number>((value) => {
+    cleanedUp.push(value);
+  });
+  // @ts-ignore we want to speed this up a bit
+  registry["intervalLength"] = 1;
+
+  let obj1: {} | null = {};
+  const token1 = {};
+  let obj2: {} | null = {};
+  const token2 = {};
+  let obj3: {} | null = {};
+  const token3 = {};
+
+  registry.register(obj1, 1, token1);
+  registry.register(obj2, 2, token2);
+  registry.register(obj3, 3, token3);
+
+  expect(cleanedUp).toStrictEqual([]);
+
+  obj1 = null;
+  await waitFor(() => {
+    global.gc!();
+    expect(cleanedUp).toStrictEqual([1]);
+  });
+
+  registry.unregister(token3);
+  obj3 = null;
+  await expect(
+    waitFor(() => {
+      global.gc!();
+      expect(cleanedUp).toStrictEqual([1, 3]);
+    })
+  ).rejects.toThrow();
+
+  obj2 = null;
+  await waitFor(() => {
+    global.gc!();
+    expect(cleanedUp).toStrictEqual([1, 2]);
+  });
+});

--- a/src/utilities/internal/polyfilled/index.react-native.ts
+++ b/src/utilities/internal/polyfilled/index.react-native.ts
@@ -1,0 +1,1 @@
+export { FinalizationRegistry } from "./FinalizationRegistry.js";

--- a/src/utilities/internal/polyfilled/index.ts
+++ b/src/utilities/internal/polyfilled/index.ts
@@ -1,0 +1,2 @@
+const F = FinalizationRegistry;
+export { F as FinalizationRegistry };


### PR DESCRIPTION
Triggered by https://community.apollographql.com/t/how-to-evict-all-related-queries-from-cache-that-reference-ids-of-deleted-entities/9408/3 and this thread: https://x.com/jerelmiller/status/1960375395649257814