### PR TITLE
Fix accidental deep re-export from `/react` out of `/react/internals`

### DIFF
--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -525,7 +525,7 @@ export type InternalRefetchQueriesResult<TResult> = TResult extends boolean ? Pr
 // @public (undocumented)
 export type InternalRefetchQueryDescriptor = RefetchQueryDescriptor | ApolloClient.QueryOptions;
 
-// @public (undocumented)
+// @internal @deprecated (undocumented)
 export namespace InternalTypes {
     export type { NextFetchPolicyContext, QueryManager };
 }

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -21,7 +21,7 @@ import type { GetDataState } from '@apollo/client';
 import type { HookWrappers } from '@apollo/client/react/internal';
 import type { IgnoreModifier } from '@apollo/client/cache';
 import type { InternalRefetchQueriesInclude } from '@apollo/client';
-import type { InternalTypes } from '@apollo/client';
+import type { InternalTypes as InternalTypes_2 } from '@apollo/client';
 import type { MaybeMasked } from '@apollo/client';
 import type { MaybeMasked as MaybeMasked_2 } from '@apollo/client/masking';
 import type { MissingTree } from '@apollo/client/cache';
@@ -92,6 +92,11 @@ type From<TData> = StoreObject_2 | Reference_2 | FragmentType<NoInfer_2<TData>> 
 
 // @public (undocumented)
 export function getApolloContext(): ReactTypes.Context<ApolloContextValue>;
+
+// @internal @deprecated (undocumented)
+export namespace InternalTypes {
+    export type { HookWrappers };
+}
 
 // @public @deprecated (undocumented)
 export type LazyQueryExecFunction<TData = unknown, TVariables extends OperationVariables = OperationVariables> = useLazyQuery.ExecFunction<TData, TVariables>;
@@ -528,7 +533,7 @@ export namespace useLazyQuery {
         client?: ApolloClient;
         errorPolicy?: ErrorPolicy;
         fetchPolicy?: WatchQueryFetchPolicy;
-        nextFetchPolicy?: WatchQueryFetchPolicy | ((this: ApolloClient.WatchQueryOptions<TData, TVariables>, currentFetchPolicy: WatchQueryFetchPolicy, context: InternalTypes.NextFetchPolicyContext<TData, TVariables>) => WatchQueryFetchPolicy);
+        nextFetchPolicy?: WatchQueryFetchPolicy | ((this: ApolloClient.WatchQueryOptions<TData, TVariables>, currentFetchPolicy: WatchQueryFetchPolicy, context: InternalTypes_2.NextFetchPolicyContext<TData, TVariables>) => WatchQueryFetchPolicy);
         notifyOnNetworkStatusChange?: boolean;
         pollInterval?: number;
         refetchWritePolicy?: RefetchWritePolicy;
@@ -697,7 +702,7 @@ export namespace useQuery {
             errorPolicy?: ErrorPolicy;
             fetchPolicy?: WatchQueryFetchPolicy;
             initialFetchPolicy?: WatchQueryFetchPolicy;
-            nextFetchPolicy?: WatchQueryFetchPolicy | ((this: ApolloClient.WatchQueryOptions<TData, TVariables>, currentFetchPolicy: WatchQueryFetchPolicy, context: InternalTypes.NextFetchPolicyContext<TData, TVariables>) => WatchQueryFetchPolicy);
+            nextFetchPolicy?: WatchQueryFetchPolicy | ((this: ApolloClient.WatchQueryOptions<TData, TVariables>, currentFetchPolicy: WatchQueryFetchPolicy, context: InternalTypes_2.NextFetchPolicyContext<TData, TVariables>) => WatchQueryFetchPolicy);
             notifyOnNetworkStatusChange?: boolean;
             pollInterval?: number;
             refetchWritePolicy?: RefetchWritePolicy;

--- a/.api-reports/api-report-react_internal.api.md
+++ b/.api-reports/api-report-react_internal.api.md
@@ -5,22 +5,15 @@
 ```ts
 
 import type { ApolloClient } from '@apollo/client';
-import type { createQueryPreloader } from '@apollo/client/react';
 import type { DataState } from '@apollo/client';
 import type { DecoratedPromise } from '@apollo/client/utilities/internal';
 import type { DocumentNode } from 'graphql';
+import type { InternalTypes } from '@apollo/client/react';
 import type { MaybeMasked } from '@apollo/client/masking';
 import type { MaybeMasked as MaybeMasked_2 } from '@apollo/client';
 import type { Observable } from 'rxjs';
 import type { ObservableQuery } from '@apollo/client';
 import type { OperationVariables } from '@apollo/client';
-import type { useBackgroundQuery } from '@apollo/client/react';
-import type { useFragment } from '@apollo/client/react';
-import type { useQuery } from '@apollo/client/react';
-import type { useQueryRefHandlers } from '@apollo/client/react';
-import type { useReadQuery } from '@apollo/client/react';
-import type { useSuspenseFragment } from '@apollo/client/react';
-import type { useSuspenseQuery } from '@apollo/client/react';
 
 // Warning: (ae-forgotten-export) The symbol "WrappedQueryRef" needs to be exported by the entry point index.d.ts
 //
@@ -86,9 +79,6 @@ interface FragmentReferenceOptions {
 // @public (undocumented)
 type FragmentRefPromise<TData> = DecoratedPromise<TData>;
 
-// @public (undocumented)
-type FunctionSignature<T> = T extends (...args: infer A) => infer R ? (...args: A) => R : never;
-
 // Warning: (ae-forgotten-export) The symbol "SuspenseCache" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
@@ -101,12 +91,8 @@ export function getSuspenseCache(client: ApolloClient & {
 // @public (undocumented)
 export function getWrappedPromise<TData, TStates extends DataState<TData>["dataState"]>(queryRef: WrappedQueryRef<TData, any, TStates>): QueryRefPromise<TData, TStates>;
 
-// Warning: (ae-forgotten-export) The symbol "WrappableHooks" needs to be exported by the entry point index.d.ts
-//
-// @internal @deprecated
-export type HookWrappers = {
-    [K in keyof WrappableHooks]?: (originalHook: WrappableHooks[K]) => WrappableHooks[K];
-};
+// @public (undocumented)
+export type HookWrappers = InternalTypes.HookWrappers;
 
 // @public (undocumented)
 export class InternalQueryReference<TData = unknown, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"]> {
@@ -239,28 +225,6 @@ export function unwrapQueryRef<TData, TStates extends DataState<TData>["dataStat
 
 // @public (undocumented)
 export function updateWrappedQueryRef<TData, TStates extends DataState<TData>["dataState"]>(queryRef: WrappedQueryRef<TData, any, TStates>, promise: QueryRefPromise<TData, TStates>): void;
-
-// @public (undocumented)
-interface WrappableHooks {
-    // Warning: (ae-forgotten-export) The symbol "FunctionSignature" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
-    createQueryPreloader: FunctionSignature<typeof createQueryPreloader>;
-    // (undocumented)
-    useBackgroundQuery: FunctionSignature<typeof useBackgroundQuery>;
-    // (undocumented)
-    useFragment: FunctionSignature<typeof useFragment>;
-    // (undocumented)
-    useQuery: FunctionSignature<typeof useQuery>;
-    // (undocumented)
-    useQueryRefHandlers: FunctionSignature<typeof useQueryRefHandlers>;
-    // (undocumented)
-    useReadQuery: FunctionSignature<typeof useReadQuery>;
-    // (undocumented)
-    useSuspenseFragment: FunctionSignature<typeof useSuspenseFragment>;
-    // (undocumented)
-    useSuspenseQuery: FunctionSignature<typeof useSuspenseQuery>;
-}
 
 // @internal @deprecated
 interface WrappedQueryRef<TData = unknown, TVariables extends OperationVariables = OperationVariables, TStates extends DataState<TData>["dataState"] = "complete" | "streaming"> extends QueryRef<TData, TVariables, TStates> {

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -1420,7 +1420,7 @@ export type InternalRefetchQueriesResult<TResult> = TResult extends boolean ? Pr
 // @public (undocumented)
 export type InternalRefetchQueryDescriptor = RefetchQueryDescriptor | ApolloClient.QueryOptions;
 
-// @public (undocumented)
+// @internal @deprecated (undocumented)
 export namespace InternalTypes {
     export type { NextFetchPolicyContext, QueryManager };
 }

--- a/.changeset/hip-mangos-hope.md
+++ b/.changeset/hip-mangos-hope.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix accidental deep re-export from `/react` out of `/react/internals`

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -188,6 +188,7 @@ export { build, version } from "../version.js";
 // internal types
 import type { QueryManager } from "./QueryManager.js";
 import type { NextFetchPolicyContext } from "./watchQueryOptions.js";
+/** @internal */
 export declare namespace InternalTypes {
   export type { NextFetchPolicyContext, QueryManager };
 }

--- a/src/react/hooks/internal/wrapHook.ts
+++ b/src/react/hooks/internal/wrapHook.ts
@@ -12,11 +12,10 @@ import type {
   useSuspenseFragment,
   useSuspenseQuery,
 } from "@apollo/client/react";
+import { wrapperSymbol } from "@apollo/client/react/internal";
 
 // direct import to avoid circular dependency
 import { getApolloContext } from "../../context/ApolloContext.js";
-
-export const wrapperSymbol = Symbol.for("apollo.hook.wrappers");
 
 type FunctionSignature<T> =
   T extends (...args: infer A) => infer R ? (...args: A) => R : never;

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -65,4 +65,11 @@ export type {
   UseSuspenseQueryResult,
 } from "./types/deprecated.js";
 
+// internal types
+import type { HookWrappers } from "./hooks/internal/wrapHook.js";
+/** @internal */
+export declare namespace InternalTypes {
+  export type { HookWrappers };
+}
+
 export const reactCompilerVersion = "uncompiled" as string;

--- a/src/react/internal/index.ts
+++ b/src/react/internal/index.ts
@@ -1,3 +1,4 @@
+import type { InternalTypes as ReactInternalTypes } from "@apollo/client/react";
 export { getSuspenseCache } from "./cache/getSuspenseCache.js";
 export type { CacheKey, FragmentKey, QueryKey } from "./cache/types.js";
 export type { PreloadedQueryRef, QueryRef } from "./cache/QueryReference.js";
@@ -10,8 +11,6 @@ export {
   wrapQueryRef,
 } from "./cache/QueryReference.js";
 export type { SuspenseCacheOptions } from "./cache/SuspenseCache.js";
-// eslint-disable-next-line local-rules/import-from-inside-other-export
-export type { HookWrappers } from "../hooks/internal/wrapHook.js";
-// eslint-disable-next-line local-rules/import-from-inside-other-export
-export { wrapperSymbol } from "../hooks/internal/wrapHook.js";
+export type HookWrappers = ReactInternalTypes.HookWrappers;
+export const wrapperSymbol = Symbol.for("apollo.hook.wrappers");
 export type { FetchMoreFunction, RefetchFunction } from "./types.js";


### PR DESCRIPTION
fix `local-rules/import-from-inside-other-export` where `/react/internals` imported directly from `/react`

This caused `react` to be pulled into a RSC bundle, resulting in apollographql/apollo-client-integrations#499