### PR TITLE
Remove outdated information in doc blocks

### DIFF
--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -226,7 +226,7 @@ export namespace ApolloClient {
         // (undocumented)
         defaultContext?: Partial<DefaultContext>;
         defaultOptions?: ApolloClient.DefaultOptions;
-        devtools?: DevtoolsOptions;
+        devtools?: ApolloClient.DevtoolsOptions;
         // (undocumented)
         documentTransform?: DocumentTransform;
         // (undocumented)

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -237,7 +237,7 @@ export namespace ApolloClient {
         // (undocumented)
         defaultContext?: Partial<DefaultContext>;
         defaultOptions?: ApolloClient.DefaultOptions;
-        devtools?: DevtoolsOptions;
+        devtools?: ApolloClient.DevtoolsOptions;
         // (undocumented)
         documentTransform?: DocumentTransform;
         // (undocumented)

--- a/docs/source/api/core/ApolloClient.mdx
+++ b/docs/source/api/core/ApolloClient.mdx
@@ -150,3 +150,9 @@ You can override any default option you specify in this object by providing a
 different value for the same option in individual function calls.
 
 > **Note:** The `useQuery` hook uses Apollo Client's `watchQuery` function. To set `defaultOptions` when using the `useQuery` hook, make sure to set them under the `defaultOptions.watchQuery` property.
+
+<InterfaceDetails
+  canonicalReference="@apollo/client!ApolloClient.DevtoolsOptions:interface"
+  headingLevel={3}
+  displayName="ApolloClient.DevtoolsOptions"
+/>

--- a/docs/source/api/core/ApolloClient.mdx
+++ b/docs/source/api/core/ApolloClient.mdx
@@ -92,6 +92,18 @@ For more information on the `defaultOptions` object, see the [Default Options](#
   canonicalReference="@apollo/client!ApolloClient#getObservableQueries:member(1)"
   headingLevel={3}
 />
+<FunctionDetails
+  canonicalReference="@apollo/client!ApolloClient#extract:member(1)"
+  headingLevel={3}
+/>
+<FunctionDetails
+  canonicalReference="@apollo/client!ApolloClient#restore:member(1)"
+  headingLevel={3}
+/>
+<FunctionDetails
+  canonicalReference="@apollo/client!ApolloClient#setLink:member(1)"
+  headingLevel={3}
+/>
 
 ## Types
 

--- a/docs/source/api/core/ApolloClient.mdx
+++ b/docs/source/api/core/ApolloClient.mdx
@@ -110,6 +110,7 @@ For more information on the `defaultOptions` object, see the [Default Options](#
 <InterfaceDetails
   canonicalReference="@apollo/client!ApolloClient.Options:interface"
   headingLevel={3}
+  displayName="ApolloClient.Options"
   customPropertyOrder={[
     "cache",
     "link",
@@ -124,6 +125,7 @@ For more information on the `defaultOptions` object, see the [Default Options](#
 <InterfaceDetails
   canonicalReference="@apollo/client!ApolloClient.DefaultOptions:interface"
   headingLevel={3}
+  displayName="ApolloClient.DefaultOptions"
 />
 
 ##### Example `defaultOptions` object

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -1418,6 +1418,14 @@ export class ApolloClient {
 
   /**
    * Exposes the cache's complete state, in a serializable format for later restoration.
+   *
+   * @remarks
+   *
+   * This can be useful for debugging in order to inspect the full state of the
+   * cache.
+   *
+   * @param optimistic - Determines whether the result contains data from the
+   * optimistic layer
    */
   public extract(optimistic?: boolean) {
     return this.cache.extract(optimistic);

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -118,7 +118,7 @@ export declare namespace ApolloClient {
      *
      * @since 3.11.0
      */
-    devtools?: DevtoolsOptions;
+    devtools?: ApolloClient.DevtoolsOptions;
 
     /**
      * Determines if data masking is enabled for the client.

--- a/src/utilities/caching/sizes.ts
+++ b/src/utilities/caching/sizes.ts
@@ -211,9 +211,6 @@ export interface CacheSizes {
   /**
    * Cache size for the `maybeBroadcastWatch` method on [`InMemoryCache`](https://github.com/apollographql/apollo-client/blob/main/src/cache/inmemory/inMemoryCache.ts).
    *
-   * Note: `maybeBroadcastWatch` will be set to the `resultCacheMaxSize` option and
-   * will fall back to this configuration value if the option is not set.
-   *
    * @defaultValue
    * Defaults to `5000`.
    *
@@ -228,10 +225,6 @@ export interface CacheSizes {
   /**
    * Cache size for the `executeSelectionSet` method on [`StoreReader`](https://github.com/apollographql/apollo-client/blob/main/src/cache/inmemory/readFromStore.ts).
    *
-   * Note:
-   * `executeSelectionSet` will be set to the `resultCacheMaxSize` option and
-   * will fall back to this configuration value if the option is not set.
-   *
    * @defaultValue
    * Defaults to `50000`.
    *
@@ -242,10 +235,6 @@ export interface CacheSizes {
   "inMemoryCache.executeSelectionSet": number;
   /**
    * Cache size for the `executeSubSelectedArray` method on [`StoreReader`](https://github.com/apollographql/apollo-client/blob/main/src/cache/inmemory/readFromStore.ts).
-   *
-   * Note:
-   * `executeSubSelectedArray` will be set to the `resultCacheMaxSize` option and
-   * will fall back to this configuration value if the option is not set.
    *
    * @defaultValue
    * Defaults to `10000`.


### PR DESCRIPTION
Found this while working on https://github.com/apollographql/apollo-client-devtools/pull/1607