### PR TITLE
Support `skipToken` with `useQuery`

### DIFF
--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -682,14 +682,32 @@ export function useQuery<TData = unknown, TVariables extends OperationVariables 
 }): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial">;
 
 // @public
+export function useQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken): useQuery.Result<TData, TVariables, "empty", Record<string, never>>;
+
+// @public
+export function useQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
+    returnPartialData: true;
+})): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial", Partial<TVariables>>;
+
+// @public
 export function useQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
     returnPartialData: boolean;
 }): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial">;
 
 // @public
+export function useQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
+    returnPartialData: boolean;
+})): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial", Partial<TVariables>>;
+
+// @public
 export function useQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
 options?: useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>
 ] : [options: useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>]): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming">;
+
+// @public
+export function useQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
+options?: SkipToken | useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>
+] : [options: SkipToken | useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>]): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming", Partial<TVariables>>;
 
 // @public (undocumented)
 export namespace useQuery {
@@ -715,7 +733,7 @@ export namespace useQuery {
     // (undocumented)
     export namespace Base {
         // (undocumented)
-        export interface Result<TData = unknown, TVariables extends OperationVariables = OperationVariables> {
+        export interface Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TReturnVariables extends OperationVariables = TVariables> {
             client: ApolloClient;
             error?: ErrorLike;
             fetchMore: <TFetchData = TData, TFetchVars extends OperationVariables = TVariables>(fetchMoreOptions: ObservableQuery.FetchMoreOptions<TData, TVariables, TFetchData, TFetchVars>) => Promise<ApolloClient.QueryResult<MaybeMasked_2<TFetchData>>>;
@@ -728,7 +746,7 @@ export namespace useQuery {
             stopPolling: () => void;
             subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
             updateQuery: (mapFn: UpdateQueryMapFn<TData, TVariables>) => void;
-            variables: TVariables;
+            variables: TReturnVariables;
         }
     }
     // (undocumented)
@@ -756,7 +774,7 @@ export namespace useQuery {
     // (undocumented)
     export type Options<TData = unknown, TVariables extends OperationVariables = OperationVariables> = Base.Options<TData, TVariables> & VariablesOption<TVariables>;
     // (undocumented)
-    export type Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"]> = Base.Result<TData, TVariables> & GetDataState<MaybeMasked_2<TData>, TStates>;
+    export type Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"], TReturnVariables extends OperationVariables = TVariables> = Base.Result<TData, TVariables, TReturnVariables> & GetDataState<MaybeMasked_2<TData>, TStates>;
 }
 
 // @public (undocumented)

--- a/.changeset/tame-grapes-kiss.md
+++ b/.changeset/tame-grapes-kiss.md
@@ -1,0 +1,13 @@
+---
+"@apollo/client": patch
+---
+
+Support `skipToken` with `useQuery` to skip execution.
+
+```ts
+import { skipToken, useQuery } from "@apollo/client/react"
+
+// Use `skipToken` in place of `skip: true` for better type safety
+// for required variables
+const { data } = useQuery(QUERY, id ? { variables: { id } } : skipToken);
+```

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43867,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38749,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33600,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27651
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 43807,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 38705,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33582,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27649
 }

--- a/docs/source/api/react/skipToken.mdx
+++ b/docs/source/api/react/skipToken.mdx
@@ -7,8 +7,14 @@ description: Apollo Client API reference
 
 ## `skipToken`
 
-`skipToken` provides a type-safe mechanism to skip query execution. It is currently supported with `useSuspenseQuery` and `useBackgroundQuery`.
+`skipToken` provides a type-safe mechanism to skip query execution. It is currently supported with `useQuery`, `useSuspenseQuery` and `useBackgroundQuery`.
 When you pass a `skipToken` to one of the supported hooks instead of the `options` object, the hook will not cause any requests or suspenseful behavior and keeps the last `data` available. It is typically used conditionally to start query execution when the input data is available.
+
+```js title="Recommended usage of skipToken with useQuery"
+import { skipToken, useQuery } from "@apollo/client/react";
+
+const { data } = useQuery(query, id ? { variables: { id } } : skipToken);
+```
 
 ```js title="Recommended usage of skipToken with useSuspenseQuery"
 import { skipToken, useSuspenseQuery } from "@apollo/client/react";
@@ -26,9 +32,7 @@ const [queryRef] = useBackgroundQuery(
 );
 ```
 
-<blockquote>
-
-Note: **Why do we recommend `skipToken` over `{ skip: true }`?**
+### Why do we recommend `skipToken` over `{ skip: true }`?
 
 Imagine this very common scenario for `skip`: You want to skip your query if a certain required variable is not set. You might be tempted to write something like this:
 
@@ -76,5 +80,3 @@ const { data } = useSuspenseQuery(
 ```
 
 Here it becomes apparent for TypeScript that there is a direct connection between skipping and the `variables` option - and it will work without unsafe workarounds.
-
-</blockquote>

--- a/docs/source/data/queries.mdx
+++ b/docs/source/data/queries.mdx
@@ -799,6 +799,64 @@ Uses the same logic as `cache-first`, except this query does _not_ automatically
 </tbody>
 </table>
 
+<MinVersion version="4.0.4">
+
+## Skipping queries with `skipToken`
+
+</MinVersion>
+
+`skipToken` provides a type-safe mechanism to skip query execution. When you pass `skipToken` to `useQuery` instead of the options object, the hook will not execute the query and keeps the last `data` available. It is typically used conditionally to start query execution when the input data is available.
+
+```js title="Recommended usage of skipToken with useQuery"
+import { skipToken, useQuery } from "@apollo/client/react";
+
+const { data } = useQuery(query, id ? { variables: { id } } : skipToken);
+```
+
+Imagine this common scenario: You want to skip your query if a certain required variable is not set. You might be tempted to write something like this:
+
+```ts
+const { data } = useQuery(query, {
+  variables: { id },
+  skip: !id,
+});
+```
+
+But in that case, TypeScript will complain:
+
+```
+Type 'number | undefined' is not assignable to type 'number'.
+      Type 'undefined' is not assignable to type 'number'.ts(2769)
+```
+
+To get around that, you have to tell TypeScript to ignore the fact that `id` could be `undefined`:
+
+```ts
+const { data } = useQuery(query, {
+  variables: { id: id! },
+  skip: !id,
+});
+```
+
+Alternatively, you could also use some obscure default value:
+
+```ts
+const { data } = useQuery(query, {
+  variables: { id: id || 0 },
+  skip: !id,
+});
+```
+
+Both of these solutions hide a potential bug. If your `skip` logic becomes more complex, you might accidentally introduce a bug that causes your query to execute, even when `id` is still `undefined`. In that case, TypeScript cannot warn you about it.
+
+Instead we recommend using `skipToken`. It provides type safety without the need for an obscure default value:
+
+```ts
+const { data } = useQuery(query, id ? { variables: { id } } : skipToken);
+```
+
+Here it becomes apparent for TypeScript that there is a direct connection between skipping and the `variables` option - and it will work without unsafe workarounds.
+
 ## `useQuery` API
 
 Supported options and result fields for the `useQuery` hook are listed below.

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -8192,11 +8192,12 @@ describe("useQuery Hook", () => {
       );
 
       using _disabledAct = disableActEnvironment();
-      const { takeSnapshot, rerender } = await renderHookToSnapshotStream(
+      const renderStream = await renderHookToSnapshotStream(
         ({ skip, variables }) =>
           useQuery(query, skip ? skipToken : { variables }),
         { wrapper, initialProps: { skip: false, variables: undefined as any } }
       );
+      const { takeSnapshot, rerender } = renderStream;
 
       await expect(takeSnapshot()).resolves.toStrictEqualTyped({
         data: undefined,
@@ -8218,14 +8219,8 @@ describe("useQuery Hook", () => {
 
       await rerender({ skip: true, variables: { someVar: true } });
 
-      await expect(takeSnapshot()).resolves.toStrictEqualTyped({
-        data: undefined,
-        dataState: "empty",
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        previousData: { hello: "world" },
-        variables: { someVar: true },
-      });
+      // new variables aren't applied yet so we see the same value returned
+      await expect(renderStream).toRerenderWithSimilarSnapshot();
 
       expect(linkFn).toHaveBeenCalledTimes(1);
     });

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -13986,6 +13986,13 @@ describe.skip("Type Tests", () => {
     useQuery(query, { variables: {} });
     useQuery(query, { variables: { foo: "bar" } });
     useQuery(query, { variables: { bar: "baz" } });
+
+    let skip!: boolean;
+    useQuery(query, skip ? skipToken : undefined);
+    useQuery(query, skip ? skipToken : {});
+    useQuery(query, skip ? skipToken : { variables: {} });
+    useQuery(query, skip ? skipToken : { variables: { foo: "bar" } });
+    useQuery(query, skip ? skipToken : { variables: { bar: "baz" } });
   });
 
   test("variables are optional and can be anything with unspecified TVariables on a TypedDocumentNode", () => {
@@ -13996,6 +14003,13 @@ describe.skip("Type Tests", () => {
     useQuery(query, { variables: {} });
     useQuery(query, { variables: { foo: "bar" } });
     useQuery(query, { variables: { bar: "baz" } });
+
+    let skip!: boolean;
+    useQuery(query, skip ? skipToken : undefined);
+    useQuery(query, skip ? skipToken : {});
+    useQuery(query, skip ? skipToken : { variables: {} });
+    useQuery(query, skip ? skipToken : { variables: { foo: "bar" } });
+    useQuery(query, skip ? skipToken : { variables: { bar: "baz" } });
   });
 
   test("variables are optional when TVariables are empty", () => {
@@ -14013,6 +14027,16 @@ describe.skip("Type Tests", () => {
         foo: "bar",
       },
     });
+
+    let skip!: boolean;
+    useQuery(query, skip ? skipToken : undefined);
+    useQuery(query, skip ? skipToken : {});
+    useQuery(query, skip ? skipToken : { variables: {} });
+    useQuery(
+      query,
+      // @ts-expect-error unknown variables
+      skip ? skipToken : { variables: { foo: "bar" } }
+    );
   });
 
   test("is invalid when TVariables is `never`", () => {
@@ -14036,6 +14060,30 @@ describe.skip("Type Tests", () => {
         foo: "bar",
       },
     });
+
+    let skip!: boolean;
+    // @ts-expect-error
+    useQuery(query, skip ? skipToken : undefined);
+    useQuery(
+      query,
+      // @ts-expect-error
+      skip ? skipToken : {}
+    );
+    useQuery(
+      query,
+      // @ts-expect-error
+      skip ? skipToken : { variables: {} }
+    );
+    useQuery(
+      query,
+      // @ts-expect-error
+      skip ? skipToken : { variables: undefined }
+    );
+    useQuery(
+      query,
+      // @ts-expect-error unknown variables
+      skip ? skipToken : { variables: { foo: "bar" } }
+    );
   });
 
   test("optional variables are optional", () => {
@@ -14059,6 +14107,35 @@ describe.skip("Type Tests", () => {
         foo: "bar",
       },
     });
+
+    let skip!: boolean;
+    useQuery(query, skip ? skipToken : undefined);
+    useQuery(query, skip ? skipToken : {});
+    useQuery(query, skip ? skipToken : { variables: {} });
+    useQuery(query, skip ? skipToken : { variables: { limit: 10 } });
+    useQuery(
+      query,
+      skip ? skipToken : (
+        {
+          variables: {
+            // @ts-expect-error unknown variables
+            foo: "bar",
+          },
+        }
+      )
+    );
+    useQuery(
+      query,
+      skip ? skipToken : (
+        {
+          variables: {
+            limit: 10,
+            // @ts-expect-error unknown variables
+            foo: "bar",
+          },
+        }
+      )
+    );
   });
 
   test("enforces required variables when TVariables includes required variables", () => {
@@ -14085,6 +14162,44 @@ describe.skip("Type Tests", () => {
         foo: "bar",
       },
     });
+
+    let skip!: boolean;
+    // @ts-expect-error missing variables option
+    useQuery(query, skip ? skipToken : undefined);
+    useQuery(
+      query,
+      // @ts-expect-error missing variables option
+      skip ? skipToken : {}
+    );
+    useQuery(
+      query,
+      // @ts-expect-error missing required variables
+      skip ? skipToken : { variables: {} }
+    );
+    useQuery(query, skip ? skipToken : { variables: { id: "1" } });
+    useQuery(
+      query,
+      skip ? skipToken : (
+        {
+          variables: {
+            // @ts-expect-error unknown variables
+            foo: "bar",
+          },
+        }
+      )
+    );
+    useQuery(
+      query,
+      skip ? skipToken : (
+        {
+          variables: {
+            id: "1",
+            // @ts-expect-error unknown variables
+            foo: "bar",
+          },
+        }
+      )
+    );
   });
 
   test("requires variables with mixed TVariables", () => {
@@ -14120,5 +14235,61 @@ describe.skip("Type Tests", () => {
         foo: "bar",
       },
     });
+
+    let skip!: boolean;
+    // @ts-expect-error missing variables option
+    useQuery(query, skip ? skipToken : undefined);
+    useQuery(
+      query,
+      // @ts-expect-error missing variables option
+      skip ? skipToken : {}
+    );
+    useQuery(
+      query,
+      // @ts-expect-error missing required variables
+      skip ? skipToken : { variables: {} }
+    );
+    useQuery(query, skip ? skipToken : { variables: { id: "1" } });
+    useQuery(
+      query,
+      skip ? skipToken : { variables: { id: "1", language: "en" } }
+    );
+    useQuery(
+      query,
+      skip ? skipToken : (
+        {
+          variables: {
+            id: "1",
+            // @ts-expect-error unknown variables
+            foo: "bar",
+          },
+        }
+      )
+    );
+    useQuery(
+      query,
+      skip ? skipToken : (
+        {
+          variables: {
+            id: "1",
+            language: "en",
+            // @ts-expect-error unknown variables
+            foo: "bar",
+          },
+        }
+      )
+    );
+  });
+
+  test("always returns empty data/dataState with unconditional skipToken", () => {
+    const query: TypedDocumentNode<
+      { character: string },
+      { id: string; language?: string }
+    > = gql``;
+
+    const { data, dataState } = useQuery(query, skipToken);
+
+    expectTypeOf(data).toEqualTypeOf<undefined>();
+    expectTypeOf(dataState).toEqualTypeOf<"empty">();
   });
 });

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -8682,11 +8682,7 @@ describe("useQuery Hook", () => {
           ({ skip }) =>
             useQuery(
               query,
-              skip ? skipToken : (
-                {
-                  fetchPolicy: "cache-and-network",
-                }
-              )
+              skip ? skipToken : { fetchPolicy: "cache-and-network" }
             ),
           {
             initialProps: {

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -8676,8 +8676,6 @@ describe("useQuery Hook", () => {
         link,
       });
 
-      const correctInitialFetchPolicy: WatchQueryFetchPolicy = "cache-first";
-
       using _disabledAct = disableActEnvironment();
       const { takeSnapshot, getCurrentSnapshot, rerender } =
         await renderHookToSnapshotStream(

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -14285,9 +14285,10 @@ describe.skip("Type Tests", () => {
       { id: string; language?: string }
     > = gql``;
 
-    const { data, dataState } = useQuery(query, skipToken);
+    const { data, dataState, variables } = useQuery(query, skipToken);
 
     expectTypeOf(data).toEqualTypeOf<undefined>();
     expectTypeOf(dataState).toEqualTypeOf<"empty">();
+    expectTypeOf(variables).toEqualTypeOf<Record<string, never>>();
   });
 });

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -1706,7 +1706,7 @@ describe("useQuery Hook", () => {
       });
 
       using _disabledAct = disableActEnvironment();
-      const { takeSnapshot, rerender } = await renderHookToSnapshotStream(
+      const renderStream = await renderHookToSnapshotStream(
         ({ id, skip }) =>
           useQuery(query, skip ? skipToken : { variables: { id } }),
         {
@@ -1716,6 +1716,7 @@ describe("useQuery Hook", () => {
           ),
         }
       );
+      const { takeSnapshot, rerender } = renderStream;
 
       await expect(takeSnapshot()).resolves.toStrictEqualTyped({
         data: undefined,
@@ -1744,14 +1745,7 @@ describe("useQuery Hook", () => {
 
       await rerender({ id: 2, skip: true });
 
-      await expect(takeSnapshot()).resolves.toStrictEqualTyped({
-        data: undefined,
-        dataState: "empty",
-        loading: false,
-        networkStatus: NetworkStatus.ready,
-        previousData: { user: { __typename: "User", id: 1, name: "User 1" } },
-        variables: { id: 2 },
-      });
+      await expect(renderStream).toRerenderWithSimilarSnapshot();
 
       client.writeQuery({
         query,

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -518,6 +518,8 @@ function useOptions<TData, TVariables extends OperationVariables>(
       mergeOptions(defaultOptions, { ...options, query });
 
     if (options.skip) {
+      watchQueryOptions.initialFetchPolicy =
+        options.initialFetchPolicy || options.fetchPolicy;
       watchQueryOptions.fetchPolicy = "standby";
     }
 


### PR DESCRIPTION
Closes #11524

Add support for `skipToken` with `useQuery`. 