### PR TITLE
Fix an issue when `invariant` is called by external libraries when no dev error message handler is loaded.

### DIFF
--- a/.changeset/rare-months-camp.md
+++ b/.changeset/rare-months-camp.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix an issue when `invariant` is called by external libraries when no dev error message handler is loaded.

--- a/src/utilities/invariant/index.ts
+++ b/src/utilities/invariant/index.ts
@@ -122,6 +122,12 @@ function getFallbackErrorMsg(
   messageArgs: unknown[] = []
 ) {
   if (!message) return;
+  if (typeof message === "string") {
+    return messageArgs.reduce<string>(
+      (msg, arg) => msg.replace(/%[sdfo]/, stringify(arg)),
+      message
+    );
+  }
   return `An error occurred! For more details, see the full error text at https://go.apollo.dev/c/err#${encodeURIComponent(
     JSON.stringify({
       version,


### PR DESCRIPTION
This fixes an error when `invariant` is called by external libraries and no dev error message handler is loaded.

As in that case, `message` will be a string and not a compiled-away number, error messages for invariant violations would now look like this, including a link:

> Invariant Violation: An error occurred! For more details, see the full error text at https://go.apollo.dev/c/err#%7B%22version%22%3A%224.0.0%22%2C%22message%22%3A%22No%20apolloClientTransport%20defined%20on%20router%20context%22%2C%22args%22%3A%5B%5D%7D

For one, our error page couldn't display that (fixed now), but also creating the link in the first place didn't make a lot of sense, since that string message could also just be printed out in the error message.