### PR TITLE
Create mechanism to add experimental features to Apollo Client

### DIFF
--- a/.changeset/olive-queens-fold.md
+++ b/.changeset/olive-queens-fold.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Create mechanism to add experimental features to Apollo Client

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -132,6 +132,8 @@ export declare namespace ApolloClient {
      * queries.
      */
     incrementalHandler?: Incremental.Handler<any>;
+
+    experiments?: ApolloClient.Experiment[];
   }
 
   interface DevtoolsOptions {
@@ -610,6 +612,10 @@ export declare namespace ApolloClient {
       variables?: TVariables;
     }
   }
+
+  export interface Experiment {
+    (this: ApolloClient, options: ApolloClient.Options): void;
+  }
 }
 
 /**
@@ -708,6 +714,7 @@ export class ApolloClient {
       dataMasking,
       link,
       incrementalHandler = new NotImplementedHandler(),
+      experiments = [],
     } = options;
 
     this.link = link;
@@ -759,6 +766,8 @@ export class ApolloClient {
     }
 
     if (this.devtoolsConfig.enabled) this.connectToDevTools();
+
+    experiments.forEach((experiment) => experiment.call(this, options));
   }
 
   private connectToDevTools() {


### PR DESCRIPTION
This will allow to execute code in the constructor of Apollo Client, essentially allowing for us to modify anything, from overwriting methods, swapping out prototypes, overwriting hook behaviour etc.

These could be exposed as exports from `@apollo/client/experiments/name`, with usage like
```ts
import { throwOnErrorFieldAccess } from "@apollo/client/experiments/toe"
import { matchFragmentsByQueryManipulation } from "@apollo/client/experiments/noMorePossibleTypes"

export const client = new ApolloClient({
  link,
  cache,
  experiments: [throwOnErrorFieldAccess, matchFragmentsByQueryManipulation]
})