### PR TITLE
More robust handling of local state default value when read function is defined

### DIFF
--- a/.api-reports/api-report-cache.api.md
+++ b/.api-reports/api-report-cache.api.md
@@ -94,6 +94,7 @@ export abstract class ApolloCache {
     abstract removeOptimistic(id: string): void;
     // (undocumented)
     abstract reset(options?: Cache_2.ResetOptions): Promise<void>;
+    resolvesClientField?(typename: string, fieldName: string): boolean;
     abstract restore(serializedState: unknown): this;
     // (undocumented)
     transformDocument(document: DocumentNode): DocumentNode;
@@ -543,6 +544,8 @@ export class InMemoryCache extends ApolloCache {
     removeOptimistic(idToRemove: string): void;
     // (undocumented)
     reset(options?: Cache_2.ResetOptions): Promise<void>;
+    // (undocumented)
+    resolvesClientField(typename: string, fieldName: string): boolean;
     // (undocumented)
     restore(data: NormalizedCacheObject): this;
     // (undocumented)

--- a/.api-reports/api-report-local-state.api.md
+++ b/.api-reports/api-report-local-state.api.md
@@ -14,6 +14,7 @@ import type { NoInfer as NoInfer_2 } from '@apollo/client/utilities/internal';
 import type { OperationVariables } from '@apollo/client';
 import type { RemoveIndexSignature } from '@apollo/client/utilities/internal';
 import type { TypedDocumentNode } from '@apollo/client';
+import type { WatchQueryFetchPolicy } from '@apollo/client';
 
 // @public (undocumented)
 type InferContextValueFromResolvers<TResolvers> = TResolvers extends {
@@ -91,7 +92,7 @@ export class LocalState<TResolvers extends LocalState.Resolvers = LocalState.Res
     ]);
     addResolvers(resolvers: TResolvers): void;
     // (undocumented)
-    execute<TData = unknown, TVariables extends OperationVariables = OperationVariables>({ document, client, context, remoteResult, variables, onlyRunForcedResolvers, returnPartialData, }: {
+    execute<TData = unknown, TVariables extends OperationVariables = OperationVariables>({ document, client, context, remoteResult, variables, onlyRunForcedResolvers, returnPartialData, fetchPolicy, }: {
         document: DocumentNode | TypedDocumentNode<TData, TVariables>;
         client: ApolloClient;
         context: DefaultContext | undefined;
@@ -99,6 +100,7 @@ export class LocalState<TResolvers extends LocalState.Resolvers = LocalState.Res
         variables: TVariables | undefined;
         onlyRunForcedResolvers?: boolean;
         returnPartialData?: boolean;
+        fetchPolicy: WatchQueryFetchPolicy;
     }): Promise<FormattedExecutionResult<TData>>;
     // (undocumented)
     getExportedVariables<TVariables extends OperationVariables = OperationVariables>({ document, client, context, variables, }: {

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -95,6 +95,7 @@ export abstract class ApolloCache {
     abstract removeOptimistic(id: string): void;
     // (undocumented)
     abstract reset(options?: Cache_2.ResetOptions): Promise<void>;
+    resolvesClientField?(typename: string, fieldName: string): boolean;
     abstract restore(serializedState: unknown): this;
     // (undocumented)
     transformDocument(document: DocumentNode): DocumentNode;
@@ -1381,6 +1382,8 @@ export class InMemoryCache extends ApolloCache {
     // (undocumented)
     reset(options?: Cache_2.ResetOptions): Promise<void>;
     // (undocumented)
+    resolvesClientField(typename: string, fieldName: string): boolean;
+    // (undocumented)
     restore(data: NormalizedCacheObject): this;
     // (undocumented)
     retain(rootId: string, optimistic?: boolean): number;
@@ -1577,7 +1580,7 @@ class LocalState<TResolvers extends LocalState.Resolvers = LocalState.Resolvers<
     ]);
     addResolvers(resolvers: TResolvers): void;
     // (undocumented)
-    execute<TData = unknown, TVariables extends OperationVariables = OperationVariables>({ document, client, context, remoteResult, variables, onlyRunForcedResolvers, returnPartialData, }: {
+    execute<TData = unknown, TVariables extends OperationVariables = OperationVariables>({ document, client, context, remoteResult, variables, onlyRunForcedResolvers, returnPartialData, fetchPolicy, }: {
         document: DocumentNode | TypedDocumentNode<TData, TVariables>;
         client: ApolloClient;
         context: DefaultContext | undefined;
@@ -1585,6 +1588,7 @@ class LocalState<TResolvers extends LocalState.Resolvers = LocalState.Resolvers<
         variables: TVariables | undefined;
         onlyRunForcedResolvers?: boolean;
         returnPartialData?: boolean;
+        fetchPolicy: WatchQueryFetchPolicy;
     }): Promise<FormattedExecutionResult<TData>>;
     // (undocumented)
     getExportedVariables<TVariables extends OperationVariables = OperationVariables>({ document, client, context, variables, }: {
@@ -2723,9 +2727,9 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/core/ApolloClient.ts:362:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:368:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:180:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
-// src/local-state/LocalState.ts:147:5 - (ae-forgotten-export) The symbol "LocalState" needs to be exported by the entry point index.d.ts
-// src/local-state/LocalState.ts:200:7 - (ae-forgotten-export) The symbol "LocalState" needs to be exported by the entry point index.d.ts
-// src/local-state/LocalState.ts:243:7 - (ae-forgotten-export) The symbol "LocalState" needs to be exported by the entry point index.d.ts
+// src/local-state/LocalState.ts:149:5 - (ae-forgotten-export) The symbol "LocalState" needs to be exported by the entry point index.d.ts
+// src/local-state/LocalState.ts:202:7 - (ae-forgotten-export) The symbol "LocalState" needs to be exported by the entry point index.d.ts
+// src/local-state/LocalState.ts:245:7 - (ae-forgotten-export) The symbol "LocalState" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.changeset/flat-worms-notice.md
+++ b/.changeset/flat-worms-notice.md
@@ -1,0 +1,7 @@
+---
+"@apollo/client": minor
+---
+
+Don't set the fallback value of a `@client` field to `null` when a `read` function is defined. Instead the `read` function will be called with an `existing` value of `undefined` to allow default arguments to be used to set the returned value.
+
+When a `read` function is not defined nor is there a defined resolver for the field, warn and set the value to `null` only in that instance.

--- a/.changeset/perfect-crabs-smile.md
+++ b/.changeset/perfect-crabs-smile.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Ensure `LocalState` doesn't try to read from the cache when using a `no-cache` fetch policy.

--- a/.changeset/shaggy-islands-yell.md
+++ b/.changeset/shaggy-islands-yell.md
@@ -2,4 +2,4 @@
 "@apollo/client": patch
 ---
 
-Warn when using a `no-cache` fetch policy when a `@client` field resolves the value from the cache that defines a `read` function.
+Warn when using a `no-cache` fetch policy without a local resolver defined. `no-cache` queries do not read or write to the cache which meant `no-cache` queries are silently incomplete when the `@client` field value was handled by a cache `read` function.

--- a/.changeset/shaggy-islands-yell.md
+++ b/.changeset/shaggy-islands-yell.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Warn when using a `no-cache` fetch policy when a `@client` field resolves the value from the cache that defines a `read` function.

--- a/.changeset/unlucky-cooks-rhyme.md
+++ b/.changeset/unlucky-cooks-rhyme.md
@@ -2,6 +2,6 @@
 "@apollo/client": minor
 ---
 
-Add an abstract `resolvesClientField` function to `ApolloCache` that can be used by 3rd party caches to determine if it can resolve a `@client` field when a local resolver is not defined.
+Add an abstract `resolvesClientField` function to `ApolloCache` that can be used by caches to tell `LocalState` if it can resolve a `@client` field when a local resolver is not defined.
 
-`LocalState` will emit a warning and set a fallback value of `null` when `resolvesClientField` returns `false`, or isn't defined. Returning `true` from `resolvesClientField` signals that a mechanism in the cache will set the field value. In this case, `LocalState` won't set the field so that `undefined` is used as the initial value.
+`LocalState` will emit a warning and set a fallback value of `null` when no local resolver is defined and `resolvesClientField` returns `false`, or isn't defined. Returning `true` from `resolvesClientField` signals that a mechanism in the cache will set the field value. In this case, `LocalState` won't set the field value.

--- a/.changeset/unlucky-cooks-rhyme.md
+++ b/.changeset/unlucky-cooks-rhyme.md
@@ -1,0 +1,7 @@
+---
+"@apollo/client": minor
+---
+
+Add an abstract `resolvesClientField` function to `ApolloCache` that can be used by 3rd party caches to determine if it can resolve a `@client` field when a local resolver is not defined.
+
+`LocalState` will emit a warning and set a fallback value of `null` when `resolvesClientField` returns `false`, or isn't defined. Returning `true` from `resolvesClientField` signals that a mechanism in the cache will set the field value. In this case, `LocalState` won't set the field so that `undefined` is used as the initial value.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 44693,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 44753,
   "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 39420,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33834,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33901,
   "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27727
 }

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 44542,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 39461,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33696,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27707
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 44693,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 39420,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33834,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27727
 }

--- a/src/__tests__/local-state/general.ts
+++ b/src/__tests__/local-state/general.ts
@@ -1522,13 +1522,13 @@ test.each(["cache-first", "network-only"] as const)(
   "sets existing value of `@client` field to undefined when read function is present",
   async (fetchPolicy) => {
     const query = gql`
-    query GetUser {
-      user {
-        firstName @client
-        lastName
+      query GetUser {
+        user {
+          firstName @client
+          lastName
+        }
       }
-    }
-  `;
+    `;
 
     const read = jest.fn((value = "Fallback") => value);
     const client = new ApolloClient({

--- a/src/__tests__/local-state/general.ts
+++ b/src/__tests__/local-state/general.ts
@@ -1557,7 +1557,8 @@ test.each(["cache-first", "network-only"] as const)(
   }
 );
 
-test("sets existing value of `@client` field to null when using no-cache with read function", async () => {
+test("sets existing value of `@client` field to null and warns when using no-cache with read function", async () => {
+  using _ = spyOnConsole("warn");
   const query = gql`
     query GetUser {
       user {
@@ -1597,9 +1598,15 @@ test("sets existing value of `@client` field to null when using no-cache with re
   });
 
   expect(read).not.toHaveBeenCalled();
+  expect(console.warn).toHaveBeenCalledTimes(1);
+  expect(console.warn).toHaveBeenCalledWith(
+    "The '%s' field resolves the value from the cache, but a 'no-cache' fetch policy was used. The field value has been set to `null`. Either define a local resolver or use a fetch policy that uses the cache to ensure the field is resolved correctly.",
+    "User.firstName"
+  );
 });
 
-test("sets existing value of `@client` field to null when merge function is present", async () => {
+test("sets existing value of `@client` field to null and warns when merge function but not read function is present", async () => {
+  using _ = spyOnConsole("warn");
   const query = gql`
     query GetUser {
       user {
@@ -1642,4 +1649,10 @@ test("sets existing value of `@client` field to null when merge function is pres
 
   expect(merge).toHaveBeenCalledTimes(1);
   expect(merge).toHaveBeenCalledWith(undefined, null, expect.anything());
+
+  expect(console.warn).toHaveBeenCalledTimes(1);
+  expect(console.warn).toHaveBeenCalledWith(
+    "Could not find a resolver or the cache doesn't resolve the '%s' field. The field value has been set to `null`.",
+    "User.firstName"
+  );
 });

--- a/src/__tests__/local-state/general.ts
+++ b/src/__tests__/local-state/general.ts
@@ -1530,7 +1530,7 @@ test.each(["cache-first", "network-only"] as const)(
     }
   `;
 
-    const read = jest.fn((value) => value ?? null);
+    const read = jest.fn((value = "Fallback") => value);
     const client = new ApolloClient({
       cache: new InMemoryCache({
         typePolicies: {
@@ -1555,7 +1555,7 @@ test.each(["cache-first", "network-only"] as const)(
       client.query({ query, fetchPolicy })
     ).resolves.toStrictEqualTyped({
       data: {
-        user: { __typename: "User", firstName: null, lastName: "Smith" },
+        user: { __typename: "User", firstName: "Fallback", lastName: "Smith" },
       },
     });
 
@@ -1575,7 +1575,7 @@ test("sets existing value of `@client` field to null and warns when using no-cac
     }
   `;
 
-  const read = jest.fn((value) => value ?? null);
+  const read = jest.fn((value) => value ?? "Fallback");
   const client = new ApolloClient({
     cache: new InMemoryCache({
       typePolicies: {

--- a/src/__tests__/local-state/general.ts
+++ b/src/__tests__/local-state/general.ts
@@ -26,6 +26,13 @@ import {
 } from "@apollo/client/testing/internal";
 import { InvariantError } from "@apollo/client/utilities/invariant";
 
+const WARNINGS = {
+  MISSING_RESOLVER:
+    "Could not find a resolver for the '%s' field nor does the cache resolve the field. The field value has been set to `null`. Either define a resolver for the field or ensure the cache can resolve the value, for example, by adding a 'read' function to a field policy in 'InMemoryCache'.",
+  NO_CACHE:
+    "The '%s' field resolves the value from the cache, for example from a 'read' function, but a 'no-cache' fetch policy was used. The field value has been set to `null`. Either define a local resolver or use a fetch policy that uses the cache to ensure the field is resolved correctly.",
+};
+
 describe("General functionality", () => {
   test("should not impact normal non-@client use", async () => {
     const query = gql`
@@ -1600,7 +1607,7 @@ test("sets existing value of `@client` field to null and warns when using no-cac
   expect(read).not.toHaveBeenCalled();
   expect(console.warn).toHaveBeenCalledTimes(1);
   expect(console.warn).toHaveBeenCalledWith(
-    "The '%s' field resolves the value from the cache, but a 'no-cache' fetch policy was used. The field value has been set to `null`. Either define a local resolver or use a fetch policy that uses the cache to ensure the field is resolved correctly.",
+    WARNINGS.NO_CACHE,
     "User.firstName"
   );
 });
@@ -1652,7 +1659,7 @@ test("sets existing value of `@client` field to null and warns when merge functi
 
   expect(console.warn).toHaveBeenCalledTimes(1);
   expect(console.warn).toHaveBeenCalledWith(
-    "Could not find a resolver or the cache doesn't resolve the '%s' field. The field value has been set to `null`.",
+    WARNINGS.MISSING_RESOLVER,
     "User.firstName"
   );
 });

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -178,6 +178,28 @@ export abstract class ApolloCache {
     return null;
   }
 
+  // Local state API
+
+  /**
+   * Determines whether a `@client` field can be resolved by the cache. Used
+   * when `LocalState` does not have a local resolver that can resolve the
+   * field.
+   *
+   * @remarks Cache implementations should return `true` if a mechanism in the
+   * cache is expected to provide a value for the field. `LocalState` will set
+   * the value of the field to `undefined` in order for the cache to handle it.
+   *
+   * Cache implementations should return `false` to indicate that it cannot
+   * handle resolving the field (either because it doesn't have a mechanism to
+   * do so, or because the user hasn't provided enough information to resolve
+   * the field). Returning `false` will emit a warning and set the value of the
+   * field to `null`.
+   *
+   * A cache that doesn't implement `resolvesClientField` will be treated the
+   * same as returning `false`.
+   */
+  public resolvesClientField?(typename: string, fieldName: string): boolean;
+
   // Transactional API
 
   // The batch method is intended to replace/subsume both performTransaction

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -530,6 +530,10 @@ export class InMemoryCache extends ApolloCache {
     return this.config.fragments?.lookup(fragmentName) || null;
   }
 
+  public resolvesClientField(typename: string, fieldName: string): boolean {
+    return !!this.policies.getReadFunction(typename, fieldName);
+  }
+
   protected broadcastWatches(options?: BroadcastOptions) {
     if (!this.txCount) {
       this.watches.forEach((c) => this.maybeBroadcastWatch(c, options));

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -331,6 +331,7 @@ export class QueryManager {
           optimisticResponse: isOptimistic ? optimisticResponse : void 0,
         },
         variables,
+        fetchPolicy,
         {},
         false
       )
@@ -748,7 +749,7 @@ export class QueryManager {
   ): SubscriptionObservable<ApolloClient.SubscribeResult<TData>> {
     let { query, variables } = options;
     const {
-      fetchPolicy,
+      fetchPolicy = "cache-first",
       errorPolicy = "none",
       context = {},
       extensions = {},
@@ -785,6 +786,7 @@ export class QueryManager {
           query,
           context,
           variables,
+          fetchPolicy,
           extensions
         );
 
@@ -864,7 +866,8 @@ export class QueryManager {
   private getObservableFromLink<TData = unknown>(
     query: DocumentNode,
     context: DefaultContext | undefined,
-    variables?: OperationVariables,
+    variables: OperationVariables,
+    fetchPolicy: WatchQueryFetchPolicy,
     extensions?: Record<string, any>,
     // Prefer context.queryDeduplication if specified.
     deduplication: boolean = context?.queryDeduplication ??
@@ -994,6 +997,7 @@ export class QueryManager {
               remoteResult: result as FormattedExecutionResult<TData>,
               context,
               variables,
+              fetchPolicy,
             })
           );
         })
@@ -1041,7 +1045,8 @@ export class QueryManager {
     return this.getObservableFromLink<TData>(
       linkDocument,
       options.context,
-      options.variables
+      options.variables,
+      options.fetchPolicy
     ).observable.pipe(
       map((incoming) => {
         // Use linkDocument rather than queryInfo.document so the
@@ -1602,6 +1607,7 @@ export class QueryManager {
             variables,
             onlyRunForcedResolvers: true,
             returnPartialData: true,
+            fetchPolicy,
           }).then(
             (resolved): QueryNotification.FromCache<TData> => ({
               kind: "N",

--- a/src/local-state/LocalState.ts
+++ b/src/local-state/LocalState.ts
@@ -726,11 +726,11 @@ export class LocalState<
                 resolverName
               );
               return null;
-            } else {
-              // assume the cache will handle returning the correct value
-              returnPartialData = true;
-              return;
             }
+
+            // assume the cache will handle returning the correct value
+            returnPartialData = true;
+            return;
           }
 
           if (!returnPartialData) {

--- a/src/local-state/LocalState.ts
+++ b/src/local-state/LocalState.ts
@@ -722,7 +722,7 @@ export class LocalState<
           if (cache.resolvesClientField?.(typename, fieldName)) {
             if (fetchPolicy === "no-cache") {
               invariant.warn(
-                "The '%s' field resolves the value from the cache, but a 'no-cache' fetch policy was used. The field value has been set to `null`. Either define a local resolver or use a fetch policy that uses the cache to ensure the field is resolved correctly.",
+                "The '%s' field resolves the value from the cache, for example from a 'read' function, but a 'no-cache' fetch policy was used. The field value has been set to `null`. Either define a local resolver or use a fetch policy that uses the cache to ensure the field is resolved correctly.",
                 resolverName
               );
               return null;
@@ -735,7 +735,7 @@ export class LocalState<
 
           if (!returnPartialData) {
             invariant.warn(
-              "Could not find a resolver or the cache doesn't resolve the '%s' field. The field value has been set to `null`.",
+              "Could not find a resolver for the '%s' field nor does the cache resolve the field. The field value has been set to `null`. Either define a resolver for the field or ensure the cache can resolve the value, for example, by adding a 'read' function to a field policy in 'InMemoryCache'.",
               resolverName
             );
             return null;

--- a/src/local-state/LocalState.ts
+++ b/src/local-state/LocalState.ts
@@ -715,7 +715,7 @@ export class LocalState<
             isInMemoryCache(cache) &&
             cache.policies.getReadFunction(typename, fieldName)
           ) {
-            // assume the read function will handle writing the correct value
+            // assume the read function will handle returning the correct value
             returnPartialData = true;
             return;
           }

--- a/src/local-state/LocalState.ts
+++ b/src/local-state/LocalState.ts
@@ -712,14 +712,13 @@ export class LocalState<
         // Warn when a resolver is not defined.
       : (
         () => {
-          const { cache } = client;
           const fieldFromCache = getCacheResultAtPath(diff, path);
 
           if (fieldFromCache !== undefined) {
             return fieldFromCache;
           }
 
-          if (cache.resolvesClientField?.(typename, fieldName)) {
+          if (client.cache.resolvesClientField?.(typename, fieldName)) {
             if (fetchPolicy === "no-cache") {
               invariant.warn(
                 "The '%s' field resolves the value from the cache, for example from a 'read' function, but a 'no-cache' fetch policy was used. The field value has been set to `null`. Either define a local resolver or use a fetch policy that uses the cache to ensure the field is resolved correctly.",

--- a/src/local-state/LocalState.ts
+++ b/src/local-state/LocalState.ts
@@ -23,6 +23,7 @@ import type {
   InMemoryCache,
   OperationVariables,
   TypedDocumentNode,
+  WatchQueryFetchPolicy,
 } from "@apollo/client";
 import { cacheSlot } from "@apollo/client/cache";
 import { LocalStateError, toErrorLike } from "@apollo/client/errors";
@@ -64,6 +65,7 @@ interface ExecContext {
   exportedVariableDefs: Record<string, ExportedVariable>;
   diff: Cache.DiffResult<any>;
   returnPartialData: boolean;
+  fetchPolicy?: WatchQueryFetchPolicy;
 }
 
 /**
@@ -337,6 +339,7 @@ export class LocalState<
     variables = {} as TVariables,
     onlyRunForcedResolvers = false,
     returnPartialData = false,
+    fetchPolicy,
   }: {
     document: DocumentNode | TypedDocumentNode<TData, TVariables>;
     client: ApolloClient;
@@ -346,6 +349,7 @@ export class LocalState<
     variables: TVariables | undefined;
     onlyRunForcedResolvers?: boolean;
     returnPartialData?: boolean;
+    fetchPolicy: WatchQueryFetchPolicy;
   }): Promise<FormattedExecutionResult<TData>> {
     if (__DEV__) {
       invariant(
@@ -402,6 +406,7 @@ export class LocalState<
       exportedVariableDefs,
       diff,
       returnPartialData,
+      fetchPolicy,
     };
 
     const localResult = await this.resolveSelectionSet(
@@ -678,6 +683,7 @@ export class LocalState<
       operationDefinition,
       phase,
       onlyRunForcedResolvers,
+      fetchPolicy,
     } = execContext;
     let { returnPartialData } = execContext;
     const isRootField = parentSelectionSet === operationDefinition.selectionSet;
@@ -712,6 +718,7 @@ export class LocalState<
           }
 
           if (
+            fetchPolicy !== "no-cache" &&
             isInMemoryCache(cache) &&
             cache.policies.getReadFunction(typename, fieldName)
           ) {

--- a/src/local-state/LocalState.ts
+++ b/src/local-state/LocalState.ts
@@ -719,13 +719,18 @@ export class LocalState<
             return fieldFromCache;
           }
 
-          if (
-            fetchPolicy !== "no-cache" &&
-            cache.resolvesClientField?.(typename, fieldName)
-          ) {
-            // assume the cache will handle returning the correct value
-            returnPartialData = true;
-            return;
+          if (cache.resolvesClientField?.(typename, fieldName)) {
+            if (fetchPolicy === "no-cache") {
+              invariant.warn(
+                "The '%s' field resolves the value from the cache, but a 'no-cache' fetch policy was used. The field value has been set to `null`. Either define a local resolver or use a fetch policy that uses the cache to ensure the field is resolved correctly.",
+                resolverName
+              );
+              return null;
+            } else {
+              // assume the cache will handle returning the correct value
+              returnPartialData = true;
+              return;
+            }
           }
 
           if (!returnPartialData) {

--- a/src/local-state/LocalState.ts
+++ b/src/local-state/LocalState.ts
@@ -376,12 +376,15 @@ export class LocalState<
 
     const rootValue = remoteResult ? remoteResult.data : {};
 
-    const diff = client.cache.diff<Record<string, any>>({
-      query: toQueryOperation(document),
-      variables,
-      returnPartialData: true,
-      optimistic: false,
-    });
+    const diff: Cache.DiffResult<Record<string, any>> =
+      fetchPolicy === "no-cache" ?
+        { result: null, complete: false }
+      : client.cache.diff<Record<string, any>>({
+          query: toQueryOperation(document),
+          variables,
+          returnPartialData: true,
+          optimistic: false,
+        });
 
     const requestContext = { ...client.defaultContext, ...context };
     const execContext: ExecContext = {

--- a/src/local-state/__tests__/LocalState/aliases.test.ts
+++ b/src/local-state/__tests__/LocalState/aliases.test.ts
@@ -41,6 +41,7 @@ test("resolves @client fields mixed with aliased server fields", async () => {
       context: {},
       remoteResult,
       variables: {},
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: {
@@ -81,6 +82,7 @@ test("resolves aliased @client fields", async () => {
       context: {},
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: { fie: { bar: true, __typename: "Foo" } },
@@ -137,6 +139,7 @@ test("resolves deeply nested aliased @client fields", async () => {
       context: {},
       remoteResult,
       variables: {},
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: {
@@ -190,6 +193,7 @@ test("respects aliases for *nested fields* on the @client-tagged node", async ()
       context: {},
       remoteResult,
       variables: {},
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: {
@@ -231,6 +235,7 @@ test("does not confuse fields aliased to each other", async () => {
       context: {},
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: {
@@ -269,6 +274,7 @@ test("does not confuse fields aliased to each other with boolean values", async 
       context: {},
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: {

--- a/src/local-state/__tests__/LocalState/async.test.ts
+++ b/src/local-state/__tests__/LocalState/async.test.ts
@@ -33,6 +33,7 @@ test("supports async @client resolvers", async () => {
       context: {},
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: { isLoggedIn: true },
@@ -130,6 +131,7 @@ test("handles nested asynchronous @client resolvers", async () => {
       context: {},
       variables: { id: developerId },
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: {
@@ -201,6 +203,7 @@ test("supports async @client resolvers mixed with remotely resolved data", async
       context: {},
       variables: {},
       remoteResult,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: {

--- a/src/local-state/__tests__/LocalState/base.test.ts
+++ b/src/local-state/__tests__/LocalState/base.test.ts
@@ -34,6 +34,7 @@ test("runs resolvers for @client queries", async () => {
       context: {},
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: { foo: { __typename: "Foo", bar: true } },
@@ -69,6 +70,7 @@ test("can add resolvers after LocalState is instantiated", async () => {
       context: {},
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: { foo: { __typename: "Foo", bar: true } },
@@ -108,6 +110,7 @@ test("handles queries with a mix of @client and server fields", async () => {
       context: {},
       variables: {},
       remoteResult,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: {
@@ -165,6 +168,7 @@ test("runs resolvers for deeply nested @client fields", async () => {
       context: {},
       variables: {},
       remoteResult,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: {
@@ -214,6 +218,7 @@ test("has access to query variables in @client resolvers", async () => {
       context: {},
       variables: { id: 1 },
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: { foo: { __typename: "Foo", bar: 1 } },
@@ -266,6 +271,7 @@ test("combines local @client resolver results with server results, for the same 
       context: {},
       variables: {},
       remoteResult,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: {
@@ -309,6 +315,7 @@ test("handles resolvers that return booleans", async () => {
       context: {},
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: { isInCart: false },
@@ -351,6 +358,7 @@ test("does not run resolvers without @client directive", async () => {
       context: {},
       variables: {},
       remoteResult,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: {
@@ -405,6 +413,7 @@ test("does not run resolvers without @client directive with nested field", async
       context: {},
       variables: {},
       remoteResult,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: {
@@ -462,6 +471,7 @@ test("allows child resolvers from a parent resolved field from a local resolver"
       context: {},
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: {
@@ -518,6 +528,7 @@ test("can use remote result to resolve @client field", async () => {
       context: {},
       variables: {},
       remoteResult,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: {
@@ -567,6 +578,7 @@ test("throws error when query does not contain client fields", async () => {
       context: {},
       variables: {},
       remoteResult,
+      fetchPolicy: "cache-first",
     })
   ).rejects.toEqual(
     new InvariantError("Expected document to contain `@client` fields.")
@@ -595,6 +607,7 @@ test("does not warn when a resolver is missing for an `@client` field", async ()
       context: {},
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({ data: { foo: null } });
 
@@ -625,6 +638,7 @@ test("does not warn for client child fields of a server field", async () => {
       context: {},
       variables: {},
       remoteResult,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: { foo: { __typename: "Foo", bar: null } },
@@ -661,6 +675,7 @@ test("warns when a resolver returns undefined and sets value to null", async () 
       context: {},
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({ data: { foo: null } });
 
@@ -701,6 +716,7 @@ test("warns if a parent resolver omits a field with no child resolver", async ()
       context: {},
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: { foo: { __typename: "Foo", bar: true, baz: null } },
@@ -745,6 +761,7 @@ test("warns if a parent resolver omits a field and child has @client field", asy
       context: {},
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: { foo: { __typename: "Foo", bar: true, baz: null } },
@@ -791,6 +808,7 @@ test("adds an error when the __typename cannot be resolved", async () => {
       context: {},
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: { foo: null },
@@ -844,6 +862,7 @@ test("can return more data than needed in resolver which is accessible by child 
       context: {},
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: { foo: { __typename: "Foo", bar: "random" } },
@@ -882,6 +901,7 @@ test("does not execute child resolver when parent is null", async () => {
       context: {},
       variables: {},
       remoteResult,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: { currentUser: null },
@@ -929,6 +949,7 @@ test("does not execute root scalar resolver data when remote data returns null",
       context: {},
       variables: {},
       remoteResult,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: null,
@@ -979,6 +1000,7 @@ test("does not run object resolver when remote data returns null", async () => {
       context: {},
       variables: {},
       remoteResult,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: null,
@@ -1037,6 +1059,7 @@ test("does not run root resolvers when multiple client fields are defined when r
       context: {},
       variables: {},
       remoteResult,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: null,
@@ -1084,6 +1107,7 @@ test("does not execute resolver if client field is a child of a server field whe
       context: {},
       variables: {},
       remoteResult,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: null,

--- a/src/local-state/__tests__/LocalState/base.test.ts
+++ b/src/local-state/__tests__/LocalState/base.test.ts
@@ -6,6 +6,13 @@ import { InvariantError } from "@apollo/client/utilities/invariant";
 
 import { gql } from "./testUtils.js";
 
+const WARNINGS = {
+  MISSING_RESOLVER:
+    "Could not find a resolver for the '%s' field nor does the cache resolve the field. The field value has been set to `null`. Either define a resolver for the field or ensure the cache can resolve the value, for example, by adding a 'read' function to a field policy in 'InMemoryCache'.",
+  NO_CACHE:
+    "The '%s' field resolves the value from the cache, for example from a 'read' function, but a 'no-cache' fetch policy was used. The field value has been set to `null`. Either define a local resolver or use a fetch policy that uses the cache to ensure the field is resolved correctly.",
+};
+
 test("runs resolvers for @client queries", async () => {
   const document = gql`
     query Test {
@@ -613,7 +620,7 @@ test("warns and sets value to null when a resolver is missing for an `@client` f
 
   expect(console.warn).toHaveBeenCalledTimes(1);
   expect(console.warn).toHaveBeenCalledWith(
-    "Could not find a resolver or the cache doesn't resolve the '%s' field. The field value has been set to `null`.",
+    WARNINGS.MISSING_RESOLVER,
     "Query.foo"
   );
 });
@@ -689,7 +696,7 @@ test("warns and sets value to null for client child fields of a server field wit
 
   expect(console.warn).toHaveBeenCalledTimes(1);
   expect(console.warn).toHaveBeenCalledWith(
-    "Could not find a resolver or the cache doesn't resolve the '%s' field. The field value has been set to `null`.",
+    WARNINGS.MISSING_RESOLVER,
     "Foo.bar"
   );
 });
@@ -777,10 +784,7 @@ test("warns when using a no-cache query with a read function but no resolver fun
   ).resolves.toStrictEqualTyped({ data: { foo: null } });
 
   expect(console.warn).toHaveBeenCalledTimes(1);
-  expect(console.warn).toHaveBeenCalledWith(
-    "The '%s' field resolves the value from the cache, but a 'no-cache' fetch policy was used. The field value has been set to `null`. Either define a local resolver or use a fetch policy that uses the cache to ensure the field is resolved correctly.",
-    "Query.foo"
-  );
+  expect(console.warn).toHaveBeenCalledWith(WARNINGS.NO_CACHE, "Query.foo");
 });
 
 test("warns when using a no-cache query with a read function but no resolver function on child @client field", async () => {
@@ -824,10 +828,7 @@ test("warns when using a no-cache query with a read function but no resolver fun
   });
 
   expect(console.warn).toHaveBeenCalledTimes(1);
-  expect(console.warn).toHaveBeenCalledWith(
-    "The '%s' field resolves the value from the cache, but a 'no-cache' fetch policy was used. The field value has been set to `null`. Either define a local resolver or use a fetch policy that uses the cache to ensure the field is resolved correctly.",
-    "Foo.bar"
-  );
+  expect(console.warn).toHaveBeenCalledWith(WARNINGS.NO_CACHE, "Foo.bar");
 });
 
 test("warns when a resolver returns undefined and sets value to null", async () => {

--- a/src/local-state/__tests__/LocalState/base.test.ts
+++ b/src/local-state/__tests__/LocalState/base.test.ts
@@ -4,14 +4,7 @@ import { LocalState } from "@apollo/client/local-state";
 import { spyOnConsole } from "@apollo/client/testing/internal";
 import { InvariantError } from "@apollo/client/utilities/invariant";
 
-import { gql } from "./testUtils.js";
-
-const WARNINGS = {
-  MISSING_RESOLVER:
-    "Could not find a resolver for the '%s' field nor does the cache resolve the field. The field value has been set to `null`. Either define a resolver for the field or ensure the cache can resolve the value, for example, by adding a 'read' function to a field policy in 'InMemoryCache'.",
-  NO_CACHE:
-    "The '%s' field resolves the value from the cache, for example from a 'read' function, but a 'no-cache' fetch policy was used. The field value has been set to `null`. Either define a local resolver or use a fetch policy that uses the cache to ensure the field is resolved correctly.",
-};
+import { gql, WARNINGS } from "./testUtils.js";
 
 test("runs resolvers for @client queries", async () => {
   const document = gql`

--- a/src/local-state/__tests__/LocalState/cache.test.ts
+++ b/src/local-state/__tests__/LocalState/cache.test.ts
@@ -7,7 +7,7 @@ import {
 import { LocalState } from "@apollo/client/local-state";
 import { spyOnConsole } from "@apollo/client/testing/internal";
 
-import { gql } from "./testUtils.js";
+import { gql, WARNINGS } from "./testUtils.js";
 
 test("can write to the cache with a mutation", async () => {
   const query = gql`
@@ -345,7 +345,7 @@ test("handles read functions for root object field from cache if resolver is not
   });
 });
 
-test("does not warn if resolver is not defined if cache does not have value", async () => {
+test("warns if resolver or read function isn't defined if cache does not have value", async () => {
   using _ = spyOnConsole("warn");
   const document = gql`
     query {
@@ -371,7 +371,11 @@ test("does not warn if resolver is not defined if cache does not have value", as
     })
   ).resolves.toStrictEqualTyped({ data: { count: null } });
 
-  expect(console.warn).not.toHaveBeenCalled();
+  expect(console.warn).toHaveBeenCalledTimes(1);
+  expect(console.warn).toHaveBeenCalledWith(
+    WARNINGS.MISSING_RESOLVER,
+    "Query.count"
+  );
 });
 
 test("reads from the cache on a nested scalar field by default if a resolver is not defined", async () => {
@@ -723,7 +727,11 @@ test("does not confuse field missing resolver with root field of same name on a 
     },
   });
 
-  expect(console.warn).not.toHaveBeenCalled();
+  expect(console.warn).toHaveBeenCalledTimes(1);
+  expect(console.warn).toHaveBeenCalledWith(
+    WARNINGS.MISSING_RESOLVER,
+    "User.count"
+  );
 });
 
 test("does not confuse field missing resolver with root field of same name on a non-normalized record", async () => {
@@ -776,7 +784,11 @@ test("does not confuse field missing resolver with root field of same name on a 
     },
   });
 
-  expect(console.warn).not.toHaveBeenCalled();
+  expect(console.warn).toHaveBeenCalledTimes(1);
+  expect(console.warn).toHaveBeenCalledWith(
+    WARNINGS.MISSING_RESOLVER,
+    "User.count"
+  );
 });
 
 test("warns on undefined value if partial data is written to the cache for an object client field", async () => {

--- a/src/local-state/__tests__/LocalState/cache.test.ts
+++ b/src/local-state/__tests__/LocalState/cache.test.ts
@@ -45,6 +45,7 @@ test("can write to the cache with a mutation", async () => {
       context: {},
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({ data: { start: true } });
 
@@ -104,6 +105,7 @@ test("can write to the cache with a mutation using an ID", async () => {
       context: {},
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({ data: { start: true } });
 
@@ -174,6 +176,7 @@ test("does not overwrite __typename when writing to the cache with an id", async
       context: {},
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({ data: { start: true } });
 
@@ -214,6 +217,7 @@ test("reads from the cache on a root scalar field by default if a resolver is no
       context: {},
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({ data: { count: 10 } });
 });
@@ -253,6 +257,7 @@ test("reads from the cache on a root object field by default if a resolver is no
       context: {},
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: { user: { __typename: "User", id: 1, name: "Test User" } },
@@ -292,6 +297,7 @@ test("handles read functions for root scalar field from cache if resolver is not
       context: {},
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({ data: { count: 10 } });
 });
@@ -332,6 +338,7 @@ test("handles read functions for root object field from cache if resolver is not
       context: {},
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: { user: { __typename: "User", id: 1, name: "Test User" } },
@@ -360,6 +367,7 @@ test("does not warn if resolver is not defined if cache does not have value", as
       context: {},
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({ data: { count: null } });
 
@@ -401,6 +409,7 @@ test("reads from the cache on a nested scalar field by default if a resolver is 
       context: {},
       variables: {},
       remoteResult: { data: { user: { __typename: "User", id: 1 } } },
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: { user: { __typename: "User", id: 1, isLoggedIn: true } },
@@ -461,6 +470,7 @@ test("reads from the cache with a read function on a nested scalar field if a re
       remoteResult: {
         data: { user: { __typename: "User", id: 1 } },
       },
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: { user: { __typename: "User", id: 1, isLoggedIn: true } },
@@ -511,6 +521,7 @@ test("reads from the cache on a nested object field by default if a resolver is 
       remoteResult: {
         data: { user: { __typename: "User", id: 1 } },
       },
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: {
@@ -580,6 +591,7 @@ test("reads from the cache with a read function on a nested object field by defa
       remoteResult: {
         data: { user: { __typename: "User", id: 1 } },
       },
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: {
@@ -647,6 +659,7 @@ test("reads from the cache on a nested client field on a non-normalized object",
       remoteResult: {
         data: { user: { __typename: "User" } },
       },
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: {
@@ -697,6 +710,7 @@ test("does not confuse field missing resolver with root field of same name on a 
       remoteResult: {
         data: { user: { __typename: "User", id: 1 } },
       },
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: {
@@ -750,6 +764,7 @@ test("does not confuse field missing resolver with root field of same name on a 
       remoteResult: {
         data: { user: { __typename: "User" } },
       },
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: {
@@ -814,6 +829,7 @@ test("warns on undefined value if partial data is written to the cache for an ob
       remoteResult: {
         data: { user: { __typename: "User", id: 1 } },
       },
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: {
@@ -880,6 +896,7 @@ test("uses a written cache value from a nested client field from parent resolver
       context: {},
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: { user: { __typename: "User", id: 1, name: "Test User" } },

--- a/src/local-state/__tests__/LocalState/context.test.ts
+++ b/src/local-state/__tests__/LocalState/context.test.ts
@@ -34,6 +34,7 @@ test("passes client in context to resolvers", async () => {
       context: {},
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: { foo: { __typename: "Foo", bar: 1 } },
@@ -85,6 +86,7 @@ test("can access request context in resolvers", async () => {
       context: { id: 1 },
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: { foo: { __typename: "Foo", bar: 1 } },
@@ -134,6 +136,7 @@ test("can access phase in resolver context", async () => {
       context: {},
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: { foo: { __typename: "Foo", bar: "resolve" } },
@@ -174,6 +177,7 @@ test("can use custom context function used as request context", async () => {
       context: {},
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: { foo: { __typename: "Foo", bar: true } },
@@ -220,6 +224,7 @@ test("context function can merge request context and custom context", async () =
       context: { isRequestBarEnabled: true },
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: { foo: { __typename: "Foo", bar: true } },

--- a/src/local-state/__tests__/LocalState/errors.test.ts
+++ b/src/local-state/__tests__/LocalState/errors.test.ts
@@ -36,6 +36,7 @@ test("handles errors thrown in a resolver", async () => {
       context: {},
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: { foo: null },
@@ -88,6 +89,7 @@ test("handles errors thrown in a child resolver", async () => {
       context: {},
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: { foo: { __typename: "Foo", bar: null } },
@@ -146,6 +148,7 @@ test("adds errors for each field that throws errors", async () => {
       context: {},
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: { foo: { __typename: "Foo", bar: null, baz: null, qux: true } },
@@ -208,6 +211,7 @@ test("handles errors thrown in a child resolver from parent array", async () => 
       context: {},
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: {
@@ -283,6 +287,7 @@ test("handles errors thrown in a child resolver for an array from a single item"
       context: {},
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: {
@@ -339,6 +344,7 @@ test("serializes a thrown GraphQLError and merges extensions", async () => {
       context: {},
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: { foo: null },
@@ -393,6 +399,7 @@ test("overwrites localState extension from thrown GraphQLError if provided", asy
       context: {},
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: { foo: null },
@@ -452,6 +459,7 @@ test("concatenates client errors with server errors", async () => {
       context: {},
       variables: {},
       remoteResult,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: { foo: null, baz: { __typename: "Baz", qux: null } },
@@ -502,6 +510,7 @@ test("handles errors thrown in async resolvers", async () => {
       context: {},
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: { foo: null },
@@ -551,6 +560,7 @@ test("handles rejected promises returned in async resolvers", async () => {
       context: {},
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: { foo: null },
@@ -614,6 +624,7 @@ test("handles errors thrown for resolvers on fields inside fragments", async () 
       context: {},
       variables: {},
       remoteResult,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: {
@@ -671,6 +682,7 @@ test("handles remote errors with no local resolver errors", async () => {
       context: {},
       variables: {},
       remoteResult,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: {

--- a/src/local-state/__tests__/LocalState/forcedResolvers.test.ts
+++ b/src/local-state/__tests__/LocalState/forcedResolvers.test.ts
@@ -40,6 +40,7 @@ test("runs resolvers marked with @client(always: true)", async () => {
       context: {},
       variables: {},
       remoteResult: { data: client.readQuery({ query: document }) },
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: {
@@ -65,6 +66,7 @@ test("runs resolvers marked with @client(always: true)", async () => {
       context: {},
       variables: {},
       remoteResult: { data: client.readQuery({ query: document }) },
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: {
@@ -120,6 +122,7 @@ test("only runs forced resolvers for fields marked with `@client(always: true)`,
       variables: {},
       remoteResult: undefined,
       onlyRunForcedResolvers: true,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: { name: "John Smith", isLoggedIn: true },
@@ -185,6 +188,7 @@ test("runs nested forced resolvers from non-forced client descendant field", asy
       variables: {},
       remoteResult: undefined,
       onlyRunForcedResolvers: true,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: {
@@ -238,6 +242,7 @@ test("warns for client fields without cached data and resolvers when running for
       variables: {},
       remoteResult: { data: { user: { __typename: "User", id: 1 } } },
       onlyRunForcedResolvers: true,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     // Note: name is null because we are only running forced resolvers and

--- a/src/local-state/__tests__/LocalState/fragments.test.ts
+++ b/src/local-state/__tests__/LocalState/fragments.test.ts
@@ -52,6 +52,7 @@ test("handles @client fields inside fragments", async () => {
       context: {},
       variables: {},
       remoteResult,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: {
@@ -100,6 +101,7 @@ test("handles a mix of @client fields with fragments and server fields", async (
       context: {},
       variables: {},
       remoteResult,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: {
@@ -154,6 +156,7 @@ it("matches fragments with fragment conditions", async () => {
       context: {},
       variables: {},
       remoteResult,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: {
@@ -200,6 +203,7 @@ test("throws when cache does not implement fragmentMatches", async () => {
       context: {},
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).rejects.toEqual(
     new InvariantError(
@@ -240,6 +244,7 @@ test("does not traverse fragment when fragment spread type condition does not ma
       context: {},
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({ data: { foo: { __typename: "Foo" } } });
 });
@@ -277,6 +282,7 @@ test("can use a fragments on interface types defined by possibleTypes", async ()
       context: {},
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: {

--- a/src/local-state/__tests__/LocalState/partialData.test.ts
+++ b/src/local-state/__tests__/LocalState/partialData.test.ts
@@ -30,6 +30,7 @@ test("omits field and does not warn if resolver not defined when returnPartialDa
       variables: {},
       remoteResult: { data: { user: { __typename: "User", id: 1 } } },
       returnPartialData: true,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: { user: { __typename: "User", id: 1 } },
@@ -81,6 +82,7 @@ test("omits client fields without cached values when running forced resolvers wi
       remoteResult: { data: { user: { __typename: "User", id: 1 } } },
       returnPartialData: true,
       onlyRunForcedResolvers: true,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     // Note: name is omitted because we are only running forced resolvers and

--- a/src/local-state/__tests__/LocalState/rootValue.test.ts
+++ b/src/local-state/__tests__/LocalState/rootValue.test.ts
@@ -37,6 +37,7 @@ test("passes parent value as empty object to root resolver for client-only query
       context: {},
       variables: {},
       remoteResult: undefined,
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: { foo: { __typename: "Foo", bar: true } },
@@ -79,6 +80,7 @@ test("passes rootValue as remote result to root resolver when server fields are 
       context: {},
       variables: {},
       remoteResult: { data: { bar: { __typename: "Bar", baz: true } } },
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: {

--- a/src/local-state/__tests__/LocalState/subscriptions.test.ts
+++ b/src/local-state/__tests__/LocalState/subscriptions.test.ts
@@ -26,6 +26,7 @@ test("throws when given a subscription with no client fields", async () => {
       context: {},
       variables: {},
       remoteResult: { data: { field: 1 } },
+      fetchPolicy: "cache-first",
     })
   ).rejects.toEqual(
     new InvariantError("Expected document to contain `@client` fields.")
@@ -64,6 +65,7 @@ test("adds @client fields with subscription results", async () => {
       context: {},
       variables: {},
       remoteResult: { data: { field: 1 } },
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: { field: 1, count: 1 },
@@ -76,6 +78,7 @@ test("adds @client fields with subscription results", async () => {
       context: {},
       variables: {},
       remoteResult: { data: { field: 2 } },
+      fetchPolicy: "cache-first",
     })
   ).resolves.toStrictEqualTyped({
     data: { field: 2, count: 2 },

--- a/src/local-state/__tests__/LocalState/testUtils.ts
+++ b/src/local-state/__tests__/LocalState/testUtils.ts
@@ -4,3 +4,10 @@ import { addTypenameToDocument } from "@apollo/client/utilities";
 
 export const gql = (...args: Parameters<typeof origGql>) =>
   addTypenameToDocument(origGql(...args));
+
+export const WARNINGS = {
+  MISSING_RESOLVER:
+    "Could not find a resolver for the '%s' field nor does the cache resolve the field. The field value has been set to `null`. Either define a resolver for the field or ensure the cache can resolve the value, for example, by adding a 'read' function to a field policy in 'InMemoryCache'.",
+  NO_CACHE:
+    "The '%s' field resolves the value from the cache, for example from a 'read' function, but a 'no-cache' fetch policy was used. The field value has been set to `null`. Either define a local resolver or use a fetch policy that uses the cache to ensure the field is resolved correctly.",
+};


### PR DESCRIPTION
Closes #12930.

Better detect whether the cache can handle resolving a client field and warn if neither a local resolver or read function is defined. If a `read` function is defined, don't set a default value of `null` for the field to allow for the `read` function to set the value. This allows default parameters to work again.

This also adds a check for `no-cache` fetch policies and will warn if used with a `@client` field since the cache is not read. This fixes an issue where using a `no-cache` fetch policy would read from the cache to get the cache `diff` to resolve the field. 