### PR TITLE
Remove `ignoreResults` from MutationOptionsDocumentation and MutationResultDocumentation

### DIFF
--- a/src/react/types/types.documentation.ts
+++ b/src/react/types/types.documentation.ts
@@ -447,25 +447,12 @@ export interface MutationOptionsDocumentation {
    * @docGroup 1. Operation options
    */
   onError: unknown;
-  /**
-   * If `true`:
-   *
-   * - The initial state update (setting loading to true) is skipped
-   * - The success state update (setting data and setting loading to false) is skipped
-   * - Error updates will still occur
-   *
-   * The default value is `false`.
-   *
-   * This option is useful when you want to execute a mutation but don't need to track its progress or result in the UI, potentially improving performance by reducing re-renders.
-   *
-   * @docGroup 1. Operation options
-   */
-  ignoreResults: unknown;
 }
 
 export interface MutationResultDocumentation {
   /**
-   * The data returned from your mutation. Can be `undefined` if `ignoreResults` is `true`.
+   * The data returned from your mutation. Can be `undefined` if the `errorPolicy` is
+   * all`or`ignore`and the server returns a GraphQL response with`errors` but not`data` or a network error is returned.
    */
   data: unknown;
   /**

--- a/src/react/types/types.documentation.ts
+++ b/src/react/types/types.documentation.ts
@@ -451,8 +451,9 @@ export interface MutationOptionsDocumentation {
 
 export interface MutationResultDocumentation {
   /**
-   * The data returned from your mutation. Can be `undefined` if the `errorPolicy` is
-   * all`or`ignore`and the server returns a GraphQL response with`errors` but not`data` or a network error is returned.
+   * The data returned from your mutation. Can be `undefined` if the `errorPolicy`
+   * is `all` or `ignore` and the server returns a GraphQL response with `errors`
+   * but not `data` or a network error is returned.
    */
   data: unknown;
   /**


### PR DESCRIPTION
Those has been removed in v4