### PR TITLE
Filter `operationType` in payload of `GraphQLWsLink`

### DIFF
--- a/.changeset/healthy-jokes-sing.md
+++ b/.changeset/healthy-jokes-sing.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Don't send `operationType` in the payload sent by `GraphQLWsLink`.

--- a/src/link/subscriptions/index.ts
+++ b/src/link/subscriptions/index.ts
@@ -79,9 +79,9 @@ export class GraphQLWsLink extends ApolloLink {
     operation: ApolloLink.Operation
   ): Observable<ApolloLink.Result> {
     return new Observable((observer) => {
-      const { operationType, ...request } = operation;
+      const { query, variables, operationName, extensions } = operation;
       return this.client.subscribe<ApolloLink.Result>(
-        { ...request, query: print(operation.query) },
+        { variables, operationName, extensions, query: print(query) },
         {
           next: observer.next.bind(observer),
           complete: observer.complete.bind(observer),

--- a/src/link/subscriptions/index.ts
+++ b/src/link/subscriptions/index.ts
@@ -79,8 +79,9 @@ export class GraphQLWsLink extends ApolloLink {
     operation: ApolloLink.Operation
   ): Observable<ApolloLink.Result> {
     return new Observable((observer) => {
+      const { operationType, ...request } = operation;
       return this.client.subscribe<ApolloLink.Result>(
-        { ...operation, query: print(operation.query) },
+        { ...request, query: print(operation.query) },
         {
           next: observer.next.bind(observer),
           complete: observer.complete.bind(observer),


### PR DESCRIPTION
Fixes #12946

Removes the `operationType` key in the payload sent by `GraphQLWsLink` which was causing issues with HotChocolate.