### PR TITLE
chore: add `@deprecated` notice to `variableMatcher`

### DIFF
--- a/.api-reports/api-report-testing.api.md
+++ b/.api-reports/api-report-testing.api.md
@@ -1203,7 +1203,7 @@ export interface MockedResponse<out TData = Record<string, any>, out TVariables 
     result?: FetchResult<Unmasked<TData>> | ResultFunction<FetchResult<Unmasked<TData>>, TVariables>;
     // Warning: (ae-forgotten-export) The symbol "VariableMatcher" needs to be exported by the entry point index.d.ts
     //
-    // (undocumented)
+    // @deprecated (undocumented)
     variableMatcher?: VariableMatcher<TVariables>;
 }
 

--- a/.api-reports/api-report-testing_core.api.md
+++ b/.api-reports/api-report-testing_core.api.md
@@ -1158,7 +1158,7 @@ export interface MockedResponse<out TData = Record<string, any>, out TVariables 
     result?: FetchResult<Unmasked<TData>> | ResultFunction<FetchResult<Unmasked<TData>>, TVariables>;
     // Warning: (ae-forgotten-export) The symbol "VariableMatcher" needs to be exported by the entry point index.d.ts
     //
-    // (undocumented)
+    // @deprecated (undocumented)
     variableMatcher?: VariableMatcher<TVariables>;
 }
 

--- a/.changeset/silver-eggs-switch.md
+++ b/.changeset/silver-eggs-switch.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Add a deprecation message for the `variableMatcher` option in `MockLink`.

--- a/src/testing/core/mocking/mockLink.ts
+++ b/src/testing/core/mocking/mockLink.ts
@@ -49,6 +49,10 @@ export interface MockedResponse<
     | ResultFunction<FetchResult<Unmasked<TData>>, TVariables>;
   error?: Error;
   delay?: number;
+  /**
+   * @deprecated `variableMatcher` will be removed in Apollo Client 4.0. Please use the
+   * `request.variables` option with a callback function instead to get the same behavior.
+   */
   variableMatcher?: VariableMatcher<TVariables>;
   /**
    * @deprecated `newData` will be removed in Apollo Client 4.0. Please use the

--- a/src/testing/core/mocking/mockLink.ts
+++ b/src/testing/core/mocking/mockLink.ts
@@ -50,8 +50,17 @@ export interface MockedResponse<
   error?: Error;
   delay?: number;
   /**
-   * @deprecated `variableMatcher` will be removed in Apollo Client 4.0. Please use the
-   * `request.variables` option with a callback function instead to get the same behavior.
+   * @deprecated `variableMatcher` has been moved in Apollo Client 4.0. This
+   * option is safe to use in Apollo Client 3.x.
+   *
+   * **Recommended now**
+   *
+   * No action needed
+   *
+   * **When upgrading**
+   *
+   * Provide a callback function to `request.variables` to get the same
+   * behavior.
    */
   variableMatcher?: VariableMatcher<TVariables>;
   /**


### PR DESCRIPTION
`variableMatcher` was removed from `Mocklink.MockedResponse` on Apollo Client 4.0