### PR TITLE
Update `accept` header used with `GraphQL17Alpha9Handler`

### DIFF
--- a/.changeset/slimy-ducks-scream.md
+++ b/.changeset/slimy-ducks-scream.md
@@ -2,4 +2,4 @@
 "@apollo/client": patch
 ---
 
-Update the `accept` header used with the `GraphQL17Alpha9Handler` to `multipart/mixed;incrementalDeliverySpec=graphql/incremental/v0.1` to ensure the newest incremental delivery format is requested.
+Update the `accept` header used with the `GraphQL17Alpha9Handler` to `multipart/mixed;incrementalSpec=v0.2` to ensure the newest incremental delivery format is requested.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 44849,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 39477,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 44831,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 39452,
   "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 33875,
   "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 27756
 }

--- a/src/incremental/handlers/graphql17Alpha9.ts
+++ b/src/incremental/handlers/graphql17Alpha9.ts
@@ -259,8 +259,9 @@ export class GraphQL17Alpha9Handler
     if (hasDirectives(["defer", "stream"], request.query)) {
       const context = request.context ?? {};
       const http = (context.http ??= {});
+      // https://specs.apollo.dev/incremental/v0.2/
       http.accept = [
-        "multipart/mixed;incrementalDeliverySpec=graphql/incremental/v0.1",
+        "multipart/mixed;incrementalSpec=v0.2",
         ...(http.accept || []),
       ];
 

--- a/src/link/http/__tests__/HttpLink.ts
+++ b/src/link/http/__tests__/HttpLink.ts
@@ -1636,7 +1636,7 @@ describe("HttpLink", () => {
             headers: {
               "content-type": "application/json",
               accept:
-                "multipart/mixed;incrementalDeliverySpec=graphql/incremental/v0.1,application/graphql-response+json,application/json;q=0.9",
+                "multipart/mixed;incrementalSpec=v0.2,application/graphql-response+json,application/json;q=0.9",
             },
           })
         );
@@ -1744,7 +1744,7 @@ describe("HttpLink", () => {
             headers: {
               "content-type": "application/json",
               accept:
-                "multipart/mixed;incrementalDeliverySpec=graphql/incremental/v0.1,application/graphql-response+json,application/json;q=0.9",
+                "multipart/mixed;incrementalSpec=v0.2,application/graphql-response+json,application/json;q=0.9",
             },
           })
         );


### PR DESCRIPTION
Updates the header based on changes in https://github.com/apollographql/apollo-server/pull/8148