### PR TITLE
Remove outdated section in docs

### DIFF
--- a/docs/source/development-testing/reducing-bundle-size.mdx
+++ b/docs/source/development-testing/reducing-bundle-size.mdx
@@ -198,9 +198,3 @@ Apollo Client is more than a data fetcher. It's a normalized request and respons
 To build a similar experience with other libraries, you need to write custom logic, libraries, and component wrappers. Scaling this custom code to all your app components often creates a bundle larger than Apollo Client's.
 
 A custom implementation also means extra maintenance work for your team. By using Apollo Client, you hand off that ownership to a team specializing in GraphQL clients.
-
-### Legacy support
-
-Apollo Client v3 supports legacy JavaScript syntax. It also includes support for some now deprecated features. Similarly, v3 offers broad browser compatibility, extending back to IE11.
-
-The next major version will prioritize contemporary browser support. This transition will streamline the client by removing unnecessary polyfills and phasing out support for legacy syntax and features. Ultimately, these changes reduce bundle size but require a major version release.


### PR DESCRIPTION
Removes the "Legacy support" section on the [reducing bundle size](https://www.apollographql.com/docs/react/development-testing/reducing-bundle-size) doc which is no longer relevant to v4.