### PR TITLE
Add guidence for using the data masking jscodeshift/codemod migration

### DIFF
--- a/docs/source/data/fragments.mdx
+++ b/docs/source/data/fragments.mdx
@@ -1476,7 +1476,7 @@ This is rather tedious to do by hand for large applications. Apollo Client provi
      without the development-only warnings.
    </Note>
 
-The codemod supports `.js`, `.jsx`, `.ts`, `.tsx`, `.graphql`, and `.gql` files. For `.graphql` and `.gql` files, make sure to specify the file extensions to operate on explicitly.
+The codemod supports `.js`, `.jsx`, `.ts`, `.tsx`, `.graphql`, and `.gql` files. For `.graphql` and `.gql` files, explicitly specify the file extensions.
 
 ```sh
 npx jscodeshift -t ../path/to/apollo-client/scripts/codemods/data-masking/unmask.ts --extensions graphql ./src/**/*.graphql --mode migrate


### PR DESCRIPTION
Hello!

First contribution, was working in our private codebase on migrating over to the new data masking feature in 3.12— but I realized I'd never actually used `jscodeshift` on non-js files before (we use `*.graphql` files internally). The docs mentioned the code mod supports this migration, but mentioned a "graphql parser" I wasn't able to find reference to anywhere.

I was able to get the codemod running eventually, so I wanted to contribute back some tweaks to the guidance in the docs for anyone else that may be similarly confused.

This change just removes reference to the graphql parser (as it is built into the migration script), and adds a callout to explicitly include the extensions to operate on, as per https://github.com/facebook/jscodeshift/issues/582

Thanks!

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:

### Checklist:
- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
-->
