### PR TITLE
docs: fix Apollo Link URL

### DIFF
--- a/docs/source/data/error-handling.mdx
+++ b/docs/source/data/error-handling.mdx
@@ -451,8 +451,8 @@ See the [`RetryLink` API reference](../api/link/apollo-link-retry/) for more det
 
 ## Additional resources
 
-- [`ErrorLink` documentation](../link/apollo-link-error/)
-- [`RetryLink` documentation](../link/apollo-link-retry/)
+- [`ErrorLink` documentation](../api/link/apollo-link-error/)
+- [`RetryLink` documentation](../api/link/apollo-link-retry/)
 - Individual error class references:
   - [`CombinedGraphQLErrors`](../api/errors/CombinedGraphQLErrors/)
   - [`CombinedProtocolErrors`](../api/errors/CombinedProtocolErrors/)


### PR DESCRIPTION
Updates broken link to ErrorLink docs.

Changes URL from [/docs/react/link/apollo-link-error](https://www.apollographql.com/docs/react/link/apollo-link-error) (404) to [/docs/react/api/link/apollo-link-error](https://www.apollographql.com/docs/react/api/link/apollo-link-error) (valid).