### PR TITLE
Add `headers` transport option for enhanced client awareness

### DIFF
--- a/.api-reports/api-report-link_client-awareness.api.md
+++ b/.api-reports/api-report-link_client-awareness.api.md
@@ -11,7 +11,7 @@ export namespace ClientAwarenessLink {
     // (undocumented)
     export interface ClientAwarenessOptions {
         name?: string;
-        transport?: "headers" | "extensions" | false;
+        transport?: "headers" | false;
         version?: string;
     }
     export interface ContextOptions {

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -796,7 +796,7 @@ namespace ClientAwarenessLink {
     // (undocumented)
     interface ClientAwarenessOptions {
         name?: string;
-        transport?: "headers" | "extensions" | false;
+        transport?: "headers" | false;
         version?: string;
     }
     interface ContextOptions {

--- a/.changeset/beige-hounds-whisper.md
+++ b/.changeset/beige-hounds-whisper.md
@@ -2,4 +2,4 @@
 "@apollo/client": minor
 ---
 
-Add support for `extensions` transport for client awareness and `headers` transport for enhanced client awareness.
+Support `headers` transport for enhanced client awareness.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 45723,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 40417,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 45747,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 40364,
   "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 34745,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 28568
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 28546
 }

--- a/src/link/client-awareness/ClientAwarenessLink.ts
+++ b/src/link/client-awareness/ClientAwarenessLink.ts
@@ -43,7 +43,7 @@ export declare namespace ClientAwarenessLink {
      *
      * @defaultValue "headers"
      */
-    transport?: "headers" | "extensions" | false;
+    transport?: "headers" | false;
   }
   export interface EnhancedClientAwarenessOptions {
     /**
@@ -140,14 +140,6 @@ export class ClientAwarenessLink extends ApolloLink {
               ),
             };
           });
-        }
-
-        if (transport === "extensions") {
-          operation.extensions = compact(
-            // setting these first so that they can be overridden by user-provided extensions
-            { clientApp: { name, version } },
-            operation.extensions
-          );
         }
       }
       {

--- a/src/link/client-awareness/__tests__/ClientAwarenessLink.test.ts
+++ b/src/link/client-awareness/__tests__/ClientAwarenessLink.test.ts
@@ -85,33 +85,6 @@ describe("feature: client awareness", () => {
     });
   });
 
-  test("can use `extensions` as transport", () => {
-    const terminatingLink = new MockSubscriptionLink();
-    const client = new ApolloClient({
-      link: new ClientAwarenessLink({
-        clientAwareness: { transport: "extensions" },
-      }).concat(terminatingLink),
-      cache: new InMemoryCache(),
-      clientAwareness: {
-        name: "test-client",
-        version: "1.0.0",
-      },
-    });
-
-    void client.query({ query });
-    const headers = terminatingLink.operation?.getContext().headers;
-    const extensions = terminatingLink.operation?.extensions;
-    expect(headers).toStrictEqual(undefined);
-    expect(extensions).toStrictEqual(
-      expect.objectContaining({
-        clientApp: {
-          name: "test-client",
-          version: "1.0.0",
-        },
-      })
-    );
-  });
-
   test("can be disabled from `ClientAwarenessLink` constructor, even with options present", () => {
     const terminatingLink = new MockSubscriptionLink();
     const client = new ApolloClient({


### PR DESCRIPTION
Closes #12998

Adds the `headers` transport option for enhanced client awareness