### PR TITLE
Fix `readField` during merge of objects sandwiched between circular objects.

### DIFF
--- a/.changeset/pink-jobs-sing.md
+++ b/.changeset/pink-jobs-sing.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix `readField` during merge of objects sandwiched between circular objects.

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -565,7 +565,7 @@ export abstract class EntityStore implements NormalizedCache {
       isReference(objectOrReference) ?
         this.get(objectOrReference.__ref, storeFieldName)
       : objectOrReference && objectOrReference[storeFieldName]
-    ) as SafeReadonly<T>;
+    ) as SafeReadonly<T> | undefined;
 
   // Returns true for non-normalized StoreObjects and non-dangling
   // References, indicating that readField(name, objOrRef) has a chance of

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -891,7 +891,7 @@ export class Policies {
 
   public readField<V = StoreValue>(
     options: ReadFieldOptions,
-    context: ReadMergeModifyContext
+    context: (ReadMergeModifyContext & { incomingById?: never }) | WriteContext
   ): SafeReadonly<V> | undefined {
     const objectOrReference = options.from;
     if (!objectOrReference) return;
@@ -899,20 +899,27 @@ export class Policies {
     const nameOrField = options.field || options.fieldName;
     if (!nameOrField) return;
 
+    const incomingObject =
+      isReference(objectOrReference) ?
+        context.incomingById?.get(objectOrReference.__ref)?.storeObject
+      : undefined;
+
     if (options.typename === void 0) {
-      const typename = context.store.getFieldValue<string>(
-        objectOrReference,
-        "__typename"
-      );
+      const typename =
+        context.store.getFieldValue<string>(objectOrReference, "__typename") ??
+        incomingObject?.["__typename"];
       if (typename) options.typename = typename;
     }
 
     const storeFieldName = this.getStoreFieldName(options);
     const fieldName = fieldNameFromStoreName(storeFieldName);
-    const existing = context.store.getFieldValue<V>(
+    let existing = context.store.getFieldValue<V>(
       objectOrReference,
       storeFieldName
     );
+    if (existing === undefined) {
+      existing = incomingObject?.[storeFieldName] as typeof existing;
+    }
     const policy = this.getFieldPolicy(options.typename, fieldName);
     const read = policy && policy.read;
 


### PR DESCRIPTION
See https://github.com/apollographql/apollo-client/issues/9315#issuecomment-2564615852 for the user reproduction.

The test for this uncovers additional problems that might be fixed later.

The general problem here is a situation where an incoming object has another normalized object both as a parent and child.

```
Parent:1.foo -> Child:2.bar -> Parent:1
```

So, in this case, the `merge` function for `Parent` runs before the `merge` for `Child` has a chance to run - and the `readField` function that would like to access properties of `Child` cannot read them from the store yet.

This doesn't happen for non-circular objects, since these are merged from `incomingById` in a leaf-to-root order, but in this circular case, leaf and root are the same object - so no matter which order they are merged in, a child will have unmerged fields.

I'm not happy with this solution, so putting it as draft for now. I'd be happy to feedback.