### PR TITLE
Expose `source` in `nextFetchPolicy` callbacks

### DIFF
--- a/.changeset/fifty-rings-report.md
+++ b/.changeset/fifty-rings-report.md
@@ -1,0 +1,7 @@
+---
+"@apollo/client": patch
+---
+
+Prevent passing `nextFetchPolicy` into `preloadQuery`
+
+This was already prevented in the TypeScript types, but unlike `useBackgroundQuery` and other suspenseful hooks, if called with an `option` object that included `nextFetchPolicy`, `preloadQuery` would still pass it along to `watchQuery` internally. This change ensures that `nextFetchPolicy` is always removed from the options passed to `watchQuery` inside `preloadQuery`.

--- a/.changeset/fuzzy-guests-notice.md
+++ b/.changeset/fuzzy-guests-notice.md
@@ -1,0 +1,36 @@
+---
+"@apollo/client": patch
+---
+
+Expose `source` in `nextFetchPolicy` callbacks.
+
+This allows `nextFetchPolicy` function to adjust their behavior based on what source (`useQuery`, `useLazyQuery`, etc.) is triggering the fetch policy change.
+This can be useful in `defaultOptions` where you want different `nextFetchPolicy` logic depending on how the query was initiated.
+
+E.g. this change would restore the Apollo Client 3.0 behavior where `useLazyQuery`'s `nextFetchPolicy` would be reset to `initialFetchPolicy` with every variable change:
+
+```ts
+new ApolloClient({
+  // ...
+  defaultOptions: {
+    watchQuery: {
+      nextFetchPolicy: (current, { reason, initialFetchPolicy, source }) => {
+        if (reason === "variables-changed" && source === "useLazyQuery") {
+          return initialFetchPolicy;
+        }
+        return current;
+      },
+    },
+  },
+});
+```
+
+Possible values for `source` are:
+```ts
+  export type Source =
+    | "unknown"
+    | "ApolloClient.watchQuery"
+    | "ApolloClient.getObservableQueries"
+    | "useQuery"
+    | "useLazyQuery";
+```

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -262,6 +262,13 @@ export declare namespace ObservableQuery {
     retain(): this;
   }
 
+  export type Source =
+    | "unknown"
+    | "ApolloClient.watchQuery"
+    | "ApolloClient.getObservableQueries"
+    | "useQuery"
+    | "useLazyQuery";
+
   export namespace DocumentationTypes {
     type OperatorFunctionChain<From, To> = [];
     interface ObservableMethods<TData, OperatorResult> {
@@ -363,17 +370,22 @@ export class ObservableQuery<
     return this.queryManager.cache;
   }
 
+  public source: ObservableQuery.Source;
+
   constructor({
     queryManager,
     options,
     transformedQuery = queryManager.transform(options.query),
+    source = "unknown",
   }: {
     queryManager: QueryManager;
     options: ApolloClient.WatchQueryOptions<TData, TVariables>;
     transformedQuery?: DocumentNode | TypedDocumentNode<TData, TVariables>;
     queryId?: string;
+    source: ObservableQuery.Source;
   }) {
     this.queryManager = queryManager;
+    this.source = source;
 
     // active state
     this.waitForNetworkResult = options.fetchPolicy === "network-only";
@@ -1277,7 +1289,13 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
         options.fetchPolicy = options.nextFetchPolicy.call(
           options as any,
           fetchPolicy,
-          { reason, options, observable: this, initialFetchPolicy }
+          {
+            reason,
+            options,
+            observable: this,
+            initialFetchPolicy,
+            source: this.source,
+          }
         );
       } else if (reason === "variables-changed") {
         options.fetchPolicy = initialFetchPolicy;

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -591,6 +591,7 @@ export class QueryManager {
       queryManager: this,
       options,
       transformedQuery: query,
+      source: "ApolloClient.watchQuery",
     });
 
     return observable;
@@ -710,6 +711,7 @@ export class QueryManager {
             ...options,
             fetchPolicy: "network-only",
           },
+          source: "ApolloClient.getObservableQueries",
         });
         queries.add(oq);
       });

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -51,6 +51,7 @@ export interface NextFetchPolicyContext<
   observable: ObservableQuery<TData, TVariables>;
   options: ApolloClient.WatchQueryOptions<TData, TVariables>;
   initialFetchPolicy: WatchQueryFetchPolicy;
+  source: ObservableQuery.Source;
 }
 
 export type UpdateQueryOptions<TData, TVariables extends OperationVariables> = {

--- a/src/react/hooks/__tests__/useLazyQuery.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery.test.tsx
@@ -2805,8 +2805,14 @@ describe("useLazyQuery Hook", () => {
               trackClosureValue("skipPollAttempt", count);
               return false;
             },
-            nextFetchPolicy: (currentFetchPolicy) => {
+            nextFetchPolicy: (currentFetchPolicy, context) => {
               trackClosureValue("nextFetchPolicy", count);
+              expect(context).toStrictEqualTyped({
+                initialFetchPolicy: "cache-first",
+                reason: expect.any(String),
+                options: expect.any(Object),
+                source: "useLazyQuery",
+              });
               return currentFetchPolicy;
             },
           });

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -8719,7 +8719,12 @@ describe("useQuery Hook", () => {
         },
         nextFetchPolicy(currentFetchPolicy, context) {
           expect(currentFetchPolicy).toBe("cache-and-network");
-          expect(context.initialFetchPolicy).toBe("cache-and-network");
+          expect(context).toStrictEqualTyped({
+            initialFetchPolicy: "cache-and-network",
+            reason: expect.any(String),
+            options: expect.any(Object),
+            source: "useQuery",
+          });
           reasons.push(context.reason);
           return currentFetchPolicy;
         },
@@ -8830,7 +8835,12 @@ describe("useQuery Hook", () => {
         },
         nextFetchPolicy(currentFetchPolicy, context) {
           expect(currentFetchPolicy).toBe("cache-and-network");
-          expect(context.initialFetchPolicy).toBe("cache-and-network");
+          expect(context).toStrictEqualTyped({
+            initialFetchPolicy: "cache-and-network",
+            reason: expect.any(String),
+            options: expect.any(Object),
+            source: "useQuery",
+          });
           reasons.push(context.reason);
           return currentFetchPolicy;
         },
@@ -8949,7 +8959,7 @@ describe("useQuery Hook", () => {
       expect(nextFetchPolicy).toHaveBeenNthCalledWith(
         1,
         "network-only",
-        expect.objectContaining({ reason: "after-fetch" })
+        expect.objectContaining({ reason: "after-fetch", source: "useQuery" })
       );
       // `nextFetchPolicy(..., {reason: "after-fetch"})` changed it to
       // cache-only
@@ -8968,6 +8978,7 @@ describe("useQuery Hook", () => {
         "network-only",
         expect.objectContaining({
           reason: "variables-changed",
+          source: "useQuery",
         })
       );
 
@@ -8998,6 +9009,7 @@ describe("useQuery Hook", () => {
         "cache-and-network",
         expect.objectContaining({
           reason: "after-fetch",
+          source: "useQuery",
         })
       );
       // `nextFetchPolicy(..., {reason: "after-fetch"})` changed it to

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -342,13 +342,16 @@ export function useLazyQuery<
   const calledDuringRender = useRenderGuard();
 
   function createObservable() {
-    return client.watchQuery({
-      ...options,
-      query,
-      initialFetchPolicy: options?.fetchPolicy,
-      fetchPolicy: "standby",
-      [variablesUnknownSymbol]: true,
-    } as ApolloClient.WatchQueryOptions<TData, TVariables>);
+    return Object.assign(
+      client.watchQuery({
+        ...options,
+        query,
+        initialFetchPolicy: options?.fetchPolicy,
+        fetchPolicy: "standby",
+        [variablesUnknownSymbol]: true,
+      } as ApolloClient.WatchQueryOptions<TData, TVariables>),
+      { source: "useLazyQuery" }
+    );
   }
 
   const [currentClient, setCurrentClient] = React.useState(client);

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -422,6 +422,7 @@ function useQuery_<TData, TVariables extends OperationVariables>(
     previous?: InternalState<TData, TVariables>
   ): InternalState<TData, TVariables> {
     const observable = client.watchQuery(watchQueryOptions);
+    observable.source = "useQuery";
 
     return {
       client,

--- a/src/react/query-preloader/createQueryPreloader.ts
+++ b/src/react/query-preloader/createQueryPreloader.ts
@@ -191,6 +191,7 @@ const _createQueryPreloader: typeof createQueryPreloader = (client) => {
         ...options,
         query,
         notifyOnNetworkStatusChange: false,
+        nextFetchPolicy: undefined,
       } as ApolloClient.WatchQueryOptions<any, any>),
       {
         autoDisposeTimeoutMs:

--- a/src/react/ssr/useSSRQuery.ts
+++ b/src/react/ssr/useSSRQuery.ts
@@ -69,6 +69,7 @@ export const useSSRQuery = function (
           "cache-first"
         : options.fetchPolicy,
     });
+    observable.source = "useQuery";
     this.onCreatedObservableQuery(observable, query, options.variables);
   }
   return {


### PR DESCRIPTION
I'm not 100% sure if this change is worth the amount of code, or if it's too niche. Putting it up for discussion.