### PR TITLE
Ensure that `compact` and `mergeOptions` preserve symbol keys.

### DIFF
--- a/.changeset/sweet-hairs-impress.md
+++ b/.changeset/sweet-hairs-impress.md
@@ -1,0 +1,13 @@
+---
+"@apollo/client": patch
+---
+
+Ensure that `compact` and `mergeOptions` preserve symbol keys.
+
+This fixes an issue where the change introduced in 4.0.11 via #13049 would not
+be applied if `defaultOptions` for `watchQuery` were declared.
+
+Please note that `compact` and `mergeOptions` are considered internal utilities
+and they might have similar behavior changes in future releases.
+Do not use them in your application code - a change like this is not considered
+breaking and will not be announced as such.

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -8511,6 +8511,24 @@ describe("ApolloClient", () => {
       );
     });
   });
+
+  test("`client.watchQuery` should forward symbol keys on `options` even with `defaultOptions` present on `ApolloClient`", () => {
+    const client = new ApolloClient({
+      cache: new InMemoryCache(),
+      link: ApolloLink.empty(),
+      defaultOptions: {
+        watchQuery: {},
+      },
+    });
+
+    const obsQuery = client.watchQuery({
+      query: gql`query Test { hello }`,
+      [variablesUnknownSymbol]: true,
+      fetchPolicy: "standby",
+    });
+
+    expect(obsQuery["variablesUnknown"]).toBe(true);
+  });
 });
 
 describe.skip("type tests", () => {

--- a/src/utilities/internal/__tests__/compact.test.ts
+++ b/src/utilities/internal/__tests__/compact.test.ts
@@ -54,3 +54,31 @@ test("should not leave undefined properties in result object", () => {
   expect(hasOwn.call(result, "c")).toBe(false);
   expect(result).toEqual({ a: 2 });
 });
+
+test("should preserve symbol options", () => {
+  const symA = Symbol("a");
+  const symB = Symbol("b");
+
+  const result = compact(
+    {
+      [symA]: 123,
+      [symB]: 456,
+      foo: "bar",
+    },
+    {
+      [symA]: 789,
+      baz: "qux",
+    },
+    {
+      [symA]: void 0,
+      byd: "tbd",
+    }
+  );
+  expect(result).toStrictEqualTyped({
+    [symA]: 789,
+    [symB]: 456,
+    foo: "bar",
+    baz: "qux",
+    byd: "tbd",
+  });
+});

--- a/src/utilities/internal/compact.ts
+++ b/src/utilities/internal/compact.ts
@@ -13,8 +13,8 @@ export function compact<TArgs extends any[]>(
 
   objects.forEach((obj) => {
     if (!obj) return;
-    Object.keys(obj).forEach((key) => {
-      const value = (obj as any)[key];
+    Reflect.ownKeys(obj).forEach((key: keyof typeof obj) => {
+      const value = obj[key];
       if (value !== void 0) {
         result[key] = value;
       }


### PR DESCRIPTION
Fixes #13093