### PR TITLE
add extra logging about React Compiler incompatibilities

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -144,7 +144,7 @@ export default [
     },
   },
   {
-    ...reactHooks.configs.flat.recommended,
+    ...reactHooks.configs.flat["recommended-latest"],
     files: ["src/react/**/*.ts", "src/react/**/*.tsx"],
     ignores: ["**/__tests__/**/*.*", "**/*.d.ts"],
   },


### PR DESCRIPTION
This doesn't change anything about the library, it just helps surface these problems in the build step, to help us eliminate them at another point in time.

Notably, this surfaces more problems than the ESLint plugin, which makes it worthwhile to have this logging.

---

This is what we currently get:

```log

Compilation failed: dist/react/hooks-compiled/useBackgroundQuery.js:8:42, original source /home/runner/work/apollo-client/apollo-client/src/react/hooks/useBackgroundQuery.ts:428:4
Reason: Hooks may not be referenced as normal values, they must be called. See https://react.dev/reference/rules/react-calls-components-and-hooks#never-pass-around-hooks-as-regular-values

Compilation failed: dist/react/hooks-compiled/useBackgroundQuery.js:23:4, original source /home/runner/work/apollo-client/apollo-client/src/react/hooks/useBackgroundQuery.ts:459:2
Reason: (BuildHIR::lowerExpression) Handle ||= operators in AssignmentExpression

Compilation failed: dist/react/hooks-compiled/useFragment.js:7:35, original source /home/runner/work/apollo-client/apollo-client/src/react/hooks/useFragment.ts:188:4
Reason: Hooks may not be referenced as normal values, they must be called. See https://react.dev/reference/rules/react-calls-components-and-hooks#never-pass-around-hooks-as-regular-values

Compilation failed: dist/react/hooks-compiled/useLazyQuery.js:134:22, original source /home/runner/work/apollo-client/apollo-client/src/react/hooks/useLazyQuery.ts:504:16
Reason: Cannot access refs during render
Details: React refs are values that are not needed for rendering. Refs should only be accessed outside of render, such as in event handlers or effects. Accessing a ref value (the `current` property) during render can cause your component not to update as expected (https://react.dev/reference/react/useRef)

Compilation failed: dist/react/hooks-compiled/useLazyQuery.js:134:21, original source /home/runner/work/apollo-client/apollo-client/src/react/hooks/useLazyQuery.ts:504:15
Reason: Cannot access refs during render
Details: React refs are values that are not needed for rendering. Refs should only be accessed outside of render, such as in event handlers or effects. Accessing a ref value (the `current` property) during render can cause your component not to update as expected (https://react.dev/reference/react/useRef)

Compilation failed: dist/react/hooks-compiled/useLazyQuery.js:130:26, original source /home/runner/work/apollo-client/apollo-client/src/react/hooks/useLazyQuery.ts:500:20
Reason: Cannot access refs during render
Details: React refs are values that are not needed for rendering. Refs should only be accessed outside of render, such as in event handlers or effects. Accessing a ref value (the `current` property) during render can cause your component not to update as expected (https://react.dev/reference/react/useRef)

Compilation failed: dist/react/hooks-compiled/useLazyQuery.js:130:26, original source /home/runner/work/apollo-client/apollo-client/src/react/hooks/useLazyQuery.ts:500:20
Reason: Cannot access refs during render
Details: React refs are values that are not needed for rendering. Refs should only be accessed outside of render, such as in event handlers or effects. Accessing a ref value (the `current` property) during render can cause your component not to update as expected (https://react.dev/reference/react/useRef)

Compilation failed: dist/react/hooks-compiled/useLazyQuery.js:130:26, original source /home/runner/work/apollo-client/apollo-client/src/react/hooks/useLazyQuery.ts:500:20
Reason: Cannot access refs during render
Details: React refs are values that are not needed for rendering. Refs should only be accessed outside of render, such as in event handlers or effects. Accessing a ref value (the `current` property) during render can cause your component not to update as expected (https://react.dev/reference/react/useRef)

Compilation failed: dist/react/hooks-compiled/useQuery.js:26:32, original source /home/runner/work/apollo-client/apollo-client/src/react/hooks/useQuery.ts:396:4
Reason: Hooks may not be referenced as normal values, they must be called. See https://react.dev/reference/rules/react-calls-components-and-hooks#never-pass-around-hooks-as-regular-values

Compilation failed: dist/react/hooks-compiled/useQueryRefHandlers.js:33:43, original source /home/runner/work/apollo-client/apollo-client/src/react/hooks/useQueryRefHandlers.ts:85:4
Reason: Hooks may not be referenced as normal values, they must be called. See https://react.dev/reference/rules/react-calls-components-and-hooks#never-pass-around-hooks-as-regular-values

Compilation failed: dist/react/hooks-compiled/useReactiveVar.js:31:28, original source /home/runner/work/apollo-client/apollo-client/src/react/hooks/useReactiveVar.ts:37:26
Reason: [InferMutationAliasingEffects] Expected value kind to be initialized
Details: <unknown> onNext$11

Compilation failed: dist/react/hooks-compiled/useReadQuery.js:43:36, original source /home/runner/work/apollo-client/apollo-client/src/react/hooks/useReadQuery.ts:105:34
Reason: Hooks may not be referenced as normal values, they must be called. See https://react.dev/reference/rules/react-calls-components-and-hooks#never-pass-around-hooks-as-regular-values

Compilation failed: dist/react/hooks-compiled/useSuspenseFragment.js:9:43, original source /home/runner/work/apollo-client/apollo-client/src/react/hooks/useSuspenseFragment.ts:184:4
Reason: Hooks may not be referenced as normal values, they must be called. See https://react.dev/reference/rules/react-calls-components-and-hooks#never-pass-around-hooks-as-regular-values

Compilation failed: dist/react/hooks-compiled/useSuspenseFragment.js:35:8, original source /home/runner/work/apollo-client/apollo-client/src/react/hooks/useSuspenseFragment.ts:233:4
Reason: This value cannot be modified
Details: Modifying a value returned from 'useState()', which should not be modified directly. Use the setter function to update instead

Compilation failed: dist/react/hooks-compiled/useSuspenseFragment.js:37:8, original source /home/runner/work/apollo-client/apollo-client/src/react/hooks/useSuspenseFragment.ts:235:4
Reason: This value cannot be modified
Details: Modifying a value returned from 'useState()', which should not be modified directly. Use the setter function to update instead

Compilation failed: dist/react/hooks-compiled/useSuspenseQuery.js:12:40, original source /home/runner/work/apollo-client/apollo-client/src/react/hooks/useSuspenseQuery.ts:356:4
Reason: Hooks may not be referenced as normal values, they must be called. See https://react.dev/reference/rules/react-calls-components-and-hooks#never-pass-around-hooks-as-regular-values

Compilation failed: dist/react/hooks-compiled/useSuspenseQuery.js:29:8, original source /home/runner/work/apollo-client/apollo-client/src/react/hooks/useSuspenseQuery.ts:395:4
Reason: This value cannot be modified
Details: Modifying a value returned from 'useState()', which should not be modified directly. Use the setter function to update instead

Compilation failed: dist/react/hooks-compiled/useSuspenseQuery.js:31:8, original source /home/runner/work/apollo-client/apollo-client/src/react/hooks/useSuspenseQuery.ts:397:4
Reason: This value cannot be modified
Details: Modifying a value returned from 'useState()', which should not be modified directly. Use the setter function to update instead

Compilation failed: dist/react/hooks-compiled/useSuspenseQuery.js:36:8, original source /home/runner/work/apollo-client/apollo-client/src/react/hooks/useSuspenseQuery.ts:403:4
Reason: This value cannot be modified
Details: Modifying a value returned from 'useState()', which should not be modified directly. Use the setter function to update instead

Compilation failed: dist/react/hooks-compiled/internal/useDeepMemo.js:6:9, original source /home/runner/work/apollo-client/apollo-client/src/react/hooks/internal/useDeepMemo.ts:11:7
Reason: Cannot access refs during render
Details: React refs are values that are not needed for rendering. Refs should only be accessed outside of render, such as in event handlers or effects. Accessing a ref value (the `current` property) during render can cause your component not to update as expected (https://react.dev/reference/react/useRef)

Compilation failed: dist/react/hooks-compiled/internal/useDeepMemo.js:6:8, original source /home/runner/work/apollo-client/apollo-client/src/react/hooks/internal/useDeepMemo.ts:11:6
Reason: Cannot access refs during render
Details: React refs are values that are not needed for rendering. Refs should only be accessed outside of render, such as in event handlers or effects. Accessing a ref value (the `current` property) during render can cause your component not to update as expected (https://react.dev/reference/react/useRef)

Compilation failed: dist/react/hooks-compiled/internal/useDeepMemo.js:6:8, original source /home/runner/work/apollo-client/apollo-client/src/react/hooks/internal/useDeepMemo.ts:11:6
Reason: Cannot access refs during render
Details: React refs are values that are not needed for rendering. Refs should only be accessed outside of render, such as in event handlers or effects. Accessing a ref value (the `current` property) during render can cause your component not to update as expected (https://react.dev/reference/react/useRef)

Compilation failed: dist/react/hooks-compiled/internal/useDeepMemo.js:6:8, original source /home/runner/work/apollo-client/apollo-client/src/react/hooks/internal/useDeepMemo.ts:11:6
Reason: Cannot access refs during render
Details: React refs are values that are not needed for rendering. Refs should only be accessed outside of render, such as in event handlers or effects. Accessing a ref value (the `current` property) during render can cause your component not to update as expected (https://react.dev/reference/react/useRef)

Compilation failed: dist/react/hooks-compiled/internal/useDeepMemo.js:6:31, original source /home/runner/work/apollo-client/apollo-client/src/react/hooks/internal/useDeepMemo.ts:11:29
Reason: Cannot access refs during render
Details: React refs are values that are not needed for rendering. Refs should only be accessed outside of render, such as in event handlers or effects. Accessing a ref value (the `current` property) during render can cause your component not to update as expected (https://react.dev/reference/react/useRef)

Compilation failed: dist/react/hooks-compiled/internal/useDeepMemo.js:10:11, original source /home/runner/work/apollo-client/apollo-client/src/react/hooks/internal/useDeepMemo.ts:15:9
Reason: Cannot access refs during render
Details: React refs are values that are not needed for rendering. Refs should only be accessed outside of render, such as in event handlers or effects. Accessing a ref value (the `current` property) during render can cause your component not to update as expected (https://react.dev/reference/react/useRef)
```

Especially things like

```log
Compilation failed: dist/react/hooks-compiled/useReactiveVar.js:31:28, original source /home/runner/work/apollo-client/apollo-client/src/react/hooks/useReactiveVar.ts:37:26
Reason: [InferMutationAliasingEffects] Expected value kind to be initialized
Details: <unknown> onNext$11
```
would otherwise not surface.