### PR TITLE
Improve the return type of `client.query`

### DIFF
--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -375,7 +375,6 @@ export class ApolloClient {
     query<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: ApolloClient.QueryOptions<TData, TVariables> & {
         errorPolicy: "all";
     }): Promise<ApolloClient.QueryResult<MaybeMasked<TData>, "all">>;
-    // (undocumented)
     query<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: ApolloClient.QueryOptions<TData, TVariables> & {
         errorPolicy: "ignore";
     }): Promise<ApolloClient.QueryResult<MaybeMasked<TData>, "ignore">>;

--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -270,10 +270,19 @@ export namespace ApolloClient {
         fetchPolicy?: FetchPolicy;
     } & VariablesOption<NoInfer<TVariables>>;
     // (undocumented)
-    export interface QueryResult<TData = unknown> {
+    export type QueryResult<TData = unknown, TErrorPolicy extends ErrorPolicy | undefined = undefined> = TErrorPolicy extends "none" ? {
+        data: TData;
+        error?: never;
+    } : TErrorPolicy extends "all" ? {
         data: TData | undefined;
         error?: ErrorLike;
-    }
+    } : TErrorPolicy extends "ignore" ? {
+        data: TData | undefined;
+        error?: never;
+    } : {
+        data: TData | undefined;
+        error?: ErrorLike;
+    };
     // (undocumented)
     export type ReadFragmentOptions<TData, TVariables extends OperationVariables> = Base.ReadFragmentOptions<TData, TVariables> & VariablesOption<TVariables> & Cache_2.CacheIdentifierOption<TData>;
     // (undocumented)
@@ -363,7 +372,14 @@ export class ApolloClient {
     onResetStore(cb: () => Promise<any>): () => void;
     set prioritizeCacheValues(value: boolean);
     get prioritizeCacheValues(): boolean;
-    query<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: ApolloClient.QueryOptions<TData, TVariables>): Promise<ApolloClient.QueryResult<MaybeMasked<TData>>>;
+    query<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: ApolloClient.QueryOptions<TData, TVariables> & {
+        errorPolicy: "all";
+    }): Promise<ApolloClient.QueryResult<MaybeMasked<TData>, "all">>;
+    // (undocumented)
+    query<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: ApolloClient.QueryOptions<TData, TVariables> & {
+        errorPolicy: "ignore";
+    }): Promise<ApolloClient.QueryResult<MaybeMasked<TData>, "ignore">>;
+    query<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: ApolloClient.QueryOptions<TData, TVariables>): Promise<ApolloClient.QueryResult<MaybeMasked<TData>, "none">>;
     // (undocumented)
     queryDeduplication: boolean;
     readFragment<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: ApolloClient.ReadFragmentOptions<TData, TVariables>): Unmasked<TData> | null;
@@ -1182,7 +1198,7 @@ export type WatchQueryOptions<TVariables extends OperationVariables = OperationV
 
 // Warnings were encountered during analysis:
 //
-// src/core/ApolloClient.ts:375:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
+// src/core/ApolloClient.ts:405:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:371:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:194:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 

--- a/.api-reports/api-report-react_internal.api.md
+++ b/.api-reports/api-report-react_internal.api.md
@@ -9,6 +9,7 @@ import type { DataState } from '@apollo/client';
 import type { DecoratedPromise } from '@apollo/client/utilities/internal';
 import type { DocumentNode } from 'graphql';
 import type { DocumentTypeDecoration } from '@graphql-typed-document-node/core';
+import { ErrorLike } from '@apollo/client';
 import type { InternalTypes } from '@apollo/client/react';
 import type { MaybeMasked } from '@apollo/client/masking';
 import type { MaybeMasked as MaybeMasked_2 } from '@apollo/client';
@@ -109,7 +110,10 @@ export class InternalQueryReference<TData = unknown, TStates extends DataState<T
     // (undocumented)
     get disposed(): boolean;
     // (undocumented)
-    fetchMore(options: ObservableQuery.FetchMoreOptions<TData, any, any, any>): Promise<ApolloClient.QueryResult<TData>>;
+    fetchMore(options: ObservableQuery.FetchMoreOptions<TData, any, any, any>): Promise<{
+        data: TData | undefined;
+        error?: ErrorLike;
+    }>;
     // (undocumented)
     readonly key: QueryKey;
     // Warning: (ae-forgotten-export) The symbol "Listener" needs to be exported by the entry point index.d.ts
@@ -121,7 +125,10 @@ export class InternalQueryReference<TData = unknown, TStates extends DataState<T
     // (undocumented)
     promise: QueryRefPromise<TData, TStates>;
     // (undocumented)
-    refetch(variables: OperationVariables | undefined): Promise<ApolloClient.QueryResult<TData>>;
+    refetch(variables: OperationVariables | undefined): Promise<{
+        data: TData | undefined;
+        error?: ErrorLike;
+    }>;
     // (undocumented)
     reinitialize(): void;
     // (undocumented)

--- a/.api-reports/api-report-utilities_internal.api.md
+++ b/.api-reports/api-report-utilities_internal.api.md
@@ -10,7 +10,7 @@ import type { ASTNode } from 'graphql';
 import type { DataValue } from '@apollo/client';
 import type { DirectiveNode } from 'graphql';
 import type { DocumentNode } from 'graphql';
-import type { ErrorLike } from '@apollo/client';
+import { ErrorLike } from '@apollo/client';
 import type { FieldNode } from 'graphql';
 import type { FormattedExecutionResult } from 'graphql';
 import type { FragmentDefinitionNode } from 'graphql';
@@ -492,7 +492,10 @@ export type StreamInfoTrie = Trie<{
 export function stringifyForDisplay(value: any, space?: number): string;
 
 // @internal @deprecated (undocumented)
-export function toQueryResult<TData = unknown>(value: ObservableQuery.Result<TData>): ApolloClient.QueryResult<TData>;
+export function toQueryResult<TData = unknown>(value: ObservableQuery.Result<TData>): {
+    data: TData | undefined;
+    error?: ErrorLike;
+};
 
 // @public (undocumented)
 type TupleToIntersection<T extends any[]> = T extends [infer A] ? A : T extends [infer A, infer B] ? A & B : T extends [infer A, infer B, infer C] ? A & B & C : T extends [infer A, infer B, infer C, infer D] ? A & B & C & D : T extends [infer A, infer B, infer C, infer D, infer E] ? A & B & C & D & E : T extends (infer U)[] ? U : any;

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -428,7 +428,6 @@ export class ApolloClient {
     query<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: ApolloClient.QueryOptions<TData, TVariables> & {
         errorPolicy: "all";
     }): Promise<ApolloClient.QueryResult<MaybeMasked<TData>, "all">>;
-    // (undocumented)
     query<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: ApolloClient.QueryOptions<TData, TVariables> & {
         errorPolicy: "ignore";
     }): Promise<ApolloClient.QueryResult<MaybeMasked<TData>, "ignore">>;

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -322,10 +322,19 @@ export namespace ApolloClient {
         fetchPolicy?: FetchPolicy;
     } & VariablesOption<NoInfer<TVariables>>;
     // (undocumented)
-    export interface QueryResult<TData = unknown> {
+    export type QueryResult<TData = unknown, TErrorPolicy extends ErrorPolicy | undefined = undefined> = TErrorPolicy extends "none" ? {
+        data: TData;
+        error?: never;
+    } : TErrorPolicy extends "all" ? {
         data: TData | undefined;
         error?: ErrorLike;
-    }
+    } : TErrorPolicy extends "ignore" ? {
+        data: TData | undefined;
+        error?: never;
+    } : {
+        data: TData | undefined;
+        error?: ErrorLike;
+    };
     // (undocumented)
     export type ReadFragmentOptions<TData, TVariables extends OperationVariables> = Base.ReadFragmentOptions<TData, TVariables> & VariablesOption<TVariables> & Cache_2.CacheIdentifierOption<TData>;
     // (undocumented)
@@ -416,7 +425,14 @@ export class ApolloClient {
     onResetStore(cb: () => Promise<any>): () => void;
     set prioritizeCacheValues(value: boolean);
     get prioritizeCacheValues(): boolean;
-    query<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: ApolloClient.QueryOptions<TData, TVariables>): Promise<ApolloClient.QueryResult<MaybeMasked<TData>>>;
+    query<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: ApolloClient.QueryOptions<TData, TVariables> & {
+        errorPolicy: "all";
+    }): Promise<ApolloClient.QueryResult<MaybeMasked<TData>, "all">>;
+    // (undocumented)
+    query<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: ApolloClient.QueryOptions<TData, TVariables> & {
+        errorPolicy: "ignore";
+    }): Promise<ApolloClient.QueryResult<MaybeMasked<TData>, "ignore">>;
+    query<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: ApolloClient.QueryOptions<TData, TVariables>): Promise<ApolloClient.QueryResult<MaybeMasked<TData>, "none">>;
     // (undocumented)
     queryDeduplication: boolean;
     readFragment<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: ApolloClient.ReadFragmentOptions<TData, TVariables>): Unmasked<TData> | null;
@@ -2862,7 +2878,7 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/cache/inmemory/policies.ts:173:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/types.ts:135:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
 // src/core/ApolloClient.ts:173:5 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
-// src/core/ApolloClient.ts:375:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
+// src/core/ApolloClient.ts:405:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:371:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:194:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/local-state/LocalState.ts:149:5 - (ae-forgotten-export) The symbol "LocalState" needs to be exported by the entry point index.d.ts

--- a/.changeset/chilly-ravens-agree.md
+++ b/.changeset/chilly-ravens-agree.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": minor
+---
+
+Improve the accuracy of `client.query` return type to better detect the current `errorPolicy`. The `data` property is no longer nullable when the `errorPolicy` is `none`. This makes it possible to remove the `undefined` checks or optional chaining in most cases.

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -4164,6 +4164,7 @@ describe("@connection", () => {
 
       expect(result).toStrictEqualTyped({
         data: undefined,
+        // @ts-expect-error using defaultOptions which is type safe
         error: new CombinedGraphQLErrors({ errors }),
       });
     });

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -243,13 +243,34 @@ export declare namespace ApolloClient {
     fetchPolicy?: FetchPolicy;
   } & VariablesOption<NoInfer<TVariables>>;
 
-  export interface QueryResult<TData = unknown> {
-    /** {@inheritDoc @apollo/client!QueryResultDocumentation#data:member} */
-    data: TData | undefined;
+  export type QueryResult<
+    TData = unknown,
+    TErrorPolicy extends ErrorPolicy = "none",
+  > = TErrorPolicy extends "none" ?
+    {
+      /** {@inheritDoc @apollo/client!QueryResultDocumentation#data:member} */
+      data: TData;
 
-    /** {@inheritDoc @apollo/client!QueryResultDocumentation#error:member} */
-    error?: ErrorLike;
-  }
+      /** {@inheritDoc @apollo/client!QueryResultDocumentation#error:member} */
+      error?: never;
+    }
+  : TErrorPolicy extends "all" ?
+    {
+      /** {@inheritDoc @apollo/client!QueryResultDocumentation#data:member} */
+      data: TData | undefined;
+
+      /** {@inheritDoc @apollo/client!QueryResultDocumentation#error:member} */
+      error?: ErrorLike;
+    }
+  : TErrorPolicy extends "ignore" ?
+    {
+      /** {@inheritDoc @apollo/client!QueryResultDocumentation#data:member} */
+      data: TData | undefined;
+
+      /** {@inheritDoc @apollo/client!QueryResultDocumentation#error:member} */
+      error?: never;
+    }
+  : never;
 
   /**
    * Options object for the `client.refetchQueries` method.
@@ -979,6 +1000,32 @@ export class ApolloClient {
    * describe how this query should be treated e.g. whether it should hit the
    * server at all or just resolve from the cache, etc.
    */
+  public query<
+    TData = unknown,
+    TVariables extends OperationVariables = OperationVariables,
+  >(
+    options: ApolloClient.QueryOptions<TData, TVariables> & {
+      errorPolicy: "all";
+    }
+  ): Promise<ApolloClient.QueryResult<MaybeMasked<TData>, "all">>;
+
+  public query<
+    TData = unknown,
+    TVariables extends OperationVariables = OperationVariables,
+  >(
+    options: ApolloClient.QueryOptions<TData, TVariables> & {
+      errorPolicy: "ignore";
+    }
+  ): Promise<ApolloClient.QueryResult<MaybeMasked<TData>, "ignore">>;
+
+  /** {@inheritDoc @apollo/client!ApolloClient#query:member(1)} */
+  public query<
+    TData = unknown,
+    TVariables extends OperationVariables = OperationVariables,
+  >(
+    options: ApolloClient.QueryOptions<TData, TVariables>
+  ): Promise<ApolloClient.QueryResult<MaybeMasked<TData>>>;
+
   public query<
     TData = unknown,
     TVariables extends OperationVariables = OperationVariables,

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -1033,7 +1033,7 @@ export class ApolloClient {
     TVariables extends OperationVariables = OperationVariables,
   >(
     options: ApolloClient.QueryOptions<TData, TVariables>
-  ): Promise<ApolloClient.QueryResult<MaybeMasked<TData>>>;
+  ): Promise<ApolloClient.QueryResult<MaybeMasked<TData>, "none">>;
 
   public query<
     TData = unknown,

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -245,7 +245,7 @@ export declare namespace ApolloClient {
 
   export type QueryResult<
     TData = unknown,
-    TErrorPolicy extends ErrorPolicy = "none",
+    TErrorPolicy extends ErrorPolicy | undefined = undefined,
   > = TErrorPolicy extends "none" ?
     {
       /** {@inheritDoc @apollo/client!QueryResultDocumentation#data:member} */
@@ -270,7 +270,16 @@ export declare namespace ApolloClient {
       /** {@inheritDoc @apollo/client!QueryResultDocumentation#error:member} */
       error?: never;
     }
-  : never;
+  : // Fallback case via `undefined` for backwards compatibility. Helps with
+    // other APIs such as `ObservableQuery.refetch()` which we don't know the
+    // errorPolicy
+    {
+      /** {@inheritDoc @apollo/client!QueryResultDocumentation#data:member} */
+      data: TData | undefined;
+
+      /** {@inheritDoc @apollo/client!QueryResultDocumentation#error:member} */
+      error?: ErrorLike;
+    };
 
   /**
    * Options object for the `client.refetchQueries` method.

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -1018,6 +1018,7 @@ export class ApolloClient {
     }
   ): Promise<ApolloClient.QueryResult<MaybeMasked<TData>, "all">>;
 
+  /** {@inheritDoc @apollo/client!ApolloClient#query:member(1)} */
   public query<
     TData = unknown,
     TVariables extends OperationVariables = OperationVariables,

--- a/src/core/__tests__/client.query/types.test.ts
+++ b/src/core/__tests__/client.query/types.test.ts
@@ -1,0 +1,89 @@
+import { expectTypeOf } from "expect-type";
+
+import type { ErrorLike, TypedDocumentNode } from "@apollo/client";
+import { ApolloClient, ApolloLink, gql, InMemoryCache } from "@apollo/client";
+
+describe.skip("type tests", () => {
+  test("returns TData by default", async () => {
+    interface Query {
+      greeting: string;
+    }
+    type Variables = Record<string, never>;
+    const query: TypedDocumentNode<Query, Variables> = gql`
+      query {
+        greeting
+      }
+    `;
+
+    const client = createClient();
+
+    expectTypeOf(await client.query({ query })).toEqualTypeOf<{
+      data: Query;
+      error?: never;
+    }>();
+  });
+
+  test("returns TData with errorPolicy: none", async () => {
+    interface Query {
+      greeting: string;
+    }
+    type Variables = Record<string, never>;
+    const query: TypedDocumentNode<Query, Variables> = gql`
+      query {
+        greeting
+      }
+    `;
+
+    const client = createClient();
+
+    expectTypeOf(
+      await client.query({ query, errorPolicy: "none" })
+    ).toEqualTypeOf<{ data: Query; error?: never }>();
+  });
+
+  test("returns TData | undefined with errorPolicy: all", async () => {
+    interface Query {
+      greeting: string;
+    }
+    type Variables = Record<string, never>;
+    const query: TypedDocumentNode<Query, Variables> = gql`
+      query {
+        greeting
+      }
+    `;
+
+    const client = createClient();
+
+    expectTypeOf(
+      await client.query({ query, errorPolicy: "all" })
+    ).toEqualTypeOf<{ data: Query | undefined; error?: ErrorLike }>();
+  });
+
+  test("returns TData | undefined with errorPolicy: ignore", async () => {
+    interface Query {
+      greeting: string;
+    }
+    type Variables = Record<string, never>;
+    const query: TypedDocumentNode<Query, Variables> = gql`
+      query {
+        greeting
+      }
+    `;
+
+    const client = createClient();
+
+    expectTypeOf(
+      await client.query({ query, errorPolicy: "ignore" })
+    ).toEqualTypeOf<{
+      data: Query | undefined;
+      error?: never;
+    }>();
+  });
+});
+
+function createClient() {
+  return new ApolloClient({
+    cache: new InMemoryCache(),
+    link: ApolloLink.empty(),
+  });
+}

--- a/src/core/__tests__/client.query/types.test.ts
+++ b/src/core/__tests__/client.query/types.test.ts
@@ -8,8 +8,8 @@ describe.skip("type tests", () => {
     interface Query {
       greeting: string;
     }
-    type Variables = Record<string, never>;
-    const query: TypedDocumentNode<Query, Variables> = gql`
+
+    const query: TypedDocumentNode<Query, Record<string, never>> = gql`
       query {
         greeting
       }
@@ -27,8 +27,8 @@ describe.skip("type tests", () => {
     interface Query {
       greeting: string;
     }
-    type Variables = Record<string, never>;
-    const query: TypedDocumentNode<Query, Variables> = gql`
+
+    const query: TypedDocumentNode<Query, Record<string, never>> = gql`
       query {
         greeting
       }
@@ -45,8 +45,8 @@ describe.skip("type tests", () => {
     interface Query {
       greeting: string;
     }
-    type Variables = Record<string, never>;
-    const query: TypedDocumentNode<Query, Variables> = gql`
+
+    const query: TypedDocumentNode<Query, Record<string, never>> = gql`
       query {
         greeting
       }
@@ -63,8 +63,8 @@ describe.skip("type tests", () => {
     interface Query {
       greeting: string;
     }
-    type Variables = Record<string, never>;
-    const query: TypedDocumentNode<Query, Variables> = gql`
+
+    const query: TypedDocumentNode<Query, Record<string, never>> = gql`
       query {
         greeting
       }


### PR DESCRIPTION
Fixes #13123

Improves the return type of `client.query` to be smarter about the applied `errorPolicy`. The `data` and `error` properties now better reflect the expected runtime value for a given `errorPolicy`. 

This allow the removal of `undefined` checks or optional chaining for most uses of `client.query`.

> [!NOTE]
> The `ApolloClient.QueryResult` type is used in several places throughout the code base, most of which do not know the underlying `errorPolicy` applied (e.g. `refetchQueries`, which might have a mix of `ObservableQuery` instances with different error policies). As such, I left a fallback case that leaves the type as-is. You need to be explicit about an error policy in order to get the smarter types.