### PR TITLE
Fix issue with `useQuery` polling when `skip` was initialized with `true`

### DIFF
--- a/.changeset/chilly-games-punch.md
+++ b/.changeset/chilly-games-punch.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix an issue where `useQuery` would poll with `pollInterval` when `skip` was initialized to `true`.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 46840,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 41509,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 35546,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 29292
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 46872,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 41484,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 35505,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 29301
 }

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1424,15 +1424,13 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     } = this;
 
     const shouldCancelPolling = () => {
-      const {
-        options: { fetchPolicy, pollInterval },
-      } = this;
+      const { options } = this;
 
       return (
-        !pollInterval ||
+        !options.pollInterval ||
         !this.hasObservers() ||
-        fetchPolicy === "cache-only" ||
-        fetchPolicy === "standby"
+        options.fetchPolicy === "cache-only" ||
+        options.fetchPolicy === "standby"
       );
     };
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1423,12 +1423,20 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
       options: { fetchPolicy, pollInterval },
     } = this;
 
-    if (
-      !pollInterval ||
-      !this.hasObservers() ||
-      fetchPolicy === "cache-only" ||
-      fetchPolicy === "standby"
-    ) {
+    const shouldCancelPolling = () => {
+      const {
+        options: { fetchPolicy, pollInterval },
+      } = this;
+
+      return (
+        !pollInterval ||
+        !this.hasObservers() ||
+        fetchPolicy === "cache-only" ||
+        fetchPolicy === "standby"
+      );
+    };
+
+    if (shouldCancelPolling()) {
       if (__DEV__) {
         if (
           !this.didWarnCacheOnlyPolling &&
@@ -1455,7 +1463,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     info.interval = pollInterval;
 
     const maybeFetch = () => {
-      if (this.options.fetchPolicy === "standby") {
+      if (shouldCancelPolling()) {
         return this.cancelPolling();
       }
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1463,6 +1463,8 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     info.interval = pollInterval;
 
     const maybeFetch = () => {
+      // defense against options changing after the setTimeout changes in case
+      // the call site forgets to call cancelPolling
       if (shouldCancelPolling()) {
         return this.cancelPolling();
       }

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1455,6 +1455,10 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     info.interval = pollInterval;
 
     const maybeFetch = () => {
+      if (this.options.fetchPolicy === "standby") {
+        return this.cancelPolling();
+      }
+
       if (this.pollingInfo) {
         if (
           !isNetworkRequestInFlight(this.networkStatus) &&

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1423,7 +1423,12 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
       options: { fetchPolicy, pollInterval },
     } = this;
 
-    if (!pollInterval || !this.hasObservers() || fetchPolicy === "cache-only") {
+    if (
+      !pollInterval ||
+      !this.hasObservers() ||
+      fetchPolicy === "cache-only" ||
+      fetchPolicy === "standby"
+    ) {
       if (__DEV__) {
         if (
           !this.didWarnCacheOnlyPolling &&


### PR DESCRIPTION
Fixes #13154

Polling was properly skipped when changing from `skip: false` to `skip: true`, but when `skip` was initialized to `true`, polling kicked in.

This was due to calling [`updatePolling`](https://github.com/apollographql/apollo-client/blob/8a6e12c7f3069b0879318fb9d82366d610073245/src/core/ObservableQuery.ts#L452) in a `setTimeout` which runs after `reobserve` is called when first subscribing to `ObservableQuery` (which properly cancels polling when the [`fetchPolicy` is `standby`](https://github.com/apollographql/apollo-client/blob/8a6e12c7f3069b0879318fb9d82366d610073245/src/core/ObservableQuery.ts#L1618-L1620)). Now `updatePolling` will also check for `standby` and cancel polling if detected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `useQuery` incorrectly initiating polling when `skip` was set to `true` on the initial render. Polling now correctly remains inactive until `skip` is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->